### PR TITLE
[Customer Portal v2][BE] Add product-consumption service: deployment license and usage import

### DIFF
--- a/apps/customer-portal/backend-v2/.env.example
+++ b/apps/customer-portal/backend-v2/.env.example
@@ -31,6 +31,11 @@ AI_CHAT_AGENT_WS_SCOPES=
 # local development only.
 WS_ALLOWED_ORIGINS=
 
+# Product-consumption service (deployment license provisioning + usage import) —
+# a separate service, not entity-service.
+PRODUCT_CONSUMPTION_BASE_URL=
+PRODUCT_CONSUMPTION_SCOPES=
+
 # Auth
 # AUTH_TOKEN_VALIDATOR_ENABLED=false (below) skips JWT signature verification —
 # local development only. Production MUST set it to true with a real

--- a/apps/customer-portal/backend-v2/CLAUDE.md
+++ b/apps/customer-portal/backend-v2/CLAUDE.md
@@ -86,10 +86,11 @@ private `do()` shape as `internal/entity`:
   struct, so it's merged directly into `dto.UserMeResponse`/`dto.UserUpdateResponse` in
   `internal/handler/users.go` — again no separate mapping layer needed.
 
-All four service clients (entity, updates, SCIM, the AI chat agent) authenticate as the same shared
-OAuth2 client-credentials app in `cmd/server/main.go` — only each service's `*_BASE_URL`/`*_SCOPES`
-env vars differ (confirmed against the Ballerina backend's `Config.toml`, where every module,
-including the AI chat agent's WebSocket variant, declares the same `clientId`/`tokenUrl`).
+All five service clients (entity, updates, SCIM, the AI chat agent, the product-consumption
+service) authenticate as the same shared OAuth2 client-credentials app in `cmd/server/main.go` —
+only each service's `*_BASE_URL`/`*_SCOPES` env vars differ (confirmed against the Ballerina
+backend's `Config.toml`, where every module, including the AI chat agent's WebSocket variant,
+declares the same `clientId`/`tokenUrl`).
 
 ## The AI chat agent
 
@@ -160,7 +161,12 @@ It backs two routes:
   yet. Read the whole function before touching it — a subtly wrong condition could create a
   duplicate WSO2 API Manager application. The handler first calls `entity.GetProject` purely as an
   access-control gate (mirroring the Ballerina backend), discarding the result — entity-service is
-  still the actual authorization boundary for "does this caller own this project."
+  still the actual authorization boundary for "does this caller own this project." Because up to 5
+  sequential upstream calls can plausibly exceed the server's global `WriteTimeout` (see
+  `cmd/server/main.go`) even when no single step is slow, the handler extends its own write
+  deadline via `http.NewResponseController(w).SetWriteDeadline` — which only works because
+  `middleware.responseWriter` forwards `SetWriteDeadline`/`SetReadDeadline` to the underlying
+  `ResponseWriter`, the same reason it forwards `Hijack` for the WebSocket route above.
 - `POST /deployment-usages` — imports a deployment-usage zip file. Unlike every other endpoint in
   this backend, the request body is **raw binary**, not JSON — see `readBinaryBody` in
   `internal/handler/response.go` (a `readJSONBody` counterpart with a larger size cap,

--- a/apps/customer-portal/backend-v2/CLAUDE.md
+++ b/apps/customer-portal/backend-v2/CLAUDE.md
@@ -24,15 +24,20 @@ backend's own CLAUDE.md too if something here is underspecified.
 `POST /projects/{id}/conversations/search`, `GET /conversations/{id}/messages`,
 `POST /projects/{projectId}/conversations/{conversationId}/messages`,
 `GET /projects/{id}/conversations/{conversationId}/summary`, `GET /ws`,
-`GET /updates/product-update-levels`, `POST /updates/levels/search`) across four upstream
-services: entity-service, the WSO2 Updates service, SCIM, and the AI chat agent (see "The AI chat
-agent" below — unlike the other three, it isn't entity-service-backed at all). The Ballerina
-backend exposes ~100 routes across many more modules (registry tokens, escalations, incidents,
-problems, task SLAs, tasks, groups/service-offerings/configuration-items, account/project contacts,
-project update, generic user search, etc.) — none of those are ported yet, several because they
-have no genuine equivalent on `cs-tools/entity-service` or aren't actually customer-portal features
-at all (see "Which entity-service" below on how to tell the difference before porting one). Follow
-the recipe below to add the next one.
+`POST /projects/{projectId}/deployments/{deploymentId}/license`, `POST /deployment-usages`,
+`GET /updates/product-update-levels`, `POST /updates/levels/search`) across five upstream
+services: entity-service, the WSO2 Updates service, SCIM, the AI chat agent, and the
+product-consumption service (see "The AI chat agent" and "The product-consumption service" below —
+unlike the other three, neither is entity-service-backed at all). The Ballerina backend exposes
+~100 routes across many more modules (registry tokens, escalations, incidents, problems, task
+SLAs, tasks, groups/service-offerings/configuration-items, account/project contacts, project
+update, generic user search, project/case/deployment/conversation/time-card stats, case feedback,
+instance search/metrics, global search, etc.) — none of those are ported yet, several because they
+have no genuine equivalent on `cs-tools/entity-service` (confirmed by grepping
+`entity-service/internal/server/routes.go` for each — stats, feedback, instance metrics, escalations,
+and global search all come up empty) or aren't actually customer-portal features at all (see "Which
+entity-service" below on how to tell the difference before porting one). Follow the recipe below to
+add the next one.
 
 ## Which entity-service
 
@@ -135,6 +140,34 @@ Primary authorization on `GET /ws` is the same JWT middleware chain as every oth
 cross-site WebSocket hijacking, restricting which browser `Origin`s may open the connection — set
 via the optional `WS_ALLOWED_ORIGINS` env var (comma-separated; unset allows any origin, local
 development only).
