### PR TITLE
Fix CSM portal directory table UX

### DIFF
--- a/apps/csm-portal/webapp/src/components/AsyncEntityMultiSelect.tsx
+++ b/apps/csm-portal/webapp/src/components/AsyncEntityMultiSelect.tsx
@@ -14,8 +14,15 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Autocomplete, TextField } from "@wso2/oxygen-ui";
-import { useMemo, useState, type JSX } from "react";
+import {
+  Autocomplete,
+  Box,
+  Checkbox,
+  ListItemText,
+  TextField,
+  Tooltip,
+} from "@wso2/oxygen-ui";
+import { useMemo, useState, type HTMLAttributes, type JSX } from "react";
 import { useDebouncedValue } from "@hooks/useDebouncedValue";
 
 interface AsyncEntityMultiSelectOption {
@@ -46,6 +53,10 @@ export interface AsyncEntityMultiSelectProps<T> {
    * watch list) — shown until a real search result for the same id replaces
    * them. Same purpose as `AsyncEntitySelect`'s `knownLabel`, plural. */
   knownLabels?: Record<string, string>;
+  /** Render selected values as a compact, single-line summary matching
+   * Select-based multi-filters. Other form usages retain removable chips by
+   * default. */
+  compactSelectedValues?: boolean;
 }
 
 /**
@@ -67,6 +78,7 @@ export default function AsyncEntityMultiSelect<T>({
   getId,
   getLabel,
   knownLabels,
+  compactSelectedValues = false,
 }: AsyncEntityMultiSelectProps<T>): JSX.Element {
   const [searchTerm, setSearchTerm] = useState("");
   const [open, setOpen] = useState(false);
@@ -113,6 +125,44 @@ export default function AsyncEntityMultiSelect<T>({
       filterOptions={(opts) => opts}
       getOptionLabel={(opt) => opt.label}
       isOptionEqualToValue={(opt, val) => opt.id === val.id}
+      renderOption={(props, option, { selected }) => {
+        const { key, ...liProps } = props as HTMLAttributes<HTMLLIElement> & { key: string };
+        return (
+          <li key={key} {...liProps} style={{ paddingTop: 2, paddingBottom: 2 }}>
+            <Checkbox size="small" checked={selected} sx={{ mr: 1, p: 0.25 }} />
+            <ListItemText
+              primary={option.label}
+              slotProps={{ primary: { style: { fontSize: 13 } } }}
+            />
+          </li>
+        );
+      }}
+      renderTags={
+        compactSelectedValues
+          ? (tagValues) => {
+              const displayText = tagValues.map((option) => option.label).join(", ");
+              const content = (
+                <Box
+                  component="span"
+                  sx={{
+                    flex: "1 1 0",
+                    minWidth: 0,
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {displayText}
+                </Box>
+              );
+              return tagValues.length === 1 ? content : (
+                <Tooltip title={displayText} placement="top">
+                  {content}
+                </Tooltip>
+              );
+            }
+          : undefined
+      }
       onChange={(_event, next) => {
         setLabelById((prev) => {
           const merged = { ...prev };

--- a/apps/csm-portal/webapp/src/components/ResponsiveRoleChips.tsx
+++ b/apps/csm-portal/webapp/src/components/ResponsiveRoleChips.tsx
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Box, Chip, Stack } from "@wso2/oxygen-ui";
+import { Box, Chip, Stack, useTheme } from "@wso2/oxygen-ui";
 import {
   useCallback,
   useLayoutEffect,
@@ -67,6 +67,7 @@ export default function ResponsiveRoleChips({
   userLabel,
   onViewAll,
 }: ResponsiveRoleChipsProps): JSX.Element {
+  const theme = useTheme();
   const containerRef = useRef<HTMLDivElement>(null);
   const chipMeasureRefs = useRef<Array<HTMLDivElement | null>>([]);
   const moreMeasureRef = useRef<HTMLDivElement>(null);
@@ -83,7 +84,7 @@ export default function ResponsiveRoleChips({
       (_, index) => chipMeasureRefs.current[index]?.offsetWidth ?? 0,
     );
     const moreWidth = moreMeasureRef.current?.offsetWidth ?? 0;
-    const gap = 4;
+    const gap = Number.parseFloat(theme.spacing(0.5));
     const allRolesWidth = chipWidths.reduce(
       (total, width, index) => total + width + (index === 0 ? 0 : gap),
       0,
@@ -101,8 +102,8 @@ export default function ResponsiveRoleChips({
       usedWidth += widthBeforeRole + chipWidths[i];
       nextVisibleCount += 1;
     }
-    setVisibleCount(nextVisibleCount);
-  }, [roleIds]);
+    setVisibleCount(Math.max(nextVisibleCount, Math.min(chipWidths.length, 1)));
+  }, [roleIds, theme]);
 
   useLayoutEffect(() => {
     calculateVisibleCount();
@@ -124,7 +125,10 @@ export default function ResponsiveRoleChips({
             label={labels[index]}
             variant="outlined"
             color={(INTERNAL_USER_ROLES as string[]).includes(role) ? "primary" : "default"}
-            sx={{ flexShrink: 0 }}
+            sx={{
+              minWidth: 0,
+              flexShrink: index === visibleCount - 1 && hiddenRoleCount > 0 ? 1 : 0,
+            }}
           />
         ))}
         {hiddenRoleCount > 0 && (
@@ -147,6 +151,7 @@ export default function ResponsiveRoleChips({
       </Stack>
       <Stack
         aria-hidden
+        data-testid="role-measure"
         direction="row"
         spacing={0.5}
         sx={{ position: "absolute", visibility: "hidden", pointerEvents: "none" }}

--- a/apps/csm-portal/webapp/src/components/ResponsiveRoleChips.tsx
+++ b/apps/csm-portal/webapp/src/components/ResponsiveRoleChips.tsx
@@ -69,8 +69,7 @@ export default function ResponsiveRoleChips({
 }: ResponsiveRoleChipsProps): JSX.Element {
   const theme = useTheme();
   const containerRef = useRef<HTMLDivElement>(null);
-  const chipMeasureRefs = useRef<Array<HTMLDivElement | null>>([]);
-  const moreMeasureRef = useRef<HTMLDivElement>(null);
+  const measureRowRef = useRef<HTMLDivElement>(null);
   const [visibleCount, setVisibleCount] = useState(Math.min(roleIds.length, 1));
   const labels = useMemo(
     () => roleIds.map((role) => roleDisplayName(role, roleNameById)),
@@ -80,10 +79,12 @@ export default function ResponsiveRoleChips({
   const calculateVisibleCount = useCallback((): void => {
     const availableWidth = containerRef.current?.clientWidth ?? 0;
     if (availableWidth <= 0) return;
-    const chipWidths = roleIds.map(
-      (_, index) => chipMeasureRefs.current[index]?.offsetWidth ?? 0,
-    );
-    const moreWidth = moreMeasureRef.current?.offsetWidth ?? 0;
+    const measureNodes = Array.from(measureRowRef.current?.children ?? []) as HTMLElement[];
+    const chipWidths = measureNodes.slice(0, roleIds.length).map((chip) => chip.offsetWidth);
+    const moreWidth = measureNodes[roleIds.length]?.offsetWidth ?? 0;
+    // The measurement row may not have committed yet. Keep the safe one-chip
+    // fallback instead of interpreting missing measurements as "all fit".
+    if (chipWidths.length !== roleIds.length || chipWidths.some((width) => width === 0)) return;
     const gap = Number.parseFloat(theme.spacing(0.5));
     const allRolesWidth = chipWidths.reduce(
       (total, width, index) => total + width + (index === 0 ? 0 : gap),
@@ -150,24 +151,27 @@ export default function ResponsiveRoleChips({
         )}
       </Stack>
       <Stack
+        ref={measureRowRef}
         aria-hidden
         data-testid="role-measure"
         direction="row"
         spacing={0.5}
-        sx={{ position: "absolute", visibility: "hidden", pointerEvents: "none" }}
+        sx={{
+          position: "absolute",
+          width: "max-content",
+          visibility: "hidden",
+          pointerEvents: "none",
+        }}
       >
         {labels.map((label, index) => (
           <Chip
             key={`${roleIds[index]}-measure`}
-            ref={(element) => {
-              chipMeasureRefs.current[index] = element;
-            }}
             size="small"
             variant="outlined"
             label={label}
           />
         ))}
-        <Chip ref={moreMeasureRef} size="small" variant="outlined" label={`+${roleIds.length} more`} />
+        <Chip size="small" variant="outlined" label={`+${roleIds.length} more`} />
       </Stack>
     </Box>
   );

--- a/apps/csm-portal/webapp/src/components/UserRefLink.test.tsx
+++ b/apps/csm-portal/webapp/src/components/UserRefLink.test.tsx
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
@@ -53,6 +53,27 @@ beforeEach(() => {
 });
 
 describe("UserRefLink", () => {
+  it("clears a hover underline after the hover behavior is disabled", () => {
+    const view = renderWithProviders(
+      <UserRefLink name="Jane Doe" userId={JANE_UUID} underlineOnHover />,
+    );
+    const link = screen.getByRole("link", { name: "Jane Doe" });
+    fireEvent.mouseEnter(link);
+    expect(link).toHaveStyle({ textDecoration: "underline" });
+
+    view.rerender(
+      <QueryClientProvider client={new QueryClient()}>
+        <MemoryRouter>
+          <UserRefLink name="Jane Doe" userId={JANE_UUID} underlineOnHover={false} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+    fireEvent.mouseLeave(screen.getByRole("link", { name: "Jane Doe" }));
+    expect(screen.getByRole("link", { name: "Jane Doe" })).toHaveStyle({
+      textDecoration: "none",
+    });
+  });
+
   it("renders a link to /people/<id> when an id is already known", async () => {
     renderWithProviders(
       <UserRefLink name="Jane Doe" email="jane.doe@example.com" userId={JANE_UUID} />,

--- a/apps/csm-portal/webapp/src/components/UserRefLink.tsx
+++ b/apps/csm-portal/webapp/src/components/UserRefLink.tsx
@@ -40,6 +40,14 @@ interface UserRefLinkProps {
   userId?: string | null;
   /** Optional className passthrough for layout tweaks. */
   className?: string;
