### PR TITLE
[Entity-Service] Add remaining customer portal endpoints

### DIFF
--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -3743,12 +3743,20 @@ type CreateProblemRequest struct {
 	PrimaryIncidentID *string `json:"primaryIncidentId,omitempty"`
 }
 
-// ConversationState represents the state of a conversation.
+// ConversationState represents the state of a conversation. Only ACTIVE and
+// RESOLVED are accepted as SearchConversationsFilters.States values (the
+// search endpoint's own filter allow-list); all five values are accepted as
+// UpdateConversationRequest.State (the transition allow-list PATCH
+// /conversations/{id} enforces), matching the Ballerina reference's SN state
+// keys 2-6 respectively.
 type ConversationState string
 
 const (
-	ConversationStateActive   ConversationState = "ACTIVE"
-	ConversationStateResolved ConversationState = "RESOLVED"
+	ConversationStateActive    ConversationState = "ACTIVE"
+	ConversationStateResolved  ConversationState = "RESOLVED"
+	ConversationStateConverted ConversationState = "CONVERTED"
+	ConversationStateAbandoned ConversationState = "ABANDONED"
+	ConversationStateClosed    ConversationState = "CLOSED"
 )
 
 // ConversationSortField enumerates the columns available for sorting conversation search results.
@@ -3807,4 +3815,691 @@ type SearchConversationsResponse struct {
 	Total         int                      `json:"total"`
 	Offset        int                      `json:"offset"`
 	Limit         int                      `json:"limit"`
+}
+
+// ConversationDetails is the response for GET /conversations/{id}.
+type ConversationDetails struct {
+	ID             string     `json:"id"`
+	Number         *string    `json:"number"`
+	InitialMessage *string    `json:"initialMessage"`
+	MessageCount   int        `json:"messageCount"`
+	Project        *EntityRef `json:"project"`
+	Case           *EntityRef `json:"case"`
+	State          *string    `json:"state"`
+	CreatedOn      string     `json:"createdOn"`
+	CreatedBy      string     `json:"createdBy"`
+	UpdatedOn      string     `json:"updatedOn"`
+	UpdatedBy      string     `json:"updatedBy"`
+}
+
+// CreateConversationRequest is the request body for POST /conversations.
+type CreateConversationRequest struct {
+	ProjectID      string `json:"projectId"`
+	InitialMessage string `json:"initialMessage"`
+}
+
+// CreatedConversation is the conversation summary returned after creation.
+type CreatedConversation struct {
+	ID        string  `json:"id"`
+	Number    string  `json:"number"`
+	CreatedBy string  `json:"createdBy"`
+	CreatedOn string  `json:"createdOn"`
+	State     *string `json:"state"`
+}
+
+// CreateConversationResponse is the response for POST /conversations.
+type CreateConversationResponse struct {
+	Message      string              `json:"message"`
+	Conversation CreatedConversation `json:"conversation"`
+}
+
+// UpdateConversationRequest is the request body for PATCH /conversations/{id}.
+// State must be one of ACTIVE, RESOLVED, CONVERTED, ABANDONED, or CLOSED —
+// the same allow-list the Ballerina reference enforces inline (SN state keys
+// 2-6), translated here to this package's string-enum convention rather than
+// exposing the raw SN integer.
+type UpdateConversationRequest struct {
+	State ConversationState `json:"state"`
+}
+
+// UpdatedConversation is the conversation summary returned after an update.
+type UpdatedConversation struct {
+	ID        string  `json:"id"`
+	Number    *string `json:"number"`
+	UpdatedOn string  `json:"updatedOn"`
+	UpdatedBy string  `json:"updatedBy"`
+	State     *string `json:"state"`
+}
+
+// UpdateConversationResponse is the response for PATCH /conversations/{id}.
+type UpdateConversationResponse struct {
+	Message      string              `json:"message"`
+	Conversation UpdatedConversation `json:"conversation"`
+}
+
+// --- global metadata and search (ServiceNow data source only) ---
+
+// FeedbackEmojiChip is a selectable follow-up option shown under a feedback emoji.
+type FeedbackEmojiChip struct {
+	ID    string `json:"id"`
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+// FeedbackEmoji is one of the emoji choices offered on the case feedback form.
+type FeedbackEmoji struct {
+	ID              string              `json:"id"`
+	Name            string              `json:"name"`
+	Value           string              `json:"value"`
+	UnselectedImage string              `json:"unselectedImage"`
+	SelectedImage   string              `json:"selectedImage"`
+	Chips           []FeedbackEmojiChip `json:"chips"`
+}
+
+// SystemMetadataResponse is the response for GET /metadata — system-wide
+// reference data used across the frontend (not project- or case-scoped).
+type SystemMetadataResponse struct {
+	TimeZones      []ChoiceListItem     `json:"timeZones"`
+	ProjectTypes   []ReferenceTableItem `json:"projectTypes"`
+	FeedbackEmojis []FeedbackEmoji      `json:"feedbackEmojies"`
+}
+
+// GlobalSearchFilters holds the optional filter criteria for POST /search.
+// Tables restricts which entity types are searched; valid values are
+// "projects" and "cases" (both are searched when omitted).
+type GlobalSearchFilters struct {
+	SearchQuery string   `json:"searchQuery,omitempty"`
+	Tables      []string `json:"tables,omitempty"`
+}
+
+// GlobalSearchSort specifies the sort field/order for POST /search.
+type GlobalSearchSort struct {
+	Field string `json:"field,omitempty"`
+	Order string `json:"order,omitempty"`
+}
+
+// GlobalSearchRequest is the request body for POST /search. Every field is
+// optional — an empty request body is valid and searches both tables with
+// default pagination, matching the Ballerina reference.
+type GlobalSearchRequest struct {
+	Filters            *GlobalSearchFilters `json:"filters,omitempty"`
+	SortBy             *GlobalSearchSort    `json:"sortBy,omitempty"`
+	ProjectsPagination *Pagination          `json:"projectsPagination,omitempty"`
+	CasesPagination    *Pagination          `json:"casesPagination,omitempty"`
+}
+
+// GlobalSearchProject is a project row in a global search result.
+type GlobalSearchProject struct {
+	ID                  string             `json:"id"`
+	Name                string             `json:"name"`
+	Description         *string            `json:"description"`
+	Key                 string             `json:"key"`
+	Type                ReferenceTableItem `json:"type"`
+	CreatedOn           string             `json:"createdOn"`
+	StartDate           *string            `json:"startDate"`
+	EndDate             *string            `json:"endDate"`
+	HasPdpSubscription  bool               `json:"hasPdpSubscription"`
+	ClosureState        *string            `json:"closureState"`
+	Account             ReferenceTableItem `json:"account"`
+	ActiveChatsCount    int                `json:"activeChatsCount"`
+	ActionRequiredCount int                `json:"actionRequiredCount"`
+	OutstandingCount    int                `json:"outstandingCount"`
+}
+
+// GlobalSearchCase is a case row in a global search result.
+type GlobalSearchCase struct {
+	ID               string              `json:"id"`
+	InternalID       string              `json:"internalId"`
+	Number           string              `json:"number"`
+	Title            *string             `json:"title"`
+	Description      *string             `json:"description"`
+	CreatedOn        string              `json:"createdOn"`
+	CreatedBy        string              `json:"createdBy"`
+	UpdatedOn        string              `json:"updatedOn"`
+	Project          *ReferenceTableItem `json:"project"`
+	CaseType         *ReferenceTableItem `json:"caseType"`
+	State            *ChoiceListItem     `json:"state"`
+	Severity         *ChoiceListItem     `json:"severity"`
+	AssignedEngineer *ReferenceTableItem `json:"assignedEngineer"`
+	Account          ReferenceTableItem  `json:"account"`
+}
+
+// GlobalSearchResponse is the response for POST /search.
+type GlobalSearchResponse struct {
+	Query         string                `json:"query"`
+	ProjectsTotal int                   `json:"projectsTotal"`
+	CasesTotal    int                   `json:"casesTotal"`
+	Projects      []GlobalSearchProject `json:"projects"`
+	Cases         []GlobalSearchCase    `json:"cases"`
+}
+
+// VulnerabilityMetaResponse is the response for GET /products/vulnerabilities/meta.
+type VulnerabilityMetaResponse struct {
+	Severities []ChoiceListItem `json:"severities"`
+}
+
+// --- case feedback (ServiceNow data source only) ---
+
+// SubmitCaseFeedbackRequest is the request body for POST /cases/{id}/feedback.
+type SubmitCaseFeedbackRequest struct {
+	EmojiID           string   `json:"emojiId"`
+	ChipIDs           []string `json:"chipIds,omitempty"`
+	AdditionalComment *string  `json:"additionalComment,omitempty"`
+}
+
+// CaseFeedbackResult is the feedback record created by a submission.
+type CaseFeedbackResult struct {
+	ID           string `json:"id"`
+	AssessmentID string `json:"assessmentId"`
+	CaseID       string `json:"caseId"`
+	CreatedBy    string `json:"createdBy"`
+	CreatedOn    string `json:"createdOn"`
+}
+
+// SubmitCaseFeedbackResponse is the response for POST /cases/{id}/feedback.
+type SubmitCaseFeedbackResponse struct {
+	Message  string             `json:"message"`
+	Feedback CaseFeedbackResult `json:"feedback"`
+}
+
+// CaseFeedbackEmojiRef is the emoji reference embedded in GET /cases/{id}/feedback.
+type CaseFeedbackEmojiRef struct {
+	ID            string `json:"id"`
+	Name          string `json:"name"`
+	SelectedImage string `json:"selectedImage"`
+}
+
+// CaseFeedback is the response for GET /cases/{id}/feedback.
+type CaseFeedback struct {
+	ID                string               `json:"id"`
+	Emoji             CaseFeedbackEmojiRef `json:"emoji"`
+	ChipIDs           []string             `json:"chips"`
+	AssessmentID      string               `json:"assessmentId"`
+	CreatedBy         string               `json:"createdBy"`
+	CreatedOn         string               `json:"createdOn"`
+	AdditionalComment *string              `json:"additionalComment"`
+}
+
+// --- attachment gaps (ServiceNow data source only) ---
+
+// AttachmentDetails is the response for GET /attachments/{id} — attachment
+// metadata plus its base64-encoded file content. Note ServiceNow's
+// attachment-details lookup does not resolve the uploader to a UserReference
+// the way the search/comment paths do (only those two carry a createdByUser
+// object) — CreatedBy is a bare string here, and there is no ReferenceType in
+// the upstream response at all, so it is deliberately not modeled below.
+type AttachmentDetails struct {
+	ID          string    `json:"id"`
+	ReferenceID string    `json:"referenceId"`
+	Name        string    `json:"name"`
+	Type        string    `json:"type"`
+	SizeBytes   int       `json:"sizeBytes"`
+	Description *string   `json:"description"`
+	CreatedBy   string    `json:"createdBy"`
+	CreatedOn   time.Time `json:"createdOn"`
+	DownloadURL *string   `json:"downloadUrl"`
+	PreviewURL  *string   `json:"previewUrl"`
+	Content     string    `json:"content"`
+}
+
+// UpdateAttachmentRequest is the request body for PATCH /attachments/{id}.
+// ReferenceType must be "case" or "deployment"; for "case" Name is required
+// and Description is not allowed; for "deployment" at least one of Name or
+// Description must be present.
+type UpdateAttachmentRequest struct {
+	ID            string        `json:"-"`
+	ReferenceID   string        `json:"referenceId"`
+	ReferenceType ReferenceType `json:"referenceType"`
+	Name          *string       `json:"name,omitempty"`
+	Description   *string       `json:"description,omitempty"`
+}
+
+// UpdatedAttachment holds the fields returned after updating an attachment.
+type UpdatedAttachment struct {
+	ID        string    `json:"id"`
+	UpdatedOn time.Time `json:"updatedOn"`
+	UpdatedBy string    `json:"updatedBy"`
+}
+
+// UpdateAttachmentResponse is the response for PATCH /attachments/{id}.
+type UpdateAttachmentResponse struct {
+	Message    string            `json:"message"`
+	Attachment UpdatedAttachment `json:"attachment"`
+}
+
+// --- deployed product metrics (ServiceNow data source only) ---
+
+// DeployedProductMetricsRequest is the request body for
+// POST /deployed-products/{id}/metrics/search. All fields are required;
+// StartDate/EndDate use YYYY-MM-DD format, must be strictly ordered, and must
+// not span more than one year (see validateDateRange in the service layer).
+type DeployedProductMetricsRequest struct {
+	DeploymentID string `json:"deploymentId"`
+	StartDate    string `json:"startDate"`
+	EndDate      string `json:"endDate"`
+}
+
+// DeployedProductMetricsInstance is a single instance's contribution to a
+// metrics chart entry.
+type DeployedProductMetricsInstance struct {
+	ID    string `json:"id"`
+	Name  string `json:"name"`
+	Cores int    `json:"cores"`
+}
+
+// DeployedProductMetricsChartEntry is one date's worth of core-count data.
+type DeployedProductMetricsChartEntry struct {
+	Date          string                           `json:"date"`
+	InstanceCount int                              `json:"instanceCount"`
+	TotalCores    int                              `json:"totalCores"`
+	MinCores      int                              `json:"minCores"`
+	MaxCores      int                              `json:"maxCores"`
+	AvgCores      float64                          `json:"avgCores"`
+	Instances     []DeployedProductMetricsInstance `json:"instances"`
+}
+
+// DeployedProductMetricsDateRange is the queried date range echoed back in a summary.
+type DeployedProductMetricsDateRange struct {
+	Start string `json:"start"`
+	End   string `json:"end"`
+}
+
+// DeployedProductMetricsSummary is the summary statistics for a metrics query.
+type DeployedProductMetricsSummary struct {
+	DateRange      DeployedProductMetricsDateRange `json:"dateRange"`
+	TotalInstances int                             `json:"totalInstances"`
+	MinCores       *int                            `json:"minCores"`
+	MaxCores       *int                            `json:"maxCores"`
+	AvgCores       *float64                        `json:"avgCores"`
+}
+
+// DeployedProductMetricsResponse is the response for
+// POST /deployed-products/{id}/metrics/search.
+type DeployedProductMetricsResponse struct {
+	DeployedProduct ReferenceTableItem                 `json:"deployedProduct"`
+	Summary         DeployedProductMetricsSummary      `json:"summary"`
+	ChartData       []DeployedProductMetricsChartEntry `json:"chartData"`
+}
+
+// DeployedProductUsageCountsRequest is the request body for
+// POST /deployed-products/{id}/metrics/usage-counts/search. Same shape and
+// date-range validation as DeployedProductMetricsRequest.
+type DeployedProductUsageCountsRequest struct {
+	DeploymentID string `json:"deploymentId"`
+	StartDate    string `json:"startDate"`
+	EndDate      string `json:"endDate"`
+}
+
+// UsageCountInstance is a single instance's contribution to a usage-count entry.
+type UsageCountInstance struct {
+	ID    string  `json:"id"`
+	Name  string  `json:"name"`
+	Value float64 `json:"value"`
+}
+
+// UsageCountEntry is one count type's aggregated value on a single date.
+type UsageCountEntry struct {
+	Value       float64              `json:"value"`
+	Aggregation string               `json:"aggregation"`
+	Instances   []UsageCountInstance `json:"instances"`
+}
+
+// DeployedProductUsageCountsChartEntry is one date's worth of usage-count
+// data. Counts is keyed by count-type name — ServiceNow defines an open set
+// of count types, not a fixed enum, so this stays a map rather than a struct.
+type DeployedProductUsageCountsChartEntry struct {
+	Date   string                     `json:"date"`
+	Counts map[string]UsageCountEntry `json:"counts"`
+}
+
+// CountTypeAggregation is the summary statistics for a single count type over
+// the queried date range.
+type CountTypeAggregation struct {
+	Aggregation string  `json:"aggregation"`
+	Min         float64 `json:"min"`
+	Max         float64 `json:"max"`
+	Avg         float64 `json:"avg"`
+}
+
+// DeployedProductUsageCountsSummary is the summary statistics for a
+// usage-counts query. CountTypes is keyed by count-type name, same rationale
+// as DeployedProductUsageCountsChartEntry.Counts.
+type DeployedProductUsageCountsSummary struct {
+	DateRange  DeployedProductMetricsDateRange `json:"dateRange"`
+	CountTypes map[string]CountTypeAggregation `json:"countTypes"`
+}
+
+// DeployedProductUsageCountsResponse is the response for
+// POST /deployed-products/{id}/metrics/usage-counts/search.
+type DeployedProductUsageCountsResponse struct {
+	DeployedProduct ReferenceTableItem                     `json:"deployedProduct"`
+	Summary         DeployedProductUsageCountsSummary      `json:"summary"`
+	ChartData       []DeployedProductUsageCountsChartEntry `json:"chartData"`
+}
+
+// --- escalations (ServiceNow data source only) ---
+
+// EscalationAction identifies whether an escalation request escalates or
+// de-escalates a case.
+type EscalationAction string
+
+const (
+	EscalationActionEscalate   EscalationAction = "ESCALATE"
+	EscalationActionDeescalate EscalationAction = "DEESCALATE"
+)
+
+// CreateEscalationRequest is the request body for POST /escalations. Action
+// defaults to ESCALATE when omitted (matched case-insensitively); Reason is
+// required when the (defaulted) action is ESCALATE.
+type CreateEscalationRequest struct {
+	CaseID string            `json:"caseId"`
+	Reason *string           `json:"reason,omitempty"`
+	Action *EscalationAction `json:"action,omitempty"`
+}
+
+// EscalationNotifiedUser is a user notified about an escalation.
+type EscalationNotifiedUser struct {
+	ID       string  `json:"id"`
+	UserName string  `json:"userName"`
+	Name     *string `json:"name"`
+	Email    *string `json:"email"`
+}
+
+// CreatedEscalation holds the escalation details returned after creation.
+// Unlike Escalation (search results), it has no UpdatedOn — the create
+// response doesn't carry one, matching the Ballerina reference.
+type CreatedEscalation struct {
+	ID                 string                   `json:"id"`
+	Case               ReferenceTableItem       `json:"case"`
+	CurrentLevel       ChoiceListItem           `json:"currentLevel"`
+	PreviousLevel      ChoiceListItem           `json:"previousLevel"`
+	CreatedBy          string                   `json:"createdBy"`
+	CreatedOn          string                   `json:"createdOn"`
+	Reason             *string                  `json:"reason"`
+	NotificationSentTo []EscalationNotifiedUser `json:"notificationSentTo"`
+}
+
+// CreateEscalationResponse is the response for POST /escalations.
+type CreateEscalationResponse struct {
+	Message    string            `json:"message"`
+	Escalation CreatedEscalation `json:"escalation"`
+}
+
+// Escalation is a single escalation row in search results.
+type Escalation struct {
+	ID                 string                   `json:"id"`
+	Case               ReferenceTableItem       `json:"case"`
+	CurrentLevel       ChoiceListItem           `json:"currentLevel"`
+	PreviousLevel      ChoiceListItem           `json:"previousLevel"`
+	CreatedBy          string                   `json:"createdBy"`
+	CreatedOn          string                   `json:"createdOn"`
+	UpdatedOn          string                   `json:"updatedOn"`
+	Reason             *string                  `json:"reason"`
+	NotificationSentTo []EscalationNotifiedUser `json:"notificationSentTo"`
+}
+
+// SearchEscalationsFilters holds the optional filter criteria for POST /escalations/search.
+type SearchEscalationsFilters struct {
+	CaseIDs       []string `json:"caseIds,omitempty"`
+	CurrentLevels []int    `json:"currentLevels,omitempty"`
+}
+
+// EscalationSortField enumerates the columns available for sorting escalation search results.
+type EscalationSortField string
+
+const (
+	EscalationSortFieldCreatedOn EscalationSortField = "createdOn"
+	EscalationSortFieldUpdatedOn EscalationSortField = "updatedOn"
+)
+
+// EscalationSortOrder controls the sort direction for escalation search results.
+type EscalationSortOrder string
+
+const (
+	EscalationSortOrderAsc  EscalationSortOrder = "asc"
+	EscalationSortOrderDesc EscalationSortOrder = "desc"
+)
+
+// EscalationSort specifies the sort field/order for POST /escalations/search.
+type EscalationSort struct {
+	Field EscalationSortField `json:"field"`
+	Order EscalationSortOrder `json:"order"`
+}
+
+// SearchEscalationsRequest is the request body for POST /escalations/search.
+type SearchEscalationsRequest struct {
+	Filters    *SearchEscalationsFilters `json:"filters,omitempty"`
+	SortBy     *EscalationSort           `json:"sortBy,omitempty"`
+	Pagination Pagination                `json:"pagination"`
+}
+
+// SearchEscalationsResponse is the paginated result of an escalation search.
+type SearchEscalationsResponse struct {
+	Escalations []Escalation `json:"escalations"`
+	Total       int          `json:"total"`
+	Offset      int          `json:"offset"`
+	Limit       int          `json:"limit"`
+}
+
+// --- case-grouped time cards (ServiceNow data source only) ---
+
+// CaseTimeCardBillingInfo is a billable/non-billable time breakdown.
+type CaseTimeCardBillingInfo struct {
+	TotalTime float64 `json:"totalTime"`
+	Count     int     `json:"count"`
+}
+
+// CaseTimeCardCaseRef is the case reference embedded in a case time-card summary.
+type CaseTimeCardCaseRef struct {
+	ID        string     `json:"id"`
+	Number    string     `json:"number"`
+	Name      string     `json:"name"`
+	UpdatedOn string     `json:"updatedOn"`
+	Project   *EntityRef `json:"project"`
+}
+
+// CaseTimeCardSummary is the time-card rollup for a single case.
+type CaseTimeCardSummary struct {
+	Case        CaseTimeCardCaseRef     `json:"case"`
+	TotalTime   float64                 `json:"totalTime"`
+	TotalCount  int                     `json:"totalCount"`
+	Billable    CaseTimeCardBillingInfo `json:"billable"`
+	NonBillable CaseTimeCardBillingInfo `json:"nonBillable"`
+}
+
+// SearchCaseTimeCardsResponse is the response for POST /cases/time-cards/search
+// — time cards grouped and rolled up by case, rather than the flat
+// per-time-card rows POST /time-cards/search returns. Uses the same request
+// type as that endpoint (SearchTimeCardsRequest) since the upstream SN
+// payload shape is identical between the two.
+type SearchCaseTimeCardsResponse struct {
+	Cases  []CaseTimeCardSummary `json:"cases"`
+	Total  int                   `json:"total"`
+	Offset int                   `json:"offset"`
+	Limit  int                   `json:"limit"`
+}
+
+// --- instances / metrics (ServiceNow data source only) ---
+
+// InstanceSearchFilters holds the optional filter criteria for
+// POST /instances/search. ProjectIDs, DeploymentIDs, and DeployedProductIDs
+// are mutually exclusive — at most one may be non-empty.
+type InstanceSearchFilters struct {
+	StartDate          *string  `json:"startDate,omitempty"`
+	EndDate            *string  `json:"endDate,omitempty"`
+	ProjectIDs         []string `json:"projectIds,omitempty"`
+	DeploymentIDs      []string `json:"deploymentIds,omitempty"`
+	DeployedProductIDs []string `json:"deployedProductIds,omitempty"`
+}
+
+// SearchInstancesRequest is the request body for POST /instances/search.
+// Unlike the other 4 instance endpoints, Filters (including its dates) is
+// entirely optional.
+type SearchInstancesRequest struct {
+	Filters    *InstanceSearchFilters `json:"filters,omitempty"`
+	Pagination Pagination             `json:"pagination"`
+}
+
+// InstanceMetadata is the metadata block embedded in an Instance.
+type InstanceMetadata struct {
+	ID                 string         `json:"id"`
+	CoreCount          *int           `json:"coreCount"`
+	Updates            *int           `json:"updates"`
+	JDKVersion         *string        `json:"jdkVersion"`
+	DeploymentMetadata map[string]any `json:"deploymentMetadata"`
+	CreatedOn          string         `json:"createdOn"`
+	UpdatedOn          string         `json:"updatedOn"`
+	CustomCreatedOn    *string        `json:"customCreatedOn"`
+	CustomUpdatedOn    *string        `json:"customUpdatedOn"`
+}
+
+// Instance is a single instance row.
+type Instance struct {
+	ID              string              `json:"id"`
+	Key             string              `json:"key"`
+	Project         *ReferenceTableItem `json:"project"`
+	Deployment      *ReferenceTableItem `json:"deployment"`
+	Product         *ReferenceTableItem `json:"product"`
+	DeployedProduct *ReferenceTableItem `json:"deployedProduct"`
+	CreatedOn       string              `json:"createdOn"`
+	UpdatedOn       string              `json:"updatedOn"`
+	Metadata        *InstanceMetadata   `json:"metadata"`
+}
+
+// SearchInstancesResponse is the response for POST /instances/search.
+type SearchInstancesResponse struct {
+	Instances []Instance `json:"instances"`
+	Total     int        `json:"total"`
+	Offset    int        `json:"offset"`
+	Limit     int        `json:"limit"`
+}
+
+// InstanceDateRangeFilters is the shared filter shape for
+// POST /instances/metrics/search and POST /instances/usages/search.
+// StartDate/EndDate are required; ProjectIDs, DeploymentIDs, and
+// DeployedProductIDs are mutually exclusive — at most one may be non-empty.
+type InstanceDateRangeFilters struct {
+	StartDate          string   `json:"startDate"`
+	EndDate            string   `json:"endDate"`
+	ProjectIDs         []string `json:"projectIds,omitempty"`
+	DeploymentIDs      []string `json:"deploymentIds,omitempty"`
+	DeployedProductIDs []string `json:"deployedProductIds,omitempty"`
+}
+
+// InstanceMetricsRequest is the request body for POST /instances/metrics/search.
+type InstanceMetricsRequest struct {
+	Filters InstanceDateRangeFilters `json:"filters"`
+}
+
+// InstanceDataPoint is a single metric snapshot for an instance.
+type InstanceDataPoint struct {
+	Date               string         `json:"date"`
+	CreatedOn          string         `json:"createdOn"`
+	CoreCount          *int           `json:"coreCount"`
+	JDKVersion         *string        `json:"jdkVersion"`
+	Updates            *int           `json:"updates"`
+	DeploymentMetadata map[string]any `json:"deploymentMetadata"`
+}
+
+// InstanceMetric is one instance's metric time series, ordered newest to oldest.
+type InstanceMetric struct {
+	InstanceID      string              `json:"instanceId"`
+	InstanceKey     string              `json:"instanceKey"`
+	Project         *ReferenceTableItem `json:"project"`
+	Deployment      *ReferenceTableItem `json:"deployment"`
+	Product         *ReferenceTableItem `json:"product"`
+	DeployedProduct *ReferenceTableItem `json:"deployedProduct"`
+	DataPoints      []InstanceDataPoint `json:"dataPoints"`
+}
+
+// InstanceMetricsResponse is the response for POST /instances/metrics/search.
+type InstanceMetricsResponse struct {
+	Metrics        []InstanceMetric `json:"metrics"`
+	TotalInstances int              `json:"totalInstances"`
+	StartDate      string           `json:"startDate"`
+	EndDate        string           `json:"endDate"`
+}
+
+// InstanceUsageRequest is the request body for POST /instances/usages/search.
+type InstanceUsageRequest struct {
+	Filters InstanceDateRangeFilters `json:"filters"`
+}
+
+// InstanceSummary is one period's usage counts for an instance, keyed by an
+// open set of count-type names (e.g. "TOTAL_USERS", "TRANSACTION_COUNT").
+type InstanceSummary struct {
+	Period string         `json:"period"`
+	Counts map[string]int `json:"counts"`
+}
+
+// InstanceUsageEntry is one instance's usage time series.
+type InstanceUsageEntry struct {
+	InstanceID      string              `json:"instanceId"`
+	InstanceKey     string              `json:"instanceKey"`
+	Project         *ReferenceTableItem `json:"project"`
+	Deployment      *ReferenceTableItem `json:"deployment"`
+	Product         *ReferenceTableItem `json:"product"`
+	DeployedProduct *ReferenceTableItem `json:"deployedProduct"`
+	PeriodSummaries []InstanceSummary   `json:"periodSummaries"`
+}
+
+// InstanceUsageResponse is the response for POST /instances/usages/search.
+type InstanceUsageResponse struct {
+	Usages         []InstanceUsageEntry `json:"usages"`
+	TotalInstances int                  `json:"totalInstances"`
+	StartDate      string               `json:"startDate"`
+	EndDate        string               `json:"endDate"`
+}
+
+// InstanceStatsFilters extends InstanceDateRangeFilters with an optional
+// dataSource discriminator, used by the two .../stats/search endpoints only.
+type InstanceStatsFilters struct {
+	StartDate          string   `json:"startDate"`
+	EndDate            string   `json:"endDate"`
+	ProjectIDs         []string `json:"projectIds,omitempty"`
+	DeploymentIDs      []string `json:"deploymentIds,omitempty"`
+	DeployedProductIDs []string `json:"deployedProductIds,omitempty"`
+	// DataSource filters by how the data point was recorded: 1 = API Call, 2 = File Upload.
+	DataSource *int `json:"dataSource,omitempty"`
+}
+
+// InstanceMetricsStatsRequest is the request body for POST /instances/metrics/stats/search.
+type InstanceMetricsStatsRequest struct {
+	Filters InstanceStatsFilters `json:"filters"`
+}
+
+// InstanceMetricSummary is the current/min/max/avg summary for a
+// metrics-stats query.
+type InstanceMetricSummary struct {
+	Current float64 `json:"current"`
+	Min     float64 `json:"min"`
+	Max     float64 `json:"max"`
+	Avg     float64 `json:"avg"`
+}
+
+// InstanceMetricsStatsResponse is the response for
+// POST /instances/metrics/stats/search. Stats is keyed by date, then by
+// metric name (e.g. "TOTAL_CORES") — an open set defined by ServiceNow, not
+// a fixed enum.
+type InstanceMetricsStatsResponse struct {
+	Stats     map[string]map[string]int `json:"stats"`
+	Summary   InstanceMetricSummary     `json:"summary"`
+	Total     int                       `json:"total"`
+	StartDate string                    `json:"startDate"`
+	EndDate   string                    `json:"endDate"`
+}
+
+// InstanceUsageStatsRequest is the request body for POST /instances/usages/stats/search.
+type InstanceUsageStatsRequest struct {
+	Filters InstanceStatsFilters `json:"filters"`
+}
+
+// InstanceUsageStatsResponse is the response for POST /instances/usages/stats/search.
+// Stats is keyed by date, then by metric name, same rationale as
+// InstanceMetricsStatsResponse.Stats.
+type InstanceUsageStatsResponse struct {
+	Stats     map[string]map[string]int `json:"stats"`
+	Total     int                       `json:"total"`
+	StartDate string                    `json:"startDate"`
+	EndDate   string                    `json:"endDate"`
 }

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -4125,9 +4125,7 @@ type DeployedProductMetricsResponse struct {
 // POST /deployed-products/{id}/metrics/usage-counts/search. Same shape and
 // date-range validation as DeployedProductMetricsRequest.
 type DeployedProductUsageCountsRequest struct {
-	DeploymentID string `json:"deploymentId"`
-	StartDate    string `json:"startDate"`
-	EndDate      string `json:"endDate"`
+	DeployedProductMetricsRequest
 }
 
 // UsageCountInstance is a single instance's contribution to a usage-count entry.
@@ -4454,11 +4452,7 @@ type InstanceUsageResponse struct {
 // InstanceStatsFilters extends InstanceDateRangeFilters with an optional
 // dataSource discriminator, used by the two .../stats/search endpoints only.
 type InstanceStatsFilters struct {
-	StartDate          string   `json:"startDate"`
-	EndDate            string   `json:"endDate"`
-	ProjectIDs         []string `json:"projectIds,omitempty"`
-	DeploymentIDs      []string `json:"deploymentIds,omitempty"`
-	DeployedProductIDs []string `json:"deployedProductIds,omitempty"`
+	InstanceDateRangeFilters
 	// DataSource filters by how the data point was recorded: 1 = API Call, 2 = File Upload.
 	DataSource *int `json:"dataSource,omitempty"`
 }

--- a/entity-service/internal/handler/case_handler.go
+++ b/entity-service/internal/handler/case_handler.go
@@ -243,6 +243,60 @@ func (h *CaseHandler) DeleteCaseAttachment(w http.ResponseWriter, r *http.Reques
 	_ = json.NewEncoder(w).Encode(resp)
 }
 
+// GetAttachmentByID handles GET /attachments/{id}.
+func (h *CaseHandler) GetAttachmentByID(w http.ResponseWriter, r *http.Request) {
+	resp, err := h.svc.GetAttachmentByID(r.Context(), r.PathValue("id"))
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// UpdateAttachment handles PATCH /attachments/{id}.
+func (h *CaseHandler) UpdateAttachment(w http.ResponseWriter, r *http.Request) {
+	var req domain.UpdateAttachmentRequest
+	if !decodeRequest(w, r, &req) {
+		return
+	}
+	req.ID = r.PathValue("id")
+	resp, err := h.svc.UpdateAttachment(r.Context(), req)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// GetCaseFeedback handles GET /cases/{id}/feedback.
+func (h *CaseHandler) GetCaseFeedback(w http.ResponseWriter, r *http.Request) {
+	resp, err := h.svc.GetCaseFeedback(r.Context(), r.PathValue("id"))
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// SubmitCaseFeedback handles POST /cases/{id}/feedback.
+func (h *CaseHandler) SubmitCaseFeedback(w http.ResponseWriter, r *http.Request) {
+	var req domain.SubmitCaseFeedbackRequest
+	if !decodeRequest(w, r, &req) {
+		return
+	}
+	resp, err := h.svc.SubmitCaseFeedback(r.Context(), r.PathValue("id"), req)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
 // AddCaseTag handles POST /cases/{id}/tags.
 func (h *CaseHandler) AddCaseTag(w http.ResponseWriter, r *http.Request) {
 	caseID := r.PathValue("id")

--- a/entity-service/internal/handler/conversation_handler.go
+++ b/entity-service/internal/handler/conversation_handler.go
@@ -49,3 +49,45 @@ func (h *ConversationHandler) SearchConversations(w http.ResponseWriter, r *http
 	w.WriteHeader(http.StatusOK)
 	_ = json.NewEncoder(w).Encode(resp)
 }
+
+// GetConversation handles GET /conversations/{id}.
+func (h *ConversationHandler) GetConversation(w http.ResponseWriter, r *http.Request) {
+	resp, err := h.svc.GetConversation(r.Context(), r.PathValue("id"))
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// CreateConversation handles POST /conversations.
+func (h *ConversationHandler) CreateConversation(w http.ResponseWriter, r *http.Request) {
+	var req domain.CreateConversationRequest
+	if !decodeRequest(w, r, &req) {
+		return
+	}
+	resp, err := h.svc.CreateConversation(r.Context(), req)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// UpdateConversation handles PATCH /conversations/{id}.
+func (h *ConversationHandler) UpdateConversation(w http.ResponseWriter, r *http.Request) {
+	var req domain.UpdateConversationRequest
+	if !decodeRequest(w, r, &req) {
+		return
+	}
+	resp, err := h.svc.UpdateConversation(r.Context(), r.PathValue("id"), req)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}

--- a/entity-service/internal/handler/deployed_product_handler.go
+++ b/entity-service/internal/handler/deployed_product_handler.go
@@ -81,3 +81,33 @@ func (h *DeployedProductHandler) PatchDeployedProduct(w http.ResponseWriter, r *
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(result)
 }
+
+// SearchDeployedProductMetrics handles POST /deployed-products/{id}/metrics/search.
+func (h *DeployedProductHandler) SearchDeployedProductMetrics(w http.ResponseWriter, r *http.Request) {
+	var req domain.DeployedProductMetricsRequest
+	if !decodeRequest(w, r, &req) {
+		return
+	}
+	resp, err := h.svc.SearchDeployedProductMetrics(r.Context(), r.PathValue("id"), req)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// SearchDeployedProductUsageCounts handles POST /deployed-products/{id}/metrics/usage-counts/search.
+func (h *DeployedProductHandler) SearchDeployedProductUsageCounts(w http.ResponseWriter, r *http.Request) {
+	var req domain.DeployedProductUsageCountsRequest
+	if !decodeRequest(w, r, &req) {
+		return
+	}
+	resp, err := h.svc.SearchDeployedProductUsageCounts(r.Context(), r.PathValue("id"), req)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}

--- a/entity-service/internal/handler/escalation_handler.go
+++ b/entity-service/internal/handler/escalation_handler.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package handler is declared in user_handler.go.
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/service"
+)
+
+// EscalationHandler handles HTTP requests for the escalations resource.
+type EscalationHandler struct {
+	svc service.EscalationService
+}
+
+// NewEscalationHandler constructs an EscalationHandler with the given service.
+func NewEscalationHandler(svc service.EscalationService) *EscalationHandler {
+	return &EscalationHandler{svc: svc}
+}
+
+// SearchEscalations handles POST /escalations/search.
+func (h *EscalationHandler) SearchEscalations(w http.ResponseWriter, r *http.Request) {
+	var req domain.SearchEscalationsRequest
+	if !decodeRequest(w, r, &req) {
+		return
+	}
+	resp, err := h.svc.SearchEscalations(r.Context(), req)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// CreateEscalation handles POST /escalations.
+func (h *EscalationHandler) CreateEscalation(w http.ResponseWriter, r *http.Request) {
+	var req domain.CreateEscalationRequest
+	if !decodeRequest(w, r, &req) {
+		return
+	}
+	resp, err := h.svc.CreateEscalation(r.Context(), req)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(resp)
+}

--- a/entity-service/internal/handler/global_handler.go
+++ b/entity-service/internal/handler/global_handler.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package handler is declared in user_handler.go.
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/service"
+)
+
+// GlobalHandler handles HTTP requests for system-wide metadata and cross-entity search.
+type GlobalHandler struct {
+	svc service.GlobalService
+}
+
+// NewGlobalHandler constructs a GlobalHandler with the given service.
+func NewGlobalHandler(svc service.GlobalService) *GlobalHandler {
+	return &GlobalHandler{svc: svc}
+}
+
+// GetSystemMetadata handles GET /metadata.
+func (h *GlobalHandler) GetSystemMetadata(w http.ResponseWriter, r *http.Request) {
+	resp, err := h.svc.GetSystemMetadata(r.Context())
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// GlobalSearch handles POST /search.
+func (h *GlobalHandler) GlobalSearch(w http.ResponseWriter, r *http.Request) {
+	var req domain.GlobalSearchRequest
+	if !decodeRequest(w, r, &req) {
+		return
+	}
+	resp, err := h.svc.GlobalSearch(r.Context(), req)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}

--- a/entity-service/internal/handler/instance_handler.go
+++ b/entity-service/internal/handler/instance_handler.go
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package handler is declared in user_handler.go.
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/service"
+)
+
+// InstanceHandler handles HTTP requests for the instances resource.
+type InstanceHandler struct {
+	svc service.InstanceService
+}
+
+// NewInstanceHandler constructs an InstanceHandler with the given service.
+func NewInstanceHandler(svc service.InstanceService) *InstanceHandler {
+	return &InstanceHandler{svc: svc}
+}
+
+// SearchInstances handles POST /instances/search.
+func (h *InstanceHandler) SearchInstances(w http.ResponseWriter, r *http.Request) {
+	var req domain.SearchInstancesRequest
+	if !decodeRequest(w, r, &req) {
+		return
+	}
+	resp, err := h.svc.SearchInstances(r.Context(), req)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// SearchInstanceMetrics handles POST /instances/metrics/search.
+func (h *InstanceHandler) SearchInstanceMetrics(w http.ResponseWriter, r *http.Request) {
+	var req domain.InstanceMetricsRequest
+	if !decodeRequest(w, r, &req) {
+		return
+	}
+	resp, err := h.svc.SearchInstanceMetrics(r.Context(), req)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// SearchInstanceUsage handles POST /instances/usages/search.
+func (h *InstanceHandler) SearchInstanceUsage(w http.ResponseWriter, r *http.Request) {
+	var req domain.InstanceUsageRequest
+	if !decodeRequest(w, r, &req) {
+		return
+	}
+	resp, err := h.svc.SearchInstanceUsage(r.Context(), req)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// SearchInstanceMetricsStats handles POST /instances/metrics/stats/search.
+func (h *InstanceHandler) SearchInstanceMetricsStats(w http.ResponseWriter, r *http.Request) {
+	var req domain.InstanceMetricsStatsRequest
+	if !decodeRequest(w, r, &req) {
+		return
+	}
+	resp, err := h.svc.SearchInstanceMetricsStats(r.Context(), req)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// SearchInstanceUsageStats handles POST /instances/usages/stats/search.
+func (h *InstanceHandler) SearchInstanceUsageStats(w http.ResponseWriter, r *http.Request) {
+	var req domain.InstanceUsageStatsRequest
+	if !decodeRequest(w, r, &req) {
+		return
+	}
+	resp, err := h.svc.SearchInstanceUsageStats(r.Context(), req)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}

--- a/entity-service/internal/handler/product_vulnerability_handler.go
+++ b/entity-service/internal/handler/product_vulnerability_handler.go
@@ -62,3 +62,14 @@ func (h *ProductVulnerabilityHandler) GetProductVulnerability(w http.ResponseWri
 	w.WriteHeader(http.StatusOK)
 	_ = json.NewEncoder(w).Encode(result)
 }
+
+// GetVulnerabilityMeta handles GET /products/vulnerabilities/meta.
+func (h *ProductVulnerabilityHandler) GetVulnerabilityMeta(w http.ResponseWriter, r *http.Request) {
+	result, err := h.svc.GetVulnerabilityMeta(r.Context())
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(result)
+}

--- a/entity-service/internal/handler/time_card_handler.go
+++ b/entity-service/internal/handler/time_card_handler.go
@@ -50,6 +50,21 @@ func (h *TimeCardHandler) SearchTimeCards(w http.ResponseWriter, r *http.Request
 	_ = json.NewEncoder(w).Encode(resp)
 }
 
+// SearchCaseTimeCards handles POST /cases/time-cards/search.
+func (h *TimeCardHandler) SearchCaseTimeCards(w http.ResponseWriter, r *http.Request) {
+	var req domain.SearchTimeCardsRequest
+	if !decodeRequest(w, r, &req) {
+		return
+	}
+	resp, err := h.svc.SearchCaseTimeCards(r.Context(), req)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
 // CreateTimeCard handles POST /time-cards.
 func (h *TimeCardHandler) CreateTimeCard(w http.ResponseWriter, r *http.Request) {
 	var req domain.CreateTimeCardRequest

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -177,6 +177,21 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 		conversationHandler = handler.NewConversationHandler(service.NewServiceNowConversationService(serviceNowIntegrationServiceClient))
 	}
 
+	var globalHandler *handler.GlobalHandler
+	if cfg.DataSource == config.DataSourceServiceNow {
+		globalHandler = handler.NewGlobalHandler(service.NewServiceNowGlobalService(serviceNowIntegrationServiceClient))
+	}
+
+	var escalationHandler *handler.EscalationHandler
+	if cfg.DataSource == config.DataSourceServiceNow {
+		escalationHandler = handler.NewEscalationHandler(service.NewServiceNowEscalationService(serviceNowIntegrationServiceClient))
+	}
+
+	var instanceHandler *handler.InstanceHandler
+	if cfg.DataSource == config.DataSourceServiceNow {
+		instanceHandler = handler.NewInstanceHandler(service.NewServiceNowInstanceService(serviceNowIntegrationServiceClient))
+	}
+
 	var itServiceHandler *handler.ITServiceHandler
 	if cfg.DataSource == config.DataSourceServiceNow {
 		itServiceHandler = handler.NewITServiceHandler(service.NewServiceNowITServiceService(serviceNowIntegrationServiceClient))
@@ -283,6 +298,8 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 	mux.HandleFunc("POST /deployed-products", deployedProductHandler.CreateDeployedProduct)
 	mux.HandleFunc("POST /deployed-products/search", deployedProductHandler.SearchDeployedProducts)
 	mux.HandleFunc("PATCH /deployed-products/{id}", deployedProductHandler.PatchDeployedProduct)
+	mux.HandleFunc("POST /deployed-products/{id}/metrics/search", deployedProductHandler.SearchDeployedProductMetrics)
+	mux.HandleFunc("POST /deployed-products/{id}/metrics/usage-counts/search", deployedProductHandler.SearchDeployedProductUsageCounts)
 	mux.HandleFunc("GET /cases/{id}", caseHandler.GetCase)
 	mux.HandleFunc("PATCH /cases/{id}", caseHandler.PatchCase)
 	mux.HandleFunc("POST /cases", caseHandler.CreateCase)
@@ -292,7 +309,11 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 	mux.HandleFunc("POST /attachments", caseHandler.CreateCaseAttachment)
 	mux.HandleFunc("POST /attachments/search", caseHandler.SearchCaseAttachments)
 	mux.HandleFunc("GET /attachments/{id}/content", caseHandler.GetCaseAttachmentContent)
+	mux.HandleFunc("GET /attachments/{id}", caseHandler.GetAttachmentByID)
+	mux.HandleFunc("PATCH /attachments/{id}", caseHandler.UpdateAttachment)
 	mux.HandleFunc("DELETE /attachments/{id}", caseHandler.DeleteCaseAttachment)
+	mux.HandleFunc("GET /cases/{id}/feedback", caseHandler.GetCaseFeedback)
+	mux.HandleFunc("POST /cases/{id}/feedback", caseHandler.SubmitCaseFeedback)
 	mux.HandleFunc("POST /cases/{id}/tags", caseHandler.AddCaseTag)
 	mux.HandleFunc("DELETE /cases/{id}/tags/{tagId}", caseHandler.RemoveCaseTag)
 	mux.HandleFunc("GET /tags/search", caseHandler.SearchTags)
@@ -320,6 +341,7 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 		mux.HandleFunc("POST /time-cards/search", timeCardHandler.SearchTimeCards)
 		mux.HandleFunc("POST /time-cards", timeCardHandler.CreateTimeCard)
 		mux.HandleFunc("PATCH /time-cards/{id}", timeCardHandler.UpdateTimeCard)
+		mux.HandleFunc("POST /cases/time-cards/search", timeCardHandler.SearchCaseTimeCards)
 	}
 
 	if catalogHandler != nil {
@@ -330,6 +352,7 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 	if productVulnerabilityHandler != nil {
 		mux.HandleFunc("POST /products/vulnerabilities/search", productVulnerabilityHandler.SearchProductVulnerabilities)
 		mux.HandleFunc("GET /products/vulnerabilities/{id}", productVulnerabilityHandler.GetProductVulnerability)
+		mux.HandleFunc("GET /products/vulnerabilities/meta", productVulnerabilityHandler.GetVulnerabilityMeta)
 	}
 
 	if itServiceHandler != nil {
@@ -386,6 +409,27 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 
 	if conversationHandler != nil {
 		mux.HandleFunc("POST /conversations/search", conversationHandler.SearchConversations)
+		mux.HandleFunc("GET /conversations/{id}", conversationHandler.GetConversation)
+		mux.HandleFunc("POST /conversations", conversationHandler.CreateConversation)
+		mux.HandleFunc("PATCH /conversations/{id}", conversationHandler.UpdateConversation)
+	}
+
+	if globalHandler != nil {
+		mux.HandleFunc("GET /metadata", globalHandler.GetSystemMetadata)
+		mux.HandleFunc("POST /search", globalHandler.GlobalSearch)
+	}
+
+	if escalationHandler != nil {
+		mux.HandleFunc("POST /escalations/search", escalationHandler.SearchEscalations)
+		mux.HandleFunc("POST /escalations", escalationHandler.CreateEscalation)
+	}
+
+	if instanceHandler != nil {
+		mux.HandleFunc("POST /instances/search", instanceHandler.SearchInstances)
+		mux.HandleFunc("POST /instances/metrics/search", instanceHandler.SearchInstanceMetrics)
+		mux.HandleFunc("POST /instances/usages/search", instanceHandler.SearchInstanceUsage)
+		mux.HandleFunc("POST /instances/metrics/stats/search", instanceHandler.SearchInstanceMetricsStats)
+		mux.HandleFunc("POST /instances/usages/stats/search", instanceHandler.SearchInstanceUsageStats)
 	}
 
 	return middleware.CorrelationID(

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -538,3 +538,19 @@ func (s *caseService) RemoveCaseTag(_ context.Context, _, _ string) error {
 func (s *caseService) SearchTags(_ context.Context, _ string, _ int) ([]domain.Tag, error) {
 	return nil, &apierror.ServiceUnavailableError{Msg: "case tags are only supported for the ServiceNow data source"}
 }
+
+func (s *caseService) GetCaseFeedback(_ context.Context, _ string) (domain.CaseFeedback, error) {
+	return domain.CaseFeedback{}, &apierror.ServiceUnavailableError{Msg: "case feedback is only supported for the ServiceNow data source"}
+}
+
+func (s *caseService) SubmitCaseFeedback(_ context.Context, _ string, _ domain.SubmitCaseFeedbackRequest) (domain.SubmitCaseFeedbackResponse, error) {
+	return domain.SubmitCaseFeedbackResponse{}, &apierror.ServiceUnavailableError{Msg: "case feedback is only supported for the ServiceNow data source"}
+}
+
+func (s *caseService) GetAttachmentByID(_ context.Context, _ string) (domain.AttachmentDetails, error) {
+	return domain.AttachmentDetails{}, &apierror.ServiceUnavailableError{Msg: "attachments are only supported for the ServiceNow data source"}
+}
+
+func (s *caseService) UpdateAttachment(_ context.Context, _ domain.UpdateAttachmentRequest) (domain.UpdateAttachmentResponse, error) {
+	return domain.UpdateAttachmentResponse{}, &apierror.ServiceUnavailableError{Msg: "attachments are only supported for the ServiceNow data source"}
+}

--- a/entity-service/internal/service/deployed_product_service.go
+++ b/entity-service/internal/service/deployed_product_service.go
@@ -66,3 +66,13 @@ func (s *deployedProductService) CreateDeployedProduct(_ context.Context, _ doma
 func (s *deployedProductService) UpdateDeployedProduct(_ context.Context, _ domain.UpdateDeployedProductRequest) (domain.UpdateDeployedProductResponse, error) {
 	return domain.UpdateDeployedProductResponse{}, &apierror.ValidationError{Msg: "UpdateDeployedProduct is not supported for the PostgreSQL data source"}
 }
+
+// SearchDeployedProductMetrics is not supported for the PostgreSQL data source.
+func (s *deployedProductService) SearchDeployedProductMetrics(_ context.Context, _ string, _ domain.DeployedProductMetricsRequest) (domain.DeployedProductMetricsResponse, error) {
+	return domain.DeployedProductMetricsResponse{}, &apierror.ServiceUnavailableError{Msg: "deployed product metrics are only supported for the ServiceNow data source"}
+}
+
+// SearchDeployedProductUsageCounts is not supported for the PostgreSQL data source.
+func (s *deployedProductService) SearchDeployedProductUsageCounts(_ context.Context, _ string, _ domain.DeployedProductUsageCountsRequest) (domain.DeployedProductUsageCountsResponse, error) {
+	return domain.DeployedProductUsageCountsResponse{}, &apierror.ServiceUnavailableError{Msg: "deployed product metrics are only supported for the ServiceNow data source"}
+}

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -193,6 +193,15 @@ type DeployedProductService interface {
 	// Either detail fields or Active=false must be provided, but not both.
 	// Supported by the ServiceNow data source only.
 	UpdateDeployedProduct(ctx context.Context, req domain.UpdateDeployedProductRequest) (domain.UpdateDeployedProductResponse, error)
+	// SearchDeployedProductMetrics returns core-count metrics for the deployed product
+	// identified by id, charted over req's date range. A ValidationError is returned for
+	// invalid input (malformed UUID, invalid/unordered dates, or a range exceeding one year).
+	// Supported by the ServiceNow data source only.
+	SearchDeployedProductMetrics(ctx context.Context, id string, req domain.DeployedProductMetricsRequest) (domain.DeployedProductMetricsResponse, error)
+	// SearchDeployedProductUsageCounts returns usage-count metrics for the deployed product
+	// identified by id, charted over req's date range. Same validation as
+	// SearchDeployedProductMetrics. Supported by the ServiceNow data source only.
+	SearchDeployedProductUsageCounts(ctx context.Context, id string, req domain.DeployedProductUsageCountsRequest) (domain.DeployedProductUsageCountsResponse, error)
 }
 
 // CaseService defines the operations available on the cases entity.
@@ -255,6 +264,22 @@ type CaseService interface {
 	// Not yet available in the backing service: no Ballerina/Choreo endpoint exists yet for a
 	// case-agnostic tag search; see SearchTags in sn_case_service.go for the requested contract.
 	SearchTags(ctx context.Context, query string, limit int) ([]domain.Tag, error)
+	// GetCaseFeedback returns the feedback previously submitted for the case identified
+	// by id. A NotFoundError is returned if none has been submitted.
+	// Supported by the ServiceNow data source only.
+	GetCaseFeedback(ctx context.Context, id string) (domain.CaseFeedback, error)
+	// SubmitCaseFeedback records feedback for the case identified by id. A ValidationError
+	// is returned for invalid input. Supported by the ServiceNow data source only.
+	SubmitCaseFeedback(ctx context.Context, id string, req domain.SubmitCaseFeedbackRequest) (domain.SubmitCaseFeedbackResponse, error)
+	// GetAttachmentByID returns the metadata and base64-encoded content of the attachment
+	// identified by id. A NotFoundError is returned if it does not exist.
+	// Supported by the ServiceNow data source only.
+	GetAttachmentByID(ctx context.Context, id string) (domain.AttachmentDetails, error)
+	// UpdateAttachment updates the name and/or description of the attachment identified by
+	// req.ID. A ValidationError is returned for invalid input (referenceType must be "case"
+	// or "deployment"; "case" requires name and forbids description; "deployment" requires
+	// at least one of name or description). Supported by the ServiceNow data source only.
+	UpdateAttachment(ctx context.Context, req domain.UpdateAttachmentRequest) (domain.UpdateAttachmentResponse, error)
 }
 
 // CaseGithubIssueService defines the operation for filing a GitHub issue from a case.
@@ -329,6 +354,10 @@ type TimeCardService interface {
 	// UpdateTimeCard edits an editable (submitted) time card, or transitions its
 	// state (approve/reject) when req.State is set. SN enforces authorization.
 	UpdateTimeCard(ctx context.Context, req domain.UpdateTimeCardRequest) (domain.TimeCardMutationResponse, error)
+	// SearchCaseTimeCards returns a paginated list of time cards grouped and rolled up by
+	// case, using the same filters as SearchTimeCards. Supported by the ServiceNow data
+	// source only.
+	SearchCaseTimeCards(ctx context.Context, req domain.SearchTimeCardsRequest) (domain.SearchCaseTimeCardsResponse, error)
 }
 
 // ConfigurationItemService defines the operations available on the configuration items entity.
@@ -416,6 +445,10 @@ type ProductVulnerabilityService interface {
 	// GetProductVulnerability returns the detail of a single vulnerability by its UUID.
 	// A NotFoundError is returned if the vulnerability does not exist.
 	GetProductVulnerability(ctx context.Context, id string) (domain.ProductVulnerabilityView, error)
+
+	// GetVulnerabilityMeta returns the valid severity choices for product vulnerabilities.
+	// Supported by the ServiceNow data source only.
+	GetVulnerabilityMeta(ctx context.Context) (domain.VulnerabilityMetaResponse, error)
 }
 
 // IncidentService defines the operations available on the incidents entity.
@@ -459,6 +492,40 @@ type ConversationService interface {
 	// project IDs, states, search query, and createdByMe. A ValidationError is returned
 	// for invalid input.
 	SearchConversations(ctx context.Context, req domain.SearchConversationsRequest) (domain.SearchConversationsResponse, error)
+	// GetConversation returns the detail of a single conversation by its UUID.
+	// A NotFoundError is returned if the conversation does not exist.
+	GetConversation(ctx context.Context, id string) (domain.ConversationDetails, error)
+	// CreateConversation starts a new conversation on the project identified by
+	// req.ProjectID. A ValidationError is returned for invalid input.
+	CreateConversation(ctx context.Context, req domain.CreateConversationRequest) (domain.CreateConversationResponse, error)
+	// UpdateConversation transitions the conversation identified by id to req.State. A
+	// ValidationError is returned if State is not one of ACTIVE, RESOLVED, CONVERTED,
+	// ABANDONED, or CLOSED.
+	UpdateConversation(ctx context.Context, id string, req domain.UpdateConversationRequest) (domain.UpdateConversationResponse, error)
+}
+
+// GlobalService serves system-wide metadata and cross-entity search that
+// isn't scoped to any single project or case.
+// All methods require the ServiceNow data source; there is no Postgres fallback.
+type GlobalService interface {
+	// GetSystemMetadata returns system-wide reference data (time zones, project types,
+	// and feedback emoji choices) used across the frontend.
+	GetSystemMetadata(ctx context.Context) (domain.SystemMetadataResponse, error)
+	// GlobalSearch searches projects and/or cases matching req's filters. Every field of
+	// req is optional; an empty request searches both tables with default pagination.
+	GlobalSearch(ctx context.Context, req domain.GlobalSearchRequest) (domain.GlobalSearchResponse, error)
+}
+
+// EscalationService defines the operations available on the escalations entity.
+// All methods require the ServiceNow data source; there is no Postgres fallback.
+type EscalationService interface {
+	// SearchEscalations returns a paginated list of escalations filtered by optional case
+	// IDs and current escalation levels. A ValidationError is returned for invalid input.
+	SearchEscalations(ctx context.Context, req domain.SearchEscalationsRequest) (domain.SearchEscalationsResponse, error)
+	// CreateEscalation escalates or de-escalates the case identified by req.CaseID.
+	// Action defaults to ESCALATE when omitted; Reason is required when the (defaulted)
+	// action is ESCALATE. A ValidationError is returned for invalid input.
+	CreateEscalation(ctx context.Context, req domain.CreateEscalationRequest) (domain.CreateEscalationResponse, error)
 }
 
 // RoleService serves the platform's assignable-role catalogue.
@@ -471,4 +538,27 @@ type RoleService interface {
 type TeamService interface {
 	// SearchTeams returns a paginated slice of the team registry.
 	SearchTeams(ctx context.Context, req domain.SearchTeamsRequest) (domain.SearchTeamsResponse, error)
+}
+
+// InstanceService defines the operations available on the instances entity.
+// All methods require the ServiceNow data source; there is no Postgres fallback.
+type InstanceService interface {
+	// SearchInstances returns a paginated list of instances filtered by optional
+	// project/deployment/deployed-product IDs (mutually exclusive) and date range.
+	// A ValidationError is returned for invalid input.
+	SearchInstances(ctx context.Context, req domain.SearchInstancesRequest) (domain.SearchInstancesResponse, error)
+	// SearchInstanceMetrics returns per-instance metric time series over req's required
+	// date range, filtered by optional project/deployment/deployed-product IDs (mutually
+	// exclusive). A ValidationError is returned for invalid input.
+	SearchInstanceMetrics(ctx context.Context, req domain.InstanceMetricsRequest) (domain.InstanceMetricsResponse, error)
+	// SearchInstanceUsage returns per-instance usage time series over req's required date
+	// range. Same filter rules as SearchInstanceMetrics.
+	SearchInstanceUsage(ctx context.Context, req domain.InstanceUsageRequest) (domain.InstanceUsageResponse, error)
+	// SearchInstanceMetricsStats returns aggregated metric statistics over req's required
+	// date range. Same filter rules as SearchInstanceMetrics, plus an optional data-source
+	// filter.
+	SearchInstanceMetricsStats(ctx context.Context, req domain.InstanceMetricsStatsRequest) (domain.InstanceMetricsStatsResponse, error)
+	// SearchInstanceUsageStats returns aggregated usage statistics over req's required
+	// date range. Same filter rules as SearchInstanceMetricsStats.
+	SearchInstanceUsageStats(ctx context.Context, req domain.InstanceUsageStatsRequest) (domain.InstanceUsageStatsResponse, error)
 }

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -1943,6 +1943,269 @@ func (s *snCaseService) DeleteCaseAttachment(ctx context.Context, req domain.Del
 	return domain.DeleteAttachmentResponse{Message: snResp.Message}, nil
 }
 
+// snAttachmentDetails mirrors the Choreo GET /attachments/{id} response
+// (Ballerina's AttachmentResponse — every Attachment field plus content).
+// ServiceNow's attachment-details lookup returns a bare createdBy string with
+// no createdByUser/referenceType, unlike the search path (see snAttachment).
+type snAttachmentDetails struct {
+	ID          string  `json:"id"`
+	ReferenceID string  `json:"referenceId"`
+	Name        string  `json:"name"`
+	Type        string  `json:"type"`
+	SizeBytes   int     `json:"sizeBytes"`
+	Description *string `json:"description"`
+	CreatedBy   string  `json:"createdBy"`
+	CreatedOn   string  `json:"createdOn"`
+	DownloadURL *string `json:"downloadUrl"`
+	PreviewURL  *string `json:"previewUrl"`
+	Content     string  `json:"content"`
+}
+
+func (s *snCaseService) GetAttachmentByID(ctx context.Context, id string) (domain.AttachmentDetails, error) {
+	if err := validateUUIDs("id", []string{id}); err != nil {
+		return domain.AttachmentDetails{}, err
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+
+	raw, err := s.client.Get(ctx, "/attachments/"+uuidToSysid(id), token)
+	if err != nil {
+		return domain.AttachmentDetails{}, err
+	}
+
+	var snResp snAttachmentDetails
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.AttachmentDetails{}, fmt.Errorf("sn get attachment: parse response: %w", err)
+	}
+
+	createdOn, err := time.Parse(snCreatedOnLayout, snResp.CreatedOn)
+	if err != nil {
+		return domain.AttachmentDetails{}, fmt.Errorf("sn get attachment: parse createdOn %q: %w", snResp.CreatedOn, err)
+	}
+
+	return domain.AttachmentDetails{
+		ID:          sysidToUUID(snResp.ID),
+		ReferenceID: sysidToUUID(snResp.ReferenceID),
+		Name:        snResp.Name,
+		Type:        snResp.Type,
+		SizeBytes:   snResp.SizeBytes,
+		Description: snResp.Description,
+		CreatedBy:   snResp.CreatedBy,
+		CreatedOn:   createdOn,
+		DownloadURL: snResp.DownloadURL,
+		PreviewURL:  snResp.PreviewURL,
+		Content:     snResp.Content,
+	}, nil
+}
+
+// validateAttachmentUpdate mirrors the Ballerina reference's
+// validateAttachmentUpdatePayload exactly: referenceType must be case or
+// deployment; case requires name and forbids description; deployment
+// requires at least one of name or description.
+func validateAttachmentUpdate(req domain.UpdateAttachmentRequest) error {
+	if req.ReferenceType != domain.ReferenceTypeCase && req.ReferenceType != domain.ReferenceTypeDeployment {
+		return &apierror.ValidationError{Msg: fmt.Sprintf("invalid reference type %q. Only 'case' and 'deployment' are allowed", req.ReferenceType)}
+	}
+	if req.ReferenceType == domain.ReferenceTypeCase {
+		if req.Description != nil {
+			return &apierror.ValidationError{Msg: "description field is not allowed for case reference type"}
+		}
+		if req.Name == nil || strings.TrimSpace(*req.Name) == "" {
+			return &apierror.ValidationError{Msg: "name field is required for case reference type"}
+		}
+	}
+	if req.ReferenceType == domain.ReferenceTypeDeployment {
+		hasName := req.Name != nil && strings.TrimSpace(*req.Name) != ""
+		hasDescription := req.Description != nil && strings.TrimSpace(*req.Description) != ""
+		if !hasName && !hasDescription {
+			return &apierror.ValidationError{Msg: "at least one field (name or description) must be provided for deployment reference type"}
+		}
+	}
+	return nil
+}
+
+// snUpdateAttachmentPayload mirrors the Choreo PATCH /attachments/{id} request body.
+type snUpdateAttachmentPayload struct {
+	ReferenceID   string  `json:"referenceId"`
+	ReferenceType string  `json:"referenceType"`
+	Name          *string `json:"name,omitempty"`
+	Description   *string `json:"description,omitempty"`
+}
+
+// snUpdateAttachmentResponse mirrors the Choreo PATCH /attachments/{id} response.
+type snUpdateAttachmentResponse struct {
+	Message    string `json:"message"`
+	Attachment struct {
+		ID        string `json:"id"`
+		UpdatedOn string `json:"updatedOn"`
+		UpdatedBy string `json:"updatedBy"`
+	} `json:"attachment"`
+}
+
+func (s *snCaseService) UpdateAttachment(ctx context.Context, req domain.UpdateAttachmentRequest) (domain.UpdateAttachmentResponse, error) {
+	if err := validateUUIDs("id", []string{req.ID}); err != nil {
+		return domain.UpdateAttachmentResponse{}, err
+	}
+	if err := validateUUIDs("referenceId", []string{req.ReferenceID}); err != nil {
+		return domain.UpdateAttachmentResponse{}, err
+	}
+	if err := validateAttachmentUpdate(req); err != nil {
+		return domain.UpdateAttachmentResponse{}, err
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+
+	payload := snUpdateAttachmentPayload{
+		ReferenceID:   uuidToSysid(req.ReferenceID),
+		ReferenceType: string(req.ReferenceType),
+		Name:          req.Name,
+		Description:   req.Description,
+	}
+
+	raw, err := s.client.Patch(ctx, "/attachments/"+uuidToSysid(req.ID), token, payload)
+	if err != nil {
+		return domain.UpdateAttachmentResponse{}, err
+	}
+
+	var snResp snUpdateAttachmentResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.UpdateAttachmentResponse{}, fmt.Errorf("sn update attachment: parse response: %w", err)
+	}
+
+	updatedOn, err := time.Parse(snCreatedOnLayout, snResp.Attachment.UpdatedOn)
+	if err != nil {
+		return domain.UpdateAttachmentResponse{}, fmt.Errorf("sn update attachment: parse updatedOn %q: %w", snResp.Attachment.UpdatedOn, err)
+	}
+
+	return domain.UpdateAttachmentResponse{
+		Message: snResp.Message,
+		Attachment: domain.UpdatedAttachment{
+			ID:        sysidToUUID(snResp.Attachment.ID),
+			UpdatedOn: updatedOn,
+			UpdatedBy: snResp.Attachment.UpdatedBy,
+		},
+	}, nil
+}
+
+// snCaseFeedbackEmojiRef mirrors the emoji reference embedded in the Choreo
+// GET /cases/{id}/feedback response.
+type snCaseFeedbackEmojiRef struct {
+	ID            string `json:"id"`
+	Name          string `json:"name"`
+	SelectedImage string `json:"selectedImage"`
+}
+
+// snCaseFeedbackGetResponse mirrors the Choreo GET /cases/{id}/feedback response.
+type snCaseFeedbackGetResponse struct {
+	ID                string                 `json:"id"`
+	Emoji             snCaseFeedbackEmojiRef `json:"emoji"`
+	Chips             []string               `json:"chips"`
+	AssessmentID      string                 `json:"assessmentId"`
+	CreatedBy         string                 `json:"createdBy"`
+	CreatedOn         string                 `json:"createdOn"`
+	AdditionalComment *string                `json:"additionalComment"`
+}
+
+func (s *snCaseService) GetCaseFeedback(ctx context.Context, id string) (domain.CaseFeedback, error) {
+	if err := validateUUIDs("id", []string{id}); err != nil {
+		return domain.CaseFeedback{}, err
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+
+	raw, err := s.client.Get(ctx, "/cases/"+uuidToSysid(id)+"/feedback", token)
+	if err != nil {
+		return domain.CaseFeedback{}, err
+	}
+
+	var snResp snCaseFeedbackGetResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.CaseFeedback{}, fmt.Errorf("sn get case feedback: parse response: %w", err)
+	}
+
+	chips := make([]string, 0, len(snResp.Chips))
+	for _, c := range snResp.Chips {
+		chips = append(chips, sysidToUUID(c))
+	}
+
+	return domain.CaseFeedback{
+		ID: sysidToUUID(snResp.ID),
+		Emoji: domain.CaseFeedbackEmojiRef{
+			ID:            sysidToUUID(snResp.Emoji.ID),
+			Name:          snResp.Emoji.Name,
+			SelectedImage: snResp.Emoji.SelectedImage,
+		},
+		ChipIDs:           chips,
+		AssessmentID:      sysidToUUID(snResp.AssessmentID),
+		CreatedBy:         snResp.CreatedBy,
+		CreatedOn:         snResp.CreatedOn,
+		AdditionalComment: snResp.AdditionalComment,
+	}, nil
+}
+
+// snSubmitCaseFeedbackPayload mirrors the Choreo POST /cases/{id}/feedback request body.
+type snSubmitCaseFeedbackPayload struct {
+	EmojiID           string   `json:"emojiId"`
+	ChipIDs           []string `json:"chipIds,omitempty"`
+	AdditionalComment *string  `json:"additionalComment,omitempty"`
+}
+
+// snCaseFeedbackResult mirrors the Choreo CaseFeedbackResult shape.
+type snCaseFeedbackResult struct {
+	ID           string `json:"id"`
+	AssessmentID string `json:"assessmentId"`
+	CaseID       string `json:"caseId"`
+	CreatedBy    string `json:"createdBy"`
+	CreatedOn    string `json:"createdOn"`
+}
+
+// snSubmitCaseFeedbackResponse mirrors the Choreo POST /cases/{id}/feedback response.
+type snSubmitCaseFeedbackResponse struct {
+	Message  string               `json:"message"`
+	Feedback snCaseFeedbackResult `json:"feedback"`
+}
+
+func (s *snCaseService) SubmitCaseFeedback(ctx context.Context, id string, req domain.SubmitCaseFeedbackRequest) (domain.SubmitCaseFeedbackResponse, error) {
+	if err := validateUUIDs("id", []string{id}); err != nil {
+		return domain.SubmitCaseFeedbackResponse{}, err
+	}
+	if err := validateUUIDs("emojiId", []string{req.EmojiID}); err != nil {
+		return domain.SubmitCaseFeedbackResponse{}, err
+	}
+	if err := validateUUIDs("chipIds", req.ChipIDs); err != nil {
+		return domain.SubmitCaseFeedbackResponse{}, err
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+
+	payload := snSubmitCaseFeedbackPayload{
+		EmojiID:           uuidToSysid(req.EmojiID),
+		ChipIDs:           uuidsToSysids(req.ChipIDs),
+		AdditionalComment: req.AdditionalComment,
+	}
+
+	raw, err := s.client.Post(ctx, "/cases/"+uuidToSysid(id)+"/feedback", token, payload)
+	if err != nil {
+		return domain.SubmitCaseFeedbackResponse{}, err
+	}
+
+	var snResp snSubmitCaseFeedbackResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.SubmitCaseFeedbackResponse{}, fmt.Errorf("sn submit case feedback: parse response: %w", err)
+	}
+
+	return domain.SubmitCaseFeedbackResponse{
+		Message: snResp.Message,
+		Feedback: domain.CaseFeedbackResult{
+			ID:           sysidToUUID(snResp.Feedback.ID),
+			AssessmentID: sysidToUUID(snResp.Feedback.AssessmentID),
+			CaseID:       sysidToUUID(snResp.Feedback.CaseID),
+			CreatedBy:    snResp.Feedback.CreatedBy,
+			CreatedOn:    snResp.Feedback.CreatedOn,
+		},
+	}, nil
+}
+
 // validateOrGroupEnums validates one OrGroups branch's enum-valued fields
 // against the same validXxx maps the top-level (AND-only) filters use,
 // mirroring that validation exactly (unrecognized values would otherwise be

--- a/entity-service/internal/service/sn_conversation_service.go
+++ b/entity-service/internal/service/sn_conversation_service.go
@@ -36,18 +36,18 @@ type snConversationsResponse struct {
 }
 
 type snConversation struct {
-	ID             *string                  `json:"id"`
-	Number         *string                  `json:"number"`
-	InitialMessage *string                  `json:"initialMessage"`
-	MessageCount   int                      `json:"messageCount"`
-	Project        *snConversationEntityRef `json:"project"`
-	Case           *snConversationEntityRef `json:"case"`
-	State          *snConversationIntLabel  `json:"state"`
-	CreatedOn      string                   `json:"createdOn"`
-	CreatedBy      string                   `json:"createdBy"`
+	ID             *string                 `json:"id"`
+	Number         *string                 `json:"number"`
+	InitialMessage *string                 `json:"initialMessage"`
+	MessageCount   int                     `json:"messageCount"`
+	Project        *snEntityRef            `json:"project"`
+	Case           *snEntityRef            `json:"case"`
+	State          *snConversationIntLabel `json:"state"`
+	CreatedOn      string                  `json:"createdOn"`
+	CreatedBy      string                  `json:"createdBy"`
 }
 
-type snConversationEntityRef struct {
+type snEntityRef struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
 }
@@ -252,17 +252,17 @@ func (s *snConversationService) SearchConversations(ctx context.Context, req dom
 // (Ballerina's ConversationResponse, which inclusion-copies every field of
 // Conversation and adds updatedOn/updatedBy — flattened here).
 type snConversationDetails struct {
-	ID             string                   `json:"id"`
-	Number         *string                  `json:"number"`
-	InitialMessage *string                  `json:"initialMessage"`
-	MessageCount   int                      `json:"messageCount"`
-	CreatedOn      string                   `json:"createdOn"`
-	CreatedBy      string                   `json:"createdBy"`
-	Project        *snConversationEntityRef `json:"project"`
-	Case           *snConversationEntityRef `json:"case"`
-	State          *snConversationIntLabel  `json:"state"`
-	UpdatedOn      string                   `json:"updatedOn"`
-	UpdatedBy      string                   `json:"updatedBy"`
+	ID             string                  `json:"id"`
+	Number         *string                 `json:"number"`
+	InitialMessage *string                 `json:"initialMessage"`
+	MessageCount   int                     `json:"messageCount"`
+	CreatedOn      string                  `json:"createdOn"`
+	CreatedBy      string                  `json:"createdBy"`
+	Project        *snEntityRef            `json:"project"`
+	Case           *snEntityRef            `json:"case"`
+	State          *snConversationIntLabel `json:"state"`
+	UpdatedOn      string                  `json:"updatedOn"`
+	UpdatedBy      string                  `json:"updatedBy"`
 }
 
 func (s *snConversationService) GetConversation(ctx context.Context, id string) (domain.ConversationDetails, error) {

--- a/entity-service/internal/service/sn_conversation_service.go
+++ b/entity-service/internal/service/sn_conversation_service.go
@@ -77,20 +77,40 @@ type snConversationFilters struct {
 }
 
 // snConversationStateKeyMap maps domain ConversationState enums to SN numeric state keys.
+// Covers all 5 transition states (used by UpdateConversation and to interpret
+// GetConversation's state, which may be any of them), though search filters
+// (validConversationState) only ever accept ACTIVE/RESOLVED.
 var snConversationStateKeyMap = map[domain.ConversationState]int{
-	domain.ConversationStateActive:   2,
-	domain.ConversationStateResolved: 3,
+	domain.ConversationStateActive:    2,
+	domain.ConversationStateResolved:  3,
+	domain.ConversationStateConverted: 4,
+	domain.ConversationStateAbandoned: 5,
+	domain.ConversationStateClosed:    6,
 }
 
 // snConversationStateLabelMap maps SN numeric state keys to domain enum strings.
 var snConversationStateLabelMap = map[int]string{
 	2: "ACTIVE",
 	3: "RESOLVED",
+	4: "CONVERTED",
+	5: "ABANDONED",
+	6: "CLOSED",
 }
 
 var validConversationState = map[domain.ConversationState]bool{
 	domain.ConversationStateActive:   true,
 	domain.ConversationStateResolved: true,
+}
+
+// validConversationUpdateState is the full transition allow-list PATCH
+// /conversations/{id} enforces — every state a conversation can be moved to,
+// not just the two the search endpoint allows filtering by.
+var validConversationUpdateState = map[domain.ConversationState]bool{
+	domain.ConversationStateActive:    true,
+	domain.ConversationStateResolved:  true,
+	domain.ConversationStateConverted: true,
+	domain.ConversationStateAbandoned: true,
+	domain.ConversationStateClosed:    true,
 }
 
 var validConversationSortField = map[domain.ConversationSortField]bool{
@@ -225,5 +245,186 @@ func (s *snConversationService) SearchConversations(ctx context.Context, req dom
 		Total:         snResp.TotalRecords,
 		Limit:         req.Pagination.Limit,
 		Offset:        req.Pagination.Offset,
+	}, nil
+}
+
+// snConversationDetails mirrors the Choreo GET /conversations/{id} response
+// (Ballerina's ConversationResponse, which inclusion-copies every field of
+// Conversation and adds updatedOn/updatedBy — flattened here).
+type snConversationDetails struct {
+	ID             string                   `json:"id"`
+	Number         *string                  `json:"number"`
+	InitialMessage *string                  `json:"initialMessage"`
+	MessageCount   int                      `json:"messageCount"`
+	CreatedOn      string                   `json:"createdOn"`
+	CreatedBy      string                   `json:"createdBy"`
+	Project        *snConversationEntityRef `json:"project"`
+	Case           *snConversationEntityRef `json:"case"`
+	State          *snConversationIntLabel  `json:"state"`
+	UpdatedOn      string                   `json:"updatedOn"`
+	UpdatedBy      string                   `json:"updatedBy"`
+}
+
+func (s *snConversationService) GetConversation(ctx context.Context, id string) (domain.ConversationDetails, error) {
+	if err := validateUUIDs("id", []string{id}); err != nil {
+		return domain.ConversationDetails{}, err
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+
+	raw, err := s.client.Get(ctx, "/conversations/"+uuidToSysid(id), token)
+	if err != nil {
+		return domain.ConversationDetails{}, err
+	}
+
+	var snResp snConversationDetails
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.ConversationDetails{}, fmt.Errorf("sn get conversation: parse response: %w", err)
+	}
+
+	details := domain.ConversationDetails{
+		ID:             sysidToUUID(snResp.ID),
+		Number:         snResp.Number,
+		InitialMessage: snResp.InitialMessage,
+		MessageCount:   snResp.MessageCount,
+		CreatedOn:      snResp.CreatedOn,
+		CreatedBy:      snResp.CreatedBy,
+		UpdatedOn:      snResp.UpdatedOn,
+		UpdatedBy:      snResp.UpdatedBy,
+	}
+	if snResp.Project != nil {
+		details.Project = &domain.EntityRef{ID: sysidToUUID(snResp.Project.ID), Name: snResp.Project.Name}
+	}
+	if snResp.Case != nil {
+		details.Case = &domain.EntityRef{ID: sysidToUUID(snResp.Case.ID), Name: snResp.Case.Name}
+	}
+	if snResp.State != nil {
+		if label, ok := snConversationStateLabelMap[snResp.State.ID]; ok {
+			details.State = &label
+		}
+	}
+
+	return details, nil
+}
+
+// snConversationCreatePayload mirrors the Choreo POST /conversations request body.
+type snConversationCreatePayload struct {
+	ProjectID      string `json:"projectId"`
+	InitialMessage string `json:"initialMessage"`
+}
+
+type snCreatedConversation struct {
+	ID        string                 `json:"id"`
+	Number    string                 `json:"number"`
+	CreatedBy string                 `json:"createdBy"`
+	CreatedOn string                 `json:"createdOn"`
+	State     snConversationIntLabel `json:"state"`
+}
+
+// snConversationCreateResponse mirrors the Choreo POST /conversations response.
+type snConversationCreateResponse struct {
+	Message      string                `json:"message"`
+	Conversation snCreatedConversation `json:"conversation"`
+}
+
+func (s *snConversationService) CreateConversation(ctx context.Context, req domain.CreateConversationRequest) (domain.CreateConversationResponse, error) {
+	if err := validateUUIDs("projectId", []string{req.ProjectID}); err != nil {
+		return domain.CreateConversationResponse{}, err
+	}
+	if req.InitialMessage == "" {
+		return domain.CreateConversationResponse{}, &apierror.ValidationError{Msg: "initialMessage is required"}
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+
+	payload := snConversationCreatePayload{
+		ProjectID:      uuidToSysid(req.ProjectID),
+		InitialMessage: req.InitialMessage,
+	}
+
+	raw, err := s.client.Post(ctx, "/conversations", token, payload)
+	if err != nil {
+		return domain.CreateConversationResponse{}, err
+	}
+
+	var snResp snConversationCreateResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.CreateConversationResponse{}, fmt.Errorf("sn create conversation: parse response: %w", err)
+	}
+
+	state := snConversationStateLabelMap[snResp.Conversation.State.ID]
+	var statePtr *string
+	if state != "" {
+		statePtr = &state
+	}
+
+	return domain.CreateConversationResponse{
+		Message: snResp.Message,
+		Conversation: domain.CreatedConversation{
+			ID:        sysidToUUID(snResp.Conversation.ID),
+			Number:    snResp.Conversation.Number,
+			CreatedBy: snResp.Conversation.CreatedBy,
+			CreatedOn: snResp.Conversation.CreatedOn,
+			State:     statePtr,
+		},
+	}, nil
+}
+
+// snConversationUpdatePayload mirrors the Choreo PATCH /conversations/{id} request body.
+type snConversationUpdatePayload struct {
+	StateKey int `json:"stateKey"`
+}
+
+type snUpdatedConversation struct {
+	ID        string                 `json:"id"`
+	Number    *string                `json:"number"`
+	UpdatedOn string                 `json:"updatedOn"`
+	UpdatedBy string                 `json:"updatedBy"`
+	State     snConversationIntLabel `json:"state"`
+}
+
+// snConversationUpdateResponse mirrors the Choreo PATCH /conversations/{id} response.
+type snConversationUpdateResponse struct {
+	Message      string                `json:"message"`
+	Conversation snUpdatedConversation `json:"conversation"`
+}
+
+func (s *snConversationService) UpdateConversation(ctx context.Context, id string, req domain.UpdateConversationRequest) (domain.UpdateConversationResponse, error) {
+	if err := validateUUIDs("id", []string{id}); err != nil {
+		return domain.UpdateConversationResponse{}, err
+	}
+	if !validConversationUpdateState[req.State] {
+		return domain.UpdateConversationResponse{}, &apierror.ValidationError{Msg: "state contains invalid value: " + string(req.State)}
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+
+	payload := snConversationUpdatePayload{StateKey: snConversationStateKeyMap[req.State]}
+
+	raw, err := s.client.Patch(ctx, "/conversations/"+uuidToSysid(id), token, payload)
+	if err != nil {
+		return domain.UpdateConversationResponse{}, err
+	}
+
+	var snResp snConversationUpdateResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.UpdateConversationResponse{}, fmt.Errorf("sn update conversation: parse response: %w", err)
+	}
+
+	state := snConversationStateLabelMap[snResp.Conversation.State.ID]
+	var statePtr *string
+	if state != "" {
+		statePtr = &state
+	}
+
+	return domain.UpdateConversationResponse{
+		Message: snResp.Message,
+		Conversation: domain.UpdatedConversation{
+			ID:        sysidToUUID(snResp.Conversation.ID),
+			Number:    snResp.Conversation.Number,
+			UpdatedOn: snResp.Conversation.UpdatedOn,
+			UpdatedBy: snResp.Conversation.UpdatedBy,
+			State:     statePtr,
+		},
 	}, nil
 }

--- a/entity-service/internal/service/sn_deployed_product_service.go
+++ b/entity-service/internal/service/sn_deployed_product_service.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strconv"
 	"time"
 
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
@@ -361,39 +360,6 @@ func (s *snDeployedProductService) SearchDeployedProducts(ctx context.Context, r
 	}, nil
 }
 
-// validateDateRange enforces the same rules as the Ballerina reference's
-// shared validateDateRange helper: both dates must be exactly 10 characters
-// in YYYY-MM-DD format, startDate must be strictly before endDate, and the
-// span between them must not exceed one year.
-func validateDateRange(startDate, endDate string) error {
-	if len(startDate) != 10 || len(endDate) != 10 ||
-		startDate[4:5] != "-" || startDate[7:8] != "-" ||
-		endDate[4:5] != "-" || endDate[7:8] != "-" {
-		return &apierror.ValidationError{Msg: "invalid date format. Expected YYYY-MM-DD"}
-	}
-
-	startYear, errSY := strconv.Atoi(startDate[0:4])
-	startMonth, errSM := strconv.Atoi(startDate[5:7])
-	startDay, errSD := strconv.Atoi(startDate[8:10])
-	endYear, errEY := strconv.Atoi(endDate[0:4])
-	endMonth, errEM := strconv.Atoi(endDate[5:7])
-	endDay, errED := strconv.Atoi(endDate[8:10])
-	if errSY != nil || errSM != nil || errSD != nil || errEY != nil || errEM != nil || errED != nil {
-		return &apierror.ValidationError{Msg: "invalid date format. Expected YYYY-MM-DD"}
-	}
-
-	if startDate >= endDate {
-		return &apierror.ValidationError{Msg: "endDate must be after startDate"}
-	}
-
-	yearDiff := endYear - startYear
-	if yearDiff > 1 || (yearDiff == 1 && (endMonth > startMonth || (endMonth == startMonth && endDay > startDay))) {
-		return &apierror.ValidationError{Msg: "date range must not exceed 1 year"}
-	}
-
-	return nil
-}
-
 // snDeployedProductMetricsInstance mirrors the Choreo
 // DeployedProductMetricsInstance shape.
 type snDeployedProductMetricsInstance struct {
@@ -438,6 +404,12 @@ type snDeployedProductMetricsResponse struct {
 	ChartData       []snDeployedProductMetricsChartEntry `json:"chartData"`
 }
 
+type snDeployedProductMetricsSearchPayload struct {
+	DeploymentID string `json:"deploymentId"`
+	StartDate    string `json:"startDate"`
+	EndDate      string `json:"endDate"`
+}
+
 func (s *snDeployedProductService) SearchDeployedProductMetrics(ctx context.Context, id string, req domain.DeployedProductMetricsRequest) (domain.DeployedProductMetricsResponse, error) {
 	if err := validateUUIDs("id", []string{id}); err != nil {
 		return domain.DeployedProductMetricsResponse{}, err
@@ -451,11 +423,7 @@ func (s *snDeployedProductService) SearchDeployedProductMetrics(ctx context.Cont
 
 	token := middleware.UserIDTokenFromContext(ctx)
 
-	payload := struct {
-		DeploymentID string `json:"deploymentId"`
-		StartDate    string `json:"startDate"`
-		EndDate      string `json:"endDate"`
-	}{
+	payload := snDeployedProductMetricsSearchPayload{
 		DeploymentID: uuidToSysid(req.DeploymentID),
 		StartDate:    req.StartDate,
 		EndDate:      req.EndDate,
@@ -562,11 +530,7 @@ func (s *snDeployedProductService) SearchDeployedProductUsageCounts(ctx context.
 
 	token := middleware.UserIDTokenFromContext(ctx)
 
-	payload := struct {
-		DeploymentID string `json:"deploymentId"`
-		StartDate    string `json:"startDate"`
-		EndDate      string `json:"endDate"`
-	}{
+	payload := snDeployedProductMetricsSearchPayload{
 		DeploymentID: uuidToSysid(req.DeploymentID),
 		StartDate:    req.StartDate,
 		EndDate:      req.EndDate,

--- a/entity-service/internal/service/sn_deployed_product_service.go
+++ b/entity-service/internal/service/sn_deployed_product_service.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
@@ -357,5 +358,261 @@ func (s *snDeployedProductService) SearchDeployedProducts(ctx context.Context, r
 		Limit:            req.Pagination.Limit,
 		Offset:           req.Pagination.Offset,
 		HasMore:          req.Pagination.Offset+len(views) < total,
+	}, nil
+}
+
+// validateDateRange enforces the same rules as the Ballerina reference's
+// shared validateDateRange helper: both dates must be exactly 10 characters
+// in YYYY-MM-DD format, startDate must be strictly before endDate, and the
+// span between them must not exceed one year.
+func validateDateRange(startDate, endDate string) error {
+	if len(startDate) != 10 || len(endDate) != 10 ||
+		startDate[4:5] != "-" || startDate[7:8] != "-" ||
+		endDate[4:5] != "-" || endDate[7:8] != "-" {
+		return &apierror.ValidationError{Msg: "invalid date format. Expected YYYY-MM-DD"}
+	}
+
+	startYear, errSY := strconv.Atoi(startDate[0:4])
+	startMonth, errSM := strconv.Atoi(startDate[5:7])
+	startDay, errSD := strconv.Atoi(startDate[8:10])
+	endYear, errEY := strconv.Atoi(endDate[0:4])
+	endMonth, errEM := strconv.Atoi(endDate[5:7])
+	endDay, errED := strconv.Atoi(endDate[8:10])
+	if errSY != nil || errSM != nil || errSD != nil || errEY != nil || errEM != nil || errED != nil {
+		return &apierror.ValidationError{Msg: "invalid date format. Expected YYYY-MM-DD"}
+	}
+
+	if startDate >= endDate {
+		return &apierror.ValidationError{Msg: "endDate must be after startDate"}
+	}
+
+	yearDiff := endYear - startYear
+	if yearDiff > 1 || (yearDiff == 1 && (endMonth > startMonth || (endMonth == startMonth && endDay > startDay))) {
+		return &apierror.ValidationError{Msg: "date range must not exceed 1 year"}
+	}
+
+	return nil
+}
+
+// snDeployedProductMetricsInstance mirrors the Choreo
+// DeployedProductMetricsInstance shape.
+type snDeployedProductMetricsInstance struct {
+	ID    string `json:"id"`
+	Name  string `json:"name"`
+	Cores int    `json:"cores"`
+}
+
+// snDeployedProductMetricsChartEntry mirrors the Choreo
+// DeployedProductMetricsChartEntry shape.
+type snDeployedProductMetricsChartEntry struct {
+	Date          string                             `json:"date"`
+	InstanceCount int                                `json:"instanceCount"`
+	TotalCores    int                                `json:"totalCores"`
+	MinCores      int                                `json:"minCores"`
+	MaxCores      int                                `json:"maxCores"`
+	AvgCores      float64                            `json:"avgCores"`
+	Instances     []snDeployedProductMetricsInstance `json:"instances"`
+}
+
+// snDeployedProductMetricsDateRange mirrors the Choreo dateRange shape shared
+// by both metrics and usage-counts summaries.
+type snDeployedProductMetricsDateRange struct {
+	Start string `json:"start"`
+	End   string `json:"end"`
+}
+
+// snDeployedProductMetricsSummary mirrors the Choreo DeployedProductMetricsSummary shape.
+type snDeployedProductMetricsSummary struct {
+	DateRange      snDeployedProductMetricsDateRange `json:"dateRange"`
+	TotalInstances int                               `json:"totalInstances"`
+	MinCores       *int                              `json:"minCores"`
+	MaxCores       *int                              `json:"maxCores"`
+	AvgCores       *float64                          `json:"avgCores"`
+}
+
+// snDeployedProductMetricsResponse mirrors the Choreo
+// POST /deployed-products/{id}/metrics/search response.
+type snDeployedProductMetricsResponse struct {
+	DeployedProduct snReferenceTableItem                 `json:"deployedProduct"`
+	Summary         snDeployedProductMetricsSummary      `json:"summary"`
+	ChartData       []snDeployedProductMetricsChartEntry `json:"chartData"`
+}
+
+func (s *snDeployedProductService) SearchDeployedProductMetrics(ctx context.Context, id string, req domain.DeployedProductMetricsRequest) (domain.DeployedProductMetricsResponse, error) {
+	if err := validateUUIDs("id", []string{id}); err != nil {
+		return domain.DeployedProductMetricsResponse{}, err
+	}
+	if err := validateUUIDs("deploymentId", []string{req.DeploymentID}); err != nil {
+		return domain.DeployedProductMetricsResponse{}, err
+	}
+	if err := validateDateRange(req.StartDate, req.EndDate); err != nil {
+		return domain.DeployedProductMetricsResponse{}, err
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+
+	payload := struct {
+		DeploymentID string `json:"deploymentId"`
+		StartDate    string `json:"startDate"`
+		EndDate      string `json:"endDate"`
+	}{
+		DeploymentID: uuidToSysid(req.DeploymentID),
+		StartDate:    req.StartDate,
+		EndDate:      req.EndDate,
+	}
+
+	raw, err := s.client.Post(ctx, "/deployed-products/"+uuidToSysid(id)+"/metrics/search", token, payload)
+	if err != nil {
+		return domain.DeployedProductMetricsResponse{}, err
+	}
+
+	var snResp snDeployedProductMetricsResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.DeployedProductMetricsResponse{}, fmt.Errorf("sn deployed product metrics: parse response: %w", err)
+	}
+
+	chartData := make([]domain.DeployedProductMetricsChartEntry, 0, len(snResp.ChartData))
+	for _, e := range snResp.ChartData {
+		instances := make([]domain.DeployedProductMetricsInstance, 0, len(e.Instances))
+		for _, i := range e.Instances {
+			instances = append(instances, domain.DeployedProductMetricsInstance{ID: i.ID, Name: i.Name, Cores: i.Cores})
+		}
+		chartData = append(chartData, domain.DeployedProductMetricsChartEntry{
+			Date:          e.Date,
+			InstanceCount: e.InstanceCount,
+			TotalCores:    e.TotalCores,
+			MinCores:      e.MinCores,
+			MaxCores:      e.MaxCores,
+			AvgCores:      e.AvgCores,
+			Instances:     instances,
+		})
+	}
+
+	return domain.DeployedProductMetricsResponse{
+		DeployedProduct: snResp.DeployedProduct.toDomain(),
+		Summary: domain.DeployedProductMetricsSummary{
+			DateRange: domain.DeployedProductMetricsDateRange{
+				Start: snResp.Summary.DateRange.Start,
+				End:   snResp.Summary.DateRange.End,
+			},
+			TotalInstances: snResp.Summary.TotalInstances,
+			MinCores:       snResp.Summary.MinCores,
+			MaxCores:       snResp.Summary.MaxCores,
+			AvgCores:       snResp.Summary.AvgCores,
+		},
+		ChartData: chartData,
+	}, nil
+}
+
+// snUsageCountInstance mirrors the Choreo UsageCountInstance shape.
+type snUsageCountInstance struct {
+	ID    string  `json:"id"`
+	Name  string  `json:"name"`
+	Value float64 `json:"value"`
+}
+
+// snUsageCountEntry mirrors the Choreo UsageCountEntry shape.
+type snUsageCountEntry struct {
+	Value       float64                `json:"value"`
+	Aggregation string                 `json:"aggregation"`
+	Instances   []snUsageCountInstance `json:"instances"`
+}
+
+// snDeployedProductUsageCountsChartEntry mirrors the Choreo
+// DeployedProductUsageCountsChartEntry shape. Counts is keyed by count-type
+// name, an open set defined by ServiceNow, not a fixed enum.
+type snDeployedProductUsageCountsChartEntry struct {
+	Date   string                       `json:"date"`
+	Counts map[string]snUsageCountEntry `json:"counts"`
+}
+
+// snCountTypeAggregation mirrors the Choreo CountTypeAggregation shape.
+type snCountTypeAggregation struct {
+	Aggregation string  `json:"aggregation"`
+	Min         float64 `json:"min"`
+	Max         float64 `json:"max"`
+	Avg         float64 `json:"avg"`
+}
+
+// snDeployedProductUsageCountsSummary mirrors the Choreo
+// DeployedProductUsageCountsSummary shape.
+type snDeployedProductUsageCountsSummary struct {
+	DateRange  snDeployedProductMetricsDateRange `json:"dateRange"`
+	CountTypes map[string]snCountTypeAggregation `json:"countTypes"`
+}
+
+// snDeployedProductUsageCountsResponse mirrors the Choreo
+// POST /deployed-products/{id}/metrics/usage-counts/search response.
+type snDeployedProductUsageCountsResponse struct {
+	DeployedProduct snReferenceTableItem                     `json:"deployedProduct"`
+	Summary         snDeployedProductUsageCountsSummary      `json:"summary"`
+	ChartData       []snDeployedProductUsageCountsChartEntry `json:"chartData"`
+}
+
+func (s *snDeployedProductService) SearchDeployedProductUsageCounts(ctx context.Context, id string, req domain.DeployedProductUsageCountsRequest) (domain.DeployedProductUsageCountsResponse, error) {
+	if err := validateUUIDs("id", []string{id}); err != nil {
+		return domain.DeployedProductUsageCountsResponse{}, err
+	}
+	if err := validateUUIDs("deploymentId", []string{req.DeploymentID}); err != nil {
+		return domain.DeployedProductUsageCountsResponse{}, err
+	}
+	if err := validateDateRange(req.StartDate, req.EndDate); err != nil {
+		return domain.DeployedProductUsageCountsResponse{}, err
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+
+	payload := struct {
+		DeploymentID string `json:"deploymentId"`
+		StartDate    string `json:"startDate"`
+		EndDate      string `json:"endDate"`
+	}{
+		DeploymentID: uuidToSysid(req.DeploymentID),
+		StartDate:    req.StartDate,
+		EndDate:      req.EndDate,
+	}
+
+	raw, err := s.client.Post(ctx, "/deployed-products/"+uuidToSysid(id)+"/metrics/usage-counts/search", token, payload)
+	if err != nil {
+		return domain.DeployedProductUsageCountsResponse{}, err
+	}
+
+	var snResp snDeployedProductUsageCountsResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.DeployedProductUsageCountsResponse{}, fmt.Errorf("sn deployed product usage counts: parse response: %w", err)
+	}
+
+	toDomainUsageCountEntry := func(e snUsageCountEntry) domain.UsageCountEntry {
+		instances := make([]domain.UsageCountInstance, 0, len(e.Instances))
+		for _, i := range e.Instances {
+			instances = append(instances, domain.UsageCountInstance{ID: i.ID, Name: i.Name, Value: i.Value})
+		}
+		return domain.UsageCountEntry{Value: e.Value, Aggregation: e.Aggregation, Instances: instances}
+	}
+
+	chartData := make([]domain.DeployedProductUsageCountsChartEntry, 0, len(snResp.ChartData))
+	for _, e := range snResp.ChartData {
+		counts := make(map[string]domain.UsageCountEntry, len(e.Counts))
+		for k, v := range e.Counts {
+			counts[k] = toDomainUsageCountEntry(v)
+		}
+		chartData = append(chartData, domain.DeployedProductUsageCountsChartEntry{Date: e.Date, Counts: counts})
+	}
+
+	countTypes := make(map[string]domain.CountTypeAggregation, len(snResp.Summary.CountTypes))
+	for k, v := range snResp.Summary.CountTypes {
+		countTypes[k] = domain.CountTypeAggregation{Aggregation: v.Aggregation, Min: v.Min, Max: v.Max, Avg: v.Avg}
+	}
+
+	return domain.DeployedProductUsageCountsResponse{
+		DeployedProduct: snResp.DeployedProduct.toDomain(),
+		Summary: domain.DeployedProductUsageCountsSummary{
+			DateRange: domain.DeployedProductMetricsDateRange{
+				Start: snResp.Summary.DateRange.Start,
+				End:   snResp.Summary.DateRange.End,
+			},
+			CountTypes: countTypes,
+		},
+		ChartData: chartData,
 	}, nil
 }

--- a/entity-service/internal/service/sn_escalation_service.go
+++ b/entity-service/internal/service/sn_escalation_service.go
@@ -1,0 +1,267 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/middleware"
+	integrationservice "github.com/wso2-open-operations/cs-tools/entity-service/internal/servicenow-integration-service"
+)
+
+// snEscalationNotifiedUser mirrors the Choreo notificationSentTo entry shape.
+type snEscalationNotifiedUser struct {
+	ID       string  `json:"id"`
+	UserName string  `json:"userName"`
+	Name     *string `json:"name"`
+	Email    *string `json:"email"`
+}
+
+func (u snEscalationNotifiedUser) toDomain() domain.EscalationNotifiedUser {
+	return domain.EscalationNotifiedUser{
+		ID:       sysidToUUID(u.ID),
+		UserName: u.UserName,
+		Name:     u.Name,
+		Email:    u.Email,
+	}
+}
+
+func toDomainEscalationNotifiedUsers(users []snEscalationNotifiedUser) []domain.EscalationNotifiedUser {
+	out := make([]domain.EscalationNotifiedUser, 0, len(users))
+	for _, u := range users {
+		out = append(out, u.toDomain())
+	}
+	return out
+}
+
+// snEscalation mirrors the Choreo Escalation shape (search results).
+type snEscalation struct {
+	ID                 string                     `json:"id"`
+	Case               snReferenceTableItem       `json:"case"`
+	CurrentLevel       snChoiceOption             `json:"currentLevel"`
+	PreviousLevel      snChoiceOption             `json:"previousLevel"`
+	CreatedBy          string                     `json:"createdBy"`
+	CreatedOn          string                     `json:"createdOn"`
+	UpdatedOn          string                     `json:"updatedOn"`
+	Reason             *string                    `json:"reason"`
+	NotificationSentTo []snEscalationNotifiedUser `json:"notificationSentTo"`
+}
+
+func (e snEscalation) toDomain() domain.Escalation {
+	return domain.Escalation{
+		ID:                 sysidToUUID(e.ID),
+		Case:               e.Case.toDomain(),
+		CurrentLevel:       e.CurrentLevel.toDomain(),
+		PreviousLevel:      e.PreviousLevel.toDomain(),
+		CreatedBy:          e.CreatedBy,
+		CreatedOn:          e.CreatedOn,
+		UpdatedOn:          e.UpdatedOn,
+		Reason:             e.Reason,
+		NotificationSentTo: toDomainEscalationNotifiedUsers(e.NotificationSentTo),
+	}
+}
+
+// snSearchEscalationsFilters mirrors the Choreo EscalationSearchPayload.filters shape.
+type snSearchEscalationsFilters struct {
+	CaseIDs       []string `json:"caseIds,omitempty"`
+	CurrentLevels []int    `json:"currentLevels,omitempty"`
+}
+
+// snEscalationSort mirrors the Choreo EscalationSearchPayload.sortBy shape.
+type snEscalationSort struct {
+	Field string `json:"field"`
+	Order string `json:"order"`
+}
+
+// snSearchEscalationsPayload mirrors the Choreo POST /escalations/search request body.
+type snSearchEscalationsPayload struct {
+	Filters    *snSearchEscalationsFilters `json:"filters,omitempty"`
+	SortBy     *snEscalationSort           `json:"sortBy,omitempty"`
+	Pagination snProjectPagination         `json:"pagination"`
+}
+
+// snSearchEscalationsResponse mirrors the Choreo POST /escalations/search response.
+type snSearchEscalationsResponse struct {
+	Escalations  []snEscalation `json:"escalations"`
+	TotalRecords int            `json:"totalRecords"`
+	Limit        int            `json:"limit"`
+	Offset       int            `json:"offset"`
+}
+
+var validEscalationSortField = map[domain.EscalationSortField]bool{
+	domain.EscalationSortFieldCreatedOn: true,
+	domain.EscalationSortFieldUpdatedOn: true,
+}
+
+var validEscalationSortOrder = map[domain.EscalationSortOrder]bool{
+	domain.EscalationSortOrderAsc:  true,
+	domain.EscalationSortOrderDesc: true,
+}
+
+type snEscalationService struct {
+	client *integrationservice.Client
+}
+
+// NewServiceNowEscalationService constructs an EscalationService backed by the Choreo API.
+func NewServiceNowEscalationService(client *integrationservice.Client) EscalationService {
+	return &snEscalationService{client: client}
+}
+
+func (s *snEscalationService) SearchEscalations(ctx context.Context, req domain.SearchEscalationsRequest) (domain.SearchEscalationsResponse, error) {
+	if err := normalizePagination(&req.Pagination); err != nil {
+		return domain.SearchEscalationsResponse{}, err
+	}
+	if req.Filters != nil {
+		if err := validateUUIDs("caseIds", req.Filters.CaseIDs); err != nil {
+			return domain.SearchEscalationsResponse{}, err
+		}
+	}
+	if req.SortBy != nil {
+		if req.SortBy.Field != "" && !validEscalationSortField[req.SortBy.Field] {
+			return domain.SearchEscalationsResponse{}, &apierror.ValidationError{Msg: "sortBy.field contains invalid value: " + string(req.SortBy.Field)}
+		}
+		if req.SortBy.Order != "" && !validEscalationSortOrder[req.SortBy.Order] {
+			return domain.SearchEscalationsResponse{}, &apierror.ValidationError{Msg: "sortBy.order contains invalid value: " + string(req.SortBy.Order)}
+		}
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+
+	payload := snSearchEscalationsPayload{
+		Pagination: snProjectPagination{Limit: req.Pagination.Limit, Offset: req.Pagination.Offset},
+	}
+	if req.Filters != nil {
+		payload.Filters = &snSearchEscalationsFilters{
+			CaseIDs:       uuidsToSysids(req.Filters.CaseIDs),
+			CurrentLevels: req.Filters.CurrentLevels,
+		}
+	}
+	if req.SortBy != nil {
+		payload.SortBy = &snEscalationSort{Field: string(req.SortBy.Field), Order: string(req.SortBy.Order)}
+	}
+
+	raw, err := s.client.Post(ctx, "/escalations/search", token, payload)
+	if err != nil {
+		return domain.SearchEscalationsResponse{}, err
+	}
+
+	var snResp snSearchEscalationsResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.SearchEscalationsResponse{}, fmt.Errorf("sn search escalations: parse response: %w", err)
+	}
+
+	escalations := make([]domain.Escalation, 0, len(snResp.Escalations))
+	for _, e := range snResp.Escalations {
+		escalations = append(escalations, e.toDomain())
+	}
+
+	return domain.SearchEscalationsResponse{
+		Escalations: escalations,
+		Total:       snResp.TotalRecords,
+		Limit:       req.Pagination.Limit,
+		Offset:      req.Pagination.Offset,
+	}, nil
+}
+
+// snCreateEscalationPayload mirrors the Choreo POST /escalations request body,
+// already normalized (action upper-cased and defaulted to ESCALATE, reason
+// defaulted to "") — mirrors the Ballerina reference's own normalizedPayload
+// construction in the resource function, done here in the service layer.
+type snCreateEscalationPayload struct {
+	CaseID string `json:"caseId"`
+	Reason string `json:"reason"`
+	Action string `json:"action"`
+}
+
+// snCreatedEscalation mirrors the Choreo EscalationCreateResponse.escalation
+// shape — notably it has no updatedOn, unlike snEscalation (search results).
+type snCreatedEscalation struct {
+	ID                 string                     `json:"id"`
+	Case               snReferenceTableItem       `json:"case"`
+	CurrentLevel       snChoiceOption             `json:"currentLevel"`
+	PreviousLevel      snChoiceOption             `json:"previousLevel"`
+	CreatedBy          string                     `json:"createdBy"`
+	CreatedOn          string                     `json:"createdOn"`
+	Reason             *string                    `json:"reason"`
+	NotificationSentTo []snEscalationNotifiedUser `json:"notificationSentTo"`
+}
+
+// snCreateEscalationResponse mirrors the Choreo POST /escalations response.
+type snCreateEscalationResponse struct {
+	Message    string              `json:"message"`
+	Escalation snCreatedEscalation `json:"escalation"`
+}
+
+func (s *snEscalationService) CreateEscalation(ctx context.Context, req domain.CreateEscalationRequest) (domain.CreateEscalationResponse, error) {
+	if err := validateUUIDs("caseId", []string{req.CaseID}); err != nil {
+		return domain.CreateEscalationResponse{}, err
+	}
+
+	action := domain.EscalationActionEscalate
+	if req.Action != nil {
+		action = domain.EscalationAction(strings.ToUpper(string(*req.Action)))
+	}
+	if action != domain.EscalationActionEscalate && action != domain.EscalationActionDeescalate {
+		return domain.CreateEscalationResponse{}, &apierror.ValidationError{
+			Msg: fmt.Sprintf("invalid action %q. Allowed actions: %s, %s", action, domain.EscalationActionEscalate, domain.EscalationActionDeescalate),
+		}
+	}
+	reason := ""
+	if req.Reason != nil {
+		reason = *req.Reason
+	}
+	if action == domain.EscalationActionEscalate && strings.TrimSpace(reason) == "" {
+		return domain.CreateEscalationResponse{}, &apierror.ValidationError{Msg: "reason is required when action is ESCALATE"}
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+
+	payload := snCreateEscalationPayload{
+		CaseID: uuidToSysid(req.CaseID),
+		Reason: reason,
+		Action: string(action),
+	}
+
+	raw, err := s.client.Post(ctx, "/escalations", token, payload)
+	if err != nil {
+		return domain.CreateEscalationResponse{}, err
+	}
+
+	var snResp snCreateEscalationResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.CreateEscalationResponse{}, fmt.Errorf("sn create escalation: parse response: %w", err)
+	}
+
+	return domain.CreateEscalationResponse{
+		Message: snResp.Message,
+		Escalation: domain.CreatedEscalation{
+			ID:                 sysidToUUID(snResp.Escalation.ID),
+			Case:               snResp.Escalation.Case.toDomain(),
+			CurrentLevel:       snResp.Escalation.CurrentLevel.toDomain(),
+			PreviousLevel:      snResp.Escalation.PreviousLevel.toDomain(),
+			CreatedBy:          snResp.Escalation.CreatedBy,
+			CreatedOn:          snResp.Escalation.CreatedOn,
+			Reason:             snResp.Escalation.Reason,
+			NotificationSentTo: toDomainEscalationNotifiedUsers(snResp.Escalation.NotificationSentTo),
+		},
+	}, nil
+}

--- a/entity-service/internal/service/sn_global_service.go
+++ b/entity-service/internal/service/sn_global_service.go
@@ -1,0 +1,294 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/middleware"
+	integrationservice "github.com/wso2-open-operations/cs-tools/entity-service/internal/servicenow-integration-service"
+)
+
+// snFeedbackEmojiChip mirrors the Choreo FeedbackEmojiChip shape.
+type snFeedbackEmojiChip struct {
+	ID    string `json:"id"`
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+// snFeedbackEmoji mirrors the Choreo FeedbackEmoji shape.
+type snFeedbackEmoji struct {
+	ID              string                `json:"id"`
+	Name            string                `json:"name"`
+	Value           string                `json:"value"`
+	UnselectedImage string                `json:"unselectedImage"`
+	SelectedImage   string                `json:"selectedImage"`
+	Chips           []snFeedbackEmojiChip `json:"chips"`
+}
+
+func (e snFeedbackEmoji) toDomain() domain.FeedbackEmoji {
+	chips := make([]domain.FeedbackEmojiChip, 0, len(e.Chips))
+	for _, c := range e.Chips {
+		chips = append(chips, domain.FeedbackEmojiChip{ID: sysidToUUID(c.ID), Name: c.Name, Value: c.Value})
+	}
+	return domain.FeedbackEmoji{
+		ID:              sysidToUUID(e.ID),
+		Name:            e.Name,
+		Value:           e.Value,
+		UnselectedImage: e.UnselectedImage,
+		SelectedImage:   e.SelectedImage,
+		Chips:           chips,
+	}
+}
+
+// snSystemMetadataResponse mirrors the Choreo GET /metadata response.
+type snSystemMetadataResponse struct {
+	TimeZones      []snChoiceOption       `json:"timeZones"`
+	ProjectTypes   []snReferenceTableItem `json:"projectTypes"`
+	FeedbackEmojis []snFeedbackEmoji      `json:"feedbackEmojies"`
+}
+
+// snGlobalSearchFilters mirrors the Choreo GlobalSearchPayload.filters shape.
+type snGlobalSearchFilters struct {
+	SearchQuery string   `json:"searchQuery,omitempty"`
+	Tables      []string `json:"tables,omitempty"`
+}
+
+// snGlobalSearchSort mirrors the Choreo GlobalSearchPayload.sortBy shape.
+type snGlobalSearchSort struct {
+	Field string `json:"field,omitempty"`
+	Order string `json:"order,omitempty"`
+}
+
+// snGlobalSearchPayload mirrors the Choreo POST /search request body.
+type snGlobalSearchPayload struct {
+	Filters            *snGlobalSearchFilters `json:"filters,omitempty"`
+	SortBy             *snGlobalSearchSort    `json:"sortBy,omitempty"`
+	ProjectsPagination *snProjectPagination   `json:"projectsPagination,omitempty"`
+	CasesPagination    *snProjectPagination   `json:"casesPagination,omitempty"`
+}
+
+// snGlobalSearchProject mirrors a project row in the Choreo POST /search response.
+type snGlobalSearchProject struct {
+	ID                  string               `json:"id"`
+	Name                string               `json:"name"`
+	Description         *string              `json:"description"`
+	Key                 string               `json:"key"`
+	Type                snReferenceTableItem `json:"type"`
+	CreatedOn           string               `json:"createdOn"`
+	StartDate           *string              `json:"startDate"`
+	EndDate             *string              `json:"endDate"`
+	HasPdpSubscription  bool                 `json:"hasPdpSubscription"`
+	ClosureState        *string              `json:"closureState"`
+	Account             snReferenceTableItem `json:"account"`
+	ActiveChatsCount    int                  `json:"activeChatsCount"`
+	ActionRequiredCount int                  `json:"actionRequiredCount"`
+	OutstandingCount    int                  `json:"outstandingCount"`
+}
+
+func (p snGlobalSearchProject) toDomain() domain.GlobalSearchProject {
+	return domain.GlobalSearchProject{
+		ID:                  sysidToUUID(p.ID),
+		Name:                p.Name,
+		Description:         p.Description,
+		Key:                 p.Key,
+		Type:                p.Type.toDomain(),
+		CreatedOn:           p.CreatedOn,
+		StartDate:           p.StartDate,
+		EndDate:             p.EndDate,
+		HasPdpSubscription:  p.HasPdpSubscription,
+		ClosureState:        p.ClosureState,
+		Account:             p.Account.toDomain(),
+		ActiveChatsCount:    p.ActiveChatsCount,
+		ActionRequiredCount: p.ActionRequiredCount,
+		OutstandingCount:    p.OutstandingCount,
+	}
+}
+
+// snGlobalSearchCase mirrors a case row in the Choreo POST /search response.
+// InternalID is the WSO2-internal case identifier (a separate concept from
+// the sysid), passed through unchanged like everywhere else it appears.
+type snGlobalSearchCase struct {
+	ID               string                `json:"id"`
+	InternalID       string                `json:"internalId"`
+	Number           string                `json:"number"`
+	Title            *string               `json:"title"`
+	Description      *string               `json:"description"`
+	CreatedOn        string                `json:"createdOn"`
+	CreatedBy        string                `json:"createdBy"`
+	UpdatedOn        string                `json:"updatedOn"`
+	Project          *snReferenceTableItem `json:"project"`
+	CaseType         *snReferenceTableItem `json:"caseType"`
+	State            *snChoiceOption       `json:"state"`
+	Severity         *snChoiceOption       `json:"severity"`
+	AssignedEngineer *snReferenceTableItem `json:"assignedEngineer"`
+	Account          snReferenceTableItem  `json:"account"`
+}
+
+func (c snGlobalSearchCase) toDomain() domain.GlobalSearchCase {
+	out := domain.GlobalSearchCase{
+		ID:          sysidToUUID(c.ID),
+		InternalID:  c.InternalID,
+		Number:      c.Number,
+		Title:       c.Title,
+		Description: c.Description,
+		CreatedOn:   c.CreatedOn,
+		CreatedBy:   c.CreatedBy,
+		UpdatedOn:   c.UpdatedOn,
+		Account:     c.Account.toDomain(),
+	}
+	if c.Project != nil {
+		v := c.Project.toDomain()
+		out.Project = &v
+	}
+	if c.CaseType != nil {
+		v := c.CaseType.toDomain()
+		out.CaseType = &v
+	}
+	if c.State != nil {
+		v := c.State.toDomain()
+		out.State = &v
+	}
+	if c.Severity != nil {
+		v := c.Severity.toDomain()
+		out.Severity = &v
+	}
+	if c.AssignedEngineer != nil {
+		v := c.AssignedEngineer.toDomain()
+		out.AssignedEngineer = &v
+	}
+	return out
+}
+
+// snGlobalSearchResponse mirrors the Choreo POST /search response.
+type snGlobalSearchResponse struct {
+	Query         string                  `json:"query"`
+	ProjectsTotal int                     `json:"projectsTotal"`
+	CasesTotal    int                     `json:"casesTotal"`
+	Projects      []snGlobalSearchProject `json:"projects"`
+	Cases         []snGlobalSearchCase    `json:"cases"`
+}
+
+var validGlobalSearchTables = map[string]bool{"projects": true, "cases": true}
+var validGlobalSearchSortOrder = map[string]bool{"asc": true, "desc": true}
+
+type snGlobalService struct {
+	client *integrationservice.Client
+}
+
+// NewServiceNowGlobalService constructs a GlobalService backed by the Choreo API.
+func NewServiceNowGlobalService(client *integrationservice.Client) GlobalService {
+	return &snGlobalService{client: client}
+}
+
+func (s *snGlobalService) GetSystemMetadata(ctx context.Context) (domain.SystemMetadataResponse, error) {
+	token := middleware.UserIDTokenFromContext(ctx)
+
+	raw, err := s.client.Get(ctx, "/metadata", token)
+	if err != nil {
+		return domain.SystemMetadataResponse{}, err
+	}
+
+	var snResp snSystemMetadataResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.SystemMetadataResponse{}, fmt.Errorf("sn system metadata: parse response: %w", err)
+	}
+
+	emojis := make([]domain.FeedbackEmoji, 0, len(snResp.FeedbackEmojis))
+	for _, e := range snResp.FeedbackEmojis {
+		emojis = append(emojis, e.toDomain())
+	}
+
+	return domain.SystemMetadataResponse{
+		TimeZones:      toDomainChoiceListItems(snResp.TimeZones),
+		ProjectTypes:   toDomainReferenceTableItems(snResp.ProjectTypes),
+		FeedbackEmojis: emojis,
+	}, nil
+}
+
+func (s *snGlobalService) GlobalSearch(ctx context.Context, req domain.GlobalSearchRequest) (domain.GlobalSearchResponse, error) {
+	if req.Filters != nil {
+		if err := validateSearchQuery(req.Filters.SearchQuery); err != nil {
+			return domain.GlobalSearchResponse{}, err
+		}
+		for _, t := range req.Filters.Tables {
+			if !validGlobalSearchTables[t] {
+				return domain.GlobalSearchResponse{}, &apierror.ValidationError{Msg: "filters.tables contains invalid value: " + t}
+			}
+		}
+	}
+	if req.SortBy != nil && req.SortBy.Order != "" && !validGlobalSearchSortOrder[req.SortBy.Order] {
+		return domain.GlobalSearchResponse{}, &apierror.ValidationError{Msg: "sortBy.order contains invalid value: " + req.SortBy.Order}
+	}
+	if req.ProjectsPagination != nil {
+		if err := normalizePagination(req.ProjectsPagination); err != nil {
+			return domain.GlobalSearchResponse{}, err
+		}
+	}
+	if req.CasesPagination != nil {
+		if err := normalizePagination(req.CasesPagination); err != nil {
+			return domain.GlobalSearchResponse{}, err
+		}
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+
+	payload := snGlobalSearchPayload{}
+	if req.Filters != nil {
+		payload.Filters = &snGlobalSearchFilters{SearchQuery: req.Filters.SearchQuery, Tables: req.Filters.Tables}
+	}
+	if req.SortBy != nil {
+		payload.SortBy = &snGlobalSearchSort{Field: req.SortBy.Field, Order: req.SortBy.Order}
+	}
+	if req.ProjectsPagination != nil {
+		payload.ProjectsPagination = &snProjectPagination{Limit: req.ProjectsPagination.Limit, Offset: req.ProjectsPagination.Offset}
+	}
+	if req.CasesPagination != nil {
+		payload.CasesPagination = &snProjectPagination{Limit: req.CasesPagination.Limit, Offset: req.CasesPagination.Offset}
+	}
+
+	raw, err := s.client.Post(ctx, "/search", token, payload)
+	if err != nil {
+		return domain.GlobalSearchResponse{}, err
+	}
+
+	var snResp snGlobalSearchResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.GlobalSearchResponse{}, fmt.Errorf("sn global search: parse response: %w", err)
+	}
+
+	projects := make([]domain.GlobalSearchProject, 0, len(snResp.Projects))
+	for _, p := range snResp.Projects {
+		projects = append(projects, p.toDomain())
+	}
+	cases := make([]domain.GlobalSearchCase, 0, len(snResp.Cases))
+	for _, c := range snResp.Cases {
+		cases = append(cases, c.toDomain())
+	}
+
+	return domain.GlobalSearchResponse{
+		Query:         snResp.Query,
+		ProjectsTotal: snResp.ProjectsTotal,
+		CasesTotal:    snResp.CasesTotal,
+		Projects:      projects,
+		Cases:         cases,
+	}, nil
+}

--- a/entity-service/internal/service/sn_instance_service.go
+++ b/entity-service/internal/service/sn_instance_service.go
@@ -411,24 +411,16 @@ type snInstanceStatsFilters struct {
 }
 
 func validateInstanceStatsFilters(f domain.InstanceStatsFilters) (snInstanceStatsFilters, error) {
-	if err := validateUUIDs("projectIds", f.ProjectIDs); err != nil {
-		return snInstanceStatsFilters{}, err
-	}
-	if err := validateUUIDs("deploymentIds", f.DeploymentIDs); err != nil {
-		return snInstanceStatsFilters{}, err
-	}
-	if err := validateUUIDs("deployedProductIds", f.DeployedProductIDs); err != nil {
-		return snInstanceStatsFilters{}, err
-	}
-	if err := validateExclusiveIDFilters(f.ProjectIDs, f.DeploymentIDs, f.DeployedProductIDs); err != nil {
+	base, err := validateInstanceDateRangeFilters(f.InstanceDateRangeFilters)
+	if err != nil {
 		return snInstanceStatsFilters{}, err
 	}
 	return snInstanceStatsFilters{
-		StartDate:          f.StartDate,
-		EndDate:            f.EndDate,
-		ProjectIDs:         uuidsToSysids(f.ProjectIDs),
-		DeploymentIDs:      uuidsToSysids(f.DeploymentIDs),
-		DeployedProductIDs: uuidsToSysids(f.DeployedProductIDs),
+		StartDate:          base.StartDate,
+		EndDate:            base.EndDate,
+		ProjectIDs:         base.ProjectIDs,
+		DeploymentIDs:      base.DeploymentIDs,
+		DeployedProductIDs: base.DeployedProductIDs,
 		DataSource:         f.DataSource,
 	}, nil
 }

--- a/entity-service/internal/service/sn_instance_service.go
+++ b/entity-service/internal/service/sn_instance_service.go
@@ -1,0 +1,537 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/middleware"
+	integrationservice "github.com/wso2-open-operations/cs-tools/entity-service/internal/servicenow-integration-service"
+)
+
+// validateExclusiveIDFilters mirrors the Ballerina reference's shared
+// validateIdFilterMutualExclusivity: at most one of projectIDs, deploymentIDs,
+// and deployedProductIDs may be non-empty.
+func validateExclusiveIDFilters(projectIDs, deploymentIDs, deployedProductIDs []string) error {
+	filled := 0
+	if len(projectIDs) > 0 {
+		filled++
+	}
+	if len(deploymentIDs) > 0 {
+		filled++
+	}
+	if len(deployedProductIDs) > 0 {
+		filled++
+	}
+	if filled > 1 {
+		return &apierror.ValidationError{Msg: "only one of projectIds, deploymentIds, or deployedProductIds can be provided at a time"}
+	}
+	return nil
+}
+
+// snInstanceMetadata mirrors the Choreo InstanceMetadata shape.
+type snInstanceMetadata struct {
+	ID                 string         `json:"id"`
+	CoreCount          *int           `json:"coreCount"`
+	Updates            *int           `json:"updates"`
+	JDKVersion         *string        `json:"jdkVersion"`
+	DeploymentMetadata map[string]any `json:"deploymentMetadata"`
+	CreatedOn          string         `json:"createdOn"`
+	UpdatedOn          string         `json:"updatedOn"`
+	CustomCreatedOn    *string        `json:"customCreatedOn"`
+	CustomUpdatedOn    *string        `json:"customUpdatedOn"`
+}
+
+func (m *snInstanceMetadata) toDomain() *domain.InstanceMetadata {
+	if m == nil {
+		return nil
+	}
+	return &domain.InstanceMetadata{
+		ID:                 sysidToUUID(m.ID),
+		CoreCount:          m.CoreCount,
+		Updates:            m.Updates,
+		JDKVersion:         m.JDKVersion,
+		DeploymentMetadata: m.DeploymentMetadata,
+		CreatedOn:          m.CreatedOn,
+		UpdatedOn:          m.UpdatedOn,
+		CustomCreatedOn:    m.CustomCreatedOn,
+		CustomUpdatedOn:    m.CustomUpdatedOn,
+	}
+}
+
+// toDomainOptionalRef converts an optional snReferenceTableItem to a
+// domain.ReferenceTableItem pointer, used throughout this file for the
+// project/deployment/product/deployedProduct reference fields, all of which
+// are nullable in the Choreo response.
+func toDomainOptionalRef(r *snReferenceTableItem) *domain.ReferenceTableItem {
+	if r == nil {
+		return nil
+	}
+	v := r.toDomain()
+	return &v
+}
+
+// snInstance mirrors the Choreo Instance shape.
+type snInstance struct {
+	ID              string                `json:"id"`
+	Key             string                `json:"key"`
+	Project         *snReferenceTableItem `json:"project"`
+	Deployment      *snReferenceTableItem `json:"deployment"`
+	Product         *snReferenceTableItem `json:"product"`
+	DeployedProduct *snReferenceTableItem `json:"deployedProduct"`
+	CreatedOn       string                `json:"createdOn"`
+	UpdatedOn       string                `json:"updatedOn"`
+	Metadata        *snInstanceMetadata   `json:"metadata"`
+}
+
+func (i snInstance) toDomain() domain.Instance {
+	return domain.Instance{
+		ID:              sysidToUUID(i.ID),
+		Key:             i.Key,
+		Project:         toDomainOptionalRef(i.Project),
+		Deployment:      toDomainOptionalRef(i.Deployment),
+		Product:         toDomainOptionalRef(i.Product),
+		DeployedProduct: toDomainOptionalRef(i.DeployedProduct),
+		CreatedOn:       i.CreatedOn,
+		UpdatedOn:       i.UpdatedOn,
+		Metadata:        i.Metadata.toDomain(),
+	}
+}
+
+// snInstanceSearchFilters mirrors the Choreo InstanceSearchPayload.filters shape.
+type snInstanceSearchFilters struct {
+	StartDate          *string  `json:"startDate,omitempty"`
+	EndDate            *string  `json:"endDate,omitempty"`
+	ProjectIDs         []string `json:"projectIds,omitempty"`
+	DeploymentIDs      []string `json:"deploymentIds,omitempty"`
+	DeployedProductIDs []string `json:"deployedProductIds,omitempty"`
+}
+
+// snInstanceSearchPayload mirrors the Choreo POST /instances/search request body.
+type snInstanceSearchPayload struct {
+	Filters    *snInstanceSearchFilters `json:"filters,omitempty"`
+	Pagination snProjectPagination      `json:"pagination"`
+}
+
+// snInstancesResponse mirrors the Choreo POST /instances/search response.
+type snInstancesResponse struct {
+	Instances    []snInstance `json:"instances"`
+	TotalRecords int          `json:"totalRecords"`
+	Limit        int          `json:"limit"`
+	Offset       int          `json:"offset"`
+}
+
+type snInstanceService struct {
+	client *integrationservice.Client
+}
+
+// NewServiceNowInstanceService constructs an InstanceService backed by the Choreo API.
+func NewServiceNowInstanceService(client *integrationservice.Client) InstanceService {
+	return &snInstanceService{client: client}
+}
+
+func (s *snInstanceService) SearchInstances(ctx context.Context, req domain.SearchInstancesRequest) (domain.SearchInstancesResponse, error) {
+	if err := normalizePagination(&req.Pagination); err != nil {
+		return domain.SearchInstancesResponse{}, err
+	}
+
+	payload := snInstanceSearchPayload{
+		Pagination: snProjectPagination{Limit: req.Pagination.Limit, Offset: req.Pagination.Offset},
+	}
+
+	if req.Filters != nil {
+		if err := validateUUIDs("projectIds", req.Filters.ProjectIDs); err != nil {
+			return domain.SearchInstancesResponse{}, err
+		}
+		if err := validateUUIDs("deploymentIds", req.Filters.DeploymentIDs); err != nil {
+			return domain.SearchInstancesResponse{}, err
+		}
+		if err := validateUUIDs("deployedProductIds", req.Filters.DeployedProductIDs); err != nil {
+			return domain.SearchInstancesResponse{}, err
+		}
+		if err := validateExclusiveIDFilters(req.Filters.ProjectIDs, req.Filters.DeploymentIDs, req.Filters.DeployedProductIDs); err != nil {
+			return domain.SearchInstancesResponse{}, err
+		}
+
+		payload.Filters = &snInstanceSearchFilters{
+			StartDate:          req.Filters.StartDate,
+			EndDate:            req.Filters.EndDate,
+			ProjectIDs:         uuidsToSysids(req.Filters.ProjectIDs),
+			DeploymentIDs:      uuidsToSysids(req.Filters.DeploymentIDs),
+			DeployedProductIDs: uuidsToSysids(req.Filters.DeployedProductIDs),
+		}
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+
+	raw, err := s.client.Post(ctx, "/instances/search", token, payload)
+	if err != nil {
+		return domain.SearchInstancesResponse{}, err
+	}
+
+	var snResp snInstancesResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.SearchInstancesResponse{}, fmt.Errorf("sn search instances: parse response: %w", err)
+	}
+
+	instances := make([]domain.Instance, 0, len(snResp.Instances))
+	for _, i := range snResp.Instances {
+		instances = append(instances, i.toDomain())
+	}
+
+	return domain.SearchInstancesResponse{
+		Instances: instances,
+		Total:     snResp.TotalRecords,
+		Limit:     snResp.Limit,
+		Offset:    snResp.Offset,
+	}, nil
+}
+
+// snInstanceDateRangeFilters mirrors the shared filters shape used by
+// InstanceMetricsPayload and InstanceUsagePayload.
+type snInstanceDateRangeFilters struct {
+	StartDate          string   `json:"startDate"`
+	EndDate            string   `json:"endDate"`
+	ProjectIDs         []string `json:"projectIds,omitempty"`
+	DeploymentIDs      []string `json:"deploymentIds,omitempty"`
+	DeployedProductIDs []string `json:"deployedProductIds,omitempty"`
+}
+
+func validateInstanceDateRangeFilters(f domain.InstanceDateRangeFilters) (snInstanceDateRangeFilters, error) {
+	if err := validateUUIDs("projectIds", f.ProjectIDs); err != nil {
+		return snInstanceDateRangeFilters{}, err
+	}
+	if err := validateUUIDs("deploymentIds", f.DeploymentIDs); err != nil {
+		return snInstanceDateRangeFilters{}, err
+	}
+	if err := validateUUIDs("deployedProductIds", f.DeployedProductIDs); err != nil {
+		return snInstanceDateRangeFilters{}, err
+	}
+	if err := validateExclusiveIDFilters(f.ProjectIDs, f.DeploymentIDs, f.DeployedProductIDs); err != nil {
+		return snInstanceDateRangeFilters{}, err
+	}
+	return snInstanceDateRangeFilters{
+		StartDate:          f.StartDate,
+		EndDate:            f.EndDate,
+		ProjectIDs:         uuidsToSysids(f.ProjectIDs),
+		DeploymentIDs:      uuidsToSysids(f.DeploymentIDs),
+		DeployedProductIDs: uuidsToSysids(f.DeployedProductIDs),
+	}, nil
+}
+
+// snInstanceMetricsPayload mirrors the Choreo POST /instances/metrics/search request body.
+type snInstanceMetricsPayload struct {
+	Filters snInstanceDateRangeFilters `json:"filters"`
+}
+
+// snInstanceDataPoint mirrors the Choreo InstanceDataPoint shape.
+type snInstanceDataPoint struct {
+	Date               string         `json:"date"`
+	CreatedOn          string         `json:"createdOn"`
+	CoreCount          *int           `json:"coreCount"`
+	JDKVersion         *string        `json:"jdkVersion"`
+	Updates            *int           `json:"updates"`
+	DeploymentMetadata map[string]any `json:"deploymentMetadata"`
+}
+
+// snInstanceMetric mirrors the Choreo InstanceMetric shape.
+type snInstanceMetric struct {
+	InstanceID      string                `json:"instanceId"`
+	InstanceKey     string                `json:"instanceKey"`
+	Project         *snReferenceTableItem `json:"project"`
+	Deployment      *snReferenceTableItem `json:"deployment"`
+	Product         *snReferenceTableItem `json:"product"`
+	DeployedProduct *snReferenceTableItem `json:"deployedProduct"`
+	DataPoints      []snInstanceDataPoint `json:"dataPoints"`
+}
+
+// snInstanceMetricsResponse mirrors the Choreo POST /instances/metrics/search response.
+type snInstanceMetricsResponse struct {
+	Metrics        []snInstanceMetric `json:"metrics"`
+	TotalInstances int                `json:"totalInstances"`
+	StartDate      string             `json:"startDate"`
+	EndDate        string             `json:"endDate"`
+}
+
+func (s *snInstanceService) SearchInstanceMetrics(ctx context.Context, req domain.InstanceMetricsRequest) (domain.InstanceMetricsResponse, error) {
+	filters, err := validateInstanceDateRangeFilters(req.Filters)
+	if err != nil {
+		return domain.InstanceMetricsResponse{}, err
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+
+	payload := snInstanceMetricsPayload{Filters: filters}
+
+	raw, err := s.client.Post(ctx, "/instances/metrics/search", token, payload)
+	if err != nil {
+		return domain.InstanceMetricsResponse{}, err
+	}
+
+	var snResp snInstanceMetricsResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.InstanceMetricsResponse{}, fmt.Errorf("sn instance metrics: parse response: %w", err)
+	}
+
+	metrics := make([]domain.InstanceMetric, 0, len(snResp.Metrics))
+	for _, m := range snResp.Metrics {
+		dataPoints := make([]domain.InstanceDataPoint, 0, len(m.DataPoints))
+		for _, dp := range m.DataPoints {
+			dataPoints = append(dataPoints, domain.InstanceDataPoint{
+				Date:               dp.Date,
+				CreatedOn:          dp.CreatedOn,
+				CoreCount:          dp.CoreCount,
+				JDKVersion:         dp.JDKVersion,
+				Updates:            dp.Updates,
+				DeploymentMetadata: dp.DeploymentMetadata,
+			})
+		}
+		metrics = append(metrics, domain.InstanceMetric{
+			InstanceID:      sysidToUUID(m.InstanceID),
+			InstanceKey:     m.InstanceKey,
+			Project:         toDomainOptionalRef(m.Project),
+			Deployment:      toDomainOptionalRef(m.Deployment),
+			Product:         toDomainOptionalRef(m.Product),
+			DeployedProduct: toDomainOptionalRef(m.DeployedProduct),
+			DataPoints:      dataPoints,
+		})
+	}
+
+	return domain.InstanceMetricsResponse{
+		Metrics:        metrics,
+		TotalInstances: snResp.TotalInstances,
+		StartDate:      snResp.StartDate,
+		EndDate:        snResp.EndDate,
+	}, nil
+}
+
+// snInstanceUsagePayload mirrors the Choreo POST /instances/usages/search request body.
+type snInstanceUsagePayload struct {
+	Filters snInstanceDateRangeFilters `json:"filters"`
+}
+
+// snInstanceSummary mirrors the Choreo InstanceSummary shape.
+type snInstanceSummary struct {
+	Period string         `json:"period"`
+	Counts map[string]int `json:"counts"`
+}
+
+// snInstanceUsageEntry mirrors the Choreo InstanceUsageEntry shape.
+type snInstanceUsageEntry struct {
+	InstanceID      string                `json:"instanceId"`
+	InstanceKey     string                `json:"instanceKey"`
+	Project         *snReferenceTableItem `json:"project"`
+	Deployment      *snReferenceTableItem `json:"deployment"`
+	Product         *snReferenceTableItem `json:"product"`
+	DeployedProduct *snReferenceTableItem `json:"deployedProduct"`
+	PeriodSummaries []snInstanceSummary   `json:"periodSummaries"`
+}
+
+// snInstanceUsageResponse mirrors the Choreo POST /instances/usages/search response.
+type snInstanceUsageResponse struct {
+	Usages         []snInstanceUsageEntry `json:"usages"`
+	TotalInstances int                    `json:"totalInstances"`
+	StartDate      string                 `json:"startDate"`
+	EndDate        string                 `json:"endDate"`
+}
+
+func (s *snInstanceService) SearchInstanceUsage(ctx context.Context, req domain.InstanceUsageRequest) (domain.InstanceUsageResponse, error) {
+	filters, err := validateInstanceDateRangeFilters(req.Filters)
+	if err != nil {
+		return domain.InstanceUsageResponse{}, err
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+
+	payload := snInstanceUsagePayload{Filters: filters}
+
+	raw, err := s.client.Post(ctx, "/instances/usages/search", token, payload)
+	if err != nil {
+		return domain.InstanceUsageResponse{}, err
+	}
+
+	var snResp snInstanceUsageResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.InstanceUsageResponse{}, fmt.Errorf("sn instance usage: parse response: %w", err)
+	}
+
+	usages := make([]domain.InstanceUsageEntry, 0, len(snResp.Usages))
+	for _, u := range snResp.Usages {
+		summaries := make([]domain.InstanceSummary, 0, len(u.PeriodSummaries))
+		for _, sm := range u.PeriodSummaries {
+			summaries = append(summaries, domain.InstanceSummary{Period: sm.Period, Counts: sm.Counts})
+		}
+		usages = append(usages, domain.InstanceUsageEntry{
+			InstanceID:      sysidToUUID(u.InstanceID),
+			InstanceKey:     u.InstanceKey,
+			Project:         toDomainOptionalRef(u.Project),
+			Deployment:      toDomainOptionalRef(u.Deployment),
+			Product:         toDomainOptionalRef(u.Product),
+			DeployedProduct: toDomainOptionalRef(u.DeployedProduct),
+			PeriodSummaries: summaries,
+		})
+	}
+
+	return domain.InstanceUsageResponse{
+		Usages:         usages,
+		TotalInstances: snResp.TotalInstances,
+		StartDate:      snResp.StartDate,
+		EndDate:        snResp.EndDate,
+	}, nil
+}
+
+// snInstanceStatsFilters mirrors the shared filters shape used by
+// InstanceMetricsStatsPayload and InstanceUsageStatsPayload — adds the
+// optional dataSource discriminator on top of snInstanceDateRangeFilters.
+type snInstanceStatsFilters struct {
+	StartDate          string   `json:"startDate"`
+	EndDate            string   `json:"endDate"`
+	ProjectIDs         []string `json:"projectIds,omitempty"`
+	DeploymentIDs      []string `json:"deploymentIds,omitempty"`
+	DeployedProductIDs []string `json:"deployedProductIds,omitempty"`
+	DataSource         *int     `json:"dataSource,omitempty"`
+}
+
+func validateInstanceStatsFilters(f domain.InstanceStatsFilters) (snInstanceStatsFilters, error) {
+	if err := validateUUIDs("projectIds", f.ProjectIDs); err != nil {
+		return snInstanceStatsFilters{}, err
+	}
+	if err := validateUUIDs("deploymentIds", f.DeploymentIDs); err != nil {
+		return snInstanceStatsFilters{}, err
+	}
+	if err := validateUUIDs("deployedProductIds", f.DeployedProductIDs); err != nil {
+		return snInstanceStatsFilters{}, err
+	}
+	if err := validateExclusiveIDFilters(f.ProjectIDs, f.DeploymentIDs, f.DeployedProductIDs); err != nil {
+		return snInstanceStatsFilters{}, err
+	}
+	return snInstanceStatsFilters{
+		StartDate:          f.StartDate,
+		EndDate:            f.EndDate,
+		ProjectIDs:         uuidsToSysids(f.ProjectIDs),
+		DeploymentIDs:      uuidsToSysids(f.DeploymentIDs),
+		DeployedProductIDs: uuidsToSysids(f.DeployedProductIDs),
+		DataSource:         f.DataSource,
+	}, nil
+}
+
+// snInstanceMetricsStatsPayload mirrors the Choreo POST /instances/metrics/stats request body.
+type snInstanceMetricsStatsPayload struct {
+	Filters snInstanceStatsFilters `json:"filters"`
+}
+
+// snInstanceMetricSummary mirrors the Choreo MetricSummary shape.
+type snInstanceMetricSummary struct {
+	Current float64 `json:"curr"`
+	Min     float64 `json:"min"`
+	Max     float64 `json:"max"`
+	Avg     float64 `json:"avg"`
+}
+
+// snInstanceMetricsStatsResponse mirrors the Choreo POST /instances/metrics/stats response.
+type snInstanceMetricsStatsResponse struct {
+	Stats        map[string]map[string]int `json:"stats"`
+	Summary      snInstanceMetricSummary   `json:"summary"`
+	TotalRecords int                       `json:"totalRecords"`
+	StartDate    string                    `json:"startDate"`
+	EndDate      string                    `json:"endDate"`
+}
+
+// SearchInstanceMetricsStats calls the Choreo /instances/metrics/stats
+// endpoint — note this SN path has no trailing /search, unlike this method's
+// own exposed route, mirroring the Ballerina reference's own asymmetry
+// between its resource path and the downstream servicenow module call.
+func (s *snInstanceService) SearchInstanceMetricsStats(ctx context.Context, req domain.InstanceMetricsStatsRequest) (domain.InstanceMetricsStatsResponse, error) {
+	filters, err := validateInstanceStatsFilters(req.Filters)
+	if err != nil {
+		return domain.InstanceMetricsStatsResponse{}, err
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+
+	payload := snInstanceMetricsStatsPayload{Filters: filters}
+
+	raw, err := s.client.Post(ctx, "/instances/metrics/stats", token, payload)
+	if err != nil {
+		return domain.InstanceMetricsStatsResponse{}, err
+	}
+
+	var snResp snInstanceMetricsStatsResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.InstanceMetricsStatsResponse{}, fmt.Errorf("sn instance metrics stats: parse response: %w", err)
+	}
+
+	return domain.InstanceMetricsStatsResponse{
+		Stats: snResp.Stats,
+		Summary: domain.InstanceMetricSummary{
+			Current: snResp.Summary.Current,
+			Min:     snResp.Summary.Min,
+			Max:     snResp.Summary.Max,
+			Avg:     snResp.Summary.Avg,
+		},
+		Total:     snResp.TotalRecords,
+		StartDate: snResp.StartDate,
+		EndDate:   snResp.EndDate,
+	}, nil
+}
+
+// snInstanceUsageStatsPayload mirrors the Choreo POST /instances/usages/stats request body.
+type snInstanceUsageStatsPayload struct {
+	Filters snInstanceStatsFilters `json:"filters"`
+}
+
+// snInstanceUsageStatsResponse mirrors the Choreo POST /instances/usages/stats response.
+type snInstanceUsageStatsResponse struct {
+	Stats        map[string]map[string]int `json:"stats"`
+	TotalRecords int                       `json:"totalRecords"`
+	StartDate    string                    `json:"startDate"`
+	EndDate      string                    `json:"endDate"`
+}
+
+// SearchInstanceUsageStats calls the Choreo /instances/usages/stats endpoint
+// — same no-trailing-/search asymmetry as SearchInstanceMetricsStats.
+func (s *snInstanceService) SearchInstanceUsageStats(ctx context.Context, req domain.InstanceUsageStatsRequest) (domain.InstanceUsageStatsResponse, error) {
+	filters, err := validateInstanceStatsFilters(req.Filters)
+	if err != nil {
+		return domain.InstanceUsageStatsResponse{}, err
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+
+	payload := snInstanceUsageStatsPayload{Filters: filters}
+
+	raw, err := s.client.Post(ctx, "/instances/usages/stats", token, payload)
+	if err != nil {
+		return domain.InstanceUsageStatsResponse{}, err
+	}
+
+	var snResp snInstanceUsageStatsResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.InstanceUsageStatsResponse{}, fmt.Errorf("sn instance usage stats: parse response: %w", err)
+	}
+
+	return domain.InstanceUsageStatsResponse{
+		Stats:     snResp.Stats,
+		Total:     snResp.TotalRecords,
+		StartDate: snResp.StartDate,
+		EndDate:   snResp.EndDate,
+	}, nil
+}

--- a/entity-service/internal/service/sn_product_vulnerability_service.go
+++ b/entity-service/internal/service/sn_product_vulnerability_service.go
@@ -185,3 +185,24 @@ func (s *snProductVulnerabilityService) GetProductVulnerability(ctx context.Cont
 
 	return snVulnerabilityToView(v), nil
 }
+
+// snVulnerabilityMetaResponse mirrors the Choreo GET /products/vulnerabilities/meta response.
+type snVulnerabilityMetaResponse struct {
+	Severities []snChoiceOption `json:"severities"`
+}
+
+func (s *snProductVulnerabilityService) GetVulnerabilityMeta(ctx context.Context) (domain.VulnerabilityMetaResponse, error) {
+	token := middleware.UserIDTokenFromContext(ctx)
+
+	raw, err := s.client.Get(ctx, "/products/vulnerabilities/meta", token)
+	if err != nil {
+		return domain.VulnerabilityMetaResponse{}, err
+	}
+
+	var snResp snVulnerabilityMetaResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.VulnerabilityMetaResponse{}, fmt.Errorf("sn vulnerability meta: parse response: %w", err)
+	}
+
+	return domain.VulnerabilityMetaResponse{Severities: toDomainChoiceListItems(snResp.Severities)}, nil
+}

--- a/entity-service/internal/service/sn_time_card_service.go
+++ b/entity-service/internal/service/sn_time_card_service.go
@@ -329,11 +329,11 @@ type snCaseTimeCardBillingInfo struct {
 // snCaseTimeCardCaseRef mirrors the case reference embedded in the Choreo
 // CaseTimeCardSummary shape.
 type snCaseTimeCardCaseRef struct {
-	ID        string                   `json:"id"`
-	Number    string                   `json:"number"`
-	Name      string                   `json:"name"`
-	UpdatedOn string                   `json:"updatedOn"`
-	Project   *snConversationEntityRef `json:"project"`
+	ID        string       `json:"id"`
+	Number    string       `json:"number"`
+	Name      string       `json:"name"`
+	UpdatedOn string       `json:"updatedOn"`
+	Project   *snEntityRef `json:"project"`
 }
 
 // snCaseTimeCardSummary mirrors the Choreo CaseTimeCardSummary shape.

--- a/entity-service/internal/service/sn_time_card_service.go
+++ b/entity-service/internal/service/sn_time_card_service.go
@@ -193,18 +193,20 @@ func NewServiceNowTimeCardService(client *integrationservice.Client) TimeCardSer
 	return &snTimeCardService{client: client}
 }
 
-func (s *snTimeCardService) SearchTimeCards(ctx context.Context, req domain.SearchTimeCardsRequest) (domain.SearchTimeCardsResponse, error) {
+// buildTimeCardSearchPayload validates req and builds the SN request payload
+// shared by both POST /time-cards/search and POST /cases/time-cards/search —
+// the two endpoints take an identical request shape and differ only in
+// response shape (flat time-card rows vs. rolled up by case).
+func buildTimeCardSearchPayload(req domain.SearchTimeCardsRequest) (snTimeCardSearchPayload, error) {
 	if err := normalizePagination(&req.Pagination); err != nil {
-		return domain.SearchTimeCardsResponse{}, err
+		return snTimeCardSearchPayload{}, err
 	}
-
-	token := middleware.UserIDTokenFromContext(ctx)
 
 	var snSortBy *snTimeCardSort
 	if req.SortBy.Field != "" {
 		snField, ok := snTimeCardSortFieldMap[req.SortBy.Field]
 		if !ok {
-			return domain.SearchTimeCardsResponse{}, &apierror.ValidationError{Msg: "sortBy.field " + string(req.SortBy.Field) + " is not supported by ServiceNow"}
+			return snTimeCardSearchPayload{}, &apierror.ValidationError{Msg: "sortBy.field " + string(req.SortBy.Field) + " is not supported by ServiceNow"}
 		}
 		order := string(req.SortBy.Order)
 		if order == "" {
@@ -221,34 +223,34 @@ func (s *snTimeCardService) SearchTimeCards(ctx context.Context, req domain.Sear
 	if req.Filters != nil {
 		for _, state := range req.Filters.States {
 			if _, ok := validTimeCardStates[state]; !ok {
-				return domain.SearchTimeCardsResponse{}, &apierror.ValidationError{Msg: "states contains invalid value: " + string(state)}
+				return snTimeCardSearchPayload{}, &apierror.ValidationError{Msg: "states contains invalid value: " + string(state)}
 			}
 		}
 		if err := validateUUIDs("projectIds", req.Filters.ProjectIDs); err != nil {
-			return domain.SearchTimeCardsResponse{}, err
+			return snTimeCardSearchPayload{}, err
 		}
 		if req.Filters.CaseID != nil {
 			if err := validateUUIDs("caseId", []string{*req.Filters.CaseID}); err != nil {
-				return domain.SearchTimeCardsResponse{}, err
+				return snTimeCardSearchPayload{}, err
 			}
 		}
 		if req.Filters.UserID != nil {
 			if err := validateUUIDs("userId", []string{*req.Filters.UserID}); err != nil {
-				return domain.SearchTimeCardsResponse{}, err
+				return snTimeCardSearchPayload{}, err
 			}
 		}
 		if req.Filters.ApproverID != nil {
 			if err := validateUUIDs("approverId", []string{*req.Filters.ApproverID}); err != nil {
-				return domain.SearchTimeCardsResponse{}, err
+				return snTimeCardSearchPayload{}, err
 			}
 		}
 		if req.Filters.ApprovedByID != nil {
 			if err := validateUUIDs("approvedById", []string{*req.Filters.ApprovedByID}); err != nil {
-				return domain.SearchTimeCardsResponse{}, err
+				return snTimeCardSearchPayload{}, err
 			}
 		}
 		if err := validateUUIDs("userIds", req.Filters.UserIDs); err != nil {
-			return domain.SearchTimeCardsResponse{}, err
+			return snTimeCardSearchPayload{}, err
 		}
 
 		snStates := make([]string, 0, len(req.Filters.States))
@@ -284,6 +286,17 @@ func (s *snTimeCardService) SearchTimeCards(ctx context.Context, req domain.Sear
 		payload.Filters = &filters
 	}
 
+	return payload, nil
+}
+
+func (s *snTimeCardService) SearchTimeCards(ctx context.Context, req domain.SearchTimeCardsRequest) (domain.SearchTimeCardsResponse, error) {
+	payload, err := buildTimeCardSearchPayload(req)
+	if err != nil {
+		return domain.SearchTimeCardsResponse{}, err
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+
 	raw, err := s.client.Post(ctx, "/time-cards/search", token, payload)
 	if err != nil {
 		return domain.SearchTimeCardsResponse{}, err
@@ -304,6 +317,85 @@ func (s *snTimeCardService) SearchTimeCards(ctx context.Context, req domain.Sear
 		Total:     snResp.TotalRecords,
 		Limit:     snResp.Limit,
 		Offset:    snResp.Offset,
+	}, nil
+}
+
+// snCaseTimeCardBillingInfo mirrors the Choreo CaseTimeCardBillingInfo shape.
+type snCaseTimeCardBillingInfo struct {
+	TotalTime float64 `json:"totalTime"`
+	Count     int     `json:"count"`
+}
+
+// snCaseTimeCardCaseRef mirrors the case reference embedded in the Choreo
+// CaseTimeCardSummary shape.
+type snCaseTimeCardCaseRef struct {
+	ID        string                   `json:"id"`
+	Number    string                   `json:"number"`
+	Name      string                   `json:"name"`
+	UpdatedOn string                   `json:"updatedOn"`
+	Project   *snConversationEntityRef `json:"project"`
+}
+
+// snCaseTimeCardSummary mirrors the Choreo CaseTimeCardSummary shape.
+type snCaseTimeCardSummary struct {
+	Case        snCaseTimeCardCaseRef     `json:"case"`
+	TotalTime   float64                   `json:"totalTime"`
+	TotalCount  int                       `json:"totalCount"`
+	Billable    snCaseTimeCardBillingInfo `json:"billable"`
+	NonBillable snCaseTimeCardBillingInfo `json:"nonBillable"`
+}
+
+// snCaseTimeCardsSearchResponse mirrors the Choreo POST /cases/time-cards/search response.
+type snCaseTimeCardsSearchResponse struct {
+	Cases        []snCaseTimeCardSummary `json:"cases"`
+	TotalRecords int                     `json:"totalRecords"`
+	Limit        int                     `json:"limit"`
+	Offset       int                     `json:"offset"`
+}
+
+func (s *snTimeCardService) SearchCaseTimeCards(ctx context.Context, req domain.SearchTimeCardsRequest) (domain.SearchCaseTimeCardsResponse, error) {
+	payload, err := buildTimeCardSearchPayload(req)
+	if err != nil {
+		return domain.SearchCaseTimeCardsResponse{}, err
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+
+	raw, err := s.client.Post(ctx, "/cases/time-cards/search", token, payload)
+	if err != nil {
+		return domain.SearchCaseTimeCardsResponse{}, err
+	}
+
+	var snResp snCaseTimeCardsSearchResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.SearchCaseTimeCardsResponse{}, fmt.Errorf("sn case time cards: parse response: %w", err)
+	}
+
+	cases := make([]domain.CaseTimeCardSummary, 0, len(snResp.Cases))
+	for _, c := range snResp.Cases {
+		summary := domain.CaseTimeCardSummary{
+			Case: domain.CaseTimeCardCaseRef{
+				ID:        sysidToUUID(c.Case.ID),
+				Number:    c.Case.Number,
+				Name:      c.Case.Name,
+				UpdatedOn: c.Case.UpdatedOn,
+			},
+			TotalTime:   c.TotalTime,
+			TotalCount:  c.TotalCount,
+			Billable:    domain.CaseTimeCardBillingInfo{TotalTime: c.Billable.TotalTime, Count: c.Billable.Count},
+			NonBillable: domain.CaseTimeCardBillingInfo{TotalTime: c.NonBillable.TotalTime, Count: c.NonBillable.Count},
+		}
+		if c.Case.Project != nil {
+			summary.Case.Project = &domain.EntityRef{ID: sysidToUUID(c.Case.Project.ID), Name: c.Case.Project.Name}
+		}
+		cases = append(cases, summary)
+	}
+
+	return domain.SearchCaseTimeCardsResponse{
+		Cases:  cases,
+		Total:  snResp.TotalRecords,
+		Limit:  snResp.Limit,
+		Offset: snResp.Offset,
 	}, nil
 }
 

--- a/entity-service/internal/service/user_service.go
+++ b/entity-service/internal/service/user_service.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strconv"
 	"unicode/utf8"
 
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
@@ -37,6 +38,39 @@ func validateUUIDs(field string, ids []string) error {
 			return &apierror.ValidationError{Msg: fmt.Sprintf("%s contains invalid UUID: %q", field, id)}
 		}
 	}
+	return nil
+}
+
+// validateDateRange enforces the same rules as the Ballerina reference's
+// shared validateDateRange helper: both dates must be exactly 10 characters
+// in YYYY-MM-DD format, startDate must be strictly before endDate, and the
+// span between them must not exceed one year.
+func validateDateRange(startDate, endDate string) error {
+	if len(startDate) != 10 || len(endDate) != 10 ||
+		startDate[4:5] != "-" || startDate[7:8] != "-" ||
+		endDate[4:5] != "-" || endDate[7:8] != "-" {
+		return &apierror.ValidationError{Msg: "invalid date format. Expected YYYY-MM-DD"}
+	}
+
+	startYear, errSY := strconv.Atoi(startDate[0:4])
+	startMonth, errSM := strconv.Atoi(startDate[5:7])
+	startDay, errSD := strconv.Atoi(startDate[8:10])
+	endYear, errEY := strconv.Atoi(endDate[0:4])
+	endMonth, errEM := strconv.Atoi(endDate[5:7])
+	endDay, errED := strconv.Atoi(endDate[8:10])
+	if errSY != nil || errSM != nil || errSD != nil || errEY != nil || errEM != nil || errED != nil {
+		return &apierror.ValidationError{Msg: "invalid date format. Expected YYYY-MM-DD"}
+	}
+
+	if startDate >= endDate {
+		return &apierror.ValidationError{Msg: "endDate must be after startDate"}
+	}
+
+	yearDiff := endYear - startYear
+	if yearDiff > 1 || (yearDiff == 1 && (endMonth > startMonth || (endMonth == startMonth && endDay > startDay))) {
+		return &apierror.ValidationError{Msg: "date range must not exceed 1 year"}
+	}
+
 	return nil
 }
 

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -10775,7 +10775,9 @@ components:
 
     EscalationAction:
       type: string
-      description: Defaults to ESCALATE when omitted.
+      description: >
+        Defaults to ESCALATE when omitted. Matched case-insensitively by the service,
+        but callers should send the upper-case form.
       enum: [ESCALATE, DEESCALATE]
 
     CreateEscalationRequest:

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -1635,6 +1635,114 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
 
   /attachments/{id}:
+    get:
+      summary: Get an attachment's metadata and base64-encoded content (ServiceNow data source only).
+      description: >
+        Distinct from GET /attachments/{id}/content, which streams the raw binary. This
+        endpoint returns JSON metadata plus the content as a base64 data URI.
+      operationId: getAttachment
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Attachment UUID.
+      responses:
+        "200":
+          description: The attachment's metadata and content.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AttachmentDetails'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: Attachment not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "503":
+          description: Attachments are only supported for the ServiceNow data source.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    patch:
+      summary: Update an attachment's reference, name, or description (ServiceNow data source only).
+      operationId: updateAttachment
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Attachment UUID.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateAttachmentRequest'
+      responses:
+        "200":
+          description: Attachment updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UpdateAttachmentResponse'
+        "400":
+          description: >-
+            Bad request — invalid referenceType (only case and deployment are accepted here);
+            for case, name is required and description is not allowed; for deployment, at
+            least one of name or description must be provided.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Missing or invalid x-user-id-token header (ServiceNow data source only).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: Attachment not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "503":
+          description: Attachments are only supported for the ServiceNow data source.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
     delete:
       summary: Delete a case attachment (ServiceNow data source only).
       operationId: deleteCaseAttachment
@@ -3300,6 +3408,844 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         "500":
           description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /metadata:
+    get:
+      summary: Get system-wide reference metadata (time zones, project types, feedback emojis).
+      description: ServiceNow data source only; there is no Postgres equivalent.
+      operationId: getSystemMetadata
+      responses:
+        "200":
+          description: System-wide reference metadata.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SystemMetadataResponse'
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "503":
+          description: System metadata is only supported for the ServiceNow data source.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /search:
+    post:
+      summary: Global search across projects and cases (ServiceNow data source only).
+      description: >
+        Runs a single free-text query against both the projects and cases tables and
+        returns paginated results for each independently.
+      operationId: globalSearch
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GlobalSearchRequest'
+      responses:
+        "200":
+          description: Projects and cases matching the query.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GlobalSearchResponse'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "503":
+          description: Global search is only supported for the ServiceNow data source.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /products/vulnerabilities/meta:
+    get:
+      summary: Get reference metadata for product vulnerabilities (ServiceNow data source only).
+      description: >
+        Distinct from GET /products/vulnerabilities/{id} — "meta" is a literal path segment
+        here, not a vulnerability ID.
+      operationId: getProductVulnerabilityMeta
+      responses:
+        "200":
+          description: Reference metadata for product vulnerabilities.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VulnerabilityMetaResponse'
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "503":
+          description: Vulnerability metadata is only supported for the ServiceNow data source.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /conversations/{id}:
+    get:
+      summary: Get a single conversation by ID (ServiceNow data source only).
+      operationId: getConversation
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Conversation UUID.
+      responses:
+        "200":
+          description: The conversation detail.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConversationDetails'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: Conversation not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "503":
+          description: Conversations are only supported for the ServiceNow data source.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    patch:
+      summary: Update a conversation's state (ServiceNow data source only).
+      operationId: updateConversation
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Conversation UUID.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateConversationRequest'
+      responses:
+        "200":
+          description: Conversation updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UpdateConversationResponse'
+        "400":
+          description: Bad request — invalid or missing state.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Missing or invalid x-user-id-token header (ServiceNow data source only).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: Conversation not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "503":
+          description: Conversations are only supported for the ServiceNow data source.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /conversations:
+    post:
+      summary: Start a new conversation on a project (ServiceNow data source only).
+      operationId: createConversation
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateConversationRequest'
+      responses:
+        "201":
+          description: Conversation created successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateConversationResponse'
+        "400":
+          description: Bad request — missing projectId/initialMessage, or other invalid field.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Missing or invalid x-user-id-token header (ServiceNow data source only).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: Project not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "503":
+          description: Conversations are only supported for the ServiceNow data source.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /cases/{id}/feedback:
+    get:
+      summary: Get the feedback submitted for a case (ServiceNow data source only).
+      operationId: getCaseFeedback
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Case UUID.
+      responses:
+        "200":
+          description: The feedback submitted for the case.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CaseFeedback'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: Case not found, or no feedback has been submitted for this case yet.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "503":
+          description: Case feedback is only supported for the ServiceNow data source.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    post:
+      summary: Submit feedback for a case (ServiceNow data source only).
+      operationId: submitCaseFeedback
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Case UUID.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SubmitCaseFeedbackRequest'
+      responses:
+        "201":
+          description: Feedback submitted successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubmitCaseFeedbackResponse'
+        "400":
+          description: Bad request — missing emojiId, or other invalid field.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Missing or invalid x-user-id-token header (ServiceNow data source only).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: Case not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "503":
+          description: Case feedback is only supported for the ServiceNow data source.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /deployed-products/{id}/metrics/search:
+    post:
+      summary: Get deployed-product cores metrics over a date range (ServiceNow data source only).
+      operationId: searchDeployedProductMetrics
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Deployed product UUID.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeployedProductMetricsRequest'
+      responses:
+        "200":
+          description: Cores metrics for the deployed product over the requested date range.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeployedProductMetricsResponse'
+        "400":
+          description: Bad request — invalid date range, or other invalid field.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: Deployed product or deployment not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "503":
+          description: Deployed product metrics are only supported for the ServiceNow data source.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /deployed-products/{id}/metrics/usage-counts/search:
+    post:
+      summary: Get deployed-product usage-count metrics over a date range (ServiceNow data source only).
+      operationId: searchDeployedProductUsageCounts
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Deployed product UUID.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeployedProductUsageCountsRequest'
+      responses:
+        "200":
+          description: Usage-count metrics for the deployed product over the requested date range.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeployedProductUsageCountsResponse'
+        "400":
+          description: Bad request — invalid date range, or other invalid field.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: Deployed product or deployment not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "503":
+          description: Deployed product usage counts are only supported for the ServiceNow data source.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /escalations/search:
+    post:
+      summary: Search case escalations (ServiceNow data source only).
+      operationId: searchEscalations
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SearchEscalationsRequest'
+      responses:
+        "200":
+          description: Escalations matching the filters.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchEscalationsResponse'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "503":
+          description: Escalations are only supported for the ServiceNow data source.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /escalations:
+    post:
+      summary: Escalate or de-escalate a case (ServiceNow data source only).
+      description: >
+        Defaults to action ESCALATE when omitted, which requires a non-blank reason.
+        DEESCALATE does not require a reason.
+      operationId: createEscalation
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateEscalationRequest'
+      responses:
+        "201":
+          description: Escalation recorded successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateEscalationResponse'
+        "400":
+          description: Bad request — missing caseId, missing reason for an ESCALATE action, or other invalid field.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Missing or invalid x-user-id-token header (ServiceNow data source only).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: Case not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "503":
+          description: Escalations are only supported for the ServiceNow data source.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /cases/time-cards/search:
+    post:
+      summary: Search time cards rolled up by case (ServiceNow data source only).
+      description: >
+        Same request shape as POST /time-cards/search, but results are grouped by case
+        with per-case billable/non-billable totals instead of returned as flat rows.
+      operationId: searchCaseTimeCards
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SearchTimeCardsRequest'
+      responses:
+        "200":
+          description: Time cards matching the filters, rolled up by case.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchCaseTimeCardsResponse'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "503":
+          description: Case time cards are only supported for the ServiceNow data source.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /instances/search:
+    post:
+      summary: Search instances (ServiceNow data source only).
+      description: >
+        projectIds, deploymentIds, and deployedProductIds in filters are mutually exclusive —
+        at most one may be non-empty.
+      operationId: searchInstances
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SearchInstancesRequest'
+      responses:
+        "200":
+          description: Instances matching the filters.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchInstancesResponse'
+        "400":
+          description: Bad request — invalid UUID, or more than one of projectIds/deploymentIds/deployedProductIds provided.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "503":
+          description: Instances are only supported for the ServiceNow data source.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /instances/metrics/search:
+    post:
+      summary: Fetch per-instance metric time series over a date range (ServiceNow data source only).
+      description: >
+        filters.startDate/endDate are required. projectIds, deploymentIds, and
+        deployedProductIds are mutually exclusive — at most one may be non-empty.
+      operationId: searchInstanceMetrics
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InstanceMetricsRequest'
+      responses:
+        "200":
+          description: Per-instance metric time series over the requested date range.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InstanceMetricsResponse'
+        "400":
+          description: Bad request — invalid UUID, missing/invalid date, or more than one ID filter provided.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "503":
+          description: Instances are only supported for the ServiceNow data source.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /instances/usages/search:
+    post:
+      summary: Fetch per-instance usage time series over a date range (ServiceNow data source only).
+      description: >
+        Same filter rules as POST /instances/metrics/search.
+      operationId: searchInstanceUsage
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InstanceUsageRequest'
+      responses:
+        "200":
+          description: Per-instance usage time series over the requested date range.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InstanceUsageResponse'
+        "400":
+          description: Bad request — invalid UUID, missing/invalid date, or more than one ID filter provided.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "503":
+          description: Instances are only supported for the ServiceNow data source.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /instances/metrics/stats/search:
+    post:
+      summary: Fetch aggregated instance metric statistics over a date range (ServiceNow data source only).
+      description: >
+        Same filter rules as POST /instances/metrics/search, plus an optional dataSource filter
+        (1 = API Call, 2 = File Upload).
+      operationId: searchInstanceMetricsStats
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InstanceMetricsStatsRequest'
+      responses:
+        "200":
+          description: Aggregated metric statistics over the requested date range.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InstanceMetricsStatsResponse'
+        "400":
+          description: Bad request — invalid UUID, missing/invalid date, or more than one ID filter provided.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "503":
+          description: Instances are only supported for the ServiceNow data source.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /instances/usages/stats/search:
+    post:
+      summary: Fetch aggregated instance usage statistics over a date range (ServiceNow data source only).
+      description: >
+        Same filter rules as POST /instances/metrics/stats/search.
+      operationId: searchInstanceUsageStats
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InstanceUsageStatsRequest'
+      responses:
+        "200":
+          description: Aggregated usage statistics over the requested date range.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InstanceUsageStatsResponse'
+        "400":
+          description: Bad request — invalid UUID, missing/invalid date, or more than one ID filter provided.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "503":
+          description: Instances are only supported for the ServiceNow data source.
           content:
             application/json:
               schema:
@@ -9066,3 +10012,1260 @@ components:
             $ref: '#/components/schemas/ChoiceListItem'
         resolvedCount:
           $ref: '#/components/schemas/ResolvedCountBreakdown'
+
+    SystemMetadataResponse:
+      type: object
+      description: The response for GET /metadata — system-wide reference data (not project- or case-scoped).
+      required: [timeZones, projectTypes, feedbackEmojies]
+      properties:
+        timeZones:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChoiceListItem'
+        projectTypes:
+          type: array
+          items:
+            $ref: '#/components/schemas/ReferenceTableItem'
+        feedbackEmojies:
+          type: array
+          items:
+            $ref: '#/components/schemas/FeedbackEmoji'
+
+    FeedbackEmojiChip:
+      type: object
+      description: A selectable follow-up option shown under a feedback emoji.
+      required: [id, name, value]
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        value:
+          type: string
+
+    FeedbackEmoji:
+      type: object
+      description: One of the emoji choices offered on the case feedback form.
+      required: [id, name, value, unselectedImage, selectedImage, chips]
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        value:
+          type: string
+        unselectedImage:
+          type: string
+        selectedImage:
+          type: string
+        chips:
+          type: array
+          items:
+            $ref: '#/components/schemas/FeedbackEmojiChip'
+
+    GlobalSearchFilters:
+      type: object
+      properties:
+        searchQuery:
+          type: string
+          maxLength: 200
+          description: Free-text query matched against project and case fields.
+        tables:
+          type: array
+          items:
+            type: string
+            enum: [projects, cases]
+          description: Restrict the search to these entity types. Both are searched when omitted.
+
+    GlobalSearchSort:
+      type: object
+      properties:
+        field:
+          type: string
+        order:
+          type: string
+          enum: [asc, desc]
+
+    GlobalSearchRequest:
+      type: object
+      description: >
+        Every field is optional — an empty request body ({}) is valid and searches both
+        tables with default pagination.
+      properties:
+        filters:
+          $ref: '#/components/schemas/GlobalSearchFilters'
+        sortBy:
+          $ref: '#/components/schemas/GlobalSearchSort'
+        projectsPagination:
+          $ref: '#/components/schemas/Pagination'
+        casesPagination:
+          $ref: '#/components/schemas/Pagination'
+
+    GlobalSearchProject:
+      type: object
+      required:
+        - id
+        - name
+        - key
+        - type
+        - createdOn
+        - hasPdpSubscription
+        - account
+        - activeChatsCount
+        - actionRequiredCount
+        - outstandingCount
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
+        key:
+          type: string
+        type:
+          $ref: '#/components/schemas/ReferenceTableItem'
+        createdOn:
+          type: string
+        startDate:
+          type: string
+          nullable: true
+        endDate:
+          type: string
+          nullable: true
+        hasPdpSubscription:
+          type: boolean
+        closureState:
+          type: string
+          nullable: true
+        account:
+          $ref: '#/components/schemas/ReferenceTableItem'
+        activeChatsCount:
+          type: integer
+        actionRequiredCount:
+          type: integer
+        outstandingCount:
+          type: integer
+
+    GlobalSearchCase:
+      type: object
+      required: [id, internalId, number, createdOn, createdBy, updatedOn, account]
+      properties:
+        id:
+          type: string
+          format: uuid
+        internalId:
+          type: string
+        number:
+          type: string
+        title:
+          type: string
+          nullable: true
+        description:
+          type: string
+          nullable: true
+        createdOn:
+          type: string
+        createdBy:
+          type: string
+        updatedOn:
+          type: string
+        project:
+          $ref: '#/components/schemas/ReferenceTableItem'
+          nullable: true
+        caseType:
+          $ref: '#/components/schemas/ReferenceTableItem'
+          nullable: true
+        state:
+          $ref: '#/components/schemas/ChoiceListItem'
+          nullable: true
+        severity:
+          $ref: '#/components/schemas/ChoiceListItem'
+          nullable: true
+        assignedEngineer:
+          $ref: '#/components/schemas/ReferenceTableItem'
+          nullable: true
+        account:
+          $ref: '#/components/schemas/ReferenceTableItem'
+
+    GlobalSearchResponse:
+      type: object
+      required: [query, projectsTotal, casesTotal, projects, cases]
+      properties:
+        query:
+          type: string
+        projectsTotal:
+          type: integer
+        casesTotal:
+          type: integer
+        projects:
+          type: array
+          items:
+            $ref: '#/components/schemas/GlobalSearchProject'
+        cases:
+          type: array
+          items:
+            $ref: '#/components/schemas/GlobalSearchCase'
+
+    VulnerabilityMetaResponse:
+      type: object
+      required: [severities]
+      properties:
+        severities:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChoiceListItem'
+
+    ConversationState:
+      type: string
+      description: >
+        Only ACTIVE and RESOLVED are accepted by the conversation search filter; all five
+        values are accepted transitions for PATCH /conversations/{id}.
+      enum: [ACTIVE, RESOLVED, CONVERTED, ABANDONED, CLOSED]
+
+    ConversationDetails:
+      type: object
+      description: The response for GET /conversations/{id}.
+      required: [id, messageCount, createdOn, createdBy, updatedOn, updatedBy]
+      properties:
+        id:
+          type: string
+          format: uuid
+        number:
+          type: string
+          nullable: true
+        initialMessage:
+          type: string
+          nullable: true
+        messageCount:
+          type: integer
+        project:
+          $ref: '#/components/schemas/EntityRef'
+          nullable: true
+        case:
+          $ref: '#/components/schemas/EntityRef'
+          nullable: true
+        state:
+          $ref: '#/components/schemas/ConversationState'
+          nullable: true
+        createdOn:
+          type: string
+        createdBy:
+          type: string
+        updatedOn:
+          type: string
+        updatedBy:
+          type: string
+
+    CreateConversationRequest:
+      type: object
+      required: [projectId, initialMessage]
+      properties:
+        projectId:
+          type: string
+          format: uuid
+        initialMessage:
+          type: string
+
+    CreatedConversation:
+      type: object
+      required: [id, number, createdBy, createdOn]
+      properties:
+        id:
+          type: string
+          format: uuid
+        number:
+          type: string
+        createdBy:
+          type: string
+        createdOn:
+          type: string
+        state:
+          $ref: '#/components/schemas/ConversationState'
+          nullable: true
+
+    CreateConversationResponse:
+      type: object
+      required: [message, conversation]
+      properties:
+        message:
+          type: string
+        conversation:
+          $ref: '#/components/schemas/CreatedConversation'
+
+    UpdateConversationRequest:
+      type: object
+      required: [state]
+      properties:
+        state:
+          $ref: '#/components/schemas/ConversationState'
+
+    UpdatedConversation:
+      type: object
+      required: [id, updatedOn, updatedBy]
+      properties:
+        id:
+          type: string
+          format: uuid
+        number:
+          type: string
+          nullable: true
+        updatedOn:
+          type: string
+        updatedBy:
+          type: string
+        state:
+          $ref: '#/components/schemas/ConversationState'
+          nullable: true
+
+    UpdateConversationResponse:
+      type: object
+      required: [message, conversation]
+      properties:
+        message:
+          type: string
+        conversation:
+          $ref: '#/components/schemas/UpdatedConversation'
+
+    CaseFeedbackEmojiRef:
+      type: object
+      required: [id, name, selectedImage]
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        selectedImage:
+          type: string
+
+    CaseFeedback:
+      type: object
+      description: The response for GET /cases/{id}/feedback.
+      required: [id, emoji, chips, assessmentId, createdBy, createdOn]
+      properties:
+        id:
+          type: string
+          format: uuid
+        emoji:
+          $ref: '#/components/schemas/CaseFeedbackEmojiRef'
+        chips:
+          type: array
+          nullable: true
+          items:
+            type: string
+            format: uuid
+        assessmentId:
+          type: string
+          format: uuid
+        createdBy:
+          type: string
+        createdOn:
+          type: string
+        additionalComment:
+          type: string
+          nullable: true
+
+    SubmitCaseFeedbackRequest:
+      type: object
+      required: [emojiId]
+      properties:
+        emojiId:
+          type: string
+          format: uuid
+        chipIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+        additionalComment:
+          type: string
+          nullable: true
+
+    CaseFeedbackResult:
+      type: object
+      required: [id, assessmentId, caseId, createdBy, createdOn]
+      properties:
+        id:
+          type: string
+          format: uuid
+        assessmentId:
+          type: string
+          format: uuid
+        caseId:
+          type: string
+          format: uuid
+        createdBy:
+          type: string
+        createdOn:
+          type: string
+
+    SubmitCaseFeedbackResponse:
+      type: object
+      required: [message, feedback]
+      properties:
+        message:
+          type: string
+        feedback:
+          $ref: '#/components/schemas/CaseFeedbackResult'
+
+    AttachmentDetails:
+      type: object
+      description: >
+        The response for GET /attachments/{id}. Distinct from GET /attachments/{id}/content,
+        which streams the raw binary — this endpoint returns JSON metadata plus the content
+        as a base64 data URI.
+      required: [id, referenceId, name, type, sizeBytes, createdBy, createdOn, content]
+      properties:
+        id:
+          type: string
+          format: uuid
+        referenceId:
+          type: string
+          format: uuid
+        name:
+          type: string
+        type:
+          type: string
+        sizeBytes:
+          type: integer
+        description:
+          type: string
+          nullable: true
+        createdBy:
+          type: string
+        createdOn:
+          type: string
+          format: date-time
+        downloadUrl:
+          type: string
+          nullable: true
+        previewUrl:
+          type: string
+          nullable: true
+        content:
+          type: string
+          description: Base64 data URI of the attachment content (e.g. data:image/png;base64,...).
+
+    UpdateAttachmentRequest:
+      type: object
+      description: >
+        referenceType accepts only case and deployment (the broader ReferenceType enum also
+        has conversation, change_request, and incident, but this endpoint rejects those). For
+        case, name is required and description is not allowed; for deployment, at least one
+        of name or description must be provided.
+      required: [referenceId, referenceType]
+      properties:
+        referenceId:
+          type: string
+          format: uuid
+        referenceType:
+          type: string
+          enum: [case, deployment]
+        name:
+          type: string
+        description:
+          type: string
+
+    UpdatedAttachment:
+      type: object
+      required: [id, updatedOn, updatedBy]
+      properties:
+        id:
+          type: string
+          format: uuid
+        updatedOn:
+          type: string
+          format: date-time
+        updatedBy:
+          type: string
+
+    UpdateAttachmentResponse:
+      type: object
+      required: [message, attachment]
+      properties:
+        message:
+          type: string
+        attachment:
+          $ref: '#/components/schemas/UpdatedAttachment'
+
+    DeployedProductMetricsRequest:
+      type: object
+      required: [deploymentId, startDate, endDate]
+      properties:
+        deploymentId:
+          type: string
+          format: uuid
+        startDate:
+          type: string
+          format: date
+        endDate:
+          type: string
+          format: date
+
+    DeployedProductMetricsInstance:
+      type: object
+      description: A single instance's contribution to a metrics chart entry.
+      required: [id, name, cores]
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        cores:
+          type: integer
+
+    DeployedProductMetricsChartEntry:
+      type: object
+      description: One date's worth of core-count data.
+      required: [date, instanceCount, totalCores, minCores, maxCores, avgCores, instances]
+      properties:
+        date:
+          type: string
+        instanceCount:
+          type: integer
+        totalCores:
+          type: integer
+        minCores:
+          type: integer
+        maxCores:
+          type: integer
+        avgCores:
+          type: number
+          format: double
+        instances:
+          type: array
+          items:
+            $ref: '#/components/schemas/DeployedProductMetricsInstance'
+
+    DeployedProductMetricsDateRange:
+      type: object
+      required: [start, end]
+      properties:
+        start:
+          type: string
+        end:
+          type: string
+
+    DeployedProductMetricsSummary:
+      type: object
+      required: [dateRange, totalInstances]
+      properties:
+        dateRange:
+          $ref: '#/components/schemas/DeployedProductMetricsDateRange'
+        totalInstances:
+          type: integer
+        minCores:
+          type: integer
+          nullable: true
+        maxCores:
+          type: integer
+          nullable: true
+        avgCores:
+          type: number
+          format: double
+          nullable: true
+
+    DeployedProductMetricsResponse:
+      type: object
+      required: [deployedProduct, summary, chartData]
+      properties:
+        deployedProduct:
+          $ref: '#/components/schemas/ReferenceTableItem'
+        summary:
+          $ref: '#/components/schemas/DeployedProductMetricsSummary'
+        chartData:
+          type: array
+          items:
+            $ref: '#/components/schemas/DeployedProductMetricsChartEntry'
+
+    DeployedProductUsageCountsRequest:
+      type: object
+      required: [deploymentId, startDate, endDate]
+      properties:
+        deploymentId:
+          type: string
+          format: uuid
+        startDate:
+          type: string
+          format: date
+        endDate:
+          type: string
+          format: date
+
+    CountTypeAggregation:
+      type: object
+      description: Summary statistics for a single count type over the queried date range.
+      required: [aggregation, min, max, avg]
+      properties:
+        aggregation:
+          type: string
+        min:
+          type: number
+          format: double
+        max:
+          type: number
+          format: double
+        avg:
+          type: number
+          format: double
+
+    DeployedProductUsageCountsSummary:
+      type: object
+      required: [dateRange, countTypes]
+      properties:
+        dateRange:
+          $ref: '#/components/schemas/DeployedProductMetricsDateRange'
+        countTypes:
+          type: object
+          description: >
+            Keyed by count-type name — ServiceNow defines an open set of count types, not a
+            fixed enum.
+          additionalProperties:
+            $ref: '#/components/schemas/CountTypeAggregation'
+
+    UsageCountInstance:
+      type: object
+      required: [id, name, value]
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        value:
+          type: number
+          format: double
+
+    UsageCountEntry:
+      type: object
+      required: [value, aggregation, instances]
+      properties:
+        value:
+          type: number
+          format: double
+        aggregation:
+          type: string
+        instances:
+          type: array
+          items:
+            $ref: '#/components/schemas/UsageCountInstance'
+
+    DeployedProductUsageCountsChartEntry:
+      type: object
+      required: [date, counts]
+      properties:
+        date:
+          type: string
+        counts:
+          type: object
+          description: >
+            Keyed by count-type name — an open set, see
+            DeployedProductUsageCountsSummary.countTypes.
+          additionalProperties:
+            $ref: '#/components/schemas/UsageCountEntry'
+
+    DeployedProductUsageCountsResponse:
+      type: object
+      required: [deployedProduct, summary, chartData]
+      properties:
+        deployedProduct:
+          $ref: '#/components/schemas/ReferenceTableItem'
+        summary:
+          $ref: '#/components/schemas/DeployedProductUsageCountsSummary'
+        chartData:
+          type: array
+          items:
+            $ref: '#/components/schemas/DeployedProductUsageCountsChartEntry'
+
+    SearchEscalationsFilters:
+      type: object
+      properties:
+        caseIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+        currentLevels:
+          type: array
+          items:
+            type: integer
+
+    EscalationSort:
+      type: object
+      required: [field, order]
+      properties:
+        field:
+          type: string
+          enum: [createdOn, updatedOn]
+        order:
+          type: string
+          enum: [asc, desc]
+
+    SearchEscalationsRequest:
+      type: object
+      required: [pagination]
+      properties:
+        filters:
+          $ref: '#/components/schemas/SearchEscalationsFilters'
+        sortBy:
+          $ref: '#/components/schemas/EscalationSort'
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+
+    EscalationNotifiedUser:
+      type: object
+      required: [id, userName]
+      properties:
+        id:
+          type: string
+          format: uuid
+        userName:
+          type: string
+        name:
+          type: string
+          nullable: true
+        email:
+          type: string
+          nullable: true
+
+    Escalation:
+      type: object
+      description: A single escalation row in search results.
+      required: [id, case, currentLevel, previousLevel, createdBy, createdOn, updatedOn, notificationSentTo]
+      properties:
+        id:
+          type: string
+          format: uuid
+        case:
+          $ref: '#/components/schemas/ReferenceTableItem'
+        currentLevel:
+          $ref: '#/components/schemas/ChoiceListItem'
+        previousLevel:
+          $ref: '#/components/schemas/ChoiceListItem'
+        createdBy:
+          type: string
+        createdOn:
+          type: string
+        updatedOn:
+          type: string
+        reason:
+          type: string
+          nullable: true
+        notificationSentTo:
+          type: array
+          items:
+            $ref: '#/components/schemas/EscalationNotifiedUser'
+
+    SearchEscalationsResponse:
+      type: object
+      required: [escalations, total, offset, limit]
+      properties:
+        escalations:
+          type: array
+          items:
+            $ref: '#/components/schemas/Escalation'
+        total:
+          type: integer
+        offset:
+          type: integer
+        limit:
+          type: integer
+
+    EscalationAction:
+      type: string
+      description: Defaults to ESCALATE when omitted.
+      enum: [ESCALATE, DEESCALATE]
+
+    CreateEscalationRequest:
+      type: object
+      required: [caseId]
+      properties:
+        caseId:
+          type: string
+          format: uuid
+        reason:
+          type: string
+          description: Required (non-blank) when action is ESCALATE (the default); optional when DEESCALATE.
+        action:
+          $ref: '#/components/schemas/EscalationAction'
+
+    CreatedEscalation:
+      type: object
+      description: >
+        Unlike Escalation (search results), this has no updatedOn — the create response
+        doesn't carry one.
+      required: [id, case, currentLevel, previousLevel, createdBy, createdOn, notificationSentTo]
+      properties:
+        id:
+          type: string
+          format: uuid
+        case:
+          $ref: '#/components/schemas/ReferenceTableItem'
+        currentLevel:
+          $ref: '#/components/schemas/ChoiceListItem'
+        previousLevel:
+          $ref: '#/components/schemas/ChoiceListItem'
+        createdBy:
+          type: string
+        createdOn:
+          type: string
+        reason:
+          type: string
+          nullable: true
+        notificationSentTo:
+          type: array
+          items:
+            $ref: '#/components/schemas/EscalationNotifiedUser'
+
+    CreateEscalationResponse:
+      type: object
+      required: [message, escalation]
+      properties:
+        message:
+          type: string
+        escalation:
+          $ref: '#/components/schemas/CreatedEscalation'
+
+    CaseTimeCardBillingInfo:
+      type: object
+      required: [totalTime, count]
+      properties:
+        totalTime:
+          type: number
+          format: double
+        count:
+          type: integer
+
+    CaseTimeCardCaseRef:
+      type: object
+      required: [id, number, name, updatedOn]
+      properties:
+        id:
+          type: string
+          format: uuid
+        number:
+          type: string
+        name:
+          type: string
+        updatedOn:
+          type: string
+        project:
+          $ref: '#/components/schemas/EntityRef'
+          nullable: true
+
+    CaseTimeCardSummary:
+      type: object
+      description: The time-card rollup for a single case.
+      required: [case, totalTime, totalCount, billable, nonBillable]
+      properties:
+        case:
+          $ref: '#/components/schemas/CaseTimeCardCaseRef'
+        totalTime:
+          type: number
+          format: double
+        totalCount:
+          type: integer
+        billable:
+          $ref: '#/components/schemas/CaseTimeCardBillingInfo'
+        nonBillable:
+          $ref: '#/components/schemas/CaseTimeCardBillingInfo'
+
+    SearchCaseTimeCardsResponse:
+      type: object
+      description: >
+        The response for POST /cases/time-cards/search — time cards grouped and rolled up by
+        case, rather than the flat per-time-card rows POST /time-cards/search returns.
+      required: [cases, total, offset, limit]
+      properties:
+        cases:
+          type: array
+          items:
+            $ref: '#/components/schemas/CaseTimeCardSummary'
+        total:
+          type: integer
+        offset:
+          type: integer
+        limit:
+          type: integer
+
+    InstanceSearchFilters:
+      type: object
+      description: >
+        projectIds, deploymentIds, and deployedProductIds are mutually exclusive — at most
+        one may be non-empty.
+      properties:
+        startDate:
+          type: string
+          format: date
+          nullable: true
+        endDate:
+          type: string
+          format: date
+          nullable: true
+        projectIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+        deploymentIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+        deployedProductIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+
+    SearchInstancesRequest:
+      type: object
+      required: [pagination]
+      properties:
+        filters:
+          $ref: '#/components/schemas/InstanceSearchFilters'
+          nullable: true
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+
+    InstanceMetadata:
+      type: object
+      required: [id, createdOn, updatedOn]
+      properties:
+        id:
+          type: string
+          format: uuid
+        coreCount:
+          type: integer
+          nullable: true
+        updates:
+          type: integer
+          nullable: true
+        jdkVersion:
+          type: string
+          nullable: true
+        deploymentMetadata:
+          type: object
+          additionalProperties: true
+          nullable: true
+        createdOn:
+          type: string
+        updatedOn:
+          type: string
+        customCreatedOn:
+          type: string
+          nullable: true
+        customUpdatedOn:
+          type: string
+          nullable: true
+
+    Instance:
+      type: object
+      required: [id, key, createdOn, updatedOn]
+      properties:
+        id:
+          type: string
+          format: uuid
+        key:
+          type: string
+        project:
+          $ref: '#/components/schemas/ReferenceTableItem'
+          nullable: true
+        deployment:
+          $ref: '#/components/schemas/ReferenceTableItem'
+          nullable: true
+        product:
+          $ref: '#/components/schemas/ReferenceTableItem'
+          nullable: true
+        deployedProduct:
+          $ref: '#/components/schemas/ReferenceTableItem'
+          nullable: true
+        createdOn:
+          type: string
+        updatedOn:
+          type: string
+        metadata:
+          $ref: '#/components/schemas/InstanceMetadata'
+          nullable: true
+
+    SearchInstancesResponse:
+      type: object
+      required: [instances, total, offset, limit]
+      properties:
+        instances:
+          type: array
+          items:
+            $ref: '#/components/schemas/Instance'
+        total:
+          type: integer
+        offset:
+          type: integer
+        limit:
+          type: integer
+
+    InstanceDateRangeFilters:
+      type: object
+      description: >
+        Shared filters for POST /instances/metrics/search and POST /instances/usages/search.
+        projectIds, deploymentIds, and deployedProductIds are mutually exclusive — at most
+        one may be non-empty.
+      required: [startDate, endDate]
+      properties:
+        startDate:
+          type: string
+          format: date
+        endDate:
+          type: string
+          format: date
+        projectIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+        deploymentIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+        deployedProductIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+
+    InstanceMetricsRequest:
+      type: object
+      required: [filters]
+      properties:
+        filters:
+          $ref: '#/components/schemas/InstanceDateRangeFilters'
+
+    InstanceDataPoint:
+      type: object
+      required: [date, createdOn]
+      properties:
+        date:
+          type: string
+        createdOn:
+          type: string
+        coreCount:
+          type: integer
+          nullable: true
+        jdkVersion:
+          type: string
+          nullable: true
+        updates:
+          type: integer
+          nullable: true
+        deploymentMetadata:
+          type: object
+          additionalProperties: true
+          nullable: true
+
+    InstanceMetric:
+      type: object
+      description: One instance's metric time series, ordered newest to oldest.
+      required: [instanceId, instanceKey, dataPoints]
+      properties:
+        instanceId:
+          type: string
+          format: uuid
+        instanceKey:
+          type: string
+        project:
+          $ref: '#/components/schemas/ReferenceTableItem'
+          nullable: true
+        deployment:
+          $ref: '#/components/schemas/ReferenceTableItem'
+          nullable: true
+        product:
+          $ref: '#/components/schemas/ReferenceTableItem'
+          nullable: true
+        deployedProduct:
+          $ref: '#/components/schemas/ReferenceTableItem'
+          nullable: true
+        dataPoints:
+          type: array
+          items:
+            $ref: '#/components/schemas/InstanceDataPoint'
+
+    InstanceMetricsResponse:
+      type: object
+      required: [metrics, totalInstances, startDate, endDate]
+      properties:
+        metrics:
+          type: array
+          items:
+            $ref: '#/components/schemas/InstanceMetric'
+        totalInstances:
+          type: integer
+        startDate:
+          type: string
+        endDate:
+          type: string
+
+    InstanceUsageRequest:
+      type: object
+      required: [filters]
+      properties:
+        filters:
+          $ref: '#/components/schemas/InstanceDateRangeFilters'
+
+    InstanceSummary:
+      type: object
+      description: >
+        One period's usage counts for an instance, keyed by an open set of count-type names
+        (e.g. "TOTAL_USERS", "TRANSACTION_COUNT").
+      required: [period, counts]
+      properties:
+        period:
+          type: string
+        counts:
+          type: object
+          additionalProperties:
+            type: integer
+
+    InstanceUsageEntry:
+      type: object
+      required: [instanceId, instanceKey, periodSummaries]
+      properties:
+        instanceId:
+          type: string
+          format: uuid
+        instanceKey:
+          type: string
+        project:
+          $ref: '#/components/schemas/ReferenceTableItem'
+          nullable: true
+        deployment:
+          $ref: '#/components/schemas/ReferenceTableItem'
+          nullable: true
+        product:
+          $ref: '#/components/schemas/ReferenceTableItem'
+          nullable: true
+        deployedProduct:
+          $ref: '#/components/schemas/ReferenceTableItem'
+          nullable: true
+        periodSummaries:
+          type: array
+          items:
+            $ref: '#/components/schemas/InstanceSummary'
+
+    InstanceUsageResponse:
+      type: object
+      required: [usages, totalInstances, startDate, endDate]
+      properties:
+        usages:
+          type: array
+          items:
+            $ref: '#/components/schemas/InstanceUsageEntry'
+        totalInstances:
+          type: integer
+        startDate:
+          type: string
+        endDate:
+          type: string
+
+    InstanceStatsFilters:
+      type: object
+      description: >
+        Extends the shared date-range filters with an optional dataSource discriminator,
+        used by the two .../stats/search endpoints only.
+      required: [startDate, endDate]
+      properties:
+        startDate:
+          type: string
+          format: date
+        endDate:
+          type: string
+          format: date
+        projectIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+        deploymentIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+        deployedProductIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+        dataSource:
+          type: integer
+          nullable: true
+          description: "1 = API Call, 2 = File Upload."
+
+    InstanceMetricsStatsRequest:
+      type: object
+      required: [filters]
+      properties:
+        filters:
+          $ref: '#/components/schemas/InstanceStatsFilters'
+
+    InstanceMetricSummary:
+      type: object
+      required: [current, min, max, avg]
+      properties:
+        current:
+          type: number
+        min:
+          type: number
+        max:
+          type: number
+        avg:
+          type: number
+
+    InstanceMetricsStatsResponse:
+      type: object
+      description: >
+        stats is keyed by date, then by an open set of metric names (e.g. "TOTAL_CORES") —
+        an open set defined by ServiceNow, not a fixed enum.
+      required: [stats, summary, total, startDate, endDate]
+      properties:
+        stats:
+          type: object
+          additionalProperties:
+            type: object
+            additionalProperties:
+              type: integer
+        summary:
+          $ref: '#/components/schemas/InstanceMetricSummary'
+        total:
+          type: integer
+        startDate:
+          type: string
+        endDate:
+          type: string
+
+    InstanceUsageStatsRequest:
+      type: object
+      required: [filters]
+      properties:
+        filters:
+          $ref: '#/components/schemas/InstanceStatsFilters'
+
+    InstanceUsageStatsResponse:
+      type: object
+      description: >
+        stats is keyed by date, then by an open set of metric names, same rationale as
+        InstanceMetricsStatsResponse.stats. Unlike that response, there is no summary block.
+      required: [stats, total, startDate, endDate]
+      properties:
+        stats:
+          type: object
+          additionalProperties:
+            type: object
+            additionalProperties:
+              type: integer
+        total:
+          type: integer
+        startDate:
+          type: string
+        endDate:
+          type: string


### PR DESCRIPTION
## Purpose

Ports the remaining ServiceNow-backed entity-service endpoints consumed by customer-portal-backend, completing the project metadata and statistics work.

## Changes

- Add global metadata, search, and vulnerability metadata endpoints
- Add conversation CRUD and case feedback endpoints
- Complete attachment and deployed-product metrics endpoints
- Add escalation, case time-card, and instance endpoints
- Expand the OpenAPI specification and service interfaces
- Add shared validation for instance ID filters and date ranges

## Validation

- Route-contract tests
- Go build and vet
- gofmt
- gosec (0 issues)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added conversation retrieval, creation, updates, and expanded conversation states.
  * Added attachment viewing and editing, case feedback submission and retrieval, and vulnerability metadata.
  * Added global search, system metadata, escalation management, and case time-card summaries.
  * Added deployed-product metrics and usage reporting.
  * Added instance search, metrics, usage, and statistical summaries.
* **Documentation**
  * Expanded API documentation with the new endpoints, request formats, response models, filters, and validation rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->