### PR TITLE
[CSM Portal] remove Account Manager and Region rows from the case customer card

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.tsx
@@ -38,7 +38,6 @@ import {
   Eye,
   History,
   Link as LinkIcon,
-  MapPin,
   Paperclip,
   Plus,
   Search,
@@ -241,23 +240,11 @@ export function CustomerContextWidget({
           )}
         </Typography>
       </MetaRow>
-      <MetaRow label="Account Manager">
-        <Typography variant="body2">{ctx.accountManager}</Typography>
-      </MetaRow>
       {ctx.technicalOwner && (
         <MetaRow label="Technical Owner">
           <Typography variant="body2">{ctx.technicalOwner}</Typography>
         </MetaRow>
       )}
-      <MetaRow label="Region">
-        <Typography
-          variant="body2"
-          sx={{ display: "flex", alignItems: "center", gap: 0.5 }}
-        >
-          <MapPin size={12} />
-          {ctx.region}
-        </Typography>
-      </MetaRow>
       {(ctx.creTeam || ctx.sreTeam) && (
         <MetaRow label="CRE / SRE team">
           <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5 }}>


### PR DESCRIPTION
## Purpose
The Customer card on a case's Details tab showed Account Manager and Region fields that aren't relevant to the CS engineer's case-detail workflow.

## Goals
Remove those two fields from the card.

## Approach
Deleted the "Account Manager" and "Region" rows from `CustomerContextWidget` (the Customer card), plus the now-unused `MapPin` icon import. Every other row in the card, an unrelated second "Region" row in a different widget (deployment/product context), and the underlying data type are all untouched — this is purely a display-layer removal, not a data-model change.

## User stories
As a CS engineer viewing a case's Details tab, the Customer card only shows fields relevant to handling the case.

## Release note
Removed the Account Manager and Region fields from the case Details tab's Customer card.

## Documentation
N/A — UI-only removal, no documented behavior changed.

## Training
N/A — not training content.

## Certification
N/A — no certification exam impact.

## Marketing
N/A — minor UI cleanup, not a marketable feature.

## Automation tests
 - Unit tests
   `CaseDetailWidgets.test.tsx` (23 tests) covers this component and only used the removed fields as fixture data, not as assertions — no test changes were needed; full file re-run passes.
 - Integration tests
   N/A — no e2e spec asserts on these specific fields.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A for TypeScript — ran `eslint`/`tsc -b`, both clean
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no sample app impact.

## Related PRs
None.

## Migrations (if applicable)
N/A — no data/schema migration.

## Test environment
Verified locally: `eslint`, `pnpm run build` (`tsc -b && vite build`), and `vitest run CaseDetailWidgets.test.tsx` (23/23) all clean.

## Learning
N/A.
