### PR TITLE
[CSM Portal] Add refresh buttons to case detail tabs and list pages

### DIFF
--- a/apps/csm-portal/webapp/src/components/RefreshButton.tsx
+++ b/apps/csm-portal/webapp/src/components/RefreshButton.tsx
@@ -20,7 +20,7 @@ import type { JSX } from "react";
 import { formatRelativeTime } from "@features/csm-dashboard/utils/abtDashboard";
 
 interface RefreshButtonProps {
-  /** Re-runs the widget's query. Wire to the react-query `refetch`. */
+  /** Re-runs the underlying query. Wire to the react-query `refetch`. */
   onRefresh: () => void;
   /** True while a fetch is in flight; disables the control to avoid re-entrancy. */
   isFetching: boolean;
@@ -31,9 +31,9 @@ interface RefreshButtonProps {
 }
 
 /**
- * Reusable dashboard-widget refresh control. Mirrors the SLA table's refresh
- * button (icon button + "last refreshed" hint), so refresh looks and behaves
- * the same across the app.
+ * Reusable refresh control (icon button + "last refreshed" hint), shared
+ * across dashboard widgets, case detail tabs, and list pages so refresh
+ * looks and behaves the same everywhere.
  */
 export default function RefreshButton({
   onRefresh,

--- a/apps/csm-portal/webapp/src/features/csm-accounts/pages/CsmAccountsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-accounts/pages/CsmAccountsPage.tsx
@@ -38,7 +38,7 @@ import {
   type SearchAccountsRequest,
 } from "@features/csm-accounts/types/csmAccounts";
 import { BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
-import RefreshButton from "@features/csm-dashboard/components/RefreshButton";
+import RefreshButton from "@components/RefreshButton";
 
 const DEFAULT_ROWS_PER_PAGE = 20;
 // Top option is the backend's max page limit; larger requests are rejected.

--- a/apps/csm-portal/webapp/src/features/csm-accounts/pages/CsmAccountsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-accounts/pages/CsmAccountsPage.tsx
@@ -38,6 +38,7 @@ import {
   type SearchAccountsRequest,
 } from "@features/csm-accounts/types/csmAccounts";
 import { BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
+import RefreshButton from "@features/csm-dashboard/components/RefreshButton";
 
 const DEFAULT_ROWS_PER_PAGE = 20;
 // Top option is the backend's max page limit; larger requests are rejected.
@@ -73,7 +74,8 @@ export default function CsmAccountsPage(): JSX.Element {
     };
   }, [debouncedSearch, page, rowsPerPage]);
 
-  const { data, isLoading, isFetching, isError, error } = useSearchAccounts(request);
+  const { data, isLoading, isFetching, isError, error, refetch, dataUpdatedAt } =
+    useSearchAccounts(request);
 
   const handleSearchChange = (e: ChangeEvent<HTMLInputElement>) => {
     setSearchInput(e.target.value);
@@ -90,9 +92,17 @@ export default function CsmAccountsPage(): JSX.Element {
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
-      <Typography variant="body2" color="text.secondary">
-        Search across account name and Salesforce ID (case-insensitive).
-      </Typography>
+      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 1 }}>
+        <Typography variant="body2" color="text.secondary">
+          Search across account name and Salesforce ID (case-insensitive).
+        </Typography>
+        <RefreshButton
+          onRefresh={() => void refetch()}
+          isFetching={isFetching}
+          updatedAt={dataUpdatedAt}
+          label="Refresh accounts"
+        />
+      </Box>
 
       <TextField
         size="small"

--- a/apps/csm-portal/webapp/src/features/csm-admin/components/DirectoryEntityTable.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/components/DirectoryEntityTable.tsx
@@ -31,7 +31,7 @@ import { type ChangeEvent, type JSX } from "react";
 import { Link as RouterLink } from "react-router";
 import QueryErrorState from "@components/QueryErrorState";
 import { BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
-import RefreshButton from "@features/csm-dashboard/components/RefreshButton";
+import RefreshButton from "@components/RefreshButton";
 
 const ROWS_PER_PAGE_OPTIONS = [10, 20, BE_MAX_PAGE_LIMIT];
 

--- a/apps/csm-portal/webapp/src/features/csm-admin/components/DirectoryEntityTable.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/components/DirectoryEntityTable.tsx
@@ -31,6 +31,7 @@ import { type ChangeEvent, type JSX } from "react";
 import { Link as RouterLink } from "react-router";
 import QueryErrorState from "@components/QueryErrorState";
 import { BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
+import RefreshButton from "@features/csm-dashboard/components/RefreshButton";
 
 const ROWS_PER_PAGE_OPTIONS = [10, 20, BE_MAX_PAGE_LIMIT];
 
@@ -59,6 +60,8 @@ interface DirectoryEntityTableProps {
   onPageChange: (page: number) => void;
   rowsPerPage: number;
   onRowsPerPageChange: (rowsPerPage: number) => void;
+  onRefresh: () => void;
+  refreshedAt?: number;
 }
 
 /**
@@ -83,6 +86,8 @@ export default function DirectoryEntityTable({
   onPageChange,
   rowsPerPage,
   onRowsPerPageChange,
+  onRefresh,
+  refreshedAt,
 }: DirectoryEntityTableProps): JSX.Element {
   const entityLabel =
     entityNounPlural.charAt(0).toUpperCase() +
@@ -98,14 +103,22 @@ export default function DirectoryEntityTable({
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
-      <TextField
-        size="small"
-        label={`Search ${entityNounPlural}`}
-        value={search}
-        onChange={handleSearchChange}
-        sx={{ maxWidth: 360 }}
-        slotProps={{ htmlInput: { "aria-label": `Search ${entityNounPlural} by name` } }}
-      />
+      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 1 }}>
+        <TextField
+          size="small"
+          label={`Search ${entityNounPlural}`}
+          value={search}
+          onChange={handleSearchChange}
+          sx={{ maxWidth: 360, flex: 1 }}
+          slotProps={{ htmlInput: { "aria-label": `Search ${entityNounPlural} by name` } }}
+        />
+        <RefreshButton
+          onRefresh={onRefresh}
+          isFetching={isFetching}
+          updatedAt={refreshedAt}
+          label={`Refresh ${entityNounPlural}`}
+        />
+      </Box>
 
       <Box sx={{ border: 1, borderColor: "divider", borderRadius: 1, overflow: "hidden" }}>
         <TableContainer>

--- a/apps/csm-portal/webapp/src/features/csm-admin/components/DirectoryMembersList.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/components/DirectoryMembersList.tsx
@@ -37,6 +37,7 @@ import type { SearchUsersRequest } from "@features/csm-users/types/csmUsers";
 import { BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
 import { useNavTransition } from "@hooks/useNavTransition";
 import { displayUserTimezone } from "@utils/userDirectoryDisplay";
+import RefreshButton from "@features/csm-dashboard/components/RefreshButton";
 
 const DEFAULT_ROWS_PER_PAGE = 20;
 const ROWS_PER_PAGE_OPTIONS = [10, 20, BE_MAX_PAGE_LIMIT];
@@ -78,7 +79,15 @@ export default function DirectoryMembersList({
     filters: { [filterKey]: [entityId] },
   };
 
-  const { data, isLoading, isFetching, isError, error } = useSearchUsers(request);
+  const {
+    data,
+    isLoading,
+    isFetching,
+    isError,
+    error,
+    refetch,
+    dataUpdatedAt,
+  } = useSearchUsers(request);
   const users = data?.users ?? [];
   const total = data?.total ?? 0;
 
@@ -94,7 +103,16 @@ export default function DirectoryMembersList({
   };
 
   return (
-    <Box sx={{ border: 1, borderColor: "divider", borderRadius: 1, overflow: "hidden" }}>
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+      <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
+        <RefreshButton
+          onRefresh={() => void refetch()}
+          isFetching={isFetching}
+          updatedAt={dataUpdatedAt}
+          label={`Refresh ${entityNoun} members`}
+        />
+      </Box>
+      <Box sx={{ border: 1, borderColor: "divider", borderRadius: 1, overflow: "hidden" }}>
       <TableContainer sx={{ overflow: "visible" }}>
         <Table
           size="small"
@@ -246,6 +264,7 @@ export default function DirectoryMembersList({
         showFirstButton
         showLastButton
       />
+      </Box>
     </Box>
   );
 }

--- a/apps/csm-portal/webapp/src/features/csm-admin/components/DirectoryMembersList.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/components/DirectoryMembersList.tsx
@@ -37,7 +37,7 @@ import type { SearchUsersRequest } from "@features/csm-users/types/csmUsers";
 import { BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
 import { useNavTransition } from "@hooks/useNavTransition";
 import { displayUserTimezone } from "@utils/userDirectoryDisplay";
-import RefreshButton from "@features/csm-dashboard/components/RefreshButton";
+import RefreshButton from "@components/RefreshButton";
 
 const DEFAULT_ROWS_PER_PAGE = 20;
 const ROWS_PER_PAGE_OPTIONS = [10, 20, BE_MAX_PAGE_LIMIT];

--- a/apps/csm-portal/webapp/src/features/csm-admin/pages/CsmGroupsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/pages/CsmGroupsPage.tsx
@@ -42,7 +42,8 @@ export default function CsmGroupsPage(): JSX.Element {
     [debouncedSearch, page, rowsPerPage],
   );
 
-  const { data, isLoading, isFetching, isError, error } = useSearchGroupsPage(request);
+  const { data, isLoading, isFetching, isError, error, refetch, dataUpdatedAt } =
+    useSearchGroupsPage(request);
 
   const handleSearchChange = (value: string): void => {
     setSearch(value);
@@ -75,6 +76,8 @@ export default function CsmGroupsPage(): JSX.Element {
         onPageChange={setPage}
         rowsPerPage={rowsPerPage}
         onRowsPerPageChange={handleRowsPerPageChange}
+        onRefresh={() => void refetch()}
+        refreshedAt={dataUpdatedAt}
       />
     </Box>
   );

--- a/apps/csm-portal/webapp/src/features/csm-admin/pages/CsmRolesPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/pages/CsmRolesPage.tsx
@@ -42,7 +42,8 @@ export default function CsmRolesPage(): JSX.Element {
     [debouncedSearch, page, rowsPerPage],
   );
 
-  const { data, isLoading, isFetching, isError, error } = useSearchRoles(request);
+  const { data, isLoading, isFetching, isError, error, refetch, dataUpdatedAt } =
+    useSearchRoles(request);
 
   const handleSearchChange = (value: string): void => {
     setSearch(value);
@@ -75,6 +76,8 @@ export default function CsmRolesPage(): JSX.Element {
         onPageChange={setPage}
         rowsPerPage={rowsPerPage}
         onRowsPerPageChange={handleRowsPerPageChange}
+        onRefresh={() => void refetch()}
+        refreshedAt={dataUpdatedAt}
       />
     </Box>
   );

--- a/apps/csm-portal/webapp/src/features/csm-admin/pages/CsmTeamsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/pages/CsmTeamsPage.tsx
@@ -43,7 +43,8 @@ export default function CsmTeamsPage(): JSX.Element {
     [debouncedSearch, page, rowsPerPage],
   );
 
-  const { data, isLoading, isFetching, isError, error } = useSearchTeams(request);
+  const { data, isLoading, isFetching, isError, error, refetch, dataUpdatedAt } =
+    useSearchTeams(request);
 
   const handleSearchChange = (value: string): void => {
     setSearch(value);
@@ -76,6 +77,8 @@ export default function CsmTeamsPage(): JSX.Element {
         onPageChange={setPage}
         rowsPerPage={rowsPerPage}
         onRowsPerPageChange={handleRowsPerPageChange}
+        onRefresh={() => void refetch()}
+        refreshedAt={dataUpdatedAt}
       />
     </Box>
   );

--- a/apps/csm-portal/webapp/src/features/csm-announcements/pages/CsmAnnouncementsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-announcements/pages/CsmAnnouncementsPage.tsx
@@ -54,6 +54,7 @@ import {
 import { announcementStateRole } from "@features/csm-announcements/utils/announcementState";
 import { STATE_LABEL } from "@features/csm-dashboard/utils/abtDashboard";
 import type { CaseState } from "@features/csm-dashboard/types/abtDashboard";
+import RefreshButton from "@features/csm-dashboard/components/RefreshButton";
 
 const DEFAULT_ROWS_PER_PAGE = 20;
 const ROWS_PER_PAGE_OPTIONS = [10, 20, 50];
@@ -141,11 +142,8 @@ export default function CsmAnnouncementsPage(): JSX.Element {
   const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_ROWS_PER_PAGE);
   const debouncedSearch = useDebouncedValue(filters.search.trim(), 300);
 
-  const { data, isLoading, isFetching, isError, error } = useSearchAnnouncements(
-    { ...filters, search: debouncedSearch },
-    page,
-    rowsPerPage,
-  );
+  const { data, isLoading, isFetching, isError, error, refetch, dataUpdatedAt } =
+    useSearchAnnouncements({ ...filters, search: debouncedSearch }, page, rowsPerPage);
 
   const announcements = data?.announcements ?? [];
   const total = data?.total ?? 0;
@@ -165,11 +163,19 @@ export default function CsmAnnouncementsPage(): JSX.Element {
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
-      <Box>
-        <Typography variant="h5">Announcements</Typography>
-        <Typography variant="body2" color="text.secondary">
-          Customer-facing announcements published across projects and tiers.
-        </Typography>
+      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 1 }}>
+        <Box>
+          <Typography variant="h5">Announcements</Typography>
+          <Typography variant="body2" color="text.secondary">
+            Customer-facing announcements published across projects and tiers.
+          </Typography>
+        </Box>
+        <RefreshButton
+          onRefresh={() => void refetch()}
+          isFetching={isFetching}
+          updatedAt={dataUpdatedAt}
+          label="Refresh announcements"
+        />
       </Box>
 
       {/* Filters — search + state + project, all "show all" by default */}

--- a/apps/csm-portal/webapp/src/features/csm-announcements/pages/CsmAnnouncementsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-announcements/pages/CsmAnnouncementsPage.tsx
@@ -54,7 +54,7 @@ import {
 import { announcementStateRole } from "@features/csm-announcements/utils/announcementState";
 import { STATE_LABEL } from "@features/csm-dashboard/utils/abtDashboard";
 import type { CaseState } from "@features/csm-dashboard/types/abtDashboard";
-import RefreshButton from "@features/csm-dashboard/components/RefreshButton";
+import RefreshButton from "@components/RefreshButton";
 
 const DEFAULT_ROWS_PER_PAGE = 20;
 const ROWS_PER_PAGE_OPTIONS = [10, 20, 50];

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CallRequestsWidget.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CallRequestsWidget.tsx
@@ -50,7 +50,7 @@ import { RejectCallDialog } from "./RejectCallDialog";
 import { SendCallNotesDialog } from "./SendCallNotesDialog";
 import { CancelCallDialog } from "./CancelCallDialog";
 import { CallRequestsTable } from "./CallRequestsTable";
-import RefreshButton from "@features/csm-dashboard/components/RefreshButton";
+import RefreshButton from "@components/RefreshButton";
 
 // ---------------------------------------------------------------------------
 // Types

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CallRequestsWidget.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CallRequestsWidget.tsx
@@ -50,6 +50,7 @@ import { RejectCallDialog } from "./RejectCallDialog";
 import { SendCallNotesDialog } from "./SendCallNotesDialog";
 import { CancelCallDialog } from "./CancelCallDialog";
 import { CallRequestsTable } from "./CallRequestsTable";
+import RefreshButton from "@features/csm-dashboard/components/RefreshButton";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -95,10 +96,8 @@ export function CallRequestsWidget({
   const [stateFilter, setStateFilter] = useState<BeCallRequestStateKey | "">("");
   const activeStates = stateFilter ? [stateFilter] : undefined;
 
-  const { data, isLoading, isError, refetch } = useGetCsmCaseCallRequests(
-    caseId,
-    activeStates,
-  );
+  const { data, isLoading, isError, refetch, isFetching, dataUpdatedAt } =
+    useGetCsmCaseCallRequests(caseId, activeStates);
   const postCallRequest = usePostCsmCaseCallRequest();
   const patchCallRequest = usePatchCsmCaseCallRequest();
 
@@ -282,6 +281,12 @@ export function CallRequestsWidget({
             )}
           </Box>
           <Box sx={{ display: "flex", gap: 1, alignItems: "center", flexWrap: "wrap" }}>
+            <RefreshButton
+              onRefresh={() => void refetch()}
+              isFetching={isFetching}
+              updatedAt={dataUpdatedAt}
+              label="Refresh call requests"
+            />
             {/* State filter */}
             <FormControl size="small" sx={{ minWidth: 180 }}>
               <InputLabel id="cr-filter-label">Filter by state</InputLabel>

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.tsx
@@ -78,7 +78,7 @@ import type { ProjectDetails } from "@features/csm-projects/types/csmProjects";
 import type { BeDeployment } from "@api/backend/types";
 import RelativeTime from "@components/RelativeTime";
 import UserRefLink from "@components/UserRefLink";
-import RefreshButton from "@features/csm-dashboard/components/RefreshButton";
+import RefreshButton from "@components/RefreshButton";
 
 // ---------------------------------------------------------------------------
 // Shared widget shell

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.tsx
@@ -78,6 +78,7 @@ import type { ProjectDetails } from "@features/csm-projects/types/csmProjects";
 import type { BeDeployment } from "@api/backend/types";
 import RelativeTime from "@components/RelativeTime";
 import UserRefLink from "@components/UserRefLink";
+import RefreshButton from "@features/csm-dashboard/components/RefreshButton";
 
 // ---------------------------------------------------------------------------
 // Shared widget shell
@@ -565,6 +566,9 @@ export function WatchersWidget({
   onAdd,
   onRemove,
   isSaving,
+  onRefresh,
+  isRefreshing,
+  refreshedAt,
 }: {
   watchers: CaseWatcher[];
   /** Add a watcher by email — the caller PATCHes the full replacement watch
@@ -576,6 +580,11 @@ export function WatchersWidget({
   onRemove?: (watcher: CaseWatcher) => void;
   /** True while a watch-list PATCH is in flight; disables add/remove. */
   isSaving?: boolean;
+  /** Re-runs the case-detail query the watch list comes from. Omit to hide
+   * the refresh control. */
+  onRefresh?: () => void;
+  isRefreshing?: boolean;
+  refreshedAt?: number;
 }): JSX.Element {
   const [addOpen, setAddOpen] = useState(false);
   const existingEmails = useMemo(
@@ -591,17 +600,27 @@ export function WatchersWidget({
       title="Watchers"
       icon={<Users size={16} />}
       action={
-        onAdd ? (
-          <Button
-            size="small"
-            variant="text"
-            startIcon={<Plus size={14} />}
-            disabled={isSaving}
-            onClick={() => setAddOpen((v) => !v)}
-          >
-            Add watcher
-          </Button>
-        ) : undefined
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+          {onRefresh && (
+            <RefreshButton
+              onRefresh={onRefresh}
+              isFetching={!!isRefreshing}
+              updatedAt={refreshedAt}
+              label="Refresh watchers"
+            />
+          )}
+          {onAdd && (
+            <Button
+              size="small"
+              variant="text"
+              startIcon={<Plus size={14} />}
+              disabled={isSaving}
+              onClick={() => setAddOpen((v) => !v)}
+            >
+              Add watcher
+            </Button>
+          )}
+        </Box>
       }
     >
       {watchers.length === 0 ? (
@@ -744,6 +763,9 @@ export function AttachmentsWidget({
   onDelete,
   deletingId,
   preview,
+  onRefresh,
+  isRefreshing,
+  refreshedAt,
 }: {
   attachments: CaseAttachment[];
   /** List query is loading. */
@@ -781,6 +803,10 @@ export function AttachmentsWidget({
     previewTarget: CaseAttachment | null;
     onPreviewTargetChange: (attachment: CaseAttachment | null) => void;
   };
+  /** Re-runs the attachments list query. Omit to hide the refresh control. */
+  onRefresh?: () => void;
+  isRefreshing?: boolean;
+  refreshedAt?: number;
 }): JSX.Element {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const sorted = [...attachments].sort(
@@ -803,6 +829,14 @@ export function AttachmentsWidget({
         icon={<Paperclip size={16} />}
         action={
           <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+            {onRefresh && (
+              <RefreshButton
+                onRefresh={onRefresh}
+                isFetching={!!isRefreshing}
+                updatedAt={refreshedAt}
+                label="Refresh attachments"
+              />
+            )}
             {onUpload && (
               <Button
                 size="small"

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/ChildCasesWidget.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/ChildCasesWidget.tsx
@@ -33,7 +33,7 @@ import { useNavTransition } from "@hooks/useNavTransition";
 import { useSearchChildCases } from "@features/csm-cases/api/useSearchChildCases";
 import SeverityChip from "@components/SeverityChip";
 import StateChip from "@components/StateChip";
-import RefreshButton from "@features/csm-dashboard/components/RefreshButton";
+import RefreshButton from "@components/RefreshButton";
 
 const CHILD_CASES_COLUMNS = ["Case", "Severity", "State", "Assignee"];
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/ChildCasesWidget.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/ChildCasesWidget.tsx
@@ -33,6 +33,7 @@ import { useNavTransition } from "@hooks/useNavTransition";
 import { useSearchChildCases } from "@features/csm-cases/api/useSearchChildCases";
 import SeverityChip from "@components/SeverityChip";
 import StateChip from "@components/StateChip";
+import RefreshButton from "@features/csm-dashboard/components/RefreshButton";
 
 const CHILD_CASES_COLUMNS = ["Case", "Severity", "State", "Assignee"];
 
@@ -49,7 +50,14 @@ interface ChildCasesWidgetProps {
  * endpoint.
  */
 export function ChildCasesWidget({ caseId }: ChildCasesWidgetProps): JSX.Element {
-  const { data, isLoading, isError } = useSearchChildCases(caseId);
+  const {
+    data,
+    isLoading,
+    isError,
+    refetch,
+    isFetching,
+    dataUpdatedAt,
+  } = useSearchChildCases(caseId);
   const navigate = useNavTransition();
 
   const cases = data?.cases ?? [];
@@ -61,11 +69,26 @@ export function ChildCasesWidget({ caseId }: ChildCasesWidgetProps): JSX.Element
 
   return (
     <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 2 }}>
-      <Box sx={{ display: "flex", alignItems: "center", gap: 0.75 }}>
-        <GitFork size={16} />
-        <Typography variant="subtitle2">
-          Child cases{!isLoading && !isError && total > 0 ? ` (${total})` : ""}
-        </Typography>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 1,
+        }}
+      >
+        <Box sx={{ display: "flex", alignItems: "center", gap: 0.75 }}>
+          <GitFork size={16} />
+          <Typography variant="subtitle2">
+            Child cases{!isLoading && !isError && total > 0 ? ` (${total})` : ""}
+          </Typography>
+        </Box>
+        <RefreshButton
+          onRefresh={() => void refetch()}
+          isFetching={isFetching}
+          updatedAt={dataUpdatedAt}
+          label="Refresh child cases"
+        />
       </Box>
 
       {isError ? (

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmIssuesView.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmIssuesView.tsx
@@ -58,7 +58,7 @@ import {
 } from "@features/csm-cases/utils/casesSort";
 import { stateLabel } from "@features/csm-dashboard/utils/abtDashboard";
 import { WORK_STATE_LABEL } from "@features/csm-cases/utils/caseWorkState";
-import RefreshButton from "@features/csm-dashboard/components/RefreshButton";
+import RefreshButton from "@components/RefreshButton";
 import type { BeCaseSearchPayload, BeCaseSearchResponse } from "@api/backend/types";
 import type { CsmCaseRow } from "@features/csm-cases/types/csmCases";
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmIssuesView.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmIssuesView.tsx
@@ -58,6 +58,7 @@ import {
 } from "@features/csm-cases/utils/casesSort";
 import { stateLabel } from "@features/csm-dashboard/utils/abtDashboard";
 import { WORK_STATE_LABEL } from "@features/csm-cases/utils/caseWorkState";
+import RefreshButton from "@features/csm-dashboard/components/RefreshButton";
 import type { BeCaseSearchPayload, BeCaseSearchResponse } from "@api/backend/types";
 import type { CsmCaseRow } from "@features/csm-cases/types/csmCases";
 
@@ -188,13 +189,15 @@ export default function CsmIssuesView({
     [filters, debouncedSearch, showSeverityFilter, lockedFilters],
   );
 
-  const { data, isLoading, isFetching, isError, error } = useGetCsmCases(
-    queryFilters,
-    page,
-    rowsPerPage,
-    true,
-    sortOrder,
-  );
+  const {
+    data,
+    isLoading,
+    isFetching,
+    isError,
+    error,
+    refetch,
+    dataUpdatedAt,
+  } = useGetCsmCases(queryFilters, page, rowsPerPage, true, sortOrder);
 
   const handleSortOrderChange = (order: CasesSortOrder): void => {
     setSortOrder(order);
@@ -367,6 +370,12 @@ export default function CsmIssuesView({
           {breachedCount > 0 && (
             <Chip size="small" color="error" label={`${breachedCount} breached`} />
           )}
+          <RefreshButton
+            onRefresh={() => void refetch()}
+            isFetching={isFetching}
+            updatedAt={dataUpdatedAt}
+            label={`Refresh ${entityNoun}`}
+          />
           <FilteredCsvExportButton<CsmCaseRow>
             entityName={entityNoun.replace(/\s+/g, "-")}
             entityNounPlural={entityNoun}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/LinkedChangeRequestsWidget.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/LinkedChangeRequestsWidget.tsx
@@ -38,7 +38,7 @@ import {
   changeRequestStateColor,
   changeRequestStateLabel,
 } from "@features/csm-operations/utils/changeRequests";
-import RefreshButton from "@features/csm-dashboard/components/RefreshButton";
+import RefreshButton from "@components/RefreshButton";
 
 const LINKED_CHANGE_REQUESTS_COLUMNS = ["Change request", "State", "Target environment"];
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/LinkedChangeRequestsWidget.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/LinkedChangeRequestsWidget.tsx
@@ -29,7 +29,7 @@ import {
 } from "@wso2/oxygen-ui";
 import { GitPullRequest } from "@wso2/oxygen-ui-icons-react";
 import type { JSX } from "react";
-import { useQueries } from "@tanstack/react-query";
+import { useQueries, useQueryClient } from "@tanstack/react-query";
 import { useNavTransition } from "@hooks/useNavTransition";
 import { useBackendApi } from "@api/backend/client";
 import { ApiQueryKeys } from "@constants/apiConstants";
@@ -38,6 +38,7 @@ import {
   changeRequestStateColor,
   changeRequestStateLabel,
 } from "@features/csm-operations/utils/changeRequests";
+import RefreshButton from "@features/csm-dashboard/components/RefreshButton";
 
 const LINKED_CHANGE_REQUESTS_COLUMNS = ["Change request", "State", "Target environment"];
 
@@ -73,6 +74,7 @@ export function LinkedChangeRequestsWidget({
 }: LinkedChangeRequestsWidgetProps): JSX.Element {
   const api = useBackendApi();
   const navigate = useNavTransition();
+  const queryClient = useQueryClient();
   const refs = changeRequests ?? [];
 
   const queries = useQueries({
@@ -87,13 +89,35 @@ export function LinkedChangeRequestsWidget({
       staleTime: 30_000,
     })),
   });
+  const isFetching = queries.some((q) => q.isFetching);
+  const refreshRows = (): void => {
+    for (const ref of refs) {
+      void queryClient.invalidateQueries({
+        queryKey: [ApiQueryKeys.CHANGE_REQUEST_DETAILS, ref.id],
+      });
+    }
+  };
 
   return (
     <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 2 }}>
-      <Box sx={{ display: "flex", alignItems: "center", gap: 0.75 }}>
-        <GitPullRequest size={16} />
-        <Typography variant="subtitle2">Linked change requests</Typography>
-        <Chip size="small" variant="outlined" label={`${refs.length} total`} />
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 1,
+        }}
+      >
+        <Box sx={{ display: "flex", alignItems: "center", gap: 0.75 }}>
+          <GitPullRequest size={16} />
+          <Typography variant="subtitle2">Linked change requests</Typography>
+          <Chip size="small" variant="outlined" label={`${refs.length} total`} />
+        </Box>
+        <RefreshButton
+          onRefresh={refreshRows}
+          isFetching={isFetching}
+          label="Refresh linked change requests"
+        />
       </Box>
 
       <TableContainer>

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/LinkedServiceRequestsWidget.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/LinkedServiceRequestsWidget.tsx
@@ -37,6 +37,7 @@ import {
   type ChildCaseRow,
 } from "@features/csm-cases/api/useSearchChildCases";
 import StateChip from "@components/StateChip";
+import RefreshButton from "@features/csm-dashboard/components/RefreshButton";
 
 const LINKED_SERVICE_REQUESTS_COLUMNS = ["Case", "State", "Assignee"];
 
@@ -83,7 +84,14 @@ export function LinkedServiceRequestsWidget({
   onCreateServiceRequest,
   createDisabled = false,
 }: LinkedServiceRequestsWidgetProps): JSX.Element {
-  const { data, isLoading, isError } = useSearchChildCases(caseId);
+  const {
+    data,
+    isLoading,
+    isError,
+    refetch,
+    isFetching,
+    dataUpdatedAt,
+  } = useSearchChildCases(caseId);
   const navigate = useNavTransition();
 
   const enrichedById = useMemo(() => {
@@ -120,19 +128,27 @@ export function LinkedServiceRequestsWidget({
             Linked service requests{refs.length > 0 ? ` (${refs.length})` : ""}
           </Typography>
         </Box>
-        <Tooltip title={createDisabled ? "This case is closed — it's read-only." : ""}>
-          <Box component="span">
-            <Button
-              size="small"
-              variant="outlined"
-              startIcon={<Plus size={14} />}
-              onClick={onCreateServiceRequest}
-              disabled={createDisabled}
-            >
-              Create service request
-            </Button>
-          </Box>
-        </Tooltip>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+          <RefreshButton
+            onRefresh={() => void refetch()}
+            isFetching={isFetching}
+            updatedAt={dataUpdatedAt}
+            label="Refresh linked service requests"
+          />
+          <Tooltip title={createDisabled ? "This case is closed — it's read-only." : ""}>
+            <Box component="span">
+              <Button
+                size="small"
+                variant="outlined"
+                startIcon={<Plus size={14} />}
+                onClick={onCreateServiceRequest}
+                disabled={createDisabled}
+              >
+                Create service request
+              </Button>
+            </Box>
+          </Tooltip>
+        </Box>
       </Box>
 
       <TableContainer>

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/LinkedServiceRequestsWidget.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/LinkedServiceRequestsWidget.tsx
@@ -37,7 +37,7 @@ import {
   type ChildCaseRow,
 } from "@features/csm-cases/api/useSearchChildCases";
 import StateChip from "@components/StateChip";
-import RefreshButton from "@features/csm-dashboard/components/RefreshButton";
+import RefreshButton from "@components/RefreshButton";
 
 const LINKED_SERVICE_REQUESTS_COLUMNS = ["Case", "State", "Assignee"];
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -110,6 +110,7 @@ import { usePostCaseGithubIssue } from "@features/csm-cases/api/useCsmCaseGithub
 import CaseActivitiesFeed from "@features/csm-cases/components/CaseActivitiesFeed";
 import { scrollToFragmentWithRetry } from "@features/csm-cases/utils/permalinkScroll";
 import CaseMetaBand from "@features/csm-cases/components/CaseMetaBand";
+import RefreshButton from "@features/csm-dashboard/components/RefreshButton";
 import {
   AttachmentsWidget,
   CustomerContextWidget,
@@ -336,7 +337,15 @@ export default function CsmCaseDetailPage(): JSX.Element {
   // detail page, which never got the state set.
   const fromListState = location.state as { from?: string } | undefined;
   const resolvedBackPath = fromListState?.from ?? backPath;
-  const { data, isLoading, isError, error } = useGetCsmCaseDetail(caseId);
+  const {
+    data,
+    isLoading,
+    isError,
+    error,
+    refetch: refetchCaseDetail,
+    isFetching: isFetchingCaseDetail,
+    dataUpdatedAt: caseDetailUpdatedAt,
+  } = useGetCsmCaseDetail(caseId);
   // The route alone isn't a reliable signal once data has loaded: a "Related
   // case" link always points at /cases/:id regardless of the target's actual
   // type, so an announcement opened that way would otherwise render the full
@@ -385,6 +394,8 @@ export default function CsmCaseDetailPage(): JSX.Element {
     data: comments,
     isLoading: isCommentsLoading,
     isError: isCommentsError,
+    refetch: refetchComments,
+    isFetching: isFetchingComments,
   } = useGetCsmCaseComments(caseId);
   // Audited field/state changes (the "State changes" lifecycle lane), loaded
   // from the dedicated activities endpoint — kept separate from the comments
@@ -393,6 +404,8 @@ export default function CsmCaseDetailPage(): JSX.Element {
     data: activityAudit,
     isLoading: isActivityLoading,
     isError: isActivityError,
+    refetch: refetchActivities,
+    isFetching: isFetchingActivities,
   } = useGetCsmCaseActivities(caseId);
   // The chat transcript the case was spawned from, when linked. Loaded lazily
   // off the case's conversation id and merged into the comment stream below so
@@ -403,6 +416,8 @@ export default function CsmCaseDetailPage(): JSX.Element {
     data: chatMessages,
     isLoading: isChatLoading,
     isError: isChatError,
+    refetch: refetchChat,
+    isFetching: isFetchingChat,
   } = useGetCsmConversationMessages(data?.conversationId);
   const postComment = usePostCsmCaseComment();
   const {
@@ -410,6 +425,8 @@ export default function CsmCaseDetailPage(): JSX.Element {
     isLoading: isAttachmentsLoading,
     isError: isAttachmentsError,
     refetch: refetchAttachments,
+    isFetching: isFetchingAttachments,
+    dataUpdatedAt: attachmentsUpdatedAt,
   } = useGetCsmCaseAttachments(caseId);
   const postAttachment = usePostCsmCaseAttachment();
   const downloadAttachment = useDownloadCsmCaseAttachment();
@@ -423,9 +440,11 @@ export default function CsmCaseDetailPage(): JSX.Element {
   const { data: slaList } = useGetCsmCaseSlas(
     isAnnouncement ? undefined : caseId,
   );
-  const { data: callRequests } = useGetCsmCaseCallRequests(
-    isAnnouncement ? undefined : caseId,
-  );
+  const {
+    data: callRequests,
+    refetch: refetchCallRequests,
+    isFetching: isFetchingCallRequests,
+  } = useGetCsmCaseCallRequests(isAnnouncement ? undefined : caseId);
   const { data: caseTasks } = useSearchCaseTasks(
     isAnnouncement ? undefined : caseId,
   );
@@ -433,18 +452,25 @@ export default function CsmCaseDetailPage(): JSX.Element {
   // only runs when the case actually has a deployment link (SN-sourced cases
   // may have none). Reuses the project's deployment list rather than a
   // single-deployment GET, since the backend has no `/deployments/{id}` route.
-  const { data: projectDeployments, isLoading: isProjectDeploymentsLoading } =
-    useSearchDeployments(
-      data?.productContext.deploymentId ? data.projectId : undefined,
-    );
+  const {
+    data: projectDeployments,
+    isLoading: isProjectDeploymentsLoading,
+    refetch: refetchProjectDeployments,
+    isFetching: isFetchingProjectDeployments,
+  } = useSearchDeployments(
+    data?.productContext.deploymentId ? data.projectId : undefined,
+  );
   const liveDeployment = projectDeployments?.find(
     (d) => d.id === data?.productContext.deploymentId,
   );
   // Richer account/project facts for the Customer card, beyond what's
   // embedded in the case-detail payload's `customerContext` snapshot.
-  const { data: caseProject, isLoading: isCaseProjectLoading } = useGetProject(
-    data?.projectId,
-  );
+  const {
+    data: caseProject,
+    isLoading: isCaseProjectLoading,
+    refetch: refetchCaseProject,
+    isFetching: isFetchingCaseProject,
+  } = useGetProject(data?.projectId);
   const patchCase = usePatchCsmCase(caseId);
   const patchCaseById = usePatchCsmCaseById();
   const createTask = useCreateCaseTask(caseId);
@@ -624,6 +650,38 @@ export default function CsmCaseDetailPage(): JSX.Element {
       },
     });
   }, [permalinkFragment, activitiesFeedReady, showError]);
+
+  // Re-runs every source the Activities tab's merged timeline draws from —
+  // comments, the audit trail, the linked chat transcript (a no-op when
+  // disabled), attachments, and call requests (the last only enriches a
+  // field-change entry that references one, but a stale label there is still
+  // worth refreshing). ServiceNow only refreshes a single tab like this in
+  // its own case UI; the whole page previously had to be reloaded to see
+  // this tab's data change.
+  const isRefreshingActivities =
+    isFetchingComments ||
+    isFetchingActivities ||
+    isFetchingChat ||
+    isFetchingAttachments ||
+    isFetchingCallRequests;
+  const refreshActivitiesTab = (): void => {
+    void refetchComments();
+    void refetchActivities();
+    void refetchChat();
+    void refetchAttachments();
+    void refetchCallRequests();
+  };
+
+  // Re-runs every source the Details tab renders: the case itself plus the
+  // two supplemental lookups (project, live deployment) the Customer/Product
+  // cards enrich with.
+  const isRefreshingDetails =
+    isFetchingCaseDetail || isFetchingCaseProject || isFetchingProjectDeployments;
+  const refreshDetailsTab = (): void => {
+    void refetchCaseDetail();
+    void refetchCaseProject();
+    void refetchProjectDeployments();
+  };
 
   useEffect(() => {
     // State-transition feedback is sticky (persists until dismissed) so it
@@ -1872,15 +1930,29 @@ export default function CsmCaseDetailPage(): JSX.Element {
           )}
 
           <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 2 }}>
-            <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
-              <Typography variant="subtitle2">Activity timeline</Typography>
-              {!isCommentsLoading && (
-                <Chip
-                  size="small"
-                  variant="outlined"
-                  label={`${safeComments.length + (activityAudit?.length ?? 0) + attachmentList.length} entries`}
-                />
-              )}
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                gap: 1.5,
+              }}
+            >
+              <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
+                <Typography variant="subtitle2">Activity timeline</Typography>
+                {!isCommentsLoading && (
+                  <Chip
+                    size="small"
+                    variant="outlined"
+                    label={`${safeComments.length + (activityAudit?.length ?? 0) + attachmentList.length} entries`}
+                  />
+                )}
+              </Box>
+              <RefreshButton
+                onRefresh={refreshActivitiesTab}
+                isFetching={isRefreshingActivities}
+                label="Refresh activity timeline"
+              />
             </Box>
 
             {isCommentsLoading || isChatLoading || isActivityLoading ? (
@@ -1946,7 +2018,15 @@ export default function CsmCaseDetailPage(): JSX.Element {
           }}
         >
           <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 1.5 }}>
-            <Typography variant="subtitle2">Identifiers &amp; timestamps</Typography>
+            <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 1 }}>
+              <Typography variant="subtitle2">Identifiers &amp; timestamps</Typography>
+              <RefreshButton
+                onRefresh={refreshDetailsTab}
+                isFetching={isRefreshingDetails}
+                updatedAt={caseDetailUpdatedAt}
+                label="Refresh case details"
+              />
+            </Box>
             <Box
               sx={{
                 display: "grid",
@@ -2033,11 +2113,12 @@ export default function CsmCaseDetailPage(): JSX.Element {
         <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
           {/* Case-level action, not scoped to any one card below: the dialog
               lets the user pick parent-vs-related for any target case, so it
-              doesn't belong nested inside one specific relationship card.
-              Left-aligned to read in flow with the cards' own title-left
-              layout below, rather than floating alone in right-side
-              whitespace. */}
-          <Box sx={{ display: "flex", justifyContent: "flex-start" }}>
+              doesn't belong nested inside one specific relationship card. The
+              refresh button on the other side of this same row re-runs the
+              case-detail query, which is where each card's linked-item refs
+              (id/number/name) come from — each card's own enrichment data
+              (state, assignee, ...) has its own refresh button instead. */}
+          <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 1 }}>
             {/* Same read-only-once-closed rule as the comment composer,
                 attachment upload, and tag add/remove below — a link PATCH
                 on a closed case would otherwise fail server-side and only
@@ -2056,6 +2137,12 @@ export default function CsmCaseDetailPage(): JSX.Element {
                 </Button>
               </Box>
             </Tooltip>
+            <RefreshButton
+              onRefresh={() => void refetchCaseDetail()}
+              isFetching={isFetchingCaseDetail}
+              updatedAt={caseDetailUpdatedAt}
+              label="Refresh linked items"
+            />
           </Box>
           <Box
             sx={{
@@ -2107,6 +2194,9 @@ export default function CsmCaseDetailPage(): JSX.Element {
             onAdd={onAddWatcher}
             onRemove={onRemoveWatcher}
             isSaving={patchCase.isPending}
+            onRefresh={() => void refetchCaseDetail()}
+            isRefreshing={isFetchingCaseDetail}
+            refreshedAt={caseDetailUpdatedAt}
           />
         </Box>
       )}
@@ -2121,6 +2211,9 @@ export default function CsmCaseDetailPage(): JSX.Element {
             loading={isAttachmentsLoading}
             error={isAttachmentsError}
             onRetry={() => void refetchAttachments()}
+            onRefresh={() => void refetchAttachments()}
+            isRefreshing={isFetchingAttachments}
+            refreshedAt={attachmentsUpdatedAt}
             uploading={postAttachment.isPending}
             uploadError={
               postAttachment.isError

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -110,7 +110,7 @@ import { usePostCaseGithubIssue } from "@features/csm-cases/api/useCsmCaseGithub
 import CaseActivitiesFeed from "@features/csm-cases/components/CaseActivitiesFeed";
 import { scrollToFragmentWithRetry } from "@features/csm-cases/utils/permalinkScroll";
 import CaseMetaBand from "@features/csm-cases/components/CaseMetaBand";
-import RefreshButton from "@features/csm-dashboard/components/RefreshButton";
+import RefreshButton from "@components/RefreshButton";
 import {
   AttachmentsWidget,
   CustomerContextWidget,

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/AgentsLandingPagePilot.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/AgentsLandingPagePilot.tsx
@@ -22,7 +22,7 @@ import type { BeDashboardWidget } from "@api/backend/types";
 import { useDashboard } from "@features/csm-dashboard/api/useDashboard";
 import DashboardWidgetTile from "@features/csm-dashboard/components/DashboardWidgetTile";
 import SectionCard from "@features/csm-dashboard/components/SectionCard";
-import RefreshButton from "@features/csm-dashboard/components/RefreshButton";
+import RefreshButton from "@components/RefreshButton";
 
 /** Placeholder tile count while the dashboard detail is in flight. */
 const PILOT_TILE_COUNT = 3;

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/CaseCompositionCharts.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/CaseCompositionCharts.tsx
@@ -23,7 +23,7 @@ import {
   useCaseComposition,
 } from "@features/csm-dashboard/api/useCaseComposition";
 import { MATRIX_SEVERITIES } from "@features/csm-dashboard/api/useCaseCountsMatrix";
-import RefreshButton from "@features/csm-dashboard/components/RefreshButton";
+import RefreshButton from "@components/RefreshButton";
 import CompositionDonut, {
   type CompositionSlice,
 } from "@features/csm-dashboard/components/CompositionDonut";

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/CaseCountsMatrix.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/CaseCountsMatrix.tsx
@@ -39,7 +39,7 @@ import type {
   Severity,
 } from "@features/csm-dashboard/types/abtDashboard";
 import SectionCard from "@features/csm-dashboard/components/SectionCard";
-import RefreshButton from "@features/csm-dashboard/components/RefreshButton";
+import RefreshButton from "@components/RefreshButton";
 
 /** Build a `/cases?...` href for the given severity and/or state filter. */
 function casesHref(severity?: Severity, state?: CaseState): string {

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/MyAssignedCases.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/MyAssignedCases.tsx
@@ -26,7 +26,7 @@ import {
 } from "@features/csm-dashboard/api/useGetMyAssignedOpenCases";
 import { useCurrentUser } from "@context/current-user/CurrentUserContext";
 import SectionCard from "@features/csm-dashboard/components/SectionCard";
-import RefreshButton from "@features/csm-dashboard/components/RefreshButton";
+import RefreshButton from "@components/RefreshButton";
 
 // Deep-link to the full cases list, pre-filtered to the caller's non-closed
 // cases. `assignees=@me` resolves against the current user server-side; the

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/pages/DashboardWidgetPreviewPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/pages/DashboardWidgetPreviewPage.tsx
@@ -23,6 +23,7 @@ import { BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
 import { useCurrentUser } from "@context/current-user/CurrentUserContext";
 import { useDebouncedValue } from "@hooks/useDebouncedValue";
 import { useWidgetData } from "@features/csm-dashboard/api/useWidgetData";
+import RefreshButton from "@features/csm-dashboard/components/RefreshButton";
 import { WIDGET_LIST_RENDERERS } from "@features/csm-dashboard/config/widgetListConfig";
 import { resourceTypeForPreviewSlug } from "@features/csm-dashboard/config/widgetResourceConfig";
 import {
@@ -144,7 +145,7 @@ function DashboardWidgetPreviewContent({
     return trimmed ? { ...filters, searchQuery: trimmed } : filters;
   }, [filters, debouncedSearch]);
 
-  const { data, isLoading, isError } = useWidgetData(
+  const { data, isLoading, isError, isFetching, refetch, dataUpdatedAt } = useWidgetData(
     widgetId,
     resourceType,
     queriedFilters,
@@ -167,7 +168,15 @@ function DashboardWidgetPreviewContent({
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
       {backButton}
-      <Typography variant="h5">{displayName}</Typography>
+      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 1 }}>
+        <Typography variant="h5">{displayName}</Typography>
+        <RefreshButton
+          onRefresh={() => void refetch()}
+          isFetching={isFetching}
+          updatedAt={dataUpdatedAt}
+          label={`Refresh ${displayName}`}
+        />
+      </Box>
       <TextField
         size="small"
         label="Search"

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/pages/DashboardWidgetPreviewPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/pages/DashboardWidgetPreviewPage.tsx
@@ -23,7 +23,7 @@ import { BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
 import { useCurrentUser } from "@context/current-user/CurrentUserContext";
 import { useDebouncedValue } from "@hooks/useDebouncedValue";
 import { useWidgetData } from "@features/csm-dashboard/api/useWidgetData";
-import RefreshButton from "@features/csm-dashboard/components/RefreshButton";
+import RefreshButton from "@components/RefreshButton";
 import { WIDGET_LIST_RENDERERS } from "@features/csm-dashboard/config/widgetListConfig";
 import { resourceTypeForPreviewSlug } from "@features/csm-dashboard/config/widgetResourceConfig";
 import {

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestsTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestsTab.tsx
@@ -52,6 +52,7 @@ import {
   writeChangeRequestFiltersToUrl,
 } from "@features/csm-operations/utils/changeRequestsFiltersUrl";
 import ChangeRequestsFilterBar from "@features/csm-operations/components/ChangeRequestsFilterBar";
+import RefreshButton from "@features/csm-dashboard/components/RefreshButton";
 import type {
   BeChangeRequestSearchPayload,
   BeChangeRequestSearchResponse,
@@ -117,7 +118,7 @@ export default function ChangeRequestsTab(): JSX.Element {
     [debouncedSearch, filters.states, filters.impacts, filters.closedStartDate, filters.closedEndDate, page, rowsPerPage],
   );
 
-  const { data, isLoading, isError, error, isFetching } =
+  const { data, isLoading, isError, error, isFetching, refetch, dataUpdatedAt } =
     useSearchChangeRequests(payload);
 
   const changeRequests = data?.changeRequests ?? [];
@@ -186,7 +187,13 @@ export default function ChangeRequestsTab(): JSX.Element {
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
-      <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 1 }}>
+      <Box sx={{ display: "flex", justifyContent: "flex-end", alignItems: "center", gap: 1 }}>
+        <RefreshButton
+          onRefresh={() => void refetch()}
+          isFetching={isFetching}
+          updatedAt={dataUpdatedAt}
+          label="Refresh change requests"
+        />
         <FilteredCsvExportButton<BeChangeRequestSearchView>
           entityName="change-requests"
           header={["Number", "Subject", "Project", "State", "Impact", "Planned start", "Updated"]}

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestsTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestsTab.tsx
@@ -52,7 +52,7 @@ import {
   writeChangeRequestFiltersToUrl,
 } from "@features/csm-operations/utils/changeRequestsFiltersUrl";
 import ChangeRequestsFilterBar from "@features/csm-operations/components/ChangeRequestsFilterBar";
-import RefreshButton from "@features/csm-dashboard/components/RefreshButton";
+import RefreshButton from "@components/RefreshButton";
 import type {
   BeChangeRequestSearchPayload,
   BeChangeRequestSearchResponse,

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/IncidentsTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/IncidentsTab.tsx
@@ -53,7 +53,7 @@ import {
   writeIncidentFiltersToUrl,
 } from "@features/csm-operations/utils/incidentsFiltersUrl";
 import IncidentsFilterBar from "@features/csm-operations/components/IncidentsFilterBar";
-import RefreshButton from "@features/csm-dashboard/components/RefreshButton";
+import RefreshButton from "@components/RefreshButton";
 import type { BeIncident, BeIncidentSearchPayload, BeIncidentSearchResponse } from "@api/backend/types";
 
 const DEFAULT_ROWS_PER_PAGE = 20;

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/IncidentsTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/IncidentsTab.tsx
@@ -53,6 +53,7 @@ import {
   writeIncidentFiltersToUrl,
 } from "@features/csm-operations/utils/incidentsFiltersUrl";
 import IncidentsFilterBar from "@features/csm-operations/components/IncidentsFilterBar";
+import RefreshButton from "@features/csm-dashboard/components/RefreshButton";
 import type { BeIncident, BeIncidentSearchPayload, BeIncidentSearchResponse } from "@api/backend/types";
 
 const DEFAULT_ROWS_PER_PAGE = 20;
@@ -98,7 +99,8 @@ export default function IncidentsTab(): JSX.Element {
     [filters, debouncedSearch, page, rowsPerPage],
   );
 
-  const { data, isLoading, isError, error, isFetching } = useSearchIncidents(payload);
+  const { data, isLoading, isError, error, isFetching, refetch, dataUpdatedAt } =
+    useSearchIncidents(payload);
 
   const incidents = data?.incidents ?? [];
   const total = data?.total ?? 0;
@@ -169,7 +171,13 @@ export default function IncidentsTab(): JSX.Element {
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
-      <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 1 }}>
+      <Box sx={{ display: "flex", justifyContent: "flex-end", alignItems: "center", gap: 1 }}>
+        <RefreshButton
+          onRefresh={() => void refetch()}
+          isFetching={isFetching}
+          updatedAt={dataUpdatedAt}
+          label="Refresh incidents"
+        />
         <FilteredCsvExportButton<BeIncident>
           entityName="incidents"
           header={["Number", "Subject", "Caller", "State", "Priority", "Opened", "Updated"]}

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ProblemsTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ProblemsTab.tsx
@@ -41,6 +41,7 @@ import {
   type ProblemFilters,
 } from "@features/csm-operations/utils/problems";
 import ProblemsFilterBar from "@features/csm-operations/components/ProblemsFilterBar";
+import RefreshButton from "@features/csm-dashboard/components/RefreshButton";
 
 const DEFAULT_ROWS_PER_PAGE = 20;
 const ROWS_PER_PAGE_OPTIONS = [10, 20, 50];
@@ -69,7 +70,8 @@ export default function ProblemsTab(): JSX.Element {
     [debouncedSearch, filters.states, page, rowsPerPage],
   );
 
-  const { data, isLoading, isError, error, isFetching } = useSearchProblems(payload);
+  const { data, isLoading, isError, error, isFetching, refetch, dataUpdatedAt } =
+    useSearchProblems(payload);
 
   const problems = data?.problems ?? [];
   const total = data?.total ?? 0;
@@ -91,7 +93,13 @@ export default function ProblemsTab(): JSX.Element {
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
-      <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
+      <Box sx={{ display: "flex", justifyContent: "flex-end", alignItems: "center", gap: 1 }}>
+        <RefreshButton
+          onRefresh={() => void refetch()}
+          isFetching={isFetching}
+          updatedAt={dataUpdatedAt}
+          label="Refresh problems"
+        />
         <Button
           variant="contained"
           color="primary"

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ProblemsTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ProblemsTab.tsx
@@ -41,7 +41,7 @@ import {
   type ProblemFilters,
 } from "@features/csm-operations/utils/problems";
 import ProblemsFilterBar from "@features/csm-operations/components/ProblemsFilterBar";
-import RefreshButton from "@features/csm-dashboard/components/RefreshButton";
+import RefreshButton from "@components/RefreshButton";
 
 const DEFAULT_ROWS_PER_PAGE = 20;
 const ROWS_PER_PAGE_OPTIONS = [10, 20, 50];

--- a/apps/csm-portal/webapp/src/features/csm-projects/pages/CsmProjectsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/pages/CsmProjectsPage.tsx
@@ -33,7 +33,7 @@ import { useDebouncedValue } from "@hooks/useDebouncedValue";
 import { useNavTransition } from "@hooks/useNavTransition";
 import { useSearchProjects } from "@features/csm-projects/api/useSearchProjects";
 import ClosureStateChip from "@features/csm-projects/components/ClosureStateChip";
-import RefreshButton from "@features/csm-dashboard/components/RefreshButton";
+import RefreshButton from "@components/RefreshButton";
 import type { SearchProjectsRequest } from "@features/csm-projects/types/csmProjects";
 import { BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
 

--- a/apps/csm-portal/webapp/src/features/csm-projects/pages/CsmProjectsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/pages/CsmProjectsPage.tsx
@@ -33,6 +33,7 @@ import { useDebouncedValue } from "@hooks/useDebouncedValue";
 import { useNavTransition } from "@hooks/useNavTransition";
 import { useSearchProjects } from "@features/csm-projects/api/useSearchProjects";
 import ClosureStateChip from "@features/csm-projects/components/ClosureStateChip";
+import RefreshButton from "@features/csm-dashboard/components/RefreshButton";
 import type { SearchProjectsRequest } from "@features/csm-projects/types/csmProjects";
 import { BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
 
@@ -68,7 +69,8 @@ export default function CsmProjectsPage(): JSX.Element {
     [debouncedSearch, page, rowsPerPage],
   );
 
-  const { data, isLoading, isFetching, isError, error } = useSearchProjects(request);
+  const { data, isLoading, isFetching, isError, error, refetch, dataUpdatedAt } =
+    useSearchProjects(request);
 
   const handleSearchChange = (e: ChangeEvent<HTMLInputElement>) => {
     setSearchInput(e.target.value);
@@ -85,9 +87,17 @@ export default function CsmProjectsPage(): JSX.Element {
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
-      <Typography variant="body2" color="text.secondary">
-        Search across project name, project key, and subscription type.
-      </Typography>
+      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 1 }}>
+        <Typography variant="body2" color="text.secondary">
+          Search across project name, project key, and subscription type.
+        </Typography>
+        <RefreshButton
+          onRefresh={() => void refetch()}
+          isFetching={isFetching}
+          updatedAt={dataUpdatedAt}
+          label="Refresh projects"
+        />
+      </Box>
 
       <TextField
         size="small"

--- a/apps/csm-portal/webapp/src/features/csm-security-center/components/ProductVulnerabilitiesTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-security-center/components/ProductVulnerabilitiesTab.tsx
@@ -42,7 +42,7 @@ import {
 } from "@features/csm-security-center/utils/vulnerabilities";
 import type { BeVulnerabilityPriority } from "@api/backend/types";
 import { useNavTransition } from "@hooks/useNavTransition";
-import RefreshButton from "@features/csm-dashboard/components/RefreshButton";
+import RefreshButton from "@components/RefreshButton";
 
 const DEFAULT_ROWS_PER_PAGE = 20;
 const ROWS_PER_PAGE_OPTIONS = [10, 20, 50];

--- a/apps/csm-portal/webapp/src/features/csm-security-center/components/ProductVulnerabilitiesTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-security-center/components/ProductVulnerabilitiesTab.tsx
@@ -42,6 +42,7 @@ import {
 } from "@features/csm-security-center/utils/vulnerabilities";
 import type { BeVulnerabilityPriority } from "@api/backend/types";
 import { useNavTransition } from "@hooks/useNavTransition";
+import RefreshButton from "@features/csm-dashboard/components/RefreshButton";
 
 const DEFAULT_ROWS_PER_PAGE = 20;
 const ROWS_PER_PAGE_OPTIONS = [10, 20, 50];
@@ -70,7 +71,7 @@ export default function ProductVulnerabilitiesTab(): JSX.Element {
     [debouncedSearch, priorityFilter, page, rowsPerPage],
   );
 
-  const { data, isLoading, isError, error, isFetching } =
+  const { data, isLoading, isError, error, isFetching, refetch, dataUpdatedAt } =
     useSearchProductVulnerabilities(payload);
 
   const vulnerabilities = data?.productVulnerabilities ?? [];
@@ -93,7 +94,8 @@ export default function ProductVulnerabilitiesTab(): JSX.Element {
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
-      <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
+      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 2, flexWrap: "wrap" }}>
+        <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
         <TextField
           value={searchInput}
           onChange={handleSearchChange}
@@ -129,6 +131,13 @@ export default function ProductVulnerabilitiesTab(): JSX.Element {
             </MenuItem>
           ))}
         </TextField>
+        </Box>
+        <RefreshButton
+          onRefresh={() => void refetch()}
+          isFetching={isFetching}
+          updatedAt={dataUpdatedAt}
+          label="Refresh vulnerabilities"
+        />
       </Box>
 
       <Box sx={{ border: 1, borderColor: "divider", borderRadius: 1, overflow: "hidden" }}>

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/CaseTimeCardsPanel.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/CaseTimeCardsPanel.tsx
@@ -36,6 +36,7 @@ import TimeCardStatusChip from "@features/csm-timecards/components/TimeCardStatu
 import TimeCardReviewDialog from "@features/csm-timecards/components/TimeCardReviewDialog";
 import TimeCardTruncatedNotice from "@features/csm-timecards/components/TimeCardTruncatedNotice";
 import type { CsmTimeCard } from "@features/csm-timecards/types/timeCards";
+import RefreshButton from "@features/csm-dashboard/components/RefreshButton";
 
 interface CaseTimeCardsPanelProps {
   caseId: string;
@@ -53,7 +54,8 @@ export default function CaseTimeCardsPanel({
   caseId,
   onLogTime,
 }: CaseTimeCardsPanelProps): JSX.Element {
-  const { data, isLoading, isError } = useCaseTimeCards(caseId);
+  const { data, isLoading, isError, refetch, isFetching, dataUpdatedAt } =
+    useCaseTimeCards(caseId);
   const isTeamLead = useIsTeamLead();
   const me = useCurrentEngineer();
   const decide = useDecideTimeCard();
@@ -81,14 +83,22 @@ export default function CaseTimeCardsPanel({
           <Clock size={16} />
           <Typography variant="subtitle2">Time tracked</Typography>
         </Box>
-        <Button
-          size="small"
-          variant="text"
-          startIcon={<Plus size={14} />}
-          onClick={onLogTime}
-        >
-          Log time
-        </Button>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+          <RefreshButton
+            onRefresh={() => void refetch()}
+            isFetching={isFetching}
+            updatedAt={dataUpdatedAt}
+            label="Refresh time cards"
+          />
+          <Button
+            size="small"
+            variant="text"
+            startIcon={<Plus size={14} />}
+            onClick={onLogTime}
+          >
+            Log time
+          </Button>
+        </Box>
       </Box>
 
       <Box

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/CaseTimeCardsPanel.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/CaseTimeCardsPanel.tsx
@@ -36,7 +36,7 @@ import TimeCardStatusChip from "@features/csm-timecards/components/TimeCardStatu
 import TimeCardReviewDialog from "@features/csm-timecards/components/TimeCardReviewDialog";
 import TimeCardTruncatedNotice from "@features/csm-timecards/components/TimeCardTruncatedNotice";
 import type { CsmTimeCard } from "@features/csm-timecards/types/timeCards";
-import RefreshButton from "@features/csm-dashboard/components/RefreshButton";
+import RefreshButton from "@components/RefreshButton";
 
 interface CaseTimeCardsPanelProps {
   caseId: string;

--- a/apps/csm-portal/webapp/src/features/csm-timecards/pages/CsmTimeCardsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/pages/CsmTimeCardsPage.tsx
@@ -67,7 +67,7 @@ import { BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 import { useSuccessBanner } from "@context/success-banner/SuccessBannerContext";
 import { TIME_CARD_STATE_META } from "@features/csm-timecards/constants/timeCardConstants";
-import RefreshButton from "@features/csm-dashboard/components/RefreshButton";
+import RefreshButton from "@components/RefreshButton";
 import { useTimecardRole } from "@features/csm-timecards/hooks/useTimecardRole";
 import TimeCardsTable from "@features/csm-timecards/components/TimeCardsTable";
 import TimeCardReviewDialog from "@features/csm-timecards/components/TimeCardReviewDialog";
@@ -437,22 +437,25 @@ export default function CsmTimeCardsPage(): JSX.Element {
             onClear={clearFilters}
           />
 
+          <Box sx={{ display: "flex", justifyContent: "flex-end", alignItems: "center", gap: 1 }}>
+            <RefreshButton
+              onRefresh={() => void myCards.refetch()}
+              isFetching={myCards.isFetching}
+              updatedAt={myCards.dataUpdatedAt}
+              label="Refresh my time sheets"
+            />
+            {!myCards.isError && (
+              <ExportCsvButton
+                cards={mineFilteredCards}
+                filename={`time-cards-my-sheets-${todayStamp}.csv`}
+              />
+            )}
+          </Box>
+
           {myCards.isError ? (
             <Typography color="error">Could not load your time cards.</Typography>
           ) : (
             <>
-              <Box sx={{ display: "flex", justifyContent: "flex-end", alignItems: "center", gap: 1 }}>
-                <RefreshButton
-                  onRefresh={() => void myCards.refetch()}
-                  isFetching={myCards.isFetching}
-                  updatedAt={myCards.dataUpdatedAt}
-                  label="Refresh my time sheets"
-                />
-                <ExportCsvButton
-                  cards={mineFilteredCards}
-                  filename={`time-cards-my-sheets-${todayStamp}.csv`}
-                />
-              </Box>
               <TimeCardsTable
                 cards={mineFilteredCards}
                 isLoading={myCards.isLoading}
@@ -521,22 +524,25 @@ export default function CsmTimeCardsPage(): JSX.Element {
 
           <GroupByToggle value={groupBy} onChange={setGroupBy} />
 
+          <Box sx={{ display: "flex", justifyContent: "flex-end", alignItems: "center", gap: 1 }}>
+            <RefreshButton
+              onRefresh={() => void allCards.refetch()}
+              isFetching={allCards.isFetching}
+              updatedAt={allCards.dataUpdatedAt}
+              label="Refresh time cards"
+            />
+            {!allCards.isError && (
+              <ExportCsvButton
+                cards={allFilteredCards}
+                filename={`time-cards-all-${todayStamp}.csv`}
+              />
+            )}
+          </Box>
+
           {allCards.isError ? (
             <Typography color="error">Could not load time cards.</Typography>
           ) : (
             <>
-              <Box sx={{ display: "flex", justifyContent: "flex-end", alignItems: "center", gap: 1 }}>
-                <RefreshButton
-                  onRefresh={() => void allCards.refetch()}
-                  isFetching={allCards.isFetching}
-                  updatedAt={allCards.dataUpdatedAt}
-                  label="Refresh time cards"
-                />
-                <ExportCsvButton
-                  cards={allFilteredCards}
-                  filename={`time-cards-all-${todayStamp}.csv`}
-                />
-              </Box>
               <TimeCardsTable
                 cards={allFilteredCards}
                 isLoading={allCards.isLoading}
@@ -596,22 +602,25 @@ export default function CsmTimeCardsPage(): JSX.Element {
 
           <GroupByToggle value={groupBy} onChange={setGroupBy} />
 
+          <Box sx={{ display: "flex", justifyContent: "flex-end", alignItems: "center", gap: 1 }}>
+            <RefreshButton
+              onRefresh={() => void queue.refetch()}
+              isFetching={queue.isFetching}
+              updatedAt={queue.dataUpdatedAt}
+              label="Refresh approval queue"
+            />
+            {!queue.isError && (
+              <ExportCsvButton
+                cards={approvalsFilteredCards}
+                filename={`time-cards-approvals-${todayStamp}.csv`}
+              />
+            )}
+          </Box>
+
           {queue.isError ? (
             <Typography color="error">Could not load the approval queue.</Typography>
           ) : (
             <>
-              <Box sx={{ display: "flex", justifyContent: "flex-end", alignItems: "center", gap: 1 }}>
-                <RefreshButton
-                  onRefresh={() => void queue.refetch()}
-                  isFetching={queue.isFetching}
-                  updatedAt={queue.dataUpdatedAt}
-                  label="Refresh approval queue"
-                />
-                <ExportCsvButton
-                  cards={approvalsFilteredCards}
-                  filename={`time-cards-approvals-${todayStamp}.csv`}
-                />
-              </Box>
               <TimeCardsTable
                 cards={approvalsFilteredCards}
                 isLoading={queue.isLoading}

--- a/apps/csm-portal/webapp/src/features/csm-timecards/pages/CsmTimeCardsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/pages/CsmTimeCardsPage.tsx
@@ -67,6 +67,7 @@ import { BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 import { useSuccessBanner } from "@context/success-banner/SuccessBannerContext";
 import { TIME_CARD_STATE_META } from "@features/csm-timecards/constants/timeCardConstants";
+import RefreshButton from "@features/csm-dashboard/components/RefreshButton";
 import { useTimecardRole } from "@features/csm-timecards/hooks/useTimecardRole";
 import TimeCardsTable from "@features/csm-timecards/components/TimeCardsTable";
 import TimeCardReviewDialog from "@features/csm-timecards/components/TimeCardReviewDialog";
@@ -440,7 +441,13 @@ export default function CsmTimeCardsPage(): JSX.Element {
             <Typography color="error">Could not load your time cards.</Typography>
           ) : (
             <>
-              <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
+              <Box sx={{ display: "flex", justifyContent: "flex-end", alignItems: "center", gap: 1 }}>
+                <RefreshButton
+                  onRefresh={() => void myCards.refetch()}
+                  isFetching={myCards.isFetching}
+                  updatedAt={myCards.dataUpdatedAt}
+                  label="Refresh my time sheets"
+                />
                 <ExportCsvButton
                   cards={mineFilteredCards}
                   filename={`time-cards-my-sheets-${todayStamp}.csv`}
@@ -518,7 +525,13 @@ export default function CsmTimeCardsPage(): JSX.Element {
             <Typography color="error">Could not load time cards.</Typography>
           ) : (
             <>
-              <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
+              <Box sx={{ display: "flex", justifyContent: "flex-end", alignItems: "center", gap: 1 }}>
+                <RefreshButton
+                  onRefresh={() => void allCards.refetch()}
+                  isFetching={allCards.isFetching}
+                  updatedAt={allCards.dataUpdatedAt}
+                  label="Refresh time cards"
+                />
                 <ExportCsvButton
                   cards={allFilteredCards}
                   filename={`time-cards-all-${todayStamp}.csv`}
@@ -587,7 +600,13 @@ export default function CsmTimeCardsPage(): JSX.Element {
             <Typography color="error">Could not load the approval queue.</Typography>
           ) : (
             <>
-              <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
+              <Box sx={{ display: "flex", justifyContent: "flex-end", alignItems: "center", gap: 1 }}>
+                <RefreshButton
+                  onRefresh={() => void queue.refetch()}
+                  isFetching={queue.isFetching}
+                  updatedAt={queue.dataUpdatedAt}
+                  label="Refresh approval queue"
+                />
                 <ExportCsvButton
                   cards={approvalsFilteredCards}
                   filename={`time-cards-approvals-${todayStamp}.csv`}

--- a/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.tsx
@@ -51,6 +51,7 @@ import { useSearchUsers } from "@features/csm-users/api/useSearchUsers";
 import { useSearchRoles } from "@features/csm-admin/api/useSearchRoles";
 import { useSearchTeams } from "@features/csm-admin/api/useSearchTeams";
 import ResponsiveRoleChips from "@components/ResponsiveRoleChips";
+import RefreshButton from "@features/csm-dashboard/components/RefreshButton";
 import type { SearchUsersRequest } from "@features/csm-users/types/csmUsers";
 import {
   readUsersFiltersFromUrl,
@@ -124,7 +125,8 @@ export default function CsmUsersPage(): JSX.Element {
     [debouncedSearch, page, rowsPerPage, filters],
   );
 
-  const { data, isLoading, isFetching, isError, error } = useSearchUsers(request);
+  const { data, isLoading, isFetching, isError, error, refetch, dataUpdatedAt } =
+    useSearchUsers(request);
 
   const handleSearchChange = (e: ChangeEvent<HTMLInputElement>) => {
     setFilters({ ...filters, search: e.target.value });
@@ -154,10 +156,18 @@ export default function CsmUsersPage(): JSX.Element {
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
-      <Typography variant="body2" color="text.secondary">
-        Search across username and email (case-insensitive). Filter by role, group, team and
-        status.
-      </Typography>
+      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 1 }}>
+        <Typography variant="body2" color="text.secondary">
+          Search across username and email (case-insensitive). Filter by role, group, team and
+          status.
+        </Typography>
+        <RefreshButton
+          onRefresh={() => void refetch()}
+          isFetching={isFetching}
+          updatedAt={dataUpdatedAt}
+          label="Refresh users"
+        />
+      </Box>
 
       <Stack direction={{ xs: "column", sm: "row" }} spacing={2} sx={{ flexWrap: "wrap" }}>
         <TextField

--- a/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.tsx
@@ -51,7 +51,7 @@ import { useSearchUsers } from "@features/csm-users/api/useSearchUsers";
 import { useSearchRoles } from "@features/csm-admin/api/useSearchRoles";
 import { useSearchTeams } from "@features/csm-admin/api/useSearchTeams";
 import ResponsiveRoleChips from "@components/ResponsiveRoleChips";
-import RefreshButton from "@features/csm-dashboard/components/RefreshButton";
+import RefreshButton from "@components/RefreshButton";
 import type { SearchUsersRequest } from "@features/csm-users/types/csmUsers";
 import {
   readUsersFiltersFromUrl,

--- a/apps/csm-portal/webapp/src/features/updates/pages/CsmUpdatesPage.tsx
+++ b/apps/csm-portal/webapp/src/features/updates/pages/CsmUpdatesPage.tsx
@@ -49,7 +49,7 @@ import type { SelectChangeEvent } from "@wso2/oxygen-ui";
 import DOMPurify from "dompurify";
 import { useGetProductUpdateLevels } from "@features/updates/api/useGetProductUpdateLevels";
 import { usePostUpdateLevelsSearch } from "@features/updates/api/usePostUpdateLevelsSearch";
-import RefreshButton from "@features/csm-dashboard/components/RefreshButton";
+import RefreshButton from "@components/RefreshButton";
 import type {
   ProductUpdateLevel,
   SearchUpdatesPayload,
@@ -772,7 +772,16 @@ export default function CsmUpdatesPage(): JSX.Element {
 
       {/* Results */}
       {search && (
-        <Box>
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+          <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
+            <RefreshButton
+              onRefresh={() => void searchResult.refetch()}
+              isFetching={searchResult.isFetching}
+              updatedAt={searchResult.dataUpdatedAt}
+              label="Refresh updates"
+            />
+          </Box>
+
           {searchResult.isLoading ? (
             <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
               <CircularProgress />
@@ -788,25 +797,17 @@ export default function CsmUpdatesPage(): JSX.Element {
             </Typography>
           ) : (
             <Stack spacing={2}>
-              <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 1 }}>
-                <Typography variant="body2" color="text.secondary">
-                  There are <strong>{sortedEntries.length}</strong> updates with{" "}
-                  <strong>{counts.security}</strong> security,{" "}
-                  <strong>{counts.regular}</strong> regular
-                  {counts.mixed > 0 && (
-                    <>
-                      , and <strong>{counts.mixed}</strong> mixed
-                    </>
-                  )}{" "}
-                  updates.
-                </Typography>
-                <RefreshButton
-                  onRefresh={() => void searchResult.refetch()}
-                  isFetching={searchResult.isFetching}
-                  updatedAt={searchResult.dataUpdatedAt}
-                  label="Refresh updates"
-                />
-              </Box>
+              <Typography variant="body2" color="text.secondary">
+                There are <strong>{sortedEntries.length}</strong> updates with{" "}
+                <strong>{counts.security}</strong> security,{" "}
+                <strong>{counts.regular}</strong> regular
+                {counts.mixed > 0 && (
+                  <>
+                    , and <strong>{counts.mixed}</strong> mixed
+                  </>
+                )}{" "}
+                updates.
+              </Typography>
 
               <TableContainer component={Paper}>
                 <Table sx={{ minWidth: 650, width: "100%", tableLayout: "fixed" }}>

--- a/apps/csm-portal/webapp/src/features/updates/pages/CsmUpdatesPage.tsx
+++ b/apps/csm-portal/webapp/src/features/updates/pages/CsmUpdatesPage.tsx
@@ -49,6 +49,7 @@ import type { SelectChangeEvent } from "@wso2/oxygen-ui";
 import DOMPurify from "dompurify";
 import { useGetProductUpdateLevels } from "@features/updates/api/useGetProductUpdateLevels";
 import { usePostUpdateLevelsSearch } from "@features/updates/api/usePostUpdateLevelsSearch";
+import RefreshButton from "@features/csm-dashboard/components/RefreshButton";
 import type {
   ProductUpdateLevel,
   SearchUpdatesPayload,
@@ -787,17 +788,25 @@ export default function CsmUpdatesPage(): JSX.Element {
             </Typography>
           ) : (
             <Stack spacing={2}>
-              <Typography variant="body2" color="text.secondary">
-                There are <strong>{sortedEntries.length}</strong> updates with{" "}
-                <strong>{counts.security}</strong> security,{" "}
-                <strong>{counts.regular}</strong> regular
-                {counts.mixed > 0 && (
-                  <>
-                    , and <strong>{counts.mixed}</strong> mixed
-                  </>
-                )}{" "}
-                updates.
-              </Typography>
+              <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 1 }}>
+                <Typography variant="body2" color="text.secondary">
+                  There are <strong>{sortedEntries.length}</strong> updates with{" "}
+                  <strong>{counts.security}</strong> security,{" "}
+                  <strong>{counts.regular}</strong> regular
+                  {counts.mixed > 0 && (
+                    <>
+                      , and <strong>{counts.mixed}</strong> mixed
+                    </>
+                  )}{" "}
+                  updates.
+                </Typography>
+                <RefreshButton
+                  onRefresh={() => void searchResult.refetch()}
+                  isFetching={searchResult.isFetching}
+                  updatedAt={searchResult.dataUpdatedAt}
+                  label="Refresh updates"
+                />
+              </Box>
 
               <TableContainer component={Paper}>
                 <Table sx={{ minWidth: 650, width: "100%", tableLayout: "fixed" }}>


### PR DESCRIPTION
## Purpose
ServiceNow lets you refresh an individual tab within a case's details. In the CSM portal
webapp, seeing changed data anywhere — a case detail tab, or any searchable list page —
required a full page reload. There was no way to just re-pull one tab's or one list's data.

## Goals
Add a refresh control everywhere a tab or page shows live, potentially-stale query data, so
a user can pull fresh data in place instead of reloading the whole page.

## Approach
Reused the existing `RefreshButton` component (icon button + "Last refreshed X ago" hint),
already used on the dashboard's widget cards — same look and behavior everywhere now.

Every button wires directly to the underlying React Query hook's own
`refetch`/`isFetching`/`dataUpdatedAt`. No new query keys, no cross-component cache
invalidation — every hook touched here is a plain `useQuery` passthrough, so this is additive
wiring, not a data-layer change.

**Case detail page** (`CsmCaseDetailPage.tsx`) — every tab:
- Activities: one button refreshes all of its merged sources (comments, state-change audit,
  linked chat, attachments, call requests).
- Details: case detail + project + live deployment.
- Linked Items: a page-level button refreshes the case-detail-sourced ref lists, plus each of
  the three sub-widgets (Child cases, Linked service requests, Linked change requests) got its
  own button for its own enrichment query.
- Watchers, Attachments, Time tracking, Call requests: each wired to its own query.
- SLA and Tasks tabs were **not** touched — both are `hidden: true` in `TAB_DEFS` and
  unreachable from the tab bar in this build.

**List pages** — one button per page/tab, wired to that page's search hook:
- Cases, Operations → Service Requests, Security Center → Security Reports, Engagements: all
  share `CsmIssuesView`, so one change covers all four.
- Operations → Change Requests / Incidents / Problems, Security Center → Vulnerabilities: each
  has its own tab component.
- Admin → Users: its own page.
- Admin → Roles / Groups / Teams: share `DirectoryEntityTable`; their member pages share
  `DirectoryMembersList` — one change each covers three pages.
- Customers → Accounts / Projects, Announcements: each its own page.
- Updates: refresh only applies once a search has run (the page is filter-then-search, not a
  live list) — reruns the same search.
- Time Cards: all three tabs (My sheets / All / Approvals) independently.
- Dashboard widget "View more" preview page.

## User stories
As a CS engineer, I can refresh a single case-detail tab or list page in place, without
reloading the whole app and losing my scroll position/filters/open dialogs.

## Release note
Case detail tabs and list pages across the CSM portal now have a refresh button, so you no
longer need to reload the page to see updated data.

## Documentation
N/A — no published documentation covers this internal UI behavior.

## Training
N/A.

## Certification
N/A.

## Marketing
N/A.

## Automation tests
- Unit tests: none added — this is additive UI wiring onto existing, already-tested query
  hooks; no new query/business logic to unit test. `tsc -b` and `eslint` clean on every touched
  file. The existing `vitest` suites for these features were re-run (`csm-cases`, `csm-admin`,
  `csm-operations`, `csm-security-center`, `csm-accounts`, `csm-projects`,
  `csm-announcements`, `updates`, `csm-timecards`, `csm-users`, `csm-dashboard`): the only
  failures are 6 pre-existing ones (`CsmRolesPage.test.tsx`, `CsmAnnouncementsPage.test.tsx`),
  confirmed via `git stash` to fail identically without this change.
- Production `vite build` clean.
- Integration tests: none — no integration-test harness exists for this app. **Not manually
  verified in a browser** — I don't have a live backend/Asgardeo session in this environment,
  so only the type-check/lint/test/build gates are confirmed, not an actual click-through.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? no — TypeScript/React only, nothing for a JVM tool to analyse.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
None.

## Migrations (if applicable)
N/A — no schema or data change, UI-only.

## Test environment
- Node.js, pnpm (via `./node_modules/.bin/*` directly — the `pnpm` CLI itself errors with
  "packages field missing or empty" in this environment).
- macOS.
- `tsc -b`, `eslint`, `vitest`, `vite build` — all clean as noted above.
- Not manually verified in a browser against a live backend in this session.

## Learning
N/A.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added manual refresh controls throughout the portal, enabling users to reload data on-demand across accounts, teams, groups, roles, announcements, cases, projects, timecards, and user directories.
  * Refresh buttons display loading states and last-updated timestamps for visibility into data freshness.
  * Users can refresh individual sections without full-page reloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->