### PR TITLE
feat(customer-portal): add case write-ops and deployment endpoints

### DIFF
--- a/apps/customer-portal/backend-v2/CLAUDE.md
+++ b/apps/customer-portal/backend-v2/CLAUDE.md
@@ -6,14 +6,16 @@ responses for the frontend. This is a Go rewrite of the Ballerina backend at
 `apps/customer-portal/backend`, modeled on `apps/csm-portal/backend`'s conventions — read that
 backend's own CLAUDE.md too if something here is underspecified.
 
-**Status: in progress.** 11 routes are wired up so far (`GET /health`, `GET`/`PATCH /users/me`,
+**Status: in progress.** 16 routes are wired up so far (`GET /health`, `GET`/`PATCH /users/me`,
 `POST /accounts/search`, `GET /accounts/{id}`, `POST /projects/search`, `GET /projects/{id}`,
-`POST /cases/search`, `GET /cases/{id}`, `GET /updates/product-update-levels`,
-`POST /updates/levels/search`) across three upstream services: entity-service, the WSO2 Updates
-service, and SCIM. The Ballerina backend exposes ~100 routes across many more modules (deployments,
-deployed products, attachments, comments, conversations, change requests, call requests, catalogs,
-time cards, registry tokens, contacts, escalations, product vulnerabilities, AI chat/websocket,
-etc.) — none of those are ported yet. Follow the recipe below to add the next one.
+`POST /cases/search`, `GET /cases/{id}`, `POST /cases`, `PATCH /cases/{id}`,
+`POST /cases/{id}/comments`, `POST /deployments/search`, `POST /deployments`,
+`GET /updates/product-update-levels`, `POST /updates/levels/search`) across three upstream
+services: entity-service, the WSO2 Updates service, and SCIM. The Ballerina backend exposes ~100
+routes across many more modules (deployed products, attachments, comments, conversations, change
+requests, call requests, catalogs, time cards, registry tokens, contacts, escalations, product
+vulnerabilities, AI chat/websocket, etc.) — none of those are ported yet. Follow the recipe below
+to add the next one.
 
 ## Which entity-service
 
@@ -99,10 +101,28 @@ here, it's resolved once in the mapper. Also deliberately excluded from account 
 (annual recurring revenue — WSO2-internal financial data, never expose to the customer) and `Pod`
 (WSO2-internal account routing).
 
-Request bodies are the exception: incoming search/filter payloads are decoded directly into the
-entity package's request structs (e.g. `entity.SearchProjectsRequest`) with no separate DTO layer,
-since those shapes are already what the frontend needs to send — there is nothing to hide on the
-request side.
+Request bodies are usually the exception: incoming search/filter/create payloads are decoded
+directly into the entity package's request structs (e.g. `entity.SearchProjectsRequest`,
+`entity.CreateCaseRequest`) with no separate DTO layer, since those shapes are already what the
+frontend needs to send and every field is customer-appropriate — there is nothing to hide.
+
+**But when entity-service's request contract mixes customer-safe fields with internal-only ones,
+build a restricted portal request DTO too.** `entity.UpdateCaseRequest` (`PATCH /cases/{id}`) is
+the example: it has 18 optional fields, but `workState`, `assigneeEmail`, `parentId`/
+`relatedCaseId`/`deploymentId`/`deployedProductId` (case relinking), `autocloseHoldUntil`, and the
+`fixEta`/`bestCaseFixEta`/`mostLikelyFixEta`/`worstCaseFixEta` quartet are internal WSO2 support
+operations, not things a customer should be able to set on their own case. `dto.UpdateCaseRequest`
+(`internal/dto/case.go`) exposes only the customer-safe subset (state, severity, subject,
+description, watchList, resolutionCode, cause, closeNotes), and
+`dto.BuildEntityUpdateCaseRequest(id, req)` builds the full entity-service request from it, leaving
+every excluded field zero/nil — so even if a client sends `{"workState": "ongoing"}`, it's silently
+dropped (the portal struct has no such field) rather than forwarded. The same pattern applies to
+`POST /cases/{id}/comments`: entity-service accepts `type: work_note|comment|activity`, but
+`dto.BuildEntityCreateCaseCommentRequest` always forces `type: comment`, regardless of what the
+client sends — a customer should never be able to create an internal work-note or system-activity
+entry. When you add a write endpoint, check the entity-service request struct for fields that read
+as "internal support operation" rather than "customer self-service action" before deciding whether
+to pass it through directly or build a restricted DTO.
 
 ## Adding a new endpoint
 

--- a/apps/customer-portal/backend-v2/README.md
+++ b/apps/customer-portal/backend-v2/README.md
@@ -5,7 +5,7 @@ Go rewrite of the Ballerina backend at `apps/customer-portal/backend`. It is a b
 [`entity-service`](../../../entity-service) (this repo's `cs-tools/entity-service`, not the
 `digiops-cs/entity-service` the Ballerina backend targets), and shapes the responses for the frontend.
 
