### PR TITLE
[CSM][BE] Add project metadata and statistics endpoints

### DIFF
--- a/apps/customer-portal/backend-v2/CLAUDE.md
+++ b/apps/customer-portal/backend-v2/CLAUDE.md
@@ -182,11 +182,12 @@ It backs two routes:
 ## Project metadata and stats — reshaped, not passed through
 
 `GET /projects/{id}/filters`, `/features`, `/stats`, `/stats/cases`, `/stats/conversations`,
-`/stats/support`, `/stats/time-cards`, and `/stats/change-requests` all read from just three
+`/stats/support`, `/stats/time-cards`, and `/stats/change-requests` all read from seven
 entity-service endpoints (`GetProjectMetadata`, `GetProjectCaseStats`,
-`GetProjectConversationStats`, plus the standalone deployment/activity/time-card/change-request
-stats calls) — the Ballerina backend fans a handful of raw entity-service responses out into eight
-differently-shaped, purpose-built views rather than exposing them 1:1, and `internal/dto/project_stats.go`
+`GetProjectConversationStats`, `GetProjectDeploymentStats`, `GetProjectStats`,
+`GetProjectTimeCardStats`, and `GetProjectChangeRequestStats`) — the Ballerina backend fans a
+handful of raw entity-service responses out into eight differently-shaped, purpose-built views
+rather than exposing them 1:1, and `internal/dto/project_stats.go`
 replicates that fan-out exactly (ported from the Ballerina backend's `getProjectFilters`,
 `mapProjectFeatures`, `mapCaseStats`, `getConversationStats`, and
 `mapProjectChangeRequestStatsResponse` in `utils.bal`):

--- a/apps/customer-portal/backend-v2/CLAUDE.md
+++ b/apps/customer-portal/backend-v2/CLAUDE.md
@@ -6,7 +6,7 @@ responses for the frontend. This is a Go rewrite of the Ballerina backend at
 `apps/customer-portal/backend`, modeled on `apps/csm-portal/backend`'s conventions — read that
 backend's own CLAUDE.md too if something here is underspecified.
 
-**Status: in progress.** 50 routes are wired up so far (`GET /health`, `GET`/`PATCH /users/me`,
+**Status: in progress.** 60 routes are wired up so far (`GET /health`, `GET`/`PATCH /users/me`,
 `POST /accounts/search`, `GET /accounts/{id}`, `POST /projects/search`, `GET /projects/{id}`,
 `POST /cases/search`, `GET /cases/{id}`, `POST /cases`, `PATCH /cases/{id}`,
 `POST /cases/{id}/comments`, `POST /cases/{id}/activities/search`, `POST /deployments/search`,
@@ -25,14 +25,18 @@ backend's own CLAUDE.md too if something here is underspecified.
 `POST /projects/{projectId}/conversations/{conversationId}/messages`,
 `GET /projects/{id}/conversations/{conversationId}/summary`, `GET /ws`,
 `POST /projects/{projectId}/deployments/{deploymentId}/license`, `POST /deployment-usages`,
+`GET /projects/{id}/filters`, `GET /projects/{id}/features`, `GET /projects/{id}/stats`,
+`GET /projects/{id}/stats/cases`, `GET /projects/{id}/stats/conversations`,
+`GET /projects/{id}/stats/support`, `GET /projects/{id}/stats/time-cards`,
+`GET /projects/{id}/stats/change-requests`,
 `GET /updates/product-update-levels`, `POST /updates/levels/search`) across five upstream
 services: entity-service, the WSO2 Updates service, SCIM, the AI chat agent, and the
 product-consumption service (see "The AI chat agent" and "The product-consumption service" below —
 unlike the other three, neither is entity-service-backed at all). The Ballerina backend exposes
 ~100 routes across many more modules (registry tokens, escalations, incidents, problems, task
 SLAs, tasks, groups/service-offerings/configuration-items, account/project contacts, project
-update, generic user search, project/case/deployment/conversation/time-card stats, case feedback,
-instance search/metrics, global search, etc.) — none of those are ported yet, several because they
+update, generic user search, case feedback, instance search/metrics, global search, etc.) — none
+of those are ported yet, several because they
 have no genuine equivalent on `cs-tools/entity-service` (confirmed by grepping
 `entity-service/internal/server/routes.go` for each — stats, feedback, instance metrics, escalations,
 and global search all come up empty) or aren't actually customer-portal features at all (see "Which
@@ -174,6 +178,47 @@ It backs two routes:
   check in the handler, both mirroring the Ballerina backend's `validateDeploymentUsageImportRequest`.
   The Go client base64-encodes the bytes before forwarding to the upstream service, matching its
   JSON contract exactly (`{"email": "...", "zip": "<base64>"}`).
