### PR TITLE
fix(customer-portal): show a friendly message for 503/504 backend errors

### DIFF
--- a/apps/customer-portal/webapp/src/hooks/__tests__/useAuthApiClient.test.ts
+++ b/apps/customer-portal/webapp/src/hooks/__tests__/useAuthApiClient.test.ts
@@ -107,4 +107,42 @@ describe("useAuthApiClient", () => {
     expect(getIdTokenMock).toHaveBeenCalledTimes(2);
     expect(globalThis.fetch).not.toHaveBeenCalled();
   });
+
+  it.each([503, 504])(
+    "replaces a raw gateway body/statusText with a friendly message for %d",
+    async (status) => {
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        new Response("upstream timeout", {
+          status,
+          statusText: "upstream timeout",
+        }),
+      ) as typeof fetch;
+
+      const { result } = renderHook(() => useAuthApiClient());
+      const response = await result.current("https://api.test/resource");
+
+      expect(response.status).toBe(status);
+      expect(response.statusText).toBe(
+        status === 503 ? "Service Unavailable" : "Gateway Timeout",
+      );
+      const body = await response.json();
+      expect(body.message).toMatch(/try again/i);
+    },
+  );
+
+  it("passes through other statuses unchanged", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ message: "not found" }), {
+        status: 404,
+        statusText: "Not Found",
+      }),
+    ) as typeof fetch;
+
+    const { result } = renderHook(() => useAuthApiClient());
+    const response = await result.current("https://api.test/resource");
+
+    expect(response.status).toBe(404);
+    const body = await response.json();
+    expect(body.message).toBe("not found");
+  });
 });

--- a/apps/customer-portal/webapp/src/hooks/__tests__/useAuthApiClient.test.ts
+++ b/apps/customer-portal/webapp/src/hooks/__tests__/useAuthApiClient.test.ts
@@ -126,23 +126,36 @@ describe("useAuthApiClient", () => {
         status === 503 ? "Service Unavailable" : "Gateway Timeout",
       );
       const body = await response.json();
-      expect(body.message).toMatch(/try again/i);
+      expect(body).toEqual({
+        message:
+          status === 503
+            ? "The service is temporarily unavailable. Please try again in a few moments."
+            : "The request timed out. Please try again in a few moments.",
+      });
+      expect(response.headers.get("Content-Type")).toBe("application/json");
     },
   );
 
-  it("passes through other statuses unchanged", async () => {
-    globalThis.fetch = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({ message: "not found" }), {
-        status: 404,
-        statusText: "Not Found",
-      }),
-    ) as typeof fetch;
+  it.each([
+    [404, "Not Found", "not found"],
+    [500, "Internal Server Error", "internal error"],
+  ] as const)(
+    "passes through other statuses unchanged: %d",
+    async (status, statusText, message) => {
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ message }), {
+          status,
+          statusText,
+        }),
+      ) as typeof fetch;
 
-    const { result } = renderHook(() => useAuthApiClient());
-    const response = await result.current("https://api.test/resource");
+      const { result } = renderHook(() => useAuthApiClient());
+      const response = await result.current("https://api.test/resource");
 
-    expect(response.status).toBe(404);
-    const body = await response.json();
-    expect(body.message).toBe("not found");
-  });
+      expect(response.status).toBe(status);
+      expect(response.statusText).toBe(statusText);
+      const body = await response.json();
+      expect(body.message).toBe(message);
+    },
+  );
 });

--- a/apps/customer-portal/webapp/src/hooks/useAuthApiClient.ts
+++ b/apps/customer-portal/webapp/src/hooks/useAuthApiClient.ts
@@ -32,6 +32,30 @@ const isTokenExpiredError = (error: unknown): boolean =>
   "code" in error &&
   (error as { code: string }).code === ASGARDEO_UNAUTHENTICATED_CODE;
 
+// 503/504 come from a gateway/proxy in front of the backend, not the backend
+// itself, so the body and statusText are often raw infra text (e.g. an HTML
+// error page, or a reason phrase like "upstream timeout") rather than
+// anything fit to show a user. Substitute a clean, consistent message here —
+// the one place every API call passes through — so every hook and display
+// site downstream shows the same friendly text regardless of how it extracts
+// its error message.
+const UNAVAILABLE_MESSAGES: Record<number, string> = {
+  503: "The service is temporarily unavailable. Please try again in a few moments.",
+  504: "The request timed out. Please try again in a few moments.",
+};
+
+const withFriendlyUnavailableMessage = (response: Response): Response => {
+  const message = UNAVAILABLE_MESSAGES[response.status];
+  if (!message) {
+    return response;
+  }
+  return new Response(JSON.stringify({ message }), {
+    status: response.status,
+    statusText: response.status === 503 ? "Service Unavailable" : "Gateway Timeout",
+    headers: { "Content-Type": "application/json" },
+  });
+};
+
 // A custom hook that automatically fetches a fresh ID Token from Asgardeo.
 export function useAuthApiClient() {
   const { getIdToken, signIn } = useAsgardeo();
@@ -83,10 +107,11 @@ export function useAuthApiClient() {
     if (!token) {
       throw new Error("Unable to retrieve ID token");
     }
-    return fetch(input, {
+    const response = await fetch(input, {
       ...options,
       headers: buildRequestHeaders(options, token),
     });
+    return withFriendlyUnavailableMessage(response);
   };
 
   // Redirect to a full sign-in, single-flighted so concurrent auth failures


### PR DESCRIPTION
## Summary
- 503 (Service Unavailable) and 504 (Gateway Timeout) responses usually come from a gateway/proxy in front of the backend, not the backend itself, so the body/statusText is often raw infra text (e.g. an HTML error page, or a reason phrase like "upstream timeout") that isn't fit to show a user.
- `authFetch` in `useAuthApiClient.ts` is the single choke point every API hook's request passes through, so it now substitutes a clean, consistent message for 503/504 responses before returning them — every hook and display site downstream (toast, `ApiErrorState`, etc.) shows the same friendly text regardless of how it extracts its error message.
- Other statuses (e.g. 500) are left untouched, since those are returned by the backend itself and typically carry a real, useful message.

## Test plan
- [x] Added unit tests in `useAuthApiClient.test.ts` covering: 503 substitution, 504 substitution, and pass-through of other statuses (404) unchanged — all passing.
- [x] Ran the existing `useAuthApiClient` test suite (8/8 passing).
- [x] Ran the full webapp test suite; confirmed the pre-existing failures (Router context / MUI test-setup issues) are unrelated and fail identically on `main` without this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of temporary gateway errors.
  * HTTP 503 and 504 responses now display clear retry guidance with consistent messaging.
  * Other error responses, such as 404, continue to pass through unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->