### PR TITLE
[CSM Portal] Add quick-preview drawer to the cases list

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasePreviewDrawer.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasePreviewDrawer.tsx
@@ -1,0 +1,168 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Box,
+  Button,
+  Divider,
+  Drawer,
+  IconButton,
+  Skeleton,
+  Stack,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { X } from "@wso2/oxygen-ui-icons-react";
+import { useMemo, type JSX, type ReactNode } from "react";
+import { Link as RouterLink } from "react-router";
+import RelativeTime from "@components/RelativeTime";
+import SeverityChip from "@components/SeverityChip";
+import StateChip from "@components/StateChip";
+import WorkStateChip from "@components/WorkStateChip";
+import CsmCaseCommentBubble from "@features/csm-cases/components/CsmCaseCommentBubble";
+import { useGetCsmCaseComments } from "@features/csm-cases/api/useCsmCaseComments";
+import { caseTypeDetailBasePath, caseTypeHasSeverity } from "@features/csm-cases/utils/caseType";
+import type { CsmCaseRow } from "@features/csm-cases/types/csmCases";
+
+// "The last few at least" — deliberately not the full thread (that's the
+// whole reason this exists instead of just linking to the case): a quick
+// look, not a second copy of the Activities tab.
+const RECENT_COMMENTS_LIMIT = 5;
+
+interface CasePreviewDrawerProps {
+  /** The row being previewed. `null` keeps the drawer mounted-but-closed, so
+   * its close transition can play instead of unmounting mid-animation. */
+  row: CsmCaseRow | null;
+  onClose: () => void;
+}
+
+function MetaField({ label, children }: { label: string; children: ReactNode }): JSX.Element {
+  return (
+    <Box sx={{ minWidth: 0 }}>
+      <Typography variant="caption" color="text.secondary">
+        {label}
+      </Typography>
+      <Typography variant="body2" noWrap>
+        {children}
+      </Typography>
+    </Box>
+  );
+}
+
+/**
+ * Read-only "quick look" for a case row — subject/state/severity plus the
+ * last handful of comments — without leaving the list. Deliberately thin:
+ * this is a preview, not a second case detail page (no composer, no action
+ * bar, no full activity/audit timeline). "View full details" always stays
+ * one click away for anything this doesn't cover.
+ */
+export default function CasePreviewDrawer({ row, onClose }: CasePreviewDrawerProps): JSX.Element {
+  const caseId = row?.id;
+  const { data: comments, isLoading, isError } = useGetCsmCaseComments(caseId);
+
+  const recentComments = useMemo(() => {
+    if (!comments) return [];
+    return [...comments]
+      .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+      .slice(0, RECENT_COMMENTS_LIMIT);
+  }, [comments]);
+
+  const detailPath = row ? `${caseTypeDetailBasePath(row.caseType)}/${row.id}` : "#";
+
+  return (
+    <Drawer
+      anchor="right"
+      open={!!row}
+      onClose={onClose}
+      slotProps={{ paper: { sx: { width: { xs: "100%", sm: 420 } } } }}
+    >
+      {row && (
+        <Box sx={{ display: "flex", flexDirection: "column", height: "100%" }}>
+          <Box sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 1.5 }}>
+            <Box sx={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 1 }}>
+              <Box sx={{ minWidth: 0 }}>
+                <Typography variant="subtitle2" color="text.secondary" noWrap>
+                  {row.wso2CaseId}
+                  {row.wso2CaseId && row.caseNumber ? " · " : ""}
+                  {row.caseNumber}
+                </Typography>
+                <Typography variant="h6" sx={{ wordBreak: "break-word" }}>
+                  {row.subject}
+                </Typography>
+              </Box>
+              <IconButton size="small" onClick={onClose} aria-label="Close preview">
+                <X size={18} />
+              </IconButton>
+            </Box>
+            <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
+              <StateChip state={row.state} variant="outlined" />
+              {row.state === "work_in_progress" && row.workState && (
+                <WorkStateChip workState={row.workState} />
+              )}
+              {caseTypeHasSeverity(row.caseType) && <SeverityChip severity={row.severity} />}
+            </Box>
+          </Box>
+
+          <Divider />
+
+          <Box sx={{ flex: 1, overflowY: "auto", p: 2.5, display: "flex", flexDirection: "column", gap: 2.5 }}>
+            <Box sx={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 2 }}>
+              <MetaField label="Project">{row.projectName || "—"}</MetaField>
+              <MetaField label="Product">{row.product || "—"}</MetaField>
+              <MetaField label="Assignee">{row.assignee || "Unassigned"}</MetaField>
+              <MetaField label="Updated">
+                <RelativeTime iso={row.updatedAt} />
+              </MetaField>
+            </Box>
+
+            <Box>
+              <Typography variant="subtitle2" sx={{ mb: 1.5 }}>
+                Recent activity
+              </Typography>
+              {isLoading ? (
+                <Stack gap={1.5}>
+                  <Skeleton variant="rounded" height={64} />
+                  <Skeleton variant="rounded" height={64} />
+                </Stack>
+              ) : isError ? (
+                <Typography variant="body2" color="error">
+                  Could not load comments.
+                </Typography>
+              ) : recentComments.length === 0 ? (
+                <Typography variant="body2" color="text.secondary">
+                  No comments yet.
+                </Typography>
+              ) : (
+                <Stack gap={1.5}>
+                  {recentComments.map((comment) => (
+                    <CsmCaseCommentBubble key={comment.id} comment={comment} />
+                  ))}
+                </Stack>
+              )}
+            </Box>
+          </Box>
+
+          <Divider />
+
+          <Box sx={{ p: 2 }}>
+            <Button component={RouterLink} to={detailPath} variant="contained" fullWidth onClick={onClose}>
+              View full details
+            </Button>
+          </Box>
+        </Box>
+      )}
+    </Drawer>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.test.tsx
@@ -15,12 +15,33 @@
 // under the License.
 
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
-import type { JSX } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+import type { JSX, ReactElement } from "react";
 import { useLocation, MemoryRouter, Route, Routes } from "react-router";
 import "@testing-library/jest-dom/vitest";
