### PR TITLE
[Entity-Service] Add project-scoped metadata and statistics endpoints

### DIFF
--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -634,6 +634,171 @@ type SearchProjectsResponse struct {
 	HasMore  bool          `json:"hasMore"`
 }
 
+// --- project metadata/stats (ServiceNow data source only) ---
+
+// ChoiceListItem is one available option for a ServiceNow choice-list field —
+// used in metadata responses that enumerate the valid values for a field
+// (e.g. case states, severities) rather than classify a single record, and in
+// stats responses that report a count per option.
+type ChoiceListItem struct {
+	ID    string `json:"id"`
+	Label string `json:"label"`
+	Count *int   `json:"count,omitempty"`
+}
+
+// ReferenceTableItem is a reference to a row in another ServiceNow table,
+// used in metadata/stats responses (e.g. case types) — richer than EntityRef:
+// adds an optional record number, WSO2-internal ID, and per-item count.
+type ReferenceTableItem struct {
+	ID         string  `json:"id"`
+	Name       string  `json:"name"`
+	Number     *string `json:"number,omitempty"`
+	InternalID *string `json:"internalId,omitempty"`
+	Count      *int    `json:"count,omitempty"`
+}
+
+// ProjectFeatures is the feature-access configuration for a project.
+type ProjectFeatures struct {
+	ProjectType                    ReferenceTableItem `json:"projectType"`
+	AcceptedSeverityValues         []ChoiceListItem   `json:"acceptedSeverityValues"`
+	HasServiceRequestWriteAccess   bool               `json:"hasServiceRequestWriteAccess"`
+	HasServiceRequestReadAccess    bool               `json:"hasServiceRequestReadAccess"`
+	HasSraWriteAccess              bool               `json:"hasSraWriteAccess"`
+	HasSraReadAccess               bool               `json:"hasSraReadAccess"`
+	HasChangeRequestReadAccess     bool               `json:"hasChangeRequestReadAccess"`
+	HasEngagementsReadAccess       bool               `json:"hasEngagementsReadAccess"`
+	HasUpdatesReadAccess           bool               `json:"hasUpdatesReadAccess"`
+	HasTimeLogsReadAccess          bool               `json:"hasTimeLogsReadAccess"`
+	HasDeploymentWriteAccess       bool               `json:"hasDeploymentWriteAccess"`
+	HasDeploymentReadAccess        bool               `json:"hasDeploymentReadAccess"`
+	HasComponentAnalysisReadAccess bool               `json:"hasComponentAnalysisReadAccess"`
+	HasUsageMetricsReadAccess      bool               `json:"hasUsageMetricsReadAccess"`
+	// DefaultCaseProductCategories/SrProductCategories are plain strings, not a
+	// named Go enum type, matching this file's convention for enum-like fields.
+	DefaultCaseProductCategories []string `json:"defaultCaseProductCategories,omitempty"`
+	SrProductCategories          []string `json:"srProductCategories,omitempty"`
+}
+
+// ProjectMetadataResponse is the response for GET /projects/{id}/metadata —
+// reference data (choice lists, feature flags) for building the project's UI,
+// not project-specific field values.
+type ProjectMetadataResponse struct {
+	CaseStates                  []ChoiceListItem     `json:"caseStates"`
+	CallRequestStates           []ChoiceListItem     `json:"callRequestStates"`
+	ChangeRequestStates         []ChoiceListItem     `json:"changeRequestStates"`
+	ConversationStates          []ChoiceListItem     `json:"conversationStates"`
+	TimeCardStates              []ChoiceListItem     `json:"timeCardStates"`
+	ChangeRequestImpacts        []ChoiceListItem     `json:"changeRequestImpacts"`
+	Severities                  []ChoiceListItem     `json:"severities"`
+	SeverityBasedAllocationTime map[string]int       `json:"severityBasedAllocationTime"`
+	IssueTypes                  []ChoiceListItem     `json:"issueTypes"`
+	DeploymentTypes             []ChoiceListItem     `json:"deploymentTypes"`
+	CaseTypes                   []ReferenceTableItem `json:"caseTypes"`
+	EngagementTypes             []ChoiceListItem     `json:"engagementTypes"`
+	EngagementPaymentTypes      []ChoiceListItem     `json:"engagementPaymentTypes"`
+	Features                    ProjectFeatures      `json:"features"`
+}
+
+// ProjectStatsOutstandingCount groups the outstanding-work-item counts
+// embedded in ProjectStatsResponse.
+type ProjectStatsOutstandingCount struct {
+	CaseCount           int `json:"caseCount"`
+	ServiceRequestCount int `json:"serviceRequestCount"`
+	EngagementCount     int `json:"engagementCount"`
+	SraCount            int `json:"sraCount"`
+	ChangeRequestCount  int `json:"changeRequestCount"`
+	AnnouncementCount   int `json:"announcementCount"`
+}
+
+// ProjectStatsResponse is the response for GET /projects/{id}/stats.
+type ProjectStatsResponse struct {
+	TotalHours           float64                      `json:"totalHours"`
+	BillableHours        float64                      `json:"billableHours"`
+	SLAStatus            string                       `json:"slaStatus"`
+	DeploymentCount      int                          `json:"deploymentCount"`
+	DeployedProductCount int                          `json:"deployedProductCount"`
+	InstanceCount        int                          `json:"instanceCount"`
+	OutstandingCount     ProjectStatsOutstandingCount `json:"outstandingCount"`
+}
+
+// ResolvedCountBreakdown groups the resolved-count breakdown shared by case
+// and change-request stats responses.
+type ResolvedCountBreakdown struct {
+	Total          int `json:"total"`
+	CurrentMonth   int `json:"currentMonth"`
+	PastThirtyDays int `json:"pastThirtyDays"`
+}
+
+// ProjectCaseStatsChangeRate groups the period-over-period change-rate
+// figures embedded in ProjectCaseStatsResponse.
+type ProjectCaseStatsChangeRate struct {
+	ResolvedEngagements float64 `json:"resolvedEngagements"`
+	AverageResponseTime float64 `json:"averageResponseTime"`
+}
+
+// CasesTrend is the severity breakdown for a single time-unit bucket in a
+// case-count trend series.
+type CasesTrend struct {
+	Period     string           `json:"period"`
+	Severities []ChoiceListItem `json:"severities"`
+}
+
+// ProjectCaseStatsRequest is the input for GET /projects/{id}/cases/stats.
+type ProjectCaseStatsRequest struct {
+	// CaseTypes is a plain string slice, not a named Go enum type, matching
+	// this file's convention for enum-like fields.
+	CaseTypes []string
+	CreatedBy string
+}
+
+// ProjectCaseStatsResponse is the response for GET /projects/{id}/cases/stats.
+type ProjectCaseStatsResponse struct {
+	TotalCount                     int                        `json:"totalCount"`
+	ActiveCount                    int                        `json:"activeCount"`
+	OutstandingCount               int                        `json:"outstandingCount"`
+	ActionRequiredCount            int                        `json:"actionRequiredCount"`
+	AverageResponseTime            float64                    `json:"averageResponseTime"`
+	ResolvedCount                  ResolvedCountBreakdown     `json:"resolvedCount"`
+	ChangeRate                     ProjectCaseStatsChangeRate `json:"changeRate"`
+	StateCount                     []ChoiceListItem           `json:"stateCount"`
+	SeverityCount                  []ChoiceListItem           `json:"severityCount"`
+	OutstandingSeverityCount       []ChoiceListItem           `json:"outstandingSeverityCount"`
+	EngagementTypeCount            []ChoiceListItem           `json:"engagementTypeCount"`
+	OutstandingEngagementTypeCount []ChoiceListItem           `json:"outstandingEngagementTypeCount"`
+	CaseTypeCount                  []ReferenceTableItem       `json:"caseTypeCount"`
+	CasesTrend                     []CasesTrend               `json:"casesTrend"`
+}
+
+// ProjectConversationStatsResponse is the response for GET /projects/{id}/conversations/stats.
+type ProjectConversationStatsResponse struct {
+	TotalCount  int              `json:"totalCount"`
+	ActiveCount int              `json:"activeCount"`
+	StateCount  []ChoiceListItem `json:"stateCount"`
+}
+
+// ProjectDeploymentStatsResponse is the response for GET /projects/{id}/deployments/stats.
+type ProjectDeploymentStatsResponse struct {
+	TotalCount       int     `json:"totalCount"`
+	LastDeploymentOn *string `json:"lastDeploymentOn"`
+}
+
+// ProjectTimeCardStatsResponse is the response for GET /projects/{id}/time-cards/stats.
+type ProjectTimeCardStatsResponse struct {
+	TotalHours       float64 `json:"totalHours"`
+	BillableHours    float64 `json:"billableHours"`
+	NonBillableHours float64 `json:"nonBillableHours"`
+}
+
+// ProjectChangeRequestStatsResponse is the response for GET /projects/{id}/change-requests/stats.
+type ProjectChangeRequestStatsResponse struct {
+	TotalCount          int                    `json:"totalCount"`
+	ActiveCount         int                    `json:"activeCount"`
+	OutstandingCount    int                    `json:"outstandingCount"`
+	ActionRequiredCount int                    `json:"actionRequiredCount"`
+	StateCount          []ChoiceListItem       `json:"stateCount"`
+	ResolvedCount       ResolvedCountBreakdown `json:"resolvedCount"`
+}
+
 // ProductClass classifies a product as either a standalone software or a managed service.
 type ProductClass string
 

