### PR TITLE
[Customer Portal v2][BE] Add deployment update, comments, product vulnerabilities, catalogs, time cards, and AI chat agent endpoints

### DIFF
--- a/apps/customer-portal/backend-v2/.choreo/component.yaml
+++ b/apps/customer-portal/backend-v2/.choreo/component.yaml
@@ -10,3 +10,13 @@ endpoints:
     networkVisibilities:
       - Public
     schemaFilePath: openapi.yaml
+
+  - name: customer-portal-websocket
+    displayName: Customer Portal Websocket
+    service:
+      basePath: /
+      port: 8080
+    type: WS
+    networkVisibilities:
+      - Public
+    schemaFilePath: asyncapi.yaml

--- a/apps/customer-portal/backend-v2/.env.example
+++ b/apps/customer-portal/backend-v2/.env.example
@@ -26,6 +26,10 @@ AI_CHAT_AGENT_BASE_URL=
 AI_CHAT_AGENT_SCOPES=
 AI_CHAT_AGENT_WS_BASE_URL=
 AI_CHAT_AGENT_WS_SCOPES=
+# Comma-separated browser Origins allowed to open GET /ws (defense in depth
+# against cross-site WebSocket hijacking). Leave unset to allow any origin —
+# local development only.
+WS_ALLOWED_ORIGINS=
 
 # Auth
 # AUTH_TOKEN_VALIDATOR_ENABLED=false (below) skips JWT signature verification —

--- a/apps/customer-portal/backend-v2/.env.example
+++ b/apps/customer-portal/backend-v2/.env.example
@@ -19,6 +19,14 @@ UPDATES_SCOPES=
 SCIM_BASE_URL=
 SCIM_SCOPES=
 
+# AI chat agent — a separate Python service (not entity-service) powering
+# case classification, chat, and KB recommendations. Authenticates as the
+# same shared OAuth2 app as the services above; only the base URLs differ.
+AI_CHAT_AGENT_BASE_URL=
+AI_CHAT_AGENT_SCOPES=
+AI_CHAT_AGENT_WS_BASE_URL=
+AI_CHAT_AGENT_WS_SCOPES=
+
 # Auth
 # AUTH_TOKEN_VALIDATOR_ENABLED=false (below) skips JWT signature verification —
 # local development only. Production MUST set it to true with a real

--- a/apps/customer-portal/backend-v2/CLAUDE.md
+++ b/apps/customer-portal/backend-v2/CLAUDE.md
@@ -6,22 +6,33 @@ responses for the frontend. This is a Go rewrite of the Ballerina backend at
 `apps/customer-portal/backend`, modeled on `apps/csm-portal/backend`'s conventions — read that
 backend's own CLAUDE.md too if something here is underspecified.
 
-**Status: in progress.** 35 routes are wired up so far (`GET /health`, `GET`/`PATCH /users/me`,
+**Status: in progress.** 50 routes are wired up so far (`GET /health`, `GET`/`PATCH /users/me`,
 `POST /accounts/search`, `GET /accounts/{id}`, `POST /projects/search`, `GET /projects/{id}`,
 `POST /cases/search`, `GET /cases/{id}`, `POST /cases`, `PATCH /cases/{id}`,
 `POST /cases/{id}/comments`, `POST /cases/{id}/activities/search`, `POST /deployments/search`,
-`POST /deployments`, `POST /deployed-products/search`, `POST /deployed-products`,
-`PATCH /deployed-products/{id}`, `POST /attachments`, `POST /attachments/search`,
-`GET /attachments/{id}/content`, `DELETE /attachments/{id}`, `POST /products/search`,
-`POST /products/{id}/versions/search`, `POST /change-requests`, `POST /change-requests/search`,
-`GET /change-requests/{id}`, `PATCH /change-requests/{id}`, `GET /change-requests/{id}/approvals`,
-`POST /change-requests/{id}/approvals/decision`, `POST /call-requests`,
-`POST /call-requests/search`, `PATCH /call-requests/{id}`, `GET /updates/product-update-levels`,
-`POST /updates/levels/search`) across three upstream services: entity-service, the WSO2 Updates
-service, and SCIM. The Ballerina backend exposes ~100 routes across many more modules (generic
-comments, conversations, catalogs, time cards, registry tokens, contacts, escalations, product
-vulnerabilities, incidents, problems, task SLAs, tasks, groups/service-offerings/configuration-items,
-AI chat/websocket, etc.) — none of those are ported yet. Follow the recipe below to add the next one.
+`POST /deployments`, `PATCH /deployments/{id}`, `POST /deployed-products/search`,
+`POST /deployed-products`, `PATCH /deployed-products/{id}`, `POST /attachments`,
+`POST /attachments/search`, `GET /attachments/{id}/content`, `DELETE /attachments/{id}`,
+`POST /products/search`, `POST /products/{id}/versions/search`,
+`POST /products/vulnerabilities/search`, `GET /products/vulnerabilities/{id}`,
+`POST /catalogs/search`, `GET /catalogs/{catalogId}/items/{catalogItemId}/variables`,
+`POST /time-cards/search`, `POST /comments`, `POST /comments/search`, `POST /change-requests`,
+`POST /change-requests/search`, `GET /change-requests/{id}`, `PATCH /change-requests/{id}`,
+`GET /change-requests/{id}/approvals`, `POST /change-requests/{id}/approvals/decision`,
+`POST /call-requests`, `POST /call-requests/search`, `PATCH /call-requests/{id}`,
+`POST /cases/classify`, `POST /conversations/recommendations/search`,
+`POST /projects/{id}/conversations/search`, `GET /conversations/{id}/messages`,
+`POST /projects/{projectId}/conversations/{conversationId}/messages`,
+`GET /projects/{id}/conversations/{conversationId}/summary`, `GET /ws`,
+`GET /updates/product-update-levels`, `POST /updates/levels/search`) across four upstream
+services: entity-service, the WSO2 Updates service, SCIM, and the AI chat agent (see "The AI chat
+agent" below — unlike the other three, it isn't entity-service-backed at all). The Ballerina
+backend exposes ~100 routes across many more modules (registry tokens, escalations, incidents,
+problems, task SLAs, tasks, groups/service-offerings/configuration-items, account/project contacts,
+project update, generic user search, etc.) — none of those are ported yet, several because they
+have no genuine equivalent on `cs-tools/entity-service` or aren't actually customer-portal features
+at all (see "Which entity-service" below on how to tell the difference before porting one). Follow
+the recipe below to add the next one.
 
 ## Which entity-service
 
@@ -36,6 +47,22 @@ deployment will 404 on those. If the Ballerina backend has an endpoint with no `
 equivalent at all (e.g. `GET /metadata` — entity-service has no metadata endpoint), do not invent
 one; add a code comment at the call site noting the gap and flag it instead of fabricating a
 response.
+
+**Existing on `cs-tools/entity-service` is necessary but not sufficient — also confirm the
+Ballerina backend actually exposes it as a customer-portal feature.** `cs-tools/entity-service`
+implements plenty of routes this backend should *not* port: some are genuinely customer-facing but
+belong to a different portal (e.g. `POST /cases/{id}/github-issues` — filing an engineering bug
+against an internal repo is a support-agent action with zero precedent anywhere in the Ballerina
+customer-portal backend), and some read like customer features but the Ballerina backend actually
+serves the equivalent from an entirely different, non-`cs-tools` microservice (e.g.
+`POST /accounts/{id}/contacts/search` / `POST /projects/{id}/contacts/search` look like read
+analogues of the Ballerina backend's project-contact endpoints, but those are actually backed by
+the separate `user_management` module/microservice, not entity-service at all — porting the
+`cs-tools/entity-service` version would expose a different, unrelated dataset under a
+similar-looking URL). Before implementing anything new, grep
+`apps/customer-portal/backend/modules/entity/entity.bal` (or the relevant sibling module) for the
+Ballerina function that would call it, and check what it actually resolves to — a route only earns
+a place in this backend once both checks pass.
 
 ## Other upstream services
 
@@ -54,9 +81,52 @@ private `do()` shape as `internal/entity`:
   struct, so it's merged directly into `dto.UserMeResponse`/`dto.UserUpdateResponse` in
   `internal/handler/users.go` — again no separate mapping layer needed.
 
-All three service clients (entity, updates, SCIM) authenticate as the same shared OAuth2
-client-credentials app in `cmd/server/main.go` — only each service's `*_BASE_URL`/`*_SCOPES` env
-vars differ.
+All four service clients (entity, updates, SCIM, the AI chat agent) authenticate as the same shared
+OAuth2 client-credentials app in `cmd/server/main.go` — only each service's `*_BASE_URL`/`*_SCOPES`
+env vars differ (confirmed against the Ballerina backend's `Config.toml`, where every module,
+including the AI chat agent's WebSocket variant, declares the same `clientId`/`tokenUrl`).
+
+## The AI chat agent
+
+`internal/aichatagent` is a fourth upstream client, but unlike entity/updates/SCIM it talks to a
+**separate Python service that has no relationship to `cs-tools/entity-service` at all** — see
+`apps/customer-portal/backend`'s `modules/ai_chat_agent` for the Ballerina backend's equivalent
+client. It has its own HTTP API (`internal/aichatagent/client.go`) and a distinct WebSocket
+endpoint (`internal/aichatagent/ws.go`, using `github.com/gorilla/websocket` — the one third-party
+dependency in this otherwise-stdlib-only backend, since `net/http` has no server-side WebSocket
+support).
+
+`internal/handler/ai_chat.go` (case classification, KB recommendations, conversation search,
+conversation messages, conversation summary) and `internal/handler/websocket.go` (the real-time
+chat proxy) both mix calls to the AI agent with calls to entity-service's conversation/comment
+routes — mirroring the Ballerina backend's own design (a conversation thread lives in
+entity-service; the AI agent only handles the live message exchange). Three entity-service gaps
+block a full 1:1 port, all flagged with `TODO(entity-service)` at their call sites rather than
+worked around — do not build a workaround for these; wait for the actual entity-service methods:
+
+- **No `createConversation` / `updateConversation`** — only `POST /conversations/search` exists
+  (see `internal/entity/conversations.go`). This blocks: starting a brand-new AI chat conversation
+  (`POST /projects/{id}/conversations` from the Ballerina backend is not ported at all — there is no
+  way to mint a conversation ID), and marking a conversation `resolved` when the AI agent reports
+  `resolved: true` (skipped in both `internal/handler/ai_chat.go`'s `SendConversationMessage` and
+  `internal/handler/websocket.go`).
+- **No `createdBy` override on `entity.CreateCommentRequest`** — the Ballerina backend attributes
+  the AI agent's own reply to a special "chat agent" identity when saving it as a comment;
+  `cs-tools/entity-service` always attributes a created comment to the caller's own authenticated
+  identity. Since there is no way to correctly attribute the AI's reply, this backend does **not**
+  save it as a comment at all (only the customer's own message is saved, since that attribution is
+  correct as-is) — saving it under the wrong identity would be worse than not saving it.
+
+`GET /ws?sessionId={projectId}` keeps the Ballerina backend's query parameter name for wire
+compatibility even though it actually carries the *project* ID, not a session ID — the AI agent's
+own per-conversation session key is derived as `"{projectId}:{conversationId}"` inside the handler.
+Because a brand-new conversation can't be created (see above), this endpoint only supports
+*resuming* an existing conversation — the browser must supply a `conversationId` in its first
+message, or the handler returns an `error` event rather than silently failing. One simplification
+versus the Ballerina backend: Go's `http.Server` runs each upgraded connection in its own
+goroutine, processing one message at a time in a blocking loop, so there's no need for the
+Ballerina implementation's explicit "already streaming" busy-flag/mutex — a second incoming message
+simply can't arrive until the handler returns from the first.
 
 ## Middleware chain
 
@@ -110,6 +180,17 @@ here, it's resolved once in the mapper. Also deliberately excluded from account 
 technique — e.g. `ProductVersionView.ReleaseDate` is typed `*string` even though the Postgres shape
 is `time.Time` and the ServiceNow shape is a plain string, because a Go `*string` field decodes a
 JSON string value regardless of which the source type actually was.
+
+**When the Ballerina backend exposes a thinner shape than entity-service's own struct, match the
+Ballerina backend, not entity-service.** `POST /time-cards/search`'s `dto.TimeCardSummary` excludes
+entity-service's per-category time breakdowns (`timeAnalyzing`, `timeSettingUp`, etc.),
+`issueComplexity`, `workLogComment`, `rejectionReason`, and the eligible-approvers list — not
+because any of them are individually dangerous, but because the Ballerina backend's own `TimeCard`
+type (`apps/customer-portal/backend/modules/entity/types.bal`) never exposed them either. When
+porting an endpoint, read the Ballerina backend's response type for the equivalent feature, not just
+the request/response pair on `cs-tools/entity-service` — the Ballerina shape is itself a design
+decision about what a customer should see, and entity-service's superset shouldn't leak through it
+by default.
 
 **`json.RawMessage` on a request field usually means "preserve three states," not "skip validation."**
 `entity.UpdateDeployedProductRequest.Description` is `json.RawMessage` specifically so entity-service
@@ -165,6 +246,13 @@ Two more examples, both in this same "restrict, don't mirror" category:
   labels these "agent-side fields, set when an engineer schedules or concludes the call." They're
   still exposed on the *read* side (`dto.CallRequestSummary`) since the customer should be able to
   see the outcome of their own call, just not set it themselves.
+- `POST /comments` / `POST /comments/search` (generic comments — distinct from `POST /cases/{id}/comments`,
+  these attach to any reference entity: case, conversation, change_request, deployment, incident)
+  restrict in *both* directions: `dto.BuildEntityCreateCommentRequest` forces `type: comment` on
+  write for the same reason as case comments, and `dto.BuildEntitySearchCommentsRequest` forces
+  `filters.type: comment` on **read** too — entity-service's search endpoint returns `work_note`
+  entries verbatim unless the caller filters them out, and those are internal WSO2 annotations that
+  must never reach the customer regardless of which reference entity they're attached to.
 
 **Not every field worth restricting is a security decision — some are just an unenforced entity-service
 scoping convenience.** `PATCH /deployed-products/{id}`'s `deploymentId` field looks similar to the

--- a/apps/customer-portal/backend-v2/CLAUDE.md
+++ b/apps/customer-portal/backend-v2/CLAUDE.md
@@ -128,6 +128,12 @@ goroutine, processing one message at a time in a blocking loop, so there's no ne
 Ballerina implementation's explicit "already streaming" busy-flag/mutex — a second incoming message
 simply can't arrive until the handler returns from the first.
 
+Primary authorization on `GET /ws` is the same JWT middleware chain as every other route.
+`WebSocketHandler`'s `gorilla/websocket.Upgrader.CheckOrigin` adds a defense-in-depth check against
+cross-site WebSocket hijacking, restricting which browser `Origin`s may open the connection — set
+via the optional `WS_ALLOWED_ORIGINS` env var (comma-separated; unset allows any origin, local
+development only).
+
 ## Middleware chain
 
 `SecurityHeaders → CorrelationID → Auth → Logger → Mux`

--- a/apps/customer-portal/backend-v2/CLAUDE.md
+++ b/apps/customer-portal/backend-v2/CLAUDE.md
@@ -124,9 +124,11 @@ Because a brand-new conversation can't be created (see above), this endpoint onl
 *resuming* an existing conversation — the browser must supply a `conversationId` in its first
 message, or the handler returns an `error` event rather than silently failing. One simplification
 versus the Ballerina backend: Go's `http.Server` runs each upgraded connection in its own
-goroutine, processing one message at a time in a blocking loop, so there's no need for the
-Ballerina implementation's explicit "already streaming" busy-flag/mutex — a second incoming message
-simply can't arrive until the handler returns from the first.
+goroutine, and the handler's `ReadMessage` → `handleMessage` loop is a single blocking sequence —
+it does not read or process the next frame until `handleMessage` returns, and never starts a
+concurrent read or upstream stream. So there's no need for the Ballerina implementation's explicit
+"already streaming" busy-flag/mutex; the client can still send another frame at any time, this
+handler simply won't look at it until the current one finishes.
 
 Primary authorization on `GET /ws` is the same JWT middleware chain as every other route.
 `WebSocketHandler`'s `gorilla/websocket.Upgrader.CheckOrigin` adds a defense-in-depth check against

--- a/apps/customer-portal/backend-v2/README.md
+++ b/apps/customer-portal/backend-v2/README.md
@@ -5,8 +5,9 @@ Go rewrite of the Ballerina backend at `apps/customer-portal/backend`. It is a b
 [`entity-service`](../../../entity-service) (this repo's `cs-tools/entity-service`, not the
 `digiops-cs/entity-service` the Ballerina backend targets), and shapes the responses for the frontend.
 
-This is a work in progress — only the 35 routes listed below are implemented so far, across
-entity-service, the WSO2 Updates service, and SCIM. Everything else the Ballerina backend exposes
+This is a work in progress — only the 50 routes listed below are implemented so far, across
+entity-service, the WSO2 Updates service, SCIM, and the AI chat agent (a separate Python service —
+see [CLAUDE.md](./CLAUDE.md#the-ai-chat-agent)). Everything else the Ballerina backend exposes
 still needs a Go handler; add them following the pattern described in
 [CLAUDE.md](./CLAUDE.md#adding-a-new-endpoint).
 
@@ -28,9 +29,9 @@ Backend starts at `http://localhost:8080`.
 - Entry point: `cmd/server/main.go`
 - Authentication:
   - Incoming requests: JWT Bearer token; pass as `x-jwt-assertion` header when testing locally
-  - Outbound calls to entity-service, the Updates service, and SCIM: OAuth2 client credentials
-    grant, shared across all three (optional — entity-service itself does not validate inbound
-    credentials, see [CLAUDE.md](./CLAUDE.md))
+  - Outbound calls to entity-service, the Updates service, SCIM, and the AI chat agent: OAuth2
+    client credentials grant, shared across all four (optional — entity-service itself does not
+    validate inbound credentials, see [CLAUDE.md](./CLAUDE.md))
 
 ## Prerequisites
 
@@ -39,6 +40,8 @@ Backend starts at `http://localhost:8080`.
   `GET`/`PATCH /users/me` require `DATA_SOURCE=servicenow`)
 - A running instance of the WSO2 Updates service and the SCIM operations service (for the
   `/updates/*` routes and phone-number fields on `/users/me`)
+- A running instance of the AI chat agent (a separate Python service, not entity-service — for
+  `/cases/classify`, `/conversations/*`, `/projects/*/conversations/*`, and `/ws`)
 
 ## Testing
 
@@ -77,8 +80,8 @@ Copy `.env.example` to `.env` and fill in the values.
 
 ### Shared OAuth2 client credentials
 
-Every upstream service client (entity-service, updates, SCIM) authenticates as the same OAuth2
-client-credentials app — only each service's base URL and scopes differ.
+Every upstream service client (entity-service, updates, SCIM, the AI chat agent) authenticates as
+the same OAuth2 client-credentials app — only each service's base URL and scopes differ.
 
 | Variable | Description |
 |---|---|
@@ -104,6 +107,17 @@ client-credentials app — only each service's base URL and scopes differ.
 |---|---|
 | `SCIM_BASE_URL` | Base URL of the SCIM operations service |
 | `SCIM_SCOPES` | Comma-separated OAuth2 scopes (optional) |
