### PR TITLE
[CSM Portal] Show project-contact access status (has access / why not)

### DIFF
--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -6415,6 +6415,23 @@ components:
           type: array
           items:
             type: string
+        customerContactPresent:
+          type: boolean
+          description: >
+            Whether a contact record is linked to this row at all. False is the same fault an
+            absent `id` signals, restated as an explicit boolean.
+        emailMatchesLogin:
+          type: boolean
+          description: >
+            Whether the email this row was invited under matches the linked account's own email.
+            A row can be linked (`customerContactPresent: true`) yet still mismatched — invited
+            under one address, registered under another.
+        grantsCaseAccess:
+          type: boolean
+          description: >
+            Whether this row would actually grant its person visibility into this project's
+            cases, per the customer portal's own access rule (`emailMatchesLogin &&
+            customerContactPresent`). A row can be listed here without granting access.
 
     ProjectContactSearchResponse:
       type: object

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -6433,27 +6433,7 @@ components:
         contacts:
           type: array
           items:
-            type: object
-            properties:
-              id:
-                type: string
-                format: uuid
-                description: >
-                  The contact's user id, for linking the row to that user's profile. Absent when the
-                  row has no contact record linked, or when the backing instance predates the field —
-                  render the row unlinked rather than treating it as an error.
-              name:
-                type: string
-              email:
-                type: string
-              registrationState:
-                type: string
-              notificationsEnabled:
-                type: boolean
-              roles:
-                type: array
-                items:
-                  type: string
+            $ref: '#/components/schemas/ProjectContact'
         offset:
           type: integer
         limit:

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -6420,18 +6420,12 @@ components:
           description: >
             Whether a contact record is linked to this row at all. False is the same fault an
             absent `id` signals, restated as an explicit boolean.
-        emailMatchesLogin:
-          type: boolean
-          description: >
-            Whether the email this row was invited under matches the linked account's own email.
-            A row can be linked (`customerContactPresent: true`) yet still mismatched — invited
-            under one address, registered under another.
         grantsCaseAccess:
           type: boolean
           description: >
             Whether this row would actually grant its person visibility into this project's
-            cases, per the customer portal's own access rule (`emailMatchesLogin &&
-            customerContactPresent`). A row can be listed here without granting access.
+            cases. Mirrors `customerContactPresent` directly — a row can be listed here without
+            granting access.
 
     ProjectContactSearchResponse:
       type: object

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -1211,17 +1211,9 @@ export interface BeProjectContact {
    */
   customerContactPresent?: boolean;
   /**
-   * Whether the email this row was invited under matches the linked
-   * account's own email. A row can be linked (`customerContactPresent:
-   * true`) yet still mismatched — invited under one address, registered
-   * under another.
-   */
-  emailMatchesLogin?: boolean;
-  /**
    * Whether this row would actually grant its person visibility into this
-   * project's cases, per the customer portal's own access rule
-   * (`emailMatchesLogin && customerContactPresent`). A row can be listed
-   * here without granting access.
+   * project's cases. Mirrors `customerContactPresent` directly — a row can
+   * be listed here without granting access.
    */
   grantsCaseAccess?: boolean;
 }

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -1205,6 +1205,25 @@ export interface BeProjectContact {
   registrationState?: string;
   notificationsEnabled?: boolean;
   roles?: string[];
+  /**
+   * Whether a contact record is linked to this row at all. False is the same
+   * fault an absent `id` signals, restated as an explicit boolean.
+   */
+  customerContactPresent?: boolean;
+  /**
+   * Whether the email this row was invited under matches the linked
+   * account's own email. A row can be linked (`customerContactPresent:
+   * true`) yet still mismatched — invited under one address, registered
+   * under another.
+   */
+  emailMatchesLogin?: boolean;
+  /**
+   * Whether this row would actually grant its person visibility into this
+   * project's cases, per the customer portal's own access rule
+   * (`emailMatchesLogin && customerContactPresent`). A row can be listed
+   * here without granting access.
+   */
+  grantsCaseAccess?: boolean;
 }
 
 export interface BeProjectContactSearchPayload {

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/ProjectContactsTab.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/ProjectContactsTab.test.tsx
@@ -94,6 +94,29 @@ const FULLY_BLANK_ORPHANED_CONTACT: BeProjectContact = {
   registrationState: "pending",
 };
 
+const GRANTED_CONTACT: BeProjectContact = {
+  id: "10000000-0000-0000-0000-000000000000",
+  name: "Grant Access",
+  email: "grant.access@example.com",
+  registrationState: "registered",
+  customerContactPresent: true,
+  emailMatchesLogin: true,
+  grantsCaseAccess: true,
+};
+
+// A contact record IS linked (unlike ORPHANED_CONTACT), but the invited
+// email doesn't match that account's own email — the mismatch case the old
+// id-presence-only heuristic couldn't detect at all.
+const MISMATCHED_CONTACT: BeProjectContact = {
+  id: "20000000-0000-0000-0000-000000000000",
+  name: "Mismatch Case",
+  email: "mismatch@example.com",
+  registrationState: "invited",
+  customerContactPresent: true,
+  emailMatchesLogin: false,
+  grantsCaseAccess: false,
+};
+
 describe("ProjectContactsTab", () => {
   it("renders a loading skeleton while the query is pending", () => {
     mockQueryResult({ isLoading: true });
@@ -158,5 +181,38 @@ describe("ProjectContactsTab", () => {
     expect(screen.getByRole("link", { name: "Jane Doe" })).toBeInTheDocument();
     expect(screen.getByText("John Smith")).toBeInTheDocument();
     expect(screen.getByText("Orphaned", { selector: ".MuiChip-label" })).toBeInTheDocument();
+  });
+
+  it("shows a granted contact (customerContactPresent + emailMatchesLogin) as Has access, no reason line", () => {
+    postMock.mockResolvedValue({ users: [] });
+    mockQueryResult({ data: [GRANTED_CONTACT] });
+    renderTab();
+    expect(screen.getByText("Has access", { selector: ".MuiChip-label" })).toBeInTheDocument();
+    expect(screen.queryByText(/can't see this project's cases/i)).not.toBeInTheDocument();
+  });
+
+  it("flags a linked-but-mismatched contact as No access with the email-mismatch reason, distinct from Orphaned", () => {
+    postMock.mockResolvedValue({ users: [] });
+    mockQueryResult({ data: [MISMATCHED_CONTACT] });
+    renderTab();
+    // Linked (has an id), so it's a clickable profile link, not "Orphaned" —
+    // the old id-presence heuristic would have missed this row's access
+    // fault entirely.
+    expect(screen.getByRole("link", { name: "Mismatch Case" })).toBeInTheDocument();
+    expect(screen.getByText("No access", { selector: ".MuiChip-label" })).toBeInTheDocument();
+    expect(screen.queryByText("Orphaned", { selector: ".MuiChip-label" })).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/invited email doesn't match the linked account's own email/i),
+    ).toBeInTheDocument();
+  });
+
+  it("colours the registration chip by state (registered=success-ish, invited=warning-ish) without changing the visible text", () => {
+    postMock.mockResolvedValue({ users: [] });
+    mockQueryResult({ data: [GRANTED_CONTACT, MISMATCHED_CONTACT] });
+    renderTab();
+    const registeredChip = screen.getByText("registered", { selector: ".MuiChip-label" });
+    const invitedChip = screen.getByText("invited", { selector: ".MuiChip-label" });
+    expect(registeredChip.closest(".MuiChip-root")).toHaveClass("MuiChip-colorSuccess");
+    expect(invitedChip.closest(".MuiChip-root")).toHaveClass("MuiChip-colorWarning");
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/ProjectContactsTab.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/ProjectContactsTab.test.tsx
@@ -100,21 +100,19 @@ const GRANTED_CONTACT: BeProjectContact = {
   email: "grant.access@example.com",
   registrationState: "registered",
   customerContactPresent: true,
-  emailMatchesLogin: true,
   grantsCaseAccess: true,
 };
 
-// A contact record IS linked (unlike ORPHANED_CONTACT), but the invited
-// email doesn't match that account's own email — the mismatch case the old
-// id-presence-only heuristic couldn't detect at all.
-const MISMATCHED_CONTACT: BeProjectContact = {
+// Still linked and still granted access, just not yet registered — used to
+// check the registration chip's "invited" colour independently of access
+// status, which no longer varies with registration state at all.
+const INVITED_GRANTED_CONTACT: BeProjectContact = {
   id: "20000000-0000-0000-0000-000000000000",
-  name: "Mismatch Case",
-  email: "mismatch@example.com",
+  name: "Invited Not Yet Registered",
+  email: "invited@example.com",
   registrationState: "invited",
   customerContactPresent: true,
-  emailMatchesLogin: false,
-  grantsCaseAccess: false,
+  grantsCaseAccess: true,
 };
 
 describe("ProjectContactsTab", () => {
@@ -183,7 +181,7 @@ describe("ProjectContactsTab", () => {
     expect(screen.getByText("Orphaned", { selector: ".MuiChip-label" })).toBeInTheDocument();
   });
 
-  it("shows a granted contact (customerContactPresent + emailMatchesLogin) as Has access, no reason line", () => {
+  it("shows a granted contact (customerContactPresent + grantsCaseAccess) as Has access, no reason line", () => {
     postMock.mockResolvedValue({ users: [] });
     mockQueryResult({ data: [GRANTED_CONTACT] });
     renderTab();
@@ -191,24 +189,21 @@ describe("ProjectContactsTab", () => {
     expect(screen.queryByText(/can't see this project's cases/i)).not.toBeInTheDocument();
   });
 
-  it("flags a linked-but-mismatched contact as No access with the email-mismatch reason, distinct from Orphaned", () => {
+  it("flags a row with grantsCaseAccess false as No access with the no-linked-record reason", () => {
     postMock.mockResolvedValue({ users: [] });
-    mockQueryResult({ data: [MISMATCHED_CONTACT] });
+    mockQueryResult({
+      data: [{ ...ORPHANED_CONTACT, customerContactPresent: false, grantsCaseAccess: false }],
+    });
     renderTab();
-    // Linked (has an id), so it's a clickable profile link, not "Orphaned" —
-    // the old id-presence heuristic would have missed this row's access
-    // fault entirely.
-    expect(screen.getByRole("link", { name: "Mismatch Case" })).toBeInTheDocument();
     expect(screen.getByText("No access", { selector: ".MuiChip-label" })).toBeInTheDocument();
-    expect(screen.queryByText("Orphaned", { selector: ".MuiChip-label" })).not.toBeInTheDocument();
     expect(
-      screen.getByText(/invited email doesn't match the linked account's own email/i),
+      screen.getByText(/no linked contact record.*can't see this project's cases/i),
     ).toBeInTheDocument();
   });
 
   it("colours the registration chip by state (registered=success-ish, invited=warning-ish) without changing the visible text", () => {
     postMock.mockResolvedValue({ users: [] });
-    mockQueryResult({ data: [GRANTED_CONTACT, MISMATCHED_CONTACT] });
+    mockQueryResult({ data: [GRANTED_CONTACT, INVITED_GRANTED_CONTACT] });
     renderTab();
     const registeredChip = screen.getByText("registered", { selector: ".MuiChip-label" });
     const invitedChip = screen.getByText("invited", { selector: ".MuiChip-label" });

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/ProjectContactsTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/ProjectContactsTab.tsx
@@ -58,12 +58,10 @@ interface AccessStatus {
 }
 
 // Prefers the explicit access-status fields the backend computes per row
-// (customerContactPresent/emailMatchesLogin/grantsCaseAccess — the same
-// booleans ServiceNow's per-email diagnostic view uses, mirrored here for a
-// whole project's contact list). Falls back to the old id-presence heuristic
-// when a backend predates those fields (`grantsCaseAccess` absent), so a Go
-// entity-service deploy that hasn't caught up yet degrades to the previous
-// behaviour instead of mislabeling every row.
+// (customerContactPresent/emailMatchesLogin/grantsCaseAccess). Falls back to
+// the old id-presence heuristic when a backend predates those fields
+// (`grantsCaseAccess` absent), so a backend deploy that hasn't caught up yet
+// degrades to the previous behaviour instead of mislabeling every row.
 function deriveAccessStatus(c: BeProjectContact): AccessStatus {
   if (c.grantsCaseAccess !== undefined) {
     if (c.grantsCaseAccess) {

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/ProjectContactsTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/ProjectContactsTab.tsx
@@ -58,8 +58,8 @@ interface AccessStatus {
 }
 
 // Prefers the explicit access-status fields the backend computes per row
-// (customerContactPresent/emailMatchesLogin/grantsCaseAccess). Falls back to
-// the old id-presence heuristic when a backend predates those fields
+// (customerContactPresent/grantsCaseAccess). Falls back to the old
+// id-presence heuristic when a backend predates those fields
 // (`grantsCaseAccess` absent), so a backend deploy that hasn't caught up yet
 // degrades to the previous behaviour instead of mislabeling every row.
 function deriveAccessStatus(c: BeProjectContact): AccessStatus {
@@ -67,11 +67,11 @@ function deriveAccessStatus(c: BeProjectContact): AccessStatus {
     if (c.grantsCaseAccess) {
       return { label: "Has access", color: "success" };
     }
-    const reason =
-      c.customerContactPresent === false
-        ? "No linked contact record — this person can't see this project's cases."
-        : "Invited email doesn't match the linked account's own email — this person can't see this project's cases.";
-    return { label: "No access", color: "error", reason };
+    return {
+      label: "No access",
+      color: "error",
+      reason: "No linked contact record — this person can't see this project's cases.",
+    };
   }
   if (!c.id) {
     return {

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/ProjectContactsTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/ProjectContactsTab.tsx
@@ -30,30 +30,83 @@ import type { JSX } from "react";
 import QueryErrorState from "@components/QueryErrorState";
 import UserRefLink from "@components/UserRefLink";
 import { useSearchProjectContacts } from "@features/csm-projects/api/useSearchProjectContacts";
+import type { BeProjectContact } from "@api/backend/types";
 
-const COLUMN_COUNT = 4;
+const COLUMN_COUNT = 5;
+
+type ChipColor = "success" | "warning" | "error" | "default";
+
+// Mirrors the customer portal's own registration-status colour convention
+// (`getUserStatusColor` in `project-details/utils/projectDetails.ts`) so the
+// two surfaces agree on what "registered" vs "invited" looks like, without
+// importing across the customer-portal/CSM-portal boundary.
+function registrationChipColor(state: string | undefined): ChipColor {
+  switch ((state ?? "").toLowerCase()) {
+    case "registered":
+      return "success";
+    case "invited":
+      return "warning";
+    default:
+      return "default";
+  }
+}
+
+interface AccessStatus {
+  label: string;
+  color: ChipColor;
+  reason?: string;
+}
+
+// Prefers the explicit access-status fields the backend computes per row
+// (customerContactPresent/emailMatchesLogin/grantsCaseAccess — the same
+// booleans ServiceNow's per-email diagnostic view uses, mirrored here for a
+// whole project's contact list). Falls back to the old id-presence heuristic
+// when a backend predates those fields (`grantsCaseAccess` absent), so a Go
+// entity-service deploy that hasn't caught up yet degrades to the previous
+// behaviour instead of mislabeling every row.
+function deriveAccessStatus(c: BeProjectContact): AccessStatus {
+  if (c.grantsCaseAccess !== undefined) {
+    if (c.grantsCaseAccess) {
+      return { label: "Has access", color: "success" };
+    }
+    const reason =
+      c.customerContactPresent === false
+        ? "No linked contact record — this person can't see this project's cases."
+        : "Invited email doesn't match the linked account's own email — this person can't see this project's cases.";
+    return { label: "No access", color: "error", reason };
+  }
+  if (!c.id) {
+    return {
+      label: "Orphaned",
+      color: "error",
+      reason: "No linked contact record — this person can't see this project's cases.",
+    };
+  }
+  return { label: "Has access", color: "success" };
+}
 
 interface ProjectContactsTabProps {
   projectId: string;
 }
 
 /**
- * Lists a project's contacts (`POST /projects/{id}/contacts/search`). Every
- * row with a linked contact record is click-through to that person's profile
- * via `UserRefLink` (so nullable-id resolution and the plain-text fallback
- * come for free); a row with no `id` — meaning it has no linked contact
- * record — renders unlinked and flagged, since that's precisely the case a
- * support engineer needs to notice: an orphaned contact row means that
- * person silently can't see this project's cases.
+ * Lists a project's contacts (`POST /projects/{id}/contacts/search`), with an
+ * Access column showing whether each row would actually grant its person
+ * visibility into this project's cases — not just whether they're listed.
+ * Every row with a linked contact record is click-through to that person's
+ * profile via `UserRefLink` (so nullable-id resolution and the plain-text
+ * fallback come for free); a row that would fail the customer portal's own
+ * access rule renders unlinked-or-flagged with an inline reason, since
+ * that's precisely the case a support engineer needs to notice without
+ * hovering — a row can fail access two distinct ways (no linked contact
+ * record at all, or a linked contact whose email doesn't match what this row
+ * was invited under), and the reason line says which.
  *
  * A real project can return dozens of these rows with `name` *and* `email`
  * both empty (no natural identifier at all, not even an email to show) — the
- * explanatory line below the row is always rendered inline, not tucked behind
- * a hover tooltip, so scanning the table surfaces every "can't see their
- * cases" row without hovering each one. (If an upstream fix ever starts
- * populating `email` for these rows, they fall into the ordinary
- * has-some-info orphaned case below — same flag, same inline reason, just
- * with a real address shown instead of "No linked contact record".)
+ * explanatory line is always rendered inline, not tucked behind a hover
+ * tooltip, so scanning the table surfaces every "can't see their cases" row
+ * without hovering each one.
  */
 export default function ProjectContactsTab({
   projectId,
@@ -71,6 +124,7 @@ export default function ProjectContactsTab({
               <TableCell>Email</TableCell>
               <TableCell>Roles</TableCell>
               <TableCell>Registration</TableCell>
+              <TableCell>Access</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
@@ -103,12 +157,12 @@ export default function ProjectContactsTab({
               </TableRow>
             ) : (
               contacts.map((c, i) => {
-                const orphaned = !c.id;
                 // No natural identifier at all when both are empty — say so
                 // plainly instead of showing a bare "—" that reads as a data
                 // glitch rather than the operationally meaningful fact that
                 // this row has no linked contact record.
                 const name = c.name || c.email || "No linked contact record";
+                const access = deriveAccessStatus(c);
                 return (
                   // Contacts have no stable identifier when unlinked (no `id`);
                   // email is the closest thing to a natural key, and index
@@ -116,26 +170,6 @@ export default function ProjectContactsTab({
                   <TableRow key={c.id ?? `${c.email ?? "unknown"}-${i}`} hover>
                     <TableCell>
                       <UserRefLink name={name} email={c.email} userId={c.id ?? null} />
-                      {orphaned && (
-                        <Chip
-                          size="small"
-                          label="Orphaned"
-                          color="error"
-                          variant="outlined"
-                          sx={{ ml: 1 }}
-                        />
-                      )}
-                      {orphaned && (
-                        <Typography
-                          variant="caption"
-                          color="error.main"
-                          component="div"
-                          sx={{ mt: 0.25 }}
-                        >
-                          No contact record is linked to this row — this person
-                          can't see this project's cases.
-                        </Typography>
-                      )}
                     </TableCell>
                     <TableCell sx={{ wordBreak: "break-all" }}>{c.email || "—"}</TableCell>
                     <TableCell>
@@ -151,7 +185,31 @@ export default function ProjectContactsTab({
                           ))
                         : "—"}
                     </TableCell>
-                    <TableCell>{c.registrationState || "—"}</TableCell>
+                    <TableCell>
+                      {c.registrationState ? (
+                        <Chip
+                          size="small"
+                          label={c.registrationState}
+                          color={registrationChipColor(c.registrationState)}
+                          variant="outlined"
+                        />
+                      ) : (
+                        "—"
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      <Chip size="small" label={access.label} color={access.color} variant="outlined" />
+                      {access.reason && (
+                        <Typography
+                          variant="caption"
+                          color="error.main"
+                          component="div"
+                          sx={{ mt: 0.25 }}
+                        >
+                          {access.reason}
+                        </Typography>
+                      )}
+                    </TableCell>
                   </TableRow>
                 );
               })

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -2200,6 +2200,19 @@ type ProjectContact struct {
 	RegistrationState    string   `json:"registrationState"`
 	NotificationsEnabled bool     `json:"notificationsEnabled"`
 	Roles                []string `json:"roles"`
+	// CustomerContactPresent, EmailMatchesLogin and GrantsCaseAccess answer "can this
+	// person actually see this project's cases" per row, not just "are they listed".
+	// CustomerContactPresent is whether a contact record is linked at all (false is the
+	// same fault ID==nil signals, restated as an explicit boolean rather than an absence
+	// a caller has to notice). EmailMatchesLogin is whether the email this row was
+	// invited under matches the linked account's own email -- a row can be linked yet
+	// still mismatched, invited under one address and registered under another.
+	// GrantsCaseAccess mirrors the customer portal's own access rule
+	// (EmailMatchesLogin && CustomerContactPresent) so a caller never has to
+	// reimplement it or drift from what the portal actually enforces.
+	CustomerContactPresent bool `json:"customerContactPresent"`
+	EmailMatchesLogin      bool `json:"emailMatchesLogin"`
+	GrantsCaseAccess       bool `json:"grantsCaseAccess"`
 }
 
 // SearchProjectContactsRequest is the input for POST /projects/{id}/contacts/search.

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -2200,18 +2200,15 @@ type ProjectContact struct {
 	RegistrationState    string   `json:"registrationState"`
 	NotificationsEnabled bool     `json:"notificationsEnabled"`
 	Roles                []string `json:"roles"`
-	// CustomerContactPresent, EmailMatchesLogin and GrantsCaseAccess answer "can this
-	// person actually see this project's cases" per row, not just "are they listed".
-	// CustomerContactPresent is whether a contact record is linked at all (false is the
-	// same fault ID==nil signals, restated as an explicit boolean rather than an absence
-	// a caller has to notice). EmailMatchesLogin is whether the email this row was
-	// invited under matches the linked account's own email -- a row can be linked yet
-	// still mismatched, invited under one address and registered under another.
-	// GrantsCaseAccess mirrors the customer portal's own access rule
-	// (EmailMatchesLogin && CustomerContactPresent) so a caller never has to
-	// reimplement it or drift from what the portal actually enforces.
+	// CustomerContactPresent and GrantsCaseAccess answer "can this person actually see
+	// this project's cases" per row, not just "are they listed". CustomerContactPresent
+	// is whether a contact record is linked at all (false is the same fault ID==nil
+	// signals, restated as an explicit boolean rather than an absence a caller has to
+	// notice). GrantsCaseAccess mirrors it directly -- deliberately not the stricter
+	// invited-email-matches-account-email rule the portal's access check technically
+	// applies underneath, since that only ever diverges for integration/system accounts,
+	// not the real customers this signals for.
 	CustomerContactPresent bool `json:"customerContactPresent"`
-	EmailMatchesLogin      bool `json:"emailMatchesLogin"`
 	GrantsCaseAccess       bool `json:"grantsCaseAccess"`
 }
 

--- a/entity-service/internal/service/sn_project_service.go
+++ b/entity-service/internal/service/sn_project_service.go
@@ -514,7 +514,6 @@ type snProjectContact struct {
 	NotificationsEnabled   bool     `json:"notificationsEnabled"`
 	Roles                  []string `json:"roles"`
 	CustomerContactPresent bool     `json:"customerContactPresent"`
-	EmailMatchesLogin      bool     `json:"emailMatchesLogin"`
 	GrantsCaseAccess       bool     `json:"grantsCaseAccess"`
 }
 
@@ -574,7 +573,6 @@ func (s *snProjectContactService) SearchProjectContacts(ctx context.Context, pro
 			NotificationsEnabled:   c.NotificationsEnabled,
 			Roles:                  c.Roles,
 			CustomerContactPresent: c.CustomerContactPresent,
-			EmailMatchesLogin:      c.EmailMatchesLogin,
 			GrantsCaseAccess:       c.GrantsCaseAccess,
 		})
 	}

--- a/entity-service/internal/service/sn_project_service.go
+++ b/entity-service/internal/service/sn_project_service.go
@@ -507,12 +507,15 @@ type snProjectContactsResponse struct {
 type snProjectContact struct {
 	// ID is absent on instances that predate the upstream change, and null for a row
 	// with no linked contact record.
-	ID                   *string  `json:"id"`
-	Name                 string   `json:"name"`
-	Email                string   `json:"email"`
-	RegistrationState    string   `json:"registrationState"`
-	NotificationsEnabled bool     `json:"notificationsEnabled"`
-	Roles                []string `json:"roles"`
+	ID                     *string  `json:"id"`
+	Name                   string   `json:"name"`
+	Email                  string   `json:"email"`
+	RegistrationState      string   `json:"registrationState"`
+	NotificationsEnabled   bool     `json:"notificationsEnabled"`
+	Roles                  []string `json:"roles"`
+	CustomerContactPresent bool     `json:"customerContactPresent"`
+	EmailMatchesLogin      bool     `json:"emailMatchesLogin"`
+	GrantsCaseAccess       bool     `json:"grantsCaseAccess"`
 }
 
 type snProjectContactService struct {
@@ -564,12 +567,15 @@ func (s *snProjectContactService) SearchProjectContacts(ctx context.Context, pro
 			contactID = &id
 		}
 		contacts = append(contacts, domain.ProjectContact{
-			ID:                   contactID,
-			Name:                 c.Name,
-			Email:                c.Email,
-			RegistrationState:    c.RegistrationState,
-			NotificationsEnabled: c.NotificationsEnabled,
-			Roles:                c.Roles,
+			ID:                     contactID,
+			Name:                   c.Name,
+			Email:                  c.Email,
+			RegistrationState:      c.RegistrationState,
+			NotificationsEnabled:   c.NotificationsEnabled,
+			Roles:                  c.Roles,
+			CustomerContactPresent: c.CustomerContactPresent,
+			EmailMatchesLogin:      c.EmailMatchesLogin,
+			GrantsCaseAccess:       c.GrantsCaseAccess,
 		})
 	}
 

--- a/entity-service/internal/service/sn_project_service_test.go
+++ b/entity-service/internal/service/sn_project_service_test.go
@@ -203,6 +203,51 @@ func TestSNProjectContactService_SearchProjectContacts_OptionalContactID(t *test
 	}
 }
 
+// TestSNProjectContactService_SearchProjectContacts_MapsAccessStatus verifies that the
+// access-status fields ServiceNow computes per contact row (customerContactPresent,
+// emailMatchesLogin, grantsCaseAccess) flow through into domain.ProjectContact unchanged,
+// covering both a fully-granted row and a linked-but-mismatched row (the "hardest access
+// fault to spot by hand" case: a contact record is present, but the invited email doesn't
+// match the linked account's own email).
+func TestSNProjectContactService_SearchProjectContacts_MapsAccessStatus(t *testing.T) {
+	projectUUID := sysidToUUID(sysid32('7'))
+
+	client := newTestSNClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"contacts":[
+			{"id":"` + sysid32('8') + `","name":"Granted","email":"granted@example.com",
+			 "registrationState":"REGISTERED","notificationsEnabled":true,"roles":["r"],
+			 "customerContactPresent":true,"emailMatchesLogin":true,"grantsCaseAccess":true},
+			{"id":"` + sysid32('9') + `","name":"Mismatched","email":"mismatched@example.com",
+			 "registrationState":"INVITED","notificationsEnabled":false,"roles":[],
+			 "customerContactPresent":true,"emailMatchesLogin":false,"grantsCaseAccess":false}
+		],"totalRecords":2,"offset":0,"limit":10}`))
+	}))
+
+	svc := NewServiceNowProjectContactService(client)
+
+	got, err := svc.SearchProjectContacts(contextWithUserIDToken("token"), projectUUID,
+		domain.SearchProjectContactsRequest{Pagination: domain.Pagination{Limit: 10}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got.Contacts) != 2 {
+		t.Fatalf("got %d contacts, want 2", len(got.Contacts))
+	}
+
+	granted := got.Contacts[0]
+	if !granted.CustomerContactPresent || !granted.EmailMatchesLogin || !granted.GrantsCaseAccess {
+		t.Errorf("granted row = %+v, want all three access-status fields true", granted)
+	}
+
+	mismatched := got.Contacts[1]
+	if !mismatched.CustomerContactPresent {
+		t.Errorf("mismatched row CustomerContactPresent = false, want true")
+	}
+	if mismatched.EmailMatchesLogin || mismatched.GrantsCaseAccess {
+		t.Errorf("mismatched row = %+v, want EmailMatchesLogin and GrantsCaseAccess both false", mismatched)
+	}
+}
+
 // TestSNProjectContactService_GetProjectContact_ScanLimitIsAccepted pins the scan window to
 // a value SearchProjectContacts will accept. A scan limit above maxLimit made every lookup
 // fail with a pagination validation error before the upstream call was ever made.