+  /**
+   * Set to `false` to skip the hover-underline treatment — for callers whose
+   * container already signals clickability on its own (e.g. a table row
+   * that's itself clickable with its own hover background), where the
+   * underline would just be redundant. Defaults to `true`, since in most
+   * usages this link is the only clickability signal on the name.
+   */
+  underlineOnHover?: boolean;
 }
 
 /**
@@ -55,6 +63,7 @@ export default function UserRefLink({
   email,
   userId,
   className,
+  underlineOnHover = true,
 }: UserRefLinkProps): JSX.Element {
   const resolvedId = useResolvedUserId(email, userId);
 
@@ -72,10 +81,12 @@ export default function UserRefLink({
         cursor: "pointer",
       }}
       onMouseEnter={(e) => {
+        if (!underlineOnHover) return;
         (e.currentTarget as HTMLAnchorElement).style.textDecoration =
           "underline";
       }}
       onMouseLeave={(e) => {
+        if (!underlineOnHover) return;
         (e.currentTarget as HTMLAnchorElement).style.textDecoration = "none";
       }}
     >

--- a/apps/csm-portal/webapp/src/components/UserRefLink.tsx
+++ b/apps/csm-portal/webapp/src/components/UserRefLink.tsx
@@ -86,7 +86,6 @@ export default function UserRefLink({
           "underline";
       }}
       onMouseLeave={(e) => {
-        if (!underlineOnHover) return;
         (e.currentTarget as HTMLAnchorElement).style.textDecoration = "none";
       }}
     >

--- a/apps/csm-portal/webapp/src/components/side-nav-bar/CsmSideBar.tsx
+++ b/apps/csm-portal/webapp/src/components/side-nav-bar/CsmSideBar.tsx
@@ -15,7 +15,7 @@
 // under the License.
 
 import { Box, Link, Sidebar, Tooltip, Typography } from "@wso2/oxygen-ui";
-import { useRef, type JSX } from "react";
+import { useEffect, useRef, type JSX } from "react";
 import { Link as NavigateLink, useLocation } from "react-router";
 import { navNodePath, navSectionForPath } from "@config/csmNavItems";
 import { featureState, visibleNavSections } from "@config/featureFlags";
@@ -56,7 +56,9 @@ export default function CsmSideBar({
   const location = useLocation();
   const lastSectionId = useRef("dashboard");
   const activeItem = pickActiveId(location.pathname, lastSectionId.current);
-  lastSectionId.current = activeItem;
+  useEffect(() => {
+    lastSectionId.current = activeItem;
+  }, [activeItem]);
 
   return (
     <Sidebar

--- a/apps/csm-portal/webapp/src/components/side-nav-bar/CsmSideBar.tsx
+++ b/apps/csm-portal/webapp/src/components/side-nav-bar/CsmSideBar.tsx
@@ -15,7 +15,7 @@
 // under the License.
 
 import { Box, Link, Sidebar, Tooltip, Typography } from "@wso2/oxygen-ui";
-import { type JSX } from "react";
+import { useRef, type JSX } from "react";
 import { Link as NavigateLink, useLocation } from "react-router";
 import { navNodePath, navSectionForPath } from "@config/csmNavItems";
 import { featureState, visibleNavSections } from "@config/featureFlags";
@@ -37,11 +37,14 @@ interface CsmSideBarProps {
   onToggleExpand?: (id: string) => void;
 }
 
-function pickActiveId(pathname: string): string {
+function pickActiveId(pathname: string, lastSectionId: string): string {
   if (pathname === "/" || pathname === "") return "dashboard";
   // Highlight the owning *section* — a second-level tab has no rail entry of
   // its own, so `/operations/incidents/42` still lights up Operations.
-  return navSectionForPath(pathname)?.id ?? "dashboard";
+  // Routes with no owning section (e.g. `/people/:id`, linked from all over
+  // the app, not just Settings > Users) fall back to whichever section was
+  // last active instead of hard-jumping to Dashboard.
+  return navSectionForPath(pathname)?.id ?? lastSectionId;
 }
 
 export default function CsmSideBar({
@@ -51,7 +54,9 @@ export default function CsmSideBar({
   onToggleExpand,
 }: CsmSideBarProps): JSX.Element {
   const location = useLocation();
-  const activeItem = pickActiveId(location.pathname);
+  const lastSectionId = useRef("dashboard");
+  const activeItem = pickActiveId(location.pathname, lastSectionId.current);
+  lastSectionId.current = activeItem;
 
   return (
     <Sidebar

--- a/apps/csm-portal/webapp/src/features/csm-admin/components/DirectoryEntityTable.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/components/DirectoryEntityTable.tsx
@@ -27,10 +27,10 @@ import {
   TextField,
   Typography,
 } from "@wso2/oxygen-ui";
-import { type ChangeEvent, type JSX, type KeyboardEvent } from "react";
+import { type ChangeEvent, type JSX } from "react";
+import { Link as RouterLink } from "react-router";
 import QueryErrorState from "@components/QueryErrorState";
 import { BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
-import { useNavTransition } from "@hooks/useNavTransition";
 
 const ROWS_PER_PAGE_OPTIONS = [10, 20, BE_MAX_PAGE_LIMIT];
 
@@ -84,7 +84,6 @@ export default function DirectoryEntityTable({
   rowsPerPage,
   onRowsPerPageChange,
 }: DirectoryEntityTableProps): JSX.Element {
-  const navigate = useNavTransition();
   const entityLabel =
     entityNounPlural.charAt(0).toUpperCase() +
     entityNounPlural.slice(1, entityNounPlural.endsWith("s") ? -1 : undefined);
@@ -120,8 +119,8 @@ export default function DirectoryEntityTable({
                 <TableCell>{entityLabel}</TableCell>
               </TableRow>
             </TableHead>
-            <TableBody>
-              {isLoading || isFetching ? (
+            <TableBody sx={isFetching && !isLoading ? { opacity: 0.6 } : undefined}>
+              {isLoading ? (
                 Array.from({ length: rowsPerPage }).map((_, i) => (
                   <TableRow key={i}>
                     <TableCell>
@@ -153,35 +152,37 @@ export default function DirectoryEntityTable({
               ) : (
                 rows.map((row) => {
                   const destination = `${memberBasePath}/${encodeURIComponent(row.id)}`;
-                  const openMembers = (): void => {
-                    navigate(destination, { state: { name: row.name } });
-                  };
-                  const handleRowKeyDown = (e: KeyboardEvent<HTMLTableRowElement>): void => {
-                    if (e.key === "Enter" || e.key === " ") {
-                      e.preventDefault();
-                      openMembers();
-                    }
-                  };
 
                   return (
                     <TableRow
                       key={row.id}
                       hover
-                      tabIndex={0}
-                      onClick={openMembers}
-                      onKeyDown={handleRowKeyDown}
-                      aria-label={`View members of ${row.name}`}
-                      sx={{
-                        cursor: "pointer",
-                        "&:focus-visible": {
-                          outline: "2px solid",
-                          outlineColor: "primary.main",
-                          outlineOffset: -2,
-                        },
-                      }}
+                      sx={{ position: "relative", cursor: "pointer" }}
                     >
-                      <TableCell sx={{ minWidth: 0 }}>
-                        <Typography variant="body2" noWrap title={row.name}>
+                      <TableCell sx={{ minWidth: 0, position: "relative" }}>
+                        <Box
+                          component={RouterLink}
+                          to={destination}
+                          state={{ name: row.name }}
+                          aria-label={`View members of ${row.name}`}
+                          sx={{
+                            position: "absolute",
+                            inset: 0,
+                            color: "inherit",
+                            textDecoration: "none",
+                            "&:focus-visible": {
+                              outline: "2px solid",
+                              outlineColor: "primary.main",
+                              outlineOffset: -2,
+                            },
+                          }}
+                        />
+                        <Typography
+                          variant="body2"
+                          noWrap
+                          title={row.name}
+                          sx={{ position: "relative", pointerEvents: "none" }}
+                        >
                           {row.name}
                         </Typography>
                         {row.family && (
@@ -189,7 +190,7 @@ export default function DirectoryEntityTable({
                             variant="caption"
                             color="text.secondary"
                             noWrap
-                            sx={{ display: "block" }}
+                            sx={{ display: "block", position: "relative", pointerEvents: "none" }}
                           >
                             {row.family.toUpperCase()} team
                           </Typography>

--- a/apps/csm-portal/webapp/src/features/csm-admin/components/DirectoryEntityTable.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/components/DirectoryEntityTable.tsx
@@ -27,10 +27,10 @@ import {
   TextField,
   Typography,
 } from "@wso2/oxygen-ui";
-import { type ChangeEvent, type JSX } from "react";
-import { Link as RouterLink } from "react-router";
+import { type ChangeEvent, type JSX, type KeyboardEvent } from "react";
 import QueryErrorState from "@components/QueryErrorState";
 import { BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
+import { useNavTransition } from "@hooks/useNavTransition";
 
 const ROWS_PER_PAGE_OPTIONS = [10, 20, BE_MAX_PAGE_LIMIT];
 
@@ -84,6 +84,11 @@ export default function DirectoryEntityTable({
   rowsPerPage,
   onRowsPerPageChange,
 }: DirectoryEntityTableProps): JSX.Element {
+  const navigate = useNavTransition();
+  const entityLabel =
+    entityNounPlural.charAt(0).toUpperCase() +
+    entityNounPlural.slice(1, entityNounPlural.endsWith("s") ? -1 : undefined);
+
   const handleSearchChange = (e: ChangeEvent<HTMLInputElement>): void => {
     onSearchChange(e.target.value);
   };
@@ -112,13 +117,11 @@ export default function DirectoryEntityTable({
           >
             <TableHead>
               <TableRow sx={{ bgcolor: "action.hover" }}>
-                <TableCell>Name</TableCell>
+                <TableCell>{entityLabel}</TableCell>
               </TableRow>
             </TableHead>
-            <TableBody
-              sx={isFetching ? { opacity: 0.6, transition: "opacity 0.15s" } : undefined}
-            >
-              {isLoading ? (
+            <TableBody>
+              {isLoading || isFetching ? (
                 Array.from({ length: rowsPerPage }).map((_, i) => (
                   <TableRow key={i}>
                     <TableCell>
@@ -148,27 +151,53 @@ export default function DirectoryEntityTable({
                   </TableCell>
                 </TableRow>
               ) : (
-                rows.map((row) => (
-                  <TableRow key={row.id} hover>
-                    <TableCell>
-                      <Typography
-                        component={RouterLink}
-                        to={`${memberBasePath}/${encodeURIComponent(row.id)}`}
-                        state={{ name: row.name }}
-                        variant="body2"
-                        sx={(t) => ({
-                          fontWeight: 600,
-                          textDecoration: "none",
-                          color: t.palette.primary.dark,
-                          ...t.applyStyles("dark", { color: t.palette.primary.main }),
-                          "&:hover": { textDecoration: "underline" },
-                        })}
-                      >
-                        {row.family ? `${row.name} (${row.family})` : row.name}
-                      </Typography>
-                    </TableCell>
-                  </TableRow>
-                ))
+                rows.map((row) => {
+                  const destination = `${memberBasePath}/${encodeURIComponent(row.id)}`;
+                  const openMembers = (): void => {
+                    navigate(destination, { state: { name: row.name } });
+                  };
+                  const handleRowKeyDown = (e: KeyboardEvent<HTMLTableRowElement>): void => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      openMembers();
+                    }
+                  };
+
+                  return (
+                    <TableRow
+                      key={row.id}
+                      hover
+                      tabIndex={0}
+                      onClick={openMembers}
+                      onKeyDown={handleRowKeyDown}
+                      aria-label={`View members of ${row.name}`}
+                      sx={{
+                        cursor: "pointer",
+                        "&:focus-visible": {
+                          outline: "2px solid",
+                          outlineColor: "primary.main",
+                          outlineOffset: -2,
+                        },
+                      }}
+                    >
+                      <TableCell sx={{ minWidth: 0 }}>
+                        <Typography variant="body2" noWrap title={row.name}>
+                          {row.name}
+                        </Typography>
+                        {row.family && (
+                          <Typography
+                            variant="caption"
+                            color="text.secondary"
+                            noWrap
+                            sx={{ display: "block" }}
+                          >
+                            {row.family.toUpperCase()} team
+                          </Typography>
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  );
+                })
               )}
             </TableBody>
           </Table>

--- a/apps/csm-portal/webapp/src/features/csm-admin/components/DirectoryMembersList.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/components/DirectoryMembersList.test.tsx
@@ -14,11 +14,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import "@testing-library/jest-dom/vitest";
 import type { ComponentProps } from "react";
-import { MemoryRouter } from "react-router";
+import { MemoryRouter, Route, Routes } from "react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 const authFetchMock = vi.fn();
@@ -70,12 +70,20 @@ function renderList(
   return render(
     <QueryClientProvider client={queryClient}>
       <MemoryRouter>
-        <DirectoryMembersList
-          filterKey="roleIds"
-          entityId="agent"
-          entityNoun="role"
-          {...props}
-        />
+        <Routes>
+          <Route
+            path="/"
+            element={
+              <DirectoryMembersList
+                filterKey="roleIds"
+                entityId="agent"
+                entityNoun="role"
+                {...props}
+              />
+            }
+          />
+          <Route path="/people/:id" element={<div>User profile page</div>} />
+        </Routes>
       </MemoryRouter>
     </QueryClientProvider>,
   );
@@ -154,14 +162,26 @@ describe("DirectoryMembersList", () => {
     expect(body.filters).toEqual({ teamIds: ["alpha"] });
   });
 
-  it("renders a member row linking to the person's profile via UserRefLink", async () => {
+  it("renders the member identity linking to the person's profile", async () => {
     authFetchMock.mockResolvedValueOnce(
       jsonResponse({ users: [MEMBER], total: 1, limit: 20, offset: 0 }),
     );
     renderList();
 
-    const link = await screen.findByRole("link", { name: "jane.doe" });
+    const link = await screen.findByRole("link", { name: "Jane Doe" });
     expect(link).toHaveAttribute("href", `/people/${MEMBER.id}`);
+  });
+
+  it("navigates the whole member row to the same user profile page as the users table", async () => {
+    authFetchMock.mockResolvedValueOnce(
+      jsonResponse({ users: [MEMBER], total: 1, limit: 20, offset: 0 }),
+    );
+    renderList();
+
+    const row = (await screen.findByText("Jane Doe")).closest("tr");
+    expect(row).not.toBeNull();
+    fireEvent.click(row as HTMLElement);
+    expect(await screen.findByText("User profile page")).toBeInTheDocument();
   });
 
   it("renders an empty state (not an error) when the filter matches nobody", async () => {
@@ -174,11 +194,7 @@ describe("DirectoryMembersList", () => {
     expect(screen.queryByText(/Failed to load members/i)).not.toBeInTheDocument();
   });
 
-  it("truncates a member's roles beyond 3 with a '+N more' chip, same as the user list", async () => {
-    // Regression test: role truncation was implemented directly in
-    // CsmUsersPage's own row rendering, not as a shared component, so every
-    // role/group/team member-list page rendered every role uncapped despite
-    // the user list itself being fixed.
+  it("uses the same responsive single-line role summary as the users table", async () => {
     const memberWithManyRoles = {
       ...MEMBER,
       roles: ["agent", "admin", "commenter", "customer", "partner"],
@@ -191,11 +207,13 @@ describe("DirectoryMembersList", () => {
     // Names come from the roles catalogue lookup, proving it's wired, not
     // just raw ids threaded through unchanged.
     expect(await screen.findByText("Agent")).toBeInTheDocument();
-    expect(screen.getByText("Admin")).toBeInTheDocument();
-    expect(screen.getByText("Commenter")).toBeInTheDocument();
+    // jsdom has no layout width, so the responsive component uses its safe
+    // one-chip fallback. Browsers expand this up to the actual column width.
+    expect(screen.queryByText("Admin")).not.toBeInTheDocument();
+    expect(screen.queryByText("Commenter")).not.toBeInTheDocument();
     expect(screen.queryByText("Customer")).not.toBeInTheDocument();
     expect(screen.queryByText("Partner")).not.toBeInTheDocument();
-    expect(screen.getByText("+2 more")).toBeInTheDocument();
+    expect(screen.getByText("+4 more")).toBeInTheDocument();
   });
 
   it("does not show a '+N more' chip at 3 roles or fewer", async () => {

--- a/apps/csm-portal/webapp/src/features/csm-admin/components/DirectoryMembersList.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/components/DirectoryMembersList.test.tsx
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import "@testing-library/jest-dom/vitest";
 import type { ComponentProps } from "react";
@@ -184,6 +184,18 @@ describe("DirectoryMembersList", () => {
     expect(await screen.findByText("User profile page")).toBeInTheDocument();
   });
 
+  it("navigates a focused member row to the user profile with Enter", async () => {
+    authFetchMock.mockResolvedValueOnce(
+      jsonResponse({ users: [MEMBER], total: 1, limit: 20, offset: 0 }),
+    );
+    renderList();
+
+    const row = (await screen.findByText("Jane Doe")).closest("tr");
+    expect(row).not.toBeNull();
+    fireEvent.keyDown(row as HTMLElement, { key: "Enter" });
+    expect(await screen.findByText("User profile page")).toBeInTheDocument();
+  });
+
   it("renders an empty state (not an error) when the filter matches nobody", async () => {
     authFetchMock.mockResolvedValueOnce(
       jsonResponse({ users: [], total: 0, limit: 20, offset: 0 }),
@@ -206,14 +218,17 @@ describe("DirectoryMembersList", () => {
 
     // Names come from the roles catalogue lookup, proving it's wired, not
     // just raw ids threaded through unchanged.
-    expect(await screen.findByText("Agent")).toBeInTheDocument();
+    await waitFor(() => expect(screen.getAllByText("Agent").length).toBeGreaterThan(0));
+    const row = screen.getByText("Jane Doe").closest("tr") as HTMLElement;
+    const visibleRoles = within(row).getByTestId("role-measure").previousElementSibling as HTMLElement;
+    expect(within(visibleRoles).getByText("Agent")).toBeInTheDocument();
     // jsdom has no layout width, so the responsive component uses its safe
     // one-chip fallback. Browsers expand this up to the actual column width.
-    expect(screen.queryByText("Admin")).not.toBeInTheDocument();
-    expect(screen.queryByText("Commenter")).not.toBeInTheDocument();
-    expect(screen.queryByText("Customer")).not.toBeInTheDocument();
-    expect(screen.queryByText("Partner")).not.toBeInTheDocument();
-    expect(screen.getByText("+4 more")).toBeInTheDocument();
+    expect(within(visibleRoles).queryByText("Admin")).not.toBeInTheDocument();
+    expect(within(visibleRoles).queryByText("Commenter")).not.toBeInTheDocument();
+    expect(within(visibleRoles).queryByText("Customer")).not.toBeInTheDocument();
+    expect(within(visibleRoles).queryByText("Partner")).not.toBeInTheDocument();
+    expect(within(visibleRoles).getByText("+4 more")).toBeInTheDocument();
   });
 
   it("does not show a '+N more' chip at 3 roles or fewer", async () => {
@@ -222,8 +237,11 @@ describe("DirectoryMembersList", () => {
     );
     renderList();
 
-    expect(await screen.findByText("Agent")).toBeInTheDocument();
-    expect(screen.queryByText(/more$/)).not.toBeInTheDocument();
+    await waitFor(() => expect(screen.getAllByText("Agent").length).toBeGreaterThan(0));
+    const row = screen.getByText("Jane Doe").closest("tr") as HTMLElement;
+    const visibleRoles = within(row).getByTestId("role-measure").previousElementSibling as HTMLElement;
+    expect(within(visibleRoles).getByText("Agent")).toBeInTheDocument();
+    expect(within(visibleRoles).queryByText(/more$/)).not.toBeInTheDocument();
   });
 
   it("renders an error state when the search fails", async () => {

--- a/apps/csm-portal/webapp/src/features/csm-admin/components/DirectoryMembersList.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/components/DirectoryMembersList.tsx
@@ -32,19 +32,15 @@ import QueryErrorState from "@components/QueryErrorState";
 import UserRefLink from "@components/UserRefLink";
 import { useSearchUsers } from "@features/csm-users/api/useSearchUsers";
 import { useSearchRoles } from "@features/csm-admin/api/useSearchRoles";
-import ResponsiveRoleChips from "@features/csm-users/components/ResponsiveRoleChips";
+import ResponsiveRoleChips from "@components/ResponsiveRoleChips";
 import type { SearchUsersRequest } from "@features/csm-users/types/csmUsers";
 import { BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
 import { useNavTransition } from "@hooks/useNavTransition";
+import { displayUserTimezone } from "@utils/userDirectoryDisplay";
 
 const DEFAULT_ROWS_PER_PAGE = 20;
 const ROWS_PER_PAGE_OPTIONS = [10, 20, BE_MAX_PAGE_LIMIT];
 const COLUMN_COUNT = 4;
-
-function displayTimezone(timezone: string | null | undefined): string {
-  const value = timezone?.trim();
-  return !value || /^-*none-*$/i.test(value) ? "—" : value;
-}
 
 /** Which `UserSearchFilters` key membership in this entity narrows on. */
 export type DirectoryMemberFilterKey = "roleIds" | "groupIds" | "teamIds";
