### PR TITLE
[CSM Portal Microapp] Fix : /cases/search 400s and enable native touch scrolling

### DIFF
--- a/apps/csm-portal/microapp/src/index.css
+++ b/apps/csm-portal/microapp/src/index.css
@@ -34,6 +34,9 @@ body {
   overscroll-behavior: none;
   -ms-overflow-style: none;
   scrollbar-width: none;
+  -webkit-overflow-scrolling: touch;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
 }
 
 body::-webkit-scrollbar {

--- a/apps/csm-portal/microapp/src/services/announcements.ts
+++ b/apps/csm-portal/microapp/src/services/announcements.ts
@@ -20,11 +20,10 @@
 // newest-updated first, mirroring `services/cases.ts` `cases.infinite`.
 
 import { infiniteQueryOptions } from "@tanstack/react-query";
-import { CASES_SEARCH_ENDPOINT } from "@config/endpoints";
-import type { CaseSearchPayloadDto, CaseSearchResponseDto } from "@src/types";
+import type { CaseSearchPayloadDto } from "@src/types";
 import { toCaseSummary, type CaseSummary } from "@src/types";
 import type { AnnouncementFilters } from "@utils/announcements";
-import apiClient from "./apiClient";
+import { postCasesSearch } from "./cases";
 
 export interface AnnouncementSearchResult {
   items: CaseSummary[];
@@ -52,7 +51,7 @@ async function searchAnnouncements(filters: AnnouncementFilters, offset: number)
       ...(filters.projects.length ? { projectIds: filters.projects.map((p) => p.id) } : {}),
     },
   };
