### PR TITLE
[CSM Portal] add cross-case call request search and dashboard widget support

### DIFF
--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -145,7 +145,7 @@ func main() {
 	mux.HandleFunc("DELETE /attachments/{id}", caseHandler.DeleteCaseAttachment)
 	mux.HandleFunc("POST /cases/{id}/call-requests", caseHandler.CreateCallRequest)
 	mux.HandleFunc("POST /cases/{id}/call-requests/search", caseHandler.SearchCallRequests)
-	mux.HandleFunc("POST /call-requests/search-all", caseHandler.SearchAllCallRequests)
+	mux.HandleFunc("POST /call-requests/search", caseHandler.SearchAllCallRequests)
 	mux.HandleFunc("PATCH /cases/{caseId}/call-requests/{callRequestId}", caseHandler.PatchCallRequest)
 	mux.HandleFunc("POST /cases/{id}/github-issues", caseHandler.CreateCaseGithubIssue)
 	mux.HandleFunc("POST /cases/{id}/tags", caseHandler.AddCaseTag)

--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -145,6 +145,7 @@ func main() {
 	mux.HandleFunc("DELETE /attachments/{id}", caseHandler.DeleteCaseAttachment)
 	mux.HandleFunc("POST /cases/{id}/call-requests", caseHandler.CreateCallRequest)
 	mux.HandleFunc("POST /cases/{id}/call-requests/search", caseHandler.SearchCallRequests)
+	mux.HandleFunc("POST /call-requests/search-all", caseHandler.SearchAllCallRequests)
 	mux.HandleFunc("PATCH /cases/{caseId}/call-requests/{callRequestId}", caseHandler.PatchCallRequest)
 	mux.HandleFunc("POST /cases/{id}/github-issues", caseHandler.CreateCaseGithubIssue)
 	mux.HandleFunc("POST /cases/{id}/tags", caseHandler.AddCaseTag)

--- a/apps/csm-portal/backend/internal/dashboard/registry.go
+++ b/apps/csm-portal/backend/internal/dashboard/registry.go
@@ -352,6 +352,7 @@ var validWidgetResourceTypes = map[ResourceType]bool{
 	ResourceCase: true, ResourceIncident: true, ResourceChangeRequest: true,
 	ResourceAccount: true, ResourceProject: true, ResourceUser: true,
 	ResourceTimeCard: true, ResourceProblem: true, ResourceProductVulnerability: true,
+	ResourceCallRequest: true,
 }
 
 var validWidgetShapes = map[Shape]bool{

--- a/apps/csm-portal/backend/internal/dashboard/widgets.go
+++ b/apps/csm-portal/backend/internal/dashboard/widgets.go
@@ -50,6 +50,7 @@ const (
 	ResourceTimeCard             ResourceType = "time_card"
 	ResourceProblem              ResourceType = "problem"
 	ResourceProductVulnerability ResourceType = "product_vulnerability"
+	ResourceCallRequest          ResourceType = "call_request"
 )
 
 // Shape is how a widget's resolved data should be rendered.

--- a/apps/csm-portal/backend/internal/entity/customer.go
+++ b/apps/csm-portal/backend/internal/entity/customer.go
@@ -347,6 +347,13 @@ func (c *CustomerEntityClient) SearchCallRequests(ctx context.Context, body []by
 	return c.do(ctx, http.MethodPost, "/call-requests/search", body)
 }
 
+// SearchAllCallRequests calls POST /call-requests/search-all on the entity service
+// (standalone call request search, not scoped to a parent case). Response is
+// returned as raw JSON; typed response structs are deferred.
+func (c *CustomerEntityClient) SearchAllCallRequests(ctx context.Context, body []byte) ([]byte, error) {
+	return c.do(ctx, http.MethodPost, "/call-requests/search-all", body)
+}
+
 // PatchCallRequest calls PATCH /call-requests/{id} on the entity service.
 // Response is returned as raw JSON.
 func (c *CustomerEntityClient) PatchCallRequest(ctx context.Context, callRequestID string, body []byte) ([]byte, error) {

--- a/apps/csm-portal/backend/internal/handler/cases.go
+++ b/apps/csm-portal/backend/internal/handler/cases.go
@@ -885,9 +885,13 @@ func (h *CaseHandler) SearchCallRequests(w http.ResponseWriter, r *http.Request)
 	writeJSON(w, http.StatusOK, result)
 }
 
-// SearchAllCallRequests handles POST /call-requests/search-all — standalone call
+// SearchAllCallRequests handles POST /call-requests/search — standalone call
 // request search across all cases (not scoped to one case; see SearchCallRequests
-// for that path). Raw pass-through body/response.
+// for that path, which is nested under /cases/{id}/). Raw pass-through
+// body/response. Despite the shared "search" name with the case-scoped path,
+// this is a distinct route (flat, no case-id path param) with no collision --
+// forwards to the entity service's own /call-requests/search-all, which keeps
+// its "-all" suffix to stay distinct from ITS sibling case-scoped path.
 func (h *CaseHandler) SearchAllCallRequests(w http.ResponseWriter, r *http.Request) {
 	user := middleware.UserInfoFromContext(r.Context())
 	if user == nil {

--- a/apps/csm-portal/backend/internal/handler/cases.go
+++ b/apps/csm-portal/backend/internal/handler/cases.go
@@ -83,6 +83,7 @@ type entityCaseClient interface {
 	DeleteCaseAttachment(ctx context.Context, attachmentID string) ([]byte, error)
 	CreateCallRequest(ctx context.Context, body []byte) ([]byte, error)
 	SearchCallRequests(ctx context.Context, body []byte) ([]byte, error)
+	SearchAllCallRequests(ctx context.Context, body []byte) ([]byte, error)
 	PatchCallRequest(ctx context.Context, callRequestID string, body []byte) ([]byte, error)
 	CreateCaseGithubIssue(ctx context.Context, caseID string, body []byte) ([]byte, error)
 	AddCaseTag(ctx context.Context, caseID string, body []byte) ([]byte, error)
@@ -877,6 +878,43 @@ func (h *CaseHandler) SearchCallRequests(w http.ResponseWriter, r *http.Request)
 	result, err := h.entity.SearchCallRequests(r.Context(), entityBody)
 	if err != nil {
 		slog.ErrorContext(r.Context(), "entity SearchCallRequests failed", "userID", user.UserID, "caseID", caseID, "err", err)
+		mapUpstreamErrorGeneric(w, err, "Failed to search call requests.")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, result)
+}
+
+// SearchAllCallRequests handles POST /call-requests/search-all — standalone call
+// request search across all cases (not scoped to one case; see SearchCallRequests
+// for that path). Raw pass-through body/response.
+func (h *CaseHandler) SearchAllCallRequests(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			writeError(w, http.StatusRequestEntityTooLarge, ErrMsgTooLarge)
+			return
+		}
+		writeError(w, http.StatusBadRequest, errMsgReadBody)
+		return
+	}
+
+	if !json.Valid(body) {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.SearchAllCallRequests(r.Context(), body)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity SearchAllCallRequests failed", "userID", user.UserID, "err", err)
 		mapUpstreamErrorGeneric(w, err, "Failed to search call requests.")
 		return
 	}

--- a/apps/csm-portal/backend/internal/handler/cases.go
+++ b/apps/csm-portal/backend/internal/handler/cases.go
@@ -911,7 +911,7 @@ func (h *CaseHandler) SearchAllCallRequests(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	if !json.Valid(body) {
+	if !isJSONObjectOrEmpty(body) {
 		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
 		return
 	}

--- a/apps/csm-portal/backend/internal/handler/helpers_test.go
+++ b/apps/csm-portal/backend/internal/handler/helpers_test.go
@@ -99,6 +99,7 @@ type mockEntityCaseClient struct {
 	deleteCaseAttachmentFn     func(ctx context.Context, attachmentID string) ([]byte, error)
 	createCallRequestFn        func(ctx context.Context, body []byte) ([]byte, error)
 	searchCallRequestsFn       func(ctx context.Context, body []byte) ([]byte, error)
+	searchAllCallRequestsFn    func(ctx context.Context, body []byte) ([]byte, error)
 	patchCallRequestFn         func(ctx context.Context, callRequestID string, body []byte) ([]byte, error)
 	createCaseGithubIssueFn    func(ctx context.Context, caseID string, body []byte) ([]byte, error)
 	addCaseTagFn               func(ctx context.Context, caseID string, body []byte) ([]byte, error)
@@ -193,6 +194,13 @@ func (m *mockEntityCaseClient) CreateCallRequest(ctx context.Context, body []byt
 func (m *mockEntityCaseClient) SearchCallRequests(ctx context.Context, body []byte) ([]byte, error) {
 	if m.searchCallRequestsFn != nil {
 		return m.searchCallRequestsFn(ctx, body)
+	}
+	return []byte(`{"callRequests":[],"total":0,"limit":20,"offset":0}`), nil
+}
+
+func (m *mockEntityCaseClient) SearchAllCallRequests(ctx context.Context, body []byte) ([]byte, error) {
+	if m.searchAllCallRequestsFn != nil {
+		return m.searchAllCallRequestsFn(ctx, body)
 	}
 	return []byte(`{"callRequests":[],"total":0,"limit":20,"offset":0}`), nil
 }

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -2299,6 +2299,53 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
+  /call-requests/search-all:
+    post:
+      summary: Search call requests across all cases, filtered by assignee/state.
+      description: >
+        Returns a paginated list of call requests (ServiceNow data source only). Call
+        requests are inherently case-related; this endpoint provides independent search
+        and filtering capabilities across cases, distinct from
+        /cases/{id}/call-requests/search which is scoped to a single case.
+      operationId: searchAllCallRequests
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SearchAllCallRequestsPayload'
+      responses:
+        "200":
+          description: Call requests matching the supplied filters.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchCallRequestsResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
   /cases/{caseId}/call-requests/{callRequestId}:
     patch:
       summary: Update a call request (ServiceNow data source only). Alias with caseId param name.
@@ -5327,6 +5374,7 @@ components:
             - time_card
             - problem
             - product_vulnerability
+            - call_request
           description: Which resource's /search endpoint this widget's filters target
         shape:
           type: string
@@ -8583,6 +8631,54 @@ components:
                   - notes_pending
                   - concluded
               description: Filter by one or more states.
+        pagination:
+          allOf:
+            - $ref: '#/components/schemas/Pagination'
+            - properties:
+                limit:
+                  default: 20
+                  maximum: 100
+
+    SearchAllCallRequestsPayload:
+      type: object
+      additionalProperties: false
+      properties:
+        filters:
+          type: object
+          additionalProperties: false
+          properties:
+            assignedUserIds:
+              type: array
+              items:
+                type: string
+                format: uuid
+              description: Filter by the parent case's assigned user(s).
+            states:
+              type: array
+              items:
+                type: string
+                enum:
+                  - pending_on_customer
+                  - pending_on_wso2
+                  - scheduled
+                  - customer_rejected
+                  - wso2_rejected
+                  - canceled
+                  - notes_pending
+                  - concluded
+              description: Filter by one or more states.
+        sortBy:
+          type: object
+          additionalProperties: false
+          properties:
+            field:
+              type: string
+              enum: [createdOn, updatedOn, scheduleTime]
+              description: Field to sort by.
+            order:
+              type: string
+              enum: [asc, desc]
+              description: Sort direction.
         pagination:
           allOf:
             - $ref: '#/components/schemas/Pagination'

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -2299,14 +2299,16 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
-  /call-requests/search-all:
+  /call-requests/search:
     post:
       summary: Search call requests across all cases, filtered by assignee/state.
       description: >
         Returns a paginated list of call requests (ServiceNow data source only). Call
         requests are inherently case-related; this endpoint provides independent search
         and filtering capabilities across cases, distinct from
-        /cases/{id}/call-requests/search which is scoped to a single case.
+        /cases/{id}/call-requests/search which is scoped to a single case. Forwards to
+        the entity service's /call-requests/search-all, which keeps its "-all" suffix
+        to stay distinct from that service's own case-scoped sibling path.
       operationId: searchAllCallRequests
       requestBody:
         required: true

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -2770,7 +2770,8 @@ export type BeWidgetResourceType =
   | "time_card"
   | "problem"
   | "product_vulnerability"
-  | "task";
+  | "task"
+  | "call_request";
 
 /**
  * How a widget's resolved data should be rendered. `pie` and `bar` both

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
@@ -112,6 +112,9 @@ export default function DashboardWidgetTile({
     selectedTeamGroupId,
   );
   const config = WIDGET_RESOURCE_CONFIG[resourceType];
+  // Thousands separators for shape "count"'s big number -- used both in the
+  // visible Typography and the tile's aria-label, so both stay in sync.
+  const formattedCount = (data?.total ?? 0).toLocaleString();
 
   if (!config) {
     // resourceType came from a runtime-configurable backend registry (not a
@@ -385,7 +388,7 @@ export default function DashboardWidgetTile({
               textOverflow: "ellipsis",
             }}
           >
-            {data?.total ?? 0}
+            {formattedCount}
           </Typography>
         </Box>
       </Box>
@@ -414,7 +417,7 @@ export default function DashboardWidgetTile({
         // layer above this anchor, not inside it as descendant text anymore
         // (that's the whole point -- see the comment above), so it needs its
         // own accessible name instead of inheriting one from its content.
-        aria-label={`${displayName}: ${data?.total ?? 0}`}
+        aria-label={`${displayName}: ${formattedCount}`}
         sx={{
           position: "absolute",
           inset: 0,

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetListConfig.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetListConfig.tsx
@@ -55,6 +55,7 @@ import { normalizeUser, type User, type SnUser } from "@features/csm-users/types
 import UserRefLink from "@components/UserRefLink";
 import { vulnerabilityPriorityColor } from "@features/csm-security-center/utils/vulnerabilities";
 import type { BeProductVulnerabilityView } from "@api/backend/types";
+import type { BeCallRequestView } from "@api/backend/types";
 
 /** Raw item shape a dashboard widget's `/search` response resolves to —
  * matches `WidgetItem` in `widgetResourceConfig.ts` (kept loose there since
@@ -454,6 +455,47 @@ function TaskWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.Elem
   );
 }
 
+/** Call request: unlike task, `CallRequestView.case.id` is always present, so
+ * rows navigate straight to the owning case's real detail page rather than
+ * opening a dialog. */
+function CallRequestWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.Element {
+  const callRequests = items as unknown as BeCallRequestView[];
+  return (
+    <DashboardMiniTable
+      isLoading={isLoading}
+      emptyMessage="No call requests match this widget's filters."
+      columns={[
+        { label: "Number", width: "minmax(90px, 0.7fr)" },
+        { label: "Reason", width: "minmax(160px, 2fr)" },
+        { label: "State", width: "minmax(100px, 1fr)" },
+        { label: "Scheduled", width: "minmax(90px, 1fr)" },
+      ]}
+      rows={callRequests.map((cr, i) => ({
+        key: cr.id ?? `call-request-${i}`,
+        href: cr.case?.id ? `/cases/${cr.case.id}` : undefined,
+        cells: [
+          <Typography key="number" variant="body2" noWrap>
+            {cr.number || "—"}
+          </Typography>,
+          <Typography key="reason" variant="body2" noWrap title={cr.reason ?? undefined}>
+            {cr.reason || "—"}
+          </Typography>,
+          cr.state?.label ? (
+            <Chip key="state" size="small" variant="outlined" label={cr.state.label} />
+          ) : (
+            <Typography key="state" variant="body2">
+              —
+            </Typography>
+          ),
+          <Typography key="scheduled" variant="caption" color="text.secondary" noWrap>
+            {formatDate(cr.scheduleTime)}
+          </Typography>,
+        ],
+      }))}
+    />
+  );
+}
+
 /** Per-resourceType renderer for a `shape: "list"` dashboard widget. Every
  * resource type is covered — `WIDGET_RESOURCE_CONFIG` (in
  * `widgetResourceConfig.ts`) is keyed the same way, so a missing entry here
@@ -472,4 +514,5 @@ export const WIDGET_LIST_RENDERERS: Record<
   time_card: TimeCardWidgetList,
   product_vulnerability: ProductVulnerabilityWidgetList,
   task: TaskWidgetList,
+  call_request: CallRequestWidgetList,
 };

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetListConfig.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetListConfig.tsx
@@ -71,6 +71,21 @@ function formatDate(value?: string | null): string {
   );
 }
 
+/** Date + time, for columns where same-day values must stay distinguishable
+ * (e.g. a call request's scheduled time) -- `formatDate` alone drops the
+ * hour/minute and collapses same-day rows to an identical-looking value. */
+function formatDateTime(value?: string | null): string {
+  return (
+    formatBackendTimestampForDisplay(value, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    }) ?? "—"
+  );
+}
+
 export interface WidgetListRendererProps {
   items: WidgetItem[];
   isLoading: boolean;
@@ -488,7 +503,7 @@ function CallRequestWidgetList({ items, isLoading }: WidgetListRendererProps): J
             </Typography>
           ),
           <Typography key="scheduled" variant="caption" color="text.secondary" noWrap>
-            {formatDate(cr.scheduleTime)}
+            {formatDateTime(cr.scheduleTime)}
           </Typography>,
         ],
       }))}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.ts
@@ -470,6 +470,28 @@ export const WIDGET_RESOURCE_CONFIG: Record<
     iconColor: "warning",
     previewSlug: "tasks",
   },
+  call_request: {
+    searchEndpoint: "/call-requests/search-all",
+    itemsKey: "callRequests",
+    primaryLabel: (item) => {
+      const number = asString(item.number);
+      const reason = asString(item.reason);
+      return [number, reason].filter(Boolean).join(" — ") || "—";
+    },
+    secondaryLabel: (item) => {
+      const state = item.state as { label?: string } | undefined;
+      return state?.label;
+    },
+    // No widget filters a call request by anything the cases list can render as a
+    // filtered view (state keys differ entirely from case state), so the tile-level
+    // "view all" click has nowhere sensible to land other than the dashboard itself
+    // -- unlike a per-row click, which goes straight to the owning case (see the
+    // list renderer in widgetListConfig.tsx, not this file).
+    buildHref: () => "/dashboard",
+    icon: Clock,
+    iconColor: "info",
+    previewSlug: "call-requests",
+  },
 };
 
 /** Reverse lookup of `previewSlug` back to its `resourceType`, for the

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.ts
@@ -471,7 +471,7 @@ export const WIDGET_RESOURCE_CONFIG: Record<
     previewSlug: "tasks",
   },
   call_request: {
-    searchEndpoint: "/call-requests/search-all",
+    searchEndpoint: "/call-requests/search",
     itemsKey: "callRequests",
     primaryLabel: (item) => {
       const number = asString(item.number);

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -2880,6 +2880,44 @@ type SearchCallRequestsResponse struct {
 	Limit        int               `json:"limit"`
 }
 
+// CallRequestSortField enumerates the columns available for sorting a
+// cross-case call request search.
+type CallRequestSortField string
+
+const (
+	CallRequestSortFieldCreatedOn    CallRequestSortField = "createdOn"
+	CallRequestSortFieldUpdatedOn    CallRequestSortField = "updatedOn"
+	CallRequestSortFieldScheduleTime CallRequestSortField = "scheduleTime"
+)
+
+// CallRequestSortOrder controls the sort direction for call request search.
+type CallRequestSortOrder string
+
+const (
+	CallRequestSortOrderAsc  CallRequestSortOrder = "asc"
+	CallRequestSortOrderDesc CallRequestSortOrder = "desc"
+)
+
+// CallRequestSort specifies the sort field and direction for call request search results.
+type CallRequestSort struct {
+	Field CallRequestSortField `json:"field"`
+	Order CallRequestSortOrder `json:"order"`
+}
+
+// SearchAllCallRequestsFilters holds optional filter criteria for the
+// standalone (not case-scoped) call request search.
+type SearchAllCallRequestsFilters struct {
+	AssignedUserIDs []string               `json:"assignedUserIds"`
+	States          []CallRequestStateType `json:"states"`
+}
+
+// SearchAllCallRequestsRequest is the input for POST /call-requests/search-all.
+type SearchAllCallRequestsRequest struct {
+	Filters    SearchAllCallRequestsFilters `json:"filters"`
+	SortBy     CallRequestSort              `json:"sortBy"`
+	Pagination Pagination                   `json:"pagination"`
+}
+
 // UpdateCallRequestRequest is the input for PATCH /call-requests/{id}.
 // ID is injected from the URL path parameter and excluded from JSON decoding.
 // CaseID is optional; when provided the SN service verifies the call request

--- a/entity-service/internal/handler/call_request_handler.go
+++ b/entity-service/internal/handler/call_request_handler.go
@@ -67,6 +67,21 @@ func (h *CallRequestHandler) SearchCallRequests(w http.ResponseWriter, r *http.R
 	_ = json.NewEncoder(w).Encode(resp)
 }
 
+// SearchAllCallRequests handles POST /call-requests/search-all.
+func (h *CallRequestHandler) SearchAllCallRequests(w http.ResponseWriter, r *http.Request) {
+	var req domain.SearchAllCallRequestsRequest
+	if !decodeRequest(w, r, &req) {
+		return
+	}
+	resp, err := h.svc.SearchAllCallRequests(r.Context(), req)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
 // PatchCallRequest handles PATCH /call-requests/{id}.
 func (h *CallRequestHandler) PatchCallRequest(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -283,6 +283,7 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 	if callRequestHandler != nil {
 		mux.HandleFunc("POST /call-requests", callRequestHandler.CreateCallRequest)
 		mux.HandleFunc("POST /call-requests/search", callRequestHandler.SearchCallRequests)
+		mux.HandleFunc("POST /call-requests/search-all", callRequestHandler.SearchAllCallRequests)
 		mux.HandleFunc("PATCH /call-requests/{id}", callRequestHandler.PatchCallRequest)
 	}
 

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -262,6 +262,11 @@ type CallRequestService interface {
 	// SearchCallRequests returns a paginated list of call requests for the given case.
 	// A ValidationError is returned for invalid input.
 	SearchCallRequests(ctx context.Context, req domain.SearchCallRequestsRequest) (domain.SearchCallRequestsResponse, error)
+	// SearchAllCallRequests returns a paginated list of call requests across all
+	// cases, filtered by assignee/state -- distinct from SearchCallRequests, which
+	// is scoped to one case and has no filter set of its own.
+	// A ValidationError is returned for invalid input.
+	SearchAllCallRequests(ctx context.Context, req domain.SearchAllCallRequestsRequest) (domain.SearchCallRequestsResponse, error)
 	// UpdateCallRequest updates the state or other fields of a call request.
 	// The target state selects the behaviour (customer/agent transitions, scheduling,
 	// rejection, conclusion with notes). A ValidationError is returned for invalid

--- a/entity-service/internal/service/sn_call_request_service.go
+++ b/entity-service/internal/service/sn_call_request_service.go
@@ -67,6 +67,24 @@ type snCallRequestSearchFilters struct {
 	StateKeys []int `json:"stateKeys,omitempty"`
 }
 
+// snCallRequestsSearchAllPayload mirrors POST /call-requests/search-all in the SN
+// integration service (standalone, not case-scoped).
+type snCallRequestsSearchAllPayload struct {
+	Filters    *snCallRequestsSearchAllFilters `json:"filters,omitempty"`
+	SortBy     *snCallRequestSort              `json:"sortBy,omitempty"`
+	Pagination snProjectPagination             `json:"pagination"`
+}
+
+type snCallRequestsSearchAllFilters struct {
+	AssignedUserIDs []string `json:"assignedUserIds,omitempty"`
+	StateKeys       []int    `json:"stateKeys,omitempty"`
+}
+
+type snCallRequestSort struct {
+	Field string `json:"field"`
+	Order string `json:"order"`
+}
+
 // snCallRequestsResponse mirrors the SN integration service POST /call-requests/search response.
 type snCallRequestsResponse struct {
 	CallRequests []snCallRequest `json:"callRequests"`
@@ -283,8 +301,23 @@ func (s *snCallRequestService) SearchCallRequests(ctx context.Context, req domai
 		return domain.SearchCallRequestsResponse{}, fmt.Errorf("sn call requests: parse search response: %w", err)
 	}
 
-	views := make([]domain.CallRequestView, 0, len(snResp.CallRequests))
-	for _, cr := range snResp.CallRequests {
+	views := mapSNCallRequestsToViews(snResp.CallRequests)
+
+	total := snResp.TotalRecords
+	return domain.SearchCallRequestsResponse{
+		CallRequests: views,
+		Total:        total,
+		Limit:        req.Pagination.Limit,
+		Offset:       req.Pagination.Offset,
+	}, nil
+}
+
+// mapSNCallRequestsToViews converts raw SN call request records to domain views.
+// Shared by SearchCallRequests (case-scoped) and SearchAllCallRequests (cross-case) --
+// both call the same underlying SN response shape.
+func mapSNCallRequestsToViews(crs []snCallRequest) []domain.CallRequestView {
+	views := make([]domain.CallRequestView, 0, len(crs))
+	for _, cr := range crs {
 		views = append(views, domain.CallRequestView{
 			ID:     sysidToUUID(cr.ID),
 			Number: cr.Number,
@@ -310,13 +343,89 @@ func (s *snCallRequestService) SearchCallRequests(ctx context.Context, req domai
 			ActualDurationMin:  cr.ActualDurationMin,
 		})
 	}
+	return views
+}
 
-	total := snResp.TotalRecords
+// validCallRequestSortField is the set of accepted CallRequestSortField values.
+var validCallRequestSortField = map[domain.CallRequestSortField]bool{
+	domain.CallRequestSortFieldCreatedOn:    true,
+	domain.CallRequestSortFieldUpdatedOn:    true,
+	domain.CallRequestSortFieldScheduleTime: true,
+}
+
+// validCallRequestSortOrder is the set of accepted CallRequestSortOrder values.
+var validCallRequestSortOrder = map[domain.CallRequestSortOrder]bool{
+	domain.CallRequestSortOrderAsc:  true,
+	domain.CallRequestSortOrderDesc: true,
+}
+
+// SearchAllCallRequests implements CallRequestService.
+func (s *snCallRequestService) SearchAllCallRequests(ctx context.Context, req domain.SearchAllCallRequestsRequest) (domain.SearchCallRequestsResponse, error) {
+	if err := normalizePagination(&req.Pagination); err != nil {
+		return domain.SearchCallRequestsResponse{}, err
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+
+	if err := validateUUIDs("filters.assignedUserIds", req.Filters.AssignedUserIDs); err != nil {
+		return domain.SearchCallRequestsResponse{}, err
+	}
+
+	if req.SortBy.Field == "" {
+		req.SortBy.Field = domain.CallRequestSortFieldUpdatedOn
+	} else if !validCallRequestSortField[req.SortBy.Field] {
+		return domain.SearchCallRequestsResponse{}, &apierror.ValidationError{Msg: "sortBy.field must be one of: createdOn, updatedOn, scheduleTime"}
+	}
+	if req.SortBy.Order == "" {
+		req.SortBy.Order = domain.CallRequestSortOrderDesc
+	} else if !validCallRequestSortOrder[req.SortBy.Order] {
+		return domain.SearchCallRequestsResponse{}, &apierror.ValidationError{Msg: "sortBy.order must be one of: asc, desc"}
+	}
+
+	payload := snCallRequestsSearchAllPayload{
+		Pagination: snProjectPagination{Limit: req.Pagination.Limit, Offset: req.Pagination.Offset},
+		SortBy: &snCallRequestSort{
+			Field: string(req.SortBy.Field),
+			Order: string(req.SortBy.Order),
+		},
+	}
+
+	var filters snCallRequestsSearchAllFilters
+	hasFilters := false
+	if len(req.Filters.AssignedUserIDs) > 0 {
+		filters.AssignedUserIDs = uuidsToSysids(req.Filters.AssignedUserIDs)
+		hasFilters = true
+	}
+	if len(req.Filters.States) > 0 {
+		keys := make([]int, 0, len(req.Filters.States))
+		for _, st := range req.Filters.States {
+			if _, ok := validCallRequestStates[st]; !ok {
+				return domain.SearchCallRequestsResponse{}, &apierror.ValidationError{Msg: fmt.Sprintf("invalid state %q", st)}
+			}
+			keys = append(keys, callRequestStateToKey[st])
+		}
+		filters.StateKeys = keys
+		hasFilters = true
+	}
+	if hasFilters {
+		payload.Filters = &filters
+	}
+
+	raw, err := s.client.Post(ctx, "/call-requests/search-all", token, payload)
+	if err != nil {
+		return domain.SearchCallRequestsResponse{}, err
+	}
+
+	var snResp snCallRequestsResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.SearchCallRequestsResponse{}, fmt.Errorf("sn call requests: parse search-all response: %w", err)
+	}
+
 	return domain.SearchCallRequestsResponse{
-		CallRequests: views,
-		Total:        total,
-		Limit:        req.Pagination.Limit,
+		CallRequests: mapSNCallRequestsToViews(snResp.CallRequests),
+		Total:        snResp.TotalRecords,
 		Offset:       req.Pagination.Offset,
+		Limit:        req.Pagination.Limit,
 	}, nil
 }
 

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -6809,11 +6809,13 @@ components:
         field:
           type: string
           enum: [createdOn, updatedOn, scheduleTime]
-          description: Field to sort by.
+          default: updatedOn
+          description: Field to sort by. Defaults to updatedOn when omitted.
         order:
           type: string
           enum: [asc, desc]
-          description: Sort direction.
+          default: desc
+          description: Sort direction. Defaults to desc when omitted.
 
     SearchAllCallRequestsFilters:
       type: object

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -1490,6 +1490,47 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /call-requests/search-all:
+    post:
+      summary: Search call requests across all cases, filtered by assignee/state.
+      description: >
+        Returns a paginated list of call requests (ServiceNow data source only). Call
+        requests are inherently case-related; this endpoint provides independent search
+        and filtering capabilities across cases, distinct from /call-requests/search
+        which is scoped to a single case.
+      operationId: searchAllCallRequests
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SearchAllCallRequestsRequest'
+      responses:
+        "200":
+          description: Call requests matching the supplied filters.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchCallRequestsResponse'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /call-requests/{id}:
     patch:
       summary: Update a call request (supported by the backing data source only).
@@ -6760,6 +6801,55 @@ components:
           type: integer
         limit:
           type: integer
+
+    CallRequestSort:
+      type: object
+      additionalProperties: false
+      properties:
+        field:
+          type: string
+          enum: [createdOn, updatedOn, scheduleTime]
+          description: Field to sort by.
+        order:
+          type: string
+          enum: [asc, desc]
+          description: Sort direction.
+
+    SearchAllCallRequestsFilters:
+      type: object
+      additionalProperties: false
+      properties:
+        assignedUserIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+          description: Filter by the parent case's assigned user(s).
+        states:
+          type: array
+          items:
+            type: string
+            enum:
+              - pending_on_customer
+              - pending_on_wso2
+              - scheduled
+              - customer_rejected
+              - wso2_rejected
+              - canceled
+              - notes_pending
+              - concluded
+          description: Filter by one or more call request states.
+
+    SearchAllCallRequestsRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        filters:
+          $ref: '#/components/schemas/SearchAllCallRequestsFilters'
+        sortBy:
+          $ref: '#/components/schemas/CallRequestSort'
+        pagination:
+          $ref: '#/components/schemas/Pagination'
 
     UpdateCallRequestRequest:
       type: object


### PR DESCRIPTION
## Purpose
The CSM portal only supported searching call requests within a single case. There was no way to see call requests across all of a CS engineer's cases (e.g. for a dashboard tile listing pending call requests), and dashboard widget config had no resource type for call requests at all.

## Goals
- Add a standalone, cross-case call request search through the Go entity-service and CSM BFF.
- Add `call_request` as a supported dashboard widget resource type, so a dashboard config can define a widget that lists call requests with click-through to the owning case.

## Approach
- **Entity-service**: new `SearchAllCallRequests` method on `CallRequestService`, backed by a new call to the SN integration service's `POST /call-requests/search-all`; reuses the existing `CallRequestView`/`SearchCallRequestsResponse` types (same shape as the existing case-scoped search). Extracted the existing response-mapping loop into a shared helper used by both the case-scoped and cross-case search paths.
- **BFF**: new `POST /call-requests/search` route on `CaseHandler`, forwarding to the entity service's `/call-requests/search-all` (which keeps its own "-all" suffix to stay distinct from its own case-scoped sibling path). The BFF's flat `/call-requests/search` doesn't collide with the existing case-scoped path, which lives at `/cases/{id}/call-requests/search`. Added `call_request` to the dashboard package's resource-type enum and validation map.
- **Webapp**: added `call_request` to `BeWidgetResourceType`, a `WIDGET_RESOURCE_CONFIG` entry (`searchEndpoint: /call-requests/search`), and a `CallRequestWidgetList` renderer — each row's click destination is the owning case (`/cases/{case.id}`), since call requests have a real detail page (the parent case) unlike some other resource types.
- `openapi.yaml` updated in both the entity-service and BFF for the new paths/schemas.

## User stories
As a CS engineer, I want a dashboard widget that shows call requests across all my cases (not just one case at a time), so I can track pending/scheduled calls at a glance and jump straight to the relevant case.

## Release note
Adds a cross-case call request search endpoint and a corresponding dashboard widget resource type with case click-through.

## Documentation
N/A — internal API/dashboard-config addition, no external-facing docs.

## Automation tests
- Unit tests: existing entity-service and BFF test suites pass unchanged (`go test ./...`); extended the BFF's mock entity client for the new interface method.
- Integration tests: manually verified live through the full stack (entity-service → Ballerina proxy → real ServiceNow DEV tenant) — filtering by a real case's assignee returns exactly that case's 3 known call requests, consistently at the entity-service, BFF, and webapp layers. Also verified in a real browser: a dashboard widget using `resourceType: call_request` renders the 3 rows and clicking one navigates to the correct case detail page.

## Security checks
- Followed secure coding standards? yes
- Ran FindSecurityBugs plugin and verified report? N/A — Go/TypeScript, not Java; `go vet` and `pnpm lint` both ran clean on the changed files.
- Confirmed no keys/passwords/tokens/secrets committed? yes

## Related PRs
Depends on a corresponding Ballerina entity-service change (adding the new standalone search endpoint this PR's entity-service layer calls), tracked separately in a private repo.

## Migrations
N/A

## Test environment
Local Go entity-service and BFF, local webapp dev server, tested against a real backing ServiceNow DEV tenant via the Ballerina proxy layer, with a real browser session.

## Learning
Mirrored this codebase's existing standalone-vs-case-scoped search split (`searchTasks`/`searchCaseTasks`) for the new call-request search, and the existing dashboard `WIDGET_RESOURCE_CONFIG`/`WIDGET_LIST_RENDERERS` exhaustive-map pattern for wiring up the new resource type on the frontend.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cross-case call-request search with filtering by assignee and state.
  * Added sorting by creation, update, or scheduled time, with pagination support.
  * Added dashboard widgets for displaying call requests, including status and scheduled-time details.
  * Call-request rows can navigate directly to their associated case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->