### PR TITLE
[CSM Portal] filter the ABT dashboard's team picker to the right family

### DIFF
--- a/apps/csm-portal/backend/internal/directory/directory_test.go
+++ b/apps/csm-portal/backend/internal/directory/directory_test.go
@@ -278,6 +278,36 @@ func TestSearchTeams_FiltersOnNameOrKey(t *testing.T) {
 	}
 }
 
+func TestSearchTeams_FiltersOnFamily(t *testing.T) {
+	dir := mustDirectory(t, registryFixture, "")
+
+	if got := dir.SearchTeams(SearchRequest{Filters: SearchFilters{Family: "cre-abt"}}); got.Total != 1 || got.Teams[0].ID != "alpha" {
+		t.Fatalf("family=cre-abt matched %+v, want just alpha", got.Teams)
+	}
+	// Case-insensitive: the registry row spelled it "CRE-ABT" (see
+	// registryFixture), and parseFamily normalizes storage to lowercase, but a
+	// caller filtering with either case must match.
+	if got := dir.SearchTeams(SearchRequest{Filters: SearchFilters{Family: "CRE-ABT"}}); got.Total != 1 {
+		t.Errorf("family=CRE-ABT (uppercase) matched %d teams, want 1", got.Total)
+	}
+	if got := dir.SearchTeams(SearchRequest{Filters: SearchFilters{Family: "sre-abt"}}); got.Total != 1 || got.Teams[0].ID != "beta" {
+		t.Fatalf("family=sre-abt matched %+v, want just beta", got.Teams)
+	}
+	// gamma has no family at all -- a family filter must exclude it, not treat
+	// an empty Family field as a wildcard match.
+	if got := dir.SearchTeams(SearchRequest{Filters: SearchFilters{Family: "cre"}}); got.Total != 0 {
+		t.Errorf("family=cre matched %d teams, want 0 (none of alpha/beta/gamma is plain cre)", got.Total)
+	}
+	// No family filter at all: every team, same as before this field existed.
+	if got := dir.SearchTeams(SearchRequest{}); got.Total != 3 {
+		t.Errorf("no family filter matched %d teams, want all 3", got.Total)
+	}
+	// Combined with searchQuery: both must match.
+	if got := dir.SearchTeams(SearchRequest{Filters: SearchFilters{SearchQuery: "beta", Family: "cre-abt"}}); got.Total != 0 {
+		t.Errorf("searchQuery=beta AND family=cre-abt matched %d teams, want 0 (beta is sre-abt)", got.Total)
+	}
+}
+
 // A returned page must not alias the startup snapshot, or a caller appending to
 // it would corrupt every later response.
 func TestSearchTeams_PageDoesNotAliasTheSnapshot(t *testing.T) {

--- a/apps/csm-portal/backend/internal/directory/search.go
+++ b/apps/csm-portal/backend/internal/directory/search.go
@@ -32,6 +32,11 @@ type Pagination struct {
 // SearchFilters holds the optional filter criteria both catalogues accept.
 type SearchFilters struct {
 	SearchQuery string `json:"searchQuery,omitempty"`
+	// Family restricts POST /teams/search to teams whose TeamResult.Family
+	// exactly matches (case-insensitive) — e.g. "cre-abt" for the ABT
+	// dashboard's team picker. Ignored by SearchRoles. A team with no family
+	// configured never matches a non-empty filter.
+	Family string `json:"family,omitempty"`
 }
 
 // SearchRequest is the body of POST /teams/search and POST /roles/search.
@@ -46,9 +51,9 @@ type TeamResult struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
 	// Family may be empty: not every team is classified into a family. It is
-	// what a discipline-scoped team picker would filter on (an SRE dashboard
-	// offering only sre-abt teams), but nothing filters on it yet -- the
-	// dashboard picker renders every team this endpoint returns.
+	// what SearchRequest.Filters.Family filters on -- a discipline-scoped
+	// picker (e.g. an SRE dashboard offering only sre-abt teams) requests it
+	// via the frontend's own dashboard-type -> family mapping.
 	Family string `json:"family,omitempty"`
 	// GroupID is the backing group's id in this platform's UUID form, suitable
 	// for the case-search integrationCsTeam filter. Omitted when the registry
@@ -80,8 +85,11 @@ type SearchRolesResponse struct {
 }
 
 // SearchTeams serves the team catalogue entirely from the startup-resolved
-// index: no upstream call, on this request or any other. Matching is a
-// case-insensitive substring of either the display name or the key.
+// index: no upstream call, on this request or any other. SearchQuery matching
+// is a case-insensitive substring of either the display name or the key;
+// Family matching is a case-insensitive exact match against TeamResult.Family
+// (a discipline-scoped picker, e.g. an SRE dashboard, passes "sre-abt" to
+// exclude every other family, including teams with no family at all).
 func (d *Directory) SearchTeams(req SearchRequest) SearchTeamsResponse {
 	teams := d.teamResults
 	if q := strings.TrimSpace(req.Filters.SearchQuery); q != "" {
@@ -90,6 +98,15 @@ func (d *Directory) SearchTeams(req SearchRequest) SearchTeamsResponse {
 		for _, t := range teams {
 			if strings.Contains(strings.ToLower(t.Name), needle) ||
 				strings.Contains(strings.ToLower(t.ID), needle) {
+				filtered = append(filtered, t)
+			}
+		}
+		teams = filtered
+	}
+	if fam := strings.TrimSpace(req.Filters.Family); fam != "" {
+		filtered := make([]TeamResult, 0, len(teams))
+		for _, t := range teams {
+			if strings.EqualFold(t.Family, fam) {
 				filtered = append(filtered, t)
 			}
 		}

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -6150,10 +6150,9 @@ components:
             Team family classification. The `-abt` variants are account-based teams; the
             bare variants classify a member of the same discipline who is not on an
             account-based team. Omitted when the team is not classified into a family:
-            not every team is. This is the field a discipline-scoped team picker *can*
-            filter on: it is what would let an SRE-scoped dashboard offer only
-            `sre-abt` teams. Nothing does so yet. Today's picker renders every team
-            this endpoint returns, and the scoping is a follow-up.
+            not every team is. This is the field a discipline-scoped team picker filters
+            on via `SearchTeamsRequest.filters.family` — an SRE-scoped dashboard's picker
+            requests `sre-abt` and gets only those teams back.
         groupId:
           type: string
           description: >
@@ -6170,6 +6169,13 @@ components:
           properties:
             searchQuery:
               type: string
+            family:
+              type: string
+              enum: [cre-abt, cre, sre-abt, sre]
+              description: >
+                Restrict results to teams whose family exactly matches (case-insensitive).
+                A team with no family configured never matches. Used by a discipline-scoped
+                picker, e.g. a `cre`-type dashboard's team selector passes `cre-abt`.
         pagination:
           $ref: '#/components/schemas/UserPagination'
 

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -2867,6 +2867,12 @@ export interface BeDashboardWidget {
 export interface BeDashboardListItem {
   id: string;
   displayName: string;
+  /** Who the dashboard is built for. Drives which team `family` the team
+   * picker requests (see `abtFamilyForDashboardType` in `useTeams.ts`) —
+   * `cre` teams see only `cre-abt` teams, `sre` only `sre-abt`. Omitted only
+   * for a definition that predates the field (the deprecated single-variable
+   * configuration path). */
+  type?: "cre" | "sre" | "cs";
   isDefault: boolean;
   /** Whether this dashboard should show a team selector (from
    * `POST /teams/search`) alongside the dashboard switcher when selected —

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useTeams.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useTeams.test.tsx
@@ -25,7 +25,7 @@ vi.mock("@api/backend/client", () => ({
   useBackendApi: () => ({ post: postMock }),
 }));
 
-import { useTeams } from "@features/csm-dashboard/api/useTeams";
+import { abtFamilyForDashboardType, useTeams } from "@features/csm-dashboard/api/useTeams";
 
 function wrapper({ children }: { children: ReactNode }) {
   const queryClient = new QueryClient({
@@ -62,5 +62,56 @@ describe("useTeams", () => {
   it("does not fetch when disabled", () => {
     renderHook(() => useTeams(false), { wrapper });
     expect(postMock).not.toHaveBeenCalled();
+  });
+
+  it("passes filters.family through when given", async () => {
+    postMock.mockResolvedValue({
+      teams: [{ id: "castor", name: "Castor", family: "cre-abt" }],
+    });
+
+    const { result } = renderHook(() => useTeams(true, "cre-abt"), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(postMock).toHaveBeenCalledWith("/teams/search", {
+      filters: { family: "cre-abt" },
+      pagination: { offset: 0, limit: 100 },
+    });
+  });
+
+  it("uses a distinct query key per family so a family-scoped and an unscoped fetch don't share a cache entry", async () => {
+    postMock
+      .mockResolvedValueOnce({ teams: [{ id: "castor", name: "Castor" }] })
+      .mockResolvedValueOnce({
+        teams: [
+          { id: "castor", name: "Castor" },
+          { id: "iam_us", name: "IAM-US" },
+        ],
+      });
+
+    const scoped = renderHook(() => useTeams(true, "cre-abt"), { wrapper });
+    const unscoped = renderHook(() => useTeams(true), { wrapper });
+
+    await waitFor(() => expect(scoped.result.current.isSuccess).toBe(true));
+    await waitFor(() => expect(unscoped.result.current.isSuccess).toBe(true));
+
+    expect(postMock).toHaveBeenCalledTimes(2);
+    expect(scoped.result.current.data).toHaveLength(1);
+    expect(unscoped.result.current.data).toHaveLength(2);
+  });
+});
+
+describe("abtFamilyForDashboardType", () => {
+  it("maps cre to cre-abt", () => {
+    expect(abtFamilyForDashboardType("cre")).toBe("cre-abt");
+  });
+
+  it("maps sre to sre-abt", () => {
+    expect(abtFamilyForDashboardType("sre")).toBe("sre-abt");
+  });
+
+  it("returns undefined for cs and for an untyped dashboard", () => {
+    expect(abtFamilyForDashboardType("cs")).toBeUndefined();
+    expect(abtFamilyForDashboardType(undefined)).toBeUndefined();
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useTeams.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useTeams.ts
@@ -17,9 +17,10 @@
 import { useQuery, type UseQueryResult } from "@tanstack/react-query";
 import { ApiQueryKeys } from "@constants/apiConstants";
 import { useBackendApi } from "@api/backend/client";
-import type { BeTeam } from "@api/backend/types";
+import type { BeDashboardListItem, BeTeam } from "@api/backend/types";
 
 interface TeamsSearchPayload {
+  filters?: { family?: string };
   pagination: { offset: number; limit: number };
 }
 
@@ -28,21 +29,49 @@ interface TeamsSearchResponse {
 }
 
 /**
+ * Maps a dashboard's `type` to the team `family` its picker should be
+ * scoped to — `cre` dashboards offer only `cre-abt` teams, `sre` only
+ * `sre-abt`. `cs` and an untyped (legacy) dashboard aren't team-based at
+ * all, so this only matters for dashboards where `isTeamBased` is true.
+ */
+export function abtFamilyForDashboardType(
+  type: BeDashboardListItem["type"],
+): string | undefined {
+  switch (type) {
+    case "cre":
+      return "cre-abt";
+    case "sre":
+      return "sre-abt";
+    default:
+      return undefined;
+  }
+}
+
+/**
  * Every team from `POST /teams/search`, for the team selector a team-based
  * dashboard shows alongside the dashboard switcher (see
  * `AbtDashboardHeader`), and for `CsmDashboardPage` to resolve the selected
  * team's own `groupId` — the value substituted for the `__current_team__`
- * filter placeholder (see `teamFilterPlaceholder.ts`).
+ * filter placeholder (see `teamFilterPlaceholder.ts`). `family`, when given,
+ * scopes the result to that team family only (see
+ * `abtFamilyForDashboardType`) — omitted, every team in the registry is
+ * returned regardless of family.
  */
-export function useTeams(enabled: boolean): UseQueryResult<BeTeam[], Error> {
+export function useTeams(
+  enabled: boolean,
+  family?: string,
+): UseQueryResult<BeTeam[], Error> {
   const api = useBackendApi();
 
   return useQuery<BeTeam[], Error>({
-    queryKey: [ApiQueryKeys.CSM_TEAMS],
+    queryKey: [ApiQueryKeys.CSM_TEAMS, family ?? null],
     queryFn: async (): Promise<BeTeam[]> => {
       const res = await api.post<TeamsSearchPayload, TeamsSearchResponse>(
         "/teams/search",
-        { pagination: { offset: 0, limit: 100 } },
+        {
+          filters: family ? { family } : undefined,
+          pagination: { offset: 0, limit: 100 },
+        },
       );
       return res.teams ?? [];
     },

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/AbtDashboardHeader.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/AbtDashboardHeader.test.tsx
@@ -31,6 +31,7 @@ import AbtDashboardHeader from "@features/csm-dashboard/components/AbtDashboardH
 const DASHBOARD_LIST = [
   { id: "agents_pilot", displayName: "Engineer overview", isDefault: true, isTeamBased: false },
   { id: "team_performance", displayName: "Team performance", isDefault: false, isTeamBased: true },
+  { id: "abt", displayName: "ABT Dashboard", type: "cre" as const, isDefault: false, isTeamBased: true },
 ];
 
 function renderWithClient(ui: ReactNode) {
@@ -121,5 +122,44 @@ describe("AbtDashboardHeader", () => {
     fireEvent.click(await within(listbox).findByText("CS Team Leads"));
 
     expect(onTeamChange).toHaveBeenCalledWith("cs_team_leads");
+  });
+
+  it("scopes the team query to the dashboard's family for a typed dashboard", () => {
+    postMock.mockResolvedValue({
+      teams: [{ id: "castor", name: "Castor", family: "cre-abt" }],
+    });
+
+    renderWithClient(
+      <AbtDashboardHeader
+        dashboardKey="abt"
+        onDashboardChange={vi.fn()}
+        dashboardList={DASHBOARD_LIST}
+        selectedTeamId={undefined}
+        onTeamChange={vi.fn()}
+      />,
+    );
+
+    expect(postMock).toHaveBeenCalledWith("/teams/search", {
+      filters: { family: "cre-abt" },
+      pagination: { offset: 0, limit: 100 },
+    });
+  });
+
+  it("does not scope the team query for an untyped team-based dashboard", () => {
+    postMock.mockResolvedValue({ teams: [] });
+
+    renderWithClient(
+      <AbtDashboardHeader
+        dashboardKey="team_performance"
+        onDashboardChange={vi.fn()}
+        dashboardList={DASHBOARD_LIST}
+        selectedTeamId={undefined}
+        onTeamChange={vi.fn()}
+      />,
+    );
+
+    expect(postMock).toHaveBeenCalledWith("/teams/search", {
+      pagination: { offset: 0, limit: 100 },
+    });
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/AbtDashboardHeader.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/AbtDashboardHeader.tsx
@@ -18,7 +18,7 @@ import { Box, FormControl, MenuItem, Select, Typography } from "@wso2/oxygen-ui"
 import { type JSX } from "react";
 import type { BeDashboardListItem } from "@api/backend/types";
 import type { DashboardKey } from "@features/csm-dashboard/types/abtDashboard";
-import { useTeams } from "@features/csm-dashboard/api/useTeams";
+import { abtFamilyForDashboardType, useTeams } from "@features/csm-dashboard/api/useTeams";
 
 interface AbtDashboardHeaderProps {
   dashboardKey: DashboardKey;
@@ -38,7 +38,10 @@ interface AbtDashboardHeaderProps {
 
 /**
  * Dashboard header: title, the dashboard switcher, and (for a dashboard
- * flagged `isTeamBased`) a team selector sourced from `POST /teams/search`.
+ * flagged `isTeamBased`) a team selector sourced from `POST /teams/search`,
+ * scoped to the current dashboard's family (`abtFamilyForDashboardType`) —
+ * a `cre` dashboard's picker offers only `cre-abt` teams, `sre` only
+ * `sre-abt`; a dashboard with no `type` gets every team, unfiltered.
  * Both the selected dashboard and the selected team are owned by the parent
  * (`CsmDashboardPage`), which keeps them in sync with the URL (a fragment,
  * not a query param) so a specific dashboard/team view is shareable. The
@@ -59,8 +62,9 @@ export default function AbtDashboardHeader({
 }: AbtDashboardHeaderProps): JSX.Element {
   const currentOption = dashboardList.find((o) => o.id === dashboardKey);
   const isTeamBased = currentOption?.isTeamBased ?? false;
+  const family = abtFamilyForDashboardType(currentOption?.type);
 
-  const teams = useTeams(isTeamBased);
+  const teams = useTeams(isTeamBased, family);
 
   return (
     <Box

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/pages/CsmDashboardPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/pages/CsmDashboardPage.test.tsx
@@ -56,6 +56,7 @@ vi.mock("@features/csm-dashboard/api/useDashboardList", () => ({
 // the real API client, which throws under vitest (no runtime config).
 vi.mock("@features/csm-dashboard/api/useTeams", () => ({
   useTeams: vi.fn(() => ({ data: undefined })),
+  abtFamilyForDashboardType: vi.fn(() => undefined),
 }));
 
 vi.mock("@context/current-user/CurrentUserContext", () => ({

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/pages/CsmDashboardPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/pages/CsmDashboardPage.tsx
@@ -66,13 +66,14 @@ export default function CsmDashboardPage(): JSX.Element {
   // isDefault and isTeamBased must match (not isTeamBased alone, and not
   // isDefault alone) — see the module doc comment above.
   //
-  // Deliberately type-blind: `type` is not on `BeDashboardListItem` at all
-  // yet, so this cannot key off it. The backend loader is held to ONE
-  // isDefault dashboard in total to match — without that, a second typed
-  // default would be perfectly valid config and which one a user landed on
-  // would come down to the backend's filename ordering. Making this
-  // type-aware and loosening the loader to one default per type are the same
-  // change; do not do either alone.
+  // Deliberately type-blind: `type` IS on `BeDashboardListItem` now (added
+  // for the team picker's family filter, see abtFamilyForDashboardType in
+  // useTeams.ts), but default-dashboard selection still isn't keyed off it.
+  // The backend loader is held to ONE isDefault dashboard in total to match
+  // — without that, a second typed default would be perfectly valid config
+  // and which one a user landed on would come down to the backend's filename
+  // ordering. Making this type-aware and loosening the loader to one default
+  // per type are the same change; do not do either alone.
   const preferredEntry = userHasTeam
     ? list?.find((d) => d.isDefault && d.isTeamBased)
     : list?.find((d) => d.isDefault && !d.isTeamBased);
@@ -118,10 +119,15 @@ export default function CsmDashboardPage(): JSX.Element {
     isTeamBased && !hashTeamId && userHasTeam ? currentUser.user?.team?.teamKey : undefined;
   const selectedTeamId = hashTeamId ?? defaultTeamId;
 
-  // Every team, for resolving the selected team's `groupId` (the
-  // `__current_team__` filter placeholder's real value) — same query
-  // AbtDashboardHeader's own team selector uses; react-query dedupes the
-  // fetch since both share the same query key.
+  // Every team, unfiltered, for resolving the selected team's `groupId` (the
+  // `__current_team__` filter placeholder's real value). Deliberately NOT
+  // scoped to the current dashboard's family the way AbtDashboardHeader's own
+  // picker query is (see abtFamilyForDashboardType): the signed-in user's own
+  // team can be outside that family (e.g. a `cre` non-ABT team member viewing
+  // a `cre` dashboard, whose picker only offers `cre-abt` teams), and
+  // `defaultTeamId` still needs it resolved to a real groupId. A separate,
+  // differently-scoped query from the header's — react-query no longer
+  // dedupes these into one fetch.
   const teams = useTeams(isTeamBased);
   const selectedTeamGroupId = teams.data?.find((t) => t.id === selectedTeamId)?.groupId;
 


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

The ABT dashboard's team picker lists every team in the registry regardless of the dashboard's own type, so a CRE-type dashboard's picker shows every CRE team including ones that have nothing to do with ABT (e.g. a generic integration team), alongside the real ABT teams. We are adding a way to scope that picker to the right team family. No related issue.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

- `POST /teams/search` accepts an optional `filters.family` so a caller can ask for only the teams belonging to a given family.
- The ABT dashboard header derives the right family from the current dashboard's own type and requests only that family's teams.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

- Backend: `filters.family` on `POST /teams/search` does a case-insensitive exact match against each team's configured family, excluding teams with no family at all when a family filter is given. New test covers the filter.
- Frontend: `AbtDashboardHeader` derives the family from the current dashboard's type via a new `abtFamilyForDashboardType` helper (cre → cre-abt, sre → sre-abt) and passes it through `useTeams`. The dashboard page's own separate `useTeams` call — used only to resolve the signed-in user's own team into a group id — is deliberately left unfiltered, since a user's real team can be outside the dashboard's own family; it no longer shares a query key with the header's now-scoped query.
- `openapi.yaml` updated for the new request/response fields.

## User stories
N/A — internal dashboard UX improvement, not a distinct user story.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

The ABT dashboard's team picker now shows only the teams that belong to that dashboard's own family, instead of every team in the registry.

## Documentation
N/A — no external product docs describe this internal dashboard behavior.

## Training
N/A — no training content covers this internal dashboard.

## Certification
N/A — no certification exam covers this internal dashboard.

## Marketing
N/A — internal UX improvement, no user-facing feature to promote.

## Automation tests
 - Unit tests
   > New backend test for the family filter; new/updated frontend tests for `useTeams` and `AbtDashboardHeader`. `go test`, `go vet`, `gofmt` and `npx tsc -b --noEmit` all clean; relevant `vitest` suites (121 tests across the dashboard feature) pass.
 - Integration tests
   > N/A — no integration test suite exists for this service; verified via unit tests.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A for Go/TypeScript — `go vet` and `eslint` ran clean instead
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
None.

## Migrations (if applicable)
N/A — no data migration; this is an additive request/response field.

## Test environment
Local development environment (macOS), Go 1.26+, Node/npm per `apps/csm-portal/webapp/package.json`.

## Learning
N/A
