### PR TITLE
[Customer Portal][Webapp]Send attachments inline with case creation for security report analysis

### DIFF
--- a/apps/customer-portal/webapp/src/features/support/pages/CreateCasePage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/CreateCasePage.tsx
@@ -950,6 +950,16 @@ export default function CreateCasePage(): JSX.Element {
       severityKey = parsedSeverity;
     }
 
+    let inlineAttachments: Array<{ file: string; name: string }> | undefined;
+    if (isSecurityReport) {
+      inlineAttachments = await Promise.all(
+        attachments.map(async (item) => ({
+          file: await fileToBase64Content(item.file),
+          name: attachmentNamesRef.current.get(item.id) || item.file.name,
+        })),
+      );
+    }
+
     const payload: CreateCaseRequest = {
       type: isSecurityReport
         ? CaseType.SECURITY_REPORT_ANALYSIS
@@ -968,6 +978,7 @@ export default function CreateCasePage(): JSX.Element {
         conversationId,
       }),
       ...(watchList.length > 0 && { watchList }),
+      ...(inlineAttachments && { attachments: inlineAttachments }),
     };
 
     postCase(payload, {
@@ -1013,7 +1024,7 @@ export default function CreateCasePage(): JSX.Element {
 
         let failedAttachmentNames: string[] = [];
         let attachmentsStillUploading = false;
-        if (attachments.length > 0) {
+        if (!isSecurityReport && attachments.length > 0) {
           setIsPreparingAttachments(true);
           const uploadPromise = uploadAttachments();
           const timedOut = await Promise.race([


### PR DESCRIPTION
## Summary
- Security Report Analysis cases now send attachments directly in the case-creation payload (`attachments` field) instead of uploading them via a separate attachment endpoint after creation, since attachments are mandatory for this case type.
- All other case types keep the existing flow: create case first, then upload attachments separately via the attachments endpoint.

## Test plan
- [ ] Create a Security Report Analysis case with one or more attachments and verify they're included in the case-creation request payload and no separate attachment upload call is made.
- [ ] Create a Security Report Analysis case with no attachments and confirm the mandatory-attachment validation still blocks submission.
- [ ] Create a regular (non-SRA) case with attachments and verify the existing two-step flow (create case, then upload attachments) still works as before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Security report attachments are now included directly when creating a case.
  * Regular case attachments continue to upload separately after case creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->