### PR TITLE
fix(csm-portal): case detail Linked Items tab, action bar, and cross-page back nav

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-accounts/pages/CsmAccountDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-accounts/pages/CsmAccountDetailPage.tsx
@@ -30,7 +30,7 @@ import {
 } from "@wso2/oxygen-ui";
 import { ArrowLeft } from "@wso2/oxygen-ui-icons-react";
 import { type JSX, type ReactNode } from "react";
-import { Link as RouterLink, useParams } from "react-router";
+import { Link as RouterLink, useLocation, useParams } from "react-router";
 import { useAccountProjects } from "@features/csm-accounts/api/useAccountProjects";
 import { useGetAccount } from "@features/csm-accounts/api/useGetAccount";
 import {
@@ -95,7 +95,7 @@ function BackButton({ onClick }: { onClick: () => void }): JSX.Element {
       onClick={onClick}
       sx={{ alignSelf: "flex-start" }}
     >
-      Back to accounts
+      Back
     </Button>
   );
 }
@@ -188,6 +188,12 @@ function ProjectsSection({ accountId }: { accountId: string }): JSX.Element {
 export default function CsmAccountDetailPage(): JSX.Element {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavTransition();
+  const location = useLocation();
+  // Prefer wherever the caller came from (e.g. a case's Overview panel) over
+  // the hardcoded accounts list, so Back returns to that page instead of
+  // skipping past it — same convention as CsmCaseDetailPage's own back path.
+  const fromListState = location.state as { from?: string } | undefined;
+  const resolvedBackPath = fromListState?.from ?? "/customers/accounts";
   const { data, isLoading, isError } = useGetAccount(id);
 
   if (isLoading) {
@@ -202,7 +208,7 @@ export default function CsmAccountDetailPage(): JSX.Element {
   if (isError) {
     return (
       <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
-        <BackButton onClick={() => navigate("/customers/accounts")} />
+        <BackButton onClick={() => navigate(resolvedBackPath)} />
         <Typography variant="body1" color="error">
           Could not load account {id}.
         </Typography>
@@ -213,7 +219,7 @@ export default function CsmAccountDetailPage(): JSX.Element {
   if (!data) {
     return (
       <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
-        <BackButton onClick={() => navigate("/customers/accounts")} />
+        <BackButton onClick={() => navigate(resolvedBackPath)} />
         <Typography variant="h5">Account not found</Typography>
         <Typography variant="body2" color="text.secondary">
           No account with id <code>{id}</code>.
@@ -228,7 +234,7 @@ export default function CsmAccountDetailPage(): JSX.Element {
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 2.5 }}>
-      <BackButton onClick={() => navigate("/customers/accounts")} />
+      <BackButton onClick={() => navigate(resolvedBackPath)} />
 
       <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, flexWrap: "wrap" }}>
         <Typography variant="h5">{a.name}</Typography>

--- a/apps/csm-portal/webapp/src/features/csm-accounts/pages/CsmAccountsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-accounts/pages/CsmAccountsPage.tsx
@@ -28,10 +28,10 @@ import {
   TextField,
   Typography,
 } from "@wso2/oxygen-ui";
-import { useMemo, useState, type ChangeEvent, type JSX } from "react";
-import { Link as RouterLink } from "react-router";
+import { useMemo, useState, type ChangeEvent, type JSX, type KeyboardEvent } from "react";
 import QueryErrorState from "@components/QueryErrorState";
 import { useDebouncedValue } from "@hooks/useDebouncedValue";
+import { useNavTransition } from "@hooks/useNavTransition";
 import { useSearchAccounts } from "@features/csm-accounts/api/useSearchAccounts";
 import {
   resolveAccountTier,
@@ -56,6 +56,7 @@ function formatDate(value?: string | null): string {
 }
 
 export default function CsmAccountsPage(): JSX.Element {
+  const navigate = useNavTransition();
   const [searchInput, setSearchInput] = useState("");
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_ROWS_PER_PAGE);
@@ -148,20 +149,32 @@ export default function CsmAccountsPage(): JSX.Element {
               ) : (
                 accounts.map((a) => {
                   const tier = resolveAccountTier(a);
+                  const goToAccount = (): void => navigate(`/customers/accounts/${a.id}`);
+                  const handleRowKeyDown = (e: KeyboardEvent<HTMLTableRowElement>): void => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      goToAccount();
+                    }
+                  };
                   return (
-                    <TableRow key={a.id} hover>
+                    <TableRow
+                      key={a.id}
+                      hover
+                      onClick={goToAccount}
+                      onKeyDown={handleRowKeyDown}
+                      tabIndex={0}
+                      aria-label={`View account ${a.name}`}
+                      sx={{
+                        cursor: "pointer",
+                        "&:focus-visible": {
+                          outline: "2px solid",
+                          outlineColor: "primary.main",
+                          outlineOffset: -2,
+                        },
+                      }}
+                    >
                       <TableCell>
-                        <Typography
-                          component={RouterLink}
-                          to={`/customers/accounts/${a.id}`}
-                          variant="body2"
-                          sx={(t) => ({
-                            textDecoration: "none",
-                            color: t.palette.primary.dark,
-                            ...t.applyStyles("dark", { color: t.palette.primary.main }),
-                            "&:hover": { textDecoration: "underline" },
-                          })}
-                        >
+                        <Typography variant="body2" noWrap>
                           {a.name}
                         </Typography>
                       </TableCell>

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
@@ -464,10 +464,11 @@ export default function CaseActionBar({
       }}
     >
       {!!caseDetail.acknowledgedBy && ACKNOWLEDGEABLE_SEVERITIES.has(caseDetail.severity) && (
-        // Leads the bar as context, read before the action buttons — same
-        // slot the Acknowledge button occupies before anyone claims the
-        // case (see below), so there's never a gap where people go looking
-        // for who acknowledged it.
+        // Leads the bar as context, read before the action buttons. Mutually
+        // exclusive with the Acknowledge button below (only one of the two
+        // ever renders, since one implies the case is already claimed and
+        // the other implies it isn't) — they sit in different positions,
+        // not "the same slot": this leads the bar, the button trails it.
         <Typography variant="body2" color="text.secondary" noWrap>
           Acknowledged by{" "}
           <UserRefLink

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
@@ -21,6 +21,7 @@ import {
   Menu,
   MenuItem,
   Tooltip,
+  Typography,
 } from "@wso2/oxygen-ui";
 import {
   AlertTriangle,
@@ -30,7 +31,6 @@ import {
   ChevronDown,
   Clock,
   Copy,
-  Eye,
   Gauge,
   GitBranch,
   Inbox,
@@ -49,6 +49,7 @@ import type {
 } from "@features/csm-cases/types/csmCases";
 import type { CaseState, Severity } from "@features/csm-dashboard/types/abtDashboard";
 import { stateLabel } from "@features/csm-dashboard/utils/abtDashboard";
+import UserRefLink from "@components/UserRefLink";
 
 /**
  * Presentation for a transition *into* a given state. The button LABEL is never
@@ -462,26 +463,18 @@ export default function CaseActionBar({
         justifyContent: { xs: "flex-start", md: "flex-end" },
       }}
     >
-      {!!onAcknowledge && canAcknowledge(caseDetail) && (
-        // Sits to the left of the state control and stays outlined: claiming a
-        // case is a lighter act than moving it through its lifecycle, so it must
-        // not out-shout the primary transition.
-        <Button
-          size="small"
-          variant="outlined"
-          color="primary"
-          startIcon={
-            isAcknowledging ? (
-              <CircularProgress size={14} color="inherit" />
-            ) : (
-              <Eye size={16} />
-            )
-          }
-          disabled={isAcknowledging || isPending}
-          onClick={() => void onAcknowledge()}
-        >
-          Acknowledge
-        </Button>
+      {!!caseDetail.acknowledgedBy && ACKNOWLEDGEABLE_SEVERITIES.has(caseDetail.severity) && (
+        // Leads the bar as context, read before the action buttons — same
+        // slot the Acknowledge button occupies before anyone claims the
+        // case (see below), so there's never a gap where people go looking
+        // for who acknowledged it.
+        <Typography variant="body2" color="text.secondary" noWrap>
+          Acknowledged by{" "}
+          <UserRefLink
+            name={caseDetail.acknowledgedBy.name}
+            email={caseDetail.acknowledgedBy.email}
+          />
+        </Typography>
       )}
       {primary.length === 1 && (
         // A single reachable state needs no menu — show the transition
@@ -558,6 +551,24 @@ export default function CaseActionBar({
             })}
           </Menu>
         </>
+      )}
+
+      {!!onAcknowledge && canAcknowledge(caseDetail) && (
+        // Sits between the state control and "More": claiming a case is a
+        // lighter act than moving it through its lifecycle, so it trails the
+        // primary transition rather than leading the bar. No leading icon,
+        // for the same plain label-only look as "Change state"/"More" — a
+        // spinner still appears in its place while the claim is in flight.
+        <Button
+          size="small"
+          variant="outlined"
+          color="primary"
+          startIcon={isAcknowledging ? <CircularProgress size={14} color="inherit" /> : undefined}
+          disabled={isAcknowledging || isPending}
+          onClick={() => void onAcknowledge()}
+        >
+          Acknowledge
+        </Button>
       )}
 
       <Button

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseMetaBand.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseMetaBand.tsx
@@ -14,12 +14,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Box, Card, Typography } from "@wso2/oxygen-ui";
+import { Box, Card, Tooltip, Typography } from "@wso2/oxygen-ui";
 import { ChevronDown, ChevronUp } from "@wso2/oxygen-ui-icons-react";
 import { useState, type JSX, type ReactNode } from "react";
 import { Link as RouterLink } from "react-router";
 import { tierLabel, tierColor } from "@features/csm-cases/utils/caseTier";
 import type { CsmCaseDetail } from "@features/csm-cases/types/csmCases";
+import { parentRecordPath } from "@features/csm-cases/utils/parentRecordRoute";
 import SemanticChip from "@components/SemanticChip";
 import UserRefLink from "@components/UserRefLink";
 import DeploymentDetailsDialog from "@features/csm-projects/components/DeploymentDetailsDialog";
@@ -69,9 +70,15 @@ function Cell({
 
 function LinkText({
   to,
+  state,
   children,
 }: {
   to: string;
+  /** Router state forwarded to the destination — e.g. `{ from: ... }` so a
+   * case-to-case link (unlike Account/Project, which have no "Back" button
+   * of their own to feed) can return to this page instead of falling
+   * through to a hardcoded list route. */
+  state?: unknown;
   children: ReactNode;
 }): JSX.Element {
   return (
@@ -80,6 +87,7 @@ function LinkText({
     <Typography
       component={RouterLink}
       to={to}
+      state={state}
       variant="body2"
       noWrap
       sx={(t) => ({
@@ -177,6 +185,12 @@ export default function CaseMetaBand({
   const product = c.productContext;
   const tier = c.customerContext.tier;
   const [showDeployment, setShowDeployment] = useState(false);
+  // So Back on the Account/Project/related-case/parent-case page returns here
+  // instead of falling through to that page's own hardcoded list route (same
+  // fix already applied to ChildCasesWidget/LinkedServiceRequestsWidget's row
+  // navigation) — those destination pages read `location.state.from`.
+  const backState = { from: `/cases/${c.id}` };
+  const parentPath = parentRecordPath(c.parentCase);
   // Deployment/product/assignee are support-workflow facts (which environment,
   // who's triaging it) that don't apply to a read-only announcement broadcast —
   // mirrors the hidden SLA/time-tracking/call-request tabs and action bar.
@@ -272,7 +286,7 @@ export default function CaseMetaBand({
         >
           <Cell label="Account" maxWidth={isAnnouncement ? 240 : undefined}>
             {c.accountId ? (
-              <LinkText to={`/customers/accounts/${c.accountId}`}>
+              <LinkText to={`/customers/accounts/${c.accountId}`} state={backState}>
                 {c.customer}
               </LinkText>
             ) : (
@@ -297,7 +311,7 @@ export default function CaseMetaBand({
           )}
           <Cell label="Project" maxWidth={isAnnouncement ? 240 : undefined}>
             {c.projectId ? (
-              <LinkText to={`/customers/projects/${c.projectId}`}>
+              <LinkText to={`/customers/projects/${c.projectId}`} state={backState}>
                 {c.projectName}
               </LinkText>
             ) : (
@@ -368,6 +382,28 @@ export default function CaseMetaBand({
                   )}
                 </Typography>
               </Cell>
+              {c.relatedCase && (
+                <Cell label="Related case">
+                  <LinkText to={`/cases/${c.relatedCase.id}`} state={backState}>
+                    {c.relatedCase.caseNumber ?? c.relatedCase.id}
+                  </LinkText>
+                </Cell>
+              )}
+              {c.parentCase && (
+                <Cell label="Parent case">
+                  {parentPath ? (
+                    <LinkText to={parentPath} state={backState}>
+                      {c.parentCase.caseNumber ?? c.parentCase.id}
+                    </LinkText>
+                  ) : (
+                    <Tooltip title="This parent record's type could not be resolved, so it can't be opened from here.">
+                      <Typography variant="body2" noWrap color="text.secondary">
+                        {c.parentCase.caseNumber ?? c.parentCase.id}
+                      </Typography>
+                    </Tooltip>
+                  )}
+                </Cell>
+              )}
             </>
           )}
         </Box>

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/ChildCasesWidget.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/ChildCasesWidget.tsx
@@ -17,7 +17,6 @@
 import {
   Box,
   Card,
-  Chip,
   Skeleton,
   Table,
   TableBody,
@@ -54,15 +53,18 @@ export function ChildCasesWidget({ caseId }: ChildCasesWidgetProps): JSX.Element
 
   const cases = data?.cases ?? [];
   const total = data?.total ?? cases.length;
+  // So Back on the child case's own page returns here instead of falling
+  // through to that case's hardcoded list route (see CsmCaseDetailPage's
+  // `resolvedBackPath`, which prefers `location.state.from` when present).
+  const backPath = `/cases/${encodeURIComponent(caseId)}`;
 
   return (
     <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 2 }}>
       <Box sx={{ display: "flex", alignItems: "center", gap: 0.75 }}>
         <GitFork size={16} />
-        <Typography variant="subtitle2">Child cases</Typography>
-        {!isLoading && !isError && (
-          <Chip size="small" variant="outlined" label={`${total} total`} />
-        )}
+        <Typography variant="subtitle2">
+          Child cases{!isLoading && !isError && total > 0 ? ` (${total})` : ""}
+        </Typography>
       </Box>
 
       {isError ? (
@@ -71,12 +73,19 @@ export function ChildCasesWidget({ caseId }: ChildCasesWidgetProps): JSX.Element
         </Typography>
       ) : (
         <TableContainer>
-          <Table size="small">
+          {/* Deliberately NOT table-layout:fixed — that takes each column's
+              width literally, and a narrow one (e.g. state's old "1%" hack)
+              just collapses instead of sizing to content, bleeding its text
+              into the next column. Auto layout sizes Severity/State/Assignee
+              to their actual content and only the Case/Assignee `Typography`
+              below (via `maxWidth` + `noWrap`) truncate. */}
+          <Table size="small" sx={{ width: "100%" }}>
             <TableHead>
               <TableRow>
-                {CHILD_CASES_COLUMNS.map((col) => (
-                  <TableCell key={col}>{col}</TableCell>
-                ))}
+                <TableCell>Case</TableCell>
+                <TableCell>Severity</TableCell>
+                <TableCell sx={{ whiteSpace: "nowrap" }}>State</TableCell>
+                <TableCell>Assignee</TableCell>
               </TableRow>
             </TableHead>
             <TableBody>
@@ -92,43 +101,52 @@ export function ChildCasesWidget({ caseId }: ChildCasesWidgetProps): JSX.Element
                 ))
               ) : cases.length === 0 ? (
                 <TableRow>
-                  <TableCell
-                    colSpan={CHILD_CASES_COLUMNS.length}
-                    align="center"
-                    sx={{ py: 3 }}
-                  >
+                  <TableCell colSpan={CHILD_CASES_COLUMNS.length} align="center">
                     <Typography variant="body2" color="text.secondary">
                       No child cases linked to this case.
                     </Typography>
                   </TableCell>
                 </TableRow>
               ) : (
-                cases.map((c) => (
-                  <TableRow
-                    key={c.id}
-                    hover
-                    onClick={() => navigate(`/cases/${encodeURIComponent(c.id)}`)}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter" || e.key === " ") {
-                        e.preventDefault();
-                        navigate(`/cases/${encodeURIComponent(c.id)}`);
+                cases.map((c) => {
+                  const caseLabel = `${c.caseNumber ?? c.id} — ${c.subject}`;
+                  return (
+                    <TableRow
+                      key={c.id}
+                      hover
+                      onClick={() =>
+                        navigate(`/cases/${encodeURIComponent(c.id)}`, { state: { from: backPath } })
                       }
-                    }}
-                    tabIndex={0}
-                    role="button"
-                    aria-label={`View case ${c.caseNumber ?? c.id}`}
-                    sx={{ cursor: "pointer" }}
-                  >
-                    <TableCell>{c.caseNumber ?? c.id} — {c.subject}</TableCell>
-                    <TableCell>
-                      <SeverityChip severity={c.severity} />
-                    </TableCell>
-                    <TableCell>
-                      <StateChip state={c.state} />
-                    </TableCell>
-                    <TableCell>{c.assigneeName ?? "—"}</TableCell>
-                  </TableRow>
-                ))
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          navigate(`/cases/${encodeURIComponent(c.id)}`, { state: { from: backPath } });
+                        }
+                      }}
+                      tabIndex={0}
+                      role="button"
+                      aria-label={`View case ${c.caseNumber ?? c.id}`}
+                      sx={{ cursor: "pointer" }}
+                    >
+                      <TableCell sx={{ maxWidth: 0, width: "40%" }}>
+                        <Typography variant="body2" noWrap title={caseLabel}>
+                          {caseLabel}
+                        </Typography>
+                      </TableCell>
+                      <TableCell>
+                        <SeverityChip severity={c.severity} />
+                      </TableCell>
+                      <TableCell sx={{ whiteSpace: "nowrap" }}>
+                        <StateChip state={c.state} />
+                      </TableCell>
+                      <TableCell sx={{ maxWidth: 0, width: "25%" }}>
+                        <Typography variant="body2" noWrap title={c.assigneeName ?? "—"}>
+                          {c.assigneeName ?? "—"}
+                        </Typography>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })
               )}
             </TableBody>
           </Table>

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/ChildCasesWidget.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/ChildCasesWidget.tsx
@@ -28,6 +28,7 @@ import {
 } from "@wso2/oxygen-ui";
 import { GitFork } from "@wso2/oxygen-ui-icons-react";
 import type { JSX } from "react";
+import { Link as RouterLink } from "react-router";
 import { useNavTransition } from "@hooks/useNavTransition";
 import { useSearchChildCases } from "@features/csm-cases/api/useSearchChildCases";
 import SeverityChip from "@components/SeverityChip";
@@ -110,26 +111,29 @@ export function ChildCasesWidget({ caseId }: ChildCasesWidgetProps): JSX.Element
               ) : (
                 cases.map((c) => {
                   const caseLabel = `${c.caseNumber ?? c.id} — ${c.subject}`;
+                  const casePath = `/cases/${encodeURIComponent(c.id)}`;
                   return (
                     <TableRow
                       key={c.id}
                       hover
-                      onClick={() =>
-                        navigate(`/cases/${encodeURIComponent(c.id)}`, { state: { from: backPath } })
-                      }
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter" || e.key === " ") {
-                          e.preventDefault();
-                          navigate(`/cases/${encodeURIComponent(c.id)}`, { state: { from: backPath } });
-                        }
-                      }}
-                      tabIndex={0}
-                      role="button"
-                      aria-label={`View case ${c.caseNumber ?? c.id}`}
+                      onClick={() => navigate(casePath, { state: { from: backPath } })}
                       sx={{ cursor: "pointer" }}
                     >
                       <TableCell sx={{ maxWidth: 0, width: "40%" }}>
-                        <Typography variant="body2" noWrap title={caseLabel}>
+                        {/* A real link, not a `role="button"` override on the
+                            row — that strips the row's implicit ARIA role,
+                            leaving its cells with no valid parent role. The
+                            row's own onClick above is just a mouse
+                            convenience on top of this. */}
+                        <Typography
+                          component={RouterLink}
+                          to={casePath}
+                          state={{ from: backPath }}
+                          variant="body2"
+                          noWrap
+                          title={caseLabel}
+                          sx={{ color: "inherit", textDecoration: "none", display: "block" }}
+                        >
                           {caseLabel}
                         </Typography>
                       </TableCell>

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/LinkCaseDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/LinkCaseDialog.tsx
@@ -17,19 +17,18 @@
 import {
   Box,
   Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
+  Divider,
   FormControlLabel,
   InputAdornment,
+  Modal,
+  Paper,
   Radio,
   RadioGroup,
   Skeleton,
   TextField,
   Typography,
 } from "@wso2/oxygen-ui";
-import { Search } from "@wso2/oxygen-ui-icons-react";
+import { CheckCircle, Search } from "@wso2/oxygen-ui-icons-react";
 import { useMemo, useState, type JSX } from "react";
 import { useDebouncedValue } from "@hooks/useDebouncedValue";
 import {
@@ -59,9 +58,17 @@ interface LinkCaseDialogProps {
  * incident that spawned it) or as a **related case** (`PATCH
  * { relatedCaseId }`, a looser cross-link not subject to the child-case
  * close restriction). Search reuses the same `POST /cases/search` lookup as
- * the quick-nav palette. Modeled on {@link AssignEngineerDialog}'s
- * search-and-pick pattern, but over cases instead of users. ServiceNow-source
- * only; the caller surfaces a rejection on another source.
+ * the quick-nav palette. Picking a search result doesn't link immediately —
+ * it shows a selected-case summary panel (case number/subject, severity,
+ * state, assignee) to confirm against first, the same "search → pick →
+ * review before committing" shape {@link ProjectSelectionField} uses for
+ * picking a project on case creation; a "Change" button clears the
+ * selection back to search, and the actual PATCH only fires from the
+ * dialog's "Link" action. A plain `Modal` + `Paper` rather than `Dialog` —
+ * same reasoning as {@link ProjectSelectionField}'s confirm panel: `Dialog`'s
+ * paper renders on the theme's more opaque `background.paper`, while bare
+ * `Paper` gets the lighter, translucent "acrylic" look for free. ServiceNow-
+ * source only; the caller surfaces a rejection on another source.
  */
 export default function LinkCaseDialog({
   currentCaseId,
@@ -71,6 +78,7 @@ export default function LinkCaseDialog({
 }: LinkCaseDialogProps): JSX.Element {
   const [linkType, setLinkType] = useState<CaseLinkType>("parent");
   const [input, setInput] = useState("");
+  const [selected, setSelected] = useState<QuickCaseHit | null>(null);
   const search = useDebouncedValue(input.trim(), 300);
   const { data, isFetching, isError } = useQuickCaseSearch(search);
 
@@ -85,7 +93,7 @@ export default function LinkCaseDialog({
       variant="text"
       color="inherit"
       disabled={isLinking}
-      onClick={() => onLink(hit.id, linkType)}
+      onClick={() => setSelected(hit)}
       sx={{
         justifyContent: "flex-start",
         textTransform: "none",
@@ -108,10 +116,33 @@ export default function LinkCaseDialog({
   );
 
   return (
-    <Dialog open onClose={onClose} maxWidth="xs" fullWidth>
-      <DialogTitle>Link to another case</DialogTitle>
-      <DialogContent dividers>
-        <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+    <Modal
+      open
+      onClose={onClose}
+      slotProps={{ backdrop: { sx: { backgroundColor: "transparent" } } }}
+    >
+      <Paper
+        elevation={3}
+        sx={{
+          position: "fixed",
+          top: "10vh",
+          left: "50%",
+          transform: "translateX(-50%)",
+          width: { xs: "calc(100% - 32px)", sm: 440 },
+          maxWidth: 440,
+          maxHeight: "80vh",
+          display: "flex",
+          flexDirection: "column",
+          outline: "none",
+          border: "1px solid",
+          borderColor: "divider",
+        }}
+      >
+        <Typography variant="h6" sx={{ p: 3, pb: 2 }}>
+          Link to another case
+        </Typography>
+        <Divider />
+        <Box sx={{ p: 3, overflowY: "auto", display: "flex", flexDirection: "column", gap: 1.5 }}>
           <RadioGroup
             row
             value={linkType}
@@ -136,58 +167,119 @@ export default function LinkCaseDialog({
               : "A looser cross-link; not subject to the child-case close restriction."}
           </Typography>
 
-          <TextField
-            value={input}
-            onChange={(e) => setInput(e.target.value)}
-            placeholder="Search by case number or subject…"
-            size="small"
-            fullWidth
-            autoFocus
-            InputProps={{
-              startAdornment: (
-                <InputAdornment position="start">
-                  <Search size={16} />
-                </InputAdornment>
-              ),
-            }}
-          />
+          {selected ? (
+            // Confirm-before-committing panel — same shape as
+            // ProjectSelectionField's "selected project" summary: a
+            // success-tinted panel with the pick's key facts and a "Change"
+            // button back to search, rather than linking on row-click.
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "flex-start",
+                gap: 1,
+                px: 1.5,
+                py: 1,
+                borderRadius: 1,
+                border: "1px solid",
+                borderColor: "success.main",
+                bgcolor: "success.50",
+              }}
+            >
+              <Box sx={{ display: "flex", color: "success.main", flexShrink: 0, mt: 0.25 }}>
+                <CheckCircle size={16} aria-hidden />
+              </Box>
+              <Box sx={{ minWidth: 0, flex: 1 }}>
+                <Typography variant="body2" noWrap sx={{ fontWeight: 600, lineHeight: 1.3 }}>
+                  {selected.caseNumber ?? selected.wso2CaseId ?? selected.id} — {selected.subject}
+                </Typography>
+                <Box sx={{ display: "flex", alignItems: "center", gap: 0.75, mt: 0.5 }}>
+                  <SeverityChip severity={selected.severity} />
+                  <StateChip state={selected.state} />
+                  {selected.assigneeName && (
+                    <Typography variant="caption" color="text.secondary" noWrap>
+                      {selected.assigneeName}
+                    </Typography>
+                  )}
+                </Box>
+              </Box>
+              <Button
+                size="small"
+                variant="text"
+                disabled={isLinking}
+                onClick={() => setSelected(null)}
+                sx={{ minWidth: 0, px: 1, flexShrink: 0 }}
+              >
+                Change
+              </Button>
+            </Box>
+          ) : (
+            // Own tight gap (not the outer content Box's 1.5-unit gap) between
+            // the search box and whatever's below it — a Fragment here would
+            // let the outer gap apply between TextField and this area too,
+            // compounding with any padding on the hint text below.
+            <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5 }}>
+              <TextField
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                placeholder="Search by case number or subject…"
+                size="small"
+                fullWidth
+                autoFocus
+                InputProps={{
+                  startAdornment: (
+                    <InputAdornment position="start">
+                      <Search size={16} />
+                    </InputAdornment>
+                  ),
+                }}
+              />
 
-          <Box sx={{ minHeight: 160 }}>
-            {search.length < QUICK_CASE_MIN_QUERY_LEN ? (
-              <Typography variant="body2" color="text.secondary" sx={{ py: 2 }}>
-                Type at least {QUICK_CASE_MIN_QUERY_LEN} characters to search.
-              </Typography>
-            ) : isFetching ? (
-              <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5, pt: 0.75 }}>
-                {[0, 1, 2].map((i) => (
-                  <Skeleton key={i} variant="rounded" height={44} />
-                ))}
+              <Box>
+                {search.length < QUICK_CASE_MIN_QUERY_LEN ? (
+                  <Typography variant="caption" color="text.secondary">
+                    Type at least {QUICK_CASE_MIN_QUERY_LEN} characters to search
+                  </Typography>
+                ) : isFetching ? (
+                  <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5, minHeight: 160 }}>
+                    {[0, 1, 2].map((i) => (
+                      <Skeleton key={i} variant="rounded" height={44} />
+                    ))}
+                  </Box>
+                ) : isError ? (
+                  <Typography variant="caption" color="error">
+                    Could not search cases. Try again.
+                  </Typography>
+                ) : candidates.length === 0 ? (
+                  <Typography variant="caption" color="text.secondary">
+                    No matching cases.
+                  </Typography>
+                ) : (
+                  <Box sx={{ display: "flex", flexDirection: "column", minHeight: 160 }}>
+                    {candidates.map(renderHit)}
+                  </Box>
+                )}
               </Box>
-            ) : isError ? (
-              <Typography variant="body2" color="error" sx={{ py: 2 }}>
-                Could not search cases. Try again.
-              </Typography>
-            ) : candidates.length === 0 ? (
-              <Typography variant="body2" color="text.secondary" sx={{ py: 2 }}>
-                No matching cases.
-              </Typography>
-            ) : (
-              <Box sx={{ display: "flex", flexDirection: "column" }}>
-                {candidates.map(renderHit)}
-              </Box>
-            )}
-          </Box>
+            </Box>
+          )}
 
           <Typography variant="caption" color="text.secondary">
             Linking applies to ServiceNow-managed cases.
           </Typography>
         </Box>
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={onClose} disabled={isLinking}>
-          Cancel
-        </Button>
-      </DialogActions>
-    </Dialog>
+        <Divider />
+        <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 1.5, p: 2 }}>
+          <Button variant="outlined" color="inherit" onClick={onClose} disabled={isLinking}>
+            Cancel
+          </Button>
+          <Button
+            variant="contained"
+            disabled={!selected || isLinking}
+            onClick={() => selected && onLink(selected.id, linkType)}
+          >
+            {isLinking ? "Linking…" : "Link"}
+          </Button>
+        </Box>
+      </Paper>
+    </Modal>
   );
 }

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/LinkCaseDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/LinkCaseDialog.tsx
@@ -29,7 +29,7 @@ import {
   Typography,
 } from "@wso2/oxygen-ui";
 import { CheckCircle, Search } from "@wso2/oxygen-ui-icons-react";
-import { useMemo, useState, type JSX } from "react";
+import { useEffect, useMemo, useRef, useState, type JSX } from "react";
 import { useDebouncedValue } from "@hooks/useDebouncedValue";
 import {
   QUICK_CASE_MIN_QUERY_LEN,
@@ -81,6 +81,13 @@ export default function LinkCaseDialog({
   const [selected, setSelected] = useState<QuickCaseHit | null>(null);
   const search = useDebouncedValue(input.trim(), 300);
   const { data, isFetching, isError } = useQuickCaseSearch(search);
+  // MUI Button doesn't forward `autoFocus` to its underlying element, so once
+  // the search list unmounts in favour of the confirm panel, focus would
+  // otherwise drop to the document body. Move it to "Change" explicitly.
+  const changeButtonRef = useRef<HTMLButtonElement>(null);
+  useEffect(() => {
+    if (selected) changeButtonRef.current?.focus();
+  }, [selected]);
 
   const candidates = useMemo(
     () => (data ?? []).filter((c) => c.id !== currentCaseId),
@@ -123,6 +130,9 @@ export default function LinkCaseDialog({
     >
       <Paper
         elevation={3}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="link-case-dialog-title"
         sx={{
           position: "fixed",
           top: "10vh",
@@ -138,7 +148,7 @@ export default function LinkCaseDialog({
           borderColor: "divider",
         }}
       >
-        <Typography variant="h6" sx={{ p: 3, pb: 2 }}>
+        <Typography id="link-case-dialog-title" variant="h6" sx={{ p: 3, pb: 2 }}>
           Link to another case
         </Typography>
         <Divider />
@@ -203,6 +213,7 @@ export default function LinkCaseDialog({
                 </Box>
               </Box>
               <Button
+                ref={changeButtonRef}
                 size="small"
                 variant="text"
                 disabled={isLinking}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/LinkedServiceRequestsWidget.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/LinkedServiceRequestsWidget.tsx
@@ -1,0 +1,207 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Box,
+  Button,
+  Card,
+  Skeleton,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { Link as LinkIcon, Plus } from "@wso2/oxygen-ui-icons-react";
+import { useMemo, type JSX } from "react";
+import { useNavTransition } from "@hooks/useNavTransition";
+import {
+  useSearchChildCases,
+  type ChildCaseRow,
+} from "@features/csm-cases/api/useSearchChildCases";
+import StateChip from "@components/StateChip";
+
+const LINKED_SERVICE_REQUESTS_COLUMNS = ["Case", "State", "Assignee"];
+
+export interface LinkedServiceRequestRef {
+  id: string;
+  number: string;
+  name: string;
+}
+
+interface LinkedServiceRequestsWidgetProps {
+  /** UUID of the case whose linked service requests are listed. */
+  caseId: string;
+  /**
+   * The authoritative set of linked service requests, straight off the case
+   * detail response — always shown in full, even if a row can't be enriched
+   * below (see `useSearchChildCases` cap note).
+   */
+  linkedServiceRequests: LinkedServiceRequestRef[] | undefined;
+  onCreateServiceRequest: () => void;
+}
+
+/**
+ * Linked service requests — same underlying relationship `ChildCasesWidget`
+ * queries (`parentId` pointing at this case), just restricted to the ids the
+ * case-detail response already names as service requests. Calling
+ * `useSearchChildCases(caseId)` here too (rather than a bespoke query) means
+ * React Query dedupes the network request against `ChildCasesWidget`, which
+ * renders alongside this on the same tab.
+ *
+ * Only `id`/`number`/`name` are guaranteed for each linked request (that's
+ * all the case-detail payload carries); state/assignee come from the shared
+ * children search and are enriched in once that resolves. A ref whose id
+ * isn't found there (e.g. beyond the children search's page cap) still
+ * renders with its known number/name — never silently dropped, just shown
+ * with "—" for the columns that couldn't be enriched.
+ */
+export function LinkedServiceRequestsWidget({
+  caseId,
+  linkedServiceRequests,
+  onCreateServiceRequest,
+}: LinkedServiceRequestsWidgetProps): JSX.Element {
+  const { data, isLoading, isError } = useSearchChildCases(caseId);
+  const navigate = useNavTransition();
+
+  const enrichedById = useMemo(() => {
+    const map = new Map<string, ChildCaseRow>();
+    for (const row of data?.cases ?? []) {
+      map.set(row.id, row);
+    }
+    return map;
+  }, [data]);
+
+  const refs = linkedServiceRequests ?? [];
+  // isError means enrichment is unavailable, not pending — fall straight to
+  // "—" rather than a skeleton that would spin forever.
+  const enriching = isLoading && !isError;
+  // So Back on the linked case's own page returns here instead of falling
+  // through to that case's hardcoded list route (see CsmCaseDetailPage's
+  // `resolvedBackPath`, which prefers `location.state.from` when present).
+  const backPath = `/cases/${encodeURIComponent(caseId)}`;
+
+  return (
+    <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 1.5 }}>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 1,
+          flexWrap: "wrap",
+        }}
+      >
+        <Box sx={{ display: "flex", alignItems: "center", gap: 0.75 }}>
+          <LinkIcon size={16} />
+          <Typography variant="subtitle2">
+            Linked service requests{refs.length > 0 ? ` (${refs.length})` : ""}
+          </Typography>
+        </Box>
+        <Button
+          size="small"
+          variant="outlined"
+          startIcon={<Plus size={14} />}
+          onClick={onCreateServiceRequest}
+        >
+          Create service request
+        </Button>
+      </Box>
+
+      <TableContainer>
+        {/* Deliberately NOT table-layout:fixed — that takes each column's
+            width literally, and a narrow one (e.g. state's old "1%" hack)
+            just collapses instead of sizing to content, bleeding its text
+            into the next column. Auto layout sizes State to its actual
+            content and only the Case/Assignee `Typography` below (via
+            `maxWidth` + `noWrap`) truncate. */}
+        <Table size="small" sx={{ width: "100%" }}>
+          <TableHead>
+            <TableRow>
+              <TableCell>Case</TableCell>
+              <TableCell sx={{ whiteSpace: "nowrap" }}>State</TableCell>
+              <TableCell>Assignee</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {refs.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={LINKED_SERVICE_REQUESTS_COLUMNS.length} align="center">
+                  <Typography variant="body2" color="text.secondary">
+                    No service requests linked to this case.
+                  </Typography>
+                </TableCell>
+              </TableRow>
+            ) : (
+              refs.map((sr) => {
+                const enriched = enrichedById.get(sr.id);
+                const caseLabel = `${sr.number} — ${sr.name}`;
+                const assigneeLabel = enriched ? enriched.assigneeName ?? "—" : "—";
+                return (
+                  <TableRow
+                    key={sr.id}
+                    hover
+                    onClick={() =>
+                      navigate(`/cases/${encodeURIComponent(sr.id)}`, { state: { from: backPath } })
+                    }
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        navigate(`/cases/${encodeURIComponent(sr.id)}`, { state: { from: backPath } });
+                      }
+                    }}
+                    tabIndex={0}
+                    role="button"
+                    aria-label={`View case ${sr.number}`}
+                    sx={{ cursor: "pointer" }}
+                  >
+                    <TableCell sx={{ maxWidth: 0, width: "50%" }}>
+                      <Typography variant="body2" noWrap title={caseLabel}>
+                        {caseLabel}
+                      </Typography>
+                    </TableCell>
+                    <TableCell sx={{ whiteSpace: "nowrap" }}>
+                      {enriched ? (
+                        <StateChip state={enriched.state} />
+                      ) : enriching ? (
+                        <Skeleton variant="text" width={64} />
+                      ) : (
+                        "—"
+                      )}
+                    </TableCell>
+                    <TableCell sx={{ maxWidth: 0, width: "25%" }}>
+                      {enriching ? (
+                        <Skeleton variant="text" width={72} />
+                      ) : (
+                        <Typography variant="body2" noWrap title={assigneeLabel}>
+                          {assigneeLabel}
+                        </Typography>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                );
+              })
+            )}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </Card>
+  );
+}
+
+export default LinkedServiceRequestsWidget;

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/LinkedServiceRequestsWidget.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/LinkedServiceRequestsWidget.tsx
@@ -25,10 +25,12 @@ import {
   TableContainer,
   TableHead,
   TableRow,
+  Tooltip,
   Typography,
 } from "@wso2/oxygen-ui";
 import { Link as LinkIcon, Plus } from "@wso2/oxygen-ui-icons-react";
 import { useMemo, type JSX } from "react";
+import { Link as RouterLink } from "react-router";
 import { useNavTransition } from "@hooks/useNavTransition";
 import {
   useSearchChildCases,
@@ -54,6 +56,10 @@ interface LinkedServiceRequestsWidgetProps {
    */
   linkedServiceRequests: LinkedServiceRequestRef[] | undefined;
   onCreateServiceRequest: () => void;
+  /** Disables "Create service request" once the case is closed — matches
+   * the read-only rule the rest of the case detail page applies (comment
+   * composer, attachment upload, tag add/remove, "Link to another case"). */
+  createDisabled?: boolean;
 }
 
 /**
@@ -75,6 +81,7 @@ export function LinkedServiceRequestsWidget({
   caseId,
   linkedServiceRequests,
   onCreateServiceRequest,
+  createDisabled = false,
 }: LinkedServiceRequestsWidgetProps): JSX.Element {
   const { data, isLoading, isError } = useSearchChildCases(caseId);
   const navigate = useNavTransition();
@@ -113,14 +120,19 @@ export function LinkedServiceRequestsWidget({
             Linked service requests{refs.length > 0 ? ` (${refs.length})` : ""}
           </Typography>
         </Box>
-        <Button
-          size="small"
-          variant="outlined"
-          startIcon={<Plus size={14} />}
-          onClick={onCreateServiceRequest}
-        >
-          Create service request
-        </Button>
+        <Tooltip title={createDisabled ? "This case is closed — it's read-only." : ""}>
+          <Box component="span">
+            <Button
+              size="small"
+              variant="outlined"
+              startIcon={<Plus size={14} />}
+              onClick={onCreateServiceRequest}
+              disabled={createDisabled}
+            >
+              Create service request
+            </Button>
+          </Box>
+        </Tooltip>
       </Box>
 
       <TableContainer>
@@ -152,26 +164,29 @@ export function LinkedServiceRequestsWidget({
                 const enriched = enrichedById.get(sr.id);
                 const caseLabel = `${sr.number} — ${sr.name}`;
                 const assigneeLabel = enriched ? enriched.assigneeName ?? "—" : "—";
+                const casePath = `/cases/${encodeURIComponent(sr.id)}`;
                 return (
                   <TableRow
                     key={sr.id}
                     hover
-                    onClick={() =>
-                      navigate(`/cases/${encodeURIComponent(sr.id)}`, { state: { from: backPath } })
-                    }
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter" || e.key === " ") {
-                        e.preventDefault();
-                        navigate(`/cases/${encodeURIComponent(sr.id)}`, { state: { from: backPath } });
-                      }
-                    }}
-                    tabIndex={0}
-                    role="button"
-                    aria-label={`View case ${sr.number}`}
+                    onClick={() => navigate(casePath, { state: { from: backPath } })}
                     sx={{ cursor: "pointer" }}
                   >
                     <TableCell sx={{ maxWidth: 0, width: "50%" }}>
-                      <Typography variant="body2" noWrap title={caseLabel}>
+                      {/* A real link, not a `role="button"` override on the
+                          row — that strips the row's implicit ARIA role,
+                          leaving its cells with no valid parent role. The
+                          row's own onClick above is just a mouse
+                          convenience on top of this. */}
+                      <Typography
+                        component={RouterLink}
+                        to={casePath}
+                        state={{ from: backPath }}
+                        variant="body2"
+                        noWrap
+                        title={caseLabel}
+                        sx={{ color: "inherit", textDecoration: "none", display: "block" }}
+                      >
                         {caseLabel}
                       </Typography>
                     </TableCell>

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -43,8 +43,6 @@ import {
   Paperclip,
   PauseCircle,
   Phone,
-  Plus,
-  Users,
   X,
 } from "@wso2/oxygen-ui-icons-react";
 import { useCallback, useEffect, useMemo, useState, type JSX } from "react";
@@ -103,6 +101,7 @@ import AddTagDialog from "@features/csm-cases/components/AddTagDialog";
 import { useCreateCaseTask } from "@features/csm-cases/api/useCreateCaseTask";
 import { useAddCaseTag, useRemoveCaseTag } from "@features/csm-cases/api/useCaseTags";
 import { ChildCasesWidget } from "@features/csm-cases/components/ChildCasesWidget";
+import { LinkedServiceRequestsWidget } from "@features/csm-cases/components/LinkedServiceRequestsWidget";
 import { LinkedChangeRequestsWidget } from "@features/csm-cases/components/LinkedChangeRequestsWidget";
 import { CreateGithubIssueDialog } from "@features/csm-cases/components/CreateGithubIssueDialog";
 import { isCloudSupportSubscription } from "@features/csm-projects/utils/subscriptionType";
@@ -129,7 +128,6 @@ import CaseTimeCardsPanel from "@features/csm-timecards/components/CaseTimeCards
 import LogTimeCardDialog from "@features/csm-timecards/components/LogTimeCardDialog";
 import { usePostTimeCard } from "@features/csm-timecards/api/useTimeCards";
 import { caseIdLabel } from "@features/csm-cases/utils/caseIdentity";
-import { parentRecordPath } from "@features/csm-cases/utils/parentRecordRoute";
 import { formatAbsoluteForUser } from "@utils/dateTime";
 import {
   isBlankHtml,
@@ -145,6 +143,7 @@ import {
 import { useRecordRecentView } from "@features/csm-recent/hooks/useRecentViews";
 import { useIdTokenClaims } from "@hooks/useIdTokenClaims";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
+import { useSuccessBanner } from "@context/success-banner/SuccessBannerContext";
 import QueryErrorState from "@components/QueryErrorState";
 import RelativeTime from "@components/RelativeTime";
 import SeverityChip from "@components/SeverityChip";
@@ -283,7 +282,12 @@ const TAB_DEFS: Array<{
 }> = [
   { id: "activities", label: "Activities", icon: <Activity size={16} /> },
   { id: "details", label: "Details", icon: <ListChecks size={16} /> },
-  { id: "related", label: "Related", icon: <Users size={16} /> },
+  // Label is "Linked Items", not "Related" — "related" is also a distinct
+  // link type (LinkCaseDialog's CaseLinkType) shown inside this same tab,
+  // and reusing the word for the tab name too was confusing the two. Same
+  // chain-link icon as "Link to another case"/"Linked service requests"
+  // inside this tab, not the people icon "Related" used.
+  { id: "related", label: "Linked Items", icon: <LinkIcon size={16} /> },
   { id: "watchers", label: "Watchers", icon: <Eye size={16} /> },
   { id: "sla", label: "SLAs", icon: <Clock size={16} />, hidden: true },
   { id: "attachments", label: "Attachments", icon: <Paperclip size={16} /> },
@@ -457,6 +461,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
     claims?.email?.split("@")[0] ||
     "Unknown engineer";
   const { showError } = useErrorBanner();
+  const { showSuccess } = useSuccessBanner();
   const isDarkMode = useDarkMode();
   const [feedback, setFeedback] = useState<Feedback | null>(null);
   const [activeTab, setActiveTab] = useState<CaseTabId>("activities");
@@ -667,6 +672,11 @@ export default function CsmCaseDetailPage(): JSX.Element {
       others: MyOngoingCase[],
       successMessage: string,
       successSeverity: FeedbackSeverity,
+      // Defaults to the inline sticky banner; `startWork`'s `assign_to_me`
+      // caller overrides this to the floating success toast instead — see
+      // the note on `startWork` below.
+      reportSuccess: (message: string) => void = () =>
+        setFeedback({ message: successMessage, severity: successSeverity, sticky: true }),
     ) => {
       if (others.length > 0) {
         setPauseConflict(others);
@@ -678,11 +688,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
         showError("Could not mark the case ongoing. Please try again.", err);
         return;
       }
-      setFeedback({
-        message: successMessage,
-        severity: successSeverity,
-        sticky: true,
-      });
+      reportSuccess(successMessage);
     },
     [patchCase, showError],
   );
@@ -698,23 +704,19 @@ export default function CsmCaseDetailPage(): JSX.Element {
     try {
       const result = await patchCase.mutateAsync({ acknowledge: true });
       const holder = result.case?.acknowledgedBy?.name?.trim();
-      setFeedback(
+      showSuccess(
         result.case?.alreadyAcknowledged
-          ? {
-              message: holder
-                ? `This case was already acknowledged by ${holder}.`
-                : "This case was already acknowledged.",
-              severity: "info",
-              sticky: true,
-            }
-          : { message: "Case acknowledged.", severity: "success", sticky: true },
+          ? holder
+            ? `This case was already acknowledged by ${holder}.`
+            : "This case was already acknowledged."
+          : "Case acknowledged.",
       );
     } catch (err) {
       showError("Could not acknowledge the case. Please try again.", err);
     } finally {
       setIsAcknowledging(false);
     }
-  }, [patchCase, showError]);
+  }, [patchCase, showError, showSuccess]);
 
   // Starting work: enforce the single-active-case rule.
   // 1) look up the engineer's other ongoing cases (abort on failure — we
@@ -723,7 +725,14 @@ export default function CsmCaseDetailPage(): JSX.Element {
   // "Start progress" transition and the "Assign to me" shortcut, which also
   // puts the case into progress once the assignment lands.
   const startWork = useCallback(
-    async (successMessage: string, successSeverity: FeedbackSeverity) => {
+    async (
+      successMessage: string,
+      successSeverity: FeedbackSeverity,
+      // "Assign to me" passes the floating success toast here instead of the
+      // default inline banner (see `resolveOngoingConflict`) — everything
+      // else sharing this function (Start/Resume work) keeps the banner.
+      reportSuccess?: (message: string) => void,
+    ) => {
       if (!data) return;
       const caseId = data.id;
       let others: MyOngoingCase[];
@@ -747,7 +756,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
         );
         return;
       }
-      await resolveOngoingConflict(others, successMessage, successSeverity);
+      await resolveOngoingConflict(others, successMessage, successSeverity, reportSuccess);
     },
     [data, findMyOngoingCases, patchCase, showError, resolveOngoingConflict],
   );
@@ -782,7 +791,11 @@ export default function CsmCaseDetailPage(): JSX.Element {
             { assigneeEmail: currentUserEmail },
             {
               onSuccess: () =>
-                void startWork(LIFECYCLE_TOAST.assign_to_me, LIFECYCLE_SEVERITY.assign_to_me),
+                void startWork(
+                  LIFECYCLE_TOAST.assign_to_me,
+                  LIFECYCLE_SEVERITY.assign_to_me,
+                  showSuccess,
+                ),
               onError: (err) =>
                 showError("Could not assign the case to you.", err),
             },
@@ -1026,6 +1039,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
     [
       data,
       showError,
+      showSuccess,
       patchCase,
       findMyOngoingCases,
       detailPath,
@@ -1084,17 +1098,13 @@ export default function CsmCaseDetailPage(): JSX.Element {
         {
           onSuccess: () => {
             setAssignOpen(false);
-            setFeedback({
-              message: "Case reassigned.",
-              severity: "success",
-              sticky: true,
-            });
+            showSuccess("Case reassigned.");
           },
           onError: (err) => showError("Could not reassign the case.", err),
         },
       );
     },
-    [patchCase, showError],
+    [patchCase, showError, showSuccess],
   );
 
   // Submits the Post Resolution Activity dialog: PATCHes state alongside
@@ -1506,10 +1516,6 @@ export default function CsmCaseDetailPage(): JSX.Element {
   }
 
   const c = data;
-  // Narrowed once here so the JSX below can use it without a non-null
-  // assertion — `c.relatedCase` on its own doesn't stay narrowed across the
-  // `onClick` closure.
-  const relatedCase = c.relatedCase;
   const isClosed = c.state === "closed";
   // The backend rejects a customer-visible comment unless the case is
   // work_in_progress + ongoing. Internal work notes are allowed in any state,
@@ -1619,57 +1625,10 @@ export default function CsmCaseDetailPage(): JSX.Element {
                 <SeverityChip severity={c.severity} withLabel />
               )}
             {!isAnnouncement && <StateChip state={c.state} />}
-            {!isAnnouncement && relatedCase && (
-              <Chip
-                size="small"
-                variant="outlined"
-                clickable
-                icon={<LinkIcon size={14} />}
-                label={`Related: ${relatedCase.caseNumber ?? relatedCase.id}`}
-                // Carries the same "back to list" target forward — there's no
-                // breadcrumb chain back through this case, so the related
-                // case's own back button returns to the filtered list this
-                // one was opened from rather than losing it a step early.
-                onClick={() =>
-                  navigate(`/cases/${relatedCase.id}`, {
-                    state: { from: resolvedBackPath },
-                  })
-                }
-                sx={{ fontWeight: 600 }}
-              />
-            )}
-            {!isAnnouncement &&
-              c.parentCase &&
-              (() => {
-                const parentPath = parentRecordPath(c.parentCase);
-                return (
-                  <Chip
-                    size="small"
-                    variant="outlined"
-                    clickable={parentPath !== null}
-                    icon={<LinkIcon size={14} />}
-                    label={`Parent: ${c.parentCase.caseNumber ?? c.parentCase.id}`}
-                    // Carries the "back to list" target forward the same way
-                    // the related-case chip does, so the parent record's own
-                    // back button returns to the filtered list this case was
-                    // opened from.
-                    onClick={
-                      parentPath === null
-                        ? undefined
-                        : () =>
-                            navigate(parentPath, {
-                              state: { from: resolvedBackPath },
-                            })
-                    }
-                    title={
-                      parentPath === null
-                        ? "This parent record's type could not be resolved, so it cannot be opened from here."
-                        : undefined
-                    }
-                    sx={{ fontWeight: 600 }}
-                  />
-                );
-              })()}
+            {/* Related/Parent moved to CaseMetaBand's Overview cells — those
+                are singular facts (never more than one each), so a compact
+                "Cell" fits better than a chip crowding this row, especially
+                once both are present on the same case at once. */}
             {!isAnnouncement &&
               c.autoclosureStep &&
               c.autoclosureStep !== "DEFAULT" && (
@@ -2070,76 +2029,57 @@ export default function CsmCaseDetailPage(): JSX.Element {
       )}
 
       {activeTab === "related" && (
-        <Box
-          sx={{
-            display: "grid",
-            gap: 2,
-            gridTemplateColumns: {
-              xs: "1fr",
-              md: "repeat(2, minmax(0, 1fr))",
-            },
-            alignItems: "start",
-          }}
-        >
-          <ChildCasesWidget caseId={c.id} />
-          {/* Content-relevance, not a data-source gate: shown whenever this is
-              a service request (the only case type that carries the link) or
-              the list already has entries — never checks the record's data
-              source. */}
-          {(isServiceRequest || (c.linkedChangeRequests?.length ?? 0) > 0) && (
-            <LinkedChangeRequestsWidget changeRequests={c.linkedChangeRequests} />
-          )}
-          <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 1.5 }}>
-            <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 1, flexWrap: "wrap" }}>
-              <Typography variant="subtitle2">Linked service requests</Typography>
-              <Box sx={{ display: "flex", gap: 1 }}>
-                <Button
-                  size="small"
-                  variant="outlined"
-                  startIcon={<Plus size={14} />}
-                  onClick={() => {
-                    const navState: CreateServiceRequestFromCaseNavState = {
-                      projectId: c.projectId,
-                      relatedCaseId: c.id,
-                      relatedCaseNumber: c.caseNumber,
-                      deploymentId: c.productContext.deploymentId,
-                      deployedProductId: c.productContext.deployedProductId,
-                    };
-                    navigate("/operations/service-requests/new", { state: navState });
-                  }}
-                >
-                  Create service request
-                </Button>
-                <Button
-                  size="small"
-                  variant="outlined"
-                  startIcon={<LinkIcon size={14} />}
-                  onClick={() => setLinkCaseOpen(true)}
-                >
-                  Link to another case
-                </Button>
-              </Box>
-            </Box>
-            {c.linkedServiceRequests && c.linkedServiceRequests.length > 0 ? (
-              <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
-                {c.linkedServiceRequests.map((sr) => (
-                  <Chip
-                    key={sr.id}
-                    size="small"
-                    variant="outlined"
-                    clickable
-                    label={`${sr.number} — ${sr.name}`}
-                    onClick={() => navigate(`/cases/${encodeURIComponent(sr.id)}`)}
-                    sx={{ fontWeight: 600 }}
-                  />
-                ))}
-              </Box>
-            ) : (
-              <Typography variant="body2" color="text.secondary">
-                No service requests linked to this case.
-              </Typography>
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+          {/* Case-level action, not scoped to any one card below: the dialog
+              lets the user pick parent-vs-related for any target case, so it
+              doesn't belong nested inside one specific relationship card.
+              Left-aligned to read in flow with the cards' own title-left
+              layout below, rather than floating alone in right-side
+              whitespace. */}
+          <Box sx={{ display: "flex", justifyContent: "flex-start" }}>
+            <Button
+              size="small"
+              variant="outlined"
+              startIcon={<LinkIcon size={14} />}
+              onClick={() => setLinkCaseOpen(true)}
+            >
+              Link to another case
+            </Button>
+          </Box>
+          <Box
+            sx={{
+              display: "grid",
+              gap: 2,
+              gridTemplateColumns: {
+                xs: "1fr",
+                md: "repeat(2, minmax(0, 1fr))",
+              },
+              alignItems: "start",
+            }}
+          >
+            <ChildCasesWidget caseId={c.id} />
+            {/* Content-relevance, not a data-source gate: shown whenever this is
+                a service request (the only case type that carries the link) or
+                the list already has entries — never checks the record's data
+                source. */}
+            {(isServiceRequest || (c.linkedChangeRequests?.length ?? 0) > 0) && (
+              <LinkedChangeRequestsWidget changeRequests={c.linkedChangeRequests} />
             )}
-          </Card>
+            <LinkedServiceRequestsWidget
+              caseId={c.id}
+              linkedServiceRequests={c.linkedServiceRequests}
+              onCreateServiceRequest={() => {
+                const navState: CreateServiceRequestFromCaseNavState = {
+                  projectId: c.projectId,
+                  relatedCaseId: c.id,
+                  relatedCaseNumber: c.caseNumber,
+                  deploymentId: c.productContext.deploymentId,
+                  deployedProductId: c.productContext.deployedProductId,
+                };
+                navigate("/operations/service-requests/new", { state: navState });
+              }}
+            />
+          </Box>
         </Box>
       )}
 
@@ -2147,8 +2087,8 @@ export default function CsmCaseDetailPage(): JSX.Element {
         <Box sx={{ display: "grid", gap: 2, gridTemplateColumns: "1fr" }}>
           {/* Watchers list — moved off the (single-line) overview Cell so a
               long watch list has room to wrap as chips, and given its own
-              tab (split out of "Related") since it's not actually related
-              content. Add/remove are inline here (no separate dialog);
+              tab (split out of "Linked Items") since it's not actually a
+              linked record. Add/remove are inline here (no separate dialog);
               "Manage watchers…" in the action bar just jumps to this tab. */}
           <WatchersWidget
             watchers={c.watchers}

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -28,6 +28,7 @@ import {
   Skeleton,
   Tab,
   Tabs,
+  Tooltip,
   Typography,
 } from "@wso2/oxygen-ui";
 import {
@@ -2037,14 +2038,24 @@ export default function CsmCaseDetailPage(): JSX.Element {
               layout below, rather than floating alone in right-side
               whitespace. */}
           <Box sx={{ display: "flex", justifyContent: "flex-start" }}>
-            <Button
-              size="small"
-              variant="outlined"
-              startIcon={<LinkIcon size={14} />}
-              onClick={() => setLinkCaseOpen(true)}
-            >
-              Link to another case
-            </Button>
+            {/* Same read-only-once-closed rule as the comment composer,
+                attachment upload, and tag add/remove below — a link PATCH
+                on a closed case would otherwise fail server-side and only
+                surface as a generic error banner instead of being disabled
+                up front with a clear reason. */}
+            <Tooltip title={isClosed ? "This case is closed — it's read-only." : ""}>
+              <Box component="span">
+                <Button
+                  size="small"
+                  variant="outlined"
+                  startIcon={<LinkIcon size={14} />}
+                  onClick={() => setLinkCaseOpen(true)}
+                  disabled={isClosed}
+                >
+                  Link to another case
+                </Button>
+              </Box>
+            </Tooltip>
           </Box>
           <Box
             sx={{
@@ -2068,6 +2079,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
             <LinkedServiceRequestsWidget
               caseId={c.id}
               linkedServiceRequests={c.linkedServiceRequests}
+              createDisabled={isClosed}
               onCreateServiceRequest={() => {
                 const navState: CreateServiceRequestFromCaseNavState = {
                   projectId: c.projectId,

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/DeploymentDetailsDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/DeploymentDetailsDialog.tsx
@@ -80,6 +80,9 @@ export default function DeploymentDetailsDialog({
     >
       <Paper
         elevation={3}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="deployment-details-dialog-title"
         sx={{
           position: "fixed",
           top: "10vh",
@@ -96,7 +99,9 @@ export default function DeploymentDetailsDialog({
         }}
       >
         <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, flexWrap: "wrap", p: 3, pb: 2 }}>
-          <Typography variant="h6">{deployment.name || "Deployment"}</Typography>
+          <Typography id="deployment-details-dialog-title" variant="h6">
+            {deployment.name || "Deployment"}
+          </Typography>
           {deployment.type && (
             <Chip size="small" variant="outlined" label={deploymentTypeLabel(deployment.type)} />
           )}

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/DeploymentDetailsDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/DeploymentDetailsDialog.tsx
@@ -18,10 +18,9 @@ import {
   Box,
   Button,
   Chip,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
+  Divider,
+  Modal,
+  Paper,
   Typography,
 } from "@wso2/oxygen-ui";
 import { type JSX, type ReactNode } from "react";
@@ -56,7 +55,10 @@ function MetaCell({ label, children }: { label: string; children: ReactNode }): 
  * Read-only details for a single deployment: its metadata plus the products
  * deployed in it (loaded by {@link DeployedProductsPanel} when this dialog
  * mounts). Editing the deployment and managing deployed products are separate
- * concerns handled elsewhere / not yet backed by the API.
+ * concerns handled elsewhere / not yet backed by the API. A plain `Modal` +
+ * `Paper` rather than `Dialog` — same reasoning as {@link LinkCaseDialog}:
+ * `Dialog`'s paper renders on the theme's more opaque `background.paper`,
+ * while bare `Paper` gets the lighter, translucent "acrylic" look for free.
  */
 export default function DeploymentDetailsDialog({
   deployment,
@@ -71,17 +73,36 @@ export default function DeploymentDetailsDialog({
   );
 
   return (
-    <Dialog open onClose={onClose} maxWidth="md" fullWidth>
-      <DialogTitle>
-        <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, flexWrap: "wrap" }}>
-          <span>{deployment.name || "Deployment"}</span>
+    <Modal
+      open
+      onClose={onClose}
+      slotProps={{ backdrop: { sx: { backgroundColor: "transparent" } } }}
+    >
+      <Paper
+        elevation={3}
+        sx={{
+          position: "fixed",
+          top: "10vh",
+          left: "50%",
+          transform: "translateX(-50%)",
+          width: { xs: "calc(100% - 32px)", sm: "calc(100% - 64px)", md: 900 },
+          maxWidth: 900,
+          maxHeight: "80vh",
+          display: "flex",
+          flexDirection: "column",
+          outline: "none",
+          border: "1px solid",
+          borderColor: "divider",
+        }}
+      >
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, flexWrap: "wrap", p: 3, pb: 2 }}>
+          <Typography variant="h6">{deployment.name || "Deployment"}</Typography>
           {deployment.type && (
             <Chip size="small" variant="outlined" label={deploymentTypeLabel(deployment.type)} />
           )}
         </Box>
-      </DialogTitle>
-      <DialogContent dividers>
-        <Box sx={{ display: "flex", flexDirection: "column", gap: 2.5 }}>
+        <Divider />
+        <Box sx={{ p: 3, overflowY: "auto", display: "flex", flexDirection: "column", gap: 2.5 }}>
           {hasMeta && (
             <Box
               sx={{
@@ -110,10 +131,13 @@ export default function DeploymentDetailsDialog({
 
           <DeployedProductsPanel deploymentId={deployment.id} projectId={deployment.projectId} />
         </Box>
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={onClose}>Close</Button>
-      </DialogActions>
-    </Dialog>
+        <Divider />
+        <Box sx={{ display: "flex", justifyContent: "flex-end", p: 2 }}>
+          <Button variant="outlined" color="inherit" onClick={onClose}>
+            Close
+          </Button>
+        </Box>
+      </Paper>
+    </Modal>
   );
 }

--- a/apps/csm-portal/webapp/src/features/csm-projects/pages/CsmProjectDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/pages/CsmProjectDetailPage.tsx
@@ -28,7 +28,7 @@ import {
 } from "@wso2/oxygen-ui";
 import { ArrowLeft, ChevronDown, Plus } from "@wso2/oxygen-ui-icons-react";
 import { useState, type JSX, type MouseEvent, type ReactNode } from "react";
-import { Link as RouterLink, useParams } from "react-router";
+import { Link as RouterLink, useLocation, useParams } from "react-router";
 import { useGetProject } from "@features/csm-projects/api/useGetProject";
 import CsmIssuesView from "@features/csm-cases/components/CsmIssuesView";
 import ClosureStateChip from "@features/csm-projects/components/ClosureStateChip";
@@ -126,7 +126,7 @@ function BackButton({ onClick }: { onClick: () => void }): JSX.Element {
       onClick={onClick}
       sx={{ alignSelf: "flex-start" }}
     >
-      Back to projects
+      Back
     </Button>
   );
 }
@@ -134,6 +134,12 @@ function BackButton({ onClick }: { onClick: () => void }): JSX.Element {
 export default function CsmProjectDetailPage(): JSX.Element {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavTransition();
+  const location = useLocation();
+  // Prefer wherever the caller came from (e.g. a case's Overview panel) over
+  // the hardcoded projects list, so Back returns to that page instead of
+  // skipping past it — same convention as CsmCaseDetailPage's own back path.
+  const fromListState = location.state as { from?: string } | undefined;
+  const resolvedBackPath = fromListState?.from ?? "/customers/projects";
   const { data, isLoading, isError } = useGetProject(id);
   const [activeTab, setActiveTab] = useState<ProjectTabId>("overview");
   const [createMenuAnchor, setCreateMenuAnchor] = useState<HTMLElement | null>(
@@ -152,7 +158,7 @@ export default function CsmProjectDetailPage(): JSX.Element {
   if (isError) {
     return (
       <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
-        <BackButton onClick={() => navigate("/customers/projects")} />
+        <BackButton onClick={() => navigate(resolvedBackPath)} />
         <Typography variant="body1" color="error">
           Could not load project {id}.
         </Typography>
@@ -163,7 +169,7 @@ export default function CsmProjectDetailPage(): JSX.Element {
   if (!data) {
     return (
       <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
-        <BackButton onClick={() => navigate("/customers/projects")} />
+        <BackButton onClick={() => navigate(resolvedBackPath)} />
         <Typography variant="h5">Project not found</Typography>
         <Typography variant="body2" color="text.secondary">
           No project with id <code>{id}</code>.
@@ -176,7 +182,7 @@ export default function CsmProjectDetailPage(): JSX.Element {
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 2.5 }}>
-      <BackButton onClick={() => navigate("/customers/projects")} />
+      <BackButton onClick={() => navigate(resolvedBackPath)} />
 
       <Box
         sx={{

--- a/apps/csm-portal/webapp/src/features/csm-projects/pages/CsmProjectsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/pages/CsmProjectsPage.tsx
@@ -27,10 +27,10 @@ import {
   TextField,
   Typography,
 } from "@wso2/oxygen-ui";
-import { useMemo, useState, type ChangeEvent, type JSX } from "react";
-import { Link as RouterLink } from "react-router";
+import { useMemo, useState, type ChangeEvent, type JSX, type KeyboardEvent } from "react";
 import QueryErrorState from "@components/QueryErrorState";
 import { useDebouncedValue } from "@hooks/useDebouncedValue";
+import { useNavTransition } from "@hooks/useNavTransition";
 import { useSearchProjects } from "@features/csm-projects/api/useSearchProjects";
 import ClosureStateChip from "@features/csm-projects/components/ClosureStateChip";
 import type { SearchProjectsRequest } from "@features/csm-projects/types/csmProjects";
@@ -53,6 +53,7 @@ function formatDate(value?: string | null): string {
 }
 
 export default function CsmProjectsPage(): JSX.Element {
+  const navigate = useNavTransition();
   const [searchInput, setSearchInput] = useState("");
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_ROWS_PER_PAGE);
@@ -139,34 +140,48 @@ export default function CsmProjectsPage(): JSX.Element {
                   </TableCell>
                 </TableRow>
               ) : (
-                projects.map((p) => (
-                  <TableRow key={p.id} hover>
-                    <TableCell>
-                      <Typography
-                        component={RouterLink}
-                        to={`/customers/projects/${p.id}`}
-                        variant="body2"
-                        sx={(t) => ({
-                          textDecoration: "none",
-                          color: t.palette.primary.dark,
-                          ...t.applyStyles("dark", { color: t.palette.primary.main }),
-                          "&:hover": { textDecoration: "underline" },
-                        })}
-                      >
-                        {p.name}
-                      </Typography>
-                    </TableCell>
-                    <TableCell>{p.key}</TableCell>
-                    <TableCell>
-                      <ClosureStateChip
-                        closureState={p.closureState}
-                        emptyFallback="—"
-                      />
-                    </TableCell>
-                    <TableCell>{formatDate(p.startDate)}</TableCell>
-                    <TableCell>{formatDate(p.endDate)}</TableCell>
-                  </TableRow>
-                ))
+                projects.map((p) => {
+                  const goToProject = (): void => navigate(`/customers/projects/${p.id}`);
+                  const handleRowKeyDown = (e: KeyboardEvent<HTMLTableRowElement>): void => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      goToProject();
+                    }
+                  };
+                  return (
+                    <TableRow
+                      key={p.id}
+                      hover
+                      onClick={goToProject}
+                      onKeyDown={handleRowKeyDown}
+                      tabIndex={0}
+                      aria-label={`View project ${p.name}`}
+                      sx={{
+                        cursor: "pointer",
+                        "&:focus-visible": {
+                          outline: "2px solid",
+                          outlineColor: "primary.main",
+                          outlineOffset: -2,
+                        },
+                      }}
+                    >
+                      <TableCell>
+                        <Typography variant="body2" noWrap>
+                          {p.name}
+                        </Typography>
+                      </TableCell>
+                      <TableCell>{p.key}</TableCell>
+                      <TableCell>
+                        <ClosureStateChip
+                          closureState={p.closureState}
+                          emptyFallback="—"
+                        />
+                      </TableCell>
+                      <TableCell>{formatDate(p.startDate)}</TableCell>
+                      <TableCell>{formatDate(p.endDate)}</TableCell>
+                    </TableRow>
+                  );
+                })
               )}
             </TableBody>
           </Table>


### PR DESCRIPTION
## Summary
- Renamed the "Related" tab to "Linked Items" (collided with the "related case" link type) and restyled Linked service requests as a table matching Child cases.
- Moved "Link to another case" to a shared tab-level action, and moved Related/Parent chips out of the crowded header row into CaseMetaBand's Overview cells.
- Reordered CaseActionBar so Acknowledge trails the primary state action; shows "Acknowledged by" in that slot once claimed.
- Fixed back-navigation: clicking into a child case, linked SR, related/parent case, or an Account/Project from the case Overview now passes `state: { from }` so Back returns to the originating case instead of a hardcoded list route. `CsmAccountDetailPage`/`CsmProjectDetailPage` didn't implement this pattern at all — added it.
- Restyled `LinkCaseDialog` and `DeploymentDetailsDialog` as translucent Modal+Paper (matching the create-case project-confirmation panel) instead of the opaque `Dialog`; `LinkCaseDialog` now confirms the picked case before linking instead of linking on row-click.
- Made the Accounts/Projects list tables consistent with the Users table: whole row clickable, no hover-underline on the name link.

## Test plan
- [ ] Case detail → Linked Items tab: verify Child cases / Linked service requests tables render, empty-state row height/alignment, "Link to another case" opens the restyled dialog and links correctly.
- [ ] Acknowledge a case, confirm the action bar reorders and shows "Acknowledged by".
- [ ] From a case, click a child case / linked SR / related / parent / Account / Project, then click Back — confirm it returns to the originating case (not a list).
- [ ] Accounts and Projects list pages: click anywhere in a row to navigate; hover shows no underline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added linked service request and case relationship views to case details.
  * Added a confirmation step when linking cases.
  * Account and project rows now support click and keyboard navigation.
  * Back navigation now returns to the originating page when available.
* **Improvements**
  * Updated case action feedback with success notifications.
  * Refined deployment details and linking dialogs.
  * Improved table layouts, truncation, focus styling, and accessibility labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->