### PR TITLE
[CSM Portal] Surface which dropdown failed on the service request creation page

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateServiceRequestPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateServiceRequestPage.tsx
@@ -277,7 +277,7 @@ export default function CreateServiceRequestPage(): JSX.Element {
             }}
           >
             <Typography variant="body2" color="error.main">
-              Some dropdown options failed to load — see the affected field below for which one.
+              Some dropdown options failed to load. See the failed fields below for details.
             </Typography>
             <Button size="small" variant="outlined" onClick={retryOptions}>
               Retry all

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateServiceRequestPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateServiceRequestPage.tsx
@@ -277,10 +277,10 @@ export default function CreateServiceRequestPage(): JSX.Element {
             }}
           >
             <Typography variant="body2" color="error.main">
-              Some dropdown options failed to load.
+              Some dropdown options failed to load — see the affected field below for which one.
             </Typography>
             <Button size="small" variant="outlined" onClick={retryOptions}>
-              Retry
+              Retry all
             </Button>
           </Box>
         )}
@@ -313,6 +313,8 @@ export default function CreateServiceRequestPage(): JSX.Element {
               </Select>
               {!projectId ? (
                 <FormHelperText>Select a project first</FormHelperText>
+              ) : deployments.isError ? (
+                <FormHelperText error>Failed to load deployments.</FormHelperText>
               ) : deployments.isLoading ? (
                 <FormHelperText>Loading deployments…</FormHelperText>
               ) : (deployments.data ?? []).length === 0 ? (
@@ -339,6 +341,8 @@ export default function CreateServiceRequestPage(): JSX.Element {
               </Select>
               {!deploymentId ? (
                 <FormHelperText>Select a deployment first</FormHelperText>
+              ) : deployedProducts.isError ? (
+                <FormHelperText error>Failed to load deployed products.</FormHelperText>
               ) : deployedProducts.isLoading ? (
                 <FormHelperText>Loading products…</FormHelperText>
               ) : (deployedProducts.data ?? []).length === 0 ? (
@@ -365,6 +369,8 @@ export default function CreateServiceRequestPage(): JSX.Element {
               </Select>
               {!deployedProductId ? (
                 <FormHelperText>Select a deployed product first</FormHelperText>
+              ) : catalogs.isError ? (
+                <FormHelperText error>Failed to load catalogs.</FormHelperText>
               ) : catalogs.isLoading ? (
                 <FormHelperText>Loading catalogs…</FormHelperText>
               ) : noCatalogs ? (


### PR DESCRIPTION
## Purpose
The Service Request creation page shows a generic "Some dropdown options failed to load" banner when any of the three dependent dropdown queries (deployments, deployed products, catalogs) errors, with no indication of which one — an engineer had no way to tell what's actually broken short of opening devtools. Resolves #2607 (the frontend half — the underlying root cause, deployed-product category being decoded as the wrong type, was already fixed in #1297).

## Goals
Let an engineer see which specific dropdown failed to load, in that field's own helper text, without needing devtools — while keeping the existing aggregate banner as a quick "retry everything" summary rather than the only error surface.

## Approach
Each of the three dependent `Select` fields (Deployment, Deployed product, Catalog) already had its own `FormHelperText` covering "select the parent field first" / loading / empty states, but never its own error state — so a persistent query failure fell through to `null`, leaving only the generic aggregate banner as any signal at all. Added an `isError` branch to each field's helper text (`Failed to load deployments.` / `Failed to load deployed products.` / `Failed to load catalogs.`), and reworded the aggregate banner to point at the per-field detail (`Retry all` instead of `Retry`) instead of standing alone as the only explanation.

Deliberately unchanged: submission still blocks when a genuinely-required dropdown's data failed to load (e.g. deployed products) — that's correct, not the bug. The bug was the lack of visibility into *why*, not that it blocks.

## User stories
As a CS engineer creating a service request, if a dropdown fails to load I can see which one directly under that field, instead of only a generic banner with no indication of what's actually broken.

## Release note
The service request creation page now shows which specific dropdown (deployment, deployed product, or catalog) failed to load, instead of only a generic error banner.

## Documentation
N/A — no user-facing documentation covers this internal error-state detail.

## Training
N/A — no training content covers this flow.

## Certification
N/A — no certification exam covers the internal CSM portal.

## Marketing
N/A — internal tooling.

## Automation tests
- Unit tests: no new tests added — this is a small, purely additive conditional-rendering change (3 new ternary branches) on a page with no existing test file; introducing a full render harness (mocking 7+ hooks) for this alone would be disproportionate to the change. Verified via `tsc -b` (clean), `eslint` (clean), and `vitest run src/features/csm-operations` (181/181 passing, no regressions), plus a production `vite build` (clean).
- Integration tests: none — no integration-test harness exists for this app.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? no — this PR is TypeScript-only, nothing for a JVM static-analysis tool to check.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
- wso2-enterprise/digiops-cs#1297 — the backend root-cause fix (deployed-product category decoding), already merged. This PR is the remaining frontend half rksk flagged as a separate, genuine defect on #2607.

## Migrations (if applicable)
N/A — no schema or data change.

## Test environment
- Node.js, pnpm (webapp toolchain)
- macOS
- `tsc -b`, `eslint`, `vitest` (jsdom), `vite build` — all clean/passing as noted above
- Not manually verified in a browser against a live backend in this session

## Learning
N/A — straightforward, no research phase beyond reading the issue thread's own root-cause analysis.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service request dropdown errors by identifying affected fields.
  * Added a “Retry all” action for recovering from dropdown loading errors.
  * Added clear helper text when deployment, product, or catalog data fails to load.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->