### PR TITLE
[CSM] Pie/bar dashboard widget charts and titled widget sections

### DIFF
--- a/apps/csm-portal/backend/internal/dashboard/widgets.go
+++ b/apps/csm-portal/backend/internal/dashboard/widgets.go
@@ -54,9 +54,25 @@ type Shape string
 const (
 	ShapeCount Shape = "count" // single resolved number
 	ShapeList  Shape = "list"  // top-N matching records
-	ShapePie   Shape = "pie"   // grouped counts — NOT resolvable by any /search endpoint today (no aggregate endpoint exists anywhere in the stack); keep the const so a future dashboard doesn't need a schema migration, but do not wire any rendering logic for it beyond accepting the value
-	ShapeBar   Shape = "bar"   // same caveat as ShapePie
+	ShapePie   Shape = "pie"   // one search per Slices entry, each resolved via its own total — see PieSlice
+	ShapeBar   Shape = "bar"   // same resolution as ShapePie (one search per Slices entry); differs only in how the frontend renders the resolved data
 )
+
+// PieSlice is one wedge of a Shape "pie" widget. The caller resolves its
+// value by issuing that widget's own ResourceType's /search with Filters
+// merged under the widget's own base Filters (this slice's keys win on
+// conflict) and pagination.limit=1, reading total off the response — the
+// exact same mechanism Shape "count" uses, just once per slice.
+type PieSlice struct {
+	Label string `json:"label"`
+	// Color is a palette key ("primary", "secondary", "success", "error",
+	// "info", "warning") the frontend already uses elsewhere in this system
+	// (see WidgetTemplate's own icon color convention on the frontend) — not
+	// validated here, forwarded verbatim. Falls back to a fixed rotation over
+	// the same palette on the frontend if omitted.
+	Color   string         `json:"color,omitempty"`
+	Filters map[string]any `json:"filters"`
+}
 
 // WidgetTemplate is resource-agnostic: Filters is opaque JSON, forwarded
 // verbatim (after __current_user__ substitution) as the filters object of