@@ -117,8 +113,8 @@ export default function DirectoryMembersList({
               <TableCell sx={{ width: "12%" }}>Timezone</TableCell>
             </TableRow>
           </TableHead>
-          <TableBody>
-            {isLoading || isFetching ? (
+          <TableBody sx={isFetching && !isLoading ? { opacity: 0.6 } : undefined}>
+            {isLoading ? (
               Array.from({ length: rowsPerPage }).map((_, i) => (
                 <TableRow key={i}>
                   {Array.from({ length: COLUMN_COUNT }).map((__, c) => (
@@ -231,7 +227,7 @@ export default function DirectoryMembersList({
                         </Stack>
                       )}
                     </TableCell>
-                    <TableCell>{displayTimezone(u.timezone)}</TableCell>
+                    <TableCell>{displayUserTimezone(u.timezone)}</TableCell>
                   </TableRow>
                 );
               })

--- a/apps/csm-portal/webapp/src/features/csm-admin/components/DirectoryMembersList.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/components/DirectoryMembersList.tsx
@@ -100,7 +100,6 @@ export default function DirectoryMembersList({
           size="small"
           aria-label={`${entityNoun} members`}
           sx={{
-            minWidth: 900,
             tableLayout: "fixed",
             "& .MuiTableCell-root": { borderColor: "divider" },
           }}

--- a/apps/csm-portal/webapp/src/features/csm-admin/components/DirectoryMembersList.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/components/DirectoryMembersList.tsx
@@ -16,7 +16,6 @@
 
 import {
   Box,
-  Chip,
   Skeleton,
   Table,
   TableBody,
@@ -25,20 +24,27 @@ import {
   TableHead,
   TablePagination,
   TableRow,
+  Stack,
   Typography,
 } from "@wso2/oxygen-ui";
-import { useMemo, useState, type ChangeEvent, type JSX } from "react";
+import { useMemo, useState, type ChangeEvent, type JSX, type KeyboardEvent } from "react";
 import QueryErrorState from "@components/QueryErrorState";
 import UserRefLink from "@components/UserRefLink";
 import { useSearchUsers } from "@features/csm-users/api/useSearchUsers";
 import { useSearchRoles } from "@features/csm-admin/api/useSearchRoles";
-import RoleChipList from "@features/csm-admin/components/RoleChipList";
+import ResponsiveRoleChips from "@features/csm-users/components/ResponsiveRoleChips";
 import type { SearchUsersRequest } from "@features/csm-users/types/csmUsers";
 import { BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
+import { useNavTransition } from "@hooks/useNavTransition";
 
 const DEFAULT_ROWS_PER_PAGE = 20;
 const ROWS_PER_PAGE_OPTIONS = [10, 20, BE_MAX_PAGE_LIMIT];
-const COLUMN_COUNT = 5;
+const COLUMN_COUNT = 4;
+
+function displayTimezone(timezone: string | null | undefined): string {
+  const value = timezone?.trim();
+  return !value || /^-*none-*$/i.test(value) ? "—" : value;
+}
 
 /** Which `UserSearchFilters` key membership in this entity narrows on. */
 export type DirectoryMemberFilterKey = "roleIds" | "groupIds" | "teamIds";
@@ -67,6 +73,7 @@ export default function DirectoryMembersList({
   entityId,
   entityNoun,
 }: DirectoryMembersListProps): JSX.Element {
+  const navigate = useNavTransition();
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_ROWS_PER_PAGE);
 
@@ -93,14 +100,21 @@ export default function DirectoryMembersList({
   return (
     <Box sx={{ border: 1, borderColor: "divider", borderRadius: 1, overflow: "hidden" }}>
       <TableContainer>
-        <Table size="small" aria-label={`${entityNoun} members`} sx={{ "& .MuiTableCell-root": { borderColor: "divider" } }}>
+        <Table
+          size="small"
+          aria-label={`${entityNoun} members`}
+          sx={{
+            minWidth: 900,
+            tableLayout: "fixed",
+            "& .MuiTableCell-root": { borderColor: "divider" },
+          }}
+        >
           <TableHead>
             <TableRow sx={{ bgcolor: "action.hover" }}>
-              <TableCell>Username</TableCell>
-              <TableCell>Name</TableCell>
-              <TableCell>Email</TableCell>
-              <TableCell>Roles</TableCell>
-              <TableCell>Status</TableCell>
+              <TableCell sx={{ width: "32%" }}>User</TableCell>
+              <TableCell sx={{ width: "44%" }}>Roles</TableCell>
+              <TableCell sx={{ width: "12%" }}>Status</TableCell>
+              <TableCell sx={{ width: "12%" }}>Timezone</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
@@ -132,35 +146,95 @@ export default function DirectoryMembersList({
                 </TableCell>
               </TableRow>
             ) : (
-              users.map((u) => (
-                <TableRow key={u.id} hover>
-                  <TableCell>
-                    <UserRefLink name={u.userName} email={u.email} userId={u.id} />
-                  </TableCell>
-                  <TableCell>{u.name || "—"}</TableCell>
-                  <TableCell sx={{ wordBreak: "break-all" }}>{u.email}</TableCell>
-                  <TableCell>
-                    <RoleChipList
-                      roleIds={u.roles ?? []}
-                      roleNameById={roleNameById}
-                      userId={u.id}
-                      userLabel={u.name || u.userName}
-                    />
-                  </TableCell>
-                  <TableCell>
-                    {u.active === undefined ? (
-                      "—"
-                    ) : (
-                      <Chip
-                        size="small"
-                        label={u.active ? "Active" : "Inactive"}
-                        color={u.active ? "success" : "default"}
-                        variant="outlined"
+              users.map((u) => {
+                const profilePath = `/people/${encodeURIComponent(u.id)}`;
+                const goToProfile = (): void => navigate(profilePath);
+                const handleRowKeyDown = (e: KeyboardEvent<HTMLTableRowElement>): void => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    goToProfile();
+                  }
+                };
+                const displayName = u.name?.trim();
+                const primaryIdentity = displayName || u.userName;
+                const secondaryIdentity = [
+                  u.userName !== primaryIdentity ? u.userName : undefined,
+                  u.email !== primaryIdentity && u.email !== u.userName ? u.email : undefined,
+                ].filter((value): value is string => Boolean(value));
+
+                return (
+                  <TableRow
+                    key={u.id}
+                    hover
+                    tabIndex={0}
+                    onClick={goToProfile}
+                    onKeyDown={handleRowKeyDown}
+                    aria-label={`View profile for ${u.name || u.userName}`}
+                    sx={{
+                      cursor: "pointer",
+                      "&:focus-visible": {
+                        outline: "2px solid",
+                        outlineColor: "primary.main",
+                        outlineOffset: -2,
+                      },
+                    }}
+                  >
+                    <TableCell sx={{ minWidth: 0 }}>
+                      <UserRefLink
+                        name={primaryIdentity}
+                        email={u.email}
+                        userId={u.id}
+                        underlineOnHover={false}
                       />
-                    )}
-                  </TableCell>
-                </TableRow>
-              ))
+                      {secondaryIdentity.length > 0 && (
+                        <Typography
+                          variant="caption"
+                          color="text.secondary"
+                          noWrap
+                          title={secondaryIdentity.join(" · ")}
+                          sx={{ display: "block" }}
+                        >
+                          {secondaryIdentity.join(" · ")}
+                        </Typography>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      {u.roles && u.roles.length > 0 ? (
+                        <ResponsiveRoleChips
+                          roleIds={u.roles}
+                          roleNameById={roleNameById}
+                          userLabel={u.name || u.userName}
+                          onViewAll={goToProfile}
+                        />
+                      ) : (
+                        "—"
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      {u.active === undefined ? (
+                        "—"
+                      ) : (
+                        <Stack direction="row" spacing={0.75} alignItems="center">
+                          <Box
+                            aria-hidden
+                            sx={{
+                              width: 7,
+                              height: 7,
+                              flexShrink: 0,
+                              borderRadius: "50%",
+                              bgcolor: u.active ? "success.main" : "text.disabled",
+                            }}
+                          />
+                          <Typography variant="body2">
+                            {u.active ? "Active" : "Inactive"}
+                          </Typography>
+                        </Stack>
+                      )}
+                    </TableCell>
+                    <TableCell>{displayTimezone(u.timezone)}</TableCell>
+                  </TableRow>
+                );
+              })
             )}
           </TableBody>
         </Table>

--- a/apps/csm-portal/webapp/src/features/csm-users/components/ResponsiveRoleChips.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/components/ResponsiveRoleChips.tsx
@@ -1,0 +1,156 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+// Licensed under the Apache License, Version 2.0.
+
+import { Box, Chip, Stack } from "@wso2/oxygen-ui";
+import {
+  useCallback,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type JSX,
+} from "react";
+import { INTERNAL_USER_ROLES } from "@features/csm-users/types/csmUsers";
+
+const ROLE_CATALOGUE_ALIASES: Record<string, string> = {
+  "sn_customerservice.admin": "admin",
+  "wso2_agent": "agent",
+  "sn_customerservice.commenter": "commenter",
+  "sn_customerservice.customer": "customer",
+  "sn_customerservice.customer_admin": "customer_admin",
+  "snc_external": "external",
+  "snc_internal": "internal",
+  "sn_customerservice.partner": "partner",
+  "sn_customerservice.partner_admin": "partner_admin",
+  "sn_customerservice.timecard_approver": "timecard_approver",
+};
+
+function roleDisplayName(role: string, roleNameById: Map<string, string>): string {
+  const catalogueKey = ROLE_CATALOGUE_ALIASES[role] ?? role;
+  const catalogueName = roleNameById.get(role) ?? roleNameById.get(catalogueKey);
+  if (catalogueName) return catalogueName;
+
+  const readableKey = catalogueKey.includes(".")
+    ? catalogueKey.slice(catalogueKey.lastIndexOf(".") + 1)
+    : catalogueKey;
+  return readableKey
+    .split("_")
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+interface ResponsiveRoleChipsProps {
+  roleIds: string[];
+  roleNameById: Map<string, string>;
+  userLabel: string;
+  onViewAll: () => void;
+}
+
+/** One-line, width-aware role summary shared by every user directory table. */
+export default function ResponsiveRoleChips({
+  roleIds,
+  roleNameById,
+  userLabel,
+  onViewAll,
+}: ResponsiveRoleChipsProps): JSX.Element {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const chipMeasureRefs = useRef<Array<HTMLDivElement | null>>([]);
+  const moreMeasureRef = useRef<HTMLDivElement>(null);
+  const [visibleCount, setVisibleCount] = useState(Math.min(roleIds.length, 1));
+  const labels = useMemo(
+    () => roleIds.map((role) => roleDisplayName(role, roleNameById)),
+    [roleIds, roleNameById],
+  );
+
+  const calculateVisibleCount = useCallback((): void => {
+    const availableWidth = containerRef.current?.clientWidth ?? 0;
+    if (availableWidth <= 0) return;
+    const chipWidths = roleIds.map(
+      (_, index) => chipMeasureRefs.current[index]?.offsetWidth ?? 0,
+    );
+    const moreWidth = moreMeasureRef.current?.offsetWidth ?? 0;
+    const gap = 4;
+    const allRolesWidth = chipWidths.reduce(
+      (total, width, index) => total + width + (index === 0 ? 0 : gap),
+      0,
+    );
+    if (allRolesWidth <= availableWidth) {
+      setVisibleCount(chipWidths.length);
+      return;
+    }
+
+    let usedWidth = 0;
+    let nextVisibleCount = 0;
+    for (let i = 0; i < chipWidths.length; i += 1) {
+      const widthBeforeRole = i === 0 ? 0 : gap;
+      if (usedWidth + widthBeforeRole + chipWidths[i] + gap + moreWidth > availableWidth) break;
+      usedWidth += widthBeforeRole + chipWidths[i];
+      nextVisibleCount += 1;
+    }
+    setVisibleCount(nextVisibleCount);
+  }, [roleIds]);
+
+  useLayoutEffect(() => {
+    calculateVisibleCount();
+    const container = containerRef.current;
+    if (!container || typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(calculateVisibleCount);
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, [calculateVisibleCount, labels]);
+
+  const hiddenRoleCount = roleIds.length - visibleCount;
+  return (
+    <Box ref={containerRef} sx={{ position: "relative", width: "100%", minWidth: 0 }}>
+      <Stack direction="row" spacing={0.5} sx={{ flexWrap: "nowrap", overflow: "hidden" }}>
+        {roleIds.slice(0, visibleCount).map((role, index) => (
+          <Chip
+            key={role}
+            size="small"
+            label={labels[index]}
+            variant="outlined"
+            color={(INTERNAL_USER_ROLES as string[]).includes(role) ? "primary" : "default"}
+            sx={{ flexShrink: 0 }}
+          />
+        ))}
+        {hiddenRoleCount > 0 && (
+          <Chip
+            size="small"
+            variant="outlined"
+            label={`+${hiddenRoleCount} more`}
+            clickable
+            sx={{ flexShrink: 0 }}
+            onClick={(e) => {
+              e.stopPropagation();
+              onViewAll();
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") e.stopPropagation();
+            }}
+            aria-label={`View all ${roleIds.length} roles for ${userLabel}`}
+          />
+        )}
+      </Stack>
+      <Stack
+        aria-hidden
+        direction="row"
+        spacing={0.5}
+        sx={{ position: "absolute", visibility: "hidden", pointerEvents: "none" }}
+      >
+        {labels.map((label, index) => (
+          <Chip
+            key={`${roleIds[index]}-measure`}
+            ref={(element) => {
+              chipMeasureRefs.current[index] = element;
+            }}
+            size="small"
+            variant="outlined"
+            label={label}
+          />
+        ))}
+        <Chip ref={moreMeasureRef} size="small" variant="outlined" label={`+${roleIds.length} more`} />
+      </Stack>
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-users/components/ResponsiveRoleChips.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/components/ResponsiveRoleChips.tsx
@@ -1,5 +1,18 @@
 // Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
-// Licensed under the Apache License, Version 2.0.
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
 import { Box, Chip, Stack } from "@wso2/oxygen-ui";
 import {

--- a/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.test.tsx
@@ -148,6 +148,24 @@ describe("CsmUsersPage", () => {
     const body = JSON.parse(requestInit.body as string);
     expect(body.filters).toEqual({});
   });
+
+  it("clears selected role and team filters from their controls", async () => {
+    renderPage("/admin/users?roles=agent&teams=alpha");
+    await waitFor(() => expect(authFetchMock).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear roles filter" }));
+    await waitFor(() => {
+      const body = JSON.parse(authFetchMock.mock.calls.at(-1)?.[1].body as string);
+      expect(body.filters.roleIds).toBeUndefined();
+      expect(body.filters.teamIds).toEqual(["alpha"]);
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear teams filter" }));
+    await waitFor(() => {
+      const body = JSON.parse(authFetchMock.mock.calls.at(-1)?.[1].body as string);
+      expect(body.filters.teamIds).toBeUndefined();
+    });
+  });
 });
 
 describe("CsmUsersPage — role truncation and row navigation", () => {
@@ -210,37 +228,40 @@ describe("CsmUsersPage — role truncation and row navigation", () => {
     renderPage("/admin/users");
 
     // Wait until the role-name catalogue has resolved the raw keys before asserting.
-    await waitFor(() => expect(screen.getByText("Agent")).toBeInTheDocument());
+    await waitFor(() => expect(screen.getAllByText("Agent").length).toBeGreaterThan(0));
 
     const janeRow = screen.getByText("Jane Doe").closest("tr") as HTMLElement;
     const johnRow = screen.getByText("John Smith").closest("tr") as HTMLElement;
+    const janeRoles = within(janeRow).getByTestId("role-measure").previousElementSibling as HTMLElement;
+    const johnRoles = within(johnRow).getByTestId("role-measure").previousElementSibling as HTMLElement;
 
     // jsdom has no layout width, so the responsive list uses its safe
     // one-chip fallback and exposes the remainder through a legible chip.
-    expect(within(janeRow).getByText("Agent")).toBeInTheDocument();
-    expect(within(janeRow).getByText("+4 more")).toBeInTheDocument();
-    expect(within(janeRow).queryByText("Admin")).not.toBeInTheDocument();
-    expect(within(janeRow).queryByText("Commenter")).not.toBeInTheDocument();
-    expect(within(janeRow).queryByText("Partner")).not.toBeInTheDocument();
-    expect(within(janeRow).queryByText("Customer Admin")).not.toBeInTheDocument();
+    expect(within(janeRoles).getByText("Agent")).toBeInTheDocument();
+    expect(within(janeRoles).getByText("+4 more")).toBeInTheDocument();
+    expect(within(janeRoles).queryByText("Admin")).not.toBeInTheDocument();
+    expect(within(janeRoles).queryByText("Commenter")).not.toBeInTheDocument();
+    expect(within(janeRoles).queryByText("Partner")).not.toBeInTheDocument();
+    expect(within(janeRoles).queryByText("Customer Admin")).not.toBeInTheDocument();
 
     // The same fallback remains a single line for a shorter role list.
     // Fully-qualified ServiceNow keys resolve through the same short-key
     // catalogue used by the role filter.
-    expect(within(johnRow).getByText("Internal")).toBeInTheDocument();
-    expect(within(johnRow).queryByText("Admin")).not.toBeInTheDocument();
-    expect(within(johnRow).getByText("+1 more")).toBeInTheDocument();
+    expect(within(johnRoles).getByText("Internal")).toBeInTheDocument();
+    expect(within(johnRoles).queryByText("Admin")).not.toBeInTheDocument();
+    expect(within(johnRoles).getByText("+1 more")).toBeInTheDocument();
   });
 
   it("treats role chips as row content and navigates their row to the user profile", async () => {
     renderPageWithDestinations("/admin/users");
 
-    await waitFor(() => expect(screen.getByText("Agent")).toBeInTheDocument());
+    await waitFor(() => expect(screen.getAllByText("Agent").length).toBeGreaterThan(0));
     const janeRow = screen.getByText("Jane Doe").closest("tr") as HTMLElement;
+    const janeRoles = within(janeRow).getByTestId("role-measure").previousElementSibling as HTMLElement;
 
     // Role chips are informational in this table; clicking one follows the
     // containing row to the user rather than opening the role directory.
-    fireEvent.click(within(janeRow).getByText("Agent"));
+    fireEvent.click(within(janeRoles).getByText("Agent"));
     expect(await screen.findByText("User profile page")).toBeInTheDocument();
     expect(screen.queryByText("Role members page")).not.toBeInTheDocument();
   });

--- a/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.test.tsx
@@ -167,7 +167,7 @@ describe("CsmUsersPage — role truncation and row navigation", () => {
     name: "John Smith",
     email: "john.smith@example.com",
     active: true,
-    roles: ["agent", "admin"],
+    roles: ["snc_internal", "admin"],
     createdOn: "2025-01-01T00:00:00Z",
     updatedOn: "2025-06-01T00:00:00Z",
   };
@@ -184,6 +184,7 @@ describe("CsmUsersPage — role truncation and row navigation", () => {
             { id: "commenter", name: "Commenter" },
             { id: "partner", name: "Partner" },
             { id: "customer_admin", name: "Customer Admin" },
+            { id: "internal", name: "Internal" },
           ],
           total: 5,
           limit: 50,
@@ -205,42 +206,43 @@ describe("CsmUsersPage — role truncation and row navigation", () => {
     );
   });
 
-  it("shows a legible overflow chip beyond 3 roles, and no overflow chip at 3 or fewer", async () => {
+  it("keeps roles on one line and provides a more chip for roles that do not fit", async () => {
     renderPage("/admin/users");
 
-    // Both rows carry "Agent"/"Admin" — wait until the role-name catalogue
-    // has resolved them from the raw keys ("agent"/"admin") before asserting.
-    await waitFor(() => expect(screen.getAllByText("Agent")).toHaveLength(2));
+    // Wait until the role-name catalogue has resolved the raw keys before asserting.
+    await waitFor(() => expect(screen.getByText("Agent")).toBeInTheDocument());
 
     const janeRow = screen.getByText("Jane Doe").closest("tr") as HTMLElement;
     const johnRow = screen.getByText("John Smith").closest("tr") as HTMLElement;
 
-    // 5 roles: 3 visible + a legible "+2 more" overflow chip, the other 2 roles hidden.
+    // jsdom has no layout width, so the responsive list uses its safe
+    // one-chip fallback and exposes the remainder through a legible chip.
     expect(within(janeRow).getByText("Agent")).toBeInTheDocument();
-    expect(within(janeRow).getByText("Admin")).toBeInTheDocument();
-    expect(within(janeRow).getByText("Commenter")).toBeInTheDocument();
-    expect(within(janeRow).getByText("+2 more")).toBeInTheDocument();
+    expect(within(janeRow).getByText("+4 more")).toBeInTheDocument();
+    expect(within(janeRow).queryByText("Admin")).not.toBeInTheDocument();
+    expect(within(janeRow).queryByText("Commenter")).not.toBeInTheDocument();
     expect(within(janeRow).queryByText("Partner")).not.toBeInTheDocument();
     expect(within(janeRow).queryByText("Customer Admin")).not.toBeInTheDocument();
 
-    // 2 roles: both visible, no overflow chip for this row.
-    expect(within(johnRow).getByText("Agent")).toBeInTheDocument();
-    expect(within(johnRow).getByText("Admin")).toBeInTheDocument();
-    expect(within(johnRow).queryByText(/more$/)).not.toBeInTheDocument();
+    // The same fallback remains a single line for a shorter role list.
+    // Fully-qualified ServiceNow keys resolve through the same short-key
+    // catalogue used by the role filter.
+    expect(within(johnRow).getByText("Internal")).toBeInTheDocument();
+    expect(within(johnRow).queryByText("Admin")).not.toBeInTheDocument();
+    expect(within(johnRow).getByText("+1 more")).toBeInTheDocument();
   });
 
-  it("navigates a row click to that user's profile, but a nested role chip click to the role page instead", async () => {
+  it("treats role chips as row content and navigates their row to the user profile", async () => {
     renderPageWithDestinations("/admin/users");
 
-    await waitFor(() => expect(screen.getAllByText("Agent")).toHaveLength(2));
+    await waitFor(() => expect(screen.getByText("Agent")).toBeInTheDocument());
     const janeRow = screen.getByText("Jane Doe").closest("tr") as HTMLElement;
 
-    // Clicking the role chip must land on the role page, not the profile —
-    // the row itself is also clickable, so this only holds if the chip stops
-    // the click from bubbling up to the row's own handler.
+    // Role chips are informational in this table; clicking one follows the
+    // containing row to the user rather than opening the role directory.
     fireEvent.click(within(janeRow).getByText("Agent"));
-    expect(await screen.findByText("Role members page")).toBeInTheDocument();
-    expect(screen.queryByText("User profile page")).not.toBeInTheDocument();
+    expect(await screen.findByText("User profile page")).toBeInTheDocument();
+    expect(screen.queryByText("Role members page")).not.toBeInTheDocument();
   });
 
   it("navigates a whole-row click (outside any nested chip/link) to the user's profile", async () => {

--- a/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.tsx
@@ -203,6 +203,7 @@ export default function CsmUsersPage(): JSX.Element {
             useSearch={useSearchGroups}
             getId={(g) => g.id}
             getLabel={(g) => g.name}
+            compactSelectedValues
           />
         </Box>
 

--- a/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.tsx
@@ -17,7 +17,6 @@
 import {
   Box,
   Checkbox,
-  Chip,
   FormControl,
   InputLabel,
   ListItemText,
@@ -33,7 +32,6 @@ import {
   TableHead,
   TablePagination,
   TableRow,
-  TableSortLabel,
   TextField,
   Typography,
   type SelectChangeEvent,
@@ -49,13 +47,8 @@ import { useSearchGroups } from "@api/useSearchGroups";
 import { useSearchUsers } from "@features/csm-users/api/useSearchUsers";
 import { useSearchRoles } from "@features/csm-admin/api/useSearchRoles";
 import { useSearchTeams } from "@features/csm-admin/api/useSearchTeams";
-import DirectoryEntityChip from "@features/csm-admin/components/DirectoryEntityChip";
-import {
-  INTERNAL_USER_ROLES,
-  type SearchUsersRequest,
-  type UserSortField,
-  type UserSortOrder,
-} from "@features/csm-users/types/csmUsers";
+import ResponsiveRoleChips from "@features/csm-users/components/ResponsiveRoleChips";
+import type { SearchUsersRequest } from "@features/csm-users/types/csmUsers";
 import {
   readUsersFiltersFromUrl,
   writeUsersFiltersToUrl,
@@ -67,10 +60,11 @@ import type { BeGroup } from "@api/backend/types";
 const DEFAULT_ROWS_PER_PAGE = 20;
 // Top option is the backend's max page limit; larger requests are rejected.
 const ROWS_PER_PAGE_OPTIONS = [10, 20, BE_MAX_PAGE_LIMIT];
-// Roles beyond this many collapse into a single "+N more" chip that links to
-// the user's profile — a table cell isn't the place to enumerate every role a
-// user carries.
-const MAX_VISIBLE_ROLES = 3;
+/** Normalise the different empty timezone values emitted by user sources. */
+function displayTimezone(timezone: string | null | undefined): string {
+  const value = timezone?.trim();
+  return !value || /^-*none-*$/i.test(value) ? "—" : value;
+}
 
 /**
  * The users list, with filters reflected in the URL (`search`, `roles`,
@@ -92,8 +86,6 @@ export default function CsmUsersPage(): JSX.Element {
 
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_ROWS_PER_PAGE);
-  const [sortField, setSortField] = useState<UserSortField>("name");
-  const [sortOrder, setSortOrder] = useState<UserSortOrder>("asc");
 
   const setFilters = (next: UsersFilters): void => {
     setPage(0);
@@ -129,9 +121,9 @@ export default function CsmUsersPage(): JSX.Element {
         ...(filters.teamIds.length > 0 && { teamIds: filters.teamIds }),
         ...(filters.active !== "all" && { active: filters.active === "active" }),
       },
-      sortBy: { field: sortField, order: sortOrder },
+      sortBy: { field: "name", order: "asc" },
     }),
-    [debouncedSearch, page, rowsPerPage, filters, sortField, sortOrder],
+    [debouncedSearch, page, rowsPerPage, filters],
   );
 
   const { data, isLoading, isFetching, isError, error } = useSearchUsers(request);
@@ -157,16 +149,6 @@ export default function CsmUsersPage(): JSX.Element {
 
   const handleActiveChange = (e: SelectChangeEvent) => {
     setFilters({ ...filters, active: e.target.value as UsersFilters["active"] });
-  };
-
-  const handleSort = (field: UserSortField) => {
-    if (sortField === field) {
-      setSortOrder((o) => (o === "asc" ? "desc" : "asc"));
-    } else {
-      setSortField(field);
-      setSortOrder("asc");
-    }
-    setPage(0);
   };
 
   const users = data?.users ?? [];
@@ -262,40 +244,39 @@ export default function CsmUsersPage(): JSX.Element {
 
       <Box sx={{ border: 1, borderColor: "divider", borderRadius: 1, overflow: "hidden" }}>
         <TableContainer>
-          <Table size="small" aria-label="Users search results" sx={{ "& .MuiTableCell-root": { borderColor: "divider" } }}>
+          <Table
+            size="small"
+            aria-label="Users search results"
+            sx={{
+              minWidth: 900,
+              tableLayout: "fixed",
+              "& .MuiTableCell-root": { borderColor: "divider" },
+            }}
+          >
             <TableHead>
               <TableRow sx={{ bgcolor: "action.hover" }}>
-                <TableCell>Username</TableCell>
-                <TableCell sortDirection={sortField === "name" ? sortOrder : false}>
-                  <TableSortLabel
-                    active={sortField === "name"}
-                    direction={sortField === "name" ? sortOrder : "asc"}
-                    onClick={() => handleSort("name")}
-                  >
-                    Name
-                  </TableSortLabel>
-                </TableCell>
-                <TableCell>Email</TableCell>
-                <TableCell>Roles</TableCell>
-                <TableCell>Status</TableCell>
-                <TableCell>Timezone</TableCell>
+                <TableCell sx={{ width: "32%" }}>User</TableCell>
+                <TableCell sx={{ width: "44%" }}>Roles</TableCell>
+                <TableCell sx={{ width: "12%" }}>Status</TableCell>
+                <TableCell sx={{ width: "12%" }}>Timezone</TableCell>
               </TableRow>
             </TableHead>
             <TableBody>
               {isLoading || isFetching ? (
                 Array.from({ length: rowsPerPage }).map((_, i) => (
                   <TableRow key={i}>
-                    <TableCell><Skeleton variant="rounded" width="70%" height={18} /></TableCell>
-                    <TableCell><Skeleton variant="rounded" width="75%" height={18} /></TableCell>
-                    <TableCell><Skeleton variant="rounded" width="85%" height={18} /></TableCell>
+                    <TableCell>
+                      <Skeleton variant="rounded" width="65%" height={18} />
+                      <Skeleton variant="rounded" width="85%" height={14} sx={{ mt: 0.75 }} />
+                    </TableCell>
                     <TableCell><Skeleton variant="rounded" width={64} height={22} /></TableCell>
-                    <TableCell><Skeleton variant="rounded" width={60} height={22} /></TableCell>
+                    <TableCell><Skeleton variant="rounded" width={64} height={18} /></TableCell>
                     <TableCell><Skeleton variant="rounded" width="55%" height={18} /></TableCell>
                   </TableRow>
                 ))
               ) : isError ? (
                 <TableRow>
-                  <TableCell colSpan={6} align="center">
+                  <TableCell colSpan={4} align="center">
                     <QueryErrorState
                       message={error instanceof Error && error.message.trim() ? error.message : "Failed to load users."}
                       error={error}
@@ -304,7 +285,7 @@ export default function CsmUsersPage(): JSX.Element {
                 </TableRow>
               ) : users.length === 0 ? (
                 <TableRow>
-                  <TableCell colSpan={6} align="center" sx={{ py: 4 }}>
+                  <TableCell colSpan={4} align="center" sx={{ py: 4 }}>
                     <Typography variant="body2" color="text.secondary">
                       No users found.
                     </Typography>
@@ -320,8 +301,12 @@ export default function CsmUsersPage(): JSX.Element {
                       goToProfile();
                     }
                   };
-                  const visibleRoles = u.roles?.slice(0, MAX_VISIBLE_ROLES) ?? [];
-                  const hiddenRoleCount = Math.max((u.roles?.length ?? 0) - MAX_VISIBLE_ROLES, 0);
+                  const displayName = u.name?.trim();
+                  const primaryIdentity = displayName || u.userName;
+                  const secondaryIdentity = [
+                    u.userName !== primaryIdentity ? u.userName : undefined,
+                    u.email !== primaryIdentity && u.email !== u.userName ? u.email : undefined,
+                  ].filter((value): value is string => Boolean(value));
 
                   return (
                     <TableRow
@@ -331,70 +316,68 @@ export default function CsmUsersPage(): JSX.Element {
                       onKeyDown={handleRowKeyDown}
                       tabIndex={0}
                       aria-label={`View profile for ${u.name || u.userName}`}
-                      sx={{ cursor: "pointer" }}
+                      sx={{
+                        cursor: "pointer",
+                        "&:focus-visible": {
+                          outline: "2px solid",
+                          outlineColor: "primary.main",
+                          outlineOffset: -2,
+                        },
+                      }}
                     >
-                      <TableCell>
-                        <UserRefLink name={u.userName} email={u.email} userId={u.id} />
+                      <TableCell sx={{ minWidth: 0 }}>
+                        <UserRefLink
+                          name={primaryIdentity}
+                          email={u.email}
+                          userId={u.id}
+                          underlineOnHover={false}
+                        />
+                        {secondaryIdentity.length > 0 && (
+                          <Typography
+                            variant="caption"
+                            color="text.secondary"
+                            noWrap
+                            title={secondaryIdentity.join(" · ")}
+                            sx={{ display: "block" }}
+                          >
+                            {secondaryIdentity.join(" · ")}
+                          </Typography>
+                        )}
                       </TableCell>
-                      <TableCell>{u.name || "—"}</TableCell>
-                      <TableCell>{u.email}</TableCell>
                       <TableCell>
-                        <Stack direction="row" spacing={0.5} sx={{ flexWrap: "wrap", gap: 0.5 }}>
-                          {u.roles && u.roles.length > 0 ? (
-                            <>
-                              {visibleRoles.map((r) => (
-                                <DirectoryEntityChip
-                                  key={r}
-                                  id={r}
-                                  name={roleNameById.get(r) ?? r}
-                                  routeBase="/admin/roles"
-                                  color={(INTERNAL_USER_ROLES as string[]).includes(r) ? "primary" : "default"}
-                                />
-                              ))}
-                              {hiddenRoleCount > 0 && (
-                                <Chip
-                                  size="small"
-                                  variant="outlined"
-                                  label={`+${hiddenRoleCount} more`}
-                                  clickable
-                                  onClick={(e) => {
-                                    e.stopPropagation();
-                                    goToProfile();
-                                  }}
-                                  onKeyDown={(e) => {
-                                    if (e.key === "Enter" || e.key === " ") {
-                                      e.stopPropagation();
-                                    }
-                                  }}
-                                  aria-label={`View all ${u.roles.length} roles for ${u.name || u.userName}`}
-                                />
-                              )}
-                            </>
-                          ) : u.userType ? (
-                            <Chip
-                              size="small"
-                              label={u.userType}
-                              color={u.userType === "internal" ? "primary" : "default"}
-                              variant="outlined"
-                            />
-                          ) : (
-                            "—"
-                          )}
-                        </Stack>
+                        {u.roles && u.roles.length > 0 ? (
+                          <ResponsiveRoleChips
+                            roleIds={u.roles}
+                            roleNameById={roleNameById}
+                            userLabel={u.name || u.userName}
+                            onViewAll={goToProfile}
+                          />
+                        ) : (
+                          "—"
+                        )}
                       </TableCell>
                       <TableCell>
                         {u.active === undefined ? (
                           "—"
                         ) : (
-                          <Chip
-                            size="small"
-                            label={u.active ? "Active" : "Inactive"}
-                            color={u.active ? "success" : "default"}
-                            variant="outlined"
-                          />
+                          <Stack direction="row" spacing={0.75} alignItems="center">
+                            <Box
+                              aria-hidden
+                              sx={{
+                                width: 7,
+                                height: 7,
+                                flexShrink: 0,
+                                borderRadius: "50%",
+                                bgcolor: u.active ? "success.main" : "text.disabled",
+                              }}
+                            />
+                            <Typography variant="body2">
+                              {u.active ? "Active" : "Inactive"}
+                            </Typography>
+                          </Stack>
                         )}
                       </TableCell>
-                      <TableCell>{u.timezone ?? "—"}</TableCell>
+                      <TableCell>{displayTimezone(u.timezone)}</TableCell>
                     </TableRow>
                   );
                 })

--- a/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.tsx
@@ -319,7 +319,6 @@ export default function CsmUsersPage(): JSX.Element {
             size="small"
             aria-label="Users search results"
             sx={{
-              minWidth: 900,
               tableLayout: "fixed",
               "& .MuiTableCell-root": { borderColor: "divider" },
             }}

--- a/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.tsx
@@ -172,7 +172,7 @@ export default function CsmUsersPage(): JSX.Element {
           sx={{ minWidth: 280, flex: 1 }}
         />
 
-        <FormControl size="small" sx={{ minWidth: 200 }}>
+        <FormControl size="small" sx={{ width: 200, flexShrink: 0 }}>
           <InputLabel id="user-roles-label">Roles</InputLabel>
           <Select
             labelId="user-roles-label"
@@ -180,9 +180,24 @@ export default function CsmUsersPage(): JSX.Element {
             value={filters.roleIds}
             onChange={handleRoleChange}
             input={<OutlinedInput label="Roles" />}
-            renderValue={(selected) =>
-              (selected as string[]).map((id) => roleNameById.get(id) ?? id).join(", ")
-            }
+            MenuProps={{
+              anchorOrigin: { vertical: "bottom", horizontal: "left" },
+              transformOrigin: { vertical: "top", horizontal: "left" },
+              slotProps: { paper: { sx: { maxHeight: 320 } } },
+            }}
+            renderValue={(selected) => {
+              const label = (selected as string[])
+                .map((id) => roleNameById.get(id) ?? id)
+                .join(", ");
+              return <Box component="span" title={label}>{label}</Box>;
+            }}
+            sx={{
+              "& .MuiSelect-select": {
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+              },
+            }}
           >
             {roles.map((role) => (
               <MenuItem key={role.id} value={role.id}>
@@ -207,7 +222,7 @@ export default function CsmUsersPage(): JSX.Element {
           />
         </Box>
 
-        <FormControl size="small" sx={{ minWidth: 200 }}>
+        <FormControl size="small" sx={{ width: 200, flexShrink: 0 }}>
           <InputLabel id="user-teams-label">Teams</InputLabel>
           <Select
             labelId="user-teams-label"
@@ -215,9 +230,24 @@ export default function CsmUsersPage(): JSX.Element {
             value={filters.teamIds}
             onChange={handleTeamChange}
             input={<OutlinedInput label="Teams" />}
-            renderValue={(selected) =>
-              (selected as string[]).map((id) => teamNameById.get(id) ?? id).join(", ")
-            }
+            MenuProps={{
+              anchorOrigin: { vertical: "bottom", horizontal: "left" },
+              transformOrigin: { vertical: "top", horizontal: "left" },
+              slotProps: { paper: { sx: { maxHeight: 320 } } },
+            }}
+            renderValue={(selected) => {
+              const label = (selected as string[])
+                .map((id) => teamNameById.get(id) ?? id)
+                .join(", ");
+              return <Box component="span" title={label}>{label}</Box>;
+            }}
+            sx={{
+              "& .MuiSelect-select": {
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+              },
+            }}
           >
             {teams.map((team) => (
               <MenuItem key={team.id} value={team.id}>

--- a/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.tsx
@@ -18,6 +18,8 @@ import {
   Box,
   Checkbox,
   FormControl,
+  IconButton,
+  InputAdornment,
   InputLabel,
   ListItemText,
   MenuItem,
@@ -36,6 +38,7 @@ import {
   Typography,
   type SelectChangeEvent,
 } from "@wso2/oxygen-ui";
+import { X } from "@wso2/oxygen-ui-icons-react";
 import { useMemo, useState, type ChangeEvent, type JSX, type KeyboardEvent } from "react";
 import { useSearchParams } from "react-router";
 import QueryErrorState from "@components/QueryErrorState";
@@ -47,7 +50,7 @@ import { useSearchGroups } from "@api/useSearchGroups";
 import { useSearchUsers } from "@features/csm-users/api/useSearchUsers";
 import { useSearchRoles } from "@features/csm-admin/api/useSearchRoles";
 import { useSearchTeams } from "@features/csm-admin/api/useSearchTeams";
-import ResponsiveRoleChips from "@features/csm-users/components/ResponsiveRoleChips";
+import ResponsiveRoleChips from "@components/ResponsiveRoleChips";
 import type { SearchUsersRequest } from "@features/csm-users/types/csmUsers";
 import {
   readUsersFiltersFromUrl,
@@ -56,16 +59,11 @@ import {
 } from "@features/csm-users/utils/usersFiltersUrl";
 import { BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
 import type { BeGroup } from "@api/backend/types";
+import { displayUserTimezone } from "@utils/userDirectoryDisplay";
 
 const DEFAULT_ROWS_PER_PAGE = 20;
 // Top option is the backend's max page limit; larger requests are rejected.
 const ROWS_PER_PAGE_OPTIONS = [10, 20, BE_MAX_PAGE_LIMIT];
-/** Normalise the different empty timezone values emitted by user sources. */
-function displayTimezone(timezone: string | null | undefined): string {
-  const value = timezone?.trim();
-  return !value || /^-*none-*$/i.test(value) ? "—" : value;
-}
-
 /**
  * The users list, with filters reflected in the URL (`search`, `roles`,
  * `groups`, `teams`, `active`) so a filtered link is shareable and survives a
@@ -179,7 +177,28 @@ export default function CsmUsersPage(): JSX.Element {
             multiple
             value={filters.roleIds}
             onChange={handleRoleChange}
-            input={<OutlinedInput label="Roles" />}
+            input={
+              <OutlinedInput
+                label="Roles"
+                endAdornment={
+                  filters.roleIds.length > 0 ? (
+                    <InputAdornment position="end" sx={{ mr: 1.5 }}>
+                      <IconButton
+                        size="small"
+                        aria-label="Clear roles filter"
+                        onMouseDown={(e) => e.stopPropagation()}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setFilters({ ...filters, roleIds: [] });
+                        }}
+                      >
+                        <X size={14} />
+                      </IconButton>
+                    </InputAdornment>
+                  ) : undefined
+                }
+              />
+            }
             MenuProps={{
               anchorOrigin: { vertical: "bottom", horizontal: "left" },
               transformOrigin: { vertical: "top", horizontal: "left" },
@@ -229,7 +248,28 @@ export default function CsmUsersPage(): JSX.Element {
             multiple
             value={filters.teamIds}
             onChange={handleTeamChange}
-            input={<OutlinedInput label="Teams" />}
+            input={
+              <OutlinedInput
+                label="Teams"
+                endAdornment={
+                  filters.teamIds.length > 0 ? (
+                    <InputAdornment position="end" sx={{ mr: 1.5 }}>
+                      <IconButton
+                        size="small"
+                        aria-label="Clear teams filter"
+                        onMouseDown={(e) => e.stopPropagation()}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setFilters({ ...filters, teamIds: [] });
+                        }}
+                      >
+                        <X size={14} />
+                      </IconButton>
+                    </InputAdornment>
+                  ) : undefined
+                }
+              />
+            }
             MenuProps={{
               anchorOrigin: { vertical: "bottom", horizontal: "left" },
               transformOrigin: { vertical: "top", horizontal: "left" },
@@ -292,8 +332,8 @@ export default function CsmUsersPage(): JSX.Element {
                 <TableCell sx={{ width: "12%" }}>Timezone</TableCell>
               </TableRow>
             </TableHead>
-            <TableBody>
-              {isLoading || isFetching ? (
+            <TableBody sx={isFetching && !isLoading ? { opacity: 0.6 } : undefined}>
+              {isLoading ? (
                 Array.from({ length: rowsPerPage }).map((_, i) => (
                   <TableRow key={i}>
                     <TableCell>
@@ -408,7 +448,7 @@ export default function CsmUsersPage(): JSX.Element {
                           </Stack>
                         )}
                       </TableCell>
-                      <TableCell>{displayTimezone(u.timezone)}</TableCell>
+                      <TableCell>{displayUserTimezone(u.timezone)}</TableCell>
                     </TableRow>
                   );
                 })

--- a/apps/csm-portal/webapp/src/utils/userDirectoryDisplay.ts
+++ b/apps/csm-portal/webapp/src/utils/userDirectoryDisplay.ts
@@ -1,0 +1,21 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/** Normalise empty timezone values emitted by the supported user sources. */
+export function displayUserTimezone(timezone: string | null | undefined): string {
+  const value = timezone?.trim();
+  return !value || /^-*none-*$/i.test(value) ? "—" : value;
+}


### PR DESCRIPTION
## Summary
- keep Settings active when opening user profiles from administration pages
- align Users, Roles, Groups, Teams, and member tables with consistent row navigation and styling
- add responsive one-line role summaries with friendly catalogue labels
- ensure users without platform roles are shown without a misleading user-type role

## Validation
- git diff --check
- pre-push test suite passed

## Notes
- Frontend Vitest and TypeScript checks could not be run locally because Node.js is unavailable in the current shell.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added responsive role chips that show available roles based on screen space, with a “+N more” option.
  * Updated user and directory tables with streamlined columns, clearer identity details, status indicators, and normalized timezone display.
  * Enabled keyboard-accessible row navigation to user profiles.
  * Added optional control for hover underlines on user reference links.

* **Bug Fixes**
  * Preserved the active sidebar section when navigating to routes without a designated section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->