### PR TITLE
[CSM Portal] five small fixes: PDF preview, pause wording, customer card fields, dashboard header, All-ABTs team scope

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-cases/components/AttachmentPreviewDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/AttachmentPreviewDialog.tsx
@@ -16,6 +16,7 @@
 
 import {
   Box,
+  Button,
   CircularProgress,
   Dialog,
   DialogContent,
@@ -24,7 +25,7 @@ import {
   Typography,
 } from "@wso2/oxygen-ui";
 import { X } from "@wso2/oxygen-ui-icons-react";
-import { useEffect, useState, type JSX } from "react";
+import { useEffect, useRef, useState, type JSX } from "react";
 import type { CaseAttachment } from "@features/csm-cases/types/csmCases";
 import { getAttachmentPreviewKind } from "@features/csm-cases/utils/attachmentPreview";
 
@@ -43,12 +44,13 @@ interface AttachmentPreviewDialogProps {
 }
 
 /**
- * Inline preview for image/PDF attachments (the two families in the
- * backend's safe-content-type allowlist that make sense to render inline —
- * see {@link getAttachmentPreviewKind}). Fetches the attachment's
- * bytes via `fetchContent` (the same authenticated content endpoint the
- * download action uses) and renders them from a `blob:` object URL, which is
- * revoked on close/unmount to avoid leaking memory.
+ * Preview for image/PDF attachments (the two families in the backend's
+ * safe-content-type allowlist that make sense to preview — see
+ * {@link getAttachmentPreviewKind}). Fetches the attachment's bytes via
+ * `fetchContent` (the same authenticated content endpoint the download
+ * action uses) and turns them into a `blob:` object URL, which is revoked on
+ * close/unmount to avoid leaking memory. Images render inline; PDFs open in
+ * a new browser tab instead (see the PDF-branch comment below for why).
  */
 export default function AttachmentPreviewDialog({
   attachment,
@@ -58,6 +60,9 @@ export default function AttachmentPreviewDialog({
   const [objectUrl, setObjectUrl] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Guards the auto-open effect below so a PDF is only opened in a new tab
+  // once per loaded object URL, not on every re-render.
+  const pdfAutoOpenedUrlRef = useRef<string | null>(null);
 
   // Track which attachment the state above belongs to, and reconcile it
   // *synchronously during render* the moment `attachment` changes (React's
@@ -74,6 +79,7 @@ export default function AttachmentPreviewDialog({
     setObjectUrl(null);
     setError(null);
     setLoading(!!attachment);
+    pdfAutoOpenedUrlRef.current = null;
   }
 
   useEffect(() => {
@@ -109,6 +115,24 @@ export default function AttachmentPreviewDialog({
 
   const kind = attachment ? getAttachmentPreviewKind(attachment.contentType) : null;
   const open = !!attachment;
+
+  // PDFs used to render inline in a sandboxed iframe pointed at the blob
+  // URL, but Chrome's built-in PDF viewer refuses to render at all inside a
+  // sandboxed iframe (https://crbug.com/413851) and shows its own
+  // "blocked by Chrome" interstitial instead of the PDF, regardless of which
+  // sandbox flags are set. There is no fix that keeps the preview inline
+  // without either dropping the sandbox (unsafe for attacker-controlled
+  // bytes) or shipping a pdf.js renderer, so PDFs are opened in a new tab
+  // instead. This fires once automatically as soon as the blob is ready;
+  // the button below is the fallback for when the browser's popup blocker
+  // swallows that automatic call (it runs from a user click, so it is never
+  // blocked).
+  useEffect(() => {
+    if (kind !== "pdf" || !objectUrl) return;
+    if (pdfAutoOpenedUrlRef.current === objectUrl) return;
+    pdfAutoOpenedUrlRef.current = objectUrl;
+    window.open(objectUrl, "_blank", "noopener,noreferrer");
+  }, [kind, objectUrl]);
 
   return (
     <Dialog
@@ -168,26 +192,28 @@ export default function AttachmentPreviewDialog({
           />
         ) : objectUrl && kind === "pdf" ? (
           <Box
-            component="iframe"
-            src={objectUrl}
-            title={attachment?.filename}
-            // The PDF bytes come from an uploaded attachment, so treat this
-            // as untrusted content even though it is served from a
-            // same-origin `blob:` URL. `allow-same-origin` is required for
-            // Chrome/Firefox's built-in PDF viewer to render at all inside a
-            // sandboxed iframe (verified: without it the viewer shows a
-            // broken-plugin placeholder instead of the PDF). Deliberately NOT
-            // combined with `allow-scripts`: `allow-same-origin` +
-            // `allow-scripts` together is a known sandbox-defeating pattern
-            // (the frame gets both a real origin and the ability to run
-            // script, so any embedded PDF JS action could reach this page's
-            // own origin/session). The browser's built-in PDF viewer is a
-            // native renderer, not scripted web content, so it doesn't need
-            // `allow-scripts` to display/scroll/zoom a PDF; `allow-forms`
-            // isn't needed for a read-only preview either.
-            sandbox="allow-same-origin"
-            sx={{ width: "100%", height: "70vh", border: 0 }}
-          />
+            sx={{
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              gap: 2,
+              textAlign: "center",
+              p: 3,
+            }}
+          >
+            <Typography variant="body2" color="text.secondary">
+              PDF attachments open in a new browser tab.
+            </Typography>
+            <Button
+              variant="outlined"
+              size="small"
+              onClick={() =>
+                window.open(objectUrl, "_blank", "noopener,noreferrer")
+              }
+            >
+              Open {attachment?.filename}
+            </Button>
+          </Box>
         ) : null}
       </DialogContent>
     </Dialog>

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.tsx
@@ -38,7 +38,6 @@ import {
   Eye,
   History,
   Link as LinkIcon,
-  MapPin,
   Paperclip,
   Plus,
   Search,
@@ -241,23 +240,11 @@ export function CustomerContextWidget({
           )}
         </Typography>
       </MetaRow>
-      <MetaRow label="Account Manager">
-        <Typography variant="body2">{ctx.accountManager}</Typography>
-      </MetaRow>
       {ctx.technicalOwner && (
         <MetaRow label="Technical Owner">
           <Typography variant="body2">{ctx.technicalOwner}</Typography>
         </MetaRow>
       )}
-      <MetaRow label="Region">
-        <Typography
-          variant="body2"
-          sx={{ display: "flex", alignItems: "center", gap: 0.5 }}
-        >
-          <MapPin size={12} />
-          {ctx.region}
-        </Typography>
-      </MetaRow>
       {(ctx.creTeam || ctx.sreTeam) && (
         <MetaRow label="CRE / SRE team">
           <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5 }}>

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -955,7 +955,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
               onSuccess: () =>
                 setFeedback({
                   message:
-                    "Work paused — customer replies are disabled until you resume.",
+                    "Work paused — you can't post public replies until you resume.",
                   severity: "warning",
                   sticky: true,
                 }),

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/caseWorkState.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/caseWorkState.ts
@@ -48,7 +48,7 @@ export function publicCommentGateReason(
 ): string | null {
   if (caseAcceptsPublicComments(state, workState)) return null;
   if (state === "work_in_progress" && workState === "paused") {
-    return "This case is paused — customer replies are disabled. Resume work to reply to the customer.";
+    return "This case is paused — public replies are disabled. Resume work to reply to the customer.";
   }
   return "Customer replies are disabled unless the case is actively in progress.";
 }

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetData.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetData.ts
@@ -56,13 +56,14 @@ export function useWidgetData(
    * `widgetPreviewUrl.ts`) into the signed-in user's real id, so a request
    * never goes out with the literal placeholder still in it. */
   enabled = true,
-  /** The currently selected team's own `groupId`, used to resolve a case
-   * widget's `__current_team__` filter placeholder (see
-   * `teamFilterPlaceholder.ts`) before it's sent. `undefined` for a
-   * non-team-based dashboard, or while the team isn't resolved yet — in
-   * which case any `integrationCsTeam` entry carrying that placeholder is
-   * dropped rather than sent literally. */
-  selectedTeamGroupId?: string,
+  /** The currently selected team's own `groupId`, or an array of every
+   * team's `groupId` in the current dashboard's family for the "All ABTs"
+   * option (see `ALL_TEAMS_SENTINEL`), used to resolve a case widget's
+   * `__current_team__` filter placeholder (see `teamFilterPlaceholder.ts`)
+   * before it's sent. `undefined` for a non-team-based dashboard, or while
+   * the team isn't resolved yet — in which case any `integrationCsTeam`
+   * entry carrying that placeholder is dropped rather than sent literally. */
+  selectedTeamGroupId?: string | string[],
 ): UseQueryResult<WidgetData, Error> {
   const api = useBackendApi();
   const config = WIDGET_RESOURCE_CONFIG[resourceType];

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetPieData.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetPieData.test.tsx
@@ -49,7 +49,7 @@ describe("useWidgetPieData", () => {
 
     const { result } = renderHook(
       () =>
-        useWidgetPieData("case", { states: ["open"] }, [
+        useWidgetPieData("widget-1", "case", { states: ["open"] }, [
           { label: "Critical", query: { severities: "critical" } },
           { label: "High", query: { severities: "high" } },
         ]),
@@ -75,7 +75,7 @@ describe("useWidgetPieData", () => {
   });
 
   it("fires no queries and returns a zero total for an empty slices array", () => {
-    const { result } = renderHook(() => useWidgetPieData("case", {}, []), { wrapper });
+    const { result } = renderHook(() => useWidgetPieData("widget-1", "case", {}, []), { wrapper });
 
     expect(postMock).not.toHaveBeenCalled();
     expect(result.current.slices).toEqual([]);
@@ -89,6 +89,7 @@ describe("useWidgetPieData", () => {
     const { result } = renderHook(
       () =>
         useWidgetPieData(
+          "widget-1",
           "case",
           { filters: [{ field: "state", op: "in", values: ["open"] }] },
           [
@@ -129,6 +130,7 @@ describe("useWidgetPieData", () => {
     renderHook(
       () =>
         useWidgetPieData(
+          "widget-1",
           "case",
           { filters: [{ field: "state", op: "in", values: ["open"] }] },
           [
@@ -163,7 +165,7 @@ describe("useWidgetPieData", () => {
 
     const { result } = renderHook(
       () =>
-        useWidgetPieData("case", {}, [
+        useWidgetPieData("widget-1", "case", {}, [
           { label: "A", query: { a: "1" } },
           { label: "B", query: { b: "2" } },
         ]),

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetPieData.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetPieData.ts
@@ -47,11 +47,13 @@ export function useWidgetPieData(
   resourceType: BeWidgetResourceType,
   baseFilters: Record<string, unknown>,
   slices: BeDashboardPieSlice[],
-  /** The currently selected team's own `groupId`, for resolving a
-   * `__current_team__` filter placeholder (see `teamFilterPlaceholder.ts`)
-   * — applied AFTER `mergeWidgetFilters`, since a slice's own `query` may
-   * carry the placeholder too, not just the widget's base `query`. */
-  selectedTeamGroupId?: string,
+  /** The currently selected team's own `groupId`, or an array of every
+   * team's `groupId` in the current dashboard's family for the "All ABTs"
+   * option (see `ALL_TEAMS_SENTINEL`), for resolving a `__current_team__`
+   * filter placeholder (see `teamFilterPlaceholder.ts`) — applied AFTER
+   * `mergeWidgetFilters`, since a slice's own `query` may carry the
+   * placeholder too, not just the widget's base `query`. */
+  selectedTeamGroupId?: string | string[],
 ): WidgetPieData {
   const api = useBackendApi();
   const config = WIDGET_RESOURCE_CONFIG[resourceType];

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetPieData.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetPieData.ts
@@ -43,6 +43,7 @@ export interface WidgetPieData {
  * fires no queries at all.
  */
 export function useWidgetPieData(
+  widgetId: string,
   resourceType: BeWidgetResourceType,
   baseFilters: Record<string, unknown>,
   slices: BeDashboardPieSlice[],
@@ -65,6 +66,7 @@ export function useWidgetPieData(
         queryKey: [
           ApiQueryKeys.CSM_DASHBOARD_WIDGET_DATA,
           "pie-slice",
+          widgetId,
           resourceType,
           filters,
         ],

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/AbtDashboardHeader.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/AbtDashboardHeader.test.tsx
@@ -27,6 +27,7 @@ vi.mock("@api/backend/client", () => ({
 }));
 
 import AbtDashboardHeader from "@features/csm-dashboard/components/AbtDashboardHeader";
+import { ALL_TEAMS_SENTINEL } from "@features/csm-dashboard/utils/teamFilterPlaceholder";
 
 const DASHBOARD_LIST = [
   { id: "agents_pilot", displayName: "Engineer overview", isDefault: true, isTeamBased: false },
@@ -165,5 +166,52 @@ describe("AbtDashboardHeader", () => {
     expect(postMock).toHaveBeenCalledWith("/teams/search", {
       pagination: { offset: 0, limit: 100 },
     });
+  });
+
+  it("offers an 'All ABTs' option alongside the real teams for a team-based dashboard", async () => {
+    postMock.mockResolvedValue({
+      teams: [{ id: "castor", name: "Castor", family: "cre-abt" }],
+    });
+
+    renderWithClient(
+      <AbtDashboardHeader
+        dashboardKey="abt"
+        onDashboardChange={vi.fn()}
+        dashboardList={DASHBOARD_LIST}
+        selectedTeamId={undefined}
+        onTeamChange={vi.fn()}
+      />,
+    );
+
+    const [teamSelect] = screen.getAllByRole("combobox");
+    fireEvent.mouseDown(teamSelect);
+    const listbox = await screen.findByRole("listbox");
+
+    expect(within(listbox).getByText("All ABTs")).toBeInTheDocument();
+    expect(await within(listbox).findByText("Castor")).toBeInTheDocument();
+  });
+
+  it("calls onTeamChange with the sentinel value when 'All ABTs' is selected", async () => {
+    postMock.mockResolvedValue({
+      teams: [{ id: "castor", name: "Castor", family: "cre-abt" }],
+    });
+    const onTeamChange = vi.fn();
+
+    renderWithClient(
+      <AbtDashboardHeader
+        dashboardKey="abt"
+        onDashboardChange={vi.fn()}
+        dashboardList={DASHBOARD_LIST}
+        selectedTeamId={undefined}
+        onTeamChange={onTeamChange}
+      />,
+    );
+
+    const [teamSelect] = screen.getAllByRole("combobox");
+    fireEvent.mouseDown(teamSelect);
+    const listbox = await screen.findByRole("listbox");
+    fireEvent.click(within(listbox).getByText("All ABTs"));
+
+    expect(onTeamChange).toHaveBeenCalledWith(ALL_TEAMS_SENTINEL);
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/AbtDashboardHeader.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/AbtDashboardHeader.test.tsx
@@ -86,7 +86,9 @@ describe("AbtDashboardHeader", () => {
       pagination: { offset: 0, limit: 100 },
     });
 
-    const [teamSelect] = screen.getAllByRole("combobox");
+    // Dashboard order is: dashboard selector, then team selector — see
+    // AbtDashboardHeader's layout.
+    const [, teamSelect] = screen.getAllByRole("combobox");
     fireEvent.mouseDown(teamSelect);
     const listbox = await screen.findByRole("listbox");
     // The teams query resolves asynchronously; retry (findByText) rather
@@ -116,7 +118,9 @@ describe("AbtDashboardHeader", () => {
       />,
     );
 
-    const [teamSelect] = screen.getAllByRole("combobox");
+    // Dashboard order is: dashboard selector, then team selector — see
+    // AbtDashboardHeader's layout.
+    const [, teamSelect] = screen.getAllByRole("combobox");
     fireEvent.mouseDown(teamSelect);
     const listbox = await screen.findByRole("listbox");
     fireEvent.click(await within(listbox).findByText("CS Team Leads"));

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/AbtDashboardHeader.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/AbtDashboardHeader.test.tsx
@@ -183,7 +183,7 @@ describe("AbtDashboardHeader", () => {
       />,
     );
 
-    const [teamSelect] = screen.getAllByRole("combobox");
+    const [, teamSelect] = screen.getAllByRole("combobox");
     fireEvent.mouseDown(teamSelect);
     const listbox = await screen.findByRole("listbox");
 
@@ -207,7 +207,7 @@ describe("AbtDashboardHeader", () => {
       />,
     );
 
-    const [teamSelect] = screen.getAllByRole("combobox");
+    const [, teamSelect] = screen.getAllByRole("combobox");
     fireEvent.mouseDown(teamSelect);
     const listbox = await screen.findByRole("listbox");
     fireEvent.click(within(listbox).getByText("All ABTs"));

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/AbtDashboardHeader.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/AbtDashboardHeader.tsx
@@ -19,6 +19,7 @@ import { type JSX } from "react";
 import type { BeDashboardListItem } from "@api/backend/types";
 import type { DashboardKey } from "@features/csm-dashboard/types/abtDashboard";
 import { abtFamilyForDashboardType, useTeams } from "@features/csm-dashboard/api/useTeams";
+import { ALL_TEAMS_SENTINEL } from "@features/csm-dashboard/utils/teamFilterPlaceholder";
 
 interface AbtDashboardHeaderProps {
   dashboardKey: DashboardKey;
@@ -26,12 +27,18 @@ interface AbtDashboardHeaderProps {
   /** Every dashboard in the BE registry (GET /dashboards), for the switcher. */
   dashboardList: BeDashboardListItem[];
   /** The currently selected team, controlled by the parent (URL-synced,
-   * defaulted to the signed-in user's own team once resolved — see
+   * defaulted to the signed-in user's own team once resolved, or to
+   * `ALL_TEAMS_SENTINEL` when the signed-in user has no home team — see
    * `CsmDashboardPage`). `undefined` when the current dashboard isn't
    * `isTeamBased` (the parent never passes a stale team id through in that
    * case) or, briefly, while the team list/user profile are still loading.
-   * There is deliberately no "All teams" option any more — every team-based
-   * dashboard view has a real team selected. */
+   * The Select also offers an `ALL_TEAMS_SENTINEL`-valued "All ABTs" entry
+   * (see `teamFilterPlaceholder.ts`) — every team-based dashboard view now
+   * has either a real team or "All ABTs" selected, never nothing. This is
+   * narrower than, and unrelated to, the earlier "My ABT / All customers"
+   * toggle removed 2026-08-02: that one spanned every team in the whole
+   * registry, this one never leaves the current dashboard's own family
+   * (`abtFamilyForDashboardType`). */
   selectedTeamId: string | undefined;
   onTeamChange: (teamId: string | undefined) => void;
 }
@@ -51,7 +58,9 @@ interface AbtDashboardHeaderProps {
  * to the widget grid. The earlier My ABT / All customers toggle was removed
  * entirely — ABT scoping was never implemented and dashboards carry no
  * other special behavior beyond which one (and, for team-based ones, which
- * team) is selected.
+ * team) is selected. The picker's "All ABTs" entry (`ALL_TEAMS_SENTINEL`)
+ * scopes to every team in the CURRENT dashboard's own family, not every
+ * team in the registry — see `selectedTeamId`'s own doc comment above.
  */
 export default function AbtDashboardHeader({
   dashboardKey,
@@ -105,6 +114,7 @@ export default function AbtDashboardHeader({
               displayEmpty
               aria-label="Select team"
             >
+              <MenuItem value={ALL_TEAMS_SENTINEL}>All ABTs</MenuItem>
               {(teams.data ?? []).map((t) => (
                 <MenuItem key={t.id} value={t.id}>
                   {t.name}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/AbtDashboardHeader.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/AbtDashboardHeader.tsx
@@ -83,6 +83,20 @@ export default function AbtDashboardHeader({
         </Typography>
       </Box>
       <Box sx={{ display: "flex", gap: 1, alignItems: "center", flexWrap: "wrap" }}>
+        <FormControl size="small" sx={{ minWidth: 200 }}>
+          <Select
+            value={dashboardKey}
+            onChange={(e) => onDashboardChange(e.target.value as DashboardKey)}
+            displayEmpty
+            aria-label="Select dashboard"
+          >
+            {dashboardList.map((o) => (
+              <MenuItem key={o.id} value={o.id}>
+                {o.displayName}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
         {isTeamBased && (
           <FormControl size="small" sx={{ minWidth: 180 }}>
             <Select
@@ -99,20 +113,6 @@ export default function AbtDashboardHeader({
             </Select>
           </FormControl>
         )}
-        <FormControl size="small" sx={{ minWidth: 200 }}>
-          <Select
-            value={dashboardKey}
-            onChange={(e) => onDashboardChange(e.target.value as DashboardKey)}
-            displayEmpty
-            aria-label="Select dashboard"
-          >
-            {dashboardList.map((o) => (
-              <MenuItem key={o.id} value={o.id}>
-                {o.displayName}
-              </MenuItem>
-            ))}
-          </Select>
-        </FormControl>
       </Box>
     </Box>
   );

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/AgentsLandingPagePilot.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/AgentsLandingPagePilot.test.tsx
@@ -158,34 +158,25 @@ describe("AgentsLandingPagePilot", () => {
     expect(screen.queryByText("3")).not.toBeInTheDocument();
   });
 
-  it("shows skeleton tiles again and re-fetches every widget's own data when refresh is clicked", async () => {
-    getMock.mockResolvedValueOnce(DASHBOARD_DETAIL);
+  it("re-fetches only that section's own widgets when its refresh button is clicked, without re-pulling the dashboard config", async () => {
+    getMock.mockResolvedValue(DASHBOARD_DETAIL);
     postMock.mockResolvedValue(searchResponseFor(3));
 
-    const { container } = renderWithClient(<AgentsLandingPagePilot dashboardId="agents_pilot" />);
+    renderWithClient(<AgentsLandingPagePilot dashboardId="agents_pilot" />);
     await waitFor(() => expect(screen.getByText("My Patches")).toBeInTheDocument());
     expect(postMock).toHaveBeenCalledTimes(3);
+    expect(getMock).toHaveBeenCalledTimes(1);
 
-    let resolveRefetch: (value: typeof DASHBOARD_DETAIL) => void = () => {};
-    getMock.mockReturnValueOnce(
-      new Promise((resolve) => {
-        resolveRefetch = resolve;
-      }),
-    );
+    // All three DASHBOARD_DETAIL widgets are unsectioned, so they share the
+    // one untitled default group — its refresh button carries a plain
+    // "Refresh section" label (no section name to fold into it).
+    fireEvent.click(screen.getByRole("button", { name: "Refresh section" }));
 
-    fireEvent.click(screen.getByRole("button", { name: "Refresh widget pilot" }));
-
-    // Skeletons reappear immediately, before the held-open refetch resolves —
-    // not just stale tiles sitting there while new data loads underneath.
-    await waitFor(() =>
-      expect(container.querySelectorAll(".MuiSkeleton-root").length).toBe(3),
-    );
-
-    resolveRefetch(DASHBOARD_DETAIL);
-
-    // Every widget's own /cases/search re-runs too, not just the dashboard
-    // metadata — 3 more calls on top of the initial 3.
+    // Every widget in that section re-runs its own /cases/search — 3 more
+    // calls on top of the initial 3 — but the dashboard's own metadata GET
+    // is not re-pulled (a section refresh is data-only).
     await waitFor(() => expect(postMock).toHaveBeenCalledTimes(6));
+    expect(getMock).toHaveBeenCalledTimes(1);
     expect(screen.getByText("My Patches")).toBeInTheDocument();
   });
 

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/AgentsLandingPagePilot.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/AgentsLandingPagePilot.tsx
@@ -106,44 +106,50 @@ export default function AgentsLandingPagePilot({
   selectedTeamGroupId,
 }: AgentsLandingPagePilotProps): JSX.Element {
   const queryClient = useQueryClient();
-  const { data, isLoading, isError, isFetching, refetch } =
-    useDashboard(dashboardId);
-  // Separate from `isFetching` (which only covers the dashboard's own
-  // metadata refetch): each tile resolves its own count/list data via its
-  // own `useWidgetData` query, so a "refresh" click has to also invalidate
-  // those — tracked here so the skeleton grid stays up across the whole
-  // round trip, not just the metadata half of it.
-  const [isRefreshing, setIsRefreshing] = useState(false);
+  const { data, isLoading, isError } = useDashboard(dashboardId);
+  // Per-section refresh (below) tracks its own in-flight state, keyed by
+  // section, independently of the dashboard-metadata refresh above — a
+  // section refresh never touches `useDashboard`'s own refetch (config is
+  // not re-pulled), only that section's own widgets' data queries.
+  const [refreshingSections, setRefreshingSections] = useState<Set<string>>(new Set());
 
-  const handleRefresh = async (): Promise<void> => {
-    setIsRefreshing(true);
+  /**
+   * Invalidates only the widget-data queries belonging to `widgetIds` —
+   * both shapes' query keys carry a widget id, just at a different
+   * position: `[KEY, widgetId, ...]` for count/list (see `useWidgetData`),
+   * `[KEY, "pie-slice", widgetId, ...]` for pie/bar (see
+   * `useWidgetPieData`). Never touches `useDashboard`'s own metadata query.
+   */
+  const invalidateWidgets = (widgetIds: Set<string>): Promise<void> =>
+    queryClient.invalidateQueries({
+      predicate: (query) => {
+        const key = query.queryKey;
+        if (key[0] !== ApiQueryKeys.CSM_DASHBOARD_WIDGET_DATA) return false;
+        const widgetId = key[1] === "pie-slice" ? key[2] : key[1];
+        return typeof widgetId === "string" && widgetIds.has(widgetId);
+      },
+    });
+
+  const handleSectionRefresh = async (sectionKey: string, widgetIds: Set<string>): Promise<void> => {
+    setRefreshingSections((prev) => new Set(prev).add(sectionKey));
     try {
-      await Promise.all([
-        refetch(),
-        queryClient.invalidateQueries({
-          queryKey: [ApiQueryKeys.CSM_DASHBOARD_WIDGET_DATA],
-        }),
-      ]);
+      await invalidateWidgets(widgetIds);
     } finally {
-      setIsRefreshing(false);
+      setRefreshingSections((prev) => {
+        const next = new Set(prev);
+        next.delete(sectionKey);
+        return next;
+      });
     }
   };
 
   return (
-    <SectionCard
-      action={
-        <RefreshButton
-          onRefresh={() => void handleRefresh()}
-          isFetching={isFetching || isRefreshing}
-          label="Refresh widget pilot"
-        />
-      }
-    >
+    <SectionCard>
       {isError ? (
         <Typography variant="body2" color="text.secondary">
           Could not load the widget pilot.
         </Typography>
-      ) : isLoading || isRefreshing ? (
+      ) : isLoading ? (
         <Box sx={WIDGET_GRID_SX}>
           {Array.from({ length: PILOT_TILE_COUNT }, (_, i) => (
             <Card key={i} variant="outlined" sx={{ p: 1.75, gridColumn: "span 4" }}>
@@ -184,15 +190,35 @@ export default function AgentsLandingPagePilot({
                 const chartWidgets = group.widgets.filter((w) => w.shape === "pie" || w.shape === "bar");
                 if (mainWidgets.length === 0 && chartWidgets.length === 0) return null;
 
+                const sectionKey = group.section ?? `__default_${i}`;
+                const sectionWidgetIds = new Set(group.widgets.map((w) => w.widgetId));
+
                 return (
-                  <Fragment key={group.section ?? `__default_${i}`}>
+                  <Fragment key={sectionKey}>
                     {i > 0 && <Divider />}
                     <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
-                      {group.section && (
-                        <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
-                          {group.section}
-                        </Typography>
-                      )}
+                      <Box
+                        sx={{
+                          display: "flex",
+                          alignItems: "center",
+                          justifyContent: group.section ? "space-between" : "flex-end",
+                        }}
+                      >
+                        {group.section && (
+                          <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+                            {group.section}
+                          </Typography>
+                        )}
+                        <RefreshButton
+                          onRefresh={() => void handleSectionRefresh(sectionKey, sectionWidgetIds)}
+                          isFetching={refreshingSections.has(sectionKey)}
+                          label={
+                            group.section
+                              ? `Refresh ${group.section}`
+                              : "Refresh section"
+                          }
+                        />
+                      </Box>
                       {mainWidgets.length > 0 && (
                         <Box sx={WIDGET_GRID_SX}>{mainWidgets.map(renderTile)}</Box>
                       )}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/AgentsLandingPagePilot.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/AgentsLandingPagePilot.tsx
@@ -83,12 +83,20 @@ function widgetGridColumnSx(widget: BeDashboardWidget) {
 interface AgentsLandingPagePilotProps {
   /** Id of the dashboard to render (e.g. "agents_pilot"). */
   dashboardId: string;
-  /** The currently selected team's own `groupId` (see `BeTeam.groupId`),
-   * only meaningful for an `isTeamBased` dashboard — threaded straight
-   * through to every tile so each can resolve its own `__current_team__`
-   * filter placeholder (see `teamFilterPlaceholder.ts`). `undefined` for a
+  /** The currently selected team's own `groupId` (see `BeTeam.groupId`), or
+   * an array of every team's `groupId` in the current dashboard's family
+   * when the "All ABTs" option is selected (see `ALL_TEAMS_SENTINEL` in
+   * `teamFilterPlaceholder.ts`) — only meaningful for an `isTeamBased`
+   * dashboard, threaded straight through to every tile so each can resolve
+   * its own `__current_team__` filter placeholder. `undefined` for a
    * non-team-based dashboard, or while the team isn't resolved yet. */
-  selectedTeamGroupId?: string;
+  selectedTeamGroupId?: string | string[];
+  /** Human-readable label for the selected team (its own display `name`,
+   * or the literal `"All ABTs"`) — threaded down for each tile's own
+   * `{{currentTeam}}` widget text placeholder (see
+   * `widgetTextPlaceholder.ts`). `undefined` in the same cases
+   * `selectedTeamGroupId` is. */
+  selectedTeamLabel?: string;
 }
 
 /**
@@ -104,6 +112,7 @@ interface AgentsLandingPagePilotProps {
 export default function AgentsLandingPagePilot({
   dashboardId,
   selectedTeamGroupId,
+  selectedTeamLabel,
 }: AgentsLandingPagePilotProps): JSX.Element {
   const queryClient = useQueryClient();
   const { data, isLoading, isError } = useDashboard(dashboardId);
@@ -173,6 +182,7 @@ export default function AgentsLandingPagePilot({
                   listLimit={widget.listLimit}
                   slices={widget.slices}
                   selectedTeamGroupId={selectedTeamGroupId}
+                  selectedTeamLabel={selectedTeamLabel}
                 />
               </Box>
             );

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.test.tsx
@@ -996,6 +996,67 @@ describe("DashboardWidgetTile", () => {
     expect(postMock).not.toHaveBeenCalled();
   });
 
+  it("resolves the {{currentTeam}} text token in displayName/description to the selected team's own label", async () => {
+    postMock.mockResolvedValue({ total: 3, cases: [], limit: 1, offset: 0, hasMore: false });
+
+    renderWithClient(
+      <DashboardWidgetTile
+        widgetId="team_open_incidents"
+        displayName="Open Incidents — {{currentTeam}}"
+        description="Open incidents for {{currentTeam}}."
+        resourceType="case"
+        shape="count"
+        filters={{}}
+        selectedTeamLabel="Castor"
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByText("3")).toBeInTheDocument());
+    expect(screen.getByText("Open Incidents — Castor")).toBeInTheDocument();
+    const infoButton = screen.getByRole("button", { name: "About Open Incidents — Castor" });
+    fireEvent.mouseOver(infoButton);
+    const tooltip = await screen.findByRole("tooltip");
+    expect(tooltip).toHaveTextContent("Open incidents for Castor.");
+  });
+
+  it("resolves the {{currentTeam}} text token to the literal 'All ABTs' when that's the selected team label", async () => {
+    postMock.mockResolvedValue({ total: 3, cases: [], limit: 1, offset: 0, hasMore: false });
+
+    renderWithClient(
+      <DashboardWidgetTile
+        widgetId="team_open_incidents"
+        displayName="Open Incidents — {{currentTeam}}"
+        resourceType="case"
+        shape="count"
+        filters={{}}
+        selectedTeamLabel="All ABTs"
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByText("3")).toBeInTheDocument());
+    expect(screen.getByText("Open Incidents — All ABTs")).toBeInTheDocument();
+  });
+
+  it("strips the {{currentTeam}} text token cleanly (no literal token, no dangling separator) when unresolved", async () => {
+    postMock.mockResolvedValue({ total: 3, cases: [], limit: 1, offset: 0, hasMore: false });
+
+    renderWithClient(
+      <DashboardWidgetTile
+        widgetId="team_open_incidents"
+        displayName="Open Incidents — {{currentTeam}}"
+        resourceType="case"
+        shape="count"
+        filters={{}}
+        // No selectedTeamLabel passed — the unresolved case (non-team-based
+        // dashboard, or the team list/user profile still loading).
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByText("3")).toBeInTheDocument());
+    expect(screen.getByText("Open Incidents")).toBeInTheDocument();
+    expect(screen.queryByText(/\{\{currentTeam\}\}/)).not.toBeInTheDocument();
+  });
+
   it("renders an unsupported-widget message instead of crashing for an unrecognized resourceType", () => {
     renderWithClient(
       <DashboardWidgetTile

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
@@ -106,6 +106,7 @@ export default function DashboardWidgetTile({
     selectedTeamGroupId,
   );
   const pieData = useWidgetPieData(
+    widgetId,
     resourceType,
     filters,
     shape === "pie" || shape === "bar" ? (slices ?? []) : [],

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
@@ -27,6 +27,7 @@ import { WIDGET_LIST_RENDERERS } from "@features/csm-dashboard/config/widgetList
 import { buildWidgetPreviewHref } from "@features/csm-dashboard/utils/widgetPreviewUrl";
 import { mergeWidgetFilters } from "@features/csm-dashboard/utils/widgetFilterMerge";
 import { resolveTeamPlaceholder } from "@features/csm-dashboard/utils/teamFilterPlaceholder";
+import { resolveWidgetText } from "@features/csm-dashboard/utils/widgetTextPlaceholder";
 import DashboardPieChart from "@features/csm-dashboard/components/DashboardPieChart";
 import DashboardBarChart from "@features/csm-dashboard/components/DashboardBarChart";
 
@@ -51,14 +52,23 @@ interface DashboardWidgetTileProps {
    * `useWidgetPieData`). Empty/absent renders an empty chart rather than
    * crashing. */
   slices?: BeDashboardPieSlice[];
-  /** The currently selected team's own `groupId` (see `BeTeam.groupId`),
+  /** The currently selected team's own `groupId` (see `BeTeam.groupId`), or
+   * an array of every team's `groupId` in the current dashboard's family
+   * when the "All ABTs" option is selected (see `ALL_TEAMS_SENTINEL`),
    * threaded down from `CsmDashboardPage` for resolving this widget's own
    * `__current_team__` filter placeholder (see `teamFilterPlaceholder.ts`)
    * — never the team registry key. `undefined` for a non-team-based
    * dashboard, or while the team isn't resolved yet (any `integrationCsTeam`
    * filter entry carrying the placeholder is then dropped, not sent
    * literally). */
-  selectedTeamGroupId?: string;
+  selectedTeamGroupId?: string | string[];
+  /** Human-readable label for the selected team (its own display `name`, or
+   * the literal `"All ABTs"`) — used to resolve the `{{currentTeam}}` text
+   * placeholder (see `widgetTextPlaceholder.ts`) inside `displayName`/
+   * `description` before render. `undefined` in the same cases
+   * `selectedTeamGroupId` is (the token is then stripped rather than left
+   * literally visible). */
+  selectedTeamLabel?: string;
 }
 
 /**
@@ -87,10 +97,18 @@ export default function DashboardWidgetTile({
   listLimit,
   slices,
   selectedTeamGroupId,
+  selectedTeamLabel,
 }: DashboardWidgetTileProps): JSX.Element {
   const theme = useTheme();
   const navigate = useNavigate();
   const { user } = useCurrentUser();
+  // Resolve the `{{currentTeam}}` text placeholder before anything below
+  // renders/reads `displayName`/`description` — every other use of those two
+  // props in this component reads the resolved value, never the raw one, so
+  // the token never leaks into the UI (or the "View more"/preview-page href,
+  // which carries `displayName` verbatim — see `buildWidgetPreviewHref`).
+  const resolvedDisplayName = resolveWidgetText(displayName, selectedTeamLabel) ?? displayName;
+  const resolvedDescription = resolveWidgetText(description, selectedTeamLabel);
   // Shape "pie" resolves via useWidgetPieData instead (one search per
   // slice) — skip this one's own network call rather than wasting it, but
   // still call the hook unconditionally (rules of hooks; a widget's shape
@@ -124,7 +142,7 @@ export default function DashboardWidgetTile({
     return (
       <Card variant="outlined" sx={{ p: 1.75 }}>
         <Typography variant="caption" color="text.secondary">
-          {displayName}
+          {resolvedDisplayName}
         </Typography>
         <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
           Unsupported widget type.
@@ -166,11 +184,11 @@ export default function DashboardWidgetTile({
   // (see the pie/bar branch below), so an icon there would just duplicate
   // it. Renders only when this widget actually has a `description` to show
   // — an empty/absent one means there's nothing to disclose.
-  const infoIcon = shape === "count" && description && (
-    <Tooltip title={description}>
+  const infoIcon = shape === "count" && resolvedDescription && (
+    <Tooltip title={resolvedDescription}>
       <IconButton
         size="small"
-        aria-label={`About ${displayName}`}
+        aria-label={`About ${resolvedDisplayName}`}
         sx={{
           position: "absolute",
           top: 8,
@@ -202,7 +220,7 @@ export default function DashboardWidgetTile({
         <Icon size={16} />
       </Box>
       <Typography variant="caption" color="text.secondary" sx={{ mt: 0.5 }}>
-        {displayName}
+        {resolvedDisplayName}
       </Typography>
     </Box>
   );
@@ -234,7 +252,7 @@ export default function DashboardWidgetTile({
                   to={buildWidgetPreviewHref({
                     previewSlug: config.previewSlug,
                     widgetId,
-                    displayName,
+                    displayName: resolvedDisplayName,
                     filters,
                     currentUserId: user?.id,
                   })}
@@ -296,7 +314,7 @@ export default function DashboardWidgetTile({
         <Box
           role="button"
           tabIndex={0}
-          aria-label={`View all cases for ${displayName}`}
+          aria-label={`View all cases for ${resolvedDisplayName}`}
           onClick={handleTileClick}
           onKeyDown={handleTileKeyDown}
           sx={{
@@ -318,10 +336,10 @@ export default function DashboardWidgetTile({
               chart below it — so the chart's top edge (and, at the size this
               chart renders at, its tooltip) never sits flush against/behind
               the title row above it. */}
-          <Box sx={{ pb: description ? 1 : 2.5 }}>{header}</Box>
-          {description && (
+          <Box sx={{ pb: resolvedDescription ? 1 : 2.5 }}>{header}</Box>
+          {resolvedDescription && (
             <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
-              {description}
+              {resolvedDescription}
             </Typography>
           )}
           <Box sx={{ pointerEvents: "auto" }}>
@@ -376,7 +394,7 @@ export default function DashboardWidgetTile({
         </Box>
         <Box sx={{ minWidth: 0, flex: 1 }}>
           <Typography variant="caption" color="text.secondary" noWrap>
-            {displayName}
+            {resolvedDisplayName}
           </Typography>
           <Typography
             noWrap
@@ -418,7 +436,7 @@ export default function DashboardWidgetTile({
         // layer above this anchor, not inside it as descendant text anymore
         // (that's the whole point -- see the comment above), so it needs its
         // own accessible name instead of inheriting one from its content.
-        aria-label={`${displayName}: ${formattedCount}`}
+        aria-label={`${resolvedDisplayName}: ${formattedCount}`}
         sx={{
           position: "absolute",
           inset: 0,

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/pages/CsmDashboardPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/pages/CsmDashboardPage.test.tsx
@@ -390,11 +390,11 @@ describe("CsmDashboardPage", () => {
         "data-team-label",
         "All ABTs",
       );
-      // The team selector is the first of the two comboboxes for a
-      // team-based dashboard, and shows its currently selected value even
-      // while closed.
+      // The team selector is the second of the two comboboxes for a
+      // team-based dashboard (the dashboard selector renders first), and
+      // shows its currently selected value even while closed.
       const selects = screen.getAllByRole("combobox");
-      expect(within(selects[0]).getByText("All ABTs")).toBeInTheDocument();
+      expect(within(selects[1]).getByText("All ABTs")).toBeInTheDocument();
     });
 
     it("does not default to 'All ABTs' when the URL already names a real team", () => {

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/pages/CsmDashboardPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/pages/CsmDashboardPage.test.tsx
@@ -71,11 +71,21 @@ vi.mock("@features/csm-dashboard/components/AgentsLandingPagePilot", () => ({
   default: ({
     dashboardId,
     selectedTeamGroupId,
+    selectedTeamLabel,
   }: {
     dashboardId: string;
-    selectedTeamGroupId?: string;
+    selectedTeamGroupId?: string | string[];
+    selectedTeamLabel?: string;
   }) => (
-    <div data-testid="agents-landing-pilot" data-team-group-id={selectedTeamGroupId ?? ""}>
+    <div
+      data-testid="agents-landing-pilot"
+      data-team-group-id={
+        Array.isArray(selectedTeamGroupId)
+          ? selectedTeamGroupId.join(",")
+          : (selectedTeamGroupId ?? "")
+      }
+      data-team-label={selectedTeamLabel ?? ""}
+    >
       {dashboardId}
     </div>
   ),
@@ -364,6 +374,43 @@ describe("CsmDashboardPage", () => {
 
       expect(screen.getByTestId("agents-landing-pilot")).toHaveTextContent(
         "agents_pilot",
+      );
+    });
+
+    it("defaults the team selector to 'All ABTs' when the user has no home team, for a directly-viewed team-based dashboard", () => {
+      mockListResult({ data: LIST_WITH_TEAM_DASHBOARD, isLoading: false });
+      mockCurrentUser({ user: { team: undefined }, isLoading: false });
+
+      renderAt("/dashboard#team_performance");
+
+      expect(screen.getByTestId("agents-landing-pilot")).toHaveTextContent(
+        "team_performance",
+      );
+      expect(screen.getByTestId("agents-landing-pilot")).toHaveAttribute(
+        "data-team-label",
+        "All ABTs",
+      );
+      // The team selector is the first of the two comboboxes for a
+      // team-based dashboard, and shows its currently selected value even
+      // while closed.
+      const selects = screen.getAllByRole("combobox");
+      expect(within(selects[0]).getByText("All ABTs")).toBeInTheDocument();
+    });
+
+    it("does not default to 'All ABTs' when the URL already names a real team", () => {
+      mockListResult({ data: LIST_WITH_TEAM_DASHBOARD, isLoading: false });
+      mockCurrentUser({ user: { team: undefined }, isLoading: false });
+
+      renderAt("/dashboard#team_performance.cs_team_leads");
+
+      expect(currentHash()).toBe("#team_performance.cs_team_leads");
+      // teams.data is undefined in this mock, so the real team's name can't
+      // resolve to a label either — the point of this test is that it's
+      // NOT "All ABTs" (the URL-named real team id always wins over the
+      // no-home-team default, per `selectedTeamId`'s own precedence).
+      expect(screen.getByTestId("agents-landing-pilot")).toHaveAttribute(
+        "data-team-label",
+        "",
       );
     });
 

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/pages/CsmDashboardPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/pages/CsmDashboardPage.test.tsx
@@ -242,10 +242,11 @@ describe("CsmDashboardPage", () => {
 
     renderAt("/dashboard#team_performance.cs_team_leads");
 
-    // Two comboboxes render for a team-based dashboard (team + dashboard);
-    // the dashboard switcher is always the second.
+    // Two comboboxes render for a team-based dashboard (dashboard + team);
+    // the dashboard switcher is always the first — see AbtDashboardHeader's
+    // layout (dashboard selector, then team selector).
     const selects = screen.getAllByRole("combobox");
-    const select = selects[selects.length - 1];
+    const select = selects[0];
     fireEvent.mouseDown(select);
     fireEvent.click(within(screen.getByRole("listbox")).getByText("Operations"));
 

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/pages/CsmDashboardPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/pages/CsmDashboardPage.tsx
@@ -20,13 +20,14 @@ import { useLocation, useNavigate } from "react-router";
 import AbtDashboardHeader from "@features/csm-dashboard/components/AbtDashboardHeader";
 import AgentsLandingPagePilot from "@features/csm-dashboard/components/AgentsLandingPagePilot";
 import { useDashboardList } from "@features/csm-dashboard/api/useDashboardList";
-import { useTeams } from "@features/csm-dashboard/api/useTeams";
+import { abtFamilyForDashboardType, useTeams } from "@features/csm-dashboard/api/useTeams";
 import { useCurrentUser } from "@context/current-user/CurrentUserContext";
 import type { DashboardKey } from "@features/csm-dashboard/types/abtDashboard";
 import {
   buildDashboardHash,
   parseDashboardHash,
 } from "@features/csm-dashboard/utils/dashboardUrlHash";
+import { ALL_TEAMS_SENTINEL } from "@features/csm-dashboard/utils/teamFilterPlaceholder";
 
 /**
  * Top-level CSM dashboard. The dashboard list is BE-driven (`GET
@@ -114,9 +115,15 @@ export default function CsmDashboardPage(): JSX.Element {
   // resolved, but only ever as a default: the moment the URL itself names a
   // team (including one written by the user's own pick — see
   // `handleTeamChange`), that value always wins over this one, so a manual
-  // switch is never fought on re-render.
+  // switch is never fought on re-render. A user with NO home team (or
+  // whose profile hasn't resolved one yet) defaults to `ALL_TEAMS_SENTINEL`
+  // ("All ABTs") rather than an empty selection — see `AbtDashboardHeader`.
   const defaultTeamId =
-    isTeamBased && !hashTeamId && userHasTeam ? currentUser.user?.team?.teamKey : undefined;
+    isTeamBased && !hashTeamId
+      ? userHasTeam
+        ? currentUser.user?.team?.teamKey
+        : ALL_TEAMS_SENTINEL
+      : undefined;
   const selectedTeamId = hashTeamId ?? defaultTeamId;
 
   // Every team, unfiltered, for resolving the selected team's `groupId` (the
@@ -129,7 +136,32 @@ export default function CsmDashboardPage(): JSX.Element {
   // differently-scoped query from the header's — react-query no longer
   // dedupes these into one fetch.
   const teams = useTeams(isTeamBased);
-  const selectedTeamGroupId = teams.data?.find((t) => t.id === selectedTeamId)?.groupId;
+
+  // "All ABTs" resolves to every team in the CURRENT DASHBOARD's own family
+  // specifically (not the signed-in user's own team's family, which is what
+  // the unscoped `teams` query above is for) — filtering the same
+  // unscoped `teams.data` client-side by family, rather than firing a
+  // second, family-scoped query, since `teams.data` already has every
+  // team's `family` on it.
+  const currentDashboardFamily = abtFamilyForDashboardType(currentEntry?.type);
+  const allTeamsInFamilyGroupIds = useMemo(
+    () =>
+      (teams.data ?? [])
+        .filter((t) => t.family === currentDashboardFamily)
+        .map((t) => t.groupId)
+        .filter((groupId): groupId is string => Boolean(groupId)),
+    [teams.data, currentDashboardFamily],
+  );
+
+  const selectedTeam = teams.data?.find((t) => t.id === selectedTeamId);
+  const selectedTeamGroupId: string | string[] | undefined =
+    selectedTeamId === ALL_TEAMS_SENTINEL ? allTeamsInFamilyGroupIds : selectedTeam?.groupId;
+  // Human-readable label for the selected team, threaded down for the
+  // `{{currentTeam}}` widget text placeholder (see
+  // `widgetTextPlaceholder.ts`) — never the opaque `groupId` above, which is
+  // useless for display.
+  const selectedTeamLabel: string | undefined =
+    selectedTeamId === ALL_TEAMS_SENTINEL ? "All ABTs" : selectedTeam?.name;
 
   const writeHash = useCallback(
     (nextDashboardId: string, nextTeamId: string | undefined) => {
@@ -196,6 +228,7 @@ export default function CsmDashboardPage(): JSX.Element {
       <AgentsLandingPagePilot
         dashboardId={dashboardKey}
         selectedTeamGroupId={selectedTeamGroupId}
+        selectedTeamLabel={selectedTeamLabel}
       />
     </Box>
   );

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/utils/teamFilterPlaceholder.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/utils/teamFilterPlaceholder.test.ts
@@ -100,4 +100,79 @@ describe("resolveTeamPlaceholder", () => {
 
     expect(resolveTeamPlaceholder(filters, "team-group-id")).toBe(filters);
   });
+
+  it("splices every groupId in an array into the placeholder's spot ('All ABTs')", () => {
+    const filters = {
+      filters: [
+        { field: "state", op: "in", values: ["open"] },
+        { field: "integrationCsTeam", op: "in", values: [CURRENT_TEAM_PLACEHOLDER] },
+      ],
+    };
+
+    const resolved = resolveTeamPlaceholder(filters, ["group-a", "group-b", "group-c"]);
+
+    expect(resolved).toEqual({
+      filters: [
+        { field: "state", op: "in", values: ["open"] },
+        {
+          field: "integrationCsTeam",
+          op: "in",
+          values: ["group-a", "group-b", "group-c"],
+        },
+      ],
+    });
+  });
+
+  it("keeps a literal value alongside a spliced-in array, in position", () => {
+    const filters = {
+      filters: [
+        {
+          field: "integrationCsTeam",
+          op: "in",
+          values: ["some-literal-group-id", CURRENT_TEAM_PLACEHOLDER],
+        },
+      ],
+    };
+
+    const resolved = resolveTeamPlaceholder(filters, ["group-a", "group-b"]);
+
+    expect(resolved).toEqual({
+      filters: [
+        {
+          field: "integrationCsTeam",
+          op: "in",
+          values: ["some-literal-group-id", "group-a", "group-b"],
+        },
+      ],
+    });
+  });
+
+  it("drops the integrationCsTeam entry entirely when given an empty array", () => {
+    const filters = {
+      filters: [
+        { field: "state", op: "in", values: ["open"] },
+        { field: "integrationCsTeam", op: "in", values: [CURRENT_TEAM_PLACEHOLDER] },
+      ],
+    };
+
+    const resolved = resolveTeamPlaceholder(filters, []);
+
+    expect(resolved).toEqual({
+      filters: [{ field: "state", op: "in", values: ["open"] }],
+    });
+  });
+
+  it("still substitutes a single string 1:1, same as before array support existed", () => {
+    const filters = {
+      filters: [
+        { field: "integrationCsTeam", op: "in", values: [CURRENT_TEAM_PLACEHOLDER] },
+      ],
+    };
+
+    const resolved = resolveTeamPlaceholder(filters, "single-group-id");
+
+    expect(resolved).toEqual({
+      filters: [{ field: "integrationCsTeam", op: "in", values: ["single-group-id"] }],
+    });
+  });
 });

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/utils/teamFilterPlaceholder.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/utils/teamFilterPlaceholder.ts
@@ -28,6 +28,20 @@ import { isCaseFieldFilterArray, type WidgetCaseFieldFilterLike } from "./widget
  */
 export const CURRENT_TEAM_PLACEHOLDER = "__current_team__";
 
+/**
+ * Sentinel `selectedTeamId`/`selectedTeamGroupId` value for the team
+ * picker's "All ABTs" option (see `AbtDashboardHeader`) — every team in the
+ * current dashboard's own family (`abtFamilyForDashboardType`), OR'd
+ * together, rather than exactly one team's `groupId`. `__`-prefixed so it
+ * can never collide with a real `BeTeam.id` (registry team keys like
+ * `"castor"` never use that convention). This is deliberately narrower than
+ * the "My ABT / All customers" toggle removed 2026-08-02 (see
+ * `AbtDashboardHeader`'s own doc comment) — that toggle spanned every team
+ * in the whole registry; this one never leaves the current dashboard's
+ * family.
+ */
+export const ALL_TEAMS_SENTINEL = "__all__";
+
 const TEAM_FILTER_FIELD = "integrationCsTeam";
 
 /**
@@ -39,20 +53,29 @@ const TEAM_FILTER_FIELD = "integrationCsTeam";
  * this platform's UUID (`BeTeam.groupId`), never the team registry key
  * (`BeTeam.id`) that `integrationCsTeam` values are NOT keyed by.
  *
- * If `selectedTeamGroupId` is undefined — no team selected yet, or the
- * selected team has no group configured in the deployment's team registry —
- * the `integrationCsTeam` entry is DROPPED from the filter array entirely,
- * rather than either (a) sent with the literal placeholder string, which the
- * entity-service would either reject with a 400 (not a valid UUID) or,
- * worse, silently treat as a value that matches nothing, or (b) sent with an
- * empty `values` array, which the entity-service also rejects for a
- * non-`isEmpty`/`isNotEmpty` op. Dropping the condition instead just widens
- * the query back to "every team" — the same result as if this filter had
- * never been applied — which is the safer failure mode for a dashboard
- * tile: a count/list that's too broad is visibly wrong (an obviously large
- * number, or rows from other teams) and gets noticed, where a query that
- * silently matches zero rows reads as "there's nothing to see here" and
- * doesn't.
+ * `selectedTeamGroupId` may also be an array of `groupId`s — the "All ABTs"
+ * case (see {@link ALL_TEAMS_SENTINEL}): every team in the current
+ * dashboard's family, OR'd together. The single placeholder occurrence in
+ * `values` is then spliced out and replaced with all of them (`in` already
+ * supports multiple values — no backend change needed), rather than the
+ * 1:1 substitution a single string gets. An empty array is treated the same
+ * as `undefined` (see below) — a family with no teams configured is no
+ * different from no team selected at all.
+ *
+ * If `selectedTeamGroupId` is undefined (or an empty array) — no team
+ * selected yet, or the selected team has no group configured in the
+ * deployment's team registry — the `integrationCsTeam` entry is DROPPED
+ * from the filter array entirely, rather than either (a) sent with the
+ * literal placeholder string, which the entity-service would either reject
+ * with a 400 (not a valid UUID) or, worse, silently treat as a value that
+ * matches nothing, or (b) sent with an empty `values` array, which the
+ * entity-service also rejects for a non-`isEmpty`/`isNotEmpty` op. Dropping
+ * the condition instead just widens the query back to "every team" — the
+ * same result as if this filter had never been applied — which is the
+ * safer failure mode for a dashboard tile: a count/list that's too broad is
+ * visibly wrong (an obviously large number, or rows from other teams) and
+ * gets noticed, where a query that silently matches zero rows reads as
+ * "there's nothing to see here" and doesn't.
  *
  * Every other filter entry, and every other resourceType's filters shape
  * (this only touches the case-search generic field/op/values DSL), passes
@@ -60,10 +83,14 @@ const TEAM_FILTER_FIELD = "integrationCsTeam";
  */
 export function resolveTeamPlaceholder(
   filters: Record<string, unknown>,
-  selectedTeamGroupId: string | undefined,
+  selectedTeamGroupId: string | string[] | undefined,
 ): Record<string, unknown> {
   const fieldFilters = filters.filters;
   if (!isCaseFieldFilterArray(fieldFilters)) return filters;
+
+  const hasReplacement =
+    selectedTeamGroupId !== undefined &&
+    (!Array.isArray(selectedTeamGroupId) || selectedTeamGroupId.length > 0);
 
   let changed = false;
   const resolved: WidgetCaseFieldFilterLike[] = [];
@@ -74,13 +101,19 @@ export function resolveTeamPlaceholder(
       continue;
     }
     changed = true;
-    if (!selectedTeamGroupId) {
+    if (!hasReplacement) {
       // Drop the entry entirely — see the doc comment above.
       continue;
     }
     resolved.push({
       ...entry,
-      values: values.map((v) => (v === CURRENT_TEAM_PLACEHOLDER ? selectedTeamGroupId : v)),
+      values: values.flatMap((v) =>
+        v === CURRENT_TEAM_PLACEHOLDER
+          ? Array.isArray(selectedTeamGroupId)
+            ? selectedTeamGroupId
+            : [selectedTeamGroupId as string]
+          : [v],
+      ),
     });
   }
 

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/utils/widgetTextPlaceholder.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/utils/widgetTextPlaceholder.test.ts
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { describe, expect, it } from "vitest";
+import { resolveWidgetText } from "./widgetTextPlaceholder";
+
+describe("resolveWidgetText", () => {
+  it("resolves the token to a real team's display name", () => {
+    expect(resolveWidgetText("Open Incidents — {{currentTeam}}", "Castor")).toBe(
+      "Open Incidents — Castor",
+    );
+  });
+
+  it("resolves the token to the literal 'All ABTs' string", () => {
+    expect(resolveWidgetText("Open Incidents — {{currentTeam}}", "All ABTs")).toBe(
+      "Open Incidents — All ABTs",
+    );
+  });
+
+  it("strips the token to empty and trims a trailing em-dash separator when unresolved", () => {
+    expect(resolveWidgetText("Cases — {{currentTeam}}", undefined)).toBe("Cases");
+  });
+
+  it("strips the token to empty and trims a trailing hyphen separator when unresolved", () => {
+    expect(resolveWidgetText("Cases - {{currentTeam}}", undefined)).toBe("Cases");
+  });
+
+  it("strips the token to empty and trims a trailing pipe separator when unresolved", () => {
+    expect(resolveWidgetText("Cases | {{currentTeam}}", undefined)).toBe("Cases");
+  });
+
+  it("returns text unchanged when it carries no token at all", () => {
+    expect(resolveWidgetText("Open Incidents", "Castor")).toBe("Open Incidents");
+    expect(resolveWidgetText("Open Incidents", undefined)).toBe("Open Incidents");
+  });
+
+  it("returns undefined when text itself is undefined", () => {
+    expect(resolveWidgetText(undefined, "Castor")).toBeUndefined();
+    expect(resolveWidgetText(undefined, undefined)).toBeUndefined();
+  });
+
+  it("substitutes every occurrence of the token when resolved", () => {
+    expect(resolveWidgetText("{{currentTeam}} cases for {{currentTeam}}", "Castor")).toBe(
+      "Castor cases for Castor",
+    );
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/utils/widgetTextPlaceholder.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/utils/widgetTextPlaceholder.ts
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+ * Text-interpolation token a widget config author may put inside a
+ * `displayName`/`description` string (e.g.
+ * `"Open Incidents — {{currentTeam}}"` in a dashboard config JSON), resolved
+ * client-side by `resolveWidgetText` below. Deliberately a distinct, more
+ * visually obvious shape (`{{double-curly}}`) than the `__snake__`-style
+ * filter-value placeholders in `teamFilterPlaceholder.ts`
+ * (`CURRENT_TEAM_PLACEHOLDER`, `ALL_TEAMS_SENTINEL`) — those live inside a
+ * filter entry's `values` array and are resolved into the case-search
+ * filter DSL; this one is resolved into plain text a user reads, so a
+ * config author should be able to tell the two mechanisms apart at a
+ * glance.
+ */
+export const CURRENT_TEAM_TEXT_TOKEN = "{{currentTeam}}";
+
+/**
+ * Substitutes every occurrence of {@link CURRENT_TEAM_TEXT_TOKEN} in a
+ * widget's `displayName`/`description` with `teamLabel` — the selected
+ * team's own display `name` (e.g. `"Castor"`), or the literal string
+ * `"All ABTs"` when the "All ABTs" option is selected (see
+ * `ALL_TEAMS_SENTINEL` in `teamFilterPlaceholder.ts`). `teamLabel` is a
+ * human-readable label, never a `groupId` (an opaque UUID, useless for
+ * display) or the team registry key.
+ *
+ * When `teamLabel` is `undefined` — not a team-based dashboard, or the team
+ * list/user profile is still loading — the token is stripped to an empty
+ * string rather than left literally visible to the user, and a resulting
+ * trailing separator (` — `, ` | `, ` - `) plus any trailing whitespace is
+ * trimmed off, so `"Cases — {{currentTeam}}"` unresolved renders as
+ * `"Cases"` rather than `"Cases — "`. This is a best-effort cosmetic trim
+ * (a single trailing separator), not a general template engine — it does
+ * not handle the token appearing mid-string with trailing text after it.
+ *
+ * Returns `text` itself unchanged (same reference) when it doesn't contain
+ * the token at all, and `undefined` when `text` itself is `undefined` (the
+ * `description` prop is optional).
+ */
+export function resolveWidgetText(
+  text: string | undefined,
+  teamLabel: string | undefined,
+): string | undefined {
+  if (text === undefined || !text.includes(CURRENT_TEAM_TEXT_TOKEN)) return text;
+
+  if (teamLabel !== undefined) {
+    return text.split(CURRENT_TEAM_TEXT_TOKEN).join(teamLabel);
+  }
+
+  const stripped = text.split(CURRENT_TEAM_TEXT_TOKEN).join("");
+  return stripped.replace(/\s*[—|-]\s*$/, "").trimEnd();
+}


### PR DESCRIPTION
## Purpose
Five small-to-medium, independent CSM Portal fixes/improvements, bundled into one PR:
1. PDF attachment previews were unusable — Chrome blocked its own native PDF plugin inside the sandboxed iframe used to render them.
2. The case-pause messaging implied the customer couldn't reply, when pausing actually only blocks the CS engineer's public replies.
3. The case Details tab's Customer card showed Account Manager and Region fields not relevant to the CS engineer's workflow.
4. The dashboard header's team selector rendered before the dashboard selector even though team availability depends on the chosen dashboard, and refreshing dashboard data required a single all-or-nothing button.
5. Team-based dashboards could only ever scope widget data to one team at a time, with no way to view every team in the dashboard's family at once.

## Goals
- Restore PDF attachment previewability without weakening the iframe sandbox posture.
- Make the pause toast/composer hint accurately describe what's restricted.
- Drop the two irrelevant Customer-card fields.
- Reorder the dashboard header selectors and let each dashboard section refresh independently.
- Add an "All ABTs" team scope and a `{{currentTeam}}` widget text placeholder.

## Approach
1. **PDF preview**: Chrome's native PDF plugin does not render inside a sandboxed iframe at all (a Chromium-side behavior, not tied to a specific `sandbox` flag combination), so the iframe approach reliably triggered Chrome's own block interstitial. Replaced it with `window.open()` on the already-fetched blob URL (auto-opened once per attachment, plus a manual fallback button for popup blockers). Image preview is unchanged.
2. **Pause wording**: reworded two hardcoded strings (pause toast, composer hint) from "customer replies are disabled" to "public replies are disabled" — copy-only, no behavior change.
3. **Customer card fields**: deleted the "Account Manager" and "Region" rows from `CustomerContextWidget`; display-only removal, data type and other widgets untouched.
4. **Dashboard header/refresh**: moved the dashboard selector before the team selector (visibility logic unchanged). Removed the single global refresh button; each dashboard section (titled or the untitled default group) now gets its own refresh button, scoped to invalidate only that section's own widgets' data queries — each widget already fetches independently via its own React Query hook, so this needed no data-fetching restructure, just widget-id-scoped invalidation (which also required adding a `widgetId` to the pie/bar widget query key, previously only present on count/list widgets).
5. **All ABTs team scope**: team-based dashboards can now scope widget data to every team in the dashboard's own family at once (selectable from the team picker, and the default when the signed-in user has no home team), via a sentinel value resolved server-side per widget. A widget's `displayName`/`description` can also interpolate `{{currentTeam}}`, resolving to the selected team's name or "All ABTs".

Items 4 and 5 touch overlapping dashboard files; combined and re-verified together (see Test environment) — two of item 5's own tests needed a one-line index fix after item 4's selector reorder (team selector moved from the first combobox to the second), included in this PR.

No screenshots included — items 1/2/3 either remove a broken interstitial/irrelevant fields or change copy only; items 4/5 are header-layout/control changes matching existing visual patterns already used elsewhere in the app.

## User stories
- As a CS engineer, I can preview a PDF attached to a case without hitting a browser error.
- As a CS engineer, when I pause a case I see accurate messaging about what's actually restricted.
- As a CS engineer viewing a case's Details tab, the Customer card only shows fields relevant to handling the case.
- As a CS engineer viewing a team-based dashboard, I pick the dashboard first and then narrow by team; I can refresh just the section I'm looking at instead of waiting on the whole page; I can view every team in a dashboard family at once instead of only one team.

## Release note
- Fixed PDF attachment previews being blocked by Chrome; PDFs now open in a new tab.
- Reworded the case-pause messaging to correctly describe that pausing blocks the engineer's public replies, not the customer's.
- Removed the Account Manager and Region fields from the case Details tab's Customer card.
- Reordered the dashboard header (dashboard selector before team selector) and replaced the single dashboard-wide refresh button with a refresh button per section.
- Added an "All ABTs" team scope for team-based dashboards, plus a `{{currentTeam}}` widget text placeholder.

## Documentation
N/A — all five changes are internal portal UI behavior, no external doc impact.

## Training
N/A — not training content.

## Certification
N/A — no certification exam impact.

## Marketing
N/A — bug fixes and minor UX improvements, not marketable features.

## Automation tests
 - Unit tests
   All five changes verified together on the combined branch; updated the specific assertions that pinned old behavior (old header order, old single-refresh mechanism, old pie-slice query-key shape, old team-selector-is-first-combobox index). Full affected-feature suites (`csm-cases` + `csm-dashboard`, 392 tests) on this combined branch: 390 passed, 2 pre-existing failures (`CaseActionBar.test.tsx`, `LinkCaseDialog.test.tsx`) — confirmed identical on unmodified `origin/main` in a clean worktree before attributing them, unrelated to any of these five changes.
 - Integration tests
   N/A — no e2e specs cover these specific interactions yet.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A for TypeScript — ran `eslint`/`tsc -b`, both clean
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no sample app impact.

## Related PRs
None.

## Migrations (if applicable)
N/A — no data/schema migration.

## Test environment
Verified locally on the combined branch: `pnpm run build` (`tsc -b && vite build`) clean; `eslint` clean on all changed files; `vitest run src/features/csm-cases src/features/csm-dashboard` — 390/392 passed, the 2 failures confirmed pre-existing on unmodified `main`.

## Learning
PDF-in-sandboxed-iframe root-caused via the Chromium issue tracker (crbug.com/413851): sandboxed iframes break Chrome's native PDF plugin regardless of sandbox flags.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “All ABTs” team selection for applicable dashboards.
  * Dashboard widgets now display the selected team in names and descriptions.
  * Added individual refresh controls for each dashboard section.
  * Dashboard defaults now fall back to “All ABTs” when no home team is available.
  * PDF attachments open automatically in a new browser tab, with a fallback button if blocked.

* **Bug Fixes**
  * Clarified that public replies are unavailable while case work is paused.
  * Simplified customer context details by removing Account Manager and Region fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->