### PR TITLE
feat(customer-portal): add change request and call request modules

### DIFF
--- a/apps/customer-portal/backend-v2/CLAUDE.md
+++ b/apps/customer-portal/backend-v2/CLAUDE.md
@@ -6,19 +6,22 @@ responses for the frontend. This is a Go rewrite of the Ballerina backend at
 `apps/customer-portal/backend`, modeled on `apps/csm-portal/backend`'s conventions — read that
 backend's own CLAUDE.md too if something here is underspecified.
 
-**Status: in progress.** 26 routes are wired up so far (`GET /health`, `GET`/`PATCH /users/me`,
+**Status: in progress.** 35 routes are wired up so far (`GET /health`, `GET`/`PATCH /users/me`,
 `POST /accounts/search`, `GET /accounts/{id}`, `POST /projects/search`, `GET /projects/{id}`,
 `POST /cases/search`, `GET /cases/{id}`, `POST /cases`, `PATCH /cases/{id}`,
 `POST /cases/{id}/comments`, `POST /cases/{id}/activities/search`, `POST /deployments/search`,
 `POST /deployments`, `POST /deployed-products/search`, `POST /deployed-products`,
 `PATCH /deployed-products/{id}`, `POST /attachments`, `POST /attachments/search`,
 `GET /attachments/{id}/content`, `DELETE /attachments/{id}`, `POST /products/search`,
-`POST /products/{id}/versions/search`, `GET /updates/product-update-levels`,
+`POST /products/{id}/versions/search`, `POST /change-requests`, `POST /change-requests/search`,
+`GET /change-requests/{id}`, `PATCH /change-requests/{id}`, `GET /change-requests/{id}/approvals`,
+`POST /change-requests/{id}/approvals/decision`, `POST /call-requests`,
+`POST /call-requests/search`, `PATCH /call-requests/{id}`, `GET /updates/product-update-levels`,
 `POST /updates/levels/search`) across three upstream services: entity-service, the WSO2 Updates
 service, and SCIM. The Ballerina backend exposes ~100 routes across many more modules (generic
-comments, conversations, change requests, call requests, catalogs, time cards, registry tokens,
-contacts, escalations, product vulnerabilities, AI chat/websocket, etc.) — none of those are ported
-yet. Follow the recipe below to add the next one.
+comments, conversations, catalogs, time cards, registry tokens, contacts, escalations, product
+vulnerabilities, incidents, problems, task SLAs, tasks, groups/service-offerings/configuration-items,
+AI chat/websocket, etc.) — none of those are ported yet. Follow the recipe below to add the next one.
 
 ## Which entity-service
 
@@ -149,6 +152,42 @@ client sends — a customer should never be able to create an internal work-note
 entry. When you add a write endpoint, check the entity-service request struct for fields that read
 as "internal support operation" rather than "customer self-service action" before deciding whether
 to pass it through directly or build a restricted DTO.