@@ -64,14 +80,27 @@ const (
 // shape is {filters: {...}, pagination: {...}}). The BE never interprets
 // filter contents beyond substituting the current-user placeholder.
 type WidgetTemplate struct {
-	ID           string         `json:"id"`
-	DisplayName  string         `json:"displayName"`
+	ID          string `json:"id"`
+	DisplayName string `json:"displayName"`
+	// Description is an explanatory subtitle shown under DisplayName —
+	// config-owned text, not hardcoded per ResourceType/Shape on the
+	// frontend.
+	Description  string         `json:"description,omitempty"`
 	ResourceType ResourceType   `json:"resourceType"`
 	Shape        Shape          `json:"shape"`
 	GridWidth    int            `json:"gridWidth"` // 1-12, CSS grid columns out of 12
 	Filters      map[string]any `json:"filters"`
-	GroupBy      string         `json:"groupBy,omitempty"`   // only meaningful for Shape pie/bar — see the caveat on those consts; unused by every widget below
+	GroupBy      string         `json:"groupBy,omitempty"`   // unused
 	ListLimit    int            `json:"listLimit,omitempty"` // only meaningful for Shape list; how many records to show
+	Slices       []PieSlice     `json:"slices,omitempty"`    // only meaningful for Shape pie/bar; one search per slice
+	// Section groups widgets sharing the same (non-empty) value under a
+	// titled sub-section within the dashboard, in the order that value
+	// first appears among the dashboard's widgets — e.g. a handful of
+	// "count" widgets all set to Section: "SLA Violation" render together
+	// under that heading, separately from the dashboard's other widgets.
+	// Widgets with no Section (the common case) render in one untitled
+	// group, exactly as before this field existed.
+	Section string `json:"section,omitempty"`
 }
 
 // Dashboard is a single dashboard's metadata plus its widget templates.
@@ -136,6 +165,18 @@ func DashboardByID(id string) (Dashboard, bool) {
 // userIds). It does not mutate tpl.Filters.
 func ResolveFilters(tpl WidgetTemplate, currentUserID string) map[string]any {
 	return substituteCurrentUser(tpl.Filters, currentUserID).(map[string]any)
+}
+
+// ResolveSliceFilters is ResolveFilters' counterpart for one Shape "pie"
+// slice: substitutes CurrentUserPlaceholder in slice.Filters only. It
+// deliberately does NOT merge in the widget's own base Filters — the caller
+// (frontend) merges this slice's filters under the widget's own resolved
+// Filters itself (this slice's keys win on conflict), the same way it
+// already merges any other per-slice override. Sending the two separately,
+// rather than one pre-merged object per slice, avoids repeating the base
+// filters' JSON in every slice over the wire. Does not mutate slice.Filters.
+func ResolveSliceFilters(slice PieSlice, currentUserID string) map[string]any {
+	return substituteCurrentUser(slice.Filters, currentUserID).(map[string]any)
 }
 
 func substituteCurrentUser(v any, currentUserID string) any {

--- a/apps/csm-portal/backend/internal/dashboard/widgets_test.go
+++ b/apps/csm-portal/backend/internal/dashboard/widgets_test.go
@@ -126,3 +126,80 @@ func TestParseDashboardsConfig_ValidRoundTrip(t *testing.T) {
 		t.Errorf("ResolveFilters(...)[assignedUserIds] = %v, want [\"user-123\"]", resolved["assignedUserIds"])
 	}
 }
+
+func TestParseDashboardsConfig_PieWidgetSlicesAndDescription(t *testing.T) {
+	const raw = `[
+		{
+			"id": "team_performance",
+			"displayName": "Team performance",
+			"widgets": [
+				{
+					"id": "cases_by_severity",
+					"displayName": "Cases by severity",
+					"description": "Share of active cases at each severity level.",
+					"resourceType": "case",
+					"shape": "pie",
+					"gridWidth": 6,
+					"filters": {"states": ["open"]},
+					"slices": [
+						{"label": "Critical", "color": "error", "filters": {"severities": ["critical"]}},
+						{"label": "Mine", "filters": {"assignedUserIds": ["__current_user__"]}}
+					]
+				}
+			]
+		}
+	]`
+
+	got := ParseDashboardsConfig(raw)
+	if len(got) != 1 || len(got[0].Widgets) != 1 {
+		t.Fatalf("ParseDashboardsConfig(raw) = %+v, want 1 dashboard with 1 widget", got)
+	}
+
+	w := got[0].Widgets[0]
+	if w.Description != "Share of active cases at each severity level." {
+		t.Errorf("WidgetTemplate.Description = %q, want the configured subtitle", w.Description)
+	}
+	if len(w.Slices) != 2 {
+		t.Fatalf("len(WidgetTemplate.Slices) = %d, want 2", len(w.Slices))
+	}
+	if w.Slices[0].Label != "Critical" || w.Slices[0].Color != "error" {
+		t.Errorf("Slices[0] = %+v, want {Label: Critical, Color: error}", w.Slices[0])
+	}
+
+	// A slice's own filters resolve the current-user placeholder
+	// independently of the widget's own base Filters — ResolveSliceFilters
+	// must not require (or merge in) the base at all.
+	resolved := ResolveSliceFilters(w.Slices[1], "user-123")
+	assigned, ok := resolved["assignedUserIds"].([]any)
+	if !ok || len(assigned) != 1 || assigned[0] != "user-123" {
+		t.Errorf("ResolveSliceFilters(Slices[1], ...)[assignedUserIds] = %v, want [\"user-123\"]", resolved["assignedUserIds"])
+	}
+	if _, present := resolved["states"]; present {
+		t.Errorf("ResolveSliceFilters must not merge in the widget's own base filters, got %v", resolved)
+	}
+}
+
+func TestParseDashboardsConfig_WidgetSection(t *testing.T) {
+	const raw = `[
+		{
+			"id": "team_performance",
+			"displayName": "Team performance",
+			"widgets": [
+				{"id": "team_open_cases", "displayName": "Team Open P0/P1", "resourceType": "case", "shape": "count", "gridWidth": 6, "filters": {}},
+				{"id": "incident_wow", "displayName": "Incident WOW", "section": "SLA Violation", "resourceType": "incident", "shape": "count", "gridWidth": 6, "filters": {}}
+			]
+		}
+	]`
+
+	got := ParseDashboardsConfig(raw)
+	if len(got) != 1 || len(got[0].Widgets) != 2 {
+		t.Fatalf("ParseDashboardsConfig(raw) = %+v, want 1 dashboard with 2 widgets", got)
+	}
+
+	if section := got[0].Widgets[0].Section; section != "" {
+		t.Errorf("team_open_cases.Section = %q, want empty (no section configured)", section)
+	}
+	if section := got[0].Widgets[1].Section; section != "SLA Violation" {
+		t.Errorf("incident_wow.Section = %q, want %q", section, "SLA Violation")
+	}
+}

--- a/apps/csm-portal/backend/internal/handler/dashboards.go
+++ b/apps/csm-portal/backend/internal/handler/dashboards.go
@@ -25,19 +25,32 @@ import (
 	"github.com/wso2-open-operations/cs-tools/apps/csm-portal/backend/internal/middleware"
 )
 
+// dashboardPieSliceView is one wedge of a Shape "pie" widget — see
+// dashboard.PieSlice. Filters is this slice's own criteria only (already
+// __current_user__-resolved), meant to be merged under the parent widget's
+// own (also resolved) Filters by the caller.
+type dashboardPieSliceView struct {
+	Label   string         `json:"label"`
+	Color   string         `json:"color,omitempty"`
+	Filters map[string]any `json:"filters"`
+}
+
 // dashboardWidgetView is a single widget's filter criteria and display
 // metadata, returned as part of GET /dashboards/{dashboardId}. The caller
 // resolves each widget's own data by issuing its own POST /{resourceType}s/search
 // request (see ResourceType) with Filters.
 type dashboardWidgetView struct {
-	WidgetID     string                 `json:"widgetId"`
-	DisplayName  string                 `json:"displayName"`
-	ResourceType dashboard.ResourceType `json:"resourceType"`
-	Shape        dashboard.Shape        `json:"shape"`
-	GridWidth    int                    `json:"gridWidth"`
-	Filters      map[string]any         `json:"filters"`
-	GroupBy      string                 `json:"groupBy,omitempty"`
-	ListLimit    int                    `json:"listLimit,omitempty"`
+	WidgetID     string                  `json:"widgetId"`
+	DisplayName  string                  `json:"displayName"`
+	Description  string                  `json:"description,omitempty"`
+	ResourceType dashboard.ResourceType  `json:"resourceType"`
+	Shape        dashboard.Shape         `json:"shape"`
+	GridWidth    int                     `json:"gridWidth"`
+	Filters      map[string]any          `json:"filters"`
+	GroupBy      string                  `json:"groupBy,omitempty"`
+	ListLimit    int                     `json:"listLimit,omitempty"`
+	Slices       []dashboardPieSliceView `json:"slices,omitempty"`
+	Section      string                  `json:"section,omitempty"`
 }
 
 // dashboardListItemView is a dashboard's list-level metadata, returned by
@@ -150,15 +163,29 @@ func (h *DashboardHandler) GetDashboardDetail(w http.ResponseWriter, r *http.Req
 
 	widgets := make([]dashboardWidgetView, 0, len(d.Widgets))
 	for _, tpl := range d.Widgets {
+		var slices []dashboardPieSliceView
+		if len(tpl.Slices) > 0 {
+			slices = make([]dashboardPieSliceView, 0, len(tpl.Slices))
+			for _, slice := range tpl.Slices {
+				slices = append(slices, dashboardPieSliceView{
+					Label:   slice.Label,
+					Color:   slice.Color,
+					Filters: dashboard.ResolveSliceFilters(slice, currentUserID),
+				})
+			}
+		}
 		widgets = append(widgets, dashboardWidgetView{
 			WidgetID:     tpl.ID,
 			DisplayName:  tpl.DisplayName,
+			Description:  tpl.Description,
 			ResourceType: tpl.ResourceType,
 			Shape:        tpl.Shape,
 			GridWidth:    tpl.GridWidth,
 			Filters:      dashboard.ResolveFilters(tpl, currentUserID),
 			GroupBy:      tpl.GroupBy,
 			ListLimit:    tpl.ListLimit,
+			Slices:       slices,
+			Section:      tpl.Section,
 		})
 	}
 

--- a/apps/csm-portal/backend/internal/handler/dashboards_test.go
+++ b/apps/csm-portal/backend/internal/handler/dashboards_test.go
@@ -61,7 +61,12 @@ const testDashboardsConfigJSON = `[
   ]},
   {"id":"team_performance","displayName":"Team performance","targetTeam":"cs_team_leads","isTeamBased":true,"widgets":[
     {"id":"time_cards_pending_approval","displayName":"Time Cards Pending Approval","resourceType":"time_card","shape":"count","gridWidth":6,"filters":{"states":["pending"]}},
-    {"id":"team_open_cases","displayName":"Team Open P0/P1","resourceType":"case","shape":"count","gridWidth":6,"filters":{"severities":["catastrophic","critical"],"states":["open","work_in_progress"]}}
+    {"id":"team_open_cases","displayName":"Team Open P0/P1","resourceType":"case","shape":"count","gridWidth":6,"filters":{"severities":["catastrophic","critical"],"states":["open","work_in_progress"]}},
+    {"id":"cases_by_severity","displayName":"Cases by severity","description":"Share of active cases at each severity level.","resourceType":"case","shape":"pie","gridWidth":6,"filters":{"states":["open","work_in_progress"]},"slices":[
+      {"label":"Critical","color":"error","filters":{"severities":["critical"]}},
+      {"label":"Mine","filters":{"assignedUserIds":["__current_user__"]}}
+    ]},
+    {"id":"incident_wow","displayName":"Incident WOW","section":"SLA Violation","resourceType":"incident","shape":"count","gridWidth":6,"filters":{}}
   ]}
 ]`
 
@@ -505,6 +510,118 @@ func TestGetDashboardDetail(t *testing.T) {
 		}
 		if s, ok := priority.(string); !ok || s != "critical" {
 			t.Errorf("critical_vulns filters.priority = %v (%T), want string %q", priority, priority, "critical")
+		}
+	})
+
+	t.Run("team_performance's pie widget resolves description, slices, and per-slice current-user placeholders", func(t *testing.T) {
+		h := NewDashboardHandler(&mockEntityUserClient{})
+		r := withUser(withDashboardID(httptest.NewRequest(http.MethodGet, "/dashboards/team_performance", nil), "team_performance"))
+		w := httptest.NewRecorder()
+		h.GetDashboardDetail(w, r)
+
+		assertStatus(t, w, http.StatusOK)
+		body := w.Body.Bytes()
+		t.Logf("GET /dashboards/team_performance response: %s", body)
+
+		var result dashboardDetailView
+		if err := json.Unmarshal(body, &result); err != nil {
+			t.Fatalf("decode response body: %v; raw: %s", err, body)
+		}
+
+		byID := make(map[string]dashboardWidgetView)
+		for _, wd := range result.Widgets {
+			byID[wd.WidgetID] = wd
+		}
+		pie, ok := byID["cases_by_severity"]
+		if !ok {
+			t.Fatalf("missing widget %q in response", "cases_by_severity")
+		}
+		if pie.Description != "Share of active cases at each severity level." {
+			t.Errorf("cases_by_severity Description = %q, want the configured subtitle", pie.Description)
+		}
+		if len(pie.Slices) != 2 {
+			t.Fatalf("len(cases_by_severity.Slices) = %d, want 2", len(pie.Slices))
+		}
+
+		var critical, mine *dashboardPieSliceView
+		for i := range pie.Slices {
+			switch pie.Slices[i].Label {
+			case "Critical":
+				critical = &pie.Slices[i]
+			case "Mine":
+				mine = &pie.Slices[i]
+			}
+		}
+		if critical == nil {
+			t.Fatalf("missing the %q slice in cases_by_severity.Slices", "Critical")
+		}
+		if critical.Color != "error" {
+			t.Errorf("Critical slice Color = %q, want %q", critical.Color, "error")
+		}
+		if _, present := critical.Filters["states"]; present {
+			t.Errorf("Critical slice Filters must not carry the widget's own base filters, got %v", critical.Filters)
+		}
+
+		if mine == nil {
+			t.Fatalf("missing the %q slice in cases_by_severity.Slices", "Mine")
+		}
+		assigned, ok := mine.Filters["assignedUserIds"].([]any)
+		if !ok || len(assigned) != 1 || assigned[0] != resolvedCurrentUserID {
+			t.Errorf("Mine slice assignedUserIds = %v, want [%q] (resolved, not the raw placeholder)", mine.Filters["assignedUserIds"], resolvedCurrentUserID)
+		}
+
+		// Confirm the wire keys match the updated openapi.yaml schema.
+		var raw map[string]json.RawMessage
+		if err := json.Unmarshal(body, &raw); err != nil {
+			t.Fatalf("decode response body as raw keys: %v; raw: %s", err, body)
+		}
+		var rawWidgets []map[string]json.RawMessage
+		if err := json.Unmarshal(raw["widgets"], &rawWidgets); err != nil {
+			t.Fatalf("decode widgets as raw keys: %v; raw: %s", err, raw["widgets"])
+		}
+		var rawPie map[string]json.RawMessage
+		for _, obj := range rawWidgets {
+			var id string
+			if err := json.Unmarshal(obj["widgetId"], &id); err == nil && id == "cases_by_severity" {
+				rawPie = obj
+			}
+		}
+		if rawPie == nil {
+			t.Fatalf("cases_by_severity not found among raw widgets: %v", rawWidgets)
+		}
+		assertJSONKeysSuperset(t, rawPie, append(append([]string(nil), dashboardWidgetJSONKeys...), "description", "slices"), "cases_by_severity")
+	})
+
+	t.Run("team_performance's incident_wow widget carries its configured section, unset for widgets with no section", func(t *testing.T) {
+		h := NewDashboardHandler(&mockEntityUserClient{})
+		r := withUser(withDashboardID(httptest.NewRequest(http.MethodGet, "/dashboards/team_performance", nil), "team_performance"))
+		w := httptest.NewRecorder()
+		h.GetDashboardDetail(w, r)
+
+		assertStatus(t, w, http.StatusOK)
+		var result dashboardDetailView
+		if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+			t.Fatalf("decode response body: %v; raw: %s", err, w.Body.Bytes())
+		}
+		byID := make(map[string]dashboardWidgetView)
+		for _, wd := range result.Widgets {
+			byID[wd.WidgetID] = wd
+		}
+
+		wow, ok := byID["incident_wow"]
+		if !ok {
+			t.Fatalf("missing widget %q in response", "incident_wow")
+		}
+		if wow.Section != "SLA Violation" {
+			t.Errorf("incident_wow.Section = %q, want %q", wow.Section, "SLA Violation")
+		}
+
+		teamOpenCases, ok := byID["team_open_cases"]
+		if !ok {
+			t.Fatalf("missing widget %q in response", "team_open_cases")
+		}
+		if teamOpenCases.Section != "" {
+			t.Errorf("team_open_cases.Section = %q, want empty (no section configured)", teamOpenCases.Section)
 		}
 	})
 

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -5282,6 +5282,11 @@ components:
           description: Static id of the widget template within its dashboard
         displayName:
           type: string
