### PR TITLE
[Customer Portal][Backend] Log warning instead of silent 404 for missing case feedback

### DIFF
--- a/apps/customer-portal/backend/service.bal
+++ b/apps/customer-portal/backend/service.bal
@@ -2421,6 +2421,7 @@ service http:InterceptableService / on new http:Listener(9090, listenerConf) {
             }
 
             if getStatusCode(feedbackResponse) == http:STATUS_NOT_FOUND {
+                log:printWarn(string `Feedback not found for case with ID: ${id}.`);
                 return <http:NotFound>{
                     body: {
                         message: string `Feedback not found for case with ID: ${id}.`


### PR DESCRIPTION
## Summary
- The feedback GET endpoint returned a plain 404 with no logging when a case had no feedback yet, making it hard to distinguish from a silently swallowed issue.
- Added `log:printWarn` for the 404 case so it's visible in logs without being treated as an error (existing `log:printError` is reserved for actual failures).

## Test plan
- [ ] Trigger `GET /cases/{id}/feedback` for a case with no feedback and confirm a warning is logged and a 404 is still returned to the client.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added warning logging when case feedback cannot be found, while preserving the existing “404 Not Found” response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->