### PR TITLE
feat(customer-portal): add deployed products, attachments, activities, products

### DIFF
--- a/apps/customer-portal/backend-v2/CLAUDE.md
+++ b/apps/customer-portal/backend-v2/CLAUDE.md
@@ -6,16 +6,19 @@ responses for the frontend. This is a Go rewrite of the Ballerina backend at
 `apps/customer-portal/backend`, modeled on `apps/csm-portal/backend`'s conventions — read that
 backend's own CLAUDE.md too if something here is underspecified.
 
-**Status: in progress.** 16 routes are wired up so far (`GET /health`, `GET`/`PATCH /users/me`,
+**Status: in progress.** 26 routes are wired up so far (`GET /health`, `GET`/`PATCH /users/me`,
 `POST /accounts/search`, `GET /accounts/{id}`, `POST /projects/search`, `GET /projects/{id}`,
 `POST /cases/search`, `GET /cases/{id}`, `POST /cases`, `PATCH /cases/{id}`,
-`POST /cases/{id}/comments`, `POST /deployments/search`, `POST /deployments`,
-`GET /updates/product-update-levels`, `POST /updates/levels/search`) across three upstream
-services: entity-service, the WSO2 Updates service, and SCIM. The Ballerina backend exposes ~100
-routes across many more modules (deployed products, attachments, comments, conversations, change
-requests, call requests, catalogs, time cards, registry tokens, contacts, escalations, product
-vulnerabilities, AI chat/websocket, etc.) — none of those are ported yet. Follow the recipe below
-to add the next one.
+`POST /cases/{id}/comments`, `POST /cases/{id}/activities/search`, `POST /deployments/search`,
+`POST /deployments`, `POST /deployed-products/search`, `POST /deployed-products`,
+`PATCH /deployed-products/{id}`, `POST /attachments`, `POST /attachments/search`,
+`GET /attachments/{id}/content`, `DELETE /attachments/{id}`, `POST /products/search`,
+`POST /products/{id}/versions/search`, `GET /updates/product-update-levels`,
+`POST /updates/levels/search`) across three upstream services: entity-service, the WSO2 Updates
+service, and SCIM. The Ballerina backend exposes ~100 routes across many more modules (generic
+comments, conversations, change requests, call requests, catalogs, time cards, registry tokens,
+contacts, escalations, product vulnerabilities, AI chat/websocket, etc.) — none of those are ported
+yet. Follow the recipe below to add the next one.
 
 ## Which entity-service
 