+        description:
+          type: string
+          description: >
+            Explanatory subtitle shown under displayName. Config-owned text,
+            not hardcoded per resourceType/shape on the frontend.
         resourceType:
           type: string
           enum:
@@ -5303,10 +5308,11 @@ components:
             - pie
             - bar
           description: >
-            How the widget's data should be rendered once resolved. pie/bar
-            are not resolvable by any /search endpoint today (no aggregate
-            endpoint exists anywhere in the stack); reserved for a future
-            dashboard.
+            How the widget's data should be rendered once resolved. shapes
+            "pie" and "bar" both resolve one search per slices entry, the
+            same way "count" resolves its own single search (see slices
+            below) — they differ only in how the frontend renders the same
+            resolved data (wedges vs. bars), not in how it's fetched.
         gridWidth:
           type: integer
           minimum: 1
@@ -5319,13 +5325,50 @@ components:
             Filter criteria for this widget, with any current-user
             placeholder already substituted. Pass this directly as the
             filters of that resourceType's own POST /{resourceType}s/search
-            request to resolve the widget's data.
+            request to resolve the widget's data. For shapes "pie"/"bar"
+            this is a shared base merged under every slices entry's own
+            filters (caller-side; slices entry keys win on conflict) rather
+            than queried on its own.
         groupBy:
           type: string
-          description: Only meaningful for shape pie/bar; the field to group counts by
+          description: Unused
         listLimit:
           type: integer
           description: Only meaningful for shape list; how many records to show
+        slices:
+          type: array
+          description: >
+            Only meaningful for shapes "pie"/"bar": one search per entry,
+            each resolved via its own total, the same mechanism shape
+            "count" uses. Merge each entry's filters under this widget's
+            own filters (entry keys win on conflict) before searching.
+          items:
+            type: object
+            properties:
+              label:
+                type: string
+              color:
+                type: string
+                description: >
+                  Palette key (e.g. "primary", "error") the frontend already
+                  uses elsewhere in this system; not validated here, forwarded
+                  verbatim. Falls back to a fixed rotation over the same
+                  palette on the frontend if omitted.
+              filters:
+                type: object
+                additionalProperties: true
+                description: >
+                  This slice's own criteria only, with any current-user
+                  placeholder already substituted — merge under the parent
+                  widget's own filters to resolve this slice's total.
+        section:
+          type: string
+          description: >
+            Groups widgets sharing the same (non-empty) value under a
+            titled sub-section within the dashboard, in the order that
+            value first appears among the dashboard's widgets. Widgets
+            with no section (the common case) render in one untitled
+            group, same as before this field existed.
 
     DashboardListItem:
       type: object

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -2712,10 +2712,10 @@ export type BeWidgetResourceType =
   | "product_vulnerability";
 
 /**
- * How a widget's resolved data should be rendered. `bar` is not resolvable
- * by any `/search` endpoint today (no aggregate endpoint exists anywhere in
- * the stack) — reserved for a future dashboard. `pie` is resolved the same
- * way `count` is, just once per slice — see {@link BeDashboardWidget.slices}.
+ * How a widget's resolved data should be rendered. `pie` and `bar` both
+ * resolve the same way `count` does, just once per slice — see
+ * {@link BeDashboardWidget.slices} — differing only in how the frontend
+ * renders the resolved data (wedges vs. bars), not in how it's fetched.
  */
 export type BeWidgetShape = "count" | "list" | "pie" | "bar";
 

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -2712,11 +2712,35 @@ export type BeWidgetResourceType =
   | "product_vulnerability";
 
 /**
- * How a widget's resolved data should be rendered. `pie`/`bar` are not
- * resolvable by any `/search` endpoint today (no aggregate endpoint exists
- * anywhere in the stack) — reserved for a future dashboard.
+ * How a widget's resolved data should be rendered. `bar` is not resolvable
+ * by any `/search` endpoint today (no aggregate endpoint exists anywhere in
+ * the stack) — reserved for a future dashboard. `pie` is resolved the same
+ * way `count` is, just once per slice — see {@link BeDashboardWidget.slices}.
  */
 export type BeWidgetShape = "count" | "list" | "pie" | "bar";
+
+/** Palette key a dashboard config can use to color a pie slice — the same
+ * vocabulary `WidgetResourceConfig.iconColor` already uses elsewhere in this
+ * system, so one dashboard has one consistent color language. */
+export type BeWidgetPaletteColor =
+  | "primary"
+  | "secondary"
+  | "success"
+  | "error"
+  | "info"
+  | "warning";
+
+/** One wedge of a `shape: "pie"` widget. Resolved by issuing this
+ * resourceType's own `POST /{resourceType}s/search` with `filters` merged
+ * under the widget's own base `filters` (this slice's keys win on
+ * conflict) and `pagination: { limit: 1 }`, reading `total` — the exact
+ * same mechanism `shape: "count"` uses, just once per slice. */
+export interface BeDashboardPieSlice {
+  label: string;
+  /** Falls back to a fixed rotation over the same palette if omitted. */
+  color?: BeWidgetPaletteColor;
+  filters: Record<string, unknown>;
+}
 
 /**
  * A single widget template, embedded in {@link BeDashboard}: display metadata
@@ -2727,6 +2751,9 @@ export type BeWidgetShape = "count" | "list" | "pie" | "bar";
 export interface BeDashboardWidget {
   widgetId: string;
   displayName: string;
+  /** Explanatory subtitle shown under `displayName` — config-owned text,
+   * not hardcoded per resourceType/shape on the frontend. */
+  description?: string;
   resourceType: BeWidgetResourceType;
   shape: BeWidgetShape;
   /** CSS grid columns out of 12 this widget should occupy. */
