### PR TITLE
Fix CSM role chip overflow after directory table update

### DIFF
--- a/apps/csm-portal/webapp/src/components/ResponsiveRoleChips.tsx
+++ b/apps/csm-portal/webapp/src/components/ResponsiveRoleChips.tsx
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Box, Chip, Stack, useTheme } from "@wso2/oxygen-ui";
+import { Box, Chip, Stack } from "@wso2/oxygen-ui";
 import {
   useCallback,
   useLayoutEffect,
@@ -67,9 +67,9 @@ export default function ResponsiveRoleChips({
   userLabel,
   onViewAll,
 }: ResponsiveRoleChipsProps): JSX.Element {
-  const theme = useTheme();
   const containerRef = useRef<HTMLDivElement>(null);
-  const measureRowRef = useRef<HTMLDivElement>(null);
+  const chipMeasureRefs = useRef<Array<HTMLDivElement | null>>([]);
+  const moreMeasureRef = useRef<HTMLDivElement>(null);
   const [visibleCount, setVisibleCount] = useState(Math.min(roleIds.length, 1));
   const labels = useMemo(
     () => roleIds.map((role) => roleDisplayName(role, roleNameById)),
@@ -79,13 +79,11 @@ export default function ResponsiveRoleChips({
   const calculateVisibleCount = useCallback((): void => {
     const availableWidth = containerRef.current?.clientWidth ?? 0;
     if (availableWidth <= 0) return;
-    const measureNodes = Array.from(measureRowRef.current?.children ?? []) as HTMLElement[];
-    const chipWidths = measureNodes.slice(0, roleIds.length).map((chip) => chip.offsetWidth);
-    const moreWidth = measureNodes[roleIds.length]?.offsetWidth ?? 0;
-    // The measurement row may not have committed yet. Keep the safe one-chip
-    // fallback instead of interpreting missing measurements as "all fit".
-    if (chipWidths.length !== roleIds.length || chipWidths.some((width) => width === 0)) return;
-    const gap = Number.parseFloat(theme.spacing(0.5));
+    const chipWidths = roleIds.map(
+      (_, index) => chipMeasureRefs.current[index]?.offsetWidth ?? 0,
+    );
+    const moreWidth = moreMeasureRef.current?.offsetWidth ?? 0;
+    const gap = 4;
     const allRolesWidth = chipWidths.reduce(
       (total, width, index) => total + width + (index === 0 ? 0 : gap),
       0,
@@ -98,13 +96,16 @@ export default function ResponsiveRoleChips({
     let usedWidth = 0;
     let nextVisibleCount = 0;
     for (let i = 0; i < chipWidths.length; i += 1) {
+      const roleWidth = chipWidths[i];
       const widthBeforeRole = i === 0 ? 0 : gap;
-      if (usedWidth + widthBeforeRole + chipWidths[i] + gap + moreWidth > availableWidth) break;
-      usedWidth += widthBeforeRole + chipWidths[i];
+      const needsMoreChip = i < chipWidths.length - 1;
+      const reservedMoreWidth = needsMoreChip ? gap + moreWidth : 0;
+      if (usedWidth + widthBeforeRole + roleWidth + reservedMoreWidth > availableWidth) break;
+      usedWidth += widthBeforeRole + roleWidth;
       nextVisibleCount += 1;
     }
-    setVisibleCount(Math.max(nextVisibleCount, Math.min(chipWidths.length, 1)));
-  }, [roleIds, theme]);
+    setVisibleCount(nextVisibleCount);
+  }, [roleIds]);
 
   useLayoutEffect(() => {
     calculateVisibleCount();
@@ -126,10 +127,7 @@ export default function ResponsiveRoleChips({
             label={labels[index]}
             variant="outlined"
             color={(INTERNAL_USER_ROLES as string[]).includes(role) ? "primary" : "default"}
-            sx={{
-              minWidth: 0,
-              flexShrink: index === visibleCount - 1 && hiddenRoleCount > 0 ? 1 : 0,
-            }}
+            sx={{ flexShrink: 0 }}
           />
         ))}
         {hiddenRoleCount > 0 && (
@@ -151,27 +149,29 @@ export default function ResponsiveRoleChips({
         )}
       </Stack>
       <Stack
-        ref={measureRowRef}
         aria-hidden
         data-testid="role-measure"
         direction="row"
         spacing={0.5}
-        sx={{
-          position: "absolute",
-          width: "max-content",
-          visibility: "hidden",
-          pointerEvents: "none",
-        }}
+        sx={{ position: "absolute", visibility: "hidden", pointerEvents: "none" }}
       >
         {labels.map((label, index) => (
           <Chip
             key={`${roleIds[index]}-measure`}
+            ref={(element) => {
+              chipMeasureRefs.current[index] = element;
+            }}
             size="small"
             variant="outlined"
             label={label}
           />
         ))}
-        <Chip size="small" variant="outlined" label={`+${roleIds.length} more`} />
+        <Chip
+          ref={moreMeasureRef}
+          size="small"
+          variant="outlined"
+          label={`+${roleIds.length} more`}
+        />
       </Stack>
     </Box>
   );

--- a/apps/csm-portal/webapp/src/features/csm-admin/components/DirectoryMembersList.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/components/DirectoryMembersList.tsx
@@ -100,6 +100,7 @@ export default function DirectoryMembersList({
           size="small"
           aria-label={`${entityNoun} members`}
           sx={{
+            width: "100%",
             tableLayout: "fixed",
             "& .MuiTableCell-root": { borderColor: "divider" },
           }}

--- a/apps/csm-portal/webapp/src/features/csm-admin/components/DirectoryMembersList.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/components/DirectoryMembersList.tsx
@@ -95,7 +95,7 @@ export default function DirectoryMembersList({
 
   return (
     <Box sx={{ border: 1, borderColor: "divider", borderRadius: 1, overflow: "hidden" }}>
-      <TableContainer>
+      <TableContainer sx={{ overflow: "visible" }}>
         <Table
           size="small"
           aria-label={`${entityNoun} members`}

--- a/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.tsx
@@ -314,7 +314,7 @@ export default function CsmUsersPage(): JSX.Element {
       </Stack>
 
       <Box sx={{ border: 1, borderColor: "divider", borderRadius: 1, overflow: "hidden" }}>
-        <TableContainer>
+        <TableContainer sx={{ overflow: "visible" }}>
           <Table
             size="small"
             aria-label="Users search results"

--- a/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.tsx
@@ -319,6 +319,7 @@ export default function CsmUsersPage(): JSX.Element {
             size="small"
             aria-label="Users search results"
             sx={{
+              width: "100%",
               tableLayout: "fixed",
               "& .MuiTableCell-root": { borderColor: "divider" },
             }}


### PR DESCRIPTION
## Summary
- constrain user directory tables to the visible page width
- restore the role-chip fitting behavior that worked before the review follow-up
- preserve the responsive +N more summary without adding a table scrollbar

## Validation
- git diff --check
- pre-push test suite passed

## Context
Follow-up to merged PR #1339.