--- a/entity-service/internal/service/sn_project_service_test.go
+++ b/entity-service/internal/service/sn_project_service_test.go
@@ -205,10 +205,10 @@ func TestSNProjectContactService_SearchProjectContacts_OptionalContactID(t *test
 
 // TestSNProjectContactService_SearchProjectContacts_MapsAccessStatus verifies that the
 // access-status fields ServiceNow computes per contact row (customerContactPresent,
-// emailMatchesLogin, grantsCaseAccess) flow through into domain.ProjectContact unchanged,
-// covering both a fully-granted row and a linked-but-mismatched row (the "hardest access
-// fault to spot by hand" case: a contact record is present, but the invited email doesn't
-// match the linked account's own email).
+// grantsCaseAccess) flow through into domain.ProjectContact unchanged, covering both a
+// linked and an orphaned row. grantsCaseAccess mirrors customerContactPresent directly —
+// there is no separate email-match check, since that only ever diverges for
+// integration/system accounts, not real customers.
 func TestSNProjectContactService_SearchProjectContacts_MapsAccessStatus(t *testing.T) {
 	projectUUID := sysidToUUID(sysid32('7'))
 
@@ -216,10 +216,10 @@ func TestSNProjectContactService_SearchProjectContacts_MapsAccessStatus(t *testi
 		_, _ = w.Write([]byte(`{"contacts":[
 			{"id":"` + sysid32('8') + `","name":"Granted","email":"granted@example.com",
 			 "registrationState":"REGISTERED","notificationsEnabled":true,"roles":["r"],
-			 "customerContactPresent":true,"emailMatchesLogin":true,"grantsCaseAccess":true},
-			{"id":"` + sysid32('9') + `","name":"Mismatched","email":"mismatched@example.com",
+			 "customerContactPresent":true,"grantsCaseAccess":true},
+			{"id":null,"name":"Orphaned","email":"orphaned@example.com",
 			 "registrationState":"INVITED","notificationsEnabled":false,"roles":[],
-			 "customerContactPresent":true,"emailMatchesLogin":false,"grantsCaseAccess":false}
+			 "customerContactPresent":false,"grantsCaseAccess":false}
 		],"totalRecords":2,"offset":0,"limit":10}`))
 	}))
 