@@ -2734,13 +2761,25 @@ export interface BeDashboardWidget {
   /**
    * Opaque filter criteria, with any current-user placeholder already
    * substituted. Pass this directly as the `filters` of that
-   * `resourceType`'s own `POST /{resourceType}s/search` request.
+   * `resourceType`'s own `POST /{resourceType}s/search` request. For
+   * shapes "pie"/"bar" this is a shared base merged under every slice's own
+   * `filters` (see {@link BeDashboardPieSlice}), rather than queried on
+   * its own.
    */
   filters: Record<string, unknown>;
   /** Only meaningful for shape pie/bar; the field to group counts by. */
   groupBy?: string;
+  /** Only meaningful for shapes "pie"/"bar": one search per slice, each
+   * read via its own `total`. */
+  slices?: BeDashboardPieSlice[];
   /** Only meaningful for shape list; how many records to show. */
   listLimit?: number;
+  /** Groups widgets sharing the same (non-empty) value under a titled
+   * sub-section within the dashboard, in the order that value first
+   * appears among the dashboard's widgets. Widgets with no `section` (the
+   * common case) render in one untitled group, same as before this field
+   * existed. */
+  section?: string;
 }
 
 /**

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetPieData.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetPieData.test.tsx
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { ReactNode } from "react";
+
+const postMock = vi.fn();
+
+vi.mock("@api/backend/client", () => ({
+  useBackendApi: () => ({ post: postMock }),
+}));
+
+import { useWidgetPieData } from "@features/csm-dashboard/api/useWidgetPieData";
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+describe("useWidgetPieData", () => {
+  beforeEach(() => {
+    postMock.mockReset();
+  });
+
+  it("issues one search per slice, own filters merged under the widget's base filters, limit 1", async () => {
+    postMock.mockImplementation((_path: string, body: { filters: Record<string, unknown> }) => {
+      if (body.filters.severities === "critical") return Promise.resolve({ total: 1 });
+      if (body.filters.severities === "high") return Promise.resolve({ total: 3 });
+      return Promise.resolve({ total: 0 });
+    });
+
+    const { result } = renderHook(
+      () =>
+        useWidgetPieData("case", { states: ["open"] }, [
+          { label: "Critical", filters: { severities: "critical" } },
+          { label: "High", filters: { severities: "high" } },
+        ]),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(postMock).toHaveBeenCalledTimes(2);
+    expect(postMock).toHaveBeenCalledWith("/cases/search", {
+      filters: { states: ["open"], severities: "critical" },
+      pagination: { offset: 0, limit: 1 },
+    });
+    expect(postMock).toHaveBeenCalledWith("/cases/search", {
+      filters: { states: ["open"], severities: "high" },
+      pagination: { offset: 0, limit: 1 },
+    });
+    expect(result.current.slices).toEqual([
+      { label: "Critical", filters: { severities: "critical" }, value: 1 },
+      { label: "High", filters: { severities: "high" }, value: 3 },
+    ]);
+    expect(result.current.total).toBe(4);
+  });
+
+  it("fires no queries and returns a zero total for an empty slices array", () => {
+    const { result } = renderHook(() => useWidgetPieData("case", {}, []), { wrapper });
+
+    expect(postMock).not.toHaveBeenCalled();
+    expect(result.current.slices).toEqual([]);
+    expect(result.current.total).toBe(0);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("surfaces isError when any one slice's search fails", async () => {
+    postMock
+      .mockResolvedValueOnce({ total: 2 })
+      .mockRejectedValueOnce(new Error("boom"));
+
+    const { result } = renderHook(
+      () =>
+        useWidgetPieData("case", {}, [
+          { label: "A", filters: { a: "1" } },
+          { label: "B", filters: { b: "2" } },
+        ]),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetPieData.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetPieData.ts
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useQueries } from "@tanstack/react-query";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import { useBackendApi } from "@api/backend/client";
+import type { BeDashboardPieSlice, BeWidgetResourceType } from "@api/backend/types";
+import { WIDGET_RESOURCE_CONFIG } from "@features/csm-dashboard/config/widgetResourceConfig";
+
+export interface PieSliceResult extends BeDashboardPieSlice {
+  value: number;
+}
+
+export interface WidgetPieData {
+  slices: PieSliceResult[];
+  total: number;
+  isLoading: boolean;
+  isError: boolean;
+}
+
+/**
+ * Resolves a `shape: "pie"` widget's per-slice values: one independent
+ * `POST {resourceType}/search` per slice — its own `filters` merged under
+ * the widget's own base `filters` (slice keys win on conflict) — with
+ * `pagination: { limit: 1 }`, reading `total` off each. The exact same
+ * mechanism `shape: "count"` (see `useWidgetData`) uses, just fired once
+ * per slice instead of once for the whole widget. An empty `slices` array
+ * fires no queries at all.
+ */
+export function useWidgetPieData(
+  resourceType: BeWidgetResourceType,
+  baseFilters: Record<string, unknown>,
+  slices: BeDashboardPieSlice[],
+): WidgetPieData {
+  const api = useBackendApi();
+  const config = WIDGET_RESOURCE_CONFIG[resourceType];
+
+  const queries = useQueries({
+    queries: slices.map((slice) => {
+      const filters = { ...baseFilters, ...slice.filters };
+      return {
+        queryKey: [
+          ApiQueryKeys.CSM_DASHBOARD_WIDGET_DATA,
+          "pie-slice",
+          resourceType,
+          filters,
+        ],
+        queryFn: async (): Promise<number> => {
+          if (!config) {
+            throw new Error(`Unsupported widget resourceType: ${resourceType}`);
+          }
+          const res = await api.post<
+            { filters: Record<string, unknown>; pagination: { offset: number; limit: number } },
+            Record<string, unknown>
+          >(config.searchEndpoint, {
+            filters,
+            pagination: { offset: 0, limit: 1 },
+          });
+          return typeof res.total === "number" ? res.total : 0;
+        },
+        staleTime: 60_000,
+      };
+    }),
+  });
+
+  const isLoading = queries.some((q) => q.isLoading);
+  const isError = queries.some((q) => q.isError);
+  const results: PieSliceResult[] = slices.map((slice, i) => ({
+    ...slice,
+    value: queries[i]?.data ?? 0,
+  }));
+  const total = results.reduce((sum, s) => sum + s.value, 0);
+
+  return { slices: results, total, isLoading, isError };
+}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/AgentsLandingPagePilot.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/AgentsLandingPagePilot.test.tsx
@@ -188,4 +188,51 @@ describe("AgentsLandingPagePilot", () => {
     await waitFor(() => expect(postMock).toHaveBeenCalledTimes(6));
     expect(screen.getByText("My Patches")).toBeInTheDocument();
   });
+
+  it("groups widgets sharing a `section` under a titled heading, separate from unsectioned widgets", async () => {
+    getMock.mockResolvedValue({
+      id: "team_performance",
+      displayName: "Team performance",
+      isDefault: false,
+      widgets: [
+        {
+          widgetId: "team_open_cases",
+          displayName: "Team Open P0/P1",
+          resourceType: "case",
+          shape: "count",
+          gridWidth: 6,
+          filters: {},
+        },
+        {
+          widgetId: "incident_wow",
+          displayName: "Incident WOW",
+          section: "SLA Violation",
+          resourceType: "case",
+          shape: "count",
+          gridWidth: 6,
+          filters: {},
+        },
+        {
+          widgetId: "query_wow",
+          displayName: "Query WOW",
+          section: "SLA Violation",
+          resourceType: "case",
+          shape: "count",
+          gridWidth: 6,
+          filters: {},
+        },
+      ],
+    });
+    postMock.mockResolvedValue(searchResponseFor(3));
+
+    renderWithClient(<AgentsLandingPagePilot dashboardId="team_performance" />);
+
+    await waitFor(() => expect(screen.getByText("Team Open P0/P1")).toBeInTheDocument());
+    expect(screen.getByText("Incident WOW")).toBeInTheDocument();
+    expect(screen.getByText("Query WOW")).toBeInTheDocument();
+
+    // Exactly one "SLA Violation" heading — both of its widgets share the
+    // section, they don't each get their own repeated heading.
+    expect(screen.getAllByText("SLA Violation")).toHaveLength(1);
+  });
 });

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/AgentsLandingPagePilot.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/AgentsLandingPagePilot.tsx
@@ -14,10 +14,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Box, Card, Skeleton, Typography } from "@wso2/oxygen-ui";
+import { Box, Card, Divider, Skeleton, Typography } from "@wso2/oxygen-ui";
 import { useQueryClient } from "@tanstack/react-query";
-import { useState, type JSX } from "react";
+import { Fragment, useState, type JSX } from "react";
 import { ApiQueryKeys } from "@constants/apiConstants";
+import type { BeDashboardWidget } from "@api/backend/types";
 import { useDashboard } from "@features/csm-dashboard/api/useDashboard";
 import DashboardWidgetTile from "@features/csm-dashboard/components/DashboardWidgetTile";
 import SectionCard from "@features/csm-dashboard/components/SectionCard";
@@ -25,6 +26,59 @@ import RefreshButton from "@features/csm-dashboard/components/RefreshButton";
 
 /** Placeholder tile count while the dashboard detail is in flight. */
 const PILOT_TILE_COUNT = 3;