-This is a work in progress — only the 11 routes listed below are implemented so far, across
+This is a work in progress — only the 16 routes listed below are implemented so far, across
 entity-service, the WSO2 Updates service, and SCIM. Everything else the Ballerina backend exposes
 still needs a Go handler; add them following the pattern described in
 [CLAUDE.md](./CLAUDE.md#adding-a-new-endpoint).
@@ -133,7 +133,8 @@ backend-v2/
 │   │   ├── users.go             # GetMe, PatchMe
 │   │   ├── accounts.go          # SearchAccounts, GetAccount
 │   │   ├── projects.go          # SearchProjects, GetProject
-│   │   └── cases.go             # SearchCases, GetCase
+│   │   ├── cases.go             # SearchCases, GetCase, CreateCase, UpdateCase, CreateCaseComment
+│   │   └── deployments.go       # SearchDeployments, CreateDeployment
 │   ├── updates/                 # OAuth2 HTTP client for the WSO2 Updates service
 │   │   ├── client.go            # Config/Client/do()
 │   │   ├── types.go             # upstream (snake_case) vs portal (camelCase) structs
@@ -147,7 +148,8 @@ backend-v2/
 │   │   ├── user.go
 │   │   ├── account.go
 │   │   ├── project.go
-│   │   └── case.go
+│   │   ├── case.go
+│   │   └── deployment.go
 │   ├── middleware/
 │   │   ├── auth.go              # JWT validation; injects UserInfo into context
 │   │   ├── correlation.go       # X-CSM-Correlation-ID propagation + slog enrichment
@@ -158,7 +160,8 @@ backend-v2/
 │       ├── users.go             # GET/PATCH /users/me
 │       ├── accounts.go          # POST /accounts/search, GET /accounts/{id}
 │       ├── projects.go          # POST /projects/search, GET /projects/{id}
-│       ├── cases.go             # POST /cases/search, GET /cases/{id}
+│       ├── cases.go             # cases search/get/create/update/comment
+│       ├── deployments.go       # POST /deployments/search, POST /deployments
 │       └── updates.go           # GET /updates/product-update-levels, POST /updates/levels/search
 ├── .choreo/component.yaml
 ├── openapi.yaml
@@ -178,6 +181,11 @@ backend-v2/
 - `GET /projects/{id}` — get project by ID
 - `POST /cases/search` — search cases
 - `GET /cases/{id}` — get case by ID
+- `POST /cases` — create a case
+- `PATCH /cases/{id}` — update a case (restricted, customer-safe field subset — see CLAUDE.md)
+- `POST /cases/{id}/comments` — add a comment to a case (always a plain customer comment)
+- `POST /deployments/search` — search deployments
+- `POST /deployments` — create a deployment (ServiceNow data source only)
 - `GET /updates/product-update-levels` — list product update levels
 - `POST /updates/levels/search` — search update descriptions between two update levels
 
@@ -225,6 +233,26 @@ curl -X POST http://localhost:8080/cases/search \
   -d '{"pagination":{"limit":10,"offset":0},"filters":{"searchQuery":"login error"}}'
 
 curl -H "x-jwt-assertion: $JWT" http://localhost:8080/cases/<case-id>
+
+curl -X POST http://localhost:8080/cases \
+  -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
+  -d '{"type":"case","projectId":"<project-id>","deploymentId":"<deployment-id>","subject":"Login error","description":"...","severity":"high","issueType":"question"}'
+
+curl -X PATCH http://localhost:8080/cases/<case-id> \
+  -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
+  -d '{"state":"closed","closeNotes":"Resolved on our end, thanks!"}'
+
+curl -X POST http://localhost:8080/cases/<case-id>/comments \
+  -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
+  -d '{"content":"Any update on this?"}'
+
+curl -X POST http://localhost:8080/deployments/search \
+  -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
+  -d '{"pagination":{"limit":10,"offset":0}}'
+
+curl -X POST http://localhost:8080/deployments \
+  -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
+  -d '{"projectId":"<project-id>","name":"Production"}'
 
 curl -H "x-jwt-assertion: $JWT" http://localhost:8080/updates/product-update-levels
 

--- a/apps/customer-portal/backend-v2/cmd/server/main.go
+++ b/apps/customer-portal/backend-v2/cmd/server/main.go
@@ -79,6 +79,7 @@ func main() {
 	userHandler := handler.NewUserHandler(entityClient, scimClient)
 	projectHandler := handler.NewProjectHandler(entityClient)
 	caseHandler := handler.NewCaseHandler(entityClient)
+	deploymentHandler := handler.NewDeploymentHandler(entityClient)
 	accountHandler := handler.NewAccountHandler(entityClient)
 	updatesHandler := handler.NewUpdatesHandler(updatesClient)
 
@@ -105,6 +106,14 @@ func main() {
 
 	mux.HandleFunc("POST /cases/search", caseHandler.SearchCases)
 	mux.HandleFunc("GET /cases/{id}", caseHandler.GetCase)
+	mux.HandleFunc("POST /cases", caseHandler.CreateCase)
+	mux.HandleFunc("PATCH /cases/{id}", caseHandler.PatchCase)
+	mux.HandleFunc("POST /cases/{id}/comments", caseHandler.CreateCaseComment)
+
+	mux.HandleFunc("POST /deployments/search", deploymentHandler.SearchDeployments)
+	// POST /deployments only succeeds against entity-service's ServiceNow
+	// data source — see internal/entity/deployments.go.
+	mux.HandleFunc("POST /deployments", deploymentHandler.CreateDeployment)
 
 	mux.HandleFunc("POST /accounts/search", accountHandler.SearchAccounts)
 	mux.HandleFunc("GET /accounts/{id}", accountHandler.GetAccount)

--- a/apps/customer-portal/backend-v2/internal/dto/case.go
+++ b/apps/customer-portal/backend-v2/internal/dto/case.go
@@ -262,10 +262,15 @@ func MapCaseCreate(r entity.CreateCaseResponse) CaseCreateResponse {
 // DeploymentID/DeployedProductID (case relinking), AutocloseHoldUntil
 // (ServiceNow auto-closure workflow control), and FixEta/BestCaseFixEta/
 // MostLikelyFixEta/WorstCaseFixEta (fix-commitment dates set by support
-// engineers, not the customer). Exactly one of State/Severity/Subject/
-// Description/WatchList must be set per entity-service's own validation;
-// ResolutionCode/Cause/CloseNotes are only accepted alongside a closing
-// State transition.
+// engineers, not the customer). entity-service requires exactly one of
+// State/Severity/WorkState/WatchList/AssigneeEmail/ParentID/RelatedCaseID/
+// AutocloseHoldUntil/Subject/Description/DeploymentID/DeployedProductID/
+// FixEta/BestCaseFixEta/MostLikelyFixEta/WorstCaseFixEta to be set (see
+// entity.UpdateCaseRequest's doc comment) — since this portal DTO only
+// exposes State/Severity/Subject/Description/WatchList of that set, exactly
+// one of those five must be set here too. ResolutionCode/Cause/CloseNotes
+// are secondary fields, only accepted alongside a closing State transition,
+// and don't count toward the exactly-one rule.
 type UpdateCaseRequest struct {
 	State          *string  `json:"state,omitempty"`
 	Severity       *string  `json:"severity,omitempty"`
@@ -295,16 +300,17 @@ func BuildEntityUpdateCaseRequest(id string, req UpdateCaseRequest) entity.Updat
 }
 
 // CaseUpdateResponse is the portal's response for PATCH /cases/{id}.
-// Deliberately excludes entity-service's UpdatedBy (internal actor identity)
-// and the Best/MostLikely/WorstCaseFixEta trio, for the same reasons as
-// CaseDetails above.
+// Deliberately excludes entity-service's UpdatedBy (internal actor identity),
+// WatchList (CSM-engineer-facing only — CaseView/CaseDetails exclude it for
+// the same reason, so the update response must not leak watcher email
+// addresses that the read path never returns), and the Best/MostLikely/
+// WorstCaseFixEta trio, for the same reasons as CaseDetails above.
 type CaseUpdateResponse struct {
 	ID             string     `json:"id"`
 	UpdatedOn      time.Time  `json:"updatedOn"`
 	State          string     `json:"state,omitempty"`
 	Severity       string     `json:"severity,omitempty"`
 	WorkState      *string    `json:"workState,omitempty"`
-	WatchList      []string   `json:"watchList,omitempty"`
 	AssignedTo     *PersonRef `json:"assignedTo,omitempty"`
 	ResolutionCode *string    `json:"resolutionCode,omitempty"`
 	Cause          *string    `json:"cause,omitempty"`
@@ -318,18 +324,6 @@ type CaseUpdateResponse struct {
 func MapCaseUpdate(r entity.UpdateCaseResponse) CaseUpdateResponse {
 	c := r.Case
 
-	var watchList []string
-	if len(c.WatchList) > 0 {
-		watchList = make([]string, 0, len(c.WatchList))
-		for _, w := range c.WatchList {
-			if w.Email != "" {
-				watchList = append(watchList, w.Email)
-			} else {
-				watchList = append(watchList, w.UserName)
-			}
-		}
-	}
-
 	var assignedTo *PersonRef
 	if c.AssignedTo != nil {
 		assignedTo = &PersonRef{Name: c.AssignedTo.Name, Email: c.AssignedTo.Email}
@@ -341,7 +335,6 @@ func MapCaseUpdate(r entity.UpdateCaseResponse) CaseUpdateResponse {
 		State:          c.State,
 		Severity:       c.Severity,
 		WorkState:      c.WorkState,
-		WatchList:      watchList,
 		AssignedTo:     assignedTo,
 		ResolutionCode: c.ResolutionCode,
 		Cause:          c.Cause,

--- a/apps/customer-portal/backend-v2/internal/dto/case.go
+++ b/apps/customer-portal/backend-v2/internal/dto/case.go
@@ -300,17 +300,19 @@ func BuildEntityUpdateCaseRequest(id string, req UpdateCaseRequest) entity.Updat
 }
 
 // CaseUpdateResponse is the portal's response for PATCH /cases/{id}.
-// Deliberately excludes entity-service's UpdatedBy (internal actor identity),
-// WatchList (CSM-engineer-facing only — CaseView/CaseDetails exclude it for
-// the same reason, so the update response must not leak watcher email
-// addresses that the read path never returns), and the Best/MostLikely/
-// WorstCaseFixEta trio, for the same reasons as CaseDetails above.
+// Deliberately excludes entity-service's UpdatedBy (internal actor identity)
+// and the Best/MostLikely/WorstCaseFixEta trio, for the same reasons as
+// CaseDetails above. WatchList IS included (unlike CaseView/CaseDetails,
+// which omit it) — a customer who just updated the watch list needs
+// confirmation of who's on it now, so this is a deliberate exception to the
+// read-path exclusion rather than an oversight.
 type CaseUpdateResponse struct {
 	ID             string     `json:"id"`
 	UpdatedOn      time.Time  `json:"updatedOn"`
 	State          string     `json:"state,omitempty"`
 	Severity       string     `json:"severity,omitempty"`
 	WorkState      *string    `json:"workState,omitempty"`
+	WatchList      []string   `json:"watchList,omitempty"`
 	AssignedTo     *PersonRef `json:"assignedTo,omitempty"`
 	ResolutionCode *string    `json:"resolutionCode,omitempty"`
 	Cause          *string    `json:"cause,omitempty"`
@@ -324,6 +326,18 @@ type CaseUpdateResponse struct {
 func MapCaseUpdate(r entity.UpdateCaseResponse) CaseUpdateResponse {
 	c := r.Case
 
+	var watchList []string
+	if len(c.WatchList) > 0 {
+		watchList = make([]string, 0, len(c.WatchList))
+		for _, w := range c.WatchList {
+			if w.Email != "" {
+				watchList = append(watchList, w.Email)
+			} else {
+				watchList = append(watchList, w.UserName)
+			}
+		}
+	}
+
 	var assignedTo *PersonRef
 	if c.AssignedTo != nil {
 		assignedTo = &PersonRef{Name: c.AssignedTo.Name, Email: c.AssignedTo.Email}
@@ -335,6 +349,7 @@ func MapCaseUpdate(r entity.UpdateCaseResponse) CaseUpdateResponse {
 		State:          c.State,
 		Severity:       c.Severity,
 		WorkState:      c.WorkState,
+		WatchList:      watchList,
 		AssignedTo:     assignedTo,
 		ResolutionCode: c.ResolutionCode,
 		Cause:          c.Cause,

--- a/apps/customer-portal/backend-v2/internal/dto/case.go
+++ b/apps/customer-portal/backend-v2/internal/dto/case.go
@@ -234,3 +234,156 @@ func MapCaseDetails(c entity.CaseView) CaseDetails {
 		Tags:                  tags,
 	}
 }
+
+// CaseCreateResponse is the portal's response for POST /cases. Deliberately
+// excludes entity-service's InternalID, consistent with the other case DTOs.
+type CaseCreateResponse struct {
+	ID        string    `json:"id"`
+	Number    string    `json:"number"`
+	CreatedOn time.Time `json:"createdOn"`
+	State     string    `json:"state"`
+}
+
+// MapCaseCreate builds the portal response from entity-service's CreateCaseResponse.
+func MapCaseCreate(r entity.CreateCaseResponse) CaseCreateResponse {
+	return CaseCreateResponse{
+		ID:        r.Case.ID,
+		Number:    r.Case.Number,
+		CreatedOn: r.Case.CreatedOn,
+		State:     r.Case.State,
+	}
+}
+
+// UpdateCaseRequest is the portal's request shape for PATCH /cases/{id} — a
+// deliberately restricted subset of entity-service's UpdateCaseRequest.
+// Excluded fields are internal WSO2 support operations, not customer
+// self-service actions: WorkState (CSM engineer work-in-progress tracking),
+// AssigneeEmail (support engineer assignment), ParentID/RelatedCaseID/
+// DeploymentID/DeployedProductID (case relinking), AutocloseHoldUntil
+// (ServiceNow auto-closure workflow control), and FixEta/BestCaseFixEta/
+// MostLikelyFixEta/WorstCaseFixEta (fix-commitment dates set by support
+// engineers, not the customer). Exactly one of State/Severity/Subject/
+// Description/WatchList must be set per entity-service's own validation;
+// ResolutionCode/Cause/CloseNotes are only accepted alongside a closing
+// State transition.
+type UpdateCaseRequest struct {
+	State          *string  `json:"state,omitempty"`
+	Severity       *string  `json:"severity,omitempty"`
+	Subject        *string  `json:"subject,omitempty"`
+	Description    *string  `json:"description,omitempty"`
+	WatchList      []string `json:"watchList,omitempty"`
+	ResolutionCode *string  `json:"resolutionCode,omitempty"`
+	Cause          *string  `json:"cause,omitempty"`
+	CloseNotes     *string  `json:"closeNotes,omitempty"`
+}
+
+// BuildEntityUpdateCaseRequest converts the portal's restricted update
+// request into entity-service's full request shape, leaving every excluded
+// field zero/nil.
+func BuildEntityUpdateCaseRequest(id string, req UpdateCaseRequest) entity.UpdateCaseRequest {
+	return entity.UpdateCaseRequest{
+		ID:             id,
+		State:          req.State,
+		Severity:       req.Severity,
+		Subject:        req.Subject,
+		Description:    req.Description,
+		WatchList:      req.WatchList,
+		ResolutionCode: req.ResolutionCode,
+		Cause:          req.Cause,
+		CloseNotes:     req.CloseNotes,
+	}
+}
+
+// CaseUpdateResponse is the portal's response for PATCH /cases/{id}.
+// Deliberately excludes entity-service's UpdatedBy (internal actor identity)
+// and the Best/MostLikely/WorstCaseFixEta trio, for the same reasons as
+// CaseDetails above.
+type CaseUpdateResponse struct {
+	ID             string     `json:"id"`
+	UpdatedOn      time.Time  `json:"updatedOn"`
+	State          string     `json:"state,omitempty"`
+	Severity       string     `json:"severity,omitempty"`
+	WorkState      *string    `json:"workState,omitempty"`
+	WatchList      []string   `json:"watchList,omitempty"`
+	AssignedTo     *PersonRef `json:"assignedTo,omitempty"`
+	ResolutionCode *string    `json:"resolutionCode,omitempty"`
+	Cause          *string    `json:"cause,omitempty"`
+	CloseNotes     *string    `json:"closeNotes,omitempty"`
+	ResolvedOn     *time.Time `json:"resolvedOn,omitempty"`
+	ParentCase     *NumberRef `json:"parentCase,omitempty"`
+	FixEta         *time.Time `json:"fixEta,omitempty"`
+}
+
+// MapCaseUpdate builds the portal response from entity-service's UpdateCaseResponse.
+func MapCaseUpdate(r entity.UpdateCaseResponse) CaseUpdateResponse {
+	c := r.Case
+
+	var watchList []string
+	if len(c.WatchList) > 0 {
+		watchList = make([]string, 0, len(c.WatchList))
+		for _, w := range c.WatchList {
+			if w.Email != "" {
+				watchList = append(watchList, w.Email)
+			} else {
+				watchList = append(watchList, w.UserName)
+			}
+		}
+	}
+
+	var assignedTo *PersonRef
+	if c.AssignedTo != nil {
+		assignedTo = &PersonRef{Name: c.AssignedTo.Name, Email: c.AssignedTo.Email}
+	}
+
+	return CaseUpdateResponse{
+		ID:             c.ID,
+		UpdatedOn:      c.UpdatedOn,
+		State:          c.State,
+		Severity:       c.Severity,
+		WorkState:      c.WorkState,
+		WatchList:      watchList,
+		AssignedTo:     assignedTo,
+		ResolutionCode: c.ResolutionCode,
+		Cause:          c.Cause,
+		CloseNotes:     c.CloseNotes,
+		ResolvedOn:     c.ResolvedOn,
+		ParentCase:     mapNumberRef(c.ParentCase),
+		FixEta:         c.FixEta,
+	}
+}
+
+// CaseCommentRequest is the portal's request shape for POST /cases/{id}/comments.
+// entity-service also supports "work_note" and "activity" comment types, but
+// those are internal WSO2 support annotations — the customer portal only
+// ever lets a customer post a plain "comment"; see
+// BuildEntityCreateCaseCommentRequest.
+type CaseCommentRequest struct {
+	Content string `json:"content"`
+}
+
+// BuildEntityCreateCaseCommentRequest converts the portal's comment request
+// into entity-service's request shape, forcing Type to "comment" regardless
+// of anything the caller might otherwise try to set.
+func BuildEntityCreateCaseCommentRequest(caseID string, req CaseCommentRequest) entity.CreateCaseCommentRequest {
+	return entity.CreateCaseCommentRequest{
+		CaseID:  caseID,
+		Type:    entity.CommentTypeComment,
+		Content: req.Content,
+	}
+}
+
+// CaseCommentResponse is the portal's response for POST /cases/{id}/comments.
+type CaseCommentResponse struct {
+	ID        string    `json:"id"`
+	CreatedOn time.Time `json:"createdOn"`
+	CreatedBy string    `json:"createdBy"`
+}
+
+// MapCaseComment builds the portal response from entity-service's CreateCaseCommentResponse.
+func MapCaseComment(r entity.CreateCaseCommentResponse) CaseCommentResponse {
+	return CaseCommentResponse{
+		ID:        r.Comment.ID,
+		CreatedOn: r.Comment.CreatedOn,
+		CreatedBy: r.Comment.CreatedBy,
+	}
+}

--- a/apps/customer-portal/backend-v2/internal/dto/deployment.go
+++ b/apps/customer-portal/backend-v2/internal/dto/deployment.go
@@ -1,0 +1,84 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dto
+
+import (
+	"time"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+)
+
+// DeploymentSummary is one item of the portal's response for POST /deployments/search.
+type DeploymentSummary struct {
+	ID          string    `json:"id"`
+	Number      string    `json:"number"`
+	Name        string    `json:"name"`
+	Type        string    `json:"type"`
+	Description *string   `json:"description,omitempty"`
+	CreatedBy   *Ref      `json:"createdBy,omitempty"`
+	Project     Ref       `json:"project"`
+	CreatedOn   time.Time `json:"createdOn"`
+	UpdatedOn   time.Time `json:"updatedOn"`
+}
+
+// SearchDeploymentsResponse is the portal's response for POST /deployments/search.
+type SearchDeploymentsResponse struct {
+	Deployments []DeploymentSummary `json:"deployments"`
+	Total       int                 `json:"total"`
+	Limit       int                 `json:"limit"`
+	Offset      int                 `json:"offset"`
+	HasMore     bool                `json:"hasMore"`
+}
+
+// MapSearchDeployments builds the portal response from entity-service's SearchDeploymentsResponse.
+func MapSearchDeployments(r entity.SearchDeploymentsResponse) SearchDeploymentsResponse {
+	deployments := make([]DeploymentSummary, 0, len(r.Deployments))
+	for _, d := range r.Deployments {
+		deployments = append(deployments, DeploymentSummary{
+			ID:          d.ID,
+			Number:      d.Number,
+			Name:        d.Name,
+			Type:        d.Type,
+			Description: d.Description,
+			CreatedBy:   mapRef(d.CreatedBy),
+			Project:     Ref{ID: d.Project.ID, Name: d.Project.Name},
+			CreatedOn:   d.CreatedOn,
+			UpdatedOn:   d.UpdatedOn,
+		})
+	}
+	return SearchDeploymentsResponse{
+		Deployments: deployments,
+		Total:       r.Total,
+		Limit:       r.Limit,
+		Offset:      r.Offset,
+		HasMore:     r.HasMore,
+	}
+}
+
+// DeploymentCreateResponse is the portal's response for POST /deployments.
+type DeploymentCreateResponse struct {
+	ID        string    `json:"id"`
+	CreatedOn time.Time `json:"createdOn"`
+}
+
+// MapDeploymentCreate builds the portal response from entity-service's CreateDeploymentResponse.
+func MapDeploymentCreate(r entity.CreateDeploymentResponse) DeploymentCreateResponse {
+	return DeploymentCreateResponse{
+		ID:        r.Deployment.ID,
+		CreatedOn: r.Deployment.CreatedOn,
+	}
+}

--- a/apps/customer-portal/backend-v2/internal/entity/cases.go
+++ b/apps/customer-portal/backend-v2/internal/entity/cases.go
@@ -35,3 +35,24 @@ func (c *Client) GetCase(ctx context.Context, id string) (CaseView, error) {
 	err := c.getJSON(ctx, fmt.Sprintf("/cases/%s", url.PathEscape(id)), &out)
 	return out, err
 }
+
+// CreateCase calls POST /cases.
+func (c *Client) CreateCase(ctx context.Context, req CreateCaseRequest) (CreateCaseResponse, error) {
+	var out CreateCaseResponse
+	err := c.postJSON(ctx, "/cases", req, &out)
+	return out, err
+}
+
+// UpdateCase calls PATCH /cases/{id}.
+func (c *Client) UpdateCase(ctx context.Context, id string, req UpdateCaseRequest) (UpdateCaseResponse, error) {
+	var out UpdateCaseResponse
+	err := c.patchJSON(ctx, fmt.Sprintf("/cases/%s", url.PathEscape(id)), req, &out)
+	return out, err
+}
+
+// CreateCaseComment calls POST /cases/{id}/comments.
+func (c *Client) CreateCaseComment(ctx context.Context, caseID string, req CreateCaseCommentRequest) (CreateCaseCommentResponse, error) {
+	var out CreateCaseCommentResponse
+	err := c.postJSON(ctx, fmt.Sprintf("/cases/%s/comments", url.PathEscape(caseID)), req, &out)
+	return out, err
+}

--- a/apps/customer-portal/backend-v2/internal/entity/deployments.go
+++ b/apps/customer-portal/backend-v2/internal/entity/deployments.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package entity
+
+import "context"
+
+// SearchDeployments calls POST /deployments/search.
+func (c *Client) SearchDeployments(ctx context.Context, req SearchDeploymentsRequest) (SearchDeploymentsResponse, error) {
+	var out SearchDeploymentsResponse
+	err := c.postJSON(ctx, "/deployments/search", req, &out)
+	return out, err
+}
+
+// CreateDeployment calls POST /deployments.
+//
+// NOTE: only entity-service's ServiceNow data source supports this route —
+// see CreateDeploymentRequest's doc comment.
+func (c *Client) CreateDeployment(ctx context.Context, req CreateDeploymentRequest) (CreateDeploymentResponse, error) {
+	var out CreateDeploymentResponse
+	err := c.postJSON(ctx, "/deployments", req, &out)
+	return out, err
+}

--- a/apps/customer-portal/backend-v2/internal/entity/types.go
+++ b/apps/customer-portal/backend-v2/internal/entity/types.go
@@ -365,6 +365,155 @@ type SearchCasesResponse struct {
 	Limit  int              `json:"limit"`
 }
 
+// Variable is a key-value pair used in service-request case creation.
+type Variable struct {
+	ID    string `json:"id"`
+	Value string `json:"value"`
+}
+
+// CaseAttachment is a file attachment for security-report-analysis case
+// creation. File must be a base64 data URI (e.g. "data:application/pdf;base64,...").
+type CaseAttachment struct {
+	Name string `json:"name"`
+	File string `json:"file"`
+}
+
+// CreateCaseRequest is the input for POST /cases. CreatedBy is never
+// serialized (json:"-") — entity-service derives the creator from its own
+// auth context, not the request body.
+type CreateCaseRequest struct {
+	CreatedBy         string           `json:"-"`
+	Type              string           `json:"type"`
+	ProjectID         string           `json:"projectId"`
+	DeploymentID      string           `json:"deploymentId"`
+	DeployedProductID string           `json:"deployedProductId,omitempty"`
+	Subject           string           `json:"subject"`
+	Description       string           `json:"description"`
+	Severity          string           `json:"severity"`
+	IssueType         string           `json:"issueType"`
+	CatalogID         string           `json:"catalogId,omitempty"`
+	CatalogItemID     string           `json:"catalogItemId,omitempty"`
+	Variables         []Variable       `json:"variables,omitempty"`
+	RelatedCaseID     string           `json:"relatedCaseId,omitempty"`
+	ConversationID    string           `json:"conversationId,omitempty"`
+	WatchList         []string         `json:"watchList,omitempty"`
+	Attachments       []CaseAttachment `json:"attachments,omitempty"`
+}
+
+// CreateCaseDetails carries the key fields of a newly created case.
+type CreateCaseDetails struct {
+	ID         string    `json:"id"`
+	InternalID string    `json:"internalId"`
+	Number     string    `json:"number"`
+	CreatedBy  string    `json:"createdBy"`
+	CreatedOn  time.Time `json:"createdOn"`
+	State      string    `json:"state"`
+}
+
+// CreateCaseResponse is entity-service's response for POST /cases.
+type CreateCaseResponse struct {
+	Message string            `json:"message"`
+	Case    CreateCaseDetails `json:"case"`
+}
+
+// UpdateCaseRequest is the full field set entity-service accepts for
+// PATCH /cases/{id}. This is entity-service's raw contract — the portal only
+// exposes a customer-safe subset of these fields; see dto.UpdateCaseRequest
+// and dto.BuildEntityUpdateCaseRequest for which ones and why.
+type UpdateCaseRequest struct {
+	ID                 string     `json:"-"`
+	State              *string    `json:"state,omitempty"`
+	Severity           *string    `json:"severity,omitempty"`
+	WorkState          *string    `json:"workState,omitempty"`
+	WatchList          []string   `json:"watchList,omitempty"`
+	AssigneeEmail      *string    `json:"assigneeEmail,omitempty"`
+	ResolutionCode     *string    `json:"resolutionCode,omitempty"`
+	Cause              *string    `json:"cause,omitempty"`
+	CloseNotes         *string    `json:"closeNotes,omitempty"`
+	ParentID           *string    `json:"parentId,omitempty"`
+	RelatedCaseID      *string    `json:"relatedCaseId,omitempty"`
+	AutocloseHoldUntil *time.Time `json:"autocloseHoldUntil,omitempty"`
+	Subject            *string    `json:"subject,omitempty"`
+	Description        *string    `json:"description,omitempty"`
+	DeploymentID       *string    `json:"deploymentId,omitempty"`
+	DeployedProductID  *string    `json:"deployedProductId,omitempty"`
+	FixEta             *time.Time `json:"fixEta,omitempty"`
+	BestCaseFixEta     *time.Time `json:"bestCaseFixEta,omitempty"`
+	MostLikelyFixEta   *time.Time `json:"mostLikelyFixEta,omitempty"`
+	WorstCaseFixEta    *time.Time `json:"worstCaseFixEta,omitempty"`
+}
+
+// WatchListUser is a user watching a case (ServiceNow data source only).
+type WatchListUser struct {
+	ID       string `json:"id"`
+	UserName string `json:"userName"`
+	Name     string `json:"name,omitempty"`
+	Email    string `json:"email,omitempty"`
+}
+
+// UpdatedCase carries the case fields entity-service returns after a
+// successful PATCH /cases/{id}.
+type UpdatedCase struct {
+	ID             string               `json:"id"`
+	UpdatedOn      time.Time            `json:"updatedOn"`
+	UpdatedBy      string               `json:"updatedBy,omitempty"`
+	State          string               `json:"state,omitempty"`
+	Severity       string               `json:"severity,omitempty"`
+	WorkState      *string              `json:"workState"`
+	WatchList      []WatchListUser      `json:"watchList,omitempty"`
+	AssignedTo     *AssignedEngineerRef `json:"assignedTo,omitempty"`
+	ResolutionCode *string              `json:"resolutionCode,omitempty"`
+	Cause          *string              `json:"cause,omitempty"`
+	CloseNotes     *string              `json:"closeNotes,omitempty"`
+	ResolvedOn     *time.Time           `json:"resolvedOn,omitempty"`
+	ParentCase     *CaseNumberRef       `json:"parentCase,omitempty"`
+	// FixEta is the customer-facing fix-commitment date; the internal-only
+	// Best/MostLikely/WorstCaseFixEta fields are intentionally not decoded
+	// here — see CaseView's doc comment above for why.
+	FixEta *time.Time `json:"fixEta,omitempty"`
+}
+
+// UpdateCaseResponse is entity-service's response for PATCH /cases/{id}.
+type UpdateCaseResponse struct {
+	Message string      `json:"message"`
+	Case    UpdatedCase `json:"case"`
+}
+
+// CommentType classifies a case comment. entity-service supports
+// "work_note" and "activity" too, but the customer portal only ever creates
+// (and should only ever create) plain "comment" entries — see
+// dto.BuildEntityCreateCaseCommentRequest.
+type CommentType string
+
+const (
+	CommentTypeWorkNote CommentType = "work_note"
+	CommentTypeComment  CommentType = "comment"
+	CommentTypeActivity CommentType = "activity"
+)
+
+// CreateCaseCommentRequest is the input for POST /cases/{id}/comments.
+// CaseID and CreatedBy are never serialized (json:"-") — CaseID comes from
+// the URL path, CreatedBy from entity-service's own auth context.
+type CreateCaseCommentRequest struct {
+	CaseID    string      `json:"-"`
+	CreatedBy string      `json:"-"`
+	Type      CommentType `json:"type"`
+	Content   string      `json:"content"`
+}
+
+// CaseCommentDetail carries the key fields of a newly created comment.
+type CaseCommentDetail struct {
+	ID        string    `json:"id"`
+	CreatedOn time.Time `json:"createdOn"`
+	CreatedBy string    `json:"createdBy"`
+}
+
+// CreateCaseCommentResponse is entity-service's response for POST /cases/{id}/comments.
+type CreateCaseCommentResponse struct {
+	Message string            `json:"message"`
+	Comment CaseCommentDetail `json:"comment"`
+}
+
 // CaseView is entity-service's response for GET /cases/{id}.
 type CaseView struct {
 	ID                     string                    `json:"id"`
@@ -406,4 +555,61 @@ type CaseView struct {
 	// workflow state to end customers.
 	FixEta *time.Time `json:"fixEta"`
 	Tags   []Tag      `json:"tags"`
+}
+
+// --- deployments ---
+
+// SearchDeploymentsRequest is the input for POST /deployments/search.
+type SearchDeploymentsRequest struct {
+	Pagination      Pagination `json:"pagination"`
+	SearchQuery     string     `json:"searchQuery,omitempty"`
+	ProjectIDs      []string   `json:"projectIds,omitempty"`
+	DeploymentTypes []string   `json:"deploymentTypes,omitempty"`
+}
+
+// DeploymentView is a single search result item from POST /deployments/search.
+type DeploymentView struct {
+	ID          string     `json:"id"`
+	Number      string     `json:"number"`
+	Name        string     `json:"name"`
+	Type        string     `json:"type"`
+	Description *string    `json:"description"`
+	CreatedBy   *EntityRef `json:"createdBy"`
+	Project     EntityRef  `json:"project"`
+	CreatedOn   time.Time  `json:"createdOn"`
+	UpdatedOn   time.Time  `json:"updatedOn"`
+}
+
+// SearchDeploymentsResponse is entity-service's response for POST /deployments/search.
+type SearchDeploymentsResponse struct {
+	Deployments []DeploymentView `json:"deployments"`
+	Total       int              `json:"total"`
+	Limit       int              `json:"limit"`
+	Offset      int              `json:"offset"`
+	HasMore     bool             `json:"hasMore"`
+}
+
+// CreateDeploymentRequest is the input for POST /deployments.
+//
+// NOTE: entity-service only supports deployment creation on its ServiceNow
+// data source — a Postgres-mode deployment always returns 400 for this
+// route (see cs-tools/entity-service/internal/service/deployment_service.go).
+type CreateDeploymentRequest struct {
+	ProjectID   string  `json:"projectId"`
+	Name        string  `json:"name"`
+	Type        *string `json:"type,omitempty"`
+	Description string  `json:"description,omitempty"`
+}
+
+// CreatedDeployment carries the key fields of a newly created deployment.
+type CreatedDeployment struct {
+	ID        string    `json:"id"`
+	CreatedOn time.Time `json:"createdOn"`
+	CreatedBy string    `json:"createdBy"`
+}
+
+// CreateDeploymentResponse is entity-service's response for POST /deployments.
+type CreateDeploymentResponse struct {
+	Message    string            `json:"message"`
+	Deployment CreatedDeployment `json:"deployment"`
 }

--- a/apps/customer-portal/backend-v2/internal/handler/cases.go
+++ b/apps/customer-portal/backend-v2/internal/handler/cases.go
@@ -31,6 +31,9 @@ import (
 type entityCaseClient interface {
 	SearchCases(ctx context.Context, req entity.SearchCasesRequest) (entity.SearchCasesResponse, error)
 	GetCase(ctx context.Context, id string) (entity.CaseView, error)
+	CreateCase(ctx context.Context, req entity.CreateCaseRequest) (entity.CreateCaseResponse, error)
+	UpdateCase(ctx context.Context, id string, req entity.UpdateCaseRequest) (entity.UpdateCaseResponse, error)
+	CreateCaseComment(ctx context.Context, caseID string, req entity.CreateCaseCommentRequest) (entity.CreateCaseCommentResponse, error)
 }
 
 // CaseHandler handles HTTP requests for case operations.
@@ -94,4 +97,115 @@ func (h *CaseHandler) GetCase(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSONValue(w, http.StatusOK, dto.MapCaseDetails(result))
+}
+
+// CreateCase handles POST /cases.
+func (h *CaseHandler) CreateCase(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	body, ok := readJSONBody(w, r)
+	if !ok {
+		return
+	}
+
+	var req entity.CreateCaseRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+	// CreatedBy is server-set from the authenticated caller, never from the
+	// request body (the struct's json:"-" tag means a client-supplied value
+	// would be silently dropped anyway, but set it explicitly for clarity).
+	req.CreatedBy = user.Email
+
+	result, err := h.entity.CreateCase(r.Context(), req)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity CreateCase failed", "userID", user.UserID, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to create case.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusCreated, dto.MapCaseCreate(result))
+}
+
+// PatchCase handles PATCH /cases/{id}.
+func (h *CaseHandler) PatchCase(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	id := r.PathValue("id")
+	if id == "" || !uuidRe.MatchString(id) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	body, ok := readJSONBody(w, r)
+	if !ok {
+		return
+	}
+
+	var req dto.UpdateCaseRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+	if req.State == nil && req.Severity == nil && req.Subject == nil && req.Description == nil && len(req.WatchList) == 0 {
+		writeError(w, http.StatusBadRequest, "At least one field must be provided for update.")
+		return
+	}
+
+	result, err := h.entity.UpdateCase(r.Context(), id, dto.BuildEntityUpdateCaseRequest(id, req))
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity UpdateCase failed", "userID", user.UserID, "caseID", id, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to update case.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusOK, dto.MapCaseUpdate(result))
+}
+
+// CreateCaseComment handles POST /cases/{id}/comments.
+func (h *CaseHandler) CreateCaseComment(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	id := r.PathValue("id")
+	if id == "" || !uuidRe.MatchString(id) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	body, ok := readJSONBody(w, r)
+	if !ok {
+		return
+	}
+
+	var req dto.CaseCommentRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+	if req.Content == "" {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.CreateCaseComment(r.Context(), id, dto.BuildEntityCreateCaseCommentRequest(id, req))
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity CreateCaseComment failed", "userID", user.UserID, "caseID", id, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to add comment.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusCreated, dto.MapCaseComment(result))
 }

--- a/apps/customer-portal/backend-v2/internal/handler/cases.go
+++ b/apps/customer-portal/backend-v2/internal/handler/cases.go
@@ -156,8 +156,16 @@ func (h *CaseHandler) PatchCase(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
 		return
 	}
-	if req.State == nil && req.Severity == nil && req.Subject == nil && req.Description == nil && len(req.WatchList) == 0 {
-		writeError(w, http.StatusBadRequest, "At least one field must be provided for update.")
+	// entity-service requires exactly one of these primary fields per PATCH —
+	// see dto.UpdateCaseRequest's doc comment.
+	primaryFieldsSet := 0
+	for _, set := range []bool{req.State != nil, req.Severity != nil, req.Subject != nil, req.Description != nil, len(req.WatchList) > 0} {
+		if set {
+			primaryFieldsSet++
+		}
+	}
+	if primaryFieldsSet != 1 {
+		writeError(w, http.StatusBadRequest, "Exactly one of state, severity, subject, description, or watchList must be provided.")
 		return
 	}
 

--- a/apps/customer-portal/backend-v2/internal/handler/deployments.go
+++ b/apps/customer-portal/backend-v2/internal/handler/deployments.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/dto"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/middleware"
+)
+
+// entityDeploymentClient abstracts the entity-service deployment operations
+// used by DeploymentHandler.
+type entityDeploymentClient interface {
+	SearchDeployments(ctx context.Context, req entity.SearchDeploymentsRequest) (entity.SearchDeploymentsResponse, error)
+	CreateDeployment(ctx context.Context, req entity.CreateDeploymentRequest) (entity.CreateDeploymentResponse, error)
+}
+
+// DeploymentHandler handles HTTP requests for deployment operations.
+type DeploymentHandler struct {
+	entity entityDeploymentClient
+}
+
+// NewDeploymentHandler creates a DeploymentHandler backed by the given entity client.
+func NewDeploymentHandler(entity entityDeploymentClient) *DeploymentHandler {
+	return &DeploymentHandler{entity: entity}
+}
+
+// SearchDeployments handles POST /deployments/search.
+func (h *DeploymentHandler) SearchDeployments(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	body, ok := readJSONBody(w, r)
+	if !ok {
+		return
+	}
+
+	var req entity.SearchDeploymentsRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.SearchDeployments(r.Context(), req)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity SearchDeployments failed", "userID", user.UserID, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to search deployments.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusOK, dto.MapSearchDeployments(result))
+}
+
+// CreateDeployment handles POST /deployments.
+//
+// NOTE: entity-service only supports this route on its ServiceNow data
+// source — a Postgres-mode deployment returns 400 for every call, which
+// mapUpstreamError surfaces as ErrMsgBadRequest.
+func (h *DeploymentHandler) CreateDeployment(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	body, ok := readJSONBody(w, r)
+	if !ok {
+		return
+	}
+
+	var req entity.CreateDeploymentRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.CreateDeployment(r.Context(), req)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity CreateDeployment failed", "userID", user.UserID, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to create deployment.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusCreated, dto.MapDeploymentCreate(result))
+}

--- a/apps/customer-portal/backend-v2/openapi.yaml
+++ b/apps/customer-portal/backend-v2/openapi.yaml
@@ -1368,6 +1368,10 @@ components:
           type: string
         workState:
           type: string
+        watchList:
+          type: array
+          items:
+            type: string
         assignedTo:
           $ref: '#/components/schemas/PersonRef'
         resolutionCode:

--- a/apps/customer-portal/backend-v2/openapi.yaml
+++ b/apps/customer-portal/backend-v2/openapi.yaml
@@ -367,6 +367,184 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
+    patch:
+      summary: Update a case.
+      description: >
+        Exactly one of state/severity/subject/description/watchList is
+        required. This is a deliberately restricted subset of
+        entity-service's update contract — internal WSO2 support fields
+        (work state, engineer assignment, fix-ETA dates, case relinking,
+        auto-closure control) are not customer-settable.
+      operationId: patchCasesId
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CaseUpdateRequest'
+        required: true
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CaseUpdateResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: NotFound
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /cases:
+    post:
+      summary: Create a case.
+      operationId: postCases
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CaseCreateRequest'
+        required: true
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CaseCreateResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /cases/{id}/comments:
+    post:
+      summary: Add a comment to a case.
+      description: >
+        Always creates a plain customer comment — entity-service's
+        "work_note"/"activity" comment types are internal WSO2 support
+        annotations and are not exposed here.
+      operationId: postCasesIdComments
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CaseCommentRequest'
+        required: true
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CaseCommentResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: NotFound
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
 
   /cases/search:
     post:
@@ -385,6 +563,105 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SearchCasesResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /deployments/search:
+    post:
+      summary: Search deployments.
+      operationId: postDeploymentsSearch
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SearchDeploymentsRequest'
+        required: true
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchDeploymentsResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /deployments:
+    post:
+      summary: Create a deployment.
+      description: >
+        Only entity-service's ServiceNow data source supports this route —
+        a Postgres-mode deployment always returns 400.
+      operationId: postDeployments
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateDeploymentRequest'
+        required: true
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeploymentCreateResponse'
         "400":
           description: BadRequest
           content:
@@ -978,6 +1255,232 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/CaseTag'
+
+    CaseCreateRequest:
+      type: object
+      required: [type, projectId, deploymentId, subject, description, severity, issueType]
+      properties:
+        type:
+          type: string
+          description: "\"case\", \"service_request\", or \"security_report_analysis\""
+        projectId:
+          type: string
+          format: uuid
+        deploymentId:
+          type: string
+          format: uuid
+        deployedProductId:
+          type: string
+          format: uuid
+        subject:
+          type: string
+        description:
+          type: string
+        severity:
+          type: string
+        issueType:
+          type: string
+        catalogId:
+          type: string
+          description: Required when type is "service_request".
+        catalogItemId:
+          type: string
+          description: Required when type is "service_request".
+        variables:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              value:
+                type: string
+        relatedCaseId:
+          type: string
+          format: uuid
+        conversationId:
+          type: string
+          format: uuid
+        watchList:
+          type: array
+          items:
+            type: string
+        attachments:
+          type: array
+          description: Required (at least one) when type is "security_report_analysis".
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+              file:
+                type: string
+                description: Base64 data URI, e.g. "data:application/pdf;base64,...".
+
+    CaseCreateResponse:
+      type: object
+      properties:
+        id:
+          type: string
+        number:
+          type: string
+        createdOn:
+          type: string
+        state:
+          type: string
+
+    CaseUpdateRequest:
+      description: >
+        Exactly one of state/severity/subject/description/watchList is
+        required. resolutionCode/cause/closeNotes are only accepted
+        alongside a closing state transition.
+      type: object
+      properties:
+        state:
+          type: string
+        severity:
+          type: string
+        subject:
+          type: string
+        description:
+          type: string
+        watchList:
+          type: array
+          items:
+            type: string
+        resolutionCode:
+          type: string
+        cause:
+          type: string
+        closeNotes:
+          type: string
+
+    CaseUpdateResponse:
+      type: object
+      properties:
+        id:
+          type: string
+        updatedOn:
+          type: string
+        state:
+          type: string
+        severity:
+          type: string
+        workState:
+          type: string
+        watchList:
+          type: array
+          items:
+            type: string
+        assignedTo:
+          $ref: '#/components/schemas/PersonRef'
+        resolutionCode:
+          type: string
+        cause:
+          type: string
+        closeNotes:
+          type: string
+        resolvedOn:
+          type: string
+        parentCase:
+          $ref: '#/components/schemas/NumberRef'
+        fixEta:
+          type: string
+
+    CaseCommentRequest:
+      type: object
+      required: [content]
+      properties:
+        content:
+          type: string
+
+    CaseCommentResponse:
+      type: object
+      properties:
+        id:
+          type: string
+        createdOn:
+          type: string
+        createdBy:
+          type: string
+
+    # ---- deployments ----
+
+    SearchDeploymentsRequest:
+      type: object
+      properties:
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+        searchQuery:
+          type: string
+        projectIds:
+          type: array
+          items:
+            type: string
+        deploymentTypes:
+          type: array
+          items:
+            type: string
+
+    DeploymentSummary:
+      type: object
+      properties:
+        id:
+          type: string
+        number:
+          type: string
+        name:
+          type: string
+        type:
+          type: string
+        description:
+          type: string
+        createdBy:
+          $ref: '#/components/schemas/Ref'
+        project:
+          $ref: '#/components/schemas/Ref'
+        createdOn:
+          type: string
+        updatedOn:
+          type: string
+
+    SearchDeploymentsResponse:
+      type: object
+      properties:
+        deployments:
+          type: array
+          items:
+            $ref: '#/components/schemas/DeploymentSummary'
+        total:
+          type: integer
+        limit:
+          type: integer
+        offset:
+          type: integer
+        hasMore:
+          type: boolean
+
+    CreateDeploymentRequest:
+      type: object
+      required: [projectId, name]
+      properties:
+        projectId:
+          type: string
+          format: uuid
+        name:
+          type: string
+        type:
+          type: string
+        description:
+          type: string
+
+    DeploymentCreateResponse:
+      type: object
+      properties:
+        id:
+          type: string
+        createdOn:
+          type: string
 
     # ---- updates ----
 

--- a/apps/customer-portal/backend-v2/openapi.yaml
+++ b/apps/customer-portal/backend-v2/openapi.yaml
@@ -1368,10 +1368,6 @@ components:
           type: string
         workState:
           type: string
-        watchList:
-          type: array
-          items:
-            type: string
         assignedTo:
           $ref: '#/components/schemas/PersonRef'
         resolutionCode:


### PR DESCRIPTION
## Summary
- Adds 5 more endpoints to `apps/customer-portal/backend-v2` (16 total): `POST /cases`, `PATCH /cases/{id}`, `POST /cases/{id}/comments`, `POST /deployments/search`, `POST /deployments`.
- **Restricted write requests**: unlike search/create endpoints elsewhere in this backend (which decode straight into entity-service's request struct since every field is customer-appropriate), `PATCH /cases/{id}` and `POST /cases/{id}/comments` mix customer-safe fields with internal WSO2 support-only ones:
  - `dto.UpdateCaseRequest` exposes only `state`/`severity`/`subject`/`description`/`watchList`/`resolutionCode`/`cause`/`closeNotes`. Fields like `workState`, `assigneeEmail`, case-relinking fields, `autocloseHoldUntil`, and the `fixEta`/`bestCaseFixEta`/`mostLikelyFixEta`/`worstCaseFixEta` quartet are internal support operations and are silently dropped if a client tries to send them (verified in manual testing below).
  - `POST /cases/{id}/comments` always creates a plain `"comment"`, never entity-service's internal `"work_note"`/`"activity"` types, regardless of what the client sends.
- `POST /deployments` only succeeds against entity-service's ServiceNow data source (Postgres-mode always 400s) — documented in code, README, and openapi.yaml.
- Updates `openapi.yaml` (5 new paths + 11 new schemas), `README.md`, and `CLAUDE.md` (new section explaining when to build a restricted request DTO vs. decode directly).

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` all clean
- [x] `gosec -fmt=text ./...` reports 0 issues
- [x] `openapi.yaml` validated as well-formed YAML with all new paths/schemas present
- [x] Manually verified: `PATCH /cases/{id}` with only `{"workState":"ongoing"}` correctly falls through to the "at least one field" 400 (confirming the field is actually dropped, not just undocumented); empty-body/empty-content requests return 400; valid requests against an unreachable upstream map cleanly to 500
- [ ] Wire up against a real running entity-service instance (ServiceNow data source, for `/users/me` and `POST /deployments`)

## Linked issues
Closes wso2-enterprise/wso2-digital-team-project-management#847
Closes wso2-enterprise/wso2-digital-team-project-management#848
Closes wso2-enterprise/wso2-digital-team-project-management#849
Closes wso2-enterprise/wso2-digital-team-project-management#850
Closes wso2-enterprise/wso2-digital-team-project-management#851

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added case creation and partial update capabilities.
  * Added support for posting comments to cases.
  * Added deployment search with pagination.
  * Added deployment creation for ServiceNow environments.
  * Added validation, authentication, and clear API responses for new operations.

* **Documentation**
  * Updated API documentation and examples for all newly available routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