--- a/entity-service/internal/handler/project_stats_handler.go
+++ b/entity-service/internal/handler/project_stats_handler.go
@@ -1,0 +1,120 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package handler is declared in user_handler.go.
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/service"
+)
+
+// ProjectStatsHandler handles HTTP requests for project-scoped metadata and
+// statistics, backed by the ServiceNow data source only.
+type ProjectStatsHandler struct {
+	svc service.ProjectStatsService
+}
+
+// NewProjectStatsHandler constructs a ProjectStatsHandler with the given service.
+func NewProjectStatsHandler(svc service.ProjectStatsService) *ProjectStatsHandler {
+	return &ProjectStatsHandler{svc: svc}
+}
+
+// GetProjectMetadata handles GET /projects/{id}/metadata.
+func (h *ProjectStatsHandler) GetProjectMetadata(w http.ResponseWriter, r *http.Request) {
+	resp, err := h.svc.GetProjectMetadata(r.Context(), r.PathValue("id"))
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// GetProjectStats handles GET /projects/{id}/stats.
+func (h *ProjectStatsHandler) GetProjectStats(w http.ResponseWriter, r *http.Request) {
+	resp, err := h.svc.GetProjectStats(r.Context(), r.PathValue("id"))
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// GetProjectCaseStats handles GET /projects/{id}/cases/stats.
+func (h *ProjectStatsHandler) GetProjectCaseStats(w http.ResponseWriter, r *http.Request) {
+	req := domain.ProjectCaseStatsRequest{
+		CaseTypes: r.URL.Query()["caseTypes"],
+		CreatedBy: r.URL.Query().Get("createdBy"),
+	}
+	resp, err := h.svc.GetProjectCaseStats(r.Context(), r.PathValue("id"), req)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// GetProjectConversationStats handles GET /projects/{id}/conversations/stats.
+func (h *ProjectStatsHandler) GetProjectConversationStats(w http.ResponseWriter, r *http.Request) {
+	resp, err := h.svc.GetProjectConversationStats(r.Context(), r.PathValue("id"), r.URL.Query().Get("createdBy"))
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// GetProjectDeploymentStats handles GET /projects/{id}/deployments/stats.
+func (h *ProjectStatsHandler) GetProjectDeploymentStats(w http.ResponseWriter, r *http.Request) {
+	resp, err := h.svc.GetProjectDeploymentStats(r.Context(), r.PathValue("id"))
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// GetProjectTimeCardStats handles GET /projects/{id}/time-cards/stats.
+func (h *ProjectStatsHandler) GetProjectTimeCardStats(w http.ResponseWriter, r *http.Request) {
+	resp, err := h.svc.GetProjectTimeCardStats(
+		r.Context(), r.PathValue("id"), r.URL.Query().Get("startDate"), r.URL.Query().Get("endDate"),
+	)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// GetProjectChangeRequestStats handles GET /projects/{id}/change-requests/stats.
+func (h *ProjectStatsHandler) GetProjectChangeRequestStats(w http.ResponseWriter, r *http.Request) {
+	resp, err := h.svc.GetProjectChangeRequestStats(r.Context(), r.PathValue("id"))
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -80,6 +80,11 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 		projectUpdateHandler = handler.NewProjectUpdateHandler(service.NewServiceNowProjectUpdateService(serviceNowIntegrationServiceClient))
 	}
 
+	var projectStatsHandler *handler.ProjectStatsHandler
+	if cfg.DataSource == config.DataSourceServiceNow {
+		projectStatsHandler = handler.NewProjectStatsHandler(service.NewServiceNowProjectStatsService(serviceNowIntegrationServiceClient))
+	}
+
 	productRepo := repository.NewProductRepository(db)
 	productSvc := service.NewProductService(productRepo)
 	productHandler := handler.NewProductHandler(productSvc)
@@ -252,6 +257,15 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 	}
 	if projectUpdateHandler != nil {
 		mux.HandleFunc("PATCH /projects/{id}", projectUpdateHandler.UpdateProject)
+	}
+	if projectStatsHandler != nil {
+		mux.HandleFunc("GET /projects/{id}/metadata", projectStatsHandler.GetProjectMetadata)
+		mux.HandleFunc("GET /projects/{id}/stats", projectStatsHandler.GetProjectStats)
+		mux.HandleFunc("GET /projects/{id}/cases/stats", projectStatsHandler.GetProjectCaseStats)
+		mux.HandleFunc("GET /projects/{id}/conversations/stats", projectStatsHandler.GetProjectConversationStats)
+		mux.HandleFunc("GET /projects/{id}/deployments/stats", projectStatsHandler.GetProjectDeploymentStats)
+		mux.HandleFunc("GET /projects/{id}/time-cards/stats", projectStatsHandler.GetProjectTimeCardStats)
+		mux.HandleFunc("GET /projects/{id}/change-requests/stats", projectStatsHandler.GetProjectChangeRequestStats)
 	}
 	if snProductHandler != nil {
 		mux.HandleFunc("POST /products/search", snProductHandler.SearchProducts)

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -91,6 +91,30 @@ type ProjectUpdateService interface {
 	UpdateProject(ctx context.Context, id string, req domain.ProjectUpdateRequest) (domain.ProjectUpdateResponse, error)
 }
 
+// ProjectStatsService defines the project-scoped metadata and statistics
+// operations. All methods require the ServiceNow data source; there is no
+// Postgres fallback.
+type ProjectStatsService interface {
+	// GetProjectMetadata returns the reference data (choice lists, feature
+	// flags) needed to build the project's UI.
+	GetProjectMetadata(ctx context.Context, projectID string) (domain.ProjectMetadataResponse, error)
+	// GetProjectStats returns the project's overall statistics.
+	GetProjectStats(ctx context.Context, projectID string) (domain.ProjectStatsResponse, error)
+	// GetProjectCaseStats returns the project's case statistics, optionally
+	// filtered by case type and/or creator.
+	GetProjectCaseStats(ctx context.Context, projectID string, req domain.ProjectCaseStatsRequest) (domain.ProjectCaseStatsResponse, error)
+	// GetProjectConversationStats returns the project's conversation
+	// statistics, optionally filtered by creator.
+	GetProjectConversationStats(ctx context.Context, projectID, createdBy string) (domain.ProjectConversationStatsResponse, error)
+	// GetProjectDeploymentStats returns the project's deployment statistics.
+	GetProjectDeploymentStats(ctx context.Context, projectID string) (domain.ProjectDeploymentStatsResponse, error)
+	// GetProjectTimeCardStats returns the project's time-card statistics,
+	// optionally filtered by a startDate/endDate range (each yyyy-MM-dd).
+	GetProjectTimeCardStats(ctx context.Context, projectID, startDate, endDate string) (domain.ProjectTimeCardStatsResponse, error)
+	// GetProjectChangeRequestStats returns the project's change-request statistics.
+	GetProjectChangeRequestStats(ctx context.Context, projectID string) (domain.ProjectChangeRequestStatsResponse, error)
+}
+
 // ProjectContactService defines the operations available on project contacts.
 // All methods require the ServiceNow data source; there is no Postgres fallback.
 type ProjectContactService interface {

--- a/entity-service/internal/service/sn_project_stats_service.go
+++ b/entity-service/internal/service/sn_project_stats_service.go
@@ -1,0 +1,506 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/middleware"
+	integrationservice "github.com/wso2-open-operations/cs-tools/entity-service/internal/servicenow-integration-service"
+)
+
+// snFlexibleID decodes a JSON value that may arrive as either a string or a
+// number into a string — matches upstream choice-list items, whose id field
+// is typed int|string on the Choreo side.
+type snFlexibleID string
+
+func (f *snFlexibleID) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err == nil {
+		*f = snFlexibleID(s)
+		return nil
+	}
+	var n json.Number
+	if err := json.Unmarshal(data, &n); err != nil {
+		return err
+	}
+	*f = snFlexibleID(n.String())
+	return nil
+}
+
+// snChoiceOption mirrors the Choreo ChoiceListItem shape.
+type snChoiceOption struct {
+	ID    snFlexibleID `json:"id"`
+	Label string       `json:"label"`
+	Count *int         `json:"count,omitempty"`
+}
+
+func (i snChoiceOption) toDomain() domain.ChoiceListItem {
+	return domain.ChoiceListItem{ID: string(i.ID), Label: i.Label, Count: i.Count}
+}
+
+func toDomainChoiceListItems(items []snChoiceOption) []domain.ChoiceListItem {
+	out := make([]domain.ChoiceListItem, 0, len(items))
+	for _, i := range items {
+		out = append(out, i.toDomain())
+	}
+	return out
+}
+
+// snReferenceTableItem mirrors the Choreo ReferenceTableItem shape — its id
+// is always a plain sysid, unlike snChoiceOption's.
+type snReferenceTableItem struct {
+	ID         string  `json:"id"`
+	Name       string  `json:"name"`
+	Number     *string `json:"number,omitempty"`
+	InternalID *string `json:"internalId,omitempty"`
+	Count      *int    `json:"count,omitempty"`
+}
+
+func (i snReferenceTableItem) toDomain() domain.ReferenceTableItem {
+	return domain.ReferenceTableItem{
+		ID:         sysidToUUID(i.ID),
+		Name:       i.Name,
+		Number:     i.Number,
+		InternalID: i.InternalID,
+		Count:      i.Count,
+	}
+}
+
+func toDomainReferenceTableItems(items []snReferenceTableItem) []domain.ReferenceTableItem {
+	out := make([]domain.ReferenceTableItem, 0, len(items))
+	for _, i := range items {
+		out = append(out, i.toDomain())
+	}
+	return out
+}
+
+// snProjectFeatures mirrors the Choreo ProjectFeatures shape.
+type snProjectFeatures struct {
+	ProjectType                    snReferenceTableItem `json:"projectType"`
+	AcceptedSeverityValues         []snChoiceOption     `json:"acceptedSeverityValues"`
+	HasServiceRequestWriteAccess   bool                 `json:"hasServiceRequestWriteAccess"`
+	HasServiceRequestReadAccess    bool                 `json:"hasServiceRequestReadAccess"`
+	HasSraWriteAccess              bool                 `json:"hasSraWriteAccess"`
+	HasSraReadAccess               bool                 `json:"hasSraReadAccess"`
+	HasChangeRequestReadAccess     bool                 `json:"hasChangeRequestReadAccess"`
+	HasEngagementsReadAccess       bool                 `json:"hasEngagementsReadAccess"`
+	HasUpdatesReadAccess           bool                 `json:"hasUpdatesReadAccess"`
+	HasTimeLogsReadAccess          bool                 `json:"hasTimeLogsReadAccess"`
+	HasDeploymentWriteAccess       bool                 `json:"hasDeploymentWriteAccess"`
+	HasDeploymentReadAccess        bool                 `json:"hasDeploymentReadAccess"`
+	HasComponentAnalysisReadAccess bool                 `json:"hasComponentAnalysisReadAccess"`
+	HasUsageMetricsReadAccess      bool                 `json:"hasUsageMetricsReadAccess"`
+	DefaultCaseProductCategories   []string             `json:"defaultCaseProductCategories,omitempty"`
+	SrProductCategories            []string             `json:"srProductCategories,omitempty"`
+}
+
+func (f snProjectFeatures) toDomain() domain.ProjectFeatures {
+	return domain.ProjectFeatures{
+		ProjectType:                    f.ProjectType.toDomain(),
+		AcceptedSeverityValues:         toDomainChoiceListItems(f.AcceptedSeverityValues),
+		HasServiceRequestWriteAccess:   f.HasServiceRequestWriteAccess,
+		HasServiceRequestReadAccess:    f.HasServiceRequestReadAccess,
+		HasSraWriteAccess:              f.HasSraWriteAccess,
+		HasSraReadAccess:               f.HasSraReadAccess,
+		HasChangeRequestReadAccess:     f.HasChangeRequestReadAccess,
+		HasEngagementsReadAccess:       f.HasEngagementsReadAccess,
+		HasUpdatesReadAccess:           f.HasUpdatesReadAccess,
+		HasTimeLogsReadAccess:          f.HasTimeLogsReadAccess,
+		HasDeploymentWriteAccess:       f.HasDeploymentWriteAccess,
+		HasDeploymentReadAccess:        f.HasDeploymentReadAccess,
+		HasComponentAnalysisReadAccess: f.HasComponentAnalysisReadAccess,
+		HasUsageMetricsReadAccess:      f.HasUsageMetricsReadAccess,
+		DefaultCaseProductCategories:   f.DefaultCaseProductCategories,
+		SrProductCategories:            f.SrProductCategories,
+	}
+}
+
+// snProjectMetadataResponse mirrors the Choreo GET /projects/{id}/metadata response.
+type snProjectMetadataResponse struct {
+	CaseStates                  []snChoiceOption       `json:"caseStates"`
+	CallRequestStates           []snChoiceOption       `json:"callRequestStates"`
+	ChangeRequestStates         []snChoiceOption       `json:"changeRequestStates"`
+	ConversationStates          []snChoiceOption       `json:"conversationStates"`
+	TimeCardStates              []snChoiceOption       `json:"timeCardStates"`
+	ChangeRequestImpacts        []snChoiceOption       `json:"changeRequestImpacts"`
+	Severities                  []snChoiceOption       `json:"severities"`
+	SeverityBasedAllocationTime map[string]int         `json:"severityBasedAllocationTime"`
+	IssueTypes                  []snChoiceOption       `json:"issueTypes"`
+	DeploymentTypes             []snChoiceOption       `json:"deploymentTypes"`
+	CaseTypes                   []snReferenceTableItem `json:"caseTypes"`
+	EngagementTypes             []snChoiceOption       `json:"engagementTypes"`
+	EngagementPaymentTypes      []snChoiceOption       `json:"engagementPaymentTypes"`
+	Features                    snProjectFeatures      `json:"features"`
+}
+
+// snProjectStatsOutstandingCount mirrors the outstandingCount object embedded
+// in the Choreo GET /projects/{id}/stats response.
+type snProjectStatsOutstandingCount struct {
+	CaseCount           int `json:"caseCount"`
+	ServiceRequestCount int `json:"serviceRequestCount"`
+	EngagementCount     int `json:"engagementCount"`
+	SraCount            int `json:"sraCount"`
+	ChangeRequestCount  int `json:"changeRequestCount"`
+	AnnouncementCount   int `json:"announcementCount"`
+}
+
+// snProjectStatsResponse mirrors the Choreo GET /projects/{id}/stats response.
+type snProjectStatsResponse struct {
+	TotalHours           float64                        `json:"totalHours"`
+	BillableHours        float64                        `json:"billableHours"`
+	SLAStatus            string                         `json:"slaStatus"`
+	DeploymentCount      int                            `json:"deploymentCount"`
+	DeployedProductCount int                            `json:"deployedProductCount"`
+	InstanceCount        int                            `json:"instanceCount"`
+	OutstandingCount     snProjectStatsOutstandingCount `json:"outstandingCount"`
+}
+
+// snResolvedCountBreakdown mirrors the resolvedCount object shared by the
+// Choreo case-stats and change-request-stats responses.
+type snResolvedCountBreakdown struct {
+	Total          int `json:"total"`
+	CurrentMonth   int `json:"currentMonth"`
+	PastThirtyDays int `json:"pastThirtyDays"`
+}
+
+func (r snResolvedCountBreakdown) toDomain() domain.ResolvedCountBreakdown {
+	return domain.ResolvedCountBreakdown{Total: r.Total, CurrentMonth: r.CurrentMonth, PastThirtyDays: r.PastThirtyDays}
+}
+
+// snProjectCaseStatsChangeRate mirrors the changeRate object embedded in the
+// Choreo GET /projects/{id}/cases/stats response.
+type snProjectCaseStatsChangeRate struct {
+	ResolvedEngagements float64 `json:"resolvedEngagements"`
+	AverageResponseTime float64 `json:"averageResponseTime"`
+}
+
+// snCasesTrend mirrors one entry of the casesTrend array embedded in the
+// Choreo GET /projects/{id}/cases/stats response.
+type snCasesTrend struct {
+	Period     string           `json:"period"`
+	Severities []snChoiceOption `json:"severities"`
+}
+
+// snProjectCaseStatsResponse mirrors the Choreo GET /projects/{id}/cases/stats response.
+type snProjectCaseStatsResponse struct {
+	TotalCount                     int                          `json:"totalCount"`
+	ActiveCount                    int                          `json:"activeCount"`
+	OutstandingCount               int                          `json:"outstandingCount"`
+	ActionRequiredCount            int                          `json:"actionRequiredCount"`
+	AverageResponseTime            float64                      `json:"averageResponseTime"`
+	ResolvedCount                  snResolvedCountBreakdown     `json:"resolvedCount"`
+	ChangeRate                     snProjectCaseStatsChangeRate `json:"changeRate"`
+	StateCount                     []snChoiceOption             `json:"stateCount"`
+	SeverityCount                  []snChoiceOption             `json:"severityCount"`
+	OutstandingSeverityCount       []snChoiceOption             `json:"outstandingSeverityCount"`
+	EngagementTypeCount            []snChoiceOption             `json:"engagementTypeCount"`
+	OutstandingEngagementTypeCount []snChoiceOption             `json:"outstandingEngagementTypeCount"`
+	CaseTypeCount                  []snReferenceTableItem       `json:"caseTypeCount"`
+	CasesTrend                     []snCasesTrend               `json:"casesTrend"`
+}
+
+// snProjectConversationStatsResponse mirrors the Choreo
+// GET /projects/{id}/conversations/stats response.
+type snProjectConversationStatsResponse struct {
+	TotalCount  int              `json:"totalCount"`
+	ActiveCount int              `json:"activeCount"`
+	StateCount  []snChoiceOption `json:"stateCount"`
+}
+
+// snProjectDeploymentStatsResponse mirrors the Choreo
+// GET /projects/{id}/deployments/stats response.
+type snProjectDeploymentStatsResponse struct {
+	TotalCount       int     `json:"totalCount"`
+	LastDeploymentOn *string `json:"lastDeploymentOn"`
+}
+
+// snProjectTimeCardStatsResponse mirrors the Choreo
+// GET /projects/{id}/time-cards/stats response.
+type snProjectTimeCardStatsResponse struct {
+	TotalHours       float64 `json:"totalHours"`
+	BillableHours    float64 `json:"billableHours"`
+	NonBillableHours float64 `json:"nonBillableHours"`
+}
+
+// snProjectChangeRequestStatsResponse mirrors the Choreo
+// GET /projects/{id}/change-requests/stats response.
+type snProjectChangeRequestStatsResponse struct {
+	TotalCount          int                      `json:"totalCount"`
+	ActiveCount         int                      `json:"activeCount"`
+	OutstandingCount    int                      `json:"outstandingCount"`
+	ActionRequiredCount int                      `json:"actionRequiredCount"`
+	StateCount          []snChoiceOption         `json:"stateCount"`
+	ResolvedCount       snResolvedCountBreakdown `json:"resolvedCount"`
+}
+
+type snProjectStatsService struct {
+	client *integrationservice.Client
+}
+
+// NewServiceNowProjectStatsService constructs a ProjectStatsService backed by the Choreo API.
+func NewServiceNowProjectStatsService(client *integrationservice.Client) ProjectStatsService {
+	return &snProjectStatsService{client: client}
+}
+
+// GetProjectMetadata implements ProjectStatsService.
+func (s *snProjectStatsService) GetProjectMetadata(ctx context.Context, projectID string) (domain.ProjectMetadataResponse, error) {
+	if err := validateUUIDs("id", []string{projectID}); err != nil {
+		return domain.ProjectMetadataResponse{}, err
+	}
+	token := middleware.UserIDTokenFromContext(ctx)
+
+	raw, err := s.client.Get(ctx, "/projects/"+uuidToSysid(projectID)+"/metadata", token)
+	if err != nil {
+		return domain.ProjectMetadataResponse{}, err
+	}
+
+	var snResp snProjectMetadataResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.ProjectMetadataResponse{}, fmt.Errorf("sn project metadata: parse response: %w", err)
+	}
+
+	return domain.ProjectMetadataResponse{
+		CaseStates:                  toDomainChoiceListItems(snResp.CaseStates),
+		CallRequestStates:           toDomainChoiceListItems(snResp.CallRequestStates),
+		ChangeRequestStates:         toDomainChoiceListItems(snResp.ChangeRequestStates),
+		ConversationStates:          toDomainChoiceListItems(snResp.ConversationStates),
+		TimeCardStates:              toDomainChoiceListItems(snResp.TimeCardStates),
+		ChangeRequestImpacts:        toDomainChoiceListItems(snResp.ChangeRequestImpacts),
+		Severities:                  toDomainChoiceListItems(snResp.Severities),
+		SeverityBasedAllocationTime: snResp.SeverityBasedAllocationTime,
+		IssueTypes:                  toDomainChoiceListItems(snResp.IssueTypes),
+		DeploymentTypes:             toDomainChoiceListItems(snResp.DeploymentTypes),
+		CaseTypes:                   toDomainReferenceTableItems(snResp.CaseTypes),
+		EngagementTypes:             toDomainChoiceListItems(snResp.EngagementTypes),
+		EngagementPaymentTypes:      toDomainChoiceListItems(snResp.EngagementPaymentTypes),
+		Features:                    snResp.Features.toDomain(),
+	}, nil
+}
+
+// GetProjectStats implements ProjectStatsService.
+func (s *snProjectStatsService) GetProjectStats(ctx context.Context, projectID string) (domain.ProjectStatsResponse, error) {
+	if err := validateUUIDs("id", []string{projectID}); err != nil {
+		return domain.ProjectStatsResponse{}, err
+	}
+	token := middleware.UserIDTokenFromContext(ctx)
+
+	raw, err := s.client.Get(ctx, "/projects/"+uuidToSysid(projectID)+"/stats", token)
+	if err != nil {
+		return domain.ProjectStatsResponse{}, err
+	}
+
+	var snResp snProjectStatsResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.ProjectStatsResponse{}, fmt.Errorf("sn project stats: parse response: %w", err)
+	}
+
+	return domain.ProjectStatsResponse{
+		TotalHours:           snResp.TotalHours,
+		BillableHours:        snResp.BillableHours,
+		SLAStatus:            snResp.SLAStatus,
+		DeploymentCount:      snResp.DeploymentCount,
+		DeployedProductCount: snResp.DeployedProductCount,
+		InstanceCount:        snResp.InstanceCount,
+		OutstandingCount: domain.ProjectStatsOutstandingCount{
+			CaseCount:           snResp.OutstandingCount.CaseCount,
+			ServiceRequestCount: snResp.OutstandingCount.ServiceRequestCount,
+			EngagementCount:     snResp.OutstandingCount.EngagementCount,
+			SraCount:            snResp.OutstandingCount.SraCount,
+			ChangeRequestCount:  snResp.OutstandingCount.ChangeRequestCount,
+			AnnouncementCount:   snResp.OutstandingCount.AnnouncementCount,
+		},
+	}, nil
+}
+
+// GetProjectCaseStats implements ProjectStatsService.
+func (s *snProjectStatsService) GetProjectCaseStats(ctx context.Context, projectID string, req domain.ProjectCaseStatsRequest) (domain.ProjectCaseStatsResponse, error) {
+	if err := validateUUIDs("id", []string{projectID}); err != nil {
+		return domain.ProjectCaseStatsResponse{}, err
+	}
+	token := middleware.UserIDTokenFromContext(ctx)
+
+	q := url.Values{}
+	for _, ct := range req.CaseTypes {
+		q.Add("caseTypes", ct)
+	}
+	if req.CreatedBy != "" {
+		q.Set("createdBy", req.CreatedBy)
+	}
+	path := "/projects/" + uuidToSysid(projectID) + "/cases/stats"
+	if len(q) > 0 {
+		path += "?" + q.Encode()
+	}
+
+	raw, err := s.client.Get(ctx, path, token)
+	if err != nil {
+		return domain.ProjectCaseStatsResponse{}, err
+	}
+
+	var snResp snProjectCaseStatsResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.ProjectCaseStatsResponse{}, fmt.Errorf("sn project case stats: parse response: %w", err)
+	}
+
+	trend := make([]domain.CasesTrend, 0, len(snResp.CasesTrend))
+	for _, t := range snResp.CasesTrend {
+		trend = append(trend, domain.CasesTrend{Period: t.Period, Severities: toDomainChoiceListItems(t.Severities)})
+	}
+
+	return domain.ProjectCaseStatsResponse{
+		TotalCount:          snResp.TotalCount,
+		ActiveCount:         snResp.ActiveCount,
+		OutstandingCount:    snResp.OutstandingCount,
+		ActionRequiredCount: snResp.ActionRequiredCount,
+		AverageResponseTime: snResp.AverageResponseTime,
+		ResolvedCount:       snResp.ResolvedCount.toDomain(),
+		ChangeRate: domain.ProjectCaseStatsChangeRate{
+			ResolvedEngagements: snResp.ChangeRate.ResolvedEngagements,
+			AverageResponseTime: snResp.ChangeRate.AverageResponseTime,
+		},
+		StateCount:                     toDomainChoiceListItems(snResp.StateCount),
+		SeverityCount:                  toDomainChoiceListItems(snResp.SeverityCount),
+		OutstandingSeverityCount:       toDomainChoiceListItems(snResp.OutstandingSeverityCount),
+		EngagementTypeCount:            toDomainChoiceListItems(snResp.EngagementTypeCount),
+		OutstandingEngagementTypeCount: toDomainChoiceListItems(snResp.OutstandingEngagementTypeCount),
+		CaseTypeCount:                  toDomainReferenceTableItems(snResp.CaseTypeCount),
+		CasesTrend:                     trend,
+	}, nil
+}
+
+// GetProjectConversationStats implements ProjectStatsService.
+func (s *snProjectStatsService) GetProjectConversationStats(ctx context.Context, projectID, createdBy string) (domain.ProjectConversationStatsResponse, error) {
+	if err := validateUUIDs("id", []string{projectID}); err != nil {
+		return domain.ProjectConversationStatsResponse{}, err
+	}
+	token := middleware.UserIDTokenFromContext(ctx)
+
+	q := url.Values{}
+	if createdBy != "" {
+		q.Set("createdBy", createdBy)
+	}
+	path := "/projects/" + uuidToSysid(projectID) + "/conversations/stats"
+	if len(q) > 0 {
+		path += "?" + q.Encode()
+	}
+
+	raw, err := s.client.Get(ctx, path, token)
+	if err != nil {
+		return domain.ProjectConversationStatsResponse{}, err
+	}
+
+	var snResp snProjectConversationStatsResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.ProjectConversationStatsResponse{}, fmt.Errorf("sn project conversation stats: parse response: %w", err)
+	}
+
+	return domain.ProjectConversationStatsResponse{
+		TotalCount:  snResp.TotalCount,
+		ActiveCount: snResp.ActiveCount,
+		StateCount:  toDomainChoiceListItems(snResp.StateCount),
+	}, nil
+}
+
+// GetProjectDeploymentStats implements ProjectStatsService.
+func (s *snProjectStatsService) GetProjectDeploymentStats(ctx context.Context, projectID string) (domain.ProjectDeploymentStatsResponse, error) {
+	if err := validateUUIDs("id", []string{projectID}); err != nil {
+		return domain.ProjectDeploymentStatsResponse{}, err
+	}
+	token := middleware.UserIDTokenFromContext(ctx)
+
+	raw, err := s.client.Get(ctx, "/projects/"+uuidToSysid(projectID)+"/deployments/stats", token)
+	if err != nil {
+		return domain.ProjectDeploymentStatsResponse{}, err
+	}
+
+	var snResp snProjectDeploymentStatsResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.ProjectDeploymentStatsResponse{}, fmt.Errorf("sn project deployment stats: parse response: %w", err)
+	}
+
+	return domain.ProjectDeploymentStatsResponse{
+		TotalCount:       snResp.TotalCount,
+		LastDeploymentOn: snResp.LastDeploymentOn,
+	}, nil
+}
+
+// GetProjectTimeCardStats implements ProjectStatsService.
+func (s *snProjectStatsService) GetProjectTimeCardStats(ctx context.Context, projectID, startDate, endDate string) (domain.ProjectTimeCardStatsResponse, error) {
+	if err := validateUUIDs("id", []string{projectID}); err != nil {
+		return domain.ProjectTimeCardStatsResponse{}, err
+	}
+	token := middleware.UserIDTokenFromContext(ctx)
+
+	q := url.Values{}
+	if startDate != "" {
+		q.Set("startDate", startDate)
+	}
+	if endDate != "" {
+		q.Set("endDate", endDate)
+	}
+	path := "/projects/" + uuidToSysid(projectID) + "/time-cards/stats"
+	if len(q) > 0 {
+		path += "?" + q.Encode()
+	}
+
+	raw, err := s.client.Get(ctx, path, token)
+	if err != nil {
+		return domain.ProjectTimeCardStatsResponse{}, err
+	}
+
+	var snResp snProjectTimeCardStatsResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.ProjectTimeCardStatsResponse{}, fmt.Errorf("sn project time card stats: parse response: %w", err)
+	}
+
+	return domain.ProjectTimeCardStatsResponse{
+		TotalHours:       snResp.TotalHours,
+		BillableHours:    snResp.BillableHours,
+		NonBillableHours: snResp.NonBillableHours,
+	}, nil
+}
+
+// GetProjectChangeRequestStats implements ProjectStatsService.
+func (s *snProjectStatsService) GetProjectChangeRequestStats(ctx context.Context, projectID string) (domain.ProjectChangeRequestStatsResponse, error) {
+	if err := validateUUIDs("id", []string{projectID}); err != nil {
+		return domain.ProjectChangeRequestStatsResponse{}, err
+	}
+	token := middleware.UserIDTokenFromContext(ctx)
+
+	raw, err := s.client.Get(ctx, "/projects/"+uuidToSysid(projectID)+"/change-requests/stats", token)
+	if err != nil {
+		return domain.ProjectChangeRequestStatsResponse{}, err
+	}
+
+	var snResp snProjectChangeRequestStatsResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.ProjectChangeRequestStatsResponse{}, fmt.Errorf("sn project change request stats: parse response: %w", err)
+	}
+
+	return domain.ProjectChangeRequestStatsResponse{
+		TotalCount:          snResp.TotalCount,
+		ActiveCount:         snResp.ActiveCount,
+		OutstandingCount:    snResp.OutstandingCount,
+		ActionRequiredCount: snResp.ActionRequiredCount,
+		StateCount:          toDomainChoiceListItems(snResp.StateCount),
+		ResolvedCount:       snResp.ResolvedCount.toDomain(),
+	}, nil
+}