+
+/** 12-column grid, matching each widget's own `gridWidth`; on very small
+ * screens there's only room for 4 columns, so a wide widget there wraps to
+ * (at most) one extra row rather than overflowing. */
+const WIDGET_GRID_SX = {
+  display: "grid",
+  gap: 1.5,
+  gridTemplateColumns: {
+    xs: "repeat(4, minmax(0, 1fr))",
+    sm: "repeat(12, minmax(0, 1fr))",
+  },
+} as const;
+
+interface WidgetGroup {
+  /** `undefined` for the untitled/default group — every widget with no
+   * `section` set lands here, rendered exactly as before this field
+   * existed (no heading). */
+  section?: string;
+  widgets: BeDashboardWidget[];
+}
+
+/** Groups widgets by `section`, preserving the order each distinct section
+ * value (including the untitled default) first appears among `widgets` —
+ * see `BeDashboardWidget.section`. */
+function groupWidgetsBySection(widgets: BeDashboardWidget[]): WidgetGroup[] {
+  const groups: WidgetGroup[] = [];
+  const indexBySection = new Map<string | undefined, number>();
+  for (const widget of widgets) {
+    const key = widget.section || undefined;
+    let index = indexBySection.get(key);
+    if (index === undefined) {
+      index = groups.length;
+      indexBySection.set(key, index);
+      groups.push({ section: key, widgets: [] });
+    }
+    groups[index].widgets.push(widget);
+  }
+  return groups;
+}
+
+function widgetGridColumnSx(widget: BeDashboardWidget) {
+  // A list-shape widget renders a real table (4 rows, several columns) —
+  // its configured `gridWidth` was sized for the old compact text list, so
+  // it always spans the full row here regardless of that value.
+  return widget.shape === "list"
+    ? { gridColumn: "1 / -1" }
+    : {
+        gridColumn: {
+          xs: `span ${Math.min(widget.gridWidth, 4)}`,
+          sm: `span ${widget.gridWidth}`,
+        },
+      };
+}
 
 interface AgentsLandingPagePilotProps {
   /** Id of the dashboard to render (e.g. "agents_pilot"). */
@@ -82,55 +136,71 @@ export default function AgentsLandingPagePilot({
         <Typography variant="body2" color="text.secondary">
           Could not load the widget pilot.
         </Typography>
-      ) : (
-        <Box
-          sx={{
-            display: "grid",
-            gap: 1.5,
-            // 12-column grid, matching each widget's own `gridWidth`; on very
-            // small screens there's only room for 4 columns, so a wide widget
-            // there wraps to (at most) one extra row rather than overflowing.
-            gridTemplateColumns: {
-              xs: "repeat(4, minmax(0, 1fr))",
-              sm: "repeat(12, minmax(0, 1fr))",
-            },
-          }}
-        >
-          {isLoading || isRefreshing
-            ? Array.from({ length: PILOT_TILE_COUNT }, (_, i) => (
-                <Card key={i} variant="outlined" sx={{ p: 1.75, gridColumn: "span 4" }}>
-                  <Skeleton variant="rounded" height={48} />
-                </Card>
-              ))
-            : (data?.widgets ?? []).map((widget) => (
-                <Box
-                  key={widget.widgetId}
-                  sx={
-                    // A list-shape widget renders a real table (4 rows,
-                    // several columns) — its configured `gridWidth` was
-                    // sized for the old compact text list, so it always
-                    // spans the full row here regardless of that value.
-                    widget.shape === "list"
-                      ? { gridColumn: "1 / -1" }
-                      : {
-                          gridColumn: {
-                            xs: `span ${Math.min(widget.gridWidth, 4)}`,
-                            sm: `span ${widget.gridWidth}`,
-                          },
-                        }
-                  }
-                >
-                  <DashboardWidgetTile
-                    widgetId={widget.widgetId}
-                    displayName={widget.displayName}
-                    resourceType={widget.resourceType}
-                    shape={widget.shape}
-                    filters={widget.filters}
-                    listLimit={widget.listLimit}
-                  />
-                </Box>
-              ))}
+      ) : isLoading || isRefreshing ? (
+        <Box sx={WIDGET_GRID_SX}>
+          {Array.from({ length: PILOT_TILE_COUNT }, (_, i) => (
+            <Card key={i} variant="outlined" sx={{ p: 1.75, gridColumn: "span 4" }}>
+              <Skeleton variant="rounded" height={48} />
+            </Card>
+          ))}
         </Box>
+      ) : (
+        (() => {
+          const widgets = data?.widgets ?? [];
+          const renderTile = (widget: BeDashboardWidget) => {
+            return (
+              <Box key={widget.widgetId} sx={widgetGridColumnSx(widget)}>
+                <DashboardWidgetTile
+                  widgetId={widget.widgetId}
+                  displayName={widget.displayName}
+                  description={widget.description}
+                  resourceType={widget.resourceType}
+                  shape={widget.shape}
+                  filters={widget.filters}
+                  listLimit={widget.listLimit}
+                  slices={widget.slices}
+                />
+              </Box>
+            );
+          };
+
+          const groups = groupWidgetsBySection(widgets);
+
+          return (
+            <Box sx={{ display: "flex", flexDirection: "column", gap: 2.5 }}>
+              {groups.map((group, i) => {
+                // Chart-shaped widgets (pie/bar) are visually grouped into
+                // their own row below this group's count/list tiles, rather
+                // than sharing one undifferentiated grid with them.
+                const mainWidgets = group.widgets.filter((w) => w.shape !== "pie" && w.shape !== "bar");
+                const chartWidgets = group.widgets.filter((w) => w.shape === "pie" || w.shape === "bar");
+                if (mainWidgets.length === 0 && chartWidgets.length === 0) return null;
+
+                return (
+                  <Fragment key={group.section ?? `__default_${i}`}>
+                    {i > 0 && <Divider />}
+                    <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+                      {group.section && (
+                        <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+                          {group.section}
+                        </Typography>
+                      )}
+                      {mainWidgets.length > 0 && (
+                        <Box sx={WIDGET_GRID_SX}>{mainWidgets.map(renderTile)}</Box>
+                      )}
+                      {chartWidgets.length > 0 && (
+                        <>
+                          {mainWidgets.length > 0 && <Divider sx={{ my: 0.5 }} />}
+                          <Box sx={WIDGET_GRID_SX}>{chartWidgets.map(renderTile)}</Box>
+                        </>
+                      )}
+                    </Box>
+                  </Fragment>
+                );
+              })}
+            </Box>
+          );
+        })()
       )}
     </SectionCard>
   );

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardBarChart.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardBarChart.tsx
@@ -1,0 +1,163 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Box, Skeleton, Typography, alpha, useTheme } from "@wso2/oxygen-ui";
+import { Inbox } from "@wso2/oxygen-ui-icons-react";
+import { Bar, BarChart, Cell } from "@wso2/oxygen-ui-charts-react";
+import { useState, type JSX } from "react";
+import type { BeWidgetPaletteColor } from "@api/backend/types";
+import type { PieSliceResult } from "@features/csm-dashboard/api/useWidgetPieData";
+import { useDarkMode } from "@utils/useDarkMode";
+
+const CHART_HEIGHT_PX = 220;
+
+/** Used in order when a slice's own config omits `color`. */
+const DEFAULT_COLOR_ROTATION: BeWidgetPaletteColor[] = [
+  "primary",
+  "warning",
+  "secondary",
+  "info",
+  "success",
+  "error",
+];
+
+interface DashboardBarChartProps {
+  slices: PieSliceResult[];
+  total: number;
+  isLoading: boolean;
+  isError: boolean;
+  onSliceClick: (slice: PieSliceResult) => void;
+}
+
+/**
+ * Bar chart for a `shape: "bar"` dashboard widget — one bar per slice
+ * (`useWidgetPieData` is shape-agnostic: it resolves N labeled slice totals
+ * the same way regardless of whether they render as wedges or bars), each
+ * clickable through to that slice's own filtered case list, same as
+ * `DashboardPieChart`'s wedges/legend rows. A total of 0 renders an empty
+ * state instead of an all-grey chart, same treatment as `DashboardPieChart`.
+ */
+export default function DashboardBarChart({
+  slices,
+  total,
+  isLoading,
+  isError,
+  onSliceClick,
+}: DashboardBarChartProps): JSX.Element {
+  const theme = useTheme();
+  const isDarkMode = useDarkMode();
+  const [activeIndex, setActiveIndex] = useState<number | undefined>(undefined);
+
+  const colorFor = (slice: PieSliceResult, i: number): string => {
+    const key = slice.color ?? DEFAULT_COLOR_ROTATION[i % DEFAULT_COLOR_ROTATION.length];
+    return theme.palette[key].main;
+  };
+
+  if (isLoading) {
+    return <Skeleton variant="rounded" height={CHART_HEIGHT_PX} />;
+  }
+
+  if (isError) {
+    return (
+      <Typography variant="body2" color="text.secondary">
+        Could not load this widget.
+      </Typography>
+    );
+  }
+
+  if (total === 0) {
+    return (
+      <Box
+        sx={{
+          minHeight: CHART_HEIGHT_PX,
+          width: "100%",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: 1.5,
+        }}
+      >
+        <Box
+          sx={{
+            width: 52,
+            height: 52,
+            borderRadius: "50%",
+            bgcolor: alpha(theme.palette.grey[500], 0.08),
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <Inbox size={24} color={isDarkMode ? theme.palette.grey[400] : theme.palette.grey[500]} />
+        </Box>
+        <Typography variant="body2" sx={{ color: isDarkMode ? theme.palette.grey[400] : theme.palette.text.disabled }}>
+          Nothing to show here right now
+        </Typography>
+      </Box>
+    );
+  }
+
+  const chartData = slices.map((slice) => ({ name: slice.label, value: slice.value }));
+
+  return (
+    <Box sx={{ width: "100%", height: CHART_HEIGHT_PX, "& .recharts-bar-rectangle": { cursor: "pointer" } }}>
+      <BarChart
+        data={chartData}
+        xAxisDataKey="name"
+        height="100%"
+        width="100%"
+        legend={{ show: false }}
+        yAxis={{ show: false }}
+        grid={{ show: false }}
+        // Library default top margin (12px) is too tight once each bar has
+        // its own always-visible value label sitting above it.
+        margin={{ top: 24, right: 8, bottom: 8, left: 0 }}
+        // cursor: false drops the library's default full-height highlight
+        // box behind the hovered bar — the bar's own hover color/border is
+        // enough of a highlight on its own.
+        tooltip={{ show: true, wrapperStyle: { zIndex: 1000 }, cursor: false }}
+      >
+        <Bar
+          dataKey="value"
+          radius={[4, 4, 0, 0]}
+          isAnimationActive={false}
+          label={{
+            position: "top",
+            fill: isDarkMode ? theme.palette.common.white : theme.palette.text.primary,
+            fontSize: 13,
+            fontWeight: 600,
+          }}
+          onMouseEnter={(_data: unknown, i: number) => setActiveIndex(i)}
+          onMouseLeave={() => setActiveIndex(undefined)}
+          onClick={(_data: unknown, i: number) => {
+            const slice = slices[i];
+            if (slice) onSliceClick(slice);
+          }}
+        >
+          {slices.map((slice, i) => (
+            <Cell
+              key={slice.label}
+              fill={colorFor(slice, i)}
+              stroke={activeIndex === i ? colorFor(slice, i) : "none"}
+              strokeWidth={activeIndex === i ? 2 : 0}
+            />
+          ))}
+        </Bar>
+      </BarChart>
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardPieChart.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardPieChart.tsx
@@ -1,0 +1,246 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Box, Skeleton, Typography, alpha, useTheme } from "@wso2/oxygen-ui";
+import { Inbox } from "@wso2/oxygen-ui-icons-react";
+import { Cell, Pie, PieChart } from "@wso2/oxygen-ui-charts-react";
+import { useState, type JSX } from "react";
+import type { BeWidgetPaletteColor } from "@api/backend/types";
+import type { PieSliceResult } from "@features/csm-dashboard/api/useWidgetPieData";
+import { useDarkMode } from "@utils/useDarkMode";
+
+const CHART_SIZE_PX = 180;
+const INNER_RADIUS_PX = 62;
+const OUTER_RADIUS_PX = 88;
+
+/** Used in order when a slice's own config omits `color`. */
+const DEFAULT_COLOR_ROTATION: BeWidgetPaletteColor[] = [
+  "primary",
+  "warning",
+  "secondary",
+  "info",
+  "success",
+  "error",
+];
+
+interface DashboardPieChartProps {
+  slices: PieSliceResult[];
+  total: number;
+  isLoading: boolean;
+  isError: boolean;
+  onSliceClick: (slice: PieSliceResult) => void;
+}
+
+/**
+ * Donut chart + legend for a `shape: "pie"` dashboard widget — a fixed
+ * center total, one wedge (and one legend row) per slice, both clickable
+ * through to that slice's own filtered case list (see
+ * `DashboardWidgetTile`'s pie branch for how the destination href is
+ * built). A total of 0 renders an empty state (same treatment as the
+ * customer-portal app's own dashboard charts) instead of an all-grey ring.
+ */
+export default function DashboardPieChart({
+  slices,
+  total,
+  isLoading,
+  isError,
+  onSliceClick,
+}: DashboardPieChartProps): JSX.Element {
+  const theme = useTheme();
+  const isDarkMode = useDarkMode();
+  const [activeIndex, setActiveIndex] = useState<number | undefined>(undefined);
+
+  const colorFor = (slice: PieSliceResult, i: number): string => {
+    const key = slice.color ?? DEFAULT_COLOR_ROTATION[i % DEFAULT_COLOR_ROTATION.length];
+    return theme.palette[key].main;
+  };
+
+  if (isLoading) {
+    return (
+      <Box sx={{ display: "flex", alignItems: "center", gap: 3 }}>
+        <Skeleton variant="circular" width={CHART_SIZE_PX} height={CHART_SIZE_PX} sx={{ flexShrink: 0 }} />
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 1, flex: 1 }}>
+          {slices.map((slice) => (
+            <Skeleton key={slice.label} variant="rounded" height={20} />
+          ))}
+        </Box>
+      </Box>
+    );
+  }
+
+  if (isError) {
+    return (
+      <Typography variant="body2" color="text.secondary">
+        Could not load this widget.
+      </Typography>
+    );
+  }
+
+  if (total === 0) {
+    return (
+      <Box
+        sx={{
+          minHeight: CHART_SIZE_PX,
+          width: "100%",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: 1.5,
+        }}
+      >
+        <Box
+          sx={{
+            width: 52,
+            height: 52,
+            borderRadius: "50%",
+            bgcolor: alpha(theme.palette.grey[500], 0.08),
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          {/* text.disabled/text.secondary render too close to the
+              background's own color in this app's dark theme (same issue
+              fixed for the bar chart's value labels) — grey[400] is legible
+              against a dark background without looking harsh in light mode. */}
+          <Inbox size={24} color={isDarkMode ? theme.palette.grey[400] : theme.palette.grey[500]} />
+        </Box>
+        <Typography variant="body2" sx={{ color: isDarkMode ? theme.palette.grey[400] : theme.palette.text.disabled }}>
+          Nothing to show here right now
+        </Typography>
+      </Box>
+    );
+  }
+
+  const chartData = slices.map((slice) => ({ name: slice.label, value: slice.value }));
+
+  return (
+    <Box sx={{ display: "flex", alignItems: "center", gap: 3, flexWrap: "wrap" }}>
+      <Box
+        sx={{
+          position: "relative",
+          width: CHART_SIZE_PX,
+          height: CHART_SIZE_PX,
+          flexShrink: 0,
+          "& .recharts-pie-sector": { cursor: "pointer" },
+        }}
+      >
+        {/* wrapperStyle's zIndex matches the same fix the customer-portal
+            app's own dashboard charts use (see OutstandingIncidentsChart.tsx)
+            — without it the tooltip can render underneath/get clipped by
+            this tile's own header, looking cut off / see-through.
+            margin: PieChart's own default is {top:12,right:24,left:24,
+            bottom:40} — the large bottom value reserves room for a legend,
+            which is disabled here. Left uncleared, that asymmetric margin
+            shifts the plot's (and so the ring's) center downward within the
+            180x180 box, making the top of the donut look pushed toward /
+            cut off by this tile's own header above it. */}
+        <PieChart
+          width="100%"
+          height="100%"
+          legend={{ show: false }}
+          margin={{ top: 0, right: 0, bottom: 0, left: 0 }}
+          tooltip={{ show: true, wrapperStyle: { zIndex: 1000 } }}
+        >
+          <Pie
+            data={chartData}
+            cx="50%"
+            cy="50%"
+            innerRadius={INNER_RADIUS_PX}
+            outerRadius={OUTER_RADIUS_PX}
+            paddingAngle={0}
+            dataKey="value"
+            nameKey="name"
+            startAngle={90}
+            endAngle={-270}
+            label={false}
+            labelLine={false}
+            onMouseEnter={(_data: unknown, i: number) => setActiveIndex(i)}
+            onMouseLeave={() => setActiveIndex(undefined)}
+            onClick={(_data: unknown, i: number) => {
+              const slice = slices[i];
+              if (slice) onSliceClick(slice);
+            }}
+          >
+            {slices.map((slice, i) => (
+              <Cell
+                key={slice.label}
+                fill={colorFor(slice, i)}
+                stroke={activeIndex === i ? colorFor(slice, i) : "none"}
+                strokeWidth={activeIndex === i ? 3 : 0}
+              />
+            ))}
+          </Pie>
+        </PieChart>
+        <Box
+          sx={{
+            position: "absolute",
+            inset: 0,
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            pointerEvents: "none",
+          }}
+        >
+          <Typography variant="h5">{total}</Typography>
+          <Typography variant="caption" color="text.secondary">
+            Total
+          </Typography>
+        </Box>
+      </Box>
+
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 0.75, flex: 1, minWidth: 180 }}>
+        {slices.map((slice, i) => {
+          const pct = total > 0 ? Math.round((slice.value / total) * 100) : 0;
+          return (
+            <Box
+              key={slice.label}
+              onClick={() => onSliceClick(slice)}
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                gap: 1,
+                px: 0.5,
+                py: 0.25,
+                borderRadius: 1,
+                cursor: "pointer",
+                "&:hover": { bgcolor: "action.hover" },
+              }}
+            >
+              <Box
+                sx={{
+                  width: 10,
+                  height: 10,
+                  borderRadius: "50%",
+                  bgcolor: colorFor(slice, i),
+                  flexShrink: 0,
+                }}
+              />
+              <Typography variant="body2" sx={{ flex: 1 }} noWrap>
+                {slice.label}
+              </Typography>
+              <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                {slice.value} ({pct}%)
+              </Typography>
+            </Box>
+          );
+        })}
+      </Box>
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.test.tsx
@@ -14,12 +14,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import "@testing-library/jest-dom/vitest";
-import type { ReactNode } from "react";
-import { MemoryRouter } from "react-router";
+import { Children, cloneElement, isValidElement, type ReactElement, type ReactNode } from "react";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router";
 
 const postMock = vi.fn();
 
@@ -39,6 +39,63 @@ vi.mock("@context/current-user/CurrentUserContext", () => ({
     isError: false,
   }),
 }));
