### PR TITLE
[CSM][Web] Dashboard list-widget tables, view-more preview page, error message cleanup

### DIFF
--- a/apps/csm-portal/webapp/src/App.tsx
+++ b/apps/csm-portal/webapp/src/App.tsx
@@ -47,6 +47,9 @@ import { ErrorPageProvider } from "@context/error-page/ErrorPageContext";
 const CsmDashboardPage = lazy(
   () => import("@features/csm-dashboard/pages/CsmDashboardPage"),
 );
+const DashboardWidgetPreviewPage = lazy(
+  () => import("@features/csm-dashboard/pages/DashboardWidgetPreviewPage"),
+);
 const CsmCasesPage = lazy(
   () => import("@features/csm-cases/pages/CsmCasesPage"),
 );
@@ -335,6 +338,15 @@ export default function App(): JSX.Element {
                   />
 
                   <Route path="dashboard" element={<CsmDashboardPage />} />
+                  {/* Dashboard widget "View more" preview — :previewSlug is
+                      one of WIDGET_RESOURCE_CONFIG's own previewSlug values
+                      (e.g. "cases"), resolved back to a resourceType by
+                      resourceTypeForPreviewSlug. Distinct from the resource's
+                      own real list route (e.g. /cases). */}
+                  <Route
+                    path="dashboard/:previewSlug"
+                    element={<DashboardWidgetPreviewPage />}
+                  />
                   <Route path="cases" element={<CsmCasesPage />} />
                   <Route path="cases/new" element={<CsmCaseCreatePage />} />
                   <Route path="cases/:caseId" element={<CsmCaseDetailPage />} />

--- a/apps/csm-portal/webapp/src/features/csm-accounts/pages/CsmAccountDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-accounts/pages/CsmAccountDetailPage.tsx
@@ -134,7 +134,7 @@ function ProjectsSection({ accountId }: { accountId: string }): JSX.Element {
               <TableRow>
                 <TableCell colSpan={4} align="center">
                   <QueryErrorState
-                    message={error instanceof Error ? error.message : "Failed to load projects."}
+                    message={error instanceof Error && error.message.trim() ? error.message : "Failed to load projects."}
                     error={error}
                   />
                 </TableCell>

--- a/apps/csm-portal/webapp/src/features/csm-accounts/pages/CsmAccountDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-accounts/pages/CsmAccountDetailPage.tsx
@@ -134,7 +134,7 @@ function ProjectsSection({ accountId }: { accountId: string }): JSX.Element {
               <TableRow>
                 <TableCell colSpan={4} align="center">
                   <QueryErrorState
-                    message={`Failed to load projects: ${error instanceof Error ? error.message : "unknown error"}`}
+                    message={error instanceof Error ? error.message : "Failed to load projects."}
                     error={error}
                   />
                 </TableCell>

--- a/apps/csm-portal/webapp/src/features/csm-accounts/pages/CsmAccountsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-accounts/pages/CsmAccountsPage.tsx
@@ -132,7 +132,7 @@ export default function CsmAccountsPage(): JSX.Element {
                 <TableRow>
                   <TableCell colSpan={6} align="center">
                     <QueryErrorState
-                      message={error instanceof Error ? error.message : "Failed to load accounts."}
+                      message={error instanceof Error && error.message.trim() ? error.message : "Failed to load accounts."}
                       error={error}
                     />
                   </TableCell>

--- a/apps/csm-portal/webapp/src/features/csm-accounts/pages/CsmAccountsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-accounts/pages/CsmAccountsPage.tsx
@@ -132,7 +132,7 @@ export default function CsmAccountsPage(): JSX.Element {
                 <TableRow>
                   <TableCell colSpan={6} align="center">
                     <QueryErrorState
-                      message={`Failed to load accounts: ${error instanceof Error ? error.message : "unknown error"}`}
+                      message={error instanceof Error ? error.message : "Failed to load accounts."}
                       error={error}
                     />
                   </TableCell>

--- a/apps/csm-portal/webapp/src/features/csm-admin/components/DirectoryEntityTable.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/components/DirectoryEntityTable.tsx
@@ -130,9 +130,11 @@ export default function DirectoryEntityTable({
                 <TableRow>
                   <TableCell align="center">
                     <QueryErrorState
-                      message={`Failed to load ${entityNounPlural}: ${
-                        error instanceof Error ? error.message : "unknown error"
-                      }`}
+                      message={
+                        error instanceof Error
+                          ? error.message
+                          : `Failed to load ${entityNounPlural}.`
+                      }
                       error={error}
                     />
                   </TableCell>

--- a/apps/csm-portal/webapp/src/features/csm-admin/components/DirectoryMembersList.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/components/DirectoryMembersList.test.tsx
@@ -217,6 +217,6 @@ describe("DirectoryMembersList", () => {
     } as unknown as Response);
     renderList();
 
-    expect(await screen.findByText(/Failed to load members/i)).toBeInTheDocument();
+    expect(await screen.findByText("Internal Server Error")).toBeInTheDocument();
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-admin/components/DirectoryMembersList.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/components/DirectoryMembersList.tsx
@@ -118,7 +118,7 @@ export default function DirectoryMembersList({
               <TableRow>
                 <TableCell colSpan={COLUMN_COUNT} align="center">
                   <QueryErrorState
-                    message={`Failed to load members: ${error instanceof Error ? error.message : "unknown error"}`}
+                    message={error instanceof Error ? error.message : "Failed to load members."}
                     error={error}
                   />
                 </TableCell>

--- a/apps/csm-portal/webapp/src/features/csm-admin/components/DirectoryMembersList.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/components/DirectoryMembersList.tsx
@@ -118,7 +118,7 @@ export default function DirectoryMembersList({
               <TableRow>
                 <TableCell colSpan={COLUMN_COUNT} align="center">
                   <QueryErrorState
-                    message={error instanceof Error ? error.message : "Failed to load members."}
+                    message={error instanceof Error && error.message.trim() ? error.message : "Failed to load members."}
                     error={error}
                   />
                 </TableCell>

--- a/apps/csm-portal/webapp/src/features/csm-announcements/pages/CsmAnnouncementsPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-announcements/pages/CsmAnnouncementsPage.test.tsx
@@ -92,7 +92,7 @@ describe("CsmAnnouncementsPage — list states", () => {
   it("surfaces the error message on failure", () => {
     mockResult({ isError: true, error: new Error("boom") });
     render(<CsmAnnouncementsPage />);
-    expect(screen.getByText(/failed to load announcements: boom/i)).toBeInTheDocument();
+    expect(screen.getByText("boom")).toBeInTheDocument();
   });
 });
 

--- a/apps/csm-portal/webapp/src/features/csm-announcements/pages/CsmAnnouncementsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-announcements/pages/CsmAnnouncementsPage.tsx
@@ -269,7 +269,7 @@ export default function CsmAnnouncementsPage(): JSX.Element {
                 <TableRow>
                   <TableCell colSpan={6} align="center">
                     <QueryErrorState
-                      message={error instanceof Error ? error.message : "Failed to load announcements."}
+                      message={error instanceof Error && error.message.trim() ? error.message : "Failed to load announcements."}
                       error={error}
                     />
                   </TableCell>

--- a/apps/csm-portal/webapp/src/features/csm-announcements/pages/CsmAnnouncementsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-announcements/pages/CsmAnnouncementsPage.tsx
@@ -269,7 +269,7 @@ export default function CsmAnnouncementsPage(): JSX.Element {
                 <TableRow>
                   <TableCell colSpan={6} align="center">
                     <QueryErrorState
-                      message={`Failed to load announcements: ${error instanceof Error ? error.message : "unknown error"}`}
+                      message={error instanceof Error ? error.message : "Failed to load announcements."}
                       error={error}
                     />
                   </TableCell>

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/AssignEngineerDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/AssignEngineerDialog.tsx
@@ -18,6 +18,7 @@ import {
   Avatar,
   Box,
   Button,
+  CircularProgress,
   Dialog,
   DialogActions,
   DialogContent,
@@ -77,6 +78,14 @@ export default function AssignEngineerDialog({
   onAssign,
 }: AssignEngineerDialogProps): JSX.Element {
   const [input, setInput] = useState("");
+  // Which target's assign click is in flight — `isAssigning` alone (a plain
+  // disable) was easy to miss, especially on a fast request, so the clicked
+  // button also swaps its icon for a spinner instead of just dimming.
+  const [pendingEmail, setPendingEmail] = useState<string | null>(null);
+  const handleAssign = (email: string): void => {
+    setPendingEmail(email);
+    onAssign(email);
+  };
   const search = useDebouncedValue(input.trim(), 300);
   const { data, isFetching, isError } = useSearchUsers({
     filters: {
@@ -122,9 +131,15 @@ export default function AssignEngineerDialog({
             <Button
               variant="outlined"
               size="small"
-              startIcon={<UserCheck size={16} />}
+              startIcon={
+                isAssigning && pendingEmail === currentUserEmail ? (
+                  <CircularProgress size={14} color="inherit" />
+                ) : (
+                  <UserCheck size={16} />
+                )
+              }
               disabled={isAssigning}
-              onClick={() => onAssign(currentUserEmail)}
+              onClick={() => handleAssign(currentUserEmail)}
               sx={{ alignSelf: "flex-start" }}
             >
               Assign to me
@@ -172,13 +187,14 @@ export default function AssignEngineerDialog({
               <Box sx={{ display: "flex", flexDirection: "column" }}>
                 {engineers.map((u) => {
                   const name = fullName(u);
+                  const isPendingForThis = isAssigning && pendingEmail === u.email;
                   return (
                     <Button
                       key={u.id}
                       variant="text"
                       color="inherit"
                       disabled={isAssigning}
-                      onClick={() => onAssign(u.email)}
+                      onClick={() => handleAssign(u.email)}
                       sx={{
                         justifyContent: "flex-start",
                         textTransform: "none",
@@ -187,9 +203,23 @@ export default function AssignEngineerDialog({
                         gap: 1.25,
                       }}
                     >
-                      <Avatar sx={{ width: 28, height: 28, fontSize: "0.75rem" }}>
-                        {initialsOf(name)}
-                      </Avatar>
+                      {isPendingForThis ? (
+                        <Box
+                          sx={{
+                            width: 28,
+                            height: 28,
+                            display: "flex",
+                            alignItems: "center",
+                            justifyContent: "center",
+                          }}
+                        >
+                          <CircularProgress size={18} color="inherit" />
+                        </Box>
+                      ) : (
+                        <Avatar sx={{ width: 28, height: 28, fontSize: "0.75rem" }}>
+                          {initialsOf(name)}
+                        </Avatar>
+                      )}
                       <Box sx={{ minWidth: 0, textAlign: "left" }}>
                         <Typography variant="body2" sx={{ lineHeight: 1.2 }} noWrap>
                           {name}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.test.tsx
@@ -217,6 +217,52 @@ describe("CaseActionBar — nextStates-driven buttons", () => {
   });
 });
 
+describe("CaseActionBar — isPending shows a spinner and disables the click", () => {
+  it("shows a spinner and disables the single primary button (e.g. Assign to me) while isPending", () => {
+    render(
+      <CaseActionBar
+        caseDetail={{
+          ...caseInState("open", ["work_in_progress"]),
+          assigneeIsMe: false,
+        }}
+        onAction={() => {}}
+        isPending
+      />,
+    );
+    const button = screen.getByRole("button", { name: /assign to me/i });
+    expect(button).toBeDisabled();
+    expect(button.querySelector(".MuiCircularProgress-root")).toBeInTheDocument();
+  });
+
+  it("disables the Change-state trigger while isPending, when there are multiple primary buttons", () => {
+    render(
+      <CaseActionBar
+        caseDetail={caseInState("solution_proposed", ["closed", "waiting_on_wso2"])}
+        onAction={() => {}}
+        isPending
+      />,
+    );
+    const button = screen.getByRole("button", { name: /change state/i });
+    expect(button).toBeDisabled();
+    expect(button.querySelector(".MuiCircularProgress-root")).toBeInTheDocument();
+  });
+
+  it("leaves the primary button enabled with its normal icon when isPending is unset", () => {
+    render(
+      <CaseActionBar
+        caseDetail={{
+          ...caseInState("open", ["work_in_progress"]),
+          assigneeIsMe: false,
+        }}
+        onAction={() => {}}
+      />,
+    );
+    const button = screen.getByRole("button", { name: /assign to me/i });
+    expect(button).not.toBeDisabled();
+    expect(button.querySelector(".MuiCircularProgress-root")).not.toBeInTheDocument();
+  });
+});
+
 describe("CaseActionBar — reassign gating for WIP-Ongoing", () => {
   /** Open the "More" overflow and return the reassign engineer menu item. */
   function openReassignItem(): HTMLElement {

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
@@ -17,6 +17,7 @@
 import {
   Box,
   Button,
+  CircularProgress,
   Menu,
   MenuItem,
   Tooltip,
@@ -381,6 +382,11 @@ interface CaseActionBarProps {
    * or stale. Only ever applied to a `targetState === "closed"` button.
    */
   closeBlockedReason?: string;
+  /** True while a lifecycle PATCH from this bar (e.g. "Assign to me") is in
+   * flight — disables the primary action and swaps its icon for a spinner,
+   * so a click has visible feedback even before the resulting toast/state
+   * change lands. */
+  isPending?: boolean;
 }
 
 /**
@@ -394,6 +400,7 @@ export default function CaseActionBar({
   caseDetail,
   onAction,
   closeBlockedReason,
+  isPending = false,
 }: CaseActionBarProps): JSX.Element {
   const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
   const [stateMenuAnchor, setStateMenuAnchor] = useState<HTMLElement | null>(null);
@@ -435,8 +442,8 @@ export default function CaseActionBar({
               size="small"
               variant="contained"
               color={p.color}
-              startIcon={p.icon}
-              disabled={blocked}
+              startIcon={isPending ? <CircularProgress size={14} color="inherit" /> : p.icon}
+              disabled={blocked || isPending}
               onClick={() => runPrimary(p)}
             >
               {p.label}
@@ -457,7 +464,8 @@ export default function CaseActionBar({
             size="small"
             variant="contained"
             color="primary"
-            endIcon={<ChevronDown size={16} />}
+            endIcon={isPending ? <CircularProgress size={14} color="inherit" /> : <ChevronDown size={16} />}
+            disabled={isPending}
             onClick={(e) => setStateMenuAnchor(e.currentTarget)}
           >
             Change state

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.tsx
@@ -16,6 +16,7 @@
 
 import {
   Box,
+  Chip,
   Skeleton,
   TableSortLabel,
   Typography,
@@ -30,13 +31,23 @@ import StateChip from "@components/StateChip";
 import WorkStateChip from "@components/WorkStateChip";
 import type { CsmCaseRow } from "@features/csm-cases/types/csmCases";
 import type { CasesSortOrder } from "@features/csm-cases/utils/casesSort";
+import {
+  CASE_TYPE_COLOR,
+  CASE_TYPE_LABEL,
+  caseTypeDetailBasePath,
+  caseTypeHasSeverity,
+} from "@features/csm-cases/utils/caseType";
 
 interface CasesListProps {
   cases: CsmCaseRow[];
   isLoading: boolean;
   /** Number of skeleton rows to show while loading. Defaults to 6. */
   skeletonCount?: number;
-  /** Base path for detail links. Defaults to "/cases". */
+  /** Base path for detail links. Omit to have each row route to its own
+   * case type's own detail page (see `caseTypeDetailBasePath`) — the right
+   * choice for a mixed-type list. Pass an explicit value only when every row
+   * is already locked to one type (e.g. the Engagements/Security Center
+   * tabs), to route there directly without a per-row type check. */
   detailBasePath?: string;
   /** Hide the Severity column. Severity (S1-S4) is a support-case concept, so
    * non-case lists (service requests, engagements, security reports) hide it —
@@ -51,10 +62,14 @@ interface CasesListProps {
 }
 
 // Every column is left-aligned for a consistent scan line down the table.
+// Type (case / service request / security report / ...) is gated by the same
+// flag as Severity: both are noise in a list already locked to one case type
+// (see `hideSeverityColumn`'s callers), useful in the mixed, general list.
 const HEADER_CELLS_WITH_SEVERITY: string[] = [
   "Case ID",
   "Subject",
   "Product",
+  "Type",
   "Severity",
   "State",
 ];
@@ -70,7 +85,7 @@ const HEADER_CELLS_WITHOUT_SEVERITY: string[] = [
 // The work-state chip (only present for WIP cases) stacks under the State chip
 // in the State column, so it doesn't need a column of its own.
 const GRID_WITH_SEVERITY =
-  "minmax(120px, 0.9fr) minmax(280px, 3fr) minmax(140px, 1fr) auto minmax(110px, 1fr) auto";
+  "minmax(120px, 0.9fr) minmax(280px, 3fr) minmax(140px, 1fr) auto auto minmax(110px, 1fr) auto";
 const GRID_WITHOUT_SEVERITY =
   "minmax(120px, 0.9fr) minmax(280px, 3fr) minmax(140px, 1fr) minmax(110px, 1fr) auto";
 
@@ -78,7 +93,7 @@ export default function CasesList({
   cases,
   isLoading,
   skeletonCount = 6,
-  detailBasePath = "/cases",
+  detailBasePath,
   hideSeverityColumn = false,
   sortOrder,
   onSortOrderChange,
@@ -190,6 +205,7 @@ export default function CasesList({
 
       {!isLoading &&
         cases.map((c) => {
+          const rowBasePath = detailBasePath ?? caseTypeDetailBasePath(c.caseType);
           return (
             // A real anchor (not a click-handler div) so the row supports
             // cmd/middle-click "open in new tab" — essential when an engineer
@@ -198,12 +214,12 @@ export default function CasesList({
             <Box
               key={c.id}
               component={RouterLink}
-              to={`${detailBasePath}/${c.id}`}
+              to={`${rowBasePath}/${c.id}`}
               // Carries the current (filtered) list URL forward so the detail
               // page's back button can return to it instead of a bare,
               // filter-less list path.
               state={{ from: `${location.pathname}${location.search}` }}
-              onMouseEnter={() => preloadRoute(detailBasePath)}
+              onMouseEnter={() => preloadRoute(rowBasePath)}
               sx={{
                 gridColumn: "1 / -1",
                 display: "grid",
@@ -272,7 +288,25 @@ export default function CasesList({
               </Typography>
               {!hideSeverityColumn && (
                 <Box sx={{ justifySelf: "start" }}>
-                  <SeverityChip severity={c.severity} clickable />
+                  {c.caseType ? (
+                    <Chip
+                      size="small"
+                      variant="outlined"
+                      color={CASE_TYPE_COLOR[c.caseType]}
+                      label={CASE_TYPE_LABEL[c.caseType]}
+                    />
+                  ) : (
+                    "—"
+                  )}
+                </Box>
+              )}
+              {!hideSeverityColumn && (
+                <Box sx={{ justifySelf: "start" }}>
+                  {caseTypeHasSeverity(c.caseType) ? (
+                    <SeverityChip severity={c.severity} clickable />
+                  ) : (
+                    "—"
+                  )}
                 </Box>
               )}
               {/* State chip, with the work-state chip stacked beneath it (the

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -296,6 +296,30 @@ const TAB_DEFS: Array<{
   { id: "tasks", label: "Tasks", icon: <CheckSquare size={16} />, hidden: true },
 ];
 
+/**
+ * Whether `from` (the router-state origin path, e.g. from `CasesList`'s row
+ * link) actually points at `backPath`'s own list — as opposed to some other
+ * origin (a dashboard widget's "View more"/row link, say) that merely also
+ * sets `state.from` so the back button still returns there. Compares the
+ * pathname exactly and, when `backPath` carries query params of its own
+ * (e.g. "/operations?tab=service_requests"), requires `from` to carry the
+ * same values for those — extra params `from` has on top (filters, search)
+ * don't disqualify a match.
+ */
+function pathMatchesBackPath(from: string | undefined, backPath: string): boolean {
+  if (!from) return true;
+  const [fromPath, fromQuery] = from.split("?");
+  const [expectedPath, expectedQuery] = backPath.split("?");
+  if (fromPath !== expectedPath) return false;
+  if (!expectedQuery) return true;
+  const fromParams = new URLSearchParams(fromQuery ?? "");
+  const expectedParams = new URLSearchParams(expectedQuery);
+  for (const [key, value] of expectedParams) {
+    if (fromParams.get(key) !== value) return false;
+  }
+  return true;
+}
+
 export default function CsmCaseDetailPage(): JSX.Element {
   const { caseId } = useParams<{ caseId: string }>();
   const navigate = useNavTransition();
@@ -315,15 +339,6 @@ export default function CsmCaseDetailPage(): JSX.Element {
         : isSecurityReportRoute
           ? "/security-center?tab=security_reports"
           : "/cases";
-  const backLabel = isEngagementRoute
-    ? "Back to engagements"
-    : isServiceRequestRoute
-      ? "Back to service requests"
-      : isAnnouncementRoute
-        ? "Back to announcements"
-        : isSecurityReportRoute
-          ? "Back to security reports"
-          : "Back to cases";
   const detailPath = isEngagementRoute
     ? `/engagements/${caseId}`
     : isServiceRequestRoute
@@ -340,6 +355,23 @@ export default function CsmCaseDetailPage(): JSX.Element {
   // detail page, which never got the state set.
   const fromListState = location.state as { from?: string } | undefined;
   const resolvedBackPath = fromListState?.from ?? backPath;
+  // A "Back to <type>" label is only accurate when the caller actually came
+  // from that type's own list — e.g. a dashboard widget's "My Cases" tile
+  // also sets `state.from` (so the button still returns to the dashboard,
+  // not a bare /cases), but it isn't the cases list, so labelling it "Back
+  // to cases" would be wrong. Generic "Back" covers every other origin.
+  const cameFromOwnList = pathMatchesBackPath(fromListState?.from, backPath);
+  const backLabel = !cameFromOwnList
+    ? "Back"
+    : isEngagementRoute
+      ? "Back to engagements"
+      : isServiceRequestRoute
+        ? "Back to service requests"
+        : isAnnouncementRoute
+          ? "Back to announcements"
+          : isSecurityReportRoute
+            ? "Back to security reports"
+            : "Back to cases";
   const { data, isLoading, isError, error } = useGetCsmCaseDetail(caseId);
   // The route alone isn't a reliable signal once data has loaded: a "Related
   // case" link always points at /cases/:id regardless of the target's actual

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -1684,6 +1684,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
               caseDetail={c}
               onAction={onAction}
               closeBlockedReason={closeBlockedReason}
+              isPending={patchCase.isPending}
             />
           </Box>
         )}

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -1445,7 +1445,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
           Back
         </Button>
         <QueryErrorState
-          message={error instanceof Error ? error.message : "Could not load this case."}
+          message={error instanceof Error && error.message.trim() ? error.message : "Could not load this case."}
           error={error}
         />
       </Box>

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -1454,7 +1454,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
           {backLabel}
         </Button>
         <QueryErrorState
-          message={`Could not load this case: ${error instanceof Error ? error.message : "unknown error"}`}
+          message={error instanceof Error ? error.message : "Could not load this case."}
           error={error}
         />
       </Box>

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -296,30 +296,6 @@ const TAB_DEFS: Array<{
   { id: "tasks", label: "Tasks", icon: <CheckSquare size={16} />, hidden: true },
 ];
 
-/**
- * Whether `from` (the router-state origin path, e.g. from `CasesList`'s row
- * link) actually points at `backPath`'s own list — as opposed to some other
- * origin (a dashboard widget's "View more"/row link, say) that merely also
- * sets `state.from` so the back button still returns there. Compares the
- * pathname exactly and, when `backPath` carries query params of its own
- * (e.g. "/operations?tab=service_requests"), requires `from` to carry the
- * same values for those — extra params `from` has on top (filters, search)
- * don't disqualify a match.
- */
-function pathMatchesBackPath(from: string | undefined, backPath: string): boolean {
-  if (!from) return true;
-  const [fromPath, fromQuery] = from.split("?");
-  const [expectedPath, expectedQuery] = backPath.split("?");
-  if (fromPath !== expectedPath) return false;
-  if (!expectedQuery) return true;
-  const fromParams = new URLSearchParams(fromQuery ?? "");
-  const expectedParams = new URLSearchParams(expectedQuery);
-  for (const [key, value] of expectedParams) {
-    if (fromParams.get(key) !== value) return false;
-  }
-  return true;
-}
-
 export default function CsmCaseDetailPage(): JSX.Element {
   const { caseId } = useParams<{ caseId: string }>();
   const navigate = useNavTransition();
@@ -355,23 +331,6 @@ export default function CsmCaseDetailPage(): JSX.Element {
   // detail page, which never got the state set.
   const fromListState = location.state as { from?: string } | undefined;
   const resolvedBackPath = fromListState?.from ?? backPath;
-  // A "Back to <type>" label is only accurate when the caller actually came
-  // from that type's own list — e.g. a dashboard widget's "My Cases" tile
-  // also sets `state.from` (so the button still returns to the dashboard,
-  // not a bare /cases), but it isn't the cases list, so labelling it "Back
-  // to cases" would be wrong. Generic "Back" covers every other origin.
-  const cameFromOwnList = pathMatchesBackPath(fromListState?.from, backPath);
-  const backLabel = !cameFromOwnList
-    ? "Back"
-    : isEngagementRoute
-      ? "Back to engagements"
-      : isServiceRequestRoute
-        ? "Back to service requests"
-        : isAnnouncementRoute
-          ? "Back to announcements"
-          : isSecurityReportRoute
-            ? "Back to security reports"
-            : "Back to cases";
   const { data, isLoading, isError, error } = useGetCsmCaseDetail(caseId);
   // The route alone isn't a reliable signal once data has loaded: a "Related
   // case" link always points at /cases/:id regardless of the target's actual
@@ -1483,7 +1442,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
           onClick={() => navigate(resolvedBackPath)}
           sx={{ alignSelf: "flex-start" }}
         >
-          {backLabel}
+          Back
         </Button>
         <QueryErrorState
           message={error instanceof Error ? error.message : "Could not load this case."}
@@ -1503,7 +1462,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
           onClick={() => navigate(resolvedBackPath)}
           sx={{ alignSelf: "flex-start" }}
         >
-          {backLabel}
+          Back
         </Button>
         <Typography variant="h5">Case not found</Typography>
         <Typography variant="body2" color="text.secondary">
@@ -1554,7 +1513,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
         onClick={() => navigate(resolvedBackPath)}
         sx={{ alignSelf: "flex-start" }}
       >
-        {backLabel}
+        Back
       </Button>
 
       <Box

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/caseType.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/caseType.ts
@@ -38,3 +38,46 @@ export const CASE_TYPE_LABEL: Record<BeCaseType, string> = {
   announcement: "Announcement",
   engagement: "Engagement",
 };
+
+type ChipColor = "default" | "info" | "warning" | "success" | "error";
+
+/** Chip color per case type — `case` (the default/majority type) stays
+ * neutral, the others get a distinguishing color. */
+export const CASE_TYPE_COLOR: Record<BeCaseType, ChipColor> = {
+  case: "default",
+  service_request: "info",
+  security_report_analysis: "warning",
+  announcement: "success",
+  engagement: "default",
+};
+
+/**
+ * Whether severity (S1-S4) is a meaningful concept for this case type. Only
+ * plain support cases (`case`) actually have one set with any intent — every
+ * other type still carries a `severity` in the search response (the field
+ * isn't type-gated upstream), but it's not something anyone sets or acts on
+ * for those, so the UI hides it there rather than show a value nobody put
+ * any thought into. A missing `caseType` (legacy rows) is treated as `case`.
+ */
+export function caseTypeHasSeverity(caseType: BeCaseType | undefined): boolean {
+  return caseType === undefined || caseType === "case";
+}
+
+/** Where a case's own detail page lives, keyed by its type — each
+ * non-`case` type has its own dedicated route/detail page (different
+ * fields/actions), not just a filtered view of `/cases`. */
+export function caseTypeDetailBasePath(caseType: BeCaseType | undefined): string {
+  switch (caseType) {
+    case "service_request":
+      return "/operations/service-requests";
+    case "security_report_analysis":
+      return "/security-center/security-reports";
+    case "engagement":
+      return "/engagements";
+    case "announcement":
+      return "/announcements";
+    case "case":
+    default:
+      return "/cases";
+  }
+}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetData.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetData.ts
@@ -46,10 +46,20 @@ export function useWidgetData(
   filters: Record<string, unknown>,
   shape: BeWidgetShape,
   listLimit?: number,
+  /** Row offset for a `shape: "list"` widget — only meaningful there, and
+   * only actually used by `DashboardWidgetPreviewPage`'s pagination; the
+   * compact tile always fetches from the start. */
+  offset = 0,
+  /** Set to `false` to defer the query — used by `DashboardWidgetPreviewPage`
+   * while it's still waiting to resolve a `@me`-style filter sentinel (see
+   * `widgetPreviewUrl.ts`) into the signed-in user's real id, so a request
+   * never goes out with the literal placeholder still in it. */
+  enabled = true,
 ): UseQueryResult<WidgetData, Error> {
   const api = useBackendApi();
   const config = WIDGET_RESOURCE_CONFIG[resourceType];
   const limit = shape === "list" ? (listLimit ?? DEFAULT_LIST_LIMIT) : 1;
+  const effectiveOffset = shape === "list" ? offset : 0;
 
   return useQuery<WidgetData, Error>({
     queryKey: [
@@ -58,7 +68,9 @@ export function useWidgetData(
       resourceType,
       filters,
       limit,
+      effectiveOffset,
     ],
+    enabled,
     queryFn: async (): Promise<WidgetData> => {
       if (!config) {
         // A widget's resourceType came back from the backend (now a
@@ -72,7 +84,7 @@ export function useWidgetData(
         Record<string, unknown>
       >(config.searchEndpoint, {
         filters,
-        pagination: { offset: 0, limit },
+        pagination: { offset: effectiveOffset, limit },
       });
       const total = typeof res.total === "number" ? res.total : 0;
       const rawItems = res[config.itemsKey];

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetData.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetData.ts
@@ -22,7 +22,7 @@ import { WIDGET_RESOURCE_CONFIG } from "@features/csm-dashboard/config/widgetRes
 
 /** Default number of rows fetched for a `shape: "list"` widget when the
  * template doesn't set its own `listLimit`. */
-const DEFAULT_LIST_LIMIT = 5;
+const DEFAULT_LIST_LIMIT = 4;
 
 export interface WidgetData {
   /** Total matching records — what a `shape: "count"` tile renders. */

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/AgentsLandingPagePilot.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/AgentsLandingPagePilot.test.tsx
@@ -27,6 +27,12 @@ const postMock = vi.fn();
 vi.mock("@api/backend/client", () => ({
   useBackendApi: () => ({ get: getMock, post: postMock }),
 }));
+// A `shape: "list"` tile renders through widgetListConfig.tsx, which pulls in
+// useTimeSheets.ts (time_card's mapper) — that module reads `window.config`
+// at load via `@config/apiConfig`, unavailable under vitest.
+vi.mock("@config/apiConfig", () => ({
+  apiConfig: { backendUrl: "https://example.test" },
+}));
 
 import AgentsLandingPagePilot from "@features/csm-dashboard/components/AgentsLandingPagePilot";
 

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/AgentsLandingPagePilot.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/AgentsLandingPagePilot.test.tsx
@@ -33,6 +33,13 @@ vi.mock("@api/backend/client", () => ({
 vi.mock("@config/apiConfig", () => ({
   apiConfig: { backendUrl: "https://example.test" },
 }));
+vi.mock("@context/current-user/CurrentUserContext", () => ({
+  useCurrentUser: () => ({
+    user: { id: "11111111-aaaa-bbbb-cccc-000000000001" },
+    isLoading: false,
+    isError: false,
+  }),
+}));
 
 import AgentsLandingPagePilot from "@features/csm-dashboard/components/AgentsLandingPagePilot";
 

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/AgentsLandingPagePilot.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/AgentsLandingPagePilot.tsx
@@ -108,7 +108,7 @@ export default function AgentsLandingPagePilot({
                 <Box
                   key={widget.widgetId}
                   sx={
-                    // A list-shape widget renders a real table (5 rows,
+                    // A list-shape widget renders a real table (4 rows,
                     // several columns) — its configured `gridWidth` was
                     // sized for the old compact text list, so it always
                     // spans the full row here regardless of that value.

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/AgentsLandingPagePilot.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/AgentsLandingPagePilot.tsx
@@ -107,12 +107,20 @@ export default function AgentsLandingPagePilot({
             : (data?.widgets ?? []).map((widget) => (
                 <Box
                   key={widget.widgetId}
-                  sx={{
-                    gridColumn: {
-                      xs: `span ${Math.min(widget.gridWidth, 4)}`,
-                      sm: `span ${widget.gridWidth}`,
-                    },
-                  }}
+                  sx={
+                    // A list-shape widget renders a real table (5 rows,
+                    // several columns) — its configured `gridWidth` was
+                    // sized for the old compact text list, so it always
+                    // spans the full row here regardless of that value.
+                    widget.shape === "list"
+                      ? { gridColumn: "1 / -1" }
+                      : {
+                          gridColumn: {
+                            xs: `span ${Math.min(widget.gridWidth, 4)}`,
+                            sm: `span ${widget.gridWidth}`,
+                          },
+                        }
+                  }
                 >
                   <DashboardWidgetTile
                     widgetId={widget.widgetId}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/AgentsLandingPagePilot.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/AgentsLandingPagePilot.tsx
@@ -70,8 +70,6 @@ export default function AgentsLandingPagePilot({
 
   return (
     <SectionCard
-      title="Widget pilot"
-      subtitle="Config-driven dashboard widgets (preview)"
       action={
         <RefreshButton
           onRefresh={() => void handleRefresh()}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardMiniTable.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardMiniTable.tsx
@@ -37,8 +37,8 @@ interface DashboardMiniTableProps {
   columns: DashboardMiniTableColumn[];
   rows: DashboardMiniTableRow[];
   isLoading: boolean;
-  /** Number of skeleton rows to show while loading. Defaults to 5 — dashboard
-   * list widgets are always capped at 5 records. */
+  /** Number of skeleton rows to show while loading. Defaults to 4 — dashboard
+   * list widgets are always capped at 4 records. */
   skeletonCount?: number;
   emptyMessage: string;
 }
@@ -55,7 +55,7 @@ export default function DashboardMiniTable({
   columns,
   rows,
   isLoading,
-  skeletonCount = 5,
+  skeletonCount = 4,
   emptyMessage,
 }: DashboardMiniTableProps): JSX.Element {
   const theme = useTheme();
@@ -64,7 +64,6 @@ export default function DashboardMiniTable({
   return (
     <Box
       sx={{
-        mt: 1,
         border: 1,
         borderColor: "divider",
         borderRadius: 1,

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardMiniTable.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardMiniTable.tsx
@@ -1,0 +1,159 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Box, Skeleton, Typography, useTheme } from "@wso2/oxygen-ui";
+import type { JSX, ReactNode } from "react";
+import { Link as RouterLink } from "react-router";
+
+export interface DashboardMiniTableColumn {
+  label: string;
+  /** CSS grid track for this column. Defaults to an equal-share flexible track. */
+  width?: string;
+}
+
+export interface DashboardMiniTableRow {
+  key: string;
+  /** Row's own detail page — the row is a real link (not a click handler),
+   * same rationale as `CasesList`: supports cmd/middle-click and exposes a
+   * copyable URL. */
+  href: string;
+  cells: ReactNode[];
+}
+
+interface DashboardMiniTableProps {
+  columns: DashboardMiniTableColumn[];
+  rows: DashboardMiniTableRow[];
+  isLoading: boolean;
+  /** Number of skeleton rows to show while loading. Defaults to 5 — dashboard
+   * list widgets are always capped at 5 records. */
+  skeletonCount?: number;
+  emptyMessage: string;
+}
+
+/**
+ * Compact grid-based table for a dashboard `shape: "list"` widget — same
+ * visual pattern as `CasesList`/`TimeCardsTable` (a single CSS grid context
+ * driving header + row column tracks via `subgrid`, rather than a full MUI
+ * `Table`), but generic over columns/cells so each resource type only
+ * supplies its own column labels and cell content instead of a bespoke
+ * table component.
+ */
+export default function DashboardMiniTable({
+  columns,
+  rows,
+  isLoading,
+  skeletonCount = 5,
+  emptyMessage,
+}: DashboardMiniTableProps): JSX.Element {
+  const theme = useTheme();
+  const gridTemplateColumns = columns.map((c) => c.width ?? "minmax(80px, 1fr)").join(" ");
+
+  return (
+    <Box
+      sx={{
+        mt: 1,
+        border: 1,
+        borderColor: "divider",
+        borderRadius: 1,
+        overflow: "hidden",
+        display: "grid",
+        gridTemplateColumns,
+        columnGap: 2,
+      }}
+    >
+      <Box
+        sx={{
+          gridColumn: "1 / -1",
+          display: "grid",
+          gridTemplateColumns: "subgrid",
+          columnGap: 2,
+          alignItems: "center",
+          px: 1.5,
+          py: 1,
+          bgcolor: "action.hover",
+          borderBottom: 1,
+          borderColor: "divider",
+        }}
+      >
+        {columns.map((c) => (
+          <Typography key={c.label} variant="caption" color="text.secondary" sx={{ fontWeight: 600 }}>
+            {c.label}
+          </Typography>
+        ))}
+      </Box>
+
+      {isLoading &&
+        Array.from({ length: skeletonCount }).map((_, i) => (
+          <Box
+            key={i}
+            sx={{
+              gridColumn: "1 / -1",
+              px: 1.5,
+              py: 1,
+              borderBottom: 1,
+              borderColor: "divider",
+              "&:last-of-type": { borderBottom: 0 },
+            }}
+          >
+            <Skeleton variant="rounded" height={20} />
+          </Box>
+        ))}
+
+      {!isLoading && rows.length === 0 && (
+        <Box sx={{ gridColumn: "1 / -1", px: 1.5, py: 2.5, textAlign: "center" }}>
+          <Typography variant="body2" color="text.secondary">
+            {emptyMessage}
+          </Typography>
+        </Box>
+      )}
+
+      {!isLoading &&
+        rows.map((row) => (
+          <Box
+            key={row.key}
+            component={RouterLink}
+            to={row.href}
+            sx={{
+              gridColumn: "1 / -1",
+              display: "grid",
+              gridTemplateColumns: "subgrid",
+              columnGap: 2,
+              alignItems: "center",
+              px: 1.5,
+              py: 1,
+              borderBottom: 1,
+              borderColor: "divider",
+              cursor: "pointer",
+              color: "inherit",
+              textDecoration: "none",
+              "&:hover": { bgcolor: "action.hover" },
+              "&:focus-visible": {
+                outline: `2px solid ${theme.palette.primary.main}`,
+                outlineOffset: -2,
+              },
+              "&:last-of-type": { borderBottom: 0 },
+            }}
+          >
+            {row.cells.map((cell, i) => (
+              <Box key={i} sx={{ minWidth: 0 }}>
+                {cell}
+              </Box>
+            ))}
+          </Box>
+        ))}
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardMiniTable.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardMiniTable.tsx
@@ -28,8 +28,10 @@ export interface DashboardMiniTableRow {
   key: string;
   /** Row's own detail page — the row is a real link (not a click handler),
    * same rationale as `CasesList`: supports cmd/middle-click and exposes a
-   * copyable URL. */
-  href: string;
+   * copyable URL. Omit when the row's id is unknown (e.g. a nullable `id`
+   * field on the search response) — the row then renders inert rather than
+   * linking to a broken `/…/undefined` URL. */
+  href?: string;
   cells: ReactNode[];
 }
 
@@ -123,8 +125,7 @@ export default function DashboardMiniTable({
         rows.map((row) => (
           <Box
             key={row.key}
-            component={RouterLink}
-            to={row.href}
+            {...(row.href ? { component: RouterLink, to: row.href } : {})}
             sx={{
               gridColumn: "1 / -1",
               display: "grid",
@@ -135,15 +136,17 @@ export default function DashboardMiniTable({
               py: 1,
               borderBottom: 1,
               borderColor: "divider",
-              cursor: "pointer",
               color: "inherit",
               textDecoration: "none",
-              "&:hover": { bgcolor: "action.hover" },
-              "&:focus-visible": {
-                outline: `2px solid ${theme.palette.primary.main}`,
-                outlineOffset: -2,
-              },
               "&:last-of-type": { borderBottom: 0 },
+              ...(row.href && {
+                cursor: "pointer",
+                "&:hover": { bgcolor: "action.hover" },
+                "&:focus-visible": {
+                  outline: `2px solid ${theme.palette.primary.main}`,
+                  outlineOffset: -2,
+                },
+              }),
             }}
           >
             {row.cells.map((cell, i) => (

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.test.tsx
@@ -32,6 +32,13 @@ vi.mock("@api/backend/client", () => ({
 vi.mock("@config/apiConfig", () => ({
   apiConfig: { backendUrl: "https://example.test" },
 }));
+vi.mock("@context/current-user/CurrentUserContext", () => ({
+  useCurrentUser: () => ({
+    user: { id: "11111111-aaaa-bbbb-cccc-000000000001" },
+    isLoading: false,
+    isError: false,
+  }),
+}));
 
 import DashboardWidgetTile from "@features/csm-dashboard/components/DashboardWidgetTile";
 
@@ -185,7 +192,44 @@ describe("DashboardWidgetTile", () => {
     );
 
     const viewMoreLink = await screen.findByRole("link", { name: /view more/i });
-    expect(viewMoreLink.getAttribute("href")).toMatch(/^\/cases/);
+    const href = viewMoreLink.getAttribute("href") ?? "";
+    // Goes to the widget's own preview page (real, bookmarkable URL — see
+    // widgetPreviewUrl.ts), not straight to the resource's own tab.
+    expect(href.startsWith("/dashboard/cases?")).toBe(true);
+    const params = new URLSearchParams(href.split("?")[1]);
+    expect(params.get("w")).toBe("my_critical_open_2");
+    expect(params.get("n")).toBe("My Critical & High Cases");
+    expect(params.get("f")).toBeNull();
+  });
+
+  it("masks the signed-in user's own id in the 'View more' link's filter query params", async () => {
+    postMock.mockResolvedValue({
+      total: 6,
+      cases: [{ id: "11111111-1111-1111-1111-111111111111", number: "CS-1", subject: "Disk full", state: "open" }],
+      limit: 5,
+      offset: 0,
+      hasMore: true,
+    });
+
+    renderWithClient(
+      <DashboardWidgetTile
+        widgetId="my_cases"
+        displayName="My Cases"
+        resourceType="case"
+        shape="list"
+        // "11111111-aaaa-bbbb-cccc-000000000001" is the mocked signed-in
+        // user's own id (see the CurrentUserContext mock above) — it must
+        // never appear verbatim in the resulting URL.
+        filters={{ assignedUserIds: ["11111111-aaaa-bbbb-cccc-000000000001"] }}
+        listLimit={5}
+      />,
+    );
+
+    const viewMoreLink = await screen.findByRole("link", { name: /view more/i });
+    const href = viewMoreLink.getAttribute("href") ?? "";
+    expect(href).not.toContain("11111111-aaaa-bbbb-cccc-000000000001");
+    const params = new URLSearchParams(href.split("?")[1]);
+    expect(params.get("assignedUserIds")).toBe("@me");
   });
 
   it("navigates to /cases with translated filters when a case-resource tile is clicked", async () => {

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.test.tsx
@@ -26,6 +26,12 @@ const postMock = vi.fn();
 vi.mock("@api/backend/client", () => ({
   useBackendApi: () => ({ post: postMock }),
 }));
+// A `shape: "list"` tile now renders through widgetListConfig.tsx, which
+// pulls in useTimeSheets.ts (time_card's mapper) — that module reads
+// `window.config` at load via `@config/apiConfig`, unavailable under vitest.
+vi.mock("@config/apiConfig", () => ({
+  apiConfig: { backendUrl: "https://example.test" },
+}));
 
 import DashboardWidgetTile from "@features/csm-dashboard/components/DashboardWidgetTile";
 
@@ -98,12 +104,17 @@ describe("DashboardWidgetTile", () => {
     );
   });
 
-  it("renders a compact row list for shape: list, capped at listLimit", async () => {
+  it("renders the same table the Cases tab uses for shape: list, capped at listLimit", async () => {
     postMock.mockResolvedValue({
       total: 2,
       cases: [
-        { number: "CS-1", subject: "Disk full", state: "open" },
-        { number: "CS-2", subject: "Auth failing", state: "work_in_progress" },
+        { id: "11111111-1111-1111-1111-111111111111", number: "CS-1", subject: "Disk full", state: "open" },
+        {
+          id: "22222222-2222-2222-2222-222222222222",
+          number: "CS-2",
+          subject: "Auth failing",
+          state: "work_in_progress",
+        },
       ],
       limit: 5,
       offset: 0,
@@ -121,14 +132,60 @@ describe("DashboardWidgetTile", () => {
       />,
     );
 
-    await waitFor(() =>
-      expect(screen.getByText("CS-1 — Disk full")).toBeInTheDocument(),
-    );
-    expect(screen.getByText("CS-2 — Auth failing")).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText("CS-1")).toBeInTheDocument());
+    expect(screen.getByText("Disk full")).toBeInTheDocument();
+    expect(screen.getByText("CS-2")).toBeInTheDocument();
+    expect(screen.getByText("Auth failing")).toBeInTheDocument();
     expect(postMock).toHaveBeenCalledWith("/cases/search", {
       filters: {},
       pagination: { offset: 0, limit: 5 },
     });
+  });
+
+  it("shows a 'View more' link through to the full tab only when more records exist than shown", async () => {
+    postMock.mockResolvedValue({
+      total: 1,
+      cases: [{ id: "11111111-1111-1111-1111-111111111111", number: "CS-1", subject: "Disk full", state: "open" }],
+      limit: 5,
+      offset: 0,
+      hasMore: false,
+    });
+
+    renderWithClient(
+      <DashboardWidgetTile
+        widgetId="my_critical_open"
+        displayName="My Critical & High Cases"
+        resourceType="case"
+        shape="list"
+        filters={{}}
+        listLimit={5}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByText("CS-1")).toBeInTheDocument());
+    expect(screen.queryByRole("link", { name: /view more/i })).not.toBeInTheDocument();
+
+    postMock.mockResolvedValue({
+      total: 6,
+      cases: [{ id: "11111111-1111-1111-1111-111111111111", number: "CS-1", subject: "Disk full", state: "open" }],
+      limit: 5,
+      offset: 0,
+      hasMore: true,
+    });
+
+    renderWithClient(
+      <DashboardWidgetTile
+        widgetId="my_critical_open_2"
+        displayName="My Critical & High Cases"
+        resourceType="case"
+        shape="list"
+        filters={{}}
+        listLimit={5}
+      />,
+    );
+
+    const viewMoreLink = await screen.findByRole("link", { name: /view more/i });
+    expect(viewMoreLink.getAttribute("href")).toMatch(/^\/cases/);
   });
 
   it("navigates to /cases with translated filters when a case-resource tile is clicked", async () => {

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
@@ -139,15 +139,21 @@ export default function DashboardWidgetTile({
       <Card variant="outlined" sx={{ position: "relative", p: 1.75, height: "100%" }}>
         {header}
         {isLoading ? (
-          <Skeleton variant="rounded" height={28 * (listLimit ?? 5) + 40} sx={{ mt: 1 }} />
+          <Skeleton variant="rounded" height={28 * (listLimit ?? 4) + 40} sx={{ mt: 1 }} />
         ) : isError ? (
           <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
             Could not load this widget.
           </Typography>
         ) : (
           <>
-            <ListRenderer items={data?.items ?? []} isLoading={false} />
-            {(data?.total ?? 0) > (listLimit ?? 5) && (
+            {/* CasesList/TimeCardsTable (case, time_card) carry no margin of
+                their own — this is the one place spacing between the header
+                and the table is enforced for every resource type, so the
+                header's icon never sits flush against the table's border. */}
+            <Box sx={{ mt: 1.5 }}>
+              <ListRenderer items={data?.items ?? []} isLoading={false} />
+            </Box>
+            {(data?.total ?? 0) > (listLimit ?? 4) && (
               <Box sx={{ display: "flex", justifyContent: "flex-end", mt: 1 }}>
                 <Button
                   component={RouterLink}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
@@ -14,13 +14,14 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Box, Card, Skeleton, Tooltip, Typography, alpha, useTheme } from "@wso2/oxygen-ui";
-import { Info } from "@wso2/oxygen-ui-icons-react";
-import type { JSX } from "react";
+import { Box, Button, Card, Skeleton, Tooltip, Typography, alpha, useTheme } from "@wso2/oxygen-ui";
+import { ArrowRight, Info } from "@wso2/oxygen-ui-icons-react";
+import type { JSX, ReactNode } from "react";
 import { Link as RouterLink } from "react-router";
 import type { BeWidgetResourceType, BeWidgetShape } from "@api/backend/types";
 import { useWidgetData } from "@features/csm-dashboard/api/useWidgetData";
 import { WIDGET_RESOURCE_CONFIG } from "@features/csm-dashboard/config/widgetResourceConfig";
+import { WIDGET_LIST_RENDERERS } from "@features/csm-dashboard/config/widgetListConfig";
 
 interface DashboardWidgetTileProps {
   widgetId: string;
@@ -35,10 +36,16 @@ interface DashboardWidgetTileProps {
 /**
  * Single dashboard widget tile: fetches and renders its own data
  * independently of any sibling tile, so one widget's loading/error state
- * never affects another's. Renders a big number for `shape: "count"`, a
- * compact row list for `shape: "list"`, and is clickable through to the
- * resource's own list page with the widget's filters translated into that
- * page's own URL filter scheme (see `widgetResourceConfig.ts`).
+ * never affects another's. Renders a big number for `shape: "count"`; for
+ * `shape: "list"` renders that resource type's own real table (see
+ * `widgetListConfig.tsx` — e.g. cases render through the same `CasesList`
+ * the Cases tab itself uses), capped at `listLimit`, with a "View more" link
+ * through to that resource's own tab with the widget's filters translated
+ * into that tab's own URL filter scheme (see `widgetResourceConfig.ts`).
+ *
+ * `shape: "count"` tiles are themselves one big link to that same
+ * destination; `shape: "list"` tiles can't be (their rows and "View more"
+ * need their own nested links), so only they get a plain, non-link `Card`.
  */
 export default function DashboardWidgetTile({
   widgetId,
@@ -76,6 +83,154 @@ export default function DashboardWidgetTile({
 
   const href = config.buildHref(filters);
   const Icon = config.icon;
+  const isListShape = shape === "list";
+
+  const infoIcon = (
+    // Tooltip copy is intentionally empty until the per-widget messages are
+    // finalized — the icon renders now so the layout/interaction is in place
+    // ahead of that content.
+    <Tooltip title="">
+      <Box
+        component="span"
+        sx={{
+          position: "absolute",
+          top: 8,
+          right: 8,
+          zIndex: 1,
+          display: "inline-flex",
+          color: "text.secondary",
+        }}
+      >
+        <Info size={14} />
+      </Box>
+    </Tooltip>
+  );
+
+  const header = (
+    <Box sx={{ display: "flex", alignItems: "flex-start", gap: 1.25 }}>
+      <Box
+        sx={{
+          p: 0.75,
+          mt: 0.25,
+          borderRadius: "50%",
+          bgcolor: alpha(theme.palette[config.iconColor].light, 0.1),
+          color: theme.palette[config.iconColor].light,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          flexShrink: 0,
+        }}
+      >
+        <Icon size={16} />
+      </Box>
+      <Typography variant="caption" color="text.secondary" sx={{ mt: 0.5 }}>
+        {displayName}
+      </Typography>
+    </Box>
+  );
+
+  if (isListShape) {
+    const ListRenderer = WIDGET_LIST_RENDERERS[resourceType];
+    return (
+      <Card variant="outlined" sx={{ position: "relative", p: 1.75, height: "100%" }}>
+        {infoIcon}
+        {header}
+        {isLoading ? (
+          <Skeleton variant="rounded" height={28 * (listLimit ?? 5) + 40} sx={{ mt: 1 }} />
+        ) : isError ? (
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+            Could not load this widget.
+          </Typography>
+        ) : (
+          <>
+            <ListRenderer items={data?.items ?? []} isLoading={false} />
+            {(data?.total ?? 0) > (listLimit ?? 5) && (
+              <Box sx={{ display: "flex", justifyContent: "flex-end", mt: 1 }}>
+                <Button
+                  component={RouterLink}
+                  to={href}
+                  size="small"
+                  variant="text"
+                  endIcon={<ArrowRight size={14} />}
+                >
+                  View more
+                </Button>
+              </Box>
+            )}
+          </>
+        )}
+      </Card>
+    );
+  }
+
+  let body: ReactNode;
+  if (isLoading) {
+    body = <Skeleton variant="rounded" height={48} />;
+  } else if (isError) {
+    body = (
+      <Typography variant="body2" color="text.secondary">
+        Could not load this widget.
+      </Typography>
+    );
+  } else if (shape === "count") {
+    body = (
+      <Box sx={{ display: "flex", alignItems: "flex-start", gap: 1.25 }}>
+        <Box
+          sx={{
+            p: 0.75,
+            mt: 0.25,
+            borderRadius: "50%",
+            bgcolor: alpha(theme.palette[config.iconColor].light, 0.1),
+            color: theme.palette[config.iconColor].light,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            flexShrink: 0,
+          }}
+        >
+          <Icon size={16} />
+        </Box>
+        <Box sx={{ minWidth: 0, flex: 1 }}>
+          <Typography variant="caption" color="text.secondary">
+            {displayName}
+          </Typography>
+          <Typography variant="h5" sx={{ mt: 0.5 }}>
+            {data?.total ?? 0}
+          </Typography>
+        </Box>
+      </Box>
+    );
+  } else {
+    // pie/bar: no aggregate endpoint exists anywhere in the stack today, so
+    // there is nothing to resolve or render yet — see `BeWidgetShape`.
+    body = (
+      <Box sx={{ display: "flex", alignItems: "flex-start", gap: 1.25 }}>
+        <Box
+          sx={{
+            p: 0.75,
+            mt: 0.25,
+            borderRadius: "50%",
+            bgcolor: alpha(theme.palette[config.iconColor].light, 0.1),
+            color: theme.palette[config.iconColor].light,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            flexShrink: 0,
+          }}
+        >
+          <Icon size={16} />
+        </Box>
+        <Box sx={{ minWidth: 0, flex: 1 }}>
+          <Typography variant="caption" color="text.secondary">
+            {displayName}
+          </Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+            Not yet supported.
+          </Typography>
+        </Box>
+      </Box>
+    );
+  }
 
   return (
     <Card
@@ -98,116 +253,8 @@ export default function DashboardWidgetTile({
         "&:focus-visible": { outline: "2px solid", outlineColor: "primary.main", outlineOffset: -2 },
       }}
     >
-      {/* Tooltip copy is intentionally empty until the per-widget messages
-          are finalized — the icon renders now so the layout/interaction is
-          in place ahead of that content. */}
-      <Tooltip title="">
-        <Box
-          component="span"
-          sx={{
-            position: "absolute",
-            top: 8,
-            right: 8,
-            zIndex: 1,
-            display: "inline-flex",
-            color: "text.secondary",
-          }}
-        >
-          <Info size={14} />
-        </Box>
-      </Tooltip>
-
-      {isLoading ? (
-        <Skeleton variant="rounded" height={48} />
-      ) : isError ? (
-        <Typography variant="body2" color="text.secondary">
-          Could not load this widget.
-        </Typography>
-      ) : (
-        <Box sx={{ display: "flex", alignItems: "flex-start", gap: 1.25 }}>
-          <Box
-            sx={{
-              p: 0.75,
-              mt: 0.25,
-              borderRadius: "50%",
-              bgcolor: alpha(theme.palette[config.iconColor].light, 0.1),
-              color: theme.palette[config.iconColor].light,
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              flexShrink: 0,
-            }}
-          >
-            <Icon size={16} />
-          </Box>
-          <Box sx={{ minWidth: 0, flex: 1 }}>
-            <Typography variant="caption" color="text.secondary">
-              {displayName}
-            </Typography>
-            {shape === "list" ? (
-              <WidgetListBody
-                items={data?.items ?? []}
-                limit={listLimit ?? 5}
-                resourceType={resourceType}
-              />
-            ) : shape === "count" ? (
-              <Typography variant="h5" sx={{ mt: 0.5 }}>
-                {data?.total ?? 0}
-              </Typography>
-            ) : (
-              // pie/bar: no aggregate endpoint exists anywhere in the stack
-              // today, so there is nothing to resolve or render yet — see
-              // `BeWidgetShape`.
-              <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
-                Not yet supported.
-              </Typography>
-            )}
-          </Box>
-        </Box>
-      )}
+      {infoIcon}
+      {body}
     </Card>
-  );
-}
-
-interface WidgetListBodyProps {
-  items: Record<string, unknown>[];
-  limit: number;
-  resourceType: BeWidgetResourceType;
-}
-
-function WidgetListBody({ items, limit, resourceType }: WidgetListBodyProps): JSX.Element {
-  const config = WIDGET_RESOURCE_CONFIG[resourceType];
-  const rows = items.slice(0, limit);
-
-  if (rows.length === 0) {
-    return (
-      <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
-        No records.
-      </Typography>
-    );
-  }
-
-  return (
-    <Box sx={{ mt: 0.5, display: "flex", flexDirection: "column", gap: 0.5 }}>
-      {rows.map((item, i) => {
-        const secondary = config.secondaryLabel?.(item);
-        // Rows have no stable id in this loosely-typed shape; the primary
-        // label (usually a record number) is unique enough in practice for a
-        // short, non-reorderable list, with the index as a tiebreaker.
-        const key = `${config.primaryLabel(item)}-${i}`;
-        return (
-          <Box key={key} sx={{ minWidth: 0 }}>
-            <Typography variant="body2" noWrap>
-              {config.primaryLabel(item)}
-            </Typography>
-            {secondary && (
-              <Typography variant="caption" color="text.secondary">
-                {secondary}
-              </Typography>
-            )}
-          </Box>
-        );
-      })}
-    </Box>
   );
 }

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
@@ -19,9 +19,11 @@ import { ArrowRight, Info } from "@wso2/oxygen-ui-icons-react";
 import type { JSX, ReactNode } from "react";
 import { Link as RouterLink } from "react-router";
 import type { BeWidgetResourceType, BeWidgetShape } from "@api/backend/types";
+import { useCurrentUser } from "@context/current-user/CurrentUserContext";
 import { useWidgetData } from "@features/csm-dashboard/api/useWidgetData";
 import { WIDGET_RESOURCE_CONFIG } from "@features/csm-dashboard/config/widgetResourceConfig";
 import { WIDGET_LIST_RENDERERS } from "@features/csm-dashboard/config/widgetListConfig";
+import { buildWidgetPreviewHref } from "@features/csm-dashboard/utils/widgetPreviewUrl";
 
 interface DashboardWidgetTileProps {
   widgetId: string;
@@ -29,7 +31,9 @@ interface DashboardWidgetTileProps {
   resourceType: BeWidgetResourceType;
   shape: BeWidgetShape;
   filters: Record<string, unknown>;
-  /** Only meaningful for shape "list"; how many rows to render. */
+  /** Only meaningful for shape "list"; how many rows to render. Defaults to
+   * 4 (see useWidgetData's DEFAULT_LIST_LIMIT) — set explicitly per-widget
+   * via the backend's DASHBOARDS_CONFIG, not overridden here. */
   listLimit?: number;
 }
 
@@ -40,12 +44,14 @@ interface DashboardWidgetTileProps {
  * `shape: "list"` renders that resource type's own real table (see
  * `widgetListConfig.tsx` — e.g. cases render through the same `CasesList`
  * the Cases tab itself uses), capped at `listLimit`, with a "View more" link
- * through to that resource's own tab with the widget's filters translated
- * into that tab's own URL filter scheme (see `widgetResourceConfig.ts`).
+ * to that widget's own preview page (`DashboardWidgetPreviewPage`, more rows,
+ * same table) — not directly to the resource's own tab (that's "View all",
+ * one hop further, via `widgetResourceConfig.ts`'s `buildHref`).
  *
- * `shape: "count"` tiles are themselves one big link to that same
- * destination; `shape: "list"` tiles can't be (their rows and "View more"
- * need their own nested links), so only they get a plain, non-link `Card`.
+ * `shape: "count"` tiles are themselves one big link straight to the
+ * resource's own tab; `shape: "list"` tiles can't be (their rows and "View
+ * more" need their own nested links), so only they get a plain, non-link
+ * `Card`.
  */
 export default function DashboardWidgetTile({
   widgetId,
@@ -56,6 +62,7 @@ export default function DashboardWidgetTile({
   listLimit,
 }: DashboardWidgetTileProps): JSX.Element {
   const theme = useTheme();
+  const { user } = useCurrentUser();
   const { data, isLoading, isError } = useWidgetData(
     widgetId,
     resourceType,
@@ -157,7 +164,13 @@ export default function DashboardWidgetTile({
               <Box sx={{ display: "flex", justifyContent: "flex-end", mt: 1 }}>
                 <Button
                   component={RouterLink}
-                  to={href}
+                  to={buildWidgetPreviewHref({
+                    previewSlug: config.previewSlug,
+                    widgetId,
+                    displayName,
+                    filters,
+                    currentUserId: user?.id,
+                  })}
                   size="small"
                   variant="text"
                   endIcon={<ArrowRight size={14} />}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
@@ -85,17 +85,21 @@ export default function DashboardWidgetTile({
   const Icon = config.icon;
   const isListShape = shape === "list";
 
-  const infoIcon = (
-    // Tooltip copy is intentionally empty until the per-widget messages are
-    // finalized — the icon renders now so the layout/interaction is in place
-    // ahead of that content.
+  // Count tiles only — a list-shape tile's real table already has its own
+  // header row and border right where this would otherwise sit, so it just
+  // overlapped rather than adding anything.
+  //
+  // Tooltip copy is intentionally empty until the per-widget messages are
+  // finalized — the icon renders now so the layout/interaction is in place
+  // ahead of that content.
+  const infoIcon = shape === "count" && (
     <Tooltip title="">
       <Box
         component="span"
         sx={{
           position: "absolute",
-          top: 8,
-          right: 8,
+          top: 12,
+          right: 12,
           zIndex: 1,
           display: "inline-flex",
           color: "text.secondary",
@@ -133,7 +137,6 @@ export default function DashboardWidgetTile({
     const ListRenderer = WIDGET_LIST_RENDERERS[resourceType];
     return (
       <Card variant="outlined" sx={{ position: "relative", p: 1.75, height: "100%" }}>
-        {infoIcon}
         {header}
         {isLoading ? (
           <Skeleton variant="rounded" height={28 * (listLimit ?? 5) + 40} sx={{ mt: 1 }} />

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/SectionCard.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/SectionCard.tsx
@@ -18,7 +18,10 @@ import { Box, Card, Typography } from "@wso2/oxygen-ui";
 import type { JSX, ReactNode } from "react";
 
 interface SectionCardProps {
-  title: string;
+  /** Omit for a section with no heading of its own — e.g. a pilot/preview
+   * section that shouldn't advertise its own implementation status in the
+   * UI. `action` (if any) still renders on its own. */
+  title?: string;
   subtitle?: string;
   action?: ReactNode;
   children: ReactNode;
@@ -32,24 +35,26 @@ export default function SectionCard({
 }: SectionCardProps): JSX.Element {
   return (
     <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 2 }}>
-      <Box
-        sx={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "space-between",
-          gap: 2,
-        }}
-      >
-        <Box>
-          <Typography variant="h6">{title}</Typography>
-          {subtitle && (
-            <Typography variant="body2" color="text.secondary">
-              {subtitle}
-            </Typography>
-          )}
+      {(title || subtitle || action) && (
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            gap: 2,
+          }}
+        >
+          <Box>
+            {title && <Typography variant="h6">{title}</Typography>}
+            {subtitle && (
+              <Typography variant="body2" color="text.secondary">
+                {subtitle}
+              </Typography>
+            )}
+          </Box>
+          {action}
         </Box>
-        {action}
-      </Box>
+      )}
       {children}
     </Card>
   );

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetListConfig.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetListConfig.tsx
@@ -1,0 +1,415 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/* eslint-disable react-refresh/only-export-components -- this is a config module of per-resourceType render helpers (like widgetResourceConfig.ts), not a component module; none of the individual XxxWidgetList functions are exported (fast-refresh DX only) */
+
+import { Chip, Typography } from "@wso2/oxygen-ui";
+import type { JSX } from "react";
+import type {
+  BeCaseSearchView,
+  BeIncident,
+  BeChangeRequestSearchView,
+  BeProblemSearchView,
+  BeTimeCardView,
+  BeWidgetResourceType,
+} from "@api/backend/types";
+import { formatBackendTimestampForDisplay } from "@utils/dateTime";
+import CasesList from "@features/csm-cases/components/CasesList";
+import { mapCaseSearchViewToRow } from "@features/csm-cases/utils/caseSearchPayload";
+import TimeCardsTable from "@features/csm-timecards/components/TimeCardsTable";
+import { mapTimeCard } from "@features/csm-timecards/api/useTimeSheets";
+import DashboardMiniTable from "@features/csm-dashboard/components/DashboardMiniTable";
+import {
+  incidentPriorityColor,
+  incidentPriorityLabel,
+  incidentStateColor,
+  incidentStateLabel,
+} from "@features/csm-operations/utils/incidents";
+import {
+  changeRequestImpactColor,
+  changeRequestImpactLabel,
+  changeRequestStateColor,
+  changeRequestStateLabel,
+} from "@features/csm-operations/utils/changeRequests";
+import { problemStateColor, problemStateLabel } from "@features/csm-operations/utils/problems";
+import { resolveAccountTier, type Account } from "@features/csm-accounts/types/csmAccounts";
+import type { Project } from "@features/csm-projects/types/csmProjects";
+import ClosureStateChip from "@features/csm-projects/components/ClosureStateChip";
+import { normalizeUser, type User, type SnUser } from "@features/csm-users/types/csmUsers";
+import UserRefLink from "@components/UserRefLink";
+import { vulnerabilityPriorityColor } from "@features/csm-security-center/utils/vulnerabilities";
+import type { BeProductVulnerabilityView } from "@api/backend/types";
+
+/** Raw item shape a dashboard widget's `/search` response resolves to —
+ * matches `WidgetItem` in `widgetResourceConfig.ts` (kept loose there since
+ * that file's `primaryLabel`/`secondaryLabel` extractors are resourceType-
+ * agnostic); each renderer below casts it to the same typed shape its own
+ * tab already assumes, since it's the identical upstream response. */
+type WidgetItem = Record<string, unknown>;
+
+function formatDate(value?: string | null): string {
+  return (
+    formatBackendTimestampForDisplay(value, { year: "numeric", month: "short", day: "numeric" }) ??
+    "—"
+  );
+}
+
+export interface WidgetListRendererProps {
+  items: WidgetItem[];
+  isLoading: boolean;
+}
+
+/** Case: reuses `CasesList` (the Cases tab's own table) verbatim, via the
+ * same `mapCaseSearchViewToRow` mapper the tab itself uses — real reuse, not
+ * a lookalike. `currentUserEmail` is omitted (only affects the "assigned to
+ * me" highlight, not relevant to a dashboard preview). */
+function CaseWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.Element {
+  const cases = items.map((item) =>
+    mapCaseSearchViewToRow(item as unknown as BeCaseSearchView, undefined),
+  );
+  return <CasesList cases={cases} isLoading={isLoading} skeletonCount={5} />;
+}
+
+/** Time card: reuses `TimeCardsTable` verbatim via the tab's own `mapTimeCard`
+ * mapper. Actions are off — approve/reject doesn't belong on a dashboard
+ * preview — but the always-on "view details" eye icon still works. */
+function TimeCardWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.Element {
+  const cards = items.map((item) => mapTimeCard(item as unknown as BeTimeCardView));
+  return (
+    <TimeCardsTable
+      cards={cards}
+      isLoading={isLoading}
+      skeletonCount={5}
+      emptyText="No time cards match this widget's filters."
+      groupBy="case"
+      showActionsColumn={false}
+      roleFor={() => ({ isOwner: false, isApprover: false, isAdmin: false })}
+      onCardAction={() => {}}
+    />
+  );
+}
+
+function IncidentWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.Element {
+  const incidents = items as unknown as BeIncident[];
+  return (
+    <DashboardMiniTable
+      isLoading={isLoading}
+      emptyMessage="No incidents match this widget's filters."
+      columns={[
+        { label: "Number", width: "minmax(90px, 0.7fr)" },
+        { label: "Subject", width: "minmax(160px, 2fr)" },
+        { label: "State", width: "minmax(90px, 1fr)" },
+        { label: "Priority", width: "minmax(90px, 1fr)" },
+        { label: "Updated", width: "minmax(90px, 1fr)" },
+      ]}
+      rows={incidents.map((incident, i) => ({
+        key: incident.id ?? `incident-${i}`,
+        href: `/operations/incidents/${incident.id}`,
+        cells: [
+          <Typography key="number" variant="body2" noWrap>
+            {incident.number || "—"}
+          </Typography>,
+          <Typography key="subject" variant="body2" noWrap title={incident.subject ?? undefined}>
+            {incident.subject || "—"}
+          </Typography>,
+          incident.state ? (
+            <Chip
+              key="state"
+              size="small"
+              variant="outlined"
+              color={incidentStateColor(incident.state)}
+              label={incidentStateLabel(incident.state)}
+            />
+          ) : (
+            <Typography key="state" variant="body2">
+              —
+            </Typography>
+          ),
+          incident.priority ? (
+            <Chip
+              key="priority"
+              size="small"
+              variant="outlined"
+              color={incidentPriorityColor(incident.priority)}
+              label={incidentPriorityLabel(incident.priority)}
+            />
+          ) : (
+            <Typography key="priority" variant="body2">
+              —
+            </Typography>
+          ),
+          <Typography key="updated" variant="caption" color="text.secondary" noWrap>
+            {formatDate(incident.updatedOn)}
+          </Typography>,
+        ],
+      }))}
+    />
+  );
+}
+
+function ChangeRequestWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.Element {
+  const changeRequests = items as unknown as BeChangeRequestSearchView[];
+  return (
+    <DashboardMiniTable
+      isLoading={isLoading}
+      emptyMessage="No change requests match this widget's filters."
+      columns={[
+        { label: "Number", width: "minmax(90px, 0.7fr)" },
+        { label: "Subject", width: "minmax(160px, 2fr)" },
+        { label: "State", width: "minmax(100px, 1fr)" },
+        { label: "Impact", width: "minmax(90px, 1fr)" },
+        { label: "Updated", width: "minmax(90px, 1fr)" },
+      ]}
+      rows={changeRequests.map((cr, i) => ({
+        key: cr.id ?? `cr-${i}`,
+        href: `/operations/change-requests/${cr.id}`,
+        cells: [
+          <Typography key="number" variant="body2" noWrap>
+            {cr.number || "—"}
+          </Typography>,
+          <Typography key="subject" variant="body2" noWrap title={cr.subject ?? undefined}>
+            {cr.subject || "—"}
+          </Typography>,
+          cr.state ? (
+            <Chip
+              key="state"
+              size="small"
+              variant="outlined"
+              color={changeRequestStateColor(cr.state)}
+              label={changeRequestStateLabel(cr.state)}
+            />
+          ) : (
+            <Typography key="state" variant="body2">
+              —
+            </Typography>
+          ),
+          cr.impact ? (
+            <Chip
+              key="impact"
+              size="small"
+              variant="outlined"
+              color={changeRequestImpactColor(cr.impact)}
+              label={changeRequestImpactLabel(cr.impact)}
+            />
+          ) : (
+            <Typography key="impact" variant="body2">
+              —
+            </Typography>
+          ),
+          <Typography key="updated" variant="caption" color="text.secondary" noWrap>
+            {formatDate(cr.updatedOn)}
+          </Typography>,
+        ],
+      }))}
+    />
+  );
+}
+
+function ProblemWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.Element {
+  const problems = items as unknown as BeProblemSearchView[];
+  return (
+    <DashboardMiniTable
+      isLoading={isLoading}
+      emptyMessage="No problems match this widget's filters."
+      columns={[
+        { label: "Number", width: "minmax(90px, 0.7fr)" },
+        { label: "Subject", width: "minmax(160px, 2fr)" },
+        { label: "State", width: "minmax(100px, 1fr)" },
+        { label: "Assigned to", width: "minmax(100px, 1fr)" },
+      ]}
+      rows={problems.map((problem, i) => ({
+        key: problem.id ?? `problem-${i}`,
+        href: `/operations/problems/${problem.id}`,
+        cells: [
+          <Typography key="number" variant="body2" noWrap>
+            {problem.number || "—"}
+          </Typography>,
+          <Typography key="subject" variant="body2" noWrap title={problem.subject ?? undefined}>
+            {problem.subject || "—"}
+          </Typography>,
+          problem.state ? (
+            <Chip
+              key="state"
+              size="small"
+              variant="outlined"
+              color={problemStateColor(problem.state)}
+              label={problemStateLabel(problem.state)}
+            />
+          ) : (
+            <Typography key="state" variant="body2">
+              —
+            </Typography>
+          ),
+          <Typography key="assignedTo" variant="body2" noWrap>
+            {problem.assignedTo?.name || "—"}
+          </Typography>,
+        ],
+      }))}
+    />
+  );
+}
+
+function AccountWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.Element {
+  const accounts = items as unknown as Account[];
+  return (
+    <DashboardMiniTable
+      isLoading={isLoading}
+      emptyMessage="No accounts match this widget's filters."
+      columns={[
+        { label: "Name", width: "minmax(140px, 2fr)" },
+        { label: "Tier", width: "minmax(90px, 1fr)" },
+        { label: "Region", width: "minmax(90px, 1fr)" },
+      ]}
+      rows={accounts.map((a) => {
+        const tier = resolveAccountTier(a);
+        return {
+          key: a.id,
+          href: `/customers/accounts/${a.id}`,
+          cells: [
+            <Typography key="name" variant="body2" noWrap title={a.name}>
+              {a.name}
+            </Typography>,
+            tier ? (
+              <Chip key="tier" size="small" variant="outlined" label={tier} />
+            ) : (
+              <Typography key="tier" variant="body2">
+                —
+              </Typography>
+            ),
+            <Typography key="region" variant="body2" noWrap>
+              {a.region ?? "—"}
+            </Typography>,
+          ],
+        };
+      })}
+    />
+  );
+}
+
+function ProjectWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.Element {
+  const projects = items as unknown as Project[];
+  return (
+    <DashboardMiniTable
+      isLoading={isLoading}
+      emptyMessage="No projects match this widget's filters."
+      columns={[
+        { label: "Name", width: "minmax(140px, 2fr)" },
+        { label: "Project key", width: "minmax(90px, 1fr)" },
+        { label: "State", width: "minmax(100px, 1fr)" },
+      ]}
+      rows={projects.map((p) => ({
+        key: p.id,
+        href: `/customers/projects/${p.id}`,
+        cells: [
+          <Typography key="name" variant="body2" noWrap title={p.name}>
+            {p.name}
+          </Typography>,
+          <Typography key="key" variant="body2" noWrap>
+            {p.key}
+          </Typography>,
+          <ClosureStateChip key="state" closureState={p.closureState} emptyFallback="—" />,
+        ],
+      }))}
+    />
+  );
+}
+
+function UserWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.Element {
+  const users = items.map((item) => normalizeUser(item as unknown as User | SnUser));
+  return (
+    <DashboardMiniTable
+      isLoading={isLoading}
+      emptyMessage="No users match this widget's filters."
+      columns={[
+        { label: "User", width: "minmax(140px, 2fr)" },
+        { label: "Email", width: "minmax(140px, 2fr)" },
+        { label: "Status", width: "minmax(80px, 1fr)" },
+      ]}
+      rows={users.map((u) => ({
+        key: u.id,
+        href: `/people/${encodeURIComponent(u.id)}`,
+        cells: [
+          <UserRefLink key="user" name={u.userName} email={u.email} userId={u.id} />,
+          <Typography key="email" variant="body2" noWrap>
+            {u.email}
+          </Typography>,
+          <Typography key="status" variant="body2">
+            {u.active === undefined ? "—" : u.active ? "Active" : "Inactive"}
+          </Typography>,
+        ],
+      }))}
+    />
+  );
+}
+
+function ProductVulnerabilityWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.Element {
+  const vulnerabilities = items as unknown as BeProductVulnerabilityView[];
+  return (
+    <DashboardMiniTable
+      isLoading={isLoading}
+      emptyMessage="No vulnerabilities match this widget's filters."
+      columns={[
+        { label: "CVE / ID", width: "minmax(100px, 1fr)" },
+        { label: "Product", width: "minmax(120px, 2fr)" },
+        { label: "Priority", width: "minmax(90px, 1fr)" },
+      ]}
+      rows={vulnerabilities.map((vuln) => ({
+        key: vuln.id,
+        href: `/security-center/vulnerabilities/${encodeURIComponent(vuln.id)}`,
+        cells: [
+          <Typography key="cve" variant="body2" noWrap sx={{ fontFamily: "monospace" }}>
+            {vuln.cveId || vuln.vulnerabilityId || "—"}
+          </Typography>,
+          <Typography key="product" variant="body2" noWrap>
+            {vuln.productName || "—"}
+          </Typography>,
+          vuln.priority ? (
+            <Chip
+              key="priority"
+              size="small"
+              variant="outlined"
+              color={vulnerabilityPriorityColor(vuln.priority)}
+              label={vuln.priority}
+            />
+          ) : (
+            <Typography key="priority" variant="body2">
+              —
+            </Typography>
+          ),
+        ],
+      }))}
+    />
+  );
+}
+
+/** Per-resourceType renderer for a `shape: "list"` dashboard widget. Every
+ * resource type is covered — `WIDGET_RESOURCE_CONFIG` (in
+ * `widgetResourceConfig.ts`) is keyed the same way, so a missing entry here
+ * would be a compile error, not a silent gap. */
+export const WIDGET_LIST_RENDERERS: Record<
+  BeWidgetResourceType,
+  (props: WidgetListRendererProps) => JSX.Element
+> = {
+  case: CaseWidgetList,
+  incident: IncidentWidgetList,
+  change_request: ChangeRequestWidgetList,
+  problem: ProblemWidgetList,
+  account: AccountWidgetList,
+  project: ProjectWidgetList,
+  user: UserWidgetList,
+  time_card: TimeCardWidgetList,
+  product_vulnerability: ProductVulnerabilityWidgetList,
+};

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetListConfig.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetListConfig.tsx
@@ -80,7 +80,7 @@ function CaseWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.Elem
   const cases = items.map((item) =>
     mapCaseSearchViewToRow(item as unknown as BeCaseSearchView, undefined),
   );
-  return <CasesList cases={cases} isLoading={isLoading} skeletonCount={5} />;
+  return <CasesList cases={cases} isLoading={isLoading} skeletonCount={4} />;
 }
 
 /** Time card: reuses `TimeCardsTable` verbatim via the tab's own `mapTimeCard`
@@ -92,7 +92,7 @@ function TimeCardWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.
     <TimeCardsTable
       cards={cards}
       isLoading={isLoading}
-      skeletonCount={5}
+      skeletonCount={4}
       emptyText="No time cards match this widget's filters."
       groupBy="case"
       showActionsColumn={false}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetListConfig.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetListConfig.tsx
@@ -117,7 +117,7 @@ function IncidentWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.
       ]}
       rows={incidents.map((incident, i) => ({
         key: incident.id ?? `incident-${i}`,
-        href: `/operations/incidents/${incident.id}`,
+        href: incident.id ? `/operations/incidents/${incident.id}` : undefined,
         cells: [
           <Typography key="number" variant="body2" noWrap>
             {incident.number || "—"}
@@ -175,7 +175,7 @@ function ChangeRequestWidgetList({ items, isLoading }: WidgetListRendererProps):
       ]}
       rows={changeRequests.map((cr, i) => ({
         key: cr.id ?? `cr-${i}`,
-        href: `/operations/change-requests/${cr.id}`,
+        href: cr.id ? `/operations/change-requests/${cr.id}` : undefined,
         cells: [
           <Typography key="number" variant="body2" noWrap>
             {cr.number || "—"}
@@ -232,7 +232,7 @@ function ProblemWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.E
       ]}
       rows={problems.map((problem, i) => ({
         key: problem.id ?? `problem-${i}`,
-        href: `/operations/problems/${problem.id}`,
+        href: problem.id ? `/operations/problems/${problem.id}` : undefined,
         cells: [
           <Typography key="number" variant="body2" noWrap>
             {problem.number || "—"}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.ts
@@ -300,7 +300,10 @@ export const WIDGET_RESOURCE_CONFIG: Record<
       asString(item.cveId) ?? asString(item.vulnerabilityId) ?? "—",
     secondaryLabel: (item) =>
       asString(item.priority) ?? asString(item.productName),
-    buildHref: () => "/security-center",
+    // The tab default is "security_reports" (see csmNavItems.ts), so the
+    // vulnerabilities tab needs its own `?tab=` — omitting it, as this did
+    // before, silently lands the click on the wrong tab.
+    buildHref: () => "/security-center?tab=vulnerabilities",
     icon: ShieldAlert,
     iconColor: "error",
   },

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.ts
@@ -69,6 +69,11 @@ export interface WidgetResourceConfig {
   /** Theme palette key the icon (and nothing else — see DashboardWidgetTile's
    * hover treatment) is colored with. */
   iconColor: "primary" | "secondary" | "success" | "error" | "info" | "warning";
+  /** Friendly plural URL segment for this resource type's dashboard-widget
+   * "View more" preview page, e.g. `/dashboard/cases`. Distinct from that
+   * resource's own tab path (`buildHref`'s destination) — this route is
+   * dashboard-widget-scoped, not the resource's real list page. */
+  previewSlug: string;
 }
 
 function asString(v: unknown): string | undefined {
@@ -201,6 +206,7 @@ export const WIDGET_RESOURCE_CONFIG: Record<
     buildHref: (filters) => casesHref(translateCaseDashboardFilters(filters)),
     icon: Briefcase,
     iconColor: "primary",
+    previewSlug: "cases",
   },
   incident: {
     searchEndpoint: "/incidents/search",
@@ -217,6 +223,7 @@ export const WIDGET_RESOURCE_CONFIG: Record<
       ),
     icon: AlertTriangle,
     iconColor: "warning",
+    previewSlug: "incidents",
   },
   change_request: {
     searchEndpoint: "/change-requests/search",
@@ -233,6 +240,7 @@ export const WIDGET_RESOURCE_CONFIG: Record<
       ),
     icon: GitPullRequest,
     iconColor: "info",
+    previewSlug: "change-requests",
   },
   problem: {
     searchEndpoint: "/problems/search",
@@ -244,6 +252,7 @@ export const WIDGET_RESOURCE_CONFIG: Record<
     buildHref: () => operationsHref("problems"),
     icon: AlertOctagon,
     iconColor: "error",
+    previewSlug: "problems",
   },
   account: {
     searchEndpoint: "/accounts/search",
@@ -253,6 +262,7 @@ export const WIDGET_RESOURCE_CONFIG: Record<
     buildHref: () => "/customers/accounts",
     icon: Building2,
     iconColor: "secondary",
+    previewSlug: "accounts",
   },
   project: {
     searchEndpoint: "/projects/search",
@@ -262,6 +272,7 @@ export const WIDGET_RESOURCE_CONFIG: Record<
     buildHref: () => "/customers/projects",
     icon: FolderKanban,
     iconColor: "secondary",
+    previewSlug: "projects",
   },
   user: {
     searchEndpoint: "/users/search",
@@ -276,6 +287,7 @@ export const WIDGET_RESOURCE_CONFIG: Record<
     buildHref: () => "/admin/users",
     icon: Users,
     iconColor: "info",
+    previewSlug: "users",
   },
   time_card: {
     searchEndpoint: "/time-cards/search",
@@ -292,6 +304,7 @@ export const WIDGET_RESOURCE_CONFIG: Record<
     buildHref: () => "/time-cards",
     icon: Clock,
     iconColor: "warning",
+    previewSlug: "time-cards",
   },
   product_vulnerability: {
     searchEndpoint: "/products/vulnerabilities/search",
@@ -306,8 +319,21 @@ export const WIDGET_RESOURCE_CONFIG: Record<
     buildHref: () => "/security-center?tab=vulnerabilities",
     icon: ShieldAlert,
     iconColor: "error",
+    previewSlug: "vulnerabilities",
   },
 };
+
+/** Reverse lookup of `previewSlug` back to its `resourceType`, for the
+ * dashboard widget "View more" preview page's own `/dashboard/:previewSlug`
+ * route — the only place a URL segment needs mapping back to a resourceType. */
+export function resourceTypeForPreviewSlug(
+  slug: string | undefined,
+): BeWidgetResourceType | undefined {
+  const entry = (Object.entries(WIDGET_RESOURCE_CONFIG) as [BeWidgetResourceType, WidgetResourceConfig][]).find(
+    ([, config]) => config.previewSlug === slug,
+  );
+  return entry?.[0];
+}
 
 function nestedNumber(v: unknown): string | undefined {
   if (v && typeof v === "object" && "number" in v) {

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/pages/DashboardWidgetPreviewPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/pages/DashboardWidgetPreviewPage.test.tsx
@@ -1,0 +1,190 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { MemoryRouter, Route, Routes } from "react-router";
+
+const postMock = vi.fn();
+
+vi.mock("@api/backend/client", () => ({
+  useBackendApi: () => ({ post: postMock }),
+}));
+// Pulls in widgetListConfig.tsx -> useTimeSheets.ts (time_card's mapper),
+// which reads `window.config` at load via `@config/apiConfig` — same
+// workaround as DashboardWidgetTile.test.tsx.
+vi.mock("@config/apiConfig", () => ({
+  apiConfig: { backendUrl: "https://example.test" },
+}));
+const CURRENT_USER_ID = "11111111-aaaa-bbbb-cccc-000000000001";
+vi.mock("@context/current-user/CurrentUserContext", () => ({
+  useCurrentUser: () => ({
+    user: { id: CURRENT_USER_ID },
+    isLoading: false,
+    isError: false,
+  }),
+}));
+
+import DashboardWidgetPreviewPage from "@features/csm-dashboard/pages/DashboardWidgetPreviewPage";
+import { buildWidgetPreviewHref } from "@features/csm-dashboard/utils/widgetPreviewUrl";
+
+function renderAt(initialEntry: string) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <Routes>
+          <Route path="/dashboard" element={<div>Dashboard landing</div>} />
+          <Route path="/dashboard/:previewSlug" element={<DashboardWidgetPreviewPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("DashboardWidgetPreviewPage", () => {
+  beforeEach(() => {
+    postMock.mockReset();
+  });
+
+  it("prompts to open from a widget's View more link when the URL carries no widget params", () => {
+    renderAt("/dashboard/cases");
+    expect(
+      screen.getByText(/open this page from a dashboard widget/i),
+    ).toBeInTheDocument();
+  });
+
+  it("falls back to the prompt for an unrecognized previewSlug", () => {
+    renderAt(
+      buildWidgetPreviewHref({
+        previewSlug: "not-a-real-resource",
+        widgetId: "my_critical_open",
+        displayName: "My Critical & High Cases",
+        filters: {},
+      }),
+    );
+    expect(
+      screen.getByText(/open this page from a dashboard widget/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the widget's table and paginates using the URL-provided widget id/filters", async () => {
+    postMock.mockResolvedValue({
+      total: 12,
+      cases: [{ id: "11111111-1111-1111-1111-111111111111", number: "CS-1", subject: "Disk full", state: "open" }],
+      limit: 10,
+      offset: 0,
+      hasMore: true,
+    });
+
+    renderAt(
+      buildWidgetPreviewHref({
+        previewSlug: "cases",
+        widgetId: "my_critical_open",
+        displayName: "My Critical & High Cases",
+        filters: { severities: ["critical"] },
+      }),
+    );
+
+    expect(screen.getByText("My Critical & High Cases")).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText("CS-1")).toBeInTheDocument());
+    expect(postMock).toHaveBeenCalledWith("/cases/search", {
+      filters: { severities: ["critical"] },
+      pagination: { offset: 0, limit: 10 },
+    });
+
+    // TablePagination's "next page" button.
+    fireEvent.click(screen.getByRole("button", { name: /next page/i }));
+    await waitFor(() =>
+      expect(postMock).toHaveBeenCalledWith("/cases/search", {
+        filters: { severities: ["critical"] },
+        pagination: { offset: 10, limit: 10 },
+      }),
+    );
+  });
+
+  it("resolves the masked @me sentinel back to the signed-in user's own id before querying", async () => {
+    postMock.mockResolvedValue({
+      total: 1,
+      cases: [{ id: "11111111-1111-1111-1111-111111111111", number: "CS-1", subject: "Disk full", state: "open" }],
+      limit: 10,
+      offset: 0,
+      hasMore: false,
+    });
+
+    renderAt(
+      buildWidgetPreviewHref({
+        previewSlug: "cases",
+        widgetId: "my_cases",
+        displayName: "My Cases",
+        filters: { assignedUserIds: [CURRENT_USER_ID] },
+        currentUserId: CURRENT_USER_ID,
+      }),
+    );
+
+    await waitFor(() => expect(screen.getByText("CS-1")).toBeInTheDocument());
+    expect(postMock).toHaveBeenCalledWith("/cases/search", {
+      filters: { assignedUserIds: [CURRENT_USER_ID] },
+      pagination: { offset: 0, limit: 10 },
+    });
+  });
+
+  it("merges a typed search term into the widget's own filters as searchQuery", async () => {
+    postMock.mockResolvedValue({
+      total: 1,
+      cases: [{ id: "11111111-1111-1111-1111-111111111111", number: "CS-1", subject: "Disk full", state: "open" }],
+      limit: 10,
+      offset: 0,
+      hasMore: false,
+    });
+
+    renderAt(
+      buildWidgetPreviewHref({
+        previewSlug: "cases",
+        widgetId: "my_critical_open",
+        displayName: "My Critical & High Cases",
+        filters: { severities: ["critical"] },
+      }),
+    );
+    await waitFor(() => expect(screen.getByText("CS-1")).toBeInTheDocument());
+
+    fireEvent.change(screen.getByLabelText("Search"), { target: { value: "disk" } });
+
+    await waitFor(() =>
+      expect(postMock).toHaveBeenCalledWith("/cases/search", {
+        filters: { severities: ["critical"], searchQuery: "disk" },
+        pagination: { offset: 0, limit: 10 },
+      }),
+    );
+  });
+
+  it("returns to the dashboard when Back is clicked", () => {
+    renderAt(
+      buildWidgetPreviewHref({
+        previewSlug: "cases",
+        widgetId: "my_critical_open",
+        displayName: "My Critical & High Cases",
+        filters: {},
+      }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /back/i }));
+    expect(screen.getByText("Dashboard landing")).toBeInTheDocument();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/pages/DashboardWidgetPreviewPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/pages/DashboardWidgetPreviewPage.tsx
@@ -1,0 +1,202 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Box, Button, TablePagination, TextField, Typography } from "@wso2/oxygen-ui";
+import { ArrowLeft } from "@wso2/oxygen-ui-icons-react";
+import { useMemo, useState, type ChangeEvent, type JSX } from "react";
+import { useNavigate, useParams, useSearchParams } from "react-router";
+import type { BeWidgetResourceType } from "@api/backend/types";
+import { BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
+import { useCurrentUser } from "@context/current-user/CurrentUserContext";
+import { useDebouncedValue } from "@hooks/useDebouncedValue";
+import { useWidgetData } from "@features/csm-dashboard/api/useWidgetData";
+import { WIDGET_LIST_RENDERERS } from "@features/csm-dashboard/config/widgetListConfig";
+import { resourceTypeForPreviewSlug } from "@features/csm-dashboard/config/widgetResourceConfig";
+import {
+  parseWidgetPreviewFilters,
+  resolveCurrentUserSentinels,
+} from "@features/csm-dashboard/utils/widgetPreviewUrl";
+
+const DEFAULT_ROWS_PER_PAGE = 10;
+const ROWS_PER_PAGE_OPTIONS = [10, 20, BE_MAX_PAGE_LIMIT];
+const SEARCH_DEBOUNCE_MS = 300;
+
+/**
+ * "View more" landing for a dashboard `shape: "list"` widget tile — the same
+ * per-resourceType table the tile itself renders (see `widgetListConfig.tsx`;
+ * e.g. cases render through the identical `CasesList` the Cases tab uses),
+ * paginated (real `TablePagination`, not just a bigger fixed fetch) so a
+ * viewer can browse the widget's whole matching set from here without
+ * leaving to the resource's own tab, plus a free-text search box merged
+ * into the widget's own filters (`searchQuery` — the same field every other
+ * resource search in this app already uses).
+ *
+ * Fully URL-driven (see `buildWidgetPreviewHref` in `widgetPreviewUrl.ts`)
+ * rather than router-state-based, so the page is bookmarkable/shareable and
+ * survives a refresh: the resource type is `:previewSlug` in the path, the
+ * widget's own id/display name are `w`/`n` query params, and each filter
+ * field is its own readable query param (the signed-in user's own id, where
+ * present, is masked to `@me` rather than embedded verbatim). A URL with no
+ * recognizable `previewSlug` or missing required params falls back to a
+ * "go to the dashboard" prompt instead of crashing.
+ */
+export default function DashboardWidgetPreviewPage(): JSX.Element {
+  const { previewSlug } = useParams<{ previewSlug: string }>();
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const { user, isLoading: isLoadingUser } = useCurrentUser();
+
+  const resourceType = resourceTypeForPreviewSlug(previewSlug);
+  const widgetId = searchParams.get("w");
+  const displayName = searchParams.get("n");
+  const { filters: rawFilters, needsCurrentUser } =
+    parseWidgetPreviewFilters(searchParams);
+
+  const backButton = (
+    <Button
+      variant="text"
+      size="small"
+      startIcon={<ArrowLeft size={16} />}
+      onClick={() => navigate("/dashboard")}
+      sx={{ alignSelf: "flex-start" }}
+    >
+      Back
+    </Button>
+  );
+
+  if (!resourceType || !widgetId || !displayName) {
+    return (
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+        {backButton}
+        <Typography variant="body2" color="text.secondary">
+          Open this page from a dashboard widget&rsquo;s &ldquo;View
+          more&rdquo; link.
+        </Typography>
+      </Box>
+    );
+  }
+
+  // A widget filtered to "assigned to me" carries the `@me` sentinel until
+  // the signed-in user's own id is known — hold off resolving/querying
+  // until then rather than ever sending the literal placeholder upstream.
+  if (needsCurrentUser && !user?.id) {
+    return (
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+        {backButton}
+        <Typography variant="h5">{displayName}</Typography>
+        <Typography variant="body2" color="text.secondary">
+          {isLoadingUser
+            ? "Loading…"
+            : "Could not resolve the signed-in user for this widget."}
+        </Typography>
+      </Box>
+    );
+  }
+
+  const filters = resolveCurrentUserSentinels(rawFilters, user?.id);
+
+  return (
+    <DashboardWidgetPreviewContent
+      widgetId={widgetId}
+      displayName={displayName}
+      resourceType={resourceType}
+      filters={filters}
+      backButton={backButton}
+    />
+  );
+}
+
+interface DashboardWidgetPreviewContentProps {
+  widgetId: string;
+  displayName: string;
+  resourceType: BeWidgetResourceType;
+  filters: Record<string, unknown>;
+  backButton: JSX.Element;
+}
+
+function DashboardWidgetPreviewContent({
+  widgetId,
+  displayName,
+  resourceType,
+  filters,
+  backButton,
+}: DashboardWidgetPreviewContentProps): JSX.Element {
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_ROWS_PER_PAGE);
+  const [search, setSearch] = useState("");
+  const debouncedSearch = useDebouncedValue(search, SEARCH_DEBOUNCE_MS);
+
+  const queriedFilters = useMemo(() => {
+    const trimmed = debouncedSearch.trim();
+    return trimmed ? { ...filters, searchQuery: trimmed } : filters;
+  }, [filters, debouncedSearch]);
+
+  const { data, isLoading, isError } = useWidgetData(
+    widgetId,
+    resourceType,
+    queriedFilters,
+    "list",
+    rowsPerPage,
+    page * rowsPerPage,
+  );
+  const ListRenderer = WIDGET_LIST_RENDERERS[resourceType];
+
+  const handleSearchChange = (e: ChangeEvent<HTMLInputElement>): void => {
+    setSearch(e.target.value);
+    setPage(0);
+  };
+
+  const handleRowsPerPageChange = (e: ChangeEvent<HTMLInputElement>): void => {
+    setRowsPerPage(parseInt(e.target.value, 10));
+    setPage(0);
+  };
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+      {backButton}
+      <Typography variant="h5">{displayName}</Typography>
+      <TextField
+        size="small"
+        label="Search"
+        placeholder="Search…"
+        value={search}
+        onChange={handleSearchChange}
+        slotProps={{ htmlInput: { "aria-label": "Search" } }}
+        sx={{ maxWidth: 360 }}
+      />
+      {isError ? (
+        <Typography variant="body2" color="text.secondary">
+          Could not load this widget.
+        </Typography>
+      ) : (
+        <>
+          <ListRenderer items={data?.items ?? []} isLoading={isLoading} />
+          <TablePagination
+            component="div"
+            count={data?.total ?? 0}
+            page={page}
+            onPageChange={(_, newPage) => setPage(newPage)}
+            rowsPerPage={rowsPerPage}
+            onRowsPerPageChange={handleRowsPerPageChange}
+            rowsPerPageOptions={ROWS_PER_PAGE_OPTIONS}
+            showFirstButton
+            showLastButton
+          />
+        </>
+      )}
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/utils/widgetPreviewUrl.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/utils/widgetPreviewUrl.test.ts
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { describe, expect, it } from "vitest";
+import {
+  buildWidgetPreviewHref,
+  parseWidgetPreviewFilters,
+  resolveCurrentUserSentinels,
+} from "./widgetPreviewUrl";
+
+const CURRENT_USER_ID = "11111111-aaaa-bbbb-cccc-000000000001";
+
+describe("widgetPreviewUrl", () => {
+  it("encodes each filter field as its own readable query param, not one JSON blob", () => {
+    const href = buildWidgetPreviewHref({
+      previewSlug: "cases",
+      widgetId: "my_critical_open",
+      displayName: "My Critical & High Cases",
+      filters: { severities: ["critical", "high"], states: ["open"] },
+    });
+
+    expect(href.startsWith("/dashboard/cases?")).toBe(true);
+    const params = new URLSearchParams(href.split("?")[1]);
+    expect(params.get("w")).toBe("my_critical_open");
+    expect(params.get("n")).toBe("My Critical & High Cases");
+    expect(params.get("severities")).toBe("critical,high");
+    expect(params.get("states")).toBe("open");
+    expect(params.get("f")).toBeNull();
+  });
+
+  it("masks the current user's own id to @me instead of embedding it verbatim", () => {
+    const href = buildWidgetPreviewHref({
+      previewSlug: "cases",
+      widgetId: "my_cases",
+      displayName: "My Cases",
+      filters: { assignedUserIds: [CURRENT_USER_ID] },
+      currentUserId: CURRENT_USER_ID,
+    });
+
+    expect(href).not.toContain(CURRENT_USER_ID);
+    const params = new URLSearchParams(href.split("?")[1]);
+    expect(params.get("assignedUserIds")).toBe("@me");
+  });
+
+  it("round-trips filters through parseWidgetPreviewFilters + resolveCurrentUserSentinels", () => {
+    const href = buildWidgetPreviewHref({
+      previewSlug: "cases",
+      widgetId: "my_cases",
+      displayName: "My Cases",
+      filters: { assignedUserIds: [CURRENT_USER_ID], severities: ["critical"] },
+      currentUserId: CURRENT_USER_ID,
+    });
+
+    const searchParams = new URLSearchParams(href.split("?")[1]);
+    const { filters, needsCurrentUser } = parseWidgetPreviewFilters(searchParams);
+    expect(needsCurrentUser).toBe(true);
+    expect(filters.severities).toEqual(["critical"]);
+    expect(filters.assignedUserIds).toEqual(["@me"]);
+
+    const resolved = resolveCurrentUserSentinels(filters, CURRENT_USER_ID);
+    expect(resolved.assignedUserIds).toEqual([CURRENT_USER_ID]);
+    expect(resolved.severities).toEqual(["critical"]);
+  });
+
+  it("leaves the @me sentinel in place when the current user id isn't known yet", () => {
+    const resolved = resolveCurrentUserSentinels({ assignedUserIds: ["@me"] }, undefined);
+    expect(resolved.assignedUserIds).toEqual(["@me"]);
+  });
+
+  it("ignores the reserved w/n params when parsing filters back", () => {
+    const searchParams = new URLSearchParams({ w: "id", n: "Name", severities: "critical" });
+    const { filters } = parseWidgetPreviewFilters(searchParams);
+    expect(filters).toEqual({ severities: ["critical"] });
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/utils/widgetPreviewUrl.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/utils/widgetPreviewUrl.ts
@@ -1,0 +1,138 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+const RESERVED_PARAMS = new Set(["w", "n"]);
+
+/** Placeholder swapped in for the signed-in user's own id wherever a
+ * widget's (opaque, backend-resolved) filters carry it — e.g. "My Cases"
+ * resolves to `assignedUserIds: ["<real uuid>"]` — so a bookmarked/shared
+ * preview URL never carries a bare internal user id. */
+const CURRENT_USER_SENTINEL = "@me";
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((v) => typeof v === "string");
+}
+
+/** Values this app's dashboard widget filters never actually take today
+ * (every field seen in `widgetResourceConfig.ts`'s translators is a flat
+ * string array) — kept only as a lossless fallback for a filter shape a
+ * future widget config might introduce. */
+function looksLikeJsonLiteral(raw: string): boolean {
+  return (
+    raw === "true" ||
+    raw === "false" ||
+    /^[{[]/.test(raw) ||
+    /^-?\d+(\.\d+)?$/.test(raw)
+  );
+}
+
+/**
+ * Builds the URL a dashboard widget tile's "View more" link points at — a
+ * real, bookmarkable/shareable/refresh-safe URL (no router state): the
+ * resource type is the path segment (`previewSlug`, from
+ * `WIDGET_RESOURCE_CONFIG`), the widget's own id/display name are `w`/`n`
+ * query params, and each filter field is its own readable query param
+ * (e.g. `severities=critical`) rather than one opaque JSON blob — and the
+ * signed-in user's own id, wherever it appears, is masked to `@me` (see
+ * `CURRENT_USER_SENTINEL`). Read back by `parseWidgetPreviewFilters` /
+ * `resolveCurrentUserSentinels` in `DashboardWidgetPreviewPage`.
+ */
+export function buildWidgetPreviewHref(params: {
+  previewSlug: string;
+  widgetId: string;
+  displayName: string;
+  filters: Record<string, unknown>;
+  /** The signed-in user's own id, so it can be masked rather than embedded
+   * verbatim in the URL. Omit if not yet known — the filter value(s) are
+   * then left as-is rather than masked. */
+  currentUserId?: string;
+}): string {
+  const q = new URLSearchParams();
+  q.set("w", params.widgetId);
+  q.set("n", params.displayName);
+  for (const [key, value] of Object.entries(params.filters)) {
+    if (RESERVED_PARAMS.has(key)) continue;
+    if (isStringArray(value)) {
+      if (value.length === 0) continue;
+      const masked = value.map((v) =>
+        v === params.currentUserId ? CURRENT_USER_SENTINEL : v,
+      );
+      q.set(key, masked.join(","));
+    } else if (typeof value === "string") {
+      q.set(key, value === params.currentUserId ? CURRENT_USER_SENTINEL : value);
+    } else if (value !== undefined && value !== null) {
+      q.set(key, JSON.stringify(value));
+    }
+  }
+  return `/dashboard/${params.previewSlug}?${q.toString()}`;
+}
+
+export interface ParsedWidgetPreviewFilters {
+  filters: Record<string, unknown>;
+  /** True if a filter value still carries the `@me` sentinel and needs
+   * `resolveCurrentUserSentinels` before it's safe to query with. */
+  needsCurrentUser: boolean;
+}
+
+/** Parses every non-reserved (`w`/`n`) query param back into the widget's
+ * filters object — the inverse of `buildWidgetPreviewHref`. Never throws;
+ * an individual malformed value is simply dropped rather than failing the
+ * whole page. */
+export function parseWidgetPreviewFilters(
+  searchParams: URLSearchParams,
+): ParsedWidgetPreviewFilters {
+  const filters: Record<string, unknown> = {};
+  let needsCurrentUser = false;
+
+  for (const [key, raw] of searchParams.entries()) {
+    if (RESERVED_PARAMS.has(key)) continue;
+
+    if (looksLikeJsonLiteral(raw)) {
+      try {
+        filters[key] = JSON.parse(raw);
+        continue;
+      } catch {
+        // Not actually valid JSON — fall through and treat as a plain value.
+      }
+    }
+
+    const values = raw.split(",");
+    if (values.includes(CURRENT_USER_SENTINEL)) needsCurrentUser = true;
+    filters[key] = values;
+  }
+
+  return { filters, needsCurrentUser };
+}
+
+/** Substitutes the `@me` sentinel back to the signed-in user's own id —
+ * see `buildWidgetPreviewHref`'s masking of that same id. Returns `filters`
+ * unchanged if `currentUserId` isn't known yet (caller should hold off
+ * querying in that case — see `needsCurrentUser`). */
+export function resolveCurrentUserSentinels(
+  filters: Record<string, unknown>,
+  currentUserId: string | undefined,
+): Record<string, unknown> {
+  if (!currentUserId) return filters;
+  const resolved: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(filters)) {
+    resolved[key] = Array.isArray(value)
+      ? value.map((v) => (v === CURRENT_USER_SENTINEL ? currentUserId : v))
+      : value === CURRENT_USER_SENTINEL
+        ? currentUserId
+        : value;
+  }
+  return resolved;
+}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/utils/widgetPreviewUrl.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/utils/widgetPreviewUrl.ts
@@ -26,19 +26,6 @@ function isStringArray(value: unknown): value is string[] {
   return Array.isArray(value) && value.every((v) => typeof v === "string");
 }
 
-/** Values this app's dashboard widget filters never actually take today
- * (every field seen in `widgetResourceConfig.ts`'s translators is a flat
- * string array) — kept only as a lossless fallback for a filter shape a
- * future widget config might introduce. */
-function looksLikeJsonLiteral(raw: string): boolean {
-  return (
-    raw === "true" ||
-    raw === "false" ||
-    /^[{[]/.test(raw) ||
-    /^-?\d+(\.\d+)?$/.test(raw)
-  );
-}
-
 /**
  * Builds the URL a dashboard widget tile's "View more" link points at — a
  * real, bookmarkable/shareable/refresh-safe URL (no router state): the
@@ -73,8 +60,6 @@ export function buildWidgetPreviewHref(params: {
       q.set(key, masked.join(","));
     } else if (typeof value === "string") {
       q.set(key, value === params.currentUserId ? CURRENT_USER_SENTINEL : value);
-    } else if (value !== undefined && value !== null) {
-      q.set(key, JSON.stringify(value));
     }
   }
   return `/dashboard/${params.previewSlug}?${q.toString()}`;
@@ -88,9 +73,10 @@ export interface ParsedWidgetPreviewFilters {
 }
 
 /** Parses every non-reserved (`w`/`n`) query param back into the widget's
- * filters object — the inverse of `buildWidgetPreviewHref`. Never throws;
- * an individual malformed value is simply dropped rather than failing the
- * whole page. */
+ * filters object — the inverse of `buildWidgetPreviewHref`. Every value is
+ * decoded as a comma-split string array (matching how every current dashboard
+ * widget filter field is shaped — see `widgetResourceConfig.ts`'s
+ * translators), so this never throws. */
 export function parseWidgetPreviewFilters(
   searchParams: URLSearchParams,
 ): ParsedWidgetPreviewFilters {
@@ -99,15 +85,6 @@ export function parseWidgetPreviewFilters(
 
   for (const [key, raw] of searchParams.entries()) {
     if (RESERVED_PARAMS.has(key)) continue;
-
-    if (looksLikeJsonLiteral(raw)) {
-      try {
-        filters[key] = JSON.parse(raw);
-        continue;
-      } catch {
-        // Not actually valid JSON — fall through and treat as a plain value.
-      }
-    }
 
     const values = raw.split(",");
     if (values.includes(CURRENT_USER_SENTINEL)) needsCurrentUser = true;

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestsTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestsTab.tsx
@@ -244,7 +244,7 @@ export default function ChangeRequestsTab(): JSX.Element {
                 <TableRow>
                   <TableCell colSpan={7} align="center">
                     <QueryErrorState
-                      message={`Failed to load change requests: ${error instanceof Error ? error.message : "unknown error"}`}
+                      message={error instanceof Error ? error.message : "Failed to load change requests."}
                       error={error}
                     />
                   </TableCell>

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestsTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestsTab.tsx
@@ -244,7 +244,7 @@ export default function ChangeRequestsTab(): JSX.Element {
                 <TableRow>
                   <TableCell colSpan={7} align="center">
                     <QueryErrorState
-                      message={error instanceof Error ? error.message : "Failed to load change requests."}
+                      message={error instanceof Error && error.message.trim() ? error.message : "Failed to load change requests."}
                       error={error}
                     />
                   </TableCell>

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/IncidentsTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/IncidentsTab.tsx
@@ -227,7 +227,7 @@ export default function IncidentsTab(): JSX.Element {
                 <TableRow>
                   <TableCell colSpan={7} align="center">
                     <QueryErrorState
-                      message={`Failed to load incidents: ${error instanceof Error ? error.message : "unknown error"}`}
+                      message={error instanceof Error ? error.message : "Failed to load incidents."}
                       error={error}
                     />
                   </TableCell>

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/IncidentsTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/IncidentsTab.tsx
@@ -227,7 +227,7 @@ export default function IncidentsTab(): JSX.Element {
                 <TableRow>
                   <TableCell colSpan={7} align="center">
                     <QueryErrorState
-                      message={error instanceof Error ? error.message : "Failed to load incidents."}
+                      message={error instanceof Error && error.message.trim() ? error.message : "Failed to load incidents."}
                       error={error}
                     />
                   </TableCell>

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ProblemsTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ProblemsTab.tsx
@@ -138,7 +138,7 @@ export default function ProblemsTab(): JSX.Element {
                 <TableRow>
                   <TableCell colSpan={5} align="center">
                     <QueryErrorState
-                      message={error instanceof Error ? error.message : "Failed to load problems."}
+                      message={error instanceof Error && error.message.trim() ? error.message : "Failed to load problems."}
                       error={error}
                     />
                   </TableCell>

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ProblemsTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ProblemsTab.tsx
@@ -138,7 +138,7 @@ export default function ProblemsTab(): JSX.Element {
                 <TableRow>
                   <TableCell colSpan={5} align="center">
                     <QueryErrorState
-                      message={`Failed to load problems: ${error instanceof Error ? error.message : "unknown error"}`}
+                      message={error instanceof Error ? error.message : "Failed to load problems."}
                       error={error}
                     />
                   </TableCell>

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateServiceRequestPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateServiceRequestPage.tsx
@@ -411,7 +411,7 @@ export default function CreateServiceRequestPage(): JSX.Element {
                 </Box>
               ) : variables.isError ? (
                 <QueryErrorState
-                  message={variables.error instanceof Error ? variables.error.message : "Could not load the request form for this catalog item."}
+                  message={variables.error instanceof Error && variables.error.message.trim() ? variables.error.message : "Could not load the request form for this catalog item."}
                   error={variables.error}
                 />
               ) : renderableVars.length === 0 ? (

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateServiceRequestPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateServiceRequestPage.tsx
@@ -411,7 +411,7 @@ export default function CreateServiceRequestPage(): JSX.Element {
                 </Box>
               ) : variables.isError ? (
                 <QueryErrorState
-                  message={`Could not load the request form for this catalog item: ${variables.error instanceof Error ? variables.error.message : "unknown error"}`}
+                  message={variables.error instanceof Error ? variables.error.message : "Could not load the request form for this catalog item."}
                   error={variables.error}
                 />
               ) : renderableVars.length === 0 ? (

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/DeployedProductsPanel.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/DeployedProductsPanel.tsx
@@ -176,7 +176,7 @@ export default function DeployedProductsPanel({
   if (isError) {
     return (
       <QueryErrorState
-        message={error instanceof Error ? error.message : "Failed to load deployed products."}
+        message={error instanceof Error && error.message.trim() ? error.message : "Failed to load deployed products."}
         error={error}
       />
     );

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/DeployedProductsPanel.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/DeployedProductsPanel.tsx
@@ -176,7 +176,7 @@ export default function DeployedProductsPanel({
   if (isError) {
     return (
       <QueryErrorState
-        message={`Failed to load deployed products: ${error instanceof Error ? error.message : "unknown error"}`}
+        message={error instanceof Error ? error.message : "Failed to load deployed products."}
         error={error}
       />
     );

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/DeploymentsTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/DeploymentsTab.tsx
@@ -206,7 +206,7 @@ export default function DeploymentsTab({ projectId }: DeploymentsTabProps): JSX.
                 <TableRow>
                   <TableCell colSpan={COLUMN_COUNT} align="center">
                     <QueryErrorState
-                      message={`Failed to load deployments: ${error instanceof Error ? error.message : "unknown error"}`}
+                      message={error instanceof Error ? error.message : "Failed to load deployments."}
                       error={error}
                     />
                   </TableCell>

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/DeploymentsTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/DeploymentsTab.tsx
@@ -206,7 +206,7 @@ export default function DeploymentsTab({ projectId }: DeploymentsTabProps): JSX.
                 <TableRow>
                   <TableCell colSpan={COLUMN_COUNT} align="center">
                     <QueryErrorState
-                      message={error instanceof Error ? error.message : "Failed to load deployments."}
+                      message={error instanceof Error && error.message.trim() ? error.message : "Failed to load deployments."}
                       error={error}
                     />
                   </TableCell>

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/ProjectContactsTab.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/ProjectContactsTab.test.tsx
@@ -125,7 +125,7 @@ describe("ProjectContactsTab", () => {
   it("renders an error state when the query fails", () => {
     mockQueryResult({ isError: true, error: new Error("boom") });
     renderTab();
-    expect(screen.getByText(/Failed to load project contacts/i)).toBeInTheDocument();
+    expect(screen.getByText("boom")).toBeInTheDocument();
   });
 
   it("renders an empty state rather than an empty table when the project has no contacts", () => {

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/ProjectContactsTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/ProjectContactsTab.tsx
@@ -140,7 +140,7 @@ export default function ProjectContactsTab({
               <TableRow>
                 <TableCell colSpan={COLUMN_COUNT} align="center">
                   <QueryErrorState
-                    message={`Failed to load project contacts: ${error instanceof Error ? error.message : "unknown error"}`}
+                    message={error instanceof Error ? error.message : "Failed to load project contacts."}
                     error={error}
                   />
                 </TableCell>

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/ProjectContactsTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/ProjectContactsTab.tsx
@@ -140,7 +140,7 @@ export default function ProjectContactsTab({
               <TableRow>
                 <TableCell colSpan={COLUMN_COUNT} align="center">
                   <QueryErrorState
-                    message={error instanceof Error ? error.message : "Failed to load project contacts."}
+                    message={error instanceof Error && error.message.trim() ? error.message : "Failed to load project contacts."}
                     error={error}
                   />
                 </TableCell>

--- a/apps/csm-portal/webapp/src/features/csm-projects/pages/CsmProjectsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/pages/CsmProjectsPage.tsx
@@ -125,7 +125,7 @@ export default function CsmProjectsPage(): JSX.Element {
                 <TableRow>
                   <TableCell colSpan={5} align="center">
                     <QueryErrorState
-                      message={`Failed to load projects: ${error instanceof Error ? error.message : "unknown error"}`}
+                      message={error instanceof Error ? error.message : "Failed to load projects."}
                       error={error}
                     />
                   </TableCell>

--- a/apps/csm-portal/webapp/src/features/csm-projects/pages/CsmProjectsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/pages/CsmProjectsPage.tsx
@@ -125,7 +125,7 @@ export default function CsmProjectsPage(): JSX.Element {
                 <TableRow>
                   <TableCell colSpan={5} align="center">
                     <QueryErrorState
-                      message={error instanceof Error ? error.message : "Failed to load projects."}
+                      message={error instanceof Error && error.message.trim() ? error.message : "Failed to load projects."}
                       error={error}
                     />
                   </TableCell>

--- a/apps/csm-portal/webapp/src/features/csm-security-center/components/ProductVulnerabilitiesTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-security-center/components/ProductVulnerabilitiesTab.tsx
@@ -160,7 +160,7 @@ export default function ProductVulnerabilitiesTab(): JSX.Element {
                 <TableRow>
                   <TableCell colSpan={6} align="center">
                     <QueryErrorState
-                      message={error instanceof Error ? error.message : "Failed to load vulnerabilities."}
+                      message={error instanceof Error && error.message.trim() ? error.message : "Failed to load vulnerabilities."}
                       error={error}
                     />
                   </TableCell>

--- a/apps/csm-portal/webapp/src/features/csm-security-center/components/ProductVulnerabilitiesTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-security-center/components/ProductVulnerabilitiesTab.tsx
@@ -160,7 +160,7 @@ export default function ProductVulnerabilitiesTab(): JSX.Element {
                 <TableRow>
                   <TableCell colSpan={6} align="center">
                     <QueryErrorState
-                      message={`Failed to load vulnerabilities: ${error instanceof Error ? error.message : "unknown error"}`}
+                      message={error instanceof Error ? error.message : "Failed to load vulnerabilities."}
                       error={error}
                     />
                   </TableCell>

--- a/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.tsx
@@ -297,7 +297,7 @@ export default function CsmUsersPage(): JSX.Element {
                 <TableRow>
                   <TableCell colSpan={6} align="center">
                     <QueryErrorState
-                      message={`Failed to load users: ${error instanceof Error ? error.message : "unknown error"}`}
+                      message={error instanceof Error ? error.message : "Failed to load users."}
                       error={error}
                     />
                   </TableCell>

--- a/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.tsx
@@ -297,7 +297,7 @@ export default function CsmUsersPage(): JSX.Element {
                 <TableRow>
                   <TableCell colSpan={6} align="center">
                     <QueryErrorState
-                      message={error instanceof Error ? error.message : "Failed to load users."}
+                      message={error instanceof Error && error.message.trim() ? error.message : "Failed to load users."}
                       error={error}
                     />
                   </TableCell>

--- a/apps/csm-portal/webapp/src/features/csm-users/pages/UserProfilePage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/pages/UserProfilePage.test.tsx
@@ -156,7 +156,7 @@ describe("UserProfilePage", () => {
   it("renders an error state when the query fails", () => {
     mockQueryResult({ isError: true, error: new Error("boom") });
     renderPage();
-    expect(screen.getByText(/Failed to load user/i)).toBeInTheDocument();
+    expect(screen.getByText("boom")).toBeInTheDocument();
   });
 
   it("renders a not-found state when the user is null", () => {

--- a/apps/csm-portal/webapp/src/features/csm-users/pages/UserProfilePage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/pages/UserProfilePage.tsx
@@ -390,7 +390,7 @@ export default function UserProfilePage(): JSX.Element {
       <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
         <BackButton onClick={() => navigate(-1)} />
         <QueryErrorState
-          message={error instanceof Error ? error.message : "Failed to load user."}
+          message={error instanceof Error && error.message.trim() ? error.message : "Failed to load user."}
           error={error}
         />
       </Box>

--- a/apps/csm-portal/webapp/src/features/csm-users/pages/UserProfilePage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/pages/UserProfilePage.tsx
@@ -390,7 +390,7 @@ export default function UserProfilePage(): JSX.Element {
       <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
         <BackButton onClick={() => navigate(-1)} />
         <QueryErrorState
-          message={`Failed to load user: ${error instanceof Error ? error.message : "unknown error"}`}
+          message={error instanceof Error ? error.message : "Failed to load user."}
           error={error}
         />
       </Box>

--- a/apps/csm-portal/webapp/src/features/updates/pages/CsmUpdatesPage.tsx
+++ b/apps/csm-portal/webapp/src/features/updates/pages/CsmUpdatesPage.tsx
@@ -672,7 +672,7 @@ export default function CsmUpdatesPage(): JSX.Element {
           </Typography>
           {productLevels.isError ? (
             <QueryErrorState
-              message={productLevels.error instanceof Error ? productLevels.error.message : "Could not load product catalog."}
+              message={productLevels.error instanceof Error && productLevels.error.message.trim() ? productLevels.error.message : "Could not load product catalog."}
               error={productLevels.error}
             />
           ) : productLevels.isLoading ? (
@@ -778,7 +778,7 @@ export default function CsmUpdatesPage(): JSX.Element {
             </Box>
           ) : searchResult.isError ? (
             <QueryErrorState
-              message={searchResult.error instanceof Error ? searchResult.error.message : "Could not load updates."}
+              message={searchResult.error instanceof Error && searchResult.error.message.trim() ? searchResult.error.message : "Could not load updates."}
               error={searchResult.error}
             />
           ) : sortedEntries.length === 0 ? (

--- a/apps/csm-portal/webapp/src/features/updates/pages/CsmUpdatesPage.tsx
+++ b/apps/csm-portal/webapp/src/features/updates/pages/CsmUpdatesPage.tsx
@@ -672,7 +672,7 @@ export default function CsmUpdatesPage(): JSX.Element {
           </Typography>
           {productLevels.isError ? (
             <QueryErrorState
-              message={`Could not load product catalog: ${productLevels.error instanceof Error ? productLevels.error.message : "unknown error"}`}
+              message={productLevels.error instanceof Error ? productLevels.error.message : "Could not load product catalog."}
               error={productLevels.error}
             />
           ) : productLevels.isLoading ? (
@@ -778,7 +778,7 @@ export default function CsmUpdatesPage(): JSX.Element {
             </Box>
           ) : searchResult.isError ? (
             <QueryErrorState
-              message={`Could not load updates: ${searchResult.error instanceof Error ? searchResult.error.message : "unknown error"}`}
+              message={searchResult.error instanceof Error ? searchResult.error.message : "Could not load updates."}
               error={searchResult.error}
             />
           ) : sortedEntries.length === 0 ? (


### PR DESCRIPTION
## Summary
- Stop the frontend from prefixing every error banner with its own "Failed to load X: ..." text — the backend's own (already-generic, see #1322) message is shown as-is everywhere an error is surfaced.
- Dashboard `shape: "list"` widget tiles now render real, reusable tables (the same components/mappers each resource's own tab already uses — e.g. cases via `CasesList`) instead of a plain two-line text list, capped at the widget's own configured `listLimit` (never overridden client-side).
- Added a case Type chip column (case/service_request/security_report_analysis/announcement/engagement), and severity is now only shown for the plain `case` type.
- Row clicks from a dashboard widget now land on the correct detail route for that case's actual type, not always `/cases`.
- New dedicated "View more" page (`/dashboard/:previewSlug`) — a real, bookmarkable URL (not router state) showing the same table with `TablePagination` and a free-text search box, instead of just a bigger fixed fetch.
- The preview page's URL encodes each filter as its own readable query param (e.g. `severities=critical`) instead of one opaque JSON blob, and masks the signed-in user's own id to `@me` rather than embedding it verbatim.
- Assign actions (`CaseActionBar`'s primary button and `AssignEngineerDialog`) now show a spinner and disable while the request is in flight.
- Case detail's back button always reads "Back", regardless of origin.
- Removed the "Widget pilot" / "Config-driven dashboard widgets (preview)" placeholder wording from the dashboard.

## Test plan
- [x] `tsc -b` clean
- [x] `eslint .` clean (one pre-existing, unrelated `react-hooks/exhaustive-deps` warning)
- [x] `vitest run` — all `csm-dashboard` and related tests pass (40/40 in the touched area)
- [x] Manual smoke test of the dashboard widgets, "View more" page, search, and assign spinners in a browser

Note: a full-repo `vitest run` shows 4 pre-existing failures in `CaseActionBar.test.tsx`, unrelated to this PR — confirmed via `git log -S` they predate this branch (stale tests from when the "Change state" dropdown replaced individual per-nextState buttons).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dashboard widget previews with searchable, paginated resource lists and bookmarkable URLs.
  * Added richer dashboard list widgets, reusable tables, resource-specific displays, and “View more” links.
  * Improved case lists with case-type routing, type indicators, and appropriate severity handling.
  * Added loading indicators for case assignments and actions, showing progress for the selected operation.

* **Bug Fixes**
  * Error states across accounts, cases, projects, operations, users, and announcements now show clearer underlying error details with concise fallbacks.

* **Tests**
  * Expanded coverage for dashboard previews, pagination, filters, loading states, routing, and error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->