+
+## Project metadata and stats — reshaped, not passed through
+
+`GET /projects/{id}/filters`, `/features`, `/stats`, `/stats/cases`, `/stats/conversations`,
+`/stats/support`, `/stats/time-cards`, and `/stats/change-requests` all read from just three
+entity-service endpoints (`GetProjectMetadata`, `GetProjectCaseStats`,
+`GetProjectConversationStats`, plus the standalone deployment/activity/time-card/change-request
+stats calls) — the Ballerina backend fans a handful of raw entity-service responses out into eight
+differently-shaped, purpose-built views rather than exposing them 1:1, and `internal/dto/project_stats.go`
+replicates that fan-out exactly (ported from the Ballerina backend's `getProjectFilters`,
+`mapProjectFeatures`, `mapCaseStats`, `getConversationStats`, and
+`mapProjectChangeRequestStatsResponse` in `utils.bal`):
+
+- **`/filters` and `/features` both call `GetProjectMetadata`** — there is no `GET /projects/{id}/metadata`
+  passthrough endpoint in this backend at all, because the Ballerina backend never exposed one
+  either; it only ever exposes the metadata response split into these two narrower views.
+  `ChoiceListItem`/`ReferenceTableItem` (entity-service's two "list of valid options" shapes) both
+  collapse into one `dto.ReferenceItem{id, label, count?}` for the frontend, matching the Ballerina
+  backend's own `ReferenceItem` type. `/filters`' `changeRequestStates` additionally drops three
+  internal ServiceNow workflow state IDs (`dto.restrictedChangeRequestStateIDs`) that were never
+  meant to be a customer-facing filter option.
+- **`/stats` and `/stats/support` are composite, graceful-degradation endpoints** — each combines
+  multiple independent entity-service calls (`/stats` combines case/conversation/deployment/activity
+  stats; `/stats/support` combines case/conversation stats) and returns `200` even if every one of
+  them fails, simply omitting that source's fields from the response (`dto.BuildProjectDashboardStats`/
+  `dto.BuildProjectSupportStats` take `*entity.XxxResponse`, nil meaning "this source failed to
+  load"). This exactly mirrors the Ballerina backend's own behavior — it logs each failure and moves
+  on rather than failing the whole request. `/stats/cases`, `/stats/conversations`,
+  `/stats/time-cards`, and `/stats/change-requests`, by contrast, are **not** graceful — each is a
+  single entity-service call and a failure there is a hard failure (`mapUpstreamError`), matching
+  the Ballerina backend's per-endpoint behavior exactly (verified individually, not assumed from the
+  composite endpoints' pattern).
+- **State-ID-based derived counts are hardcoded, not configurable.** `dto.caseStateIDOpen` and the
+  `conversationStateID*` constants pick specific counts out of a state-count breakdown (e.g. "how
+  many cases are in the *open* state") using the same default ServiceNow state IDs the Ballerina
+  backend's own `stateIdOpen`/`conversationStateIds` configuration defaults to. If cs-tools'
+  ServiceNow instance uses different state IDs for these, these constants need to become
+  configurable here too — they are not currently, since the Ballerina backend's own configurability
+  was never exercised away from its defaults as far as this rewrite could confirm.
+- `/stats/cases` also, in the Ballerina backend, fetches change-request stats and never uses the
+  result (dead code, presumably a leftover) — this backend does not replicate that no-op call.
 
 ## Middleware chain
 

--- a/apps/customer-portal/backend-v2/README.md
+++ b/apps/customer-portal/backend-v2/README.md
@@ -5,7 +5,7 @@ Go rewrite of the Ballerina backend at `apps/customer-portal/backend`. It is a b
 [`entity-service`](../../../entity-service) (this repo's `cs-tools/entity-service`, not the
 `digiops-cs/entity-service` the Ballerina backend targets), and shapes the responses for the frontend.
 
-This is a work in progress — only the 52 routes listed below are implemented so far, across
+This is a work in progress — only the 60 routes listed below are implemented so far, across
 entity-service, the WSO2 Updates service, SCIM, the AI chat agent, and the product-consumption
 service (two more separate services — see [CLAUDE.md](./CLAUDE.md#the-ai-chat-agent) and
 [CLAUDE.md](./CLAUDE.md#the-product-consumption-service)). Everything else the Ballerina backend
@@ -195,6 +195,7 @@ backend-v2/
 │   │   ├── user.go
 │   │   ├── account.go
 │   │   ├── project.go
+│   │   ├── project_stats.go
 │   │   ├── case.go
 │   │   ├── deployment.go
 │   │   ├── deployed_product.go
@@ -218,6 +219,7 @@ backend-v2/
 │       ├── users.go             # GET/PATCH /users/me
 │       ├── accounts.go          # POST /accounts/search, GET /accounts/{id}
 │       ├── projects.go          # POST /projects/search, GET /projects/{id}
+│       ├── project_stats.go     # project filters/features/dashboard-stats (composite, some graceful-degradation)
 │       ├── cases.go             # cases search/get/create/update/comment/activities
 │       ├── deployments.go       # POST /deployments/search, POST /deployments, PATCH /deployments/{id}
 │       ├── deployed_products.go # deployed-product search/create/update
@@ -249,6 +251,14 @@ backend-v2/
 - `GET /accounts/{id}` — get account by ID (same normalization)
 - `POST /projects/search` — search projects
 - `GET /projects/{id}` — get project by ID
+- `GET /projects/{id}/filters` — get filter-dropdown options for a project (case states, severities, issue types, etc.)
+- `GET /projects/{id}/features` — get a project's feature-access flags
+- `GET /projects/{id}/stats` — get a project's dashboard statistics (combines case/conversation/deployment/activity stats; partial failures are tolerated)
+- `GET /projects/{id}/stats/cases` — get a project's case statistics, optionally filtered by `caseTypes`/`createdBy` query params
+- `GET /projects/{id}/stats/conversations` — get a project's conversation statistics, optionally filtered by `createdBy`
+- `GET /projects/{id}/stats/support` — get a project's combined support statistics (case + conversation; partial failures are tolerated)
+- `GET /projects/{id}/stats/time-cards` — get a project's time-card statistics, optionally filtered by `startDate`/`endDate`
+- `GET /projects/{id}/stats/change-requests` — get a project's change-request statistics
 - `POST /cases/search` — search cases
 - `GET /cases/{id}` — get case by ID
 - `POST /cases` — create a case
@@ -333,6 +343,22 @@ curl -X POST http://localhost:8080/projects/search \
   -d '{"pagination":{"limit":10,"offset":0},"searchQuery":"acme"}'
 
 curl -H "x-jwt-assertion: $JWT" http://localhost:8080/projects/<project-id>
+
+curl -H "x-jwt-assertion: $JWT" http://localhost:8080/projects/<project-id>/filters
+
+curl -H "x-jwt-assertion: $JWT" http://localhost:8080/projects/<project-id>/features
+
+curl -H "x-jwt-assertion: $JWT" http://localhost:8080/projects/<project-id>/stats
+
+curl -H "x-jwt-assertion: $JWT" "http://localhost:8080/projects/<project-id>/stats/cases?caseTypes=default_case&createdBy=<user-id>"
+
+curl -H "x-jwt-assertion: $JWT" http://localhost:8080/projects/<project-id>/stats/conversations
+
+curl -H "x-jwt-assertion: $JWT" http://localhost:8080/projects/<project-id>/stats/support
+
+curl -H "x-jwt-assertion: $JWT" "http://localhost:8080/projects/<project-id>/stats/time-cards?startDate=2026-07-01&endDate=2026-07-31"
+
+curl -H "x-jwt-assertion: $JWT" http://localhost:8080/projects/<project-id>/stats/change-requests
 
 curl -X POST http://localhost:8080/cases/search \
   -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \

--- a/apps/customer-portal/backend-v2/cmd/server/main.go
+++ b/apps/customer-portal/backend-v2/cmd/server/main.go
@@ -116,6 +116,7 @@ func main() {
 
 	userHandler := handler.NewUserHandler(entityClient, scimClient)
 	projectHandler := handler.NewProjectHandler(entityClient)
+	projectStatsHandler := handler.NewProjectStatsHandler(entityClient)
 	caseHandler := handler.NewCaseHandler(entityClient)
 	deploymentHandler := handler.NewDeploymentHandler(entityClient)
 	deployedProductHandler := handler.NewDeployedProductHandler(entityClient)
@@ -153,6 +154,14 @@ func main() {
 
 	mux.HandleFunc("POST /projects/search", projectHandler.SearchProjects)
 	mux.HandleFunc("GET /projects/{id}", projectHandler.GetProject)
+	mux.HandleFunc("GET /projects/{id}/filters", projectStatsHandler.GetProjectFilters)
+	mux.HandleFunc("GET /projects/{id}/features", projectStatsHandler.GetProjectFeatures)
+	mux.HandleFunc("GET /projects/{id}/stats", projectStatsHandler.GetProjectDashboardStats)
+	mux.HandleFunc("GET /projects/{id}/stats/cases", projectStatsHandler.GetProjectCaseStats)
+	mux.HandleFunc("GET /projects/{id}/stats/conversations", projectStatsHandler.GetProjectConversationStats)
+	mux.HandleFunc("GET /projects/{id}/stats/support", projectStatsHandler.GetProjectSupportStats)
+	mux.HandleFunc("GET /projects/{id}/stats/time-cards", projectStatsHandler.GetProjectTimeCardStats)
+	mux.HandleFunc("GET /projects/{id}/stats/change-requests", projectStatsHandler.GetProjectChangeRequestStats)
 
 	mux.HandleFunc("POST /cases/search", caseHandler.SearchCases)
 	mux.HandleFunc("GET /cases/{id}", caseHandler.GetCase)

--- a/apps/customer-portal/backend-v2/internal/dto/project_stats.go
+++ b/apps/customer-portal/backend-v2/internal/dto/project_stats.go
@@ -246,22 +246,56 @@ func BuildProjectDashboardStats(
 	return out
 }
 
+// ResolvedCountBreakdown is the portal's own copy of entity-service's
+// resolved-count breakdown, kept separate per this package's "always map
+// through dto" convention.
+type ResolvedCountBreakdown struct {
+	Total          int `json:"total"`
+	CurrentMonth   int `json:"currentMonth"`
+	PastThirtyDays int `json:"pastThirtyDays"`
+}
+
+func mapResolvedCountBreakdown(r entity.ResolvedCountBreakdown) ResolvedCountBreakdown {
+	return ResolvedCountBreakdown{Total: r.Total, CurrentMonth: r.CurrentMonth, PastThirtyDays: r.PastThirtyDays}
+}
+
+// CaseStatsChangeRate is the portal's own copy of the case-stats change-rate figures.
+type CaseStatsChangeRate struct {
+	ResolvedEngagements float64 `json:"resolvedEngagements"`
+	AverageResponseTime float64 `json:"averageResponseTime"`
+}
+
+// CasesTrend is the portal's own copy of a case-count trend bucket, with
+// severities mapped through ReferenceItem instead of entity.ChoiceListItem.
+type CasesTrend struct {
+	Period     string          `json:"period"`
+	Severities []ReferenceItem `json:"severities"`
+}
+
+func mapCasesTrend(trends []entity.CasesTrend) []CasesTrend {
+	out := make([]CasesTrend, 0, len(trends))
+	for _, t := range trends {
+		out = append(out, CasesTrend{Period: t.Period, Severities: mapChoiceListItems(t.Severities)})
+	}
+	return out
+}
+
 // ProjectCaseStats is the portal's response for GET /projects/{id}/cases/stats.
 type ProjectCaseStats struct {
-	TotalCount                     int                               `json:"totalCount"`
-	ActiveCount                    int                               `json:"activeCount"`
-	OutstandingCount               int                               `json:"outstandingCount"`
-	ActionRequiredCount            int                               `json:"actionRequiredCount"`
-	AverageResponseTime            float64                           `json:"averageResponseTime"`
-	ResolvedCases                  entity.ResolvedCountBreakdown     `json:"resolvedCases"`
-	ChangeRate                     entity.ProjectCaseStatsChangeRate `json:"changeRate"`
-	StateCount                     []ReferenceItem                   `json:"stateCount"`
-	SeverityCount                  []ReferenceItem                   `json:"severityCount"`
-	OutstandingSeverityCount       []ReferenceItem                   `json:"outstandingSeverityCount"`
-	CaseTypeCount                  []ReferenceItem                   `json:"caseTypeCount"`
-	CasesTrend                     []entity.CasesTrend               `json:"casesTrend"`
-	EngagementTypeCount            []ReferenceItem                   `json:"engagementTypeCount"`
-	OutstandingEngagementTypeCount []ReferenceItem                   `json:"outstandingEngagementTypeCount"`
+	TotalCount                     int                    `json:"totalCount"`
+	ActiveCount                    int                    `json:"activeCount"`
+	OutstandingCount               int                    `json:"outstandingCount"`
+	ActionRequiredCount            int                    `json:"actionRequiredCount"`
+	AverageResponseTime            float64                `json:"averageResponseTime"`
+	ResolvedCases                  ResolvedCountBreakdown `json:"resolvedCases"`
+	ChangeRate                     CaseStatsChangeRate    `json:"changeRate"`
+	StateCount                     []ReferenceItem        `json:"stateCount"`
+	SeverityCount                  []ReferenceItem        `json:"severityCount"`
+	OutstandingSeverityCount       []ReferenceItem        `json:"outstandingSeverityCount"`
+	CaseTypeCount                  []ReferenceItem        `json:"caseTypeCount"`
+	CasesTrend                     []CasesTrend           `json:"casesTrend"`
+	EngagementTypeCount            []ReferenceItem        `json:"engagementTypeCount"`
+	OutstandingEngagementTypeCount []ReferenceItem        `json:"outstandingEngagementTypeCount"`
 }
 
 // MapProjectCaseStats builds the portal response from entity-service's
@@ -273,13 +307,13 @@ func MapProjectCaseStats(r entity.ProjectCaseStatsResponse) ProjectCaseStats {
 		OutstandingCount:               r.OutstandingCount,
 		ActionRequiredCount:            r.ActionRequiredCount,
 		AverageResponseTime:            r.AverageResponseTime,
-		ResolvedCases:                  r.ResolvedCount,
-		ChangeRate:                     r.ChangeRate,
+		ResolvedCases:                  mapResolvedCountBreakdown(r.ResolvedCount),
+		ChangeRate:                     CaseStatsChangeRate(r.ChangeRate),
 		StateCount:                     mapChoiceListItems(r.StateCount),
 		SeverityCount:                  mapChoiceListItems(r.SeverityCount),
 		OutstandingSeverityCount:       mapChoiceListItems(r.OutstandingSeverityCount),
 		CaseTypeCount:                  mapReferenceTableItems(r.CaseTypeCount),
-		CasesTrend:                     r.CasesTrend,
+		CasesTrend:                     mapCasesTrend(r.CasesTrend),
 		EngagementTypeCount:            mapChoiceListItems(r.EngagementTypeCount),
 		OutstandingEngagementTypeCount: mapChoiceListItems(r.OutstandingEngagementTypeCount),
 	}
@@ -361,12 +395,12 @@ func MapProjectTimeCardStats(r entity.ProjectTimeCardStatsResponse) ProjectTimeC
 // ProjectChangeRequestStats is the portal's response for
 // GET /projects/{id}/stats/change-requests.
 type ProjectChangeRequestStats struct {
-	TotalCount          int                           `json:"totalCount"`
-	ActiveCount         int                           `json:"activeCount"`
-	OutstandingCount    int                           `json:"outstandingCount"`
-	ActionRequiredCount int                           `json:"actionRequiredCount"`
-	StateCount          []ReferenceItem               `json:"stateCount"`
-	ResolvedCount       entity.ResolvedCountBreakdown `json:"resolvedCount"`
+	TotalCount          int                    `json:"totalCount"`
+	ActiveCount         int                    `json:"activeCount"`
+	OutstandingCount    int                    `json:"outstandingCount"`
+	ActionRequiredCount int                    `json:"actionRequiredCount"`
+	StateCount          []ReferenceItem        `json:"stateCount"`
+	ResolvedCount       ResolvedCountBreakdown `json:"resolvedCount"`
 }
 
 // MapProjectChangeRequestStats builds the portal response from
@@ -378,6 +412,6 @@ func MapProjectChangeRequestStats(r entity.ProjectChangeRequestStatsResponse) Pr
 		OutstandingCount:    r.OutstandingCount,
 		ActionRequiredCount: r.ActionRequiredCount,
 		StateCount:          mapChoiceListItems(r.StateCount),
-		ResolvedCount:       r.ResolvedCount,
+		ResolvedCount:       mapResolvedCountBreakdown(r.ResolvedCount),
 	}
 }

--- a/apps/customer-portal/backend-v2/internal/dto/project_stats.go
+++ b/apps/customer-portal/backend-v2/internal/dto/project_stats.go
@@ -1,0 +1,383 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dto
+
+import "github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+
+// ReferenceItem is a flattened {id, label, count?} view of entity-service's
+// ChoiceListItem/ReferenceTableItem — the Ballerina backend this is
+// rewriting collapses both into one uniform shape for every project
+// metadata/stats endpoint, dropping ReferenceTableItem's number/internalId
+// fields (not useful for a filter dropdown or a stats breakdown).
+type ReferenceItem struct {
+	ID    string `json:"id"`
+	Label string `json:"label"`
+	Count *int   `json:"count,omitempty"`
+}
+
+func mapChoiceListItem(i entity.ChoiceListItem) ReferenceItem {
+	return ReferenceItem{ID: i.ID, Label: i.Label, Count: i.Count}
+}
+
+func mapChoiceListItems(items []entity.ChoiceListItem) []ReferenceItem {
+	out := make([]ReferenceItem, 0, len(items))
+	for _, i := range items {
+		out = append(out, mapChoiceListItem(i))
+	}
+	return out
+}
+
+func mapReferenceTableItems(items []entity.ReferenceTableItem) []ReferenceItem {
+	out := make([]ReferenceItem, 0, len(items))
+	for _, i := range items {
+		out = append(out, ReferenceItem{ID: i.ID, Label: i.Name, Count: i.Count})
+	}
+	return out
+}
+
+// restrictedChangeRequestStateIDs are excluded from ProjectFilterOptions'
+// changeRequestStates — internal ServiceNow workflow states never meant to
+// be offered as a customer-facing filter option, matching the Ballerina
+// backend's own restrictedChangeRequestStateIds default.
+var restrictedChangeRequestStateIDs = map[string]bool{"-3": true, "-4": true, "-5": true}
+
+// ProjectFilterOptions is the portal's response for GET /projects/{id}/filters
+// — a flattened, filter-dropdown-ready view of entity-service's project
+// metadata. Deliberately excludes entity-service's ProjectFeatures (see
+// ProjectFeatures below, its own endpoint) and per-severity allocation
+// minutes' internal framing (kept as-is, it's just a lookup map the
+// frontend needs).
+type ProjectFilterOptions struct {
+	CaseStates                  []ReferenceItem `json:"caseStates"`
+	Severities                  []ReferenceItem `json:"severities"`
+	IssueTypes                  []ReferenceItem `json:"issueTypes"`
+	DeploymentTypes             []ReferenceItem `json:"deploymentTypes"`
+	CallRequestStates           []ReferenceItem `json:"callRequestStates"`
+	ChangeRequestStates         []ReferenceItem `json:"changeRequestStates"`
+	ChangeRequestImpacts        []ReferenceItem `json:"changeRequestImpacts"`
+	ConversationStates          []ReferenceItem `json:"conversationStates"`
+	CaseTypes                   []ReferenceItem `json:"caseTypes"`
+	TimeCardStates              []ReferenceItem `json:"timeCardStates"`
+	EngagementTypes             []ReferenceItem `json:"engagementTypes"`
+	EngagementPaymentTypes      []ReferenceItem `json:"engagementPaymentTypes"`
+	SeverityBasedAllocationTime map[string]int  `json:"severityBasedAllocationTime"`
+}
+
+// MapProjectFilterOptions builds the portal response from entity-service's
+// ProjectMetadataResponse.
+func MapProjectFilterOptions(m entity.ProjectMetadataResponse) ProjectFilterOptions {
+	changeRequestStates := make([]ReferenceItem, 0, len(m.ChangeRequestStates))
+	for _, s := range mapChoiceListItems(m.ChangeRequestStates) {
+		if !restrictedChangeRequestStateIDs[s.ID] {
+			changeRequestStates = append(changeRequestStates, s)
+		}
+	}
+
+	return ProjectFilterOptions{
+		CaseStates:                  mapChoiceListItems(m.CaseStates),
+		Severities:                  mapChoiceListItems(m.Severities),
+		IssueTypes:                  mapChoiceListItems(m.IssueTypes),
+		DeploymentTypes:             mapChoiceListItems(m.DeploymentTypes),
+		CallRequestStates:           mapChoiceListItems(m.CallRequestStates),
+		ChangeRequestStates:         changeRequestStates,
+		ChangeRequestImpacts:        mapChoiceListItems(m.ChangeRequestImpacts),
+		ConversationStates:          mapChoiceListItems(m.ConversationStates),
+		CaseTypes:                   mapReferenceTableItems(m.CaseTypes),
+		TimeCardStates:              mapChoiceListItems(m.TimeCardStates),
+		EngagementTypes:             mapChoiceListItems(m.EngagementTypes),
+		EngagementPaymentTypes:      mapChoiceListItems(m.EngagementPaymentTypes),
+		SeverityBasedAllocationTime: m.SeverityBasedAllocationTime,
+	}
+}
+
+// ProjectFeatures is the portal's response for GET /projects/{id}/features —
+// entity-service's ProjectMetadataResponse.Features, minus its ProjectType
+// reference (an internal ServiceNow project-type lookup, not something the
+// frontend's feature-flag consumers need).
+type ProjectFeatures struct {
+	AcceptedSeverityValues         []ReferenceItem `json:"acceptedSeverityValues"`
+	HasServiceRequestWriteAccess   bool            `json:"hasServiceRequestWriteAccess"`
+	HasServiceRequestReadAccess    bool            `json:"hasServiceRequestReadAccess"`
+	HasSraWriteAccess              bool            `json:"hasSraWriteAccess"`
+	HasSraReadAccess               bool            `json:"hasSraReadAccess"`
+	HasChangeRequestReadAccess     bool            `json:"hasChangeRequestReadAccess"`
+	HasEngagementsReadAccess       bool            `json:"hasEngagementsReadAccess"`
+	HasUpdatesReadAccess           bool            `json:"hasUpdatesReadAccess"`
+	HasTimeLogsReadAccess          bool            `json:"hasTimeLogsReadAccess"`
+	HasDeploymentWriteAccess       bool            `json:"hasDeploymentWriteAccess"`
+	HasDeploymentReadAccess        bool            `json:"hasDeploymentReadAccess"`
+	HasComponentAnalysisReadAccess bool            `json:"hasComponentAnalysisReadAccess"`
+	HasUsageMetricsReadAccess      bool            `json:"hasUsageMetricsReadAccess"`
+	DefaultCaseProductCategories   []string        `json:"defaultCaseProductCategories,omitempty"`
+	SrProductCategories            []string        `json:"srProductCategories,omitempty"`
+}
+
+// MapProjectFeatures builds the portal response from entity-service's
+// ProjectMetadataResponse.
+func MapProjectFeatures(m entity.ProjectMetadataResponse) ProjectFeatures {
+	return ProjectFeatures{
+		AcceptedSeverityValues:         mapChoiceListItems(m.Features.AcceptedSeverityValues),
+		HasServiceRequestWriteAccess:   m.Features.HasServiceRequestWriteAccess,
+		HasServiceRequestReadAccess:    m.Features.HasServiceRequestReadAccess,
+		HasSraWriteAccess:              m.Features.HasSraWriteAccess,
+		HasSraReadAccess:               m.Features.HasSraReadAccess,
+		HasChangeRequestReadAccess:     m.Features.HasChangeRequestReadAccess,
+		HasEngagementsReadAccess:       m.Features.HasEngagementsReadAccess,
+		HasUpdatesReadAccess:           m.Features.HasUpdatesReadAccess,
+		HasTimeLogsReadAccess:          m.Features.HasTimeLogsReadAccess,
+		HasDeploymentWriteAccess:       m.Features.HasDeploymentWriteAccess,
+		HasDeploymentReadAccess:        m.Features.HasDeploymentReadAccess,
+		HasComponentAnalysisReadAccess: m.Features.HasComponentAnalysisReadAccess,
+		HasUsageMetricsReadAccess:      m.Features.HasUsageMetricsReadAccess,
+		DefaultCaseProductCategories:   m.Features.DefaultCaseProductCategories,
+		SrProductCategories:            m.Features.SrProductCategories,
+	}
+}
+
+// caseStateIDOpen is the ServiceNow case state ID meaning "open", used to
+// pick the open-case count out of a case-stats state breakdown. Matches the
+// Ballerina backend's own default (stateIdOpen/caseStateIds.open) — both
+// configurable there; if cs-tools' ServiceNow instance uses different case
+// state IDs, this needs to become configurable here too.
+const caseStateIDOpen = "1"
+
+// conversationStateID{Open,Active,Resolved,Abandoned} are the ServiceNow
+// conversation state IDs used to pick specific counts out of a
+// conversation-stats state breakdown. Match the Ballerina backend's own
+// default conversationStateIds — see caseStateIDOpen's doc comment on the
+// same caveat.
+const (
+	conversationStateIDOpen      = "1"
+	conversationStateIDActive    = "2"
+	conversationStateIDResolved  = "3"
+	conversationStateIDAbandoned = "5"
+)
+
+func countForState(stateCount []ReferenceItem, stateID string) *int {
+	for _, s := range stateCount {
+		if s.ID == stateID {
+			return s.Count
+		}
+	}
+	return nil
+}
+
+// ProjectStats is the headline counters on the project dashboard.
+type ProjectStats struct {
+	OpenCases                      *int    `json:"openCases,omitempty"`
+	ActiveChats                    *int    `json:"activeChats,omitempty"`
+	Deployments                    *int    `json:"deployments,omitempty"`
+	SLAStatus                      *string `json:"slaStatus,omitempty"`
+	OutstandingCaseCount           *int    `json:"outstandingCaseCount,omitempty"`
+	OutstandingServiceRequestCount *int    `json:"outstandingServiceRequestCount,omitempty"`
+	OutstandingEngagementCount     *int    `json:"outstandingEngagementCount,omitempty"`
+	OutstandingSraCount            *int    `json:"outstandingSraCount,omitempty"`
+	OutstandingChangeRequestCount  *int    `json:"outstandingChangeRequestCount,omitempty"`
+	OutstandingAnnouncementCount   *int    `json:"outstandingAnnouncementCount,omitempty"`
+}
+
+// RecentActivity is the recent-activity panel on the project dashboard.
+type RecentActivity struct {
+	TotalHours       *float64 `json:"totalHours,omitempty"`
+	BillableHours    *float64 `json:"billableHours,omitempty"`
+	LastDeploymentOn *string  `json:"lastDeploymentOn,omitempty"`
+}
+
+// ProjectDashboardStats is the portal's response for GET /projects/{id}/stats
+// — combines entity-service's case/conversation/deployment/activity stats
+// into one dashboard view.
+type ProjectDashboardStats struct {
+	ProjectStats   ProjectStats   `json:"projectStats"`
+	RecentActivity RecentActivity `json:"recentActivity"`
+}
+
+// BuildProjectDashboardStats combines up to four independently-fetched stats
+// responses into the dashboard view, mirroring the Ballerina backend's own
+// graceful-degradation behavior: any source that failed to load is passed as
+// nil and its fields are simply omitted from the response, rather than
+// failing the whole request.
+func BuildProjectDashboardStats(
+	caseStats *entity.ProjectCaseStatsResponse,
+	conversationStats *entity.ProjectConversationStatsResponse,
+	deploymentStats *entity.ProjectDeploymentStatsResponse,
+	activityStats *entity.ProjectStatsResponse,
+) ProjectDashboardStats {
+	var out ProjectDashboardStats
+
+	if caseStats != nil {
+		mapped := MapProjectCaseStats(*caseStats)
+		out.ProjectStats.OpenCases = countForState(mapped.StateCount, caseStateIDOpen)
+	}
+	if conversationStats != nil {
+		activeCount := conversationStats.ActiveCount
+		out.ProjectStats.ActiveChats = &activeCount
+	}
+	if deploymentStats != nil {
+		totalCount := deploymentStats.TotalCount
+		out.ProjectStats.Deployments = &totalCount
+		out.RecentActivity.LastDeploymentOn = deploymentStats.LastDeploymentOn
+	}
+	if activityStats != nil {
+		slaStatus := activityStats.SLAStatus
+		out.ProjectStats.SLAStatus = &slaStatus
+		out.ProjectStats.OutstandingCaseCount = &activityStats.OutstandingCount.CaseCount
+		out.ProjectStats.OutstandingServiceRequestCount = &activityStats.OutstandingCount.ServiceRequestCount
+		out.ProjectStats.OutstandingEngagementCount = &activityStats.OutstandingCount.EngagementCount
+		out.ProjectStats.OutstandingSraCount = &activityStats.OutstandingCount.SraCount
+		out.ProjectStats.OutstandingChangeRequestCount = &activityStats.OutstandingCount.ChangeRequestCount
+		out.ProjectStats.OutstandingAnnouncementCount = &activityStats.OutstandingCount.AnnouncementCount
+		out.RecentActivity.TotalHours = &activityStats.TotalHours
+		out.RecentActivity.BillableHours = &activityStats.BillableHours
+	}
+	return out
+}
+
+// ProjectCaseStats is the portal's response for GET /projects/{id}/cases/stats.
+type ProjectCaseStats struct {
+	TotalCount                     int                               `json:"totalCount"`
+	ActiveCount                    int                               `json:"activeCount"`
+	OutstandingCount               int                               `json:"outstandingCount"`
+	ActionRequiredCount            int                               `json:"actionRequiredCount"`
+	AverageResponseTime            float64                           `json:"averageResponseTime"`
+	ResolvedCases                  entity.ResolvedCountBreakdown     `json:"resolvedCases"`
+	ChangeRate                     entity.ProjectCaseStatsChangeRate `json:"changeRate"`
+	StateCount                     []ReferenceItem                   `json:"stateCount"`
+	SeverityCount                  []ReferenceItem                   `json:"severityCount"`
+	OutstandingSeverityCount       []ReferenceItem                   `json:"outstandingSeverityCount"`
+	CaseTypeCount                  []ReferenceItem                   `json:"caseTypeCount"`
+	CasesTrend                     []entity.CasesTrend               `json:"casesTrend"`
+	EngagementTypeCount            []ReferenceItem                   `json:"engagementTypeCount"`
+	OutstandingEngagementTypeCount []ReferenceItem                   `json:"outstandingEngagementTypeCount"`
+}
+
+// MapProjectCaseStats builds the portal response from entity-service's
+// ProjectCaseStatsResponse.
+func MapProjectCaseStats(r entity.ProjectCaseStatsResponse) ProjectCaseStats {
+	return ProjectCaseStats{
+		TotalCount:                     r.TotalCount,
+		ActiveCount:                    r.ActiveCount,
+		OutstandingCount:               r.OutstandingCount,
+		ActionRequiredCount:            r.ActionRequiredCount,
+		AverageResponseTime:            r.AverageResponseTime,
+		ResolvedCases:                  r.ResolvedCount,
+		ChangeRate:                     r.ChangeRate,
+		StateCount:                     mapChoiceListItems(r.StateCount),
+		SeverityCount:                  mapChoiceListItems(r.SeverityCount),
+		OutstandingSeverityCount:       mapChoiceListItems(r.OutstandingSeverityCount),
+		CaseTypeCount:                  mapReferenceTableItems(r.CaseTypeCount),
+		CasesTrend:                     r.CasesTrend,
+		EngagementTypeCount:            mapChoiceListItems(r.EngagementTypeCount),
+		OutstandingEngagementTypeCount: mapChoiceListItems(r.OutstandingEngagementTypeCount),
+	}
+}
+
+// ConversationStats is the portal's response for GET /projects/{id}/conversations/stats
+// — a handful of specific counts picked out of entity-service's state
+// breakdown, matching the Ballerina backend's own thinner response (which
+// also drops the converted/session/total counts an internal
+// OverallConversationStats-equivalent would carry).
+type ConversationStats struct {
+	OpenCount      *int `json:"openCount,omitempty"`
+	ActiveCount    *int `json:"activeCount,omitempty"`
+	ResolvedCount  *int `json:"resolvedCount,omitempty"`
+	AbandonedCount *int `json:"abandonedCount,omitempty"`
+}
+
+// MapConversationStats builds the portal response from entity-service's
+// ProjectConversationStatsResponse.
+func MapConversationStats(r entity.ProjectConversationStatsResponse) ConversationStats {
+	stateCount := mapChoiceListItems(r.StateCount)
+	return ConversationStats{
+		OpenCount:      countForState(stateCount, conversationStateIDOpen),
+		ActiveCount:    countForState(stateCount, conversationStateIDActive),
+		ResolvedCount:  countForState(stateCount, conversationStateIDResolved),
+		AbandonedCount: countForState(stateCount, conversationStateIDAbandoned),
+	}
+}
+
+// ProjectSupportStats is the portal's response for GET /projects/{id}/stats/support.
+type ProjectSupportStats struct {
+	OngoingCases                 *int `json:"ongoingCases,omitempty"`
+	ActiveChats                  *int `json:"activeChats,omitempty"`
+	ResolvedPast30DaysCasesCount *int `json:"resolvedPast30DaysCasesCount,omitempty"`
+	ResolvedChats                *int `json:"resolvedChats,omitempty"`
+}
+
+// BuildProjectSupportStats combines independently-fetched case and
+// conversation stats into the support-stats view, mirroring the Ballerina
+// backend's own graceful-degradation behavior for this endpoint: either
+// source may be nil (failed to load) without failing the whole request.
+func BuildProjectSupportStats(caseStats *entity.ProjectCaseStatsResponse, conversationStats *entity.ProjectConversationStatsResponse) ProjectSupportStats {
+	var out ProjectSupportStats
+	if caseStats != nil {
+		activeCount := caseStats.ActiveCount
+		out.OngoingCases = &activeCount
+		pastThirtyDays := caseStats.ResolvedCount.PastThirtyDays
+		out.ResolvedPast30DaysCasesCount = &pastThirtyDays
+	}
+	if conversationStats != nil {
+		mapped := MapConversationStats(*conversationStats)
+		out.ActiveChats = mapped.ActiveCount
+		out.ResolvedChats = mapped.ResolvedCount
+	}
+	return out
+}
+
+// ProjectTimeCardStats is the portal's response for GET /projects/{id}/time-cards/stats.
+// entity-service's response has no fields worth restricting, so this is a
+// direct passthrough shape — kept as its own portal type (rather than reusing
+// entity.ProjectTimeCardStatsResponse directly) purely for this package's
+// "always map through dto" convention.
+type ProjectTimeCardStats struct {
+	TotalHours       float64 `json:"totalHours"`
+	BillableHours    float64 `json:"billableHours"`
+	NonBillableHours float64 `json:"nonBillableHours"`
+}
+
+// MapProjectTimeCardStats builds the portal response from entity-service's
+// ProjectTimeCardStatsResponse.
+func MapProjectTimeCardStats(r entity.ProjectTimeCardStatsResponse) ProjectTimeCardStats {
+	return ProjectTimeCardStats{
+		TotalHours:       r.TotalHours,
+		BillableHours:    r.BillableHours,
+		NonBillableHours: r.NonBillableHours,
+	}
+}
+
+// ProjectChangeRequestStats is the portal's response for
+// GET /projects/{id}/stats/change-requests.
+type ProjectChangeRequestStats struct {
+	TotalCount          int                           `json:"totalCount"`
+	ActiveCount         int                           `json:"activeCount"`
+	OutstandingCount    int                           `json:"outstandingCount"`
+	ActionRequiredCount int                           `json:"actionRequiredCount"`
+	StateCount          []ReferenceItem               `json:"stateCount"`
+	ResolvedCount       entity.ResolvedCountBreakdown `json:"resolvedCount"`
+}
+
+// MapProjectChangeRequestStats builds the portal response from
+// entity-service's ProjectChangeRequestStatsResponse.
+func MapProjectChangeRequestStats(r entity.ProjectChangeRequestStatsResponse) ProjectChangeRequestStats {
+	return ProjectChangeRequestStats{
+		TotalCount:          r.TotalCount,
+		ActiveCount:         r.ActiveCount,
+		OutstandingCount:    r.OutstandingCount,
+		ActionRequiredCount: r.ActionRequiredCount,
+		StateCount:          mapChoiceListItems(r.StateCount),
+		ResolvedCount:       r.ResolvedCount,
+	}
+}

--- a/apps/customer-portal/backend-v2/internal/entity/projects.go
+++ b/apps/customer-portal/backend-v2/internal/entity/projects.go
@@ -35,3 +35,86 @@ func (c *Client) GetProject(ctx context.Context, id string) (ProjectDetailsView,
 	err := c.getJSON(ctx, fmt.Sprintf("/projects/%s", url.PathEscape(id)), &out)
 	return out, err
 }
+
+// GetProjectMetadata calls GET /projects/{id}/metadata.
+//
+// NOTE: only entity-service's ServiceNow data source supports this route —
+// see cs-tools/entity-service/internal/server/routes.go.
+func (c *Client) GetProjectMetadata(ctx context.Context, id string) (ProjectMetadataResponse, error) {
+	var out ProjectMetadataResponse
+	err := c.getJSON(ctx, fmt.Sprintf("/projects/%s/metadata", url.PathEscape(id)), &out)
+	return out, err
+}
+
+// GetProjectStats calls GET /projects/{id}/stats.
+func (c *Client) GetProjectStats(ctx context.Context, id string) (ProjectStatsResponse, error) {
+	var out ProjectStatsResponse
+	err := c.getJSON(ctx, fmt.Sprintf("/projects/%s/stats", url.PathEscape(id)), &out)
+	return out, err
+}
+
+// GetProjectCaseStats calls GET /projects/{id}/cases/stats. caseTypes and
+// createdBy are both optional filters; pass caseTypes as nil/empty and
+// createdBy as "" to omit them.
+func (c *Client) GetProjectCaseStats(ctx context.Context, id string, caseTypes []string, createdBy string) (ProjectCaseStatsResponse, error) {
+	q := url.Values{}
+	for _, ct := range caseTypes {
+		q.Add("caseTypes", ct)
+	}
+	if createdBy != "" {
+		q.Set("createdBy", createdBy)
+	}
+	path := fmt.Sprintf("/projects/%s/cases/stats", url.PathEscape(id))
+	if len(q) > 0 {
+		path += "?" + q.Encode()
+	}
+	var out ProjectCaseStatsResponse
+	err := c.getJSON(ctx, path, &out)
+	return out, err
+}
+
+// GetProjectConversationStats calls GET /projects/{id}/conversations/stats.
+// createdBy is an optional filter; pass "" to omit it.
+func (c *Client) GetProjectConversationStats(ctx context.Context, id, createdBy string) (ProjectConversationStatsResponse, error) {
+	path := fmt.Sprintf("/projects/%s/conversations/stats", url.PathEscape(id))
+	if createdBy != "" {
+		path += "?" + url.Values{"createdBy": {createdBy}}.Encode()
+	}
+	var out ProjectConversationStatsResponse
+	err := c.getJSON(ctx, path, &out)
+	return out, err
+}
+
+// GetProjectDeploymentStats calls GET /projects/{id}/deployments/stats.
+func (c *Client) GetProjectDeploymentStats(ctx context.Context, id string) (ProjectDeploymentStatsResponse, error) {
+	var out ProjectDeploymentStatsResponse
+	err := c.getJSON(ctx, fmt.Sprintf("/projects/%s/deployments/stats", url.PathEscape(id)), &out)
+	return out, err
+}
+
+// GetProjectTimeCardStats calls GET /projects/{id}/time-cards/stats.
+// startDate/endDate (each yyyy-MM-dd) are an optional filter range; pass ""
+// to omit either.
+func (c *Client) GetProjectTimeCardStats(ctx context.Context, id, startDate, endDate string) (ProjectTimeCardStatsResponse, error) {
+	q := url.Values{}
+	if startDate != "" {
+		q.Set("startDate", startDate)
+	}
+	if endDate != "" {
+		q.Set("endDate", endDate)
+	}
+	path := fmt.Sprintf("/projects/%s/time-cards/stats", url.PathEscape(id))
+	if len(q) > 0 {
+		path += "?" + q.Encode()
+	}
+	var out ProjectTimeCardStatsResponse
+	err := c.getJSON(ctx, path, &out)
+	return out, err
+}
+
+// GetProjectChangeRequestStats calls GET /projects/{id}/change-requests/stats.
+func (c *Client) GetProjectChangeRequestStats(ctx context.Context, id string) (ProjectChangeRequestStatsResponse, error) {
+	var out ProjectChangeRequestStatsResponse
+	err := c.getJSON(ctx, fmt.Sprintf("/projects/%s/change-requests/stats", url.PathEscape(id)), &out)
+	return out, err
+}

--- a/apps/customer-portal/backend-v2/internal/entity/types.go
+++ b/apps/customer-portal/backend-v2/internal/entity/types.go
@@ -133,6 +133,167 @@ type ProjectDetailsView struct {
 	ProjectClosureFields
 }
 
+// --- project metadata/stats ---
+//
+// entity-service only supports these routes on its ServiceNow data source —
+// see cs-tools/entity-service/internal/server/routes.go's projectStatsHandler
+// gating.
+
+// ChoiceListItem is one available option for a ServiceNow choice-list field —
+// used in metadata responses that enumerate the valid values for a field
+// (e.g. case states, severities) rather than classify a single record, and in
+// stats responses that report a count per option.
+type ChoiceListItem struct {
+	ID    string `json:"id"`
+	Label string `json:"label"`
+	Count *int   `json:"count,omitempty"`
+}
+
+// ReferenceTableItem is a reference to a row in another ServiceNow table,
+// used in metadata/stats responses (e.g. case types) — richer than EntityRef:
+// adds an optional record number, WSO2-internal ID, and per-item count.
+type ReferenceTableItem struct {
+	ID         string  `json:"id"`
+	Name       string  `json:"name"`
+	Number     *string `json:"number,omitempty"`
+	InternalID *string `json:"internalId,omitempty"`
+	Count      *int    `json:"count,omitempty"`
+}
+
+// ProjectFeatures is the feature-access configuration for a project.
+type ProjectFeatures struct {
+	ProjectType                    ReferenceTableItem `json:"projectType"`
+	AcceptedSeverityValues         []ChoiceListItem   `json:"acceptedSeverityValues"`
+	HasServiceRequestWriteAccess   bool               `json:"hasServiceRequestWriteAccess"`
+	HasServiceRequestReadAccess    bool               `json:"hasServiceRequestReadAccess"`
+	HasSraWriteAccess              bool               `json:"hasSraWriteAccess"`
+	HasSraReadAccess               bool               `json:"hasSraReadAccess"`
+	HasChangeRequestReadAccess     bool               `json:"hasChangeRequestReadAccess"`
+	HasEngagementsReadAccess       bool               `json:"hasEngagementsReadAccess"`
+	HasUpdatesReadAccess           bool               `json:"hasUpdatesReadAccess"`
+	HasTimeLogsReadAccess          bool               `json:"hasTimeLogsReadAccess"`
+	HasDeploymentWriteAccess       bool               `json:"hasDeploymentWriteAccess"`
+	HasDeploymentReadAccess        bool               `json:"hasDeploymentReadAccess"`
+	HasComponentAnalysisReadAccess bool               `json:"hasComponentAnalysisReadAccess"`
+	HasUsageMetricsReadAccess      bool               `json:"hasUsageMetricsReadAccess"`
+	DefaultCaseProductCategories   []string           `json:"defaultCaseProductCategories,omitempty"`
+	SrProductCategories            []string           `json:"srProductCategories,omitempty"`
+}
+
+// ProjectMetadataResponse is entity-service's response for GET /projects/{id}/metadata.
+type ProjectMetadataResponse struct {
+	CaseStates                  []ChoiceListItem     `json:"caseStates"`
+	CallRequestStates           []ChoiceListItem     `json:"callRequestStates"`
+	ChangeRequestStates         []ChoiceListItem     `json:"changeRequestStates"`
+	ConversationStates          []ChoiceListItem     `json:"conversationStates"`
+	TimeCardStates              []ChoiceListItem     `json:"timeCardStates"`
+	ChangeRequestImpacts        []ChoiceListItem     `json:"changeRequestImpacts"`
+	Severities                  []ChoiceListItem     `json:"severities"`
+	SeverityBasedAllocationTime map[string]int       `json:"severityBasedAllocationTime"`
+	IssueTypes                  []ChoiceListItem     `json:"issueTypes"`
+	DeploymentTypes             []ChoiceListItem     `json:"deploymentTypes"`
+	CaseTypes                   []ReferenceTableItem `json:"caseTypes"`
+	EngagementTypes             []ChoiceListItem     `json:"engagementTypes"`
+	EngagementPaymentTypes      []ChoiceListItem     `json:"engagementPaymentTypes"`
+	Features                    ProjectFeatures      `json:"features"`
+}
+
+// ProjectStatsOutstandingCount groups the outstanding-work-item counts
+// embedded in ProjectStatsResponse.
+type ProjectStatsOutstandingCount struct {
+	CaseCount           int `json:"caseCount"`
+	ServiceRequestCount int `json:"serviceRequestCount"`
+	EngagementCount     int `json:"engagementCount"`
+	SraCount            int `json:"sraCount"`
+	ChangeRequestCount  int `json:"changeRequestCount"`
+	AnnouncementCount   int `json:"announcementCount"`
+}
+
+// ProjectStatsResponse is entity-service's response for GET /projects/{id}/stats.
+type ProjectStatsResponse struct {
+	TotalHours           float64                      `json:"totalHours"`
+	BillableHours        float64                      `json:"billableHours"`
+	SLAStatus            string                       `json:"slaStatus"`
+	DeploymentCount      int                          `json:"deploymentCount"`
+	DeployedProductCount int                          `json:"deployedProductCount"`
+	InstanceCount        int                          `json:"instanceCount"`
+	OutstandingCount     ProjectStatsOutstandingCount `json:"outstandingCount"`
+}
+
+// ResolvedCountBreakdown groups the resolved-count breakdown shared by case
+// and change-request stats responses.
+type ResolvedCountBreakdown struct {
+	Total          int `json:"total"`
+	CurrentMonth   int `json:"currentMonth"`
+	PastThirtyDays int `json:"pastThirtyDays"`
+}
+
+// ProjectCaseStatsChangeRate groups the period-over-period change-rate
+// figures embedded in ProjectCaseStatsResponse.
+type ProjectCaseStatsChangeRate struct {
+	ResolvedEngagements float64 `json:"resolvedEngagements"`
+	AverageResponseTime float64 `json:"averageResponseTime"`
+}
+
+// CasesTrend is the severity breakdown for a single time-unit bucket in a
+// case-count trend series.
+type CasesTrend struct {
+	Period     string           `json:"period"`
+	Severities []ChoiceListItem `json:"severities"`
+}
+
+// ProjectCaseStatsResponse is entity-service's response for GET /projects/{id}/cases/stats.
+type ProjectCaseStatsResponse struct {
+	TotalCount                     int                        `json:"totalCount"`
+	ActiveCount                    int                        `json:"activeCount"`
+	OutstandingCount               int                        `json:"outstandingCount"`
+	ActionRequiredCount            int                        `json:"actionRequiredCount"`
+	AverageResponseTime            float64                    `json:"averageResponseTime"`
+	ResolvedCount                  ResolvedCountBreakdown     `json:"resolvedCount"`
+	ChangeRate                     ProjectCaseStatsChangeRate `json:"changeRate"`
+	StateCount                     []ChoiceListItem           `json:"stateCount"`
+	SeverityCount                  []ChoiceListItem           `json:"severityCount"`
+	OutstandingSeverityCount       []ChoiceListItem           `json:"outstandingSeverityCount"`
+	EngagementTypeCount            []ChoiceListItem           `json:"engagementTypeCount"`
+	OutstandingEngagementTypeCount []ChoiceListItem           `json:"outstandingEngagementTypeCount"`
+	CaseTypeCount                  []ReferenceTableItem       `json:"caseTypeCount"`
+	CasesTrend                     []CasesTrend               `json:"casesTrend"`
+}
+
+// ProjectConversationStatsResponse is entity-service's response for
+// GET /projects/{id}/conversations/stats.
+type ProjectConversationStatsResponse struct {
+	TotalCount  int              `json:"totalCount"`
+	ActiveCount int              `json:"activeCount"`
+	StateCount  []ChoiceListItem `json:"stateCount"`
+}
+
+// ProjectDeploymentStatsResponse is entity-service's response for
+// GET /projects/{id}/deployments/stats.
+type ProjectDeploymentStatsResponse struct {
+	TotalCount       int     `json:"totalCount"`
+	LastDeploymentOn *string `json:"lastDeploymentOn"`
+}
+
+// ProjectTimeCardStatsResponse is entity-service's response for
+// GET /projects/{id}/time-cards/stats.
+type ProjectTimeCardStatsResponse struct {
+	TotalHours       float64 `json:"totalHours"`
+	BillableHours    float64 `json:"billableHours"`
+	NonBillableHours float64 `json:"nonBillableHours"`
+}
+
+// ProjectChangeRequestStatsResponse is entity-service's response for
+// GET /projects/{id}/change-requests/stats.
+type ProjectChangeRequestStatsResponse struct {
+	TotalCount          int                    `json:"totalCount"`
+	ActiveCount         int                    `json:"activeCount"`
+	OutstandingCount    int                    `json:"outstandingCount"`
+	ActionRequiredCount int                    `json:"actionRequiredCount"`
+	StateCount          []ChoiceListItem       `json:"stateCount"`
+	ResolvedCount       ResolvedCountBreakdown `json:"resolvedCount"`
+}
+
 // --- accounts ---
 //
 // entity-service returns a different wire shape for these two endpoints

--- a/apps/customer-portal/backend-v2/internal/handler/project_stats.go
+++ b/apps/customer-portal/backend-v2/internal/handler/project_stats.go
@@ -1,0 +1,284 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/dto"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/middleware"
+)
+
+// entityProjectStatsClient abstracts the entity-service project metadata/stats
+// operations used by ProjectStatsHandler.
+type entityProjectStatsClient interface {
+	GetProjectMetadata(ctx context.Context, id string) (entity.ProjectMetadataResponse, error)
+	GetProjectStats(ctx context.Context, id string) (entity.ProjectStatsResponse, error)
+	GetProjectCaseStats(ctx context.Context, id string, caseTypes []string, createdBy string) (entity.ProjectCaseStatsResponse, error)
+	GetProjectConversationStats(ctx context.Context, id, createdBy string) (entity.ProjectConversationStatsResponse, error)
+	GetProjectDeploymentStats(ctx context.Context, id string) (entity.ProjectDeploymentStatsResponse, error)
+	GetProjectTimeCardStats(ctx context.Context, id, startDate, endDate string) (entity.ProjectTimeCardStatsResponse, error)
+	GetProjectChangeRequestStats(ctx context.Context, id string) (entity.ProjectChangeRequestStatsResponse, error)
+}
+
+// ProjectStatsHandler handles HTTP requests for project-scoped metadata and
+// statistics.
+//
+// NOTE: entity-service only supports these routes on its ServiceNow data
+// source — see internal/entity/projects.go.
+type ProjectStatsHandler struct {
+	entity entityProjectStatsClient
+}
+
+// NewProjectStatsHandler creates a ProjectStatsHandler backed by the given entity client.
+func NewProjectStatsHandler(entityClient entityProjectStatsClient) *ProjectStatsHandler {
+	return &ProjectStatsHandler{entity: entityClient}
+}
+
+// GetProjectFilters handles GET /projects/{id}/filters.
+func (h *ProjectStatsHandler) GetProjectFilters(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	id := r.PathValue("id")
+	if id == "" || !uuidRe.MatchString(id) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	result, err := h.entity.GetProjectMetadata(r.Context(), id)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity GetProjectMetadata failed", "userID", user.UserID, "projectID", id, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to retrieve project filters.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusOK, dto.MapProjectFilterOptions(result))
+}
+
+// GetProjectFeatures handles GET /projects/{id}/features.
+func (h *ProjectStatsHandler) GetProjectFeatures(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	id := r.PathValue("id")
+	if id == "" || !uuidRe.MatchString(id) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	result, err := h.entity.GetProjectMetadata(r.Context(), id)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity GetProjectMetadata failed", "userID", user.UserID, "projectID", id, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to retrieve project features.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusOK, dto.MapProjectFeatures(result))
+}
+
+// GetProjectDashboardStats handles GET /projects/{id}/stats. Mirrors the
+// Ballerina backend's own graceful-degradation behavior: each of the four
+// underlying stats calls may fail independently without failing the whole
+// request — a failed source's fields are simply omitted from the response.
+func (h *ProjectStatsHandler) GetProjectDashboardStats(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	id := r.PathValue("id")
+	if id == "" || !uuidRe.MatchString(id) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	caseTypes := r.URL.Query()["caseTypes"]
+	createdBy := r.URL.Query().Get("createdBy")
+
+	var caseStatsPtr *entity.ProjectCaseStatsResponse
+	if caseStats, err := h.entity.GetProjectCaseStats(r.Context(), id, caseTypes, createdBy); err != nil {
+		slog.ErrorContext(r.Context(), "entity GetProjectCaseStats failed", "userID", user.UserID, "projectID", id, "err", summarizeErr(err))
+	} else {
+		caseStatsPtr = &caseStats
+	}
+
+	var conversationStatsPtr *entity.ProjectConversationStatsResponse
+	if conversationStats, err := h.entity.GetProjectConversationStats(r.Context(), id, createdBy); err != nil {
+		slog.ErrorContext(r.Context(), "entity GetProjectConversationStats failed", "userID", user.UserID, "projectID", id, "err", summarizeErr(err))
+	} else {
+		conversationStatsPtr = &conversationStats
+	}
+
+	var deploymentStatsPtr *entity.ProjectDeploymentStatsResponse
+	if deploymentStats, err := h.entity.GetProjectDeploymentStats(r.Context(), id); err != nil {
+		slog.ErrorContext(r.Context(), "entity GetProjectDeploymentStats failed", "userID", user.UserID, "projectID", id, "err", summarizeErr(err))
+	} else {
+		deploymentStatsPtr = &deploymentStats
+	}
+
+	var activityStatsPtr *entity.ProjectStatsResponse
+	if activityStats, err := h.entity.GetProjectStats(r.Context(), id); err != nil {
+		slog.ErrorContext(r.Context(), "entity GetProjectStats failed", "userID", user.UserID, "projectID", id, "err", summarizeErr(err))
+	} else {
+		activityStatsPtr = &activityStats
+	}
+
+	writeJSONValue(w, http.StatusOK, dto.BuildProjectDashboardStats(caseStatsPtr, conversationStatsPtr, deploymentStatsPtr, activityStatsPtr))
+}
+
+// GetProjectCaseStats handles GET /projects/{id}/stats/cases.
+func (h *ProjectStatsHandler) GetProjectCaseStats(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	id := r.PathValue("id")
+	if id == "" || !uuidRe.MatchString(id) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	result, err := h.entity.GetProjectCaseStats(r.Context(), id, r.URL.Query()["caseTypes"], r.URL.Query().Get("createdBy"))
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity GetProjectCaseStats failed", "userID", user.UserID, "projectID", id, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to retrieve case statistics.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusOK, dto.MapProjectCaseStats(result))
+}
+
+// GetProjectConversationStats handles GET /projects/{id}/stats/conversations.
+func (h *ProjectStatsHandler) GetProjectConversationStats(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	id := r.PathValue("id")
+	if id == "" || !uuidRe.MatchString(id) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	result, err := h.entity.GetProjectConversationStats(r.Context(), id, r.URL.Query().Get("createdBy"))
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity GetProjectConversationStats failed", "userID", user.UserID, "projectID", id, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to retrieve conversation statistics.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusOK, dto.MapConversationStats(result))
+}
+
+// GetProjectSupportStats handles GET /projects/{id}/stats/support. Like
+// GetProjectDashboardStats, both underlying calls may fail independently
+// without failing the whole request.
+func (h *ProjectStatsHandler) GetProjectSupportStats(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	id := r.PathValue("id")
+	if id == "" || !uuidRe.MatchString(id) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	caseTypes := r.URL.Query()["caseTypes"]
+	createdBy := r.URL.Query().Get("createdBy")
+
+	var caseStatsPtr *entity.ProjectCaseStatsResponse
+	if caseStats, err := h.entity.GetProjectCaseStats(r.Context(), id, caseTypes, createdBy); err != nil {
+		slog.ErrorContext(r.Context(), "entity GetProjectCaseStats failed", "userID", user.UserID, "projectID", id, "err", summarizeErr(err))
+	} else {
+		caseStatsPtr = &caseStats
+	}
+
+	var conversationStatsPtr *entity.ProjectConversationStatsResponse
+	if conversationStats, err := h.entity.GetProjectConversationStats(r.Context(), id, createdBy); err != nil {
+		slog.ErrorContext(r.Context(), "entity GetProjectConversationStats failed", "userID", user.UserID, "projectID", id, "err", summarizeErr(err))
+	} else {
+		conversationStatsPtr = &conversationStats
+	}
+
+	writeJSONValue(w, http.StatusOK, dto.BuildProjectSupportStats(caseStatsPtr, conversationStatsPtr))
+}
+
+// GetProjectTimeCardStats handles GET /projects/{id}/stats/time-cards.
+func (h *ProjectStatsHandler) GetProjectTimeCardStats(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	id := r.PathValue("id")
+	if id == "" || !uuidRe.MatchString(id) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	result, err := h.entity.GetProjectTimeCardStats(r.Context(), id, r.URL.Query().Get("startDate"), r.URL.Query().Get("endDate"))
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity GetProjectTimeCardStats failed", "userID", user.UserID, "projectID", id, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to retrieve time card statistics.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusOK, dto.MapProjectTimeCardStats(result))
+}
+
+// GetProjectChangeRequestStats handles GET /projects/{id}/stats/change-requests.
+func (h *ProjectStatsHandler) GetProjectChangeRequestStats(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	id := r.PathValue("id")
+	if id == "" || !uuidRe.MatchString(id) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	result, err := h.entity.GetProjectChangeRequestStats(r.Context(), id)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity GetProjectChangeRequestStats failed", "userID", user.UserID, "projectID", id, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to retrieve change request statistics.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusOK, dto.MapProjectChangeRequestStats(result))
+}

--- a/apps/customer-portal/backend-v2/openapi.yaml
+++ b/apps/customer-portal/backend-v2/openapi.yaml
@@ -271,6 +271,461 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
+  /projects/{id}/filters:
+    get:
+      summary: Get filter-dropdown options for a project.
+      operationId: getProjectsIdFilters
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectFilterOptions'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: NotFound
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /projects/{id}/features:
+    get:
+      summary: Get a project's feature-access flags.
+      operationId: getProjectsIdFeatures
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectFeatures'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: NotFound
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /projects/{id}/stats:
+    get:
+      summary: >-
+        Get a project's dashboard statistics (case/conversation/deployment/activity
+        combined; tolerates partial failures).
+      operationId: getProjectsIdStats
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: caseTypes
+          in: query
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+        - name: createdBy
+          in: query
+          required: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectDashboardStats'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: NotFound
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /projects/{id}/stats/cases:
+    get:
+      summary: Get a project's case statistics.
+      operationId: getProjectsIdStatsCases
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: caseTypes
+          in: query
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+        - name: createdBy
+          in: query
+          required: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectCaseStats'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: NotFound
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /projects/{id}/stats/conversations:
+    get:
+      summary: Get a project's conversation statistics.
+      operationId: getProjectsIdStatsConversations
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: createdBy
+          in: query
+          required: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConversationStats'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: NotFound
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /projects/{id}/stats/support:
+    get:
+      summary: >-
+        Get a project's combined support statistics (case + conversation;
+        tolerates partial failures).
+      operationId: getProjectsIdStatsSupport
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: caseTypes
+          in: query
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+        - name: createdBy
+          in: query
+          required: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectSupportStats'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: NotFound
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /projects/{id}/stats/time-cards:
+    get:
+      summary: Get a project's time-card statistics.
+      operationId: getProjectsIdStatsTimeCards
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: startDate
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date
+        - name: endDate
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectTimeCardStats'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: NotFound
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /projects/{id}/stats/change-requests:
+    get:
+      summary: Get a project's change-request statistics.
+      operationId: getProjectsIdStatsChangeRequests
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectChangeRequestStats'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: NotFound
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
   /projects/search:
     post:
       summary: Search projects.
@@ -4976,3 +5431,408 @@ components:
           type: string
         result:
           description: Arbitrary result payload from the upstream product-consumption service.
+
+    # ---- project stats ----
+    #
+    # GET /projects/{id}/filters, /features, /stats, /stats/cases,
+    # /stats/conversations, /stats/support, /stats/time-cards, and
+    # /stats/change-requests — see internal/dto/project_stats.go and this
+    # backend's CLAUDE.md, "Project metadata and stats — reshaped, not
+    # passed through".
+
+    ReferenceItem:
+      description: >-
+        A flattened {id, label, count?} view of entity-service's
+        ChoiceListItem/ReferenceTableItem, used across every project
+        metadata/stats endpoint.
+      type: object
+      required: [id, label]
+      properties:
+        id:
+          type: string
+        label:
+          type: string
+        count:
+          type: integer
+          nullable: true
+
+    ChoiceListItem:
+      description: >-
+        entity-service's ChoiceListItem, embedded as-is in CasesTrend.severities
+        rather than flattened to ReferenceItem.
+      type: object
+      required: [id, label]
+      properties:
+        id:
+          type: string
+        label:
+          type: string
+        count:
+          type: integer
+          nullable: true
+
+    ProjectFilterOptions:
+      type: object
+      required:
+        - caseStates
+        - severities
+        - issueTypes
+        - deploymentTypes
+        - callRequestStates
+        - changeRequestStates
+        - changeRequestImpacts
+        - conversationStates
+        - caseTypes
+        - timeCardStates
+        - engagementTypes
+        - engagementPaymentTypes
+        - severityBasedAllocationTime
+      properties:
+        caseStates:
+          type: array
+          items:
+            $ref: '#/components/schemas/ReferenceItem'
+        severities:
+          type: array
+          items:
+            $ref: '#/components/schemas/ReferenceItem'
+        issueTypes:
+          type: array
+          items:
+            $ref: '#/components/schemas/ReferenceItem'
+        deploymentTypes:
+          type: array
+          items:
+            $ref: '#/components/schemas/ReferenceItem'
+        callRequestStates:
+          type: array
+          items:
+            $ref: '#/components/schemas/ReferenceItem'
+        changeRequestStates:
+          type: array
+          items:
+            $ref: '#/components/schemas/ReferenceItem'
+        changeRequestImpacts:
+          type: array
+          items:
+            $ref: '#/components/schemas/ReferenceItem'
+        conversationStates:
+          type: array
+          items:
+            $ref: '#/components/schemas/ReferenceItem'
+        caseTypes:
+          type: array
+          items:
+            $ref: '#/components/schemas/ReferenceItem'
+        timeCardStates:
+          type: array
+          items:
+            $ref: '#/components/schemas/ReferenceItem'
+        engagementTypes:
+          type: array
+          items:
+            $ref: '#/components/schemas/ReferenceItem'
+        engagementPaymentTypes:
+          type: array
+          items:
+            $ref: '#/components/schemas/ReferenceItem'
+        severityBasedAllocationTime:
+          type: object
+          additionalProperties:
+            type: integer
+
+    ProjectFeatures:
+      type: object
+      required:
+        - acceptedSeverityValues
+        - hasServiceRequestWriteAccess
+        - hasServiceRequestReadAccess
+        - hasSraWriteAccess
+        - hasSraReadAccess
+        - hasChangeRequestReadAccess
+        - hasEngagementsReadAccess
+        - hasUpdatesReadAccess
+        - hasTimeLogsReadAccess
+        - hasDeploymentWriteAccess
+        - hasDeploymentReadAccess
+        - hasComponentAnalysisReadAccess
+        - hasUsageMetricsReadAccess
+      properties:
+        acceptedSeverityValues:
+          type: array
+          items:
+            $ref: '#/components/schemas/ReferenceItem'
+        hasServiceRequestWriteAccess:
+          type: boolean
+        hasServiceRequestReadAccess:
+          type: boolean
+        hasSraWriteAccess:
+          type: boolean
+        hasSraReadAccess:
+          type: boolean
+        hasChangeRequestReadAccess:
+          type: boolean
+        hasEngagementsReadAccess:
+          type: boolean
+        hasUpdatesReadAccess:
+          type: boolean
+        hasTimeLogsReadAccess:
+          type: boolean
+        hasDeploymentWriteAccess:
+          type: boolean
+        hasDeploymentReadAccess:
+          type: boolean
+        hasComponentAnalysisReadAccess:
+          type: boolean
+        hasUsageMetricsReadAccess:
+          type: boolean
+        defaultCaseProductCategories:
+          type: array
+          nullable: true
+          items:
+            type: string
+        srProductCategories:
+          type: array
+          nullable: true
+          items:
+            type: string
+
+    ProjectStats:
+      description: The headline counters on the project dashboard.
+      type: object
+      properties:
+        openCases:
+          type: integer
+          nullable: true
+        activeChats:
+          type: integer
+          nullable: true
+        deployments:
+          type: integer
+          nullable: true
+        slaStatus:
+          type: string
+          nullable: true
+        outstandingCaseCount:
+          type: integer
+          nullable: true
+        outstandingServiceRequestCount:
+          type: integer
+          nullable: true
+        outstandingEngagementCount:
+          type: integer
+          nullable: true
+        outstandingSraCount:
+          type: integer
+          nullable: true
+        outstandingChangeRequestCount:
+          type: integer
+          nullable: true
+        outstandingAnnouncementCount:
+          type: integer
+          nullable: true
+
+    RecentActivity:
+      description: The recent-activity panel on the project dashboard.
+      type: object
+      properties:
+        totalHours:
+          type: number
+          nullable: true
+        billableHours:
+          type: number
+          nullable: true
+        lastDeploymentOn:
+          type: string
+          nullable: true
+
+    ProjectDashboardStats:
+      description: >-
+        Combines entity-service's case/conversation/deployment/activity stats
+        into one dashboard view; tolerates any of the four sources failing
+        independently (see BuildProjectDashboardStats) — a failed source's
+        fields are simply omitted rather than failing the whole request.
+      type: object
+      required: [projectStats, recentActivity]
+      properties:
+        projectStats:
+          $ref: '#/components/schemas/ProjectStats'
+        recentActivity:
+          $ref: '#/components/schemas/RecentActivity'
+
+    ResolvedCountBreakdown:
+      description: >-
+        The resolved-count breakdown shared by case and change-request stats
+        responses.
+      type: object
+      required: [total, currentMonth, pastThirtyDays]
+      properties:
+        total:
+          type: integer
+        currentMonth:
+          type: integer
+        pastThirtyDays:
+          type: integer
+
+    ProjectCaseStatsChangeRate:
+      description: >-
+        The period-over-period change-rate figures embedded in
+        ProjectCaseStats.
+      type: object
+      required: [resolvedEngagements, averageResponseTime]
+      properties:
+        resolvedEngagements:
+          type: number
+        averageResponseTime:
+          type: number
+
+    CasesTrend:
+      description: >-
+        The severity breakdown for a single time-unit bucket in a case-count
+        trend series.
+      type: object
+      required: [period, severities]
+      properties:
+        period:
+          type: string
+        severities:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChoiceListItem'
+
+    ProjectCaseStats:
+      type: object
+      required:
+        - totalCount
+        - activeCount
+        - outstandingCount
+        - actionRequiredCount
+        - averageResponseTime
+        - resolvedCases
+        - changeRate
+        - stateCount
+        - severityCount
+        - outstandingSeverityCount
+        - caseTypeCount
+        - casesTrend
+        - engagementTypeCount
+        - outstandingEngagementTypeCount
+      properties:
+        totalCount:
+          type: integer
+        activeCount:
+          type: integer
+        outstandingCount:
+          type: integer
+        actionRequiredCount:
+          type: integer
+        averageResponseTime:
+          type: number
+        resolvedCases:
+          $ref: '#/components/schemas/ResolvedCountBreakdown'
+        changeRate:
+          $ref: '#/components/schemas/ProjectCaseStatsChangeRate'
+        stateCount:
+          type: array
+          items:
+            $ref: '#/components/schemas/ReferenceItem'
+        severityCount:
+          type: array
+          items:
+            $ref: '#/components/schemas/ReferenceItem'
+        outstandingSeverityCount:
+          type: array
+          items:
+            $ref: '#/components/schemas/ReferenceItem'
+        caseTypeCount:
+          type: array
+          items:
+            $ref: '#/components/schemas/ReferenceItem'
+        casesTrend:
+          type: array
+          items:
+            $ref: '#/components/schemas/CasesTrend'
+        engagementTypeCount:
+          type: array
+          items:
+            $ref: '#/components/schemas/ReferenceItem'
+        outstandingEngagementTypeCount:
+          type: array
+          items:
+            $ref: '#/components/schemas/ReferenceItem'
+
+    ConversationStats:
+      description: >-
+        A handful of specific counts picked out of entity-service's
+        conversation state breakdown.
+      type: object
+      properties:
+        openCount:
+          type: integer
+          nullable: true
+        activeCount:
+          type: integer
+          nullable: true
+        resolvedCount:
+          type: integer
+          nullable: true
+        abandonedCount:
+          type: integer
+          nullable: true
+
+    ProjectSupportStats:
+      description: >-
+        Combines independently-fetched case and conversation stats; tolerates
+        either source failing independently (see BuildProjectSupportStats) —
+        a failed source's fields are simply omitted rather than failing the
+        whole request.
+      type: object
+      properties:
+        ongoingCases:
+          type: integer
+          nullable: true
+        activeChats:
+          type: integer
+          nullable: true
+        resolvedPast30DaysCasesCount:
+          type: integer
+          nullable: true
+        resolvedChats:
+          type: integer
+          nullable: true
+
+    ProjectTimeCardStats:
+      type: object
+      required: [totalHours, billableHours, nonBillableHours]
+      properties:
+        totalHours:
+          type: number
+        billableHours:
+          type: number
+        nonBillableHours:
+          type: number
+
+    ProjectChangeRequestStats:
+      type: object
+      required:
+        - totalCount
+        - activeCount
+        - outstandingCount
+        - actionRequiredCount
+        - stateCount
+        - resolvedCount
+      properties:
+        totalCount:
+          type: integer
+        activeCount:
+          type: integer
+        outstandingCount:
+          type: integer
+        actionRequiredCount:
+          type: integer
+        stateCount:
+          type: array
+          items:
+            $ref: '#/components/schemas/ReferenceItem'
+        resolvedCount:
+          $ref: '#/components/schemas/ResolvedCountBreakdown'


### PR DESCRIPTION
## Summary
Adds 8 more endpoints to `apps/customer-portal/backend-v2` (60 total), consuming the 7 entity-service project-stats endpoints added in a companion PR (#1336, currently open):

- `GET /projects/{id}/filters`
- `GET /projects/{id}/features`
- `GET /projects/{id}/stats`
- `GET /projects/{id}/stats/cases`
- `GET /projects/{id}/stats/conversations`
- `GET /projects/{id}/stats/support`
- `GET /projects/{id}/stats/time-cards`
- `GET /projects/{id}/stats/change-requests`

## Not a 1:1 mapping

entity-service's 7 endpoints fan out into these 8 differently-shaped, purpose-built portal views — `internal/dto/project_stats.go` replicates the Ballerina backend's own reshaping (ported from `getProjectFilters`/`mapProjectFeatures`/`mapCaseStats`/`getConversationStats`/`mapProjectChangeRequestStatsResponse` in `utils.bal`), including:

- **`/filters` and `/features` both read `GetProjectMetadata`** and reshape it differently — there is no raw metadata-passthrough endpoint in this backend, matching the Ballerina backend, which never exposed one either.
- **`/stats` and `/stats/support` are graceful-degradation composites** — each combines multiple independent entity-service calls (case/conversation/deployment/activity stats, and case/conversation stats respectively) and returns `200` even if every one of them fails, simply omitting that source's fields from the response. This exactly matches the Ballerina backend's own behavior. The other four stats endpoints are single entity-service calls with normal hard-failure semantics — verified individually per-endpoint in the Ballerina backend's source, not assumed from the composite endpoints' pattern.
- **State-ID-based derived counts are hardcoded**, not configurable — `dto.caseStateIDOpen` and the `conversationStateID*` constants pick specific counts out of a state-count breakdown (e.g. "how many cases are open") using the same default ServiceNow state IDs the Ballerina backend's own configuration defaults to. Flagged in CLAUDE.md: if `cs-tools`' ServiceNow instance uses different state IDs, these need to become configurable here too.
- The Ballerina backend's `/stats/cases` fetches change-request stats and never uses the result (apparent dead code) — not replicated here.

Also updates `openapi.yaml` (8 new paths, 15 new schemas), `README.md`, and `CLAUDE.md`.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` all clean
- [x] `gosec -fmt=text ./...` reports 0 issues
- [x] `openapi.yaml` validated as well-formed YAML with all 8 new paths/15 new schemas present, zero dangling `$ref`s
- [x] Manually smoke-tested against a live server with an unreachable upstream: the 6 hard-failure endpoints correctly map to 500; `/stats` and `/stats/support` correctly return `200` with all fields omitted when every underlying source fails
- [ ] Wire up against a real running entity-service instance with `#1336` merged first (this PR depends on it for the underlying routes to exist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Linked issues
- Closes wso2-enterprise/wso2-digital-team-project-management#902
- Closes wso2-enterprise/wso2-digital-team-project-management#903
- Closes wso2-enterprise/wso2-digital-team-project-management#904
- Closes wso2-enterprise/wso2-digital-team-project-management#905
- Closes wso2-enterprise/wso2-digital-team-project-management#906
- Closes wso2-enterprise/wso2-digital-team-project-management#907
- Closes wso2-enterprise/wso2-digital-team-project-management#908
- Closes wso2-enterprise/wso2-digital-team-project-management#909


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added eight project endpoints for filters, feature flags, dashboard statistics, case and conversation metrics, support, time cards, and change requests.
  * Added project-level statistics with optional filtering and trend information.
  * Dashboard and support summaries continue to provide available results when some data sources are unavailable.

* **Documentation**
  * Updated API documentation and examples to cover the new endpoints and 60 implemented routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->