+// Recharts' ResponsiveContainer measures a real layout size, which jsdom
+// always reports as 0 — nothing would render. Stubbed to a plain list of
+// slice buttons (label + value), enough to assert on data/clicks without
+// depending on actual SVG geometry (same approach the customer-portal app's
+// own chart tests use for this same package).
+vi.mock("@wso2/oxygen-ui-charts-react", () => ({
+  ResponsiveContainer: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  PieChart: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Pie: ({
+    data,
+    onClick,
+  }: {
+    data: { name: string; value: number }[];
+    onClick?: (item: unknown, index: number) => void;
+  }) => (
+    <div>
+      {data.map((item, i) => (
+        <button key={item.name} type="button" onClick={() => onClick?.(item, i)}>
+          slice:{item.name}:{item.value}
+        </button>
+      ))}
+    </div>
+  ),
+  Cell: () => null,
+  // `data` is a BarChart-level prop (not Bar's own) in the real package —
+  // clone it onto the Bar child so the mock below can read it.
+  BarChart: ({
+    children,
+    data,
+  }: {
+    children: ReactNode;
+    data?: { name: string; value: number }[];
+  }) => (
+    <div>
+      {Children.map(children, (child) =>
+        isValidElement(child)
+          ? cloneElement(child as ReactElement<{ data?: typeof data }>, { data })
+          : child,
+      )}
+    </div>
+  ),
+  Bar: ({
+    data,
+    onClick,
+  }: {
+    data?: { name: string; value: number }[];
+    onClick?: (item: unknown, index: number) => void;
+  }) => (
+    <div>
+      {(data ?? []).map((item, i) => (
+        <button key={item.name} type="button" onClick={() => onClick?.(item, i)}>
+          bar:{item.name}:{item.value}
+        </button>
+      ))}
+    </div>
+  ),
+}));
 
 import DashboardWidgetTile from "@features/csm-dashboard/components/DashboardWidgetTile";
 