@@ -99,7 +102,30 @@ a genuine advantage of the DTO-mapping convention over raw passthrough — `apps
 has to model this as an OpenAPI `oneOf` in its spec and pass the ambiguity on to the frontend;
 here, it's resolved once in the mapper. Also deliberately excluded from account DTOs: `ArrToday`
 (annual recurring revenue — WSO2-internal financial data, never expose to the customer) and `Pod`
-(WSO2-internal account routing).
+(WSO2-internal account routing). `POST /products/search` and `POST /products/{id}/versions/search`
+(`internal/entity/types.go`'s `ProductView`/`ProductVersionView`) use the exact same superset-struct
+technique — e.g. `ProductVersionView.ReleaseDate` is typed `*string` even though the Postgres shape
+is `time.Time` and the ServiceNow shape is a plain string, because a Go `*string` field decodes a
+JSON string value regardless of which the source type actually was.
+
+**`json.RawMessage` on a request field usually means "preserve three states," not "skip validation."**
+`entity.UpdateDeployedProductRequest.Description` is `json.RawMessage` specifically so entity-service
+can distinguish "field absent" (omit), `"description": null` (clear the value), and
+`"description": "value"` (set it) — a plain `*string` can't represent "absent vs. explicitly null."
+When a portal request decodes straight into a struct with such a field (no restricted DTO needed
+here, since Cores/TPS/Description/Active are all customer-appropriate), the raw bytes the client
+sent pass through unchanged and this three-state semantic is preserved automatically — don't
+"simplify" the field to `*string` when porting a similar endpoint.
+
+**Binary responses use a `doBinary`-shaped client method, not `getJSON`/`postJSON`.**
+`GET /attachments/{id}/content` returns a raw file, not JSON — `entity.Client.doBinary` (added in
+`internal/entity/client.go` alongside `do`) returns `(body []byte, contentType string, error)`, and
+the handler (`internal/handler/attachments.go`) writes `Content-Type` from entity-service's own
+(already-sanitized) header value and explicitly sets `Content-Disposition: attachment` itself —
+never render an attachment inline, since entity-service's own allowlist coercion to
+`application/octet-stream` for unrecognized types is a stored-XSS mitigation this backend must not
+undo by, say, echoing a client-supplied filename into a `Content-Disposition` you construct
+yourself.
 
 Request bodies are usually the exception: incoming search/filter/create payloads are decoded
 directly into the entity package's request structs (e.g. `entity.SearchProjectsRequest`,

--- a/apps/customer-portal/backend-v2/README.md
+++ b/apps/customer-portal/backend-v2/README.md
@@ -5,7 +5,7 @@ Go rewrite of the Ballerina backend at `apps/customer-portal/backend`. It is a b
 [`entity-service`](../../../entity-service) (this repo's `cs-tools/entity-service`, not the
 `digiops-cs/entity-service` the Ballerina backend targets), and shapes the responses for the frontend.
 
-This is a work in progress — only the 16 routes listed below are implemented so far, across
+This is a work in progress — only the 26 routes listed below are implemented so far, across
 entity-service, the WSO2 Updates service, and SCIM. Everything else the Ballerina backend exposes
 still needs a Go handler; add them following the pattern described in
 [CLAUDE.md](./CLAUDE.md#adding-a-new-endpoint).
@@ -133,8 +133,11 @@ backend-v2/
 │   │   ├── users.go             # GetMe, PatchMe
 │   │   ├── accounts.go          # SearchAccounts, GetAccount
 │   │   ├── projects.go          # SearchProjects, GetProject
-│   │   ├── cases.go             # SearchCases, GetCase, CreateCase, UpdateCase, CreateCaseComment
-│   │   └── deployments.go       # SearchDeployments, CreateDeployment
+│   │   ├── cases.go             # SearchCases, GetCase, CreateCase, UpdateCase, CreateCaseComment, SearchCaseActivities
+│   │   ├── deployments.go       # SearchDeployments, CreateDeployment
+│   │   ├── deployed_products.go # SearchDeployedProducts, CreateDeployedProduct, UpdateDeployedProduct
+│   │   ├── attachments.go       # CreateAttachment, SearchAttachments, GetAttachmentContent, DeleteAttachment
+│   │   └── products.go          # SearchProducts, SearchProductVersions
 │   ├── updates/                 # OAuth2 HTTP client for the WSO2 Updates service
 │   │   ├── client.go            # Config/Client/do()
 │   │   ├── types.go             # upstream (snake_case) vs portal (camelCase) structs
@@ -149,7 +152,10 @@ backend-v2/
 │   │   ├── account.go
 │   │   ├── project.go
 │   │   ├── case.go
-│   │   └── deployment.go
+│   │   ├── deployment.go
+│   │   ├── deployed_product.go
+│   │   ├── attachment.go
+│   │   └── product.go
 │   ├── middleware/
 │   │   ├── auth.go              # JWT validation; injects UserInfo into context
 │   │   ├── correlation.go       # X-CSM-Correlation-ID propagation + slog enrichment
@@ -160,8 +166,11 @@ backend-v2/
 │       ├── users.go             # GET/PATCH /users/me
 │       ├── accounts.go          # POST /accounts/search, GET /accounts/{id}
 │       ├── projects.go          # POST /projects/search, GET /projects/{id}
-│       ├── cases.go             # cases search/get/create/update/comment
+│       ├── cases.go             # cases search/get/create/update/comment/activities
 │       ├── deployments.go       # POST /deployments/search, POST /deployments
+│       ├── deployed_products.go # deployed-product search/create/update
+│       ├── attachments.go       # attachment create/search/download/delete
+│       ├── products.go          # POST /products/search, POST /products/{id}/versions/search
 │       └── updates.go           # GET /updates/product-update-levels, POST /updates/levels/search
 ├── .choreo/component.yaml
 ├── openapi.yaml
@@ -186,6 +195,16 @@ backend-v2/
 - `POST /cases/{id}/comments` — add a comment to a case (always a plain customer comment)
 - `POST /deployments/search` — search deployments
 - `POST /deployments` — create a deployment (ServiceNow data source only)
+- `POST /deployed-products/search` — search deployed products
+- `POST /deployed-products` — create a deployed product (ServiceNow data source only)
+- `PATCH /deployed-products/{id}` — update a deployed product's cores/tps/description, or deactivate it (ServiceNow data source only)
+- `POST /attachments` — create an attachment
+- `POST /attachments/search` — search attachments
+- `GET /attachments/{id}/content` — download an attachment's raw file content
+- `DELETE /attachments/{id}` — delete an attachment
+- `POST /cases/{id}/activities/search` — search a case's activity feed (comments, attachments, field changes)
+- `POST /products/search` — search products
+- `POST /products/{id}/versions/search` — search a product's versions
 - `GET /updates/product-update-levels` — list product update levels
 - `POST /updates/levels/search` — search update descriptions between two update levels
 
@@ -253,6 +272,42 @@ curl -X POST http://localhost:8080/deployments/search \
 curl -X POST http://localhost:8080/deployments \
   -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
   -d '{"projectId":"<project-id>","name":"Production"}'
+
+curl -X POST http://localhost:8080/deployed-products/search \
+  -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
+  -d '{"pagination":{"limit":10,"offset":0},"deploymentIds":["<deployment-id>"]}'
+
+curl -X POST http://localhost:8080/deployed-products \
+  -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
+  -d '{"projectId":"<project-id>","deploymentId":"<deployment-id>","productId":"<product-id>","versionId":"<version-id>"}'
+
+curl -X PATCH http://localhost:8080/deployed-products/<deployed-product-id> \
+  -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
+  -d '{"cores":4}'
+
+curl -X POST http://localhost:8080/attachments \
+  -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
+  -d '{"referenceId":"<case-id>","referenceType":"case","name":"log.txt","type":"text/plain","file":"<base64>"}'
+
+curl -X POST http://localhost:8080/attachments/search \
+  -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
+  -d '{"referenceId":"<case-id>","referenceType":"case","pagination":{"limit":10,"offset":0}}'
+
+curl -H "x-jwt-assertion: $JWT" http://localhost:8080/attachments/<attachment-id>/content -o downloaded-file
+
+curl -X DELETE -H "x-jwt-assertion: $JWT" http://localhost:8080/attachments/<attachment-id>
+
+curl -X POST http://localhost:8080/cases/<case-id>/activities/search \
+  -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
+  -d '{"pagination":{"limit":20,"offset":0}}'
+
+curl -X POST http://localhost:8080/products/search \
+  -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
+  -d '{"pagination":{"limit":10,"offset":0},"searchQuery":"wso2am"}'
+
+curl -X POST http://localhost:8080/products/<product-id>/versions/search \
+  -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
+  -d '{"pagination":{"limit":10,"offset":0}}'
 
 curl -H "x-jwt-assertion: $JWT" http://localhost:8080/updates/product-update-levels
 

--- a/apps/customer-portal/backend-v2/cmd/server/main.go
+++ b/apps/customer-portal/backend-v2/cmd/server/main.go
@@ -80,6 +80,9 @@ func main() {
 	projectHandler := handler.NewProjectHandler(entityClient)
 	caseHandler := handler.NewCaseHandler(entityClient)
 	deploymentHandler := handler.NewDeploymentHandler(entityClient)
+	deployedProductHandler := handler.NewDeployedProductHandler(entityClient)
+	attachmentHandler := handler.NewAttachmentHandler(entityClient)
+	productHandler := handler.NewProductHandler(entityClient)
 	accountHandler := handler.NewAccountHandler(entityClient)
 	updatesHandler := handler.NewUpdatesHandler(updatesClient)
 
@@ -109,11 +112,26 @@ func main() {
 	mux.HandleFunc("POST /cases", caseHandler.CreateCase)
 	mux.HandleFunc("PATCH /cases/{id}", caseHandler.PatchCase)
 	mux.HandleFunc("POST /cases/{id}/comments", caseHandler.CreateCaseComment)
+	mux.HandleFunc("POST /cases/{id}/activities/search", caseHandler.SearchCaseActivities)
 
 	mux.HandleFunc("POST /deployments/search", deploymentHandler.SearchDeployments)
 	// POST /deployments only succeeds against entity-service's ServiceNow
 	// data source — see internal/entity/deployments.go.
 	mux.HandleFunc("POST /deployments", deploymentHandler.CreateDeployment)
+
+	mux.HandleFunc("POST /deployed-products/search", deployedProductHandler.SearchDeployedProducts)
+	// POST/PATCH /deployed-products only succeed against entity-service's
+	// ServiceNow data source — see internal/entity/deployed_products.go.
+	mux.HandleFunc("POST /deployed-products", deployedProductHandler.CreateDeployedProduct)
+	mux.HandleFunc("PATCH /deployed-products/{id}", deployedProductHandler.PatchDeployedProduct)
+
+	mux.HandleFunc("POST /attachments", attachmentHandler.CreateAttachment)
+	mux.HandleFunc("POST /attachments/search", attachmentHandler.SearchAttachments)
+	mux.HandleFunc("GET /attachments/{id}/content", attachmentHandler.GetAttachmentContent)
+	mux.HandleFunc("DELETE /attachments/{id}", attachmentHandler.DeleteAttachment)
+
+	mux.HandleFunc("POST /products/search", productHandler.SearchProducts)
+	mux.HandleFunc("POST /products/{id}/versions/search", productHandler.SearchProductVersions)
 
 	mux.HandleFunc("POST /accounts/search", accountHandler.SearchAccounts)
 	mux.HandleFunc("GET /accounts/{id}", accountHandler.GetAccount)

--- a/apps/customer-portal/backend-v2/internal/dto/attachment.go
+++ b/apps/customer-portal/backend-v2/internal/dto/attachment.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dto
+
+import (
+	"time"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+)
+
+// AttachmentCreateResponse is the portal's response for POST /attachments.
+type AttachmentCreateResponse struct {
+	ID          string    `json:"id"`
+	SizeBytes   int       `json:"sizeBytes"`
+	CreatedOn   time.Time `json:"createdOn"`
+	DownloadURL string    `json:"downloadUrl"`
+}
+
+// MapAttachmentCreate builds the portal response from entity-service's CreateAttachmentResponse.
+func MapAttachmentCreate(r entity.CreateAttachmentResponse) AttachmentCreateResponse {
+	return AttachmentCreateResponse{
+		ID:          r.Attachment.ID,
+		SizeBytes:   r.Attachment.SizeBytes,
+		CreatedOn:   r.Attachment.CreatedOn,
+		DownloadURL: r.Attachment.DownloadURL,
+	}
+}
+
+// AttachmentSummary is one item of the portal's response for POST /attachments/search.
+type AttachmentSummary struct {
+	ID            string    `json:"id"`
+	ReferenceID   string    `json:"referenceId"`
+	ReferenceType string    `json:"referenceType"`
+	Name          string    `json:"name"`
+	Type          string    `json:"type"`
+	SizeBytes     int       `json:"sizeBytes"`
+	Description   *string   `json:"description,omitempty"`
+	CreatedBy     string    `json:"createdBy"`
+	CreatedOn     time.Time `json:"createdOn"`
+	DownloadURL   *string   `json:"downloadUrl,omitempty"`
+	PreviewURL    *string   `json:"previewUrl,omitempty"`
+}
+
+// SearchAttachmentsResponse is the portal's response for POST /attachments/search.
+type SearchAttachmentsResponse struct {
+	Attachments []AttachmentSummary `json:"attachments"`
+	Total       int                 `json:"total"`
+	Limit       int                 `json:"limit"`
+	Offset      int                 `json:"offset"`
+	HasMore     bool                `json:"hasMore"`
+}
+
+// MapSearchAttachments builds the portal response from entity-service's SearchAttachmentsResponse.
+func MapSearchAttachments(r entity.SearchAttachmentsResponse) SearchAttachmentsResponse {
+	items := make([]AttachmentSummary, 0, len(r.Attachments))
+	for _, a := range r.Attachments {
+		items = append(items, AttachmentSummary{
+			ID:            a.ID,
+			ReferenceID:   a.ReferenceID,
+			ReferenceType: string(a.ReferenceType),
+			Name:          a.Name,
+			Type:          a.Type,
+			SizeBytes:     a.SizeBytes,
+			Description:   a.Description,
+			CreatedBy:     a.CreatedBy,
+			CreatedOn:     a.CreatedOn,
+			DownloadURL:   a.DownloadURL,
+			PreviewURL:    a.PreviewURL,
+		})
+	}
+	return SearchAttachmentsResponse{
+		Attachments: items,
+		Total:       r.Total,
+		Limit:       r.Limit,
+		Offset:      r.Offset,
+		HasMore:     r.HasMore,
+	}
+}
+
+// DeleteResponse is the portal's response for DELETE /attachments/{id}.
+type DeleteResponse struct {
+	Message string `json:"message"`
+}
+
+// MapDeleteAttachment builds the portal response from entity-service's DeleteAttachmentResponse.
+func MapDeleteAttachment(r entity.DeleteAttachmentResponse) DeleteResponse {
+	return DeleteResponse{Message: r.Message}
+}

--- a/apps/customer-portal/backend-v2/internal/dto/case.go
+++ b/apps/customer-portal/backend-v2/internal/dto/case.go
@@ -395,3 +395,85 @@ func MapCaseComment(r entity.CreateCaseCommentResponse) CaseCommentResponse {
 		CreatedBy: r.Comment.CreatedBy,
 	}
 }
+
+// CaseFieldChange describes a single field's value change in a case's activity feed.
+type CaseFieldChange struct {
+	Field         string `json:"field"`
+	FieldLabel    string `json:"fieldLabel"`
+	PreviousValue string `json:"previousValue"`
+	NewValue      string `json:"newValue"`
+}
+
+// CaseActivity is one entry in the portal's response for
+// POST /cases/{id}/activities/search — a discriminated union on Type, like
+// entity-service's CaseActivity. Deliberately excludes entity-service's
+// CreatedByFirstName/CreatedByLastName (redundant with CreatedBy, which
+// carries the full name) and the raw internal actor ID.
+type CaseActivity struct {
+	ID          string            `json:"id"`
+	Type        string            `json:"type"`
+	Content     string            `json:"content,omitempty"`
+	CreatedOn   time.Time         `json:"createdOn"`
+	CreatedBy   string            `json:"createdBy"`
+	CommentType *string           `json:"commentType,omitempty"`
+	FileName    string            `json:"fileName,omitempty"`
+	ContentType string            `json:"contentType,omitempty"`
+	SizeBytes   int               `json:"sizeBytes,omitempty"`
+	DownloadURL string            `json:"downloadUrl,omitempty"`
+	Changes     []CaseFieldChange `json:"changes,omitempty"`
+}
+
+// SearchCaseActivitiesResponse is the portal's response for POST /cases/{id}/activities/search.
+type SearchCaseActivitiesResponse struct {
+	Activity []CaseActivity `json:"activity"`
+	Total    int            `json:"total"`
+	Limit    int            `json:"limit"`
+	Offset   int            `json:"offset"`
+	HasMore  bool           `json:"hasMore"`
+}
+
+// MapSearchCaseActivities builds the portal response from entity-service's SearchCaseActivitiesResponse.
+func MapSearchCaseActivities(r entity.SearchCaseActivitiesResponse) SearchCaseActivitiesResponse {
+	items := make([]CaseActivity, 0, len(r.Activity))
+	for _, a := range r.Activity {
+		var commentType *string
+		if a.CommentType != nil {
+			s := string(*a.CommentType)
+			commentType = &s
+		}
+
+		var changes []CaseFieldChange
+		if len(a.Changes) > 0 {
+			changes = make([]CaseFieldChange, 0, len(a.Changes))
+			for _, c := range a.Changes {
+				changes = append(changes, CaseFieldChange{
+					Field:         c.Field,
+					FieldLabel:    c.FieldLabel,
+					PreviousValue: c.PreviousValue,
+					NewValue:      c.NewValue,
+				})
+			}
+		}
+
+		items = append(items, CaseActivity{
+			ID:          a.ID,
+			Type:        string(a.Type),
+			Content:     a.Content,
+			CreatedOn:   a.CreatedOn,
+			CreatedBy:   a.CreatedByFullName,
+			CommentType: commentType,
+			FileName:    a.FileName,
+			ContentType: a.ContentType,
+			SizeBytes:   a.SizeBytes,
+			DownloadURL: a.DownloadURL,
+			Changes:     changes,
+		})
+	}
+	return SearchCaseActivitiesResponse{
+		Activity: items,
+		Total:    r.Total,
+		Limit:    r.Limit,
+		Offset:   r.Offset,
+		HasMore:  r.HasMore,
+	}
+}

--- a/apps/customer-portal/backend-v2/internal/dto/deployed_product.go
+++ b/apps/customer-portal/backend-v2/internal/dto/deployed_product.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dto
+
+import (
+	"time"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+)
+
+// DeployedProductVersion is the version reference embedded in a deployed product.
+type DeployedProductVersion struct {
+	ID             string     `json:"id"`
+	Name           string     `json:"name"`
+	ReleasedDate   *time.Time `json:"releasedDate,omitempty"`
+	SupportEoLDate *time.Time `json:"supportEoLDate,omitempty"`
+}
+
+// DeployedProductSummary is one item of the portal's response for
+// POST /deployed-products/search.
+type DeployedProductSummary struct {
+	ID         string                  `json:"id"`
+	Deployment Ref                     `json:"deployment"`
+	Product    Ref                     `json:"product"`
+	Version    *DeployedProductVersion `json:"version,omitempty"`
+	Cores      *string                 `json:"cores,omitempty"`
+	TPS        *string                 `json:"tps,omitempty"`
+	Category   *string                 `json:"category,omitempty"`
+	CreatedOn  time.Time               `json:"createdOn"`
+	UpdatedOn  time.Time               `json:"updatedOn"`
+}
+
+// SearchDeployedProductsResponse is the portal's response for POST /deployed-products/search.
+type SearchDeployedProductsResponse struct {
+	DeployedProducts []DeployedProductSummary `json:"deployedProducts"`
+	Total            int                      `json:"total"`
+	Limit            int                      `json:"limit"`
+	Offset           int                      `json:"offset"`
+	HasMore          bool                     `json:"hasMore"`
+}
+
+func mapDeployedProductVersion(v *entity.DeployedProductVersionRef) *DeployedProductVersion {
+	if v == nil {
+		return nil
+	}
+	return &DeployedProductVersion{
+		ID:             v.ID,
+		Name:           v.Name,
+		ReleasedDate:   v.ReleasedDate,
+		SupportEoLDate: v.SupportEoLDate,
+	}
+}
+
+// MapSearchDeployedProducts builds the portal response from entity-service's SearchDeployedProductsResponse.
+func MapSearchDeployedProducts(r entity.SearchDeployedProductsResponse) SearchDeployedProductsResponse {
+	items := make([]DeployedProductSummary, 0, len(r.DeployedProducts))
+	for _, d := range r.DeployedProducts {
+		items = append(items, DeployedProductSummary{
+			ID:         d.ID,
+			Deployment: Ref{ID: d.Deployment.ID, Name: d.Deployment.Name},
+			Product:    Ref{ID: d.Product.ID, Name: d.Product.Name},
+			Version:    mapDeployedProductVersion(d.Version),
+			Cores:      d.Cores,
+			TPS:        d.TPS,
+			Category:   d.Category,
+			CreatedOn:  d.CreatedOn,
+			UpdatedOn:  d.UpdatedOn,
+		})
+	}
+	return SearchDeployedProductsResponse{
+		DeployedProducts: items,
+		Total:            r.Total,
+		Limit:            r.Limit,
+		Offset:           r.Offset,
+		HasMore:          r.HasMore,
+	}
+}
+
+// DeployedProductCreateResponse is the portal's response for POST /deployed-products.
+type DeployedProductCreateResponse struct {
+	ID        string    `json:"id"`
+	CreatedOn time.Time `json:"createdOn"`
+}
+
+// MapDeployedProductCreate builds the portal response from entity-service's CreateDeployedProductResponse.
+func MapDeployedProductCreate(r entity.CreateDeployedProductResponse) DeployedProductCreateResponse {
+	return DeployedProductCreateResponse{
+		ID:        r.DeployedProduct.ID,
+		CreatedOn: r.DeployedProduct.CreatedOn,
+	}
+}
+
+// DeployedProductUpdateResponse is the portal's response for PATCH /deployed-products/{id}.
+// Deliberately excludes entity-service's UpdatedBy (internal actor identity),
+// consistent with the other update responses in this package.
+type DeployedProductUpdateResponse struct {
+	ID        string    `json:"id"`
+	UpdatedOn time.Time `json:"updatedOn"`
+}
+
+// MapDeployedProductUpdate builds the portal response from entity-service's UpdateDeployedProductResponse.
+func MapDeployedProductUpdate(r entity.UpdateDeployedProductResponse) DeployedProductUpdateResponse {
+	return DeployedProductUpdateResponse{
+		ID:        r.DeployedProduct.ID,
+		UpdatedOn: r.DeployedProduct.UpdatedOn,
+	}
+}

--- a/apps/customer-portal/backend-v2/internal/dto/product.go
+++ b/apps/customer-portal/backend-v2/internal/dto/product.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dto
+
+import "github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+
+// ProductSummary is one item of the portal's response for POST /products/search.
+type ProductSummary struct {
+	ID        string  `json:"id"`
+	Name      string  `json:"name"`
+	Class     *string `json:"class,omitempty"`
+	CreatedOn *string `json:"createdOn,omitempty"`
+	UpdatedOn *string `json:"updatedOn,omitempty"`
+}
+
+// SearchProductsResponse is the portal's response for POST /products/search.
+type SearchProductsResponse struct {
+	Products []ProductSummary `json:"products"`
+	Total    int              `json:"total"`
+	Limit    int              `json:"limit"`
+	Offset   int              `json:"offset"`
+	HasMore  bool             `json:"hasMore"`
+}
+
+// MapSearchProducts builds the portal response from entity-service's SearchProductsResponse.
+func MapSearchProducts(r entity.SearchProductsResponse) SearchProductsResponse {
+	items := make([]ProductSummary, 0, len(r.Products))
+	for _, p := range r.Products {
+		items = append(items, ProductSummary{
+			ID:        p.ID,
+			Name:      p.Name,
+			Class:     p.Class,
+			CreatedOn: p.CreatedOn,
+			UpdatedOn: p.UpdatedOn,
+		})
+	}
+	return SearchProductsResponse{
+		Products: items,
+		Total:    r.Total,
+		Limit:    r.Limit,
+		Offset:   r.Offset,
+		HasMore:  r.HasMore,
+	}
+}
+
+// ProductVersionSummary is one item of the portal's response for
+// POST /products/{id}/versions/search. Deliberately excludes entity-service's
+// ProductID — already known from the request path, redundant here.
+type ProductVersionSummary struct {
+	ID                             string  `json:"id"`
+	Version                        string  `json:"version"`
+	CurrentSupportStatus           *string `json:"currentSupportStatus,omitempty"`
+	ReleaseDate                    *string `json:"releaseDate,omitempty"`
+	SupportEOLDate                 *string `json:"supportEolDate,omitempty"`
+	EarliestPossibleSupportEOLDate *string `json:"earliestPossibleSupportEolDate,omitempty"`
+	CreatedOn                      *string `json:"createdOn,omitempty"`
+	UpdatedOn                      *string `json:"updatedOn,omitempty"`
+}
+
+// SearchProductVersionsResponse is the portal's response for POST /products/{id}/versions/search.
+type SearchProductVersionsResponse struct {
+	ProductVersions []ProductVersionSummary `json:"productVersions"`
+	Total           int                     `json:"total"`
+	Limit           int                     `json:"limit"`
+	Offset          int                     `json:"offset"`
+	HasMore         bool                    `json:"hasMore"`
+}
+
+// MapSearchProductVersions builds the portal response from entity-service's SearchProductVersionsResponse.
+func MapSearchProductVersions(r entity.SearchProductVersionsResponse) SearchProductVersionsResponse {
+	items := make([]ProductVersionSummary, 0, len(r.ProductVersions))
+	for _, v := range r.ProductVersions {
+		items = append(items, ProductVersionSummary{
+			ID:                             v.ID,
+			Version:                        v.Version,
+			CurrentSupportStatus:           v.CurrentSupportStatus,
+			ReleaseDate:                    v.ReleaseDate,
+			SupportEOLDate:                 v.SupportEOLDate,
+			EarliestPossibleSupportEOLDate: v.EarliestPossibleSupportEOLDate,
+			CreatedOn:                      v.CreatedOn,
+			UpdatedOn:                      v.UpdatedOn,
+		})
+	}
+	return SearchProductVersionsResponse{
+		ProductVersions: items,
+		Total:           r.Total,
+		Limit:           r.Limit,
+		Offset:          r.Offset,
+		HasMore:         r.HasMore,
+	}
+}

--- a/apps/customer-portal/backend-v2/internal/entity/attachments.go
+++ b/apps/customer-portal/backend-v2/internal/entity/attachments.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package entity
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+)
+
+// CreateAttachment calls POST /attachments.
+func (c *Client) CreateAttachment(ctx context.Context, req CreateAttachmentRequest) (CreateAttachmentResponse, error) {
+	var out CreateAttachmentResponse
+	err := c.postJSON(ctx, "/attachments", req, &out)
+	return out, err
+}
+
+// SearchAttachments calls POST /attachments/search.
+func (c *Client) SearchAttachments(ctx context.Context, req SearchAttachmentsRequest) (SearchAttachmentsResponse, error) {
+	var out SearchAttachmentsResponse
+	err := c.postJSON(ctx, "/attachments/search", req, &out)
+	return out, err
+}
+
+// GetAttachmentContent calls GET /attachments/{id}/content and returns the
+// raw file bytes together with its Content-Type.
+func (c *Client) GetAttachmentContent(ctx context.Context, id string) (body []byte, contentType string, err error) {
+	return c.doBinary(ctx, fmt.Sprintf("/attachments/%s/content", url.PathEscape(id)))
+}
+
+// DeleteAttachment calls DELETE /attachments/{id}.
+func (c *Client) DeleteAttachment(ctx context.Context, id string) (DeleteAttachmentResponse, error) {
+	var out DeleteAttachmentResponse
+	err := c.deleteJSON(ctx, fmt.Sprintf("/attachments/%s", url.PathEscape(id)), &out)
+	return out, err
+}

--- a/apps/customer-portal/backend-v2/internal/entity/cases.go
+++ b/apps/customer-portal/backend-v2/internal/entity/cases.go
@@ -56,3 +56,10 @@ func (c *Client) CreateCaseComment(ctx context.Context, caseID string, req Creat
 	err := c.postJSON(ctx, fmt.Sprintf("/cases/%s/comments", url.PathEscape(caseID)), req, &out)
 	return out, err
 }
+
+// SearchCaseActivities calls POST /cases/{id}/activities/search.
+func (c *Client) SearchCaseActivities(ctx context.Context, caseID string, req SearchCaseActivitiesRequest) (SearchCaseActivitiesResponse, error) {
+	var out SearchCaseActivitiesResponse
+	err := c.postJSON(ctx, fmt.Sprintf("/cases/%s/activities/search", url.PathEscape(caseID)), req, &out)
+	return out, err
+}

--- a/apps/customer-portal/backend-v2/internal/entity/cases.go
+++ b/apps/customer-portal/backend-v2/internal/entity/cases.go
@@ -59,6 +59,7 @@ func (c *Client) CreateCaseComment(ctx context.Context, caseID string, req Creat
 
 // SearchCaseActivities calls POST /cases/{id}/activities/search.
 func (c *Client) SearchCaseActivities(ctx context.Context, caseID string, req SearchCaseActivitiesRequest) (SearchCaseActivitiesResponse, error) {
+	req.CaseID = caseID // never serialized (json:"-"); set for consistency with the struct's doc comment
 	var out SearchCaseActivitiesResponse
 	err := c.postJSON(ctx, fmt.Sprintf("/cases/%s/activities/search", url.PathEscape(caseID)), req, &out)
 	return out, err

--- a/apps/customer-portal/backend-v2/internal/entity/client.go
+++ b/apps/customer-portal/backend-v2/internal/entity/client.go
@@ -186,6 +186,58 @@ func (c *Client) do(ctx context.Context, method, path string, body []byte) ([]by
 	return respBody, nil
 }
 
+// maxBinaryResponseBytes bounds attachment downloads specifically — larger
+// than maxResponseBodyBytes since attachments (documents, images) are
+// legitimately bigger than a typical JSON API response.
+const maxBinaryResponseBytes = 25 << 20 // 25 MiB
+
+// doBinary executes an authenticated GET request against entity-service and
+// returns the raw response body together with the upstream Content-Type
+// header. Use this instead of do for endpoints that return non-JSON binary
+// content (e.g. attachment downloads).
+func (c *Client) doBinary(ctx context.Context, path string) (body []byte, contentType string, err error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path, nil)
+	if err != nil {
+		return nil, "", fmt.Errorf("entity: build request GET %s: %w", path, err)
+	}
+	if token := userIDTokenFromContext(ctx); token != "" {
+		req.Header.Set("x-user-id-token", token)
+	}
+	if id := correlationIDFromContext(ctx); id != "" {
+		req.Header.Set("X-CSM-Correlation-ID", id)
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, "", fmt.Errorf("entity: GET %s: %w", path, err)
+	}
+	defer resp.Body.Close()
+
+	limited := io.LimitReader(resp.Body, maxBinaryResponseBytes+1)
+	respBody, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, "", fmt.Errorf("entity: read response body: %w", err)
+	}
+	if len(respBody) > maxBinaryResponseBytes {
+		return nil, "", fmt.Errorf("entity: GET %s: response body exceeds %d bytes", path, maxBinaryResponseBytes)
+	}
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		const maxErrBody = 256
+		excerpt := respBody
+		if len(excerpt) > maxErrBody {
+			excerpt = excerpt[:maxErrBody]
+		}
+		return nil, "", &apierror.Error{StatusCode: resp.StatusCode, Body: string(excerpt)}
+	}
+
+	ct := resp.Header.Get("Content-Type")
+	if ct == "" {
+		ct = "application/octet-stream"
+	}
+	return respBody, ct, nil
+}
+
 // getJSON issues a GET request and decodes the JSON response into out.
 func (c *Client) getJSON(ctx context.Context, path string, out any) error {
 	body, err := c.do(ctx, http.MethodGet, path, nil)
@@ -228,6 +280,18 @@ func (c *Client) patchJSON(ctx context.Context, path string, reqBody, out any) e
 	}
 	if err := json.Unmarshal(body, out); err != nil {
 		return fmt.Errorf("entity: decode response for PATCH %s: %w", path, err)
+	}
+	return nil
+}
+
+// deleteJSON issues a DELETE request and decodes the JSON response into out.
+func (c *Client) deleteJSON(ctx context.Context, path string, out any) error {
+	body, err := c.do(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(body, out); err != nil {
+		return fmt.Errorf("entity: decode response for DELETE %s: %w", path, err)
 	}
 	return nil
 }

--- a/apps/customer-portal/backend-v2/internal/entity/deployed_products.go
+++ b/apps/customer-portal/backend-v2/internal/entity/deployed_products.go
@@ -44,6 +44,7 @@ func (c *Client) CreateDeployedProduct(ctx context.Context, req CreateDeployedPr
 // NOTE: only entity-service's ServiceNow data source supports this route —
 // see CreateDeployedProductRequest's doc comment.
 func (c *Client) UpdateDeployedProduct(ctx context.Context, id string, req UpdateDeployedProductRequest) (UpdateDeployedProductResponse, error) {
+	req.ID = id // never serialized (json:"-"); set for consistency with the struct's doc comment
 	var out UpdateDeployedProductResponse
 	err := c.patchJSON(ctx, fmt.Sprintf("/deployed-products/%s", url.PathEscape(id)), req, &out)
 	return out, err

--- a/apps/customer-portal/backend-v2/internal/entity/deployed_products.go
+++ b/apps/customer-portal/backend-v2/internal/entity/deployed_products.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package entity
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+)
+
+// SearchDeployedProducts calls POST /deployed-products/search.
+func (c *Client) SearchDeployedProducts(ctx context.Context, req SearchDeployedProductsRequest) (SearchDeployedProductsResponse, error) {
+	var out SearchDeployedProductsResponse
+	err := c.postJSON(ctx, "/deployed-products/search", req, &out)
+	return out, err
+}
+
+// CreateDeployedProduct calls POST /deployed-products.
+//
+// NOTE: only entity-service's ServiceNow data source supports this route —
+// see CreateDeployedProductRequest's doc comment.
+func (c *Client) CreateDeployedProduct(ctx context.Context, req CreateDeployedProductRequest) (CreateDeployedProductResponse, error) {
+	var out CreateDeployedProductResponse
+	err := c.postJSON(ctx, "/deployed-products", req, &out)
+	return out, err
+}
+
+// UpdateDeployedProduct calls PATCH /deployed-products/{id}.
+//
+// NOTE: only entity-service's ServiceNow data source supports this route —
+// see CreateDeployedProductRequest's doc comment.
+func (c *Client) UpdateDeployedProduct(ctx context.Context, id string, req UpdateDeployedProductRequest) (UpdateDeployedProductResponse, error) {
+	var out UpdateDeployedProductResponse
+	err := c.patchJSON(ctx, fmt.Sprintf("/deployed-products/%s", url.PathEscape(id)), req, &out)
+	return out, err
+}

--- a/apps/customer-portal/backend-v2/internal/entity/products.go
+++ b/apps/customer-portal/backend-v2/internal/entity/products.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package entity
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+)
+
+// SearchProducts calls POST /products/search.
+func (c *Client) SearchProducts(ctx context.Context, req SearchProductsRequest) (SearchProductsResponse, error) {
+	var out SearchProductsResponse
+	err := c.postJSON(ctx, "/products/search", req, &out)
+	return out, err
+}
+
+// SearchProductVersions calls POST /products/{id}/versions/search.
+func (c *Client) SearchProductVersions(ctx context.Context, productID string, req SearchProductVersionsRequest) (SearchProductVersionsResponse, error) {
+	var out SearchProductVersionsResponse
+	err := c.postJSON(ctx, fmt.Sprintf("/products/%s/versions/search", url.PathEscape(productID)), req, &out)
+	return out, err
+}

--- a/apps/customer-portal/backend-v2/internal/entity/products.go
+++ b/apps/customer-portal/backend-v2/internal/entity/products.go
@@ -31,6 +31,7 @@ func (c *Client) SearchProducts(ctx context.Context, req SearchProductsRequest) 
 
 // SearchProductVersions calls POST /products/{id}/versions/search.
 func (c *Client) SearchProductVersions(ctx context.Context, productID string, req SearchProductVersionsRequest) (SearchProductVersionsResponse, error) {
+	req.ProductID = productID // never serialized (json:"-"); set for consistency with the struct's doc comment
 	var out SearchProductVersionsResponse
 	err := c.postJSON(ctx, fmt.Sprintf("/products/%s/versions/search", url.PathEscape(productID)), req, &out)
 	return out, err

--- a/apps/customer-portal/backend-v2/internal/entity/types.go
+++ b/apps/customer-portal/backend-v2/internal/entity/types.go
@@ -613,3 +613,299 @@ type CreateDeploymentResponse struct {
 	Message    string            `json:"message"`
 	Deployment CreatedDeployment `json:"deployment"`
 }
+
+// --- deployed products ---
+
+// CreateDeployedProductRequest is the input for POST /deployed-products.
+//
+// NOTE: entity-service only supports deployed-product creation on its
+// ServiceNow data source — a Postgres-mode deployment always returns 400
+// for this route (see cs-tools/entity-service/internal/service/deployed_product_service.go).
+type CreateDeployedProductRequest struct {
+	ProjectID    string   `json:"projectId"`
+	DeploymentID string   `json:"deploymentId"`
+	ProductID    string   `json:"productId"`
+	VersionID    string   `json:"versionId"`
+	Cores        *int     `json:"cores,omitempty"`
+	TPS          *float64 `json:"tps,omitempty"`
+	Description  *string  `json:"description,omitempty"`
+}
+
+// CreatedDeployedProduct carries the key fields of a newly created deployed product.
+type CreatedDeployedProduct struct {
+	ID        string    `json:"id"`
+	CreatedOn time.Time `json:"createdOn"`
+	CreatedBy string    `json:"createdBy"`
+}
+
+// CreateDeployedProductResponse is entity-service's response for POST /deployed-products.
+type CreateDeployedProductResponse struct {
+	Message         string                 `json:"message"`
+	DeployedProduct CreatedDeployedProduct `json:"deployedProduct"`
+}
+
+// SearchDeployedProductsRequest is the input for POST /deployed-products/search.
+type SearchDeployedProductsRequest struct {
+	Pagination    Pagination `json:"pagination"`
+	DeploymentIDs []string   `json:"deploymentIds,omitempty"`
+}
+
+// DeployedProductVersionRef is the version sub-object in a DeployedProductView.
+type DeployedProductVersionRef struct {
+	ID             string     `json:"id"`
+	Name           string     `json:"name"`
+	ReleasedDate   *time.Time `json:"releasedDate"`
+	SupportEoLDate *time.Time `json:"supportEoLDate"`
+}
+
+// DeployedProductView is a single search result item from POST /deployed-products/search.
+// Cores, TPS, and Category are ServiceNow-only fields, always nil on the
+// Postgres data source.
+type DeployedProductView struct {
+	ID         string                     `json:"id"`
+	Deployment EntityRef                  `json:"deployment"`
+	Product    EntityRef                  `json:"product"`
+	Version    *DeployedProductVersionRef `json:"version"`
+	Cores      *string                    `json:"cores"`
+	TPS        *string                    `json:"tps"`
+	Category   *string                    `json:"category"`
+	CreatedOn  time.Time                  `json:"createdOn"`
+	UpdatedOn  time.Time                  `json:"updatedOn"`
+}
+
+// SearchDeployedProductsResponse is entity-service's response for POST /deployed-products/search.
+type SearchDeployedProductsResponse struct {
+	DeployedProducts []DeployedProductView `json:"deployedProducts"`
+	Total            int                   `json:"total"`
+	Limit            int                   `json:"limit"`
+	Offset           int                   `json:"offset"`
+	HasMore          bool                  `json:"hasMore"`
+}
+
+// UpdateDeployedProductRequest is the input for PATCH /deployed-products/{id}.
+// Either detail fields (Cores, TPS, Description) or Active=false must be
+// provided, but not both. Description uses json.RawMessage to preserve three
+// states: absent = omit, "null" = clear, `"value"` = set — decoding a client's
+// request body directly into this field naturally preserves that semantic.
+//
+// NOTE: entity-service only supports this route on its ServiceNow data
+// source — see CreateDeployedProductRequest's doc comment.
+type UpdateDeployedProductRequest struct {
+	ID           string          `json:"-"`
+	DeploymentID *string         `json:"deploymentId,omitempty"`
+	Cores        *int            `json:"cores,omitempty"`
+	TPS          *float64        `json:"tps,omitempty"`
+	Description  json.RawMessage `json:"description,omitempty"`
+	Active       *bool           `json:"active,omitempty"`
+}
+
+// UpdatedDeployedProduct carries the fields that may change after an update.
+type UpdatedDeployedProduct struct {
+	ID        string    `json:"id"`
+	UpdatedOn time.Time `json:"updatedOn"`
+	UpdatedBy string    `json:"updatedBy"`
+}
+
+// UpdateDeployedProductResponse is entity-service's response for PATCH /deployed-products/{id}.
+type UpdateDeployedProductResponse struct {
+	Message         string                 `json:"message"`
+	DeployedProduct UpdatedDeployedProduct `json:"deployedProduct"`
+}
+
+// --- attachments ---
+
+// ReferenceType identifies which kind of entity an attachment or comment is
+// attached to.
+type ReferenceType string
+
+const (
+	ReferenceTypeCase          ReferenceType = "case"
+	ReferenceTypeConversation  ReferenceType = "conversation"
+	ReferenceTypeChangeRequest ReferenceType = "change_request"
+	ReferenceTypeDeployment    ReferenceType = "deployment"
+	ReferenceTypeIncident      ReferenceType = "incident"
+)
+
+// CreateAttachmentRequest is the input for POST /attachments.
+type CreateAttachmentRequest struct {
+	ReferenceID   string        `json:"referenceId"`
+	ReferenceType ReferenceType `json:"referenceType"`
+	Name          string        `json:"name"`
+	Type          string        `json:"type"`
+	File          string        `json:"file"`
+	Description   *string       `json:"description,omitempty"`
+}
+
+// AttachmentDetail holds the core fields returned after creating an attachment.
+type AttachmentDetail struct {
+	ID          string    `json:"id"`
+	SizeBytes   int       `json:"sizeBytes"`
+	CreatedOn   time.Time `json:"createdOn"`
+	CreatedBy   string    `json:"createdBy"`
+	DownloadURL string    `json:"downloadUrl"`
+}
+
+// CreateAttachmentResponse is entity-service's response for POST /attachments.
+type CreateAttachmentResponse struct {
+	Message    string           `json:"message"`
+	Attachment AttachmentDetail `json:"attachment"`
+}
+
+// SearchAttachmentsRequest is the input for POST /attachments/search.
+type SearchAttachmentsRequest struct {
+	ReferenceID   string        `json:"referenceId"`
+	ReferenceType ReferenceType `json:"referenceType"`
+	Pagination    Pagination    `json:"pagination"`
+}
+
+// Attachment is a single search result item from POST /attachments/search.
+type Attachment struct {
+	ID            string        `json:"id"`
+	ReferenceID   string        `json:"referenceId"`
+	ReferenceType ReferenceType `json:"referenceType"`
+	Name          string        `json:"name"`
+	Type          string        `json:"type"`
+	SizeBytes     int           `json:"sizeBytes"`
+	Description   *string       `json:"description"`
+	CreatedBy     string        `json:"createdBy"`
+	CreatedOn     time.Time     `json:"createdOn"`
+	DownloadURL   *string       `json:"downloadUrl"`
+	PreviewURL    *string       `json:"previewUrl"`
+}
+
+// SearchAttachmentsResponse is entity-service's response for POST /attachments/search.
+type SearchAttachmentsResponse struct {
+	Attachments []Attachment `json:"attachments"`
+	Total       int          `json:"total"`
+	Limit       int          `json:"limit"`
+	Offset      int          `json:"offset"`
+	HasMore     bool         `json:"hasMore"`
+}
+
+// DeleteAttachmentResponse is entity-service's response for DELETE /attachments/{id}.
+type DeleteAttachmentResponse struct {
+	Message string `json:"message"`
+}
+
+// --- case activities ---
+
+// ActivityType discriminates the kind of entry in a case's activity feed.
+type ActivityType string
+
+const (
+	ActivityTypeComment     ActivityType = "comment"
+	ActivityTypeAttachment  ActivityType = "attachment"
+	ActivityTypeFieldChange ActivityType = "field_change"
+)
+
+// FieldChange describes a single field's value change, present only on
+// CaseActivity entries with Type == ActivityTypeFieldChange.
+type FieldChange struct {
+	Field         string `json:"field"`
+	FieldLabel    string `json:"fieldLabel"`
+	PreviousValue string `json:"previousValue"`
+	NewValue      string `json:"newValue"`
+}
+
+// CaseActivity is a single entry in a case's activity feed — a discriminated
+// union on Type. The shared fields are always present; type-specific fields
+// are populated only for the matching Type (CommentType for comments;
+// FileName/ContentType/SizeBytes/DownloadURL for attachments; Changes for
+// field changes). Field types/omitempty here mirror entity-service's struct
+// exactly (see its doc comment) — do not change to pointers.
+type CaseActivity struct {
+	ID                 string        `json:"id"`
+	Type               ActivityType  `json:"type"`
+	Content            string        `json:"content"`
+	CreatedOn          time.Time     `json:"createdOn"`
+	CreatedBy          string        `json:"createdBy"`
+	CreatedByFirstName string        `json:"createdByFirstName"`
+	CreatedByLastName  string        `json:"createdByLastName"`
+	CreatedByFullName  string        `json:"createdByFullName"`
+	CommentType        *CommentType  `json:"commentType,omitempty"`
+	FileName           string        `json:"fileName,omitempty"`
+	ContentType        string        `json:"contentType,omitempty"`
+	SizeBytes          int           `json:"sizeBytes,omitempty"`
+	DownloadURL        string        `json:"downloadUrl,omitempty"`
+	Changes            []FieldChange `json:"changes,omitempty"`
+}
+
+// SearchCaseActivitiesRequest is the input for POST /cases/{id}/activities/search.
+// CaseID is populated from the URL path parameter and is not part of the JSON body.
+type SearchCaseActivitiesRequest struct {
+	CaseID              string     `json:"-"`
+	Pagination          Pagination `json:"pagination"`
+	IncludeFieldChanges *bool      `json:"includeFieldChanges,omitempty"`
+}
+
+// SearchCaseActivitiesResponse is entity-service's response for POST /cases/{id}/activities/search.
+type SearchCaseActivitiesResponse struct {
+	Activity []CaseActivity `json:"activity"`
+	Total    int            `json:"total"`
+	Limit    int            `json:"limit"`
+	Offset   int            `json:"offset"`
+	HasMore  bool           `json:"hasMore"`
+}
+
+// --- products ---
+//
+// Like accounts, entity-service returns a different wire shape for these
+// routes depending on its DATA_SOURCE. The structs below are a superset of
+// both shapes for the same reasons documented on AccountSummary/AccountDetail
+// above: no colliding JSON keys, and every ambiguous-typed field (class,
+// dates) is typed as *string so either shape decodes cleanly.
+
+// ProductView is a single search result item from POST /products/search.
+type ProductView struct {
+	ID        string  `json:"id"`
+	Name      string  `json:"name"`
+	Class     *string `json:"class,omitempty"`
+	CreatedOn *string `json:"createdOn,omitempty"`
+	UpdatedOn *string `json:"updatedOn,omitempty"`
+}
+
+// SearchProductsRequest is the input for POST /products/search.
+type SearchProductsRequest struct {
+	Pagination  Pagination `json:"pagination"`
+	SearchQuery string     `json:"searchQuery,omitempty"`
+}
+
+// SearchProductsResponse is entity-service's response for POST /products/search.
+type SearchProductsResponse struct {
+	Products []ProductView `json:"products"`
+	Total    int           `json:"total"`
+	Limit    int           `json:"limit"`
+	Offset   int           `json:"offset"`
+	HasMore  bool          `json:"hasMore"`
+}
+
+// SearchProductVersionsRequest is the input for POST /products/{id}/versions/search.
+// ProductID is populated from the URL path parameter and is not part of the JSON body.
+type SearchProductVersionsRequest struct {
+	Pagination  Pagination `json:"pagination"`
+	ProductID   string     `json:"-"`
+	SearchQuery string     `json:"searchQuery,omitempty"`
+}
+
+// ProductVersionView is a single search result item from
+// POST /products/{id}/versions/search.
+type ProductVersionView struct {
+	ID                             string  `json:"id"`
+	ProductID                      string  `json:"productId"`
+	Version                        string  `json:"version"`
+	CurrentSupportStatus           *string `json:"currentSupportStatus,omitempty"`
+	ReleaseDate                    *string `json:"releaseDate,omitempty"`
+	SupportEOLDate                 *string `json:"supportEolDate,omitempty"`
+	EarliestPossibleSupportEOLDate *string `json:"earliestPossibleSupportEolDate,omitempty"`
+	CreatedOn                      *string `json:"createdOn,omitempty"`
+	UpdatedOn                      *string `json:"updatedOn,omitempty"`
+}
+
+// SearchProductVersionsResponse is entity-service's response for POST /products/{id}/versions/search.
+type SearchProductVersionsResponse struct {
+	ProductVersions []ProductVersionView `json:"productVersions"`
+	Total           int                  `json:"total"`
+	Limit           int                  `json:"limit"`
+	Offset          int                  `json:"offset"`
+	HasMore         bool                 `json:"hasMore"`
+}

--- a/apps/customer-portal/backend-v2/internal/handler/attachments.go
+++ b/apps/customer-portal/backend-v2/internal/handler/attachments.go
@@ -1,0 +1,159 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/dto"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/middleware"
+)
+
+// entityAttachmentClient abstracts the entity-service attachment operations
+// used by AttachmentHandler.
+type entityAttachmentClient interface {
+	CreateAttachment(ctx context.Context, req entity.CreateAttachmentRequest) (entity.CreateAttachmentResponse, error)
+	SearchAttachments(ctx context.Context, req entity.SearchAttachmentsRequest) (entity.SearchAttachmentsResponse, error)
+	GetAttachmentContent(ctx context.Context, id string) (body []byte, contentType string, err error)
+	DeleteAttachment(ctx context.Context, id string) (entity.DeleteAttachmentResponse, error)
+}
+
+// AttachmentHandler handles HTTP requests for attachment operations.
+type AttachmentHandler struct {
+	entity entityAttachmentClient
+}
+
+// NewAttachmentHandler creates an AttachmentHandler backed by the given entity client.
+func NewAttachmentHandler(entity entityAttachmentClient) *AttachmentHandler {
+	return &AttachmentHandler{entity: entity}
+}
+
+// CreateAttachment handles POST /attachments.
+func (h *AttachmentHandler) CreateAttachment(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	body, ok := readJSONBody(w, r)
+	if !ok {
+		return
+	}
+
+	var req entity.CreateAttachmentRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.CreateAttachment(r.Context(), req)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity CreateAttachment failed", "userID", user.UserID, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to create attachment.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusCreated, dto.MapAttachmentCreate(result))
+}
+
+// SearchAttachments handles POST /attachments/search.
+func (h *AttachmentHandler) SearchAttachments(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	body, ok := readJSONBody(w, r)
+	if !ok {
+		return
+	}
+
+	var req entity.SearchAttachmentsRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.SearchAttachments(r.Context(), req)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity SearchAttachments failed", "userID", user.UserID, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to search attachments.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusOK, dto.MapSearchAttachments(result))
+}
+
+// GetAttachmentContent handles GET /attachments/{id}/content. The response is
+// the raw file content, not JSON. Content-Disposition: attachment is always
+// set (mirroring entity-service's own XSS mitigation for this endpoint) so
+// browsers never render an attachment inline.
+func (h *AttachmentHandler) GetAttachmentContent(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	id := r.PathValue("id")
+	if id == "" || !uuidRe.MatchString(id) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	content, contentType, err := h.entity.GetAttachmentContent(r.Context(), id)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity GetAttachmentContent failed", "userID", user.UserID, "attachmentID", id, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to download attachment.")
+		return
+	}
+
+	w.Header().Set("Content-Type", contentType)
+	w.Header().Set("Content-Disposition", "attachment")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(content) // #nosec G705 -- Content-Type set from entity-service's own sanitized value; Content-Disposition forces download, never inline rendering
+}
+
+// DeleteAttachment handles DELETE /attachments/{id}.
+func (h *AttachmentHandler) DeleteAttachment(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	id := r.PathValue("id")
+	if id == "" || !uuidRe.MatchString(id) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	result, err := h.entity.DeleteAttachment(r.Context(), id)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity DeleteAttachment failed", "userID", user.UserID, "attachmentID", id, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to delete attachment.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusOK, dto.MapDeleteAttachment(result))
+}

--- a/apps/customer-portal/backend-v2/internal/handler/cases.go
+++ b/apps/customer-portal/backend-v2/internal/handler/cases.go
@@ -34,6 +34,7 @@ type entityCaseClient interface {
 	CreateCase(ctx context.Context, req entity.CreateCaseRequest) (entity.CreateCaseResponse, error)
 	UpdateCase(ctx context.Context, id string, req entity.UpdateCaseRequest) (entity.UpdateCaseResponse, error)
 	CreateCaseComment(ctx context.Context, caseID string, req entity.CreateCaseCommentRequest) (entity.CreateCaseCommentResponse, error)
+	SearchCaseActivities(ctx context.Context, caseID string, req entity.SearchCaseActivitiesRequest) (entity.SearchCaseActivitiesResponse, error)
 }
 
 // CaseHandler handles HTTP requests for case operations.
@@ -216,4 +217,39 @@ func (h *CaseHandler) CreateCaseComment(w http.ResponseWriter, r *http.Request) 
 	}
 
 	writeJSONValue(w, http.StatusCreated, dto.MapCaseComment(result))
+}
+
+// SearchCaseActivities handles POST /cases/{id}/activities/search.
+func (h *CaseHandler) SearchCaseActivities(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	id := r.PathValue("id")
+	if id == "" || !uuidRe.MatchString(id) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	body, ok := readJSONBody(w, r)
+	if !ok {
+		return
+	}
+
+	var req entity.SearchCaseActivitiesRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.SearchCaseActivities(r.Context(), id, req)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity SearchCaseActivities failed", "userID", user.UserID, "caseID", id, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to search case activities.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusOK, dto.MapSearchCaseActivities(result))
 }

--- a/apps/customer-portal/backend-v2/internal/handler/deployed_products.go
+++ b/apps/customer-portal/backend-v2/internal/handler/deployed_products.go
@@ -1,0 +1,153 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/dto"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/middleware"
+)
+
+// entityDeployedProductClient abstracts the entity-service deployed-product
+// operations used by DeployedProductHandler.
+type entityDeployedProductClient interface {
+	SearchDeployedProducts(ctx context.Context, req entity.SearchDeployedProductsRequest) (entity.SearchDeployedProductsResponse, error)
+	CreateDeployedProduct(ctx context.Context, req entity.CreateDeployedProductRequest) (entity.CreateDeployedProductResponse, error)
+	UpdateDeployedProduct(ctx context.Context, id string, req entity.UpdateDeployedProductRequest) (entity.UpdateDeployedProductResponse, error)
+}
+
+// DeployedProductHandler handles HTTP requests for deployed-product operations.
+type DeployedProductHandler struct {
+	entity entityDeployedProductClient
+}
+
+// NewDeployedProductHandler creates a DeployedProductHandler backed by the given entity client.
+func NewDeployedProductHandler(entity entityDeployedProductClient) *DeployedProductHandler {
+	return &DeployedProductHandler{entity: entity}
+}
+
+// SearchDeployedProducts handles POST /deployed-products/search.
+func (h *DeployedProductHandler) SearchDeployedProducts(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	body, ok := readJSONBody(w, r)
+	if !ok {
+		return
+	}
+
+	var req entity.SearchDeployedProductsRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.SearchDeployedProducts(r.Context(), req)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity SearchDeployedProducts failed", "userID", user.UserID, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to search deployed products.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusOK, dto.MapSearchDeployedProducts(result))
+}
+
+// CreateDeployedProduct handles POST /deployed-products.
+//
+// NOTE: entity-service only supports this route on its ServiceNow data
+// source — see internal/entity/deployed_products.go.
+func (h *DeployedProductHandler) CreateDeployedProduct(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	body, ok := readJSONBody(w, r)
+	if !ok {
+		return
+	}
+
+	var req entity.CreateDeployedProductRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.CreateDeployedProduct(r.Context(), req)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity CreateDeployedProduct failed", "userID", user.UserID, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to create deployed product.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusCreated, dto.MapDeployedProductCreate(result))
+}
+
+// PatchDeployedProduct handles PATCH /deployed-products/{id}.
+//
+// NOTE: entity-service only supports this route on its ServiceNow data
+// source — see internal/entity/deployed_products.go.
+func (h *DeployedProductHandler) PatchDeployedProduct(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	id := r.PathValue("id")
+	if id == "" || !uuidRe.MatchString(id) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	body, ok := readJSONBody(w, r)
+	if !ok {
+		return
+	}
+
+	var req entity.UpdateDeployedProductRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+	// entity-service requires exactly one of the detail-fields group
+	// (cores/tps/description) or active=false — never both, never neither.
+	detailFieldsSet := req.Cores != nil || req.TPS != nil || len(req.Description) > 0
+	activeSet := req.Active != nil
+	if detailFieldsSet == activeSet {
+		writeError(w, http.StatusBadRequest, "Provide either cores/tps/description or active, but not both.")
+		return
+	}
+
+	result, err := h.entity.UpdateDeployedProduct(r.Context(), id, req)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity UpdateDeployedProduct failed", "userID", user.UserID, "deployedProductID", id, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to update deployed product.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusOK, dto.MapDeployedProductUpdate(result))
+}

--- a/apps/customer-portal/backend-v2/internal/handler/deployed_products.go
+++ b/apps/customer-portal/backend-v2/internal/handler/deployed_products.go
@@ -128,6 +128,14 @@ func (h *DeployedProductHandler) PatchDeployedProduct(w http.ResponseWriter, r *
 		return
 	}
 
+	// Decoded directly into entity-service's request struct (no restricted
+	// portal DTO) — every field here is customer-appropriate, including
+	// DeploymentID: per entity-service's own doc comment on
+	// UpdateDeployedProductRequest, it isn't a mutation field but an
+	// IDOR-style scope guard ("the deployed product must belong to that
+	// deployment or the operation returns a NotFoundError") — a legitimate
+	// safety check for the frontend to supply, unlike the case-update
+	// endpoint's genuinely internal-only fields (see dto.UpdateCaseRequest).
 	var req entity.UpdateDeployedProductRequest
 	if err := json.Unmarshal(body, &req); err != nil {
 		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)

--- a/apps/customer-portal/backend-v2/internal/handler/products.go
+++ b/apps/customer-portal/backend-v2/internal/handler/products.go
@@ -1,0 +1,108 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/dto"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/middleware"
+)
+
+// entityProductClient abstracts the entity-service product operations used by ProductHandler.
+type entityProductClient interface {
+	SearchProducts(ctx context.Context, req entity.SearchProductsRequest) (entity.SearchProductsResponse, error)
+	SearchProductVersions(ctx context.Context, productID string, req entity.SearchProductVersionsRequest) (entity.SearchProductVersionsResponse, error)
+}
+
+// ProductHandler handles HTTP requests for product operations.
+type ProductHandler struct {
+	entity entityProductClient
+}
+
+// NewProductHandler creates a ProductHandler backed by the given entity client.
+func NewProductHandler(entity entityProductClient) *ProductHandler {
+	return &ProductHandler{entity: entity}
+}
+
+// SearchProducts handles POST /products/search.
+func (h *ProductHandler) SearchProducts(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	body, ok := readJSONBody(w, r)
+	if !ok {
+		return
+	}
+
+	var req entity.SearchProductsRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.SearchProducts(r.Context(), req)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity SearchProducts failed", "userID", user.UserID, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to search products.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusOK, dto.MapSearchProducts(result))
+}
+
+// SearchProductVersions handles POST /products/{id}/versions/search.
+func (h *ProductHandler) SearchProductVersions(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	id := r.PathValue("id")
+	if id == "" || !uuidRe.MatchString(id) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	body, ok := readJSONBody(w, r)
+	if !ok {
+		return
+	}
+
+	var req entity.SearchProductVersionsRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.SearchProductVersions(r.Context(), id, req)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity SearchProductVersions failed", "userID", user.UserID, "productID", id, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to search product versions.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusOK, dto.MapSearchProductVersions(result))
+}

--- a/apps/customer-portal/backend-v2/openapi.yaml
+++ b/apps/customer-portal/backend-v2/openapi.yaml
@@ -693,6 +693,540 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
+  /deployed-products/search:
+    post:
+      summary: Search deployed products.
+      operationId: postDeployedProductsSearch
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SearchDeployedProductsRequest'
+        required: true
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchDeployedProductsResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /deployed-products:
+    post:
+      summary: Create a deployed product.
+      description: >
+        Only entity-service's ServiceNow data source supports this route —
+        a Postgres-mode deployment always returns 400.
+      operationId: postDeployedProducts
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateDeployedProductRequest'
+        required: true
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeployedProductCreateResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /deployed-products/{id}:
+    patch:
+      summary: Update a deployed product.
+      description: >
+        Provide either cores/tps/description or active=false, but not both.
+        Only entity-service's ServiceNow data source supports this route —
+        a Postgres-mode deployment always returns 400.
+      operationId: patchDeployedProductsId
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateDeployedProductRequest'
+        required: true
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeployedProductUpdateResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: NotFound
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /attachments:
+    post:
+      summary: Create an attachment.
+      operationId: postAttachments
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateAttachmentRequest'
+        required: true
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AttachmentCreateResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /attachments/search:
+    post:
+      summary: Search attachments.
+      operationId: postAttachmentsSearch
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SearchAttachmentsRequest'
+        required: true
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchAttachmentsResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /attachments/{id}/content:
+    get:
+      summary: Download an attachment's raw file content.
+      description: >
+        Response body is the raw file, not JSON. Content-Disposition:
+        attachment is always set, forcing a download rather than inline
+        rendering, mirroring entity-service's own XSS mitigation for this
+        endpoint.
+      operationId: getAttachmentsIdContent
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: NotFound
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /attachments/{id}:
+    delete:
+      summary: Delete an attachment.
+      operationId: deleteAttachmentsId
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeleteResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: NotFound
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /cases/{id}/activities/search:
+    post:
+      summary: Search a case's activity feed (comments, attachments, field changes).
+      operationId: postCasesIdActivitiesSearch
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SearchCaseActivitiesRequest'
+        required: true
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchCaseActivitiesResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: NotFound
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /products/search:
+    post:
+      summary: Search products.
+      operationId: postProductsSearch
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SearchProductsRequest'
+        required: true
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchProductsResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /products/{id}/versions/search:
+    post:
+      summary: Search a product's versions.
+      operationId: postProductsIdVersionsSearch
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SearchProductVersionsRequest'
+        required: true
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchProductVersionsResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: NotFound
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
   /updates/product-update-levels:
     get:
       summary: Get product update levels.
@@ -1481,6 +2015,375 @@ components:
           type: string
         createdOn:
           type: string
+
+    # ---- deployed products ----
+
+    SearchDeployedProductsRequest:
+      type: object
+      properties:
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+        deploymentIds:
+          type: array
+          items:
+            type: string
+
+    DeployedProductVersion:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        releasedDate:
+          type: string
+        supportEoLDate:
+          type: string
+
+    DeployedProductSummary:
+      type: object
+      properties:
+        id:
+          type: string
+        deployment:
+          $ref: '#/components/schemas/Ref'
+        product:
+          $ref: '#/components/schemas/Ref'
+        version:
+          $ref: '#/components/schemas/DeployedProductVersion'
+        cores:
+          type: string
+        tps:
+          type: string
+        category:
+          type: string
+        createdOn:
+          type: string
+        updatedOn:
+          type: string
+
+    SearchDeployedProductsResponse:
+      type: object
+      properties:
+        deployedProducts:
+          type: array
+          items:
+            $ref: '#/components/schemas/DeployedProductSummary'
+        total:
+          type: integer
+        limit:
+          type: integer
+        offset:
+          type: integer
+        hasMore:
+          type: boolean
+
+    CreateDeployedProductRequest:
+      type: object
+      required: [projectId, deploymentId, productId, versionId]
+      properties:
+        projectId:
+          type: string
+          format: uuid
+        deploymentId:
+          type: string
+          format: uuid
+        productId:
+          type: string
+          format: uuid
+        versionId:
+          type: string
+          format: uuid
+        cores:
+          type: integer
+        tps:
+          type: number
+        description:
+          type: string
+
+    DeployedProductCreateResponse:
+      type: object
+      properties:
+        id:
+          type: string
+        createdOn:
+          type: string
+
+    UpdateDeployedProductRequest:
+      description: Provide either cores/tps/description or active=false, but not both.
+      type: object
+      properties:
+        deploymentId:
+          type: string
+          format: uuid
+          description: Optional — scopes the update to this deployment.
+        cores:
+          type: integer
+        tps:
+          type: number
+        description:
+          type: string
+        active:
+          type: boolean
+
+    DeployedProductUpdateResponse:
+      type: object
+      properties:
+        id:
+          type: string
+        updatedOn:
+          type: string
+
+    # ---- attachments ----
+
+    CreateAttachmentRequest:
+      type: object
+      required: [referenceId, referenceType, name, type, file]
+      properties:
+        referenceId:
+          type: string
+          format: uuid
+        referenceType:
+          type: string
+          description: "\"case\", \"conversation\", \"change_request\", \"deployment\", or \"incident\""
+        name:
+          type: string
+        type:
+          type: string
+          description: MIME/content type of the file.
+        file:
+          type: string
+          description: Base64-encoded file content.
+        description:
+          type: string
+
+    AttachmentCreateResponse:
+      type: object
+      properties:
+        id:
+          type: string
+        sizeBytes:
+          type: integer
+        createdOn:
+          type: string
+        downloadUrl:
+          type: string
+
+    SearchAttachmentsRequest:
+      type: object
+      required: [referenceId, referenceType]
+      properties:
+        referenceId:
+          type: string
+          format: uuid
+        referenceType:
+          type: string
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+
+    AttachmentSummary:
+      type: object
+      properties:
+        id:
+          type: string
+        referenceId:
+          type: string
+        referenceType:
+          type: string
+        name:
+          type: string
+        type:
+          type: string
+        sizeBytes:
+          type: integer
+        description:
+          type: string
+        createdBy:
+          type: string
+        createdOn:
+          type: string
+        downloadUrl:
+          type: string
+        previewUrl:
+          type: string
+
+    SearchAttachmentsResponse:
+      type: object
+      properties:
+        attachments:
+          type: array
+          items:
+            $ref: '#/components/schemas/AttachmentSummary'
+        total:
+          type: integer
+        limit:
+          type: integer
+        offset:
+          type: integer
+        hasMore:
+          type: boolean
+
+    DeleteResponse:
+      type: object
+      properties:
+        message:
+          type: string
+
+    # ---- case activities ----
+
+    CaseFieldChange:
+      type: object
+      properties:
+        field:
+          type: string
+        fieldLabel:
+          type: string
+        previousValue:
+          type: string
+        newValue:
+          type: string
+
+    CaseActivity:
+      description: >
+        A discriminated union on type: "comment" entries additionally carry
+        commentType; "attachment" entries carry fileName/contentType/
+        sizeBytes/downloadUrl; "field_change" entries carry changes.
+      type: object
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+          description: "\"comment\", \"attachment\", or \"field_change\""
+        content:
+          type: string
+        createdOn:
+          type: string
+        createdBy:
+          type: string
+        commentType:
+          type: string
+        fileName:
+          type: string
+        contentType:
+          type: string
+        sizeBytes:
+          type: integer
+        downloadUrl:
+          type: string
+        changes:
+          type: array
+          items:
+            $ref: '#/components/schemas/CaseFieldChange'
+
+    SearchCaseActivitiesRequest:
+      type: object
+      properties:
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+        includeFieldChanges:
+          type: boolean
+          description: When false or omitted, only comment and attachment entries are returned.
+
+    SearchCaseActivitiesResponse:
+      type: object
+      properties:
+        activity:
+          type: array
+          items:
+            $ref: '#/components/schemas/CaseActivity'
+        total:
+          type: integer
+        limit:
+          type: integer
+        offset:
+          type: integer
+        hasMore:
+          type: boolean
+
+    # ---- products ----
+
+    SearchProductsRequest:
+      type: object
+      properties:
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+        searchQuery:
+          type: string
+
+    ProductSummary:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        class:
+          type: string
+        createdOn:
+          type: string
+        updatedOn:
+          type: string
+
+    SearchProductsResponse:
+      type: object
+      properties:
+        products:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProductSummary'
+        total:
+          type: integer
+        limit:
+          type: integer
+        offset:
+          type: integer
+        hasMore:
+          type: boolean
+
+    SearchProductVersionsRequest:
+      type: object
+      properties:
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+        searchQuery:
+          type: string
+
+    ProductVersionSummary:
+      type: object
+      properties:
+        id:
+          type: string
+        version:
+          type: string
+        currentSupportStatus:
+          type: string
+        releaseDate:
+          type: string
+        supportEolDate:
+          type: string
+        earliestPossibleSupportEolDate:
+          type: string
+        createdOn:
+          type: string
+        updatedOn:
+          type: string
+
+    SearchProductVersionsResponse:
+      type: object
+      properties:
+        productVersions:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProductVersionSummary'
+        total:
+          type: integer
+        limit:
+          type: integer
+        offset:
+          type: integer
+        hasMore:
+          type: boolean
 
     # ---- updates ----
 


### PR DESCRIPTION
## Summary
Adds 10 more endpoints to `apps/customer-portal/backend-v2` (26 total):

- **Deployed products**: `POST /deployed-products/search`, `POST /deployed-products`, `PATCH /deployed-products/{id}` — create/update only succeed against entity-service's ServiceNow data source (Postgres always 400s, documented in code/README/openapi). PATCH enforces entity-service's mutually-exclusive rule (either `cores`/`tps`/`description` or `active=false`, never both) — verified in testing below.
- **Attachments**: `POST /attachments`, `POST /attachments/search`, `GET /attachments/{id}/content`, `DELETE /attachments/{id}` — the content endpoint is this backend's first binary (non-JSON) response. Adds `entity.Client.doBinary` alongside the existing JSON `do()`/`getJSON()`/`postJSON()`/`patchJSON()`/`deleteJSON()`; the handler explicitly sets `Content-Disposition: attachment` (a fresh response header this backend constructs, not just relayed from entity-service) so browsers never render an attachment inline.
- **Case activity feed**: `POST /cases/{id}/activities/search` — entity-service's `CaseActivity` is a discriminated union on `type` (comment/attachment/field_change); the Go struct mirrors its exact non-pointer `omitempty` pattern for the type-specific fields rather than "improving" it to pointers, to keep the JSON shape identical.
- **Products**: `POST /products/search`, `POST /products/{id}/versions/search` — reuses the same superset-struct technique from the accounts endpoints (PR #1302) for entity-service's Postgres/ServiceNow data-source-dependent response shapes.

Also updates `openapi.yaml` (10 new paths, ~24 new schemas), `README.md`, and `CLAUDE.md` (new notes on the `json.RawMessage` three-state pattern for `UpdateDeployedProductRequest.Description`, and the binary-response convention).

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` all clean
- [x] `gosec -fmt=text ./...` reports 0 issues
- [x] `openapi.yaml` validated as well-formed YAML with all 24 paths / new schemas present (verified no content was lost despite a large diff from mid-file insertion)
- [x] Manually verified all 10 endpoints: `PATCH /deployed-products/{id}` correctly rejects neither-nor and both-at-once field combos with 400, passes with exactly one; invalid UUID path params return 400; valid requests against an unreachable upstream map cleanly to 500 (no leakage)
- [ ] Wire up against a real running entity-service instance (ServiceNow data source, for the deployed-product write routes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Attachment management with create, search, download, and delete operations
  * Case activity feed search functionality with change tracking
  * Deployed product management capabilities including search, create, and update operations
  * Product and product version search functionality

* **Documentation**
  * Expanded API documentation with new endpoints and comprehensive schema definitions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
