### PR TITLE
[Customer Portal][Webapp] Disable empty dropdowns in case creation form

### DIFF
--- a/apps/customer-portal/webapp/src/features/support/components/case-creation-layout/form-sections/basic-information-section/BasicInformationSection.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-creation-layout/form-sections/basic-information-section/BasicInformationSection.tsx
@@ -192,7 +192,7 @@ export function BasicInformationSection({
               <FormControl
                 fullWidth
                 size="small"
-                disabled={isDeploymentDisabled}
+                disabled={isDeploymentDisabled || showNoDeploymentsHint}
               >
                 <Select
                   value={deployment}
@@ -261,7 +261,7 @@ export function BasicInformationSection({
             <FormControl
               fullWidth
               size="small"
-              disabled={isProductDropdownDisabled}
+              disabled={isProductDropdownDisabled || showNoProductsHint}
             >
               <Select
                 value={product}

--- a/apps/customer-portal/webapp/src/features/support/components/case-creation-layout/form-sections/basic-information-section/BasicInformationSection.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-creation-layout/form-sections/basic-information-section/BasicInformationSection.tsx
@@ -112,9 +112,11 @@ export function BasicInformationSection({
   );
   const useProductOptionList = Array.isArray(productOptionList);
   const hasProductRows = (productOptionList?.length ?? 0) > 0;
+  const hasEffectiveProductOptions = useProductOptionList
+    ? hasProductRows
+    : productOptionsLegacy.length > 0;
   const showNoProductsHint =
-    useProductOptionList &&
-    !hasProductRows &&
+    !hasEffectiveProductOptions &&
     !isProductDropdownDisabled &&
     !isProductLoading;
 

--- a/apps/customer-portal/webapp/src/features/support/components/case-creation-layout/form-sections/case-details-section/CaseDetailsSection.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-creation-layout/form-sections/case-details-section/CaseDetailsSection.tsx
@@ -36,6 +36,7 @@ import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 import {
   ERROR_UNSUPPORTED_TYPE,
   ERROR_SIZE_EXCEEDED,
+  EMPTY_DROPDOWN_PLACEHOLDER,
 } from "@constants/common";
 
 /**
@@ -129,6 +130,16 @@ export function CaseDetailsSection({
     color: getSeverityLegendColor(level.label),
     label: SEVERITY_LABEL_MAP[level.label] ?? level.label,
   }));
+
+  const issueTypeLabels = issueTypes
+    .map((type: unknown) =>
+      typeof type === "string" ? type : (type as { label?: string }).label,
+    )
+    .filter(
+      (label): label is string => label != null && label.trim() !== "",
+    );
+  const showNoIssueTypesHint = !isLoading && issueTypeLabels.length === 0;
+  const showNoSeverityLevelsHint = !isLoading && severityLevels.length === 0;
 
   return (
     <Paper sx={{ p: 3 }}>
@@ -419,38 +430,35 @@ export function CaseDetailsSection({
                   />
                 )}
               </Box>
-              <FormControl fullWidth size="small" disabled={isLoading}>
+              <FormControl
+                fullWidth
+                size="small"
+                disabled={isLoading || showNoIssueTypesHint}
+              >
                 <Select
                   id="issue-type-select"
                   value={issueType}
                   onChange={(e) => setIssueType(e.target.value)}
                   displayEmpty
-                  renderValue={(value) =>
-                    value === "" ? "Select Issue Type..." : value
-                  }
+                  renderValue={(value) => {
+                    if (value === "") {
+                      return showNoIssueTypesHint
+                        ? EMPTY_DROPDOWN_PLACEHOLDER
+                        : "Select Issue Type...";
+                    }
+                    return value;
+                  }}
                 >
                   <MenuItem value="" disabled>
-                    Select Issue Type...
+                    {showNoIssueTypesHint
+                      ? EMPTY_DROPDOWN_PLACEHOLDER
+                      : "Select Issue Type..."}
                   </MenuItem>
-                  {issueTypes
-                    .filter((type: unknown) => {
-                      const label =
-                        typeof type === "string"
-                          ? type
-                          : (type as { label?: string }).label;
-                      return label != null && String(label).trim() !== "";
-                    })
-                    .map((type: unknown) => {
-                      const label =
-                        typeof type === "string"
-                          ? type
-                          : ((type as { label?: string }).label as string);
-                      return (
-                        <MenuItem key={label} value={label}>
-                          {label}
-                        </MenuItem>
-                      );
-                    })}
+                  {issueTypeLabels.map((label) => (
+                    <MenuItem key={label} value={label}>
+                      {label}
+                    </MenuItem>
+                  ))}
                 </Select>
               </FormControl>
             </Grid>
@@ -510,7 +518,11 @@ export function CaseDetailsSection({
                   );
                 })()
               ) : (
-                <FormControl fullWidth size="small" disabled={isLoading}>
+                <FormControl
+                  fullWidth
+                  size="small"
+                  disabled={isLoading || showNoSeverityLevelsHint}
+                >
                   <Select
                     id="severity-level-select"
                     value={severity}
@@ -518,7 +530,9 @@ export function CaseDetailsSection({
                     displayEmpty
                     renderValue={(value) => {
                       if (value === "") {
-                        return "Select Severity Level...";
+                        return showNoSeverityLevelsHint
+                          ? EMPTY_DROPDOWN_PLACEHOLDER
+                          : "Select Severity Level...";
                       }
                       const selectedLevel = severityLevels.find(
                         (level) => level.id === value,
@@ -547,7 +561,9 @@ export function CaseDetailsSection({
                     }}
                   >
                     <MenuItem value="" disabled>
-                      Select Severity Level...
+                      {showNoSeverityLevelsHint
+                        ? EMPTY_DROPDOWN_PLACEHOLDER
+                        : "Select Severity Level..."}
                     </MenuItem>
                     {severityLevels.map((lvl) => (
                       <MenuItem key={lvl.id} value={lvl.id}>


### PR DESCRIPTION
## Summary
- Deployment and Product Version dropdowns showed "Not available" as a placeholder when there were no options, but remained clickable/enabled.
- Issue Type and Severity Level dropdowns had no empty-state handling at all.
- Now all four dropdowns disable themselves and consistently show "Not available" when their options list is empty, for clearer UX.

## Test plan
- [ ] Create a case where deployment metadata is empty — confirm Deployment field shows "Not available" and is disabled
- [ ] Create a case where product/product version list is empty — confirm same behavior
- [ ] Create a case where issue types or severity levels are empty — confirm same behavior
- [ ] Verify normal flow (options present) still works and fields remain enabled/selectable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved case creation forms by disabling dropdowns when no options are available.
  - Added clear empty-state guidance for deployment, product, issue type, and severity fields.
  - Ensured dropdowns remain disabled while their options are loading.
  - Improved issue-type option display when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->