@@ -49,6 +106,29 @@ function renderWithClient(ui: ReactNode) {
   return render(
     <QueryClientProvider client={queryClient}>
       <MemoryRouter>{ui}</MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+function LocationProbe() {
+  const location = useLocation();
+  return <div data-testid="location-probe">{location.pathname + location.search}</div>;
+}
+
+/** For tests that need to observe where a click actually navigated to —
+ * `renderWithClient` has no destination route to land on. */
+function renderWithRoutes(ui: ReactNode, destinationPath: string) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={["/"]}>
+        <Routes>
+          <Route path="/" element={ui} />
+          <Route path={destinationPath} element={<LocationProbe />} />
+        </Routes>
+      </MemoryRouter>
     </QueryClientProvider>,
   );
 }
@@ -255,22 +335,149 @@ describe("DashboardWidgetTile", () => {
     expect(params.get("states")).toBe("open");
   });
 
-  it("renders a not-yet-supported message for shape pie/bar instead of crashing", async () => {
-    postMock.mockResolvedValue({ total: 0, cases: [], limit: 1, offset: 0, hasMore: false });
+  it("shape bar: issues one search per slice and renders a bar per slice, clickable the same way as a pie slice", async () => {
+    postMock.mockImplementation(
+      (_path: string, body: { filters: Record<string, unknown> }) => {
+        const severities = body.filters.severities as string[] | undefined;
+        if (severities?.includes("critical")) return Promise.resolve({ total: 1 });
+        if (severities?.includes("high")) return Promise.resolve({ total: 3 });
+        return Promise.resolve({ total: 0 });
+      },
+    );
 
-    renderWithClient(
+    renderWithRoutes(
       <DashboardWidgetTile
         widgetId="cases_by_severity"
         displayName="Open Cases by Severity"
         resourceType="case"
         shape="bar"
+        filters={{ states: ["open"] }}
+        slices={[
+          { label: "S1 · Critical", color: "error", filters: { severities: ["critical"] } },
+          { label: "S2 · High", color: "warning", filters: { severities: ["high"] } },
+        ]}
+      />,
+      "/cases",
+    );
+
+    await waitFor(() => expect(screen.getByText("bar:S1 · Critical:1")).toBeInTheDocument());
+    expect(screen.getByText("bar:S2 · High:3")).toBeInTheDocument();
+    expect(postMock).toHaveBeenCalledWith("/cases/search", {
+      filters: { states: ["open"], severities: ["critical"] },
+      pagination: { offset: 0, limit: 1 },
+    });
+
+    fireEvent.click(screen.getByText("bar:S1 · Critical:1"));
+    await waitFor(() => expect(screen.getByTestId("location-probe")).toBeInTheDocument());
+    const probeText = screen.getByTestId("location-probe").textContent ?? "";
+    const params = new URLSearchParams(probeText.split("?")[1]);
+    expect(params.get("severities")).toBe("S1");
+    expect(params.get("states")).toBe("open");
+  });
+
+  it("shape pie: issues one search per slice (own filters merged under the widget's base filters) and renders values + percentages", async () => {
+    postMock.mockImplementation(
+      (_path: string, body: { filters: Record<string, unknown> }) => {
+        const severities = body.filters.severities as string[] | undefined;
+        if (severities?.includes("critical")) return Promise.resolve({ total: 1 });
+        if (severities?.includes("high")) return Promise.resolve({ total: 3 });
+        return Promise.resolve({ total: 0 });
+      },
+    );
+
+    renderWithClient(
+      <DashboardWidgetTile
+        widgetId="cases-by-severity"
+        displayName="Cases by severity"
+        description="Share of active cases at each severity level."
+        resourceType="case"
+        shape="pie"
+        filters={{ states: ["open"] }}
+        slices={[
+          { label: "S1 · Critical", color: "error", filters: { severities: ["critical"] } },
+          { label: "S2 · High", color: "warning", filters: { severities: ["high"] } },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("Share of active cases at each severity level.")).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText("slice:S1 · Critical:1")).toBeInTheDocument());
+    expect(screen.getByText("slice:S2 · High:3")).toBeInTheDocument();
+    expect(screen.getByText("1 (25%)")).toBeInTheDocument();
+    expect(screen.getByText("3 (75%)")).toBeInTheDocument();
+    expect(postMock).toHaveBeenCalledWith("/cases/search", {
+      filters: { states: ["open"], severities: ["critical"] },
+      pagination: { offset: 0, limit: 1 },
+    });
+    expect(postMock).toHaveBeenCalledWith("/cases/search", {
+      filters: { states: ["open"], severities: ["high"] },
+      pagination: { offset: 0, limit: 1 },
+    });
+  });
+
+  it("shape pie: clicking a slice navigates to /cases with the widget's base filters merged under that slice's own filters", async () => {
+    postMock.mockResolvedValue({ total: 2 });
+
+    renderWithRoutes(
+      <DashboardWidgetTile
+        widgetId="cases-by-severity"
+        displayName="Cases by severity"
+        resourceType="case"
+        shape="pie"
+        filters={{ states: ["open"] }}
+        slices={[{ label: "Critical", filters: { severities: ["critical"] } }]}
+      />,
+      "/cases",
+    );
+
+    await waitFor(() => expect(screen.getByText("slice:Critical:2")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("slice:Critical:2"));
+
+    await waitFor(() => expect(screen.getByTestId("location-probe")).toBeInTheDocument());
+    const probeText = screen.getByTestId("location-probe").textContent ?? "";
+    expect(probeText.startsWith("/cases?")).toBe(true);
+    const params = new URLSearchParams(probeText.split("?")[1]);
+    expect(params.get("severities")).toBe("S1");
+    expect(params.get("states")).toBe("open");
+  });
+
+  it("shape pie: clicking a legend row navigates the same way as clicking the slice", async () => {
+    postMock.mockResolvedValue({ total: 2 });
+
+    renderWithRoutes(
+      <DashboardWidgetTile
+        widgetId="cases-by-severity"
+        displayName="Cases by severity"
+        resourceType="case"
+        shape="pie"
+        filters={{}}
+        slices={[{ label: "Critical", filters: { severities: ["critical"] } }]}
+      />,
+      "/cases",
+    );
+
+    await waitFor(() => expect(screen.getByText("Critical")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("Critical"));
+
+    await waitFor(() => expect(screen.getByTestId("location-probe")).toBeInTheDocument());
+    const probeText = screen.getByTestId("location-probe").textContent ?? "";
+    expect(new URLSearchParams(probeText.split("?")[1]).get("severities")).toBe("S1");
+  });
+
+  it("shape pie: renders an empty state (no slices, zero total) rather than crashing when a widget has no slices configured yet", async () => {
+    renderWithClient(
+      <DashboardWidgetTile
+        widgetId="cases-by-severity"
+        displayName="Cases by severity"
+        resourceType="case"
+        shape="pie"
         filters={{}}
       />,
     );
 
-    await waitFor(() =>
-      expect(screen.getByText("Not yet supported.")).toBeInTheDocument(),
-    );
+    expect(screen.getByText("Cases by severity")).toBeInTheDocument();
+    expect(screen.getByText("Nothing to show here right now")).toBeInTheDocument();
+    expect(postMock).not.toHaveBeenCalled();
   });
 
   it("renders an unsupported-widget message instead of crashing for an unrecognized resourceType", () => {

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
@@ -32,7 +32,7 @@ interface DashboardWidgetTileProps {
   widgetId: string;
   displayName: string;
   /** Explanatory subtitle shown under `displayName` — only rendered for
-   * shape "pie" today, but not shape-specific by design. */
+   * shapes "pie"/"bar" today, but not shape-specific by design. */
   description?: string;
   resourceType: BeWidgetResourceType;
   shape: BeWidgetShape;

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
@@ -17,17 +17,23 @@
 import { Box, Button, Card, Skeleton, Tooltip, Typography, alpha, useTheme } from "@wso2/oxygen-ui";
 import { ArrowRight, Info } from "@wso2/oxygen-ui-icons-react";
 import type { JSX, ReactNode } from "react";
-import { Link as RouterLink } from "react-router";
-import type { BeWidgetResourceType, BeWidgetShape } from "@api/backend/types";
+import { Link as RouterLink, useNavigate } from "react-router";
+import type { BeDashboardPieSlice, BeWidgetResourceType, BeWidgetShape } from "@api/backend/types";
 import { useCurrentUser } from "@context/current-user/CurrentUserContext";
 import { useWidgetData } from "@features/csm-dashboard/api/useWidgetData";
+import { useWidgetPieData, type PieSliceResult } from "@features/csm-dashboard/api/useWidgetPieData";
 import { WIDGET_RESOURCE_CONFIG } from "@features/csm-dashboard/config/widgetResourceConfig";
 import { WIDGET_LIST_RENDERERS } from "@features/csm-dashboard/config/widgetListConfig";
 import { buildWidgetPreviewHref } from "@features/csm-dashboard/utils/widgetPreviewUrl";
+import DashboardPieChart from "@features/csm-dashboard/components/DashboardPieChart";
+import DashboardBarChart from "@features/csm-dashboard/components/DashboardBarChart";
 
 interface DashboardWidgetTileProps {
   widgetId: string;
   displayName: string;
+  /** Explanatory subtitle shown under `displayName` — only rendered for
+   * shape "pie" today, but not shape-specific by design. */
+  description?: string;
   resourceType: BeWidgetResourceType;
   shape: BeWidgetShape;
   filters: Record<string, unknown>;
@@ -35,6 +41,10 @@ interface DashboardWidgetTileProps {
    * 4 (see useWidgetData's DEFAULT_LIST_LIMIT) — set explicitly per-widget
    * via the backend's DASHBOARDS_CONFIG, not overridden here. */
   listLimit?: number;
+  /** Only meaningful for shape "pie"/"bar"; one search per slice (see
+   * `useWidgetPieData`). Empty/absent renders an empty chart rather than
+   * crashing. */
+  slices?: BeDashboardPieSlice[];
 }
 
 /**
@@ -56,19 +66,33 @@ interface DashboardWidgetTileProps {
 export default function DashboardWidgetTile({
   widgetId,
   displayName,
+  description,
   resourceType,
   shape,
   filters,
   listLimit,
+  slices,
 }: DashboardWidgetTileProps): JSX.Element {
   const theme = useTheme();
+  const navigate = useNavigate();
   const { user } = useCurrentUser();
+  // Shape "pie" resolves via useWidgetPieData instead (one search per
+  // slice) — skip this one's own network call rather than wasting it, but
+  // still call the hook unconditionally (rules of hooks; a widget's shape
+  // never changes across this component's lifetime).
   const { data, isLoading, isError } = useWidgetData(
     widgetId,
     resourceType,
     filters,
     shape,
     listLimit,
+    0,
+    shape !== "pie" && shape !== "bar",
+  );
+  const pieData = useWidgetPieData(
+    resourceType,
+    filters,
+    shape === "pie" || shape === "bar" ? (slices ?? []) : [],
   );
   const config = WIDGET_RESOURCE_CONFIG[resourceType];
 
@@ -185,6 +209,39 @@ export default function DashboardWidgetTile({
     );
   }
 
+  if (shape === "pie" || shape === "bar") {
+    // Each slice/legend row (or bar) navigates independently, so — same
+    // rationale as shape "list" — this can't be one big link the way shape
+    // "count" is; it's a plain, non-link Card with its own nested click
+    // targets.
+    const ChartComponent = shape === "pie" ? DashboardPieChart : DashboardBarChart;
+    return (
+      <Card variant="outlined" sx={{ p: 1.75, height: "100%" }}>
+        {/* The header's own bottom padding — not just a top margin on the
+            chart below it — so the chart's top edge (and, at the size this
+            chart renders at, its tooltip) never sits flush against/behind
+            the title row above it. */}
+        <Box sx={{ pb: description ? 1 : 2.5 }}>{header}</Box>
+        {description && (
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
+            {description}
+          </Typography>
+        )}
+        <Box>
+          <ChartComponent
+            slices={pieData.slices}
+            total={pieData.total}
+            isLoading={pieData.isLoading}
+            isError={pieData.isError}
+            onSliceClick={(slice: PieSliceResult) =>
+              navigate(config.buildHref({ ...filters, ...slice.filters }))
+            }
+          />
+        </Box>
+      </Card>
+    );
+  }
+
   let body: ReactNode;
   if (isLoading) {
     body = <Skeleton variant="rounded" height={48} />;
@@ -194,7 +251,7 @@ export default function DashboardWidgetTile({
         Could not load this widget.
       </Typography>
     );
-  } else if (shape === "count") {
+  } else {
     body = (
       <Box sx={{ display: "flex", alignItems: "flex-start", gap: 1.25 }}>
         <Box
@@ -218,36 +275,6 @@ export default function DashboardWidgetTile({
           </Typography>
           <Typography variant="h5" sx={{ mt: 0.5 }}>
             {data?.total ?? 0}
-          </Typography>
-        </Box>
-      </Box>
-    );
-  } else {
-    // pie/bar: no aggregate endpoint exists anywhere in the stack today, so
-    // there is nothing to resolve or render yet — see `BeWidgetShape`.
-    body = (
-      <Box sx={{ display: "flex", alignItems: "flex-start", gap: 1.25 }}>
-        <Box
-          sx={{
-            p: 0.75,
-            mt: 0.25,
-            borderRadius: "50%",
-            bgcolor: alpha(theme.palette[config.iconColor].light, 0.1),
-            color: theme.palette[config.iconColor].light,
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            flexShrink: 0,
-          }}
-        >
-          <Icon size={16} />
-        </Box>
-        <Box sx={{ minWidth: 0, flex: 1 }}>
-          <Typography variant="caption" color="text.secondary">
-            {displayName}
-          </Typography>
-          <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
-            Not yet supported.
           </Typography>
         </Box>
       </Box>


### PR DESCRIPTION
## Summary
- `shape: "pie"`/`"bar"` dashboard widgets now render a real donut/bar chart — one wedge or bar per configured `slices` entry, each resolved via its own single search+`limit:1` (the same mechanism `shape: "count"` already uses) and clickable through to that slice's own filtered list.
- New optional widget fields, all `omitempty` on the wire (no effect on existing dashboards that don't set them):
  - `description` — subtitle text shown under the widget's title.
  - `slices` — the per-wedge/bar `label`/`color`/`filters`, shared by both `pie` and `bar`.
  - `section` — groups widgets sharing the same value under a titled sub-section within a dashboard (e.g. a handful of SLA-violation count widgets under their own "SLA Violation" heading), in the order that value first appears. No `section` set renders exactly as before this field existed.
- Empty (zero-total) pie/bar widgets show an inbox icon + "Nothing to show here right now" instead of an all-grey ring/bars.
- Fixed a couple of chart-rendering bugs found along the way: the `@wso2/oxygen-ui-charts-react` `PieChart` wrapper's own default margin (`{top:12,...,bottom:40}`, sized for a legend we don't show) was pushing the donut's visual center down, making its top edge look clipped under the tile's header — cleared to `{0,0,0,0}`. The default tooltip cursor highlight (a full-height box behind the hovered bar) is now disabled in favor of the bar's own hover border.

## Test plan
- [x] `go build`/`go vet`/`go test -race` — all pass
- [x] `gosec -fmt=text ./...` — 0 issues
- [x] Frontend `tsc -b` / `eslint` — clean
- [x] Frontend `vitest run` — 792/801 pass; the 9 failures are pre-existing and unrelated (confirmed via `git log -S` they predate this branch — 4 in `CaseActionBar.test.tsx` from a stale "Change state" dropdown test, 5 in `CsmAnnouncementsPage.test.tsx` from a pre-existing router-context issue)
- [ ] Manual smoke test of pie/bar widgets, titled sections, and the empty state in a browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added pie and bar chart widgets with configurable labels, colors, descriptions, and filters.
  - Chart slices display totals, percentages, tooltips, loading and error states, and empty states.
  - Clicking a chart slice or legend item opens the corresponding filtered results.
  - Added dashboard sections with shared headings and responsive widget grouping.
- **Bug Fixes**
  - Improved widget rendering and filtering for chart-based dashboard views.
- **Documentation**
  - Updated dashboard API documentation to describe chart configuration and slice-based data behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->