### PR TITLE
[CSM Portal] restructure user profile page; drop email-match check from access status

### DIFF
--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -6071,16 +6071,19 @@ components:
     UserProjectAccess:
       type: object
       description: >
-        One project-contact row for a user, reported as stored rather than as filtered. The
-        backing access rule grants access only when the row's email matches the login exactly
-        AND a contact record is linked; rows failing either test make the project, and every
-        case on it, silently invisible to that user.
-      required: [projectId, projectName, contactEmail, contactRecordPresent, emailMatchesLogin, grantsCaseAccess]
+        One project-contact row for a user, reported as stored rather than as filtered. A
+        row with no linked contact record makes the project, and every case on it, silently
+        invisible to that user. grantsCaseAccess mirrors contactRecordPresent directly --
+        deliberately not the stricter email-match rule the live access check enforces, since
+        that only diverges for integration/system accounts.
+      required: [projectId, projectName, projectKey, contactEmail, contactRecordPresent, grantsCaseAccess]
       properties:
         projectId:
           type: string
           format: uuid
         projectName:
+          type: string
+        projectKey:
           type: string
         contactEmail:
           type: string
@@ -6088,8 +6091,6 @@ components:
           type: boolean
         contactRecordEmail:
           type: string
-        emailMatchesLogin:
-          type: boolean
         registrationState:
           type: string
         notificationsEnabled:

--- a/apps/csm-portal/webapp/src/features/csm-users/pages/UserProfilePage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/pages/UserProfilePage.test.tsx
@@ -36,7 +36,7 @@ vi.mock("@hooks/useNavTransition", () => ({
 // `BackendApiError` from it directly, so stub the module with a real class
 // (so `instanceof` still works) — same approach as
 // CsmChangeRequestDetailPage.test.tsx. `useBackendApi` also needs a working
-// `post`: RolesSection resolves role display names via `useSearchRoles`,
+// `post`: `PermissionsCard` resolves role display names via `useSearchRoles`,
 // which goes through this same client.
 const backendPostMock = vi.fn();
 vi.mock("@api/backend/client", () => ({
@@ -87,18 +87,18 @@ const BLOCKED_EXTERNAL_USER: NormalizedUserDetail = {
     {
       projectId: "proj-1",
       projectName: "Payments Platform",
+      projectKey: "PAYPLAT",
       contactEmail: "john.smith@example.com",
       contactRecordPresent: false,
-      emailMatchesLogin: false,
       grantsCaseAccess: false,
     },
     {
       projectId: "proj-2",
       projectName: "Identity Platform",
+      projectKey: "IDPLAT",
       contactEmail: "john.smith@example.com",
       contactRecordPresent: true,
       contactRecordEmail: "john.smith@example.com",
-      emailMatchesLogin: true,
       registrationState: "registered",
       notificationsEnabled: true,
       roles: ["viewer"],
@@ -165,7 +165,7 @@ describe("UserProfilePage", () => {
     expect(screen.getByText(/User not found/i)).toBeInTheDocument();
   });
 
-  it("renders an internal user's groups and teams, with roles, phone and timestamps", async () => {
+  it("renders an internal user's team inline in the Overview card, plus groups and roles", async () => {
     mockQueryResult({ data: INTERNAL_USER });
     renderPage();
     expect(screen.getByText("Jane Doe")).toBeInTheDocument();
@@ -184,32 +184,40 @@ describe("UserProfilePage", () => {
     expect(screen.queryByText("agent", { selector: ".MuiChip-label" })).not.toBeInTheDocument();
   });
 
-  it("renders 'No team assignments' rather than hiding the card when an internal user has no teams", () => {
+  it("renders 'Unassigned' rather than hiding the field when an internal user has no team", () => {
     mockQueryResult({ data: { ...INTERNAL_USER, teams: [] } });
     renderPage();
-    expect(screen.getByText("No team assignments.")).toBeInTheDocument();
+    expect(screen.getByText("Unassigned")).toBeInTheDocument();
   });
 
-  it("renders the blocking reason for a project that doesn't grant an external user case access", () => {
+  it("does not render a team field or a User groups cluster for an external user", () => {
+    mockQueryResult({ data: BLOCKED_EXTERNAL_USER });
+    renderPage();
+    expect(screen.queryByText("Team")).not.toBeInTheDocument();
+    expect(screen.queryByText(/User groups/i)).not.toBeInTheDocument();
+  });
+
+  it("renders the project key and the blocking reason for a project that doesn't grant an external user case access", () => {
     mockQueryResult({ data: BLOCKED_EXTERNAL_USER });
     renderPage();
 
     // The blocked project surfaces its reason...
     expect(screen.getByText("Payments Platform")).toBeInTheDocument();
-    expect(screen.getByText("Blocked", { selector: ".MuiChip-label" })).toBeInTheDocument();
+    expect(screen.getByText("PAYPLAT")).toBeInTheDocument();
+    expect(screen.getByText("No access", { selector: ".MuiChip-label" })).toBeInTheDocument();
     expect(
       screen.getByText(/No contact record is linked to this project/i),
     ).toBeInTheDocument();
 
-    // ...while the granted project shows no reason text at all.
+    // ...while the granted, registered project shows "Has access" and no reason.
     expect(screen.getByText("Identity Platform")).toBeInTheDocument();
-    expect(screen.getByText("Has case access", { selector: ".MuiChip-label" })).toBeInTheDocument();
-    expect(screen.queryByText(/doesn't match the login email/i)).not.toBeInTheDocument();
+    expect(screen.getByText("IDPLAT")).toBeInTheDocument();
+    expect(screen.getByText("Has access", { selector: ".MuiChip-label" })).toBeInTheDocument();
 
     expect(screen.getByText(/Blocked on 1 of 2 projects/i)).toBeInTheDocument();
   });
 
-  it("renders a mismatched-email reason distinct from a missing contact record", () => {
+  it("renders 'Invited' rather than 'Has access' for a granted row still pending registration", () => {
     mockQueryResult({
       data: {
         ...BLOCKED_EXTERNAL_USER,
@@ -217,19 +225,19 @@ describe("UserProfilePage", () => {
           {
             projectId: "proj-3",
             projectName: "Analytics Platform",
+            projectKey: "ANALYTICS",
             contactEmail: "john.smith@example.com",
             contactRecordPresent: true,
-            contactRecordEmail: "j.smith@example.com",
-            emailMatchesLogin: false,
-            grantsCaseAccess: false,
+            contactRecordEmail: "john.smith@example.com",
+            registrationState: "invited",
+            grantsCaseAccess: true,
           },
         ],
       },
     });
     renderPage();
-    expect(
-      screen.getByText(/Contact record email \(j\.smith@example\.com\) doesn't match the login email/i),
-    ).toBeInTheDocument();
+    expect(screen.getByText("Invited", { selector: ".MuiChip-label" })).toBeInTheDocument();
+    expect(screen.queryByText("Has access", { selector: ".MuiChip-label" })).not.toBeInTheDocument();
   });
 
   it("renders 'No project access records found' rather than hiding the card for an external user with none", () => {

--- a/apps/csm-portal/webapp/src/features/csm-users/pages/UserProfilePage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/pages/UserProfilePage.tsx
@@ -21,11 +21,11 @@ import {
   Card,
   Chip,
   Skeleton,
-  Stack,
   Table,
   TableBody,
   TableCell,
   TableContainer,
+  TableHead,
   TableRow,
   Typography,
 } from "@wso2/oxygen-ui";
@@ -105,92 +105,39 @@ function isInternalUser(user: NormalizedUserDetail): boolean {
   );
 }
 
+type ChipColor = "success" | "warning" | "error" | "default";
+
+interface ProjectAccessStatus {
+  label: string;
+  color: ChipColor;
+  reason?: string;
+}
+
 /**
- * Human-readable reasons a project-access row doesn't grant case access.
- * `grantsCaseAccess` is the verdict the backend already computed; these are
- * the "why" a support engineer is looking for. Order matters: the missing
- * contact record is the more fundamental failure, so it's listed first when
- * both are true.
+ * A project row's access status, folding case-access and registration state
+ * into the single "Access" column a support engineer scans: a project with no
+ * linked contact record is the fundamental failure ("No access", with the
+ * reason called out inline); one that's linked but hasn't completed
+ * registration yet reads "Invited" rather than "Has access", since the
+ * person hasn't actually logged in to see it.
  */
-function blockedReasons(pa: UserProjectAccess): string[] {
-  const reasons: string[] = [];
-  if (!pa.contactRecordPresent) {
-    reasons.push("No contact record is linked to this project for this user.");
-  } else if (!pa.emailMatchesLogin) {
-    reasons.push(
-      pa.contactRecordEmail
-        ? `Contact record email (${pa.contactRecordEmail}) doesn't match the login email (${pa.contactEmail}).`
-        : "The linked contact record's email doesn't match the login email.",
-    );
+function deriveProjectAccessStatus(pa: UserProjectAccess): ProjectAccessStatus {
+  if (!pa.grantsCaseAccess) {
+    return {
+      label: "No access",
+      color: "error",
+      reason: "No contact record is linked to this project for this user.",
+    };
   }
-  return reasons;
+  if ((pa.registrationState ?? "").toLowerCase() === "invited") {
+    return { label: "Invited", color: "warning" };
+  }
+  return { label: "Has access", color: "success" };
 }
 
-/** One row of an external user's per-project access, with the reason surfaced when blocked. */
-function ProjectAccessRow({ pa }: { pa: UserProjectAccess }): JSX.Element {
-  const reasons = blockedReasons(pa);
-  return (
-    <Box
-      sx={{
-        display: "flex",
-        flexDirection: "column",
-        gap: 0.75,
-        p: 1.5,
-        border: 1,
-        borderColor: "divider",
-        borderRadius: 1,
-      }}
-    >
-      <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
-        <Typography
-          component={RouterLink}
-          to={`/customers/projects/${pa.projectId}`}
-          variant="body2"
-          sx={(t) => ({
-            fontWeight: 600,
-            textDecoration: "none",
-            color: t.palette.primary.dark,
-            ...t.applyStyles("dark", { color: t.palette.primary.main }),
-            "&:hover": { textDecoration: "underline" },
-          })}
-        >
-          {pa.projectName}
-        </Typography>
-        <Chip
-          size="small"
-          label={pa.grantsCaseAccess ? "Has case access" : "Blocked"}
-          color={pa.grantsCaseAccess ? "success" : "error"}
-          variant="outlined"
-        />
-        {pa.registrationState && (
-          <Chip size="small" label={pa.registrationState} variant="outlined" />
-        )}
-        {pa.roles?.map((r) => (
-          <Chip key={r} size="small" label={r} variant="outlined" />
-        ))}
-      </Box>
-
-      {!pa.grantsCaseAccess && reasons.length > 0 && (
-        <Stack spacing={0.25}>
-          {reasons.map((reason) => (
-            <Typography key={reason} variant="caption" color="error.main">
-              {reason}
-            </Typography>
-          ))}
-        </Stack>
-      )}
-
-      <Typography variant="caption" color="text.secondary">
-        Contact email: {pa.contactEmail}
-        {pa.notificationsEnabled !== undefined &&
-          ` · Notifications ${pa.notificationsEnabled ? "on" : "off"}`}
-      </Typography>
-    </Box>
-  );
-}
-
-/** One row a {@link MembershipTable} renders: a role, group, or team the
- * profile's user belongs to, plus enough to link it to its directory page. */
+/** One row of {@link MembershipRow} rendered as a chip cluster: a role, group,
+ * or team the profile's user belongs to, plus enough to link it to its
+ * directory page (see `DirectoryEntityChip`). */
 interface MembershipRow {
   key: string;
   id: string;
@@ -200,22 +147,16 @@ interface MembershipRow {
 }
 
 /**
- * A single-column table of role/group/team memberships, one row per entry,
- * each name a link to that entity's directory page (see
- * `DirectoryEntityChip`). Rendered even when `rows` is empty — "no
- * memberships" is itself an answer worth showing rather than hiding the
- * section, per {@link emptyMessage}.
- *
- * Deliberately no header row naming the column ("Role"/"Group"/"Team") —
- * the enclosing card's own title already says that, and repeating it inside
- * read as "Groups" containing a table headed "Group".
+ * An inline, wrapping cluster of membership chips — deliberately not a
+ * bordered table-in-a-card: each chip already reads as a distinct item, so a
+ * per-row box around it added visual weight without adding information.
+ * Rendered even when `rows` is empty — "no memberships" is itself an answer
+ * worth showing rather than hiding the section.
  */
-function MembershipTable({
-  ariaLabel,
+function ChipCluster({
   rows,
   emptyMessage,
 }: {
-  ariaLabel: string;
   rows: MembershipRow[];
   emptyMessage: string;
 }): JSX.Element {
@@ -227,83 +168,24 @@ function MembershipTable({
     );
   }
   return (
-    <TableContainer sx={{ border: 1, borderColor: "divider", borderRadius: 1 }}>
-      <Table size="small" aria-label={ariaLabel}>
-        <TableBody>
-          {rows.map((row) => (
-            <TableRow key={row.key}>
-              <TableCell>
-                <DirectoryEntityChip
-                  id={row.id}
-                  name={row.label}
-                  routeBase={row.routeBase}
-                  color={row.color}
-                />
-              </TableCell>
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
-    </TableContainer>
+    <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
+      {rows.map((row) => (
+        <DirectoryEntityChip
+          key={row.key}
+          id={row.id}
+          name={row.label}
+          routeBase={row.routeBase}
+          color={row.color}
+        />
+      ))}
+    </Box>
   );
 }
 
-/**
- * Roles/groups/teams as three cards in a row (wrapping to stacked on narrow
- * viewports), so the three membership kinds read as siblings rather than a
- * single long vertical list. Each card's title is the only place its kind is
- * named — the table inside carries no repeated column header.
- */
-function MembershipCard({
-  title,
-  rows,
-  emptyMessage,
-}: {
-  title: string;
-  rows: MembershipRow[];
-  emptyMessage: string;
-}): JSX.Element {
-  return (
-    <Card sx={{ p: 2.5, flex: "1 1 260px", minWidth: 220, display: "flex", flexDirection: "column", gap: 2 }}>
-      <Typography variant="subtitle2">{title}</Typography>
-      <MembershipTable ariaLabel={`${title} memberships`} rows={rows} emptyMessage={emptyMessage} />
-    </Card>
-  );
-}
-
-/** This user's assigned roles (all user types). Labels resolve through the
- * same role catalogue the users list uses, so a role reads "Agent" here too,
- * not the raw key "agent". */
-function RolesSection({ user }: { user: NormalizedUserDetail }): JSX.Element {
-  const { data: rolesData } = useSearchRoles({ pagination: { limit: BE_MAX_PAGE_LIMIT } });
-  const roleNameById = useMemo(
-    () => new Map((rolesData?.roles ?? []).map((r) => [r.id, r.name])),
-    [rolesData],
-  );
-
-  const rows: MembershipRow[] = (user.roles ?? []).map((r) => ({
-    key: r,
-    id: r,
-    label: roleNameById.get(r) ?? r,
-    routeBase: "/admin/roles",
-    color: (INTERNAL_USER_ROLES as string[]).includes(r) ? "primary" : "default",
-  }));
-  return <MembershipCard title="Roles" rows={rows} emptyMessage="No roles assigned." />;
-}
-
-/** An internal user's group memberships. */
-function GroupsSection({ user }: { user: NormalizedUserDetail }): JSX.Element {
-  const rows: MembershipRow[] = (user.groups ?? []).map((g) => ({
-    key: g.id,
-    id: g.id,
-    label: g.name,
-    routeBase: "/admin/groups",
-  }));
-  return <MembershipCard title="Groups" rows={rows} emptyMessage="No group memberships." />;
-}
-
-/** An internal user's CRE/SRE team assignments. */
-function TeamsSection({ user }: { user: NormalizedUserDetail }): JSX.Element {
+/** This user's team chips, rendered inline in the Overview card — most users
+ * belong to at most one team, so a full card of its own was mostly dead
+ * space; here it reads as a normal profile attribute. */
+function TeamMetaCell({ user }: { user: NormalizedUserDetail }): JSX.Element {
   const rows: MembershipRow[] = (user.teams ?? []).map((t) => ({
     key: t.id,
     id: t.id,
@@ -311,21 +193,80 @@ function TeamsSection({ user }: { user: NormalizedUserDetail }): JSX.Element {
     routeBase: "/admin/teams",
     color: "primary",
   }));
-  return <MembershipCard title="Teams" rows={rows} emptyMessage="No team assignments." />;
+  return (
+    <MetaCell label="Team">
+      <ChipCluster rows={rows} emptyMessage="Unassigned" />
+    </MetaCell>
+  );
 }
 
 /**
- * An external user's per-project access, with the reason called out whenever
- * a project doesn't grant case access — this card exists to answer "why
- * can't this customer see their cases?" at a glance.
+ * Roles and (for internal users) groups as two side-by-side chip clusters in
+ * one card, rather than three separate cards — a user rarely has enough
+ * groups to justify a card of its own, and putting roles and groups next to
+ * each other reads as "what can this person do" at a glance.
  */
-function ProjectAccessSection({ user }: { user: NormalizedUserDetail }): JSX.Element {
+function PermissionsCard({ user }: { user: NormalizedUserDetail }): JSX.Element {
+  const { data: rolesData } = useSearchRoles({ pagination: { limit: BE_MAX_PAGE_LIMIT } });
+  const roleNameById = useMemo(
+    () => new Map((rolesData?.roles ?? []).map((r) => [r.id, r.name])),
+    [rolesData],
+  );
+
+  const roleRows: MembershipRow[] = (user.roles ?? []).map((r) => ({
+    key: r,
+    id: r,
+    label: roleNameById.get(r) ?? r,
+    routeBase: "/admin/roles",
+    color: (INTERNAL_USER_ROLES as string[]).includes(r) ? "primary" : "default",
+  }));
+
+  const internal = isInternalUser(user);
+  const groupRows: MembershipRow[] = (user.groups ?? []).map((g) => ({
+    key: g.id,
+    id: g.id,
+    label: g.name,
+    routeBase: "/admin/groups",
+  }));
+
+  return (
+    <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 2 }}>
+      <Typography variant="subtitle2">Permissions & assignments</Typography>
+      <Box sx={{ display: "flex", flexWrap: "wrap", gap: 3 }}>
+        <Box sx={{ flex: "1 1 260px", minWidth: 220, display: "flex", flexDirection: "column", gap: 1 }}>
+          <Typography variant="body2" sx={{ fontWeight: 600 }}>
+            Platform roles ({roleRows.length})
+          </Typography>
+          <ChipCluster rows={roleRows} emptyMessage="No roles assigned." />
+        </Box>
+        {internal && (
+          <Box sx={{ flex: "1 1 260px", minWidth: 220, display: "flex", flexDirection: "column", gap: 1 }}>
+            <Typography variant="body2" sx={{ fontWeight: 600 }}>
+              User groups ({groupRows.length})
+            </Typography>
+            <ChipCluster rows={groupRows} emptyMessage="No group memberships." />
+          </Box>
+        )}
+      </Box>
+    </Card>
+  );
+}
+
+/**
+ * An external user's per-project access, as a data table matching the
+ * platform's other project tables (see `ProjectContactsTab`): project name
+ * linked to its detail page, the project's short key, the roles this contact
+ * carries on it, and a single Access column that's the verdict a support
+ * engineer is looking for — with the reason called out inline whenever a
+ * project doesn't grant case access.
+ */
+function AccessibleProjectsCard({ user }: { user: NormalizedUserDetail }): JSX.Element {
   const access = user.projectAccess ?? [];
   const blockedCount = access.filter((pa) => !pa.grantsCaseAccess).length;
 
   return (
-    <Card sx={{ p: 2.5, flex: "2 1 400px", display: "flex", flexDirection: "column", gap: 2 }}>
-      <Typography variant="subtitle2">Project access</Typography>
+    <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 2 }}>
+      <Typography variant="subtitle2">Accessible projects</Typography>
 
       {user.active === false && (
         <Alert severity="error" variant="outlined">
@@ -346,11 +287,88 @@ function ProjectAccessSection({ user }: { user: NormalizedUserDetail }): JSX.Ele
               {access.length === 1 ? "" : "s"} — see the reason under each row below.
             </Alert>
           )}
-          <Stack spacing={1.5}>
-            {access.map((pa) => (
-              <ProjectAccessRow key={pa.projectId} pa={pa} />
-            ))}
-          </Stack>
+          <TableContainer sx={{ border: 1, borderColor: "divider", borderRadius: 1 }}>
+            <Table size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell>Project name</TableCell>
+                  <TableCell>Project key</TableCell>
+                  <TableCell>Project roles</TableCell>
+                  <TableCell>Access</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {access.map((pa) => {
+                  const status = deriveProjectAccessStatus(pa);
+                  return (
+                    <TableRow key={pa.projectId} hover>
+                      <TableCell>
+                        <Typography
+                          component={RouterLink}
+                          to={`/customers/projects/${pa.projectId}`}
+                          variant="body2"
+                          sx={(t) => ({
+                            fontWeight: 600,
+                            textDecoration: "none",
+                            color: t.palette.primary.dark,
+                            ...t.applyStyles("dark", { color: t.palette.primary.main }),
+                            "&:hover": { textDecoration: "underline" },
+                          })}
+                        >
+                          {pa.projectName}
+                        </Typography>
+                      </TableCell>
+                      <TableCell>
+                        {pa.projectKey ? (
+                          <Typography
+                            component="code"
+                            variant="caption"
+                            color="text.secondary"
+                            sx={{
+                              px: 0.75,
+                              py: 0.25,
+                              bgcolor: "action.hover",
+                              borderRadius: 0.5,
+                            }}
+                          >
+                            {pa.projectKey}
+                          </Typography>
+                        ) : (
+                          "—"
+                        )}
+                      </TableCell>
+                      <TableCell>
+                        {pa.roles && pa.roles.length > 0
+                          ? pa.roles.map((r) => (
+                              <Chip
+                                key={r}
+                                size="small"
+                                label={r}
+                                variant="outlined"
+                                sx={{ mr: 0.5, mb: 0.5 }}
+                              />
+                            ))
+                          : "—"}
+                      </TableCell>
+                      <TableCell>
+                        <Chip size="small" label={status.label} color={status.color} variant="outlined" />
+                        {status.reason && (
+                          <Typography
+                            variant="caption"
+                            color="error.main"
+                            component="div"
+                            sx={{ mt: 0.25 }}
+                          >
+                            {status.reason}
+                          </Typography>
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </TableContainer>
         </>
       )}
     </Card>
@@ -365,10 +383,10 @@ function ProjectAccessSection({ user }: { user: NormalizedUserDetail }): JSX.Ele
  * id through a cached lookup before the link ever appears).
  *
  * Renders everything `GET /users/{id}` returns: name, email, timezone, phone,
- * roles, created/updated times, plus — split by `userType` — an internal
- * user's group/team memberships or an external user's per-project access
- * (with the reason surfaced whenever a project doesn't grant case access, per
- * `UserProjectAccess.grantsCaseAccess`).
+ * team (internal users only), roles, created/updated times, plus — split by
+ * `userType` — an internal user's group memberships or an external user's
+ * per-project access (with the reason surfaced whenever a project doesn't
+ * grant case access, per `UserProjectAccess.grantsCaseAccess`).
  */
 export default function UserProfilePage(): JSX.Element {
   const { id } = useParams<{ id: string }>();
@@ -459,6 +477,7 @@ export default function UserProfilePage(): JSX.Element {
               {user.email}
             </Typography>
           </MetaCell>
+          {internal && <TeamMetaCell user={user} />}
           <MetaCell label="Timezone">
             <Typography variant="body2">{user.timezone ?? "Not set"}</Typography>
           </MetaCell>
@@ -476,17 +495,9 @@ export default function UserProfilePage(): JSX.Element {
         </Box>
       </Card>
 
-      <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2.5 }}>
-        <RolesSection user={user} />
-        {internal ? (
-          <>
-            <GroupsSection user={user} />
-            <TeamsSection user={user} />
-          </>
-        ) : (
-          <ProjectAccessSection user={user} />
-        )}
-      </Box>
+      <PermissionsCard user={user} />
+
+      {!internal && <AccessibleProjectsCard user={user} />}
     </Box>
   );
 }

--- a/apps/csm-portal/webapp/src/features/csm-users/types/csmUsers.ts
+++ b/apps/csm-portal/webapp/src/features/csm-users/types/csmUsers.ts
@@ -94,19 +94,20 @@ export interface UserTeamRef {
 
 /**
  * One project-contact row for an external user, reported as stored rather
- * than as filtered. The backing access rule grants access only when the
- * row's email matches the login exactly AND a contact record is linked; a
- * row failing either test makes the project, and every case on it, silently
- * invisible to that user — {@link grantsCaseAccess} is the verdict, the rest
- * of the fields are the reasons.
+ * than as filtered. A row with no linked contact record makes the project,
+ * and every case on it, silently invisible to that user —
+ * {@link grantsCaseAccess} is the verdict, mirroring
+ * {@link contactRecordPresent} directly (deliberately not the stricter
+ * email-match rule the live access check enforces, since that only diverges
+ * for integration/system accounts).
  */
 export interface UserProjectAccess {
   projectId: string;
   projectName: string;
+  projectKey: string;
   contactEmail: string;
   contactRecordPresent: boolean;
   contactRecordEmail?: string;
-  emailMatchesLogin: boolean;
   registrationState?: string;
   notificationsEnabled?: boolean;
   roles?: string[];

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -191,21 +191,24 @@ type UserTeamRef struct {
 // UserProjectAccess is one project-contact row for a user, reported as stored rather than
 // as filtered.
 //
-// The backing access rule only grants access when the row's email matches the login
-// exactly AND a contact record is linked. Rows failing either test make the project, and
-// every case on it, silently invisible to that user, so they are reported here with
-// GrantsCaseAccess spelling out the verdict instead of being dropped.
+// Rows with no linked contact record make the project, and every case on it, silently
+// invisible to that user, so they are reported here with GrantsCaseAccess spelling out the
+// verdict instead of being dropped. GrantsCaseAccess mirrors ContactRecordPresent directly
+// -- deliberately not the stricter email-match rule the live access check enforces, since
+// that only diverges for integration/system accounts, which aren't the audience this
+// signals for.
 type UserProjectAccess struct {
 	ProjectID   string `json:"projectId"`
 	ProjectName string `json:"projectName"`
+	// ProjectKey is the project's short human-readable key (e.g. "TESTPROSSUB").
+	ProjectKey string `json:"projectKey"`
 	// ContactEmail is the email as stored on the row itself.
 	ContactEmail string `json:"contactEmail"`
 	// ContactRecordPresent is false when the row has no contact record linked.
 	ContactRecordPresent bool `json:"contactRecordPresent"`
 	// ContactRecordEmail is the linked record's own email, which may differ from
-	// ContactEmail -- that mismatch is itself an access fault.
+	// ContactEmail.
 	ContactRecordEmail   string   `json:"contactRecordEmail"`
-	EmailMatchesLogin    bool     `json:"emailMatchesLogin"`
 	RegistrationState    string   `json:"registrationState"`
 	NotificationsEnabled bool     `json:"notificationsEnabled"`
 	Roles                []string `json:"roles"`

--- a/entity-service/internal/service/sn_user_directory_test.go
+++ b/entity-service/internal/service/sn_user_directory_test.go
@@ -210,8 +210,8 @@ func TestSNUserService_GetUser_ExternalProjectAccess(t *testing.T) {
 	})
 	mux.HandleFunc("/project-contacts/search", func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte(`{"contacts":[{"projectId":"` + projectSysid + `","projectName":"Proj A",` +
-			`"contactEmail":"jane@example.com","customerContactPresent":false,"customerContactEmail":null,` +
-			`"emailMatchesLogin":true,"registrationState":"INVITED","notificationsEnabled":false,` +
+			`"projectKey":"PROJA","contactEmail":"jane@example.com","customerContactPresent":false,` +
+			`"customerContactEmail":null,"registrationState":"INVITED","notificationsEnabled":false,` +
 			`"roles":[],"grantsCaseAccess":false}],"totalRecords":1}`))
 	})
 
@@ -233,6 +233,9 @@ func TestSNUserService_GetUser_ExternalProjectAccess(t *testing.T) {
 	}
 	if row.ProjectID != sysidToUUID(projectSysid) {
 		t.Fatalf("projectId = %q, want the converted id", row.ProjectID)
+	}
+	if row.ProjectKey != "PROJA" {
+		t.Fatalf("projectKey = %q, want %q", row.ProjectKey, "PROJA")
 	}
 }
 

--- a/entity-service/internal/service/sn_user_service.go
+++ b/entity-service/internal/service/sn_user_service.go
@@ -140,10 +140,10 @@ type snProjectContactRowsResponse struct {
 type snProjectContactRow struct {
 	ProjectID              string   `json:"projectId"`
 	ProjectName            string   `json:"projectName"`
+	ProjectKey             string   `json:"projectKey"`
 	ContactEmail           string   `json:"contactEmail"`
 	CustomerContactPresent bool     `json:"customerContactPresent"`
 	CustomerContactEmail   string   `json:"customerContactEmail"`
-	EmailMatchesLogin      bool     `json:"emailMatchesLogin"`
 	RegistrationState      string   `json:"registrationState"`
 	NotificationsEnabled   bool     `json:"notificationsEnabled"`
 	Roles                  []string `json:"roles"`
@@ -549,10 +549,10 @@ func (s *snUserService) resolveProjectAccess(
 		access = append(access, domain.UserProjectAccess{
 			ProjectID:            sysidToUUID(c.ProjectID),
 			ProjectName:          c.ProjectName,
+			ProjectKey:           c.ProjectKey,
 			ContactEmail:         c.ContactEmail,
 			ContactRecordPresent: c.CustomerContactPresent,
 			ContactRecordEmail:   c.CustomerContactEmail,
-			EmailMatchesLogin:    c.EmailMatchesLogin,
 			RegistrationState:    c.RegistrationState,
 			NotificationsEnabled: c.NotificationsEnabled,
 			Roles:                c.Roles,

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -3332,17 +3332,21 @@ components:
     UserProjectAccess:
       type: object
       description: >
-        One project-contact row for a user, reported as stored rather than as filtered. The
-        backing access rule grants access only when the row's email matches the login
-        exactly AND a contact record is linked; rows failing either test make the project,
-        and every case on it, silently invisible to that user.
-      required: [projectId, projectName, contactEmail, contactRecordPresent, emailMatchesLogin, grantsCaseAccess]
+        One project-contact row for a user, reported as stored rather than as filtered. A
+        row with no linked contact record makes the project, and every case on it, silently
+        invisible to that user. grantsCaseAccess mirrors contactRecordPresent directly --
+        deliberately not the stricter email-match rule the live access check enforces, since
+        that only diverges for integration/system accounts.
+      required: [projectId, projectName, projectKey, contactEmail, contactRecordPresent, grantsCaseAccess]
       properties:
         projectId:
           type: string
           format: uuid
         projectName:
           type: string
+        projectKey:
+          type: string
+          description: The project's short human-readable key (e.g. "TESTPROSSUB").
         contactEmail:
           type: string
           description: The email as stored on the row itself.
@@ -3352,8 +3356,6 @@ components:
         contactRecordEmail:
           type: string
           description: The linked record's own email, which may differ from contactEmail.
-        emailMatchesLogin:
-          type: boolean
         registrationState:
           type: string
         notificationsEnabled:


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

The CSM portal's user profile page had three problems: a dedicated Teams card that's mostly empty (most users have zero or one team), role/group chips each wrapped in their own bordered box adding visual weight with no information, and an external user's per-project access rendered as a stack of ad hoc cards rather than the platform's usual table convention. Separately, `UserProjectAccess.emailMatchesLogin` only diverges from `contactRecordPresent` for integration/system accounts — not a distinction a support engineer looking at a real customer's profile needs to see.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

- Fold Team into the Overview card as a normal attribute instead of a separate card.
- Consolidate Roles and Groups into one "Permissions & assignments" card, rendered as inline wrapping chip clusters (no per-row bordered box).
- Replace the external user's per-project access cards with an "Accessible projects" data table (project name, project key, project roles, access status), matching the existing project-contacts table convention elsewhere in the portal.
- Drop the email-match check from `UserProjectAccess`, mirroring the same simplification already made on the project-contacts tab: `grantsCaseAccess` now mirrors `contactRecordPresent` directly.
- Add `projectKey` to the same response so the new table can show it.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

Backing data source: dropped the `emailMatchesLogin` field from the row builder behind `GET /users/{id}`'s project-access lookup and added `projectKey` to the same row (verified live against both a granted and an ungranted case). Entity-service: removed `EmailMatchesLogin` from `UserProjectAccess`/`snProjectContactRow` and threaded `ProjectKey` through the existing mapping; `openapi.yaml` updated in both the entity-service and the csm-portal backend (pass-through only, no backend Go change needed there). Webapp: rewrote `UserProfilePage.tsx` — Team moves into the Overview grid as a chip cluster, Roles/Groups consolidate into a shared `PermissionsCard` using a border-free `ChipCluster`, and project access renders through a new `AccessibleProjectsCard` table with a single "Access" column (Has access / Invited / No access, with the blocking reason inline) instead of three separate status chips per row.

One file (`UserProfilePage.tsx`, 369 diff lines) is over the usual 300-line-per-file guideline — it's a single cohesive page rewrite, not something that splits sensibly across PRs.

## User stories
> Summary of user stories addressed by this change>

As a CS engineer, I can see a user's team, roles, and groups without scrolling past mostly-empty cards, and I can scan an external user's accessible projects as a table (with project key and a clear access-status column) instead of parsing a stack of individual cards.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Restructured the CSM portal's user profile page: consolidated roles/groups/team into fewer, denser cards, and replaced an external user's per-project access cards with a data table showing project name, key, roles, and access status.

## Documentation
N/A — internal CS-engineer tooling UI change, no external-facing documentation.

## Training
N/A — no training content covers this internal page.

## Certification
N/A — not covered by certification exams.

## Marketing
N/A — internal tooling, not a marketed feature.

## Automation tests
 - Unit tests
   - Entity-service: updated `TestSNUserService_GetUser_ExternalProjectAccess` to assert `projectKey` mapping and drop the removed field from its fixture; `go test ./internal/...` passes.
   - Webapp: rewrote `UserProfilePage.test.tsx` (10 tests) covering the Overview team field, the consolidated permissions card, and all three access-status states (Has access / Invited / No access with reason) in the new table; `npx vitest run` passes for the touched suite.
 - Integration tests
   - None added; covered by the unit tests above plus manual verification of the live backing data source response (see Test environment).

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — no new external inputs or dependencies introduced; this is a field removal/rename plus a UI-only restructure.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no sample code shipped with this change.

## Related PRs
None.

## Migrations (if applicable)
N/A — additive/removed response field only, no data migration.

## Test environment
`go build`/`go vet`/`go test` (Go 1.x, as pinned in `go.mod`); webapp verified with `tsc -b --noEmit`, `eslint`, and `vitest` (Node/pnpm versions per the repo's `package.json` engines field). Manually verified the live backing data source response for both a granted and an ungranted row on a non-production environment before wiring the entity-service through it.

## Learning
Matched the existing `ProjectContactsTab` table conventions (registration-chip coloring, access-status derivation) rather than inventing a new pattern, so the two similar screens read consistently to the same support engineers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added project keys to external-user project access details.
  * Updated project access statuses to reflect contact-record availability, including “Invited,” “Has access,” and “No access.”
  * Redesigned user profiles with inline membership chips, clearer permissions, and a project-access table.
  * Improved visibility of teams, roles, and groups based on user type.

* **Bug Fixes**
  * Corrected project access data and labels to match current access behavior.
  * Updated pending-registration and unassigned-team displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->