### PR TITLE
[CSM Portal] clarify case-pause messaging as blocking public replies, not customer replies

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -955,7 +955,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
               onSuccess: () =>
                 setFeedback({
                   message:
-                    "Work paused — customer replies are disabled until you resume.",
+                    "Work paused — you can't post public replies until you resume.",
                   severity: "warning",
                   sticky: true,
                 }),

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/caseWorkState.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/caseWorkState.ts
@@ -48,7 +48,7 @@ export function publicCommentGateReason(
 ): string | null {
   if (caseAcceptsPublicComments(state, workState)) return null;
   if (state === "work_in_progress" && workState === "paused") {
-    return "This case is paused — customer replies are disabled. Resume work to reply to the customer.";
+    return "This case is paused — public replies are disabled. Resume work to reply to the customer.";
   }
   return "Customer replies are disabled unless the case is actively in progress.";
 }


### PR DESCRIPTION
## Purpose
The messaging shown when a case is paused implied the customer could no longer reply/comment on the case at all. That's not what pausing does — it only disables the CS engineer's ability to post public (customer-visible) replies until the case is resumed.

## Goals
Make the pause toast and the comment-composer hint accurately describe the restriction.

## Approach
Two hardcoded, plain-text strings updated to say "public replies" are disabled rather than "customer replies": the pause success toast, and the composer's persistent hint text shown while a case is paused. No behavior change — pause/resume logic and the public-comment gating logic are untouched, this is copy-only.

## User stories
As a CS engineer, when I pause a case I see accurate messaging about what's actually restricted, instead of a message implying the customer is blocked from replying.

## Release note
Reworded the case-pause messaging to correctly describe that pausing blocks the engineer's public replies, not the customer's.

## Documentation
N/A — UI copy only, no documented behavior changed.

## Training
N/A — not training content.

## Certification
N/A — no certification exam impact.

## Marketing
N/A — copy fix, not a marketable feature.

## Automation tests
 - Unit tests
   No existing test pinned the old exact string text (the one relevant test uses a loose `/paused/i` regex), so no test changes were needed; verified via lint/build/full test suite (compared against the same run on unmodified `main` to confirm no new failures).
 - Integration tests
   N/A — no e2e spec covers this exact string.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A for TypeScript — ran `eslint`/`tsc -b`, both clean
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no sample app impact.

## Related PRs
None.

## Migrations (if applicable)
N/A — no data/schema migration.

## Test environment
Verified locally: `pnpm run lint`, `pnpm run build` (`tsc -b && vite build`), and `vitest run` (full suite, compared against unmodified `main` — identical pass/fail counts) all clean.

## Learning
N/A.