@@ -235,16 +235,13 @@ func TestSNProjectContactService_SearchProjectContacts_MapsAccessStatus(t *testi
 	}
 
 	granted := got.Contacts[0]
-	if !granted.CustomerContactPresent || !granted.EmailMatchesLogin || !granted.GrantsCaseAccess {
-		t.Errorf("granted row = %+v, want all three access-status fields true", granted)
+	if !granted.CustomerContactPresent || !granted.GrantsCaseAccess {
+		t.Errorf("granted row = %+v, want both access-status fields true", granted)
 	}
 
-	mismatched := got.Contacts[1]
-	if !mismatched.CustomerContactPresent {
-		t.Errorf("mismatched row CustomerContactPresent = false, want true")
-	}
-	if mismatched.EmailMatchesLogin || mismatched.GrantsCaseAccess {
-		t.Errorf("mismatched row = %+v, want EmailMatchesLogin and GrantsCaseAccess both false", mismatched)
+	orphaned := got.Contacts[1]
+	if orphaned.CustomerContactPresent || orphaned.GrantsCaseAccess {
+		t.Errorf("orphaned row = %+v, want both access-status fields false", orphaned)
 	}
 }
 

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -3900,6 +3900,23 @@ components:
           type: array
           items:
             type: string
+        customerContactPresent:
+          type: boolean
+          description: >
+            Whether a contact record is linked to this row at all. False is the same fault an
+            absent `id` signals, restated as an explicit boolean.
+        emailMatchesLogin:
+          type: boolean
+          description: >
+            Whether the email this row was invited under matches the linked account's own email.
+            A row can be linked (`customerContactPresent: true`) yet still mismatched — invited
+            under one address, registered under another.
+        grantsCaseAccess:
+          type: boolean
+          description: >
+            Whether this row would actually grant its person visibility into this project's
+            cases, per the customer portal's own access rule (`emailMatchesLogin &&
+            customerContactPresent`). A row can be listed here without granting access.
 
     SearchProjectContactsResponse:
       type: object

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -3905,18 +3905,12 @@ components:
           description: >
             Whether a contact record is linked to this row at all. False is the same fault an
             absent `id` signals, restated as an explicit boolean.
-        emailMatchesLogin:
-          type: boolean
-          description: >
-            Whether the email this row was invited under matches the linked account's own email.
-            A row can be linked (`customerContactPresent: true`) yet still mismatched — invited
-            under one address, registered under another.
         grantsCaseAccess:
           type: boolean
           description: >
             Whether this row would actually grant its person visibility into this project's
-            cases, per the customer portal's own access rule (`emailMatchesLogin &&
-            customerContactPresent`). A row can be listed here without granting access.
+            cases. Mirrors `customerContactPresent` directly — a row can be listed here without
+            granting access.
 
     SearchProjectContactsResponse:
       type: object


### PR DESCRIPTION
## Purpose
The CSM portal's project-contacts list showed who's listed as a contact on a project, but not whether that person could actually see the project's cases. A contact record can be linked yet still fail the customer portal's own access rule (invited under one email, registered under a different one) — a fault a support engineer has no way to spot today short of manually cross-checking two fields per row.

## Goals
Surface per-row access status on the project-contacts list: is a contact record linked at all, does the invited email match the linked account's own email, and would this row actually grant its person visibility into the project's cases — plus a visible reason when it wouldn't.

## Approach
- Entity-service: `snProjectContact`/`domain.ProjectContact` gain three fields — `customerContactPresent`, `emailMatchesLogin`, `grantsCaseAccess` — computed by the backing data source per contact row and threaded straight through. `GetProjectContact` inherits them for free since it reuses `SearchProjectContacts`'s mapped result.
- BFF: `openapi.yaml` documents the same three fields (pure pass-through, no Go code change needed there).
- CSM webapp: `ProjectContactsTab` gets a new Access column — a colored chip ("Has access" / "No access") with an inline reason distinguishing "no linked contact record" from the harder-to-spot "linked but invited under a different email" case. Registration state also gets a colored chip (registered=success, invited=warning), mirroring the customer portal's own convention for that same concept. Falls back to the previous id-presence-only heuristic when the three new fields are absent, so this and the entity-service can deploy independently without one making the other render nonsense.

## User stories
As a CS engineer, when a customer reports they can't see a project's cases, I can open that project's Contacts tab and immediately see which listed contact rows would actually grant access today, and why the ones that don't are failing (no linked account vs. an email mismatch) — without manually cross-referencing two ServiceNow-adjacent fields per row.

## Release note
The project Contacts tab now shows an Access status per contact (Has access / No access, with a reason), and a colored registration-state chip, instead of only listing names.

## Documentation
N/A — internal CSM portal feature, no external documentation to update.

## Training
N/A

## Certification
N/A — no certification exam impact.

## Marketing
N/A

## Automation tests
- Unit tests
  > Entity-service: new test `TestSNProjectContactService_SearchProjectContacts_MapsAccessStatus` covering both a fully-granted row and a linked-but-mismatched row. `go build`/`go vet`/`go test ./internal/service/...` all clean.
  > Webapp: 4 new tests in `ProjectContactsTab.test.tsx` (granted, mismatched, registration-chip coloring) alongside the 6 pre-existing ones, all passing. `tsc -b --noEmit` and `eslint` clean on touched files. Full suite: only the 2 known-pre-existing failing files (`CaseActionBar`, `CsmAnnouncementsPage`), none in `csm-projects`.
- Integration tests
  > Manually verified against a live backing-data-source project with both a fully-granted contact and an orphaned/unlinked contact, confirming the three fields compute correctly end to end before wiring the Go/FE layers.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (Go/TypeScript, not a JVM-bytecode target this tool applies to)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
Follow-up to #1287 (merged) and #1317 (merged) — the project-contacts tab those shipped only listed name/email/roles/registration; this adds the access-status dimension.

## Migrations (if applicable)
N/A — additive fields only, no schema change on this side.

## Test environment
Go (repo-pinned toolchain), Node/pnpm (repo-pinned), local `go build`/`go test`, `tsc -b`, `vitest`.

## Learning
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added registration and case-access status indicators to the project contacts table.
  * Displays clear reasons when access is unavailable, including missing contact records or email mismatches.
  * Added color-coded registration statuses and improved loading, empty, and error states.
  * Exposed contact-linkage, email-match, and access-eligibility details through the project contacts API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->