### PR TITLE
[CSM Portal] reorder dashboard header selectors, add per-section refresh

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetPieData.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetPieData.test.tsx
@@ -49,7 +49,7 @@ describe("useWidgetPieData", () => {
 
     const { result } = renderHook(
       () =>
-        useWidgetPieData("case", { states: ["open"] }, [
+        useWidgetPieData("widget-1", "case", { states: ["open"] }, [
           { label: "Critical", query: { severities: "critical" } },
           { label: "High", query: { severities: "high" } },
         ]),
@@ -75,7 +75,7 @@ describe("useWidgetPieData", () => {
   });
 
   it("fires no queries and returns a zero total for an empty slices array", () => {
-    const { result } = renderHook(() => useWidgetPieData("case", {}, []), { wrapper });
+    const { result } = renderHook(() => useWidgetPieData("widget-1", "case", {}, []), { wrapper });
 
     expect(postMock).not.toHaveBeenCalled();
     expect(result.current.slices).toEqual([]);
@@ -89,6 +89,7 @@ describe("useWidgetPieData", () => {
     const { result } = renderHook(
       () =>
         useWidgetPieData(
+          "widget-1",
           "case",
           { filters: [{ field: "state", op: "in", values: ["open"] }] },
           [
@@ -129,6 +130,7 @@ describe("useWidgetPieData", () => {
     renderHook(
       () =>
         useWidgetPieData(
+          "widget-1",
           "case",
           { filters: [{ field: "state", op: "in", values: ["open"] }] },
           [
@@ -163,7 +165,7 @@ describe("useWidgetPieData", () => {
 
     const { result } = renderHook(
       () =>
-        useWidgetPieData("case", {}, [
+        useWidgetPieData("widget-1", "case", {}, [
           { label: "A", query: { a: "1" } },
           { label: "B", query: { b: "2" } },
         ]),

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetPieData.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetPieData.ts
@@ -43,6 +43,7 @@ export interface WidgetPieData {
  * fires no queries at all.
  */
 export function useWidgetPieData(
+  widgetId: string,
   resourceType: BeWidgetResourceType,
   baseFilters: Record<string, unknown>,
   slices: BeDashboardPieSlice[],
@@ -65,6 +66,7 @@ export function useWidgetPieData(
         queryKey: [
           ApiQueryKeys.CSM_DASHBOARD_WIDGET_DATA,
           "pie-slice",
+          widgetId,
           resourceType,
           filters,
         ],

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/AbtDashboardHeader.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/AbtDashboardHeader.test.tsx
@@ -86,7 +86,9 @@ describe("AbtDashboardHeader", () => {
       pagination: { offset: 0, limit: 100 },
     });
 
-    const [teamSelect] = screen.getAllByRole("combobox");
+    // Dashboard order is: dashboard selector, then team selector — see
+    // AbtDashboardHeader's layout.
+    const [, teamSelect] = screen.getAllByRole("combobox");
     fireEvent.mouseDown(teamSelect);
     const listbox = await screen.findByRole("listbox");
     // The teams query resolves asynchronously; retry (findByText) rather
@@ -116,7 +118,9 @@ describe("AbtDashboardHeader", () => {
       />,
     );
 
-    const [teamSelect] = screen.getAllByRole("combobox");
+    // Dashboard order is: dashboard selector, then team selector — see
+    // AbtDashboardHeader's layout.
+    const [, teamSelect] = screen.getAllByRole("combobox");
     fireEvent.mouseDown(teamSelect);
     const listbox = await screen.findByRole("listbox");
     fireEvent.click(await within(listbox).findByText("CS Team Leads"));

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/AbtDashboardHeader.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/AbtDashboardHeader.tsx
@@ -83,6 +83,20 @@ export default function AbtDashboardHeader({
         </Typography>
       </Box>
       <Box sx={{ display: "flex", gap: 1, alignItems: "center", flexWrap: "wrap" }}>
+        <FormControl size="small" sx={{ minWidth: 200 }}>
+          <Select
+            value={dashboardKey}
+            onChange={(e) => onDashboardChange(e.target.value as DashboardKey)}
+            displayEmpty
+            aria-label="Select dashboard"
+          >
+            {dashboardList.map((o) => (
+              <MenuItem key={o.id} value={o.id}>
+                {o.displayName}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
         {isTeamBased && (
           <FormControl size="small" sx={{ minWidth: 180 }}>
             <Select
@@ -99,20 +113,6 @@ export default function AbtDashboardHeader({
             </Select>
           </FormControl>
         )}
-        <FormControl size="small" sx={{ minWidth: 200 }}>
-          <Select
-            value={dashboardKey}
-            onChange={(e) => onDashboardChange(e.target.value as DashboardKey)}
-            displayEmpty
-            aria-label="Select dashboard"
-          >
-            {dashboardList.map((o) => (
-              <MenuItem key={o.id} value={o.id}>
-                {o.displayName}
-              </MenuItem>
-            ))}
-          </Select>
-        </FormControl>
       </Box>
     </Box>
   );

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/AgentsLandingPagePilot.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/AgentsLandingPagePilot.test.tsx
@@ -158,34 +158,25 @@ describe("AgentsLandingPagePilot", () => {
     expect(screen.queryByText("3")).not.toBeInTheDocument();
   });
 
-  it("shows skeleton tiles again and re-fetches every widget's own data when refresh is clicked", async () => {
-    getMock.mockResolvedValueOnce(DASHBOARD_DETAIL);
+  it("re-fetches only that section's own widgets when its refresh button is clicked, without re-pulling the dashboard config", async () => {
+    getMock.mockResolvedValue(DASHBOARD_DETAIL);
     postMock.mockResolvedValue(searchResponseFor(3));
 
-    const { container } = renderWithClient(<AgentsLandingPagePilot dashboardId="agents_pilot" />);
+    renderWithClient(<AgentsLandingPagePilot dashboardId="agents_pilot" />);
     await waitFor(() => expect(screen.getByText("My Patches")).toBeInTheDocument());
     expect(postMock).toHaveBeenCalledTimes(3);
+    expect(getMock).toHaveBeenCalledTimes(1);
 
-    let resolveRefetch: (value: typeof DASHBOARD_DETAIL) => void = () => {};
-    getMock.mockReturnValueOnce(
-      new Promise((resolve) => {
-        resolveRefetch = resolve;
-      }),
-    );
+    // All three DASHBOARD_DETAIL widgets are unsectioned, so they share the
+    // one untitled default group — its refresh button carries a plain
+    // "Refresh section" label (no section name to fold into it).
+    fireEvent.click(screen.getByRole("button", { name: "Refresh section" }));
 
-    fireEvent.click(screen.getByRole("button", { name: "Refresh widget pilot" }));
-
-    // Skeletons reappear immediately, before the held-open refetch resolves —
-    // not just stale tiles sitting there while new data loads underneath.
-    await waitFor(() =>
-      expect(container.querySelectorAll(".MuiSkeleton-root").length).toBe(3),
-    );
-
-    resolveRefetch(DASHBOARD_DETAIL);
-
-    // Every widget's own /cases/search re-runs too, not just the dashboard
-    // metadata — 3 more calls on top of the initial 3.
+    // Every widget in that section re-runs its own /cases/search — 3 more
+    // calls on top of the initial 3 — but the dashboard's own metadata GET
+    // is not re-pulled (a section refresh is data-only).
     await waitFor(() => expect(postMock).toHaveBeenCalledTimes(6));
+    expect(getMock).toHaveBeenCalledTimes(1);
     expect(screen.getByText("My Patches")).toBeInTheDocument();
   });
 

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/AgentsLandingPagePilot.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/AgentsLandingPagePilot.tsx
@@ -106,44 +106,50 @@ export default function AgentsLandingPagePilot({
   selectedTeamGroupId,
 }: AgentsLandingPagePilotProps): JSX.Element {
   const queryClient = useQueryClient();
-  const { data, isLoading, isError, isFetching, refetch } =
-    useDashboard(dashboardId);
-  // Separate from `isFetching` (which only covers the dashboard's own
-  // metadata refetch): each tile resolves its own count/list data via its
-  // own `useWidgetData` query, so a "refresh" click has to also invalidate
-  // those — tracked here so the skeleton grid stays up across the whole
-  // round trip, not just the metadata half of it.
-  const [isRefreshing, setIsRefreshing] = useState(false);
+  const { data, isLoading, isError } = useDashboard(dashboardId);
+  // Per-section refresh (below) tracks its own in-flight state, keyed by
+  // section, independently of the dashboard-metadata refresh above — a
+  // section refresh never touches `useDashboard`'s own refetch (config is
+  // not re-pulled), only that section's own widgets' data queries.
+  const [refreshingSections, setRefreshingSections] = useState<Set<string>>(new Set());
 
-  const handleRefresh = async (): Promise<void> => {
-    setIsRefreshing(true);
+  /**
+   * Invalidates only the widget-data queries belonging to `widgetIds` —
+   * both shapes' query keys carry a widget id, just at a different
+   * position: `[KEY, widgetId, ...]` for count/list (see `useWidgetData`),
+   * `[KEY, "pie-slice", widgetId, ...]` for pie/bar (see
+   * `useWidgetPieData`). Never touches `useDashboard`'s own metadata query.
+   */
+  const invalidateWidgets = (widgetIds: Set<string>): Promise<void> =>
+    queryClient.invalidateQueries({
+      predicate: (query) => {
+        const key = query.queryKey;
+        if (key[0] !== ApiQueryKeys.CSM_DASHBOARD_WIDGET_DATA) return false;
+        const widgetId = key[1] === "pie-slice" ? key[2] : key[1];
+        return typeof widgetId === "string" && widgetIds.has(widgetId);
+      },
+    });
+
+  const handleSectionRefresh = async (sectionKey: string, widgetIds: Set<string>): Promise<void> => {
+    setRefreshingSections((prev) => new Set(prev).add(sectionKey));
     try {
-      await Promise.all([
-        refetch(),
-        queryClient.invalidateQueries({
-          queryKey: [ApiQueryKeys.CSM_DASHBOARD_WIDGET_DATA],
-        }),
-      ]);
+      await invalidateWidgets(widgetIds);
     } finally {
-      setIsRefreshing(false);
+      setRefreshingSections((prev) => {
+        const next = new Set(prev);
+        next.delete(sectionKey);
+        return next;
+      });
     }
   };
 
   return (
-    <SectionCard
-      action={
-        <RefreshButton
-          onRefresh={() => void handleRefresh()}
-          isFetching={isFetching || isRefreshing}
-          label="Refresh widget pilot"
-        />
-      }
-    >
+    <SectionCard>
       {isError ? (
         <Typography variant="body2" color="text.secondary">
           Could not load the widget pilot.
         </Typography>
-      ) : isLoading || isRefreshing ? (
+      ) : isLoading ? (
         <Box sx={WIDGET_GRID_SX}>
           {Array.from({ length: PILOT_TILE_COUNT }, (_, i) => (
             <Card key={i} variant="outlined" sx={{ p: 1.75, gridColumn: "span 4" }}>
@@ -184,15 +190,35 @@ export default function AgentsLandingPagePilot({
                 const chartWidgets = group.widgets.filter((w) => w.shape === "pie" || w.shape === "bar");
                 if (mainWidgets.length === 0 && chartWidgets.length === 0) return null;
 
+                const sectionKey = group.section ?? `__default_${i}`;
+                const sectionWidgetIds = new Set(group.widgets.map((w) => w.widgetId));
+
                 return (
-                  <Fragment key={group.section ?? `__default_${i}`}>
+                  <Fragment key={sectionKey}>
                     {i > 0 && <Divider />}
                     <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
-                      {group.section && (
-                        <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
-                          {group.section}
-                        </Typography>
-                      )}
+                      <Box
+                        sx={{
+                          display: "flex",
+                          alignItems: "center",
+                          justifyContent: group.section ? "space-between" : "flex-end",
+                        }}
+                      >
+                        {group.section && (
+                          <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+                            {group.section}
+                          </Typography>
+                        )}
+                        <RefreshButton
+                          onRefresh={() => void handleSectionRefresh(sectionKey, sectionWidgetIds)}
+                          isFetching={refreshingSections.has(sectionKey)}
+                          label={
+                            group.section
+                              ? `Refresh ${group.section}`
+                              : "Refresh section"
+                          }
+                        />
+                      </Box>
                       {mainWidgets.length > 0 && (
                         <Box sx={WIDGET_GRID_SX}>{mainWidgets.map(renderTile)}</Box>
                       )}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
@@ -106,6 +106,7 @@ export default function DashboardWidgetTile({
     selectedTeamGroupId,
   );
   const pieData = useWidgetPieData(
+    widgetId,
     resourceType,
     filters,
     shape === "pie" || shape === "bar" ? (slices ?? []) : [],

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/pages/CsmDashboardPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/pages/CsmDashboardPage.test.tsx
@@ -242,10 +242,11 @@ describe("CsmDashboardPage", () => {
 
     renderAt("/dashboard#team_performance.cs_team_leads");
 
-    // Two comboboxes render for a team-based dashboard (team + dashboard);
-    // the dashboard switcher is always the second.
+    // Two comboboxes render for a team-based dashboard (dashboard + team);
+    // the dashboard switcher is always the first — see AbtDashboardHeader's
+    // layout (dashboard selector, then team selector).
     const selects = screen.getAllByRole("combobox");
-    const select = selects[selects.length - 1];
+    const select = selects[0];
     fireEvent.mouseDown(select);
     fireEvent.click(within(screen.getByRole("listbox")).getByText("Operations"));
 


### PR DESCRIPTION
## Purpose
Two related dashboard-header improvements: the team selector rendered before the dashboard selector even though its availability depends on which dashboard is picked, and refreshing dashboard data required a single button that re-pulled every widget on the page even if you only cared about one section.

## Goals
Reorder the header so the dashboard selector comes first, and give each dashboard section its own scoped refresh control.

## Approach
**Header reorder**: moved the dashboard `Select` before the team `Select` in `AbtDashboardHeader`; the team selector's `isTeamBased` visibility condition is unchanged, only its position moved.

**Per-section refresh**: removed the single global refresh button (which refetched the dashboard's widget-config metadata AND invalidated every widget's data query). Each section — titled or the untitled default group — now gets its own refresh button in a small header row, invalidating only that section's own widgets' React Query data. This works because each widget already fetches its own data independently (`useWidgetData` for count/list, `useWidgetPieData` for pie/bar); the section refresh just needs to target the right subset by widget id. Pie/bar widget queries didn't previously carry a `widgetId` in their query key (only count/list did), so that was added as a prerequisite for scoping invalidation correctly to both shapes. A section refresh never re-pulls the dashboard's widget-config list — only that section's data.

No screenshot included — this is a header-layout reorder plus a repeated small icon-button addition per section, same visual pattern already used elsewhere in the app.

## User stories
As a CS engineer viewing a team-based dashboard, I pick the dashboard first and then narrow by team, matching the actual dependency between the two controls. As any dashboard viewer, I can refresh just the section I'm looking at instead of waiting on every widget on the page to reload.

## Release note
Reordered the dashboard header (dashboard selector before team selector) and replaced the single dashboard-wide refresh button with a refresh button per section.

## Documentation
N/A — internal portal UI behavior, no external doc impact.

## Training
N/A — not training content.

## Certification
N/A — no certification exam impact.

## Marketing
N/A — internal UX improvement, not a marketable feature.

## Automation tests
 - Unit tests
   Updated existing tests asserting the old header order (`AbtDashboardHeader.test.tsx`, `CsmDashboardPage.test.tsx`) and the old single-refresh-button behavior (`AgentsLandingPagePilot.test.tsx`, now asserting a section's refresh button only re-fetches that section's widgets); updated all `useWidgetPieData` call sites for the new `widgetId` parameter. Full `csm-dashboard` suite: 14 files, 121 tests, all passing.
 - Integration tests
   N/A — no e2e spec covers this header/refresh interaction.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A for TypeScript — ran `eslint`/`tsc -b`, both clean
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no sample app impact.

## Related PRs
None.

## Migrations (if applicable)
N/A — no data/schema migration.

## Test environment
Verified locally: `eslint`, `pnpm run build` (`tsc -b && vite build`), and `vitest run src/features/csm-dashboard` (14 files / 121 tests, all passing) all clean.

## Learning
N/A.