-  const { data } = await apiClient.post<CaseSearchResponseDto>(CASES_SEARCH_ENDPOINT, payload);
+  const data = await postCasesSearch(payload);
   const items = data.cases.map(toCaseSummary);
   return {
     items,

--- a/apps/csm-portal/microapp/src/services/cases.ts
+++ b/apps/csm-portal/microapp/src/services/cases.ts
@@ -50,12 +50,54 @@ export interface CaseSearchResult {
   hasMore: boolean;
 }
 
+interface CaseFieldFilter {
+  field: string;
+  op: "eq" | "in" | "notIn" | "isEmpty" | "isNotEmpty" | "gte" | "lte";
+  values?: string[];
+}
+
+// The literal `values` entry a createdBy+eq filter must carry to mean "the authenticated
+// caller" — mirrors entity-service's case_filters.go currentUserFilterPlaceholder.
+const CURRENT_USER_FILTER_PLACEHOLDER = "__current_user_email__";
+
+// /cases/search's wire contract is the generic field/op/values filter array (see
+// entity-service's case_filters.go ParseCaseFieldFilters), not the named-field shape
+// CaseSearchFiltersDto's callers build for convenience — mirrors the webapp's
+// buildCaseSearchFilters (caseSearchPayload.ts). This is the one place that translates between
+// them, so every call site below can keep building the convenience shape.
+function toWireFilters(filters: CaseSearchFiltersDto = {}): { searchQuery?: string; filters?: CaseFieldFilter[] } {
+  const fieldFilters: CaseFieldFilter[] = [];
+  if (filters.types?.length) fieldFilters.push({ field: "type", op: "in", values: filters.types });
+  if (filters.states?.length) fieldFilters.push({ field: "state", op: "in", values: filters.states });
+  if (filters.severities?.length) fieldFilters.push({ field: "severity", op: "in", values: filters.severities });
+  if (filters.workStates?.length) fieldFilters.push({ field: "workState", op: "in", values: filters.workStates });
+  if (filters.issueTypes?.length) fieldFilters.push({ field: "issueType", op: "in", values: filters.issueTypes });
+  if (filters.engagementTypes?.length)
+    fieldFilters.push({ field: "engagementType", op: "in", values: filters.engagementTypes });
+  if (filters.projectIds?.length) fieldFilters.push({ field: "projectId", op: "in", values: filters.projectIds });
+  if (filters.deploymentIds?.length)
+    fieldFilters.push({ field: "deploymentId", op: "in", values: filters.deploymentIds });
+  if (filters.assignedUserIds?.length)
+    fieldFilters.push({ field: "assignedUserId", op: "in", values: filters.assignedUserIds });
+  if (filters.productNames?.length) fieldFilters.push({ field: "product", op: "in", values: filters.productNames });
+  if (filters.createdByMe)
+    fieldFilters.push({ field: "createdBy", op: "eq", values: [CURRENT_USER_FILTER_PLACEHOLDER] });
+
+  return {
+    ...(filters.searchQuery && { searchQuery: filters.searchQuery }),
+    ...(fieldFilters.length > 0 && { filters: fieldFilters }),
+  };
+}
+
 // Exported (not just used internally) so the Home dashboard's composition query can fan out
 // count-only searches (`pagination: { limit: 1 }`, read `.total`) without going through the
 // `cases.all` query-options wrapper — mirrors the webapp's useCaseComposition.ts, which calls its
 // api client directly for the same reason.
 export const getAllCases = async (payload: CaseSearchPayloadDto = {}): Promise<CaseSearchResult> => {
-  const { data } = await apiClient.post<CaseSearchResponseDto>(CASES_SEARCH_ENDPOINT, payload);
+  const { data } = await apiClient.post<CaseSearchResponseDto>(CASES_SEARCH_ENDPOINT, {
+    ...payload,
+    filters: toWireFilters(payload.filters),
+  });
   const items = data.cases.map(toCaseSummary);
   return {
     items,

--- a/apps/csm-portal/microapp/src/services/cases.ts
+++ b/apps/csm-portal/microapp/src/services/cases.ts
@@ -89,15 +89,25 @@ function toWireFilters(filters: CaseSearchFiltersDto = {}): { searchQuery?: stri
   };
 }
 
+// The one place any caller — inside this module or elsewhere in the app — should hit
+// `/cases/search` from: applies the CaseSearchFiltersDto -> wire-contract translation above, so
+// no other module needs to know the endpoint expects the generic filter array. Exported (not just
+// used internally) for announcements.ts/engagements.ts/securityReports.ts, which each scope the
+// same endpoint to one case `type` and previously posted to it directly with the old shape.
+export async function postCasesSearch(payload: CaseSearchPayloadDto = {}): Promise<CaseSearchResponseDto> {
+  const { data } = await apiClient.post<CaseSearchResponseDto>(CASES_SEARCH_ENDPOINT, {
+    ...payload,
+    filters: toWireFilters(payload.filters),
+  });
+  return data;
+}
+
 // Exported (not just used internally) so the Home dashboard's composition query can fan out
 // count-only searches (`pagination: { limit: 1 }`, read `.total`) without going through the
 // `cases.all` query-options wrapper — mirrors the webapp's useCaseComposition.ts, which calls its
 // api client directly for the same reason.
 export const getAllCases = async (payload: CaseSearchPayloadDto = {}): Promise<CaseSearchResult> => {
-  const { data } = await apiClient.post<CaseSearchResponseDto>(CASES_SEARCH_ENDPOINT, {
-    ...payload,
-    filters: toWireFilters(payload.filters),
-  });
+  const data = await postCasesSearch(payload);
   const items = data.cases.map(toCaseSummary);
   return {
     items,

--- a/apps/csm-portal/microapp/src/services/engagements.ts
+++ b/apps/csm-portal/microapp/src/services/engagements.ts
@@ -21,11 +21,10 @@
 // `cases.infinite` and `services/announcements.ts`'s `announcements.infinite`.
 
 import { infiniteQueryOptions } from "@tanstack/react-query";
-import { CASES_SEARCH_ENDPOINT } from "@config/endpoints";
-import type { CaseSearchPayloadDto, CaseSearchResponseDto } from "@src/types";
+import type { CaseSearchPayloadDto } from "@src/types";
 import { toCaseSummary, type CaseSummary } from "@src/types";
 import type { EngagementFilters } from "@utils/engagements";
-import apiClient from "./apiClient";
+import { postCasesSearch } from "./cases";
 
 export interface EngagementSearchResult {
   items: CaseSummary[];
@@ -55,7 +54,7 @@ async function searchEngagements(filters: EngagementFilters, offset: number): Pr
       ...(filters.productNames.length ? { productNames: filters.productNames } : {}),
     },
   };
-  const { data } = await apiClient.post<CaseSearchResponseDto>(CASES_SEARCH_ENDPOINT, payload);
+  const data = await postCasesSearch(payload);
   const items = data.cases.map(toCaseSummary);
   return {
     items,

--- a/apps/csm-portal/microapp/src/services/securityReports.ts
+++ b/apps/csm-portal/microapp/src/services/securityReports.ts
@@ -22,11 +22,10 @@
 // scroll, newest-updated first, mirroring services/engagements.ts.
 
 import { infiniteQueryOptions } from "@tanstack/react-query";
-import { CASES_SEARCH_ENDPOINT } from "@config/endpoints";
-import type { CaseSearchPayloadDto, CaseSearchResponseDto } from "@src/types";
+import type { CaseSearchPayloadDto } from "@src/types";
 import { toCaseSummary, type CaseSummary } from "@src/types";
 import type { SecurityReportFilters } from "@utils/securityReports";
-import apiClient from "./apiClient";
+import { postCasesSearch } from "./cases";
 
 export interface SecurityReportSearchResult {
   items: CaseSummary[];
@@ -58,7 +57,7 @@ async function searchSecurityReports(
       ...(filters.productNames.length ? { productNames: filters.productNames } : {}),
     },
   };
-  const { data } = await apiClient.post<CaseSearchResponseDto>(CASES_SEARCH_ENDPOINT, payload);
+  const data = await postCasesSearch(payload);
   const items = data.cases.map(toCaseSummary);
   return {
     items,


### PR DESCRIPTION
## Summary
- `cases.ts`: entity-service migrated `/cases/search`'s filter contract to the generic `{filters: [{field, op, values}]}` DSL; the microapp still sent the old named-field shape (`{types, states, severities, ...}`), so every search call (dashboard composition, assigned-to-me, ongoing-case checks, Support search) was returning 400. Added a translation step in `getAllCases` that builds the new wire format, mirroring the webapp's existing `buildCaseSearchFilters`.
- `index.css`: add `-webkit-overflow-scrolling: touch`, `touch-action: manipulation`, `-webkit-tap-highlight-color: transparent` for proper momentum scrolling and tap behavior in the WebView.

## Test plan
- [x] `tsc --noEmit` passes
- [x] `eslint` passes
- [x] Verify `/cases/search` returns 200 in the app (Home dashboard, Support search) after this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added improved touch scrolling and more responsive tap behavior on mobile devices.
  * Enhanced case search with flexible field-based filters, search text, and “created by me” filtering.
  * Extended consistent filtering behavior to announcement, engagement, and security report searches.
* **Bug Fixes**
  * Improved search requests so selected filters are correctly applied when retrieving results across supported areas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->