### PR TITLE
fix(customer-portal): mark ChangeRequestResponse.approvedBy as optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ replay_pid*
 .DS_Store
 target
 Config.toml
+.env

--- a/apps/customer-portal/backend/Dependencies.toml
+++ b/apps/customer-portal/backend/Dependencies.toml
@@ -56,7 +56,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "data.jsondata"
-version = "1.1.3"
+version = "1.1.4"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.object"}
@@ -76,7 +76,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.14.11"
+version = "2.14.13"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},

--- a/apps/customer-portal/backend/modules/entity/types.bal
+++ b/apps/customer-portal/backend/modules/entity/types.bal
@@ -2316,7 +2316,7 @@ public type ChangeRequestResponse record {|
     # Indicates if the customer has permission to review
     boolean hasCustomerReviewed;
     # Internal approval details
-    ReferenceTableItem? approvedBy;
+    ReferenceTableItem? approvedBy?;
     # Internal approval date and time
     string? approvedOn;
     json...;

--- a/apps/customer-portal/backend/modules/types/types.bal
+++ b/apps/customer-portal/backend/modules/types/types.bal
@@ -1798,7 +1798,7 @@ public type ChangeRequestResponse record {|
     # Indicates if the customer has permission to review
     boolean hasCustomerReviewed;
     # Internal approval details
-    ReferenceItem? approvedBy;
+    ReferenceItem? approvedBy?;
     # Internal approval date and time
     string? approvedOn;
 |};

--- a/apps/customer-portal/backend/openapi.yaml
+++ b/apps/customer-portal/backend/openapi.yaml
@@ -4310,7 +4310,6 @@ components:
       allOf:
       - $ref: '#/components/schemas/ChangeRequest'
       - required:
-        - approvedBy
         - approvedOn
         - communicationPlan
         - createdBy

--- a/apps/customer-portal/backend/utils.bal
+++ b/apps/customer-portal/backend/utils.bal
@@ -910,7 +910,7 @@ public isolated function mapChangeRequestResponse(entity:ChangeRequestResponse r
     entity:ReferenceTableItem? deployment = response.deployment;
     entity:ReferenceTableItem? deployedProduct = response.deployedProduct;
     entity:ReferenceTableItem? product = response.product;
-    entity:ReferenceTableItem? approvedBy = response.approvedBy;
+    entity:ReferenceTableItem? approvedBy = response?.approvedBy;
     entity:ReferenceTableItem? assignedEngineer = response.assignedEngineer;
     entity:ReferenceTableItem? assignedTeam = response.assignedTeam;
     entity:ChoiceListItem? state = response.state;


### PR DESCRIPTION
## Summary
- Made `approvedBy` optional on `ChangeRequestResponse` in the customer-portal backend types
- Updated `openapi.yaml` to remove `approvedBy` from the `required` list on `ChangeRequestResponse`, keeping the spec consistent with the type

## Test plan
- [x] Backend test suite passes (ran automatically via pre-push hook)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Change request responses can now be returned without an approving user when approval information is unavailable.
  * Updated the API schema and response handling to support optional approval details.

* **Chores**
  * Updated backend dependency versions.
  * Added environment configuration files to the ignored files list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->