### PR TITLE
[CSM Portal] Lossless dashboard click-through, cases-list advanced filters, and case acknowledgement

### DIFF
--- a/apps/csm-portal/backend/internal/handler/cases.go
+++ b/apps/csm-portal/backend/internal/handler/cases.go
@@ -656,7 +656,11 @@ func (h *CaseHandler) SearchTags(w http.ResponseWriter, r *http.Request) {
 }
 
 // PatchCase handles PATCH /cases/{id}.
-// Accepts state, severity, workState, watchList, or assigneeEmail and forwards to the entity service.
+// Accepts state, severity, workState, watchList, assigneeEmail, or acknowledge and forwards
+// to the entity service. The body is forwarded verbatim, so fields with no local guard (like
+// acknowledge, whose first-write-wins semantics and role gate both live upstream) need no
+// handling here — only state and workState are pre-validated, because their guards depend on
+// the case's current state.
 func (h *CaseHandler) PatchCase(w http.ResponseWriter, r *http.Request) {
 	user := middleware.UserInfoFromContext(r.Context())
 	if user == nil {

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -5151,6 +5151,9 @@ components:
             - integrationCsTeam
             - resolutionNotes
             - parentId
+            - taskSLABusinessElapsedPercent
+            - escalationLevel
+            - escalation
         op:
           type: string
           enum: [eq, in, notIn, isEmpty, isNotEmpty, gte, lte]
@@ -5222,6 +5225,22 @@ components:
           is no distinct "resolution notes present" behavior to express.
         - **parentId** (eq): a single case UUID; matches child cases of that
           case (the hierarchical major-case/child-case relationship).
+        - **taskSLABusinessElapsedPercent** (gte / lte): a non-negative
+          integer. Matches cases with at least one Task SLA record whose
+          businessElapsedPercent falls within the given bound(s) (both bounds
+          may be supplied together to express a range, e.g. gte 75 + lte 100
+          for "at risk or breached"). Not capped at 100: a long-overdue,
+          never-resolved SLA's percentage keeps climbing well past it (values
+          in the tens of thousands are real, observed data), so 100 means
+          "breached", not "the maximum possible value". Only applied by the
+          ServiceNow data source (a Task SLA table join); filtering logic is
+          confined to the SN adapter.
+        - **escalationLevel** (in): one or more escalation level ids, "0"
+          (EL0, not escalated) through "5" (EL5, CEO). Matches cases whose
+          current escalation level is any of the given ids.
+        - **escalation** (isEmpty / isNotEmpty): values ignored; isEmpty
+          matches cases with no active escalation, isNotEmpty matches cases
+          with an active escalation.
 
     CaseSearchFilters:
       type: object

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -129,9 +129,9 @@ paths:
       summary: Update a support case.
       description: |
         Updates exactly one field of the case. Provide exactly one of: `state`, `severity`,
-        `workState`, `watchList`, `assigneeEmail`, `parentId`, `subject`, `description`,
-        `deploymentId`, `deployedProductId`, `relatedCaseId`, `autocloseHoldUntil`,
-        `bestCaseFixEta`, `mostLikelyFixEta`, or `worstCaseFixEta`.
+        `workState`, `watchList`, `assigneeEmail`, `parentId`, `acknowledge`, `subject`,
+        `description`, `deploymentId`, `deployedProductId`, `relatedCaseId`,
+        `autocloseHoldUntil`, `bestCaseFixEta`, `mostLikelyFixEta`, or `worstCaseFixEta`.
         `watchList`, `assigneeEmail`, `parentId`, and `autocloseHoldUntil` are supported only when
         the ServiceNow data source is active.
       operationId: patchCasesId
@@ -4714,9 +4714,9 @@ components:
       type: object
       description: |
         Exactly one of `state`, `severity`, `workState`, `watchList`, `assigneeEmail`, `parentId`,
-        `subject`, `description`, `deploymentId`, `deployedProductId`, `relatedCaseId`,
-        `autocloseHoldUntil`, `bestCaseFixEta`, `mostLikelyFixEta`, or `worstCaseFixEta`
-        must be provided. `watchList`, `assigneeEmail`, `parentId`, and `autocloseHoldUntil` are
+        `acknowledge`, `subject`, `description`, `deploymentId`, `deployedProductId`,
+        `relatedCaseId`, `autocloseHoldUntil`, `bestCaseFixEta`, `mostLikelyFixEta`, or
+        `worstCaseFixEta` must be provided. `watchList`, `assigneeEmail`, `parentId`, and `autocloseHoldUntil` are
         supported only for the ServiceNow data source.
         `resolutionCode`, `cause`, and `closeNotes` are optional resolution fields that may only be
         provided alongside `state: closed` or `state: solution_proposed`.
@@ -4727,6 +4727,7 @@ components:
         - required: [watchList]
         - required: [assigneeEmail]
         - required: [parentId]
+        - required: [acknowledge]
         - required: [subject]
         - required: [description]
         - required: [deploymentId]
@@ -4759,6 +4760,17 @@ components:
           type: string
           format: email
           description: Email of the engineer to assign to this case (ServiceNow only).
+        acknowledge:
+          type: boolean
+          enum: [true]
+          description: |
+            Acknowledge the case as the calling engineer: a first-write-wins claim that
+            someone has seen it and picked it up, which is distinct from assignment.
+            Succeeds without changing anything if the case is already acknowledged, in
+            which case the response carries `alreadyAcknowledged: true`. Only `true` is
+            accepted; there is no way to remove an acknowledgement. Requires an elevated
+            support role, and is supported only by data sources that record
+            acknowledgement.
         resolutionCode:
           $ref: '#/components/schemas/CaseResolutionCode'
           description: Resolution code — only allowed when state is closed or solution_proposed.
@@ -4879,6 +4891,22 @@ components:
           nullable: true
           allOf:
             - $ref: '#/components/schemas/UserReference'
+        number:
+          type: string
+          description: Human-readable case number. Returned only when the update acknowledged the case.
+        alreadyAcknowledged:
+          type: boolean
+          description: |
+            True when the case already had an acknowledger, so the request changed nothing
+            and `acknowledgedBy` names whoever claimed it first. Returned only when the
+            update set `acknowledge`.
+        acknowledgedBy:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/AssignedEngineerRef'
+          description: |
+            Engineer who now holds the acknowledgement, whether this request set it or
+            found it already set. Returned only when the update set `acknowledge`.
         resolutionCode:
           $ref: '#/components/schemas/CaseResolutionCode'
           nullable: true
@@ -5657,6 +5685,14 @@ components:
           nullable: true
           allOf:
             - $ref: '#/components/schemas/UserReference'
+        acknowledgedBy:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/AssignedEngineerRef'
+          description: |
+            Engineer who acknowledged the case, or null if nobody has. Cleared by the
+            backing data source when the case's type or severity changes or it is
+            reopened, so a materially changed case has to be acknowledged again.
         parentCase:
           $ref: '#/components/schemas/CaseNumberRef'
         relatedCase:

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -323,6 +323,14 @@ export interface BeCaseView {
   /** Canonical reference to the assigned engineer, `id` populated. See
    * {@link BeUserReference}. */
   assignedEngineerUser?: BeUserReference | null;
+  /**
+   * The CS engineer who acknowledged the case — a first-write-wins claim that
+   * someone has seen it and picked it up, which is **not** the same as being
+   * assigned to it. `null` until someone acknowledges. The backing data source
+   * clears it again when the case's type or severity changes or it is reopened,
+   * so a materially changed case has to be acknowledged afresh.
+   */
+  acknowledgedBy?: BeAssignedEngineerRef | null;
   account?: BeCaseAccountRef;
   project?: BeEntityRef;
   /** Nullable: ServiceNow-sourced cases may have no deployment / product. */
@@ -618,6 +626,7 @@ interface BeCaseUpdateNever {
   addPublicComment?: never;
   product?: never;
   publicTicket?: never;
+  acknowledge?: never;
 }
 
 /**
@@ -664,6 +673,14 @@ export type BeCaseUpdatePayload =
   | (Omit<BeCaseUpdateNever, "deployedProductId"> & { deployedProductId: string })
   /** UUID of another case to cross-link to this one as a related case (looser than `parentId`; ServiceNow only). */
   | (Omit<BeCaseUpdateNever, "relatedCaseId"> & { relatedCaseId: string })
+  /**
+   * Acknowledge the case as the signed-in engineer. Typed as the literal `true`
+   * because that is the only accepted value: acknowledgement is first-write-wins
+   * and there is no way to remove one. Acknowledging an already-acknowledged
+   * case succeeds and changes nothing, and the response then carries
+   * `alreadyAcknowledged: true` with whoever claimed it first.
+   */
+  | (Omit<BeCaseUpdateNever, "acknowledge"> & { acknowledge: true })
   /**
    * Places the case on hold in the backing data source's staged auto-closure
    * sequence until this ISO date-time (ServiceNow only). The raw
@@ -732,6 +749,16 @@ export interface BeUpdatedCase {
   mostLikelyFixEta?: string | null;
   /** Echoes the updated internal-only worst-case fix estimate. Present when the update set `worstCaseFixEta`. */
   worstCaseFixEta?: string | null;
+  /** Human-readable case number. Present when the update set `acknowledge`. */
+  number?: string;
+  /**
+   * True when the case already had an acknowledger, so the request changed
+   * nothing and `acknowledgedBy` names whoever claimed it first. Present when
+   * the update set `acknowledge`.
+   */
+  alreadyAcknowledged?: boolean;
+  /** Whoever now holds the acknowledgement. Present when the update set `acknowledge`. */
+  acknowledgedBy?: BeAssignedEngineerRef | null;
 }
 
 /** `PATCH /cases/{id}` response: a message plus the mutated case fields. */

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -772,7 +772,10 @@ export type BeCaseFieldFilterField =
   | "projectType"
   | "integrationCsTeam"
   | "resolutionNotes"
-  | "parentId";
+  | "parentId"
+  | "taskSLABusinessElapsedPercent"
+  | "escalationLevel"
+  | "escalation";
 
 /**
  * `op` enum accepted by {@link BeCaseFieldFilter}, independent of `field` —

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCaseDetail.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCaseDetail.ts
@@ -92,6 +92,14 @@ function detailFromBeCase(
     linkedChangeRequests: c.linkedChangeRequests ?? undefined,
     autoclosureStep: c.autoclosureStep ?? undefined,
     autoclosureStateTime: c.autoclosureStateTime ?? undefined,
+    acknowledgedBy: c.acknowledgedBy
+      ? {
+          // Fall back to the email when the data source returns a blank display
+          // name, so the UI never renders "Acknowledged by" with nothing after it.
+          name: c.acknowledgedBy.name?.trim() || (c.acknowledgedBy.email ?? "—"),
+          email: c.acknowledgedBy.email ?? undefined,
+        }
+      : undefined,
     assignee,
     assigneeName,
     assigneeEmail,

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.test.tsx
@@ -635,4 +635,20 @@ describe("acknowledge action", () => {
     renderBar({ severity: "S1", acknowledgedBy: undefined }, { isAcknowledging: true });
     expect(screen.getByRole("button", { name: /acknowledge/i })).toBeDisabled();
   });
+
+  it("also disables Acknowledge while a different lifecycle action's patchCase mutation is in flight", () => {
+    // Guards against the two actions sharing one mutation's isPending flag:
+    // a lifecycle transition (e.g. Assign to me) in flight must not leave
+    // Acknowledge clickable and racing it.
+    render(
+      <CaseActionBar
+        caseDetail={{ ...BASE_CASE, severity: "S1", acknowledgedBy: undefined }}
+        onAction={vi.fn()}
+        onAcknowledge={vi.fn()}
+        isAcknowledging={false}
+        isPending
+      />,
+    );
+    expect(screen.getByRole("button", { name: /acknowledge/i })).toBeDisabled();
+  });
 });

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.test.tsx
@@ -566,3 +566,73 @@ describe("CaseActionBar — Change severity is blocked on a closed case", () => 
     expect(onAction).toHaveBeenCalledWith({ secondary: "change_severity" });
   });
 });
+
+describe("acknowledge action", () => {
+  const renderBar = (
+    overrides: Partial<CsmCaseDetail>,
+    props: { onAcknowledge?: () => void; isAcknowledging?: boolean } = {},
+  ): void => {
+    render(
+      <CaseActionBar
+        caseDetail={{ ...BASE_CASE, ...overrides }}
+        onAction={vi.fn()}
+        onAcknowledge={props.onAcknowledge ?? vi.fn()}
+        isAcknowledging={props.isAcknowledging}
+      />,
+    );
+  };
+
+  it("offers acknowledge on an unacknowledged S0-S3 case", () => {
+    for (const severity of ["S0", "S1", "S2", "S3"] as const) {
+      const { unmount } = render(
+        <CaseActionBar
+          caseDetail={{ ...BASE_CASE, severity, acknowledgedBy: undefined }}
+          onAction={vi.fn()}
+          onAcknowledge={vi.fn()}
+        />,
+      );
+      expect(
+        screen.getByRole("button", { name: /acknowledge/i }),
+        `expected the acknowledge button on a ${severity} case`,
+      ).toBeInTheDocument();
+      unmount();
+    }
+  });
+
+  it("hides acknowledge on S4 — those cases raise no acknowledgement notification", () => {
+    renderBar({ severity: "S4", acknowledgedBy: undefined });
+    expect(screen.queryByRole("button", { name: /acknowledge/i })).not.toBeInTheDocument();
+  });
+
+  it("hides acknowledge once the case is acknowledged — it is first-write-wins, so there is nothing left to do", () => {
+    renderBar({ severity: "S1", acknowledgedBy: { name: "Jane Doe" } });
+    expect(screen.queryByRole("button", { name: /acknowledge/i })).not.toBeInTheDocument();
+  });
+
+  it("renders no acknowledge button when the caller wires no handler, rather than a dead control", () => {
+    render(
+      <CaseActionBar
+        caseDetail={{ ...BASE_CASE, severity: "S1", acknowledgedBy: undefined }}
+        onAction={vi.fn()}
+      />,
+    );
+    expect(screen.queryByRole("button", { name: /acknowledge/i })).not.toBeInTheDocument();
+  });
+
+  it("invokes the handler on click and disables the button while in flight", () => {
+    const onAcknowledge = vi.fn();
+    const { unmount } = render(
+      <CaseActionBar
+        caseDetail={{ ...BASE_CASE, severity: "S1", acknowledgedBy: undefined }}
+        onAction={vi.fn()}
+        onAcknowledge={onAcknowledge}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /acknowledge/i }));
+    expect(onAcknowledge).toHaveBeenCalledTimes(1);
+    unmount();
+
+    renderBar({ severity: "S1", acknowledgedBy: undefined }, { isAcknowledging: true });
+    expect(screen.getByRole("button", { name: /acknowledge/i })).toBeDisabled();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
@@ -477,7 +477,7 @@ export default function CaseActionBar({
               <Eye size={16} />
             )
           }
-          disabled={isAcknowledging}
+          disabled={isAcknowledging || isPending}
           onClick={() => void onAcknowledge()}
         >
           Acknowledge

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
@@ -30,6 +30,7 @@ import {
   ChevronDown,
   Clock,
   Copy,
+  Eye,
   Gauge,
   GitBranch,
   Inbox,
@@ -46,7 +47,7 @@ import type {
   CaseLifecycleAction,
   CsmCaseDetail,
 } from "@features/csm-cases/types/csmCases";
-import type { CaseState } from "@features/csm-dashboard/types/abtDashboard";
+import type { CaseState, Severity } from "@features/csm-dashboard/types/abtDashboard";
 import { stateLabel } from "@features/csm-dashboard/utils/abtDashboard";
 
 /**
@@ -387,6 +388,34 @@ interface CaseActionBarProps {
    * so a click has visible feedback even before the resulting toast/state
    * change lands. */
   isPending?: boolean;
+  /**
+   * Acknowledge the case as the signed-in engineer. When omitted, the
+   * acknowledge button is never rendered — so a caller that has no acknowledge
+   * mutation wired up cannot show a dead button.
+   */
+  onAcknowledge?: () => void | Promise<unknown>;
+  /** True while the acknowledge PATCH is in flight. */
+  isAcknowledging?: boolean;
+}
+
+/**
+ * Severities whose cases are worth acknowledging. S4 is excluded deliberately:
+ * it mirrors which cases the out-of-band acknowledgement notifications are
+ * raised for, so the button appears on exactly the cases an engineer could
+ * already have acknowledged from a notification, and on no others.
+ */
+const ACKNOWLEDGEABLE_SEVERITIES = new Set<Severity>(["S0", "S1", "S2", "S3"]);
+
+/**
+ * Whether the acknowledge action applies to this case: nobody has claimed it
+ * yet and it is severe enough to be worth claiming. Acknowledgement is
+ * first-write-wins, so once `acknowledgedBy` is set there is nothing left to
+ * do and the button disappears rather than turning into a no-op.
+ */
+function canAcknowledge(caseDetail: CsmCaseDetail): boolean {
+  return (
+    !caseDetail.acknowledgedBy && ACKNOWLEDGEABLE_SEVERITIES.has(caseDetail.severity)
+  );
 }
 
 /**
@@ -401,6 +430,8 @@ export default function CaseActionBar({
   onAction,
   closeBlockedReason,
   isPending = false,
+  onAcknowledge,
+  isAcknowledging = false,
 }: CaseActionBarProps): JSX.Element {
   const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
   const [stateMenuAnchor, setStateMenuAnchor] = useState<HTMLElement | null>(null);
@@ -431,6 +462,27 @@ export default function CaseActionBar({
         justifyContent: { xs: "flex-start", md: "flex-end" },
       }}
     >
+      {!!onAcknowledge && canAcknowledge(caseDetail) && (
+        // Sits to the left of the state control and stays outlined: claiming a
+        // case is a lighter act than moving it through its lifecycle, so it must
+        // not out-shout the primary transition.
+        <Button
+          size="small"
+          variant="outlined"
+          color="primary"
+          startIcon={
+            isAcknowledging ? (
+              <CircularProgress size={14} color="inherit" />
+            ) : (
+              <Eye size={16} />
+            )
+          }
+          disabled={isAcknowledging}
+          onClick={() => void onAcknowledge()}
+        >
+          Acknowledge
+        </Button>
+      )}
       {primary.length === 1 && (
         // A single reachable state needs no menu — show the transition
         // itself as one click rather than "Change state" → pick the only item.

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.test.tsx
@@ -30,6 +30,10 @@ vi.mock("@api/backend/client", () => ({
   useBackendApi: () => ({ post: postMock, get: vi.fn() }),
 }));
 
+vi.mock("@config/apiConfig", () => ({
+  apiConfig: { backendUrl: "https://example.test" },
+}));
+
 function renderBar(
   filters: CasesFilters,
   onChange = vi.fn(),
@@ -98,6 +102,23 @@ describe("CasesFilterBar — active-filter chips for URL-only fields", () => {
         createdOnGte: "2026-07-27",
       }),
     );
+  });
+
+  it("renders a date-only bound as the same local calendar date, not shifted by UTC parsing", () => {
+    renderBar({
+      ...DEFAULT_CASES_FILTERS,
+      createdOnGte: "2026-07-27",
+    });
+
+    // A bare YYYY-MM-DD bound must render as that same calendar date
+    // regardless of the runner's local timezone offset from UTC — pinning
+    // this to a fixed local Date (not `new Date("2026-07-27")`, which is
+    // parsed as UTC midnight and can roll back a day) is what makes this
+    // assertion timezone-safe.
+    const expected = new Date(2026, 6, 27).toLocaleDateString();
+    expect(
+      screen.getByText(`Created after ${expected}`),
+    ).toBeInTheDocument();
   });
 
   it("clearing one onboarding-status chip removes only that value, keeping siblings", () => {

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.test.tsx
@@ -61,12 +61,12 @@ describe("CasesFilterBar — active-filter chips for URL-only fields", () => {
     postMock.mockResolvedValue({ teams: [] });
   });
 
-  it("renders no chips when only bar-controlled fields (or nothing) are active", () => {
-    renderBar({ ...DEFAULT_CASES_FILTERS, csTeams: ["g1"], tags: ["micro-gw"] });
-    // No stray "×"-labeled chip content beyond what the bar's own controls
-    // (team select, tags input) already render.
+  it("renders no chips when nothing is active", () => {
+    renderBar({ ...DEFAULT_CASES_FILTERS });
     expect(screen.queryByText(/SLA/)).not.toBeInTheDocument();
     expect(screen.queryByText(/Escalat/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/CS team:/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/^Tag:/)).not.toBeInTheDocument();
   });
 
   it("renders one chip per URL-only filter and each is independently removable", () => {
@@ -138,59 +138,43 @@ describe("CasesFilterBar — active-filter chips for URL-only fields", () => {
   });
 });
 
-describe("CasesFilterBar — tag include/exclude control", () => {
-  beforeEach(() => {
-    postMock.mockReset();
-    postMock.mockResolvedValue({ teams: [] });
-  });
 
-  it("typing into 'Tags' sets `tags`, typing into 'Exclude tags' sets `excludeTags` — never conflated", () => {
-    const { onChange } = renderBar(DEFAULT_CASES_FILTERS);
-
-    const tagsInput = screen.getByLabelText("Tags");
-    fireEvent.change(tagsInput, { target: { value: "micro-gw" } });
-    fireEvent.keyDown(tagsInput, { key: "Enter" });
-
-    expect(onChange).toHaveBeenCalledWith(
-      expect.objectContaining({ tags: ["micro-gw"], excludeTags: [] }),
-    );
-
-    onChange.mockClear();
-    const excludeInput = screen.getByLabelText("Exclude tags");
-    fireEvent.change(excludeInput, { target: { value: "s_dip" } });
-    fireEvent.keyDown(excludeInput, { key: "Enter" });
-
-    expect(onChange).toHaveBeenCalledWith(
-      expect.objectContaining({ excludeTags: ["s_dip"] }),
-    );
-  });
-
-  it("both tags and excludeTags can be set at once (independent, not mutually exclusive)", () => {
-    renderBar({ ...DEFAULT_CASES_FILTERS, tags: ["micro-gw"], excludeTags: ["s_dip"] });
-    expect(screen.getByLabelText("Tags").closest("form, div")).toBeInTheDocument();
-    expect(screen.getByText("micro-gw")).toBeInTheDocument();
-    expect(screen.getByText("s_dip")).toBeInTheDocument();
-  });
-});
-
-describe("CasesFilterBar — CS team control", () => {
+describe("CasesFilterBar — removed bar controls fall back to chips", () => {
   beforeEach(() => {
     postMock.mockReset();
   });
 
-  it("shows team display names, not group-id UUIDs, and filters by groupId on selection", async () => {
-    postMock.mockResolvedValue({
-      teams: [
-        { id: "alpha", name: "Team Alpha", groupId: "22222222-2222-2222-2222-222222222222" },
-        { id: "beta", name: "Team Beta", groupId: "33333333-3333-3333-3333-333333333333" },
-      ],
+
+  /**
+   * The CS-team and tag bar controls were removed as clutter, so a chip is now
+   * the ONLY way these filters are visible or clearable after a dashboard
+   * click-through. If these break, a user lands on a filtered list with no way
+   * to see or undo why.
+   */
+  it("renders chips for csTeams/tags/excludeTags now that their bar controls are gone", () => {
+    const { onChange } = renderBar({
+      ...DEFAULT_CASES_FILTERS,
+      csTeams: ["g1"],
+      tags: ["micro-gw"],
+      excludeTags: ["s_dip"],
     });
 
-    renderBar(DEFAULT_CASES_FILTERS);
+    expect(screen.getByText("Tag: micro-gw")).toBeInTheDocument();
+    expect(screen.getByText("Excluding tag: s_dip")).toBeInTheDocument();
+    // Team name is unresolved here (no teams fetched), so it falls back to the
+    // id rather than hiding the chip.
+    expect(screen.getByText(/CS team: /)).toBeInTheDocument();
 
-    fireEvent.mouseDown(screen.getByLabelText("CS team"));
-    const option = await screen.findByRole("option", { name: "Team Alpha" });
-    expect(option).toBeInTheDocument();
-    expect(screen.queryByText("22222222-2222-2222-2222-222222222222")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByText("Excluding tag: s_dip").closest(".MuiChip-root")!.querySelector("svg")!);
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ excludeTags: [], tags: ["micro-gw"], csTeams: ["g1"] }),
+    );
+  });
+
+  it("no longer renders the removed CS team / Tags / Exclude tags bar controls", () => {
+    renderBar({ ...DEFAULT_CASES_FILTERS });
+    expect(screen.queryByLabelText(/^CS team$/)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/^Tags$/)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/^Exclude tags$/)).not.toBeInTheDocument();
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.test.tsx
@@ -1,0 +1,196 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import type { ReactNode } from "react";
+import CasesFilterBar, {
+  type CasesFilters,
+} from "@features/csm-cases/components/CasesFilterBar";
+import { DEFAULT_CASES_FILTERS } from "@features/csm-cases/utils/casesFiltersUrl";
+
+const postMock = vi.fn();
+
+vi.mock("@api/backend/client", () => ({
+  useBackendApi: () => ({ post: postMock, get: vi.fn() }),
+}));
+
+function renderBar(
+  filters: CasesFilters,
+  onChange = vi.fn(),
+  extraProps: Partial<Parameters<typeof CasesFilterBar>[0]> = {},
+): { onChange: ReturnType<typeof vi.fn> } {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  render(
+    <QueryClientProvider client={queryClient}>
+      <CasesFilterBar
+        filters={filters}
+        onChange={onChange}
+        onReset={() => {}}
+        isFiltersOpen
+        onFiltersToggle={() => {}}
+        availableAssigneeUsers={[]}
+        availableProjects={[]}
+        {...extraProps}
+      />
+    </QueryClientProvider> as ReactNode,
+  );
+  return { onChange };
+}
+
+describe("CasesFilterBar — active-filter chips for URL-only fields", () => {
+  beforeEach(() => {
+    postMock.mockReset();
+    postMock.mockResolvedValue({ teams: [] });
+  });
+
+  it("renders no chips when only bar-controlled fields (or nothing) are active", () => {
+    renderBar({ ...DEFAULT_CASES_FILTERS, csTeams: ["g1"], tags: ["micro-gw"] });
+    // No stray "×"-labeled chip content beyond what the bar's own controls
+    // (team select, tags input) already render.
+    expect(screen.queryByText(/SLA/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Escalat/)).not.toBeInTheDocument();
+  });
+
+  it("renders one chip per URL-only filter and each is independently removable", () => {
+    const { onChange } = renderBar({
+      ...DEFAULT_CASES_FILTERS,
+      slaElapsedPctGte: 80,
+      hasEscalation: true,
+      onboardingStatuses: ["in_progress"],
+      createdOnGte: "2026-07-27",
+    });
+
+    expect(screen.getByText("SLA ≥ 80%")).toBeInTheDocument();
+    expect(screen.getByText("Escalated")).toBeInTheDocument();
+    expect(screen.getByText("Onboarding: In progress")).toBeInTheDocument();
+    expect(screen.getByText(/Created after/)).toBeInTheDocument();
+
+    // Removing the SLA chip clears only slaElapsedPctGte, nothing else.
+    const slaChip = screen.getByText("SLA ≥ 80%");
+    const deleteIcon = slaChip.parentElement?.querySelector(
+      '[data-testid="CancelIcon"], svg',
+    );
+    fireEvent.click(deleteIcon ?? slaChip);
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        slaElapsedPctGte: null,
+        hasEscalation: true,
+        onboardingStatuses: ["in_progress"],
+        createdOnGte: "2026-07-27",
+      }),
+    );
+  });
+
+  it("clearing one onboarding-status chip removes only that value, keeping siblings", () => {
+    const { onChange } = renderBar({
+      ...DEFAULT_CASES_FILTERS,
+      onboardingStatuses: ["in_progress", "OnHold"],
+    });
+
+    expect(screen.getByText("Onboarding: In progress")).toBeInTheDocument();
+    expect(screen.getByText("Onboarding: On hold")).toBeInTheDocument();
+
+    const chip = screen.getByText("Onboarding: In progress");
+    const deleteIcon = chip.parentElement?.querySelector("svg");
+    fireEvent.click(deleteIcon ?? chip);
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ onboardingStatuses: ["OnHold"] }),
+    );
+  });
+
+  it("both SLA bounds render and clear independently", () => {
+    const { onChange } = renderBar({
+      ...DEFAULT_CASES_FILTERS,
+      slaElapsedPctGte: 80,
+      slaElapsedPctLte: 100,
+    });
+
+    expect(screen.getByText("SLA ≥ 80%")).toBeInTheDocument();
+    expect(screen.getByText("SLA ≤ 100%")).toBeInTheDocument();
+
+    const chip = screen.getByText("SLA ≤ 100%");
+    const deleteIcon = chip.parentElement?.querySelector("svg");
+    fireEvent.click(deleteIcon ?? chip);
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ slaElapsedPctGte: 80, slaElapsedPctLte: null }),
+    );
+  });
+});
+
+describe("CasesFilterBar — tag include/exclude control", () => {
+  beforeEach(() => {
+    postMock.mockReset();
+    postMock.mockResolvedValue({ teams: [] });
+  });
+
+  it("typing into 'Tags' sets `tags`, typing into 'Exclude tags' sets `excludeTags` — never conflated", () => {
+    const { onChange } = renderBar(DEFAULT_CASES_FILTERS);
+
+    const tagsInput = screen.getByLabelText("Tags");
+    fireEvent.change(tagsInput, { target: { value: "micro-gw" } });
+    fireEvent.keyDown(tagsInput, { key: "Enter" });
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ tags: ["micro-gw"], excludeTags: [] }),
+    );
+
+    onChange.mockClear();
+    const excludeInput = screen.getByLabelText("Exclude tags");
+    fireEvent.change(excludeInput, { target: { value: "s_dip" } });
+    fireEvent.keyDown(excludeInput, { key: "Enter" });
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ excludeTags: ["s_dip"] }),
+    );
+  });
+
+  it("both tags and excludeTags can be set at once (independent, not mutually exclusive)", () => {
+    renderBar({ ...DEFAULT_CASES_FILTERS, tags: ["micro-gw"], excludeTags: ["s_dip"] });
+    expect(screen.getByLabelText("Tags").closest("form, div")).toBeInTheDocument();
+    expect(screen.getByText("micro-gw")).toBeInTheDocument();
+    expect(screen.getByText("s_dip")).toBeInTheDocument();
+  });
+});
+
+describe("CasesFilterBar — CS team control", () => {
+  beforeEach(() => {
+    postMock.mockReset();
+  });
+
+  it("shows team display names, not group-id UUIDs, and filters by groupId on selection", async () => {
+    postMock.mockResolvedValue({
+      teams: [
+        { id: "alpha", name: "Team Alpha", groupId: "22222222-2222-2222-2222-222222222222" },
+        { id: "beta", name: "Team Beta", groupId: "33333333-3333-3333-3333-333333333333" },
+      ],
+    });
+
+    renderBar(DEFAULT_CASES_FILTERS);
+
+    fireEvent.mouseDown(screen.getByLabelText("CS team"));
+    const option = await screen.findByRole("option", { name: "Team Alpha" });
+    expect(option).toBeInTheDocument();
+    expect(screen.queryByText("22222222-2222-2222-2222-222222222222")).not.toBeInTheDocument();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
@@ -223,7 +223,11 @@ function humanizeToken(raw: string): string {
  * locale date when parseable, the raw string otherwise (never throws on a
  * malformed value; this is a display fallback, not validation). */
 function formatDateBound(raw: string): string {
-  const d = new Date(raw);
+  // A bare `YYYY-MM-DD` is parsed as UTC midnight by `Date`, which renders as
+  // the previous day for any locale behind UTC — pin it to local midnight.
+  const d = /^\d{4}-\d{2}-\d{2}$/.test(raw)
+    ? new Date(`${raw}T00:00:00`)
+    : new Date(raw);
   return Number.isNaN(d.getTime()) ? raw : d.toLocaleDateString();
 }
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
@@ -17,6 +17,7 @@
 import {
   Box,
   Button,
+  Chip,
   Dialog,
   DialogActions,
   DialogContent,
@@ -75,12 +76,8 @@ import AsyncProjectMultiSelect from "@features/csm-cases/components/AsyncProject
 import MultiSelectField from "@components/MultiSelectField";
 import AsyncAssigneeMultiSelect from "@features/csm-cases/components/AsyncAssigneeMultiSelect";
 import ProductNameMultiSelect from "@features/csm-cases/components/ProductNameMultiSelect";
-// TagsMultiSelect (case-list tag filter) is deliberately not wired in here
-// yet even though `CasesFilters.tags`/`excludeTags` are real fields again
-// (reinstated in the type/URL codec/search payload so dashboard tag-filter
-// widgets click through losslessly — see casesFiltersUrl.ts) — only the
-// filter-bar *control* is still pending. The component itself stays in
-// place and is unaffected by this.
+import TagsMultiSelect from "@features/csm-cases/components/TagsMultiSelect";
+import { useTeams } from "@features/csm-dashboard/api/useTeams";
 
 
 /**
@@ -209,6 +206,137 @@ const PRIMARY_STATES: CaseState[] = [
   "closed",
 ];
 
+/**
+ * Turns a raw backend token (`snake_case`, `PascalCase`, or a mix — the
+ * onboarding-status/escalation-level vocabularies aren't normalized to one
+ * casing) into a readable label: `"in_progress"` / `"OnHold"` both become
+ * `"In progress"` / `"On hold"`. Falls back to the raw token unchanged when
+ * it's empty.
+ */
+function humanizeToken(raw: string): string {
+  if (!raw) return raw;
+  const spaced = raw.replace(/_/g, " ").replace(/([a-z0-9])([A-Z])/g, "$1 $2");
+  const lower = spaced.toLowerCase();
+  return lower.charAt(0).toUpperCase() + lower.slice(1);
+}
+
+/** Formats a `createdOn`/`updatedOn`/`closedOn` bound for a chip label — a
+ * locale date when parseable, the raw string otherwise (never throws on a
+ * malformed value; this is a display fallback, not validation). */
+function formatDateBound(raw: string): string {
+  const d = new Date(raw);
+  return Number.isNaN(d.getTime()) ? raw : d.toLocaleDateString();
+}
+
+/** One removable "active filter" chip. */
+interface ActiveFilterChip {
+  key: string;
+  label: string;
+  onRemove: (filters: CasesFilters) => CasesFilters;
+}
+
+/**
+ * Fields extended onto `CasesFilters` for lossless dashboard click-through
+ * (onboarding status, SLA %, escalation, project type, the three date
+ * ranges) get no dedicated bar control of their own — ten new fields would
+ * overwhelm the bar, and most of them only ever get set by a widget
+ * click-through, not hand-picked in the bar. They must still be visible and
+ * individually removable, though, or a user landing on a dashboard-filtered
+ * cases list has no way to see (or undo) *why* it's filtered — hence one
+ * chip per active value here, shown regardless of whether the filter grid
+ * itself is expanded. `csTeams`/`tags`/`excludeTags` are deliberately
+ * excluded: they have real bar controls (below) that already show their own
+ * selection.
+ */
+function buildActiveFilterChips(filters: CasesFilters): ActiveFilterChip[] {
+  const chips: ActiveFilterChip[] = [];
+
+  filters.onboardingStatuses.forEach((status) => {
+    chips.push({
+      key: `onboarding-${status}`,
+      label: `Onboarding: ${humanizeToken(status)}`,
+      onRemove: (f) => ({
+        ...f,
+        onboardingStatuses: f.onboardingStatuses.filter((s) => s !== status),
+      }),
+    });
+  });
+
+  if (filters.slaElapsedPctGte !== null) {
+    chips.push({
+      key: "sla-gte",
+      label: `SLA ≥ ${filters.slaElapsedPctGte}%`,
+      onRemove: (f) => ({ ...f, slaElapsedPctGte: null }),
+    });
+  }
+  if (filters.slaElapsedPctLte !== null) {
+    chips.push({
+      key: "sla-lte",
+      label: `SLA ≤ ${filters.slaElapsedPctLte}%`,
+      onRemove: (f) => ({ ...f, slaElapsedPctLte: null }),
+    });
+  }
+
+  if (filters.hasEscalation !== null) {
+    chips.push({
+      key: "escalation",
+      label: filters.hasEscalation ? "Escalated" : "No escalation",
+      onRemove: (f) => ({ ...f, hasEscalation: null }),
+    });
+  }
+
+  filters.escalationLevels.forEach((level) => {
+    chips.push({
+      key: `escalation-level-${level}`,
+      label: `Escalation level: ${level}`,
+      onRemove: (f) => ({
+        ...f,
+        escalationLevels: f.escalationLevels.filter((l) => l !== level),
+      }),
+    });
+  });
+
+  filters.projectTypes.forEach((projectType) => {
+    chips.push({
+      key: `project-type-${projectType}`,
+      // No project-type name lookup exists in the frontend yet (the backend
+      // filter is keyed by an opaque id, not a slug) — shows the raw id
+      // rather than guessing at a label.
+      label: `Project type: ${projectType}`,
+      onRemove: (f) => ({
+        ...f,
+        projectTypes: f.projectTypes.filter((t) => t !== projectType),
+      }),
+    });
+  });
+
+  const dateRanges: [string, keyof CasesFilters, keyof CasesFilters][] = [
+    ["Created", "createdOnGte", "createdOnLte"],
+    ["Updated", "updatedOnGte", "updatedOnLte"],
+    ["Closed", "closedOnGte", "closedOnLte"],
+  ];
+  for (const [labelPrefix, gteKey, lteKey] of dateRanges) {
+    const gte = filters[gteKey] as string | null;
+    if (gte !== null) {
+      chips.push({
+        key: `${gteKey}`,
+        label: `${labelPrefix} after ${formatDateBound(gte)}`,
+        onRemove: (f) => ({ ...f, [gteKey]: null }),
+      });
+    }
+    const lte = filters[lteKey] as string | null;
+    if (lte !== null) {
+      chips.push({
+        key: `${lteKey}`,
+        label: `${labelPrefix} before ${formatDateBound(lte)}`,
+        onRemove: (f) => ({ ...f, [lteKey]: null }),
+      });
+    }
+  }
+
+  return chips;
+}
+
 export default function CasesFilterBar({
   filters,
   onChange,
@@ -224,6 +352,23 @@ export default function CasesFilterBar({
 }: CasesFilterBarProps): JSX.Element {
   const activeCount = countActiveFilters(filters);
   const hasActive = activeCount > 0;
+
+  // CS team is a fixed, small enough list to fetch in full (same endpoint/
+  // hook the team-based dashboards use — see AbtDashboardHeader) rather than
+  // a type-to-search async picker; `groupId` (not the registry `id`) is what
+  // `integrationCsTeam` filters on, and only teams with one configured are
+  // selectable here (an id-less team has nothing an `integrationCsTeam`
+  // filter entry could hold).
+  const { data: teams } = useTeams(true);
+  const teamOptions = useMemo(
+    () =>
+      (teams ?? [])
+        .filter((t): t is typeof t & { groupId: string } => Boolean(t.groupId))
+        .map((t) => ({ value: t.groupId, label: t.name })),
+    [teams],
+  );
+
+  const activeFilterChips = useMemo(() => buildActiveFilterChips(filters), [filters]);
 
   // ── Saved views ──────────────────────────────────────────────────────────
   // A saved view is just a name pointing at a serialized filter query string;
@@ -430,6 +575,23 @@ export default function CasesFilterBar({
         </Button>
       </Box>
 
+      {/* Fields with no bar control of their own (see `buildActiveFilterChips`'s
+          doc comment) — shown regardless of `isFiltersOpen` so a
+          dashboard-filtered arrival is self-explanatory even with the filter
+          grid collapsed, and each is individually removable right here. */}
+      {activeFilterChips.length > 0 && (
+        <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
+          {activeFilterChips.map((chip) => (
+            <Chip
+              key={chip.key}
+              size="small"
+              label={chip.label}
+              onDelete={() => onChange(chip.onRemove(filters))}
+            />
+          ))}
+        </Box>
+      )}
+
       <Dialog
         open={saveDialogOpen}
         onClose={() => setSaveDialogOpen(false)}
@@ -580,8 +742,46 @@ export default function CasesFilterBar({
                 onChange={(next) => onChange({ ...filters, productNames: next })}
               />
             </Grid>
-            {/* Tag filter deliberately omitted for now — see the removal note
-                in casesFiltersUrl.ts. `TagsMultiSelect` itself is untouched. */}
+            <Grid size={{ xs: 12, sm: 6, md: 4, lg: 2 }}>
+              {/* CS team the case's project is scoped to (`integrationCsTeam`)
+                  — one of the two broadly-useful new fields that get a real
+                  bar control (see `buildActiveFilterChips`'s doc comment for
+                  why the rest don't). Options are `groupId`s (what the filter
+                  actually matches on); labels are team display names, never
+                  the raw group-id UUID. */}
+              <MultiSelectField
+                id="cases-filter-cs-team"
+                label="CS team"
+                values={filters.csTeams}
+                options={teamOptions}
+                onChange={(next) => onChange({ ...filters, csTeams: next })}
+              />
+            </Grid>
+            <Grid size={{ xs: 12, sm: 6, md: 4, lg: 2 }}>
+              {/* Tags the case MUST carry. Two separate controls (this one
+                  plus "Exclude tags" below), not one control with an
+                  include/exclude toggle: `tags` and `excludeTags` are
+                  independent and both may be set at once (the backend ANDs
+                  them, see `CasesFilters.excludeTags`'s doc comment) — a
+                  single toggle would force picking one mode at a time and
+                  couldn't represent "has tag A, but not tag B" in one control.
+                  Reuses `TagsMultiSelect` unchanged (still the case-detail
+                  "Add tag" picker's own freeSolo input). */}
+              <TagsMultiSelect
+                id="cases-filter-tags"
+                label="Tags"
+                values={filters.tags}
+                onChange={(next) => onChange({ ...filters, tags: next })}
+              />
+            </Grid>
+            <Grid size={{ xs: 12, sm: 6, md: 4, lg: 2 }}>
+              <TagsMultiSelect
+                id="cases-filter-exclude-tags"
+                label="Exclude tags"
+                values={filters.excludeTags}
+                onChange={(next) => onChange({ ...filters, excludeTags: next })}
+              />
+            </Grid>
           </Grid>
           {activeCount > 0 && (
             <Box sx={{ display: "flex", justifyContent: "flex-end" }}>

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
@@ -75,10 +75,12 @@ import AsyncProjectMultiSelect from "@features/csm-cases/components/AsyncProject
 import MultiSelectField from "@components/MultiSelectField";
 import AsyncAssigneeMultiSelect from "@features/csm-cases/components/AsyncAssigneeMultiSelect";
 import ProductNameMultiSelect from "@features/csm-cases/components/ProductNameMultiSelect";
-// TagsMultiSelect (case-list tag filter) is deliberately not wired in here for
-// now — see the removal note on `CasesFilters.tags` in casesFiltersUrl.ts.
-// The component itself stays in place; it may come back once tag filtering
-// is revisited.
+// TagsMultiSelect (case-list tag filter) is deliberately not wired in here
+// yet even though `CasesFilters.tags`/`excludeTags` are real fields again
+// (reinstated in the type/URL codec/search payload so dashboard tag-filter
+// widgets click through losslessly — see casesFiltersUrl.ts) — only the
+// filter-bar *control* is still pending. The component itself stays in
+// place and is unaffected by this.
 
 
 /**
@@ -104,6 +106,42 @@ export interface CasesFilters {
   engagementTypes: BeEngagementType[];
   /** Product family names (e.g. "API Manager"); matches all versions of each. */
   productNames: string[];
+  /** CS team group ids (`integrationCsTeam` op:in) the case's project is scoped to. */
+  csTeams: string[];
+  /** Tags the case must carry (`tag` op:in). Independent of `excludeTags` —
+   * both may be set at once (the backend ANDs them). */
+  tags: string[];
+  /** Tags the case must NOT carry (`tag` op:notIn). Not the inverse of
+   * `tags` — a distinct field so `in` and `notIn` can never be conflated on
+   * the round trip (see `casesFiltersUrl.ts`'s codec doc comment). */
+  excludeTags: string[];
+  /** Project onboarding status values (`projectOnboardingStatus` op:in). */
+  onboardingStatuses: string[];
+  /** Inclusive lower bound on the case's active task's SLA business-elapsed
+   * percent (`taskSLABusinessElapsedPercent` op:gte). `null` = unset. */
+  slaElapsedPctGte: number | null;
+  /** Inclusive upper bound, same field, op:lte. `null` = unset. */
+  slaElapsedPctLte: number | null;
+  /** Escalation presence (`escalation` field): `true` = has an active
+   * escalation (op:isNotEmpty), `false` = has none (op:isEmpty), `null` =
+   * unfiltered. Deliberately not string-typed on the ops themselves — the
+   * value-less op IS the whole predicate here, so a tri-state is the
+   * accurate shape rather than an op name a caller could typo. */
+  hasEscalation: boolean | null;
+  /** Escalation level values (`escalationLevel` op:in). */
+  escalationLevels: string[];
+  /** Project-type ids (`projectType` op:in). */
+  projectTypes: string[];
+  /** `createdOn` range bounds (op:gte / op:lte respectively); RFC3339 or
+   * `YYYY-MM-DD`. `null` = unbounded on that side. */
+  createdOnGte: string | null;
+  createdOnLte: string | null;
+  /** `updatedOn` range bounds — same shape as `createdOnGte`/`createdOnLte`. */
+  updatedOnGte: string | null;
+  updatedOnLte: string | null;
+  /** `closedOn` range bounds — same shape as `createdOnGte`/`createdOnLte`. */
+  closedOnGte: string | null;
+  closedOnLte: string | null;
 }
 
 /**

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
@@ -57,6 +57,7 @@ import {
   readCasesFiltersFromUrl,
   writeCasesFiltersToUrl,
 } from "@features/csm-cases/utils/casesFiltersUrl";
+import { useTeams } from "@features/csm-dashboard/api/useTeams";
 import {
   deleteFilterView,
   saveFilterView,
@@ -76,8 +77,6 @@ import AsyncProjectMultiSelect from "@features/csm-cases/components/AsyncProject
 import MultiSelectField from "@components/MultiSelectField";
 import AsyncAssigneeMultiSelect from "@features/csm-cases/components/AsyncAssigneeMultiSelect";
 import ProductNameMultiSelect from "@features/csm-cases/components/ProductNameMultiSelect";
-import TagsMultiSelect from "@features/csm-cases/components/TagsMultiSelect";
-import { useTeams } from "@features/csm-dashboard/api/useTeams";
 
 
 /**
@@ -244,12 +243,45 @@ interface ActiveFilterChip {
  * individually removable, though, or a user landing on a dashboard-filtered
  * cases list has no way to see (or undo) *why* it's filtered — hence one
  * chip per active value here, shown regardless of whether the filter grid
- * itself is expanded. `csTeams`/`tags`/`excludeTags` are deliberately
- * excluded: they have real bar controls (below) that already show their own
- * selection.
+ * itself is expanded. `csTeams`/`tags`/`excludeTags` are included here too:
+ * their bar controls were removed as clutter (they are advanced, rarely
+ * hand-picked, and a better home for advanced filters is still to be
+ * designed), so a chip is now the ONLY way a user can see or clear them
+ * after arriving from a dashboard click-through.
  */
-function buildActiveFilterChips(filters: CasesFilters): ActiveFilterChip[] {
+function buildActiveFilterChips(
+  filters: CasesFilters,
+  /** groupId -> team display name, so a team chip never shows a raw UUID.
+   * Falls back to the id when the lookup has not resolved (or the team is
+   * unknown) rather than hiding the chip — an unlabelled filter the user can
+   * still see and remove beats an invisible one. */
+  teamLabels: Record<string, string> = {},
+): ActiveFilterChip[] {
   const chips: ActiveFilterChip[] = [];
+
+  filters.csTeams.forEach((groupId) => {
+    chips.push({
+      key: `csTeam-${groupId}`,
+      label: `CS team: ${teamLabels[groupId] ?? groupId}`,
+      onRemove: (f) => ({ ...f, csTeams: f.csTeams.filter((t) => t !== groupId) }),
+    });
+  });
+
+  filters.tags.forEach((tag) => {
+    chips.push({
+      key: `tag-${tag}`,
+      label: `Tag: ${tag}`,
+      onRemove: (f) => ({ ...f, tags: f.tags.filter((t) => t !== tag) }),
+    });
+  });
+
+  filters.excludeTags.forEach((tag) => {
+    chips.push({
+      key: `excludeTag-${tag}`,
+      label: `Excluding tag: ${tag}`,
+      onRemove: (f) => ({ ...f, excludeTags: f.excludeTags.filter((t) => t !== tag) }),
+    });
+  });
 
   filters.onboardingStatuses.forEach((status) => {
     chips.push({
@@ -353,22 +385,24 @@ export default function CasesFilterBar({
   const activeCount = countActiveFilters(filters);
   const hasActive = activeCount > 0;
 
-  // CS team is a fixed, small enough list to fetch in full (same endpoint/
-  // hook the team-based dashboards use — see AbtDashboardHeader) rather than
-  // a type-to-search async picker; `groupId` (not the registry `id`) is what
-  // `integrationCsTeam` filters on, and only teams with one configured are
-  // selectable here (an id-less team has nothing an `integrationCsTeam`
-  // filter entry could hold).
-  const { data: teams } = useTeams(true);
-  const teamOptions = useMemo(
+  // Only fetch the team registry when a CS-team filter is actually set -- it
+  // exists solely to label that chip, and the cases page should not pay for it
+  // on every load now that the team bar control is gone.
+  const { data: teams } = useTeams(filters.csTeams.length > 0);
+  const teamLabels = useMemo(
     () =>
-      (teams ?? [])
-        .filter((t): t is typeof t & { groupId: string } => Boolean(t.groupId))
-        .map((t) => ({ value: t.groupId, label: t.name })),
+      Object.fromEntries(
+        (teams ?? [])
+          .filter((t): t is typeof t & { groupId: string } => Boolean(t.groupId))
+          .map((t) => [t.groupId, t.name]),
+      ),
     [teams],
   );
 
-  const activeFilterChips = useMemo(() => buildActiveFilterChips(filters), [filters]);
+  const activeFilterChips = useMemo(
+    () => buildActiveFilterChips(filters, teamLabels),
+    [filters, teamLabels],
+  );
 
   // ── Saved views ──────────────────────────────────────────────────────────
   // A saved view is just a name pointing at a serialized filter query string;
@@ -740,46 +774,6 @@ export default function CasesFilterBar({
               <ProductNameMultiSelect
                 values={filters.productNames}
                 onChange={(next) => onChange({ ...filters, productNames: next })}
-              />
-            </Grid>
-            <Grid size={{ xs: 12, sm: 6, md: 4, lg: 2 }}>
-              {/* CS team the case's project is scoped to (`integrationCsTeam`)
-                  — one of the two broadly-useful new fields that get a real
-                  bar control (see `buildActiveFilterChips`'s doc comment for
-                  why the rest don't). Options are `groupId`s (what the filter
-                  actually matches on); labels are team display names, never
-                  the raw group-id UUID. */}
-              <MultiSelectField
-                id="cases-filter-cs-team"
-                label="CS team"
-                values={filters.csTeams}
-                options={teamOptions}
-                onChange={(next) => onChange({ ...filters, csTeams: next })}
-              />
-            </Grid>
-            <Grid size={{ xs: 12, sm: 6, md: 4, lg: 2 }}>
-              {/* Tags the case MUST carry. Two separate controls (this one
-                  plus "Exclude tags" below), not one control with an
-                  include/exclude toggle: `tags` and `excludeTags` are
-                  independent and both may be set at once (the backend ANDs
-                  them, see `CasesFilters.excludeTags`'s doc comment) — a
-                  single toggle would force picking one mode at a time and
-                  couldn't represent "has tag A, but not tag B" in one control.
-                  Reuses `TagsMultiSelect` unchanged (still the case-detail
-                  "Add tag" picker's own freeSolo input). */}
-              <TagsMultiSelect
-                id="cases-filter-tags"
-                label="Tags"
-                values={filters.tags}
-                onChange={(next) => onChange({ ...filters, tags: next })}
-              />
-            </Grid>
-            <Grid size={{ xs: 12, sm: 6, md: 4, lg: 2 }}>
-              <TagsMultiSelect
-                id="cases-filter-exclude-tags"
-                label="Exclude tags"
-                values={filters.excludeTags}
-                onChange={(next) => onChange({ ...filters, excludeTags: next })}
               />
             </Grid>
           </Grid>

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -1717,7 +1717,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
               caseDetail={c}
               onAction={onAction}
               closeBlockedReason={closeBlockedReason}
-              isPending={patchCase.isPending}
+              isPending={patchCase.isPending && !isAcknowledging}
               onAcknowledge={onAcknowledge}
               isAcknowledging={isAcknowledging}
             />

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -465,6 +465,10 @@ export default function CsmCaseDetailPage(): JSX.Element {
   // state adjustments below both need it: the per-case reset and the
   // per-fragment Activities-tab force.
   const permalinkFragment = location.hash?.replace(/^#/, "") ?? "";
+  // Tracked separately from patchCase.isPending: that flag is shared with the
+  // lifecycle transitions, and reusing it would spin the state button whenever
+  // someone acknowledges (and vice versa).
+  const [isAcknowledging, setIsAcknowledging] = useState(false);
   const [metaCollapsed, setMetaCollapsed] = useState(false);
   const [composerOpen, setComposerOpen] = useState(false);
   const [assignOpen, setAssignOpen] = useState(false);
@@ -682,6 +686,35 @@ export default function CsmCaseDetailPage(): JSX.Element {
     },
     [patchCase, showError],
   );
+
+  // Acknowledge: claim the case as the signed-in engineer. First-write-wins
+  // upstream, so a race with the out-of-band acknowledgement link (or another
+  // engineer clicking at the same moment) resolves to whoever landed first and
+  // is reported as such rather than surfacing as an error. The refetch that
+  // usePatchCsmCase triggers is what removes the button, so nothing here has to
+  // reconcile local state.
+  const onAcknowledge = useCallback(async (): Promise<void> => {
+    setIsAcknowledging(true);
+    try {
+      const result = await patchCase.mutateAsync({ acknowledge: true });
+      const holder = result.case?.acknowledgedBy?.name?.trim();
+      setFeedback(
+        result.case?.alreadyAcknowledged
+          ? {
+              message: holder
+                ? `This case was already acknowledged by ${holder}.`
+                : "This case was already acknowledged.",
+              severity: "info",
+              sticky: true,
+            }
+          : { message: "Case acknowledged.", severity: "success", sticky: true },
+      );
+    } catch (err) {
+      showError("Could not acknowledge the case. Please try again.", err);
+    } finally {
+      setIsAcknowledging(false);
+    }
+  }, [patchCase, showError]);
 
   // Starting work: enforce the single-active-case rule.
   // 1) look up the engineer's other ongoing cases (abort on failure — we
@@ -1685,6 +1718,8 @@ export default function CsmCaseDetailPage(): JSX.Element {
               onAction={onAction}
               closeBlockedReason={closeBlockedReason}
               isPending={patchCase.isPending}
+              onAcknowledge={onAcknowledge}
+              isAcknowledging={isAcknowledging}
             />
           </Box>
         )}

--- a/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
@@ -448,6 +448,14 @@ export interface CreateIncidentFromCaseNavState {
 export interface CsmCaseDetail extends CsmCaseRow {
   description: string;
   assignmentGroup: string;
+  /**
+   * The engineer who acknowledged the case — a first-write-wins claim that
+   * someone has seen it and picked it up, distinct from being assigned to it.
+   * Absent when nobody has acknowledged yet, which is what makes the
+   * acknowledge action available. Cleared upstream when the case's type or
+   * severity changes or it is reopened, so it can become absent again.
+   */
+  acknowledgedBy?: { name: string; email?: string };
   /** Category of issue reported, when set (e.g. "total_outage", "question"). */
   issueType?: BeCaseIssueType;
   /**

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/caseSearchPayload.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/caseSearchPayload.test.ts
@@ -1,0 +1,137 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { describe, expect, it } from "vitest";
+import type { CasesFilters } from "@features/csm-cases/components/CasesFilterBar";
+import { DEFAULT_CASES_FILTERS } from "@features/csm-cases/utils/casesFiltersUrl";
+import { buildCaseSearchFilters } from "./caseSearchPayload";
+
+function filterOf(filters: CasesFilters, field: string) {
+  return (buildCaseSearchFilters(filters, "", undefined).filters ?? []).filter(
+    (f) => f.field === field,
+  );
+}
+
+describe("buildCaseSearchFilters — new advanced-filter fields", () => {
+  it("emits integrationCsTeam op:in for csTeams", () => {
+    const filters: CasesFilters = { ...DEFAULT_CASES_FILTERS, csTeams: ["team-a"] };
+    expect(filterOf(filters, "integrationCsTeam")).toEqual([
+      { field: "integrationCsTeam", op: "in", values: ["team-a"] },
+    ]);
+  });
+
+  it("emits tag op:in and tag op:notIn as two independent entries", () => {
+    const filters: CasesFilters = {
+      ...DEFAULT_CASES_FILTERS,
+      tags: ["patch"],
+      excludeTags: ["s_dip"],
+    };
+    const tagEntries = filterOf(filters, "tag");
+    expect(tagEntries).toEqual([
+      { field: "tag", op: "in", values: ["patch"] },
+      { field: "tag", op: "notIn", values: ["s_dip"] },
+    ]);
+  });
+
+  it("does NOT invert excludeTags into an `in` entry", () => {
+    // Regression: the equivalent bug in widgetPreviewUrl.ts inverted `tag
+    // notIn` into `tag in` because it dropped the op. This asserts the
+    // payload builder never produces an `in` entry when only excludeTags is
+    // set.
+    const filters: CasesFilters = { ...DEFAULT_CASES_FILTERS, excludeTags: ["s_dip"] };
+    const tagEntries = filterOf(filters, "tag");
+    expect(tagEntries).toEqual([{ field: "tag", op: "notIn", values: ["s_dip"] }]);
+    expect(tagEntries?.some((e) => e.op === "in")).toBe(false);
+  });
+
+  it("emits projectOnboardingStatus op:in", () => {
+    const filters: CasesFilters = {
+      ...DEFAULT_CASES_FILTERS,
+      onboardingStatuses: ["in_progress"],
+    };
+    expect(filterOf(filters, "projectOnboardingStatus")).toEqual([
+      { field: "projectOnboardingStatus", op: "in", values: ["in_progress"] },
+    ]);
+  });
+
+  it("emits taskSLABusinessElapsedPercent gte and lte as separate entries", () => {
+    const filters: CasesFilters = {
+      ...DEFAULT_CASES_FILTERS,
+      slaElapsedPctGte: 50,
+      slaElapsedPctLte: 100,
+    };
+    expect(filterOf(filters, "taskSLABusinessElapsedPercent")).toEqual([
+      { field: "taskSLABusinessElapsedPercent", op: "gte", values: ["50"] },
+      { field: "taskSLABusinessElapsedPercent", op: "lte", values: ["100"] },
+    ]);
+  });
+
+  it("emits escalation isNotEmpty with no `values` when hasEscalation is true", () => {
+    const filters: CasesFilters = { ...DEFAULT_CASES_FILTERS, hasEscalation: true };
+    expect(filterOf(filters, "escalation")).toEqual([
+      { field: "escalation", op: "isNotEmpty" },
+    ]);
+  });
+
+  it("emits escalation isEmpty with no `values` when hasEscalation is false", () => {
+    const filters: CasesFilters = { ...DEFAULT_CASES_FILTERS, hasEscalation: false };
+    expect(filterOf(filters, "escalation")).toEqual([{ field: "escalation", op: "isEmpty" }]);
+  });
+
+  it("omits escalation entirely when hasEscalation is null (unfiltered)", () => {
+    const filters: CasesFilters = { ...DEFAULT_CASES_FILTERS, hasEscalation: null };
+    expect(filterOf(filters, "escalation")).toEqual([]);
+  });
+
+  it("emits escalationLevel and projectType op:in", () => {
+    const filters: CasesFilters = {
+      ...DEFAULT_CASES_FILTERS,
+      escalationLevels: ["L1"],
+      projectTypes: ["enterprise"],
+    };
+    expect(filterOf(filters, "escalationLevel")).toEqual([
+      { field: "escalationLevel", op: "in", values: ["L1"] },
+    ]);
+    expect(filterOf(filters, "projectType")).toEqual([
+      { field: "projectType", op: "in", values: ["enterprise"] },
+    ]);
+  });
+
+  it("emits createdOn/updatedOn/closedOn gte+lte as independent entries per field", () => {
+    const filters: CasesFilters = {
+      ...DEFAULT_CASES_FILTERS,
+      createdOnGte: "2026-01-01",
+      createdOnLte: "2026-03-31",
+      updatedOnGte: "2026-02-01",
+      closedOnLte: "2026-06-30",
+    };
+    expect(filterOf(filters, "createdOn")).toEqual([
+      { field: "createdOn", op: "gte", values: ["2026-01-01"] },
+      { field: "createdOn", op: "lte", values: ["2026-03-31"] },
+    ]);
+    expect(filterOf(filters, "updatedOn")).toEqual([
+      { field: "updatedOn", op: "gte", values: ["2026-02-01"] },
+    ]);
+    expect(filterOf(filters, "closedOn")).toEqual([
+      { field: "closedOn", op: "lte", values: ["2026-06-30"] },
+    ]);
+  });
+
+  it("emits nothing beyond the default filters when all new fields are unset", () => {
+    const result = buildCaseSearchFilters(DEFAULT_CASES_FILTERS, "", undefined);
+    expect(result.filters).toBeUndefined();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/caseSearchPayload.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/caseSearchPayload.ts
@@ -99,6 +99,86 @@ export function buildCaseSearchFilters(
       values: filters.productNames,
     });
   }
+  if (filters.csTeams.length > 0) {
+    fieldFilters.push({
+      field: "integrationCsTeam",
+      op: "in",
+      values: filters.csTeams,
+    });
+  }
+  // `tags`/`excludeTags` both target the `tag` field but with different ops
+  // (`in`/`notIn`) — two independent entries, not a single one an op flag
+  // toggles, so both may be active at once (the backend ANDs the array).
+  if (filters.tags.length > 0) {
+    fieldFilters.push({ field: "tag", op: "in", values: filters.tags });
+  }
+  if (filters.excludeTags.length > 0) {
+    fieldFilters.push({ field: "tag", op: "notIn", values: filters.excludeTags });
+  }
+  if (filters.onboardingStatuses.length > 0) {
+    fieldFilters.push({
+      field: "projectOnboardingStatus",
+      op: "in",
+      values: filters.onboardingStatuses,
+    });
+  }
+  if (filters.slaElapsedPctGte !== null) {
+    fieldFilters.push({
+      field: "taskSLABusinessElapsedPercent",
+      op: "gte",
+      values: [String(filters.slaElapsedPctGte)],
+    });
+  }
+  if (filters.slaElapsedPctLte !== null) {
+    fieldFilters.push({
+      field: "taskSLABusinessElapsedPercent",
+      op: "lte",
+      values: [String(filters.slaElapsedPctLte)],
+    });
+  }
+  // Value-less predicate: `escalation isEmpty`/`isNotEmpty` carry no
+  // `values` at all — the op alone is the whole filter (see
+  // `case_filters.go`'s `escalation` case). Must still be emitted whenever
+  // `hasEscalation` is non-null, exactly the class of entry
+  // `writeWidgetPreviewHref` used to silently drop for having nothing in
+  // `values` to serialize.
+  if (filters.hasEscalation === true) {
+    fieldFilters.push({ field: "escalation", op: "isNotEmpty" });
+  } else if (filters.hasEscalation === false) {
+    fieldFilters.push({ field: "escalation", op: "isEmpty" });
+  }
+  if (filters.escalationLevels.length > 0) {
+    fieldFilters.push({
+      field: "escalationLevel",
+      op: "in",
+      values: filters.escalationLevels,
+    });
+  }
+  if (filters.projectTypes.length > 0) {
+    fieldFilters.push({
+      field: "projectType",
+      op: "in",
+      values: filters.projectTypes,
+    });
+  }
+  if (filters.createdOnGte !== null) {
+    fieldFilters.push({ field: "createdOn", op: "gte", values: [filters.createdOnGte] });
+  }
+  if (filters.createdOnLte !== null) {
+    fieldFilters.push({ field: "createdOn", op: "lte", values: [filters.createdOnLte] });
+  }
+  if (filters.updatedOnGte !== null) {
+    fieldFilters.push({ field: "updatedOn", op: "gte", values: [filters.updatedOnGte] });
+  }
+  if (filters.updatedOnLte !== null) {
+    fieldFilters.push({ field: "updatedOn", op: "lte", values: [filters.updatedOnLte] });
+  }
+  if (filters.closedOnGte !== null) {
+    fieldFilters.push({ field: "closedOn", op: "gte", values: [filters.closedOnGte] });
+  }
+  if (filters.closedOnLte !== null) {
+    fieldFilters.push({ field: "closedOn", op: "lte", values: [filters.closedOnLte] });
+  }
 
   return {
     ...(search.length > 0 && { searchQuery: search }),

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.test.ts
@@ -35,11 +35,11 @@ describe("readCasesFiltersFromUrl", () => {
       "search=timeout&severities=S0,S2&states=open,work_in_progress,closed&types=case,engagement&assignees=alice@example.com,@me&workStates=ongoing,paused&projects=apim&products=API%20Manager,Asgardeo",
     );
     expect(readCasesFiltersFromUrl(params)).toEqual({
+      ...DEFAULT_CASES_FILTERS,
       search: "timeout",
       severities: ["S0", "S2"],
       states: ["open", "work_in_progress", "closed"],
       caseTypes: ["case", "engagement"],
-      engagementTypes: [],
       assignees: ["alice@example.com", "@me"],
       workStates: ["ongoing", "paused"],
       projects: ["apim"],
@@ -47,9 +47,12 @@ describe("readCasesFiltersFromUrl", () => {
     });
   });
 
-  it("ignores a stale `tags` param (case-list tag filter removed for now)", () => {
+  it("parses `tags` — a live param again, not the stale no-op it used to be", () => {
     const params = new URLSearchParams("tags=micro-gw,ws-policy");
-    expect(readCasesFiltersFromUrl(params)).toEqual(DEFAULT_CASES_FILTERS);
+    expect(readCasesFiltersFromUrl(params)).toEqual({
+      ...DEFAULT_CASES_FILTERS,
+      tags: ["micro-gw", "ws-policy"],
+    });
   });
 
   it("drops values outside the allowed enums", () => {
@@ -89,6 +92,7 @@ describe("writeCasesFiltersToUrl", () => {
 
   it("round-trips a non-default filter set", () => {
     const filters: CasesFilters = {
+      ...DEFAULT_CASES_FILTERS,
       search: "disk full",
       severities: ["S1"],
       states: ["work_in_progress"],
@@ -96,11 +100,83 @@ describe("writeCasesFiltersToUrl", () => {
       assignees: ["carol@example.com"],
       workStates: ["paused"],
       projects: ["streaming"],
-      engagementTypes: [],
       productNames: ["Identity Server", "Asgardeo"],
     };
     const round = readCasesFiltersFromUrl(writeCasesFiltersToUrl(filters));
     expect(round).toEqual(filters);
+  });
+});
+
+/**
+ * Regression coverage for the exact bug class `widgetPreviewUrl.ts` shipped
+ * (see `6a9059789`): an op silently decoding back as a different op, or a
+ * value-less op being dropped for having no `values` to serialize. This
+ * codec avoids the `field~op` mechanism that bug required fixing (see
+ * `writeCasesFiltersToUrl`'s doc comment) by giving every op its own named
+ * field — these tests exist to prove that actually holds, not just to
+ * restate the design.
+ */
+describe("op-awareness (regression: the widgetPreviewUrl field~op bug)", () => {
+  it("`tags` (op:in) and `excludeTags` (op:notIn) never conflate on a round trip", () => {
+    const filters: CasesFilters = {
+      ...DEFAULT_CASES_FILTERS,
+      excludeTags: ["s_dip"],
+    };
+    const round = readCasesFiltersFromUrl(writeCasesFiltersToUrl(filters));
+    // The bug this guards against: `tag notIn [s_dip]` decoding back as
+    // `tag in [s_dip]` — an EXCLUSION becoming a FILTER. Assert both halves:
+    // the exclusion survived, and it did NOT leak into `tags` (inclusion).
+    expect(round.excludeTags).toEqual(["s_dip"]);
+    expect(round.tags).toEqual([]);
+  });
+
+  it("`tags` and `excludeTags` survive together, independently, when both are set", () => {
+    const filters: CasesFilters = {
+      ...DEFAULT_CASES_FILTERS,
+      tags: ["patch"],
+      excludeTags: ["s_dip"],
+    };
+    const round = readCasesFiltersFromUrl(writeCasesFiltersToUrl(filters));
+    expect(round.tags).toEqual(["patch"]);
+    expect(round.excludeTags).toEqual(["s_dip"]);
+  });
+
+  it("a value-less op (`hasEscalation` / escalation isNotEmpty) survives rather than being dropped", () => {
+    const filters: CasesFilters = { ...DEFAULT_CASES_FILTERS, hasEscalation: true };
+    const href = writeCasesFiltersToUrl(filters);
+    // Assert the param is actually present, not just that the round trip
+    // happens to produce the right value some other way.
+    expect(href.get("escalation")).toBe("yes");
+    expect(readCasesFiltersFromUrl(href).hasEscalation).toBe(true);
+  });
+
+  it("the other value-less state (`hasEscalation: false` / isEmpty) also survives", () => {
+    const filters: CasesFilters = { ...DEFAULT_CASES_FILTERS, hasEscalation: false };
+    const href = writeCasesFiltersToUrl(filters);
+    expect(href.get("escalation")).toBe("no");
+    expect(readCasesFiltersFromUrl(href).hasEscalation).toBe(false);
+  });
+
+  it("a gte+lte range on one field round-trips with both bounds intact", () => {
+    const filters: CasesFilters = {
+      ...DEFAULT_CASES_FILTERS,
+      slaElapsedPctGte: 50,
+      slaElapsedPctLte: 100,
+      createdOnGte: "2026-01-01",
+      createdOnLte: "2026-03-31",
+    };
+    const round = readCasesFiltersFromUrl(writeCasesFiltersToUrl(filters));
+    expect(round.slaElapsedPctGte).toBe(50);
+    expect(round.slaElapsedPctLte).toBe(100);
+    expect(round.createdOnGte).toBe("2026-01-01");
+    expect(round.createdOnLte).toBe("2026-03-31");
+  });
+
+  it("a one-sided range only sets the bound that was given", () => {
+    const filters: CasesFilters = { ...DEFAULT_CASES_FILTERS, slaElapsedPctGte: 90 };
+    const round = readCasesFiltersFromUrl(writeCasesFiltersToUrl(filters));
+    expect(round.slaElapsedPctGte).toBe(90);
+    expect(round.slaElapsedPctLte).toBeNull();
   });
 });
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.ts
@@ -36,12 +36,27 @@ export const DEFAULT_CASES_FILTERS: CasesFilters = {
   projects: [],
   engagementTypes: [],
   productNames: [],
-  // `tags` is deliberately not part of `CasesFilters` right now — the case-list
-  // tag filter (TagsMultiSelect in CasesFilterBar) was removed from the filter
-  // bar / URL / search payload wiring for now, not deleted. `TagsMultiSelect`,
-  // `useSearchTags`, and the tag-search infrastructure are still used by the
-  // case-detail "Add tag" picker (AddTagDialog) and may be reinstated here
-  // later.
+  csTeams: [],
+  tags: [],
+  excludeTags: [],
+  onboardingStatuses: [],
+  slaElapsedPctGte: null,
+  slaElapsedPctLte: null,
+  hasEscalation: null,
+  escalationLevels: [],
+  projectTypes: [],
+  createdOnGte: null,
+  createdOnLte: null,
+  updatedOnGte: null,
+  updatedOnLte: null,
+  closedOnGte: null,
+  closedOnLte: null,
+  // Note: `tags`/`excludeTags` are real, wired-through fields as of this
+  // codec (round-trip URL + `/cases/search` payload) — only the filter-bar
+  // *control* for them is still pending; see the comment above
+  // `TagsMultiSelect`'s import in `CasesFilterBar.tsx`. `TagsMultiSelect` and
+  // `useSearchTags` remain used by the case-detail "Add tag" picker
+  // regardless.
 };
 
 const VALID_SEVERITIES: Severity[] = ["S0", "S1", "S2", "S3", "S4"];
@@ -84,6 +99,41 @@ function parseFreeFormCsv(raw: string | null, maxEntryLen = 120): string[] {
     .filter((s) => s.length > 0 && s.length <= maxEntryLen);
 }
 
+/**
+ * Parse a single free-form scalar (a date bound, a percent). `null` for an
+ * absent, empty, or over-long param — same "silently drop, never throw"
+ * policy as every other reader in this file.
+ */
+function parseFreeFormScalar(raw: string | null, maxLen = 40): string | null {
+  if (!raw) return null;
+  const trimmed = raw.trim();
+  return trimmed.length > 0 && trimmed.length <= maxLen ? trimmed : null;
+}
+
+/**
+ * Parse a single non-negative integer param (the SLA business-elapsed
+ * percent bounds — mirrors the backend's own `parseCaseFilterPercent`, which
+ * has no upper bound: a long-overdue SLA's percent keeps climbing well past
+ * 100). `null` for anything absent, negative, or non-numeric.
+ */
+function parseNonNegativeInt(raw: string | null): number | null {
+  if (!raw) return null;
+  const n = Number(raw);
+  return Number.isInteger(n) && n >= 0 ? n : null;
+}
+
+/**
+ * Parse the `escalation` param (`"yes"` | `"no"`) into the tri-state
+ * `CasesFilters.hasEscalation`. Any other value (including absence) is
+ * "unfiltered" (`null`), never silently coerced to one of the two active
+ * states.
+ */
+function parseEscalationParam(raw: string | null): boolean | null {
+  if (raw === "yes") return true;
+  if (raw === "no") return false;
+  return null;
+}
+
 export function readCasesFiltersFromUrl(
   params: URLSearchParams,
 ): CasesFilters {
@@ -105,12 +155,57 @@ export function readCasesFiltersFromUrl(
     projects: parseFreeFormCsv(params.get("projects")),
     engagementTypes: parseCsv(params.get("engagementTypes"), VALID_ENGAGEMENT_TYPES),
     productNames: parseFreeFormCsv(params.get("products")),
+    csTeams: parseFreeFormCsv(params.get("csTeams")),
+    tags: parseFreeFormCsv(params.get("tags")),
+    excludeTags: parseFreeFormCsv(params.get("excludeTags")),
+    onboardingStatuses: parseFreeFormCsv(params.get("onboardingStatuses")),
+    slaElapsedPctGte: parseNonNegativeInt(params.get("slaPctGte")),
+    slaElapsedPctLte: parseNonNegativeInt(params.get("slaPctLte")),
+    hasEscalation: parseEscalationParam(params.get("escalation")),
+    escalationLevels: parseFreeFormCsv(params.get("escalationLevels")),
+    projectTypes: parseFreeFormCsv(params.get("projectTypes")),
+    createdOnGte: parseFreeFormScalar(params.get("createdFrom")),
+    createdOnLte: parseFreeFormScalar(params.get("createdTo")),
+    updatedOnGte: parseFreeFormScalar(params.get("updatedFrom")),
+    updatedOnLte: parseFreeFormScalar(params.get("updatedTo")),
+    closedOnGte: parseFreeFormScalar(params.get("closedFrom")),
+    closedOnLte: parseFreeFormScalar(params.get("closedTo")),
   };
 }
 
 /**
  * Build the search-params object representing these filters. Default values
  * are omitted so the URL stays clean.
+ *
+ * **Op-awareness.** `writeWidgetPreviewHref` (in `csm-dashboard/utils/
+ * widgetPreviewUrl.ts`) shipped a real bug from encoding an *opaque*
+ * field/op/values array with one query param per `field` and no room for the
+ * `op`: `tag notIn [x]` decoded back as `tag in [x]` (a tag EXCLUSION became
+ * a tag FILTER) and value-less ops (`isEmpty`/`isNotEmpty`) were dropped for
+ * having no values to serialize (see `6a9059789`). That file's fix was to
+ * encode the op into the param name (`field~op`).
+ *
+ * `CasesFilters` doesn't need that trick: it is a fixed, *named*-field
+ * struct, not a generic opaque array, so every op that would otherwise
+ * collide on one field name already gets its own dedicated field/param
+ * instead —
+ *   - `tags` (op:in) vs. `excludeTags` (op:notIn) — two arrays, not one
+ *     array plus an op flag, so `in` and `notIn` can never be conflated on
+ *     the round trip;
+ *   - `slaElapsedPctGte`/`slaElapsedPctLte`, and the `createdOnGte/Lte`,
+ *     `updatedOnGte/Lte`, `closedOnGte/Lte` date-range pairs — one param per
+ *     bound, not a shared field with an op suffix;
+ *   - `hasEscalation` — a tri-state (`true`/`false`/`null`) rather than a
+ *     value-less-op name a caller could mistype; both of its states
+ *     (`isEmpty`/`isNotEmpty`) always round-trip because presence, not a
+ *     `values` array, is the entire predicate.
+ * The `field~op` failure mode (an op silently decoding back as the default)
+ * is therefore structurally not reachable here — there is no default op to
+ * fall back to, because every op already has its own field. Reuse `field~op`
+ * only if `CasesFilters` ever grows a *generic* filter escape hatch; as long
+ * as it stays a named-field struct, one param per field+op pair is both
+ * simpler and — since nothing is inferred from an omitted suffix — no less
+ * safe.
  */
 export function writeCasesFiltersToUrl(f: CasesFilters): URLSearchParams {
   const out = new URLSearchParams();
@@ -123,6 +218,27 @@ export function writeCasesFiltersToUrl(f: CasesFilters): URLSearchParams {
   if (f.projects.length) out.set("projects", f.projects.join(","));
   if (f.engagementTypes.length) out.set("engagementTypes", f.engagementTypes.join(","));
   if (f.productNames.length) out.set("products", f.productNames.join(","));
+  if (f.csTeams.length) out.set("csTeams", f.csTeams.join(","));
+  if (f.tags.length) out.set("tags", f.tags.join(","));
+  if (f.excludeTags.length) out.set("excludeTags", f.excludeTags.join(","));
+  if (f.onboardingStatuses.length) {
+    out.set("onboardingStatuses", f.onboardingStatuses.join(","));
+  }
+  if (f.slaElapsedPctGte !== null) out.set("slaPctGte", String(f.slaElapsedPctGte));
+  if (f.slaElapsedPctLte !== null) out.set("slaPctLte", String(f.slaElapsedPctLte));
+  // Value-less predicate: `hasEscalation` alone (no `values`) is the whole
+  // filter, so it must be written whenever it's non-null rather than only
+  // when some paired array is non-empty — the exact class of bug
+  // `writeWidgetPreviewHref` shipped by skipping value-less entries.
+  if (f.hasEscalation !== null) out.set("escalation", f.hasEscalation ? "yes" : "no");
+  if (f.escalationLevels.length) out.set("escalationLevels", f.escalationLevels.join(","));
+  if (f.projectTypes.length) out.set("projectTypes", f.projectTypes.join(","));
+  if (f.createdOnGte !== null) out.set("createdFrom", f.createdOnGte);
+  if (f.createdOnLte !== null) out.set("createdTo", f.createdOnLte);
+  if (f.updatedOnGte !== null) out.set("updatedFrom", f.updatedOnGte);
+  if (f.updatedOnLte !== null) out.set("updatedTo", f.updatedOnLte);
+  if (f.closedOnGte !== null) out.set("closedFrom", f.closedOnGte);
+  if (f.closedOnLte !== null) out.set("closedTo", f.closedOnLte);
   return out;
 }
 
@@ -143,6 +259,21 @@ export function countActiveFilters(f: CasesFilters): number {
   if (f.projects.length) n += 1;
   if (f.engagementTypes.length) n += 1;
   if (f.productNames.length) n += 1;
+  if (f.csTeams.length) n += 1;
+  if (f.tags.length) n += 1;
+  if (f.excludeTags.length) n += 1;
+  if (f.onboardingStatuses.length) n += 1;
+  if (f.slaElapsedPctGte !== null) n += 1;
+  if (f.slaElapsedPctLte !== null) n += 1;
+  if (f.hasEscalation !== null) n += 1;
+  if (f.escalationLevels.length) n += 1;
+  if (f.projectTypes.length) n += 1;
+  if (f.createdOnGte !== null) n += 1;
+  if (f.createdOnLte !== null) n += 1;
+  if (f.updatedOnGte !== null) n += 1;
+  if (f.updatedOnLte !== null) n += 1;
+  if (f.closedOnGte !== null) n += 1;
+  if (f.closedOnLte !== null) n += 1;
   return n;
 }
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.ts
@@ -53,10 +53,10 @@ export const DEFAULT_CASES_FILTERS: CasesFilters = {
   closedOnLte: null,
   // Note: `tags`/`excludeTags` are real, wired-through fields as of this
   // codec (round-trip URL + `/cases/search` payload) — only the filter-bar
-  // *control* for them is still pending; see the comment above
-  // `TagsMultiSelect`'s import in `CasesFilterBar.tsx`. `TagsMultiSelect` and
-  // `useSearchTags` remain used by the case-detail "Add tag" picker
-  // regardless.
+  // *control* for them is still pending; they surface only as removable
+  // chips (see `buildActiveFilterChips` in `CasesFilterBar.tsx`).
+  // `TagsMultiSelect` and `useSearchTags` remain used by the case-detail
+  // "Add tag" picker regardless.
 };
 
 const VALID_SEVERITIES: Severity[] = ["S0", "S1", "S2", "S3", "S4"];

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardBarChart.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardBarChart.tsx
@@ -17,7 +17,7 @@
 import { Box, Skeleton, Typography, alpha, useTheme } from "@wso2/oxygen-ui";
 import { Inbox } from "@wso2/oxygen-ui-icons-react";
 import { Bar, BarChart, Cell } from "@wso2/oxygen-ui-charts-react";
-import { useState, type JSX } from "react";
+import { useState, type JSX, type SyntheticEvent } from "react";
 import type { BeWidgetPaletteColor } from "@api/backend/types";
 import type { PieSliceResult } from "@features/csm-dashboard/api/useWidgetPieData";
 import { useDarkMode } from "@utils/useDarkMode";
@@ -151,7 +151,12 @@ export default function DashboardBarChart({
           }}
           onMouseEnter={(_data: unknown, i: number) => setActiveIndex(i)}
           onMouseLeave={() => setActiveIndex(undefined)}
-          onClick={(_data: unknown, i: number) => {
+          // Stops the click from also bubbling up to the tile-level
+          // click-through `DashboardWidgetTile` attaches to the whole card
+          // for shape "pie"/"bar" — see `DashboardPieChart`'s wedge onClick
+          // for the same fix and full rationale.
+          onClick={(_data: unknown, i: number, event?: SyntheticEvent) => {
+            event?.stopPropagation();
             const slice = slices[i];
             if (slice) onSliceClick(slice);
           }}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardPieChart.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardPieChart.tsx
@@ -17,7 +17,7 @@
 import { Box, Skeleton, Typography, alpha, useTheme } from "@wso2/oxygen-ui";
 import { Inbox } from "@wso2/oxygen-ui-icons-react";
 import { Cell, Pie, PieChart } from "@wso2/oxygen-ui-charts-react";
-import { useState, type JSX } from "react";
+import { useState, type JSX, type KeyboardEvent, type SyntheticEvent } from "react";
 import type { BeWidgetPaletteColor } from "@api/backend/types";
 import type { PieSliceResult } from "@features/csm-dashboard/api/useWidgetPieData";
 import { useDarkMode } from "@utils/useDarkMode";
@@ -180,7 +180,14 @@ export default function DashboardPieChart({
             labelLine={false}
             onMouseEnter={(_data: unknown, i: number) => setActiveIndex(i)}
             onMouseLeave={() => setActiveIndex(undefined)}
-            onClick={(_data: unknown, i: number) => {
+            // Stops the click from also bubbling up to the tile-level
+            // click-through `DashboardWidgetTile` attaches to the whole
+            // card for `shape: "pie"`/`"bar"` — without this, clicking a
+            // wedge would navigate to the slice's own filtered list AND
+            // then (via bubbling) immediately re-navigate to the tile's
+            // base-filtered list.
+            onClick={(_data: unknown, i: number, event?: SyntheticEvent) => {
+              event?.stopPropagation();
               const slice = slices[i];
               if (slice) onSliceClick(slice);
             }}
@@ -219,7 +226,24 @@ export default function DashboardPieChart({
           return (
             <Box
               key={slice.label}
-              onClick={() => onSliceClick(slice)}
+              role="button"
+              tabIndex={0}
+              aria-label={`${slice.label}: ${slice.value} cases (${pct}%)`}
+              // stopPropagation for the same reason as the wedge's own
+              // onClick above — this row sits inside the tile-level
+              // click-through `DashboardWidgetTile` attaches for
+              // shape "pie"/"bar".
+              onClick={(event) => {
+                event.stopPropagation();
+                onSliceClick(slice);
+              }}
+              onKeyDown={(event: KeyboardEvent) => {
+                if (event.key === "Enter" || event.key === " ") {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  onSliceClick(slice);
+                }
+              }}
               sx={{
                 display: "flex",
                 alignItems: "center",
@@ -229,6 +253,10 @@ export default function DashboardPieChart({
                 borderRadius: 1,
                 cursor: "pointer",
                 "&:hover": { bgcolor: "action.hover" },
+                "&:focus-visible": {
+                  outline: `2px solid ${theme.palette.primary.main}`,
+                  outlineOffset: -2,
+                },
               }}
             >
               <Box

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.test.tsx
@@ -656,7 +656,7 @@ describe("DashboardWidgetTile", () => {
     expect(params.get("severities")).toBeNull();
   });
 
-  it("shape pie: Enter/Space on the focused tile activates the same tile-level click-through as a click", async () => {
+  it("shape pie: Enter on the focused tile activates the same tile-level click-through as a click", async () => {
     postMock.mockResolvedValue({ total: 2 });
 
     renderWithRoutes(
@@ -684,6 +684,74 @@ describe("DashboardWidgetTile", () => {
     await waitFor(() => expect(screen.getByTestId("location-probe")).toBeInTheDocument());
     const probeText = screen.getByTestId("location-probe").textContent ?? "";
     expect(new URLSearchParams(probeText.split("?")[1]).get("states")).toBe("open");
+  });
+
+  it("shape pie: Space on the focused tile activates the same tile-level click-through as a click", async () => {
+    postMock.mockResolvedValue({ total: 2 });
+
+    renderWithRoutes(
+      <DashboardWidgetTile
+        widgetId="cases-by-severity"
+        displayName="Cases by severity"
+        resourceType="case"
+        shape="pie"
+        filters={{ filters: [{ field: "state", op: "in", values: ["open"] }] }}
+        slices={[
+          {
+            label: "Critical",
+            filters: { filters: [{ field: "severity", op: "in", values: ["critical"] }] },
+          },
+        ]}
+      />,
+      "/cases",
+    );
+
+    await waitFor(() => expect(screen.getByText("slice:Critical:2")).toBeInTheDocument());
+    const tile = screen.getByRole("button", { name: "View all cases for Cases by severity" });
+    tile.focus();
+    fireEvent.keyDown(tile, { key: " " });
+
+    await waitFor(() => expect(screen.getByTestId("location-probe")).toBeInTheDocument());
+    const probeText = screen.getByTestId("location-probe").textContent ?? "";
+    // Same destination filters as a click — states:open (tile-level), not
+    // the slice's own severity.
+    const params = new URLSearchParams(probeText.split("?")[1]);
+    expect(params.get("states")).toBe("open");
+    expect(params.get("severities")).toBeNull();
+  });
+
+  it("shape pie: the tile-level click target is a sibling of the refresh button and legend rows, not their ancestor", async () => {
+    // Regression guard for the ancestor role="button" issue: a role="button"
+    // (or role="link") ancestor makes its descendants' own roles
+    // presentational to assistive tech, so the refresh IconButton and the
+    // legend's own role="button" rows must never be nested inside the
+    // tile-level click target — only ever a sibling of it.
+    postMock.mockResolvedValue({ total: 2 });
+
+    renderWithRoutes(
+      <DashboardWidgetTile
+        widgetId="cases-by-severity"
+        displayName="Cases by severity"
+        resourceType="case"
+        shape="pie"
+        filters={{ filters: [{ field: "state", op: "in", values: ["open"] }] }}
+        slices={[
+          {
+            label: "Critical",
+            filters: { filters: [{ field: "severity", op: "in", values: ["critical"] }] },
+          },
+        ]}
+      />,
+      "/cases",
+    );
+
+    await waitFor(() => expect(screen.getByText("Critical")).toBeInTheDocument());
+    const tile = screen.getByRole("button", { name: "View all cases for Cases by severity" });
+    const refreshButton = screen.getByRole("button", { name: /Refresh/i });
+    const legendRow = screen.getByRole("button", { name: /Critical: 2 cases/ });
+
+    expect(tile.contains(refreshButton)).toBe(false);
+    expect(tile.contains(legendRow)).toBe(false);
   });
 
   it("shape pie: clicking a slice does NOT also trigger the tile-level click-through (no double-navigation)", async () => {
@@ -743,6 +811,38 @@ describe("DashboardWidgetTile", () => {
     const legendRow = screen.getByRole("button", { name: /Critical: 2 cases/ });
     legendRow.focus();
     fireEvent.keyDown(legendRow, { key: "Enter" });
+
+    await waitFor(() => expect(screen.getByTestId("location-probe")).toBeInTheDocument());
+    const probeText = screen.getByTestId("location-probe").textContent ?? "";
+    const params = new URLSearchParams(probeText.split("?")[1]);
+    expect(params.get("severities")).toBe("S1");
+    expect(params.get("states")).toBe("open");
+  });
+
+  it("shape pie: legend row is keyboard-activatable (Space) the same as a click, and doesn't also trigger the tile-level click-through", async () => {
+    postMock.mockResolvedValue({ total: 2 });
+
+    renderWithRoutes(
+      <DashboardWidgetTile
+        widgetId="cases-by-severity"
+        displayName="Cases by severity"
+        resourceType="case"
+        shape="pie"
+        filters={{ filters: [{ field: "state", op: "in", values: ["open"] }] }}
+        slices={[
+          {
+            label: "Critical",
+            filters: { filters: [{ field: "severity", op: "in", values: ["critical"] }] },
+          },
+        ]}
+      />,
+      "/cases",
+    );
+
+    await waitFor(() => expect(screen.getByText("Critical")).toBeInTheDocument());
+    const legendRow = screen.getByRole("button", { name: /Critical: 2 cases/ });
+    legendRow.focus();
+    fireEvent.keyDown(legendRow, { key: " " });
 
     await waitFor(() => expect(screen.getByTestId("location-probe")).toBeInTheDocument());
     const probeText = screen.getByTestId("location-probe").textContent ?? "";

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.test.tsx
@@ -52,11 +52,15 @@ vi.mock("@wso2/oxygen-ui-charts-react", () => ({
     onClick,
   }: {
     data: { name: string; value: number }[];
-    onClick?: (item: unknown, index: number) => void;
+    onClick?: (item: unknown, index: number, event?: unknown) => void;
   }) => (
     <div>
       {data.map((item, i) => (
-        <button key={item.name} type="button" onClick={() => onClick?.(item, i)}>
+        // Forwards the real click event as recharts' own `Pie.onClick`
+        // does (data, index, event) — DashboardPieChart's wedge onClick
+        // relies on that third argument to stop the click from also
+        // bubbling to the tile-level click-through.
+        <button key={item.name} type="button" onClick={(e) => onClick?.(item, i, e)}>
           slice:{item.name}:{item.value}
         </button>
       ))}
@@ -85,11 +89,13 @@ vi.mock("@wso2/oxygen-ui-charts-react", () => ({
     onClick,
   }: {
     data?: { name: string; value: number }[];
-    onClick?: (item: unknown, index: number) => void;
+    onClick?: (item: unknown, index: number, event?: unknown) => void;
   }) => (
     <div>
       {(data ?? []).map((item, i) => (
-        <button key={item.name} type="button" onClick={() => onClick?.(item, i)}>
+        // Forwards the real click event, same rationale as the Pie mock
+        // above.
+        <button key={item.name} type="button" onClick={(e) => onClick?.(item, i, e)}>
           bar:{item.name}:{item.value}
         </button>
       ))}
@@ -613,6 +619,136 @@ describe("DashboardWidgetTile", () => {
     await waitFor(() => expect(screen.getByTestId("location-probe")).toBeInTheDocument());
     const probeText = screen.getByTestId("location-probe").textContent ?? "";
     expect(new URLSearchParams(probeText.split("?")[1]).get("severities")).toBe("S1");
+  });
+
+  it("shape pie: clicking the tile itself (not a slice/legend row) navigates to the widget's own base filters", async () => {
+    postMock.mockResolvedValue({ total: 2 });
+
+    renderWithRoutes(
+      <DashboardWidgetTile
+        widgetId="cases-by-severity"
+        displayName="Cases by severity"
+        resourceType="case"
+        shape="pie"
+        filters={{ filters: [{ field: "state", op: "in", values: ["open"] }] }}
+        slices={[
+          {
+            label: "Critical",
+            filters: { filters: [{ field: "severity", op: "in", values: ["critical"] }] },
+          },
+        ]}
+      />,
+      "/cases",
+    );
+
+    await waitFor(() => expect(screen.getByText("slice:Critical:2")).toBeInTheDocument());
+    // The accessible tile-level click target (role="button", not a slice or
+    // legend row) — its own aria-label names the widget.
+    fireEvent.click(screen.getByRole("button", { name: "View all cases for Cases by severity" }));
+
+    await waitFor(() => expect(screen.getByTestId("location-probe")).toBeInTheDocument());
+    const probeText = screen.getByTestId("location-probe").textContent ?? "";
+    expect(probeText.startsWith("/cases?")).toBe(true);
+    const params = new URLSearchParams(probeText.split("?")[1]);
+    // The tile's own base filters (state:open), NOT the slice's severity —
+    // that's what distinguishes this from a slice/legend click.
+    expect(params.get("states")).toBe("open");
+    expect(params.get("severities")).toBeNull();
+  });
+
+  it("shape pie: Enter/Space on the focused tile activates the same tile-level click-through as a click", async () => {
+    postMock.mockResolvedValue({ total: 2 });
+
+    renderWithRoutes(
+      <DashboardWidgetTile
+        widgetId="cases-by-severity"
+        displayName="Cases by severity"
+        resourceType="case"
+        shape="pie"
+        filters={{ filters: [{ field: "state", op: "in", values: ["open"] }] }}
+        slices={[
+          {
+            label: "Critical",
+            filters: { filters: [{ field: "severity", op: "in", values: ["critical"] }] },
+          },
+        ]}
+      />,
+      "/cases",
+    );
+
+    await waitFor(() => expect(screen.getByText("slice:Critical:2")).toBeInTheDocument());
+    const tile = screen.getByRole("button", { name: "View all cases for Cases by severity" });
+    tile.focus();
+    fireEvent.keyDown(tile, { key: "Enter" });
+
+    await waitFor(() => expect(screen.getByTestId("location-probe")).toBeInTheDocument());
+    const probeText = screen.getByTestId("location-probe").textContent ?? "";
+    expect(new URLSearchParams(probeText.split("?")[1]).get("states")).toBe("open");
+  });
+
+  it("shape pie: clicking a slice does NOT also trigger the tile-level click-through (no double-navigation)", async () => {
+    postMock.mockResolvedValue({ total: 2 });
+
+    renderWithRoutes(
+      <DashboardWidgetTile
+        widgetId="cases-by-severity"
+        displayName="Cases by severity"
+        resourceType="case"
+        shape="pie"
+        filters={{ filters: [{ field: "state", op: "in", values: ["open"] }] }}
+        slices={[
+          {
+            label: "Critical",
+            filters: { filters: [{ field: "severity", op: "in", values: ["critical"] }] },
+          },
+        ]}
+      />,
+      "/cases",
+    );
+
+    await waitFor(() => expect(screen.getByText("slice:Critical:2")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("slice:Critical:2"));
+
+    await waitFor(() => expect(screen.getByTestId("location-probe")).toBeInTheDocument());
+    const probeText = screen.getByTestId("location-probe").textContent ?? "";
+    const params = new URLSearchParams(probeText.split("?")[1]);
+    // Slice's own severity survives — if the tile-level handler had also
+    // fired (bubbling not stopped), this would have been overwritten by the
+    // base-filters-only navigation and severities would be absent.
+    expect(params.get("severities")).toBe("S1");
+    expect(params.get("states")).toBe("open");
+  });
+
+  it("shape pie: legend row is keyboard-activatable (Enter) the same as a click, and doesn't also trigger the tile-level click-through", async () => {
+    postMock.mockResolvedValue({ total: 2 });
+
+    renderWithRoutes(
+      <DashboardWidgetTile
+        widgetId="cases-by-severity"
+        displayName="Cases by severity"
+        resourceType="case"
+        shape="pie"
+        filters={{ filters: [{ field: "state", op: "in", values: ["open"] }] }}
+        slices={[
+          {
+            label: "Critical",
+            filters: { filters: [{ field: "severity", op: "in", values: ["critical"] }] },
+          },
+        ]}
+      />,
+      "/cases",
+    );
+
+    await waitFor(() => expect(screen.getByText("Critical")).toBeInTheDocument());
+    const legendRow = screen.getByRole("button", { name: /Critical: 2 cases/ });
+    legendRow.focus();
+    fireEvent.keyDown(legendRow, { key: "Enter" });
+
+    await waitFor(() => expect(screen.getByTestId("location-probe")).toBeInTheDocument());
+    const probeText = screen.getByTestId("location-probe").textContent ?? "";
+    const params = new URLSearchParams(probeText.split("?")[1]);
+    expect(params.get("severities")).toBe("S1");
+    expect(params.get("states")).toBe("open");
   });
 
   it("shape pie: renders an empty state (no slices, zero total) rather than crashing when a widget has no slices configured yet", async () => {

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
@@ -245,14 +245,26 @@ export default function DashboardWidgetTile({
   if (shape === "pie" || shape === "bar") {
     // Each slice/legend row (or bar) navigates independently to that
     // slice's OWN filtered list, so — same rationale as shape "list" — this
-    // can't be one big link the way shape "count" is; it's a plain,
-    // non-link Card. It's still a click-through target in its own right,
-    // though: clicking the tile anywhere OTHER than a slice/legend row (the
-    // header, the padding, the empty state) goes to the widget's own base
-    // filters, the same destination a "count" tile with those filters would
-    // produce. Every nested interactive element (slice wedge, legend row,
-    // the refresh button) stops propagation on click, so this tile-level
-    // handler only ever fires for a genuine background click.
+    // can't be one big link the way shape "count" is. It's still a
+    // click-through target in its own right, though: clicking the tile
+    // anywhere OTHER than a slice/legend row (the header, the padding, the
+    // empty state) goes to the widget's own base filters, the same
+    // destination a "count" tile with those filters would produce.
+    //
+    // That tile-level target keeps its role="button"/Enter+Space keyboard
+    // handling (a real <a> only activates on Enter, not Space, and this
+    // control has always supported both) -- but it is now a SIBLING of the
+    // refresh button and the chart, not their ancestor: an element with an
+    // interactive role makes its descendants' own roles presentational to
+    // assistive tech, so nesting the refresh IconButton and the chart's own
+    // role="button" legend rows inside it would hide them from screen
+    // readers even though they're still clickable. The target is absolutely
+    // positioned to fill the card and sits behind (`zIndex: 0`) a
+    // `pointerEvents: "none"` content layer, so it only ever receives clicks
+    // that land on genuine background -- pointer events are switched back on
+    // (`pointerEvents: "auto"`) for the refresh button and the chart
+    // specifically, letting their own click and keyboard handling work
+    // exactly as before.
     const ChartComponent = shape === "pie" ? DashboardPieChart : DashboardBarChart;
     const tileHref = config.buildHref(resolveTeamPlaceholder(filters, selectedTeamGroupId));
     const handleTileClick = (): void => {
@@ -267,52 +279,62 @@ export default function DashboardWidgetTile({
     return (
       <Card
         variant="outlined"
-        role="button"
-        tabIndex={0}
-        aria-label={`View all cases for ${displayName}`}
-        onClick={handleTileClick}
-        onKeyDown={handleTileKeyDown}
         sx={{
           position: "relative",
           p: 1.75,
           height: "100%",
-          cursor: "pointer",
-          "&:hover": { bgcolor: "action.hover" },
-          "&:focus-visible": {
-            outline: "2px solid",
-            outlineColor: "primary.main",
-            outlineOffset: -2,
-          },
         }}
       >
-        {refreshButton}
-        {/* The header's own bottom padding — not just a top margin on the
-            chart below it — so the chart's top edge (and, at the size this
-            chart renders at, its tooltip) never sits flush against/behind
-            the title row above it. */}
-        <Box sx={{ pb: description ? 1 : 2.5 }}>{header}</Box>
-        {description && (
-          <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
-            {description}
-          </Typography>
-        )}
-        <Box>
-          <ChartComponent
-            slices={pieData.slices}
-            total={pieData.total}
-            isLoading={pieData.isLoading}
-            isError={pieData.isError}
-            onSliceClick={(slice: PieSliceResult) =>
-              navigate(
-                config.buildHref(
-                  resolveTeamPlaceholder(
-                    mergeWidgetFilters(filters, slice.filters),
-                    selectedTeamGroupId,
+        <Box
+          role="button"
+          tabIndex={0}
+          aria-label={`View all cases for ${displayName}`}
+          onClick={handleTileClick}
+          onKeyDown={handleTileKeyDown}
+          sx={{
+            position: "absolute",
+            inset: 0,
+            zIndex: 0,
+            borderRadius: "inherit",
+            cursor: "pointer",
+            "&:hover": { bgcolor: "action.hover" },
+            "&:focus-visible": {
+              outline: "2px solid",
+              outlineColor: "primary.main",
+              outlineOffset: -2,
+            },
+          }}
+        />
+        <Box sx={{ position: "relative", zIndex: 1, height: "100%", pointerEvents: "none" }}>
+          <Box sx={{ pointerEvents: "auto" }}>{refreshButton}</Box>
+          {/* The header's own bottom padding — not just a top margin on the
+              chart below it — so the chart's top edge (and, at the size this
+              chart renders at, its tooltip) never sits flush against/behind
+              the title row above it. */}
+          <Box sx={{ pb: description ? 1 : 2.5 }}>{header}</Box>
+          {description && (
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
+              {description}
+            </Typography>
+          )}
+          <Box sx={{ pointerEvents: "auto" }}>
+            <ChartComponent
+              slices={pieData.slices}
+              total={pieData.total}
+              isLoading={pieData.isLoading}
+              isError={pieData.isError}
+              onSliceClick={(slice: PieSliceResult) =>
+                navigate(
+                  config.buildHref(
+                    resolveTeamPlaceholder(
+                      mergeWidgetFilters(filters, slice.filters),
+                      selectedTeamGroupId,
+                    ),
                   ),
-                ),
-              )
-            }
-          />
+                )
+              }
+            />
+          </Box>
         </Box>
       </Card>
     );
@@ -368,28 +390,49 @@ export default function DashboardWidgetTile({
   }
 
   return (
+    // Same sibling-target restructuring as the pie/bar branch above: the
+    // whole-card click-through used to BE the refresh IconButton's own
+    // ancestor (`Card component={RouterLink}`), which hides a nested
+    // interactive control from assistive tech exactly like a nested
+    // role="button" does. The anchor here is a background sibling instead;
+    // see the pie/bar branch's comment for the pointer-events layering.
     <Card
       variant="outlined"
-      component={RouterLink}
-      to={href}
       sx={{
         position: "relative",
         p: 1.75,
-        display: "block",
         height: "100%",
-        cursor: "pointer",
-        color: "inherit",
-        textDecoration: "none",
-        transition: "box-shadow 0.2s ease, transform 0.15s ease",
-        "&:hover": {
-          boxShadow: `0 0 0 1px ${theme.palette.primary.main}, 0 4px 16px rgba(0,0,0,0.12)`,
-          transform: "translateY(-2px)",
-        },
-        "&:focus-visible": { outline: "2px solid", outlineColor: "primary.main", outlineOffset: -2 },
       }}
     >
-      {refreshButton}
-      {body}
+      <Box
+        component={RouterLink}
+        to={href}
+        // The visible count + label sit in the pointer-events-none content
+        // layer above this anchor, not inside it as descendant text anymore
+        // (that's the whole point -- see the comment above), so it needs its
+        // own accessible name instead of inheriting one from its content.
+        aria-label={`${displayName}: ${data?.total ?? 0}`}
+        sx={{
+          position: "absolute",
+          inset: 0,
+          zIndex: 0,
+          display: "block",
+          borderRadius: "inherit",
+          cursor: "pointer",
+          color: "inherit",
+          textDecoration: "none",
+          transition: "box-shadow 0.2s ease, transform 0.15s ease",
+          "&:hover": {
+            boxShadow: `0 0 0 1px ${theme.palette.primary.main}, 0 4px 16px rgba(0,0,0,0.12)`,
+            transform: "translateY(-2px)",
+          },
+          "&:focus-visible": { outline: "2px solid", outlineColor: "primary.main", outlineOffset: -2 },
+        }}
+      />
+      <Box sx={{ position: "relative", zIndex: 1, height: "100%", pointerEvents: "none" }}>
+        <Box sx={{ pointerEvents: "auto" }}>{refreshButton}</Box>
+        {body}
+      </Box>
     </Card>
   );
 }

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
@@ -16,7 +16,7 @@
 
 import { Box, Button, Card, IconButton, Skeleton, Tooltip, Typography, alpha, useTheme } from "@wso2/oxygen-ui";
 import { ArrowRight, RefreshCw } from "@wso2/oxygen-ui-icons-react";
-import type { JSX, MouseEvent, ReactNode } from "react";
+import type { JSX, KeyboardEvent, MouseEvent, ReactNode } from "react";
 import { Link as RouterLink, useNavigate } from "react-router";
 import type { BeDashboardPieSlice, BeWidgetResourceType, BeWidgetShape } from "@api/backend/types";
 import { useCurrentUser } from "@context/current-user/CurrentUserContext";
@@ -243,13 +243,48 @@ export default function DashboardWidgetTile({
   }
 
   if (shape === "pie" || shape === "bar") {
-    // Each slice/legend row (or bar) navigates independently, so — same
-    // rationale as shape "list" — this can't be one big link the way shape
-    // "count" is; it's a plain, non-link Card with its own nested click
-    // targets.
+    // Each slice/legend row (or bar) navigates independently to that
+    // slice's OWN filtered list, so — same rationale as shape "list" — this
+    // can't be one big link the way shape "count" is; it's a plain,
+    // non-link Card. It's still a click-through target in its own right,
+    // though: clicking the tile anywhere OTHER than a slice/legend row (the
+    // header, the padding, the empty state) goes to the widget's own base
+    // filters, the same destination a "count" tile with those filters would
+    // produce. Every nested interactive element (slice wedge, legend row,
+    // the refresh button) stops propagation on click, so this tile-level
+    // handler only ever fires for a genuine background click.
     const ChartComponent = shape === "pie" ? DashboardPieChart : DashboardBarChart;
+    const tileHref = config.buildHref(resolveTeamPlaceholder(filters, selectedTeamGroupId));
+    const handleTileClick = (): void => {
+      void navigate(tileHref);
+    };
+    const handleTileKeyDown = (e: KeyboardEvent): void => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        handleTileClick();
+      }
+    };
     return (
-      <Card variant="outlined" sx={{ position: "relative", p: 1.75, height: "100%" }}>
+      <Card
+        variant="outlined"
+        role="button"
+        tabIndex={0}
+        aria-label={`View all cases for ${displayName}`}
+        onClick={handleTileClick}
+        onKeyDown={handleTileKeyDown}
+        sx={{
+          position: "relative",
+          p: 1.75,
+          height: "100%",
+          cursor: "pointer",
+          "&:hover": { bgcolor: "action.hover" },
+          "&:focus-visible": {
+            outline: "2px solid",
+            outlineColor: "primary.main",
+            outlineOffset: -2,
+          },
+        }}
+      >
         {refreshButton}
         {/* The header's own bottom padding — not just a top margin on the
             chart below it — so the chart's top edge (and, at the size this

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.test.ts
@@ -170,4 +170,40 @@ describe("WIDGET_RESOURCE_CONFIG.case — previously-dropped fields", () => {
     expect(parsed.updatedOnGte).toBe("2026-01-01");
     expect(parsed.updatedOnLte).toBe("2026-06-30");
   });
+
+  it("`abt_sla_at_risk` (>=80% elapsed) and `abt_sla_violations` (>=100% elapsed) now produce distinct hrefs, each carrying its own threshold", () => {
+    // Mirrors the two real widgets' `filters` verbatim (reference/dashboard-config.json,
+    // team placeholder already resolved to a concrete groupId — the same
+    // shape `DashboardWidgetTile` passes to `buildHref` after
+    // `resolveTeamPlaceholder`). Before the data-layer commit these two
+    // hrefs were byte-identical because `taskSLABusinessElapsedPercent` was
+    // dropped entirely — see the cases-list-advanced-filters task record.
+    const teamFilters = [
+      { field: "integrationCsTeam", op: "in", values: ["22222222-2222-2222-2222-222222222222"] },
+      { field: "state", op: "in", values: ["open", "work_in_progress", "waiting_on_wso2"] },
+    ];
+    const atRiskHref = WIDGET_RESOURCE_CONFIG.case.buildHref({
+      filters: [
+        ...teamFilters,
+        { field: "taskSLABusinessElapsedPercent", op: "gte", values: ["80"] },
+      ],
+    });
+    const violationsHref = WIDGET_RESOURCE_CONFIG.case.buildHref({
+      filters: [
+        ...teamFilters,
+        { field: "taskSLABusinessElapsedPercent", op: "gte", values: ["100"] },
+      ],
+    });
+
+    expect(atRiskHref).not.toBe(violationsHref);
+
+    const atRiskParsed = readCasesFiltersFromUrl(hrefParams(atRiskHref));
+    const violationsParsed = readCasesFiltersFromUrl(hrefParams(violationsHref));
+    expect(atRiskParsed.slaElapsedPctGte).toBe(80);
+    expect(violationsParsed.slaElapsedPctGte).toBe(100);
+    // Both still carry the shared team/state constraints — only the
+    // threshold differs.
+    expect(atRiskParsed.csTeams).toEqual(violationsParsed.csTeams);
+    expect(atRiskParsed.states).toEqual(violationsParsed.states);
+  });
 });

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.test.ts
@@ -24,6 +24,7 @@
 
 import { describe, expect, it } from "vitest";
 import { WIDGET_RESOURCE_CONFIG } from "@features/csm-dashboard/config/widgetResourceConfig";
+import { readCasesFiltersFromUrl } from "@features/csm-cases/utils/casesFiltersUrl";
 
 function hrefParams(href: string): URLSearchParams {
   const [, qs] = href.split("?");
@@ -95,5 +96,78 @@ describe("WIDGET_RESOURCE_CONFIG.case.buildHref", () => {
     const params = hrefParams(href);
     expect(params.has("engagementTypes")).toBe(false);
     expect(params.has("workStates")).toBe(false);
+  });
+});
+
+/**
+ * Regression: the motivating bug for this whole feature. A widget filtering
+ * `integrationCsTeam in [<team>]` + `tag notIn [s_dip]` + `state in [...]`
+ * clicked through to `/cases?states=...` with the team and tag conditions
+ * silently dropped — a tile reading 2 landed on a list of 30 (the org-wide
+ * figure). Confirmed live three times before this fix. This suite proves the
+ * full round trip end to end: `translateCaseDashboardFilters` ->
+ * `casesHref` -> `readCasesFiltersFromUrl` — not just that the href contains
+ * the right substring.
+ */
+describe("WIDGET_RESOURCE_CONFIG.case — previously-dropped fields", () => {
+  it("carries integrationCsTeam, tag notIn, projectOnboardingStatus, escalation, escalationLevel, projectType, and SLA%/date ranges through to the href", () => {
+    const href = WIDGET_RESOURCE_CONFIG.case.buildHref({
+      filters: [
+        { field: "integrationCsTeam", op: "in", values: ["team-abt"] },
+        { field: "tag", op: "notIn", values: ["s_dip"] },
+        { field: "projectOnboardingStatus", op: "in", values: ["in_progress"] },
+        { field: "escalation", op: "isNotEmpty" },
+        { field: "escalationLevel", op: "in", values: ["L1"] },
+        { field: "projectType", op: "in", values: ["enterprise"] },
+        { field: "taskSLABusinessElapsedPercent", op: "gte", values: ["80"] },
+        { field: "createdOn", op: "gte", values: ["2026-01-01"] },
+      ],
+    });
+    const parsed = readCasesFiltersFromUrl(hrefParams(href));
+
+    expect(parsed.csTeams).toEqual(["team-abt"]);
+    expect(parsed.excludeTags).toEqual(["s_dip"]);
+    expect(parsed.tags).toEqual([]); // must NOT be inverted into an inclusion
+    expect(parsed.onboardingStatuses).toEqual(["in_progress"]);
+    expect(parsed.hasEscalation).toBe(true);
+    expect(parsed.escalationLevels).toEqual(["L1"]);
+    expect(parsed.projectTypes).toEqual(["enterprise"]);
+    expect(parsed.slaElapsedPctGte).toBe(80);
+    expect(parsed.createdOnGte).toBe("2026-01-01");
+  });
+
+  it("the org-wide-figure regression: team + tag-exclusion + state survive together, unchanged, end to end", () => {
+    const href = WIDGET_RESOURCE_CONFIG.case.buildHref({
+      filters: [
+        { field: "integrationCsTeam", op: "in", values: ["team-abt"] },
+        { field: "tag", op: "notIn", values: ["s_dip"] },
+        { field: "state", op: "in", values: ["open", "work_in_progress"] },
+      ],
+    });
+    const parsed = readCasesFiltersFromUrl(hrefParams(href));
+
+    expect(parsed.csTeams).toEqual(["team-abt"]);
+    expect(parsed.excludeTags).toEqual(["s_dip"]);
+    expect(parsed.states).toEqual(["open", "work_in_progress"]);
+  });
+
+  it("hasEscalation:false (isEmpty) round-trips distinctly from isNotEmpty", () => {
+    const href = WIDGET_RESOURCE_CONFIG.case.buildHref({
+      filters: [{ field: "escalation", op: "isEmpty" }],
+    });
+    const parsed = readCasesFiltersFromUrl(hrefParams(href));
+    expect(parsed.hasEscalation).toBe(false);
+  });
+
+  it("gte and lte on the same date field both survive independently", () => {
+    const href = WIDGET_RESOURCE_CONFIG.case.buildHref({
+      filters: [
+        { field: "updatedOn", op: "gte", values: ["2026-01-01"] },
+        { field: "updatedOn", op: "lte", values: ["2026-06-30"] },
+      ],
+    });
+    const parsed = readCasesFiltersFromUrl(hrefParams(href));
+    expect(parsed.updatedOnGte).toBe("2026-01-01");
+    expect(parsed.updatedOnLte).toBe("2026-06-30");
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.ts
@@ -139,13 +139,35 @@ function caseFilterValues(
   return fieldFilters?.find((f) => f.field === field)?.values;
 }
 
+/** Reads the first entry matching `field` AND `op` in a case widget's
+ * `filters.filters` array, or `undefined` if no such combination is present
+ * — used for fields where the op itself carries meaning (`tag` in vs.
+ * notIn, `escalation`'s value-less isEmpty vs. isNotEmpty, and each
+ * gte/lte range bound), so the wrong op is never silently matched. */
+function caseFilterEntry(
+  fieldFilters: CaseDashboardFieldFilter[] | undefined,
+  field: string,
+  op: string,
+): CaseDashboardFieldFilter | undefined {
+  return fieldFilters?.find((f) => f.field === field && f.op === op);
+}
+
 /**
  * Translate a dashboard widget's opaque case filters (the `POST
  * /cases/search`-shaped `{ filters: BeCaseFieldFilter[] }` body — see
  * `BeCaseSearchFilters`) into the cases list's own `CasesFilters` shape.
- * `tag` has no equivalent in `CasesFilters` today (the case-list tag filter
- * was pulled out of the filter bar/URL — see the note on `CasesFilters.tags`
- * in `casesFiltersUrl.ts`) and is dropped rather than invented.
+ * Every field the case-search DSL supports (see `caseFilterFieldSet` in
+ * `case_filters.go`) now has a home in `CasesFilters` and is passed through
+ * — this used to drop `taskSLABusinessElapsedPercent`, `escalationLevel`/
+ * `escalation`, `integrationCsTeam`, `tag`, `projectOnboardingStatus`,
+ * `projectType`, and the `createdOn`/`updatedOn`/`closedOn` date ranges,
+ * which was the root cause of the click-through data-loss bug this function
+ * exists to fix (a tile reading a filtered count landed on the org-wide
+ * cases list because its filters had nowhere to go). Only `orGroups`,
+ * `parentId`, and `resolutionNotes` remain genuinely dropped: no dashboard
+ * widget uses them today, and `CasesFilters` has no equivalent to invent one
+ * for without guessing at a UI treatment.
+ *
  * `assignedUserId` carries the current user's own UUID (every widget that
  * sets it does so via the current-user placeholder), and
  * `CasesFilters.assignees` is email/`@me`-based with no UUID lookup
@@ -153,15 +175,14 @@ function caseFilterValues(
  * any non-empty `assignedUserId` maps to the `@me` sentinel rather than an
  * (unresolvable) literal UUID.
  *
- * The remaining case-search DSL fields genuinely have no home in
- * `CasesFilters`/`CasesFilterBar` today and are dropped, not silently
- * mistranslated: `taskSLABusinessElapsedPercent`, `escalationLevel`/
- * `escalation`, `integrationCsTeam`, `projectOnboardingStatus`, `projectType`,
- * `createdOn`/`updatedOn`/`closedOn` date ranges, `orGroups`, `parentId`,
- * `resolutionNotes`. A widget using any of these click-throughs to an
- * unfiltered (or partially-filtered) cases list rather than erroring — adding
- * real support for each is its own case-list-page feature, not a dashboard
- * change.
+ * `tag`'s two ops (`in`/`notIn`) map to the two distinct `CasesFilters`
+ * fields `tags`/`excludeTags` — never a single field plus an inferred op —
+ * so a `notIn` widget filter can never decode as `tags` (an inclusion) the
+ * way the equivalent bug shipped once in the dashboard preview URL (see
+ * `casesFiltersUrl.ts`'s `writeCasesFiltersToUrl` doc comment for the full
+ * story). Likewise `escalation`'s value-less `isEmpty`/`isNotEmpty` map to
+ * the explicit tri-state `hasEscalation` (`false`/`true`), never silently
+ * defaulted when absent (`undefined`, i.e. not touched in `out`).
  */
 function translateCaseDashboardFilters(
   filters: Record<string, unknown>,
@@ -191,6 +212,62 @@ function translateCaseDashboardFilters(
   if (workStates && workStates.length > 0) {
     out.workStates = workStates as CasesFilters["workStates"];
   }
+
+  const csTeams = caseFilterValues(fieldFilters, "integrationCsTeam");
+  if (csTeams && csTeams.length > 0) out.csTeams = csTeams;
+
+  // `tag` in vs. notIn -> two distinct CasesFilters fields, matched by
+  // field+op together so one can never be mistaken for the other.
+  const tags = caseFilterEntry(fieldFilters, "tag", "in")?.values;
+  if (tags && tags.length > 0) out.tags = tags;
+  const excludeTags = caseFilterEntry(fieldFilters, "tag", "notIn")?.values;
+  if (excludeTags && excludeTags.length > 0) out.excludeTags = excludeTags;
+
+  const onboardingStatuses = caseFilterValues(fieldFilters, "projectOnboardingStatus");
+  if (onboardingStatuses && onboardingStatuses.length > 0) {
+    out.onboardingStatuses = onboardingStatuses;
+  }
+
+  const slaGte = caseFilterEntry(fieldFilters, "taskSLABusinessElapsedPercent", "gte")
+    ?.values?.[0];
+  if (slaGte !== undefined) {
+    const n = Number(slaGte);
+    if (Number.isInteger(n) && n >= 0) out.slaElapsedPctGte = n;
+  }
+  const slaLte = caseFilterEntry(fieldFilters, "taskSLABusinessElapsedPercent", "lte")
+    ?.values?.[0];
+  if (slaLte !== undefined) {
+    const n = Number(slaLte);
+    if (Number.isInteger(n) && n >= 0) out.slaElapsedPctLte = n;
+  }
+
+  // Value-less predicate: presence of the entry (matched by op alone, no
+  // `values` to read) is the whole filter -- must not be skipped for
+  // "having nothing to read", the exact failure mode `writeWidgetPreviewHref`
+  // shipped once for `isEmpty`/`isNotEmpty` entries generally.
+  if (caseFilterEntry(fieldFilters, "escalation", "isNotEmpty")) out.hasEscalation = true;
+  else if (caseFilterEntry(fieldFilters, "escalation", "isEmpty")) out.hasEscalation = false;
+
+  const escalationLevels = caseFilterValues(fieldFilters, "escalationLevel");
+  if (escalationLevels && escalationLevels.length > 0) {
+    out.escalationLevels = escalationLevels;
+  }
+
+  const projectTypes = caseFilterValues(fieldFilters, "projectType");
+  if (projectTypes && projectTypes.length > 0) out.projectTypes = projectTypes;
+
+  const dateRangeFields: [string, keyof CasesFilters, keyof CasesFilters][] = [
+    ["createdOn", "createdOnGte", "createdOnLte"],
+    ["updatedOn", "updatedOnGte", "updatedOnLte"],
+    ["closedOn", "closedOnGte", "closedOnLte"],
+  ];
+  for (const [beField, gteKey, lteKey] of dateRangeFields) {
+    const gte = caseFilterEntry(fieldFilters, beField, "gte")?.values?.[0];
+    if (gte !== undefined) (out as Record<string, unknown>)[gteKey] = gte;
+    const lte = caseFilterEntry(fieldFilters, beField, "lte")?.values?.[0];
+    if (lte !== undefined) (out as Record<string, unknown>)[lteKey] = lte;
+  }
+
   return out;
 }
 

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/utils/widgetPreviewUrl.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/utils/widgetPreviewUrl.test.ts
@@ -151,3 +151,57 @@ describe("widgetPreviewUrl", () => {
     ]);
   });
 });
+
+/**
+ * Regression: the preview URL used to drop each filter entry's `op`, so every
+ * entry decoded back as `in`. That INVERTED `notIn` (a tag exclusion became a
+ * tag filter) and dropped value-less ops entirely, silently widening
+ * "Unassigned Cases" into "all cases". Found by live click-through testing,
+ * not by any unit test -- hence this one.
+ */
+describe("widget preview URL — filter op round-trip", () => {
+  function roundTrip(filters: { field: string; op: string; values?: string[] }[]) {
+    const href = buildWidgetPreviewHref({
+      previewSlug: "cases",
+      widgetId: "w1",
+      displayName: "W",
+      filters: { filters },
+    });
+    const qs = href.split("?")[1] ?? "";
+    return parseWidgetPreviewFilters(new URLSearchParams(qs));
+  }
+
+  it("preserves notIn instead of inverting it to in", () => {
+    const parsed = roundTrip([{ field: "tag", op: "notIn", values: ["s_dip"] }]);
+    const entries = (parsed.filters as { filters: { field: string; op: string }[] }).filters;
+    expect(entries).toEqual([{ field: "tag", op: "notIn", values: ["s_dip"] }]);
+  });
+
+  it("preserves value-less ops rather than dropping them", () => {
+    const parsed = roundTrip([{ field: "assignedUserId", op: "isEmpty", values: [] }]);
+    const entries = (parsed.filters as { filters: { field: string; op: string }[] }).filters;
+    expect(entries).toEqual([{ field: "assignedUserId", op: "isEmpty", values: [] }]);
+  });
+
+  it("keeps the bare field=values form for the default in op", () => {
+    const href = buildWidgetPreviewHref({
+      previewSlug: "cases",
+      widgetId: "w1",
+      displayName: "W",
+      filters: { filters: [{ field: "state", op: "in", values: ["open"] }] },
+    });
+    expect(href).toContain("state=open");
+    expect(href).not.toContain("~");
+  });
+
+  it("round-trips a mixed filter set faithfully", () => {
+    const input = [
+      { field: "state", op: "in", values: ["open", "reopened"] },
+      { field: "tag", op: "notIn", values: ["s_dip", "patch"] },
+      { field: "escalation", op: "isNotEmpty", values: [] },
+    ];
+    const parsed = roundTrip(input);
+    const entries = (parsed.filters as { filters: unknown[] }).filters;
+    expect(entries).toEqual(input);
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/utils/widgetPreviewUrl.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/utils/widgetPreviewUrl.ts
@@ -28,6 +28,16 @@ const RESERVED_PARAMS = new Set(["w", "n", CASE_FILTER_MARKER]);
  * preview URL never carries a bare internal user id. */
 const CURRENT_USER_SENTINEL = "@me";
 
+/** Separates a field from a non-default op in a preview query param, e.g.
+ * `tag~notIn=s_dip`. `~` is safe: every filter field name is camelCase
+ * alphanumeric, so it can never appear in one. */
+const OP_SEPARATOR = "~";
+
+/** Ops that carry no `values` — they must still survive the round trip, so
+ * they are encoded with an empty value (`escalation~isNotEmpty=`) rather than
+ * skipped for being value-less. */
+const VALUELESS_OPS = new Set(["isEmpty", "isNotEmpty"]);
+
 function isStringArray(value: unknown): value is string[] {
   return Array.isArray(value) && value.every((v) => typeof v === "string");
 }
@@ -47,12 +57,12 @@ export interface WidgetCaseFieldFilterLike {
 /**
  * True when `value` is the `filters` array of a case widget's filters object
  * (`{ filters: BeCaseFieldFilter[] }` — see `BeCaseSearchFilters`), detected
- * structurally so this file never needs to know the resourceType. Every
- * dashboard case-filter widget today uses `op: "in"` only (see
- * `.env.example`'s `DASHBOARDS_CONFIG`); a non-`"in"` op still round-trips
- * through the URL (its `values` are preserved), but always decodes back with
- * `op: "in"` — a lossy simplification acceptable only because op isn't
- * configurable from this preview UI yet.
+ * structurally so this file never needs to know the resourceType. Ops other
+ * than `in` are common now (`notIn` tag exclusions, `isEmpty` for unassigned,
+ * `isNotEmpty` for escalated), so the op is encoded in the query param
+ * (`field~op`) and round-trips faithfully. It previously did NOT: every entry
+ * decoded back as `op: "in"`, which inverted `notIn` — a tag EXCLUSION became
+ * a tag filter — and value-less ops were dropped entirely.
  */
 export function isCaseFieldFilterArray(value: unknown): value is WidgetCaseFieldFilterLike[] {
   return (
@@ -104,11 +114,19 @@ export function buildWidgetPreviewHref(params: {
       usesCaseFieldFilterShape = true;
       for (const entry of value) {
         const values = entry.values ?? [];
-        if (values.length === 0) continue;
+        const op = entry.op || "in";
+        // A value-less op (isEmpty/isNotEmpty) is the whole predicate, so it
+        // must be emitted even with no values -- skipping it silently widened
+        // e.g. "Unassigned Cases" into "all cases".
+        if (values.length === 0 && !VALUELESS_OPS.has(op)) continue;
         const masked = values.map((v) =>
           v === params.currentUserId ? CURRENT_USER_SENTINEL : v,
         );
-        q.set(entry.field, masked.join(","));
+        // `in` keeps the bare `field=values` form so previously-shared links
+        // still resolve; any other op is encoded as `field~op` so it survives
+        // the round trip instead of silently decoding back as `in` (which
+        // inverted `notIn` -- a tag EXCLUSION became a tag filter).
+        q.set(op === "in" ? entry.field : `${entry.field}${OP_SEPARATOR}${op}`, masked.join(","));
       }
       continue;
     }
@@ -147,11 +165,13 @@ export function parseWidgetPreviewFilters(
     const fieldFilters: WidgetCaseFieldFilterLike[] = [];
     for (const [key, raw] of searchParams.entries()) {
       if (RESERVED_PARAMS.has(key)) continue;
-      const values = raw.split(",");
+      // `field~op` carries a non-default op; a bare `field` means `in`.
+      const sep = key.indexOf(OP_SEPARATOR);
+      const field = sep === -1 ? key : key.slice(0, sep);
+      const op = sep === -1 ? "in" : key.slice(sep + OP_SEPARATOR.length);
+      const values = raw === "" ? [] : raw.split(",");
       if (values.includes(CURRENT_USER_SENTINEL)) needsCurrentUser = true;
-      // Every dashboard case-filter widget today uses `op: "in"` only — see
-      // `isCaseFieldFilterArray`'s doc comment.
-      fieldFilters.push({ field: key, op: "in", values });
+      fieldFilters.push({ field, op, values });
     }
     return { filters: { filters: fieldFilters }, needsCurrentUser };
   }

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -1298,9 +1298,15 @@ type CaseView struct {
 	// assignee's own id already arrives with the response, so no extra lookup
 	// is involved. Null when the case is unassigned.
 	AssignedEngineerUser *UserReference `json:"assignedEngineerUser"`
-	ParentCase           *CaseNumberRef `json:"parentCase"`
-	RelatedCase          *CaseNumberRef `json:"relatedCase"`
-	AccountDetails       *AccountRef    `json:"account"`
+	// AcknowledgedBy is the support engineer who acknowledged the case: a
+	// first-write-wins claim that someone has seen it and picked it up, distinct
+	// from assignment. Null until someone acknowledges, and cleared again by the
+	// backing data source when the case's type or severity changes or it is
+	// reopened, so that a materially changed case has to be re-acknowledged.
+	AcknowledgedBy *AssignedEngineerRef `json:"acknowledgedBy"`
+	ParentCase     *CaseNumberRef       `json:"parentCase"`
+	RelatedCase    *CaseNumberRef       `json:"relatedCase"`
+	AccountDetails *AccountRef          `json:"account"`
 	// LinkedServiceRequests lists any service-request cases whose parent points to this
 	// case. Populated on every case detail response, not just high-severity cases.
 	LinkedServiceRequests []LinkedServiceRequestRef `json:"linkedServiceRequests"`
@@ -1646,6 +1652,13 @@ type UpdateCaseRequest struct {
 	// issue) echoed into the public comment. Required by ServiceNow when
 	// AddPublicComment is true (ServiceNow data source only).
 	PublicTicket *string `json:"publicTicket"`
+	// Acknowledge, when true, claims the case for the calling engineer: it records
+	// them as the acknowledger if nobody has acknowledged it yet, and otherwise
+	// succeeds without changing anything (the response then carries
+	// AlreadyAcknowledged). Only true is accepted — there is no unacknowledge — and
+	// it cannot be combined with any other field in the same request. Requires an
+	// elevated support role (ServiceNow data source only).
+	Acknowledge *bool `json:"acknowledge"`
 }
 
 // UpdateCaseResponse is the response for PATCH /cases/{id}.
@@ -1693,6 +1706,17 @@ type UpdatedCase struct {
 	// as a date-only "YYYY-MM-DD" string. Present only when the update set
 	// worstCaseFixEta.
 	WorstCaseFixEta *string `json:"worstCaseFixEta,omitempty"`
+	// Number echoes the case's human-readable number. Present only when the update
+	// acknowledged the case, whose confirmation message names the case by number.
+	Number string `json:"number,omitempty"`
+	// AlreadyAcknowledged reports that the case already had an acknowledger, so the
+	// request changed nothing and AcknowledgedBy names whoever claimed it first.
+	// Present only when the update set acknowledge.
+	AlreadyAcknowledged *bool `json:"alreadyAcknowledged,omitempty"`
+	// AcknowledgedBy is the engineer who now holds the acknowledgement, whether this
+	// request set it or found it already set. Present only when the update set
+	// acknowledge.
+	AcknowledgedBy *AssignedEngineerRef `json:"acknowledgedBy,omitempty"`
 }
 
 // WatchListUser is a compact user reference within the watch list.

--- a/entity-service/internal/service/sn_case_acknowledgement_test.go
+++ b/entity-service/internal/service/sn_case_acknowledgement_test.go
@@ -1,0 +1,225 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package service
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+)
+
+// Case acknowledgement: a first-write-wins claim that an engineer has picked the
+// case up, distinct from assignment. These cover the two directions the adapter is
+// responsible for -- reading acknowledgedBy off the case detail, and the
+// acknowledge write plus its echo -- and the guard rails around the write.
+
+func TestSNCaseService_GetCaseByID_MapsAcknowledgedBy(t *testing.T) {
+	ackSysid := sysid32('9')
+	newBody := func(acknowledgedBy string) string {
+		return `{
+			"id": "` + testWLCaseSysid + `",
+			"internalId": "WSO2-001",
+			"number": "CS0001001",
+			"title": "Case subject",
+			"description": "Case description",
+			"createdOn": "2026-01-01 10:00:00",
+			"updatedOn": "2026-01-02 10:00:00",
+			"createdBy": "reporter@example.com",
+			"project": {"id": "` + testProjectSysid + `", "name": "Project A"},
+			"deployment": {"id": "", "name": ""},
+			"deployedProduct": {"id": "", "name": "", "version": ""},
+			"state": {"id": 1, "label": "Open"},
+			"acknowledgedBy": ` + acknowledgedBy + `
+		}`
+	}
+
+	t.Run("populated acknowledgement maps through with the id converted to a platform UUID", func(t *testing.T) {
+		client := newTestCaseClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(newBody(`{"id": "` + ackSysid + `", "name": "Jane Doe", "email": "jane.doe@example.com"}`)))
+		})
+		svc := NewServiceNowCaseService(client, nil)
+
+		cv, err := svc.GetCaseByID(contextWithUserIDToken("token"), sysidToUUID(testWLCaseSysid))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cv.AcknowledgedBy == nil {
+			t.Fatal("AcknowledgedBy = nil, want a populated reference")
+		}
+		if got, want := cv.AcknowledgedBy.ID, sysidToUUID(ackSysid); got != want {
+			t.Fatalf("AcknowledgedBy.ID = %q, want the platform UUID %q", got, want)
+		}
+		if cv.AcknowledgedBy.Name != "Jane Doe" {
+			t.Fatalf("AcknowledgedBy.Name = %q, want %q", cv.AcknowledgedBy.Name, "Jane Doe")
+		}
+		if cv.AcknowledgedBy.Email == nil || *cv.AcknowledgedBy.Email != "jane.doe@example.com" {
+			t.Fatalf("AcknowledgedBy.Email = %v, want jane.doe@example.com", cv.AcknowledgedBy.Email)
+		}
+	})
+
+	t.Run("null acknowledgement stays nil rather than an empty reference", func(t *testing.T) {
+		// A zero-valued AssignedEngineerRef would read to a consumer as "acknowledged
+		// by someone with no name", which is the opposite of the truth. It must be nil.
+		client := newTestCaseClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(newBody(`null`)))
+		})
+		svc := NewServiceNowCaseService(client, nil)
+
+		cv, err := svc.GetCaseByID(contextWithUserIDToken("token"), sysidToUUID(testWLCaseSysid))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cv.AcknowledgedBy != nil {
+			t.Fatalf("AcknowledgedBy = %+v, want nil", cv.AcknowledgedBy)
+		}
+	})
+}
+
+func TestSNCaseService_UpdateCase_AcknowledgeSendsTrueAndEchoesBack(t *testing.T) {
+	ackSysid := sysid32('9')
+	var gotBody map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/cases/"+testCaseSysid, func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"message": "Case acknowledged successfully",
+			"case": map[string]any{
+				"id": testCaseSysid, "updatedOn": "2026-01-01 00:00:00",
+				"number":              "CS0001001",
+				"alreadyAcknowledged": false,
+				"acknowledgedBy": map[string]any{
+					"id": ackSysid, "name": "Jane Doe", "email": "jane.doe@example.com",
+				},
+			},
+		})
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowCaseService(client, nil)
+
+	acknowledge := true
+	resp, err := svc.UpdateCase(contextWithUserIDToken("token"), domain.UpdateCaseRequest{ID: testCaseUUID, Acknowledge: &acknowledge})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The acknowledge flag must reach the upstream payload -- an acknowledge request
+	// that arrives as an empty body would silently do nothing.
+	if gotBody["acknowledge"] != true {
+		t.Fatalf("upstream payload acknowledge = %v, want true", gotBody["acknowledge"])
+	}
+	if len(gotBody) != 1 {
+		t.Fatalf("upstream payload = %v, want acknowledge alone (it is mutually exclusive with every other field)", gotBody)
+	}
+	if resp.Case.Number != "CS0001001" {
+		t.Fatalf("Number = %q, want CS0001001", resp.Case.Number)
+	}
+	if resp.Case.AlreadyAcknowledged == nil || *resp.Case.AlreadyAcknowledged {
+		t.Fatalf("AlreadyAcknowledged = %v, want a pointer to false", resp.Case.AlreadyAcknowledged)
+	}
+	if resp.Case.AcknowledgedBy == nil {
+		t.Fatal("AcknowledgedBy = nil, want the new acknowledger")
+	}
+	if got, want := resp.Case.AcknowledgedBy.ID, sysidToUUID(ackSysid); got != want {
+		t.Fatalf("AcknowledgedBy.ID = %q, want the platform UUID %q", got, want)
+	}
+}
+
+func TestSNCaseService_UpdateCase_AcknowledgeAlreadyAcknowledgedIsNotAnError(t *testing.T) {
+	// Re-acknowledging is a no-op that succeeds: the caller needs to render "already
+	// acknowledged by X", which it cannot do if this surfaces as an error.
+	ackSysid := sysid32('9')
+	mux := http.NewServeMux()
+	mux.HandleFunc("/cases/"+testCaseSysid, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"message": "Case is already acknowledged",
+			"case": map[string]any{
+				"id": testCaseSysid, "updatedOn": "2026-01-01 00:00:00",
+				"number":              "CS0001001",
+				"alreadyAcknowledged": true,
+				"acknowledgedBy": map[string]any{
+					"id": ackSysid, "name": "Jane Doe", "email": "jane.doe@example.com",
+				},
+			},
+		})
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowCaseService(client, nil)
+
+	acknowledge := true
+	resp, err := svc.UpdateCase(contextWithUserIDToken("token"), domain.UpdateCaseRequest{ID: testCaseUUID, Acknowledge: &acknowledge})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Case.AlreadyAcknowledged == nil || !*resp.Case.AlreadyAcknowledged {
+		t.Fatalf("AlreadyAcknowledged = %v, want a pointer to true", resp.Case.AlreadyAcknowledged)
+	}
+	if resp.Case.AcknowledgedBy == nil || resp.Case.AcknowledgedBy.Name != "Jane Doe" {
+		t.Fatalf("AcknowledgedBy = %+v, want the existing acknowledger", resp.Case.AcknowledgedBy)
+	}
+}
+
+func TestSNCaseService_UpdateCase_AcknowledgeRejectsFalseAndCombinations(t *testing.T) {
+	client := newTestSNClient(t, http.NewServeMux())
+	svc := NewServiceNowCaseService(client, nil)
+
+	acknowledgeTrue, acknowledgeFalse := true, false
+	subject := "new subject"
+	state := domain.CaseStateWorkInProgress
+
+	tests := []struct {
+		name string
+		req  domain.UpdateCaseRequest
+	}{
+		{
+			// There is no unacknowledge. Accepting false and forwarding it would let a
+			// caller believe it cleared the field.
+			name: "acknowledge=false",
+			req:  domain.UpdateCaseRequest{ID: testCaseUUID, Acknowledge: &acknowledgeFalse},
+		},
+		{
+			name: "acknowledge combined with a combinable field",
+			req:  domain.UpdateCaseRequest{ID: testCaseUUID, Acknowledge: &acknowledgeTrue, Subject: &subject},
+		},
+		{
+			name: "acknowledge combined with another exclusive field",
+			req:  domain.UpdateCaseRequest{ID: testCaseUUID, Acknowledge: &acknowledgeTrue, State: &state},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := svc.UpdateCase(contextWithUserIDToken("token"), tc.req)
+			if err == nil {
+				t.Fatal("expected a validation error, got nil")
+			}
+			var verr *apierror.ValidationError
+			if !errors.As(err, &verr) {
+				t.Fatalf("error = %T (%v), want *apierror.ValidationError", err, err)
+			}
+		})
+	}
+}

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -67,6 +67,7 @@ type snCase struct {
 	AssignedTeam          *snCaseEntityRef            `json:"assignedTeam"`
 	Conversation          *snCaseEntityRef            `json:"conversation"`
 	AssignedEngineer      *snAssignedEngineerRef      `json:"assignedEngineer"`
+	AcknowledgedBy        *snAssignedEngineerRef      `json:"acknowledgedBy"`
 	ParentCase            *snCaseRef                  `json:"parentCase"`
 	RelatedCase           *snCaseRef                  `json:"relatedCase"`
 	Account               *snCaseAccount              `json:"account"`
@@ -804,6 +805,9 @@ func (s *snCaseService) GetCaseByID(ctx context.Context, id string) (domain.Case
 		cv.AssignedEngineer = &domain.AssignedEngineerRef{ID: sysidToUUID(c.AssignedEngineer.ID), Name: c.AssignedEngineer.Name, Email: c.AssignedEngineer.Email}
 		cv.AssignedEngineerUser = domain.NewUserReference(cv.AssignedEngineer.ID, snStr(c.AssignedEngineer.Email), c.AssignedEngineer.Name)
 	}
+	if c.AcknowledgedBy != nil {
+		cv.AcknowledgedBy = &domain.AssignedEngineerRef{ID: sysidToUUID(c.AcknowledgedBy.ID), Name: c.AcknowledgedBy.Name, Email: c.AcknowledgedBy.Email}
+	}
 	if c.ParentCase != nil {
 		cv.ParentCase = &domain.CaseNumberRef{ID: sysidToUUID(c.ParentCase.ID), Number: c.ParentCase.Number, Type: snParentCaseTypeToDomain(c.ParentCase.Type)}
 	}
@@ -1095,14 +1099,18 @@ func (s *snCaseService) SearchCaseComments(ctx context.Context, req domain.Searc
 }
 
 type snUpdateCasePayload struct {
-	StateKey       *int     `json:"stateKey,omitempty"`
-	SeverityKey    *int     `json:"severityKey,omitempty"`
-	WorkStateKey   *int     `json:"workStateKey,omitempty"`
-	WatchList      []string `json:"watchList,omitempty"`
-	AssigneeEmail  *string  `json:"assigneeEmail,omitempty"`
-	ResolutionCode *int     `json:"resolutionCode,omitempty"`
-	Cause          *string  `json:"cause,omitempty"`
-	CloseNotes     *string  `json:"closeNotes,omitempty"`
+	StateKey      *int     `json:"stateKey,omitempty"`
+	SeverityKey   *int     `json:"severityKey,omitempty"`
+	WorkStateKey  *int     `json:"workStateKey,omitempty"`
+	WatchList     []string `json:"watchList,omitempty"`
+	AssigneeEmail *string  `json:"assigneeEmail,omitempty"`
+	// Acknowledge claims the case for the calling engineer, first-write-wins. Only
+	// true is ever sent -- there is no unacknowledge -- and the backing service keeps
+	// it mutually exclusive with every other field in this payload.
+	Acknowledge    *bool   `json:"acknowledge,omitempty"`
+	ResolutionCode *int    `json:"resolutionCode,omitempty"`
+	Cause          *string `json:"cause,omitempty"`
+	CloseNotes     *string `json:"closeNotes,omitempty"`
 	// ParentID writes the native task.parent field. Confirmed already supported by the
 	// backing service's case-update payload and its validation, which already accept it
 	// as an exactly-one-field option -- fully wired.
@@ -1273,6 +1281,11 @@ type snUpdateCaseResponse struct {
 		BestCaseFixEta   *string `json:"bestCaseFixEta"`
 		MostLikelyFixEta *string `json:"mostLikelyFixEta"`
 		WorstCaseFixEta  *string `json:"worstCaseFixEta"`
+		// Number/AlreadyAcknowledged/AcknowledgedBy come back only on the
+		// acknowledge path -- see snUpdateCasePayload.Acknowledge.
+		Number              string                 `json:"number"`
+		AlreadyAcknowledged *bool                  `json:"alreadyAcknowledged"`
+		AcknowledgedBy      *snAssignedEngineerRef `json:"acknowledgedBy"`
 	} `json:"case"`
 }
 
@@ -1305,6 +1318,9 @@ func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReq
 	if req.ParentID != nil {
 		exclusiveCount++
 	}
+	if req.Acknowledge != nil {
+		exclusiveCount++
+	}
 	// combinableCount covers plain field writes with no cross-field side
 	// effects -- SN now accepts any subset of these together in one PATCH.
 	combinableCount := 0
@@ -1335,14 +1351,14 @@ func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReq
 	if req.WorstCaseFixEta != nil {
 		combinableCount++
 	}
-	const fieldList = "state, severity, workState, watchList, assigneeEmail, parentId, relatedCaseId, " +
-		"autocloseHoldUntil, subject, description, deploymentId, deployedProductId, " +
+	const fieldList = "state, severity, workState, watchList, assigneeEmail, parentId, acknowledge, " +
+		"relatedCaseId, autocloseHoldUntil, subject, description, deploymentId, deployedProductId, " +
 		"bestCaseFixEta, mostLikelyFixEta, or worstCaseFixEta"
 	if exclusiveCount == 0 && combinableCount == 0 {
 		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "at least one of " + fieldList + " must be provided"}
 	}
 	if exclusiveCount > 1 || (exclusiveCount == 1 && combinableCount > 0) {
-		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "state, severity, workState, watchList, assigneeEmail, and parentId cannot be combined with each other or with any other field in the same request"}
+		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "state, severity, workState, watchList, assigneeEmail, parentId, and acknowledge cannot be combined with each other or with any other field in the same request"}
 	}
 	if hasResolutionFields && req.State == nil {
 		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "resolutionCode, cause, and closeNotes are only allowed when state is also provided"}
@@ -1405,6 +1421,15 @@ func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReq
 	}
 	if req.AssigneeEmail != nil {
 		payload.AssigneeEmail = req.AssigneeEmail
+	}
+	if req.Acknowledge != nil {
+		// Reject false here rather than forwarding it: acknowledgement is
+		// first-write-wins with no unacknowledge path, so false has no meaning, and a
+		// caller sending it is asking for something this API cannot do.
+		if !*req.Acknowledge {
+			return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "acknowledge must be true; unacknowledging a case is not supported"}
+		}
+		payload.Acknowledge = req.Acknowledge
 	}
 	if req.ParentID != nil {
 		if err := validateUUIDs("parentId", []string{*req.ParentID}); err != nil {
@@ -1526,6 +1551,21 @@ func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReq
 			Name: snResp.Case.AssignedTo.Name,
 		}
 		resp.Case.AssignedToUser = domain.NewUserReference(resp.Case.AssignedTo.ID, "", resp.Case.AssignedTo.Name)
+	}
+	if req.Acknowledge != nil {
+		// Number and alreadyAcknowledged are only meaningful on the acknowledge path,
+		// so they are echoed only when this request was one. alreadyAcknowledged is
+		// copied verbatim rather than defaulted: if the backing service omits it, the
+		// caller sees an absent field instead of a fabricated false.
+		resp.Case.Number = snResp.Case.Number
+		resp.Case.AlreadyAcknowledged = snResp.Case.AlreadyAcknowledged
+		if snResp.Case.AcknowledgedBy != nil {
+			resp.Case.AcknowledgedBy = &domain.AssignedEngineerRef{
+				ID:    sysidToUUID(snResp.Case.AcknowledgedBy.ID),
+				Name:  snResp.Case.AcknowledgedBy.Name,
+				Email: snResp.Case.AcknowledgedBy.Email,
+			}
+		}
 	}
 	if len(snResp.Case.WatchList) > 0 {
 		wl := make([]domain.WatchListUser, 0, len(snResp.Case.WatchList))

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -786,8 +786,8 @@ paths:
       summary: Update a support case.
       description: |
         Updates exactly one field of the case. Provide exactly one of: `state`, `severity`,
-        `workState`, `watchList`, `assigneeEmail`, `bestCaseFixEta`, `mostLikelyFixEta`,
-        or `worstCaseFixEta`. `watchList`, `assigneeEmail`, `bestCaseFixEta`,
+        `workState`, `watchList`, `assigneeEmail`, `acknowledge`, `bestCaseFixEta`,
+        `mostLikelyFixEta`, or `worstCaseFixEta`. `watchList`, `assigneeEmail`, `bestCaseFixEta`,
         `mostLikelyFixEta`, and `worstCaseFixEta` are supported only when the ServiceNow data
         source is active.
       operationId: patchCase
@@ -4458,7 +4458,8 @@ components:
       type: object
       description: |
         Exactly one of `state`, `severity`, `workState`, `watchList`, `assigneeEmail`,
-        `bestCaseFixEta`, `mostLikelyFixEta`, or `worstCaseFixEta` must be provided.
+        `acknowledge`, `bestCaseFixEta`, `mostLikelyFixEta`, or `worstCaseFixEta` must be
+        provided.
         `watchList`, `assigneeEmail`, `bestCaseFixEta`, `mostLikelyFixEta`, and
         `worstCaseFixEta` are supported only for the ServiceNow data source.
         `resolutionCode`, `cause`, and `closeNotes` are optional and may only be provided alongside
@@ -4469,6 +4470,7 @@ components:
         - required: [workState]
         - required: [watchList]
         - required: [assigneeEmail]
+        - required: [acknowledge]
         - required: [bestCaseFixEta]
         - required: [mostLikelyFixEta]
         - required: [worstCaseFixEta]
@@ -4495,6 +4497,17 @@ components:
           type: string
           format: email
           description: Email of the engineer to assign to this case (ServiceNow only).
+        acknowledge:
+          type: boolean
+          enum: [true]
+          description: |
+            Acknowledge the case as the calling engineer: a first-write-wins claim that
+            someone has seen it and picked it up, which is distinct from assignment.
+            Succeeds without changing anything if the case is already acknowledged, in
+            which case the response carries `alreadyAcknowledged: true`. Only `true` is
+            accepted; there is no way to remove an acknowledgement. Requires an elevated
+            support role, and is supported only by data sources that record
+            acknowledgement.
         resolutionCode:
           type: string
           enum:
@@ -4611,6 +4624,21 @@ components:
         assignedToUser:
           nullable: true
           $ref: '#/components/schemas/UserReference'
+        number:
+          type: string
+          description: Human-readable case number. Returned only when the update acknowledged the case.
+        alreadyAcknowledged:
+          type: boolean
+          description: |
+            True when the case already had an acknowledger, so the request changed nothing
+            and `acknowledgedBy` names whoever claimed it first. Returned only when the
+            update set `acknowledge`.
+        acknowledgedBy:
+          nullable: true
+          $ref: '#/components/schemas/AssignedEngineerRef'
+          description: |
+            Engineer who now holds the acknowledgement, whether this request set it or
+            found it already set. Returned only when the update set `acknowledge`.
         resolutionCode:
           type: string
           nullable: true
@@ -5293,6 +5321,13 @@ components:
         assignedEngineerUser:
           nullable: true
           $ref: '#/components/schemas/UserReference'
+        acknowledgedBy:
+          nullable: true
+          $ref: '#/components/schemas/AssignedEngineerRef'
+          description: |
+            Engineer who acknowledged the case, or null if nobody has. Cleared by the
+            backing data source when the case's type or severity changes or it is
+            reopened, so a materially changed case has to be acknowledged again.
         parentCase:
           nullable: true
           $ref: '#/components/schemas/CaseNumberRef'


### PR DESCRIPTION
## Purpose
> Makes dashboard widget click-through actually usable, and adds case acknowledgement. Live browser testing against real ServiceNow DEV found that **none** of the ABT dashboard's widgets landed anywhere useful when clicked: the cases-list page had no way to represent most of the filters the widgets use, so a team-scoped tile opened an org-wide list. Follow-on to #1329 (merged).

## Goals
- Let the cases list represent every filter the dashboard widgets actually use, so click-through is lossless.
- Fix a shipped bug that **inverted** tag-exclusion filters in the widget preview URL.
- Give pie/bar dashboard tiles a click-through of their own.
- Add case acknowledgement (entity-service read/write, API docs, case-detail action).

## Approach

**Cases-list advanced filters.** `translateCaseDashboardFilters` passed only 7 filter fields and silently dropped `tag`, `integrationCsTeam`, `projectOnboardingStatus`, `taskSLABusinessElapsedPercent`, `escalation`/`escalationLevel`, `projectType` and all date ranges — and every widget uses at least one. `CasesFilters`, the URL codec (`casesFiltersUrl.ts`), the search payload (`caseSearchPayload.ts`) and the translator now carry them. No backend change was needed: the BFF, entity-service, Ballerina and SN already supported every one of these filters, which is why the widgets themselves query correctly — this was purely a frontend representation gap.

The measured symptom, confirmed three times: a tile reading **2** opened a list of **30**, a tile reading **0** opened **16**, another **0** opened **11** — each destination total landing exactly on the org-wide figure.

**Encoding.** `CasesFilters` is a fixed named-field struct, so rather than encoding an op per field, each op that could collide gets its own field: `tags` (in) vs `excludeTags` (notIn), `slaElapsedPctGte`/`Lte`, and `hasEscalation` as a `true`/`false`/`null` tri-state. There is no default op to fall back to, so the inversion failure mode below is structurally unreachable here rather than merely tested against.

**Filter-op bug in the widget preview URL (real, shipped).** The preview URL encoded field + values but dropped the `op`, and the parser hardcoded `op:"in"`. So `tag notIn [s_dip]` round-tripped as `tag in [s_dip]` — the "View more" page showed precisely the cases the tile *excludes* (reproduced: tile 5 rows → preview 0 rows). Value-less ops (`isEmpty`/`isNotEmpty`) were dropped entirely, silently widening "Unassigned Cases" into all cases. Now encoded as `field~op`; the default `in` keeps the bare `field=values` form so links shared before this change still resolve. The doc comment asserting "every dashboard widget uses `op:in` only" was true when written and is not anymore — corrected rather than left to license the same bug again.

**Filter-bar controls.** CS-team and tag controls were added, then removed as UI clutter (advanced, rarely hand-picked; a better home for advanced filters is still to be designed). Removing them alone would have regressed the thing they were added for, since the chip builder deliberately skipped those fields *because* they had controls — they now render as removable active-filter chips like every other URL-only filter, which is what makes a dashboard-filtered arrival self-explanatory.

**Pie/bar tiles** previously had no click-through at all; only legend rows navigated, carrying `state` alone. The tile now navigates to its own filters, and slices merge the tile's filters with the slice's.

**Case acknowledgement** (cherry-picked): entity-service read/write, CSM-portal API documentation, and the acknowledge action on the case detail page. Companion to the Ballerina layer in a corresponding entity-service change, tracked separately. Depends on SN update set `1264-S1224-T92-CST-SajithE`.

## User stories
> As a CS engineer, when I click a dashboard tile I land on a cases list filtered to exactly what the tile counted — and I can see, as chips, why it is filtered and remove any of them.
> As a CS engineer, I can acknowledge a case in one action and see who already acknowledged it.

## Release note
> Dashboard widget click-through now carries the widget's full filter set to the cases list; pie and bar tiles are clickable; case acknowledgement is available from the case detail page.

## Documentation
> N/A — internal CS-engineer tooling; no external documentation references these surfaces.

## Automation tests
- Unit tests
  > `npx tsc -b` clean. `vitest` on `csm-cases` + `csm-dashboard` passes apart from 4 pre-existing `CaseActionBar.test.tsx` failures, confirmed to fail identically on a clean tree (file untouched here). `go build`/`go vet`/`go test ./...`/`gofmt -l` clean in both Go modules.
  > Both regressions are pinned by tests **confirmed to fail against the previous code**, not merely to pass against the new one: the `notIn` round-trip, and a test named for the org-wide-figure symptom (team + tag-exclusion + state surviving translate → href → parse unchanged).
- Integration tests
  > Widget filters were verified against real `wso2sndev` counts rather than assumed — ServiceNow silently ignores an unrecognised filter field instead of erroring, so a filter that "looks right" proves nothing. Browser click-through verification against the running local stack is in progress.

## Security checks
- Followed secure coding standards? yes
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
> Follow-on to #1329 (merged). The Ballerina entity-service side of case acknowledgement is tracked in the corresponding private entity-service repo.

## Migrations (if applicable)
> N/A — no schema or data migration.

## Test environment
> macOS host; Go per `go.mod`, Node/pnpm per `package.json`; real ServiceNow DEV (`wso2sndev.service-now.com`) via a locally-run entity-service and Ballerina layer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added case acknowledgement with eligibility checks, loading feedback, first-write-wins handling, and acknowledgement details.
  - Added advanced case filters for teams, tags, onboarding status, SLA thresholds, escalation, project types, and date ranges.
  - Added active-filter chips with individual removal and URL persistence.
  - Improved dashboard charts with keyboard accessibility and direct navigation.

- **Bug Fixes**
  - Fixed case filters being dropped when navigating between dashboard widgets and previews.
  - Prevented chart interactions from triggering unintended tile navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->