### PR TITLE
[Customer Portal Microapp] fix: enable momentum scrolling and remove tap delay

### DIFF
--- a/apps/customer-portal/microapp/src/index.css
+++ b/apps/customer-portal/microapp/src/index.css
@@ -34,6 +34,9 @@ body {
   overscroll-behavior: none;
   -ms-overflow-style: none;
   scrollbar-width: none;
+  -webkit-overflow-scrolling: touch;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
 }
 
 body::-webkit-scrollbar {


### PR DESCRIPTION
## Summary
- Root document scroll (`html`/`body`) was missing `-webkit-overflow-scrolling: touch`, the standard cause of stuttery/janky scrolling in iOS WKWebViews. The app's internal `overflow:auto` containers (project switcher, rich text, markdown tables) already had this from an earlier fix, but the main page scroll didn't.
- Added `touch-action: manipulation` and `-webkit-tap-highlight-color: transparent` so touch input registers immediately instead of waiting on double-tap-zoom gesture detection, and taps don't flash gray.

Ref: https://github.com/wso2-enterprise/digiops-cs/issues/2354

## Test plan
- [ ] Verify scroll feels smooth/no stutter on iOS Safari and an Android WebView
- [ ] Confirm no double-tap-zoom or tap-highlight regressions on buttons/cards
- [ ] Confirm existing internal scroll containers (project switcher, rich text, markdown tables) still scroll correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved touch scrolling and gesture behavior on mobile devices.
  * Removed tap-highlight effects for a smoother touch interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->