### PR TITLE
[CSM Portal] User profile groups/teams/project-access, directory pages, and user-list filters

### DIFF
--- a/apps/csm-portal/webapp/src/App.tsx
+++ b/apps/csm-portal/webapp/src/App.tsx
@@ -89,6 +89,24 @@ const CsmUsersPage = lazy(
 const UserProfilePage = lazy(
   () => import("@features/csm-users/pages/UserProfilePage"),
 );
+const CsmRolesPage = lazy(
+  () => import("@features/csm-admin/pages/CsmRolesPage"),
+);
+const RoleMembersPage = lazy(
+  () => import("@features/csm-admin/pages/RoleMembersPage"),
+);
+const CsmGroupsPage = lazy(
+  () => import("@features/csm-admin/pages/CsmGroupsPage"),
+);
+const GroupMembersPage = lazy(
+  () => import("@features/csm-admin/pages/GroupMembersPage"),
+);
+const CsmTeamsPage = lazy(
+  () => import("@features/csm-admin/pages/CsmTeamsPage"),
+);
+const TeamMembersPage = lazy(
+  () => import("@features/csm-admin/pages/TeamMembersPage"),
+);
 const CsmCustomersLayout = lazy(
   () => import("@features/csm-customers/pages/CsmCustomersLayout"),
 );
@@ -272,33 +290,17 @@ export default function App(): JSX.Element {
                     element={<LegacyDetailRedirect to="/customers/projects" />}
                   />
 
-                  {/* Administration — Users tab is real, others are WIP */}
+                  {/* Administration — Users/Roles/Groups/Teams are real,
+                      Permissions is still WIP. */}
                   <Route path="admin" element={<CsmAdminLayout />}>
                     <Route
                       index
                       element={<SectionIndexRedirect sectionId="admin" />}
                     />
                     <Route path="users" element={<CsmUsersPage />} />
-                    <Route
-                      path="roles"
-                      element={
-                        <CsmComingSoonPage
-                          title="Roles"
-                          description="Role-based access control: define roles and their permission sets."
-                          blockedOn="csm-portal/backend roles endpoints"
-                        />
-                      }
-                    />
-                    <Route
-                      path="groups"
-                      element={
-                        <CsmComingSoonPage
-                          title="Groups"
-                          description="User groups for bulk role assignment and access control."
-                          blockedOn="csm-portal/backend groups endpoints"
-                        />
-                      }
-                    />
+                    <Route path="roles" element={<CsmRolesPage />} />
+                    <Route path="groups" element={<CsmGroupsPage />} />
+                    <Route path="teams" element={<CsmTeamsPage />} />
                     <Route
                       path="permissions"
                       element={
@@ -310,6 +312,14 @@ export default function App(): JSX.Element {
                       }
                     />
                   </Route>
+
+                  {/* Role/group/team member lists, one level below the
+                      directory pages above. Not admin-permission-gated:
+                      standing project rule is to show the action and let the
+                      backend reject it, never gate in the frontend. */}
+                  <Route path="admin/roles/:id" element={<RoleMembersPage />} />
+                  <Route path="admin/groups/:id" element={<GroupMembersPage />} />
+                  <Route path="admin/teams/:id" element={<TeamMembersPage />} />
 
                   {/* Person profile — reachable by clicking any user reference
                       (case creator, assignee, watchers, comment authors,

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -1087,12 +1087,25 @@ export interface BeUser {
 export interface BeUserSearchFilters {
   /** Case-insensitive match against username and email. */
   searchQuery?: string;
-  /** ServiceNow data source only. */
-  roles?: string[];
+  /** Filter by one or more role keys, as returned by `/roles/search`. Backing
+   * data source only. */
+  roleIds?: string[];
+  /** Restrict to specific users. Intersects with the other filters and lifts
+   * the active-only default. Backing data source only. */
+  userIds?: string[];
+  /** Restrict to members of these groups (group UUIDs). Backing data source
+   * only. */
+  groupIds?: string[];
+  /** Restrict to members of these teams, by team registry key. Backing data
+   * source only. */
+  teamIds?: string[];
   /** Exact match. */
   userNames?: string[];
   /** Exact match. */
   emails?: string[];
+  /** When set, restricts results to active or inactive users. Backing data
+   * source only. */
+  active?: boolean | null;
 }
 
 export interface BeUserSearchPayload {
@@ -1936,6 +1949,53 @@ export interface BeGroupSearchPayload {
 
 export interface BeGroupSearchResponse {
   groups: BeGroup[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+// ---------------------------------------------------------------------------
+// Roles & teams — the platform's own directory catalogues (`/roles/search`,
+// `/teams/search`). Unlike `BeGroup` above, which is a live query against the
+// backing data source's assignment groups, these two are curated vocabularies:
+// `/roles/search` is the set of assignable role keys that
+// `UserSearchFilters.roleIds` accepts, and `/teams/search` is the team
+// registry. A team's `id` is its registry key (e.g. "alpha"), not a UUID —
+// registry keys are stable across environments, whereas the backing group's id
+// is not, which is why the key is what this API exposes.
+// ---------------------------------------------------------------------------
+
+export interface BeRole {
+  id: string;
+  name: string;
+}
+
+export interface BeRoleSearchPayload {
+  filters?: { searchQuery?: string };
+  pagination?: BePagination;
+}
+
+export interface BeRoleSearchResponse {
+  roles: BeRole[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export interface BeTeam {
+  /** Registry team key, e.g. "alpha" — not the backing group's UUID. */
+  id: string;
+  name: string;
+  family?: string;
+}
+
+export interface BeTeamSearchPayload {
+  filters?: { searchQuery?: string };
+  pagination?: BePagination;
+}
+
+export interface BeTeamSearchResponse {
+  teams: BeTeam[];
   total: number;
   limit: number;
   offset: number;

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -1175,6 +1175,37 @@ export interface BeProjectSearchResponse extends BeSearchResponseBase {
   projects: BeProject[];
 }
 
+/**
+ * A contact's attributes for one project, from `POST /projects/{id}/contacts/search`
+ * (also the shape of `GET /projects/{id}/contacts/{contactId}`).
+ */
+export interface BeProjectContact {
+  /**
+   * The contact's user id, for linking the row to that user's profile.
+   * Absent when the row has no contact record linked, or when the backing
+   * instance predates the field — render the row unlinked rather than
+   * treating it as an error.
+   */
+  id?: string;
+  name?: string;
+  email?: string;
+  registrationState?: string;
+  notificationsEnabled?: boolean;
+  roles?: string[];
+}
+
+export interface BeProjectContactSearchPayload {
+  filters?: { searchQuery?: string };
+  pagination?: BePagination;
+}
+
+export interface BeProjectContactSearchResponse {
+  contacts: BeProjectContact[];
+  offset: number;
+  limit: number;
+  total: number;
+}
+
 // ---------------------------------------------------------------------------
 // Deployments
 // ---------------------------------------------------------------------------

--- a/apps/csm-portal/webapp/src/components/error-banner/ErrorBanner.test.tsx
+++ b/apps/csm-portal/webapp/src/components/error-banner/ErrorBanner.test.tsx
@@ -1,0 +1,98 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import "@testing-library/jest-dom/vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+import ErrorBanner from "@components/error-banner/ErrorBanner";
+
+describe("ErrorBanner", () => {
+  beforeEach(() => {
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders the message with no copy button when no reference ID is supplied", () => {
+    render(<ErrorBanner message="Something went wrong." onClose={vi.fn()} />);
+
+    expect(screen.getByText("Something went wrong.")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /copy reference id/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("copies the reference ID to the clipboard and shows a transient confirmation, without folding it into the message text", async () => {
+    render(
+      <ErrorBanner
+        message="Failed to save the change."
+        referenceId="c3f1a9e2-1234-4abc-8def-0123456789ab"
+        onClose={vi.fn()}
+      />,
+    );
+
+    // The id is not appended to the visible message string.
+    expect(screen.getByText("Failed to save the change.")).toBeInTheDocument();
+    expect(
+      screen.queryByText(/c3f1a9e2-1234-4abc-8def-0123456789ab/),
+    ).not.toBeInTheDocument();
+
+    const button = screen.getByRole("button", { name: /copy reference id/i });
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+        "c3f1a9e2-1234-4abc-8def-0123456789ab",
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /copy reference id/i })).toHaveAttribute(
+        "aria-label",
+        "Copy reference ID",
+      );
+    });
+  });
+
+  it("still renders a close button when a copy button is also present", () => {
+    // MUI's Alert only auto-renders its own close (X) button when no custom
+    // `action` is supplied; supplying one (the copy button) for the tracking
+    // id must not silently drop the close control.
+    const onClose = vi.fn();
+    render(
+      <ErrorBanner
+        message="Something went wrong."
+        referenceId="c3f1a9e2-1234-4abc-8def-0123456789ab"
+        onClose={onClose}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("calls onClose when there is no reference ID too", () => {
+    const onClose = vi.fn();
+    render(<ErrorBanner message="Something went wrong." onClose={onClose} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/apps/csm-portal/webapp/src/components/error-banner/ErrorBanner.test.tsx
+++ b/apps/csm-portal/webapp/src/components/error-banner/ErrorBanner.test.tsx
@@ -54,6 +54,9 @@ describe("ErrorBanner", () => {
       screen.queryByText(/c3f1a9e2-1234-4abc-8def-0123456789ab/),
     ).not.toBeInTheDocument();
 
+    // The aria-live status is empty before any copy attempt.
+    expect(screen.queryByText("Reference ID copied.")).not.toBeInTheDocument();
+
     const button = screen.getByRole("button", { name: /copy reference id/i });
     fireEvent.click(button);
 
@@ -63,12 +66,20 @@ describe("ErrorBanner", () => {
       );
     });
 
+    // The icon swap alone isn't a completion signal for assistive tech --
+    // this live-region text is. Assert it appears, not just that the button's
+    // own (unchanged) aria-label is still present.
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: /copy reference id/i })).toHaveAttribute(
-        "aria-label",
-        "Copy reference ID",
-      );
+      expect(screen.getByText("Reference ID copied.")).toBeInTheDocument();
     });
+
+    // ...and clears again after the transient-confirmation window.
+    await waitFor(
+      () => {
+        expect(screen.queryByText("Reference ID copied.")).not.toBeInTheDocument();
+      },
+      { timeout: 3000 },
+    );
   });
 
   it("still renders a close button when a copy button is also present", () => {

--- a/apps/csm-portal/webapp/src/components/error-banner/ErrorBanner.tsx
+++ b/apps/csm-portal/webapp/src/components/error-banner/ErrorBanner.tsx
@@ -78,18 +78,35 @@ export default function ErrorBanner({
           // included in `action` too, or it silently disappears.
           <Stack direction="row" spacing={0.5} alignItems="center">
             {referenceId && (
-              <Tooltip title={copied ? "Copied!" : "Copy reference ID"} placement="top">
-                <Button
-                  size="small"
-                  variant="text"
-                  color="inherit"
-                  onClick={handleCopy}
-                  sx={{ minWidth: 0, p: 0.5 }}
-                  aria-label="Copy reference ID"
+              <>
+                <Tooltip title={copied ? "Copied!" : "Copy reference ID"} placement="top">
+                  <Button
+                    size="small"
+                    variant="text"
+                    color="inherit"
+                    onClick={handleCopy}
+                    sx={{ minWidth: 0, p: 0.5 }}
+                    aria-label="Copy reference ID"
+                  >
+                    {copied ? <Check size={14} /> : <Copy size={14} />}
+                  </Button>
+                </Tooltip>
+                {/* The icon/tooltip swap on copy isn't announced to screen readers on
+                    its own; this visually-hidden live region is the actual completion
+                    signal for assistive tech. */}
+                <Box
+                  aria-live="polite"
+                  sx={{
+                    position: "absolute",
+                    width: 1,
+                    height: 1,
+                    overflow: "hidden",
+                    clip: "rect(0 0 0 0)",
+                  }}
                 >
-                  {copied ? <Check size={14} /> : <Copy size={14} />}
-                </Button>
-              </Tooltip>
+                  {copied ? "Reference ID copied." : ""}
+                </Box>
+              </>
             )}
             <IconButton size="small" color="inherit" onClick={onClose} aria-label="Close">
               <X size={16} />

--- a/apps/csm-portal/webapp/src/components/error-banner/ErrorBanner.tsx
+++ b/apps/csm-portal/webapp/src/components/error-banner/ErrorBanner.tsx
@@ -14,31 +14,49 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Alert, Box } from "@wso2/oxygen-ui";
+import { Alert, Box, Button, IconButton, Stack, Tooltip } from "@wso2/oxygen-ui";
+import { Check, Copy, X } from "@wso2/oxygen-ui-icons-react";
 import {
   BANNER_HEADER_GAP_PX,
   BANNER_RIGHT_GAP_PX,
   HEADER_HEIGHT_PX,
 } from "@constants/common";
-import type { JSX } from "react";
+import { useState, type JSX } from "react";
 
 interface ErrorBannerProps {
   /** User-facing error message; supplied by the caller. */
   message: string;
+  /** The request's correlation ID, when the triggering error carried one.
+   *  Rendered as a separate copy affordance rather than folded into
+   *  `message` — the banner auto-dismisses on a timer, so a raw id embedded
+   *  in the text is otherwise only copyable by hand before it vanishes. */
+  referenceId?: string;
   onClose: () => void;
 }
 
 /**
  * ErrorBanner component displayed above the footer at the right corner.
- * Uses Oxygen UI Alert component. Displays the message passed from the caller.
+ * Uses Oxygen UI Alert component. Displays the message passed from the caller,
+ * plus a one-click copy button for the correlation ID when one is available.
  *
  * @param {ErrorBannerProps} props - Component props.
  * @returns {JSX.Element} The ErrorBanner JSX.
  */
 export default function ErrorBanner({
   message,
+  referenceId,
   onClose,
 }: ErrorBannerProps): JSX.Element {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = (): void => {
+    if (!referenceId || !navigator.clipboard) return;
+    navigator.clipboard.writeText(referenceId).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }, /* swallow — clipboard denied/unavailable */ () => {});
+  };
+
   return (
     <Box
       sx={{
@@ -51,9 +69,33 @@ export default function ErrorBanner({
     >
       <Alert
         severity="error"
-        onClose={onClose}
         elevation={6}
         sx={{ width: "100%" }}
+        action={
+          // `action` replaces Alert's own auto-rendered close button (MUI only
+          // renders that button from `onClose` when no `action` is supplied),
+          // so once a copy button is added here the close control must be
+          // included in `action` too, or it silently disappears.
+          <Stack direction="row" spacing={0.5} alignItems="center">
+            {referenceId && (
+              <Tooltip title={copied ? "Copied!" : "Copy reference ID"} placement="top">
+                <Button
+                  size="small"
+                  variant="text"
+                  color="inherit"
+                  onClick={handleCopy}
+                  sx={{ minWidth: 0, p: 0.5 }}
+                  aria-label="Copy reference ID"
+                >
+                  {copied ? <Check size={14} /> : <Copy size={14} />}
+                </Button>
+              </Tooltip>
+            )}
+            <IconButton size="small" color="inherit" onClick={onClose} aria-label="Close">
+              <X size={16} />
+            </IconButton>
+          </Stack>
+        }
       >
         {message}
       </Alert>

--- a/apps/csm-portal/webapp/src/config/csmNavItems.test.ts
+++ b/apps/csm-portal/webapp/src/config/csmNavItems.test.ts
@@ -91,6 +91,6 @@ describe("rendersOwnWipPage", () => {
     const flagged = flattenNavNodes()
       .filter((node) => node.rendersOwnWipPage)
       .map((node) => node.id);
-    expect(flagged).toEqual(["admin.roles", "admin.groups", "admin.permissions"]);
+    expect(flagged).toEqual(["admin.permissions"]);
   });
 });

--- a/apps/csm-portal/webapp/src/config/csmNavItems.ts
+++ b/apps/csm-portal/webapp/src/config/csmNavItems.ts
@@ -205,20 +205,11 @@ export const CSM_NAV_ITEMS: CsmNavSection[] = [
     icon: Settings,
     children: [
       { id: "admin.users", label: "Users", href: "/admin/users" },
-      // These three route to placeholders that already name their backend
-      // blocker, so they render themselves rather than the generic WIP page.
-      {
-        id: "admin.roles",
-        label: "Roles",
-        href: "/admin/roles",
-        rendersOwnWipPage: true,
-      },
-      {
-        id: "admin.groups",
-        label: "Groups",
-        href: "/admin/groups",
-        rendersOwnWipPage: true,
-      },
+      { id: "admin.roles", label: "Roles", href: "/admin/roles" },
+      { id: "admin.groups", label: "Groups", href: "/admin/groups" },
+      { id: "admin.teams", label: "Teams", href: "/admin/teams" },
+      // Routes to a placeholder that already names its backend blocker, so it
+      // renders itself rather than the generic WIP page.
       {
         id: "admin.permissions",
         label: "Permissions",

--- a/apps/csm-portal/webapp/src/constants/apiConstants.ts
+++ b/apps/csm-portal/webapp/src/constants/apiConstants.ts
@@ -127,6 +127,8 @@ export const ApiQueryKeys = {
   CSM_ADMIN_ROLE_DETAIL: "csm-admin-role-detail",
   CSM_ADMIN_GROUPS: "csm-admin-groups",
   CSM_ADMIN_GROUP_DETAIL: "csm-admin-group-detail",
+  CSM_ADMIN_TEAMS: "csm-admin-teams",
+  CSM_ADMIN_TEAM_DETAIL: "csm-admin-team-detail",
   CSM_ADMIN_PERMISSIONS: "csm-admin-permissions",
 } as const;
 

--- a/apps/csm-portal/webapp/src/context/error-banner/ErrorBannerContext.tsx
+++ b/apps/csm-portal/webapp/src/context/error-banner/ErrorBannerContext.tsx
@@ -34,8 +34,8 @@ import { getErrorReferenceId } from "@utils/correlationId";
 interface ErrorBannerContextType {
   /**
    * Show the error banner with the given user-facing message. Pass the original
-   * error as the second argument to append a support "Reference ID" (the
-   * request's correlation ID) when one is available.
+   * error as the second argument to surface a copyable "Reference ID" (the
+   * request's correlation ID) alongside it when one is available.
    */
   showError: (message: string, error?: unknown) => void;
 }
@@ -59,11 +59,12 @@ export function ErrorBannerProvider({
   children,
 }: ErrorBannerProviderProps): JSX.Element {
   const [message, setMessage] = useState<string | null>(null);
+  const [referenceId, setReferenceId] = useState<string | undefined>(undefined);
   const [key, setKey] = useState(0);
 
   const showError = useCallback((msg: string, error?: unknown) => {
-    const referenceId = getErrorReferenceId(error);
-    setMessage(referenceId ? `${msg} (Reference ID: ${referenceId})` : msg);
+    setMessage(msg);
+    setReferenceId(getErrorReferenceId(error));
     setKey((prev) => prev + 1);
   }, []);
 
@@ -90,7 +91,12 @@ export function ErrorBannerProvider({
     <ErrorBannerContext.Provider value={contextValue}>
       {children}
       {visible && message && (
-        <ErrorBanner key={key} message={message} onClose={dismiss} />
+        <ErrorBanner
+          key={key}
+          message={message}
+          referenceId={referenceId}
+          onClose={dismiss}
+        />
       )}
     </ErrorBannerContext.Provider>
   );

--- a/apps/csm-portal/webapp/src/features/csm-admin/api/useSearchGroupsPage.ts
+++ b/apps/csm-portal/webapp/src/features/csm-admin/api/useSearchGroupsPage.ts
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { keepPreviousData, useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import { useBackendApi } from "@api/backend/client";
+import type { BeGroupSearchPayload, BeGroupSearchResponse } from "@api/backend/types";
+
+/**
+ * Paginated group search (`POST /groups/search`) for the Groups directory
+ * list page. Distinct from `useSearchGroups` (the type-ahead picker used by
+ * the change-request "Assignment group" field): that one always asks for a
+ * fixed small page and drops the total count, which isn't enough for a
+ * page-through admin list. Groups are a live query against the backing data
+ * source, unlike the curated role/team catalogues, so this list can be much
+ * larger than either of those.
+ */
+export function useSearchGroupsPage(
+  request: BeGroupSearchPayload,
+  enabled = true,
+): UseQueryResult<BeGroupSearchResponse, Error> {
+  const api = useBackendApi();
+
+  return useQuery<BeGroupSearchResponse, Error>({
+    queryKey: [ApiQueryKeys.CSM_ADMIN_GROUPS, request],
+    queryFn: () =>
+      api.post<BeGroupSearchPayload, BeGroupSearchResponse>("/groups/search", request),
+    enabled,
+    placeholderData: keepPreviousData,
+    staleTime: 30_000,
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-admin/api/useSearchRoles.ts
+++ b/apps/csm-portal/webapp/src/features/csm-admin/api/useSearchRoles.ts
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { keepPreviousData, useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import { useBackendApi } from "@api/backend/client";
+import type { BeRoleSearchPayload, BeRoleSearchResponse } from "@api/backend/types";
+
+/**
+ * Searches the platform's curated role catalogue (`POST /roles/search`) —
+ * the same values `UserSearchFilters.roleIds` accepts. Unlike
+ * `/groups/search`, this isn't a live query against the backing data source:
+ * it's a fixed, small vocabulary, so it's cached longer and reused for both
+ * the Roles directory page (paginated) and the user-list role picker (one
+ * full-catalogue page).
+ */
+export function useSearchRoles(
+  request: BeRoleSearchPayload,
+  enabled = true,
+): UseQueryResult<BeRoleSearchResponse, Error> {
+  const api = useBackendApi();
+
+  return useQuery<BeRoleSearchResponse, Error>({
+    queryKey: [ApiQueryKeys.CSM_ADMIN_ROLES, request],
+    queryFn: () =>
+      api.post<BeRoleSearchPayload, BeRoleSearchResponse>("/roles/search", request),
+    enabled,
+    placeholderData: keepPreviousData,
+    staleTime: 5 * 60_000,
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-admin/api/useSearchTeams.ts
+++ b/apps/csm-portal/webapp/src/features/csm-admin/api/useSearchTeams.ts
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { keepPreviousData, useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import { useBackendApi } from "@api/backend/client";
+import type { BeTeamSearchPayload, BeTeamSearchResponse } from "@api/backend/types";
+
+/**
+ * Searches the team registry (`POST /teams/search`) — the same values
+ * `UserSearchFilters.teamIds` accepts. A curated catalogue like
+ * `/roles/search`, not a live query against the backing data source: each
+ * team's `id` is its registry key, not a UUID. Reused for both the Teams
+ * directory page (paginated) and the user-list team picker (one
+ * full-catalogue page).
+ */
+export function useSearchTeams(
+  request: BeTeamSearchPayload,
+  enabled = true,
+): UseQueryResult<BeTeamSearchResponse, Error> {
+  const api = useBackendApi();
+
+  return useQuery<BeTeamSearchResponse, Error>({
+    queryKey: [ApiQueryKeys.CSM_ADMIN_TEAMS, request],
+    queryFn: () =>
+      api.post<BeTeamSearchPayload, BeTeamSearchResponse>("/teams/search", request),
+    enabled,
+    placeholderData: keepPreviousData,
+    staleTime: 5 * 60_000,
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-admin/components/DirectoryEntityChip.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/components/DirectoryEntityChip.test.tsx
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+
+const navigateMock = vi.fn();
+vi.mock("@hooks/useNavTransition", () => ({
+  useNavTransition: () => navigateMock,
+}));
+
+import DirectoryEntityChip from "@features/csm-admin/components/DirectoryEntityChip";
+
+describe("DirectoryEntityChip", () => {
+  it("navigates to the entity's directory page with the name as router state", () => {
+    render(<DirectoryEntityChip id="agent" name="Agent" routeBase="/admin/roles" />);
+    fireEvent.click(screen.getByText("Agent"));
+    expect(navigateMock).toHaveBeenCalledWith("/admin/roles/agent", {
+      state: { name: "Agent" },
+    });
+  });
+
+  it("stops the click from bubbling to a parent handler (e.g. a clickable table row)", () => {
+    const parentOnClick = vi.fn();
+    render(
+      <div onClick={parentOnClick}>
+        <DirectoryEntityChip id="alpha" name="Alpha Team" routeBase="/admin/teams" />
+      </div>,
+    );
+    fireEvent.click(screen.getByText("Alpha Team"));
+    expect(navigateMock).toHaveBeenCalledWith("/admin/teams/alpha", {
+      state: { name: "Alpha Team" },
+    });
+    expect(parentOnClick).not.toHaveBeenCalled();
+  });
+
+  it("encodes the id in the destination path", () => {
+    render(
+      <DirectoryEntityChip id="a/b c" name="Weird Id" routeBase="/admin/groups" />,
+    );
+    fireEvent.click(screen.getByText("Weird Id"));
+    expect(navigateMock).toHaveBeenCalledWith("/admin/groups/a%2Fb%20c", {
+      state: { name: "Weird Id" },
+    });
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-admin/components/DirectoryEntityChip.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/components/DirectoryEntityChip.tsx
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Chip } from "@wso2/oxygen-ui";
+import type { JSX, KeyboardEvent, MouseEvent } from "react";
+import { useNavTransition } from "@hooks/useNavTransition";
+
+interface DirectoryEntityChipProps {
+  /** Registry key / id of the role, group or team, e.g. "agent" or "alpha". */
+  id: string;
+  /** Display label for the chip. */
+  name: string;
+  /** e.g. "/admin/roles", "/admin/groups", "/admin/teams" — the id is appended. */
+  routeBase: string;
+  color?: "default" | "primary";
+  variant?: "outlined" | "filled";
+}
+
+/**
+ * A role/group/team name rendered as a clickable chip navigating to its
+ * directory member page (`${routeBase}/${id}`), carrying the display name as
+ * router state — the same convention `DirectoryEntityTable` uses for the
+ * directory pages themselves (see `DirectoryMemberPage`), so the member page
+ * can show the name immediately without a second lookup, falling back to the
+ * raw id when the state is unavailable (a direct/shared link).
+ *
+ * Stops the click (and Enter/Space activation the underlying `Chip` already
+ * wires up) from bubbling, so this can be nested inside a clickable table row
+ * (e.g. the users list) without also triggering the row's own navigation.
+ */
+export default function DirectoryEntityChip({
+  id,
+  name,
+  routeBase,
+  color = "default",
+  variant = "outlined",
+}: DirectoryEntityChipProps): JSX.Element {
+  const navigate = useNavTransition();
+
+  const go = (): void => {
+    navigate(`${routeBase}/${encodeURIComponent(id)}`, { state: { name } });
+  };
+
+  return (
+    <Chip
+      size="small"
+      label={name}
+      color={color}
+      variant={variant}
+      clickable
+      onClick={(e: MouseEvent) => {
+        e.stopPropagation();
+        go();
+      }}
+      // `Chip`'s own clickable behaviour already turns Enter/Space keydowns
+      // into a click, but the keydown event itself still bubbles first — stop
+      // it here too, or a parent clickable row (see the users list) would
+      // also navigate itself on the same keypress.
+      onKeyDown={(e: KeyboardEvent) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.stopPropagation();
+        }
+      }}
+    />
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-admin/components/DirectoryEntityTable.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/components/DirectoryEntityTable.tsx
@@ -1,0 +1,186 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Box,
+  Skeleton,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TablePagination,
+  TableRow,
+  TextField,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { type ChangeEvent, type JSX } from "react";
+import { Link as RouterLink } from "react-router";
+import QueryErrorState from "@components/QueryErrorState";
+import { BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
+
+const ROWS_PER_PAGE_OPTIONS = [10, 20, BE_MAX_PAGE_LIMIT];
+
+/** One row this table can render: a role, group, or team. */
+export interface DirectoryEntityRow {
+  id: string;
+  name: string;
+  /** Team-only: the CRE/SRE family, shown alongside the name when present. */
+  family?: string;
+}
+
+interface DirectoryEntityTableProps {
+  /** Plural noun for headings/empty states, e.g. "roles". */
+  entityNounPlural: string;
+  /** Route each row links to, e.g. "/admin/roles" (the id is appended). */
+  memberBasePath: string;
+  rows: DirectoryEntityRow[];
+  total: number;
+  isLoading: boolean;
+  isFetching: boolean;
+  isError: boolean;
+  error: unknown;
+  search: string;
+  onSearchChange: (value: string) => void;
+  page: number;
+  onPageChange: (page: number) => void;
+  rowsPerPage: number;
+  onRowsPerPageChange: (rowsPerPage: number) => void;
+}
+
+/**
+ * Shared list table for the Roles / Groups / Teams directory pages: a search
+ * box, a server-paginated table, and a click-through link from every row to
+ * its member list (`/admin/<kind>/:id`). The entity's display name travels
+ * with the link as router state so the member page can show it immediately,
+ * without a second catalogue lookup.
+ */
+export default function DirectoryEntityTable({
+  entityNounPlural,
+  memberBasePath,
+  rows,
+  total,
+  isLoading,
+  isFetching,
+  isError,
+  error,
+  search,
+  onSearchChange,
+  page,
+  onPageChange,
+  rowsPerPage,
+  onRowsPerPageChange,
+}: DirectoryEntityTableProps): JSX.Element {
+  const handleSearchChange = (e: ChangeEvent<HTMLInputElement>): void => {
+    onSearchChange(e.target.value);
+  };
+
+  const handleChangeRowsPerPage = (e: ChangeEvent<HTMLInputElement>): void => {
+    onRowsPerPageChange(parseInt(e.target.value, 10));
+  };
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+      <TextField
+        size="small"
+        label={`Search ${entityNounPlural}`}
+        value={search}
+        onChange={handleSearchChange}
+        sx={{ maxWidth: 360 }}
+        slotProps={{ htmlInput: { "aria-label": `Search ${entityNounPlural} by name` } }}
+      />
+
+      <Box sx={{ border: 1, borderColor: "divider", borderRadius: 1, overflow: "hidden" }}>
+        <TableContainer>
+          <Table
+            size="small"
+            aria-label={`${entityNounPlural} search results`}
+            sx={{ "& .MuiTableCell-root": { borderColor: "divider" } }}
+          >
+            <TableHead>
+              <TableRow sx={{ bgcolor: "action.hover" }}>
+                <TableCell>Name</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {isLoading || isFetching ? (
+                Array.from({ length: rowsPerPage }).map((_, i) => (
+                  <TableRow key={i}>
+                    <TableCell>
+                      <Skeleton variant="rounded" width="60%" height={18} />
+                    </TableCell>
+                  </TableRow>
+                ))
+              ) : isError ? (
+                <TableRow>
+                  <TableCell align="center">
+                    <QueryErrorState
+                      message={`Failed to load ${entityNounPlural}: ${
+                        error instanceof Error ? error.message : "unknown error"
+                      }`}
+                      error={error}
+                    />
+                  </TableCell>
+                </TableRow>
+              ) : rows.length === 0 ? (
+                <TableRow>
+                  <TableCell align="center" sx={{ py: 4 }}>
+                    <Typography variant="body2" color="text.secondary">
+                      No {entityNounPlural} found.
+                    </Typography>
+                  </TableCell>
+                </TableRow>
+              ) : (
+                rows.map((row) => (
+                  <TableRow key={row.id} hover>
+                    <TableCell>
+                      <Typography
+                        component={RouterLink}
+                        to={`${memberBasePath}/${encodeURIComponent(row.id)}`}
+                        state={{ name: row.name }}
+                        variant="body2"
+                        sx={(t) => ({
+                          fontWeight: 600,
+                          textDecoration: "none",
+                          color: t.palette.primary.dark,
+                          ...t.applyStyles("dark", { color: t.palette.primary.main }),
+                          "&:hover": { textDecoration: "underline" },
+                        })}
+                      >
+                        {row.family ? `${row.name} (${row.family})` : row.name}
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </TableContainer>
+        <TablePagination
+          component="div"
+          count={total}
+          page={page}
+          onPageChange={(_, newPage) => onPageChange(newPage)}
+          rowsPerPage={rowsPerPage}
+          onRowsPerPageChange={handleChangeRowsPerPage}
+          rowsPerPageOptions={ROWS_PER_PAGE_OPTIONS}
+          showFirstButton
+          showLastButton
+        />
+      </Box>
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-admin/components/DirectoryEntityTable.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/components/DirectoryEntityTable.tsx
@@ -115,8 +115,10 @@ export default function DirectoryEntityTable({
                 <TableCell>Name</TableCell>
               </TableRow>
             </TableHead>
-            <TableBody>
-              {isLoading || isFetching ? (
+            <TableBody
+              sx={isFetching ? { opacity: 0.6, transition: "opacity 0.15s" } : undefined}
+            >
+              {isLoading ? (
                 Array.from({ length: rowsPerPage }).map((_, i) => (
                   <TableRow key={i}>
                     <TableCell>

--- a/apps/csm-portal/webapp/src/features/csm-admin/components/DirectoryMemberPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/components/DirectoryMemberPage.tsx
@@ -1,0 +1,89 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Box, Button, Typography } from "@wso2/oxygen-ui";
+import { ArrowLeft } from "@wso2/oxygen-ui-icons-react";
+import type { JSX } from "react";
+import { Link as RouterLink, useLocation, useParams } from "react-router";
+import DirectoryMembersList, {
+  type DirectoryMemberFilterKey,
+} from "@features/csm-admin/components/DirectoryMembersList";
+
+interface DirectoryMemberPageProps {
+  filterKey: DirectoryMemberFilterKey;
+  /** Singular noun, e.g. "role". */
+  entityNoun: string;
+  /** Where the "Back" link and the breadcrumb send the user, e.g. "/admin/roles". */
+  listPath: string;
+  /** Plural label for the breadcrumb, e.g. "Roles". */
+  listLabel: string;
+}
+
+/**
+ * Shared shell for a role/group/team's member page: the entity's name
+ * (carried as router state by the directory row's link — see
+ * `DirectoryEntityTable` — falling back to the raw id for a direct/shared
+ * link that arrived without it) plus the member list itself. One shell, three
+ * thin per-entity pages (`RoleMembersPage`, `GroupMembersPage`,
+ * `TeamMembersPage`) so each still has its own route component to test the
+ * filter key against.
+ */
+export default function DirectoryMemberPage({
+  filterKey,
+  entityNoun,
+  listPath,
+  listLabel,
+}: DirectoryMemberPageProps): JSX.Element {
+  const { id } = useParams<{ id: string }>();
+  const location = useLocation();
+  const state = location.state as { name?: string } | null;
+  const name = state?.name ?? id ?? "";
+
+  if (!id) {
+    return (
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+        <Typography variant="h5">Not found</Typography>
+        <Typography variant="body2" color="text.secondary">
+          No {entityNoun} id was given.
+        </Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 2.5 }}>
+      <Button
+        component={RouterLink}
+        to={listPath}
+        variant="text"
+        size="small"
+        startIcon={<ArrowLeft size={16} />}
+        sx={{ alignSelf: "flex-start" }}
+      >
+        Back to {listLabel}
+      </Button>
+
+      <Box>
+        <Typography variant="h5">{name}</Typography>
+        <Typography variant="body2" color="text.secondary">
+          Members of this {entityNoun}
+        </Typography>
+      </Box>
+
+      <DirectoryMembersList filterKey={filterKey} entityId={id} entityNoun={entityNoun} />
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-admin/components/DirectoryMembersList.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/components/DirectoryMembersList.test.tsx
@@ -1,0 +1,170 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import type { ComponentProps } from "react";
+import { MemoryRouter } from "react-router";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+const authFetchMock = vi.fn();
+
+// useSearchUsers (csm-users/api) reads runtime config via @config/apiConfig
+// and the real Asgardeo-backed useAuthApiClient at module load — neither is
+// present under vitest, so stub both (same approach as
+// useAccountProjects.test.tsx). authFetchMock stands in for the fetch
+// wrapper the hook actually calls.
+vi.mock("@config/apiConfig", () => ({
+  apiConfig: { backendUrl: "https://example.test" },
+}));
+vi.mock("@hooks/useAuthApiClient", () => ({
+  useAuthApiClient: () => authFetchMock,
+}));
+// UserRefLink resolves an unknown id via POST /users/search through
+// useBackendApi; every row here already carries an id, so resolution is never
+// triggered, but the module still needs a working mock to import cleanly.
+vi.mock("@api/backend/client", () => ({
+  BackendApiError: class BackendApiError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+      super(message);
+      this.status = status;
+    }
+  },
+  useBackendApi: () => ({ post: vi.fn() }),
+}));
+
+import DirectoryMembersList from "@features/csm-admin/components/DirectoryMembersList";
+
+function jsonResponse(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+function renderList(
+  props: Partial<ComponentProps<typeof DirectoryMembersList>> = {},
+): ReturnType<typeof render> {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <DirectoryMembersList
+          filterKey="roleIds"
+          entityId="agent"
+          entityNoun="role"
+          {...props}
+        />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+const MEMBER = {
+  id: "00000000-0000-0000-0000-000000000000",
+  userName: "jane.doe",
+  name: "Jane Doe",
+  email: "jane.doe@example.com",
+  active: true,
+  createdOn: "2026-01-01T00:00:00Z",
+  updatedOn: "2026-01-01T00:00:00Z",
+  roles: ["agent"],
+};
+
+describe("DirectoryMembersList", () => {
+  beforeEach(() => {
+    authFetchMock.mockReset();
+  });
+
+  it("sends roleIds (not groupIds/teamIds) for a role's member page", async () => {
+    authFetchMock.mockResolvedValueOnce(
+      jsonResponse({ users: [MEMBER], total: 1, limit: 20, offset: 0 }),
+    );
+    renderList({ filterKey: "roleIds", entityId: "agent", entityNoun: "role" });
+
+    await waitFor(() => expect(authFetchMock).toHaveBeenCalled());
+    const [, requestInit] = authFetchMock.mock.calls[0];
+    const body = JSON.parse(requestInit.body as string);
+    expect(body.filters).toEqual({ roleIds: ["agent"] });
+  });
+
+  it("sends groupIds (not roleIds/teamIds) for a group's member page", async () => {
+    authFetchMock.mockResolvedValueOnce(
+      jsonResponse({ users: [MEMBER], total: 1, limit: 20, offset: 0 }),
+    );
+    renderList({
+      filterKey: "groupIds",
+      entityId: "11111111-1111-1111-1111-111111111111",
+      entityNoun: "group",
+    });
+
+    await waitFor(() => expect(authFetchMock).toHaveBeenCalled());
+    const [, requestInit] = authFetchMock.mock.calls[0];
+    const body = JSON.parse(requestInit.body as string);
+    expect(body.filters).toEqual({ groupIds: ["11111111-1111-1111-1111-111111111111"] });
+  });
+
+  it("sends teamIds (not roleIds/groupIds) for a team's member page, using the registry key as-is", async () => {
+    authFetchMock.mockResolvedValueOnce(
+      jsonResponse({ users: [MEMBER], total: 1, limit: 20, offset: 0 }),
+    );
+    renderList({ filterKey: "teamIds", entityId: "alpha", entityNoun: "team" });
+
+    await waitFor(() => expect(authFetchMock).toHaveBeenCalled());
+    const [, requestInit] = authFetchMock.mock.calls[0];
+    const body = JSON.parse(requestInit.body as string);
+    // The team id travels through untouched — it's a registry key, not a
+    // UUID, and nothing here should coerce or reformat it.
+    expect(body.filters).toEqual({ teamIds: ["alpha"] });
+  });
+
+  it("renders a member row linking to the person's profile via UserRefLink", async () => {
+    authFetchMock.mockResolvedValueOnce(
+      jsonResponse({ users: [MEMBER], total: 1, limit: 20, offset: 0 }),
+    );
+    renderList();
+
+    const link = await screen.findByRole("link", { name: "jane.doe" });
+    expect(link).toHaveAttribute("href", `/people/${MEMBER.id}`);
+  });
+
+  it("renders an empty state (not an error) when the filter matches nobody", async () => {
+    authFetchMock.mockResolvedValueOnce(
+      jsonResponse({ users: [], total: 0, limit: 20, offset: 0 }),
+    );
+    renderList({ filterKey: "teamIds", entityId: "beta", entityNoun: "team" });
+
+    expect(await screen.findByText(/No members found for this team/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Failed to load members/i)).not.toBeInTheDocument();
+  });
+
+  it("renders an error state when the search fails", async () => {
+    authFetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+      text: async () => "",
+    } as unknown as Response);
+    renderList();
+
+    expect(await screen.findByText(/Failed to load members/i)).toBeInTheDocument();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-admin/components/DirectoryMembersList.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/components/DirectoryMembersList.test.tsx
@@ -36,7 +36,10 @@ vi.mock("@hooks/useAuthApiClient", () => ({
 }));
 // UserRefLink resolves an unknown id via POST /users/search through
 // useBackendApi; every row here already carries an id, so resolution is never
-// triggered, but the module still needs a working mock to import cleanly.
+// triggered. useSearchRoles (for role display names) goes through this same
+// client, so `post` needs a real implementation -- an empty vi.fn() resolves
+// to undefined, which react-query rejects ("Query data cannot be undefined").
+const backendPostMock = vi.fn();
 vi.mock("@api/backend/client", () => ({
   BackendApiError: class BackendApiError extends Error {
     status: number;
@@ -45,7 +48,7 @@ vi.mock("@api/backend/client", () => ({
       this.status = status;
     }
   },
-  useBackendApi: () => ({ post: vi.fn() }),
+  useBackendApi: () => ({ post: backendPostMock }),
 }));
 
 import DirectoryMembersList from "@features/csm-admin/components/DirectoryMembersList";
@@ -89,9 +92,24 @@ const MEMBER = {
   roles: ["agent"],
 };
 
+const ROLES_RESPONSE = {
+  roles: [
+    { id: "agent", name: "Agent" },
+    { id: "admin", name: "Admin" },
+    { id: "commenter", name: "Commenter" },
+    { id: "customer", name: "Customer" },
+    { id: "partner", name: "Partner" },
+  ],
+  total: 5,
+  limit: 50,
+  offset: 0,
+};
+
 describe("DirectoryMembersList", () => {
   beforeEach(() => {
     authFetchMock.mockReset();
+    backendPostMock.mockReset();
+    backendPostMock.mockResolvedValue(ROLES_RESPONSE);
   });
 
   it("sends roleIds (not groupIds/teamIds) for a role's member page", async () => {
@@ -154,6 +172,40 @@ describe("DirectoryMembersList", () => {
 
     expect(await screen.findByText(/No members found for this team/i)).toBeInTheDocument();
     expect(screen.queryByText(/Failed to load members/i)).not.toBeInTheDocument();
+  });
+
+  it("truncates a member's roles beyond 3 with a '+N more' chip, same as the user list", async () => {
+    // Regression test: role truncation was implemented directly in
+    // CsmUsersPage's own row rendering, not as a shared component, so every
+    // role/group/team member-list page rendered every role uncapped despite
+    // the user list itself being fixed.
+    const memberWithManyRoles = {
+      ...MEMBER,
+      roles: ["agent", "admin", "commenter", "customer", "partner"],
+    };
+    authFetchMock.mockResolvedValueOnce(
+      jsonResponse({ users: [memberWithManyRoles], total: 1, limit: 20, offset: 0 }),
+    );
+    renderList();
+
+    // Names come from the roles catalogue lookup, proving it's wired, not
+    // just raw ids threaded through unchanged.
+    expect(await screen.findByText("Agent")).toBeInTheDocument();
+    expect(screen.getByText("Admin")).toBeInTheDocument();
+    expect(screen.getByText("Commenter")).toBeInTheDocument();
+    expect(screen.queryByText("Customer")).not.toBeInTheDocument();
+    expect(screen.queryByText("Partner")).not.toBeInTheDocument();
+    expect(screen.getByText("+2 more")).toBeInTheDocument();
+  });
+
+  it("does not show a '+N more' chip at 3 roles or fewer", async () => {
+    authFetchMock.mockResolvedValueOnce(
+      jsonResponse({ users: [MEMBER], total: 1, limit: 20, offset: 0 }),
+    );
+    renderList();
+
+    expect(await screen.findByText("Agent")).toBeInTheDocument();
+    expect(screen.queryByText(/more$/)).not.toBeInTheDocument();
   });
 
   it("renders an error state when the search fails", async () => {

--- a/apps/csm-portal/webapp/src/features/csm-admin/components/DirectoryMembersList.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/components/DirectoryMembersList.tsx
@@ -1,0 +1,181 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Box,
+  Chip,
+  Skeleton,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TablePagination,
+  TableRow,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { useState, type ChangeEvent, type JSX } from "react";
+import QueryErrorState from "@components/QueryErrorState";
+import UserRefLink from "@components/UserRefLink";
+import { useSearchUsers } from "@features/csm-users/api/useSearchUsers";
+import { INTERNAL_USER_ROLES, type SearchUsersRequest } from "@features/csm-users/types/csmUsers";
+import { BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
+
+const DEFAULT_ROWS_PER_PAGE = 20;
+const ROWS_PER_PAGE_OPTIONS = [10, 20, BE_MAX_PAGE_LIMIT];
+const COLUMN_COUNT = 5;
+
+/** Which `UserSearchFilters` key membership in this entity narrows on. */
+export type DirectoryMemberFilterKey = "roleIds" | "groupIds" | "teamIds";
+
+interface DirectoryMembersListProps {
+  /** `roleIds` for a role's member page, `groupIds` for a group's, `teamIds`
+   * for a team's — must match the entity kind exactly: sending the wrong key
+   * (e.g. `groupIds` on a team's page) would silently list the wrong
+   * people. */
+  filterKey: DirectoryMemberFilterKey;
+  /** The role key / group id / team registry key to filter on. */
+  entityId: string;
+  /** Plural noun used in the empty/error copy, e.g. "role". */
+  entityNoun: string;
+}
+
+/**
+ * A role/group/team's member list, backed by `POST /users/search` with the
+ * matching membership filter. Server-side filtered and paginated — never
+ * fetch-everything-and-slice, since a membership filter can match anywhere
+ * from zero to the whole user base. A filter matching nobody is a normal,
+ * legitimate result (an empty state), not an error.
+ */
+export default function DirectoryMembersList({
+  filterKey,
+  entityId,
+  entityNoun,
+}: DirectoryMembersListProps): JSX.Element {
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_ROWS_PER_PAGE);
+
+  const request: SearchUsersRequest = {
+    pagination: { limit: rowsPerPage, offset: page * rowsPerPage },
+    filters: { [filterKey]: [entityId] },
+  };
+
+  const { data, isLoading, isFetching, isError, error } = useSearchUsers(request);
+  const users = data?.users ?? [];
+  const total = data?.total ?? 0;
+
+  const handleChangeRowsPerPage = (e: ChangeEvent<HTMLInputElement>): void => {
+    setRowsPerPage(parseInt(e.target.value, 10));
+    setPage(0);
+  };
+
+  return (
+    <Box sx={{ border: 1, borderColor: "divider", borderRadius: 1, overflow: "hidden" }}>
+      <TableContainer>
+        <Table size="small" aria-label={`${entityNoun} members`} sx={{ "& .MuiTableCell-root": { borderColor: "divider" } }}>
+          <TableHead>
+            <TableRow sx={{ bgcolor: "action.hover" }}>
+              <TableCell>Username</TableCell>
+              <TableCell>Name</TableCell>
+              <TableCell>Email</TableCell>
+              <TableCell>Roles</TableCell>
+              <TableCell>Status</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {isLoading || isFetching ? (
+              Array.from({ length: rowsPerPage }).map((_, i) => (
+                <TableRow key={i}>
+                  {Array.from({ length: COLUMN_COUNT }).map((__, c) => (
+                    <TableCell key={c}>
+                      <Skeleton variant="rounded" width="70%" height={18} />
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : isError ? (
+              <TableRow>
+                <TableCell colSpan={COLUMN_COUNT} align="center">
+                  <QueryErrorState
+                    message={`Failed to load members: ${error instanceof Error ? error.message : "unknown error"}`}
+                    error={error}
+                  />
+                </TableCell>
+              </TableRow>
+            ) : users.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={COLUMN_COUNT} align="center" sx={{ py: 4 }}>
+                  <Typography variant="body2" color="text.secondary">
+                    No members found for this {entityNoun}.
+                  </Typography>
+                </TableCell>
+              </TableRow>
+            ) : (
+              users.map((u) => (
+                <TableRow key={u.id} hover>
+                  <TableCell>
+                    <UserRefLink name={u.userName} email={u.email} userId={u.id} />
+                  </TableCell>
+                  <TableCell>{u.name || "—"}</TableCell>
+                  <TableCell sx={{ wordBreak: "break-all" }}>{u.email}</TableCell>
+                  <TableCell>
+                    <Stack direction="row" spacing={0.5} sx={{ flexWrap: "wrap", gap: 0.5 }}>
+                      {u.roles && u.roles.length > 0
+                        ? u.roles.map((r) => (
+                            <Chip
+                              key={r}
+                              size="small"
+                              label={r}
+                              color={(INTERNAL_USER_ROLES as string[]).includes(r) ? "primary" : "default"}
+                              variant="outlined"
+                            />
+                          ))
+                        : "—"}
+                    </Stack>
+                  </TableCell>
+                  <TableCell>
+                    {u.active === undefined ? (
+                      "—"
+                    ) : (
+                      <Chip
+                        size="small"
+                        label={u.active ? "Active" : "Inactive"}
+                        color={u.active ? "success" : "default"}
+                        variant="outlined"
+                      />
+                    )}
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </TableContainer>
+      <TablePagination
+        component="div"
+        count={total}
+        page={page}
+        onPageChange={(_, newPage) => setPage(newPage)}
+        rowsPerPage={rowsPerPage}
+        onRowsPerPageChange={handleChangeRowsPerPage}
+        rowsPerPageOptions={ROWS_PER_PAGE_OPTIONS}
+        showFirstButton
+        showLastButton
+      />
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-admin/components/DirectoryMembersList.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/components/DirectoryMembersList.tsx
@@ -18,7 +18,6 @@ import {
   Box,
   Chip,
   Skeleton,
-  Stack,
   Table,
   TableBody,
   TableCell,
@@ -28,11 +27,13 @@ import {
   TableRow,
   Typography,
 } from "@wso2/oxygen-ui";
-import { useState, type ChangeEvent, type JSX } from "react";
+import { useMemo, useState, type ChangeEvent, type JSX } from "react";
 import QueryErrorState from "@components/QueryErrorState";
 import UserRefLink from "@components/UserRefLink";
 import { useSearchUsers } from "@features/csm-users/api/useSearchUsers";
-import { INTERNAL_USER_ROLES, type SearchUsersRequest } from "@features/csm-users/types/csmUsers";
+import { useSearchRoles } from "@features/csm-admin/api/useSearchRoles";
+import RoleChipList from "@features/csm-admin/components/RoleChipList";
+import type { SearchUsersRequest } from "@features/csm-users/types/csmUsers";
 import { BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
 
 const DEFAULT_ROWS_PER_PAGE = 20;
@@ -77,6 +78,12 @@ export default function DirectoryMembersList({
   const { data, isLoading, isFetching, isError, error } = useSearchUsers(request);
   const users = data?.users ?? [];
   const total = data?.total ?? 0;
+
+  const { data: rolesData } = useSearchRoles({ pagination: { limit: BE_MAX_PAGE_LIMIT } });
+  const roleNameById = useMemo(
+    () => new Map((rolesData?.roles ?? []).map((r) => [r.id, r.name])),
+    [rolesData],
+  );
 
   const handleChangeRowsPerPage = (e: ChangeEvent<HTMLInputElement>): void => {
     setRowsPerPage(parseInt(e.target.value, 10));
@@ -133,19 +140,12 @@ export default function DirectoryMembersList({
                   <TableCell>{u.name || "—"}</TableCell>
                   <TableCell sx={{ wordBreak: "break-all" }}>{u.email}</TableCell>
                   <TableCell>
-                    <Stack direction="row" spacing={0.5} sx={{ flexWrap: "wrap", gap: 0.5 }}>
-                      {u.roles && u.roles.length > 0
-                        ? u.roles.map((r) => (
-                            <Chip
-                              key={r}
-                              size="small"
-                              label={r}
-                              color={(INTERNAL_USER_ROLES as string[]).includes(r) ? "primary" : "default"}
-                              variant="outlined"
-                            />
-                          ))
-                        : "—"}
-                    </Stack>
+                    <RoleChipList
+                      roleIds={u.roles ?? []}
+                      roleNameById={roleNameById}
+                      userId={u.id}
+                      userLabel={u.name || u.userName}
+                    />
                   </TableCell>
                   <TableCell>
                     {u.active === undefined ? (

--- a/apps/csm-portal/webapp/src/features/csm-admin/components/RoleChipList.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/components/RoleChipList.tsx
@@ -1,0 +1,95 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Chip, Stack } from "@wso2/oxygen-ui";
+import type { JSX } from "react";
+import { useNavigate } from "react-router";
+import DirectoryEntityChip from "@features/csm-admin/components/DirectoryEntityChip";
+import { INTERNAL_USER_ROLES } from "@features/csm-users/types/csmUsers";
+
+// Roles beyond this many collapse into a single "+N more" chip that links to
+// the user's profile — a table cell isn't the place to enumerate every role a
+// user carries. This is the single implementation both the user list and every
+// role/group/team member list use; duplicating this logic per page is exactly
+// how it previously went missing from the member-list pages while the user
+// list got it.
+const MAX_VISIBLE_ROLES = 3;
+
+interface RoleChipListProps {
+  /** Role ids/keys this user holds. */
+  roleIds: string[];
+  /** Role id -> display name, e.g. from `useSearchRoles`. Falls back to the
+   * raw id when a name isn't known (or the lookup hasn't loaded yet). */
+  roleNameById: Map<string, string>;
+  /** The user these roles belong to, so the overflow chip has somewhere to
+   * send the viewer to see the rest. */
+  userId: string;
+  userLabel: string;
+}
+
+/**
+ * A user's roles as clickable chips (each linking to that role's directory
+ * page), capped at {@link MAX_VISIBLE_ROLES} with a "+N more" overflow chip
+ * linking to the user's own profile. Renders "—" when the user has no roles.
+ */
+export default function RoleChipList({
+  roleIds,
+  roleNameById,
+  userId,
+  userLabel,
+}: RoleChipListProps): JSX.Element {
+  const navigate = useNavigate();
+
+  if (roleIds.length === 0) {
+    return <>—</>;
+  }
+
+  const visibleRoles = roleIds.slice(0, MAX_VISIBLE_ROLES);
+  const hiddenRoleCount = Math.max(roleIds.length - MAX_VISIBLE_ROLES, 0);
+  const profilePath = `/people/${encodeURIComponent(userId)}`;
+
+  return (
+    <Stack direction="row" spacing={0.5} sx={{ flexWrap: "wrap", gap: 0.5 }}>
+      {visibleRoles.map((r) => (
+        <DirectoryEntityChip
+          key={r}
+          id={r}
+          name={roleNameById.get(r) ?? r}
+          routeBase="/admin/roles"
+          color={(INTERNAL_USER_ROLES as string[]).includes(r) ? "primary" : "default"}
+        />
+      ))}
+      {hiddenRoleCount > 0 && (
+        <Chip
+          size="small"
+          variant="outlined"
+          label={`+${hiddenRoleCount} more`}
+          clickable
+          onClick={(e) => {
+            e.stopPropagation();
+            navigate(profilePath);
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.stopPropagation();
+            }
+          }}
+          aria-label={`View all ${roleIds.length} roles for ${userLabel}`}
+        />
+      )}
+    </Stack>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-admin/pages/CsmGroupsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/pages/CsmGroupsPage.tsx
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Box, Typography } from "@wso2/oxygen-ui";
+import { useMemo, useState, type JSX } from "react";
+import DirectoryEntityTable from "@features/csm-admin/components/DirectoryEntityTable";
+import { useSearchGroupsPage } from "@features/csm-admin/api/useSearchGroupsPage";
+import { useDebouncedValue } from "@hooks/useDebouncedValue";
+import type { BeGroupSearchPayload } from "@api/backend/types";
+
+const DEFAULT_ROWS_PER_PAGE = 20;
+
+/**
+ * Assignment groups from the backing data source (`POST /groups/search`) —
+ * a live query, unlike the curated role/team catalogues, so this list can be
+ * much larger. Each row is click-through to that group's member list.
+ */
+export default function CsmGroupsPage(): JSX.Element {
+  const [search, setSearch] = useState("");
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_ROWS_PER_PAGE);
+  const debouncedSearch = useDebouncedValue(search, 300);
+
+  const request = useMemo<BeGroupSearchPayload>(
+    () => ({
+      filters: debouncedSearch.trim() ? { searchQuery: debouncedSearch.trim() } : undefined,
+      pagination: { limit: rowsPerPage, offset: page * rowsPerPage },
+    }),
+    [debouncedSearch, page, rowsPerPage],
+  );
+
+  const { data, isLoading, isFetching, isError, error } = useSearchGroupsPage(request);
+
+  const handleSearchChange = (value: string): void => {
+    setSearch(value);
+    setPage(0);
+  };
+
+  const handleRowsPerPageChange = (value: number): void => {
+    setRowsPerPage(value);
+    setPage(0);
+  };
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
+      <Typography variant="body2" color="text.secondary">
+        Assignment groups from the backing data source. Select a group to see its members.
+      </Typography>
+
+      <DirectoryEntityTable
+        entityNounPlural="groups"
+        memberBasePath="/admin/groups"
+        rows={data?.groups ?? []}
+        total={data?.total ?? 0}
+        isLoading={isLoading}
+        isFetching={isFetching}
+        isError={isError}
+        error={error}
+        search={search}
+        onSearchChange={handleSearchChange}
+        page={page}
+        onPageChange={setPage}
+        rowsPerPage={rowsPerPage}
+        onRowsPerPageChange={handleRowsPerPageChange}
+      />
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-admin/pages/CsmRolesPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/pages/CsmRolesPage.test.tsx
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { MemoryRouter } from "react-router";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+const postMock = vi.fn();
+
+vi.mock("@api/backend/client", () => ({
+  BackendApiError: class BackendApiError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+      super(message);
+      this.status = status;
+    }
+  },
+  useBackendApi: () => ({ post: postMock }),
+}));
+
+import CsmRolesPage from "@features/csm-admin/pages/CsmRolesPage";
+
+function renderPage(): ReturnType<typeof render> {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <CsmRolesPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("CsmRolesPage", () => {
+  it("renders the role catalogue and links each row to its member page", async () => {
+    postMock.mockResolvedValue({
+      roles: [
+        { id: "agent", name: "Agent" },
+        { id: "admin", name: "Admin" },
+      ],
+      total: 2,
+      limit: 20,
+      offset: 0,
+    });
+    renderPage();
+
+    const agentLink = await screen.findByRole("link", { name: "Agent" });
+    expect(agentLink).toHaveAttribute("href", "/admin/roles/agent");
+    const adminLink = await screen.findByRole("link", { name: "Admin" });
+    expect(adminLink).toHaveAttribute("href", "/admin/roles/admin");
+  });
+
+  it("renders an empty state rather than an empty table when there are no matches", async () => {
+    postMock.mockResolvedValue({ roles: [], total: 0, limit: 20, offset: 0 });
+    renderPage();
+
+    expect(await screen.findByText(/No roles found/i)).toBeInTheDocument();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-admin/pages/CsmRolesPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/pages/CsmRolesPage.tsx
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Box, Typography } from "@wso2/oxygen-ui";
+import { useMemo, useState, type JSX } from "react";
+import DirectoryEntityTable from "@features/csm-admin/components/DirectoryEntityTable";
+import { useSearchRoles } from "@features/csm-admin/api/useSearchRoles";
+import { useDebouncedValue } from "@hooks/useDebouncedValue";
+import type { BeRoleSearchPayload } from "@api/backend/types";
+
+const DEFAULT_ROWS_PER_PAGE = 20;
+
+/**
+ * The role catalogue (`POST /roles/search`) — the platform's curated,
+ * assignable role keys, not every role the backing data source knows about.
+ * Each row is click-through to that role's member list.
+ */
+export default function CsmRolesPage(): JSX.Element {
+  const [search, setSearch] = useState("");
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_ROWS_PER_PAGE);
+  const debouncedSearch = useDebouncedValue(search, 300);
+
+  const request = useMemo<BeRoleSearchPayload>(
+    () => ({
+      filters: debouncedSearch.trim() ? { searchQuery: debouncedSearch.trim() } : undefined,
+      pagination: { limit: rowsPerPage, offset: page * rowsPerPage },
+    }),
+    [debouncedSearch, page, rowsPerPage],
+  );
+
+  const { data, isLoading, isFetching, isError, error } = useSearchRoles(request);
+
+  const handleSearchChange = (value: string): void => {
+    setSearch(value);
+    setPage(0);
+  };
+
+  const handleRowsPerPageChange = (value: number): void => {
+    setRowsPerPage(value);
+    setPage(0);
+  };
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
+      <Typography variant="body2" color="text.secondary">
+        The platform&rsquo;s assignable roles. Select a role to see who holds it.
+      </Typography>
+
+      <DirectoryEntityTable
+        entityNounPlural="roles"
+        memberBasePath="/admin/roles"
+        rows={data?.roles ?? []}
+        total={data?.total ?? 0}
+        isLoading={isLoading}
+        isFetching={isFetching}
+        isError={isError}
+        error={error}
+        search={search}
+        onSearchChange={handleSearchChange}
+        page={page}
+        onPageChange={setPage}
+        rowsPerPage={rowsPerPage}
+        onRowsPerPageChange={handleRowsPerPageChange}
+      />
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-admin/pages/CsmTeamsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/pages/CsmTeamsPage.tsx
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Box, Typography } from "@wso2/oxygen-ui";
+import { useMemo, useState, type JSX } from "react";
+import DirectoryEntityTable from "@features/csm-admin/components/DirectoryEntityTable";
+import { useSearchTeams } from "@features/csm-admin/api/useSearchTeams";
+import { useDebouncedValue } from "@hooks/useDebouncedValue";
+import type { BeTeamSearchPayload } from "@api/backend/types";
+
+const DEFAULT_ROWS_PER_PAGE = 20;
+
+/**
+ * The team registry (`POST /teams/search`) — a curated catalogue, like
+ * `/roles/search`, not a live query against the backing data source. Each
+ * team's `id` is its registry key, not a UUID. Each row is click-through to
+ * that team's member list.
+ */
+export default function CsmTeamsPage(): JSX.Element {
+  const [search, setSearch] = useState("");
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_ROWS_PER_PAGE);
+  const debouncedSearch = useDebouncedValue(search, 300);
+
+  const request = useMemo<BeTeamSearchPayload>(
+    () => ({
+      filters: debouncedSearch.trim() ? { searchQuery: debouncedSearch.trim() } : undefined,
+      pagination: { limit: rowsPerPage, offset: page * rowsPerPage },
+    }),
+    [debouncedSearch, page, rowsPerPage],
+  );
+
+  const { data, isLoading, isFetching, isError, error } = useSearchTeams(request);
+
+  const handleSearchChange = (value: string): void => {
+    setSearch(value);
+    setPage(0);
+  };
+
+  const handleRowsPerPageChange = (value: number): void => {
+    setRowsPerPage(value);
+    setPage(0);
+  };
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
+      <Typography variant="body2" color="text.secondary">
+        The CRE/SRE team registry. Select a team to see its members.
+      </Typography>
+
+      <DirectoryEntityTable
+        entityNounPlural="teams"
+        memberBasePath="/admin/teams"
+        rows={data?.teams ?? []}
+        total={data?.total ?? 0}
+        isLoading={isLoading}
+        isFetching={isFetching}
+        isError={isError}
+        error={error}
+        search={search}
+        onSearchChange={handleSearchChange}
+        page={page}
+        onPageChange={setPage}
+        rowsPerPage={rowsPerPage}
+        onRowsPerPageChange={handleRowsPerPageChange}
+      />
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-admin/pages/DirectoryMemberPages.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/pages/DirectoryMemberPages.test.tsx
@@ -19,6 +19,7 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 import "@testing-library/jest-dom/vitest";
 import { MemoryRouter, Route, Routes } from "react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactElement } from "react";
 
 const authFetchMock = vi.fn();
 
@@ -28,6 +29,10 @@ vi.mock("@config/apiConfig", () => ({
 vi.mock("@hooks/useAuthApiClient", () => ({
   useAuthApiClient: () => authFetchMock,
 }));
+// useSearchRoles (for role display names) goes through this client; give
+// `post` a real resolved value so react-query doesn't warn about an
+// undefined query result.
+const backendPostMock = vi.fn().mockResolvedValue({ roles: [], total: 0, limit: 50, offset: 0 });
 vi.mock("@api/backend/client", () => ({
   BackendApiError: class BackendApiError extends Error {
     status: number;
@@ -36,7 +41,7 @@ vi.mock("@api/backend/client", () => ({
       this.status = status;
     }
   },
-  useBackendApi: () => ({ post: vi.fn() }),
+  useBackendApi: () => ({ post: backendPostMock }),
 }));
 
 import RoleMembersPage from "@features/csm-admin/pages/RoleMembersPage";
@@ -56,7 +61,7 @@ function jsonResponse(body: unknown): Response {
 function renderAt(
   path: string,
   routePath: string,
-  element: React.ReactElement,
+  element: ReactElement,
 ): ReturnType<typeof render> {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(

--- a/apps/csm-portal/webapp/src/features/csm-admin/pages/DirectoryMemberPages.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/pages/DirectoryMemberPages.test.tsx
@@ -1,0 +1,112 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { render, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+const authFetchMock = vi.fn();
+
+vi.mock("@config/apiConfig", () => ({
+  apiConfig: { backendUrl: "https://example.test" },
+}));
+vi.mock("@hooks/useAuthApiClient", () => ({
+  useAuthApiClient: () => authFetchMock,
+}));
+vi.mock("@api/backend/client", () => ({
+  BackendApiError: class BackendApiError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+      super(message);
+      this.status = status;
+    }
+  },
+  useBackendApi: () => ({ post: vi.fn() }),
+}));
+
+import RoleMembersPage from "@features/csm-admin/pages/RoleMembersPage";
+import GroupMembersPage from "@features/csm-admin/pages/GroupMembersPage";
+import TeamMembersPage from "@features/csm-admin/pages/TeamMembersPage";
+
+function jsonResponse(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+function renderAt(
+  path: string,
+  routePath: string,
+  element: React.ReactElement,
+): ReturnType<typeof render> {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route path={routePath} element={element} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+/**
+ * These exercise the actual routed page components end to end (URL -> page
+ * -> DirectoryMemberPage -> DirectoryMembersList -> the request body), not
+ * just DirectoryMembersList in isolation with hand-picked props. That
+ * distinction matters here: DirectoryMembersList.test.tsx proves the shared
+ * component sends whatever `filterKey` it's given, but a thin per-entity
+ * page passing the *wrong* `filterKey` (e.g. TeamMembersPage wired to
+ * `groupIds` instead of `teamIds`) would still pass that test — the bug is
+ * only visible by rendering the real page component, as done below.
+ */
+describe("role/group/team member pages send the correct filter key", () => {
+  beforeEach(() => {
+    authFetchMock.mockReset();
+    authFetchMock.mockResolvedValue(
+      jsonResponse({ users: [], total: 0, limit: 20, offset: 0 }),
+    );
+  });
+
+  it("RoleMembersPage filters users/search by roleIds", async () => {
+    renderAt("/admin/roles/agent", "/admin/roles/:id", <RoleMembersPage />);
+    await waitFor(() => expect(authFetchMock).toHaveBeenCalled());
+    const [, requestInit] = authFetchMock.mock.calls[0];
+    expect(JSON.parse(requestInit.body as string).filters).toEqual({ roleIds: ["agent"] });
+  });
+
+  it("GroupMembersPage filters users/search by groupIds", async () => {
+    const groupId = "11111111-1111-1111-1111-111111111111";
+    renderAt(`/admin/groups/${groupId}`, "/admin/groups/:id", <GroupMembersPage />);
+    await waitFor(() => expect(authFetchMock).toHaveBeenCalled());
+    const [, requestInit] = authFetchMock.mock.calls[0];
+    expect(JSON.parse(requestInit.body as string).filters).toEqual({ groupIds: [groupId] });
+  });
+
+  it("TeamMembersPage filters users/search by teamIds, not groupIds or roleIds", async () => {
+    renderAt("/admin/teams/alpha", "/admin/teams/:id", <TeamMembersPage />);
+    await waitFor(() => expect(authFetchMock).toHaveBeenCalled());
+    const [, requestInit] = authFetchMock.mock.calls[0];
+    expect(JSON.parse(requestInit.body as string).filters).toEqual({ teamIds: ["alpha"] });
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-admin/pages/GroupMembersPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/pages/GroupMembersPage.tsx
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { JSX } from "react";
+import DirectoryMemberPage from "@features/csm-admin/components/DirectoryMemberPage";
+
+/** A group's member list (`/admin/groups/:id`), filtered by `groupIds`. */
+export default function GroupMembersPage(): JSX.Element {
+  return (
+    <DirectoryMemberPage
+      filterKey="groupIds"
+      entityNoun="group"
+      listPath="/admin/groups"
+      listLabel="Groups"
+    />
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-admin/pages/RoleMembersPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/pages/RoleMembersPage.tsx
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { JSX } from "react";
+import DirectoryMemberPage from "@features/csm-admin/components/DirectoryMemberPage";
+
+/** A role's member list (`/admin/roles/:id`), filtered by `roleIds`. */
+export default function RoleMembersPage(): JSX.Element {
+  return (
+    <DirectoryMemberPage
+      filterKey="roleIds"
+      entityNoun="role"
+      listPath="/admin/roles"
+      listLabel="Roles"
+    />
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-admin/pages/TeamMembersPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/pages/TeamMembersPage.tsx
@@ -1,0 +1,33 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { JSX } from "react";
+import DirectoryMemberPage from "@features/csm-admin/components/DirectoryMemberPage";
+
+/**
+ * A team's member list (`/admin/teams/:id`), filtered by `teamIds`. The `:id`
+ * here is the team's registry key (e.g. "alpha"), not a UUID.
+ */
+export default function TeamMembersPage(): JSX.Element {
+  return (
+    <DirectoryMemberPage
+      filterKey="teamIds"
+      entityNoun="team"
+      listPath="/admin/teams"
+      listLabel="Teams"
+    />
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useCsmCaseActivities.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useCsmCaseActivities.ts
@@ -17,6 +17,7 @@
 import { useQuery, type UseQueryResult } from "@tanstack/react-query";
 import { ApiQueryKeys, BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
 import { useBackendApi } from "@api/backend/client";
+import { userReferenceFromBe } from "@api/backend/mappers";
 import type {
   BeCaseActivitiesSearchPayload,
   BeCaseActivitiesSearchResponse,
@@ -47,6 +48,7 @@ export function auditEntryFromBeActivity(
     id: entry.id,
     kind: "field_change",
     actor: activityAuthorName(entry),
+    actorUser: userReferenceFromBe(entry.createdByUser),
     createdAt: entry.createdOn,
     changes: (entry.changes ?? []).map((c) => ({
       field: c.field,

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/AssignEngineerDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/AssignEngineerDialog.tsx
@@ -81,9 +81,9 @@ export default function AssignEngineerDialog({
   const { data, isFetching, isError } = useSearchUsers({
     filters: {
       ...(search.length > 0 && { searchQuery: search }),
-      // Internal-facing roles only (ServiceNow source); the BE applies the
+      // Internal-facing roles only (backing data source); the BE applies the
       // filter, so we no longer client-gate on `userType` (absent on SnUser).
-      roles: INTERNAL_USER_ROLES,
+      roleIds: INTERNAL_USER_ROLES,
       // Don't offer inactive accounts as assignment targets.
       active: true,
     },

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActivitiesFeed.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActivitiesFeed.test.tsx
@@ -97,7 +97,7 @@ describe("CaseActivitiesFeed", () => {
       ],
     };
 
-    const { container } = render(
+    const { container } = renderWithRouter(
       <CaseActivitiesFeed comments={[]} audit={[entry]} attachments={[]} />,
     );
 
@@ -132,7 +132,7 @@ describe("CaseActivitiesFeed", () => {
       ],
     };
 
-    render(
+    renderWithRouter(
       <CaseActivitiesFeed comments={[]} audit={[entry]} attachments={[]} />,
     );
 
@@ -159,7 +159,7 @@ describe("CaseActivitiesFeed", () => {
       ],
     };
 
-    render(
+    renderWithRouter(
       <CaseActivitiesFeed comments={[]} audit={[entry]} attachments={[]} />,
     );
 
@@ -183,7 +183,7 @@ describe("CaseActivitiesFeed", () => {
       ],
     };
 
-    render(
+    renderWithRouter(
       <CaseActivitiesFeed comments={[]} audit={[entry]} attachments={[]} />,
     );
 
@@ -192,6 +192,60 @@ describe("CaseActivitiesFeed", () => {
     // The time is a permalink anchor to the entry, same pattern comments use.
     const permalink = document.querySelector(`a[href="#${entry.id}"]`);
     expect(permalink).not.toBeNull();
+  });
+
+  it("links the actor to their profile when actorUser carries a resolvable id", () => {
+    const entry: CaseAuditEntry = {
+      id: "fc-8",
+      kind: "field_change",
+      actor: "Jane Doe",
+      actorUser: { id: "user-1", email: "jane.doe@example.com", name: "Jane Doe" },
+      createdAt: "2026-07-01T00:00:00Z",
+      changes: [
+        {
+          field: "state",
+          fieldLabel: "State",
+          previousValue: "In Progress",
+          newValue: "Resolved",
+        },
+      ],
+    };
+
+    renderWithRouter(
+      <CaseActivitiesFeed comments={[]} audit={[entry]} attachments={[]} />,
+    );
+
+    const link = screen.getByRole("link", { name: "Jane Doe" });
+    expect(link).toHaveAttribute("href", "/people/user-1");
+  });
+
+  it("renders the actor as plain text (no link) when the activity's email field is really a username, not an address", () => {
+    // Real backend shape: activity entries never resolve `id`, and `email`
+    // sometimes holds an automation account name (e.g. "system"/"guest")
+    // rather than an address — `isPlausibleEmail` correctly refuses to
+    // resolve it, and no id-lookup request should ever fire for it.
+    const entry: CaseAuditEntry = {
+      id: "fc-9",
+      kind: "field_change",
+      actor: "System",
+      actorUser: { id: null, email: "system", name: "System" },
+      createdAt: "2026-07-01T00:00:00Z",
+      changes: [
+        {
+          field: "state",
+          fieldLabel: "State",
+          previousValue: "In Progress",
+          newValue: "Resolved",
+        },
+      ],
+    };
+
+    renderWithRouter(
+      <CaseActivitiesFeed comments={[]} audit={[entry]} attachments={[]} />,
+    );
+
+    expect(screen.getByText("System")).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "System" })).not.toBeInTheDocument();
   });
 
   it("renders every backend-provided change line, even one matching the entry's own timestamp", () => {
@@ -218,7 +272,7 @@ describe("CaseActivitiesFeed", () => {
       ],
     };
 
-    render(
+    renderWithRouter(
       <CaseActivitiesFeed comments={[]} audit={[entry]} attachments={[]} />,
     );
 
@@ -242,7 +296,7 @@ describe("CaseActivitiesFeed", () => {
       ],
     };
 
-    const { container } = render(
+    const { container } = renderWithRouter(
       <CaseActivitiesFeed comments={[]} audit={[entry]} attachments={[]} />,
     );
 
@@ -264,7 +318,7 @@ describe("CaseActivitiesFeed", () => {
       createdAt: "2026-07-01T00:00:00Z",
     };
 
-    render(
+    renderWithRouter(
       <CaseActivitiesFeed comments={[]} audit={[entry]} attachments={[]} />,
     );
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActivitiesFeed.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActivitiesFeed.tsx
@@ -341,7 +341,11 @@ export default function CaseActivitiesFeed({
                       }}
                     >
                       <Typography variant="subtitle2">
-                        {e.entry.actor}
+                        <UserRefLink
+                          name={e.entry.actor}
+                          email={e.entry.actorUser?.email}
+                          userId={e.entry.actorUser?.id}
+                        />
                       </Typography>
                       <Chip
                         size="small"

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CreateTaskDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CreateTaskDialog.tsx
@@ -93,7 +93,7 @@ export default function CreateTaskDialog({
   const { data, isFetching, isError } = useSearchUsers({
     filters: {
       ...(search.length > 0 && { searchQuery: search }),
-      roles: INTERNAL_USER_ROLES,
+      roleIds: INTERNAL_USER_ROLES,
       active: true,
     },
     pagination: { limit: 8, offset: 0 },

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmIssuesView.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmIssuesView.tsx
@@ -67,7 +67,7 @@ const ROWS_PER_PAGE_OPTIONS = [10, DEFAULT_ROWS_PER_PAGE, BE_MAX_PAGE_LIMIT];
 // URL params owned by the filter state; cleared/rewritten on change while any
 // other params (e.g. a `tab` selection) are preserved.
 const FILTER_PARAM_KEYS = [
-  "q",
+  "search",
   "severities",
   "states",
   "types",

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/TaskDetailDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/TaskDetailDialog.tsx
@@ -111,7 +111,7 @@ export function TaskDetailDialog({
   const { data: userResults, isFetching: isFetchingUsers } = useSearchUsers({
     filters: {
       ...(assigneeSearch.length > 0 && { searchQuery: assigneeSearch }),
-      roles: INTERNAL_USER_ROLES,
+      roleIds: INTERNAL_USER_ROLES,
       active: true,
     },
     pagination: { limit: 6, offset: 0 },

--- a/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
@@ -304,6 +304,12 @@ export interface CaseAuditEntry {
   id: string;
   kind: CaseAuditKind;
   actor: string;
+  /** Canonical reference to the actor, when the backend supplies one. `id` is
+   * typically null here (the activity feed doesn't resolve one) and `email`
+   * is sometimes a non-email username (e.g. an automation account) rather
+   * than a real address — `UserRefLink`'s plausibility check already refuses
+   * to look those up, so this is safe to pass through as-is. */
+  actorUser?: UserReference;
   /** Free-text summary; used when `changes` is absent (older/synthetic entries). */
   description?: string;
   createdAt: string;

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.test.ts
@@ -32,7 +32,7 @@ describe("readCasesFiltersFromUrl", () => {
 
   it("parses a fully-populated query string", () => {
     const params = new URLSearchParams(
-      "q=timeout&severities=S0,S2&states=open,work_in_progress,closed&types=case,engagement&assignees=alice@example.com,@me&workStates=ongoing,paused&projects=apim&products=API%20Manager,Asgardeo",
+      "search=timeout&severities=S0,S2&states=open,work_in_progress,closed&types=case,engagement&assignees=alice@example.com,@me&workStates=ongoing,paused&projects=apim&products=API%20Manager,Asgardeo",
     );
     expect(readCasesFiltersFromUrl(params)).toEqual({
       search: "timeout",

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.ts
@@ -96,7 +96,7 @@ export function readCasesFiltersFromUrl(
     ? parseCsv(params.get("workStates"), VALID_WORK_STATES)
     : [];
   return {
-    search: params.get("q") ?? "",
+    search: params.get("search") ?? "",
     severities: parseCsv(params.get("severities"), VALID_SEVERITIES),
     states,
     caseTypes: parseCsv(params.get("types"), VALID_CASE_TYPES),
@@ -114,7 +114,7 @@ export function readCasesFiltersFromUrl(
  */
 export function writeCasesFiltersToUrl(f: CasesFilters): URLSearchParams {
   const out = new URLSearchParams();
-  if (f.search) out.set("q", f.search);
+  if (f.search) out.set("search", f.search);
   if (f.severities.length) out.set("severities", f.severities.join(","));
   if (f.states.length) out.set("states", f.states.join(","));
   if (f.caseTypes.length) out.set("types", f.caseTypes.join(","));

--- a/apps/csm-portal/webapp/src/features/csm-projects/api/useSearchProjectContacts.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/api/useSearchProjectContacts.test.tsx
@@ -1,0 +1,71 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+
+const backendPostMock = vi.fn();
+vi.mock("@api/backend/client", () => ({
+  useBackendApi: () => ({ post: backendPostMock }),
+}));
+
+import { useSearchProjectContacts } from "@features/csm-projects/api/useSearchProjectContacts";
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+describe("useSearchProjectContacts", () => {
+  beforeEach(() => {
+    backendPostMock.mockReset();
+  });
+
+  it("stops paging once total is reached", async () => {
+    backendPostMock
+      .mockResolvedValueOnce({ contacts: [{ name: "A", email: "a@example.com" }], total: 2 })
+      .mockResolvedValueOnce({ contacts: [{ name: "B", email: "b@example.com" }], total: 2 });
+
+    const { result } = renderHook(() => useSearchProjectContacts("proj-1"), { wrapper });
+
+    await waitFor(() => expect(result.current.data).toHaveLength(2));
+    expect(backendPostMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("stops after a bounded number of pages even if total never seems reached", async () => {
+    // Regression test: total previously fell back to `all.length` on a
+    // missing value, which combined with no independent page cap meant a
+    // misbehaving `total` (or a backend that always reports more than it's
+    // actually returned) could turn this into an effectively unbounded loop.
+    backendPostMock.mockImplementation(() =>
+      Promise.resolve({ contacts: [{ name: "X", email: "x@example.com" }], total: 999_999 }),
+    );
+
+    const { result } = renderHook(() => useSearchProjectContacts("proj-1"), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true), { timeout: 5000 });
+    // Capped well below what `total: 999_999` would otherwise demand.
+    expect(backendPostMock.mock.calls.length).toBeLessThanOrEqual(100);
+  });
+
+  it("is disabled until a project id is provided", () => {
+    const { result } = renderHook(() => useSearchProjectContacts(undefined), { wrapper });
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(backendPostMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-projects/api/useSearchProjectContacts.ts
+++ b/apps/csm-portal/webapp/src/features/csm-projects/api/useSearchProjectContacts.ts
@@ -24,11 +24,17 @@ import type {
 } from "@api/backend/types";
 
 const PAGE_LIMIT = BE_MAX_PAGE_LIMIT;
+// A project with a genuinely larger contact list than this is not known to
+// exist (the largest seen in practice is ~103), but `total` is server-supplied
+// and this loop's only termination condition otherwise -- an independent cap
+// means a wrong or stuck `total` can't turn this into an unbounded fetch loop.
+const MAX_PAGES = 100;
 
 /**
  * A project's contacts, via `POST /projects/{id}/contacts/search`. Pages
  * through the full list — the response has no `hasMore` flag, so `offset +
- * contacts.length < total` is the continuation check. Disabled until a
+ * contacts.length < total` is the continuation check, bounded by
+ * {@link MAX_PAGES} regardless of what `total` reports. Disabled until a
  * project id is provided.
  */
 export function useSearchProjectContacts(
@@ -41,17 +47,21 @@ export function useSearchProjectContacts(
     queryFn: async (): Promise<BeProjectContact[]> => {
       const all: BeProjectContact[] = [];
       let total = Infinity;
-      for (let offset = 0; all.length < total; offset += PAGE_LIMIT) {
+      for (
+        let offset = 0, page = 0;
+        all.length < total && page < MAX_PAGES;
+        offset += PAGE_LIMIT, page++
+      ) {
         const res = await api.post<
           BeProjectContactSearchPayload,
           BeProjectContactSearchResponse
         >(`/projects/${encodeURIComponent(projectId ?? "")}/contacts/search`, {
           pagination: { offset, limit: PAGE_LIMIT },
         });
-        const page = res.contacts ?? [];
-        all.push(...page);
-        total = res.total ?? all.length;
-        if (page.length === 0) break;
+        const contactsPage = res.contacts ?? [];
+        all.push(...contactsPage);
+        total = res.total;
+        if (contactsPage.length === 0) break;
       }
       return all;
     },

--- a/apps/csm-portal/webapp/src/features/csm-projects/api/useSearchProjectContacts.ts
+++ b/apps/csm-portal/webapp/src/features/csm-projects/api/useSearchProjectContacts.ts
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { ApiQueryKeys, BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
+import { useBackendApi } from "@api/backend/client";
+import type {
+  BeProjectContact,
+  BeProjectContactSearchPayload,
+  BeProjectContactSearchResponse,
+} from "@api/backend/types";
+
+const PAGE_LIMIT = BE_MAX_PAGE_LIMIT;
+
+/**
+ * A project's contacts, via `POST /projects/{id}/contacts/search`. Pages
+ * through the full list — the response has no `hasMore` flag, so `offset +
+ * contacts.length < total` is the continuation check. Disabled until a
+ * project id is provided.
+ */
+export function useSearchProjectContacts(
+  projectId: string | undefined,
+): UseQueryResult<BeProjectContact[], Error> {
+  const api = useBackendApi();
+
+  return useQuery<BeProjectContact[], Error>({
+    queryKey: [ApiQueryKeys.PROJECT_CONTACTS, projectId ?? ""],
+    queryFn: async (): Promise<BeProjectContact[]> => {
+      const all: BeProjectContact[] = [];
+      let total = Infinity;
+      for (let offset = 0; all.length < total; offset += PAGE_LIMIT) {
+        const res = await api.post<
+          BeProjectContactSearchPayload,
+          BeProjectContactSearchResponse
+        >(`/projects/${encodeURIComponent(projectId ?? "")}/contacts/search`, {
+          pagination: { offset, limit: PAGE_LIMIT },
+        });
+        const page = res.contacts ?? [];
+        all.push(...page);
+        total = res.total ?? all.length;
+        if (page.length === 0) break;
+      }
+      return all;
+    },
+    enabled: !!projectId,
+    staleTime: 60_000,
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/ProjectContactsTab.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/ProjectContactsTab.test.tsx
@@ -1,0 +1,137 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { MemoryRouter } from "react-router";
+import { QueryClient, QueryClientProvider, type UseQueryResult } from "@tanstack/react-query";
+import type { BeProjectContact } from "@api/backend/types";
+
+const useSearchProjectContactsMock = vi.fn();
+const postMock = vi.fn();
+
+vi.mock("@features/csm-projects/api/useSearchProjectContacts", () => ({
+  useSearchProjectContacts: () => useSearchProjectContactsMock(),
+}));
+// The backend client reads runtime config (`CSM_PORTAL_BACKEND_BASE_URL`) at
+// module load, which isn't present under vitest. `QueryErrorState` imports
+// `BackendApiError` from it directly, so stub the module with a real class
+// (so `instanceof` still works) — same approach as
+// CsmChangeRequestDetailPage.test.tsx. UserRefLink resolves an unknown id
+// through `POST /users/search` via `useBackendApi`.
+vi.mock("@api/backend/client", () => ({
+  BackendApiError: class BackendApiError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+      super(message);
+      this.status = status;
+    }
+  },
+  useBackendApi: () => ({ post: postMock }),
+}));
+
+// Imported after the mocks above so the module picks them up.
+import ProjectContactsTab from "@features/csm-projects/components/ProjectContactsTab";
+
+function mockQueryResult(
+  overrides: Partial<UseQueryResult<BeProjectContact[], Error>>,
+): void {
+  useSearchProjectContactsMock.mockReturnValue({
+    data: [],
+    isLoading: false,
+    isError: false,
+    error: null,
+    ...overrides,
+  });
+}
+
+function renderTab(): ReturnType<typeof render> {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <ProjectContactsTab projectId="proj-1" />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+const LINKED_CONTACT: BeProjectContact = {
+  id: "00000000-0000-0000-0000-000000000000",
+  name: "Jane Doe",
+  email: "jane.doe@example.com",
+  registrationState: "registered",
+  notificationsEnabled: true,
+  roles: ["viewer"],
+};
+
+const ORPHANED_CONTACT: BeProjectContact = {
+  // No `id` — this row has no linked contact record.
+  name: "John Smith",
+  email: "john.smith@example.com",
+  registrationState: "pending",
+};
+
+describe("ProjectContactsTab", () => {
+  it("renders a loading skeleton while the query is pending", () => {
+    mockQueryResult({ isLoading: true });
+    const { container } = renderTab();
+    expect(container.querySelectorAll(".MuiSkeleton-root").length).toBeGreaterThan(0);
+  });
+
+  it("renders an error state when the query fails", () => {
+    mockQueryResult({ isError: true, error: new Error("boom") });
+    renderTab();
+    expect(screen.getByText(/Failed to load project contacts/i)).toBeInTheDocument();
+  });
+
+  it("renders an empty state rather than an empty table when the project has no contacts", () => {
+    mockQueryResult({ data: [] });
+    renderTab();
+    expect(screen.getByText(/No contacts found for this project/i)).toBeInTheDocument();
+  });
+
+  it("renders a linked contact as a clickable profile link", () => {
+    postMock.mockResolvedValue({ users: [] });
+    mockQueryResult({ data: [LINKED_CONTACT] });
+    renderTab();
+    const link = screen.getByRole("link", { name: "Jane Doe" });
+    expect(link).toHaveAttribute("href", `/people/${LINKED_CONTACT.id}`);
+    expect(screen.getByText("registered")).toBeInTheDocument();
+    expect(screen.getByText("viewer", { selector: ".MuiChip-label" })).toBeInTheDocument();
+  });
+
+  it("renders an orphaned contact (no id) without a link, flagged, and without crashing", () => {
+    postMock.mockResolvedValue({ users: [] });
+    mockQueryResult({ data: [ORPHANED_CONTACT] });
+    renderTab();
+    expect(screen.getByText("John Smith")).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "John Smith" })).not.toBeInTheDocument();
+    expect(screen.getByText("Orphaned", { selector: ".MuiChip-label" })).toBeInTheDocument();
+  });
+
+  it("renders both a linked and an orphaned row together without crashing", () => {
+    postMock.mockResolvedValue({ users: [] });
+    mockQueryResult({ data: [LINKED_CONTACT, ORPHANED_CONTACT] });
+    renderTab();
+    expect(screen.getByRole("link", { name: "Jane Doe" })).toBeInTheDocument();
+    expect(screen.getByText("John Smith")).toBeInTheDocument();
+    expect(screen.getByText("Orphaned", { selector: ".MuiChip-label" })).toBeInTheDocument();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/ProjectContactsTab.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/ProjectContactsTab.test.tsx
@@ -88,6 +88,12 @@ const ORPHANED_CONTACT: BeProjectContact = {
   registrationState: "pending",
 };
 
+// The more common real-world shape: no `id`, no `name`, *and* no `email` —
+// nothing to key the row on at all.
+const FULLY_BLANK_ORPHANED_CONTACT: BeProjectContact = {
+  registrationState: "pending",
+};
+
 describe("ProjectContactsTab", () => {
   it("renders a loading skeleton while the query is pending", () => {
     mockQueryResult({ isLoading: true });
@@ -124,6 +130,25 @@ describe("ProjectContactsTab", () => {
     expect(screen.getByText("John Smith")).toBeInTheDocument();
     expect(screen.queryByRole("link", { name: "John Smith" })).not.toBeInTheDocument();
     expect(screen.getByText("Orphaned", { selector: ".MuiChip-label" })).toBeInTheDocument();
+  });
+
+  it("renders a fully-blank orphaned row (no id, name, or email) with a clearly-marked, always-visible reason rather than a blank row", () => {
+    postMock.mockResolvedValue({ users: [] });
+    mockQueryResult({ data: [FULLY_BLANK_ORPHANED_CONTACT] });
+    renderTab();
+
+    // Never a bare blank cell — the row states plainly that it has no
+    // linked contact record...
+    expect(screen.getByText("No linked contact record")).toBeInTheDocument();
+    // ...and the operationally important consequence is visible inline
+    // (not hidden behind a hover-only tooltip).
+    expect(
+      screen.getByText(/can't see this project's cases/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Orphaned", { selector: ".MuiChip-label" })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "No linked contact record" }),
+    ).not.toBeInTheDocument();
   });
 
   it("renders both a linked and an orphaned row together without crashing", () => {

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/ProjectContactsTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/ProjectContactsTab.tsx
@@ -24,7 +24,6 @@ import {
   TableContainer,
   TableHead,
   TableRow,
-  Tooltip,
   Typography,
 } from "@wso2/oxygen-ui";
 import type { JSX } from "react";
@@ -46,6 +45,15 @@ interface ProjectContactsTabProps {
  * record — renders unlinked and flagged, since that's precisely the case a
  * support engineer needs to notice: an orphaned contact row means that
  * person silently can't see this project's cases.
+ *
+ * A real project can return dozens of these rows with `name` *and* `email`
+ * both empty (no natural identifier at all, not even an email to show) — the
+ * explanatory line below the row is always rendered inline, not tucked behind
+ * a hover tooltip, so scanning the table surfaces every "can't see their
+ * cases" row without hovering each one. (If an upstream fix ever starts
+ * populating `email` for these rows, they fall into the ordinary
+ * has-some-info orphaned case below — same flag, same inline reason, just
+ * with a real address shown instead of "No linked contact record".)
  */
 export default function ProjectContactsTab({
   projectId,
@@ -95,8 +103,12 @@ export default function ProjectContactsTab({
               </TableRow>
             ) : (
               contacts.map((c, i) => {
-                const name = c.name || c.email || "—";
                 const orphaned = !c.id;
+                // No natural identifier at all when both are empty — say so
+                // plainly instead of showing a bare "—" that reads as a data
+                // glitch rather than the operationally meaningful fact that
+                // this row has no linked contact record.
+                const name = c.name || c.email || "No linked contact record";
                 return (
                   // Contacts have no stable identifier when unlinked (no `id`);
                   // email is the closest thing to a natural key, and index
@@ -105,15 +117,24 @@ export default function ProjectContactsTab({
                     <TableCell>
                       <UserRefLink name={name} email={c.email} userId={c.id ?? null} />
                       {orphaned && (
-                        <Tooltip title="No contact record is linked to this row — this person can't see this project's cases.">
-                          <Chip
-                            size="small"
-                            label="Orphaned"
-                            color="error"
-                            variant="outlined"
-                            sx={{ ml: 1 }}
-                          />
-                        </Tooltip>
+                        <Chip
+                          size="small"
+                          label="Orphaned"
+                          color="error"
+                          variant="outlined"
+                          sx={{ ml: 1 }}
+                        />
+                      )}
+                      {orphaned && (
+                        <Typography
+                          variant="caption"
+                          color="error.main"
+                          component="div"
+                          sx={{ mt: 0.25 }}
+                        >
+                          No contact record is linked to this row — this person
+                          can't see this project's cases.
+                        </Typography>
                       )}
                     </TableCell>
                     <TableCell sx={{ wordBreak: "break-all" }}>{c.email || "—"}</TableCell>

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/ProjectContactsTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/ProjectContactsTab.tsx
@@ -1,0 +1,143 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Chip,
+  Paper,
+  Skeleton,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Tooltip,
+  Typography,
+} from "@wso2/oxygen-ui";
+import type { JSX } from "react";
+import QueryErrorState from "@components/QueryErrorState";
+import UserRefLink from "@components/UserRefLink";
+import { useSearchProjectContacts } from "@features/csm-projects/api/useSearchProjectContacts";
+
+const COLUMN_COUNT = 4;
+
+interface ProjectContactsTabProps {
+  projectId: string;
+}
+
+/**
+ * Lists a project's contacts (`POST /projects/{id}/contacts/search`). Every
+ * row with a linked contact record is click-through to that person's profile
+ * via `UserRefLink` (so nullable-id resolution and the plain-text fallback
+ * come for free); a row with no `id` — meaning it has no linked contact
+ * record — renders unlinked and flagged, since that's precisely the case a
+ * support engineer needs to notice: an orphaned contact row means that
+ * person silently can't see this project's cases.
+ */
+export default function ProjectContactsTab({
+  projectId,
+}: ProjectContactsTabProps): JSX.Element {
+  const { data, isLoading, isError, error } = useSearchProjectContacts(projectId);
+  const contacts = data ?? [];
+
+  return (
+    <Paper variant="outlined">
+      <TableContainer>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>Name</TableCell>
+              <TableCell>Email</TableCell>
+              <TableCell>Roles</TableCell>
+              <TableCell>Registration</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {isLoading ? (
+              Array.from({ length: 3 }).map((_, i) => (
+                <TableRow key={i}>
+                  {Array.from({ length: COLUMN_COUNT }).map((__, c) => (
+                    <TableCell key={c}>
+                      <Skeleton variant="rounded" width="70%" height={18} />
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : isError ? (
+              <TableRow>
+                <TableCell colSpan={COLUMN_COUNT} align="center">
+                  <QueryErrorState
+                    message={`Failed to load project contacts: ${error instanceof Error ? error.message : "unknown error"}`}
+                    error={error}
+                  />
+                </TableCell>
+              </TableRow>
+            ) : contacts.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={COLUMN_COUNT} align="center" sx={{ py: 4 }}>
+                  <Typography variant="body2" color="text.secondary">
+                    No contacts found for this project.
+                  </Typography>
+                </TableCell>
+              </TableRow>
+            ) : (
+              contacts.map((c, i) => {
+                const name = c.name || c.email || "—";
+                const orphaned = !c.id;
+                return (
+                  // Contacts have no stable identifier when unlinked (no `id`);
+                  // email is the closest thing to a natural key, and index
+                  // disambiguates the rare case of a duplicate/blank email.
+                  <TableRow key={c.id ?? `${c.email ?? "unknown"}-${i}`} hover>
+                    <TableCell>
+                      <UserRefLink name={name} email={c.email} userId={c.id ?? null} />
+                      {orphaned && (
+                        <Tooltip title="No contact record is linked to this row — this person can't see this project's cases.">
+                          <Chip
+                            size="small"
+                            label="Orphaned"
+                            color="error"
+                            variant="outlined"
+                            sx={{ ml: 1 }}
+                          />
+                        </Tooltip>
+                      )}
+                    </TableCell>
+                    <TableCell sx={{ wordBreak: "break-all" }}>{c.email || "—"}</TableCell>
+                    <TableCell>
+                      {c.roles && c.roles.length > 0
+                        ? c.roles.map((r) => (
+                            <Chip
+                              key={r}
+                              size="small"
+                              label={r}
+                              variant="outlined"
+                              sx={{ mr: 0.5, mb: 0.5 }}
+                            />
+                          ))
+                        : "—"}
+                    </TableCell>
+                    <TableCell>{c.registrationState || "—"}</TableCell>
+                  </TableRow>
+                );
+              })
+            )}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </Paper>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-projects/pages/CsmProjectDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/pages/CsmProjectDetailPage.tsx
@@ -33,6 +33,7 @@ import { useGetProject } from "@features/csm-projects/api/useGetProject";
 import CsmIssuesView from "@features/csm-cases/components/CsmIssuesView";
 import ClosureStateChip from "@features/csm-projects/components/ClosureStateChip";
 import DeploymentsTab from "@features/csm-projects/components/DeploymentsTab";
+import ProjectContactsTab from "@features/csm-projects/components/ProjectContactsTab";
 import {
   endDateLabel,
   startDateLabel,
@@ -314,16 +315,7 @@ export default function CsmProjectDetailPage(): JSX.Element {
 
       {activeTab === "deployments" && <DeploymentsTab projectId={p.id} />}
 
-      {activeTab === "contacts" && (
-        <Card sx={{ p: 2.5 }}>
-          <Typography variant="subtitle2" gutterBottom>
-            Project contacts
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            Project contacts are not available yet.
-          </Typography>
-        </Card>
-      )}
+      {activeTab === "contacts" && <ProjectContactsTab projectId={p.id} />}
 
       {activeTab === "workItems" && (
         <CsmIssuesView

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/LogTimeCardDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/LogTimeCardDialog.tsx
@@ -208,7 +208,7 @@ export default function LogTimeCardDialog({
       // Approvers must be real internal accounts — the backend requires a
       // real UUID in `approverIds`, so there is no offline/mock fallback
       // (a fabricated id would always be rejected on submit).
-      roles: INTERNAL_USER_ROLES,
+      roleIds: INTERNAL_USER_ROLES,
       active: true,
     },
     pagination: { limit: 6, offset: 0 },

--- a/apps/csm-portal/webapp/src/features/csm-users/api/useGetUserById.ts
+++ b/apps/csm-portal/webapp/src/features/csm-users/api/useGetUserById.ts
@@ -17,19 +17,10 @@
 import { useQuery, type UseQueryResult } from "@tanstack/react-query";
 import { useBackendApi } from "@api/backend/client";
 import {
-  normalizeUser,
-  type NormalizedUser,
-  type SnUser,
+  normalizeUserDetail,
+  type NormalizedUserDetail,
+  type SnUserDetail,
 } from "@features/csm-users/types/csmUsers";
-
-/**
- * `GET /users/{id}` response. The endpoint is ServiceNow-data-source only, so
- * the row is always the `SnUser` shape; `groups`/`teams`/`projectAccess` are
- * additive detail the profile page doesn't render yet (see
- * `UserProfilePage`'s "not available yet" placeholders — that wiring is a
- * separate, larger piece of work).
- */
-type SnUserDetailResponse = SnUser;
 
 /**
  * Look up a single user by id, for the person-profile page. Returns `null`
@@ -38,17 +29,17 @@ type SnUserDetailResponse = SnUser;
  */
 export function useGetUserById(
   id: string | undefined,
-): UseQueryResult<NormalizedUser | null, Error> {
+): UseQueryResult<NormalizedUserDetail | null, Error> {
   const api = useBackendApi();
 
-  return useQuery<NormalizedUser | null, Error>({
+  return useQuery<NormalizedUserDetail | null, Error>({
     queryKey: ["csm-user-by-id", id ?? ""],
-    queryFn: async (): Promise<NormalizedUser | null> => {
+    queryFn: async (): Promise<NormalizedUserDetail | null> => {
       if (!id) return null;
-      const user = await api.get<SnUserDetailResponse>(
+      const user = await api.get<SnUserDetail>(
         `/users/${encodeURIComponent(id)}`,
       );
-      return user ? normalizeUser(user) : null;
+      return user ? normalizeUserDetail(user) : null;
     },
     enabled: !!id,
     staleTime: 30_000,

--- a/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.test.tsx
@@ -120,7 +120,7 @@ describe("CsmUsersPage", () => {
 
   it("combines name/email search, role, group, team and status into one request with every key set", async () => {
     renderPage(
-      "/admin/users?q=jane&roles=agent&groups=11111111-1111-1111-1111-111111111111&teams=alpha&active=active",
+      "/admin/users?search=jane&roles=agent&groups=11111111-1111-1111-1111-111111111111&teams=alpha&active=active",
     );
 
     await waitFor(() => expect(authFetchMock).toHaveBeenCalled());

--- a/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.test.tsx
@@ -14,10 +14,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { render, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import "@testing-library/jest-dom/vitest";
-import { MemoryRouter } from "react-router";
+import { MemoryRouter, Route, Routes } from "react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 const authFetchMock = vi.fn();
@@ -63,6 +63,28 @@ function renderPage(initialPath: string): ReturnType<typeof render> {
     <QueryClientProvider client={queryClient}>
       <MemoryRouter initialEntries={[initialPath]}>
         <CsmUsersPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+/**
+ * Same as {@link renderPage}, plus marker routes for the destinations a row
+ * or a role chip can navigate to — used to assert *which* route a click
+ * actually lands on, not just that some navigation happened.
+ */
+function renderPageWithDestinations(
+  initialPath: string,
+): ReturnType<typeof render> {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[initialPath]}>
+        <Routes>
+          <Route path="/admin/users" element={<CsmUsersPage />} />
+          <Route path="/admin/roles/:id" element={<div>Role members page</div>} />
+          <Route path="/people/:id" element={<div>User profile page</div>} />
+        </Routes>
       </MemoryRouter>
     </QueryClientProvider>,
   );
@@ -125,5 +147,121 @@ describe("CsmUsersPage", () => {
     const [, requestInit] = authFetchMock.mock.calls[0];
     const body = JSON.parse(requestInit.body as string);
     expect(body.filters).toEqual({});
+  });
+});
+
+describe("CsmUsersPage — role truncation and row navigation", () => {
+  const MANY_ROLES_USER = {
+    id: "user-1",
+    userName: "jane.doe",
+    name: "Jane Doe",
+    email: "jane.doe@example.com",
+    active: true,
+    roles: ["agent", "admin", "commenter", "partner", "customer_admin"],
+    createdOn: "2025-01-01T00:00:00Z",
+    updatedOn: "2025-06-01T00:00:00Z",
+  };
+  const FEW_ROLES_USER = {
+    id: "user-2",
+    userName: "john.smith",
+    name: "John Smith",
+    email: "john.smith@example.com",
+    active: true,
+    roles: ["agent", "admin"],
+    createdOn: "2025-01-01T00:00:00Z",
+    updatedOn: "2025-06-01T00:00:00Z",
+  };
+
+  beforeEach(() => {
+    authFetchMock.mockReset();
+    postMock.mockReset();
+    postMock.mockImplementation((path: string) => {
+      if (path === "/roles/search") {
+        return Promise.resolve({
+          roles: [
+            { id: "agent", name: "Agent" },
+            { id: "admin", name: "Admin" },
+            { id: "commenter", name: "Commenter" },
+            { id: "partner", name: "Partner" },
+            { id: "customer_admin", name: "Customer Admin" },
+          ],
+          total: 5,
+          limit: 50,
+          offset: 0,
+        });
+      }
+      if (path === "/teams/search") {
+        return Promise.resolve({ teams: [], total: 0, limit: 50, offset: 0 });
+      }
+      return Promise.resolve({ groups: [], total: 0, limit: 20, offset: 0 });
+    });
+    authFetchMock.mockResolvedValue(
+      jsonResponse({
+        users: [MANY_ROLES_USER, FEW_ROLES_USER],
+        total: 2,
+        limit: 20,
+        offset: 0,
+      }),
+    );
+  });
+
+  it("shows a legible overflow chip beyond 3 roles, and no overflow chip at 3 or fewer", async () => {
+    renderPage("/admin/users");
+
+    // Both rows carry "Agent"/"Admin" — wait until the role-name catalogue
+    // has resolved them from the raw keys ("agent"/"admin") before asserting.
+    await waitFor(() => expect(screen.getAllByText("Agent")).toHaveLength(2));
+
+    const janeRow = screen.getByText("Jane Doe").closest("tr") as HTMLElement;
+    const johnRow = screen.getByText("John Smith").closest("tr") as HTMLElement;
+
+    // 5 roles: 3 visible + a legible "+2 more" overflow chip, the other 2 roles hidden.
+    expect(within(janeRow).getByText("Agent")).toBeInTheDocument();
+    expect(within(janeRow).getByText("Admin")).toBeInTheDocument();
+    expect(within(janeRow).getByText("Commenter")).toBeInTheDocument();
+    expect(within(janeRow).getByText("+2 more")).toBeInTheDocument();
+    expect(within(janeRow).queryByText("Partner")).not.toBeInTheDocument();
+    expect(within(janeRow).queryByText("Customer Admin")).not.toBeInTheDocument();
+
+    // 2 roles: both visible, no overflow chip for this row.
+    expect(within(johnRow).getByText("Agent")).toBeInTheDocument();
+    expect(within(johnRow).getByText("Admin")).toBeInTheDocument();
+    expect(within(johnRow).queryByText(/more$/)).not.toBeInTheDocument();
+  });
+
+  it("navigates a row click to that user's profile, but a nested role chip click to the role page instead", async () => {
+    renderPageWithDestinations("/admin/users");
+
+    await waitFor(() => expect(screen.getAllByText("Agent")).toHaveLength(2));
+    const janeRow = screen.getByText("Jane Doe").closest("tr") as HTMLElement;
+
+    // Clicking the role chip must land on the role page, not the profile —
+    // the row itself is also clickable, so this only holds if the chip stops
+    // the click from bubbling up to the row's own handler.
+    fireEvent.click(within(janeRow).getByText("Agent"));
+    expect(await screen.findByText("Role members page")).toBeInTheDocument();
+    expect(screen.queryByText("User profile page")).not.toBeInTheDocument();
+  });
+
+  it("navigates a whole-row click (outside any nested chip/link) to the user's profile", async () => {
+    renderPageWithDestinations("/admin/users");
+
+    await waitFor(() => expect(screen.getByText("John Smith")).toBeInTheDocument());
+
+    // Click the timezone cell — plain text, not a nested interactive element.
+    const row = screen.getByText("John Smith").closest("tr");
+    expect(row).not.toBeNull();
+    fireEvent.click(row as HTMLElement);
+    expect(await screen.findByText("User profile page")).toBeInTheDocument();
+  });
+
+  it("is keyboard-activatable: Enter on a focused row navigates to the profile", async () => {
+    renderPageWithDestinations("/admin/users");
+
+    await waitFor(() => expect(screen.getByText("John Smith")).toBeInTheDocument());
+    const row = screen.getByText("John Smith").closest("tr") as HTMLElement;
+    row.focus();
+    fireEvent.keyDown(row, { key: "Enter" });
+    expect(await screen.findByText("User profile page")).toBeInTheDocument();
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.test.tsx
@@ -1,0 +1,129 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { render, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { MemoryRouter } from "react-router";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+const authFetchMock = vi.fn();
+const postMock = vi.fn();
+
+// useSearchUsers (csm-users/api) is on the older useAuthApiClient + apiConfig
+// convention; useSearchRoles / useSearchTeams / the group picker's
+// useSearchGroups are all on useBackendApi. Both read runtime config at
+// module load, which isn't present under vitest, so stub both (same approach
+// as useAccountProjects.test.tsx / useQuickCaseSearch.test.tsx).
+vi.mock("@config/apiConfig", () => ({
+  apiConfig: { backendUrl: "https://example.test" },
+}));
+vi.mock("@hooks/useAuthApiClient", () => ({
+  useAuthApiClient: () => authFetchMock,
+}));
+vi.mock("@api/backend/client", () => ({
+  BackendApiError: class BackendApiError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+      super(message);
+      this.status = status;
+    }
+  },
+  useBackendApi: () => ({ post: postMock }),
+}));
+
+import CsmUsersPage from "@features/csm-users/pages/CsmUsersPage";
+
+function jsonResponse(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+function renderPage(initialPath: string): ReturnType<typeof render> {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[initialPath]}>
+        <CsmUsersPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("CsmUsersPage", () => {
+  beforeEach(() => {
+    authFetchMock.mockReset();
+    postMock.mockReset();
+    postMock.mockImplementation((path: string) => {
+      if (path === "/roles/search") {
+        return Promise.resolve({
+          roles: [{ id: "agent", name: "Agent" }],
+          total: 1,
+          limit: 50,
+          offset: 0,
+        });
+      }
+      if (path === "/teams/search") {
+        return Promise.resolve({
+          teams: [{ id: "alpha", name: "Alpha" }],
+          total: 1,
+          limit: 50,
+          offset: 0,
+        });
+      }
+      return Promise.resolve({ groups: [], total: 0, limit: 20, offset: 0 });
+    });
+    authFetchMock.mockResolvedValue(
+      jsonResponse({ users: [], total: 0, limit: 20, offset: 0, hasMore: false }),
+    );
+  });
+
+  it("combines name/email search, role, group, team and status into one request with every key set", async () => {
+    renderPage(
+      "/admin/users?q=jane&roles=agent&groups=11111111-1111-1111-1111-111111111111&teams=alpha&active=active",
+    );
+
+    await waitFor(() => expect(authFetchMock).toHaveBeenCalled());
+
+    // All filters land on a single /users/search call, combined (AND'd)
+    // server-side — not split across separate requests per filter.
+    expect(authFetchMock).toHaveBeenCalledTimes(1);
+    const [url, requestInit] = authFetchMock.mock.calls[0];
+    expect(url).toContain("/users/search");
+    const body = JSON.parse(requestInit.body as string);
+    expect(body.filters).toEqual({
+      searchQuery: "jane",
+      roleIds: ["agent"],
+      groupIds: ["11111111-1111-1111-1111-111111111111"],
+      teamIds: ["alpha"],
+      active: true,
+    });
+  });
+
+  it("omits every filter key when nothing is selected", async () => {
+    renderPage("/admin/users");
+
+    await waitFor(() => expect(authFetchMock).toHaveBeenCalled());
+    const [, requestInit] = authFetchMock.mock.calls[0];
+    const body = JSON.parse(requestInit.body as string);
+    expect(body.filters).toEqual({});
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.tsx
@@ -39,63 +39,93 @@ import {
   type SelectChangeEvent,
 } from "@wso2/oxygen-ui";
 import { useMemo, useState, type ChangeEvent, type JSX } from "react";
+import { useSearchParams } from "react-router";
 import QueryErrorState from "@components/QueryErrorState";
+import UserRefLink from "@components/UserRefLink";
+import AsyncEntityMultiSelect from "@components/AsyncEntityMultiSelect";
 import { useDebouncedValue } from "@hooks/useDebouncedValue";
+import { useSearchGroups } from "@api/useSearchGroups";
 import { useSearchUsers } from "@features/csm-users/api/useSearchUsers";
+import { useSearchRoles } from "@features/csm-admin/api/useSearchRoles";
+import { useSearchTeams } from "@features/csm-admin/api/useSearchTeams";
 import {
   INTERNAL_USER_ROLES,
   type SearchUsersRequest,
-  type SnUserRole,
   type UserSortField,
   type UserSortOrder,
 } from "@features/csm-users/types/csmUsers";
+import {
+  readUsersFiltersFromUrl,
+  writeUsersFiltersToUrl,
+  type UsersFilters,
+} from "@features/csm-users/utils/usersFiltersUrl";
 import { BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
+import type { BeGroup } from "@api/backend/types";
 
 const DEFAULT_ROWS_PER_PAGE = 20;
 // Top option is the backend's max page limit; larger requests are rejected.
 const ROWS_PER_PAGE_OPTIONS = [10, 20, BE_MAX_PAGE_LIMIT];
 
-const ALL_ROLES: SnUserRole[] = [
-  ...INTERNAL_USER_ROLES,
-  "commenter",
-  "external",
-  "customer",
-  "customer_admin",
-  "partner",
-  "partner_admin",
-];
-
-type ActiveFilter = "all" | "active" | "inactive";
-
+/**
+ * The users list, with filters reflected in the URL (`q`, `roles`, `groups`,
+ * `teams`, `active`) so a filtered link is shareable and survives a reload —
+ * the same `read*FiltersFromUrl` / `write*FiltersToUrl` convention the cases
+ * list uses (`casesFiltersUrl.ts`). Deliberately no project/account filter:
+ * "who is on this project" is answered by the project-contacts search
+ * instead. Role, group and team filters combine (AND together server-side).
+ */
 export default function CsmUsersPage(): JSX.Element {
-  const [searchInput, setSearchInput] = useState("");
+  const [searchParams, setSearchParams] = useSearchParams();
+  const filters = useMemo(() => readUsersFiltersFromUrl(searchParams), [searchParams]);
+
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_ROWS_PER_PAGE);
-  const [roleFilter, setRoleFilter] = useState<SnUserRole[]>([]);
-  const [activeFilter, setActiveFilter] = useState<ActiveFilter>("all");
   const [sortField, setSortField] = useState<UserSortField>("name");
   const [sortOrder, setSortOrder] = useState<UserSortOrder>("asc");
 
-  const debouncedSearch = useDebouncedValue(searchInput, 300);
+  const setFilters = (next: UsersFilters): void => {
+    setPage(0);
+    setSearchParams(writeUsersFiltersToUrl(next), { replace: true });
+  };
+
+  const debouncedSearch = useDebouncedValue(filters.search, 300);
+
+  // Role/team catalogues are small and curated, so one full-catalogue page is
+  // enough to populate the picker (unlike groups, a live, potentially large
+  // query against the backing data source — see the async group picker
+  // below).
+  const { data: rolesData } = useSearchRoles({ pagination: { limit: BE_MAX_PAGE_LIMIT } });
+  const { data: teamsData } = useSearchTeams({ pagination: { limit: BE_MAX_PAGE_LIMIT } });
+  const roles = useMemo(() => rolesData?.roles ?? [], [rolesData]);
+  const teams = useMemo(() => teamsData?.teams ?? [], [teamsData]);
+  const roleNameById = useMemo(
+    () => new Map(roles.map((r) => [r.id, r.name])),
+    [roles],
+  );
+  const teamNameById = useMemo(
+    () => new Map(teams.map((t) => [t.id, t.name])),
+    [teams],
+  );
 
   const request = useMemo<SearchUsersRequest>(
     () => ({
       pagination: { limit: rowsPerPage, offset: page * rowsPerPage },
       filters: {
         ...(debouncedSearch.trim() && { searchQuery: debouncedSearch.trim() }),
-        ...(roleFilter.length > 0 && { roles: roleFilter }),
-        ...(activeFilter !== "all" && { active: activeFilter === "active" }),
+        ...(filters.roleIds.length > 0 && { roleIds: filters.roleIds }),
+        ...(filters.groupIds.length > 0 && { groupIds: filters.groupIds }),
+        ...(filters.teamIds.length > 0 && { teamIds: filters.teamIds }),
+        ...(filters.active !== "all" && { active: filters.active === "active" }),
       },
       sortBy: { field: sortField, order: sortOrder },
     }),
-    [debouncedSearch, page, rowsPerPage, roleFilter, activeFilter, sortField, sortOrder],
+    [debouncedSearch, page, rowsPerPage, filters, sortField, sortOrder],
   );
 
   const { data, isLoading, isFetching, isError, error } = useSearchUsers(request);
 
   const handleSearchChange = (e: ChangeEvent<HTMLInputElement>) => {
-    setSearchInput(e.target.value);
-    setPage(0);
+    setFilters({ ...filters, search: e.target.value });
   };
 
   const handleChangeRowsPerPage = (e: ChangeEvent<HTMLInputElement>) => {
@@ -103,15 +133,18 @@ export default function CsmUsersPage(): JSX.Element {
     setPage(0);
   };
 
-  const handleRoleChange = (e: SelectChangeEvent<SnUserRole[]>) => {
+  const handleRoleChange = (e: SelectChangeEvent<string[]>) => {
     const value = e.target.value;
-    setRoleFilter(typeof value === "string" ? (value.split(",") as SnUserRole[]) : value);
-    setPage(0);
+    setFilters({ ...filters, roleIds: typeof value === "string" ? value.split(",") : value });
+  };
+
+  const handleTeamChange = (e: SelectChangeEvent<string[]>) => {
+    const value = e.target.value;
+    setFilters({ ...filters, teamIds: typeof value === "string" ? value.split(",") : value });
   };
 
   const handleActiveChange = (e: SelectChangeEvent) => {
-    setActiveFilter(e.target.value as ActiveFilter);
-    setPage(0);
+    setFilters({ ...filters, active: e.target.value as UsersFilters["active"] });
   };
 
   const handleSort = (field: UserSortField) => {
@@ -130,7 +163,8 @@ export default function CsmUsersPage(): JSX.Element {
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
       <Typography variant="body2" color="text.secondary">
-        Search across username and email (case-insensitive). Filter by role and status.
+        Search across username and email (case-insensitive). Filter by role, group, team and
+        status.
       </Typography>
 
       <Stack direction={{ xs: "column", sm: "row" }} spacing={2} sx={{ flexWrap: "wrap" }}>
@@ -138,7 +172,7 @@ export default function CsmUsersPage(): JSX.Element {
           size="small"
           label="Search users"
           placeholder="Search users by username or email"
-          value={searchInput}
+          value={filters.search}
           onChange={handleSearchChange}
           slotProps={{ htmlInput: { "aria-label": "Search users by username or email" } }}
           sx={{ minWidth: 280, flex: 1 }}
@@ -149,15 +183,51 @@ export default function CsmUsersPage(): JSX.Element {
           <Select
             labelId="user-roles-label"
             multiple
-            value={roleFilter}
+            value={filters.roleIds}
             onChange={handleRoleChange}
             input={<OutlinedInput label="Roles" />}
-            renderValue={(selected) => (selected as SnUserRole[]).join(", ")}
+            renderValue={(selected) =>
+              (selected as string[]).map((id) => roleNameById.get(id) ?? id).join(", ")
+            }
           >
-            {ALL_ROLES.map((role) => (
-              <MenuItem key={role} value={role}>
-                <Checkbox checked={roleFilter.includes(role)} />
-                <ListItemText primary={role} />
+            {roles.map((role) => (
+              <MenuItem key={role.id} value={role.id}>
+                <Checkbox checked={filters.roleIds.includes(role.id)} />
+                <ListItemText primary={role.name} />
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+
+        <Box sx={{ minWidth: 240, flex: 1 }}>
+          <AsyncEntityMultiSelect<BeGroup>
+            id="user-groups-filter"
+            label="Groups"
+            placeholder="Search groups…"
+            values={filters.groupIds}
+            onChange={(next) => setFilters({ ...filters, groupIds: next })}
+            useSearch={useSearchGroups}
+            getId={(g) => g.id}
+            getLabel={(g) => g.name}
+          />
+        </Box>
+
+        <FormControl size="small" sx={{ minWidth: 200 }}>
+          <InputLabel id="user-teams-label">Teams</InputLabel>
+          <Select
+            labelId="user-teams-label"
+            multiple
+            value={filters.teamIds}
+            onChange={handleTeamChange}
+            input={<OutlinedInput label="Teams" />}
+            renderValue={(selected) =>
+              (selected as string[]).map((id) => teamNameById.get(id) ?? id).join(", ")
+            }
+          >
+            {teams.map((team) => (
+              <MenuItem key={team.id} value={team.id}>
+                <Checkbox checked={filters.teamIds.includes(team.id)} />
+                <ListItemText primary={team.name} secondary={team.family} />
               </MenuItem>
             ))}
           </Select>
@@ -167,7 +237,7 @@ export default function CsmUsersPage(): JSX.Element {
           <InputLabel id="user-active-label">Status</InputLabel>
           <Select
             labelId="user-active-label"
-            value={activeFilter}
+            value={filters.active}
             onChange={handleActiveChange}
             input={<OutlinedInput label="Status" />}
           >
@@ -231,7 +301,9 @@ export default function CsmUsersPage(): JSX.Element {
               ) : (
                 users.map((u) => (
                   <TableRow key={u.id} hover>
-                    <TableCell>{u.userName}</TableCell>
+                    <TableCell>
+                      <UserRefLink name={u.userName} email={u.email} userId={u.id} />
+                    </TableCell>
                     <TableCell>{u.name || "—"}</TableCell>
                     <TableCell>{u.email}</TableCell>
                     <TableCell>

--- a/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.tsx
@@ -38,16 +38,18 @@ import {
   Typography,
   type SelectChangeEvent,
 } from "@wso2/oxygen-ui";
-import { useMemo, useState, type ChangeEvent, type JSX } from "react";
+import { useMemo, useState, type ChangeEvent, type JSX, type KeyboardEvent } from "react";
 import { useSearchParams } from "react-router";
 import QueryErrorState from "@components/QueryErrorState";
 import UserRefLink from "@components/UserRefLink";
 import AsyncEntityMultiSelect from "@components/AsyncEntityMultiSelect";
 import { useDebouncedValue } from "@hooks/useDebouncedValue";
+import { useNavTransition } from "@hooks/useNavTransition";
 import { useSearchGroups } from "@api/useSearchGroups";
 import { useSearchUsers } from "@features/csm-users/api/useSearchUsers";
 import { useSearchRoles } from "@features/csm-admin/api/useSearchRoles";
 import { useSearchTeams } from "@features/csm-admin/api/useSearchTeams";
+import DirectoryEntityChip from "@features/csm-admin/components/DirectoryEntityChip";
 import {
   INTERNAL_USER_ROLES,
   type SearchUsersRequest,
@@ -65,6 +67,10 @@ import type { BeGroup } from "@api/backend/types";
 const DEFAULT_ROWS_PER_PAGE = 20;
 // Top option is the backend's max page limit; larger requests are rejected.
 const ROWS_PER_PAGE_OPTIONS = [10, 20, BE_MAX_PAGE_LIMIT];
+// Roles beyond this many collapse into a single "+N more" chip that links to
+// the user's profile — a table cell isn't the place to enumerate every role a
+// user carries.
+const MAX_VISIBLE_ROLES = 3;
 
 /**
  * The users list, with filters reflected in the URL (`q`, `roles`, `groups`,
@@ -75,6 +81,7 @@ const ROWS_PER_PAGE_OPTIONS = [10, 20, BE_MAX_PAGE_LIMIT];
  * instead. Role, group and team filters combine (AND together server-side).
  */
 export default function CsmUsersPage(): JSX.Element {
+  const navigate = useNavTransition();
   const [searchParams, setSearchParams] = useSearchParams();
   const filters = useMemo(() => readUsersFiltersFromUrl(searchParams), [searchParams]);
 
@@ -299,50 +306,94 @@ export default function CsmUsersPage(): JSX.Element {
                   </TableCell>
                 </TableRow>
               ) : (
-                users.map((u) => (
-                  <TableRow key={u.id} hover>
-                    <TableCell>
-                      <UserRefLink name={u.userName} email={u.email} userId={u.id} />
-                    </TableCell>
-                    <TableCell>{u.name || "—"}</TableCell>
-                    <TableCell>{u.email}</TableCell>
-                    <TableCell>
-                      <Stack direction="row" spacing={0.5} sx={{ flexWrap: "wrap", gap: 0.5 }}>
-                        {u.roles && u.roles.length > 0
-                          ? u.roles.map((r) => (
-                              <Chip
-                                key={r}
-                                size="small"
-                                label={r}
-                                color={(INTERNAL_USER_ROLES as string[]).includes(r) ? "primary" : "default"}
-                                variant="outlined"
-                              />
-                            ))
-                          : u.userType
-                            ? <Chip
-                                size="small"
-                                label={u.userType}
-                                color={u.userType === "internal" ? "primary" : "default"}
-                                variant="outlined"
-                              />
-                            : "—"}
-                      </Stack>
-                    </TableCell>
-                    <TableCell>
-                      {u.active === undefined ? (
-                        "—"
-                      ) : (
-                        <Chip
-                          size="small"
-                          label={u.active ? "Active" : "Inactive"}
-                          color={u.active ? "success" : "default"}
-                          variant="outlined"
-                        />
-                      )}
-                    </TableCell>
-                    <TableCell>{u.timezone ?? "—"}</TableCell>
-                  </TableRow>
-                ))
+                users.map((u) => {
+                  const profilePath = `/people/${encodeURIComponent(u.id)}`;
+                  const goToProfile = (): void => navigate(profilePath);
+                  const handleRowKeyDown = (e: KeyboardEvent<HTMLTableRowElement>): void => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      goToProfile();
+                    }
+                  };
+                  const visibleRoles = u.roles?.slice(0, MAX_VISIBLE_ROLES) ?? [];
+                  const hiddenRoleCount = Math.max((u.roles?.length ?? 0) - MAX_VISIBLE_ROLES, 0);
+
+                  return (
+                    <TableRow
+                      key={u.id}
+                      hover
+                      onClick={goToProfile}
+                      onKeyDown={handleRowKeyDown}
+                      tabIndex={0}
+                      role="button"
+                      aria-label={`View profile for ${u.name || u.userName}`}
+                      sx={{ cursor: "pointer" }}
+                    >
+                      <TableCell>
+                        <UserRefLink name={u.userName} email={u.email} userId={u.id} />
+                      </TableCell>
+                      <TableCell>{u.name || "—"}</TableCell>
+                      <TableCell>{u.email}</TableCell>
+                      <TableCell>
+                        <Stack direction="row" spacing={0.5} sx={{ flexWrap: "wrap", gap: 0.5 }}>
+                          {u.roles && u.roles.length > 0 ? (
+                            <>
+                              {visibleRoles.map((r) => (
+                                <DirectoryEntityChip
+                                  key={r}
+                                  id={r}
+                                  name={roleNameById.get(r) ?? r}
+                                  routeBase="/admin/roles"
+                                  color={(INTERNAL_USER_ROLES as string[]).includes(r) ? "primary" : "default"}
+                                />
+                              ))}
+                              {hiddenRoleCount > 0 && (
+                                <Chip
+                                  size="small"
+                                  variant="outlined"
+                                  label={`+${hiddenRoleCount} more`}
+                                  clickable
+                                  onClick={(e) => {
+                                    e.stopPropagation();
+                                    goToProfile();
+                                  }}
+                                  onKeyDown={(e) => {
+                                    if (e.key === "Enter" || e.key === " ") {
+                                      e.stopPropagation();
+                                    }
+                                  }}
+                                  aria-label={`View all ${u.roles.length} roles for ${u.name || u.userName}`}
+                                />
+                              )}
+                            </>
+                          ) : u.userType ? (
+                            <Chip
+                              size="small"
+                              label={u.userType}
+                              color={u.userType === "internal" ? "primary" : "default"}
+                              variant="outlined"
+                            />
+                          ) : (
+                            "—"
+                          )}
+                        </Stack>
+                      </TableCell>
+                      <TableCell>
+                        {u.active === undefined ? (
+                          "—"
+                        ) : (
+                          <Chip
+                            size="small"
+                            label={u.active ? "Active" : "Inactive"}
+                            color={u.active ? "success" : "default"}
+                            variant="outlined"
+                          />
+                        )}
+                      </TableCell>
+                      <TableCell>{u.timezone ?? "—"}</TableCell>
+                    </TableRow>
+                  );
+                })
               )}
             </TableBody>
           </Table>

--- a/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.tsx
@@ -73,12 +73,17 @@ const ROWS_PER_PAGE_OPTIONS = [10, 20, BE_MAX_PAGE_LIMIT];
 const MAX_VISIBLE_ROLES = 3;
 
 /**
- * The users list, with filters reflected in the URL (`q`, `roles`, `groups`,
- * `teams`, `active`) so a filtered link is shareable and survives a reload —
- * the same `read*FiltersFromUrl` / `write*FiltersToUrl` convention the cases
- * list uses (`casesFiltersUrl.ts`). Deliberately no project/account filter:
- * "who is on this project" is answered by the project-contacts search
- * instead. Role, group and team filters combine (AND together server-side).
+ * The users list, with filters reflected in the URL (`search`, `roles`,
+ * `groups`, `teams`, `active`) so a filtered link is shareable and survives a
+ * reload — the same `read*FiltersFromUrl` / `write*FiltersToUrl` convention
+ * the cases list uses (`casesFiltersUrl.ts`). The free-text key is `search`,
+ * not `q`: both this list and the cases list originally wrote it as `?q=`,
+ * which collides with the app's QuickNav command palette (it treats `?q=` as
+ * a one-shot deep link and pops open pre-filled with whatever's there) — keep
+ * it `search` in any future change here, or that collision comes back.
+ * Deliberately no project/account filter: "who is on this project" is
+ * answered by the project-contacts search instead. Role, group and team
+ * filters combine (AND together server-side).
  */
 export default function CsmUsersPage(): JSX.Element {
   const navigate = useNavTransition();
@@ -325,7 +330,6 @@ export default function CsmUsersPage(): JSX.Element {
                       onClick={goToProfile}
                       onKeyDown={handleRowKeyDown}
                       tabIndex={0}
-                      role="button"
                       aria-label={`View profile for ${u.name || u.userName}`}
                       sx={{ cursor: "pointer" }}
                     >

--- a/apps/csm-portal/webapp/src/features/csm-users/pages/UserProfilePage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/pages/UserProfilePage.test.tsx
@@ -15,10 +15,10 @@
 // under the License.
 
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 import { MemoryRouter } from "react-router";
-import type { UseQueryResult } from "@tanstack/react-query";
+import { QueryClient, QueryClientProvider, type UseQueryResult } from "@tanstack/react-query";
 import type { NormalizedUserDetail } from "@features/csm-users/types/csmUsers";
 
 const navigateMock = vi.fn();
@@ -35,7 +35,10 @@ vi.mock("@hooks/useNavTransition", () => ({
 // module load, which isn't present under vitest. `QueryErrorState` imports
 // `BackendApiError` from it directly, so stub the module with a real class
 // (so `instanceof` still works) — same approach as
-// CsmChangeRequestDetailPage.test.tsx.
+// CsmChangeRequestDetailPage.test.tsx. `useBackendApi` also needs a working
+// `post`: RolesSection resolves role display names via `useSearchRoles`,
+// which goes through this same client.
+const backendPostMock = vi.fn();
 vi.mock("@api/backend/client", () => ({
   BackendApiError: class BackendApiError extends Error {
     status: number;
@@ -44,6 +47,7 @@ vi.mock("@api/backend/client", () => ({
       this.status = status;
     }
   },
+  useBackendApi: () => ({ post: backendPostMock }),
 }));
 vi.mock("@features/csm-users/api/useGetUserById", () => ({
   useGetUserById: () => useGetUserByIdMock(),
@@ -116,14 +120,33 @@ function mockQueryResult(
 }
 
 function renderPage(): ReturnType<typeof render> {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
-    <MemoryRouter>
-      <UserProfilePage />
-    </MemoryRouter>,
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <UserProfilePage />
+      </MemoryRouter>
+    </QueryClientProvider>,
   );
 }
 
+const ROLES_RESPONSE = {
+  roles: [
+    { id: "internal", name: "Internal" },
+    { id: "agent", name: "Agent" },
+    { id: "customer", name: "Customer" },
+  ],
+  total: 3,
+  limit: 50,
+  offset: 0,
+};
+
 describe("UserProfilePage", () => {
+  beforeEach(() => {
+    backendPostMock.mockReset();
+    backendPostMock.mockResolvedValue(ROLES_RESPONSE);
+  });
+
   it("renders a loading skeleton while the query is pending", () => {
     mockQueryResult({ isLoading: true });
     const { container } = renderPage();
@@ -142,15 +165,23 @@ describe("UserProfilePage", () => {
     expect(screen.getByText(/User not found/i)).toBeInTheDocument();
   });
 
-  it("renders an internal user's groups and teams, with roles, phone and timestamps", () => {
+  it("renders an internal user's groups and teams, with roles, phone and timestamps", async () => {
     mockQueryResult({ data: INTERNAL_USER });
     renderPage();
     expect(screen.getByText("Jane Doe")).toBeInTheDocument();
-    expect(screen.getByText("Internal", { selector: ".MuiChip-label" })).toBeInTheDocument();
     expect(screen.getByText("+10000000000")).toBeInTheDocument();
     expect(screen.getByText("Tier 2 support")).toBeInTheDocument();
     expect(screen.getByText("CRE (CRE)")).toBeInTheDocument();
-    expect(screen.getByText("agent", { selector: ".MuiChip-label" })).toBeInTheDocument();
+
+    // Role labels resolve through the roles catalogue, same as the users
+    // list, so this reads "Agent" (and "Internal", appearing twice: once as
+    // the account-type chip, once as a role chip) rather than the raw keys
+    // "agent"/"internal".
+    expect(await screen.findByText("Agent", { selector: ".MuiChip-label" })).toBeInTheDocument();
+    expect(screen.getAllByText("Internal", { selector: ".MuiChip-label" }).length).toBeGreaterThan(
+      0,
+    );
+    expect(screen.queryByText("agent", { selector: ".MuiChip-label" })).not.toBeInTheDocument();
   });
 
   it("renders 'No team assignments' rather than hiding the card when an internal user has no teams", () => {

--- a/apps/csm-portal/webapp/src/features/csm-users/pages/UserProfilePage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/pages/UserProfilePage.test.tsx
@@ -1,0 +1,217 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { MemoryRouter } from "react-router";
+import type { UseQueryResult } from "@tanstack/react-query";
+import type { NormalizedUserDetail } from "@features/csm-users/types/csmUsers";
+
+const navigateMock = vi.fn();
+const useGetUserByIdMock = vi.fn();
+
+vi.mock("react-router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router")>();
+  return { ...actual, useParams: () => ({ id: "user-1" }) };
+});
+vi.mock("@hooks/useNavTransition", () => ({
+  useNavTransition: () => navigateMock,
+}));
+// The backend client reads runtime config (`CSM_PORTAL_BACKEND_BASE_URL`) at
+// module load, which isn't present under vitest. `QueryErrorState` imports
+// `BackendApiError` from it directly, so stub the module with a real class
+// (so `instanceof` still works) — same approach as
+// CsmChangeRequestDetailPage.test.tsx.
+vi.mock("@api/backend/client", () => ({
+  BackendApiError: class BackendApiError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+      super(message);
+      this.status = status;
+    }
+  },
+}));
+vi.mock("@features/csm-users/api/useGetUserById", () => ({
+  useGetUserById: () => useGetUserByIdMock(),
+}));
+
+// Imported after the mocks above so the module picks them up.
+import UserProfilePage from "@features/csm-users/pages/UserProfilePage";
+
+const INTERNAL_USER: NormalizedUserDetail = {
+  id: "user-1",
+  userName: "jane.doe",
+  name: "Jane Doe",
+  email: "jane.doe@example.com",
+  timezone: "UTC",
+  userType: "internal",
+  active: true,
+  roles: ["internal", "agent"],
+  phone: "+10000000000",
+  createdOn: "2025-01-01T00:00:00Z",
+  updatedOn: "2025-06-01T00:00:00Z",
+  groups: [{ id: "grp-1", name: "Tier 2 support" }],
+  teams: [{ id: "team-1", name: "CRE", family: "CRE" }],
+};
+
+const BLOCKED_EXTERNAL_USER: NormalizedUserDetail = {
+  id: "user-2",
+  userName: "john.smith",
+  name: "John Smith",
+  email: "john.smith@example.com",
+  timezone: null,
+  userType: "external",
+  active: true,
+  roles: ["customer"],
+  createdOn: "2025-01-01T00:00:00Z",
+  updatedOn: "2025-06-01T00:00:00Z",
+  projectAccess: [
+    {
+      projectId: "proj-1",
+      projectName: "Payments Platform",
+      contactEmail: "john.smith@example.com",
+      contactRecordPresent: false,
+      emailMatchesLogin: false,
+      grantsCaseAccess: false,
+    },
+    {
+      projectId: "proj-2",
+      projectName: "Identity Platform",
+      contactEmail: "john.smith@example.com",
+      contactRecordPresent: true,
+      contactRecordEmail: "john.smith@example.com",
+      emailMatchesLogin: true,
+      registrationState: "registered",
+      notificationsEnabled: true,
+      roles: ["viewer"],
+      grantsCaseAccess: true,
+    },
+  ],
+};
+
+function mockQueryResult(
+  overrides: Partial<UseQueryResult<NormalizedUserDetail | null, Error>>,
+): void {
+  useGetUserByIdMock.mockReturnValue({
+    data: null,
+    isLoading: false,
+    isError: false,
+    error: null,
+    ...overrides,
+  });
+}
+
+function renderPage(): ReturnType<typeof render> {
+  return render(
+    <MemoryRouter>
+      <UserProfilePage />
+    </MemoryRouter>,
+  );
+}
+
+describe("UserProfilePage", () => {
+  it("renders a loading skeleton while the query is pending", () => {
+    mockQueryResult({ isLoading: true });
+    const { container } = renderPage();
+    expect(container.querySelectorAll(".MuiSkeleton-root").length).toBeGreaterThan(0);
+  });
+
+  it("renders an error state when the query fails", () => {
+    mockQueryResult({ isError: true, error: new Error("boom") });
+    renderPage();
+    expect(screen.getByText(/Failed to load user/i)).toBeInTheDocument();
+  });
+
+  it("renders a not-found state when the user is null", () => {
+    mockQueryResult({ data: null });
+    renderPage();
+    expect(screen.getByText(/User not found/i)).toBeInTheDocument();
+  });
+
+  it("renders an internal user's groups and teams, with roles, phone and timestamps", () => {
+    mockQueryResult({ data: INTERNAL_USER });
+    renderPage();
+    expect(screen.getByText("Jane Doe")).toBeInTheDocument();
+    expect(screen.getByText("Internal", { selector: ".MuiChip-label" })).toBeInTheDocument();
+    expect(screen.getByText("+10000000000")).toBeInTheDocument();
+    expect(screen.getByText("Tier 2 support")).toBeInTheDocument();
+    expect(screen.getByText("CRE (CRE)")).toBeInTheDocument();
+    expect(screen.getByText("agent", { selector: ".MuiChip-label" })).toBeInTheDocument();
+  });
+
+  it("renders 'No team assignments' rather than hiding the card when an internal user has no teams", () => {
+    mockQueryResult({ data: { ...INTERNAL_USER, teams: [] } });
+    renderPage();
+    expect(screen.getByText("No team assignments.")).toBeInTheDocument();
+  });
+
+  it("renders the blocking reason for a project that doesn't grant an external user case access", () => {
+    mockQueryResult({ data: BLOCKED_EXTERNAL_USER });
+    renderPage();
+
+    // The blocked project surfaces its reason...
+    expect(screen.getByText("Payments Platform")).toBeInTheDocument();
+    expect(screen.getByText("Blocked", { selector: ".MuiChip-label" })).toBeInTheDocument();
+    expect(
+      screen.getByText(/No contact record is linked to this project/i),
+    ).toBeInTheDocument();
+
+    // ...while the granted project shows no reason text at all.
+    expect(screen.getByText("Identity Platform")).toBeInTheDocument();
+    expect(screen.getByText("Has case access", { selector: ".MuiChip-label" })).toBeInTheDocument();
+    expect(screen.queryByText(/doesn't match the login email/i)).not.toBeInTheDocument();
+
+    expect(screen.getByText(/Blocked on 1 of 2 projects/i)).toBeInTheDocument();
+  });
+
+  it("renders a mismatched-email reason distinct from a missing contact record", () => {
+    mockQueryResult({
+      data: {
+        ...BLOCKED_EXTERNAL_USER,
+        projectAccess: [
+          {
+            projectId: "proj-3",
+            projectName: "Analytics Platform",
+            contactEmail: "john.smith@example.com",
+            contactRecordPresent: true,
+            contactRecordEmail: "j.smith@example.com",
+            emailMatchesLogin: false,
+            grantsCaseAccess: false,
+          },
+        ],
+      },
+    });
+    renderPage();
+    expect(
+      screen.getByText(/Contact record email \(j\.smith@example\.com\) doesn't match the login email/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders 'No project access records found' rather than hiding the card for an external user with none", () => {
+    mockQueryResult({ data: { ...BLOCKED_EXTERNAL_USER, projectAccess: [] } });
+    renderPage();
+    expect(
+      screen.getByText(/No project access records found for this user/i),
+    ).toBeInTheDocument();
+  });
+
+  it("calls out an inactive account as blocking access to every project", () => {
+    mockQueryResult({ data: { ...BLOCKED_EXTERNAL_USER, active: false } });
+    renderPage();
+    expect(screen.getByText(/account is inactive/i)).toBeInTheDocument();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-users/pages/UserProfilePage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/pages/UserProfilePage.tsx
@@ -30,13 +30,15 @@ import {
   Typography,
 } from "@wso2/oxygen-ui";
 import { ArrowLeft } from "@wso2/oxygen-ui-icons-react";
-import { type JSX, type ReactNode } from "react";
+import { useMemo, type JSX, type ReactNode } from "react";
 import { Link as RouterLink, useParams } from "react-router";
 import QueryErrorState from "@components/QueryErrorState";
 import { useNavTransition } from "@hooks/useNavTransition";
 import { formatBackendTimestampForDisplay } from "@utils/dateTime";
 import { useGetUserById } from "@features/csm-users/api/useGetUserById";
+import { useSearchRoles } from "@features/csm-admin/api/useSearchRoles";
 import DirectoryEntityChip from "@features/csm-admin/components/DirectoryEntityChip";
+import { BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
 import {
   INTERNAL_USER_ROLES,
   type NormalizedUserDetail,
@@ -269,12 +271,20 @@ function MembershipCard({
   );
 }
 
-/** This user's assigned roles (all user types). */
+/** This user's assigned roles (all user types). Labels resolve through the
+ * same role catalogue the users list uses, so a role reads "Agent" here too,
+ * not the raw key "agent". */
 function RolesSection({ user }: { user: NormalizedUserDetail }): JSX.Element {
+  const { data: rolesData } = useSearchRoles({ pagination: { limit: BE_MAX_PAGE_LIMIT } });
+  const roleNameById = useMemo(
+    () => new Map((rolesData?.roles ?? []).map((r) => [r.id, r.name])),
+    [rolesData],
+  );
+
   const rows: MembershipRow[] = (user.roles ?? []).map((r) => ({
     key: r,
     id: r,
-    label: r,
+    label: roleNameById.get(r) ?? r,
     routeBase: "/admin/roles",
     color: (INTERNAL_USER_ROLES as string[]).includes(r) ? "primary" : "default",
   }));

--- a/apps/csm-portal/webapp/src/features/csm-users/pages/UserProfilePage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/pages/UserProfilePage.tsx
@@ -26,7 +26,6 @@ import {
   TableBody,
   TableCell,
   TableContainer,
-  TableHead,
   TableRow,
   Typography,
 } from "@wso2/oxygen-ui";
@@ -204,13 +203,17 @@ interface MembershipRow {
  * `DirectoryEntityChip`). Rendered even when `rows` is empty — "no
  * memberships" is itself an answer worth showing rather than hiding the
  * section, per {@link emptyMessage}.
+ *
+ * Deliberately no header row naming the column ("Role"/"Group"/"Team") —
+ * the enclosing card's own title already says that, and repeating it inside
+ * read as "Groups" containing a table headed "Group".
  */
 function MembershipTable({
-  columnLabel,
+  ariaLabel,
   rows,
   emptyMessage,
 }: {
-  columnLabel: string;
+  ariaLabel: string;
   rows: MembershipRow[];
   emptyMessage: string;
 }): JSX.Element {
@@ -223,12 +226,7 @@ function MembershipTable({
   }
   return (
     <TableContainer sx={{ border: 1, borderColor: "divider", borderRadius: 1 }}>
-      <Table size="small" aria-label={`${columnLabel} memberships`}>
-        <TableHead>
-          <TableRow sx={{ bgcolor: "action.hover" }}>
-            <TableCell>{columnLabel}</TableCell>
-          </TableRow>
-        </TableHead>
+      <Table size="small" aria-label={ariaLabel}>
         <TableBody>
           {rows.map((row) => (
             <TableRow key={row.key}>
@@ -248,7 +246,30 @@ function MembershipTable({
   );
 }
 
-/** This user's assigned roles, as a single-column table (all user types). */
+/**
+ * Roles/groups/teams as three cards in a row (wrapping to stacked on narrow
+ * viewports), so the three membership kinds read as siblings rather than a
+ * single long vertical list. Each card's title is the only place its kind is
+ * named — the table inside carries no repeated column header.
+ */
+function MembershipCard({
+  title,
+  rows,
+  emptyMessage,
+}: {
+  title: string;
+  rows: MembershipRow[];
+  emptyMessage: string;
+}): JSX.Element {
+  return (
+    <Card sx={{ p: 2.5, flex: "1 1 260px", minWidth: 220, display: "flex", flexDirection: "column", gap: 2 }}>
+      <Typography variant="subtitle2">{title}</Typography>
+      <MembershipTable ariaLabel={`${title} memberships`} rows={rows} emptyMessage={emptyMessage} />
+    </Card>
+  );
+}
+
+/** This user's assigned roles (all user types). */
 function RolesSection({ user }: { user: NormalizedUserDetail }): JSX.Element {
   const rows: MembershipRow[] = (user.roles ?? []).map((r) => ({
     key: r,
@@ -257,15 +278,10 @@ function RolesSection({ user }: { user: NormalizedUserDetail }): JSX.Element {
     routeBase: "/admin/roles",
     color: (INTERNAL_USER_ROLES as string[]).includes(r) ? "primary" : "default",
   }));
-  return (
-    <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 2 }}>
-      <Typography variant="subtitle2">Roles</Typography>
-      <MembershipTable columnLabel="Role" rows={rows} emptyMessage="No roles assigned." />
-    </Card>
-  );
+  return <MembershipCard title="Roles" rows={rows} emptyMessage="No roles assigned." />;
 }
 
-/** An internal user's group memberships, as a single-column table. */
+/** An internal user's group memberships. */
 function GroupsSection({ user }: { user: NormalizedUserDetail }): JSX.Element {
   const rows: MembershipRow[] = (user.groups ?? []).map((g) => ({
     key: g.id,
@@ -273,15 +289,10 @@ function GroupsSection({ user }: { user: NormalizedUserDetail }): JSX.Element {
     label: g.name,
     routeBase: "/admin/groups",
   }));
-  return (
-    <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 2 }}>
-      <Typography variant="subtitle2">Groups</Typography>
-      <MembershipTable columnLabel="Group" rows={rows} emptyMessage="No group memberships." />
-    </Card>
-  );
+  return <MembershipCard title="Groups" rows={rows} emptyMessage="No group memberships." />;
 }
 
-/** An internal user's CRE/SRE team assignments, as a single-column table. */
+/** An internal user's CRE/SRE team assignments. */
 function TeamsSection({ user }: { user: NormalizedUserDetail }): JSX.Element {
   const rows: MembershipRow[] = (user.teams ?? []).map((t) => ({
     key: t.id,
@@ -290,12 +301,7 @@ function TeamsSection({ user }: { user: NormalizedUserDetail }): JSX.Element {
     routeBase: "/admin/teams",
     color: "primary",
   }));
-  return (
-    <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 2 }}>
-      <Typography variant="subtitle2">Teams</Typography>
-      <MembershipTable columnLabel="Team" rows={rows} emptyMessage="No team assignments." />
-    </Card>
-  );
+  return <MembershipCard title="Teams" rows={rows} emptyMessage="No team assignments." />;
 }
 
 /**
@@ -308,7 +314,7 @@ function ProjectAccessSection({ user }: { user: NormalizedUserDetail }): JSX.Ele
   const blockedCount = access.filter((pa) => !pa.grantsCaseAccess).length;
 
   return (
-    <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 2 }}>
+    <Card sx={{ p: 2.5, flex: "2 1 400px", display: "flex", flexDirection: "column", gap: 2 }}>
       <Typography variant="subtitle2">Project access</Typography>
 
       {user.active === false && (
@@ -460,16 +466,17 @@ export default function UserProfilePage(): JSX.Element {
         </Box>
       </Card>
 
-      <RolesSection user={user} />
-
-      {internal ? (
-        <>
-          <GroupsSection user={user} />
-          <TeamsSection user={user} />
-        </>
-      ) : (
-        <ProjectAccessSection user={user} />
-      )}
+      <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2.5 }}>
+        <RolesSection user={user} />
+        {internal ? (
+          <>
+            <GroupsSection user={user} />
+            <TeamsSection user={user} />
+          </>
+        ) : (
+          <ProjectAccessSection user={user} />
+        )}
+      </Box>
     </Box>
   );
 }

--- a/apps/csm-portal/webapp/src/features/csm-users/pages/UserProfilePage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/pages/UserProfilePage.tsx
@@ -14,17 +14,28 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Box, Button, Card, Chip, Skeleton, Stack, Typography } from "@wso2/oxygen-ui";
+import { Alert, Box, Button, Card, Chip, Skeleton, Stack, Typography } from "@wso2/oxygen-ui";
 import { ArrowLeft } from "@wso2/oxygen-ui-icons-react";
 import { type JSX, type ReactNode } from "react";
-import { useParams } from "react-router";
+import { Link as RouterLink, useParams } from "react-router";
 import QueryErrorState from "@components/QueryErrorState";
 import { useNavTransition } from "@hooks/useNavTransition";
+import { formatBackendTimestampForDisplay } from "@utils/dateTime";
 import { useGetUserById } from "@features/csm-users/api/useGetUserById";
 import {
   INTERNAL_USER_ROLES,
-  type NormalizedUser,
+  type NormalizedUserDetail,
+  type UserProjectAccess,
 } from "@features/csm-users/types/csmUsers";
+
+function formatDateTime(value?: string | null): string {
+  return (
+    formatBackendTimestampForDisplay(value, {
+      dateStyle: "medium",
+      timeStyle: "short",
+    }) ?? "—"
+  );
+}
 
 function BackButton({ onClick }: { onClick: () => void }): JSX.Element {
   return (
@@ -62,12 +73,15 @@ function MetaCell({
 }
 
 /**
- * True when `user` is internal (WSO2 staff): either the postgres source's
- * direct `userType === "internal"`, or the ServiceNow source's `roles`
- * containing one of {@link INTERNAL_USER_ROLES}. Absent both signals, the
- * user is treated as a customer.
+ * True when `user` is internal (WSO2 staff): either a direct
+ * `userType === "internal"`, or (on a backend response predating `userType`)
+ * `roles` containing one of {@link INTERNAL_USER_ROLES}. Every other
+ * `userType` value (`external`, `customer`, `system`) is treated alike as
+ * "not internal" — the two data sources don't agree on the exact label, so
+ * branching on `=== "external"` alone would silently miss the postgres
+ * source's `customer`/`system` users.
  */
-function isInternalUser(user: NormalizedUser): boolean {
+function isInternalUser(user: NormalizedUserDetail): boolean {
   if (user.userType) return user.userType === "internal";
   return (user.roles ?? []).some((r) =>
     (INTERNAL_USER_ROLES as string[]).includes(r),
@@ -75,32 +89,183 @@ function isInternalUser(user: NormalizedUser): boolean {
 }
 
 /**
- * Placeholder section for data the backend doesn't expose yet, following the
- * same visual language as `CsmComingSoonPage` and the admin `roles`/`groups`
- * stub routes: a "Coming soon" chip plus a short description of what's
- * blocked and why, so it reads as an intentional gap rather than a bug.
+ * Human-readable reasons a project-access row doesn't grant case access.
+ * `grantsCaseAccess` is the verdict the backend already computed; these are
+ * the "why" a support engineer is looking for. Order matters: the missing
+ * contact record is the more fundamental failure, so it's listed first when
+ * both are true.
  */
-function NotAvailableYetSection({
-  title,
-  description,
-  blockedOn,
-}: {
-  title: string;
-  description: string;
-  blockedOn: string;
-}): JSX.Element {
+function blockedReasons(pa: UserProjectAccess): string[] {
+  const reasons: string[] = [];
+  if (!pa.contactRecordPresent) {
+    reasons.push("No contact record is linked to this project for this user.");
+  } else if (!pa.emailMatchesLogin) {
+    reasons.push(
+      pa.contactRecordEmail
+        ? `Contact record email (${pa.contactRecordEmail}) doesn't match the login email (${pa.contactEmail}).`
+        : "The linked contact record's email doesn't match the login email.",
+    );
+  }
+  return reasons;
+}
+
+/** One row of an external user's per-project access, with the reason surfaced when blocked. */
+function ProjectAccessRow({ pa }: { pa: UserProjectAccess }): JSX.Element {
+  const reasons = blockedReasons(pa);
   return (
-    <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 1.5 }}>
-      <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
-        <Typography variant="subtitle2">{title}</Typography>
-        <Chip size="small" label="Coming soon" color="warning" variant="outlined" />
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 0.75,
+        p: 1.5,
+        border: 1,
+        borderColor: "divider",
+        borderRadius: 1,
+      }}
+    >
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
+        <Typography
+          component={RouterLink}
+          to={`/customers/projects/${pa.projectId}`}
+          variant="body2"
+          sx={(t) => ({
+            fontWeight: 600,
+            textDecoration: "none",
+            color: t.palette.primary.dark,
+            ...t.applyStyles("dark", { color: t.palette.primary.main }),
+            "&:hover": { textDecoration: "underline" },
+          })}
+        >
+          {pa.projectName}
+        </Typography>
+        <Chip
+          size="small"
+          label={pa.grantsCaseAccess ? "Has case access" : "Blocked"}
+          color={pa.grantsCaseAccess ? "success" : "error"}
+          variant="outlined"
+        />
+        {pa.registrationState && (
+          <Chip size="small" label={pa.registrationState} variant="outlined" />
+        )}
+        {pa.roles?.map((r) => (
+          <Chip key={r} size="small" label={r} variant="outlined" />
+        ))}
       </Box>
-      <Typography variant="body2" color="text.secondary">
-        {description}
-      </Typography>
+
+      {!pa.grantsCaseAccess && reasons.length > 0 && (
+        <Stack spacing={0.25}>
+          {reasons.map((reason) => (
+            <Typography key={reason} variant="caption" color="error.main">
+              {reason}
+            </Typography>
+          ))}
+        </Stack>
+      )}
+
       <Typography variant="caption" color="text.secondary">
-        Blocked on: {blockedOn}
+        Contact email: {pa.contactEmail}
+        {pa.notificationsEnabled !== undefined &&
+          ` · Notifications ${pa.notificationsEnabled ? "on" : "off"}`}
       </Typography>
+    </Box>
+  );
+}
+
+/**
+ * An internal user's group and team memberships. Rendered even when empty —
+ * "no memberships" is itself an answer worth showing rather than hiding the
+ * card.
+ */
+function GroupsAndTeamsSection({ user }: { user: NormalizedUserDetail }): JSX.Element {
+  const groups = user.groups ?? [];
+  const teams = user.teams ?? [];
+  return (
+    <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 2 }}>
+      <Typography variant="subtitle2">Groups and teams</Typography>
+      <Box
+        sx={{
+          display: "grid",
+          gap: 2,
+          gridTemplateColumns: { xs: "1fr", sm: "repeat(2, minmax(0, 1fr))" },
+        }}
+      >
+        <MetaCell label="Groups">
+          {groups.length > 0 ? (
+            <Stack direction="row" spacing={0.5} sx={{ flexWrap: "wrap", gap: 0.5 }}>
+              {groups.map((g) => (
+                <Chip key={g.id} size="small" label={g.name} variant="outlined" />
+              ))}
+            </Stack>
+          ) : (
+            <Typography variant="body2" color="text.secondary">
+              No group memberships.
+            </Typography>
+          )}
+        </MetaCell>
+        <MetaCell label="Teams">
+          {teams.length > 0 ? (
+            <Stack direction="row" spacing={0.5} sx={{ flexWrap: "wrap", gap: 0.5 }}>
+              {teams.map((t) => (
+                <Chip
+                  key={t.id}
+                  size="small"
+                  label={t.family ? `${t.name} (${t.family})` : t.name}
+                  color="primary"
+                  variant="outlined"
+                />
+              ))}
+            </Stack>
+          ) : (
+            <Typography variant="body2" color="text.secondary">
+              No team assignments.
+            </Typography>
+          )}
+        </MetaCell>
+      </Box>
+    </Card>
+  );
+}
+
+/**
+ * An external user's per-project access, with the reason called out whenever
+ * a project doesn't grant case access — this card exists to answer "why
+ * can't this customer see their cases?" at a glance.
+ */
+function ProjectAccessSection({ user }: { user: NormalizedUserDetail }): JSX.Element {
+  const access = user.projectAccess ?? [];
+  const blockedCount = access.filter((pa) => !pa.grantsCaseAccess).length;
+
+  return (
+    <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 2 }}>
+      <Typography variant="subtitle2">Project access</Typography>
+
+      {user.active === false && (
+        <Alert severity="error" variant="outlined">
+          This user's account is inactive — they can't access any project's cases,
+          regardless of the per-project rows below.
+        </Alert>
+      )}
+
+      {access.length === 0 ? (
+        <Typography variant="body2" color="text.secondary">
+          No project access records found for this user.
+        </Typography>
+      ) : (
+        <>
+          {blockedCount > 0 && (
+            <Alert severity="warning" variant="outlined">
+              Blocked on {blockedCount} of {access.length} project
+              {access.length === 1 ? "" : "s"} — see the reason under each row below.
+            </Alert>
+          )}
+          <Stack spacing={1.5}>
+            {access.map((pa) => (
+              <ProjectAccessRow key={pa.projectId} pa={pa} />
+            ))}
+          </Stack>
+        </>
+      )}
     </Card>
   );
 }
@@ -110,12 +275,13 @@ function NotAvailableYetSection({
  * portal (case creator, assignee, watchers, comment authors, attachment
  * uploaders) once its id is known or resolved (see `UserRefLink` /
  * `useResolvedUserId` — most actor fields carry only an email, resolved to an
- * id through a cached lookup before the link ever appears). Shows only what
- * `GET /users/{id}` already returns today — name, email, timezone,
- * roles/type, active status. There is no backend endpoint yet for a
- * customer's projects+roles or an internal user's groups/team, so that
- * section renders the same "not available yet" placeholder used by the admin
- * roles/groups stub routes rather than fabricating data.
+ * id through a cached lookup before the link ever appears).
+ *
+ * Renders everything `GET /users/{id}` returns: name, email, timezone, phone,
+ * roles, created/updated times, plus — split by `userType` — an internal
+ * user's group/team memberships or an external user's per-project access
+ * (with the reason surfaced whenever a project doesn't grant case access, per
+ * `UserProjectAccess.grantsCaseAccess`).
  */
 export default function UserProfilePage(): JSX.Element {
   const { id } = useParams<{ id: string }>();
@@ -209,6 +375,17 @@ export default function UserProfilePage(): JSX.Element {
           <MetaCell label="Timezone">
             <Typography variant="body2">{user.timezone ?? "Not set"}</Typography>
           </MetaCell>
+          {internal && (
+            <MetaCell label="Phone">
+              <Typography variant="body2">{user.phone ?? "Not set"}</Typography>
+            </MetaCell>
+          )}
+          <MetaCell label="Created on">
+            <Typography variant="body2">{formatDateTime(user.createdOn)}</Typography>
+          </MetaCell>
+          <MetaCell label="Updated on">
+            <Typography variant="body2">{formatDateTime(user.updatedOn)}</Typography>
+          </MetaCell>
           <MetaCell label="Roles">
             {user.roles && user.roles.length > 0 ? (
               <Stack direction="row" spacing={0.5} sx={{ flexWrap: "wrap", gap: 0.5 }}>
@@ -230,17 +407,9 @@ export default function UserProfilePage(): JSX.Element {
       </Card>
 
       {internal ? (
-        <NotAvailableYetSection
-          title="Groups, roles, and team"
-          description="This engineer's group memberships, permission roles, and CRE/SRE team assignment aren't available here yet."
-          blockedOn="csm-portal/backend groups and roles endpoints"
-        />
+        <GroupsAndTeamsSection user={user} />
       ) : (
-        <NotAvailableYetSection
-          title="Projects and roles per project"
-          description="The projects this customer has access to, and their role on each, aren't available here yet."
-          blockedOn="csm-portal/backend per-project role endpoints"
-        />
+        <ProjectAccessSection user={user} />
       )}
     </Box>
   );

--- a/apps/csm-portal/webapp/src/features/csm-users/pages/UserProfilePage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/pages/UserProfilePage.tsx
@@ -14,7 +14,22 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Alert, Box, Button, Card, Chip, Skeleton, Stack, Typography } from "@wso2/oxygen-ui";
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  Chip,
+  Skeleton,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from "@wso2/oxygen-ui";
 import { ArrowLeft } from "@wso2/oxygen-ui-icons-react";
 import { type JSX, type ReactNode } from "react";
 import { Link as RouterLink, useParams } from "react-router";
@@ -22,6 +37,7 @@ import QueryErrorState from "@components/QueryErrorState";
 import { useNavTransition } from "@hooks/useNavTransition";
 import { formatBackendTimestampForDisplay } from "@utils/dateTime";
 import { useGetUserById } from "@features/csm-users/api/useGetUserById";
+import DirectoryEntityChip from "@features/csm-admin/components/DirectoryEntityChip";
 import {
   INTERNAL_USER_ROLES,
   type NormalizedUserDetail,
@@ -172,57 +188,112 @@ function ProjectAccessRow({ pa }: { pa: UserProjectAccess }): JSX.Element {
   );
 }
 
+/** One row a {@link MembershipTable} renders: a role, group, or team the
+ * profile's user belongs to, plus enough to link it to its directory page. */
+interface MembershipRow {
+  key: string;
+  id: string;
+  label: string;
+  routeBase: string;
+  color?: "default" | "primary";
+}
+
 /**
- * An internal user's group and team memberships. Rendered even when empty —
- * "no memberships" is itself an answer worth showing rather than hiding the
- * card.
+ * A single-column table of role/group/team memberships, one row per entry,
+ * each name a link to that entity's directory page (see
+ * `DirectoryEntityChip`). Rendered even when `rows` is empty — "no
+ * memberships" is itself an answer worth showing rather than hiding the
+ * section, per {@link emptyMessage}.
  */
-function GroupsAndTeamsSection({ user }: { user: NormalizedUserDetail }): JSX.Element {
-  const groups = user.groups ?? [];
-  const teams = user.teams ?? [];
+function MembershipTable({
+  columnLabel,
+  rows,
+  emptyMessage,
+}: {
+  columnLabel: string;
+  rows: MembershipRow[];
+  emptyMessage: string;
+}): JSX.Element {
+  if (rows.length === 0) {
+    return (
+      <Typography variant="body2" color="text.secondary">
+        {emptyMessage}
+      </Typography>
+    );
+  }
+  return (
+    <TableContainer sx={{ border: 1, borderColor: "divider", borderRadius: 1 }}>
+      <Table size="small" aria-label={`${columnLabel} memberships`}>
+        <TableHead>
+          <TableRow sx={{ bgcolor: "action.hover" }}>
+            <TableCell>{columnLabel}</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {rows.map((row) => (
+            <TableRow key={row.key}>
+              <TableCell>
+                <DirectoryEntityChip
+                  id={row.id}
+                  name={row.label}
+                  routeBase={row.routeBase}
+                  color={row.color}
+                />
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}
+
+/** This user's assigned roles, as a single-column table (all user types). */
+function RolesSection({ user }: { user: NormalizedUserDetail }): JSX.Element {
+  const rows: MembershipRow[] = (user.roles ?? []).map((r) => ({
+    key: r,
+    id: r,
+    label: r,
+    routeBase: "/admin/roles",
+    color: (INTERNAL_USER_ROLES as string[]).includes(r) ? "primary" : "default",
+  }));
   return (
     <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 2 }}>
-      <Typography variant="subtitle2">Groups and teams</Typography>
-      <Box
-        sx={{
-          display: "grid",
-          gap: 2,
-          gridTemplateColumns: { xs: "1fr", sm: "repeat(2, minmax(0, 1fr))" },
-        }}
-      >
-        <MetaCell label="Groups">
-          {groups.length > 0 ? (
-            <Stack direction="row" spacing={0.5} sx={{ flexWrap: "wrap", gap: 0.5 }}>
-              {groups.map((g) => (
-                <Chip key={g.id} size="small" label={g.name} variant="outlined" />
-              ))}
-            </Stack>
-          ) : (
-            <Typography variant="body2" color="text.secondary">
-              No group memberships.
-            </Typography>
-          )}
-        </MetaCell>
-        <MetaCell label="Teams">
-          {teams.length > 0 ? (
-            <Stack direction="row" spacing={0.5} sx={{ flexWrap: "wrap", gap: 0.5 }}>
-              {teams.map((t) => (
-                <Chip
-                  key={t.id}
-                  size="small"
-                  label={t.family ? `${t.name} (${t.family})` : t.name}
-                  color="primary"
-                  variant="outlined"
-                />
-              ))}
-            </Stack>
-          ) : (
-            <Typography variant="body2" color="text.secondary">
-              No team assignments.
-            </Typography>
-          )}
-        </MetaCell>
-      </Box>
+      <Typography variant="subtitle2">Roles</Typography>
+      <MembershipTable columnLabel="Role" rows={rows} emptyMessage="No roles assigned." />
+    </Card>
+  );
+}
+
+/** An internal user's group memberships, as a single-column table. */
+function GroupsSection({ user }: { user: NormalizedUserDetail }): JSX.Element {
+  const rows: MembershipRow[] = (user.groups ?? []).map((g) => ({
+    key: g.id,
+    id: g.id,
+    label: g.name,
+    routeBase: "/admin/groups",
+  }));
+  return (
+    <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 2 }}>
+      <Typography variant="subtitle2">Groups</Typography>
+      <MembershipTable columnLabel="Group" rows={rows} emptyMessage="No group memberships." />
+    </Card>
+  );
+}
+
+/** An internal user's CRE/SRE team assignments, as a single-column table. */
+function TeamsSection({ user }: { user: NormalizedUserDetail }): JSX.Element {
+  const rows: MembershipRow[] = (user.teams ?? []).map((t) => ({
+    key: t.id,
+    id: t.id,
+    label: t.family ? `${t.name} (${t.family})` : t.name,
+    routeBase: "/admin/teams",
+    color: "primary",
+  }));
+  return (
+    <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 2 }}>
+      <Typography variant="subtitle2">Teams</Typography>
+      <MembershipTable columnLabel="Team" rows={rows} emptyMessage="No team assignments." />
     </Card>
   );
 }
@@ -386,28 +457,16 @@ export default function UserProfilePage(): JSX.Element {
           <MetaCell label="Updated on">
             <Typography variant="body2">{formatDateTime(user.updatedOn)}</Typography>
           </MetaCell>
-          <MetaCell label="Roles">
-            {user.roles && user.roles.length > 0 ? (
-              <Stack direction="row" spacing={0.5} sx={{ flexWrap: "wrap", gap: 0.5 }}>
-                {user.roles.map((r) => (
-                  <Chip
-                    key={r}
-                    size="small"
-                    label={r}
-                    color={(INTERNAL_USER_ROLES as string[]).includes(r) ? "primary" : "default"}
-                    variant="outlined"
-                  />
-                ))}
-              </Stack>
-            ) : (
-              <Typography variant="body2">—</Typography>
-            )}
-          </MetaCell>
         </Box>
       </Card>
 
+      <RolesSection user={user} />
+
       {internal ? (
-        <GroupsAndTeamsSection user={user} />
+        <>
+          <GroupsSection user={user} />
+          <TeamsSection user={user} />
+        </>
       ) : (
         <ProjectAccessSection user={user} />
       )}

--- a/apps/csm-portal/webapp/src/features/csm-users/types/csmUsers.ts
+++ b/apps/csm-portal/webapp/src/features/csm-users/types/csmUsers.ts
@@ -14,7 +14,14 @@
 // specific language governing permissions and limitations
 // under the License.
 
-export type UserType = "internal" | "customer";
+/**
+ * Whether the user is staff or a customer/partner contact. The postgres data
+ * source emits `internal`, `customer`, or `system`; the ServiceNow data
+ * source emits `internal` or `external`. Callers branching on staff-vs-not
+ * must treat everything other than `internal` alike, not just `customer` or
+ * just `external` — see `isInternalUser` in `UserProfilePage`.
+ */
+export type UserType = "internal" | "external" | "customer" | "system";
 
 /**
  * Roles as modelled by the ServiceNow data source. `internal`/`agent`/`admin`
@@ -53,7 +60,10 @@ export interface User {
 
 /**
  * User shape returned by the ServiceNow data source. No `firstName`/`lastName`
- * (use `name`), no `userType` (use `roles`), no `hasMore` on the envelope.
+ * (use `name`), no `hasMore` on the envelope. `userType` and `mobilePhone` are
+ * present on the full-profile response (`GET /users/{id}`); `userType` may be
+ * absent from the search-list response on an older backend, so callers must
+ * still fall back to `roles` (see `isInternalUser`).
  */
 export interface SnUser {
   id: string;
@@ -61,10 +71,60 @@ export interface SnUser {
   name: string;
   email: string;
   timeZone?: string | null;
+  mobilePhone?: string | null;
+  userType?: UserType;
   active: boolean;
   createdOn: string;
   updatedOn: string;
   roles: string[];
+}
+
+/** One group the user belongs to. */
+export interface UserGroupRef {
+  id: string;
+  name: string;
+}
+
+/** One CRE/SRE team the user belongs to (a subset of their groups). */
+export interface UserTeamRef {
+  id: string;
+  name: string;
+  family?: string;
+}
+
+/**
+ * One project-contact row for an external user, reported as stored rather
+ * than as filtered. The backing access rule grants access only when the
+ * row's email matches the login exactly AND a contact record is linked; a
+ * row failing either test makes the project, and every case on it, silently
+ * invisible to that user — {@link grantsCaseAccess} is the verdict, the rest
+ * of the fields are the reasons.
+ */
+export interface UserProjectAccess {
+  projectId: string;
+  projectName: string;
+  contactEmail: string;
+  contactRecordPresent: boolean;
+  contactRecordEmail?: string;
+  emailMatchesLogin: boolean;
+  registrationState?: string;
+  notificationsEnabled?: boolean;
+  roles?: string[];
+  grantsCaseAccess: boolean;
+}
+
+/**
+ * `GET /users/{id}` response: the user row plus every group they belong to,
+ * the subset of those that are teams, and — for external contacts — their
+ * per-project access. ServiceNow data source only. The membership and
+ * project-access blocks are best-effort: empty rather than absent when their
+ * upstream lookup fails.
+ */
+export interface SnUserDetail extends SnUser {
+  groups?: UserGroupRef[];
+  teams?: UserTeamRef[];
+  /** Present for external contacts only. */
+  projectAccess?: UserProjectAccess[];
 }
 
 export interface UserSearchFilters {
@@ -122,12 +182,15 @@ export interface NormalizedUser {
   name: string;
   email: string;
   timezone: string | null;
-  /** Present only from the postgres source. */
   userType?: UserType;
   /** Present only from the ServiceNow source. */
   active?: boolean;
   /** Present only from the ServiceNow source. */
   roles?: string[];
+  /** Present from either source, when the caller requested the full profile. */
+  phone?: string | null;
+  createdOn?: string;
+  updatedOn?: string;
 }
 
 export interface NormalizedUserSearchResult {
@@ -151,8 +214,12 @@ export function normalizeUser(u: User | SnUser): NormalizedUser {
       name: u.name?.trim() || "",
       email: u.email,
       timezone: u.timeZone ?? null,
+      userType: u.userType,
       active: u.active,
       roles: u.roles,
+      phone: u.mobilePhone ?? null,
+      createdOn: u.createdOn,
+      updatedOn: u.updatedOn,
     };
   }
   return {
@@ -162,6 +229,30 @@ export function normalizeUser(u: User | SnUser): NormalizedUser {
     email: u.email,
     timezone: u.timezone ?? null,
     userType: u.userType,
+    phone: u.phone ?? null,
+    createdOn: u.createdAt,
+    updatedOn: u.updatedAt,
+  };
+}
+
+/**
+ * Full-profile counterpart of {@link NormalizedUser}: adds the group/team
+ * memberships and (for external contacts) per-project access that only
+ * `GET /users/{id}` returns.
+ */
+export interface NormalizedUserDetail extends NormalizedUser {
+  groups?: UserGroupRef[];
+  teams?: UserTeamRef[];
+  projectAccess?: UserProjectAccess[];
+}
+
+/** Maps `GET /users/{id}`'s response into {@link NormalizedUserDetail}. */
+export function normalizeUserDetail(u: SnUserDetail): NormalizedUserDetail {
+  return {
+    ...normalizeUser(u),
+    groups: u.groups,
+    teams: u.teams,
+    projectAccess: u.projectAccess,
   };
 }
 

--- a/apps/csm-portal/webapp/src/features/csm-users/types/csmUsers.ts
+++ b/apps/csm-portal/webapp/src/features/csm-users/types/csmUsers.ts
@@ -129,11 +129,25 @@ export interface SnUserDetail extends SnUser {
 
 export interface UserSearchFilters {
   searchQuery?: string;
-  /** ServiceNow data source only. */
-  roles?: SnUserRole[];
+  /**
+   * Filter by one or more role keys, as returned by `POST /roles/search`.
+   * Backing data source only. Named `roleIds` (not `roles`) to match the
+   * backend contract — a role's "id" is its key (e.g. "agent"), not a
+   * separate numeric identifier.
+   */
+  roleIds?: string[];
+  /** Restrict to specific users by id. Intersects with the other filters and
+   * lifts the active-only default. Backing data source only. */
+  userIds?: string[];
+  /** Restrict to members of these groups (group ids). Backing data source
+   * only. */
+  groupIds?: string[];
+  /** Restrict to members of these teams, by team registry key (not a UUID).
+   * Backing data source only. */
+  teamIds?: string[];
   userNames?: string[];
   emails?: string[];
-  /** ServiceNow data source only. */
+  /** Backing data source only. */
   active?: boolean | null;
 }
 

--- a/apps/csm-portal/webapp/src/features/csm-users/types/csmUsers.ts
+++ b/apps/csm-portal/webapp/src/features/csm-users/types/csmUsers.ts
@@ -15,11 +15,11 @@
 // under the License.
 
 /**
- * Whether the user is staff or a customer/partner contact. The postgres data
- * source emits `internal`, `customer`, or `system`; the ServiceNow data
- * source emits `internal` or `external`. Callers branching on staff-vs-not
- * must treat everything other than `internal` alike, not just `customer` or
- * just `external` — see `isInternalUser` in `UserProfilePage`.
+ * Whether the user is staff or a customer/partner contact. The value set
+ * differs by backing data source: one emits `internal`, `customer` or
+ * `system`, the other `internal` or `external`. Callers branching on
+ * staff-vs-not must treat everything other than `internal` alike, not just
+ * `customer` or just `external` — see `isInternalUser` in `UserProfilePage`.
  */
 export type UserType = "internal" | "external" | "customer" | "system";
 
@@ -116,7 +116,8 @@ export interface UserProjectAccess {
 /**
  * `GET /users/{id}` response: the user row plus every group they belong to,
  * the subset of those that are teams, and — for external contacts — their
- * per-project access. ServiceNow data source only. The membership and
+ * per-project access. Populated only for users sourced from the data source
+ * that carries group and project-contact records. The membership and
  * project-access blocks are best-effort: empty rather than absent when their
  * upstream lookup fails.
  */

--- a/apps/csm-portal/webapp/src/features/csm-users/utils/usersFiltersUrl.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-users/utils/usersFiltersUrl.test.ts
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_USERS_FILTERS,
+  readUsersFiltersFromUrl,
+  writeUsersFiltersToUrl,
+  type UsersFilters,
+} from "@features/csm-users/utils/usersFiltersUrl";
+
+describe("usersFiltersUrl", () => {
+  it("round-trips a fully populated filter set through the URL", () => {
+    const filters: UsersFilters = {
+      search: "jane",
+      roleIds: ["agent", "admin"],
+      groupIds: ["11111111-1111-1111-1111-111111111111"],
+      teamIds: ["alpha"],
+      active: "active",
+    };
+    const params = writeUsersFiltersToUrl(filters);
+    expect(readUsersFiltersFromUrl(params)).toEqual(filters);
+  });
+
+  it("omits default values so an unfiltered list has a clean URL", () => {
+    const params = writeUsersFiltersToUrl(DEFAULT_USERS_FILTERS);
+    expect(params.toString()).toBe("");
+  });
+
+  it("reads an empty URL back to the defaults", () => {
+    expect(readUsersFiltersFromUrl(new URLSearchParams())).toEqual(
+      DEFAULT_USERS_FILTERS,
+    );
+  });
+
+  it("ignores an invalid active value rather than throwing", () => {
+    const params = new URLSearchParams("active=bogus");
+    expect(readUsersFiltersFromUrl(params).active).toBe("all");
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-users/utils/usersFiltersUrl.ts
+++ b/apps/csm-portal/webapp/src/features/csm-users/utils/usersFiltersUrl.ts
@@ -1,0 +1,85 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+ * URL (de)serialization for the users-list filter bar, following the same
+ * `read*FiltersFromUrl` / `write*FiltersToUrl` convention as the cases list
+ * (`casesFiltersUrl.ts`) so a filtered user list is shareable and survives a
+ * reload. Deliberately no project/account filter here — "who is on this
+ * project" is answered by the project-contacts search instead.
+ */
+
+export type ActiveFilter = "all" | "active" | "inactive";
+
+export interface UsersFilters {
+  search: string;
+  roleIds: string[];
+  groupIds: string[];
+  teamIds: string[];
+  active: ActiveFilter;
+}
+
+export const DEFAULT_USERS_FILTERS: UsersFilters = {
+  search: "",
+  roleIds: [],
+  groupIds: [],
+  teamIds: [],
+  active: "all",
+};
+
+const VALID_ACTIVE_VALUES: ActiveFilter[] = ["all", "active", "inactive"];
+
+/**
+ * Parse a CSV of free-form ids (role keys, group ids, team keys — none of
+ * them a fixed client-side enum). Empties stripped, length-capped per entry
+ * to avoid pathological URL growth from a hand-edited link.
+ */
+function parseIdsCsv(raw: string | null, maxEntryLen = 120): string[] {
+  if (!raw) return [];
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0 && s.length <= maxEntryLen);
+}
+
+export function readUsersFiltersFromUrl(params: URLSearchParams): UsersFilters {
+  const activeRaw = params.get("active");
+  const active: ActiveFilter = (VALID_ACTIVE_VALUES as string[]).includes(activeRaw ?? "")
+    ? (activeRaw as ActiveFilter)
+    : "all";
+
+  return {
+    search: params.get("q") ?? "",
+    roleIds: parseIdsCsv(params.get("roles")),
+    groupIds: parseIdsCsv(params.get("groups")),
+    teamIds: parseIdsCsv(params.get("teams")),
+    active,
+  };
+}
+
+/**
+ * Build the search-params object representing these filters. Default values
+ * are omitted so the URL stays clean.
+ */
+export function writeUsersFiltersToUrl(f: UsersFilters): URLSearchParams {
+  const out = new URLSearchParams();
+  if (f.search) out.set("q", f.search);
+  if (f.roleIds.length) out.set("roles", f.roleIds.join(","));
+  if (f.groupIds.length) out.set("groups", f.groupIds.join(","));
+  if (f.teamIds.length) out.set("teams", f.teamIds.join(","));
+  if (f.active !== "all") out.set("active", f.active);
+  return out;
+}

--- a/apps/csm-portal/webapp/src/features/csm-users/utils/usersFiltersUrl.ts
+++ b/apps/csm-portal/webapp/src/features/csm-users/utils/usersFiltersUrl.ts
@@ -62,7 +62,7 @@ export function readUsersFiltersFromUrl(params: URLSearchParams): UsersFilters {
     : "all";
 
   return {
-    search: params.get("q") ?? "",
+    search: params.get("search") ?? "",
     roleIds: parseIdsCsv(params.get("roles")),
     groupIds: parseIdsCsv(params.get("groups")),
     teamIds: parseIdsCsv(params.get("teams")),
@@ -76,7 +76,7 @@ export function readUsersFiltersFromUrl(params: URLSearchParams): UsersFilters {
  */
 export function writeUsersFiltersToUrl(f: UsersFilters): URLSearchParams {
   const out = new URLSearchParams();
-  if (f.search) out.set("q", f.search);
+  if (f.search) out.set("search", f.search);
   if (f.roleIds.length) out.set("roles", f.roleIds.join(","));
   if (f.groupIds.length) out.set("groups", f.groupIds.join(","));
   if (f.teamIds.length) out.set("teams", f.teamIds.join(","));

--- a/entity-service/.env.example
+++ b/entity-service/.env.example
@@ -18,3 +18,14 @@ SERVICENOW_INTEGRATION_SERVICE_TOKEN_URL=<SERVICENOW_INTEGRATION_SERVICE_TOKEN_U
 SERVICENOW_INTEGRATION_SERVICE_CLIENT_ID=<SERVICENOW_INTEGRATION_SERVICE_CLIENT_ID>
 SERVICENOW_INTEGRATION_SERVICE_CLIENT_SECRET=<SERVICENOW_INTEGRATION_SERVICE_CLIENT_SECRET>
 SERVICENOW_INTEGRATION_SERVICE_SCOPES=<SERVICENOW_INTEGRATION_SERVICE_SCOPES>
+
+# Team registry — the curated account-based-team vocabulary, as
+# "teamKey|Display Name|FAMILY" rows separated by commas. The family field is
+# optional and is CRE or SRE. Display Name must match the team's group name in
+# the backing data source exactly. No default: unset means no teams are
+# configured, and the values below are placeholders, not real team names.
+CSM_TEAM_REGISTRY=alpha|Alpha Team|CRE,beta|Beta Team|SRE,gamma|Gamma Team
+
+# Assignable-role allow-list — validates the roleIds user filter and is the
+# catalogue POST /roles/search serves. Optional; unset uses this exact list.
+CSM_USER_ROLES=agent,admin,commenter,customer,customer_admin,partner,partner_admin,internal,external,timecard_approver

--- a/entity-service/.env.example
+++ b/entity-service/.env.example
@@ -24,7 +24,7 @@ SERVICENOW_INTEGRATION_SERVICE_SCOPES=<SERVICENOW_INTEGRATION_SERVICE_SCOPES>
 # optional and is CRE or SRE. Display Name must match the team's group name in
 # the backing data source exactly. No default: unset means no teams are
 # configured, and the values below are placeholders, not real team names.
-CSM_TEAM_REGISTRY=alpha|Alpha Team|CRE,beta|Beta Team|SRE,gamma|Gamma Team
+CSM_TEAM_REGISTRY="alpha|Alpha Team|CRE,beta|Beta Team|SRE,gamma|Gamma Team"
 
 # Assignable-role allow-list — validates the roleIds user filter and is the
 # catalogue POST /roles/search serves. Optional; unset uses this exact list.

--- a/entity-service/CLAUDE.md
+++ b/entity-service/CLAUDE.md
@@ -36,6 +36,13 @@ The server loads `.env` automatically on startup (silently ignored if absent). P
 | `DB_NAME`     | yes      | —       | Database name              |
 | `DB_SSLMODE`  | no       | —       | `disable` or `require`    |
 | `SERVER_PORT` | no       | `8080`  | HTTP listen port           |
+| `CSM_TEAM_REGISTRY` | no | — (empty registry) | Curated team vocabulary: `teamKey\|Display Name\|FAMILY` rows separated by commas, family optional (`CRE`/`SRE`). Deliberately has no default — team names are organisation vocabulary and must never be committed to this repo. A malformed row is fatal at startup. |
+| `CSM_USER_ROLES` | no | the 10 built-in role names | Assignable-role allow-list, comma-separated. Validates the `roleIds` user filter and is the catalogue `POST /roles/search` serves, so the dropdown and the filter cannot disagree. |
+
+Both are flat single-line strings on purpose: the deployment platform's
+configuration UI is one-dimensional and stringifies nested collections, so a
+structured registry cannot be deployed at all. Do not introduce nested-collection
+configuration here.
 
 ## Adding a new entity
 

--- a/entity-service/README.md
+++ b/entity-service/README.md
@@ -111,6 +111,36 @@ HTTP Request
 
 > `.env` file is loaded automatically if present. Absent `.env` is silently ignored; a malformed one causes a fatal startup error.
 
+### Directory vocabularies
+
+Two curated lists are supplied as configuration rather than code, so adding a team or a role is a
+config change and a restart, not a release. Both are parsed at startup: **a malformed value is
+fatal**, so a typo stops a deploy instead of silently emptying a page.
+
+| Variable            | Required | Default                | Description                                                          |
+| ------------------- | -------- | ---------------------- | -------------------------------------------------------------------- |
+| CSM_TEAM_REGISTRY   | No       | — (empty registry)     | Team catalogue. Rows separated by `,`, fields within a row by `\|`.    |
+| CSM_USER_ROLES      | No       | the built-in role list | Assignable-role allow-list, comma-separated.                          |
+
+```bash
+# Rows are `teamKey|Display Name` or `teamKey|Display Name|FAMILY`.
+# The names below are placeholders — supply the real ones per environment.
+CSM_TEAM_REGISTRY="alpha|Alpha Team|CRE,beta|Beta Team|SRE,gamma|Gamma Team"
+
+CSM_USER_ROLES="agent,admin,commenter,customer,customer_admin,partner,partner_admin,internal,external,timecard_approver"
+```
+
+`CSM_TEAM_REGISTRY` has **no default, by design**. Team names are organisation vocabulary and are
+deliberately not committed to this repository — only placeholders appear here and in
+`.env.example`. Unset, the registry is empty and team lookups return nothing, with a warning
+logged. `displayName` is matched verbatim against the backing data source's group name when
+resolving members, so a wrong or blank one resolves **zero members silently**; that is why an empty
+field is rejected outright.
+
+`CSM_USER_ROLES` does have a default, because role names are generic platform vocabulary rather
+than organisation-specific. It drives both the `roleIds` filter validation and the catalogue that
+`POST /roles/search` serves, so the picker and the filter cannot disagree.
+
 ## Security Scanning
 
 Run [gosec](https://github.com/securego/gosec) to check for common security issues:

--- a/entity-service/cmd/api/main.go
+++ b/entity-service/cmd/api/main.go
@@ -29,7 +29,9 @@ import (
 	"github.com/joho/godotenv"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/config"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/db"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/server"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/service"
 )
 
 func main() {
@@ -41,6 +43,21 @@ func main() {
 	if err := cfg.Validate(); err != nil {
 		log.Fatalf("invalid configuration: %v", err)
 	}
+
+	// The two curated directory vocabularies are deployment configuration.
+	// Parse them here so a typo stops the deploy rather than quietly emptying
+	// a dropdown at the first request.
+	teams, err := domain.ParseAbtTeamRegistry(cfg.TeamRegistry)
+	if err != nil {
+		log.Fatalf("invalid CSM_TEAM_REGISTRY: %v", err)
+	}
+	domain.SetAbtTeams(teams)
+
+	roles, err := service.ParseUserRoles(cfg.UserRoles)
+	if err != nil {
+		log.Fatalf("invalid CSM_USER_ROLES: %v", err)
+	}
+	service.SetUserRoles(roles)
 
 	pool, err := db.NewPoolIfNeeded(cfg)
 	if err != nil {

--- a/entity-service/internal/config/config.go
+++ b/entity-service/internal/config/config.go
@@ -53,6 +53,17 @@ type Config struct {
 	ServiceNowIntegrationServiceClientID     string
 	ServiceNowIntegrationServiceClientSecret string
 	ServiceNowIntegrationServiceScopes       string
+	// TeamRegistry is the raw CSM_TEAM_REGISTRY value: the curated ABT team
+	// registry as "teamKey|Display Name|FAMILY,..." rows. Parsed and installed
+	// at startup by domain.ParseAbtTeamRegistry / domain.SetAbtTeams. Empty
+	// means no teams are configured; there is deliberately no default, because
+	// team names are organisation vocabulary that must not be committed here.
+	TeamRegistry string
+	// UserRoles is the raw CSM_USER_ROLES value: a comma-separated
+	// assignable-role allow-list. Parsed and installed at startup by
+	// service.ParseUserRoles / service.SetUserRoles. Empty falls back to the
+	// committed default list.
+	UserRoles string
 }
 
 // Load reads configuration from environment variables and returns a populated
@@ -73,6 +84,8 @@ func Load() *Config {
 		ServiceNowIntegrationServiceClientID:     os.Getenv("SERVICENOW_INTEGRATION_SERVICE_CLIENT_ID"),
 		ServiceNowIntegrationServiceClientSecret: os.Getenv("SERVICENOW_INTEGRATION_SERVICE_CLIENT_SECRET"),
 		ServiceNowIntegrationServiceScopes:       os.Getenv("SERVICENOW_INTEGRATION_SERVICE_SCOPES"),
+		TeamRegistry:                             os.Getenv("CSM_TEAM_REGISTRY"),
+		UserRoles:                                os.Getenv("CSM_USER_ROLES"),
 	}
 }
 

--- a/entity-service/internal/domain/abt_team.go
+++ b/entity-service/internal/domain/abt_team.go
@@ -17,8 +17,6 @@
 package domain
 
 import (
-	"context"
-	"encoding/json"
 	"fmt"
 	"log"
 	"strings"
@@ -37,49 +35,47 @@ const (
 	AbtFamilySRE AbtFamily = "sre"
 )
 
-// AbtTeam is one of WSO2's Account-Based Teams. The registry of teams is
-// owned by a private-repo Ballerina endpoint and fetched live at runtime —
-// team names are never hardcoded in this public repo. The registry is a flat
-// list; there is no sub-team nesting.
+// AbtTeam is one of WSO2's Account-Based Teams. Team names are organisation
+// vocabulary and are never hardcoded in this repo: the registry is supplied as
+// deployment configuration (see ParseAbtTeamRegistry) and installed once at
+// startup. The registry is a flat list; there is no sub-team nesting.
 type AbtTeam struct {
-	TeamKey     string
-	DisplayName string // the exact ServiceNow group name; matched against group-members/search's groupName
-	Family      AbtFamily // may be empty -- not every team has a family assigned
+	TeamKey string
+	// DisplayName is the exact group name in the backing data source; it is
+	// matched verbatim against group-members/search's groupName, so an empty
+	// or misspelt value silently resolves zero members. ParseAbtTeamRegistry
+	// rejects an empty one for that reason.
+	DisplayName string
+	// Family may be empty -- not every team has a family assigned.
+	Family AbtFamily
 }
-
-// AbtTeamsFetcher fetches the raw ABT team registry JSON body from the
-// upstream Ballerina cs-entity-service (GET teams). It is registered via
-// SetAbtTeamsFetcher during service wiring, before the first call to
-// AbtGroupNames or FindAbtTeamByGroupName.
-type AbtTeamsFetcher func(ctx context.Context) (json.RawMessage, error)
 
 var (
-	abtMu      sync.Mutex
-	abtFetcher AbtTeamsFetcher
-	abtLoaded  bool
-	abtTeams   []AbtTeam
+	abtMu    sync.RWMutex
+	abtTeams []AbtTeam
 )
 
-// SetAbtTeamsFetcher registers the function used to populate the in-memory
-// ABT team registry on first use. Calling this again (e.g. in tests, or if
-// service wiring re-runs) invalidates any cached registry so the next lookup
-// re-fetches via the new fetcher.
-func SetAbtTeamsFetcher(fetch AbtTeamsFetcher) {
+// SetAbtTeams installs the ABT team registry. It is called once during startup
+// with the parsed contents of the team-registry configuration, and by tests.
+// An empty registry is legal (no teams configured) and is warned about rather
+// than rejected: team names cannot be defaulted in this repo, so a deployment
+// that has not set the variable yet must still start and serve every other
+// endpoint.
+func SetAbtTeams(teams []AbtTeam) {
 	abtMu.Lock()
 	defer abtMu.Unlock()
-	abtFetcher = fetch
-	abtLoaded = false
-	abtTeams = nil
+	abtTeams = append([]AbtTeam(nil), teams...)
+	if len(abtTeams) == 0 {
+		log.Printf("abtteam: team registry is empty; team filters and the team catalogue will return nothing")
+	}
 }
 
-// AbtGroupNames returns the ServiceNow group display name for every cached
-// ABT team, suitable for a single groupNames-IN membership query. Returns an
-// empty slice if the registry has never been populated or failed to load.
+// AbtGroupNames returns the backing data source's group display name for every
+// configured ABT team, suitable for a single groupNames-IN membership query.
+// Returns an empty slice if no teams are configured.
 func AbtGroupNames() []string {
-	ensureAbtRegistryLoaded()
-
-	abtMu.Lock()
-	defer abtMu.Unlock()
+	abtMu.RLock()
+	defer abtMu.RUnlock()
 
 	names := make([]string, 0, len(abtTeams))
 	for _, team := range abtTeams {
@@ -90,13 +86,11 @@ func AbtGroupNames() []string {
 	return names
 }
 
-// FindAbtTeamByGroupName looks up the ABT team whose ServiceNow group name
-// exactly matches groupName. ok is false if no team in the registry matches.
-// FindAbtTeamByKey looks a team up by its registry key.
+// FindAbtTeamByKey looks a team up by its registry key. ok is false if no
+// configured team matches.
 func FindAbtTeamByKey(key string) (team AbtTeam, ok bool) {
-	ensureAbtRegistryLoaded()
-	abtMu.Lock()
-	defer abtMu.Unlock()
+	abtMu.RLock()
+	defer abtMu.RUnlock()
 	for _, t := range abtTeams {
 		if t.TeamKey == key {
 			return t, true
@@ -105,21 +99,21 @@ func FindAbtTeamByKey(key string) (team AbtTeam, ok bool) {
 	return AbtTeam{}, false
 }
 
-// AbtTeams returns every team in the registry. Empty if the registry never loaded.
+// AbtTeams returns every configured team. Empty if none are configured.
 func AbtTeams() []AbtTeam {
-	ensureAbtRegistryLoaded()
-	abtMu.Lock()
-	defer abtMu.Unlock()
+	abtMu.RLock()
+	defer abtMu.RUnlock()
 	out := make([]AbtTeam, len(abtTeams))
 	copy(out, abtTeams)
 	return out
 }
 
+// FindAbtTeamByGroupName looks up the ABT team whose group name in the backing
+// data source exactly matches groupName. ok is false if no configured team
+// matches.
 func FindAbtTeamByGroupName(groupName string) (team AbtTeam, ok bool) {
-	ensureAbtRegistryLoaded()
-
-	abtMu.Lock()
-	defer abtMu.Unlock()
+	abtMu.RLock()
+	defer abtMu.RUnlock()
 
 	for _, t := range abtTeams {
 		if t.DisplayName == groupName {
@@ -129,97 +123,73 @@ func FindAbtTeamByGroupName(groupName string) (team AbtTeam, ok bool) {
 	return AbtTeam{}, false
 }
 
-// ensureAbtRegistryLoaded populates abtTeams on first use. Any failure (no
-// fetcher registered, fetch error, or parse error) is logged and degrades to
-// an empty registry for that call only: the failure is not cached, so the next
-// lookup retries. Caching a failure would leave team resolution permanently
-// empty for the rest of the process after one transient upstream outage.
-func ensureAbtRegistryLoaded() {
-	abtMu.Lock()
-	fetch := abtFetcher
-	alreadyLoaded := abtLoaded
-	abtMu.Unlock()
+// ParseAbtTeamRegistry parses the team registry from its flat, single-line
+// configuration form:
+//
+//	teamKey|Display Name|FAMILY,teamKey|Display Name,...
+//
+// Rows are separated by ",", fields within a row by "|". A row carries either
+// two fields (key and display name) or three (plus the family). Whitespace
+// around every field is trimmed, so a value pasted into a web form survives.
+// A wholly blank row is skipped, which tolerates a trailing comma.
+//
+// The single-line shape is deliberate: the deployment platform's configuration
+// UI is one-dimensional and stringifies nested collections, so a structured
+// (nested-array) registry cannot be deployed at all. Do not reintroduce one.
+//
+// An empty string yields no teams and no error. Any malformed row is an error
+// naming the offending row, so a typo stops a deploy instead of silently
+// degrading team resolution at the first request.
+func ParseAbtTeamRegistry(raw string) ([]AbtTeam, error) {
+	rows := strings.Split(raw, ",")
+	teams := make([]AbtTeam, 0, len(rows))
 
-	if alreadyLoaded {
-		return
-	}
-
-	var teams []AbtTeam
-	loaded := false
-	if fetch == nil {
-		log.Printf("abtteam: no fetcher registered; ABT team registry will be empty")
-	} else {
-		raw, err := fetch(context.Background())
-		if err != nil {
-			log.Printf("abtteam: fetch teams registry failed: %v", err)
-		} else {
-			teams, err = parseAbtTeamsResponse(raw)
-			if err != nil {
-				log.Printf("abtteam: parse abt-teams registry failed: %v", err)
-				teams = nil
-			} else {
-				// A successful but empty response is still a load: the registry
-				// legitimately has no teams and there is nothing to retry.
-				loaded = true
-			}
+	for i, row := range rows {
+		if strings.TrimSpace(row) == "" {
+			continue
 		}
+
+		fields := strings.Split(row, "|")
+		if len(fields) < 2 || len(fields) > 3 {
+			return nil, fmt.Errorf(
+				"team registry row %d (%q): expected 2 or 3 %q-separated fields (teamKey|displayName[|family]), got %d",
+				i+1, strings.TrimSpace(row), "|", len(fields))
+		}
+		for j := range fields {
+			fields[j] = strings.TrimSpace(fields[j])
+		}
+
+		if fields[0] == "" {
+			return nil, fmt.Errorf("team registry row %d (%q): teamKey is empty", i+1, strings.TrimSpace(row))
+		}
+		// An empty display name is the dangerous one: it is matched verbatim
+		// against the group name upstream, so it would resolve zero members
+		// without any error surfacing anywhere.
+		if fields[1] == "" {
+			return nil, fmt.Errorf("team registry row %d (%q): displayName is empty", i+1, strings.TrimSpace(row))
+		}
+
+		team := AbtTeam{TeamKey: fields[0], DisplayName: fields[1]}
+		if len(fields) == 3 {
+			team.Family = normalizeAbtFamily(fields[2])
+		}
+		teams = append(teams, team)
 	}
 
-	abtMu.Lock()
-	defer abtMu.Unlock()
-	// Another goroutine may have loaded (or reset, via SetAbtTeamsFetcher)
-	// concurrently; only commit if still unloaded for this fetcher generation,
-	// and only on success so a failed attempt does not poison the cache.
-	if !abtLoaded && loaded {
-		abtTeams = teams
-		abtLoaded = true
-	}
-}
-
-// wireAbtTeamsResponse mirrors the Ballerina GET abt-teams response.
-type wireAbtTeamsResponse struct {
-	Teams []wireAbtTeam `json:"teams"`
-}
-
-type wireAbtTeam struct {
-	TeamKey     string `json:"teamKey"`
-	DisplayName string `json:"displayName"`
-	Family      string `json:"family"` // "CRE" | "SRE" | absent
-}
-
-// parseAbtTeamsResponse parses the wire response and normalizes the
-// uppercase wire "family" ("CRE" | "SRE") into this package's lowercase
-// AbtFamily constants. Teams with no family (absent/unrecognized wire value)
-// get an empty AbtFamily rather than a parse error -- not every team is
-// classified.
-func parseAbtTeamsResponse(raw json.RawMessage) ([]AbtTeam, error) {
-	var wire wireAbtTeamsResponse
-	if err := json.Unmarshal(raw, &wire); err != nil {
-		return nil, fmt.Errorf("abtteam: parse abt-teams response: %w", err)
-	}
-
-	teams := make([]AbtTeam, 0, len(wire.Teams))
-	for _, wt := range wire.Teams {
-		teams = append(teams, AbtTeam{
-			TeamKey:     wt.TeamKey,
-			DisplayName: wt.DisplayName,
-			Family:      normalizeAbtFamily(wt.Family),
-		})
-	}
 	return teams, nil
 }
 
-// normalizeAbtFamily normalizes the wire's uppercase "CRE"/"SRE" into this
-// package's lowercase AbtFamily constants. Any other value (including the
-// absent/empty case) is passed through lowercased rather than rejected, so an
-// unclassified team or a future family value never breaks registry parsing.
-func normalizeAbtFamily(wireFamily string) AbtFamily {
-	switch wireFamily {
+// normalizeAbtFamily normalizes the configured "CRE"/"SRE" (in any case) into
+// this package's lowercase AbtFamily constants. Any other value (including the
+// empty case) is passed through lowercased rather than rejected, so an
+// unclassified team or a future family value never blocks a deploy.
+func normalizeAbtFamily(family string) AbtFamily {
+	switch strings.ToUpper(family) {
 	case "CRE":
 		return AbtFamilyCRE
 	case "SRE":
 		return AbtFamilySRE
 	default:
-		return AbtFamily(strings.ToLower(wireFamily))
+		return AbtFamily(strings.ToLower(family))
 	}
 }

--- a/entity-service/internal/domain/abt_team_test.go
+++ b/entity-service/internal/domain/abt_team_test.go
@@ -17,31 +17,20 @@
 package domain
 
 import (
-	"context"
-	"encoding/json"
-	"errors"
+	"strings"
 	"testing"
 )
 
-// abtTeamsFixtureJSON is a representative (not real) flat ABT registry:
-// several CRE teams, an SRE team, and an unclassified team with no "family"
-// field at all (mirrors the 6 unclassified teams in the real 15-team list).
-const abtTeamsFixtureJSON = `{
-	"teams": [
-		{"teamKey": "castor", "displayName": "Castor", "family": "CRE"},
-		{"teamKey": "sirius", "displayName": "Sirius", "family": "CRE"},
-		{"teamKey": "vega", "displayName": "Vega", "family": "CRE"},
-		{"teamKey": "apollo", "displayName": "Apollo SRE Group", "family": "SRE"},
-		{"teamKey": "iam_us", "displayName": "IAM-US", "family": "CRE"},
-		{"teamKey": "customer_onboarding", "displayName": "Customer Onboarding"}
-	]
-}`
+// abtTeamRegistryFixture is a representative registry in the configured wire
+// form: two classified teams, one unclassified (2-field) team, and a
+// hyphenated display name. Every name here is an invented placeholder -- real
+// team names are organisation vocabulary and never appear in this repo.
+const abtTeamRegistryFixture = "alpha|Alpha Team|CRE,beta|Beta SRE Group|SRE,delta|Delta-Two|cre,gamma|Gamma Team"
 
-// resetAbtRegistry clears package-level ABT registry state so the calling test
-// starts from a clean, unloaded cache, and registers a cleanup that clears it
-// again on exit. Without the cleanup the last test to run leaves its fetcher and
-// cached teams in place, which any later test in this package would silently
-// inherit -- making results order-dependent.
+// resetAbtRegistry clears the package-level registry so the calling test starts
+// clean, and registers a cleanup that clears it again on exit. Without the
+// cleanup the last test to run leaves its teams in place, which any later test
+// in this package would silently inherit -- making results order-dependent.
 func resetAbtRegistry(t *testing.T) {
 	t.Helper()
 	clearAbtRegistry()
@@ -51,9 +40,17 @@ func resetAbtRegistry(t *testing.T) {
 func clearAbtRegistry() {
 	abtMu.Lock()
 	defer abtMu.Unlock()
-	abtFetcher = nil
-	abtLoaded = false
 	abtTeams = nil
+}
+
+// mustSetRegistry parses raw and installs it, failing the test on a parse error.
+func mustSetRegistry(t *testing.T, raw string) {
+	t.Helper()
+	teams, err := ParseAbtTeamRegistry(raw)
+	if err != nil {
+		t.Fatalf("ParseAbtTeamRegistry(%q) returned error: %v", raw, err)
+	}
+	SetAbtTeams(teams)
 }
 
 // TestAbtRegistry_StartsClean deliberately does NOT call resetAbtRegistry: it asserts that
@@ -61,165 +58,221 @@ func clearAbtRegistry() {
 // resetAbtRegistry's cleanup load-bearing -- drop the cleanup and this fails under
 // -shuffle=on whenever it is not scheduled first.
 func TestAbtRegistry_StartsClean(t *testing.T) {
-	abtMu.Lock()
-	fetcher, loaded, teams := abtFetcher, abtLoaded, abtTeams
-	abtMu.Unlock()
+	abtMu.RLock()
+	teams := abtTeams
+	abtMu.RUnlock()
 
-	if fetcher != nil || loaded || teams != nil {
-		t.Fatalf("registry not clean on entry: fetcher set=%t loaded=%t teams=%d; an earlier test leaked state",
-			fetcher != nil, loaded, len(teams))
+	if teams != nil {
+		t.Fatalf("registry not clean on entry: %d teams; an earlier test leaked state", len(teams))
 	}
 }
 
-func TestAbtRegistry_FetchAndCache_PopulatesCorrectly(t *testing.T) {
+func TestParseAbtTeamRegistry_PopulatesCorrectly(t *testing.T) {
 	resetAbtRegistry(t)
-	SetAbtTeamsFetcher(func(ctx context.Context) (json.RawMessage, error) {
-		return json.RawMessage(abtTeamsFixtureJSON), nil
-	})
+	mustSetRegistry(t, abtTeamRegistryFixture)
 
 	names := AbtGroupNames()
-	if len(names) != 6 {
-		t.Fatalf("AbtGroupNames() returned %d names, want 6: %v", len(names), names)
+	if len(names) != 4 {
+		t.Fatalf("AbtGroupNames() returned %d names, want 4: %v", len(names), names)
 	}
 
-	// Sirius: CRE.
-	sirius, ok := FindAbtTeamByGroupName("Sirius")
+	// Three fields, family CRE.
+	alpha, ok := FindAbtTeamByGroupName("Alpha Team")
 	if !ok {
-		t.Fatalf("expected to find Sirius")
+		t.Fatalf("expected to find Alpha Team")
 	}
-	if sirius.TeamKey != "sirius" || sirius.Family != AbtFamilyCRE {
-		t.Fatalf("Sirius = %+v, want teamKey=sirius family=cre", sirius)
+	if alpha.TeamKey != "alpha" || alpha.Family != AbtFamilyCRE {
+		t.Fatalf("Alpha Team = %+v, want teamKey=alpha family=cre", alpha)
 	}
 
-	// IAM-US: flat team (not a sub-team), CRE.
-	iamUS, ok := FindAbtTeamByGroupName("IAM-US")
+	// Three fields, family SRE, multi-word display name.
+	beta, ok := FindAbtTeamByGroupName("Beta SRE Group")
 	if !ok {
-		t.Fatalf("expected to find IAM-US")
+		t.Fatalf("expected to find Beta SRE Group")
 	}
-	if iamUS.TeamKey != "iam_us" || iamUS.Family != AbtFamilyCRE {
-		t.Fatalf("IAM-US = %+v, want teamKey=iam_us family=cre", iamUS)
+	if beta.TeamKey != "beta" || beta.Family != AbtFamilySRE {
+		t.Fatalf("Beta SRE Group = %+v, want teamKey=beta family=sre", beta)
 	}
 
-	// Apollo SRE Group: SRE.
-	apollo, ok := FindAbtTeamByGroupName("Apollo SRE Group")
+	// A lowercase family in config normalizes the same way an uppercase one does.
+	delta, ok := FindAbtTeamByGroupName("Delta-Two")
 	if !ok {
-		t.Fatalf("expected to find Apollo SRE Group")
+		t.Fatalf("expected to find Delta-Two")
 	}
-	if apollo.TeamKey != "apollo" || apollo.Family != AbtFamilySRE {
-		t.Fatalf("Apollo = %+v, want teamKey=apollo family=sre", apollo)
+	if delta.TeamKey != "delta" || delta.Family != AbtFamilyCRE {
+		t.Fatalf("Delta-Two = %+v, want teamKey=delta family=cre", delta)
 	}
 
-	// Customer Onboarding: no family field at all -- must still parse and
-	// match, with an empty Family rather than a parse error.
-	onboarding, ok := FindAbtTeamByGroupName("Customer Onboarding")
+	// Two fields: no family, and that is not an error.
+	gamma, ok := FindAbtTeamByGroupName("Gamma Team")
 	if !ok {
-		t.Fatalf("expected to find Customer Onboarding")
+		t.Fatalf("expected to find Gamma Team")
 	}
-	if onboarding.TeamKey != "customer_onboarding" || onboarding.Family != "" {
-		t.Fatalf("Customer Onboarding = %+v, want teamKey=customer_onboarding family=\"\"", onboarding)
+	if gamma.TeamKey != "gamma" || gamma.Family != "" {
+		t.Fatalf("Gamma Team = %+v, want teamKey=gamma family=\"\"", gamma)
+	}
+
+	// Lookup by key works for the same rows.
+	if team, ok := FindAbtTeamByKey("beta"); !ok || team.DisplayName != "Beta SRE Group" {
+		t.Fatalf("FindAbtTeamByKey(\"beta\") = %+v, %t; want the Beta SRE Group row", team, ok)
+	}
+	if _, ok := FindAbtTeamByKey("nope"); ok {
+		t.Fatalf("expected no match for an unknown team key")
 	}
 
 	// Unknown name -> no match.
 	if _, ok := FindAbtTeamByGroupName("Does Not Exist"); ok {
 		t.Fatalf("expected no match for unknown group name")
 	}
+
+	// AbtTeams preserves configured order.
+	all := AbtTeams()
+	if len(all) != 4 || all[0].TeamKey != "alpha" || all[3].TeamKey != "gamma" {
+		t.Fatalf("AbtTeams() = %+v, want the 4 configured rows in order", all)
+	}
 }
 
-func TestAbtRegistry_FetchFailure_DegradesToEmptyRegistry(t *testing.T) {
+// TestParseAbtTeamRegistry_TrimsWhitespace covers the value someone types into
+// a deployment platform's web form, with spaces around the separators.
+func TestParseAbtTeamRegistry_TrimsWhitespace(t *testing.T) {
 	resetAbtRegistry(t)
-	SetAbtTeamsFetcher(func(ctx context.Context) (json.RawMessage, error) {
-		return nil, errors.New("upstream unavailable")
-	})
+	mustSetRegistry(t, "  alpha | Alpha Team | CRE , beta | Beta Team ")
+
+	if _, ok := FindAbtTeamByGroupName("Alpha Team"); !ok {
+		t.Fatalf("expected \"Alpha Team\" to match after trimming; got names %v", AbtGroupNames())
+	}
+	alpha, _ := FindAbtTeamByKey("alpha")
+	if alpha.TeamKey != "alpha" || alpha.DisplayName != "Alpha Team" || alpha.Family != AbtFamilyCRE {
+		t.Fatalf("alpha = %+v, want every field trimmed", alpha)
+	}
+	beta, ok := FindAbtTeamByKey("beta")
+	if !ok || beta.DisplayName != "Beta Team" {
+		t.Fatalf("beta = %+v, %t; want DisplayName \"Beta Team\"", beta, ok)
+	}
+}
+
+// TestParseAbtTeamRegistry_TrailingCommaTolerated: a blank row is skipped, not
+// rejected -- a trailing comma is not worth failing a deploy over.
+func TestParseAbtTeamRegistry_TrailingCommaTolerated(t *testing.T) {
+	teams, err := ParseAbtTeamRegistry("alpha|Alpha Team,")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(teams) != 1 {
+		t.Fatalf("got %d teams, want 1: %+v", len(teams), teams)
+	}
+}
+
+func TestParseAbtTeamRegistry_RejectsMalformedRows(t *testing.T) {
+	cases := []struct {
+		name    string
+		raw     string
+		wantIn  string // substring the error must name
+		wantRow string // the offending row must be quoted in the error
+	}{
+		{
+			name:    "one field",
+			raw:     "alpha|Alpha Team,beta",
+			wantIn:  "row 2",
+			wantRow: "beta",
+		},
+		{
+			name:    "four fields",
+			raw:     "alpha|Alpha Team|CRE|extra",
+			wantIn:  "row 1",
+			wantRow: "alpha|Alpha Team|CRE|extra",
+		},
+		{
+			name:    "empty teamKey",
+			raw:     "alpha|Alpha Team,|Beta Team|SRE",
+			wantIn:  "teamKey is empty",
+			wantRow: "|Beta Team|SRE",
+		},
+		{
+			name:    "whitespace-only teamKey",
+			raw:     "   |Alpha Team",
+			wantIn:  "teamKey is empty",
+			wantRow: "|Alpha Team",
+		},
+		{
+			// The dangerous one: an empty display name is matched verbatim
+			// against the upstream group name, so it resolves zero members
+			// without surfacing an error anywhere.
+			name:    "empty displayName",
+			raw:     "alpha|",
+			wantIn:  "displayName is empty",
+			wantRow: "alpha|",
+		},
+		{
+			name:    "whitespace-only displayName",
+			raw:     "alpha|   |CRE",
+			wantIn:  "displayName is empty",
+			wantRow: "alpha|   |CRE",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			teams, err := ParseAbtTeamRegistry(tc.raw)
+			if err == nil {
+				t.Fatalf("ParseAbtTeamRegistry(%q) = %+v, nil; want an error", tc.raw, teams)
+			}
+			if teams != nil {
+				t.Fatalf("ParseAbtTeamRegistry(%q) returned teams %+v alongside its error; want nil", tc.raw, teams)
+			}
+			if !strings.Contains(err.Error(), tc.wantIn) {
+				t.Fatalf("error %q does not mention %q", err, tc.wantIn)
+			}
+			if !strings.Contains(err.Error(), tc.wantRow) {
+				t.Fatalf("error %q does not name the offending row %q", err, tc.wantRow)
+			}
+		})
+	}
+}
+
+// TestAbtRegistry_UnsetConfig_EmptyRegistryNoPanic: an unset variable is legal.
+// The service must start and every lookup must return empty rather than panic.
+func TestAbtRegistry_UnsetConfig_EmptyRegistryNoPanic(t *testing.T) {
+	resetAbtRegistry(t)
+
+	teams, err := ParseAbtTeamRegistry("")
+	if err != nil {
+		t.Fatalf("ParseAbtTeamRegistry(\"\") returned error %v, want nil", err)
+	}
+	if len(teams) != 0 {
+		t.Fatalf("ParseAbtTeamRegistry(\"\") = %+v, want no teams", teams)
+	}
+	SetAbtTeams(teams)
 
 	names := AbtGroupNames()
 	if names == nil {
 		t.Fatalf("AbtGroupNames() returned nil, want empty non-nil slice")
 	}
 	if len(names) != 0 {
-		t.Fatalf("AbtGroupNames() = %v, want empty on fetch failure", names)
+		t.Fatalf("AbtGroupNames() = %v, want empty", names)
 	}
-
-	if _, ok := FindAbtTeamByGroupName("Castor"); ok {
-		t.Fatalf("expected no match when registry failed to load")
+	if _, ok := FindAbtTeamByGroupName("Alpha Team"); ok {
+		t.Fatalf("expected no match against an empty registry")
 	}
-}
-
-func TestAbtRegistry_NoFetcherRegistered_DegradesToEmptyRegistry(t *testing.T) {
-	resetAbtRegistry(t)
-
-	names := AbtGroupNames()
-	if len(names) != 0 {
-		t.Fatalf("AbtGroupNames() = %v, want empty when no fetcher registered", names)
+	if _, ok := FindAbtTeamByKey("alpha"); ok {
+		t.Fatalf("expected no key match against an empty registry")
+	}
+	if got := AbtTeams(); len(got) != 0 {
+		t.Fatalf("AbtTeams() = %+v, want empty", got)
 	}
 }
 
-// TestAbtRegistry_FetchFailure_IsNotCached guards the availability property that
-// matters most here: one transient upstream failure must not leave the registry
-// permanently empty. A failed load is not committed, so the very next lookup
-// retries and picks up the recovered upstream.
-func TestAbtRegistry_FetchFailure_IsNotCached(t *testing.T) {
+// TestSetAbtTeams_CopiesInput guards against the caller mutating the slice it
+// handed over and silently rewriting the live registry.
+func TestSetAbtTeams_CopiesInput(t *testing.T) {
 	resetAbtRegistry(t)
 
-	calls := 0
-	failing := true
-	SetAbtTeamsFetcher(func(ctx context.Context) (json.RawMessage, error) {
-		calls++
-		if failing {
-			return nil, errors.New("upstream unavailable")
-		}
-		return json.RawMessage(abtTeamsFixtureJSON), nil
-	})
+	teams := []AbtTeam{{TeamKey: "alpha", DisplayName: "Alpha Team"}}
+	SetAbtTeams(teams)
+	teams[0].DisplayName = "Mutated"
 
-	if names := AbtGroupNames(); len(names) != 0 {
-		t.Fatalf("AbtGroupNames() = %v, want empty while upstream is failing", names)
-	}
-
-	// Upstream recovers. No restart, no SetAbtTeamsFetcher call.
-	failing = false
-
-	names := AbtGroupNames()
-	if len(names) != 6 {
-		t.Fatalf("after recovery AbtGroupNames() returned %d names, want 6: %v", len(names), names)
-	}
-	if _, ok := FindAbtTeamByGroupName("Castor"); !ok {
-		t.Fatalf("expected Castor to resolve after the registry recovered")
-	}
-	if calls != 2 {
-		t.Fatalf("fetcher called %d times, want 2 (one failed attempt, then one retry that is cached)", calls)
-	}
-}
-
-// TestAbtRegistry_NoFetcher_IsNotCached checks the same for the missing-fetcher
-// path: a lookup made before service wiring registers the fetcher must not
-// permanently mark the registry loaded.
-func TestAbtRegistry_NoFetcher_IsNotCached(t *testing.T) {
-	resetAbtRegistry(t)
-
-	if names := AbtGroupNames(); len(names) != 0 {
-		t.Fatalf("AbtGroupNames() = %v, want empty with no fetcher registered", names)
-	}
-
-	abtMu.Lock()
-	loaded := abtLoaded
-	abtMu.Unlock()
-	if loaded {
-		t.Fatalf("abtLoaded = true after a lookup with no fetcher; the empty registry is now permanent")
-	}
-}
-
-func TestAbtRegistry_LoadsOnlyOnce(t *testing.T) {
-	resetAbtRegistry(t)
-	calls := 0
-	SetAbtTeamsFetcher(func(ctx context.Context) (json.RawMessage, error) {
-		calls++
-		return json.RawMessage(abtTeamsFixtureJSON), nil
-	})
-
-	_ = AbtGroupNames()
-	_ = AbtGroupNames()
-	_, _ = FindAbtTeamByGroupName("Castor")
-
-	if calls != 1 {
-		t.Fatalf("fetcher called %d times, want exactly 1 (cached after first load)", calls)
+	got, ok := FindAbtTeamByKey("alpha")
+	if !ok || got.DisplayName != "Alpha Team" {
+		t.Fatalf("registry = %+v after the caller mutated its slice; want DisplayName \"Alpha Team\"", got)
 	}
 }

--- a/entity-service/internal/server/directory_routes_test.go
+++ b/entity-service/internal/server/directory_routes_test.go
@@ -1,0 +1,172 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/config"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/service"
+)
+
+// newDirectoryRouter builds the real router against a stubbed upstream, so the
+// three directory searches are exercised over HTTP exactly as a caller hits
+// them. teamRegistry and userRoles are the raw configuration values.
+func newDirectoryRouter(t *testing.T, teamRegistry, userRoles string) http.Handler {
+	t.Helper()
+
+	upstream := http.NewServeMux()
+	upstream.HandleFunc("/oauth2/token", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "test-token", "expires_in": 3600})
+	})
+	// Groups are a live query against the backing data source, unchanged by the
+	// move of the curated vocabularies into configuration.
+	upstream.HandleFunc("/groups/search", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"groups":[{"id":"11111111111111111111111111111111","name":"Some Group","active":true,"parent":null}],` +
+			`"totalRecords":1,"offset":0,"limit":20}`))
+	})
+	srv := httptest.NewServer(upstream)
+	t.Cleanup(srv.Close)
+
+	teams, err := domain.ParseAbtTeamRegistry(teamRegistry)
+	if err != nil {
+		t.Fatalf("ParseAbtTeamRegistry(%q): %v", teamRegistry, err)
+	}
+	domain.SetAbtTeams(teams)
+	t.Cleanup(func() { domain.SetAbtTeams(nil) })
+
+	roles, err := service.ParseUserRoles(userRoles)
+	if err != nil {
+		t.Fatalf("ParseUserRoles(%q): %v", userRoles, err)
+	}
+	service.SetUserRoles(roles)
+	t.Cleanup(func() {
+		defaults, _ := service.ParseUserRoles("")
+		service.SetUserRoles(defaults)
+	})
+
+	return NewRouter(nil, &config.Config{
+		DataSource:                               config.DataSourceServiceNow,
+		ServiceNowIntegrationServiceBaseURL:      srv.URL,
+		ServiceNowIntegrationServiceTokenURL:     srv.URL + "/oauth2/token",
+		ServiceNowIntegrationServiceClientID:     "test-client",
+		ServiceNowIntegrationServiceClientSecret: "test-secret",
+	})
+}
+
+func postJSON(t *testing.T, router http.Handler, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("POST %s = %d, want 200: %s", path, rec.Code, rec.Body.String())
+	}
+	return rec
+}
+
+// TestDirectorySearches_AllThreeStillWork covers the whole surface this change
+// touches: teams and roles now come from configuration, groups are still a
+// live query against the backing data source.
+func TestDirectorySearches_AllThreeStillWork(t *testing.T) {
+	router := newDirectoryRouter(t, "alpha|Alpha Team|CRE,beta|Beta Team|SRE", "agent,timecard_approver")
+
+	t.Run("teams reflect the configured registry", func(t *testing.T) {
+		rec := postJSON(t, router, "/teams/search", `{"pagination":{"limit":20}}`)
+		var got struct {
+			Teams []struct {
+				ID     string `json:"id"`
+				Name   string `json:"name"`
+				Family string `json:"family"`
+			} `json:"teams"`
+			Total int `json:"total"`
+		}
+		if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+			t.Fatalf("decode response: %v (%s)", err, rec.Body.String())
+		}
+		if got.Total != 2 {
+			t.Fatalf("total = %d, want 2: %s", got.Total, rec.Body.String())
+		}
+		if got.Teams[0].ID != "alpha" || got.Teams[0].Name != "Alpha Team" || got.Teams[0].Family != "cre" {
+			t.Fatalf("teams[0] = %+v, want the configured alpha row", got.Teams[0])
+		}
+		if got.Teams[1].ID != "beta" || got.Teams[1].Family != "sre" {
+			t.Fatalf("teams[1] = %+v, want the configured beta row", got.Teams[1])
+		}
+	})
+
+	t.Run("roles reflect the configured allow-list", func(t *testing.T) {
+		rec := postJSON(t, router, "/roles/search", `{"pagination":{"limit":20}}`)
+		var got struct {
+			Roles []struct {
+				ID   string `json:"id"`
+				Name string `json:"name"`
+			} `json:"roles"`
+			Total int `json:"total"`
+		}
+		if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+			t.Fatalf("decode response: %v (%s)", err, rec.Body.String())
+		}
+		if got.Total != 2 {
+			t.Fatalf("total = %d, want the 2 configured roles: %s", got.Total, rec.Body.String())
+		}
+		if got.Roles[0].ID != "agent" || got.Roles[1].ID != "timecard_approver" {
+			t.Fatalf("roles = %+v, want [agent timecard_approver]", got.Roles)
+		}
+	})
+
+	t.Run("groups are still a live upstream query", func(t *testing.T) {
+		rec := postJSON(t, router, "/groups/search", `{"pagination":{"limit":20}}`)
+		if !strings.Contains(rec.Body.String(), "Some Group") {
+			t.Fatalf("groups response = %s, want the upstream row", rec.Body.String())
+		}
+	})
+}
+
+// TestRolesSearch_UnconfiguredUsesDefaults: a deployment that sets nothing
+// still serves the committed default catalogue.
+func TestRolesSearch_UnconfiguredUsesDefaults(t *testing.T) {
+	router := newDirectoryRouter(t, "", "")
+
+	rec := postJSON(t, router, "/roles/search", `{"pagination":{"limit":20}}`)
+	var got struct {
+		Total int `json:"total"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode response: %v (%s)", err, rec.Body.String())
+	}
+	if got.Total != 10 {
+		t.Fatalf("total = %d, want the 10 default roles: %s", got.Total, rec.Body.String())
+	}
+
+	// An unconfigured team registry is an empty catalogue, not an error.
+	rec = postJSON(t, router, "/teams/search", `{"pagination":{"limit":20}}`)
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode response: %v (%s)", err, rec.Body.String())
+	}
+	if got.Total != 0 {
+		t.Fatalf("total = %d, want an empty team catalogue: %s", got.Total, rec.Body.String())
+	}
+}

--- a/entity-service/internal/service/role_service.go
+++ b/entity-service/internal/service/role_service.go
@@ -29,8 +29,9 @@ import (
 // The catalogue is this layer's own curated list, not a query against the backing data
 // source. That source carries dozens of roles that ship with the product and mean nothing
 // to a CS engineer, and their ids differ per environment. The keys here are stable, are
-// exactly what the user search accepts in roleIds, and come from the same map that
-// validates that filter -- so the dropdown and the filter can never disagree.
+// exactly what the user search accepts in roleIds, and come from the same configured
+// allow-list that validates that filter -- so the dropdown and the filter can never
+// disagree.
 type roleService struct{}
 
 // NewRoleService constructs a RoleService.
@@ -41,11 +42,12 @@ func NewRoleService() RoleService {
 func (s *roleService) SearchRoles(
 	_ context.Context, req domain.SearchRolesRequest,
 ) (domain.SearchRolesResponse, error) {
-	roles := make([]domain.Role, 0, len(validUserRole))
-	for key := range validUserRole {
+	catalogue := UserRoleCatalogue()
+	roles := make([]domain.Role, 0, len(catalogue))
+	for _, key := range catalogue {
 		roles = append(roles, domain.Role{ID: string(key), Name: roleDisplayName(string(key))})
 	}
-	// Map iteration order is random; sort so paging is stable across calls.
+	// Configuration order is whatever the deployer typed; sort so paging is stable.
 	sort.Slice(roles, func(i, j int) bool { return roles[i].ID < roles[j].ID })
 
 	if q := strings.TrimSpace(req.Filters.SearchQuery); q != "" {

--- a/entity-service/internal/service/sn_user_directory_test.go
+++ b/entity-service/internal/service/sn_user_directory_test.go
@@ -63,12 +63,11 @@ func itoa(n int) string {
 // would send no id filter upstream and return every user, which reads as "everyone
 // matched" — the opposite of the truth.
 func TestSNUserService_SearchUsers_TeamFilterNoMembers(t *testing.T) {
+	withTeamRegistry(t, abtTeamRegistryFixture)
+
 	searchCalled := false
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("/teams", func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte(abtTeamsFixtureJSON))
-	})
 	mux.HandleFunc("/group-members/search", func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte(`{"memberships": [], "totalRecords": 0}`))
 	})
@@ -81,7 +80,7 @@ func TestSNUserService_SearchUsers_TeamFilterNoMembers(t *testing.T) {
 
 	got, err := svc.SearchUsers(contextWithUserIDToken("token"), domain.SearchUsersRequest{
 		Pagination: domain.Pagination{Limit: 20},
-		Filters:    domain.SearchUsersFilters{TeamIDs: []string{"castor"}},
+		Filters:    domain.SearchUsersFilters{TeamIDs: []string{"alpha"}},
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -96,15 +95,14 @@ func TestSNUserService_SearchUsers_TeamFilterNoMembers(t *testing.T) {
 
 // A team filter that does resolve must send the members' ids upstream.
 func TestSNUserService_SearchUsers_TeamFilterSendsUserIDs(t *testing.T) {
+	withTeamRegistry(t, abtTeamRegistryFixture)
+
 	memberSysid := sysid32('a')
 	var captured []byte
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("/teams", func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte(abtTeamsFixtureJSON))
-	})
 	mux.HandleFunc("/group-members/search", func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte(membershipsJSON(memberSysid, "Castor")))
+		_, _ = w.Write([]byte(membershipsJSON(memberSysid, "Alpha Team")))
 	})
 	mux.HandleFunc("/users/search", func(w http.ResponseWriter, r *http.Request) {
 		captured, _ = io.ReadAll(r.Body)
@@ -115,7 +113,7 @@ func TestSNUserService_SearchUsers_TeamFilterSendsUserIDs(t *testing.T) {
 
 	got, err := svc.SearchUsers(contextWithUserIDToken("token"), domain.SearchUsersRequest{
 		Pagination: domain.Pagination{Limit: 20},
-		Filters:    domain.SearchUsersFilters{TeamIDs: []string{"castor"}},
+		Filters:    domain.SearchUsersFilters{TeamIDs: []string{"alpha"}},
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -145,10 +143,9 @@ func TestSNUserService_SearchUsers_TeamFilterSendsUserIDs(t *testing.T) {
 
 // An unknown team key is a client error, not a silent empty result.
 func TestSNUserService_SearchUsers_UnknownTeamKey(t *testing.T) {
+	withTeamRegistry(t, abtTeamRegistryFixture)
+
 	mux := http.NewServeMux()
-	mux.HandleFunc("/teams", func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte(abtTeamsFixtureJSON))
-	})
 
 	svc := NewServiceNowUserService(newTestSNClient(t, mux))
 
@@ -164,18 +161,17 @@ func TestSNUserService_SearchUsers_UnknownTeamKey(t *testing.T) {
 
 // GetUser enriches the row with every group the user is in, and marks registry teams.
 func TestSNUserService_GetUser_GroupsAndTeams(t *testing.T) {
+	withTeamRegistry(t, abtTeamRegistryFixture)
+
 	userSysid := sysid32('b')
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("/teams", func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte(abtTeamsFixtureJSON))
-	})
 	mux.HandleFunc("/users/search", func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte(usersSearchJSON(snUserRowJSON(userSysid, "staff@wso2.com", "internal"))))
 	})
 	mux.HandleFunc("/group-members/search", func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte(`{"memberships":[` +
-			`{"userId":"` + userSysid + `","groupId":"` + sysid32('c') + `","groupName":"Castor"},` +
+			`{"userId":"` + userSysid + `","groupId":"` + sysid32('c') + `","groupName":"Alpha Team"},` +
 			`{"userId":"` + userSysid + `","groupId":"` + sysid32('d') + `","groupName":"Some Other Group"}` +
 			`],"totalRecords":2}`))
 	})
@@ -189,7 +185,7 @@ func TestSNUserService_GetUser_GroupsAndTeams(t *testing.T) {
 	if len(got.Groups) != 2 {
 		t.Fatalf("got %d groups, want 2", len(got.Groups))
 	}
-	if len(got.Teams) != 1 || got.Teams[0].ID != "castor" {
+	if len(got.Teams) != 1 || got.Teams[0].ID != "alpha" {
 		t.Fatalf("teams = %+v, want just castor", got.Teams)
 	}
 	// Staff get no project-access block.
@@ -200,13 +196,12 @@ func TestSNUserService_GetUser_GroupsAndTeams(t *testing.T) {
 
 // An external contact gets project access, including rows that grant nothing.
 func TestSNUserService_GetUser_ExternalProjectAccess(t *testing.T) {
+	withTeamRegistry(t, abtTeamRegistryFixture)
+
 	userSysid := sysid32('e')
 	projectSysid := sysid32('f')
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("/teams", func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte(abtTeamsFixtureJSON))
-	})
 	mux.HandleFunc("/users/search", func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte(usersSearchJSON(snUserRowJSON(userSysid, "jane@example.com", "external"))))
 	})
@@ -243,12 +238,11 @@ func TestSNUserService_GetUser_ExternalProjectAccess(t *testing.T) {
 
 // A failing enrichment must not fail the whole profile.
 func TestSNUserService_GetUser_EnrichmentDegrades(t *testing.T) {
+	withTeamRegistry(t, abtTeamRegistryFixture)
+
 	userSysid := sysid32('1')
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("/teams", func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte(abtTeamsFixtureJSON))
-	})
 	mux.HandleFunc("/users/search", func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte(usersSearchJSON(snUserRowJSON(userSysid, "staff@wso2.com", "internal"))))
 	})
@@ -272,6 +266,8 @@ func TestSNUserService_GetUser_EnrichmentDegrades(t *testing.T) {
 
 // An id with no match is a 404, not an empty struct.
 func TestSNUserService_GetUser_NotFound(t *testing.T) {
+	withTeamRegistry(t, abtTeamRegistryFixture)
+
 	mux := http.NewServeMux()
 	mux.HandleFunc("/users/search", func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte(`{"users":[],"totalRecords":0,"offset":0,"limit":1}`))
@@ -306,10 +302,9 @@ func asNotFoundError(err error, target **apierror.NotFoundError) bool {
 // through unchanged, so without this check a bogus id reaches upstream, which answers with
 // an opaque error or an empty page that reads like a legitimate "no such user".
 func TestSNUserService_SearchUsers_RejectsMalformedFilterIDs(t *testing.T) {
+	withTeamRegistry(t, abtTeamRegistryFixture)
+
 	mux := http.NewServeMux()
-	mux.HandleFunc("/teams", func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte(abtTeamsFixtureJSON))
-	})
 	mux.HandleFunc("/users/search", func(_ http.ResponseWriter, _ *http.Request) {
 		t.Error("upstream search called; a malformed filter id should be rejected first")
 	})
@@ -347,10 +342,9 @@ func TestSNUserService_SearchUsers_RejectsMalformedFilterIDs(t *testing.T) {
 // GetUser must not report a malformed id as a missing one: "id is required" sends the caller
 // looking for a parameter they did supply.
 func TestSNUserService_GetUser_DistinguishesEmptyFromMalformedID(t *testing.T) {
+	withTeamRegistry(t, abtTeamRegistryFixture)
+
 	mux := http.NewServeMux()
-	mux.HandleFunc("/teams", func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte(abtTeamsFixtureJSON))
-	})
 	mux.HandleFunc("/users/search", func(_ http.ResponseWriter, _ *http.Request) {
 		t.Error("upstream search called; an invalid id should be rejected first")
 	})

--- a/entity-service/internal/service/sn_user_directory_test.go
+++ b/entity-service/internal/service/sn_user_directory_test.go
@@ -186,7 +186,7 @@ func TestSNUserService_GetUser_GroupsAndTeams(t *testing.T) {
 		t.Fatalf("got %d groups, want 2", len(got.Groups))
 	}
 	if len(got.Teams) != 1 || got.Teams[0].ID != "alpha" {
-		t.Fatalf("teams = %+v, want just castor", got.Teams)
+		t.Fatalf("teams = %+v, want just alpha", got.Teams)
 	}
 	// Staff get no project-access block.
 	if got.ProjectAccess != nil {

--- a/entity-service/internal/service/sn_user_service.go
+++ b/entity-service/internal/service/sn_user_service.go
@@ -163,19 +163,6 @@ type snUserSort struct {
 	Order string `json:"order"`
 }
 
-var validUserRole = map[domain.UserRole]bool{
-	domain.UserRoleInternal:         true,
-	domain.UserRoleAgent:            true,
-	domain.UserRoleAdmin:            true,
-	domain.UserRoleCommenter:        true,
-	domain.UserRoleExternal:         true,
-	domain.UserRoleCustomer:         true,
-	domain.UserRoleCustomerAdmin:    true,
-	domain.UserRolePartner:          true,
-	domain.UserRolePartnerAdmin:     true,
-	domain.UserRoleTimecardApprover: true,
-}
-
 var validUserSortField = map[domain.UserSortField]bool{
 	domain.UserSortFieldName:      true,
 	domain.UserSortFieldCreatedOn: true,
@@ -193,11 +180,8 @@ type snUserService struct {
 
 // NewServiceNowUserService constructs an SNUserService backed by the Choreo API.
 func NewServiceNowUserService(client *integrationservice.Client) SNUserService {
-	// The ABT team registry (GET teams) is static reference data served
-	// by the same Choreo-fronted Ballerina service — no user token needed.
-	domain.SetAbtTeamsFetcher(func(ctx context.Context) (json.RawMessage, error) {
-		return client.Get(ctx, "/teams", "")
-	})
+	// The ABT team registry is deployment configuration installed at startup
+	// (domain.SetAbtTeams), not something this service fetches.
 	return &snUserService{client: client}
 }
 
@@ -218,7 +202,7 @@ func (s *snUserService) SearchUsers(ctx context.Context, req domain.SearchUsersR
 		return domain.SearchSNUsersResponse{}, &apierror.ValidationError{Msg: "emails cannot contain more than 50 values"}
 	}
 	for _, role := range req.Filters.RoleIDs {
-		if !validUserRole[role] {
+		if !isValidUserRole(role) {
 			return domain.SearchSNUsersResponse{}, &apierror.ValidationError{Msg: "roleIds contains invalid value: " + string(role)}
 		}
 	}

--- a/entity-service/internal/service/sn_user_service.go
+++ b/entity-service/internal/service/sn_user_service.go
@@ -109,12 +109,17 @@ type snUserSearchPayload struct {
 }
 
 type snUserFilters struct {
-	SearchQuery string   `json:"searchQuery,omitempty"`
-	Roles       []string `json:"roles,omitempty"`
-	UserNames   []string `json:"userNames,omitempty"`
-	Emails      []string `json:"emails,omitempty"`
-	UserIDs     []string `json:"userIds,omitempty"`
-	Active      *bool    `json:"active,omitempty"`
+	SearchQuery string `json:"searchQuery,omitempty"`
+	// RoleNames is sent under the backing data source's open, unconstrained role
+	// filter rather than its closed "roles" enum -- this service's own role catalogue
+	// is itself configuration-driven (CSM_USER_ROLES) and not limited to that closed
+	// set, so a role outside it (e.g. timecard_approver) must not be sent under "roles",
+	// which the upstream layer rejects at request binding for values it doesn't recognize.
+	RoleNames []string `json:"roleNames,omitempty"`
+	UserNames []string `json:"userNames,omitempty"`
+	Emails    []string `json:"emails,omitempty"`
+	UserIDs   []string `json:"userIds,omitempty"`
+	Active    *bool    `json:"active,omitempty"`
 }
 
 // snProjectContactRowsPayload is the Choreo POST project-contacts/search request body.
@@ -276,7 +281,7 @@ func (s *snUserService) SearchUsers(ctx context.Context, req domain.SearchUsersR
 	payload := snUserSearchPayload{
 		Filters: snUserFilters{
 			SearchQuery: req.Filters.SearchQuery,
-			Roles:       roles,
+			RoleNames:   roles,
 			UserNames:   req.Filters.UserNames,
 			Emails:      req.Filters.Emails,
 			UserIDs:     userIDs,

--- a/entity-service/internal/service/sn_user_service_test.go
+++ b/entity-service/internal/service/sn_user_service_test.go
@@ -22,6 +22,8 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
+
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
 )
 
@@ -29,17 +31,23 @@ import (
 // ABT-team-resolution tests.
 var testAbtUserSysid = sysid32('9')
 
-// abtTeamsFixtureJSON is a representative (not real) flat ABT registry: a
-// CRE team (Castor), a flat IAM-US team (no sub-team nesting), an SRE team
-// (Apollo SRE Group), and an unclassified team with no "family" field.
-const abtTeamsFixtureJSON = `{
-	"teams": [
-		{"teamKey": "castor", "displayName": "Castor", "family": "CRE"},
-		{"teamKey": "iam_us", "displayName": "IAM-US", "family": "CRE"},
-		{"teamKey": "apollo", "displayName": "Apollo SRE Group", "family": "SRE"},
-		{"teamKey": "customer_onboarding", "displayName": "Customer Onboarding"}
-	]
-}`
+// abtTeamRegistryFixture is a representative registry in its configured wire
+// form: a CRE team, a hyphenated flat team (no sub-team nesting), an SRE team,
+// and an unclassified team with no family field. Every name is an invented
+// placeholder -- real team names never appear in this repo.
+const abtTeamRegistryFixture = "alpha|Alpha Team|CRE,delta|Delta-Two|CRE,beta|Beta SRE Group|SRE,gamma|Gamma Team"
+
+// withTeamRegistry installs a parsed team registry for the duration of one
+// test and clears it afterwards, so no test inherits another's registry.
+func withTeamRegistry(t *testing.T, raw string) {
+	t.Helper()
+	teams, err := domain.ParseAbtTeamRegistry(raw)
+	if err != nil {
+		t.Fatalf("ParseAbtTeamRegistry(%q): %v", raw, err)
+	}
+	domain.SetAbtTeams(teams)
+	t.Cleanup(func() { domain.SetAbtTeams(nil) })
+}
 
 // snUserMeJSON is a minimal ServiceNow GET /users/me payload for the given
 // caller sys_id.
@@ -63,6 +71,8 @@ func membershipsJSON(userID, groupName string) string {
 }
 
 func TestSNUserService_GetMe_TeamMatch(t *testing.T) {
+	withTeamRegistry(t, abtTeamRegistryFixture)
+
 	var capturedBody []byte
 
 	mux := http.NewServeMux()
@@ -70,14 +80,10 @@ func TestSNUserService_GetMe_TeamMatch(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(snUserMeJSON(testAbtUserSysid)))
 	})
-	mux.HandleFunc("/teams", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(abtTeamsFixtureJSON))
-	})
 	mux.HandleFunc("/group-members/search", func(w http.ResponseWriter, r *http.Request) {
 		capturedBody, _ = io.ReadAll(r.Body)
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(membershipsJSON(testAbtUserSysid, "Castor")))
+		_, _ = w.Write([]byte(membershipsJSON(testAbtUserSysid, "Alpha Team")))
 	})
 
 	client := newTestSNClient(t, mux)
@@ -88,10 +94,10 @@ func TestSNUserService_GetMe_TeamMatch(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if got.Team == nil {
-		t.Fatalf("Team = nil, want Castor")
+		t.Fatalf("Team = nil, want Alpha Team")
 	}
-	if got.Team.TeamKey != "castor" || got.Team.TeamName != "Castor" || got.Team.Family != "cre" {
-		t.Fatalf("Team = %+v, want {castor Castor cre}", got.Team)
+	if got.Team.TeamKey != "alpha" || got.Team.TeamName != "Alpha Team" || got.Team.Family != "cre" {
+		t.Fatalf("Team = %+v, want {alpha Alpha Team cre}", got.Team)
 	}
 
 	// The request body must send groupNames, never groupIds.
@@ -113,34 +119,32 @@ func TestSNUserService_GetMe_TeamMatch(t *testing.T) {
 	}
 	found := false
 	for _, n := range reqBody.Filters.GroupNames {
-		if n == "Castor" {
+		if n == "Alpha Team" {
 			found = true
 		}
 	}
 	if !found {
-		t.Fatalf("groupNames = %v, want it to include \"Castor\"", reqBody.Filters.GroupNames)
+		t.Fatalf("groupNames = %v, want it to include \"Alpha Team\"", reqBody.Filters.GroupNames)
 	}
 	if reqBody.Filters.UserID != testAbtUserSysid {
 		t.Fatalf("userId = %q, want %q", reqBody.Filters.UserID, testAbtUserSysid)
 	}
 }
 
-// TestSNUserService_GetMe_FlatTeamMatch_IAMUS verifies IAM-US resolves as its
-// own flat team -- the old sub-team nesting is gone, so this is just a
-// normal name match like any other team.
-func TestSNUserService_GetMe_FlatTeamMatch_IAMUS(t *testing.T) {
+// TestSNUserService_GetMe_FlatTeamMatch_HyphenatedName verifies a hyphenated team name
+// resolves as its own flat team -- there is no sub-team nesting, so this is
+// just a normal name match like any other team.
+func TestSNUserService_GetMe_FlatTeamMatch_HyphenatedName(t *testing.T) {
+	withTeamRegistry(t, abtTeamRegistryFixture)
+
 	mux := http.NewServeMux()
 	mux.HandleFunc("/users/me", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(snUserMeJSON(testAbtUserSysid)))
 	})
-	mux.HandleFunc("/teams", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(abtTeamsFixtureJSON))
-	})
 	mux.HandleFunc("/group-members/search", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(membershipsJSON(testAbtUserSysid, "IAM-US")))
+		_, _ = w.Write([]byte(membershipsJSON(testAbtUserSysid, "Delta-Two")))
 	})
 
 	client := newTestSNClient(t, mux)
@@ -151,10 +155,10 @@ func TestSNUserService_GetMe_FlatTeamMatch_IAMUS(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if got.Team == nil {
-		t.Fatalf("Team = nil, want IAM-US")
+		t.Fatalf("Team = nil, want Delta-Two")
 	}
-	if got.Team.TeamKey != "iam_us" || got.Team.TeamName != "IAM-US" || got.Team.Family != "cre" {
-		t.Fatalf("Team = %+v, want {iam_us IAM-US cre}", got.Team)
+	if got.Team.TeamKey != "delta" || got.Team.TeamName != "Delta-Two" || got.Team.Family != "cre" {
+		t.Fatalf("Team = %+v, want {delta Delta-Two cre}", got.Team)
 	}
 }
 
@@ -162,18 +166,16 @@ func TestSNUserService_GetMe_FlatTeamMatch_IAMUS(t *testing.T) {
 // "family" set still resolves correctly, with an empty Family rather than an
 // error.
 func TestSNUserService_GetMe_UnclassifiedTeamMatch(t *testing.T) {
+	withTeamRegistry(t, abtTeamRegistryFixture)
+
 	mux := http.NewServeMux()
 	mux.HandleFunc("/users/me", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(snUserMeJSON(testAbtUserSysid)))
 	})
-	mux.HandleFunc("/teams", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(abtTeamsFixtureJSON))
-	})
 	mux.HandleFunc("/group-members/search", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(membershipsJSON(testAbtUserSysid, "Customer Onboarding")))
+		_, _ = w.Write([]byte(membershipsJSON(testAbtUserSysid, "Gamma Team")))
 	})
 
 	client := newTestSNClient(t, mux)
@@ -184,22 +186,20 @@ func TestSNUserService_GetMe_UnclassifiedTeamMatch(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if got.Team == nil {
-		t.Fatalf("Team = nil, want Customer Onboarding")
+		t.Fatalf("Team = nil, want Gamma Team")
 	}
-	if got.Team.TeamKey != "customer_onboarding" || got.Team.TeamName != "Customer Onboarding" || got.Team.Family != "" {
-		t.Fatalf("Team = %+v, want {customer_onboarding \"Customer Onboarding\" \"\"}", got.Team)
+	if got.Team.TeamKey != "gamma" || got.Team.TeamName != "Gamma Team" || got.Team.Family != "" {
+		t.Fatalf("Team = %+v, want {gamma \"Gamma Team\" \"\"}", got.Team)
 	}
 }
 
 func TestSNUserService_GetMe_NoMatch(t *testing.T) {
+	withTeamRegistry(t, abtTeamRegistryFixture)
+
 	mux := http.NewServeMux()
 	mux.HandleFunc("/users/me", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(snUserMeJSON(testAbtUserSysid)))
-	})
-	mux.HandleFunc("/teams", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(abtTeamsFixtureJSON))
 	})
 	mux.HandleFunc("/group-members/search", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -223,14 +223,12 @@ func TestSNUserService_GetMe_NoMatch(t *testing.T) {
 // fails the overall /users/me response -- identity/roles must still come
 // back, with Team simply nil.
 func TestSNUserService_GetMe_GroupMembershipCallErrors_IdentityStillReturned(t *testing.T) {
+	withTeamRegistry(t, abtTeamRegistryFixture)
+
 	mux := http.NewServeMux()
 	mux.HandleFunc("/users/me", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(snUserMeJSON(testAbtUserSysid)))
-	})
-	mux.HandleFunc("/teams", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(abtTeamsFixtureJSON))
 	})
 	mux.HandleFunc("/group-members/search", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusServiceUnavailable)
@@ -251,24 +249,22 @@ func TestSNUserService_GetMe_GroupMembershipCallErrors_IdentityStillReturned(t *
 	}
 }
 
-// TestSNUserService_GetMe_RegistryFetchFails_IdentityStillReturned verifies
-// that a failure fetching the ABT team registry itself (a distinct failure
-// mode from the group-membership call failing) also degrades gracefully:
-// identity/roles still come back, Team nil.
-func TestSNUserService_GetMe_RegistryFetchFails_IdentityStillReturned(t *testing.T) {
+// TestSNUserService_GetMe_EmptyRegistry_IdentityStillReturned verifies that a
+// deployment with no team registry configured still serves identity: roles
+// come back, Team is nil, and the membership lookup is skipped entirely.
+func TestSNUserService_GetMe_EmptyRegistry_IdentityStillReturned(t *testing.T) {
+	withTeamRegistry(t, "")
+
 	mux := http.NewServeMux()
 	mux.HandleFunc("/users/me", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(snUserMeJSON(testAbtUserSysid)))
 	})
-	mux.HandleFunc("/teams", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusServiceUnavailable)
-	})
 	groupMembersCalled := false
 	mux.HandleFunc("/group-members/search", func(w http.ResponseWriter, r *http.Request) {
 		groupMembersCalled = true
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(membershipsJSON(testAbtUserSysid, "Castor")))
+		_, _ = w.Write([]byte(membershipsJSON(testAbtUserSysid, "Alpha Team")))
 	})
 
 	client := newTestSNClient(t, mux)
@@ -279,15 +275,15 @@ func TestSNUserService_GetMe_RegistryFetchFails_IdentityStillReturned(t *testing
 		t.Fatalf("unexpected error: %v (identity must still be returned)", err)
 	}
 	if got.Email != "agent@example.com" {
-		t.Fatalf("Email = %q, want agent@example.com even though registry fetch failed", got.Email)
+		t.Fatalf("Email = %q, want agent@example.com with an empty registry", got.Email)
 	}
 	if got.Team != nil {
-		t.Fatalf("Team = %+v, want nil when registry fetch fails", got.Team)
+		t.Fatalf("Team = %+v, want nil when no teams are configured", got.Team)
 	}
 	// With an empty registry, AbtGroupNames() is empty, so GetMe should
 	// short-circuit and never even call group-members/search.
 	if groupMembersCalled {
-		t.Fatalf("group-members/search was called despite an empty (failed-to-load) registry")
+		t.Fatalf("group-members/search was called despite an empty registry")
 	}
 }
 
@@ -315,7 +311,7 @@ func TestGetUserMeResponse_TeamOmittedWhenNil(t *testing.T) {
 func TestGetUserMeResponse_TeamFieldShape(t *testing.T) {
 	resp := domain.GetUserMeResponse{
 		ID: "u1", Email: "agent@example.com", Roles: []string{},
-		Team: &domain.UserTeam{TeamKey: "castor", TeamName: "Castor", Family: "cre"},
+		Team: &domain.UserTeam{TeamKey: "alpha", TeamName: "Alpha Team", Family: "cre"},
 	}
 	raw, err := json.Marshal(resp)
 	if err != nil {
@@ -333,10 +329,48 @@ func TestGetUserMeResponse_TeamFieldShape(t *testing.T) {
 	if err := json.Unmarshal(teamRaw, &team); err != nil {
 		t.Fatalf("unmarshal team: %v", err)
 	}
-	want := map[string]string{"teamKey": "castor", "teamName": "Castor", "family": "cre"}
+	want := map[string]string{"teamKey": "alpha", "teamName": "Alpha Team", "family": "cre"}
 	for k, v := range want {
 		if team[k] != v {
 			t.Fatalf("team[%q] = %q, want %q (full team object: %s)", k, team[k], v, teamRaw)
 		}
+	}
+}
+
+// TestSearchUsers_RejectsRoleOutsideConfiguredList proves the allow-list is
+// enforced on the real request path, not just in the helper.
+func TestSearchUsers_RejectsRoleOutsideConfiguredList(t *testing.T) {
+	withUserRoles(t, "agent")
+	withTeamRegistry(t, abtTeamRegistryFixture)
+
+	upstreamCalled := false
+	mux := http.NewServeMux()
+	mux.HandleFunc("/users/search", func(w http.ResponseWriter, _ *http.Request) {
+		upstreamCalled = true
+		_, _ = w.Write([]byte(`{"users":[],"totalRecords":0}`))
+	})
+	svc := NewServiceNowUserService(newTestSNClient(t, mux))
+
+	_, err := svc.SearchUsers(contextWithUserIDToken("token"), domain.SearchUsersRequest{
+		Pagination: domain.Pagination{Limit: 20},
+		Filters:    domain.SearchUsersFilters{RoleIDs: []domain.UserRole{domain.UserRoleAdmin}},
+	})
+	var verr *apierror.ValidationError
+	if !asValidationError(err, &verr) {
+		t.Fatalf("err = %v, want a ValidationError for a role outside the configured list", err)
+	}
+	if upstreamCalled {
+		t.Fatal("upstream user search was called with an unconfigured role")
+	}
+
+	// The configured role still passes validation and reaches upstream.
+	if _, err := svc.SearchUsers(contextWithUserIDToken("token"), domain.SearchUsersRequest{
+		Pagination: domain.Pagination{Limit: 20},
+		Filters:    domain.SearchUsersFilters{RoleIDs: []domain.UserRole{domain.UserRoleAgent}},
+	}); err != nil {
+		t.Fatalf("configured role \"agent\" was rejected: %v", err)
+	}
+	if !upstreamCalled {
+		t.Fatal("configured role did not reach the upstream search")
 	}
 }

--- a/entity-service/internal/service/team_service.go
+++ b/entity-service/internal/service/team_service.go
@@ -26,7 +26,7 @@ import (
 
 // teamService serves the team registry.
 //
-// The registry itself is owned upstream and fetched at runtime -- team names are
+// The registry itself is deployment configuration installed at startup -- team names are
 // organisation vocabulary and are deliberately not hardcoded in this repo. A team's id is
 // its registry key rather than the backing group's id, because those ids differ between
 // environments while the key does not.

--- a/entity-service/internal/service/user_roles.go
+++ b/entity-service/internal/service/user_roles.go
@@ -48,11 +48,24 @@ var defaultUserRoles = []domain.UserRole{
 
 // The configured allow-list does double duty: it validates the roleIds user
 // filter and it is the catalogue POST /roles/search serves. One list drives
-// both, so the dropdown and the filter can never disagree.
+// both, so the dropdown and the filter can never disagree. userRoles keeps
+// the configured order for the catalogue response; validUserRoles is the
+// same set as a map, kept in sync in SetUserRoles, so isValidUserRole is an
+// O(1) lookup rather than a linear scan on every filtered search request.
 var (
-	userRolesMu sync.RWMutex
-	userRoles   = append([]domain.UserRole(nil), defaultUserRoles...)
+	userRolesMu    sync.RWMutex
+	userRoles      = append([]domain.UserRole(nil), defaultUserRoles...)
+	validUserRoles = toUserRoleSet(defaultUserRoles)
 )
+
+// toUserRoleSet builds a membership set from an ordered role list.
+func toUserRoleSet(roles []domain.UserRole) map[domain.UserRole]bool {
+	set := make(map[domain.UserRole]bool, len(roles))
+	for _, r := range roles {
+		set[r] = true
+	}
+	return set
+}
 
 // SetUserRoles installs the assignable-role allow-list. Called once during
 // startup with the parsed configuration, and by tests.
@@ -60,6 +73,7 @@ func SetUserRoles(roles []domain.UserRole) {
 	userRolesMu.Lock()
 	defer userRolesMu.Unlock()
 	userRoles = append([]domain.UserRole(nil), roles...)
+	validUserRoles = toUserRoleSet(roles)
 }
 
 // UserRoleCatalogue returns the configured allow-list, in configured order.
@@ -73,12 +87,7 @@ func UserRoleCatalogue() []domain.UserRole {
 func isValidUserRole(role domain.UserRole) bool {
 	userRolesMu.RLock()
 	defer userRolesMu.RUnlock()
-	for _, r := range userRoles {
-		if r == role {
-			return true
-		}
-	}
-	return false
+	return validUserRoles[role]
 }
 
 // ParseUserRoles parses the assignable-role allow-list from its configuration

--- a/entity-service/internal/service/user_roles.go
+++ b/entity-service/internal/service/user_roles.go
@@ -1,0 +1,118 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package service
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+)
+
+// defaultUserRoles is the assignable-role allow-list used when none is
+// configured.
+//
+// Unlike the team registry, roles DO get a committed default: these names are
+// generic platform vocabulary (agent, admin, customer, ...) that is already
+// public in this repo, not organisation-specific vocabulary, so committing
+// them leaks nothing and a zero-config deployment behaves exactly as it did
+// when the list was hardcoded. Adding a role is a configuration change, not a
+// code change -- deliberately not a closed compile-time set.
+var defaultUserRoles = []domain.UserRole{
+	domain.UserRoleAgent,
+	domain.UserRoleAdmin,
+	domain.UserRoleCommenter,
+	domain.UserRoleCustomer,
+	domain.UserRoleCustomerAdmin,
+	domain.UserRolePartner,
+	domain.UserRolePartnerAdmin,
+	domain.UserRoleInternal,
+	domain.UserRoleExternal,
+	domain.UserRoleTimecardApprover,
+}
+
+// The configured allow-list does double duty: it validates the roleIds user
+// filter and it is the catalogue POST /roles/search serves. One list drives
+// both, so the dropdown and the filter can never disagree.
+var (
+	userRolesMu sync.RWMutex
+	userRoles   = append([]domain.UserRole(nil), defaultUserRoles...)
+)
+
+// SetUserRoles installs the assignable-role allow-list. Called once during
+// startup with the parsed configuration, and by tests.
+func SetUserRoles(roles []domain.UserRole) {
+	userRolesMu.Lock()
+	defer userRolesMu.Unlock()
+	userRoles = append([]domain.UserRole(nil), roles...)
+}
+
+// UserRoleCatalogue returns the configured allow-list, in configured order.
+func UserRoleCatalogue() []domain.UserRole {
+	userRolesMu.RLock()
+	defer userRolesMu.RUnlock()
+	return append([]domain.UserRole(nil), userRoles...)
+}
+
+// isValidUserRole reports whether role is in the configured allow-list.
+func isValidUserRole(role domain.UserRole) bool {
+	userRolesMu.RLock()
+	defer userRolesMu.RUnlock()
+	for _, r := range userRoles {
+		if r == role {
+			return true
+		}
+	}
+	return false
+}
+
+// ParseUserRoles parses the assignable-role allow-list from its configuration
+// form: a comma-separated list of role names, whitespace around each trimmed.
+// An empty string yields defaultUserRoles.
+//
+// A duplicate is an error rather than a silent de-duplication: it would double
+// an entry in the role catalogue, and it is always a typo. Errors name the
+// offending value so a bad deploy fails at startup, not at the first request.
+func ParseUserRoles(raw string) ([]domain.UserRole, error) {
+	if strings.TrimSpace(raw) == "" {
+		return append([]domain.UserRole(nil), defaultUserRoles...), nil
+	}
+
+	parts := strings.Split(raw, ",")
+	roles := make([]domain.UserRole, 0, len(parts))
+	seen := make(map[domain.UserRole]bool, len(parts))
+
+	for _, part := range parts {
+		name := strings.TrimSpace(part)
+		if name == "" {
+			// Tolerate a trailing or doubled comma.
+			continue
+		}
+		role := domain.UserRole(name)
+		if seen[role] {
+			return nil, fmt.Errorf("user role list: %q appears more than once", name)
+		}
+		seen[role] = true
+		roles = append(roles, role)
+	}
+
+	if len(roles) == 0 {
+		return nil, fmt.Errorf("user role list: no role names found in %q", raw)
+	}
+	return roles, nil
+}

--- a/entity-service/internal/service/user_roles_test.go
+++ b/entity-service/internal/service/user_roles_test.go
@@ -1,0 +1,156 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package service
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+)
+
+// withUserRoles installs a parsed role allow-list for one test and restores the
+// defaults afterwards, so no test inherits another's list.
+func withUserRoles(t *testing.T, raw string) {
+	t.Helper()
+	roles, err := ParseUserRoles(raw)
+	if err != nil {
+		t.Fatalf("ParseUserRoles(%q): %v", raw, err)
+	}
+	SetUserRoles(roles)
+	t.Cleanup(func() { SetUserRoles(defaultUserRoles) })
+}
+
+// TestParseUserRoles_UnsetFallsBackToDefaults: a zero-config deployment must
+// behave exactly as the previously hardcoded list did.
+func TestParseUserRoles_UnsetFallsBackToDefaults(t *testing.T) {
+	for _, raw := range []string{"", "   "} {
+		roles, err := ParseUserRoles(raw)
+		if err != nil {
+			t.Fatalf("ParseUserRoles(%q) returned error: %v", raw, err)
+		}
+		if len(roles) != 10 {
+			t.Fatalf("ParseUserRoles(%q) returned %d roles, want the 10 defaults: %v", raw, len(roles), roles)
+		}
+		want := map[domain.UserRole]bool{
+			domain.UserRoleAgent: true, domain.UserRoleAdmin: true, domain.UserRoleCommenter: true,
+			domain.UserRoleCustomer: true, domain.UserRoleCustomerAdmin: true, domain.UserRolePartner: true,
+			domain.UserRolePartnerAdmin: true, domain.UserRoleInternal: true, domain.UserRoleExternal: true,
+			domain.UserRoleTimecardApprover: true,
+		}
+		for _, r := range roles {
+			if !want[r] {
+				t.Fatalf("unexpected default role %q", r)
+			}
+			delete(want, r)
+		}
+		if len(want) != 0 {
+			t.Fatalf("defaults are missing %v", want)
+		}
+	}
+}
+
+func TestParseUserRoles_OverridesAndTrims(t *testing.T) {
+	roles, err := ParseUserRoles("  agent , timecard_approver ,")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(roles) != 2 || roles[0] != domain.UserRoleAgent || roles[1] != domain.UserRoleTimecardApprover {
+		t.Fatalf("roles = %v, want [agent timecard_approver]", roles)
+	}
+}
+
+func TestParseUserRoles_RejectsDuplicates(t *testing.T) {
+	_, err := ParseUserRoles("agent,admin,agent")
+	if err == nil {
+		t.Fatal("expected an error for a duplicated role name")
+	}
+	if !strings.Contains(err.Error(), "agent") {
+		t.Fatalf("error %q does not name the duplicated value", err)
+	}
+}
+
+// TestSetUserRoles_DrivesBothFilterAndCatalogue is the property the whole
+// change exists to preserve: one configured list feeds the roleIds validation
+// and POST /roles/search, so the dropdown and the filter cannot disagree.
+func TestSetUserRoles_DrivesBothFilterAndCatalogue(t *testing.T) {
+	withUserRoles(t, "agent,timecard_approver")
+
+	// Catalogue side.
+	resp, err := NewRoleService().SearchRoles(context.Background(), domain.SearchRolesRequest{})
+	if err != nil {
+		t.Fatalf("SearchRoles: %v", err)
+	}
+	if resp.Total != 2 {
+		t.Fatalf("SearchRoles returned %d roles, want 2: %+v", resp.Total, resp.Roles)
+	}
+	if resp.Roles[0].ID != "agent" || resp.Roles[0].Name != "Agent" {
+		t.Fatalf("roles[0] = %+v, want {agent Agent}", resp.Roles[0])
+	}
+	if resp.Roles[1].ID != "timecard_approver" || resp.Roles[1].Name != "Timecard Approver" {
+		t.Fatalf("roles[1] = %+v, want {timecard_approver Timecard Approver}", resp.Roles[1])
+	}
+
+	// Filter side: a configured role is accepted...
+	if !isValidUserRole(domain.UserRoleAgent) {
+		t.Fatal("configured role \"agent\" was rejected by the roleIds validation")
+	}
+	// ...and a role outside the configured list is rejected, even though it is
+	// one of the committed defaults.
+	if isValidUserRole(domain.UserRoleAdmin) {
+		t.Fatal("role \"admin\" is not in the configured list but passed validation")
+	}
+}
+
+// TestSearchTeams_ReflectsConfiguredRegistry: the team catalogue is exactly
+// what was configured, nothing hardcoded.
+func TestSearchTeams_ReflectsConfiguredRegistry(t *testing.T) {
+	withTeamRegistry(t, "alpha|Alpha Team|CRE,beta|Beta Team|SRE,gamma|Gamma Team")
+
+	resp, err := NewTeamService().SearchTeams(context.Background(), domain.SearchTeamsRequest{})
+	if err != nil {
+		t.Fatalf("SearchTeams: %v", err)
+	}
+	if resp.Total != 3 {
+		t.Fatalf("SearchTeams returned %d teams, want 3: %+v", resp.Total, resp.Teams)
+	}
+	want := []domain.Team{
+		{ID: "alpha", Name: "Alpha Team", Family: "cre"},
+		{ID: "beta", Name: "Beta Team", Family: "sre"},
+		{ID: "gamma", Name: "Gamma Team", Family: ""},
+	}
+	for i, w := range want {
+		if resp.Teams[i] != w {
+			t.Fatalf("teams[%d] = %+v, want %+v", i, resp.Teams[i], w)
+		}
+	}
+}
+
+// TestSearchTeams_EmptyRegistry: no configuration means an empty catalogue,
+// not a panic and not a stale hardcoded list.
+func TestSearchTeams_EmptyRegistry(t *testing.T) {
+	withTeamRegistry(t, "")
+
+	resp, err := NewTeamService().SearchTeams(context.Background(), domain.SearchTeamsRequest{})
+	if err != nil {
+		t.Fatalf("SearchTeams: %v", err)
+	}
+	if resp.Total != 0 || len(resp.Teams) != 0 {
+		t.Fatalf("SearchTeams = %+v, want an empty catalogue", resp)
+	}
+}


### PR DESCRIPTION
## Purpose
Backend groundwork for the CSM user profile page landed in #1287. This PR finishes the frontend
and remaining backend pieces of that work: the profile page's group/team/project-access sections
(previously placeholders), a project contacts tab, role/group/team directory pages with
click-through member lists, user-list filters, and moving the entity service's team registry and
role allow-list out of the shared upstream Ballerina layer into this CSM-only service's own
deployment configuration.

## Goals
- Let a CS engineer answer "why can't this customer see their cases?" from the profile page
  itself, with the blocking reason spelled out rather than a bare pass/fail chip.
- Make every role/group/team name across the app a link to that entity's member list, and every
  member a link back to their profile — a fully click-through directory.
- Stop the CSM entity service depending on the shared upstream service for configuration that is
  CSM-specific (team names, allowed roles), so the shared service — which also serves the live
  production customer portal — carries less that isn't its concern.

## Approach
- **Profile page**: replaced the "coming soon" placeholders for Groups/Teams/Project access with
  real tables, sourced from `GET /users/{id}`, which already returned this data. Roles, Groups and
  Teams render as three separate cards side by side rather than stacked, each card's own title
  standing in for what would otherwise be a repeated column header.
- **Project contacts tab**: lists a project's contacts via `POST /projects/{id}/contacts/search`,
  every linked row clicking through to `/people/:id`. A row with no linked contact record (an
  "orphaned" row — the person can't see the project's cases) is shown explicitly rather than
  rendered blank or hidden, since that's the operationally interesting case.
- **Role/group/team directory**: new `/admin/roles`, `/admin/groups`, `/admin/teams` index pages,
  each row linking to a member page backed by `POST /users/search`'s `roleIds`/`groupIds`/
  `teamIds` filters. Verified each member page sends the filter key matching its own entity type
  (a copy-pasted page sending the wrong key would look identical on screen while silently
  returning the wrong set).
- **User-list filters**: name/email search plus role/group/team/status filters, reflected in the
  URL so a filtered view is shareable and survives a reload. The free-text search was originally
  reflected as `?q=`, which collides with the app's own quick-nav command palette (`?q=` is a
  reserved deep-link param there); renamed to `?search=` for both the users list and, since the
  cases list had the identical bug, there too.
- Role chips beyond 3 collapse into a `+N more` chip linking to the profile, rather than every
  role rendering inline in the table cell.
- Clicking anywhere in a user-list row navigates to that user's profile; a role/group/team chip
  inside that row stops propagation so it navigates to its own entity page instead of the profile.
- **Entity service config move**: the team registry (`CSM_TEAM_REGISTRY`) and the role allow-list
  (`CSM_USER_ROLES`) are now this service's own environment configuration rather than fetched from
  the upstream Ballerina service (teams) or a hardcoded map (roles). Team names are organisation
  vocabulary and are not committed to this public repo — `.env.example` and the README carry
  placeholder names only (`alpha`/`beta`/`gamma`); real values are supplied per environment. Role
  names keep a committed default (10 values, including `timecard_approver`) since they're generic
  platform vocabulary, not organisation-specific, so a zero-config deployment still behaves as
  before.
- Fixed two bugs found along the way: case-detail activity-feed actors were never linked to their
  profile at all (a mapper silently dropped an already-populated field while building the display
  string — the case overview box worked because it read a different, correctly-wired field); and
  the toast error banner was the one error surface (of three) that folded a correlation ID into
  plain message text with no way to copy it before the banner auto-dismissed — fixed by giving it
  its own copy button, which also surfaced a MUI `Alert` quirk (supplying a custom `action` drops
  the library's own auto-rendered close button unless you re-add one yourself).

## User stories
As a CS engineer: I can see a customer's group/team/role memberships and, for external contacts,
exactly why they can or can't see a project's cases; I can browse roles/groups/teams and see who's
in each; I can filter the user list by any of those; and I no longer trip an unrelated command
palette while searching.

## Release note
Adds the user profile page's group/team/project-access sections, a project contacts tab,
role/group/team directory pages, and user-list filters; fixes an unclickable activity-feed byline
and an uncopyable error correlation ID; moves CSM-specific configuration out of the shared entity
service.

## Documentation
N/A for external docs — this is an internal CS-engineer tool. In-repo documentation (this service's
README, `.env.example`) is updated as part of this PR for the new configuration.

## Training
N/A — no training-content repo impact.

## Certification
N/A — no product certification exam impact.

## Marketing
N/A — internal tooling, not a customer-facing feature.

## Automation tests
- Unit tests
  Go: new tests for the team-registry parser (2/3-field rows, whitespace, malformed-row and
  empty-field rejection, unset-vs-configured behavior) and the role allow-list (default list,
  configured override, out-of-list rejection, and both directory endpoints reflecting configured
  values) — all proven load-bearing by reverting the fix and confirming the test fails. Full
  `go test ./internal/...` green across all packages.
  Frontend: new/updated Vitest+RTL coverage for the profile page's three membership tables, the
  project contacts tab (including the orphaned-row state), the directory index/member pages
  (asserting the request body carries the correct filter key per entity type), user-list filter
  combination and role-chip truncation/overflow, the row-click-vs-nested-chip propagation fix, the
  activity-feed actor link fix, and the error-banner copy button (including a regression test for
  the MUI close-button quirk). Full suite: 732 passing, the same 9 pre-existing failures
  (`CaseActionBar.test.tsx`, `CsmAnnouncementsPage.test.tsx`) unrelated to this change.
- Integration tests
  Live-verified against the backing data source's DEV tenant through the full local stack (webapp,
  CSM backend, Go entity service, and a local instance of the upstream data-source-integration
  service) with real authentication: profile page group/team/project-access rendering, project
  contacts including orphaned rows, directory pages and their member lists, and the role/team
  configuration move, all exercised against real data.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines: yes
- Ran FindSecurityBugs plugin and verified report: N/A (Go/TypeScript project, not a Java/Maven build this tool targets)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets: yes

## Samples
N/A

## Related PRs
Builds on #1287 (backend groundwork for the same feature, already merged). A companion change in
the private entity-service backing this platform removes a closed enum that was rejecting a valid
role name and updates its own sample configuration; tracked separately in that repo.

## Migrations (if applicable)
None at the database or API-contract level. Operationally: deployments of this service should set
`CSM_TEAM_REGISTRY` and `CSM_USER_ROLES` to their real per-environment values; both are optional
with safe defaults (empty registry / today's 10 built-in roles), so an unconfigured deployment
degrades rather than fails.

## Test environment
macOS, Node/pnpm (webapp), Go (entity service + CSM backend), real IdP authentication, a local
instance of the upstream data-source-integration service, and the backing data source's DEV
tenant — never production.

## Learning
The most useful finding here was procedural rather than technical: a live e2e/local-stack pass
caught two real bugs (the unclickable activity-feed byline, the QuickNav `?q=` collision) that
unit tests alone did not, because both required the actual running app rather than an isolated
component. Worth keeping that verification step for UI-heavy changes going forward.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added administration pages for browsing roles, groups, and teams, with searchable directories and member lists.
  * Enhanced user management with role, group, team, and active-status filters, URL-persisted search criteria, and profile navigation.
  * Added project contact listings with registration status and orphaned-contact indicators.
  * Added copyable error reference IDs.
  * Linked case activity actors to user profiles.
* **Improvements**
  * Renamed case search URL parameter to `search`.
  * Added configurable team and user-role catalogues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->