+
+Two more examples, both in this same "restrict, don't mirror" category:
+- `PATCH /change-requests/{id}` (`dto.ChangeRequestUpdateRequest`) excludes case/project/deployment
+  relinking and `assignedEngineerId`/`assignedTeamId` (support assignment) for the same reasons as
+  case updates, plus `state` specifically — state transitions go through the dedicated
+  `isCustomerApproved`/`isCustomerReviewed`/`requestApproval` fields (which *are* exposed, since
+  they're literally the customer's own approval actions) rather than letting the customer set an
+  arbitrary ServiceNow workflow state directly.
+- `PATCH /call-requests/{id}` (`dto.CallRequestUpdateRequest`) excludes `meetingDate`/`assignee`/
+  `notes`/`plan`/`attendees`/`actionItems`/`actualDurationMin` — entity-service's own doc comment
+  labels these "agent-side fields, set when an engineer schedules or concludes the call." They're
+  still exposed on the *read* side (`dto.CallRequestSummary`) since the customer should be able to
+  see the outcome of their own call, just not set it themselves.
+
+**Not every field worth restricting is a security decision — some are just an unenforced entity-service
+scoping convenience.** `PATCH /deployed-products/{id}`'s `deploymentId` field looks similar to the
+fields above (an id referencing another resource) but isn't restricted, because entity-service
+documents it as an IDOR-style scope guard the caller supplies voluntarily (verify the deployed
+product belongs to this deployment before mutating it), not a way to relink the resource. Read the
+entity-service doc comment on the field before deciding which category it falls into — don't
+pattern-match on field name alone (e.g. "any ID field" or "any assignee-shaped field").
+
+**"Exactly one" vs. "at least one" is per-entity, read entity-service's own doc comment.**
+`PATCH /cases/{id}` requires *exactly one* of its primary fields (entity-service's doc comment says
+so explicitly); `PATCH /change-requests/{id}` requires *at least one* (its doc comment says "at
+least one must be provided"). Don't assume one pattern generalizes to the other — copying the wrong
+validation produces a portal that's stricter or looser than the upstream contract, and CodeRabbit
+caught exactly this mismatch once already (see the case-update fix in this backend's PR history).
+
+Where entity-service defines many enum-like fields (change request category/priority/impact/type/
+state/risk, call request state, etc.) as named Go string types with const blocks, this file's
+convention is to flatten them to plain `string` in the mirrored struct (matching how `CaseView`
+already treats `Severity`/`State` as plain strings) — skip re-declaring the const blocks unless a
+specific value needs to be checked in Go code (e.g. `ChangeRequestApprovalDecisionRequest.Decision`
+validation in the handler compares against literal `"approved"`/`"rejected"` strings, not enum
+constants).
 
 ## Adding a new endpoint
 

--- a/apps/customer-portal/backend-v2/README.md
+++ b/apps/customer-portal/backend-v2/README.md
@@ -5,7 +5,7 @@ Go rewrite of the Ballerina backend at `apps/customer-portal/backend`. It is a b
 [`entity-service`](../../../entity-service) (this repo's `cs-tools/entity-service`, not the
 `digiops-cs/entity-service` the Ballerina backend targets), and shapes the responses for the frontend.
 
-This is a work in progress — only the 26 routes listed below are implemented so far, across
+This is a work in progress — only the 35 routes listed below are implemented so far, across
 entity-service, the WSO2 Updates service, and SCIM. Everything else the Ballerina backend exposes
 still needs a Go handler; add them following the pattern described in
 [CLAUDE.md](./CLAUDE.md#adding-a-new-endpoint).
@@ -137,7 +137,9 @@ backend-v2/
 │   │   ├── deployments.go       # SearchDeployments, CreateDeployment
 │   │   ├── deployed_products.go # SearchDeployedProducts, CreateDeployedProduct, UpdateDeployedProduct
 │   │   ├── attachments.go       # CreateAttachment, SearchAttachments, GetAttachmentContent, DeleteAttachment
-│   │   └── products.go          # SearchProducts, SearchProductVersions
+│   │   ├── products.go          # SearchProducts, SearchProductVersions
+│   │   ├── change_requests.go   # create/search/get/update, approvals get/decide
+│   │   └── call_requests.go     # CreateCallRequest, SearchCallRequests, UpdateCallRequest
 │   ├── updates/                 # OAuth2 HTTP client for the WSO2 Updates service
 │   │   ├── client.go            # Config/Client/do()
 │   │   ├── types.go             # upstream (snake_case) vs portal (camelCase) structs
@@ -155,7 +157,9 @@ backend-v2/
 │   │   ├── deployment.go
 │   │   ├── deployed_product.go
 │   │   ├── attachment.go
-│   │   └── product.go
+│   │   ├── product.go
+│   │   ├── change_request.go
+│   │   └── call_request.go
 │   ├── middleware/
 │   │   ├── auth.go              # JWT validation; injects UserInfo into context
 │   │   ├── correlation.go       # X-CSM-Correlation-ID propagation + slog enrichment
@@ -171,6 +175,8 @@ backend-v2/
 │       ├── deployed_products.go # deployed-product search/create/update
 │       ├── attachments.go       # attachment create/search/download/delete
 │       ├── products.go          # POST /products/search, POST /products/{id}/versions/search
+│       ├── change_requests.go   # change-request create/search/get/update/approvals
+│       ├── call_requests.go     # call-request create/search/update
 │       └── updates.go           # GET /updates/product-update-levels, POST /updates/levels/search
 ├── .choreo/component.yaml
 ├── openapi.yaml
@@ -203,6 +209,15 @@ backend-v2/
 - `GET /attachments/{id}/content` — download an attachment's raw file content
 - `DELETE /attachments/{id}` — delete an attachment
 - `POST /cases/{id}/activities/search` — search a case's activity feed (comments, attachments, field changes)
+- `POST /change-requests` — create a change request (ServiceNow data source only)
+- `POST /change-requests/search` — search change requests (ServiceNow data source only)
+- `GET /change-requests/{id}` — get change request by ID (ServiceNow data source only)
+- `PATCH /change-requests/{id}` — update a change request (restricted, customer-safe field subset — see CLAUDE.md; ServiceNow data source only)
+- `GET /change-requests/{id}/approvals` — get a change request's approval stages (ServiceNow data source only)
+- `POST /change-requests/{id}/approvals/decision` — approve/reject the caller's own pending approval (ServiceNow data source only)
+- `POST /call-requests` — create a call request (ServiceNow data source only)
+- `POST /call-requests/search` — search call requests, scoped by caseId in the body (ServiceNow data source only)
+- `PATCH /call-requests/{id}` — update a call request (restricted, excludes agent-only fields — see CLAUDE.md; ServiceNow data source only)
 - `POST /products/search` — search products
 - `POST /products/{id}/versions/search` — search a product's versions
 - `GET /updates/product-update-levels` — list product update levels
@@ -308,6 +323,38 @@ curl -X POST http://localhost:8080/products/search \
 curl -X POST http://localhost:8080/products/<product-id>/versions/search \
   -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
   -d '{"pagination":{"limit":10,"offset":0}}'
+
+curl -X POST http://localhost:8080/change-requests \
+  -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
+  -d '{"subject":"Upgrade WSO2 API Manager to 4.3.0"}'
+
+curl -X POST http://localhost:8080/change-requests/search \
+  -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
+  -d '{"pagination":{"limit":10,"offset":0}}'
+
+curl -H "x-jwt-assertion: $JWT" http://localhost:8080/change-requests/<change-request-id>
+
+curl -X PATCH http://localhost:8080/change-requests/<change-request-id> \
+  -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
+  -d '{"isCustomerApproved":true}'
+
+curl -H "x-jwt-assertion: $JWT" http://localhost:8080/change-requests/<change-request-id>/approvals
+
+curl -X POST http://localhost:8080/change-requests/<change-request-id>/approvals/decision \
+  -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
+  -d '{"decision":"approved"}'
+
+curl -X POST http://localhost:8080/call-requests \
+  -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
+  -d '{"caseId":"<case-id>","reason":"Discuss workaround","utcTimes":["2026-08-05T10:00:00Z"],"durationInMinutes":30}'
+
+curl -X POST http://localhost:8080/call-requests/search \
+  -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
+  -d '{"caseId":"<case-id>","pagination":{"limit":10,"offset":0}}'
+
+curl -X PATCH http://localhost:8080/call-requests/<call-request-id> \
+  -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
+  -d '{"state":"customer_rejected","cancellationReason":"No longer needed"}'
 
 curl -H "x-jwt-assertion: $JWT" http://localhost:8080/updates/product-update-levels
 

--- a/apps/customer-portal/backend-v2/cmd/server/main.go
+++ b/apps/customer-portal/backend-v2/cmd/server/main.go
@@ -83,6 +83,8 @@ func main() {
 	deployedProductHandler := handler.NewDeployedProductHandler(entityClient)
 	attachmentHandler := handler.NewAttachmentHandler(entityClient)
 	productHandler := handler.NewProductHandler(entityClient)
+	changeRequestHandler := handler.NewChangeRequestHandler(entityClient)
+	callRequestHandler := handler.NewCallRequestHandler(entityClient)
 	accountHandler := handler.NewAccountHandler(entityClient)
 	updatesHandler := handler.NewUpdatesHandler(updatesClient)
 
@@ -132,6 +134,20 @@ func main() {
 
 	mux.HandleFunc("POST /products/search", productHandler.SearchProducts)
 	mux.HandleFunc("POST /products/{id}/versions/search", productHandler.SearchProductVersions)
+
+	// entity-service only supports change requests and call requests on its
+	// ServiceNow data source — see internal/entity/change_requests.go and
+	// internal/entity/call_requests.go.
+	mux.HandleFunc("POST /change-requests", changeRequestHandler.CreateChangeRequest)
+	mux.HandleFunc("POST /change-requests/search", changeRequestHandler.SearchChangeRequests)
+	mux.HandleFunc("GET /change-requests/{id}", changeRequestHandler.GetChangeRequest)
+	mux.HandleFunc("PATCH /change-requests/{id}", changeRequestHandler.PatchChangeRequest)
+	mux.HandleFunc("GET /change-requests/{id}/approvals", changeRequestHandler.GetChangeRequestApprovals)
+	mux.HandleFunc("POST /change-requests/{id}/approvals/decision", changeRequestHandler.DecideChangeRequestApproval)
+
+	mux.HandleFunc("POST /call-requests", callRequestHandler.CreateCallRequest)
+	mux.HandleFunc("POST /call-requests/search", callRequestHandler.SearchCallRequests)
+	mux.HandleFunc("PATCH /call-requests/{id}", callRequestHandler.PatchCallRequest)
 
 	mux.HandleFunc("POST /accounts/search", accountHandler.SearchAccounts)
 	mux.HandleFunc("GET /accounts/{id}", accountHandler.GetAccount)

--- a/apps/customer-portal/backend-v2/internal/dto/call_request.go
+++ b/apps/customer-portal/backend-v2/internal/dto/call_request.go
@@ -1,0 +1,158 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dto
+
+import "github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+
+// CallRequestCreateResponse is the portal's response for POST /call-requests.
+type CallRequestCreateResponse struct {
+	ID        string `json:"id"`
+	CreatedOn string `json:"createdOn"`
+	State     string `json:"state"`
+}
+
+// MapCallRequestCreate builds the portal response from entity-service's CreateCallRequestResponse.
+func MapCallRequestCreate(r entity.CreateCallRequestResponse) CallRequestCreateResponse {
+	return CallRequestCreateResponse{
+		ID:        r.CallRequest.ID,
+		CreatedOn: r.CallRequest.CreatedOn,
+		State:     r.CallRequest.State,
+	}
+}
+
+// CallRequestStateInfo holds the state of a call request.
+type CallRequestStateInfo struct {
+	ID    string `json:"id"`
+	Label string `json:"label"`
+}
+
+// CallRequestCase is a compact reference to the case a call request belongs to.
+type CallRequestCase struct {
+	ID     string  `json:"id"`
+	Name   string  `json:"name"`
+	Number *string `json:"number,omitempty"`
+}
+
+// CallRequestSummary is one item of the portal's response for
+// POST /call-requests/search. Assignee/Notes/Plan/Attendees/ActionItems/
+// ActualDurationMin are agent-side fields entity-service populates once a
+// support engineer schedules or concludes the call — read-only information
+// for the customer, not something they set (see
+// dto.CallRequestUpdateRequest for the write-side restriction).
+type CallRequestSummary struct {
+	ID                 string               `json:"id"`
+	Number             string               `json:"number"`
+	Case               CallRequestCase      `json:"case"`
+	Reason             *string              `json:"reason,omitempty"`
+	PreferredTimes     []string             `json:"preferredTimes,omitempty"`
+	DurationMin        int                  `json:"durationMin"`
+	ScheduleTime       *string              `json:"scheduleTime,omitempty"`
+	MeetingLink        *string              `json:"meetingLink,omitempty"`
+	CreatedOn          string               `json:"createdOn"`
+	UpdatedOn          string               `json:"updatedOn"`
+	State              CallRequestStateInfo `json:"state"`
+	CancellationReason *string              `json:"cancellationReason,omitempty"`
+	Assignee           *string              `json:"assignee,omitempty"`
+	Notes              *string              `json:"notes,omitempty"`
+	Plan               *string              `json:"plan,omitempty"`
+	Attendees          *string              `json:"attendees,omitempty"`
+	ActionItems        *string              `json:"actionItems,omitempty"`
+	ActualDurationMin  *int                 `json:"actualDurationMin,omitempty"`
+}
+
+// SearchCallRequestsResponse is the portal's response for POST /call-requests/search.
+type SearchCallRequestsResponse struct {
+	CallRequests []CallRequestSummary `json:"callRequests"`
+	Total        int                  `json:"total"`
+	Offset       int                  `json:"offset"`
+	Limit        int                  `json:"limit"`
+}
+
+// MapSearchCallRequests builds the portal response from entity-service's SearchCallRequestsResponse.
+func MapSearchCallRequests(r entity.SearchCallRequestsResponse) SearchCallRequestsResponse {
+	items := make([]CallRequestSummary, 0, len(r.CallRequests))
+	for _, v := range r.CallRequests {
+		items = append(items, CallRequestSummary{
+			ID:                 v.ID,
+			Number:             v.Number,
+			Case:               CallRequestCase{ID: v.Case.ID, Name: v.Case.Name, Number: v.Case.Number},
+			Reason:             v.Reason,
+			PreferredTimes:     v.PreferredTimes,
+			DurationMin:        v.DurationMin,
+			ScheduleTime:       v.ScheduleTime,
+			MeetingLink:        v.MeetingLink,
+			CreatedOn:          v.CreatedOn,
+			UpdatedOn:          v.UpdatedOn,
+			State:              CallRequestStateInfo{ID: v.State.ID, Label: v.State.Label},
+			CancellationReason: v.CancellationReason,
+			Assignee:           v.Assignee,
+			Notes:              v.Notes,
+			Plan:               v.Plan,
+			Attendees:          v.Attendees,
+			ActionItems:        v.ActionItems,
+			ActualDurationMin:  v.ActualDurationMin,
+		})
+	}
+	return SearchCallRequestsResponse{
+		CallRequests: items,
+		Total:        r.Total,
+		Offset:       r.Offset,
+		Limit:        r.Limit,
+	}
+}
+
+// CallRequestUpdateRequest is the portal's request shape for
+// PATCH /call-requests/{id} — a deliberately restricted subset of
+// entity-service's UpdateCallRequestRequest. Excluded fields are agent-side
+// actions entity-service itself documents as "set when an engineer schedules
+// or concludes the call" — MeetingDate, Assignee, Notes, Plan, Attendees,
+// ActionItems, ActualDurationMin — none of which a customer should be able
+// to set on their own call request.
+type CallRequestUpdateRequest struct {
+	State              string   `json:"state"`
+	CancellationReason *string  `json:"cancellationReason,omitempty"`
+	UTCTimes           []string `json:"utcTimes,omitempty"`
+	DurationMinutes    *int     `json:"durationInMinutes,omitempty"`
+}
+
+// BuildEntityUpdateCallRequestRequest converts the portal's restricted update
+// request into entity-service's full request shape, leaving every excluded
+// (agent-side) field nil.
+func BuildEntityUpdateCallRequestRequest(req CallRequestUpdateRequest) entity.UpdateCallRequestRequest {
+	return entity.UpdateCallRequestRequest{
+		State:              req.State,
+		CancellationReason: req.CancellationReason,
+		UTCTimes:           req.UTCTimes,
+		DurationMinutes:    req.DurationMinutes,
+	}
+}
+
+// CallRequestUpdateResponse is the portal's response for PATCH /call-requests/{id}.
+// Deliberately excludes entity-service's UpdatedBy (internal actor identity),
+// consistent with the other update responses in this package.
+type CallRequestUpdateResponse struct {
+	ID        string `json:"id"`
+	UpdatedOn string `json:"updatedOn"`
+}
+
+// MapCallRequestUpdate builds the portal response from entity-service's UpdateCallRequestResponse.
+func MapCallRequestUpdate(r entity.UpdateCallRequestResponse) CallRequestUpdateResponse {
+	return CallRequestUpdateResponse{
+		ID:        r.CallRequest.ID,
+		UpdatedOn: r.CallRequest.UpdatedOn,
+	}
+}

--- a/apps/customer-portal/backend-v2/internal/dto/change_request.go
+++ b/apps/customer-portal/backend-v2/internal/dto/change_request.go
@@ -1,0 +1,307 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dto
+
+import "github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+
+// ChangeRequestCreateRequest is the portal's request shape for
+// POST /change-requests — a deliberately restricted subset of
+// entity-service's CreateChangeRequestRequest. Excluded fields are internal
+// WSO2 support operations, not customer self-service actions: GroupID/
+// AssignedEngineerID (support team/engineer assignment), State (entity-service
+// defaults this; a customer shouldn't set the initial workflow state
+// directly), RequestedByID (an arbitrary "on behalf of" WSO2/ServiceNow user
+// id — not something an external customer has or should supply), and
+// WorkNote (an internal support annotation, same rationale as excluding
+// entity-service's "work_note" comment type from case comments).
+type ChangeRequestCreateRequest struct {
+	Subject             string  `json:"subject"`
+	Category            *string `json:"category,omitempty"`
+	ServiceID           *string `json:"serviceId,omitempty"`
+	ServiceOfferingID   *string `json:"serviceOfferingId,omitempty"`
+	ConfigurationItemID *string `json:"configurationItemId,omitempty"`
+	Priority            *string `json:"priority,omitempty"`
+	Impact              *string `json:"impact,omitempty"`
+	Type                *string `json:"type,omitempty"`
+	Risk                *string `json:"risk,omitempty"`
+	Description         *string `json:"description,omitempty"`
+	Justification       *string `json:"justification,omitempty"`
+	ImplementationPlan  *string `json:"implementationPlan,omitempty"`
+	RiskImpactAnalysis  *string `json:"riskImpactAnalysis,omitempty"`
+	BackoutPlan         *string `json:"backoutPlan,omitempty"`
+	TestPlan            *string `json:"testPlan,omitempty"`
+	PlannedStartDate    *string `json:"plannedStartDate,omitempty"`
+	PlannedEndDate      *string `json:"plannedEndDate,omitempty"`
+	Comment             *string `json:"comment,omitempty"`
+}
+
+// BuildEntityCreateChangeRequestRequest converts the portal's restricted
+// create request into entity-service's full request shape, leaving every
+// excluded field nil.
+func BuildEntityCreateChangeRequestRequest(req ChangeRequestCreateRequest) entity.CreateChangeRequestRequest {
+	return entity.CreateChangeRequestRequest{
+		Subject:             req.Subject,
+		Category:            req.Category,
+		ServiceID:           req.ServiceID,
+		ServiceOfferingID:   req.ServiceOfferingID,
+		ConfigurationItemID: req.ConfigurationItemID,
+		Priority:            req.Priority,
+		Impact:              req.Impact,
+		Type:                req.Type,
+		Risk:                req.Risk,
+		Description:         req.Description,
+		Justification:       req.Justification,
+		ImplementationPlan:  req.ImplementationPlan,
+		RiskImpactAnalysis:  req.RiskImpactAnalysis,
+		BackoutPlan:         req.BackoutPlan,
+		TestPlan:            req.TestPlan,
+		PlannedStartDate:    req.PlannedStartDate,
+		PlannedEndDate:      req.PlannedEndDate,
+		Comment:             req.Comment,
+	}
+}
+
+// ChangeRequestCreateResponse is the portal's response for POST /change-requests.
+type ChangeRequestCreateResponse struct {
+	ID        string `json:"id"`
+	Number    string `json:"number"`
+	CreatedOn string `json:"createdOn"`
+}
+
+// MapChangeRequestCreate builds the portal response from entity-service's CreateChangeRequestResponse.
+func MapChangeRequestCreate(r entity.CreateChangeRequestResponse) ChangeRequestCreateResponse {
+	return ChangeRequestCreateResponse{
+		ID:        r.ChangeRequest.ID,
+		Number:    r.ChangeRequest.Number,
+		CreatedOn: r.ChangeRequest.CreatedOn,
+	}
+}
+
+// ChangeRequestSummary is one item of the portal's response for
+// POST /change-requests/search.
+type ChangeRequestSummary struct {
+	ID               string  `json:"id"`
+	Number           string  `json:"number"`
+	Subject          *string `json:"subject,omitempty"`
+	Description      *string `json:"description,omitempty"`
+	Project          Ref     `json:"project"`
+	Case             *Ref    `json:"case,omitempty"`
+	Deployment       *Ref    `json:"deployment,omitempty"`
+	DeployedProduct  *Ref    `json:"deployedProduct,omitempty"`
+	Product          *Ref    `json:"product,omitempty"`
+	AssignedEngineer *Ref    `json:"assignedEngineer,omitempty"`
+	AssignedTeam     *Ref    `json:"assignedTeam,omitempty"`
+	PlannedStartOn   *string `json:"plannedStartOn,omitempty"`
+	PlannedEndOn     *string `json:"plannedEndOn,omitempty"`
+	Duration         *string `json:"duration,omitempty"`
+	Impact           *string `json:"impact,omitempty"`
+	State            *string `json:"state,omitempty"`
+	Type             *string `json:"type,omitempty"`
+	CreatedOn        string  `json:"createdOn"`
+	UpdatedOn        string  `json:"updatedOn"`
+}
+
+// SearchChangeRequestsResponse is the portal's response for POST /change-requests/search.
+type SearchChangeRequestsResponse struct {
+	ChangeRequests []ChangeRequestSummary `json:"changeRequests"`
+	Total          int                    `json:"total"`
+	Offset         int                    `json:"offset"`
+	Limit          int                    `json:"limit"`
+}
+
+func mapChangeRequestSummary(v entity.SearchChangeRequestView) ChangeRequestSummary {
+	return ChangeRequestSummary{
+		ID:               v.ID,
+		Number:           v.Number,
+		Subject:          v.Subject,
+		Description:      v.Description,
+		Project:          Ref{ID: v.Project.ID, Name: v.Project.Name},
+		Case:             mapRef(v.Case),
+		Deployment:       mapRef(v.Deployment),
+		DeployedProduct:  mapRef(v.DeployedProduct),
+		Product:          mapRef(v.Product),
+		AssignedEngineer: mapRef(v.AssignedEngineer),
+		AssignedTeam:     mapRef(v.AssignedTeam),
+		PlannedStartOn:   v.PlannedStartOn,
+		PlannedEndOn:     v.PlannedEndOn,
+		Duration:         v.Duration,
+		Impact:           v.Impact,
+		State:            v.State,
+		Type:             v.Type,
+		CreatedOn:        v.CreatedOn,
+		UpdatedOn:        v.UpdatedOn,
+	}
+}
+
+// MapSearchChangeRequests builds the portal response from entity-service's SearchChangeRequestsResponse.
+func MapSearchChangeRequests(r entity.SearchChangeRequestsResponse) SearchChangeRequestsResponse {
+	items := make([]ChangeRequestSummary, 0, len(r.ChangeRequests))
+	for _, v := range r.ChangeRequests {
+		items = append(items, mapChangeRequestSummary(v))
+	}
+	return SearchChangeRequestsResponse{
+		ChangeRequests: items,
+		Total:          r.Total,
+		Offset:         r.Offset,
+		Limit:          r.Limit,
+	}
+}
+
+// ChangeRequestDetails is the portal's response for GET /change-requests/{id}
+// and PATCH /change-requests/{id}.
+type ChangeRequestDetails struct {
+	ChangeRequestSummary
+	CreatedBy           string   `json:"createdBy"`
+	Justification       *string  `json:"justification,omitempty"`
+	ImpactDescription   *string  `json:"impactDescription,omitempty"`
+	ServiceOutage       *string  `json:"serviceOutage,omitempty"`
+	CommunicationPlan   *string  `json:"communicationPlan,omitempty"`
+	RollbackPlan        *string  `json:"rollbackPlan,omitempty"`
+	TestPlan            *string  `json:"testPlan,omitempty"`
+	HasCustomerApproved bool     `json:"hasCustomerApproved"`
+	HasCustomerReviewed bool     `json:"hasCustomerReviewed"`
+	ApprovedBy          *Ref     `json:"approvedBy,omitempty"`
+	ApprovedOn          *string  `json:"approvedOn,omitempty"`
+	LegalNextStates     []string `json:"legalNextStates,omitempty"`
+}
+
+// MapChangeRequestDetails builds the portal response from entity-service's ChangeRequest.
+func MapChangeRequestDetails(r entity.ChangeRequest) ChangeRequestDetails {
+	return ChangeRequestDetails{
+		ChangeRequestSummary: mapChangeRequestSummary(r.SearchChangeRequestView),
+		CreatedBy:            r.CreatedBy,
+		Justification:        r.Justification,
+		ImpactDescription:    r.ImpactDescription,
+		ServiceOutage:        r.ServiceOutage,
+		CommunicationPlan:    r.CommunicationPlan,
+		RollbackPlan:         r.RollbackPlan,
+		TestPlan:             r.TestPlan,
+		HasCustomerApproved:  r.HasCustomerApproved,
+		HasCustomerReviewed:  r.HasCustomerReviewed,
+		ApprovedBy:           mapRef(r.ApprovedBy),
+		ApprovedOn:           r.ApprovedOn,
+		LegalNextStates:      r.LegalNextStates,
+	}
+}
+
+// ChangeRequestUpdateRequest is the portal's request shape for
+// PATCH /change-requests/{id} — a deliberately restricted subset of
+// entity-service's PatchChangeRequestRequest. Excluded fields are internal
+// WSO2 support operations: ProjectID/CaseID/DeploymentID/DeployedProductID
+// (change-request relinking), AssignedEngineerID/AssignedTeamID (support
+// assignment), and State (state transitions are driven through the
+// dedicated approval workflow — IsCustomerApproved/IsCustomerReviewed/
+// RequestApproval below — not by setting state directly).
+type ChangeRequestUpdateRequest struct {
+	Title              *string `json:"title,omitempty"`
+	Description        *string `json:"description,omitempty"`
+	PlannedStartOn     *string `json:"plannedStartOn,omitempty"`
+	PlannedEndOn       *string `json:"plannedEndOn,omitempty"`
+	Impact             *string `json:"impact,omitempty"`
+	Type               *string `json:"type,omitempty"`
+	Justification      *string `json:"justification,omitempty"`
+	ImpactDescription  *string `json:"impactDescription,omitempty"`
+	ServiceOutage      *string `json:"serviceOutage,omitempty"`
+	CommunicationPlan  *string `json:"communicationPlan,omitempty"`
+	RollbackPlan       *string `json:"rollbackPlan,omitempty"`
+	TestPlan           *string `json:"testPlan,omitempty"`
+	IsCustomerApproved *bool   `json:"isCustomerApproved,omitempty"`
+	IsCustomerReviewed *bool   `json:"isCustomerReviewed,omitempty"`
+	RequestApproval    *bool   `json:"requestApproval,omitempty"`
+}
+
+// BuildEntityPatchChangeRequestRequest converts the portal's restricted
+// update request into entity-service's full request shape, leaving every
+// excluded field nil.
+func BuildEntityPatchChangeRequestRequest(req ChangeRequestUpdateRequest) entity.PatchChangeRequestRequest {
+	return entity.PatchChangeRequestRequest{
+		Title:              req.Title,
+		Description:        req.Description,
+		PlannedStartOn:     req.PlannedStartOn,
+		PlannedEndOn:       req.PlannedEndOn,
+		Impact:             req.Impact,
+		Type:               req.Type,
+		Justification:      req.Justification,
+		ImpactDescription:  req.ImpactDescription,
+		ServiceOutage:      req.ServiceOutage,
+		CommunicationPlan:  req.CommunicationPlan,
+		RollbackPlan:       req.RollbackPlan,
+		TestPlan:           req.TestPlan,
+		IsCustomerApproved: req.IsCustomerApproved,
+		IsCustomerReviewed: req.IsCustomerReviewed,
+		RequestApproval:    req.RequestApproval,
+	}
+}
+
+// ChangeRequestApprover is a single approver's response within an approval stage.
+type ChangeRequestApprover struct {
+	ID          string  `json:"id"`
+	Name        string  `json:"name"`
+	Status      string  `json:"status"`
+	RespondedOn *string `json:"respondedOn,omitempty"`
+}
+
+// ChangeRequestApproval represents a single approval stage on a change request.
+type ChangeRequestApproval struct {
+	Stage        string                  `json:"stage"`
+	ApproverType string                  `json:"approverType"`
+	ApproverName string                  `json:"approverName"`
+	Status       string                  `json:"status"`
+	Approvers    []ChangeRequestApprover `json:"approvers"`
+}
+
+// ChangeRequestApprovals is the portal's response for GET /change-requests/{id}/approvals.
+type ChangeRequestApprovals struct {
+	Approvals []ChangeRequestApproval `json:"approvals"`
+}
+
+// MapChangeRequestApprovals builds the portal response from entity-service's ChangeRequestApprovals.
+func MapChangeRequestApprovals(r entity.ChangeRequestApprovals) ChangeRequestApprovals {
+	approvals := make([]ChangeRequestApproval, 0, len(r.Approvals))
+	for _, a := range r.Approvals {
+		approvers := make([]ChangeRequestApprover, 0, len(a.Approvers))
+		for _, ap := range a.Approvers {
+			approvers = append(approvers, ChangeRequestApprover{
+				ID:          ap.ID,
+				Name:        ap.Name,
+				Status:      ap.Status,
+				RespondedOn: ap.RespondedOn,
+			})
+		}
+		approvals = append(approvals, ChangeRequestApproval{
+			Stage:        a.Stage,
+			ApproverType: a.ApproverType,
+			ApproverName: a.ApproverName,
+			Status:       a.Status,
+			Approvers:    approvers,
+		})
+	}
+	return ChangeRequestApprovals{Approvals: approvals}
+}
+
+// ChangeRequestApprovalDecisionResponse is the portal's response for
+// POST /change-requests/{id}/approvals/decision.
+type ChangeRequestApprovalDecisionResponse struct {
+	ID    string `json:"id"`
+	State string `json:"state"`
+}
+
+// MapChangeRequestApprovalDecision builds the portal response from
+// entity-service's ChangeRequestApprovalDecisionResponse.
+func MapChangeRequestApprovalDecision(r entity.ChangeRequestApprovalDecisionResponse) ChangeRequestApprovalDecisionResponse {
+	return ChangeRequestApprovalDecisionResponse{ID: r.ID, State: r.State}
+}

--- a/apps/customer-portal/backend-v2/internal/entity/call_requests.go
+++ b/apps/customer-portal/backend-v2/internal/entity/call_requests.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package entity
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+)
+
+// CreateCallRequest calls POST /call-requests.
+//
+// NOTE: entity-service only supports call requests on its ServiceNow data
+// source — a Postgres-mode deployment 404s on every route in this file.
+func (c *Client) CreateCallRequest(ctx context.Context, req CreateCallRequestRequest) (CreateCallRequestResponse, error) {
+	var out CreateCallRequestResponse
+	err := c.postJSON(ctx, "/call-requests", req, &out)
+	return out, err
+}
+
+// SearchCallRequests calls POST /call-requests/search.
+func (c *Client) SearchCallRequests(ctx context.Context, req SearchCallRequestsRequest) (SearchCallRequestsResponse, error) {
+	var out SearchCallRequestsResponse
+	err := c.postJSON(ctx, "/call-requests/search", req, &out)
+	return out, err
+}
+
+// UpdateCallRequest calls PATCH /call-requests/{id}.
+func (c *Client) UpdateCallRequest(ctx context.Context, id string, req UpdateCallRequestRequest) (UpdateCallRequestResponse, error) {
+	req.ID = id // never serialized (json:"-"); set for consistency with the struct's doc comment
+	var out UpdateCallRequestResponse
+	err := c.patchJSON(ctx, fmt.Sprintf("/call-requests/%s", url.PathEscape(id)), req, &out)
+	return out, err
+}

--- a/apps/customer-portal/backend-v2/internal/entity/change_requests.go
+++ b/apps/customer-portal/backend-v2/internal/entity/change_requests.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package entity
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+)
+
+// CreateChangeRequest calls POST /change-requests.
+//
+// NOTE: entity-service only supports change requests on its ServiceNow data
+// source — a Postgres-mode deployment 404s on every route in this file.
+func (c *Client) CreateChangeRequest(ctx context.Context, req CreateChangeRequestRequest) (CreateChangeRequestResponse, error) {
+	var out CreateChangeRequestResponse
+	err := c.postJSON(ctx, "/change-requests", req, &out)
+	return out, err
+}
+
+// SearchChangeRequests calls POST /change-requests/search.
+func (c *Client) SearchChangeRequests(ctx context.Context, req SearchChangeRequestsRequest) (SearchChangeRequestsResponse, error) {
+	var out SearchChangeRequestsResponse
+	err := c.postJSON(ctx, "/change-requests/search", req, &out)
+	return out, err
+}
+
+// GetChangeRequest calls GET /change-requests/{id}.
+func (c *Client) GetChangeRequest(ctx context.Context, id string) (ChangeRequest, error) {
+	var out ChangeRequest
+	err := c.getJSON(ctx, fmt.Sprintf("/change-requests/%s", url.PathEscape(id)), &out)
+	return out, err
+}
+
+// UpdateChangeRequest calls PATCH /change-requests/{id}.
+func (c *Client) UpdateChangeRequest(ctx context.Context, id string, req PatchChangeRequestRequest) (PatchChangeRequestResponse, error) {
+	var out PatchChangeRequestResponse
+	err := c.patchJSON(ctx, fmt.Sprintf("/change-requests/%s", url.PathEscape(id)), req, &out)
+	return out, err
+}
+
+// GetChangeRequestApprovals calls GET /change-requests/{id}/approvals.
+func (c *Client) GetChangeRequestApprovals(ctx context.Context, id string) (ChangeRequestApprovals, error) {
+	var out ChangeRequestApprovals
+	err := c.getJSON(ctx, fmt.Sprintf("/change-requests/%s/approvals", url.PathEscape(id)), &out)
+	return out, err
+}
+
+// DecideChangeRequestApproval calls POST /change-requests/{id}/approvals/decision.
+func (c *Client) DecideChangeRequestApproval(ctx context.Context, id string, req ChangeRequestApprovalDecisionRequest) (ChangeRequestApprovalDecisionResponse, error) {
+	var out ChangeRequestApprovalDecisionResponse
+	err := c.postJSON(ctx, fmt.Sprintf("/change-requests/%s/approvals/decision", url.PathEscape(id)), req, &out)
+	return out, err
+}

--- a/apps/customer-portal/backend-v2/internal/entity/types.go
+++ b/apps/customer-portal/backend-v2/internal/entity/types.go
@@ -968,12 +968,12 @@ type ChangeRequestSort struct {
 
 // SearchChangeRequestsFilters holds the optional filter criteria for a change request search.
 type SearchChangeRequestsFilters struct {
-	ProjectIDs      []string   `json:"projectIds,omitempty"`
-	SearchQuery     string     `json:"searchQuery,omitempty"`
-	States          []string   `json:"states,omitempty"`
-	Impacts         []string   `json:"impacts,omitempty"`
-	ClosedStartDate *time.Time `json:"closedStartDate,omitempty"`
-	ClosedEndDate   *time.Time `json:"closedEndDate,omitempty"`
+	ProjectIDs      []string `json:"projectIds,omitempty"`
+	SearchQuery     string   `json:"searchQuery,omitempty"`
+	States          []string `json:"states,omitempty"`
+	Impacts         []string `json:"impacts,omitempty"`
+	ClosedStartDate *string  `json:"closedStartDate,omitempty"`
+	ClosedEndDate   *string  `json:"closedEndDate,omitempty"`
 }
 
 // SearchChangeRequestsRequest is the input for POST /change-requests/search.

--- a/apps/customer-portal/backend-v2/internal/entity/types.go
+++ b/apps/customer-portal/backend-v2/internal/entity/types.go
@@ -909,3 +909,321 @@ type SearchProductVersionsResponse struct {
 	Offset          int                  `json:"offset"`
 	HasMore         bool                 `json:"hasMore"`
 }
+
+// --- change requests ---
+//
+// entity-service only supports change requests on its ServiceNow data
+// source — DATA_SOURCE=postgres deployments don't register these routes at
+// all (404, not a data-shape difference like accounts/products).
+
+// CreateChangeRequestRequest is the input for POST /change-requests. Subject
+// is the only required field. entity-service's category/priority/impact/
+// type/state/risk fields are plain strings here (not named Go enum types),
+// matching this file's convention elsewhere (e.g. CaseView.Severity).
+type CreateChangeRequestRequest struct {
+	Subject             string  `json:"subject"`
+	Category            *string `json:"category,omitempty"`
+	ServiceID           *string `json:"serviceId,omitempty"`
+	ServiceOfferingID   *string `json:"serviceOfferingId,omitempty"`
+	ConfigurationItemID *string `json:"configurationItemId,omitempty"`
+	Priority            *string `json:"priority,omitempty"`
+	Impact              *string `json:"impact,omitempty"`
+	Type                *string `json:"type,omitempty"`
+	State               *string `json:"state,omitempty"`
+	GroupID             *string `json:"groupId,omitempty"`
+	AssignedEngineerID  *string `json:"assignedEngineerId,omitempty"`
+	Risk                *string `json:"risk,omitempty"`
+	RequestedByID       *string `json:"requestedById,omitempty"`
+	Description         *string `json:"description,omitempty"`
+	Justification       *string `json:"justification,omitempty"`
+	ImplementationPlan  *string `json:"implementationPlan,omitempty"`
+	RiskImpactAnalysis  *string `json:"riskImpactAnalysis,omitempty"`
+	BackoutPlan         *string `json:"backoutPlan,omitempty"`
+	TestPlan            *string `json:"testPlan,omitempty"`
+	PlannedStartDate    *string `json:"plannedStartDate,omitempty"`
+	PlannedEndDate      *string `json:"plannedEndDate,omitempty"`
+	Comment             *string `json:"comment,omitempty"`
+	WorkNote            *string `json:"workNote,omitempty"`
+}
+
+// ChangeRequestCreated carries the key fields of a newly created change request.
+type ChangeRequestCreated struct {
+	ID        string `json:"id"`
+	Number    string `json:"number"`
+	CreatedOn string `json:"createdOn"`
+	CreatedBy string `json:"createdBy"`
+}
+
+// CreateChangeRequestResponse is entity-service's response for POST /change-requests.
+type CreateChangeRequestResponse struct {
+	Message       string               `json:"message"`
+	ChangeRequest ChangeRequestCreated `json:"changeRequest"`
+}
+
+// ChangeRequestSort specifies the sort field and direction for change request search results.
+type ChangeRequestSort struct {
+	Field string `json:"field,omitempty"`
+	Order string `json:"order,omitempty"`
+}
+
+// SearchChangeRequestsFilters holds the optional filter criteria for a change request search.
+type SearchChangeRequestsFilters struct {
+	ProjectIDs      []string   `json:"projectIds,omitempty"`
+	SearchQuery     string     `json:"searchQuery,omitempty"`
+	States          []string   `json:"states,omitempty"`
+	Impacts         []string   `json:"impacts,omitempty"`
+	ClosedStartDate *time.Time `json:"closedStartDate,omitempty"`
+	ClosedEndDate   *time.Time `json:"closedEndDate,omitempty"`
+}
+
+// SearchChangeRequestsRequest is the input for POST /change-requests/search.
+type SearchChangeRequestsRequest struct {
+	Filters    SearchChangeRequestsFilters `json:"filters"`
+	SortBy     ChangeRequestSort           `json:"sortBy"`
+	Pagination Pagination                  `json:"pagination"`
+}
+
+// SearchChangeRequestView is a single search result item from POST /change-requests/search.
+type SearchChangeRequestView struct {
+	ID               string     `json:"id"`
+	Number           string     `json:"number"`
+	Subject          *string    `json:"subject"`
+	Description      *string    `json:"description"`
+	Project          EntityRef  `json:"project"`
+	Case             *EntityRef `json:"case"`
+	Deployment       *EntityRef `json:"deployment"`
+	DeployedProduct  *EntityRef `json:"deployedProduct"`
+	Product          *EntityRef `json:"product"`
+	AssignedEngineer *EntityRef `json:"assignedEngineer"`
+	AssignedTeam     *EntityRef `json:"assignedTeam"`
+	PlannedStartOn   *string    `json:"plannedStartOn"`
+	PlannedEndOn     *string    `json:"plannedEndOn"`
+	Duration         *string    `json:"duration"`
+	Impact           *string    `json:"impact"`
+	State            *string    `json:"state"`
+	Type             *string    `json:"type"`
+	CreatedOn        string     `json:"createdOn"`
+	UpdatedOn        string     `json:"updatedOn"`
+}
+
+// SearchChangeRequestsResponse is entity-service's response for POST /change-requests/search.
+type SearchChangeRequestsResponse struct {
+	ChangeRequests []SearchChangeRequestView `json:"changeRequests"`
+	Total          int                       `json:"total"`
+	Offset         int                       `json:"offset"`
+	Limit          int                       `json:"limit"`
+}
+
+// ChangeRequest is entity-service's response for GET /change-requests/{id}.
+// Embeds SearchChangeRequestView (matching entity-service's own struct
+// embedding, which flattens its fields into the same JSON object).
+type ChangeRequest struct {
+	SearchChangeRequestView
+	CreatedBy           string     `json:"createdBy"`
+	Justification       *string    `json:"justification"`
+	ImpactDescription   *string    `json:"impactDescription"`
+	ServiceOutage       *string    `json:"serviceOutage"`
+	CommunicationPlan   *string    `json:"communicationPlan"`
+	RollbackPlan        *string    `json:"rollbackPlan"`
+	TestPlan            *string    `json:"testPlan"`
+	HasCustomerApproved bool       `json:"hasCustomerApproved"`
+	HasCustomerReviewed bool       `json:"hasCustomerReviewed"`
+	ApprovedBy          *EntityRef `json:"approvedBy"`
+	ApprovedOn          *string    `json:"approvedOn"`
+	LegalNextStates     []string   `json:"legalNextStates"`
+}
+
+// PatchChangeRequestRequest is the full field set entity-service accepts for
+// PATCH /change-requests/{id}. This is entity-service's raw contract — the
+// portal only exposes a customer-safe subset; see
+// dto.ChangeRequestUpdateRequest for which ones and why.
+type PatchChangeRequestRequest struct {
+	Title              *string `json:"title,omitempty"`
+	Description        *string `json:"description,omitempty"`
+	ProjectID          *string `json:"projectId,omitempty"`
+	CaseID             *string `json:"caseId,omitempty"`
+	DeploymentID       *string `json:"deploymentId,omitempty"`
+	DeployedProductID  *string `json:"deployedProductId,omitempty"`
+	AssignedEngineerID *string `json:"assignedEngineerId,omitempty"`
+	AssignedTeamID     *string `json:"assignedTeamId,omitempty"`
+	PlannedStartOn     *string `json:"plannedStartOn,omitempty"`
+	PlannedEndOn       *string `json:"plannedEndOn,omitempty"`
+	Impact             *string `json:"impact,omitempty"`
+	State              *string `json:"state,omitempty"`
+	Type               *string `json:"type,omitempty"`
+	Justification      *string `json:"justification,omitempty"`
+	ImpactDescription  *string `json:"impactDescription,omitempty"`
+	ServiceOutage      *string `json:"serviceOutage,omitempty"`
+	CommunicationPlan  *string `json:"communicationPlan,omitempty"`
+	RollbackPlan       *string `json:"rollbackPlan,omitempty"`
+	TestPlan           *string `json:"testPlan,omitempty"`
+	IsCustomerApproved *bool   `json:"isCustomerApproved,omitempty"`
+	IsCustomerReviewed *bool   `json:"isCustomerReviewed,omitempty"`
+	RequestApproval    *bool   `json:"requestApproval,omitempty"`
+}
+
+// PatchChangeRequestResponse is entity-service's response for PATCH /change-requests/{id}.
+type PatchChangeRequestResponse struct {
+	Message       string        `json:"message"`
+	ChangeRequest ChangeRequest `json:"changeRequest"`
+}
+
+// ChangeRequestApprover is a single approver's response within an approval
+// stage. Status is deliberately a plain string, not a closed enum —
+// entity-service documents it as an open set (APPROVED, NOT_REQUIRED,
+// REQUESTED, REJECTED, CANCELLED, NO_CONSENSUS, or an unrecognized
+// uppercased value).
+type ChangeRequestApprover struct {
+	ID          string  `json:"id"`
+	Name        string  `json:"name"`
+	Status      string  `json:"status"`
+	RespondedOn *string `json:"respondedOn"`
+}
+
+// ChangeRequestApproval represents a single approval stage (e.g. Assess,
+// Authorize, Customer Approval) on a change request.
+type ChangeRequestApproval struct {
+	Stage        string                  `json:"stage"`
+	ApproverType string                  `json:"approverType"`
+	ApproverName string                  `json:"approverName"`
+	Status       string                  `json:"status"`
+	Approvers    []ChangeRequestApprover `json:"approvers"`
+}
+
+// ChangeRequestApprovals is entity-service's response for GET /change-requests/{id}/approvals.
+type ChangeRequestApprovals struct {
+	Approvals []ChangeRequestApproval `json:"approvals"`
+}
+
+// ChangeRequestApprovalDecisionRequest is the input for
+// POST /change-requests/{id}/approvals/decision. Decision is a plain string
+// ("approved" or "rejected" per entity-service's doc comment), not an enum type.
+type ChangeRequestApprovalDecisionRequest struct {
+	Decision string `json:"decision"`
+}
+
+// ChangeRequestApprovalDecisionResponse is entity-service's response for
+// POST /change-requests/{id}/approvals/decision.
+type ChangeRequestApprovalDecisionResponse struct {
+	ID    string `json:"id"`
+	State string `json:"state"`
+}
+
+// --- call requests ---
+//
+// entity-service only supports call requests on its ServiceNow data source.
+
+// CreateCallRequestRequest is the input for POST /call-requests.
+type CreateCallRequestRequest struct {
+	CaseID          string   `json:"caseId"`
+	Reason          string   `json:"reason"`
+	UTCTimes        []string `json:"utcTimes"`
+	DurationMinutes int      `json:"durationInMinutes"`
+}
+
+// CallRequestCreated carries the key fields of a newly created call request.
+type CallRequestCreated struct {
+	ID        string `json:"id"`
+	CreatedOn string `json:"createdOn"`
+	CreatedBy string `json:"createdBy"`
+	State     string `json:"state"`
+}
+
+// CreateCallRequestResponse is entity-service's response for POST /call-requests.
+type CreateCallRequestResponse struct {
+	Message     string             `json:"message"`
+	CallRequest CallRequestCreated `json:"callRequest"`
+}
+
+// CallRequestState holds the state of a call request: ID is the string state
+// enum key, Label is the human-readable display label.
+type CallRequestState struct {
+	ID    string `json:"id"`
+	Label string `json:"label"`
+}
+
+// CallRequestCaseRef is a reference to a case embedded in a call request.
+type CallRequestCaseRef struct {
+	ID     string  `json:"id"`
+	Name   string  `json:"name"`
+	Number *string `json:"number,omitempty"`
+}
+
+// SearchCallRequestsFilters holds the optional filter criteria for a call request search.
+type SearchCallRequestsFilters struct {
+	States []string `json:"states,omitempty"`
+}
+
+// SearchCallRequestsRequest is the input for POST /call-requests/search.
+type SearchCallRequestsRequest struct {
+	CaseID     string                     `json:"caseId"`
+	Filters    *SearchCallRequestsFilters `json:"filters,omitempty"`
+	Pagination Pagination                 `json:"pagination"`
+}
+
+// CallRequestView is a single search result item from POST /call-requests/search.
+// Assignee/Notes/Plan/Attendees/ActionItems/ActualDurationMin are agent-side
+// fields, populated once a support engineer schedules or concludes the call.
+type CallRequestView struct {
+	ID                 string             `json:"id"`
+	Number             string             `json:"number"`
+	Case               CallRequestCaseRef `json:"case"`
+	Reason             *string            `json:"reason"`
+	PreferredTimes     []string           `json:"preferredTimes"`
+	DurationMin        int                `json:"durationMin"`
+	ScheduleTime       *string            `json:"scheduleTime"`
+	MeetingLink        *string            `json:"meetingLink"`
+	CreatedOn          string             `json:"createdOn"`
+	UpdatedOn          string             `json:"updatedOn"`
+	State              CallRequestState   `json:"state"`
+	CancellationReason *string            `json:"cancellationReason,omitempty"`
+	Assignee           *string            `json:"assignee,omitempty"`
+	Notes              *string            `json:"notes,omitempty"`
+	Plan               *string            `json:"plan,omitempty"`
+	Attendees          *string            `json:"attendees,omitempty"`
+	ActionItems        *string            `json:"actionItems,omitempty"`
+	ActualDurationMin  *int               `json:"actualDurationMin,omitempty"`
+}
+
+// SearchCallRequestsResponse is entity-service's response for POST /call-requests/search.
+type SearchCallRequestsResponse struct {
+	CallRequests []CallRequestView `json:"callRequests"`
+	Total        int               `json:"total"`
+	Offset       int               `json:"offset"`
+	Limit        int               `json:"limit"`
+}
+
+// UpdateCallRequestRequest is the full field set entity-service accepts for
+// PATCH /call-requests/{id}. This is entity-service's raw contract — the
+// portal only exposes a customer-safe subset; see
+// dto.CallRequestUpdateRequest for which ones and why (the agent-side
+// fields below must never be customer-settable).
+type UpdateCallRequestRequest struct {
+	ID                 string   `json:"-"`
+	CaseID             string   `json:"caseId,omitempty"`
+	State              string   `json:"state"`
+	CancellationReason *string  `json:"cancellationReason,omitempty"`
+	UTCTimes           []string `json:"utcTimes,omitempty"`
+	DurationMinutes    *int     `json:"durationInMinutes,omitempty"`
+	// Agent-side fields, set when an engineer schedules or concludes the call.
+	MeetingDate       *string `json:"meetingDate,omitempty"`
+	Assignee          *string `json:"assignee,omitempty"`
+	Notes             *string `json:"notes,omitempty"`
+	Plan              *string `json:"plan,omitempty"`
+	Attendees         *string `json:"attendees,omitempty"`
+	ActionItems       *string `json:"actionItems,omitempty"`
+	ActualDurationMin *int    `json:"actualDurationMin,omitempty"`
+}
+
+// CallRequestUpdated carries the fields that may change after an update.
+type CallRequestUpdated struct {
+	ID        string `json:"id"`
+	UpdatedOn string `json:"updatedOn"`
+	UpdatedBy string `json:"updatedBy"`
+}
+
+// UpdateCallRequestResponse is entity-service's response for PATCH /call-requests/{id}.
+type UpdateCallRequestResponse struct {
+	Message     string             `json:"message"`
+	CallRequest CallRequestUpdated `json:"callRequest"`
+}

--- a/apps/customer-portal/backend-v2/internal/handler/call_requests.go
+++ b/apps/customer-portal/backend-v2/internal/handler/call_requests.go
@@ -1,0 +1,146 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/dto"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/middleware"
+)
+
+// entityCallRequestClient abstracts the entity-service call-request
+// operations used by CallRequestHandler.
+type entityCallRequestClient interface {
+	CreateCallRequest(ctx context.Context, req entity.CreateCallRequestRequest) (entity.CreateCallRequestResponse, error)
+	SearchCallRequests(ctx context.Context, req entity.SearchCallRequestsRequest) (entity.SearchCallRequestsResponse, error)
+	UpdateCallRequest(ctx context.Context, id string, req entity.UpdateCallRequestRequest) (entity.UpdateCallRequestResponse, error)
+}
+
+// CallRequestHandler handles HTTP requests for call-request operations.
+//
+// NOTE: entity-service only supports call requests on its ServiceNow data
+// source — a Postgres-mode deployment 404s on every route this handler serves.
+type CallRequestHandler struct {
+	entity entityCallRequestClient
+}
+
+// NewCallRequestHandler creates a CallRequestHandler backed by the given entity client.
+func NewCallRequestHandler(entity entityCallRequestClient) *CallRequestHandler {
+	return &CallRequestHandler{entity: entity}
+}
+
+// CreateCallRequest handles POST /call-requests.
+func (h *CallRequestHandler) CreateCallRequest(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	body, ok := readJSONBody(w, r)
+	if !ok {
+		return
+	}
+
+	var req entity.CreateCallRequestRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.CreateCallRequest(r.Context(), req)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity CreateCallRequest failed", "userID", user.UserID, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to create call request.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusCreated, dto.MapCallRequestCreate(result))
+}
+
+// SearchCallRequests handles POST /call-requests/search.
+func (h *CallRequestHandler) SearchCallRequests(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	body, ok := readJSONBody(w, r)
+	if !ok {
+		return
+	}
+
+	var req entity.SearchCallRequestsRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.SearchCallRequests(r.Context(), req)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity SearchCallRequests failed", "userID", user.UserID, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to search call requests.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusOK, dto.MapSearchCallRequests(result))
+}
+
+// PatchCallRequest handles PATCH /call-requests/{id}.
+func (h *CallRequestHandler) PatchCallRequest(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	id := r.PathValue("id")
+	if id == "" || !uuidRe.MatchString(id) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	body, ok := readJSONBody(w, r)
+	if !ok {
+		return
+	}
+
+	var req dto.CallRequestUpdateRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+	if req.State == "" {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.UpdateCallRequest(r.Context(), id, dto.BuildEntityUpdateCallRequestRequest(req))
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity UpdateCallRequest failed", "userID", user.UserID, "callRequestID", id, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to update call request.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusOK, dto.MapCallRequestUpdate(result))
+}

--- a/apps/customer-portal/backend-v2/internal/handler/call_requests.go
+++ b/apps/customer-portal/backend-v2/internal/handler/call_requests.go
@@ -66,6 +66,10 @@ func (h *CallRequestHandler) CreateCallRequest(w http.ResponseWriter, r *http.Re
 		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
 		return
 	}
+	if !uuidRe.MatchString(req.CaseID) || req.Reason == "" || len(req.UTCTimes) == 0 || req.DurationMinutes <= 0 {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
 
 	result, err := h.entity.CreateCallRequest(r.Context(), req)
 	if err != nil {
@@ -92,6 +96,10 @@ func (h *CallRequestHandler) SearchCallRequests(w http.ResponseWriter, r *http.R
 
 	var req entity.SearchCallRequestsRequest
 	if err := json.Unmarshal(body, &req); err != nil {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+	if !uuidRe.MatchString(req.CaseID) {
 		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
 		return
 	}

--- a/apps/customer-portal/backend-v2/internal/handler/change_requests.go
+++ b/apps/customer-portal/backend-v2/internal/handler/change_requests.go
@@ -1,0 +1,240 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/dto"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/middleware"
+)
+
+// entityChangeRequestClient abstracts the entity-service change-request
+// operations used by ChangeRequestHandler.
+type entityChangeRequestClient interface {
+	CreateChangeRequest(ctx context.Context, req entity.CreateChangeRequestRequest) (entity.CreateChangeRequestResponse, error)
+	SearchChangeRequests(ctx context.Context, req entity.SearchChangeRequestsRequest) (entity.SearchChangeRequestsResponse, error)
+	GetChangeRequest(ctx context.Context, id string) (entity.ChangeRequest, error)
+	UpdateChangeRequest(ctx context.Context, id string, req entity.PatchChangeRequestRequest) (entity.PatchChangeRequestResponse, error)
+	GetChangeRequestApprovals(ctx context.Context, id string) (entity.ChangeRequestApprovals, error)
+	DecideChangeRequestApproval(ctx context.Context, id string, req entity.ChangeRequestApprovalDecisionRequest) (entity.ChangeRequestApprovalDecisionResponse, error)
+}
+
+// ChangeRequestHandler handles HTTP requests for change-request operations.
+//
+// NOTE: entity-service only supports change requests on its ServiceNow data
+// source — a Postgres-mode deployment 404s on every route this handler serves.
+type ChangeRequestHandler struct {
+	entity entityChangeRequestClient
+}
+
+// NewChangeRequestHandler creates a ChangeRequestHandler backed by the given entity client.
+func NewChangeRequestHandler(entity entityChangeRequestClient) *ChangeRequestHandler {
+	return &ChangeRequestHandler{entity: entity}
+}
+
+// CreateChangeRequest handles POST /change-requests.
+func (h *ChangeRequestHandler) CreateChangeRequest(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	body, ok := readJSONBody(w, r)
+	if !ok {
+		return
+	}
+
+	var req dto.ChangeRequestCreateRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+	if req.Subject == "" {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.CreateChangeRequest(r.Context(), dto.BuildEntityCreateChangeRequestRequest(req))
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity CreateChangeRequest failed", "userID", user.UserID, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to create change request.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusCreated, dto.MapChangeRequestCreate(result))
+}
+
+// SearchChangeRequests handles POST /change-requests/search.
+func (h *ChangeRequestHandler) SearchChangeRequests(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	body, ok := readJSONBody(w, r)
+	if !ok {
+		return
+	}
+
+	var req entity.SearchChangeRequestsRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.SearchChangeRequests(r.Context(), req)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity SearchChangeRequests failed", "userID", user.UserID, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to search change requests.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusOK, dto.MapSearchChangeRequests(result))
+}
+
+// GetChangeRequest handles GET /change-requests/{id}.
+func (h *ChangeRequestHandler) GetChangeRequest(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	id := r.PathValue("id")
+	if id == "" || !uuidRe.MatchString(id) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	result, err := h.entity.GetChangeRequest(r.Context(), id)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity GetChangeRequest failed", "userID", user.UserID, "changeRequestID", id, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to retrieve change request.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusOK, dto.MapChangeRequestDetails(result))
+}
+
+// PatchChangeRequest handles PATCH /change-requests/{id}.
+func (h *ChangeRequestHandler) PatchChangeRequest(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	id := r.PathValue("id")
+	if id == "" || !uuidRe.MatchString(id) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	body, ok := readJSONBody(w, r)
+	if !ok {
+		return
+	}
+
+	var req dto.ChangeRequestUpdateRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+	if req == (dto.ChangeRequestUpdateRequest{}) {
+		writeError(w, http.StatusBadRequest, "At least one field must be provided for update.")
+		return
+	}
+
+	result, err := h.entity.UpdateChangeRequest(r.Context(), id, dto.BuildEntityPatchChangeRequestRequest(req))
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity UpdateChangeRequest failed", "userID", user.UserID, "changeRequestID", id, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to update change request.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusOK, dto.MapChangeRequestDetails(result.ChangeRequest))
+}
+
+// GetChangeRequestApprovals handles GET /change-requests/{id}/approvals.
+func (h *ChangeRequestHandler) GetChangeRequestApprovals(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	id := r.PathValue("id")
+	if id == "" || !uuidRe.MatchString(id) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	result, err := h.entity.GetChangeRequestApprovals(r.Context(), id)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity GetChangeRequestApprovals failed", "userID", user.UserID, "changeRequestID", id, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to retrieve change request approvals.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusOK, dto.MapChangeRequestApprovals(result))
+}
+
+// DecideChangeRequestApproval handles POST /change-requests/{id}/approvals/decision.
+func (h *ChangeRequestHandler) DecideChangeRequestApproval(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	id := r.PathValue("id")
+	if id == "" || !uuidRe.MatchString(id) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	body, ok := readJSONBody(w, r)
+	if !ok {
+		return
+	}
+
+	var req entity.ChangeRequestApprovalDecisionRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+	if req.Decision != "approved" && req.Decision != "rejected" {
+		writeError(w, http.StatusBadRequest, "decision must be \"approved\" or \"rejected\".")
+		return
+	}
+
+	result, err := h.entity.DecideChangeRequestApproval(r.Context(), id, req)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity DecideChangeRequestApproval failed", "userID", user.UserID, "changeRequestID", id, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to record approval decision.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusOK, dto.MapChangeRequestApprovalDecision(result))
+}

--- a/apps/customer-portal/backend-v2/openapi.yaml
+++ b/apps/customer-portal/backend-v2/openapi.yaml
@@ -1227,6 +1227,497 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
+  /change-requests:
+    post:
+      summary: Create a change request.
+      description: Only entity-service's ServiceNow data source supports this route.
+      operationId: postChangeRequests
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChangeRequestCreateRequest'
+        required: true
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChangeRequestCreateResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /change-requests/search:
+    post:
+      summary: Search change requests.
+      description: Only entity-service's ServiceNow data source supports this route.
+      operationId: postChangeRequestsSearch
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SearchChangeRequestsRequest'
+        required: true
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchChangeRequestsResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /change-requests/{id}:
+    get:
+      summary: Get a change request by ID.
+      description: Only entity-service's ServiceNow data source supports this route.
+      operationId: getChangeRequestsId
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChangeRequestDetails'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: NotFound
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+    patch:
+      summary: Update a change request.
+      description: >
+        At least one field is required. Only entity-service's ServiceNow data
+        source supports this route. State transitions are driven through
+        isCustomerApproved/isCustomerReviewed/requestApproval, not by setting
+        state directly.
+      operationId: patchChangeRequestsId
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChangeRequestUpdateRequest'
+        required: true
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChangeRequestDetails'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: NotFound
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /change-requests/{id}/approvals:
+    get:
+      summary: Get a change request's approval stages.
+      description: Only entity-service's ServiceNow data source supports this route.
+      operationId: getChangeRequestsIdApprovals
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChangeRequestApprovals'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: NotFound
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /change-requests/{id}/approvals/decision:
+    post:
+      summary: Record the caller's decision on their own pending change-request approval.
+      description: Only entity-service's ServiceNow data source supports this route.
+      operationId: postChangeRequestsIdApprovalsDecision
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChangeRequestApprovalDecisionRequest'
+        required: true
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChangeRequestApprovalDecisionResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: NotFound
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /call-requests:
+    post:
+      summary: Create a call request.
+      description: Only entity-service's ServiceNow data source supports this route.
+      operationId: postCallRequests
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateCallRequestRequest'
+        required: true
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CallRequestCreateResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /call-requests/search:
+    post:
+      summary: Search call requests.
+      description: >
+        Scoped by caseId in the request body (not a path segment). Only
+        entity-service's ServiceNow data source supports this route.
+      operationId: postCallRequestsSearch
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SearchCallRequestsRequest'
+        required: true
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchCallRequestsResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /call-requests/{id}:
+    patch:
+      summary: Update a call request.
+      description: >
+        state is required. Agent-side fields (meetingDate, assignee, notes,
+        plan, attendees, actionItems, actualDurationMin) are read-only for
+        the customer and not accepted here — see CallRequestSummary for
+        viewing them. Only entity-service's ServiceNow data source supports
+        this route.
+      operationId: patchCallRequestsId
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CallRequestUpdateRequest'
+        required: true
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CallRequestUpdateResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: NotFound
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
   /updates/product-update-levels:
     get:
       summary: Get product update levels.
@@ -2384,6 +2875,426 @@ components:
           type: integer
         hasMore:
           type: boolean
+
+    # ---- change requests ----
+
+    ChangeRequestCreateRequest:
+      type: object
+      required: [subject]
+      properties:
+        subject:
+          type: string
+        category:
+          type: string
+        serviceId:
+          type: string
+          format: uuid
+        serviceOfferingId:
+          type: string
+          format: uuid
+        configurationItemId:
+          type: string
+          format: uuid
+        priority:
+          type: string
+        impact:
+          type: string
+        type:
+          type: string
+        risk:
+          type: string
+        description:
+          type: string
+        justification:
+          type: string
+        implementationPlan:
+          type: string
+        riskImpactAnalysis:
+          type: string
+        backoutPlan:
+          type: string
+        testPlan:
+          type: string
+        plannedStartDate:
+          type: string
+        plannedEndDate:
+          type: string
+        comment:
+          type: string
+
+    ChangeRequestCreateResponse:
+      type: object
+      properties:
+        id:
+          type: string
+        number:
+          type: string
+        createdOn:
+          type: string
+
+    SearchChangeRequestsRequest:
+      type: object
+      properties:
+        filters:
+          type: object
+          properties:
+            projectIds:
+              type: array
+              items:
+                type: string
+            searchQuery:
+              type: string
+            states:
+              type: array
+              items:
+                type: string
+            impacts:
+              type: array
+              items:
+                type: string
+            closedStartDate:
+              type: string
+            closedEndDate:
+              type: string
+        sortBy:
+          type: object
+          properties:
+            field:
+              type: string
+            order:
+              type: string
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+
+    ChangeRequestSummary:
+      type: object
+      properties:
+        id:
+          type: string
+        number:
+          type: string
+        subject:
+          type: string
+        description:
+          type: string
+        project:
+          $ref: '#/components/schemas/Ref'
+        case:
+          $ref: '#/components/schemas/Ref'
+        deployment:
+          $ref: '#/components/schemas/Ref'
+        deployedProduct:
+          $ref: '#/components/schemas/Ref'
+        product:
+          $ref: '#/components/schemas/Ref'
+        assignedEngineer:
+          $ref: '#/components/schemas/Ref'
+        assignedTeam:
+          $ref: '#/components/schemas/Ref'
+        plannedStartOn:
+          type: string
+        plannedEndOn:
+          type: string
+        duration:
+          type: string
+        impact:
+          type: string
+        state:
+          type: string
+        type:
+          type: string
+        createdOn:
+          type: string
+        updatedOn:
+          type: string
+
+    SearchChangeRequestsResponse:
+      type: object
+      properties:
+        changeRequests:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChangeRequestSummary'
+        total:
+          type: integer
+        offset:
+          type: integer
+        limit:
+          type: integer
+
+    ChangeRequestDetails:
+      allOf:
+        - $ref: '#/components/schemas/ChangeRequestSummary'
+        - type: object
+          properties:
+            createdBy:
+              type: string
+            justification:
+              type: string
+            impactDescription:
+              type: string
+            serviceOutage:
+              type: string
+            communicationPlan:
+              type: string
+            rollbackPlan:
+              type: string
+            testPlan:
+              type: string
+            hasCustomerApproved:
+              type: boolean
+            hasCustomerReviewed:
+              type: boolean
+            approvedBy:
+              $ref: '#/components/schemas/Ref'
+            approvedOn:
+              type: string
+            legalNextStates:
+              type: array
+              items:
+                type: string
+
+    ChangeRequestUpdateRequest:
+      description: >
+        At least one field is required. State transitions are driven through
+        isCustomerApproved/isCustomerReviewed/requestApproval, not by
+        setting state directly.
+      type: object
+      properties:
+        title:
+          type: string
+        description:
+          type: string
+        plannedStartOn:
+          type: string
+        plannedEndOn:
+          type: string
+        impact:
+          type: string
+        type:
+          type: string
+        justification:
+          type: string
+        impactDescription:
+          type: string
+        serviceOutage:
+          type: string
+        communicationPlan:
+          type: string
+        rollbackPlan:
+          type: string
+        testPlan:
+          type: string
+        isCustomerApproved:
+          type: boolean
+        isCustomerReviewed:
+          type: boolean
+        requestApproval:
+          type: boolean
+
+    ChangeRequestApprover:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        status:
+          type: string
+        respondedOn:
+          type: string
+
+    ChangeRequestApproval:
+      type: object
+      properties:
+        stage:
+          type: string
+        approverType:
+          type: string
+          description: "\"STATIC_GROUP\" or \"DYNAMIC_CONTACT\""
+        approverName:
+          type: string
+        status:
+          type: string
+          description: "\"APPROVED\", \"REJECTED\", or \"PENDING\""
+        approvers:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChangeRequestApprover'
+
+    ChangeRequestApprovals:
+      type: object
+      properties:
+        approvals:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChangeRequestApproval'
+
+    ChangeRequestApprovalDecisionRequest:
+      type: object
+      required: [decision]
+      properties:
+        decision:
+          type: string
+          description: "\"approved\" or \"rejected\""
+
+    ChangeRequestApprovalDecisionResponse:
+      type: object
+      properties:
+        id:
+          type: string
+        state:
+          type: string
+
+    # ---- call requests ----
+
+    CreateCallRequestRequest:
+      type: object
+      required: [caseId, reason, utcTimes, durationInMinutes]
+      properties:
+        caseId:
+          type: string
+          format: uuid
+        reason:
+          type: string
+        utcTimes:
+          type: array
+          items:
+            type: string
+        durationInMinutes:
+          type: integer
+
+    CallRequestCreateResponse:
+      type: object
+      properties:
+        id:
+          type: string
+        createdOn:
+          type: string
+        state:
+          type: string
+
+    SearchCallRequestsRequest:
+      type: object
+      required: [caseId]
+      properties:
+        caseId:
+          type: string
+          format: uuid
+        filters:
+          type: object
+          properties:
+            states:
+              type: array
+              items:
+                type: string
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+
+    CallRequestStateInfo:
+      type: object
+      properties:
+        id:
+          type: string
+        label:
+          type: string
+
+    CallRequestCase:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        number:
+          type: string
+
+    CallRequestSummary:
+      description: >
+        assignee/notes/plan/attendees/actionItems/actualDurationMin are
+        agent-side fields, populated once a support engineer schedules or
+        concludes the call.
+      type: object
+      properties:
+        id:
+          type: string
+        number:
+          type: string
+        case:
+          $ref: '#/components/schemas/CallRequestCase'
+        reason:
+          type: string
+        preferredTimes:
+          type: array
+          items:
+            type: string
+        durationMin:
+          type: integer
+        scheduleTime:
+          type: string
+        meetingLink:
+          type: string
+        createdOn:
+          type: string
+        updatedOn:
+          type: string
+        state:
+          $ref: '#/components/schemas/CallRequestStateInfo'
+        cancellationReason:
+          type: string
+        assignee:
+          type: string
+        notes:
+          type: string
+        plan:
+          type: string
+        attendees:
+          type: string
+        actionItems:
+          type: string
+        actualDurationMin:
+          type: integer
+
+    SearchCallRequestsResponse:
+      type: object
+      properties:
+        callRequests:
+          type: array
+          items:
+            $ref: '#/components/schemas/CallRequestSummary'
+        total:
+          type: integer
+        offset:
+          type: integer
+        limit:
+          type: integer
+
+    CallRequestUpdateRequest:
+      description: >
+        Agent-side fields (meetingDate, assignee, notes, plan, attendees,
+        actionItems, actualDurationMin) are read-only for the customer and
+        not accepted here.
+      type: object
+      required: [state]
+      properties:
+        state:
+          type: string
+        cancellationReason:
+          type: string
+        utcTimes:
+          type: array
+          items:
+            type: string
+        durationInMinutes:
+          type: integer
+
+    CallRequestUpdateResponse:
+      type: object
+      properties:
+        id:
+          type: string
+        updatedOn:
+          type: string
 
     # ---- updates ----
 


### PR DESCRIPTION
## Summary
Adds 9 more endpoints to `apps/customer-portal/backend-v2` (35 total), both ServiceNow-only:

- **Change requests**: `POST /change-requests`, `POST /change-requests/search`, `GET /change-requests/{id}`, `PATCH /change-requests/{id}`, `GET /change-requests/{id}/approvals`, `POST /change-requests/{id}/approvals/decision`.
- **Call requests**: `POST /call-requests`, `POST /call-requests/search`, `PATCH /call-requests/{id}`.

Both create/update endpoints use restricted portal request DTOs, continuing the case-update pattern:
- `ChangeRequestCreateRequest` excludes `groupId`/`assignedEngineerId` (support assignment), `requestedById` (an arbitrary "on behalf of" WSO2 user id), and `workNote` (internal annotation).
- `ChangeRequestUpdateRequest` excludes case/project/deployment relinking and `assignedEngineerId`/`assignedTeamId`, plus `state` itself — state transitions go through `isCustomerApproved`/`isCustomerReviewed`/`requestApproval` instead, which *are* kept since they're the customer's own approval actions.
- `CallRequestUpdateRequest` excludes `meetingDate`/`assignee`/`notes`/`plan`/`attendees`/`actionItems`/`actualDurationMin` — entity-service's own doc comment calls these "agent-side fields, set when an engineer schedules or concludes the call." Still exposed on the *read* side so the customer can see the outcome.

Two design notes now called out explicitly in CLAUDE.md so they don't get misapplied later:
- `PATCH /deployed-products/{id}`'s `deploymentId` field looks similar to the excluded relinking fields above but isn't restricted — entity-service documents it as an IDOR-style scope guard the caller supplies voluntarily, not a relinking mechanism. Read the entity-service doc comment before restricting a field, don't pattern-match on field shape alone.
- `PATCH /cases/{id}` requires *exactly one* primary field; `PATCH /change-requests/{id}` requires *at least one* — both per entity-service's own doc comments, which differ. Verified in testing below that both validation rules are enforced correctly and independently.

Also updates `openapi.yaml` (9 new paths, ~24 new schemas), `README.md`, and `CLAUDE.md`.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` all clean
- [x] `gosec -fmt=text ./...` reports 0 issues
- [x] `openapi.yaml` validated as well-formed YAML with all 9 new paths/schemas present
- [x] Manually verified: missing required fields (subject, state) → 400; change-request PATCH at-least-one rule and call-request PATCH required-state rule both enforced; invalid approval decision value → 400; invalid UUID path params → 400; valid requests against an unreachable upstream map cleanly to 500 (no leakage)
- [ ] Wire up against a real running entity-service instance (ServiceNow data source required for every route in this PR)

## Linked issues
Closes wso2-enterprise/wso2-digital-team-project-management#863
Closes wso2-enterprise/wso2-digital-team-project-management#864
Closes wso2-enterprise/wso2-digital-team-project-management#865
Closes wso2-enterprise/wso2-digital-team-project-management#866
Closes wso2-enterprise/wso2-digital-team-project-management#867
Closes wso2-enterprise/wso2-digital-team-project-management#868
Closes wso2-enterprise/wso2-digital-team-project-management#869
Closes wso2-enterprise/wso2-digital-team-project-management#870
Closes wso2-enterprise/wso2-digital-team-project-management#871

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added customer portal support for creating, searching, viewing, and updating change requests.
  * Added change-request approval tracking and decision submission.
  * Added call-request creation, search, scheduling updates, and cancellation support.
  * Added authentication, request validation, and customer-editable field restrictions.
* **Documentation**
  * Updated API documentation with new routes, request formats, response schemas, and usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