+
+## The product-consumption service
+
+`internal/productconsumption` is a fifth upstream client for **another separate service unrelated
+to entity-service** — see `apps/customer-portal/backend`'s `modules/product_consumption_subscription`
+and `modules/product_consumption_tracking` for the Ballerina backend's two client modules, which
+this backend models as one Go package since both Ballerina modules point at the same upstream base
+URL in practice (confirmed in the Ballerina backend's `config.toml`).
+
+It backs two routes:
+- `POST /projects/{projectId}/deployments/{deploymentId}/license` — provisions (or resumes
+  provisioning) a WSO2 API Manager application/subscription/credentials for a deployment and
+  returns the resulting license. `ProcessLicenseDownload` (`internal/productconsumption/subscription.go`)
+  is a straight port of the Ballerina backend's `processLicenseDownload` state machine — it is
+  **not idempotent-by-accident-safe to reimplement casually**: it can make up to 5 sequential
+  upstream calls, several with side effects (creating an application, subscribing it, generating
+  credentials), and each step only runs if the project's upstream-tracked status hasn't reached it
+  yet. Read the whole function before touching it — a subtly wrong condition could create a
+  duplicate WSO2 API Manager application. The handler first calls `entity.GetProject` purely as an
+  access-control gate (mirroring the Ballerina backend), discarding the result — entity-service is
+  still the actual authorization boundary for "does this caller own this project."
+- `POST /deployment-usages` — imports a deployment-usage zip file. Unlike every other endpoint in
+  this backend, the request body is **raw binary**, not JSON — see `readBinaryBody` in
+  `internal/handler/response.go` (a `readJSONBody` counterpart with a larger size cap,
+  `maxZipUploadBytes`) and the `Content-Type: application/zip`/`application/x-zip-compressed`
+  check in the handler, both mirroring the Ballerina backend's `validateDeploymentUsageImportRequest`.
+  The Go client base64-encodes the bytes before forwarding to the upstream service, matching its
+  JSON contract exactly (`{"email": "...", "zip": "<base64>"}`).
 
 ## Middleware chain
 

--- a/apps/customer-portal/backend-v2/README.md
+++ b/apps/customer-portal/backend-v2/README.md
@@ -83,8 +83,9 @@ Copy `.env.example` to `.env` and fill in the values.
 
 ### Shared OAuth2 client credentials
 
-Every upstream service client (entity-service, updates, SCIM, the AI chat agent) authenticates as
-the same OAuth2 client-credentials app — only each service's base URL and scopes differ.
+Every upstream service client (entity-service, updates, SCIM, the AI chat agent, the
+product-consumption service) authenticates as the same OAuth2 client-credentials app — only each
+service's base URL and scopes differ.
 
 | Variable | Description |
 |---|---|

--- a/apps/customer-portal/backend-v2/README.md
+++ b/apps/customer-portal/backend-v2/README.md
@@ -5,10 +5,11 @@ Go rewrite of the Ballerina backend at `apps/customer-portal/backend`. It is a b
 [`entity-service`](../../../entity-service) (this repo's `cs-tools/entity-service`, not the
 `digiops-cs/entity-service` the Ballerina backend targets), and shapes the responses for the frontend.
 
-This is a work in progress — only the 50 routes listed below are implemented so far, across
-entity-service, the WSO2 Updates service, SCIM, and the AI chat agent (a separate Python service —
-see [CLAUDE.md](./CLAUDE.md#the-ai-chat-agent)). Everything else the Ballerina backend exposes
-still needs a Go handler; add them following the pattern described in
+This is a work in progress — only the 52 routes listed below are implemented so far, across
+entity-service, the WSO2 Updates service, SCIM, the AI chat agent, and the product-consumption
+service (two more separate services — see [CLAUDE.md](./CLAUDE.md#the-ai-chat-agent) and
+[CLAUDE.md](./CLAUDE.md#the-product-consumption-service)). Everything else the Ballerina backend
+exposes still needs a Go handler; add them following the pattern described in
 [CLAUDE.md](./CLAUDE.md#adding-a-new-endpoint).
 
 ## Quick Start
@@ -29,9 +30,9 @@ Backend starts at `http://localhost:8080`.
 - Entry point: `cmd/server/main.go`
 - Authentication:
   - Incoming requests: JWT Bearer token; pass as `x-jwt-assertion` header when testing locally
-  - Outbound calls to entity-service, the Updates service, SCIM, and the AI chat agent: OAuth2
-    client credentials grant, shared across all four (optional — entity-service itself does not
-    validate inbound credentials, see [CLAUDE.md](./CLAUDE.md))
+  - Outbound calls to entity-service, the Updates service, SCIM, the AI chat agent, and the
+    product-consumption service: OAuth2 client credentials grant, shared across all five (optional
+    — entity-service itself does not validate inbound credentials, see [CLAUDE.md](./CLAUDE.md))
 
 ## Prerequisites
 
@@ -42,6 +43,8 @@ Backend starts at `http://localhost:8080`.
   `/updates/*` routes and phone-number fields on `/users/me`)
 - A running instance of the AI chat agent (a separate Python service, not entity-service — for
   `/cases/classify`, `/conversations/*`, `/projects/*/conversations/*`, and `/ws`)
+- A running instance of the product-consumption service (a separate service, not entity-service —
+  for `/projects/*/deployments/*/license` and `/deployment-usages`)
 
 ## Testing
 
@@ -120,6 +123,15 @@ A separate Python service (not entity-service) — see [CLAUDE.md](./CLAUDE.md#t
 | `AI_CHAT_AGENT_WS_SCOPES` | Comma-separated OAuth2 scopes (optional) |
 | `WS_ALLOWED_ORIGINS` | Comma-separated browser Origins allowed to open `GET /ws` (optional — defense in depth against cross-site WebSocket hijacking; unset allows any origin, local development only) |
 
+### Product-consumption service
+
+A separate service (not entity-service) — see [CLAUDE.md](./CLAUDE.md#the-product-consumption-service).
+
+| Variable | Description |
+|---|---|
+| `PRODUCT_CONSUMPTION_BASE_URL` | Base URL of the product-consumption service |
+| `PRODUCT_CONSUMPTION_SCOPES` | Comma-separated OAuth2 scopes (optional) |
+
 ### Auth
 
 | Variable | Description |
@@ -173,6 +185,11 @@ backend-v2/
 │   │   ├── client.go            # Config/Client/do()/getJSON()/postJSON()
 │   │   ├── types.go             # AI chat agent's wire-format structs
 │   │   └── ws.go                # WSConfig/WSClient/StreamChat — proxies the upstream WebSocket
+│   ├── productconsumption/       # OAuth2 HTTP client for the product-consumption service (not entity-service)
+│   │   ├── client.go            # Config/Client/do()/postJSON()/patchJSON()
+│   │   ├── types.go             # product-consumption service's wire-format structs
+│   │   ├── subscription.go      # ProcessLicenseDownload — the deployment-license state machine
+│   │   └── tracking.go          # ImportDeploymentUsage
 │   ├── dto/                     # Portal-facing response shapes + Map* functions from entity types
 │   │   ├── user.go
 │   │   ├── account.go
@@ -187,6 +204,7 @@ backend-v2/
 │   │   ├── time_card.go
 │   │   ├── comment.go
 │   │   ├── ai_chat.go
+│   │   ├── product_consumption.go
 │   │   ├── change_request.go
 │   │   └── call_request.go
 │   ├── middleware/
@@ -210,6 +228,7 @@ backend-v2/
 │       ├── comments.go          # generic comment create/search
 │       ├── ai_chat.go           # case classification, recommendations, conversation search/messages/summary
 │       ├── websocket.go         # GET /ws — real-time AI chat proxy
+│       ├── product_consumption.go # deployment license provisioning, deployment usage import
 │       ├── change_requests.go   # change-request create/search/get/update/approvals
 │       ├── call_requests.go     # call-request create/search/update
 │       └── updates.go           # GET /updates/product-update-levels, POST /updates/levels/search
@@ -270,6 +289,8 @@ backend-v2/
 - `POST /projects/{projectId}/conversations/{conversationId}/messages` — send a follow-up message on an existing conversation
 - `GET /projects/{id}/conversations/{conversationId}/summary` — get a conversation's summary via the AI chat agent
 - `GET /ws?sessionId={projectId}` — WebSocket: real-time AI chat proxy for an existing conversation (see CLAUDE.md — starting a brand-new conversation isn't supported yet)
+- `POST /projects/{projectId}/deployments/{deploymentId}/license` — provision (or resume provisioning) and return a deployment's license via the product-consumption service
+- `POST /deployment-usages` — import a deployment-usage zip file (raw binary body, `Content-Type: application/zip`) via the product-consumption service
 - `GET /updates/product-update-levels` — list product update levels
 - `POST /updates/levels/search` — search update descriptions between two update levels
 
@@ -458,6 +479,13 @@ curl -H "x-jwt-assertion: $JWT" http://localhost:8080/projects/<project-id>/conv
 # Using websocat (https://github.com/vi/websocat) as an example client:
 websocat "ws://localhost:8080/ws?sessionId=<project-id>" -H "x-jwt-assertion: $JWT"
 # then send: {"message":"still seeing the error","conversationId":"<conversation-id>"}
+
+curl -X POST http://localhost:8080/projects/<project-id>/deployments/<deployment-id>/license \
+  -H "x-jwt-assertion: $JWT"
+
+curl -X POST http://localhost:8080/deployment-usages \
+  -H "x-jwt-assertion: $JWT" -H "Content-Type: application/zip" \
+  --data-binary @deployment-usage.zip
 
 curl -H "x-jwt-assertion: $JWT" http://localhost:8080/updates/product-update-levels
 

--- a/apps/customer-portal/backend-v2/cmd/server/main.go
+++ b/apps/customer-portal/backend-v2/cmd/server/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
 	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/handler"
 	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/middleware"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/productconsumption"
 	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/scim"
 	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/updates"
 )
@@ -100,6 +101,19 @@ func main() {
 	}
 	aiChatAgentWsClient := aichatagent.NewWSClient(aiChatAgentWsCfg)
 
+	// The product-consumption service is a separate service (not
+	// entity-service) that provisions deployment licenses; it also
+	// authenticates as the same shared OAuth2 app (see the Ballerina
+	// backend's Config.toml).
+	productConsumptionCfg := productconsumption.Config{
+		BaseURL:      mustEnv("PRODUCT_CONSUMPTION_BASE_URL"),
+		TokenURL:     oauth2TokenURL,
+		ClientID:     oauth2ClientID,
+		ClientSecret: oauth2ClientSecret,
+		Scopes:       splitComma(os.Getenv("PRODUCT_CONSUMPTION_SCOPES")),
+	}
+	productConsumptionClient := productconsumption.NewClient(productConsumptionCfg)
+
 	userHandler := handler.NewUserHandler(entityClient, scimClient)
 	projectHandler := handler.NewProjectHandler(entityClient)
 	caseHandler := handler.NewCaseHandler(entityClient)
@@ -117,6 +131,7 @@ func main() {
 	timeCardHandler := handler.NewTimeCardHandler(entityClient)
 	aiChatHandler := handler.NewAIChatHandler(aiChatAgentClient, entityClient)
 	webSocketHandler := handler.NewWebSocketHandler(aiChatAgentWsClient, entityClient, splitComma(os.Getenv("WS_ALLOWED_ORIGINS")))
+	productConsumptionHandler := handler.NewProductConsumptionHandler(productConsumptionClient, entityClient)
 
 	authCfg := middleware.Config{
 		JWKSEndpoint:          mustEnv("AUTH_JWKS_ENDPOINT"),
@@ -209,6 +224,11 @@ func main() {
 	mux.HandleFunc("POST /projects/{projectId}/conversations/{conversationId}/messages", aiChatHandler.SendConversationMessage)
 	mux.HandleFunc("GET /projects/{id}/conversations/{conversationId}/summary", aiChatHandler.GetConversationSummary)
 	mux.HandleFunc("GET /ws", webSocketHandler.HandleWebSocket)
+
+	// The product-consumption service is a separate service (not
+	// entity-service) — see internal/productconsumption's package doc comment.
+	mux.HandleFunc("POST /projects/{projectId}/deployments/{deploymentId}/license", productConsumptionHandler.GetDeploymentLicense)
+	mux.HandleFunc("POST /deployment-usages", productConsumptionHandler.ImportDeploymentUsage)
 
 	mux.HandleFunc("GET /updates/product-update-levels", updatesHandler.GetProductUpdateLevels)
 	mux.HandleFunc("POST /updates/levels/search", updatesHandler.SearchUpdatesBetweenUpdateLevels)

--- a/apps/customer-portal/backend-v2/internal/dto/product_consumption.go
+++ b/apps/customer-portal/backend-v2/internal/dto/product_consumption.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dto
+
+import "github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/productconsumption"
+
+// LicenseSubscriptionData carries the deployment's license/subscription
+// credentials. Every field here is deliberately included, unlike most
+// response DTOs in this package — this endpoint's entire purpose is handing
+// the customer their own deployment's license credentials.
+type LicenseSubscriptionData struct {
+	DeploymentID    string `json:"deploymentId"`
+	DeploymentName  string `json:"deploymentName"`
+	SubscriptionKey string `json:"subscriptionKey"`
+	ClientID        string `json:"clientId"`
+	ClientSecret    string `json:"clientSecret"`
+	Secrets         string `json:"secrets"`
+}
+
+// LicenseResponse is the portal's response for
+// POST /projects/{projectId}/deployments/{deploymentId}/license.
+type LicenseResponse struct {
+	SubscriptionData LicenseSubscriptionData `json:"subscriptionData"`
+	Signature        string                  `json:"signature"`
+}
+
+// MapLicense builds the portal response from the product-consumption service's License.
+func MapLicense(l productconsumption.License) LicenseResponse {
+	return LicenseResponse{
+		SubscriptionData: LicenseSubscriptionData{
+			DeploymentID:    l.SubscriptionData.DeploymentID,
+			DeploymentName:  l.SubscriptionData.DeploymentName,
+			SubscriptionKey: l.SubscriptionData.SubscriptionKey,
+			ClientID:        l.SubscriptionData.ClientID,
+			ClientSecret:    l.SubscriptionData.ClientSecret,
+			Secrets:         l.SubscriptionData.Secrets,
+		},
+		Signature: l.Signature,
+	}
+}
+
+// ImportDeploymentUsageResponse is the portal's response for POST /deployment-usages.
+type ImportDeploymentUsageResponse struct {
+	Message string `json:"message,omitempty"`
+	Result  any    `json:"result,omitempty"`
+}
+
+// MapImportDeploymentUsage builds the portal response from the
+// product-consumption service's ImportUsageResponse.
+func MapImportDeploymentUsage(r productconsumption.ImportUsageResponse) ImportDeploymentUsageResponse {
+	out := ImportDeploymentUsageResponse{Result: r.Result}
+	if r.Message != nil {
+		out.Message = *r.Message
+	}
+	return out
+}

--- a/apps/customer-portal/backend-v2/internal/handler/product_consumption.go
+++ b/apps/customer-portal/backend-v2/internal/handler/product_consumption.go
@@ -1,0 +1,125 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/dto"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/middleware"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/productconsumption"
+)
+
+// productConsumptionClient abstracts the upstream product-consumption
+// service operations used by ProductConsumptionHandler.
+type productConsumptionClient interface {
+	ProcessLicenseDownload(ctx context.Context, req productconsumption.LicenseDownloadRequest) (productconsumption.License, error)
+	ImportDeploymentUsage(ctx context.Context, email string, zipFile []byte) (productconsumption.ImportUsageResponse, error)
+}
+
+// entityProjectAccessChecker is the subset of entityProjectClient needed to
+// verify the caller has access to a project before provisioning a license.
+type entityProjectAccessChecker interface {
+	GetProject(ctx context.Context, id string) (entity.ProjectDetailsView, error)
+}
+
+// ProductConsumptionHandler handles HTTP requests for the product-consumption
+// feature: deployment license provisioning/download and deployment usage
+// import. Calls a separate upstream service (not entity-service) — see
+// internal/productconsumption's package doc comment.
+type ProductConsumptionHandler struct {
+	productConsumption productConsumptionClient
+	entity             entityProjectAccessChecker
+}
+
+// NewProductConsumptionHandler creates a ProductConsumptionHandler backed by
+// the given product-consumption and entity clients.
+func NewProductConsumptionHandler(productConsumption productConsumptionClient, entityClient entityProjectAccessChecker) *ProductConsumptionHandler {
+	return &ProductConsumptionHandler{productConsumption: productConsumption, entity: entityClient}
+}
+
+// GetDeploymentLicense handles POST /projects/{projectId}/deployments/{deploymentId}/license.
+func (h *ProductConsumptionHandler) GetDeploymentLicense(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	projectID := r.PathValue("projectId")
+	deploymentID := r.PathValue("deploymentId")
+	if !uuidRe.MatchString(projectID) || !uuidRe.MatchString(deploymentID) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	// Verify the caller can access this project before provisioning
+	// anything — entity-service's own project-access check is the
+	// authorization gate here, matching the Ballerina backend's flow.
+	if _, err := h.entity.GetProject(r.Context(), projectID); err != nil {
+		slog.ErrorContext(r.Context(), "entity GetProject failed", "userID", user.UserID, "projectID", projectID, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to retrieve project details.")
+		return
+	}
+
+	license, err := h.productConsumption.ProcessLicenseDownload(r.Context(), productconsumption.LicenseDownloadRequest{
+		Email:        user.Email,
+		DeploymentID: deploymentID,
+		ProjectID:    projectID,
+	})
+	if err != nil {
+		slog.ErrorContext(r.Context(), "productconsumption ProcessLicenseDownload failed", "userID", user.UserID, "projectID", projectID, "deploymentID", deploymentID, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to retrieve license.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusOK, dto.MapLicense(license))
+}
+
+// ImportDeploymentUsage handles POST /deployment-usages. The request body is
+// a raw zip file, not JSON.
+func (h *ProductConsumptionHandler) ImportDeploymentUsage(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	contentType := strings.ToLower(strings.TrimSpace(strings.SplitN(r.Header.Get("Content-Type"), ";", 2)[0]))
+	if contentType != "application/zip" && contentType != "application/x-zip-compressed" {
+		writeError(w, http.StatusBadRequest, "Request body must be a zip file.")
+		return
+	}
+
+	zipFile, ok := readBinaryBody(w, r, maxZipUploadBytes)
+	if !ok {
+		return
+	}
+
+	result, err := h.productConsumption.ImportDeploymentUsage(r.Context(), user.Email, zipFile)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "productconsumption ImportDeploymentUsage failed", "userID", user.UserID, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to import deployment usage data.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusOK, dto.MapImportDeploymentUsage(result))
+}

--- a/apps/customer-portal/backend-v2/internal/handler/product_consumption.go
+++ b/apps/customer-portal/backend-v2/internal/handler/product_consumption.go
@@ -21,12 +21,20 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/dto"
 	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
 	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/middleware"
 	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/productconsumption"
 )
+
+// licenseProvisioningWriteDeadline extends the response write deadline for
+// GetDeploymentLicense beyond the server's global WriteTimeout (see
+// cmd/server/main.go) — ProcessLicenseDownload can make up to 5 sequential
+// upstream requests, which can plausibly exceed the global timeout under
+// normal network latency even though no single step is slow.
+const licenseProvisioningWriteDeadline = 2 * time.Minute
 
 // productConsumptionClient abstracts the upstream product-consumption
 // service operations used by ProductConsumptionHandler.
@@ -63,6 +71,10 @@ func (h *ProductConsumptionHandler) GetDeploymentLicense(w http.ResponseWriter, 
 		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
 		return
 	}
+
+	// See licenseProvisioningWriteDeadline's doc comment. Best-effort: an
+	// unrecognized ResponseWriter simply keeps the server's default timeout.
+	_ = http.NewResponseController(w).SetWriteDeadline(time.Now().Add(licenseProvisioningWriteDeadline))
 
 	projectID := r.PathValue("projectId")
 	deploymentID := r.PathValue("deploymentId")

--- a/apps/customer-portal/backend-v2/internal/handler/response.go
+++ b/apps/customer-portal/backend-v2/internal/handler/response.go
@@ -33,6 +33,10 @@ import (
 // maxRequestBodyBytes caps request bodies accepted by search/create/update endpoints.
 const maxRequestBodyBytes = 1 << 20 // 1 MiB
 
+// maxZipUploadBytes caps the raw (non-JSON) binary body accepted by
+// POST /deployment-usages.
+const maxZipUploadBytes = 25 << 20 // 25 MiB
+
 // uuidRe validates path parameters that are expected to be UUIDs.
 var uuidRe = regexp.MustCompile(`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
 
@@ -128,6 +132,23 @@ func readJSONBody(w http.ResponseWriter, r *http.Request) (body []byte, ok bool)
 	}
 	if !json.Valid(body) {
 		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return nil, false
+	}
+	return body, true
+}
+
+// readBinaryBody caps r.Body at maxBytes and reads it fully, for endpoints
+// that accept a raw (non-JSON) request body. Writes the appropriate error
+// response and returns ok=false if the body is too large or unreadable.
+func readBinaryBody(w http.ResponseWriter, r *http.Request, maxBytes int64) (body []byte, ok bool) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBytes)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		if _, isTooLarge := err.(*http.MaxBytesError); isTooLarge {
+			writeError(w, http.StatusRequestEntityTooLarge, ErrMsgTooLarge)
+			return nil, false
+		}
+		writeError(w, http.StatusBadRequest, errMsgReadBody)
 		return nil, false
 	}
 	return body, true

--- a/apps/customer-portal/backend-v2/internal/middleware/logger.go
+++ b/apps/customer-portal/backend-v2/internal/middleware/logger.go
@@ -50,6 +50,35 @@ func (rw *responseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	return hijacker.Hijack()
 }
 
+// deadlineSetter matches the unexported interface net/http's response type
+// implements, which http.ResponseController relies on via a type assertion.
+type deadlineSetter interface {
+	SetWriteDeadline(time.Time) error
+	SetReadDeadline(time.Time) error
+}
+
+// SetWriteDeadline and SetReadDeadline forward to the underlying
+// ResponseWriter, for the same reason Hijack does above: they let
+// http.NewResponseController(w).SetWriteDeadline/SetReadDeadline work through
+// this wrapper — used by handlers whose upstream call chain can legitimately
+// exceed the server's global WriteTimeout (see
+// internal/handler/product_consumption.go's GetDeploymentLicense).
+func (rw *responseWriter) SetWriteDeadline(deadline time.Time) error {
+	ds, ok := rw.ResponseWriter.(deadlineSetter)
+	if !ok {
+		return fmt.Errorf("underlying ResponseWriter does not support setting a write deadline")
+	}
+	return ds.SetWriteDeadline(deadline)
+}
+
+func (rw *responseWriter) SetReadDeadline(deadline time.Time) error {
+	ds, ok := rw.ResponseWriter.(deadlineSetter)
+	if !ok {
+		return fmt.Errorf("underlying ResponseWriter does not support setting a read deadline")
+	}
+	return ds.SetReadDeadline(deadline)
+}
+
 // Logger is an HTTP middleware that logs each completed request via slog. The
 // correlation ID is included automatically in every record when ConfigureLogger
 // has been called (it is attached by the ctxHandler from the context).

--- a/apps/customer-portal/backend-v2/internal/productconsumption/client.go
+++ b/apps/customer-portal/backend-v2/internal/productconsumption/client.go
@@ -94,7 +94,7 @@ func NewClient(cfg Config) *Client {
 	}
 }
 
-func (c *Client) do(ctx context.Context, method, path string, body []byte) ([]byte, error) {
+func (c *Client) do(ctx context.Context, method, path, contentType string, body []byte) ([]byte, error) {
 	var reqBody io.Reader
 	if len(body) > 0 {
 		reqBody = bytes.NewReader(body)
@@ -105,7 +105,7 @@ func (c *Client) do(ctx context.Context, method, path string, body []byte) ([]by
 		return nil, fmt.Errorf("productconsumption: build request %s %s: %w", method, path, err)
 	}
 	if len(body) > 0 {
-		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Content-Type", contentType)
 	}
 
 	resp, err := c.http.Do(req)
@@ -140,11 +140,26 @@ func (c *Client) postJSON(ctx context.Context, path string, reqBody, out any) er
 	if err != nil {
 		return fmt.Errorf("productconsumption: encode request for POST %s: %w", path, err)
 	}
-	body, err := c.do(ctx, http.MethodPost, path, payload)
+	body, err := c.do(ctx, http.MethodPost, path, "application/json", payload)
 	if err != nil {
 		return err
 	}
 	if err := json.Unmarshal(body, out); err != nil {
+		return fmt.Errorf("productconsumption: decode response for POST %s: %w", path, err)
+	}
+	return nil
+}
+
+// postText issues a POST with a raw text/plain body — used only for
+// subscribeApplication, which mirrors the Ballerina backend's
+// `.post(applicationId)` call: Ballerina's http:Client sends a bare `string`
+// payload as raw text/plain, not a JSON-quoted string.
+func (c *Client) postText(ctx context.Context, path, body string, out any) error {
+	respBody, err := c.do(ctx, http.MethodPost, path, "text/plain", []byte(body))
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(respBody, out); err != nil {
 		return fmt.Errorf("productconsumption: decode response for POST %s: %w", path, err)
 	}
 	return nil
@@ -155,7 +170,7 @@ func (c *Client) patchJSON(ctx context.Context, path string, reqBody, out any) e
 	if err != nil {
 		return fmt.Errorf("productconsumption: encode request for PATCH %s: %w", path, err)
 	}
-	body, err := c.do(ctx, http.MethodPatch, path, payload)
+	body, err := c.do(ctx, http.MethodPatch, path, "application/json", payload)
 	if err != nil {
 		return err
 	}

--- a/apps/customer-portal/backend-v2/internal/productconsumption/client.go
+++ b/apps/customer-portal/backend-v2/internal/productconsumption/client.go
@@ -1,0 +1,170 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package productconsumption is the HTTP client for the upstream
+// product-consumption service — a separate service (not entity-service)
+// that provisions WSO2 API Manager applications/subscriptions/credentials to
+// generate per-deployment product licenses, and imports deployment usage
+// data. See apps/customer-portal/backend's modules/product_consumption_subscription
+// and modules/product_consumption_tracking for the Ballerina backend's
+// equivalent clients — both point at the same upstream base URL there, so
+// this package models them as one client rather than two.
+package productconsumption
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/apierror"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
+)
+
+var tokenFetchTimeout = 10 * time.Second
+
+const maxResponseBodyBytes = 10 << 20 // 10 MiB
+
+func noRedirect(_ *http.Request, _ []*http.Request) error {
+	return http.ErrUseLastResponse
+}
+
+// Config holds the configuration for the product-consumption service client.
+type Config struct {
+	BaseURL      string
+	TokenURL     string
+	ClientID     string
+	ClientSecret string
+	Scopes       []string
+}
+
+// Client is an HTTP client for the upstream product-consumption service,
+// authenticated via the OAuth2 client credentials grant.
+type Client struct {
+	http    *http.Client
+	baseURL string
+}
+
+// NewClient constructs a Client that authenticates against the
+// product-consumption service using the OAuth2 client credentials grant type.
+func NewClient(cfg Config) *Client {
+	cc := clientcredentials.Config{
+		ClientID:     cfg.ClientID,
+		ClientSecret: cfg.ClientSecret,
+		TokenURL:     cfg.TokenURL,
+		Scopes:       cfg.Scopes,
+	}
+
+	tokenCtx := context.WithValue(context.Background(), oauth2.HTTPClient,
+		&http.Client{Timeout: tokenFetchTimeout, CheckRedirect: noRedirect})
+
+	// clientcredentials.Config.Client's returned *http.Client and its
+	// Transport must not be mutated (see the package doc comment) — wrap its
+	// Transport in a fresh http.Client we own instead of setting fields
+	// directly on the returned one.
+	oauthClient := cc.Client(tokenCtx)
+	httpClient := &http.Client{
+		Transport:     oauthClient.Transport,
+		Timeout:       300 * time.Second, // matches the Ballerina client's own 300s timeout
+		CheckRedirect: noRedirect,
+	}
+
+	return &Client{
+		http:    httpClient,
+		baseURL: strings.TrimRight(cfg.BaseURL, "/"),
+	}
+}
+
+func (c *Client) do(ctx context.Context, method, path string, body []byte) ([]byte, error) {
+	var reqBody io.Reader
+	if len(body) > 0 {
+		reqBody = bytes.NewReader(body)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("productconsumption: build request %s %s: %w", method, path, err)
+	}
+	if len(body) > 0 {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("productconsumption: %s %s: %w", method, path, err)
+	}
+	defer resp.Body.Close()
+
+	limited := io.LimitReader(resp.Body, maxResponseBodyBytes+1)
+	respBody, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, fmt.Errorf("productconsumption: read response body: %w", err)
+	}
+	if len(respBody) > maxResponseBodyBytes {
+		return nil, fmt.Errorf("productconsumption: %s %s: response body exceeds %d bytes", method, path, maxResponseBodyBytes)
+	}
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		const maxErrBody = 256
+		excerpt := respBody
+		if len(excerpt) > maxErrBody {
+			excerpt = excerpt[:maxErrBody]
+		}
+		return nil, &apierror.Error{StatusCode: resp.StatusCode, Body: string(excerpt)}
+	}
+
+	return respBody, nil
+}
+
+func (c *Client) postJSON(ctx context.Context, path string, reqBody, out any) error {
+	payload, err := json.Marshal(reqBody)
+	if err != nil {
+		return fmt.Errorf("productconsumption: encode request for POST %s: %w", path, err)
+	}
+	body, err := c.do(ctx, http.MethodPost, path, payload)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(body, out); err != nil {
+		return fmt.Errorf("productconsumption: decode response for POST %s: %w", path, err)
+	}
+	return nil
+}
+
+func (c *Client) patchJSON(ctx context.Context, path string, reqBody, out any) error {
+	payload, err := json.Marshal(reqBody)
+	if err != nil {
+		return fmt.Errorf("productconsumption: encode request for PATCH %s: %w", path, err)
+	}
+	body, err := c.do(ctx, http.MethodPatch, path, payload)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(body, out); err != nil {
+		return fmt.Errorf("productconsumption: decode response for PATCH %s: %w", path, err)
+	}
+	return nil
+}
+
+func pathEscape(s string) string {
+	return url.PathEscape(s)
+}

--- a/apps/customer-portal/backend-v2/internal/productconsumption/subscription.go
+++ b/apps/customer-portal/backend-v2/internal/productconsumption/subscription.go
@@ -1,0 +1,183 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package productconsumption
+
+import (
+	"context"
+	"fmt"
+)
+
+// LicenseDownloadRequest is the input for ProcessLicenseDownload.
+type LicenseDownloadRequest struct {
+	Email        string
+	DeploymentID string
+	ProjectID    string
+}
+
+// ProcessLicenseDownload drives the upstream product-consumption service's
+// per-project provisioning state machine to completion and returns the
+// resulting deployment license. Mirrors
+// apps/customer-portal/backend's product_consumption_subscription:processLicenseDownload
+// exactly, including resuming from whatever step a project's state is
+// already at (each step below only runs if the project hasn't completed it
+// yet) — this is not a one-shot call, it can make up to 5 sequential
+// requests to the upstream service, several of which have side effects
+// (creating a WSO2 API Manager application, subscribing it, generating
+// credentials) that must not be repeated once done.
+func (c *Client) ProcessLicenseDownload(ctx context.Context, req LicenseDownloadRequest) (License, error) {
+	statusRes, err := c.getConsumptionStatus(ctx, req.ProjectID, ConsumptionStatusRequest{
+		Email:        req.Email,
+		DeploymentID: req.DeploymentID,
+	})
+	if err != nil {
+		return License{}, fmt.Errorf("productconsumption: get consumption status: %w", err)
+	}
+
+	status := consumptionStatus(statusRes.Result.Status)
+	applicationID := statusRes.Result.ApplicationID
+
+	if status == statusPending {
+		if statusRes.Result.Name == nil || statusRes.Result.Description == nil {
+			return License{}, fmt.Errorf("productconsumption: application name and description are required for application creation")
+		}
+		app, err := c.createApplication(ctx, ApplicationCreateRequest{
+			Name:        *statusRes.Result.Name,
+			Description: *statusRes.Result.Description,
+		})
+		if err != nil {
+			return License{}, fmt.Errorf("productconsumption: create application: %w", err)
+		}
+		applicationID = &app.ApplicationID
+
+		if _, err := c.updateProjectStatus(ctx, req.ProjectID, UpdateProjectStatusRequest{
+			Status:        int(statusCreated),
+			ApplicationID: applicationID,
+		}); err != nil {
+			return License{}, fmt.Errorf("productconsumption: update project status to created: %w", err)
+		}
+		status = statusCreated
+	}
+
+	if applicationID == nil {
+		return License{}, fmt.Errorf("productconsumption: application ID is required")
+	}
+
+	if status == statusCreated {
+		if _, err := c.subscribeApplication(ctx, *applicationID); err != nil {
+			return License{}, fmt.Errorf("productconsumption: subscribe application: %w", err)
+		}
+		if _, err := c.updateProjectStatus(ctx, req.ProjectID, UpdateProjectStatusRequest{
+			Status: int(statusSubscribed),
+		}); err != nil {
+			return License{}, fmt.Errorf("productconsumption: update project status to subscribed: %w", err)
+		}
+		status = statusSubscribed
+	}
+
+	if status == statusSubscribed {
+		creds, err := c.generateCredentials(ctx, *applicationID)
+		if err != nil {
+			return License{}, fmt.Errorf("productconsumption: generate credentials: %w", err)
+		}
+		if _, err := c.updateProjectStatus(ctx, req.ProjectID, UpdateProjectStatusRequest{
+			Status:         int(statusGeneratedCredentials),
+			ConsumerKey:    &creds.ConsumerKey,
+			ConsumerSecret: &creds.ConsumerSecret,
+		}); err != nil {
+			return License{}, fmt.Errorf("productconsumption: update project status to generated-credentials: %w", err)
+		}
+		status = statusGeneratedCredentials
+	}
+
+	if status == statusGeneratedCredentials {
+		keys, err := c.generateSecretKeys(ctx)
+		if err != nil {
+			return License{}, fmt.Errorf("productconsumption: generate secret keys: %w", err)
+		}
+		if _, err := c.updateProjectStatus(ctx, req.ProjectID, UpdateProjectStatusRequest{
+			Status:             int(statusGeneratedSecretKeys),
+			PrimarySecretKey:   &keys.PrimarySecretKey,
+			SecondarySecretKey: &keys.SecondarySecretKey,
+		}); err != nil {
+			return License{}, fmt.Errorf("productconsumption: update project status to generated-secret-keys: %w", err)
+		}
+		status = statusGeneratedSecretKeys
+	}
+
+	if status == statusGeneratedSecretKeys {
+		license, err := c.getDeploymentLicense(ctx, req.ProjectID, req.DeploymentID, DeploymentLicenseRequest{Email: req.Email})
+		if err != nil {
+			return License{}, fmt.Errorf("productconsumption: get deployment license: %w", err)
+		}
+		return license.Result.License, nil
+	}
+
+	return License{}, fmt.Errorf("productconsumption: unexpected application status: %d", status)
+}
+
+// getConsumptionStatus calls POST /projects/{projectId}/consumption/status.
+func (c *Client) getConsumptionStatus(ctx context.Context, projectID string, req ConsumptionStatusRequest) (ConsumptionResult, error) {
+	var out ConsumptionResult
+	err := c.postJSON(ctx, fmt.Sprintf("/projects/%s/consumption/status", pathEscape(projectID)), req, &out)
+	return out, err
+}
+
+// createApplication calls POST /applications.
+func (c *Client) createApplication(ctx context.Context, req ApplicationCreateRequest) (ApplicationCreateResponse, error) {
+	var out ApplicationCreateResponse
+	err := c.postJSON(ctx, "/applications", req, &out)
+	return out, err
+}
+
+// updateProjectStatus calls PATCH /projects/{projectId} — the
+// product-consumption service's own per-project state record.
+func (c *Client) updateProjectStatus(ctx context.Context, projectID string, req UpdateProjectStatusRequest) (ConsumptionResult, error) {
+	var out ConsumptionResult
+	err := c.patchJSON(ctx, fmt.Sprintf("/projects/%s", pathEscape(projectID)), req, &out)
+	return out, err
+}
+
+// subscribeApplication calls POST /applications/{applicationId}/subscribe.
+// The request body is the bare applicationId string, matching the upstream
+// Ballerina client's own `.post(applicationId)` call.
+func (c *Client) subscribeApplication(ctx context.Context, applicationID string) (ApplicationSubscriptionResponse, error) {
+	var out ApplicationSubscriptionResponse
+	err := c.postJSON(ctx, fmt.Sprintf("/applications/%s/subscribe", pathEscape(applicationID)), applicationID, &out)
+	return out, err
+}
+
+// generateCredentials calls POST /applications/{applicationId}/generate-credentials.
+func (c *Client) generateCredentials(ctx context.Context, applicationID string) (ApplicationKeyGenerationResponse, error) {
+	var out ApplicationKeyGenerationResponse
+	err := c.postJSON(ctx, fmt.Sprintf("/applications/%s/generate-credentials", pathEscape(applicationID)), struct{}{}, &out)
+	return out, err
+}
+
+// generateSecretKeys calls POST /generate-secret-keys.
+func (c *Client) generateSecretKeys(ctx context.Context) (SecretKeysResponse, error) {
+	var out SecretKeysResponse
+	err := c.postJSON(ctx, "/generate-secret-keys", struct{}{}, &out)
+	return out, err
+}
+
+// getDeploymentLicense calls POST /projects/{projectId}/deployments/{deploymentId}/license.
+func (c *Client) getDeploymentLicense(ctx context.Context, projectID, deploymentID string, req DeploymentLicenseRequest) (LicenseResponse, error) {
+	var out LicenseResponse
+	path := fmt.Sprintf("/projects/%s/deployments/%s/license", pathEscape(projectID), pathEscape(deploymentID))
+	err := c.postJSON(ctx, path, req, &out)
+	return out, err
+}

--- a/apps/customer-portal/backend-v2/internal/productconsumption/subscription.go
+++ b/apps/customer-portal/backend-v2/internal/productconsumption/subscription.go
@@ -156,7 +156,7 @@ func (c *Client) updateProjectStatus(ctx context.Context, projectID string, req 
 // Ballerina client's own `.post(applicationId)` call.
 func (c *Client) subscribeApplication(ctx context.Context, applicationID string) (ApplicationSubscriptionResponse, error) {
 	var out ApplicationSubscriptionResponse
-	err := c.postJSON(ctx, fmt.Sprintf("/applications/%s/subscribe", pathEscape(applicationID)), applicationID, &out)
+	err := c.postText(ctx, fmt.Sprintf("/applications/%s/subscribe", pathEscape(applicationID)), applicationID, &out)
 	return out, err
 }
 

--- a/apps/customer-portal/backend-v2/internal/productconsumption/tracking.go
+++ b/apps/customer-portal/backend-v2/internal/productconsumption/tracking.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package productconsumption
+
+import (
+	"context"
+	"encoding/base64"
+)
+
+// ImportDeploymentUsage calls POST /deployment-usages, base64-encoding
+// zipFile as the upstream service's contract requires.
+func (c *Client) ImportDeploymentUsage(ctx context.Context, email string, zipFile []byte) (ImportUsageResponse, error) {
+	req := ImportUsageRequest{
+		Email: email,
+		Zip:   base64.StdEncoding.EncodeToString(zipFile),
+	}
+	var out ImportUsageResponse
+	err := c.postJSON(ctx, "/deployment-usages", req, &out)
+	return out, err
+}

--- a/apps/customer-portal/backend-v2/internal/productconsumption/types.go
+++ b/apps/customer-portal/backend-v2/internal/productconsumption/types.go
@@ -1,0 +1,148 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package productconsumption
+
+// These types mirror the upstream product-consumption service's wire format
+// 1:1 (see apps/customer-portal/backend's modules/product_consumption_subscription
+// and modules/product_consumption_tracking, the Ballerina backend this is
+// rewriting) so json.Unmarshal can decode its responses directly.
+
+// consumptionStatus enumerates the product-consumption service's per-project
+// license-provisioning state machine.
+type consumptionStatus int
+
+const (
+	statusPending              consumptionStatus = 1
+	statusCreated              consumptionStatus = 2
+	statusSubscribed           consumptionStatus = 3
+	statusGeneratedCredentials consumptionStatus = 4
+	statusGeneratedSecretKeys  consumptionStatus = 5
+)
+
+// ConsumptionStatusRequest is the input for POST /projects/{projectId}/consumption/status.
+type ConsumptionStatusRequest struct {
+	Email        string `json:"email"`
+	DeploymentID string `json:"deploymentId"`
+}
+
+// ConsumptionData carries the current provisioning state for a project.
+type ConsumptionData struct {
+	Status        int     `json:"status"`
+	ApplicationID *string `json:"applicationId,omitempty"`
+	Name          *string `json:"name,omitempty"`
+	Description   *string `json:"description,omitempty"`
+}
+
+// ConsumptionResult wraps ConsumptionData with top-level message/applicationId
+// fields — matches the upstream service's own (slightly redundant) response shape.
+type ConsumptionResult struct {
+	Message       *string         `json:"message,omitempty"`
+	ApplicationID *string         `json:"applicationId,omitempty"`
+	Result        ConsumptionData `json:"result"`
+}
+
+// ApplicationCreateRequest is the input for POST /applications.
+type ApplicationCreateRequest struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+// ApplicationCreateResponse is the response for POST /applications.
+type ApplicationCreateResponse struct {
+	Name          string `json:"name"`
+	ApplicationID string `json:"applicationId"`
+}
+
+// UpdateProjectStatusRequest is the input for PATCH /projects/{projectId} —
+// the product-consumption service's own per-project state record, distinct
+// from entity-service's Project entity. Only the fields relevant to the
+// current state-machine step are set on each call.
+type UpdateProjectStatusRequest struct {
+	Status             int     `json:"status"`
+	ApplicationID      *string `json:"applicationId,omitempty"`
+	ConsumerKey        *string `json:"consumerKey,omitempty"`
+	ConsumerSecret     *string `json:"consumerSecret,omitempty"`
+	PrimarySecretKey   *string `json:"primarySecretKey,omitempty"`
+	SecondarySecretKey *string `json:"secondarySecretKey,omitempty"`
+}
+
+// ApplicationSubscriptionResponse is the response for
+// POST /applications/{applicationId}/subscribe.
+type ApplicationSubscriptionResponse struct {
+	ApplicationID  string `json:"applicationId"`
+	SubscriptionID string `json:"subscriptionId"`
+	APIID          string `json:"apiId"`
+}
+
+// ApplicationKeyGenerationResponse is the response for
+// POST /applications/{applicationId}/generate-credentials.
+type ApplicationKeyGenerationResponse struct {
+	ConsumerKey    string `json:"consumerKey"`
+	ConsumerSecret string `json:"consumerSecret"`
+}
+
+// SecretKeysResponse is the response for POST /generate-secret-keys.
+type SecretKeysResponse struct {
+	PrimarySecretKey   string `json:"primarySecretKey"`
+	SecondarySecretKey string `json:"secondarySecretKey"`
+}
+
+// DeploymentLicenseRequest is the input for
+// POST /projects/{projectId}/deployments/{deploymentId}/license.
+type DeploymentLicenseRequest struct {
+	Email string `json:"email"`
+}
+
+// SubscriptionData carries the deployment's license/subscription details.
+type SubscriptionData struct {
+	DeploymentID    string `json:"deploymentId"`
+	DeploymentName  string `json:"deploymentName"`
+	SubscriptionKey string `json:"subscriptionKey"`
+	ClientID        string `json:"clientId"`
+	ClientSecret    string `json:"clientSecret"`
+	Secrets         string `json:"secrets"`
+}
+
+// License is the final license payload returned to the caller.
+type License struct {
+	SubscriptionData SubscriptionData `json:"subscriptionData"`
+	Signature        string           `json:"signature"`
+}
+
+// LicenseResult wraps License with a success flag.
+type LicenseResult struct {
+	Success bool    `json:"success"`
+	License License `json:"license"`
+}
+
+// LicenseResponse is the response for
+// POST /projects/{projectId}/deployments/{deploymentId}/license.
+type LicenseResponse struct {
+	Result LicenseResult `json:"result"`
+}
+
+// ImportUsageRequest is the input for POST /deployment-usages.
+type ImportUsageRequest struct {
+	Email string `json:"email"`
+	Zip   string `json:"zip"` // base64-encoded zip file content
+}
+
+// ImportUsageResponse is the response for POST /deployment-usages.
+type ImportUsageResponse struct {
+	Message *string `json:"message,omitempty"`
+	Result  any     `json:"result,omitempty"`
+}

--- a/apps/customer-portal/backend-v2/openapi.yaml
+++ b/apps/customer-portal/backend-v2/openapi.yaml
@@ -2617,6 +2617,120 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
+  /projects/{projectId}/deployments/{deploymentId}/license:
+    post:
+      summary: Provision (or resume provisioning) and return a deployment's license.
+      description: >
+        Calls the separate product-consumption service, not entity-service —
+        see this backend's CLAUDE.md, "The product-consumption service". Can
+        make several sequential upstream calls (application creation,
+        subscription, credential/secret-key generation) depending on how far
+        the project's provisioning has already progressed.
+      operationId: postProjectsProjectIdDeploymentsDeploymentIdLicense
+      parameters:
+        - name: projectId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: deploymentId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LicenseResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: NotFound
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /deployment-usages:
+    post:
+      summary: Import a deployment-usage zip file.
+      description: >
+        Calls the separate product-consumption service, not entity-service —
+        see this backend's CLAUDE.md, "The product-consumption service". The
+        request body is a raw zip file, not JSON.
+      operationId: postDeploymentUsages
+      requestBody:
+        required: true
+        content:
+          application/zip:
+            schema:
+              type: string
+              format: binary
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ImportDeploymentUsageResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
 components:
   securitySchemes:
     bearerAuth:
@@ -4826,3 +4940,39 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/UpdateDescription'
+
+    # ---- product consumption ----
+
+    LicenseSubscriptionData:
+      type: object
+      required: [deploymentId, deploymentName, subscriptionKey, clientId, clientSecret, secrets]
+      properties:
+        deploymentId:
+          type: string
+        deploymentName:
+          type: string
+        subscriptionKey:
+          type: string
+        clientId:
+          type: string
+        clientSecret:
+          type: string
+        secrets:
+          type: string
+
+    LicenseResponse:
+      type: object
+      required: [subscriptionData, signature]
+      properties:
+        subscriptionData:
+          $ref: '#/components/schemas/LicenseSubscriptionData'
+        signature:
+          type: string
+
+    ImportDeploymentUsageResponse:
+      type: object
+      properties:
+        message:
+          type: string
+        result:
+          description: Arbitrary result payload from the upstream product-consumption service.


### PR DESCRIPTION
## Summary
Adds 2 more endpoints to `apps/customer-portal/backend-v2` (52 total):

- `POST /projects/{projectId}/deployments/{deploymentId}/license` — provision (or resume provisioning) and return a deployment's license
- `POST /deployment-usages` — import a deployment-usage zip file

## The product-consumption service

Both endpoints call **the product-consumption service — another separate upstream, not entity-service** (same category as the AI chat agent added in #1315). New `internal/productconsumption` client package. See `apps/customer-portal/backend`'s `modules/product_consumption_subscription` and `modules/product_consumption_tracking` for the Ballerina backend's two client modules — modeled here as one Go package since both point at the same upstream base URL in the Ballerina backend's own `config.toml`.

`ProcessLicenseDownload` (`internal/productconsumption/subscription.go`) is a direct port of the Ballerina backend's `processLicenseDownload` state machine: it can make up to 5 sequential upstream calls, several with side effects (creating a WSO2 API Manager application, subscribing it, generating credentials/secret keys), each only running if the project's upstream-tracked provisioning status hasn't reached it yet — so it correctly resumes from wherever a project's provisioning left off rather than always starting over.

`POST /deployment-usages` is the first endpoint in this backend with a **raw binary** (not JSON) request body — a new `readBinaryBody` helper (a `readJSONBody` counterpart with its own `maxZipUploadBytes` cap) reads the uploaded zip; the client base64-encodes it before forwarding, matching the upstream service's JSON contract exactly (`{"email": "...", "zip": "<base64>"}`).

## Scoping discipline

Per this backend's established cross-check discipline: confirmed both routes are genuine, currently-exposed Ballerina backend features (real `service.bal` resource functions, not just unused `entity.bal`-style helper functions) before porting, and confirmed no service already present in `cs-tools` provides this functionality under a different name.

Also updates `openapi.yaml` (2 new paths, 3 new schemas), `README.md`, and `CLAUDE.md`.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` all clean
- [x] `gosec -fmt=text ./...` reports 0 issues
- [x] `openapi.yaml` validated as well-formed YAML with both new paths/schemas present
- [x] Manually smoke-tested against a live server with an unreachable upstream: `POST /deployment-usages` correctly rejects a non-zip `Content-Type` (400) and cleanly maps an unreachable upstream to 500 for a valid zip upload; `POST /projects/{id}/deployments/{id}/license` cleanly maps the `entity.GetProject` access-check failure to 500 when entity-service is unreachable
- [ ] Wire up against a real running entity-service instance and the actual product-consumption service (both currently unconfigured upstreams in this environment)

## Linked issues
Closes wso2-enterprise/wso2-digital-team-project-management#887
Closes wso2-enterprise/wso2-digital-team-project-management#888

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deployment-license provisioning and retrieval.
  * Added deployment-usage imports through ZIP uploads.
  * Added validation for project access, identifiers, file types, and upload size limits.
  * Added product-consumption service integration with OAuth authentication.
  * Added API documentation, configuration examples, response schemas, and usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->