+
+### AI chat agent
+
+A separate Python service (not entity-service) — see [CLAUDE.md](./CLAUDE.md#the-ai-chat-agent).
+
+| Variable | Description |
+|---|---|
+| `AI_CHAT_AGENT_BASE_URL` | Base URL of the AI chat agent's HTTP API |
+| `AI_CHAT_AGENT_SCOPES` | Comma-separated OAuth2 scopes (optional) |
+| `AI_CHAT_AGENT_WS_BASE_URL` | Base URL of the AI chat agent's WebSocket endpoint |
+| `AI_CHAT_AGENT_WS_SCOPES` | Comma-separated OAuth2 scopes (optional) |
 
 ### Auth
 
@@ -139,7 +153,12 @@ backend-v2/
 │   │   ├── attachments.go       # CreateAttachment, SearchAttachments, GetAttachmentContent, DeleteAttachment
 │   │   ├── products.go          # SearchProducts, SearchProductVersions
 │   │   ├── change_requests.go   # create/search/get/update, approvals get/decide
-│   │   └── call_requests.go     # CreateCallRequest, SearchCallRequests, UpdateCallRequest
+│   │   ├── call_requests.go     # CreateCallRequest, SearchCallRequests, UpdateCallRequest
+│   │   ├── comments.go          # CreateComment, SearchComments (generic, any reference entity)
+│   │   ├── conversations.go     # SearchConversations
+│   │   ├── product_vulnerabilities.go # SearchProductVulnerabilities, GetProductVulnerability
+│   │   ├── catalogs.go          # SearchCatalogs, GetCatalogItemVariables
+│   │   └── time_cards.go        # SearchTimeCards
 │   ├── updates/                 # OAuth2 HTTP client for the WSO2 Updates service
 │   │   ├── client.go            # Config/Client/do()
 │   │   ├── types.go             # upstream (snake_case) vs portal (camelCase) structs
@@ -149,6 +168,10 @@ backend-v2/
 │   │   ├── client.go            # Config/Client/do()
 │   │   ├── types.go
 │   │   └── scim.go              # SearchUser, UpdateUserPhone
+│   ├── aichatagent/              # OAuth2 HTTP + WebSocket client for the AI chat agent (not entity-service)
+│   │   ├── client.go            # Config/Client/do()/getJSON()/postJSON()
+│   │   ├── types.go             # AI chat agent's wire-format structs
+│   │   └── ws.go                # WSConfig/WSClient/StreamChat — proxies the upstream WebSocket
 │   ├── dto/                     # Portal-facing response shapes + Map* functions from entity types
 │   │   ├── user.go
 │   │   ├── account.go
@@ -158,6 +181,11 @@ backend-v2/
 │   │   ├── deployed_product.go
 │   │   ├── attachment.go
 │   │   ├── product.go
+│   │   ├── product_vulnerability.go
+│   │   ├── catalog.go
+│   │   ├── time_card.go
+│   │   ├── comment.go
+│   │   ├── ai_chat.go
 │   │   ├── change_request.go
 │   │   └── call_request.go
 │   ├── middleware/
@@ -171,10 +199,16 @@ backend-v2/
 │       ├── accounts.go          # POST /accounts/search, GET /accounts/{id}
 │       ├── projects.go          # POST /projects/search, GET /projects/{id}
 │       ├── cases.go             # cases search/get/create/update/comment/activities
-│       ├── deployments.go       # POST /deployments/search, POST /deployments
+│       ├── deployments.go       # POST /deployments/search, POST /deployments, PATCH /deployments/{id}
 │       ├── deployed_products.go # deployed-product search/create/update
 │       ├── attachments.go       # attachment create/search/download/delete
 │       ├── products.go          # POST /products/search, POST /products/{id}/versions/search
+│       ├── product_vulnerabilities.go # vulnerability search/get
+│       ├── catalogs.go          # catalog search, catalog item variables
+│       ├── time_cards.go        # POST /time-cards/search
+│       ├── comments.go          # generic comment create/search
+│       ├── ai_chat.go           # case classification, recommendations, conversation search/messages/summary
+│       ├── websocket.go         # GET /ws — real-time AI chat proxy
 │       ├── change_requests.go   # change-request create/search/get/update/approvals
 │       ├── call_requests.go     # call-request create/search/update
 │       └── updates.go           # GET /updates/product-update-levels, POST /updates/levels/search
@@ -201,6 +235,7 @@ backend-v2/
 - `POST /cases/{id}/comments` — add a comment to a case (always a plain customer comment)
 - `POST /deployments/search` — search deployments
 - `POST /deployments` — create a deployment (ServiceNow data source only)
+- `PATCH /deployments/{id}` — update a deployment's name/type/description, or deactivate it
 - `POST /deployed-products/search` — search deployed products
 - `POST /deployed-products` — create a deployed product (ServiceNow data source only)
 - `PATCH /deployed-products/{id}` — update a deployed product's cores/tps/description, or deactivate it (ServiceNow data source only)
@@ -220,6 +255,20 @@ backend-v2/
 - `PATCH /call-requests/{id}` — update a call request (restricted, excludes agent-only fields — see CLAUDE.md; ServiceNow data source only)
 - `POST /products/search` — search products
 - `POST /products/{id}/versions/search` — search a product's versions
+- `POST /products/vulnerabilities/search` — search product vulnerabilities
+- `GET /products/vulnerabilities/{id}` — get a product vulnerability by ID
+- `POST /catalogs/search` — search service catalogs, scoped by deployedProductId
+- `GET /catalogs/{catalogId}/items/{catalogItemId}/variables` — get a catalog item's form variables
+- `POST /time-cards/search` — search time cards (read-only; ServiceNow data source only)
+- `POST /comments` — add a comment to any reference entity (case, conversation, change_request, deployment, incident) — always a plain customer comment
+- `POST /comments/search` — search comments on a reference entity — always filtered to plain customer comments
+- `POST /cases/classify` — classify a chat transcript into a case type/severity via the AI chat agent
+- `POST /conversations/recommendations/search` — get KB article recommendations via the AI chat agent
+- `POST /projects/{id}/conversations/search` — search a project's AI chat conversations
+- `GET /conversations/{id}/messages` — get a conversation's messages (backed by generic comment search)
+- `POST /projects/{projectId}/conversations/{conversationId}/messages` — send a follow-up message on an existing conversation
+- `GET /projects/{id}/conversations/{conversationId}/summary` — get a conversation's summary via the AI chat agent
+- `GET /ws?sessionId={projectId}` — WebSocket: real-time AI chat proxy for an existing conversation (see CLAUDE.md — starting a brand-new conversation isn't supported yet)
 - `GET /updates/product-update-levels` — list product update levels
 - `POST /updates/levels/search` — search update descriptions between two update levels
 
@@ -355,6 +404,59 @@ curl -X POST http://localhost:8080/call-requests/search \
 curl -X PATCH http://localhost:8080/call-requests/<call-request-id> \
   -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
   -d '{"state":"customer_rejected","cancellationReason":"No longer needed"}'
+
+curl -X PATCH http://localhost:8080/deployments/<deployment-id> \
+  -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
+  -d '{"name":"Production (EU)"}'
+
+curl -X POST http://localhost:8080/products/vulnerabilities/search \
+  -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
+  -d '{"pagination":{"limit":10,"offset":0},"filters":{"productName":"wso2am"}}'
+
+curl -H "x-jwt-assertion: $JWT" http://localhost:8080/products/vulnerabilities/<vulnerability-id>
+
+curl -X POST http://localhost:8080/catalogs/search \
+  -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
+  -d '{"deployedProductId":"<deployed-product-id>","pagination":{"limit":10,"offset":0}}'
+
+curl -H "x-jwt-assertion: $JWT" http://localhost:8080/catalogs/<catalog-id>/items/<catalog-item-id>/variables
+
+curl -X POST http://localhost:8080/time-cards/search \
+  -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
+  -d '{"pagination":{"limit":10,"offset":0},"filters":{"projectIds":["<project-id>"]}}'
+
+curl -X POST http://localhost:8080/comments \
+  -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
+  -d '{"referenceId":"<change-request-id>","referenceType":"change_request","content":"Any update?"}'
+
+curl -X POST http://localhost:8080/comments/search \
+  -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
+  -d '{"referenceId":"<change-request-id>","referenceType":"change_request","pagination":{"limit":10,"offset":0}}'
+
+curl -X POST http://localhost:8080/cases/classify \
+  -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
+  -d '{"chatHistory":"user: my API gateway is down\n","envProducts":{},"region":"EU","tier":"gold","projectTypeId":"<project-type-id>"}'
+
+curl -X POST http://localhost:8080/conversations/recommendations/search \
+  -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
+  -d '{"chatHistory":[{"role":"user","content":"my API gateway is down","timestamp":"2026-08-01T10:00:00Z"}],"conversationData":{"chatHistory":"user: my API gateway is down","envProducts":{},"region":"EU","tier":"gold"}}'
+
+curl -X POST http://localhost:8080/projects/<project-id>/conversations/search \
+  -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
+  -d '{"filters":{},"sortBy":{},"pagination":{"limit":10,"offset":0}}'
+
+curl -H "x-jwt-assertion: $JWT" "http://localhost:8080/conversations/<conversation-id>/messages?limit=20&offset=0"
+
+curl -X POST http://localhost:8080/projects/<project-id>/conversations/<conversation-id>/messages \
+  -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
+  -d '{"message":"It is still down","region":"EU","tier":"gold"}'
+
+curl -H "x-jwt-assertion: $JWT" http://localhost:8080/projects/<project-id>/conversations/<conversation-id>/summary
+
+# WebSocket (real-time chat proxy) — resumes an existing conversation only, see CLAUDE.md.
+# Using websocat (https://github.com/vi/websocat) as an example client:
+websocat "ws://localhost:8080/ws?sessionId=<project-id>" -H "x-jwt-assertion: $JWT"
+# then send: {"message":"still seeing the error","conversationId":"<conversation-id>"}
 
 curl -H "x-jwt-assertion: $JWT" http://localhost:8080/updates/product-update-levels
 

--- a/apps/customer-portal/backend-v2/README.md
+++ b/apps/customer-portal/backend-v2/README.md
@@ -118,6 +118,7 @@ A separate Python service (not entity-service) — see [CLAUDE.md](./CLAUDE.md#t
 | `AI_CHAT_AGENT_SCOPES` | Comma-separated OAuth2 scopes (optional) |
 | `AI_CHAT_AGENT_WS_BASE_URL` | Base URL of the AI chat agent's WebSocket endpoint |
 | `AI_CHAT_AGENT_WS_SCOPES` | Comma-separated OAuth2 scopes (optional) |
+| `WS_ALLOWED_ORIGINS` | Comma-separated browser Origins allowed to open `GET /ws` (optional — defense in depth against cross-site WebSocket hijacking; unset allows any origin, local development only) |
 
 ### Auth
 

--- a/apps/customer-portal/backend-v2/asyncapi.yaml
+++ b/apps/customer-portal/backend-v2/asyncapi.yaml
@@ -41,19 +41,28 @@ servers:
 
 channels:
   /ws:
-    parameters:
-      sessionId:
-        description: >
-          Query parameter (not a path parameter): the project ID. Named
-          sessionId for wire compatibility with the Ballerina backend this
-          replaces, even though it doesn't carry a session/conversation
-          value itself — the upstream agent's own per-conversation session
-          key is derived server-side as "{projectId}:{conversationId}".
-        schema:
-          type: string
-          format: uuid
+    bindings:
+      ws:
+        query:
+          type: object
+          properties:
+            sessionId:
+              type: string
+              format: uuid
+              description: >
+                The project ID. Named sessionId for wire compatibility with
+                the Ballerina backend this replaces, even though it doesn't
+                carry a session/conversation value itself — the upstream
+                agent's own per-conversation session key is derived
+                server-side as "{projectId}:{conversationId}".
+          required:
+            - sessionId
 
-    subscribe:
+    # AsyncAPI 2.x's publish/subscribe are named from the client's
+    # perspective: "publish" is what the client sends (this application
+    # receives), "subscribe" is what the client receives (this application
+    # sends) — the opposite of what the operationId names might suggest.
+    publish:
       operationId: SendMessage
       summary: Messages sent from client to server
       message:
@@ -61,7 +70,7 @@ channels:
           - $ref: '#/components/messages/PingMessage'
           - $ref: '#/components/messages/UserMessage'
 
-    publish:
+    subscribe:
       operationId: ReceiveMessage
       summary: Messages sent from server to client
       message:

--- a/apps/customer-portal/backend-v2/asyncapi.yaml
+++ b/apps/customer-portal/backend-v2/asyncapi.yaml
@@ -1,0 +1,374 @@
+# Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+asyncapi: '2.0.0'
+
+info:
+  title: Customer Portal AI Chat WebSocket API
+  version: '1.0.0'
+  description: >
+    Real-time proxy between the browser and the upstream AI chat agent (a
+    separate Python service — see CLAUDE.md's "The AI chat agent" section).
+    This server (internal/handler/websocket.go) forwards every message from
+    the upstream agent to the browser verbatim, so the message shapes below
+    mirror the upstream agent's own contract (see
+    apps/customer-portal/backend/asyncapi.yaml for the Ballerina backend's
+    equivalent, which this is adapted from) — with one deliberate difference:
+    conversationId is REQUIRED on UserMessage here. Unlike the Ballerina
+    backend, this server cannot start a brand-new AI chat conversation
+    (entity-service has no createConversation yet — see CLAUDE.md), so a
+    UserMessage with no conversationId gets an ErrorMessage back instead of
+    creating one.
+
+servers:
+  local:
+    url: localhost:8080
+    protocol: ws
+    description: Local server — WebSocket is served on the same port as the REST API (GET /ws), not a separate port.
+
+channels:
+  /ws:
+    parameters:
+      sessionId:
+        description: >
+          Query parameter (not a path parameter): the project ID. Named
+          sessionId for wire compatibility with the Ballerina backend this
+          replaces, even though it doesn't carry a session/conversation
+          value itself — the upstream agent's own per-conversation session
+          key is derived server-side as "{projectId}:{conversationId}".
+        schema:
+          type: string
+          format: uuid
+
+    subscribe:
+      operationId: SendMessage
+      summary: Messages sent from client to server
+      message:
+        oneOf:
+          - $ref: '#/components/messages/PingMessage'
+          - $ref: '#/components/messages/UserMessage'
+
+    publish:
+      operationId: ReceiveMessage
+      summary: Messages sent from server to client
+      message:
+        oneOf:
+          - $ref: '#/components/messages/PongMessage'
+          - $ref: '#/components/messages/ThinkingStartMessage'
+          - $ref: '#/components/messages/ThinkingStepMessage'
+          - $ref: '#/components/messages/TokenMessage'
+          - $ref: '#/components/messages/ThinkingEndMessage'
+          - $ref: '#/components/messages/FinalMessage'
+          - $ref: '#/components/messages/ErrorMessage'
+
+components:
+  messages:
+
+    PingMessage:
+      name: PingMessage
+      title: Ping
+      summary: Keepalive heartbeat, answered directly by this server (not forwarded upstream).
+      payload:
+        type: object
+        required:
+          - type
+        properties:
+          type:
+            type: string
+            enum:
+              - ping
+
+    UserMessage:
+      name: UserMessage
+      title: User Chat Message
+      summary: >
+        Send a user chat message on an existing conversation. Triggers a
+        stream of server events ending in FinalMessage or ErrorMessage.
+      payload:
+        type: object
+        required:
+          - message
+          - conversationId
+        properties:
+          message:
+            type: string
+            description: The user chat message text
+          conversationId:
+            type: string
+            format: uuid
+            description: >
+              Required — the ID of an existing conversation (obtained via
+              POST /projects/{projectId}/conversations/{conversationId}/messages
+              or another entity-service-backed flow). Omitting it returns an
+              ErrorMessage; this server cannot mint a new conversation ID.
+          envProducts:
+            type: object
+            nullable: true
+            description: Account products per environment
+            additionalProperties:
+              type: array
+              items:
+                type: string
+
+    PongMessage:
+      name: PongMessage
+      title: Pong
+      summary: Keepalive response to a client PingMessage.
+      payload:
+        type: object
+        required:
+          - type
+        properties:
+          type:
+            type: string
+            enum:
+              - pong
+          ts:
+            type: string
+            description: Unix epoch timestamp (seconds)
+
+    ThinkingStartMessage:
+      name: ThinkingStartMessage
+      title: Thinking Start
+      summary: Forwarded verbatim from the upstream agent when it starts processing. Show a loading indicator.
+      payload:
+        type: object
+        required:
+          - type
+          - agent
+        properties:
+          type:
+            type: string
+            enum:
+              - thinking_start
+          agent:
+            type: string
+          ts:
+            type: number
+
+    ThinkingStepMessage:
+      name: ThinkingStepMessage
+      title: Thinking Step
+      summary: Forwarded verbatim from the upstream agent when a tool is invoked.
+      payload:
+        type: object
+        required:
+          - type
+          - step
+          - label
+        properties:
+          type:
+            type: string
+            enum:
+              - thinking_step
+          step:
+            type: string
+            enum:
+              - tool_activity
+              - tool_info
+          label:
+            type: string
+          ts:
+            type: number
+
+    TokenMessage:
+      name: TokenMessage
+      title: Streaming Token
+      summary: Forwarded verbatim from the upstream agent — one streamed text chunk from the LLM.
+      payload:
+        type: object
+        required:
+          - type
+          - content
+        properties:
+          type:
+            type: string
+            enum:
+              - token
+          content:
+            type: string
+          ts:
+            type: number
+
+    ThinkingEndMessage:
+      name: ThinkingEndMessage
+      title: Thinking End
+      summary: Forwarded verbatim from the upstream agent after all tokens are streamed.
+      payload:
+        type: object
+        required:
+          - type
+          - agent
+        properties:
+          type:
+            type: string
+            enum:
+              - thinking_end
+          agent:
+            type: string
+          ts:
+            type: number
+
+    FinalMessage:
+      name: FinalMessage
+      title: Final Response
+      summary: >
+        Forwarded verbatim from the upstream agent — the complete structured
+        response sent once per user turn. After forwarding this event, this
+        server also saves the user's own message as an entity-service
+        comment (see CLAUDE.md — the agent's own reply is NOT saved as a
+        comment, and a resolved=true here does not update the conversation's
+        state; both are pending entity-service support).
+      payload:
+        type: object
+        required:
+          - type
+          - payload
+        properties:
+          type:
+            type: string
+            enum:
+              - final
+          payload:
+            type: object
+            required:
+              - message
+              - sessionId
+              - conversationId
+            properties:
+              message:
+                type: string
+                description: Full AI-generated response text
+              sessionId:
+                type: string
+                description: Upstream agent session key, "{projectId}:{conversationId}"
+              conversationId:
+                type: string
+              intent:
+                type: object
+                nullable: true
+                properties:
+                  intentId:
+                    type: string
+                  intentLabel:
+                    type: string
+                  confidence:
+                    type: number
+                  severity:
+                    type: string
+                  caseType:
+                    type: string
+              slotState:
+                type: object
+                nullable: true
+                properties:
+                  intentId:
+                    type: string
+                  filledSlots:
+                    type: object
+                    additionalProperties:
+                      type: string
+                  missingSlots:
+                    type: array
+                    items:
+                      type: string
+                  isComplete:
+                    type: boolean
+                  slotOptions:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      properties:
+                        slot:
+                          type: string
+                        label:
+                          type: string
+                        options:
+                          type: array
+                          items:
+                            type: string
+                        type:
+                          type: string
+              actions:
+                type: array
+                nullable: true
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                    label:
+                      type: string
+                    style:
+                      type: string
+                      enum:
+                        - primary
+                        - danger
+                    payload:
+                      type: object
+                      additionalProperties: true
+              resolved:
+                type: boolean
+                nullable: true
+                description: >
+                  When true, the Ballerina backend marks the conversation
+                  resolved in entity-service; this server does not (no
+                  updateConversation yet — see CLAUDE.md).
+              kbReferences:
+                type: array
+                nullable: true
+                items:
+                  type: object
+                  properties:
+                    sysKbId:
+                      type: string
+                    title:
+                      type: string
+
+    ErrorMessage:
+      name: ErrorMessage
+      title: Error
+      summary: >
+        Sent when the server or the upstream agent cannot process the
+        client message — including this server's own synthesized error when
+        a UserMessage omits conversationId.
+      payload:
+        type: object
+        required:
+          - type
+          - message
+        properties:
+          type:
+            type: string
+            enum:
+              - error
+          message:
+            type: string
+          details:
+            type: array
+            nullable: true
+            items:
+              type: object
+              properties:
+                loc:
+                  type: array
+                  items:
+                    type: string
+                msg:
+                  type: string
+                type:
+                  type: string

--- a/apps/customer-portal/backend-v2/cmd/server/main.go
+++ b/apps/customer-portal/backend-v2/cmd/server/main.go
@@ -31,6 +31,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/aichatagent"
 	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
 	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/handler"
 	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/middleware"
@@ -76,6 +77,29 @@ func main() {
 	}
 	scimClient := scim.NewClient(scimCfg)
 
+	// The AI chat agent is a separate Python service (not entity-service),
+	// but authenticates as the same shared OAuth2 client-credentials app as
+	// entity/updates/scim above (see the Ballerina backend's Config.toml,
+	// where every module — including ai_chat_agent's WebSocket variant —
+	// reuses the same clientId/tokenUrl); only its base URLs differ.
+	aiChatAgentCfg := aichatagent.Config{
+		BaseURL:      mustEnv("AI_CHAT_AGENT_BASE_URL"),
+		TokenURL:     oauth2TokenURL,
+		ClientID:     oauth2ClientID,
+		ClientSecret: oauth2ClientSecret,
+		Scopes:       splitComma(os.Getenv("AI_CHAT_AGENT_SCOPES")),
+	}
+	aiChatAgentClient := aichatagent.NewClient(aiChatAgentCfg)
+
+	aiChatAgentWsCfg := aichatagent.WSConfig{
+		BaseURL:      mustEnv("AI_CHAT_AGENT_WS_BASE_URL"),
+		TokenURL:     oauth2TokenURL,
+		ClientID:     oauth2ClientID,
+		ClientSecret: oauth2ClientSecret,
+		Scopes:       splitComma(os.Getenv("AI_CHAT_AGENT_WS_SCOPES")),
+	}
+	aiChatAgentWsClient := aichatagent.NewWSClient(aiChatAgentWsCfg)
+
 	userHandler := handler.NewUserHandler(entityClient, scimClient)
 	projectHandler := handler.NewProjectHandler(entityClient)
 	caseHandler := handler.NewCaseHandler(entityClient)
@@ -87,6 +111,12 @@ func main() {
 	callRequestHandler := handler.NewCallRequestHandler(entityClient)
 	accountHandler := handler.NewAccountHandler(entityClient)
 	updatesHandler := handler.NewUpdatesHandler(updatesClient)
+	commentHandler := handler.NewCommentHandler(entityClient)
+	productVulnerabilityHandler := handler.NewProductVulnerabilityHandler(entityClient)
+	catalogHandler := handler.NewCatalogHandler(entityClient)
+	timeCardHandler := handler.NewTimeCardHandler(entityClient)
+	aiChatHandler := handler.NewAIChatHandler(aiChatAgentClient, entityClient)
+	webSocketHandler := handler.NewWebSocketHandler(aiChatAgentWsClient, entityClient)
 
 	authCfg := middleware.Config{
 		JWKSEndpoint:          mustEnv("AUTH_JWKS_ENDPOINT"),
@@ -120,6 +150,7 @@ func main() {
 	// POST /deployments only succeeds against entity-service's ServiceNow
 	// data source — see internal/entity/deployments.go.
 	mux.HandleFunc("POST /deployments", deploymentHandler.CreateDeployment)
+	mux.HandleFunc("PATCH /deployments/{id}", deploymentHandler.PatchDeployment)
 
 	mux.HandleFunc("POST /deployed-products/search", deployedProductHandler.SearchDeployedProducts)
 	// POST/PATCH /deployed-products only succeed against entity-service's
@@ -151,6 +182,33 @@ func main() {
 
 	mux.HandleFunc("POST /accounts/search", accountHandler.SearchAccounts)
 	mux.HandleFunc("GET /accounts/{id}", accountHandler.GetAccount)
+
+	mux.HandleFunc("POST /comments", commentHandler.CreateComment)
+	mux.HandleFunc("POST /comments/search", commentHandler.SearchComments)
+
+	mux.HandleFunc("POST /products/vulnerabilities/search", productVulnerabilityHandler.SearchProductVulnerabilities)
+	mux.HandleFunc("GET /products/vulnerabilities/{id}", productVulnerabilityHandler.GetProductVulnerability)
+
+	mux.HandleFunc("POST /catalogs/search", catalogHandler.SearchCatalogs)
+	mux.HandleFunc("GET /catalogs/{catalogId}/items/{catalogItemId}/variables", catalogHandler.GetCatalogItemVariables)
+
+	// entity-service only supports time cards on its ServiceNow data source —
+	// see internal/entity/time_cards.go.
+	mux.HandleFunc("POST /time-cards/search", timeCardHandler.SearchTimeCards)
+
+	// AI chat feature: case classification and KB recommendations call the
+	// upstream AI chat agent directly; conversation search/messages/summary
+	// mix the AI agent with entity-service's conversation/comment routes.
+	// See handler.AIChatHandler and handler.WebSocketHandler's doc comments
+	// for the entity-service gaps (no createConversation/updateConversation,
+	// no comment createdBy override) this works around.
+	mux.HandleFunc("POST /cases/classify", aiChatHandler.ClassifyCase)
+	mux.HandleFunc("POST /conversations/recommendations/search", aiChatHandler.SearchRecommendations)
+	mux.HandleFunc("POST /projects/{id}/conversations/search", aiChatHandler.SearchConversations)
+	mux.HandleFunc("GET /conversations/{id}/messages", aiChatHandler.GetConversationMessages)
+	mux.HandleFunc("POST /projects/{projectId}/conversations/{conversationId}/messages", aiChatHandler.SendConversationMessage)
+	mux.HandleFunc("GET /projects/{id}/conversations/{conversationId}/summary", aiChatHandler.GetConversationSummary)
+	mux.HandleFunc("GET /ws", webSocketHandler.HandleWebSocket)
 
 	mux.HandleFunc("GET /updates/product-update-levels", updatesHandler.GetProductUpdateLevels)
 	mux.HandleFunc("POST /updates/levels/search", updatesHandler.SearchUpdatesBetweenUpdateLevels)

--- a/apps/customer-portal/backend-v2/cmd/server/main.go
+++ b/apps/customer-portal/backend-v2/cmd/server/main.go
@@ -116,7 +116,7 @@ func main() {
 	catalogHandler := handler.NewCatalogHandler(entityClient)
 	timeCardHandler := handler.NewTimeCardHandler(entityClient)
 	aiChatHandler := handler.NewAIChatHandler(aiChatAgentClient, entityClient)
-	webSocketHandler := handler.NewWebSocketHandler(aiChatAgentWsClient, entityClient)
+	webSocketHandler := handler.NewWebSocketHandler(aiChatAgentWsClient, entityClient, splitComma(os.Getenv("WS_ALLOWED_ORIGINS")))
 
 	authCfg := middleware.Config{
 		JWKSEndpoint:          mustEnv("AUTH_JWKS_ENDPOINT"),

--- a/apps/customer-portal/backend-v2/go.mod
+++ b/apps/customer-portal/backend-v2/go.mod
@@ -10,5 +10,6 @@ require (
 
 require (
 	github.com/MicahParks/jwkset v0.11.0 // indirect
+	github.com/gorilla/websocket v1.5.3 // indirect
 	golang.org/x/time v0.9.0 // indirect
 )

--- a/apps/customer-portal/backend-v2/go.mod
+++ b/apps/customer-portal/backend-v2/go.mod
@@ -5,11 +5,11 @@ go 1.26.0
 require (
 	github.com/MicahParks/keyfunc/v3 v3.8.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
+	github.com/gorilla/websocket v1.5.3
 	golang.org/x/oauth2 v0.27.0
 )
 
 require (
 	github.com/MicahParks/jwkset v0.11.0 // indirect
-	github.com/gorilla/websocket v1.5.3 // indirect
 	golang.org/x/time v0.9.0 // indirect
 )

--- a/apps/customer-portal/backend-v2/go.sum
+++ b/apps/customer-portal/backend-v2/go.sum
@@ -6,6 +6,8 @@ github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63Y
 github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 golang.org/x/oauth2 v0.27.0 h1:da9Vo7/tDv5RH/7nZDz1eMGS/q1Vv1N/7FCrBhI9I3M=
 golang.org/x/oauth2 v0.27.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT8=
 golang.org/x/time v0.9.0 h1:EsRrnYcQiGH+5FfbgvV4AP7qEZstoyrHB0DzarOQ4ZY=

--- a/apps/customer-portal/backend-v2/internal/aichatagent/client.go
+++ b/apps/customer-portal/backend-v2/internal/aichatagent/client.go
@@ -1,0 +1,208 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package aichatagent is the HTTP client for the upstream AI chat agent — a
+// separate Python service (not entity-service) that powers the customer
+// portal's AI chat feature: case classification, chat responses, and KB
+// article recommendations. See apps/customer-portal/backend's
+// modules/ai_chat_agent for the Ballerina backend's equivalent client.
+package aichatagent
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/apierror"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
+)
+
+// tokenFetchTimeout is the HTTP client timeout for token-endpoint requests.
+var tokenFetchTimeout = 10 * time.Second
+
+// maxResponseBodyBytes bounds how much of an AI chat agent response this
+// client will read into memory.
+const maxResponseBodyBytes = 10 << 20 // 10 MiB
+
+func noRedirect(_ *http.Request, _ []*http.Request) error {
+	return http.ErrUseLastResponse
+}
+
+type ctxKey string
+
+const correlationIDKey ctxKey = "x-csm-correlation-id" // #nosec G101 -- context map key, not a credential
+
+// WithCorrelationID returns a copy of ctx carrying the correlation ID to be
+// forwarded as X-CSM-Correlation-ID on every outgoing AI chat agent request.
+func WithCorrelationID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, correlationIDKey, id)
+}
+
+func correlationIDFromContext(ctx context.Context) string {
+	v, _ := ctx.Value(correlationIDKey).(string)
+	return v
+}
+
+// Config holds the configuration for the AI chat agent client.
+type Config struct {
+	BaseURL      string
+	TokenURL     string
+	ClientID     string
+	ClientSecret string
+	Scopes       []string
+}
+
+// Client is an HTTP client for the upstream AI chat agent, authenticated via
+// the OAuth2 client credentials grant.
+type Client struct {
+	http    *http.Client
+	baseURL string
+}
+
+// NewClient constructs a Client that authenticates against the AI chat agent
+// using the OAuth2 client credentials grant type.
+func NewClient(cfg Config) *Client {
+	cc := clientcredentials.Config{
+		ClientID:     cfg.ClientID,
+		ClientSecret: cfg.ClientSecret,
+		TokenURL:     cfg.TokenURL,
+		Scopes:       cfg.Scopes,
+	}
+
+	tokenCtx := context.WithValue(context.Background(), oauth2.HTTPClient,
+		&http.Client{Timeout: tokenFetchTimeout, CheckRedirect: noRedirect})
+
+	// clientcredentials.Config.Client's returned *http.Client and its
+	// Transport must not be mutated (see the package doc comment) — wrap its
+	// Transport in a fresh http.Client we own instead of setting fields
+	// directly on the returned one.
+	oauthClient := cc.Client(tokenCtx)
+	httpClient := &http.Client{
+		Transport:     oauthClient.Transport,
+		Timeout:       60 * time.Second,
+		CheckRedirect: noRedirect,
+	}
+
+	return &Client{
+		http:    httpClient,
+		baseURL: strings.TrimRight(cfg.BaseURL, "/"),
+	}
+}
+
+func (c *Client) do(ctx context.Context, method, path string, body []byte) ([]byte, error) {
+	var reqBody io.Reader
+	if len(body) > 0 {
+		reqBody = bytes.NewReader(body)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("aichatagent: build request %s %s: %w", method, path, err)
+	}
+	if len(body) > 0 {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if id := correlationIDFromContext(ctx); id != "" {
+		req.Header.Set("X-CSM-Correlation-ID", id)
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("aichatagent: %s %s: %w", method, path, err)
+	}
+	defer resp.Body.Close()
+
+	limited := io.LimitReader(resp.Body, maxResponseBodyBytes+1)
+	respBody, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, fmt.Errorf("aichatagent: read response body: %w", err)
+	}
+	if len(respBody) > maxResponseBodyBytes {
+		return nil, fmt.Errorf("aichatagent: %s %s: response body exceeds %d bytes", method, path, maxResponseBodyBytes)
+	}
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		const maxErrBody = 256
+		excerpt := respBody
+		if len(excerpt) > maxErrBody {
+			excerpt = excerpt[:maxErrBody]
+		}
+		return nil, &apierror.Error{StatusCode: resp.StatusCode, Body: string(excerpt)}
+	}
+
+	return respBody, nil
+}
+
+func (c *Client) getJSON(ctx context.Context, path string, out any) error {
+	body, err := c.do(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(body, out); err != nil {
+		return fmt.Errorf("aichatagent: decode response for GET %s: %w", path, err)
+	}
+	return nil
+}
+
+func (c *Client) postJSON(ctx context.Context, path string, reqBody, out any) error {
+	payload, err := json.Marshal(reqBody)
+	if err != nil {
+		return fmt.Errorf("aichatagent: encode request for POST %s: %w", path, err)
+	}
+	body, err := c.do(ctx, http.MethodPost, path, payload)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(body, out); err != nil {
+		return fmt.Errorf("aichatagent: decode response for POST %s: %w", path, err)
+	}
+	return nil
+}
+
+// CreateCaseClassification calls POST /case_classification.
+func (c *Client) CreateCaseClassification(ctx context.Context, req CaseClassificationPayload) (CaseClassificationResponse, error) {
+	var out CaseClassificationResponse
+	err := c.postJSON(ctx, "/case_classification", req, &out)
+	return out, err
+}
+
+// CreateChat calls POST /chat.
+func (c *Client) CreateChat(ctx context.Context, req ChatPayload) (ChatResponse, error) {
+	var out ChatResponse
+	err := c.postJSON(ctx, "/chat", req, &out)
+	return out, err
+}
+
+// GetRecommendations calls POST /recommendations.
+func (c *Client) GetRecommendations(ctx context.Context, req RecommendationRequest) (RecommendationResponse, error) {
+	var out RecommendationResponse
+	err := c.postJSON(ctx, "/recommendations", req, &out)
+	return out, err
+}
+
+// GetConversationSummary calls GET /chat/summary/{projectId}/{conversationId}.
+func (c *Client) GetConversationSummary(ctx context.Context, projectID, conversationID string) (ConversationSummaryResponse, error) {
+	var out ConversationSummaryResponse
+	err := c.getJSON(ctx, "/chat/summary/"+url.PathEscape(projectID)+"/"+url.PathEscape(conversationID), &out)
+	return out, err
+}

--- a/apps/customer-portal/backend-v2/internal/aichatagent/types.go
+++ b/apps/customer-portal/backend-v2/internal/aichatagent/types.go
@@ -1,0 +1,153 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package aichatagent
+
+// These types mirror the upstream Python AI chat agent's wire format 1:1
+// (see apps/customer-portal/backend's modules/ai_chat_agent/types.bal, the
+// Ballerina backend this is rewriting) so json.Unmarshal can decode its
+// responses directly.
+
+// CaseClassificationPayload is the input for POST /case_classification.
+type CaseClassificationPayload struct {
+	ChatHistory   string              `json:"chatHistory"`
+	EnvProducts   map[string][]string `json:"envProducts"`
+	Region        string              `json:"region"`
+	Tier          string              `json:"tier"`
+	ProjectTypeID string              `json:"projectTypeId"`
+}
+
+// ChatCaseInfo carries the case details inferred by case classification.
+type ChatCaseInfo struct {
+	Description      string `json:"description"`
+	ShortDescription string `json:"shortDescription"`
+	ProductName      string `json:"productName"`
+	ProductVersion   string `json:"productVersion"`
+	Environment      string `json:"environment"`
+	Tier             string `json:"tier"`
+	Region           string `json:"region"`
+}
+
+// CaseClassificationResponse is the response for POST /case_classification.
+type CaseClassificationResponse struct {
+	IssueType     string       `json:"issueType"`
+	SeverityLevel string       `json:"severityLevel"`
+	CaseInfo      ChatCaseInfo `json:"caseInfo"`
+}
+
+// ChatPayload is the input for POST /chat.
+type ChatPayload struct {
+	Message        string              `json:"message"`
+	AccountID      string              `json:"accountId"`
+	ConversationID string              `json:"conversationId"`
+	EnvProducts    map[string][]string `json:"envProducts,omitempty"`
+}
+
+// DetectedIntent is the intent classification result for UI rendering.
+type DetectedIntent struct {
+	IntentID    string  `json:"intentId"`
+	IntentLabel string  `json:"intentLabel"`
+	Confidence  float64 `json:"confidence"`
+	Severity    string  `json:"severity"`
+	CaseType    string  `json:"caseType"`
+}
+
+// SlotOption is one selectable value for a slot, rendered as a dropdown/selector by the UI.
+type SlotOption struct {
+	Slot    string   `json:"slot"`
+	Label   string   `json:"label"`
+	Options []string `json:"options"`
+	Type    string   `json:"type"`
+}
+
+// SlotState is the current slot-filling progress for UI rendering.
+type SlotState struct {
+	IntentID     string            `json:"intentId"`
+	FilledSlots  map[string]string `json:"filledSlots"`
+	MissingSlots []string          `json:"missingSlots"`
+	IsComplete   bool              `json:"isComplete"`
+	SlotOptions  []SlotOption      `json:"slotOptions"`
+}
+
+// Action is a UI action button rendered by the frontend.
+type Action struct {
+	Type    string         `json:"type"`
+	Label   string         `json:"label"`
+	Style   string         `json:"style"`
+	Payload map[string]any `json:"payload"`
+}
+
+// RecommendationItem is a single matching KB article.
+type RecommendationItem struct {
+	Title     string  `json:"title"`
+	ArticleID string  `json:"articleId"`
+	Score     float64 `json:"score"`
+}
+
+// RecommendationResponse is the response for POST /recommendations.
+type RecommendationResponse struct {
+	Query           string               `json:"query"`
+	Recommendations []RecommendationItem `json:"recommendations"`
+}
+
+// KbReference is a single KB article referenced in a chat response.
+type KbReference struct {
+	SysKbID string `json:"sysKbId"`
+	Title   string `json:"title"`
+}
+
+// ChatResponse is the response for POST /chat.
+type ChatResponse struct {
+	Message         string                  `json:"message"`
+	SessionID       string                  `json:"sessionId"`
+	ConversationID  string                  `json:"conversationId"`
+	Intent          *DetectedIntent         `json:"intent,omitempty"`
+	SlotState       *SlotState              `json:"slotState,omitempty"`
+	Actions         []Action                `json:"actions,omitempty"`
+	Recommendations *RecommendationResponse `json:"recommendations,omitempty"`
+	Resolved        *bool                   `json:"resolved,omitempty"`
+	KbReferences    []KbReference           `json:"kbReferences,omitempty"`
+}
+
+// ChatMessage is a single chat message for UI rendering (role is "user" or "assistant").
+type ChatMessage struct {
+	Role      string `json:"role"`
+	Content   string `json:"content"`
+	Timestamp string `json:"timestamp"`
+}
+
+// ConversationData carries chat-history context for a recommendation request.
+type ConversationData struct {
+	ChatHistory string              `json:"chatHistory"`
+	EnvProducts map[string][]string `json:"envProducts"`
+	Region      string              `json:"region"`
+	Tier        string              `json:"tier"`
+}
+
+// RecommendationRequest is the input for POST /recommendations.
+type RecommendationRequest struct {
+	ChatHistory      []ChatMessage    `json:"chatHistory"`
+	ConversationData ConversationData `json:"conversationData"`
+}
+
+// ConversationSummaryResponse is the response for GET /chat/summary/{projectId}/{conversationId}.
+type ConversationSummaryResponse struct {
+	AccountID               string `json:"accountId"`
+	ConversationID          string `json:"conversationId"`
+	MessagesExchanged       int    `json:"messagesExchanged"`
+	TroubleshootingAttempts int    `json:"troubleshootingAttempts"`
+	KbArticlesReviewed      int    `json:"kbArticlesReviewed"`
+}

--- a/apps/customer-portal/backend-v2/internal/aichatagent/ws.go
+++ b/apps/customer-portal/backend-v2/internal/aichatagent/ws.go
@@ -1,0 +1,167 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package aichatagent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"golang.org/x/oauth2/clientcredentials"
+)
+
+// eventTypeKey/eventPayloadKey/eventFinal/eventError mirror the upstream AI
+// chat agent's WebSocket event envelope — see apps/customer-portal/backend's
+// modules/ai_chat_agent/constants.bal.
+const (
+	eventTypeKey    = "type"
+	eventPayloadKey = "payload"
+	eventFinal      = "final"
+	eventError      = "error"
+)
+
+// WSConfig holds the configuration for dialing the upstream AI chat agent's
+// WebSocket endpoint. Kept separate from Config since the Ballerina backend
+// this is rewriting uses a distinct OAuth2 client-credentials configuration
+// for its WebSocket connection.
+type WSConfig struct {
+	BaseURL      string
+	TokenURL     string
+	ClientID     string
+	ClientSecret string
+	Scopes       []string
+}
+
+// WSClient dials the upstream AI chat agent's WebSocket endpoint.
+type WSClient struct {
+	baseURL string
+	oauth   *clientcredentials.Config
+}
+
+// NewWSClient constructs a WSClient authenticated via the OAuth2 client
+// credentials grant.
+func NewWSClient(cfg WSConfig) *WSClient {
+	return &WSClient{
+		baseURL: strings.TrimRight(cfg.BaseURL, "/"),
+		oauth: &clientcredentials.Config{
+			ClientID:     cfg.ClientID,
+			ClientSecret: cfg.ClientSecret,
+			TokenURL:     cfg.TokenURL,
+			Scopes:       cfg.Scopes,
+		},
+	}
+}
+
+// dial opens a WebSocket connection to the upstream AI chat agent for the
+// given session ID, authenticated with a bearer token obtained via OAuth2
+// client credentials.
+func (c *WSClient) dial(ctx context.Context, sessionID string) (*websocket.Conn, error) {
+	token, err := c.oauth.Token(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("aichatagent: fetch WS token: %w", err)
+	}
+
+	wsURL := strings.Replace(c.baseURL, "https://", "wss://", 1)
+	wsURL = strings.Replace(wsURL, "http://", "ws://", 1)
+	wsURL += "/ws?sessionId=" + url.QueryEscape(sessionID)
+
+	header := http.Header{}
+	header.Set("Authorization", "Bearer "+token.AccessToken)
+
+	conn, _, err := websocket.DefaultDialer.DialContext(ctx, wsURL, header)
+	if err != nil {
+		return nil, fmt.Errorf("aichatagent: dial upstream WebSocket: %w", err)
+	}
+	return conn, nil
+}
+
+// BrowserConn abstracts the browser-facing WebSocket connection just enough
+// for StreamChat to forward events to it, so the handler package's real
+// *websocket.Conn doesn't need to be imported here.
+type BrowserConn interface {
+	WriteMessage(messageType int, data []byte) error
+}
+
+// StreamChat opens a dedicated upstream WebSocket connection for sessionID,
+// sends payload, then forwards every event verbatim to caller until a
+// "final" or "error" event arrives or the upstream connection closes.
+// Mirrors apps/customer-portal/backend's ai_chat_agent:streamChat.
+func (c *WSClient) StreamChat(ctx context.Context, sessionID, payload string, caller BrowserConn) (map[string]json.RawMessage, error) {
+	conn, err := c.dial(ctx, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+
+	if err := conn.WriteMessage(websocket.TextMessage, []byte(payload)); err != nil {
+		return nil, fmt.Errorf("aichatagent: write initial message: %w", err)
+	}
+
+	finalPayload := map[string]json.RawMessage{}
+	for {
+		if dl, ok := ctx.Deadline(); ok {
+			_ = conn.SetReadDeadline(dl)
+		}
+		_, data, err := conn.ReadMessage()
+		if err != nil {
+			if websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
+				break
+			}
+			errPayload, _ := json.Marshal(map[string]string{"type": eventError, "message": err.Error()}) // #nosec G104 -- best-effort forward, connection may already be gone
+			_ = caller.WriteMessage(websocket.TextMessage, errPayload)
+			break
+		}
+
+		if writeErr := caller.WriteMessage(websocket.TextMessage, data); writeErr != nil {
+			break
+		}
+
+		var parsed map[string]json.RawMessage
+		if err := json.Unmarshal(data, &parsed); err != nil {
+			continue
+		}
+		var evtType string
+		if raw, ok := parsed[eventTypeKey]; ok {
+			_ = json.Unmarshal(raw, &evtType)
+		}
+		if evtType == eventFinal {
+			if raw, ok := parsed[eventPayloadKey]; ok {
+				var nested map[string]json.RawMessage
+				if err := json.Unmarshal(raw, &nested); err == nil {
+					finalPayload = nested
+					break
+				}
+			}
+			finalPayload = parsed
+			break
+		}
+		if evtType == eventError {
+			break
+		}
+	}
+
+	_ = conn.WriteControl(websocket.CloseMessage,
+		websocket.FormatCloseMessage(websocket.CloseNormalClosure, "session complete"),
+		time.Now().Add(2*time.Second))
+
+	return finalPayload, nil
+}

--- a/apps/customer-portal/backend-v2/internal/aichatagent/ws.go
+++ b/apps/customer-portal/backend-v2/internal/aichatagent/ws.go
@@ -39,6 +39,15 @@ const (
 	eventError      = "error"
 )
 
+// maxMessageBytes bounds the size of a single frame read from the upstream
+// AI chat agent — mirrors internal/handler/websocket.go's wsMaxMessageBytes
+// for the browser-facing side of the same proxy.
+const maxMessageBytes = 64 << 10 // 64 KiB
+
+// idleTimeout bounds how long StreamChat waits for the next frame from an
+// otherwise-healthy upstream connection.
+const idleTimeout = 5 * time.Minute
+
 // WSConfig holds the configuration for dialing the upstream AI chat agent's
 // WebSocket endpoint. Kept separate from Config since the Ballerina backend
 // this is rewriting uses a distinct OAuth2 client-credentials configuration
@@ -103,14 +112,18 @@ type BrowserConn interface {
 
 // StreamChat opens a dedicated upstream WebSocket connection for sessionID,
 // sends payload, then forwards every event verbatim to caller until a
-// "final" or "error" event arrives or the upstream connection closes.
-// Mirrors apps/customer-portal/backend's ai_chat_agent:streamChat.
+// "final" event arrives, an "error" event arrives, a read/write fails, or
+// the upstream connection closes normally. Mirrors
+// apps/customer-portal/backend's ai_chat_agent:streamChat, except it also
+// reports failure to the caller (below) via a non-nil error, so a failed
+// turn is never mistaken for a successful one.
 func (c *WSClient) StreamChat(ctx context.Context, sessionID, payload string, caller BrowserConn) (map[string]json.RawMessage, error) {
 	conn, err := c.dial(ctx, sessionID)
 	if err != nil {
 		return nil, err
 	}
 	defer conn.Close()
+	conn.SetReadLimit(maxMessageBytes)
 
 	if err := conn.WriteMessage(websocket.TextMessage, []byte(payload)); err != nil {
 		return nil, fmt.Errorf("aichatagent: write initial message: %w", err)
@@ -118,21 +131,26 @@ func (c *WSClient) StreamChat(ctx context.Context, sessionID, payload string, ca
 
 	finalPayload := map[string]json.RawMessage{}
 	for {
-		if dl, ok := ctx.Deadline(); ok {
-			_ = conn.SetReadDeadline(dl)
+		deadline := time.Now().Add(idleTimeout)
+		if dl, ok := ctx.Deadline(); ok && dl.Before(deadline) {
+			deadline = dl
 		}
+		_ = conn.SetReadDeadline(deadline)
+
 		_, data, err := conn.ReadMessage()
 		if err != nil {
 			if websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
 				break
 			}
-			errPayload, _ := json.Marshal(map[string]string{"type": eventError, "message": err.Error()}) // #nosec G104 -- best-effort forward, connection may already be gone
-			_ = caller.WriteMessage(websocket.TextMessage, errPayload)
-			break
+			// Never forward err.Error() to the browser — it can contain the
+			// upstream host/URL/TLS detail of this internal Python service.
+			// The caller (internal/handler/websocket.go) logs the real error
+			// returned here and sends its own fixed-text error event.
+			return nil, fmt.Errorf("aichatagent: read upstream message: %w", err)
 		}
 
 		if writeErr := caller.WriteMessage(websocket.TextMessage, data); writeErr != nil {
-			break
+			return nil, fmt.Errorf("aichatagent: forward message to browser: %w", writeErr)
 		}
 
 		var parsed map[string]json.RawMessage
@@ -155,7 +173,11 @@ func (c *WSClient) StreamChat(ctx context.Context, sessionID, payload string, ca
 			break
 		}
 		if evtType == eventError {
-			break
+			var upstreamMsg string
+			if raw, ok := parsed["message"]; ok {
+				_ = json.Unmarshal(raw, &upstreamMsg)
+			}
+			return nil, fmt.Errorf("aichatagent: upstream reported an error: %s", upstreamMsg)
 		}
 	}
 

--- a/apps/customer-portal/backend-v2/internal/dto/ai_chat.go
+++ b/apps/customer-portal/backend-v2/internal/dto/ai_chat.go
@@ -1,0 +1,264 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dto
+
+import (
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/aichatagent"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+)
+
+// CaseClassificationRequest is the portal's request shape for POST /cases/classify.
+// Every field here is customer-context the AI agent needs — decoded directly
+// into aichatagent.CaseClassificationPayload, no restriction needed.
+type CaseClassificationRequest struct {
+	ChatHistory   string              `json:"chatHistory"`
+	EnvProducts   map[string][]string `json:"envProducts"`
+	Region        string              `json:"region"`
+	Tier          string              `json:"tier"`
+	ProjectTypeID string              `json:"projectTypeId"`
+}
+
+// BuildCaseClassificationPayload converts the portal's request into the AI
+// chat agent's request shape.
+func BuildCaseClassificationPayload(req CaseClassificationRequest) aichatagent.CaseClassificationPayload {
+	return aichatagent.CaseClassificationPayload{
+		ChatHistory:   req.ChatHistory,
+		EnvProducts:   req.EnvProducts,
+		Region:        req.Region,
+		Tier:          req.Tier,
+		ProjectTypeID: req.ProjectTypeID,
+	}
+}
+
+// CaseClassificationResponse is the portal's response for POST /cases/classify.
+type CaseClassificationResponse struct {
+	IssueType     string `json:"issueType"`
+	SeverityLevel string `json:"severityLevel"`
+	CaseInfo      struct {
+		Description      string `json:"description"`
+		ShortDescription string `json:"shortDescription"`
+		ProductName      string `json:"productName"`
+		ProductVersion   string `json:"productVersion"`
+		Environment      string `json:"environment"`
+		Tier             string `json:"tier"`
+		Region           string `json:"region"`
+	} `json:"caseInfo"`
+}
+
+// MapCaseClassification builds the portal response from the AI chat agent's
+// CaseClassificationResponse.
+func MapCaseClassification(r aichatagent.CaseClassificationResponse) CaseClassificationResponse {
+	out := CaseClassificationResponse{
+		IssueType:     r.IssueType,
+		SeverityLevel: r.SeverityLevel,
+	}
+	out.CaseInfo.Description = r.CaseInfo.Description
+	out.CaseInfo.ShortDescription = r.CaseInfo.ShortDescription
+	out.CaseInfo.ProductName = r.CaseInfo.ProductName
+	out.CaseInfo.ProductVersion = r.CaseInfo.ProductVersion
+	out.CaseInfo.Environment = r.CaseInfo.Environment
+	out.CaseInfo.Tier = r.CaseInfo.Tier
+	out.CaseInfo.Region = r.CaseInfo.Region
+	return out
+}
+
+// ChatHistoryMessage is one message of chat-history context for a recommendation request.
+type ChatHistoryMessage struct {
+	Role      string `json:"role"`
+	Content   string `json:"content"`
+	Timestamp string `json:"timestamp"`
+}
+
+// RecommendationRequest is the portal's request shape for
+// POST /conversations/recommendations/search.
+type RecommendationRequest struct {
+	ChatHistory      []ChatHistoryMessage `json:"chatHistory"`
+	ConversationData struct {
+		ChatHistory string              `json:"chatHistory"`
+		EnvProducts map[string][]string `json:"envProducts"`
+		Region      string              `json:"region"`
+		Tier        string              `json:"tier"`
+	} `json:"conversationData"`
+}
+
+// BuildRecommendationRequest converts the portal's request into the AI chat
+// agent's request shape.
+func BuildRecommendationRequest(req RecommendationRequest) aichatagent.RecommendationRequest {
+	history := make([]aichatagent.ChatMessage, 0, len(req.ChatHistory))
+	for _, m := range req.ChatHistory {
+		history = append(history, aichatagent.ChatMessage{Role: m.Role, Content: m.Content, Timestamp: m.Timestamp})
+	}
+	return aichatagent.RecommendationRequest{
+		ChatHistory: history,
+		ConversationData: aichatagent.ConversationData{
+			ChatHistory: req.ConversationData.ChatHistory,
+			EnvProducts: req.ConversationData.EnvProducts,
+			Region:      req.ConversationData.Region,
+			Tier:        req.ConversationData.Tier,
+		},
+	}
+}
+
+// RecommendationItem is a single matching KB article.
+type RecommendationItem struct {
+	Title     string  `json:"title"`
+	ArticleID string  `json:"articleId"`
+	Score     float64 `json:"score"`
+}
+
+// RecommendationResponse is the portal's response for
+// POST /conversations/recommendations/search.
+type RecommendationResponse struct {
+	Query           string               `json:"query"`
+	Recommendations []RecommendationItem `json:"recommendations"`
+}
+
+// MapRecommendationResponse builds the portal response from the AI chat
+// agent's RecommendationResponse.
+func MapRecommendationResponse(r aichatagent.RecommendationResponse) RecommendationResponse {
+	items := make([]RecommendationItem, 0, len(r.Recommendations))
+	for _, i := range r.Recommendations {
+		items = append(items, RecommendationItem{Title: i.Title, ArticleID: i.ArticleID, Score: i.Score})
+	}
+	return RecommendationResponse{Query: r.Query, Recommendations: items}
+}
+
+// ChatMessageRequest is the portal's request shape for
+// POST /projects/{projectId}/conversations/{conversationId}/messages.
+type ChatMessageRequest struct {
+	Message     string              `json:"message"`
+	EnvProducts map[string][]string `json:"envProducts,omitempty"`
+	Region      string              `json:"region,omitempty"`
+	Tier        string              `json:"tier,omitempty"`
+}
+
+// KbReference is a single KB article referenced in a chat response.
+type KbReference struct {
+	SysKbID string `json:"sysKbId"`
+	Title   string `json:"title"`
+}
+
+// ChatResponse is the portal's response for
+// POST /projects/{projectId}/conversations/{conversationId}/messages.
+type ChatResponse struct {
+	Message         string                      `json:"message"`
+	ConversationID  string                      `json:"conversationId"`
+	Intent          *aichatagent.DetectedIntent `json:"intent,omitempty"`
+	SlotState       *aichatagent.SlotState      `json:"slotState,omitempty"`
+	Actions         []aichatagent.Action        `json:"actions,omitempty"`
+	Recommendations *RecommendationResponse     `json:"recommendations,omitempty"`
+	Resolved        *bool                       `json:"resolved,omitempty"`
+	KbReferences    []KbReference               `json:"kbReferences,omitempty"`
+}
+
+// MapChatResponse builds the portal response from the AI chat agent's ChatResponse.
+func MapChatResponse(r aichatagent.ChatResponse) ChatResponse {
+	out := ChatResponse{
+		Message:        r.Message,
+		ConversationID: r.ConversationID,
+		Intent:         r.Intent,
+		SlotState:      r.SlotState,
+		Actions:        r.Actions,
+		Resolved:       r.Resolved,
+	}
+	if len(r.KbReferences) > 0 {
+		out.KbReferences = make([]KbReference, 0, len(r.KbReferences))
+		for _, kb := range r.KbReferences {
+			out.KbReferences = append(out.KbReferences, KbReference{SysKbID: kb.SysKbID, Title: kb.Title})
+		}
+	}
+	if r.Recommendations != nil {
+		mapped := MapRecommendationResponse(*r.Recommendations)
+		out.Recommendations = &mapped
+	}
+	return out
+}
+
+// ConversationSummaryResponse is the portal's response for
+// GET /projects/{id}/conversations/{conversationId}/summary.
+type ConversationSummaryResponse struct {
+	ConversationID          string `json:"conversationId"`
+	MessagesExchanged       int    `json:"messagesExchanged"`
+	TroubleshootingAttempts int    `json:"troubleshootingAttempts"`
+	KbArticlesReviewed      int    `json:"kbArticlesReviewed"`
+}
+
+// MapConversationSummary builds the portal response from the AI chat agent's
+// ConversationSummaryResponse.
+func MapConversationSummary(r aichatagent.ConversationSummaryResponse) ConversationSummaryResponse {
+	return ConversationSummaryResponse{
+		ConversationID:          r.ConversationID,
+		MessagesExchanged:       r.MessagesExchanged,
+		TroubleshootingAttempts: r.TroubleshootingAttempts,
+		KbArticlesReviewed:      r.KbArticlesReviewed,
+	}
+}
+
+// ConversationSummary is one item of the portal's response for
+// POST /projects/{id}/conversations/search.
+type ConversationSummary struct {
+	ID             string `json:"id"`
+	Number         string `json:"number,omitempty"`
+	InitialMessage string `json:"initialMessage,omitempty"`
+	MessageCount   int    `json:"messageCount"`
+	Case           *Ref   `json:"case,omitempty"`
+	State          string `json:"state,omitempty"`
+	CreatedOn      string `json:"createdOn"`
+	CreatedBy      string `json:"createdBy"`
+}
+
+// SearchConversationsResponse is the portal's response for
+// POST /projects/{id}/conversations/search.
+type SearchConversationsResponse struct {
+	Conversations []ConversationSummary `json:"conversations"`
+	Total         int                   `json:"total"`
+	Limit         int                   `json:"limit"`
+	Offset        int                   `json:"offset"`
+}
+
+// MapSearchConversations builds the portal response from entity-service's
+// SearchConversationsResponse.
+func MapSearchConversations(r entity.SearchConversationsResponse) SearchConversationsResponse {
+	items := make([]ConversationSummary, 0, len(r.Conversations))
+	for _, c := range r.Conversations {
+		summary := ConversationSummary{
+			MessageCount: c.MessageCount,
+			Case:         mapRef(c.Case),
+			CreatedOn:    c.CreatedOn,
+			CreatedBy:    c.CreatedBy,
+		}
+		if c.ID != nil {
+			summary.ID = *c.ID
+		}
+		if c.Number != nil {
+			summary.Number = *c.Number
+		}
+		if c.InitialMessage != nil {
+			summary.InitialMessage = *c.InitialMessage
+		}
+		if c.State != nil {
+			summary.State = *c.State
+		}
+		items = append(items, summary)
+	}
+	return SearchConversationsResponse{
+		Conversations: items,
+		Total:         r.Total,
+		Limit:         r.Limit,
+		Offset:        r.Offset,
+	}
+}

--- a/apps/customer-portal/backend-v2/internal/dto/catalog.go
+++ b/apps/customer-portal/backend-v2/internal/dto/catalog.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dto
+
+import "github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+
+// CatalogItem is a single selectable item within a service catalog.
+type CatalogItem struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// Catalog is one item of the portal's response for POST /catalogs/search.
+type Catalog struct {
+	ID           string        `json:"id"`
+	Name         string        `json:"name"`
+	CatalogItems []CatalogItem `json:"catalogItems"`
+}
+
+// SearchCatalogsResponse is the portal's response for POST /catalogs/search.
+type SearchCatalogsResponse struct {
+	Catalogs []Catalog `json:"catalogs"`
+	Total    int       `json:"total"`
+	Limit    int       `json:"limit"`
+	Offset   int       `json:"offset"`
+}
+
+// MapSearchCatalogs builds the portal response from entity-service's SearchCatalogsResponse.
+func MapSearchCatalogs(r entity.SearchCatalogsResponse) SearchCatalogsResponse {
+	catalogs := make([]Catalog, 0, len(r.Catalogs))
+	for _, c := range r.Catalogs {
+		items := make([]CatalogItem, 0, len(c.CatalogItems))
+		for _, item := range c.CatalogItems {
+			items = append(items, CatalogItem{ID: item.ID, Name: item.Name})
+		}
+		catalogs = append(catalogs, Catalog{
+			ID:           c.ID,
+			Name:         c.Name,
+			CatalogItems: items,
+		})
+	}
+	return SearchCatalogsResponse{
+		Catalogs: catalogs,
+		Total:    r.Total,
+		Limit:    r.Limit,
+		Offset:   r.Offset,
+	}
+}
+
+// CatalogItemVariable is the portal's shape for a single catalog-item variable.
+type CatalogItemVariable struct {
+	ID           string `json:"id"`
+	QuestionText string `json:"questionText"`
+	Order        int    `json:"order"`
+	Type         string `json:"type"`
+}
+
+// CatalogItemVariablesResponse is the portal's response for
+// GET /catalogs/{catalogId}/items/{catalogItemId}/variables.
+type CatalogItemVariablesResponse struct {
+	Variables []CatalogItemVariable `json:"variables"`
+}
+
+// MapCatalogItemVariables builds the portal response from entity-service's
+// GetCatalogItemVariablesResponse.
+func MapCatalogItemVariables(r entity.GetCatalogItemVariablesResponse) CatalogItemVariablesResponse {
+	variables := make([]CatalogItemVariable, 0, len(r.Variables))
+	for _, v := range r.Variables {
+		variables = append(variables, CatalogItemVariable{
+			ID:           v.ID,
+			QuestionText: v.QuestionText,
+			Order:        v.Order,
+			Type:         v.Type,
+		})
+	}
+	return CatalogItemVariablesResponse{Variables: variables}
+}

--- a/apps/customer-portal/backend-v2/internal/dto/comment.go
+++ b/apps/customer-portal/backend-v2/internal/dto/comment.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dto
+
+import (
+	"time"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+)
+
+// CommentCreateRequest is the portal's request shape for POST /comments.
+// entity-service also supports "work_note" and "activity" comment types, but
+// those are internal WSO2 support annotations — the customer portal only
+// ever lets a customer post a plain "comment"; see BuildEntityCreateCommentRequest.
+type CommentCreateRequest struct {
+	ReferenceID   string `json:"referenceId"`
+	ReferenceType string `json:"referenceType"`
+	Content       string `json:"content"`
+}
+
+// BuildEntityCreateCommentRequest converts the portal's comment request into
+// entity-service's request shape, forcing Type to "comment" regardless of
+// anything the caller might otherwise try to set.
+func BuildEntityCreateCommentRequest(req CommentCreateRequest) entity.CreateCommentRequest {
+	return entity.CreateCommentRequest{
+		ReferenceID:   req.ReferenceID,
+		ReferenceType: entity.ReferenceType(req.ReferenceType),
+		Type:          entity.CommentTypeComment,
+		Content:       req.Content,
+	}
+}
+
+// CommentCreateResponse is the portal's response for POST /comments.
+type CommentCreateResponse struct {
+	ID        string    `json:"id"`
+	CreatedOn time.Time `json:"createdOn"`
+	CreatedBy string    `json:"createdBy"`
+}
+
+// MapCommentCreate builds the portal response from entity-service's CreateCommentResponse.
+func MapCommentCreate(r entity.CreateCommentResponse) CommentCreateResponse {
+	return CommentCreateResponse{
+		ID:        r.Comment.ID,
+		CreatedOn: r.Comment.CreatedOn,
+		CreatedBy: r.Comment.CreatedBy.FullName,
+	}
+}
+
+// CommentSearchRequest is the portal's request shape for POST /comments/search.
+// entity-service's Filters.Type is deliberately not exposed here — it would
+// let a caller fetch "work_note" entries (internal WSO2 support annotations
+// on the same reference), which must never reach the customer portal
+// frontend; see BuildEntitySearchCommentsRequest.
+type CommentSearchRequest struct {
+	ReferenceID   string            `json:"referenceId"`
+	ReferenceType string            `json:"referenceType"`
+	Pagination    entity.Pagination `json:"pagination"`
+}
+
+// BuildEntitySearchCommentsRequest converts the portal's search request into
+// entity-service's request shape, always filtering to Type "comment".
+func BuildEntitySearchCommentsRequest(req CommentSearchRequest) entity.SearchCommentsRequest {
+	commentType := entity.CommentTypeComment
+	return entity.SearchCommentsRequest{
+		ReferenceID:   req.ReferenceID,
+		ReferenceType: entity.ReferenceType(req.ReferenceType),
+		Pagination:    req.Pagination,
+		Filters:       &entity.CommentFilters{Type: &commentType},
+	}
+}
+
+// CommentView is one item of the portal's response for POST /comments/search.
+type CommentView struct {
+	ID        string    `json:"id"`
+	Content   string    `json:"content"`
+	CreatedOn time.Time `json:"createdOn"`
+	CreatedBy string    `json:"createdBy"`
+}
+
+// SearchCommentsResponse is the portal's response for POST /comments/search.
+type SearchCommentsResponse struct {
+	Comments []CommentView `json:"comments"`
+	Total    int           `json:"total"`
+	Limit    int           `json:"limit"`
+	Offset   int           `json:"offset"`
+	HasMore  bool          `json:"hasMore"`
+}
+
+// MapSearchComments builds the portal response from entity-service's SearchCommentsResponse.
+func MapSearchComments(r entity.SearchCommentsResponse) SearchCommentsResponse {
+	comments := make([]CommentView, 0, len(r.Comments))
+	for _, c := range r.Comments {
+		comments = append(comments, CommentView{
+			ID:        c.ID,
+			Content:   c.Content,
+			CreatedOn: c.CreatedOn,
+			CreatedBy: c.CreatedBy.FullName,
+		})
+	}
+	return SearchCommentsResponse{
+		Comments: comments,
+		Total:    r.Total,
+		Limit:    r.Limit,
+		Offset:   r.Offset,
+		HasMore:  r.HasMore,
+	}
+}

--- a/apps/customer-portal/backend-v2/internal/dto/deployment.go
+++ b/apps/customer-portal/backend-v2/internal/dto/deployment.go
@@ -82,3 +82,19 @@ func MapDeploymentCreate(r entity.CreateDeploymentResponse) DeploymentCreateResp
 		CreatedOn: r.Deployment.CreatedOn,
 	}
 }
+
+// DeploymentUpdateResponse is the portal's response for PATCH /deployments/{id}.
+// Deliberately excludes entity-service's UpdatedBy (internal actor identity),
+// consistent with the other update responses in this package.
+type DeploymentUpdateResponse struct {
+	ID        string    `json:"id"`
+	UpdatedOn time.Time `json:"updatedOn"`
+}
+
+// MapDeploymentUpdate builds the portal response from entity-service's UpdateDeploymentResponse.
+func MapDeploymentUpdate(r entity.UpdateDeploymentResponse) DeploymentUpdateResponse {
+	return DeploymentUpdateResponse{
+		ID:        r.Deployment.ID,
+		UpdatedOn: r.Deployment.UpdatedOn,
+	}
+}

--- a/apps/customer-portal/backend-v2/internal/dto/product_vulnerability.go
+++ b/apps/customer-portal/backend-v2/internal/dto/product_vulnerability.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dto
+
+import "github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+
+// ProductVulnerability is the portal's shape for a single vulnerability,
+// used both for GET /products/vulnerabilities/{id} and as one item of
+// POST /products/vulnerabilities/search's response.
+type ProductVulnerability struct {
+	ID              string  `json:"id"`
+	CveID           string  `json:"cveId"`
+	VulnerabilityID string  `json:"vulnerabilityId"`
+	Priority        string  `json:"priority"`
+	ProductName     *string `json:"productName,omitempty"`
+	ProductVersion  *string `json:"productVersion,omitempty"`
+	ComponentName   string  `json:"componentName"`
+	Version         string  `json:"version"`
+	Type            string  `json:"type"`
+	ComponentType   *string `json:"componentType,omitempty"`
+	UpdateLevel     *string `json:"updateLevel,omitempty"`
+	UseCase         *string `json:"useCase,omitempty"`
+	Justification   *string `json:"justification,omitempty"`
+	Resolution      *string `json:"resolution,omitempty"`
+}
+
+// MapProductVulnerability builds the portal shape from entity-service's ProductVulnerabilityView.
+func MapProductVulnerability(v entity.ProductVulnerabilityView) ProductVulnerability {
+	return ProductVulnerability{
+		ID:              v.ID,
+		CveID:           v.CveID,
+		VulnerabilityID: v.VulnerabilityID,
+		Priority:        v.Priority,
+		ProductName:     v.ProductName,
+		ProductVersion:  v.ProductVersion,
+		ComponentName:   v.ComponentName,
+		Version:         v.Version,
+		Type:            v.Type,
+		ComponentType:   v.ComponentType,
+		UpdateLevel:     v.UpdateLevel,
+		UseCase:         v.UseCase,
+		Justification:   v.Justification,
+		Resolution:      v.Resolution,
+	}
+}
+
+// SearchProductVulnerabilitiesResponse is the portal's response for
+// POST /products/vulnerabilities/search.
+type SearchProductVulnerabilitiesResponse struct {
+	ProductVulnerabilities []ProductVulnerability `json:"productVulnerabilities"`
+	Total                  int                    `json:"total"`
+	Limit                  int                    `json:"limit"`
+	Offset                 int                    `json:"offset"`
+}
+
+// MapSearchProductVulnerabilities builds the portal response from
+// entity-service's SearchProductVulnerabilitiesResponse.
+func MapSearchProductVulnerabilities(r entity.SearchProductVulnerabilitiesResponse) SearchProductVulnerabilitiesResponse {
+	items := make([]ProductVulnerability, 0, len(r.ProductVulnerabilities))
+	for _, v := range r.ProductVulnerabilities {
+		items = append(items, MapProductVulnerability(v))
+	}
+	return SearchProductVulnerabilitiesResponse{
+		ProductVulnerabilities: items,
+		Total:                  r.Total,
+		Limit:                  r.Limit,
+		Offset:                 r.Offset,
+	}
+}

--- a/apps/customer-portal/backend-v2/internal/dto/time_card.go
+++ b/apps/customer-portal/backend-v2/internal/dto/time_card.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dto
+
+import "github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+
+// TimeCardCaseRef is a reference to the case associated with a time card.
+type TimeCardCaseRef struct {
+	ID     string `json:"id"`
+	Name   string `json:"name"`
+	Number string `json:"number"`
+}
+
+// TimeCardSummary is one item of the portal's response for POST /time-cards/search.
+//
+// Deliberately excludes entity-service's per-category time breakdowns
+// (timeAnalyzing, timeSettingUp, timeReproducingDebugging,
+// timeProvidingSolution, timePatching), issueComplexity, workLogComment,
+// rejectionReason, and the eligible-approvers list — internal WSO2 support
+// bookkeeping the Ballerina backend this is rewriting never exposed to the
+// customer portal either.
+type TimeCardSummary struct {
+	ID          string           `json:"id"`
+	TotalTime   float64          `json:"totalTime"`
+	WorkDate    string           `json:"workDate"`
+	HasBillable bool             `json:"hasBillable"`
+	State       *string          `json:"state,omitempty"`
+	User        *Ref             `json:"user,omitempty"`
+	ApprovedBy  *Ref             `json:"approvedBy,omitempty"`
+	Project     *Ref             `json:"project,omitempty"`
+	Case        *TimeCardCaseRef `json:"case,omitempty"`
+}
+
+// SearchTimeCardsResponse is the portal's response for POST /time-cards/search.
+type SearchTimeCardsResponse struct {
+	TimeCards []TimeCardSummary `json:"timeCards"`
+	Total     int               `json:"total"`
+	Limit     int               `json:"limit"`
+	Offset    int               `json:"offset"`
+}
+
+// MapSearchTimeCards builds the portal response from entity-service's SearchTimeCardsResponse.
+func MapSearchTimeCards(r entity.SearchTimeCardsResponse) SearchTimeCardsResponse {
+	items := make([]TimeCardSummary, 0, len(r.TimeCards))
+	for _, t := range r.TimeCards {
+		items = append(items, TimeCardSummary{
+			ID:          t.ID,
+			TotalTime:   t.TotalTime,
+			WorkDate:    t.WorkDate,
+			HasBillable: t.HasBillable,
+			State:       t.State,
+			User:        mapTimeCardRef(t.User),
+			ApprovedBy:  mapTimeCardRef(t.ApprovedBy),
+			Project:     mapTimeCardRef(t.Project),
+			Case:        mapTimeCardCaseRef(t.Case),
+		})
+	}
+	return SearchTimeCardsResponse{
+		TimeCards: items,
+		Total:     r.Total,
+		Limit:     r.Limit,
+		Offset:    r.Offset,
+	}
+}
+
+func mapTimeCardRef(r *entity.TimeCardRef) *Ref {
+	if r == nil {
+		return nil
+	}
+	return &Ref{ID: r.ID, Name: r.Name}
+}
+
+func mapTimeCardCaseRef(r *entity.TimeCardCaseRef) *TimeCardCaseRef {
+	if r == nil {
+		return nil
+	}
+	return &TimeCardCaseRef{ID: r.ID, Name: r.Name, Number: r.Number}
+}

--- a/apps/customer-portal/backend-v2/internal/entity/catalogs.go
+++ b/apps/customer-portal/backend-v2/internal/entity/catalogs.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package entity
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+)
+
+// SearchCatalogs calls POST /catalogs/search.
+func (c *Client) SearchCatalogs(ctx context.Context, req SearchCatalogsRequest) (SearchCatalogsResponse, error) {
+	var out SearchCatalogsResponse
+	err := c.postJSON(ctx, "/catalogs/search", req, &out)
+	return out, err
+}
+
+// GetCatalogItemVariables calls GET /catalogs/{catalogId}/items/{catalogItemId}/variables.
+func (c *Client) GetCatalogItemVariables(ctx context.Context, catalogID, catalogItemID string) (GetCatalogItemVariablesResponse, error) {
+	var out GetCatalogItemVariablesResponse
+	path := fmt.Sprintf("/catalogs/%s/items/%s/variables", url.PathEscape(catalogID), url.PathEscape(catalogItemID))
+	err := c.getJSON(ctx, path, &out)
+	return out, err
+}

--- a/apps/customer-portal/backend-v2/internal/entity/comments.go
+++ b/apps/customer-portal/backend-v2/internal/entity/comments.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package entity
+
+import "context"
+
+// CreateComment calls POST /comments.
+func (c *Client) CreateComment(ctx context.Context, req CreateCommentRequest) (CreateCommentResponse, error) {
+	var out CreateCommentResponse
+	err := c.postJSON(ctx, "/comments", req, &out)
+	return out, err
+}
+
+// SearchComments calls POST /comments/search.
+func (c *Client) SearchComments(ctx context.Context, req SearchCommentsRequest) (SearchCommentsResponse, error) {
+	var out SearchCommentsResponse
+	err := c.postJSON(ctx, "/comments/search", req, &out)
+	return out, err
+}

--- a/apps/customer-portal/backend-v2/internal/entity/conversations.go
+++ b/apps/customer-portal/backend-v2/internal/entity/conversations.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package entity
+
+import "context"
+
+// SearchConversations calls POST /conversations/search.
+//
+// NOTE: only entity-service's ServiceNow data source supports this route —
+// see cs-tools/entity-service/internal/server/routes.go.
+func (c *Client) SearchConversations(ctx context.Context, req SearchConversationsRequest) (SearchConversationsResponse, error) {
+	var out SearchConversationsResponse
+	err := c.postJSON(ctx, "/conversations/search", req, &out)
+	return out, err
+}

--- a/apps/customer-portal/backend-v2/internal/entity/deployments.go
+++ b/apps/customer-portal/backend-v2/internal/entity/deployments.go
@@ -16,7 +16,11 @@
 
 package entity
 
-import "context"
+import (
+	"context"
+	"fmt"
+	"net/url"
+)
 
 // SearchDeployments calls POST /deployments/search.
 func (c *Client) SearchDeployments(ctx context.Context, req SearchDeploymentsRequest) (SearchDeploymentsResponse, error) {
@@ -32,5 +36,13 @@ func (c *Client) SearchDeployments(ctx context.Context, req SearchDeploymentsReq
 func (c *Client) CreateDeployment(ctx context.Context, req CreateDeploymentRequest) (CreateDeploymentResponse, error) {
 	var out CreateDeploymentResponse
 	err := c.postJSON(ctx, "/deployments", req, &out)
+	return out, err
+}
+
+// UpdateDeployment calls PATCH /deployments/{id}.
+func (c *Client) UpdateDeployment(ctx context.Context, id string, req UpdateDeploymentRequest) (UpdateDeploymentResponse, error) {
+	req.ID = id // never serialized (json:"-"); set for consistency with the struct's doc comment
+	var out UpdateDeploymentResponse
+	err := c.patchJSON(ctx, fmt.Sprintf("/deployments/%s", url.PathEscape(id)), req, &out)
 	return out, err
 }

--- a/apps/customer-portal/backend-v2/internal/entity/product_vulnerabilities.go
+++ b/apps/customer-portal/backend-v2/internal/entity/product_vulnerabilities.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package entity
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+)
+
+// SearchProductVulnerabilities calls POST /products/vulnerabilities/search.
+func (c *Client) SearchProductVulnerabilities(ctx context.Context, req SearchProductVulnerabilitiesRequest) (SearchProductVulnerabilitiesResponse, error) {
+	var out SearchProductVulnerabilitiesResponse
+	err := c.postJSON(ctx, "/products/vulnerabilities/search", req, &out)
+	return out, err
+}
+
+// GetProductVulnerability calls GET /products/vulnerabilities/{id}.
+func (c *Client) GetProductVulnerability(ctx context.Context, id string) (ProductVulnerabilityView, error) {
+	var out ProductVulnerabilityView
+	err := c.getJSON(ctx, fmt.Sprintf("/products/vulnerabilities/%s", url.PathEscape(id)), &out)
+	return out, err
+}

--- a/apps/customer-portal/backend-v2/internal/entity/time_cards.go
+++ b/apps/customer-portal/backend-v2/internal/entity/time_cards.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package entity
+
+import "context"
+
+// SearchTimeCards calls POST /time-cards/search.
+//
+// NOTE: only entity-service's ServiceNow data source supports this route —
+// see cs-tools/entity-service/internal/server/routes.go.
+func (c *Client) SearchTimeCards(ctx context.Context, req SearchTimeCardsRequest) (SearchTimeCardsResponse, error) {
+	var out SearchTimeCardsResponse
+	err := c.postJSON(ctx, "/time-cards/search", req, &out)
+	return out, err
+}

--- a/apps/customer-portal/backend-v2/internal/entity/types.go
+++ b/apps/customer-portal/backend-v2/internal/entity/types.go
@@ -614,6 +614,33 @@ type CreateDeploymentResponse struct {
 	Deployment CreatedDeployment `json:"deployment"`
 }
 
+// UpdateDeploymentRequest is the input for PATCH /deployments/{id}. Either
+// detail fields (Name, Type, Description) or Active (to deactivate) must be
+// provided, but not both groups in the same request. Active can only be set
+// to false. Description uses json.RawMessage to preserve the three-state
+// absent/null/value semantics entity-service expects (see
+// UpdateDeployedProductRequest's doc comment for the same convention).
+type UpdateDeploymentRequest struct {
+	ID          string          `json:"-"`
+	Name        *string         `json:"name,omitempty"`
+	Type        *string         `json:"type,omitempty"`
+	Description json.RawMessage `json:"description,omitempty"`
+	Active      *bool           `json:"active,omitempty"`
+}
+
+// UpdatedDeployment carries the fields of a deployment that may change after an update.
+type UpdatedDeployment struct {
+	ID        string    `json:"id"`
+	UpdatedOn time.Time `json:"updatedOn"`
+	UpdatedBy string    `json:"updatedBy"`
+}
+
+// UpdateDeploymentResponse is entity-service's response for PATCH /deployments/{id}.
+type UpdateDeploymentResponse struct {
+	Message    string            `json:"message"`
+	Deployment UpdatedDeployment `json:"deployment"`
+}
+
 // --- deployed products ---
 
 // CreateDeployedProductRequest is the input for POST /deployed-products.
@@ -847,6 +874,75 @@ type SearchCaseActivitiesResponse struct {
 	HasMore  bool           `json:"hasMore"`
 }
 
+// --- comments ---
+//
+// Generic comments attached to any reference entity (case, conversation,
+// change_request, deployment, incident — see ReferenceType above) — distinct
+// from case-specific comments (see CreateCaseCommentRequest above).
+
+// CreateCommentRequest is the input for POST /comments. Type is always
+// CommentTypeComment for portal-originated comments — see
+// dto.BuildEntityCreateCommentRequest.
+type CreateCommentRequest struct {
+	ReferenceID   string        `json:"referenceId"`
+	ReferenceType ReferenceType `json:"referenceType"`
+	Type          CommentType   `json:"type"`
+	Content       string        `json:"content"`
+}
+
+// CommentUserRef holds user details embedded in a comment response.
+type CommentUserRef struct {
+	ID        string `json:"id"`
+	FirstName string `json:"firstName"`
+	LastName  string `json:"lastName"`
+	FullName  string `json:"fullName"`
+}
+
+// CommentCreated carries the fields returned after creating a comment.
+type CommentCreated struct {
+	ID        string         `json:"id"`
+	CreatedOn time.Time      `json:"createdOn"`
+	CreatedBy CommentUserRef `json:"createdBy"`
+}
+
+// CreateCommentResponse is entity-service's response for POST /comments.
+type CreateCommentResponse struct {
+	Message string         `json:"message"`
+	Comment CommentCreated `json:"comment"`
+}
+
+// CommentFilters holds optional filter criteria for POST /comments/search.
+type CommentFilters struct {
+	Type *CommentType `json:"type,omitempty"`
+}
+
+// SearchCommentsRequest is the input for POST /comments/search.
+type SearchCommentsRequest struct {
+	ReferenceID   string          `json:"referenceId"`
+	ReferenceType ReferenceType   `json:"referenceType"`
+	Pagination    Pagination      `json:"pagination"`
+	Filters       *CommentFilters `json:"filters,omitempty"`
+}
+
+// CommentView is a single search result item from POST /comments/search.
+type CommentView struct {
+	ID          string         `json:"id"`
+	ReferenceID string         `json:"referenceId"`
+	Content     string         `json:"content"`
+	Type        CommentType    `json:"type"`
+	CreatedOn   time.Time      `json:"createdOn"`
+	CreatedBy   CommentUserRef `json:"createdBy"`
+}
+
+// SearchCommentsResponse is entity-service's response for POST /comments/search.
+type SearchCommentsResponse struct {
+	Comments []CommentView `json:"comments"`
+	Total    int           `json:"total"`
+	Limit    int           `json:"limit"`
+	Offset   int           `json:"offset"`
+	HasMore  bool          `json:"hasMore"`
+}
+
 // --- products ---
 //
 // Like accounts, entity-service returns a different wire shape for these
@@ -908,6 +1004,215 @@ type SearchProductVersionsResponse struct {
 	Limit           int                  `json:"limit"`
 	Offset          int                  `json:"offset"`
 	HasMore         bool                 `json:"hasMore"`
+}
+
+// --- product vulnerabilities ---
+
+// SearchProductVulnerabilitiesFilters holds the optional filter criteria for
+// a product vulnerability search.
+type SearchProductVulnerabilitiesFilters struct {
+	SearchQuery    string  `json:"searchQuery,omitempty"`
+	Priority       *string `json:"priority,omitempty"`
+	ProductName    string  `json:"productName,omitempty"`
+	ProductVersion string  `json:"productVersion,omitempty"`
+}
+
+// SearchProductVulnerabilitiesRequest is the input for POST /products/vulnerabilities/search.
+type SearchProductVulnerabilitiesRequest struct {
+	Filters    *SearchProductVulnerabilitiesFilters `json:"filters,omitempty"`
+	Pagination Pagination                           `json:"pagination"`
+}
+
+// ProductVulnerabilityView is entity-service's representation of a
+// vulnerability, returned both in search results and as the single-item
+// GET response.
+type ProductVulnerabilityView struct {
+	ID              string  `json:"id"`
+	CveID           string  `json:"cveId"`
+	VulnerabilityID string  `json:"vulnerabilityId"`
+	Priority        string  `json:"priority"`
+	ProductName     *string `json:"productName"`
+	ProductVersion  *string `json:"productVersion"`
+	ComponentName   string  `json:"componentName"`
+	Version         string  `json:"version"`
+	Type            string  `json:"type"`
+	ComponentType   *string `json:"componentType"`
+	UpdateLevel     *string `json:"updateLevel"`
+	UseCase         *string `json:"useCase"`
+	Justification   *string `json:"justification"`
+	Resolution      *string `json:"resolution"`
+}
+
+// SearchProductVulnerabilitiesResponse is entity-service's response for
+// POST /products/vulnerabilities/search.
+type SearchProductVulnerabilitiesResponse struct {
+	ProductVulnerabilities []ProductVulnerabilityView `json:"productVulnerabilities"`
+	Total                  int                        `json:"total"`
+	Limit                  int                        `json:"limit"`
+	Offset                 int                        `json:"offset"`
+}
+
+// --- catalogs ---
+
+// CatalogItem is a single selectable item within a service catalog.
+type CatalogItem struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// CatalogView represents a service catalog containing one or more catalog items.
+type CatalogView struct {
+	ID           string        `json:"id"`
+	Name         string        `json:"name"`
+	CatalogItems []CatalogItem `json:"catalogItems"`
+}
+
+// SearchCatalogsRequest is the input for POST /catalogs/search. DeployedProductID
+// scopes the search to catalogs available for that deployed product.
+type SearchCatalogsRequest struct {
+	DeployedProductID string     `json:"deployedProductId"`
+	Pagination        Pagination `json:"pagination"`
+}
+
+// SearchCatalogsResponse is entity-service's response for POST /catalogs/search.
+type SearchCatalogsResponse struct {
+	Catalogs []CatalogView `json:"catalogs"`
+	Total    int           `json:"total"`
+	Limit    int           `json:"limit"`
+	Offset   int           `json:"offset"`
+}
+
+// CatalogItemVariable describes a single variable (form field) on a catalog item.
+type CatalogItemVariable struct {
+	ID           string `json:"id"`
+	QuestionText string `json:"questionText"`
+	Order        int    `json:"order"`
+	Type         string `json:"type"`
+}
+
+// GetCatalogItemVariablesResponse is entity-service's response for
+// GET /catalogs/{catalogId}/items/{catalogItemId}/variables.
+type GetCatalogItemVariablesResponse struct {
+	Variables []CatalogItemVariable `json:"variables"`
+}
+
+// --- time cards ---
+
+// TimeCardFilters holds the optional filter criteria for a time card search.
+type TimeCardFilters struct {
+	ProjectIDs []string `json:"projectIds,omitempty"`
+	CaseID     *string  `json:"caseId,omitempty"`
+	StartDate  *string  `json:"startDate,omitempty"`
+	EndDate    *string  `json:"endDate,omitempty"`
+	States     []string `json:"states,omitempty"`
+}
+
+// TimeCardSort specifies the sort field and direction for time-card search results.
+type TimeCardSort struct {
+	Field string `json:"field,omitempty"`
+	Order string `json:"order,omitempty"`
+}
+
+// SearchTimeCardsRequest is the input for POST /time-cards/search. entity-service
+// also accepts userId/approverId/approvedById/userIds filters that scope results
+// to a specific WSO2 engineer — deliberately not exposed here since the portal
+// has no notion of a customer selecting a WSO2 engineer to filter by.
+type SearchTimeCardsRequest struct {
+	Filters    *TimeCardFilters `json:"filters,omitempty"`
+	SortBy     TimeCardSort     `json:"sortBy"`
+	Pagination Pagination       `json:"pagination"`
+}
+
+// TimeCardRef is a lightweight reference used for user, approvedBy, and project fields.
+type TimeCardRef struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// TimeCardCaseRef is a reference to the case associated with a time card.
+type TimeCardCaseRef struct {
+	ID     string `json:"id"`
+	Name   string `json:"name"`
+	Number string `json:"number"`
+}
+
+// TimeCardView is a single time card in search results. entity-service also
+// returns per-category time breakdowns (timeAnalyzing, timeSettingUp, etc.),
+// issueComplexity, workLogComment, rejectionReason, and the eligible-approvers
+// list — internal WSO2 support bookkeeping the Ballerina backend never
+// exposed to the customer portal either (see its thinner TimeCard type);
+// mirrored here only insofar as this backend actually decodes them, but see
+// dto.TimeCardSummary for what the portal exposes.
+type TimeCardView struct {
+	ID              string           `json:"id"`
+	TotalTime       float64          `json:"totalTime"`
+	WorkDate        string           `json:"workDate"`
+	HasBillable     bool             `json:"hasBillable"`
+	IssueComplexity *string          `json:"issueComplexity"`
+	WorkLogComment  *string          `json:"workLogComment"`
+	RejectionReason *string          `json:"rejectionReason"`
+	State           *string          `json:"state"`
+	User            *TimeCardRef     `json:"user"`
+	ApprovedBy      *TimeCardRef     `json:"approvedBy"`
+	Project         *TimeCardRef     `json:"project"`
+	Case            *TimeCardCaseRef `json:"case"`
+}
+
+// SearchTimeCardsResponse is entity-service's response for POST /time-cards/search.
+type SearchTimeCardsResponse struct {
+	TimeCards []TimeCardView `json:"timeCards"`
+	Total     int            `json:"total"`
+	Limit     int            `json:"limit"`
+	Offset    int            `json:"offset"`
+}
+
+// --- conversations ---
+//
+// Backing store for the AI chat feature's conversation threads. entity-service
+// currently only supports searching conversations — there is no create/update/
+// get-single route yet (see internal/handler/ai_chat.go's doc comment for the
+// features this blocks).
+
+// SearchConversationsFilters holds the optional filter criteria for a conversation search.
+type SearchConversationsFilters struct {
+	ProjectIDs  []string `json:"projectIds,omitempty"`
+	States      []string `json:"states,omitempty"`
+	SearchQuery string   `json:"searchQuery,omitempty"`
+	CreatedByMe bool     `json:"createdByMe,omitempty"`
+}
+
+// ConversationSort specifies the sort field and direction for conversation search results.
+type ConversationSort struct {
+	Field string `json:"field,omitempty"`
+	Order string `json:"order,omitempty"`
+}
+
+// SearchConversationsRequest is the input for POST /conversations/search.
+type SearchConversationsRequest struct {
+	Filters    SearchConversationsFilters `json:"filters"`
+	SortBy     ConversationSort           `json:"sortBy"`
+	Pagination Pagination                 `json:"pagination"`
+}
+
+// SearchConversationView is the conversation representation returned in search results.
+type SearchConversationView struct {
+	ID             *string    `json:"id"`
+	Number         *string    `json:"number"`
+	InitialMessage *string    `json:"initialMessage"`
+	MessageCount   int        `json:"messageCount"`
+	Project        *EntityRef `json:"project"`
+	Case           *EntityRef `json:"case"`
+	State          *string    `json:"state"`
+	CreatedOn      string     `json:"createdOn"`
+	CreatedBy      string     `json:"createdBy"`
+}
+
+// SearchConversationsResponse is entity-service's response for POST /conversations/search.
+type SearchConversationsResponse struct {
+	Conversations []SearchConversationView `json:"conversations"`
+	Total         int                      `json:"total"`
+	Offset        int                      `json:"offset"`
+	Limit         int                      `json:"limit"`
 }
 
 // --- change requests ---

--- a/apps/customer-portal/backend-v2/internal/handler/ai_chat.go
+++ b/apps/customer-portal/backend-v2/internal/handler/ai_chat.go
@@ -1,0 +1,299 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"strconv"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/aichatagent"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/dto"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/middleware"
+)
+
+// aiChatAgentClient abstracts the upstream AI chat agent operations used by AIChatHandler.
+type aiChatAgentClient interface {
+	CreateCaseClassification(ctx context.Context, req aichatagent.CaseClassificationPayload) (aichatagent.CaseClassificationResponse, error)
+	CreateChat(ctx context.Context, req aichatagent.ChatPayload) (aichatagent.ChatResponse, error)
+	GetRecommendations(ctx context.Context, req aichatagent.RecommendationRequest) (aichatagent.RecommendationResponse, error)
+	GetConversationSummary(ctx context.Context, projectID, conversationID string) (aichatagent.ConversationSummaryResponse, error)
+}
+
+// entityConversationClient abstracts the entity-service conversation and
+// comment operations used by AIChatHandler.
+type entityConversationClient interface {
+	SearchConversations(ctx context.Context, req entity.SearchConversationsRequest) (entity.SearchConversationsResponse, error)
+	SearchComments(ctx context.Context, req entity.SearchCommentsRequest) (entity.SearchCommentsResponse, error)
+	CreateComment(ctx context.Context, req entity.CreateCommentRequest) (entity.CreateCommentResponse, error)
+}
+
+// AIChatHandler handles HTTP requests for the AI chat feature: case
+// classification, KB article recommendations, conversation search/messages,
+// and conversation summaries. See WebSocketHandler for the real-time chat
+// proxy, and its doc comment for the entity-service gaps (no
+// createConversation/updateConversation, no comment createdBy override) that
+// this handler works around or skips the same way.
+type AIChatHandler struct {
+	ai     aiChatAgentClient
+	entity entityConversationClient
+}
+
+// NewAIChatHandler creates an AIChatHandler backed by the given AI chat agent and entity clients.
+func NewAIChatHandler(ai aiChatAgentClient, entityClient entityConversationClient) *AIChatHandler {
+	return &AIChatHandler{ai: ai, entity: entityClient}
+}
+
+// ClassifyCase handles POST /cases/classify.
+func (h *AIChatHandler) ClassifyCase(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	body, ok := readJSONBody(w, r)
+	if !ok {
+		return
+	}
+
+	var req dto.CaseClassificationRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.ai.CreateCaseClassification(r.Context(), dto.BuildCaseClassificationPayload(req))
+	if err != nil {
+		slog.ErrorContext(r.Context(), "aichatagent CreateCaseClassification failed", "userID", user.UserID, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to classify chat message.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusOK, dto.MapCaseClassification(result))
+}
+
+// SearchRecommendations handles POST /conversations/recommendations/search.
+func (h *AIChatHandler) SearchRecommendations(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	body, ok := readJSONBody(w, r)
+	if !ok {
+		return
+	}
+
+	var req dto.RecommendationRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.ai.GetRecommendations(r.Context(), dto.BuildRecommendationRequest(req))
+	if err != nil {
+		slog.ErrorContext(r.Context(), "aichatagent GetRecommendations failed", "userID", user.UserID, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to retrieve recommendations.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusOK, dto.MapRecommendationResponse(result))
+}
+
+// SearchConversations handles POST /projects/{id}/conversations/search.
+func (h *AIChatHandler) SearchConversations(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	projectID := r.PathValue("id")
+	if projectID == "" || !uuidRe.MatchString(projectID) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	body, ok := readJSONBody(w, r)
+	if !ok {
+		return
+	}
+
+	var req entity.SearchConversationsRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+	req.Filters.ProjectIDs = []string{projectID}
+
+	result, err := h.entity.SearchConversations(r.Context(), req)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity SearchConversations failed", "userID", user.UserID, "projectID", projectID, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to retrieve conversations.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusOK, dto.MapSearchConversations(result))
+}
+
+// GetConversationMessages handles GET /conversations/{id}/messages.
+// Backed by the generic comment search (referenceType=conversation), the
+// same route the portal uses for POST /comments/search.
+func (h *AIChatHandler) GetConversationMessages(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	conversationID := r.PathValue("id")
+	if conversationID == "" || !uuidRe.MatchString(conversationID) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	limit, offset, ok := parseLimitOffset(w, r)
+	if !ok {
+		return
+	}
+
+	req := dto.BuildEntitySearchCommentsRequest(dto.CommentSearchRequest{
+		ReferenceID:   conversationID,
+		ReferenceType: string(entity.ReferenceTypeConversation),
+		Pagination:    entity.Pagination{Limit: limit, Offset: offset},
+	})
+
+	result, err := h.entity.SearchComments(r.Context(), req)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity SearchComments failed", "userID", user.UserID, "conversationID", conversationID, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to retrieve conversation messages.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusOK, dto.MapSearchComments(result))
+}
+
+// SendConversationMessage handles
+// POST /projects/{projectId}/conversations/{conversationId}/messages — a
+// follow-up message on an existing conversation. See WebSocketHandler's doc
+// comment for why the AI agent's reply is not saved as a comment here and
+// the conversation's resolved state is not updated.
+func (h *AIChatHandler) SendConversationMessage(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	projectID := r.PathValue("projectId")
+	conversationID := r.PathValue("conversationId")
+	if !uuidRe.MatchString(projectID) || !uuidRe.MatchString(conversationID) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	body, ok := readJSONBody(w, r)
+	if !ok {
+		return
+	}
+
+	var req dto.ChatMessageRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+	if req.Message == "" {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	chatResp, err := h.ai.CreateChat(r.Context(), aichatagent.ChatPayload{
+		Message:        req.Message,
+		AccountID:      projectID,
+		ConversationID: conversationID,
+		EnvProducts:    req.EnvProducts,
+	})
+	if err != nil {
+		slog.ErrorContext(r.Context(), "aichatagent CreateChat failed", "userID", user.UserID, "conversationID", conversationID, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to process conversation message.")
+		return
+	}
+
+	if _, err := h.entity.CreateComment(r.Context(), entity.CreateCommentRequest{
+		ReferenceID:   conversationID,
+		ReferenceType: entity.ReferenceTypeConversation,
+		Type:          entity.CommentTypeComment,
+		Content:       req.Message,
+	}); err != nil {
+		slog.ErrorContext(r.Context(), "entity CreateComment failed for conversation message", "userID", user.UserID, "conversationID", conversationID, "err", summarizeErr(err))
+	}
+
+	writeJSONValue(w, http.StatusOK, dto.MapChatResponse(chatResp))
+}
+
+// GetConversationSummary handles GET /projects/{id}/conversations/{conversationId}/summary.
+func (h *AIChatHandler) GetConversationSummary(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	projectID := r.PathValue("id")
+	conversationID := r.PathValue("conversationId")
+	if !uuidRe.MatchString(projectID) || !uuidRe.MatchString(conversationID) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	result, err := h.ai.GetConversationSummary(r.Context(), projectID, conversationID)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "aichatagent GetConversationSummary failed", "userID", user.UserID, "conversationID", conversationID, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to retrieve conversation summary.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusOK, dto.MapConversationSummary(result))
+}
+
+// parseLimitOffset parses the limit/offset query parameters, defaulting to
+// 20/0. Writes a 400 response and returns ok=false on an invalid value.
+func parseLimitOffset(w http.ResponseWriter, r *http.Request) (limit, offset int, ok bool) {
+	limit, offset = 20, 0
+	if raw := r.URL.Query().Get("limit"); raw != "" {
+		v, err := strconv.Atoi(raw)
+		if err != nil || v < 0 {
+			writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+			return 0, 0, false
+		}
+		limit = v
+	}
+	if raw := r.URL.Query().Get("offset"); raw != "" {
+		v, err := strconv.Atoi(raw)
+		if err != nil || v < 0 {
+			writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+			return 0, 0, false
+		}
+		offset = v
+	}
+	return limit, offset, true
+}

--- a/apps/customer-portal/backend-v2/internal/handler/ai_chat.go
+++ b/apps/customer-portal/backend-v2/internal/handler/ai_chat.go
@@ -277,11 +277,15 @@ func (h *AIChatHandler) GetConversationSummary(w http.ResponseWriter, r *http.Re
 
 // parseLimitOffset parses the limit/offset query parameters, defaulting to
 // 20/0. Writes a 400 response and returns ok=false on an invalid value.
+// maxConversationMessagesLimit caps GetConversationMessages' limit query
+// param, matching this backend's other search endpoints' page-size ceiling.
+const maxConversationMessagesLimit = 100
+
 func parseLimitOffset(w http.ResponseWriter, r *http.Request) (limit, offset int, ok bool) {
 	limit, offset = 20, 0
 	if raw := r.URL.Query().Get("limit"); raw != "" {
 		v, err := strconv.Atoi(raw)
-		if err != nil || v < 0 {
+		if err != nil || v < 1 || v > maxConversationMessagesLimit {
 			writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
 			return 0, 0, false
 		}

--- a/apps/customer-portal/backend-v2/internal/handler/catalogs.go
+++ b/apps/customer-portal/backend-v2/internal/handler/catalogs.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/dto"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/middleware"
+)
+
+// entityCatalogClient abstracts the entity-service catalog operations used by CatalogHandler.
+type entityCatalogClient interface {
+	SearchCatalogs(ctx context.Context, req entity.SearchCatalogsRequest) (entity.SearchCatalogsResponse, error)
+	GetCatalogItemVariables(ctx context.Context, catalogID, catalogItemID string) (entity.GetCatalogItemVariablesResponse, error)
+}
+
+// CatalogHandler handles HTTP requests for service catalog operations.
+type CatalogHandler struct {
+	entity entityCatalogClient
+}
+
+// NewCatalogHandler creates a CatalogHandler backed by the given entity client.
+func NewCatalogHandler(entity entityCatalogClient) *CatalogHandler {
+	return &CatalogHandler{entity: entity}
+}
+
+// SearchCatalogs handles POST /catalogs/search.
+func (h *CatalogHandler) SearchCatalogs(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	body, ok := readJSONBody(w, r)
+	if !ok {
+		return
+	}
+
+	var req entity.SearchCatalogsRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+	if !uuidRe.MatchString(req.DeployedProductID) {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.SearchCatalogs(r.Context(), req)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity SearchCatalogs failed", "userID", user.UserID, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to search catalogs.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusOK, dto.MapSearchCatalogs(result))
+}
+
+// GetCatalogItemVariables handles GET /catalogs/{catalogId}/items/{catalogItemId}/variables.
+func (h *CatalogHandler) GetCatalogItemVariables(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	catalogID := r.PathValue("catalogId")
+	catalogItemID := r.PathValue("catalogItemId")
+	if !uuidRe.MatchString(catalogID) || !uuidRe.MatchString(catalogItemID) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	result, err := h.entity.GetCatalogItemVariables(r.Context(), catalogID, catalogItemID)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity GetCatalogItemVariables failed", "userID", user.UserID, "catalogID", catalogID, "catalogItemID", catalogItemID, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to retrieve catalog item variables.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusOK, dto.MapCatalogItemVariables(result))
+}

--- a/apps/customer-portal/backend-v2/internal/handler/comments.go
+++ b/apps/customer-portal/backend-v2/internal/handler/comments.go
@@ -1,0 +1,113 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/dto"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/middleware"
+)
+
+// entityCommentClient abstracts the entity-service generic-comment operations
+// used by CommentHandler.
+type entityCommentClient interface {
+	CreateComment(ctx context.Context, req entity.CreateCommentRequest) (entity.CreateCommentResponse, error)
+	SearchComments(ctx context.Context, req entity.SearchCommentsRequest) (entity.SearchCommentsResponse, error)
+}
+
+// CommentHandler handles HTTP requests for generic comments attached to any
+// reference entity (case, conversation, change_request, deployment,
+// incident) — distinct from CaseHandler's case-specific comment endpoint.
+type CommentHandler struct {
+	entity entityCommentClient
+}
+
+// NewCommentHandler creates a CommentHandler backed by the given entity client.
+func NewCommentHandler(entity entityCommentClient) *CommentHandler {
+	return &CommentHandler{entity: entity}
+}
+
+// CreateComment handles POST /comments.
+func (h *CommentHandler) CreateComment(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	body, ok := readJSONBody(w, r)
+	if !ok {
+		return
+	}
+
+	var req dto.CommentCreateRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+	if req.ReferenceID == "" || req.ReferenceType == "" || req.Content == "" {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.CreateComment(r.Context(), dto.BuildEntityCreateCommentRequest(req))
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity CreateComment failed", "userID", user.UserID, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to create comment.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusCreated, dto.MapCommentCreate(result))
+}
+
+// SearchComments handles POST /comments/search.
+func (h *CommentHandler) SearchComments(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	body, ok := readJSONBody(w, r)
+	if !ok {
+		return
+	}
+
+	var req dto.CommentSearchRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+	if req.ReferenceID == "" || req.ReferenceType == "" {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.SearchComments(r.Context(), dto.BuildEntitySearchCommentsRequest(req))
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity SearchComments failed", "userID", user.UserID, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to search comments.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusOK, dto.MapSearchComments(result))
+}

--- a/apps/customer-portal/backend-v2/internal/handler/comments.go
+++ b/apps/customer-portal/backend-v2/internal/handler/comments.go
@@ -41,6 +41,15 @@ type CommentHandler struct {
 	entity entityCommentClient
 }
 
+// validCommentReferenceType matches entity-service's own ReferenceType enum.
+var validCommentReferenceType = map[string]bool{
+	string(entity.ReferenceTypeCase):          true,
+	string(entity.ReferenceTypeConversation):  true,
+	string(entity.ReferenceTypeChangeRequest): true,
+	string(entity.ReferenceTypeDeployment):    true,
+	string(entity.ReferenceTypeIncident):      true,
+}
+
 // NewCommentHandler creates a CommentHandler backed by the given entity client.
 func NewCommentHandler(entity entityCommentClient) *CommentHandler {
 	return &CommentHandler{entity: entity}
@@ -64,7 +73,7 @@ func (h *CommentHandler) CreateComment(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
 		return
 	}
-	if req.ReferenceID == "" || req.ReferenceType == "" || req.Content == "" {
+	if !uuidRe.MatchString(req.ReferenceID) || !validCommentReferenceType[req.ReferenceType] || req.Content == "" {
 		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
 		return
 	}
@@ -97,7 +106,7 @@ func (h *CommentHandler) SearchComments(w http.ResponseWriter, r *http.Request) 
 		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
 		return
 	}
-	if req.ReferenceID == "" || req.ReferenceType == "" {
+	if !uuidRe.MatchString(req.ReferenceID) || !validCommentReferenceType[req.ReferenceType] {
 		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
 		return
 	}

--- a/apps/customer-portal/backend-v2/internal/handler/deployments.go
+++ b/apps/customer-portal/backend-v2/internal/handler/deployments.go
@@ -32,6 +32,7 @@ import (
 type entityDeploymentClient interface {
 	SearchDeployments(ctx context.Context, req entity.SearchDeploymentsRequest) (entity.SearchDeploymentsResponse, error)
 	CreateDeployment(ctx context.Context, req entity.CreateDeploymentRequest) (entity.CreateDeploymentResponse, error)
+	UpdateDeployment(ctx context.Context, id string, req entity.UpdateDeploymentRequest) (entity.UpdateDeploymentResponse, error)
 }
 
 // DeploymentHandler handles HTTP requests for deployment operations.
@@ -104,4 +105,50 @@ func (h *DeploymentHandler) CreateDeployment(w http.ResponseWriter, r *http.Requ
 	}
 
 	writeJSONValue(w, http.StatusCreated, dto.MapDeploymentCreate(result))
+}
+
+// PatchDeployment handles PATCH /deployments/{id}.
+func (h *DeploymentHandler) PatchDeployment(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	id := r.PathValue("id")
+	if id == "" || !uuidRe.MatchString(id) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	body, ok := readJSONBody(w, r)
+	if !ok {
+		return
+	}
+
+	// Decoded directly into entity-service's request struct (no restricted
+	// portal DTO) — every field here (name/type/description/active) is
+	// customer-appropriate, matching the deployed-product update endpoint.
+	var req entity.UpdateDeploymentRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+	// entity-service requires exactly one of the detail-fields group
+	// (name/type/description) or active=false — never both, never neither.
+	detailFieldsSet := req.Name != nil || req.Type != nil || len(req.Description) > 0
+	activeSet := req.Active != nil
+	if detailFieldsSet == activeSet {
+		writeError(w, http.StatusBadRequest, "Provide either name/type/description or active, but not both.")
+		return
+	}
+
+	result, err := h.entity.UpdateDeployment(r.Context(), id, req)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity UpdateDeployment failed", "userID", user.UserID, "deploymentID", id, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to update deployment.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusOK, dto.MapDeploymentUpdate(result))
 }

--- a/apps/customer-portal/backend-v2/internal/handler/deployments.go
+++ b/apps/customer-portal/backend-v2/internal/handler/deployments.go
@@ -142,6 +142,10 @@ func (h *DeploymentHandler) PatchDeployment(w http.ResponseWriter, r *http.Reque
 		writeError(w, http.StatusBadRequest, "Provide either name/type/description or active, but not both.")
 		return
 	}
+	if activeSet && *req.Active {
+		writeError(w, http.StatusBadRequest, "active can only be set to false.")
+		return
+	}
 
 	result, err := h.entity.UpdateDeployment(r.Context(), id, req)
 	if err != nil {

--- a/apps/customer-portal/backend-v2/internal/handler/product_vulnerabilities.go
+++ b/apps/customer-portal/backend-v2/internal/handler/product_vulnerabilities.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/dto"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/middleware"
+)
+
+// entityProductVulnerabilityClient abstracts the entity-service product
+// vulnerability operations used by ProductVulnerabilityHandler.
+type entityProductVulnerabilityClient interface {
+	SearchProductVulnerabilities(ctx context.Context, req entity.SearchProductVulnerabilitiesRequest) (entity.SearchProductVulnerabilitiesResponse, error)
+	GetProductVulnerability(ctx context.Context, id string) (entity.ProductVulnerabilityView, error)
+}
+
+// ProductVulnerabilityHandler handles HTTP requests for product vulnerability operations.
+type ProductVulnerabilityHandler struct {
+	entity entityProductVulnerabilityClient
+}
+
+// NewProductVulnerabilityHandler creates a ProductVulnerabilityHandler backed by the given entity client.
+func NewProductVulnerabilityHandler(entity entityProductVulnerabilityClient) *ProductVulnerabilityHandler {
+	return &ProductVulnerabilityHandler{entity: entity}
+}
+
+// SearchProductVulnerabilities handles POST /products/vulnerabilities/search.
+func (h *ProductVulnerabilityHandler) SearchProductVulnerabilities(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	body, ok := readJSONBody(w, r)
+	if !ok {
+		return
+	}
+
+	var req entity.SearchProductVulnerabilitiesRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.SearchProductVulnerabilities(r.Context(), req)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity SearchProductVulnerabilities failed", "userID", user.UserID, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to search product vulnerabilities.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusOK, dto.MapSearchProductVulnerabilities(result))
+}
+
+// GetProductVulnerability handles GET /products/vulnerabilities/{id}.
+func (h *ProductVulnerabilityHandler) GetProductVulnerability(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	id := r.PathValue("id")
+	if id == "" || !uuidRe.MatchString(id) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	result, err := h.entity.GetProductVulnerability(r.Context(), id)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity GetProductVulnerability failed", "userID", user.UserID, "vulnerabilityID", id, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to retrieve product vulnerability.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusOK, dto.MapProductVulnerability(result))
+}

--- a/apps/customer-portal/backend-v2/internal/handler/time_cards.go
+++ b/apps/customer-portal/backend-v2/internal/handler/time_cards.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/dto"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/middleware"
+)
+
+// entityTimeCardClient abstracts the entity-service time-card operations
+// used by TimeCardHandler.
+type entityTimeCardClient interface {
+	SearchTimeCards(ctx context.Context, req entity.SearchTimeCardsRequest) (entity.SearchTimeCardsResponse, error)
+}
+
+// TimeCardHandler handles HTTP requests for time-card search.
+//
+// NOTE: entity-service only supports time cards on its ServiceNow data
+// source — a Postgres-mode deployment 404s on this route. Read-only: the
+// Ballerina backend this is rewriting never exposed time-card creation or
+// updates to the customer portal, only search.
+type TimeCardHandler struct {
+	entity entityTimeCardClient
+}
+
+// NewTimeCardHandler creates a TimeCardHandler backed by the given entity client.
+func NewTimeCardHandler(entity entityTimeCardClient) *TimeCardHandler {
+	return &TimeCardHandler{entity: entity}
+}
+
+// SearchTimeCards handles POST /time-cards/search.
+func (h *TimeCardHandler) SearchTimeCards(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	body, ok := readJSONBody(w, r)
+	if !ok {
+		return
+	}
+
+	var req entity.SearchTimeCardsRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.SearchTimeCards(r.Context(), req)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity SearchTimeCards failed", "userID", user.UserID, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to search time cards.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusOK, dto.MapSearchTimeCards(result))
+}

--- a/apps/customer-portal/backend-v2/internal/handler/websocket.go
+++ b/apps/customer-portal/backend-v2/internal/handler/websocket.go
@@ -66,16 +66,28 @@ type WebSocketHandler struct {
 }
 
 // NewWebSocketHandler creates a WebSocketHandler backed by the given AI chat
-// agent WebSocket client and entity client.
-func NewWebSocketHandler(ai wsStreamer, entityClient entityCommentCreator) *WebSocketHandler {
+// agent WebSocket client and entity client. allowedOrigins restricts which
+// browser Origins may open this connection (defense in depth against
+// cross-site WebSocket hijacking) — pass nil/empty to allow any origin,
+// e.g. for local development.
+func NewWebSocketHandler(ai wsStreamer, entityClient entityCommentCreator, allowedOrigins []string) *WebSocketHandler {
+	allowed := make(map[string]bool, len(allowedOrigins))
+	for _, o := range allowedOrigins {
+		allowed[o] = true
+	}
 	return &WebSocketHandler{
 		ai:     ai,
 		entity: entityClient,
 		upgrade: websocket.Upgrader{
-			// Authorization is enforced by the same JWT middleware chain as
-			// every other route (see cmd/server/main.go); Origin is not used
-			// as a second gate here.
-			CheckOrigin: func(_ *http.Request) bool { return true },
+			// Primary authorization is still the same JWT middleware chain as
+			// every other route (see cmd/server/main.go); this Origin check is
+			// defense in depth against cross-site WebSocket hijacking. A
+			// non-browser caller (e.g. a server-to-server client) sends no
+			// Origin header at all and is allowed through either way.
+			CheckOrigin: func(r *http.Request) bool {
+				origin := r.Header.Get("Origin")
+				return origin == "" || len(allowed) == 0 || allowed[origin]
+			},
 		},
 	}
 }

--- a/apps/customer-portal/backend-v2/internal/handler/websocket.go
+++ b/apps/customer-portal/backend-v2/internal/handler/websocket.go
@@ -37,6 +37,16 @@ type wsStreamer interface {
 	StreamChat(ctx context.Context, sessionID, payload string, caller aichatagent.BrowserConn) (map[string]json.RawMessage, error)
 }
 
+// wsMaxMessageBytes bounds the size of a single WebSocket frame this handler
+// will read, on both the browser connection (here) and the upstream AI agent
+// connection (internal/aichatagent/ws.go) — protects against a peer forcing
+// a large allocation via an oversized frame.
+const wsMaxMessageBytes = 64 << 10 // 64 KiB
+
+// wsIdleTimeout bounds how long this handler waits for the next frame from
+// an idle peer before closing the connection.
+const wsIdleTimeout = 5 * time.Minute
+
 // entityCommentCreator is the subset of entityCommentClient needed to persist
 // a conversation message as a comment.
 type entityCommentCreator interface {
@@ -126,7 +136,21 @@ func (h *WebSocketHandler) HandleWebSocket(w http.ResponseWriter, r *http.Reques
 	}
 	defer conn.Close()
 
+	// The server's ReadTimeout/WriteTimeout (see cmd/server/main.go) can leave
+	// deadlines on the connection Hijack handed off for this upgrade; clear
+	// them so they don't kill an otherwise-idle-but-healthy chat session, and
+	// rely on wsIdleTimeout below instead.
+	underlying := conn.UnderlyingConn()
+	_ = underlying.SetReadDeadline(time.Time{})
+	_ = underlying.SetWriteDeadline(time.Time{})
+
+	conn.SetReadLimit(wsMaxMessageBytes)
+
 	for {
+		if err := conn.SetReadDeadline(time.Now().Add(wsIdleTimeout)); err != nil {
+			slog.WarnContext(r.Context(), "websocket set read deadline failed", "userID", user.UserID, "err", summarizeErr(err))
+			return
+		}
 		_, data, err := conn.ReadMessage()
 		if err != nil {
 			if !websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
@@ -166,8 +190,17 @@ func (h *WebSocketHandler) handleMessage(ctx context.Context, conn *websocket.Co
 	}
 
 	userMessage, _ := parsed["message"].(string)
-	parsed["conversationId"] = conversationID
-	enriched, err := json.Marshal(parsed)
+	// Forward only the fields the upstream contract defines — never the raw
+	// client-supplied map verbatim, which could otherwise let a client smuggle
+	// extra keys (e.g. its own "accountId"/"sessionId") the agent might trust.
+	upstreamPayload := map[string]any{
+		"message":        userMessage,
+		"conversationId": conversationID,
+	}
+	if envProducts, ok := parsed["envProducts"]; ok {
+		upstreamPayload["envProducts"] = envProducts
+	}
+	enriched, err := json.Marshal(upstreamPayload)
 	if err != nil {
 		_ = writeWSJSON(conn, wsEvent{Type: "error", Message: "Failed to process message."})
 		return

--- a/apps/customer-portal/backend-v2/internal/handler/websocket.go
+++ b/apps/customer-portal/backend-v2/internal/handler/websocket.go
@@ -1,0 +1,193 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/aichatagent"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/middleware"
+)
+
+// wsStreamer abstracts the AI chat agent's WebSocket proxy operation used by
+// WebSocketHandler.
+type wsStreamer interface {
+	StreamChat(ctx context.Context, sessionID, payload string, caller aichatagent.BrowserConn) (map[string]json.RawMessage, error)
+}
+
+// entityCommentCreator is the subset of entityCommentClient needed to persist
+// a conversation message as a comment.
+type entityCommentCreator interface {
+	CreateComment(ctx context.Context, req entity.CreateCommentRequest) (entity.CreateCommentResponse, error)
+}
+
+// WebSocketHandler proxies real-time chat messages between the browser and
+// the upstream AI chat agent for an existing conversation.
+//
+// NOTE: entity-service has no createConversation, so unlike the Ballerina
+// backend this is rewriting, a WebSocket message that doesn't carry an
+// existing conversationId cannot start a brand-new conversation here — the
+// caller must first create one via a future entity-service-backed endpoint.
+// TODO(entity-service): once entity-service gains createConversation, wire
+// the same "no conversationId → create one" branch the Ballerina backend has.
+// TODO(entity-service): the AI agent's own reply is not persisted as a
+// comment here (unlike Ballerina, which tags it with a special "chat agent"
+// createdBy) because entity-service's CreateCommentRequest always attributes
+// the comment to the caller's own identity — there is no createdBy override.
+// TODO(entity-service): marking the conversation "resolved" when the AI
+// agent reports resolved=true is skipped — entity-service has no
+// updateConversation yet.
+type WebSocketHandler struct {
+	ai      wsStreamer
+	entity  entityCommentCreator
+	upgrade websocket.Upgrader
+}
+
+// NewWebSocketHandler creates a WebSocketHandler backed by the given AI chat
+// agent WebSocket client and entity client.
+func NewWebSocketHandler(ai wsStreamer, entityClient entityCommentCreator) *WebSocketHandler {
+	return &WebSocketHandler{
+		ai:     ai,
+		entity: entityClient,
+		upgrade: websocket.Upgrader{
+			// Authorization is enforced by the same JWT middleware chain as
+			// every other route (see cmd/server/main.go); Origin is not used
+			// as a second gate here.
+			CheckOrigin: func(_ *http.Request) bool { return true },
+		},
+	}
+}
+
+// wsEvent is the JSON envelope used for events this handler sends directly
+// to the browser (ping/pong, errors) — matches the upstream AI chat agent's
+// own event shape so the frontend handles both uniformly.
+type wsEvent struct {
+	Type           string `json:"type"`
+	Message        string `json:"message,omitempty"`
+	ConversationID string `json:"conversationId,omitempty"`
+	TS             string `json:"ts,omitempty"`
+}
+
+// HandleWebSocket handles GET /ws?sessionId={projectId}. The query parameter
+// is named sessionId for wire compatibility with the Ballerina backend this
+// is rewriting, but it actually carries the project ID — the AI agent's own
+// per-conversation session key is derived below as "{projectId}:{conversationId}".
+func (h *WebSocketHandler) HandleWebSocket(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	projectID := r.URL.Query().Get("sessionId")
+	if projectID == "" || !uuidRe.MatchString(projectID) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	conn, err := h.upgrade.Upgrade(w, r, nil)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "websocket upgrade failed", "userID", user.UserID, "err", summarizeErr(err))
+		return
+	}
+	defer conn.Close()
+
+	for {
+		_, data, err := conn.ReadMessage()
+		if err != nil {
+			if !websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
+				slog.WarnContext(r.Context(), "websocket read error", "userID", user.UserID, "err", summarizeErr(err))
+			}
+			return
+		}
+		h.handleMessage(r.Context(), conn, user, projectID, data)
+	}
+}
+
+func (h *WebSocketHandler) handleMessage(ctx context.Context, conn *websocket.Conn, user *middleware.UserInfo, projectID string, data []byte) {
+	trimmed := strings.TrimSpace(strings.ToLower(string(data)))
+	var parsed map[string]any
+	_ = json.Unmarshal(data, &parsed)
+
+	isPing := trimmed == "ping"
+	if !isPing {
+		if t, _ := parsed["type"].(string); t == "ping" {
+			isPing = true
+		}
+	}
+	if isPing {
+		ts := strconv.FormatInt(time.Now().Unix(), 10)
+		_ = writeWSJSON(conn, wsEvent{Type: "pong", TS: ts})
+		return
+	}
+
+	conversationID, _ := parsed["conversationId"].(string)
+	if conversationID == "" || !uuidRe.MatchString(conversationID) {
+		_ = writeWSJSON(conn, wsEvent{
+			Type: "error",
+			Message: "Starting a new conversation over this connection isn't supported yet — " +
+				"include the conversationId of an existing conversation to resume it.",
+		})
+		return
+	}
+
+	userMessage, _ := parsed["message"].(string)
+	parsed["conversationId"] = conversationID
+	enriched, err := json.Marshal(parsed)
+	if err != nil {
+		_ = writeWSJSON(conn, wsEvent{Type: "error", Message: "Failed to process message."})
+		return
+	}
+
+	agentSessionID := projectID + ":" + conversationID
+	result, err := h.ai.StreamChat(ctx, agentSessionID, string(enriched), conn)
+	if err != nil {
+		slog.ErrorContext(ctx, "aichatagent StreamChat failed", "userID", user.UserID, "conversationID", conversationID, "err", summarizeErr(err))
+		_ = writeWSJSON(conn, wsEvent{Type: "error", Message: "Failed to process message."})
+		return
+	}
+
+	if userMessage != "" {
+		_, err := h.entity.CreateComment(ctx, entity.CreateCommentRequest{
+			ReferenceID:   conversationID,
+			ReferenceType: entity.ReferenceTypeConversation,
+			Type:          entity.CommentTypeComment,
+			Content:       userMessage,
+		})
+		if err != nil {
+			slog.ErrorContext(ctx, "entity CreateComment failed for conversation message", "userID", user.UserID, "conversationID", conversationID, "err", summarizeErr(err))
+		}
+	}
+
+	_ = result // the AI agent's reply is not persisted as a comment — see WebSocketHandler's doc comment.
+}
+
+func writeWSJSON(conn *websocket.Conn, v any) error {
+	payload, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	return conn.WriteMessage(websocket.TextMessage, payload)
+}

--- a/apps/customer-portal/backend-v2/internal/middleware/logger.go
+++ b/apps/customer-portal/backend-v2/internal/middleware/logger.go
@@ -17,7 +17,10 @@
 package middleware
 
 import (
+	"bufio"
+	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"time"
 )
@@ -32,6 +35,19 @@ type responseWriter struct {
 func (rw *responseWriter) WriteHeader(code int) {
 	rw.status = code
 	rw.ResponseWriter.WriteHeader(code)
+}
+
+// Hijack forwards to the underlying ResponseWriter's http.Hijacker
+// implementation. Wrapping http.ResponseWriter in responseWriter otherwise
+// hides Hijack from callers that type-assert for it — including
+// gorilla/websocket's Upgrade, which GET /ws (internal/handler/websocket.go)
+// relies on to switch the connection to WebSocket.
+func (rw *responseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	hijacker, ok := rw.ResponseWriter.(http.Hijacker)
+	if !ok {
+		return nil, nil, fmt.Errorf("underlying ResponseWriter does not support hijacking")
+	}
+	return hijacker.Hijack()
 }
 
 // Logger is an HTTP middleware that logs each completed request via slog. The

--- a/apps/customer-portal/backend-v2/openapi.yaml
+++ b/apps/customer-portal/backend-v2/openapi.yaml
@@ -2433,6 +2433,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: NotFound
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
         "500":
           description: InternalServerError
           content:
@@ -2549,6 +2555,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: NotFound
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
         "500":
           description: InternalServerError
           content:
@@ -2588,6 +2600,18 @@ paths:
                 $ref: '#/components/schemas/ErrorPayload'
         "401":
           description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
           content:
             application/json:
               schema:

--- a/apps/customer-portal/backend-v2/openapi.yaml
+++ b/apps/customer-portal/backend-v2/openapi.yaml
@@ -1806,6 +1806,793 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
+  /deployments/{id}:
+    patch:
+      summary: Update a deployment.
+      description: >
+        Provide either name/type/description or active=false, but not both.
+      operationId: patchDeploymentsId
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateDeploymentRequest'
+        required: true
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeploymentUpdateResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: NotFound
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /comments:
+    post:
+      summary: Create a generic comment.
+      description: >
+        Attaches a comment to any reference entity (case, conversation,
+        change_request, deployment, incident). Type is always "comment"
+        server-side and is not client-settable.
+      operationId: postComments
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CommentCreateRequest'
+        required: true
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CommentCreateResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /comments/search:
+    post:
+      summary: Search generic comments.
+      description: >
+        Results are always filtered server-side to type "comment" — internal
+        WSO2 work-note entries are never returned here.
+      operationId: postCommentsSearch
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CommentSearchRequest'
+        required: true
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchCommentsResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /products/vulnerabilities/search:
+    post:
+      summary: Search product vulnerabilities.
+      operationId: postProductsVulnerabilitiesSearch
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SearchProductVulnerabilitiesRequest'
+        required: true
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchProductVulnerabilitiesResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /products/vulnerabilities/{id}:
+    get:
+      summary: Get a product vulnerability by ID.
+      operationId: getProductsVulnerabilitiesId
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProductVulnerability'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: NotFound
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /catalogs/search:
+    post:
+      summary: Search service catalogs.
+      operationId: postCatalogsSearch
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SearchCatalogsRequest'
+        required: true
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchCatalogsResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /catalogs/{catalogId}/items/{catalogItemId}/variables:
+    get:
+      summary: Get a catalog item's variables.
+      operationId: getCatalogsCatalogIdItemsCatalogItemIdVariables
+      parameters:
+        - name: catalogId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: catalogItemId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CatalogItemVariablesResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: NotFound
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /time-cards/search:
+    post:
+      summary: Search time cards.
+      description: >
+        Only entity-service's ServiceNow data source supports this route —
+        a Postgres-mode deployment 404s. Excludes internal WSO2 per-category
+        time breakdowns and notes — see this backend's CLAUDE.md.
+      operationId: postTimeCardsSearch
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SearchTimeCardsRequest'
+        required: true
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchTimeCardsResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /cases/classify:
+    post:
+      summary: Classify a case from chat context.
+      description: >
+        Calls the separate AI chat agent service, not entity-service — see
+        this backend's CLAUDE.md, "The AI chat agent".
+      operationId: postCasesClassify
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CaseClassificationRequest'
+        required: true
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CaseClassificationResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /conversations/recommendations/search:
+    post:
+      summary: Search KB article recommendations for a conversation.
+      description: >
+        Calls the separate AI chat agent service, not entity-service — see
+        this backend's CLAUDE.md, "The AI chat agent".
+      operationId: postConversationsRecommendationsSearch
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RecommendationRequest'
+        required: true
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RecommendationResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /projects/{id}/conversations/search:
+    post:
+      summary: Search a project's AI chat conversations.
+      description: >
+        projectIds is set server-side from the path parameter — any
+        client-supplied value in filters.projectIds is ignored.
+      operationId: postProjectsIdConversationsSearch
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SearchConversationsRequest'
+        required: true
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchConversationsResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /conversations/{id}/messages:
+    get:
+      summary: Get a conversation's messages.
+      description: Backed by the generic comment search (referenceType=conversation).
+      operationId: getConversationsIdMessages
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 20
+        - name: offset
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 0
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchCommentsResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /projects/{projectId}/conversations/{conversationId}/messages:
+    post:
+      summary: Send a follow-up message on an existing AI chat conversation.
+      description: >
+        Sends a follow-up message on an EXISTING conversation only — there is
+        no entity-service createConversation yet (see this backend's CLAUDE.md).
+      operationId: postProjectsProjectIdConversationsConversationIdMessages
+      parameters:
+        - name: projectId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: conversationId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChatMessageRequest'
+        required: true
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChatResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /projects/{id}/conversations/{conversationId}/summary:
+    get:
+      summary: Get an AI chat conversation's summary.
+      description: >
+        Calls the separate AI chat agent service, not entity-service — see
+        this backend's CLAUDE.md, "The AI chat agent".
+      operationId: getProjectsIdConversationsConversationIdSummary
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: conversationId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConversationSummaryResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /ws:
+    get:
+      summary: >-
+        Upgrade to WebSocket for real-time AI chat (resumes an existing
+        conversation only — see repo CLAUDE.md).
+      description: >
+        This is a WebSocket upgrade endpoint — OpenAPI 3.0 has no native
+        support for describing WebSocket message framing, so only the
+        upgrade handshake is documented here. The sessionId query parameter
+        is named for wire compatibility with the Ballerina backend this
+        replaces, but actually carries the project ID.
+      operationId: getWs
+      parameters:
+        - name: sessionId
+          in: query
+          required: true
+          schema:
+            type: string
+          description: >-
+            Project ID — named sessionId for wire compatibility with the
+            Ballerina backend this replaces.
+      responses:
+        "101":
+          description: Switching Protocols
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
 components:
   securitySchemes:
     bearerAuth:
@@ -2507,6 +3294,28 @@ components:
         createdOn:
           type: string
 
+    UpdateDeploymentRequest:
+      description: Provide either name/type/description or active=false, but not both.
+      type: object
+      properties:
+        name:
+          type: string
+        type:
+          type: string
+        description:
+          type: string
+          nullable: true
+        active:
+          type: boolean
+
+    DeploymentUpdateResponse:
+      type: object
+      properties:
+        id:
+          type: string
+        updatedOn:
+          type: string
+
     # ---- deployed products ----
 
     SearchDeployedProductsRequest:
@@ -2792,6 +3601,81 @@ components:
         hasMore:
           type: boolean
 
+    # ---- comments ----
+    #
+    # Generic comments attached to any reference entity (case, conversation,
+    # change_request, deployment, incident) — distinct from the case-specific
+    # comment endpoint under POST /cases/{id}/comments.
+
+    CommentCreateRequest:
+      description: >
+        Type is always "comment" server-side and is not client-settable.
+      type: object
+      required: [referenceId, referenceType, content]
+      properties:
+        referenceId:
+          type: string
+          format: uuid
+        referenceType:
+          type: string
+          enum: [case, conversation, change_request, deployment, incident]
+        content:
+          type: string
+
+    CommentCreateResponse:
+      type: object
+      properties:
+        id:
+          type: string
+        createdOn:
+          type: string
+        createdBy:
+          type: string
+
+    CommentSearchRequest:
+      description: >
+        Results are always filtered server-side to type "comment" — internal
+        WSO2 work-note entries are never returned here.
+      type: object
+      required: [referenceId, referenceType]
+      properties:
+        referenceId:
+          type: string
+          format: uuid
+        referenceType:
+          type: string
+          enum: [case, conversation, change_request, deployment, incident]
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+
+    CommentView:
+      type: object
+      properties:
+        id:
+          type: string
+        content:
+          type: string
+        createdOn:
+          type: string
+        createdBy:
+          type: string
+
+    SearchCommentsResponse:
+      type: object
+      properties:
+        comments:
+          type: array
+          items:
+            $ref: '#/components/schemas/CommentView'
+        total:
+          type: integer
+        limit:
+          type: integer
+        offset:
+          type: integer
+        hasMore:
+          type: boolean
+
     # ---- products ----
 
     SearchProductsRequest:
@@ -2875,6 +3759,514 @@ components:
           type: integer
         hasMore:
           type: boolean
+
+    # ---- product vulnerabilities ----
+
+    SearchProductVulnerabilitiesRequest:
+      type: object
+      properties:
+        filters:
+          type: object
+          properties:
+            searchQuery:
+              type: string
+            priority:
+              type: string
+              enum: [info, low, medium, high, critical, unknown]
+            productName:
+              type: string
+            productVersion:
+              type: string
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+
+    ProductVulnerability:
+      type: object
+      properties:
+        id:
+          type: string
+        cveId:
+          type: string
+        vulnerabilityId:
+          type: string
+        priority:
+          type: string
+        productName:
+          type: string
+          nullable: true
+        productVersion:
+          type: string
+          nullable: true
+        componentName:
+          type: string
+        version:
+          type: string
+        type:
+          type: string
+        componentType:
+          type: string
+          nullable: true
+        updateLevel:
+          type: string
+          nullable: true
+        useCase:
+          type: string
+          nullable: true
+        justification:
+          type: string
+          nullable: true
+        resolution:
+          type: string
+          nullable: true
+
+    SearchProductVulnerabilitiesResponse:
+      type: object
+      properties:
+        productVulnerabilities:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProductVulnerability'
+        total:
+          type: integer
+        limit:
+          type: integer
+        offset:
+          type: integer
+
+    # ---- catalogs ----
+
+    SearchCatalogsRequest:
+      description: Scopes the search to catalogs available for the given deployed product.
+      type: object
+      required: [deployedProductId]
+      properties:
+        deployedProductId:
+          type: string
+          format: uuid
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+
+    CatalogItem:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+
+    Catalog:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        catalogItems:
+          type: array
+          items:
+            $ref: '#/components/schemas/CatalogItem'
+
+    SearchCatalogsResponse:
+      type: object
+      properties:
+        catalogs:
+          type: array
+          items:
+            $ref: '#/components/schemas/Catalog'
+        total:
+          type: integer
+        limit:
+          type: integer
+        offset:
+          type: integer
+
+    CatalogItemVariable:
+      type: object
+      properties:
+        id:
+          type: string
+        questionText:
+          type: string
+        order:
+          type: integer
+        type:
+          type: string
+
+    CatalogItemVariablesResponse:
+      type: object
+      properties:
+        variables:
+          type: array
+          items:
+            $ref: '#/components/schemas/CatalogItemVariable'
+
+    # ---- time cards ----
+
+    SearchTimeCardsRequest:
+      description: >
+        entity-service also accepts userId/approverId/approvedById/userIds
+        filters that scope results to a specific WSO2 engineer — deliberately
+        not exposed here since the portal has no notion of a customer
+        selecting a WSO2 engineer to filter by.
+      type: object
+      properties:
+        filters:
+          type: object
+          properties:
+            projectIds:
+              type: array
+              items:
+                type: string
+            caseId:
+              type: string
+            startDate:
+              type: string
+            endDate:
+              type: string
+            states:
+              type: array
+              items:
+                type: string
+        sortBy:
+          type: object
+          properties:
+            field:
+              type: string
+            order:
+              type: string
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+
+    TimeCardCaseRef:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        number:
+          type: string
+
+    TimeCardSummary:
+      description: >
+        Deliberately excludes entity-service's per-category time breakdowns,
+        issueComplexity, workLogComment, rejectionReason, and the
+        eligible-approvers list — internal WSO2 support bookkeeping never
+        exposed to the customer portal.
+      type: object
+      properties:
+        id:
+          type: string
+        totalTime:
+          type: number
+        workDate:
+          type: string
+        hasBillable:
+          type: boolean
+        state:
+          type: string
+          nullable: true
+        user:
+          $ref: '#/components/schemas/Ref'
+        approvedBy:
+          $ref: '#/components/schemas/Ref'
+        project:
+          $ref: '#/components/schemas/Ref'
+        case:
+          $ref: '#/components/schemas/TimeCardCaseRef'
+
+    SearchTimeCardsResponse:
+      type: object
+      properties:
+        timeCards:
+          type: array
+          items:
+            $ref: '#/components/schemas/TimeCardSummary'
+        total:
+          type: integer
+        limit:
+          type: integer
+        offset:
+          type: integer
+
+    # ---- ai chat ----
+    #
+    # internal/aichatagent is a separate Python service unrelated to
+    # cs-tools/entity-service — see this backend's CLAUDE.md, "The AI chat agent".
+
+    CaseClassificationRequest:
+      type: object
+      required: [chatHistory, envProducts, region, tier, projectTypeId]
+      properties:
+        chatHistory:
+          type: string
+        envProducts:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              type: string
+        region:
+          type: string
+        tier:
+          type: string
+        projectTypeId:
+          type: string
+
+    CaseClassificationResponse:
+      type: object
+      properties:
+        issueType:
+          type: string
+        severityLevel:
+          type: string
+        caseInfo:
+          type: object
+          properties:
+            description:
+              type: string
+            shortDescription:
+              type: string
+            productName:
+              type: string
+            productVersion:
+              type: string
+            environment:
+              type: string
+            tier:
+              type: string
+            region:
+              type: string
+
+    RecommendationRequest:
+      type: object
+      required: [chatHistory, conversationData]
+      properties:
+        chatHistory:
+          type: array
+          items:
+            type: object
+            properties:
+              role:
+                type: string
+              content:
+                type: string
+              timestamp:
+                type: string
+        conversationData:
+          type: object
+          properties:
+            chatHistory:
+              type: string
+            envProducts:
+              type: object
+              additionalProperties:
+                type: array
+                items:
+                  type: string
+            region:
+              type: string
+            tier:
+              type: string
+
+    RecommendationResponse:
+      type: object
+      properties:
+        query:
+          type: string
+        recommendations:
+          type: array
+          items:
+            type: object
+            properties:
+              title:
+                type: string
+              articleId:
+                type: string
+              score:
+                type: number
+
+    ChatMessageRequest:
+      description: >
+        Sends a follow-up message on an existing conversation only — there is
+        no entity-service createConversation yet (see CLAUDE.md).
+      type: object
+      required: [message]
+      properties:
+        message:
+          type: string
+        envProducts:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              type: string
+        region:
+          type: string
+        tier:
+          type: string
+
+    ChatResponse:
+      type: object
+      properties:
+        message:
+          type: string
+        conversationId:
+          type: string
+        intent:
+          type: object
+          nullable: true
+          properties:
+            intentId:
+              type: string
+            intentLabel:
+              type: string
+            confidence:
+              type: number
+            severity:
+              type: string
+            caseType:
+              type: string
+        slotState:
+          type: object
+          nullable: true
+          properties:
+            intentId:
+              type: string
+            filledSlots:
+              type: object
+              additionalProperties:
+                type: string
+            missingSlots:
+              type: array
+              items:
+                type: string
+            isComplete:
+              type: boolean
+            slotOptions:
+              type: array
+              items:
+                type: object
+                properties:
+                  slot:
+                    type: string
+                  label:
+                    type: string
+                  options:
+                    type: array
+                    items:
+                      type: string
+                  type:
+                    type: string
+        actions:
+          type: array
+          nullable: true
+          items:
+            type: object
+            properties:
+              type:
+                type: string
+              label:
+                type: string
+              style:
+                type: string
+              payload:
+                type: object
+                additionalProperties: true
+        recommendations:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/RecommendationResponse'
+        resolved:
+          type: boolean
+          nullable: true
+        kbReferences:
+          type: array
+          nullable: true
+          items:
+            type: object
+            properties:
+              sysKbId:
+                type: string
+              title:
+                type: string
+
+    ConversationSummaryResponse:
+      type: object
+      properties:
+        conversationId:
+          type: string
+        messagesExchanged:
+          type: integer
+        troubleshootingAttempts:
+          type: integer
+        kbArticlesReviewed:
+          type: integer
+
+    SearchConversationsRequest:
+      description: >
+        projectIds is set server-side from the path parameter and any
+        client-supplied value in filters.projectIds is ignored.
+      type: object
+      properties:
+        filters:
+          type: object
+          properties:
+            projectIds:
+              type: array
+              items:
+                type: string
+            states:
+              type: array
+              items:
+                type: string
+            searchQuery:
+              type: string
+            createdByMe:
+              type: boolean
+        sortBy:
+          type: object
+          properties:
+            field:
+              type: string
+            order:
+              type: string
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+
+    ConversationSummary:
+      type: object
+      properties:
+        id:
+          type: string
+        number:
+          type: string
+        initialMessage:
+          type: string
+        messageCount:
+          type: integer
+        case:
+          $ref: '#/components/schemas/Ref'
+        state:
+          type: string
+        createdOn:
+          type: string
+        createdBy:
+          type: string
+
+    SearchConversationsResponse:
+      type: object
+      properties:
+        conversations:
+          type: array
+          items:
+            $ref: '#/components/schemas/ConversationSummary'
+        total:
+          type: integer
+        limit:
+          type: integer
+        offset:
+          type: integer
 
     # ---- change requests ----
 


### PR DESCRIPTION
## Summary
Adds 15 more endpoints to `apps/customer-portal/backend-v2` (50 total):

- `PATCH /deployments/{id}` — update a deployment's name/type/description, or deactivate it
- `POST /comments`, `POST /comments/search` — generic comments on any reference entity (case, conversation, change_request, deployment, incident) — distinct from case-specific comments
- `POST /products/vulnerabilities/search`, `GET /products/vulnerabilities/{id}`
- `POST /catalogs/search`, `GET /catalogs/{catalogId}/items/{catalogItemId}/variables`
- `POST /time-cards/search` (read-only — the Ballerina backend never exposes time-card create/update to customers)
- AI chat feature: `POST /cases/classify`, `POST /conversations/recommendations/search`, `POST /projects/{id}/conversations/search`, `GET /conversations/{id}/messages`, `POST /projects/{projectId}/conversations/{conversationId}/messages`, `GET /projects/{id}/conversations/{conversationId}/summary`, `GET /ws`

## Scoping discipline

Every candidate this batch was cross-checked against **both** `cs-tools/entity-service`'s actual routes **and** the Ballerina backend's actual resource functions before porting — not just the first. This caught several `cs-tools/entity-service` routes that looked portable but aren't genuine customer-portal features: `POST /cases/{id}/github-issues` (an internal support-agent action with zero precedent in the Ballerina backend), `POST /accounts/{id}/contacts/search` / `POST /projects/{id}/contacts/search` (the Ballerina backend's equivalent-looking contact endpoints are actually backed by an entirely different `user_management` microservice, not entity-service), and the case-tags trio (`POST/DELETE /cases/{id}/tags`, `GET /tags/search` — the underlying Choreo/ServiceNow route doesn't exist yet, confirmed via entity-service's own doc comments). All noted in CLAUDE.md so they aren't re-attempted by pattern-matching on `cs-tools/entity-service` alone.

## The AI chat agent

`internal/aichatagent` is a new upstream client for a **separate Python service that has no relationship to entity-service at all** (see `apps/customer-portal/backend`'s `modules/ai_chat_agent`). It has its own HTTP API and a WebSocket endpoint (`internal/aichatagent/ws.go`, via `github.com/gorilla/websocket` — the one third-party dependency in this otherwise-stdlib-only backend, since `net/http` has no server-side WebSocket support).

Three entity-service gaps block a full 1:1 port of the Ballerina backend's AI chat flow, each flagged with `TODO(entity-service)` at its call site rather than worked around:
- No `createConversation`/`updateConversation` — blocks starting a brand-new AI chat conversation and marking one "resolved".
- No `createdBy` override on comment creation — blocks correctly attributing the AI agent's own reply when saving it as a comment (saving it under the wrong identity would be worse than not saving it, so it isn't saved).

`GET /ws?sessionId={projectId}` only supports **resuming** an existing conversation (the browser must supply a `conversationId`) — starting a new one via WebSocket hits the same `createConversation` gap.

## Incidental fix

Wiring the WebSocket route surfaced a real bug: `middleware.Logger`'s `ResponseWriter` wrapper hid `http.Hijacker` from callers doing a type assertion for it (a well-known Go gotcha with wrapped `ResponseWriter`s) — `gorilla/websocket`'s `Upgrade` needs it to hijack the TCP connection. Fixed by forwarding `Hijack()` to the underlying `ResponseWriter`.

Also updates `openapi.yaml` (15 new paths, 30 new schemas), a new `asyncapi.yaml` documenting the WebSocket contract, `.choreo/component.yaml` (new WebSocket endpoint entry), `README.md`, and `CLAUDE.md`.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` all clean
- [x] `gosec -fmt=text ./...` reports 0 issues
- [x] `openapi.yaml`/`asyncapi.yaml` validated as well-formed YAML with all new paths/schemas/channels present
- [x] Manually smoke-tested against a live server with unreachable upstreams: validation errors (400) for missing/invalid fields and UUIDs, clean 500 mapping for unreachable upstream services, and a real WebSocket handshake + ping/pong + the "conversationId required" error event, all verified end-to-end with a throwaway Go WebSocket client
- [ ] Wire up against a real running entity-service instance and the actual AI chat agent service (ServiceNow data source required for most routes in this PR; AI chat agent is a separate, currently-unconfigured upstream)

## Linked issues
Closes wso2-enterprise/wso2-digital-team-project-management#872
Closes wso2-enterprise/wso2-digital-team-project-management#873
Closes wso2-enterprise/wso2-digital-team-project-management#874
Closes wso2-enterprise/wso2-digital-team-project-management#875
Closes wso2-enterprise/wso2-digital-team-project-management#876
Closes wso2-enterprise/wso2-digital-team-project-management#877
Closes wso2-enterprise/wso2-digital-team-project-management#878
Closes wso2-enterprise/wso2-digital-team-project-management#879
Closes wso2-enterprise/wso2-digital-team-project-management#880
Closes wso2-enterprise/wso2-digital-team-project-management#881
Closes wso2-enterprise/wso2-digital-team-project-management#882
Closes wso2-enterprise/wso2-digital-team-project-management#883
Closes wso2-enterprise/wso2-digital-team-project-management#884
Closes wso2-enterprise/wso2-digital-team-project-management#885
Closes wso2-enterprise/wso2-digital-team-project-management#886

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AI chat capabilities, including case classification, recommendations, conversations, summaries, and message handling.
  * Added real-time AI chat over WebSocket connections.
  * Added APIs for product vulnerabilities, catalogs, catalog variables, time cards, and comments.
  * Added deployment update support.
  * Added authenticated conversation message persistence and structured chat responses.

* **Documentation**
  * Expanded API specifications, setup guidance, configuration details, route listings, and WebSocket usage documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