--- a/entity-service/internal/service/sn_project_stats_service.go
+++ b/entity-service/internal/service/sn_project_stats_service.go
@@ -339,8 +339,13 @@ func (s *snProjectStatsService) GetProjectCaseStats(ctx context.Context, project
 	token := middleware.UserIDTokenFromContext(ctx)
 
 	q := url.Values{}
-	for _, ct := range req.CaseTypes {
-		q.Add("caseTypes", ct)
+	if len(req.CaseTypes) > 0 {
+		if err := validateUUIDs("caseTypes", req.CaseTypes); err != nil {
+			return domain.ProjectCaseStatsResponse{}, err
+		}
+		for _, ct := range uuidsToSysids(req.CaseTypes) {
+			q.Add("caseTypes", ct)
+		}
 	}
 	if req.CreatedBy != "" {
 		q.Set("createdBy", req.CreatedBy)

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -551,6 +551,303 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /projects/{id}/metadata:
+    get:
+      summary: Get a project's reference metadata (choice lists, feature flags).
+      description: ServiceNow data source only; there is no Postgres equivalent.
+      operationId: getProjectMetadata
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: The project's reference metadata.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectMetadataResponse'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: Project not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /projects/{id}/stats:
+    get:
+      summary: Get a project's overall statistics.
+      description: ServiceNow data source only; there is no Postgres equivalent.
+      operationId: getProjectStats
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: The project's overall statistics.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectStatsResponse'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: Project not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /projects/{id}/cases/stats:
+    get:
+      summary: Get a project's case statistics, optionally filtered by case type and/or creator.
+      description: ServiceNow data source only; there is no Postgres equivalent.
+      operationId: getProjectCaseStats
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: caseTypes
+          in: query
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+          description: >
+            Restrict to these case types. Repeated for multiple values, e.g.
+            ?caseTypes=a&caseTypes=b.
+        - name: createdBy
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Restrict to cases created by this user.
+      responses:
+        "200":
+          description: The project's case statistics.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectCaseStatsResponse'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: Project not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /projects/{id}/conversations/stats:
+    get:
+      summary: Get a project's conversation statistics, optionally filtered by creator.
+      description: ServiceNow data source only; there is no Postgres equivalent.
+      operationId: getProjectConversationStats
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: createdBy
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Restrict to conversations created by this user.
+      responses:
+        "200":
+          description: The project's conversation statistics.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectConversationStatsResponse'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: Project not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /projects/{id}/deployments/stats:
+    get:
+      summary: Get a project's deployment statistics.
+      description: ServiceNow data source only; there is no Postgres equivalent.
+      operationId: getProjectDeploymentStats
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: The project's deployment statistics.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectDeploymentStatsResponse'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: Project not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /projects/{id}/time-cards/stats:
+    get:
+      summary: Get a project's time-card statistics, optionally filtered by a date range.
+      description: ServiceNow data source only; there is no Postgres equivalent.
+      operationId: getProjectTimeCardStats
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: startDate
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date
+          description: Restrict to time cards on or after this date (yyyy-MM-dd).
+        - name: endDate
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date
+          description: Restrict to time cards on or before this date (yyyy-MM-dd).
+      responses:
+        "200":
+          description: The project's time-card statistics.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectTimeCardStatsResponse'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: Project not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /projects/{id}/change-requests/stats:
+    get:
+      summary: Get a project's change-request statistics.
+      description: ServiceNow data source only; there is no Postgres equivalent.
+      operationId: getProjectChangeRequestStats
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: The project's change-request statistics.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectChangeRequestStatsResponse'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: Project not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /products/search:
     post:
       summary: Search products by name.
@@ -8370,3 +8667,395 @@ components:
           type: integer
         limit:
           type: integer
+
+    # ---- project stats ----
+
+    ChoiceListItem:
+      type: object
+      description: >
+        One available option for a ServiceNow choice-list field — used in metadata responses
+        that enumerate the valid values for a field (e.g. case states, severities) rather than
+        classify a single record, and in stats responses that report a count per option.
+      required: [id, label]
+      properties:
+        id:
+          type: string
+        label:
+          type: string
+        count:
+          type: integer
+          nullable: true
+
+    ReferenceTableItem:
+      type: object
+      description: >
+        A reference to a row in another ServiceNow table, used in metadata/stats responses
+        (e.g. case types) — richer than EntityRef: adds an optional record number,
+        WSO2-internal ID, and per-item count.
+      required: [id, name]
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        number:
+          type: string
+          nullable: true
+        internalId:
+          type: string
+          nullable: true
+        count:
+          type: integer
+          nullable: true
+
+    ProjectFeatures:
+      type: object
+      description: The feature-access configuration for a project.
+      required:
+        - projectType
+        - acceptedSeverityValues
+        - hasServiceRequestWriteAccess
+        - hasServiceRequestReadAccess
+        - hasSraWriteAccess
+        - hasSraReadAccess
+        - hasChangeRequestReadAccess
+        - hasEngagementsReadAccess
+        - hasUpdatesReadAccess
+        - hasTimeLogsReadAccess
+        - hasDeploymentWriteAccess
+        - hasDeploymentReadAccess
+        - hasComponentAnalysisReadAccess
+        - hasUsageMetricsReadAccess
+      properties:
+        projectType:
+          $ref: '#/components/schemas/ReferenceTableItem'
+        acceptedSeverityValues:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChoiceListItem'
+        hasServiceRequestWriteAccess:
+          type: boolean
+        hasServiceRequestReadAccess:
+          type: boolean
+        hasSraWriteAccess:
+          type: boolean
+        hasSraReadAccess:
+          type: boolean
+        hasChangeRequestReadAccess:
+          type: boolean
+        hasEngagementsReadAccess:
+          type: boolean
+        hasUpdatesReadAccess:
+          type: boolean
+        hasTimeLogsReadAccess:
+          type: boolean
+        hasDeploymentWriteAccess:
+          type: boolean
+        hasDeploymentReadAccess:
+          type: boolean
+        hasComponentAnalysisReadAccess:
+          type: boolean
+        hasUsageMetricsReadAccess:
+          type: boolean
+        defaultCaseProductCategories:
+          type: array
+          items:
+            type: string
+          nullable: true
+        srProductCategories:
+          type: array
+          items:
+            type: string
+          nullable: true
+
+    ProjectMetadataResponse:
+      type: object
+      description: >
+        The response for GET /projects/{id}/metadata — reference data (choice lists, feature
+        flags) for building the project's UI, not project-specific field values.
+      required:
+        - caseStates
+        - callRequestStates
+        - changeRequestStates
+        - conversationStates
+        - timeCardStates
+        - changeRequestImpacts
+        - severities
+        - severityBasedAllocationTime
+        - issueTypes
+        - deploymentTypes
+        - caseTypes
+        - engagementTypes
+        - engagementPaymentTypes
+        - features
+      properties:
+        caseStates:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChoiceListItem'
+        callRequestStates:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChoiceListItem'
+        changeRequestStates:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChoiceListItem'
+        conversationStates:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChoiceListItem'
+        timeCardStates:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChoiceListItem'
+        changeRequestImpacts:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChoiceListItem'
+        severities:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChoiceListItem'
+        severityBasedAllocationTime:
+          type: object
+          additionalProperties:
+            type: integer
+        issueTypes:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChoiceListItem'
+        deploymentTypes:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChoiceListItem'
+        caseTypes:
+          type: array
+          items:
+            $ref: '#/components/schemas/ReferenceTableItem'
+        engagementTypes:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChoiceListItem'
+        engagementPaymentTypes:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChoiceListItem'
+        features:
+          $ref: '#/components/schemas/ProjectFeatures'
+
+    ProjectStatsOutstandingCount:
+      type: object
+      description: Groups the outstanding-work-item counts embedded in ProjectStatsResponse.
+      required: [caseCount, serviceRequestCount, engagementCount, sraCount, changeRequestCount, announcementCount]
+      properties:
+        caseCount:
+          type: integer
+        serviceRequestCount:
+          type: integer
+        engagementCount:
+          type: integer
+        sraCount:
+          type: integer
+        changeRequestCount:
+          type: integer
+        announcementCount:
+          type: integer
+
+    ProjectStatsResponse:
+      type: object
+      description: The response for GET /projects/{id}/stats.
+      required:
+        - totalHours
+        - billableHours
+        - slaStatus
+        - deploymentCount
+        - deployedProductCount
+        - instanceCount
+        - outstandingCount
+      properties:
+        totalHours:
+          type: number
+          format: double
+        billableHours:
+          type: number
+          format: double
+        slaStatus:
+          type: string
+        deploymentCount:
+          type: integer
+        deployedProductCount:
+          type: integer
+        instanceCount:
+          type: integer
+        outstandingCount:
+          $ref: '#/components/schemas/ProjectStatsOutstandingCount'
+
+    ResolvedCountBreakdown:
+      type: object
+      description: >
+        Groups the resolved-count breakdown shared by case and change-request stats responses.
+      required: [total, currentMonth, pastThirtyDays]
+      properties:
+        total:
+          type: integer
+        currentMonth:
+          type: integer
+        pastThirtyDays:
+          type: integer
+
+    ProjectCaseStatsChangeRate:
+      type: object
+      description: >
+        Groups the period-over-period change-rate figures embedded in
+        ProjectCaseStatsResponse.
+      required: [resolvedEngagements, averageResponseTime]
+      properties:
+        resolvedEngagements:
+          type: number
+          format: double
+        averageResponseTime:
+          type: number
+          format: double
+
+    CasesTrend:
+      type: object
+      description: >
+        The severity breakdown for a single time-unit bucket in a case-count trend series.
+      required: [period, severities]
+      properties:
+        period:
+          type: string
+        severities:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChoiceListItem'
+
+    ProjectCaseStatsResponse:
+      type: object
+      description: The response for GET /projects/{id}/cases/stats.
+      required:
+        - totalCount
+        - activeCount
+        - outstandingCount
+        - actionRequiredCount
+        - averageResponseTime
+        - resolvedCount
+        - changeRate
+        - stateCount
+        - severityCount
+        - outstandingSeverityCount
+        - engagementTypeCount
+        - outstandingEngagementTypeCount
+        - caseTypeCount
+        - casesTrend
+      properties:
+        totalCount:
+          type: integer
+        activeCount:
+          type: integer
+        outstandingCount:
+          type: integer
+        actionRequiredCount:
+          type: integer
+        averageResponseTime:
+          type: number
+          format: double
+        resolvedCount:
+          $ref: '#/components/schemas/ResolvedCountBreakdown'
+        changeRate:
+          $ref: '#/components/schemas/ProjectCaseStatsChangeRate'
+        stateCount:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChoiceListItem'
+        severityCount:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChoiceListItem'
+        outstandingSeverityCount:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChoiceListItem'
+        engagementTypeCount:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChoiceListItem'
+        outstandingEngagementTypeCount:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChoiceListItem'
+        caseTypeCount:
+          type: array
+          items:
+            $ref: '#/components/schemas/ReferenceTableItem'
+        casesTrend:
+          type: array
+          items:
+            $ref: '#/components/schemas/CasesTrend'
+
+    ProjectConversationStatsResponse:
+      type: object
+      description: The response for GET /projects/{id}/conversations/stats.
+      required: [totalCount, activeCount, stateCount]
+      properties:
+        totalCount:
+          type: integer
+        activeCount:
+          type: integer
+        stateCount:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChoiceListItem'
+
+    ProjectDeploymentStatsResponse:
+      type: object
+      description: The response for GET /projects/{id}/deployments/stats.
+      required: [totalCount]
+      properties:
+        totalCount:
+          type: integer
+        lastDeploymentOn:
+          type: string
+          nullable: true
+
+    ProjectTimeCardStatsResponse:
+      type: object
+      description: The response for GET /projects/{id}/time-cards/stats.
+      required: [totalHours, billableHours, nonBillableHours]
+      properties:
+        totalHours:
+          type: number
+          format: double
+        billableHours:
+          type: number
+          format: double
+        nonBillableHours:
+          type: number
+          format: double
+
+    ProjectChangeRequestStatsResponse:
+      type: object
+      description: The response for GET /projects/{id}/change-requests/stats.
+      required:
+        - totalCount
+        - activeCount
+        - outstandingCount
+        - actionRequiredCount
+        - stateCount
+        - resolvedCount
+      properties:
+        totalCount:
+          type: integer
+        activeCount:
+          type: integer
+        outstandingCount:
+          type: integer
+        actionRequiredCount:
+          type: integer
+        stateCount:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChoiceListItem'
+        resolvedCount:
+          $ref: '#/components/schemas/ResolvedCountBreakdown'

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -562,6 +562,7 @@ paths:
           required: true
           schema:
             type: string
+            format: uuid
       responses:
         "200":
           description: The project's reference metadata.
@@ -599,6 +600,7 @@ paths:
           required: true
           schema:
             type: string
+            format: uuid
       responses:
         "200":
           description: The project's overall statistics.
@@ -636,6 +638,7 @@ paths:
           required: true
           schema:
             type: string
+            format: uuid
         - name: caseTypes
           in: query
           required: false
@@ -691,6 +694,7 @@ paths:
           required: true
           schema:
             type: string
+            format: uuid
         - name: createdBy
           in: query
           required: false
@@ -734,6 +738,7 @@ paths:
           required: true
           schema:
             type: string
+            format: uuid
       responses:
         "200":
           description: The project's deployment statistics.
@@ -771,6 +776,7 @@ paths:
           required: true
           schema:
             type: string
+            format: uuid
         - name: startDate
           in: query
           required: false
@@ -822,6 +828,7 @@ paths:
           required: true
           schema:
             type: string
+            format: uuid
       responses:
         "200":
           description: The project's change-request statistics.


### PR DESCRIPTION
## Summary
Ports 7 endpoints that exist in the Ballerina reference (`WSO2-Enterprise/digiops-cs/entity-service`) but were missing from this Go rewrite:

- `GET /projects/{id}/metadata`
- `GET /projects/{id}/stats`
- `GET /projects/{id}/cases/stats` (optional `caseTypes[]`/`createdBy` filters)
- `GET /projects/{id}/conversations/stats` (optional `createdBy` filter)
- `GET /projects/{id}/deployments/stats`
- `GET /projects/{id}/time-cards/stats` (optional `startDate`/`endDate` range)
- `GET /projects/{id}/change-requests/stats`

All are ServiceNow data source only, matching the Ballerina reference's own architecture — it has no Postgres/dual-datasource concept at all (confirmed: only one module, `servicenow`, in its entire codebase).

## Implementation

New `ProjectStatsService` interface + `snProjectStatsService` implementation (`internal/service/sn_project_stats_service.go`), `ProjectStatsHandler` (`internal/handler/project_stats_handler.go`), wired the same way as the existing `ProjectContactService`/`ProjectUpdateService` — a separate ServiceNow-only interface gated behind `cfg.DataSource` in `routes.go`, not folded into the base `ProjectService` (which also has a Postgres backing).

New domain types mirror the Choreo response shapes 1:1: `ChoiceListItem` (enumerates the valid values for a field, e.g. case states/severities — a different concept from classifying a single record's field) and `ReferenceTableItem` (a richer `EntityRef` with an optional record number/internal ID/count). `ChoiceListItem`'s `id` is `int|string` on the Choreo side (an inconsistency in the upstream API across different choice-list fields) — handled via a small `snFlexibleID` `UnmarshalJSON` shim scoped to the service layer only; the public domain type stays a plain `string`, consistent with every other id field in this file.

Also updates `openapi.yaml` (7 new paths, 14 new schemas).

## Scope note
This is the first of ~30 endpoints identified as missing when comparing this repo's `entity-service` against the Ballerina reference (`WSO2-Enterprise/digiops-cs/entity-service`) — remaining groups (conversations CRUD, case feedback, attachment gaps, deployed-product metrics, instances/metrics, escalations, and several smaller singles) will follow in subsequent PRs. A companion PR wires these 7 endpoints into `apps/customer-portal/backend-v2`.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` all clean
- [x] `go test ./...` passes (including existing suites, unaffected)
- [x] `gosec -fmt=text ./...` reports 0 issues
- [x] `openapi.yaml` validated as well-formed YAML with all 7 new paths/14 new schemas present, zero dangling `$ref`s
- [ ] Wire up against a real running ServiceNow-backed Choreo integration (no test coverage added for the new service methods themselves — following this file's existing pattern of relying on integration testing for thin Choreo-passthrough methods)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added project metadata and feature information.
  * Added project-wide statistics for cases, conversations, deployments, time cards, and change requests.
  * Added case statistics filtering by case type and creator, with trend and breakdown data.
  * Exposed seven new project statistics API endpoints with documented response formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->