+
+// The real client reads runtime config at module load, which isn't present
+// under vitest (same approach as CaseActivitiesFeed.test.tsx). CasesList
+// renders a CasePreviewDrawer alongside every row (closed by default here,
+// since no test opens it), which calls useGetCsmCaseComments — the mock just
+// keeps that hook's useBackendApi() call from throwing on missing runtime
+// config; its query stays disabled (no caseId) so it's never actually invoked.
+vi.mock("@api/backend/client", () => ({
+  useBackendApi: () => ({ post: vi.fn().mockResolvedValue({ comments: [] }) }),
+}));
+
 import CasesList from "@features/csm-cases/components/CasesList";
 import type { CsmCaseRow } from "@features/csm-cases/types/csmCases";
+
+function renderWithProviders(ui: ReactElement, initialEntries: string[]): ReturnType<typeof render> {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={initialEntries}>{ui}</MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
 
 const CASE: CsmCaseRow = {
   id: "case-1",
@@ -52,18 +73,15 @@ function DetailStub(): JSX.Element {
 
 describe("CasesList row navigation", () => {
   it("carries the current (filtered) list URL forward as router state", () => {
-    render(
-      <MemoryRouter
-        initialEntries={["/cases?state=work_in_progress&severity=S2"]}
-      >
-        <Routes>
-          <Route
-            path="/cases"
-            element={<CasesList cases={[CASE]} isLoading={false} />}
-          />
-          <Route path="/cases/:id" element={<DetailStub />} />
-        </Routes>
-      </MemoryRouter>,
+    renderWithProviders(
+      <Routes>
+        <Route
+          path="/cases"
+          element={<CasesList cases={[CASE]} isLoading={false} />}
+        />
+        <Route path="/cases/:id" element={<DetailStub />} />
+      </Routes>,
+      ["/cases?state=work_in_progress&severity=S2"],
     );
 
     fireEvent.click(screen.getByText("Cluster fails to start"));
@@ -74,20 +92,39 @@ describe("CasesList row navigation", () => {
   });
 
   it("carries a bare list URL forward when no filters are active", () => {
-    render(
-      <MemoryRouter initialEntries={["/cases"]}>
-        <Routes>
-          <Route
-            path="/cases"
-            element={<CasesList cases={[CASE]} isLoading={false} />}
-          />
-          <Route path="/cases/:id" element={<DetailStub />} />
-        </Routes>
-      </MemoryRouter>,
+    renderWithProviders(
+      <Routes>
+        <Route
+          path="/cases"
+          element={<CasesList cases={[CASE]} isLoading={false} />}
+        />
+        <Route path="/cases/:id" element={<DetailStub />} />
+      </Routes>,
+      ["/cases"],
     );
 
     fireEvent.click(screen.getByText("Cluster fails to start"));
 
     expect(screen.getByTestId("from-state")).toHaveTextContent("/cases");
+  });
+});
+
+describe("CasesList quick preview", () => {
+  it("opens the preview drawer instead of navigating when the preview action is clicked", () => {
+    renderWithProviders(
+      <Routes>
+        <Route
+          path="/cases"
+          element={<CasesList cases={[CASE]} isLoading={false} />}
+        />
+        <Route path="/cases/:id" element={<DetailStub />} />
+      </Routes>,
+      ["/cases"],
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Quick preview CS-1007" }));
+
+    expect(screen.getByText("View full details")).toBeInTheDocument();
+    expect(screen.queryByTestId("from-state")).not.toBeInTheDocument();
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.tsx
@@ -227,7 +227,21 @@ export default function CasesList({
           return (
             <Box
               key={c.id}
-              onClick={() => navigate(`${rowBasePath}/${c.id}`, { state: rowState })}
+              onClick={(e) => {
+                // The case-id block below is a real RouterLink: a plain click
+                // on it already navigates via its own handler (which calls
+                // preventDefault), and that click still bubbles up here — do
+                // nothing in that case, or this would push a second, duplicate
+                // history entry for the same destination. A modified click
+                // (cmd/ctrl/shift/alt) on that link deliberately does *not*
+                // preventDefault — react-router leaves it to the browser to
+                // open a new tab — so skip here too, or this would navigate
+                // the current tab away from the list while a new tab is also
+                // opening, defeating the point of cmd-click "open in new tab
+                // for reference" the link exists for.
+                if (e.defaultPrevented || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+                navigate(`${rowBasePath}/${c.id}`, { state: rowState });
+              }}
               onMouseEnter={() => preloadRoute(rowBasePath)}
               sx={{
                 gridColumn: "1 / -1",

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.tsx
@@ -184,8 +184,13 @@ export default function CasesList({
             Updated
           </Typography>
         )}
-        {/* Unlabeled — holds the per-row quick-preview action. */}
-        <Box />
+        <Typography
+          variant="caption"
+          color="text.secondary"
+          sx={{ fontWeight: 600, textAlign: "left" }}
+        >
+          Preview
+        </Typography>
       </Box>
 
       {/* Rows */}
@@ -361,7 +366,7 @@ export default function CasesList({
                     e.stopPropagation();
                     setPreviewRow(c);
                   }}
-                  sx={{ justifySelf: "end" }}
+                  sx={{ justifySelf: "center" }}
                 >
                   <Eye size={16} />
                 </IconButton>

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.tsx
@@ -17,18 +17,23 @@
 import {
   Box,
   Chip,
+  IconButton,
   Skeleton,
   TableSortLabel,
+  Tooltip,
   Typography,
   useTheme,
 } from "@wso2/oxygen-ui";
-import type { JSX } from "react";
+import { Eye } from "@wso2/oxygen-ui-icons-react";
+import { useState, type JSX } from "react";
 import { Link as RouterLink, useLocation } from "react-router";
+import { useNavTransition } from "@hooks/useNavTransition";
 import { preloadRoute } from "@utils/routePreloaders";
 import RelativeTime from "@components/RelativeTime";
 import SeverityChip from "@components/SeverityChip";
 import StateChip from "@components/StateChip";
 import WorkStateChip from "@components/WorkStateChip";
+import CasePreviewDrawer from "@features/csm-cases/components/CasePreviewDrawer";
 import type { CsmCaseRow } from "@features/csm-cases/types/csmCases";
 import type { CasesSortOrder } from "@features/csm-cases/utils/casesSort";
 import {
@@ -83,11 +88,13 @@ const HEADER_CELLS_WITHOUT_SEVERITY: string[] = [
 // Subject gets the lion's share of the row; the ids sit in their own narrow
 // column so a long subject no longer has to share one cell with them.
 // The work-state chip (only present for WIP cases) stacks under the State chip
-// in the State column, so it doesn't need a column of its own.
+// in the State column, so it doesn't need a column of its own. The trailing
+// `auto` track (unlabeled in the header, like the one before it for "Updated")
+// holds the per-row quick-preview action.
 const GRID_WITH_SEVERITY =
-  "minmax(120px, 0.9fr) minmax(280px, 3fr) minmax(140px, 1fr) auto auto minmax(110px, 1fr) auto";
+  "minmax(120px, 0.9fr) minmax(280px, 3fr) minmax(140px, 1fr) auto auto minmax(110px, 1fr) auto auto";
 const GRID_WITHOUT_SEVERITY =
-  "minmax(120px, 0.9fr) minmax(280px, 3fr) minmax(140px, 1fr) minmax(110px, 1fr) auto";
+  "minmax(120px, 0.9fr) minmax(280px, 3fr) minmax(140px, 1fr) minmax(110px, 1fr) auto auto";
 
 export default function CasesList({
   cases,
@@ -100,6 +107,8 @@ export default function CasesList({
 }: CasesListProps): JSX.Element {
   const theme = useTheme();
   const location = useLocation();
+  const navigate = useNavTransition();
+  const [previewRow, setPreviewRow] = useState<CsmCaseRow | null>(null);
   const headerCells = hideSeverityColumn
     ? HEADER_CELLS_WITHOUT_SEVERITY
     : HEADER_CELLS_WITH_SEVERITY;
@@ -175,6 +184,8 @@ export default function CasesList({
             Updated
           </Typography>
         )}
+        {/* Unlabeled — holds the per-row quick-preview action. */}
+        <Box />
       </Box>
 
       {/* Rows */}
@@ -206,19 +217,12 @@ export default function CasesList({
       {!isLoading &&
         cases.map((c) => {
           const rowBasePath = detailBasePath ?? caseTypeDetailBasePath(c.caseType);
+          const rowState = { from: `${location.pathname}${location.search}` };
+          const rowLabel = c.wso2CaseId || c.caseNumber || c.subject;
           return (
-            // A real anchor (not a click-handler div) so the row supports
-            // cmd/middle-click "open in new tab" — essential when an engineer
-            // pulls up other cases for reference — and exposes a copyable URL
-            // (ISSU-031). RouterLink keeps plain left-click as in-app SPA nav.
             <Box
               key={c.id}
-              component={RouterLink}
-              to={`${rowBasePath}/${c.id}`}
-              // Carries the current (filtered) list URL forward so the detail
-              // page's back button can return to it instead of a bare,
-              // filter-less list path.
-              state={{ from: `${location.pathname}${location.search}` }}
+              onClick={() => navigate(`${rowBasePath}/${c.id}`, { state: rowState })}
               onMouseEnter={() => preloadRoute(rowBasePath)}
               sx={{
                 gridColumn: "1 / -1",
@@ -231,21 +235,39 @@ export default function CasesList({
                 borderBottom: 1,
                 borderColor: "divider",
                 cursor: "pointer",
-                color: "inherit",
-                textDecoration: "none",
                 "&:hover": {
                   bgcolor: "action.hover",
-                },
-                "&:focus-visible": {
-                  outline: `2px solid ${theme.palette.primary.main}`,
-                  outlineOffset: -2,
                 },
                 "&:last-of-type": { borderBottom: 0 },
               }}
             >
               {/* Case ids: WSO2 internal id on top, CS number beneath. Never
-                  the UUID. "—" when the case has neither yet. */}
-              <Box sx={{ minWidth: 0 }}>
+                  the UUID. "—" when the case has neither yet. This block is
+                  the row's one real anchor — cmd/middle-click "open in new
+                  tab" (essential when pulling up other cases for reference),
+                  a copyable URL (ISSU-031), and a keyboard tab stop. The rest
+                  of the row relies on the onClick above for a mouse click
+                  anywhere in it; making the whole row a real anchor (or a
+                  role="button" override) would either force the quick-preview
+                  button below into invalid button-inside-anchor nesting, or
+                  strip the row's cells of their own semantics. */}
+              <Box
+                component={RouterLink}
+                to={`${rowBasePath}/${c.id}`}
+                state={rowState}
+                aria-label={`Open ${rowLabel}`}
+                sx={{
+                  minWidth: 0,
+                  color: "inherit",
+                  textDecoration: "none",
+                  display: "block",
+                  "&:focus-visible": {
+                    outline: `2px solid ${theme.palette.primary.main}`,
+                    outlineOffset: 2,
+                    borderRadius: 0.5,
+                  },
+                }}
+              >
                 {c.wso2CaseId && (
                   <Typography
                     variant="body2"
@@ -328,9 +350,26 @@ export default function CasesList({
               <Typography variant="caption" color="text.secondary" noWrap>
                 <RelativeTime iso={c.updatedAt} />
               </Typography>
+              {/* Quick preview. `stopPropagation` keeps the click from also
+                  bubbling up into the row's own onClick (which would open the
+                  full case instead of just previewing it). */}
+              <Tooltip title={`Quick preview ${rowLabel}`}>
+                <IconButton
+                  size="small"
+                  aria-label={`Quick preview ${rowLabel}`}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setPreviewRow(c);
+                  }}
+                  sx={{ justifySelf: "end" }}
+                >
+                  <Eye size={16} />
+                </IconButton>
+              </Tooltip>
             </Box>
           );
         })}
+      <CasePreviewDrawer row={previewRow} onClose={() => setPreviewRow(null)} />
     </Box>
   );
 }


### PR DESCRIPTION
## Purpose
The team wants a quick preview option in
the cases list view, so you don't have to open the full case detail page for a quick look at
its current state and comments — the same thing ServiceNow and Jira offer from their own list
views. The thread landed on a preview trigger opening some kind of panel, while flagging two
concerns worth designing around: showing everything as table columns doesn't work (comments
don't fit a column), and a heavy modal risks "just repeating the same thing" as the real detail
page.

## Goals
Let an engineer glance at a case's state and recent comments straight from the list, without
navigating away, and without cluttering the row when they don't need it.

## Approach
A right-side drawer (`CasePreviewDrawer`), opened by an Eye icon on each row, showing:
subject/state/severity/project/product/assignee, plus the last 5 comments (reusing the existing
`CsmCaseCommentBubble` renderer so styling/behavior matches the real Activities tab), and a
"View full details" button for anything the drawer doesn't cover. Deliberately thin — no
composer, no action bar, no full audit timeline — so it stays a quick look rather than a second
copy of the case detail page.

Adding the icon required restructuring how a row navigates: previously the entire row was one
`<a>` (`RouterLink`), which would have forced the new icon `<button>` to nest inside an anchor —
invalid HTML, unreliable for assistive tech. Switched to the pattern already used elsewhere in
this codebase (`ChildCasesWidget.tsx` / `LinkedServiceRequestsWidget.tsx`): a row-level `onClick`
(bubbling-based navigation, so a click anywhere in the row still works) plus one real
`RouterLink` around the case-id block specifically, for cmd/middle-click "open in new tab", a
copyable URL, and a keyboard tab stop. The preview icon's `onClick` stops propagation so it opens
the drawer instead of also triggering the row's navigate.

Because `CasesList` is the shared table behind `CsmIssuesView`, this lands on Cases, Operations →
Service Requests, Security Center → Security Reports, and Engagements all at once — no changes
needed in any of those four callers.

## User stories
As a CS engineer scanning the cases list, I can click a preview icon on any row to see its
current state and recent comments inline, then either close the preview or jump to the full case
if I need more.

## Release note
The cases list (and the Service Requests / Security Reports / Engagements lists that share it)
now has a quick-preview action per row — a side panel with the case's current state and last few
comments, without leaving the list.

## Documentation
N/A — no published documentation covers this internal UI behavior.

## Training
N/A.

## Certification
N/A.

## Marketing
N/A.

## Automation tests
- Unit tests: `CasesList.test.tsx` updated — mocks `@api/backend/client` and wraps renders in a
  `QueryClientProvider` (the list now always renders a `CasePreviewDrawer`, closed by default,
  which calls `useGetCsmCaseComments`; that hook needs a real QueryClient even while its query
  stays disabled). Added a test asserting the preview icon opens the drawer without navigating —
  the exact failure mode an earlier version of this change had (see commit `4332ed19a`'s message
  for what that bug was and why `fireEvent.click` caught it).
- `tsc -b`, `eslint` clean on all three touched files.
- `vitest run src/features/csm-cases`: passes except the 2 pre-existing `LinkCaseDialog.test.tsx`
  failures and `CaseActionBar.test.tsx`'s missing-config error, both confirmed unrelated via
  `git stash` earlier in the same working session.
- Production `vite build` clean.
- Integration tests: none — no integration-test harness exists for this app. **Not manually
  verified in a browser** — no live backend/Asgardeo session available in this environment.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? no — TypeScript/React only, nothing for a JVM tool to analyse.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
None.

## Migrations (if applicable)
N/A — no schema or data change, UI-only.

## Test environment
- Node.js, pnpm (via `./node_modules/.bin/*` directly — the `pnpm` CLI itself errors with
  "packages field missing or empty" in this environment).
- macOS.
- `tsc -b`, `eslint`, `vitest`, `vite build` — all clean as noted above.
- Not manually verified in a browser against a live backend in this session.

## Learning
N/A.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added quick preview for cases directly from the case list.
  * View case details, status, severity, metadata, and recent comments without leaving the list.
  * Recent comments appear newest first, with up to five displayed.
  * Added a link from the preview to the full case details.
* **Usability Improvements**
  * Clicking a case row opens its details, while case ID links and keyboard navigation remain available.
  * Added clear loading, error, and empty states to the preview.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->