### PR TITLE
[CSM Portal] mobile-device banner + fix {{currentTeam}} token in section headings

### DIFF
--- a/apps/csm-portal/webapp/public/config.js.example
+++ b/apps/csm-portal/webapp/public/config.js.example
@@ -66,4 +66,15 @@ window.config = {
   CSM_PORTAL_TOP_BANNER_ENABLED: false,
   // Optional top banner rendered above the header (raw HTML string):
   // CSM_PORTAL_TOP_BANNER_HTML: '<div style="background-color:#000;height:6.8rem"><a href="https://wso2.com/wso2con/" target="_blank"><img style="object-fit:cover;height:100%;width:100%" src="banner.png" role="presentation"></a></div>',
+
+  // Dismissible banner nudging engineers on a detected mobile phone browser
+  // toward the WSO2 Super App micro-app. Unlike the customer portal, this
+  // never blocks access -- engineers can dismiss it and keep using the web
+  // portal on a phone. Leave the store URLs unset to suppress the banner
+  // even when enabled (no download destination to offer).
+  CSM_PORTAL_MOBILE_APP_PROMPT_ENABLED: false,
+  // CSM_PORTAL_MOBILE_APP_IOS_STORE_URL: "https://apps.apple.com/app/id0000000000",
+  // CSM_PORTAL_MOBILE_APP_ANDROID_STORE_URL: "https://play.google.com/store/apps/details?id=com.example.app",
+  // Also show the banner on tablets, not just phones (default false).
+  // CSM_PORTAL_MOBILE_APP_INCLUDE_TABLETS: false,
 };

--- a/apps/csm-portal/webapp/src/components/mobile-app-banner/MobileAppBanner.test.tsx
+++ b/apps/csm-portal/webapp/src/components/mobile-app-banner/MobileAppBanner.test.tsx
@@ -1,0 +1,144 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import "@testing-library/jest-dom/vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DeviceType, MobileOs } from "@/types/mobileDevice";
+
+const mockConfig = {
+  enabled: true,
+  iosStoreUrl: "https://apps.apple.com/app/example",
+  androidStoreUrl: "https://play.google.com/store/apps/details?id=example",
+  includeTablets: false,
+};
+
+vi.mock("@utils/deviceDetection", () => ({
+  detectMobileDevice: vi.fn(),
+}));
+
+vi.mock("@config/mobileAppConfig", () => ({
+  getMobileAppConfig: vi.fn(() => mockConfig),
+  getMobileAppStoreUrl: (os: string) =>
+    os === "ios" ? mockConfig.iosStoreUrl : mockConfig.androidStoreUrl,
+}));
+
+import { detectMobileDevice } from "@utils/deviceDetection";
+import MobileAppBanner from "@components/mobile-app-banner/MobileAppBanner";
+
+describe("MobileAppBanner", () => {
+  beforeEach(() => {
+    mockConfig.enabled = true;
+    mockConfig.iosStoreUrl = "https://apps.apple.com/app/example";
+    mockConfig.androidStoreUrl =
+      "https://play.google.com/store/apps/details?id=example";
+    mockConfig.includeTablets = false;
+    vi.stubGlobal("open", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("renders nothing on desktop (no device detected)", () => {
+    vi.mocked(detectMobileDevice).mockReturnValue(null);
+
+    render(<MobileAppBanner />);
+
+    expect(screen.queryByText("Get the WSO2 Super App")).toBeNull();
+  });
+
+  it("renders nothing when the prompt is disabled even on a mobile device", () => {
+    mockConfig.enabled = false;
+    vi.mocked(detectMobileDevice).mockReturnValue({
+      os: MobileOs.Ios,
+      deviceType: DeviceType.Phone,
+    });
+
+    render(<MobileAppBanner />);
+
+    expect(screen.queryByText("Get the WSO2 Super App")).toBeNull();
+  });
+
+  it("renders nothing when no store URL is configured for the detected OS", () => {
+    mockConfig.iosStoreUrl = undefined as unknown as string;
+    vi.mocked(detectMobileDevice).mockReturnValue({
+      os: MobileOs.Ios,
+      deviceType: DeviceType.Phone,
+    });
+
+    render(<MobileAppBanner />);
+
+    expect(screen.queryByText("Get the WSO2 Super App")).toBeNull();
+  });
+
+  it("shows the banner on a detected mobile phone", () => {
+    vi.mocked(detectMobileDevice).mockReturnValue({
+      os: MobileOs.Android,
+      deviceType: DeviceType.Phone,
+    });
+
+    render(<MobileAppBanner />);
+
+    expect(screen.getByText("Get the WSO2 Super App")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /download/i })).toBeInTheDocument();
+  });
+
+  it("dismisses on close and stays hidden until re-mounted with a new visible state", () => {
+    vi.mocked(detectMobileDevice).mockReturnValue({
+      os: MobileOs.Ios,
+      deviceType: DeviceType.Phone,
+    });
+
+    render(<MobileAppBanner />);
+    expect(screen.getByText("Get the WSO2 Super App")).toBeInTheDocument();
+
+    const dismissButton = screen.getByRole("button", { name: /close/i });
+    fireEvent.click(dismissButton);
+
+    expect(screen.queryByText("Get the WSO2 Super App")).toBeNull();
+  });
+
+  it("opens the store URL via window.open when the download action is used", () => {
+    vi.mocked(detectMobileDevice).mockReturnValue({
+      os: MobileOs.Ios,
+      deviceType: DeviceType.Phone,
+    });
+
+    render(<MobileAppBanner />);
+    fireEvent.click(screen.getByRole("button", { name: /download/i }));
+
+    expect(window.open).toHaveBeenCalledWith(
+      "https://apps.apple.com/app/example",
+      "_blank",
+      "noopener,noreferrer",
+    );
+  });
+
+  it("blocks a javascript: store URL instead of opening it", () => {
+    mockConfig.iosStoreUrl = "javascript:alert('xss')";
+    vi.mocked(detectMobileDevice).mockReturnValue({
+      os: MobileOs.Ios,
+      deviceType: DeviceType.Phone,
+    });
+
+    render(<MobileAppBanner />);
+    fireEvent.click(screen.getByRole("button", { name: /download/i }));
+
+    expect(window.open).not.toHaveBeenCalled();
+  });
+});

--- a/apps/csm-portal/webapp/src/components/mobile-app-banner/MobileAppBanner.test.tsx
+++ b/apps/csm-portal/webapp/src/components/mobile-app-banner/MobileAppBanner.test.tsx
@@ -129,7 +129,7 @@ describe("MobileAppBanner", () => {
     );
   });
 
-  it("blocks a javascript: store URL instead of opening it", () => {
+  it("suppresses the banner entirely for a javascript: store URL, rather than rendering a dead Download button", () => {
     mockConfig.iosStoreUrl = "javascript:alert('xss')";
     vi.mocked(detectMobileDevice).mockReturnValue({
       os: MobileOs.Ios,
@@ -137,8 +137,21 @@ describe("MobileAppBanner", () => {
     });
 
     render(<MobileAppBanner />);
-    fireEvent.click(screen.getByRole("button", { name: /download/i }));
 
+    expect(screen.queryByText("Get the WSO2 Super App")).toBeNull();
+    expect(screen.queryByRole("button", { name: /download/i })).toBeNull();
     expect(window.open).not.toHaveBeenCalled();
+  });
+
+  it("suppresses the banner for a store URL that fails to parse at all", () => {
+    mockConfig.iosStoreUrl = "http://";
+    vi.mocked(detectMobileDevice).mockReturnValue({
+      os: MobileOs.Ios,
+      deviceType: DeviceType.Phone,
+    });
+
+    render(<MobileAppBanner />);
+
+    expect(screen.queryByText("Get the WSO2 Super App")).toBeNull();
   });
 });

--- a/apps/csm-portal/webapp/src/components/mobile-app-banner/MobileAppBanner.tsx
+++ b/apps/csm-portal/webapp/src/components/mobile-app-banner/MobileAppBanner.tsx
@@ -38,6 +38,25 @@ const OS_LABELS: Record<MobileOs, string> = {
 };
 
 /**
+ * Validates a configured store URL and returns its normalized `http(s)` form,
+ * or `undefined` when it's missing or unsupported (e.g. a `javascript:`/
+ * `data:` URI, or a string that doesn't parse as a URL at all). Used both to
+ * decide whether the banner should show at all and as the actual value
+ * `window.open` navigates to -- a config value that fails this check must
+ * never render a Download button that silently does nothing on click.
+ */
+function resolveDownloadUrl(storeUrl: string | undefined): string | undefined {
+  if (!storeUrl) return undefined;
+  try {
+    const parsed = new URL(storeUrl, window.location.origin);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return undefined;
+    return parsed.toString();
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * MobileAppBanner component.
  *
  * Dismissible banner nudging CS engineers on a detected mobile phone (and
@@ -64,8 +83,9 @@ export default function MobileAppBanner(): JSX.Element | null {
   const storeUrl = device
     ? getMobileAppStoreUrl(device.os, mobileAppConfig)
     : undefined;
+  const downloadUrl = resolveDownloadUrl(storeUrl);
 
-  const visible = mobileAppConfig.enabled && device !== null && !!storeUrl;
+  const visible = mobileAppConfig.enabled && device !== null && !!downloadUrl;
 
   // State for the banner dismissal.
   const [dismissed, setDismissed] = useState<boolean>(false);
@@ -78,21 +98,14 @@ export default function MobileAppBanner(): JSX.Element | null {
     }
   }, [visible]);
 
-  if (!visible || dismissed || !device || !storeUrl) {
+  if (!visible || dismissed || !device || !downloadUrl) {
     return null;
   }
 
   const osLabel = OS_LABELS[device.os];
 
   const handleDownload = (): void => {
-    try {
-      const parsed = new URL(storeUrl, window.location.origin);
-      // Allowlist http(s) only to block javascript:/data: URIs.
-      if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return;
-      window.open(parsed.toString(), "_blank", "noopener,noreferrer");
-    } catch {
-      // ignore invalid URLs
-    }
+    window.open(downloadUrl, "_blank", "noopener,noreferrer");
   };
 
   return (

--- a/apps/csm-portal/webapp/src/components/mobile-app-banner/MobileAppBanner.tsx
+++ b/apps/csm-portal/webapp/src/components/mobile-app-banner/MobileAppBanner.tsx
@@ -1,0 +1,131 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Alert,
+  AlertTitle,
+  Box,
+  Button,
+  Collapse,
+  IconButton,
+  Stack,
+} from "@wso2/oxygen-ui";
+import { X } from "@wso2/oxygen-ui-icons-react";
+import { useEffect, useMemo, useState, type JSX } from "react";
+import {
+  getMobileAppConfig,
+  getMobileAppStoreUrl,
+} from "@config/mobileAppConfig";
+import { MobileOs, type MobileDeviceInfo } from "@/types/mobileDevice";
+import { detectMobileDevice } from "@utils/deviceDetection";
+
+const OS_LABELS: Record<MobileOs, string> = {
+  [MobileOs.Ios]: "iOS",
+  [MobileOs.Android]: "Android",
+};
+
+/**
+ * MobileAppBanner component.
+ *
+ * Dismissible banner nudging CS engineers on a detected mobile phone (and
+ * optionally tablet) browser toward the WSO2 Super App micro-app, without
+ * blocking access -- engineers can dismiss it and keep using the web portal
+ * on a phone, unlike the customer portal's full-page mobile gate.
+ *
+ * Built directly on `Alert` (not the higher-level `NotificationBanner`):
+ * `NotificationBanner`/MUI `Alert` only auto-renders its own close icon when
+ * no custom `action` node is supplied, so a banner that also needs a
+ * "Download" action button must pack both into `action` itself -- see
+ * `ErrorBanner.tsx` for the same pattern already established in this app.
+ *
+ * @returns {JSX.Element | null} The MobileAppBanner component.
+ */
+export default function MobileAppBanner(): JSX.Element | null {
+  const mobileAppConfig = useMemo(() => getMobileAppConfig(), []);
+  const device = useMemo<MobileDeviceInfo | null>(
+    () =>
+      detectMobileDevice({ includeTablets: mobileAppConfig.includeTablets }),
+    [mobileAppConfig.includeTablets],
+  );
+
+  const storeUrl = device
+    ? getMobileAppStoreUrl(device.os, mobileAppConfig)
+    : undefined;
+
+  const visible = mobileAppConfig.enabled && device !== null && !!storeUrl;
+
+  // State for the banner dismissal.
+  const [dismissed, setDismissed] = useState<boolean>(false);
+
+  // Reset the dismissed state when the visibility configuration changes to true.
+  useEffect(() => {
+    if (visible) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- reset dismissal when banner is re-shown
+      setDismissed(false);
+    }
+  }, [visible]);
+
+  if (!visible || dismissed || !device || !storeUrl) {
+    return null;
+  }
+
+  const osLabel = OS_LABELS[device.os];
+
+  const handleDownload = (): void => {
+    try {
+      const parsed = new URL(storeUrl, window.location.origin);
+      // Allowlist http(s) only to block javascript:/data: URIs.
+      if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return;
+      window.open(parsed.toString(), "_blank", "noopener,noreferrer");
+    } catch {
+      // ignore invalid URLs
+    }
+  };
+
+  return (
+    <Collapse in>
+      <Alert
+        severity="info"
+        variant="filled"
+        action={
+          <Stack direction="row" spacing={0.5} alignItems="center">
+            <Button
+              color="inherit"
+              size="small"
+              onClick={handleDownload}
+              sx={{ fontWeight: 600, textDecoration: "underline" }}
+            >
+              Download
+            </Button>
+            <IconButton
+              size="small"
+              color="inherit"
+              onClick={() => setDismissed(true)}
+              aria-label="Close"
+            >
+              <X size={16} />
+            </IconButton>
+          </Stack>
+        }
+      >
+        <AlertTitle sx={{ mb: 0 }}>Get the WSO2 Super App</AlertTitle>
+        <Box component="span">
+          {`This portal isn't optimized for ${osLabel} browsers. CSM Portal is also available as a micro-app inside the WSO2 Super App for a better mobile experience.`}
+        </Box>
+      </Alert>
+    </Collapse>
+  );
+}

--- a/apps/csm-portal/webapp/src/config/authConfig.ts
+++ b/apps/csm-portal/webapp/src/config/authConfig.ts
@@ -47,6 +47,17 @@ declare global {
       CSM_PORTAL_ANNOUNCEMENT_BANNER_VISIBLE?: boolean;
       CSM_PORTAL_ANNOUNCEMENT_BANNER_STORAGE_KEY?: string;
       CSM_PORTAL_ANNOUNCEMENT_BANNER_HTML?: string;
+      /**
+       * Dismissible banner nudging CS engineers on a detected mobile phone
+       * (and optionally tablet) browser toward the WSO2 Super App micro-app
+       * instead of the full web portal. Unlike the customer portal's
+       * equivalent, this never blocks access -- engineers may need emergency
+       * mobile access. See `mobileAppConfig.ts`.
+       */
+      CSM_PORTAL_MOBILE_APP_PROMPT_ENABLED?: boolean;
+      CSM_PORTAL_MOBILE_APP_IOS_STORE_URL?: string;
+      CSM_PORTAL_MOBILE_APP_ANDROID_STORE_URL?: string;
+      CSM_PORTAL_MOBILE_APP_INCLUDE_TABLETS?: boolean;
     };
   }
 }

--- a/apps/csm-portal/webapp/src/config/mobileAppConfig.ts
+++ b/apps/csm-portal/webapp/src/config/mobileAppConfig.ts
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { MobileOs } from "@/types/mobileDevice";
+
+export interface MobileAppConfig {
+  enabled: boolean;
+  iosStoreUrl?: string;
+  androidStoreUrl?: string;
+  includeTablets: boolean;
+}
+
+/**
+ * Reads mobile-app banner settings from window.config.
+ *
+ * @returns {MobileAppConfig} Resolved mobile app configuration.
+ */
+export function getMobileAppConfig(): MobileAppConfig {
+  const config = window.config;
+
+  return {
+    enabled: config?.CSM_PORTAL_MOBILE_APP_PROMPT_ENABLED ?? false,
+    iosStoreUrl: config?.CSM_PORTAL_MOBILE_APP_IOS_STORE_URL,
+    androidStoreUrl: config?.CSM_PORTAL_MOBILE_APP_ANDROID_STORE_URL,
+    includeTablets: config?.CSM_PORTAL_MOBILE_APP_INCLUDE_TABLETS ?? false,
+  };
+}
+
+/**
+ * Resolves the app-store URL for the given mobile OS.
+ *
+ * @param {MobileOs} os - Target mobile operating system.
+ * @param {MobileAppConfig} mobileAppConfig - Mobile app configuration.
+ * @returns {string | undefined} Store URL when configured.
+ */
+export function getMobileAppStoreUrl(
+  os: MobileOs,
+  mobileAppConfig: MobileAppConfig = getMobileAppConfig(),
+): string | undefined {
+  return os === MobileOs.Ios
+    ? mobileAppConfig.iosStoreUrl
+    : mobileAppConfig.androidStoreUrl;
+}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/AgentsLandingPagePilot.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/AgentsLandingPagePilot.test.tsx
@@ -226,4 +226,32 @@ describe("AgentsLandingPagePilot", () => {
     // section, they don't each get their own repeated heading.
     expect(screen.getAllByText("SLA Violation")).toHaveLength(1);
   });
+
+  it("resolves the {{currentTeam}} text token in a section heading, same as a widget's own displayName", async () => {
+    getMock.mockResolvedValue({
+      id: "team_performance",
+      displayName: "Team performance",
+      isDefault: false,
+      widgets: [
+        {
+          widgetId: "team_open_cases",
+          displayName: "Team Open P0/P1",
+          section: "Overall - {{currentTeam}}",
+          resourceType: "case",
+          shape: "count",
+          gridWidth: 6,
+          query: {},
+        },
+      ],
+    });
+    postMock.mockResolvedValue(searchResponseFor(1));
+
+    renderWithClient(
+      <AgentsLandingPagePilot dashboardId="team_performance" selectedTeamLabel="Castor" />,
+    );
+
+    await waitFor(() => expect(screen.getByText("Team Open P0/P1")).toBeInTheDocument());
+    expect(screen.getByText("Overall - Castor")).toBeInTheDocument();
+    expect(screen.queryByText(/{{currentTeam}}/)).not.toBeInTheDocument();
+  });
 });

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/AgentsLandingPagePilot.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/AgentsLandingPagePilot.tsx
@@ -23,6 +23,7 @@ import { useDashboard } from "@features/csm-dashboard/api/useDashboard";
 import DashboardWidgetTile from "@features/csm-dashboard/components/DashboardWidgetTile";
 import SectionCard from "@features/csm-dashboard/components/SectionCard";
 import RefreshButton from "@components/RefreshButton";
+import { resolveWidgetText } from "@features/csm-dashboard/utils/widgetTextPlaceholder";
 
 /** Placeholder tile count while the dashboard detail is in flight. */
 const PILOT_TILE_COUNT = 3;
@@ -202,6 +203,11 @@ export default function AgentsLandingPagePilot({
 
                 const sectionKey = group.section ?? `__default_${i}`;
                 const sectionWidgetIds = new Set(group.widgets.map((w) => w.widgetId));
+                // Section titles support the same {{currentTeam}} text token as
+                // an individual widget's own displayName/description (see
+                // widgetTextPlaceholder.ts) — resolve it once here so both the
+                // visible heading and the refresh button's label stay in sync.
+                const resolvedSectionTitle = resolveWidgetText(group.section, selectedTeamLabel);
 
                 return (
                   <Fragment key={sectionKey}>
@@ -211,20 +217,20 @@ export default function AgentsLandingPagePilot({
                         sx={{
                           display: "flex",
                           alignItems: "center",
-                          justifyContent: group.section ? "space-between" : "flex-end",
+                          justifyContent: resolvedSectionTitle ? "space-between" : "flex-end",
                         }}
                       >
-                        {group.section && (
+                        {resolvedSectionTitle && (
                           <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
-                            {group.section}
+                            {resolvedSectionTitle}
                           </Typography>
                         )}
                         <RefreshButton
                           onRefresh={() => void handleSectionRefresh(sectionKey, sectionWidgetIds)}
                           isFetching={refreshingSections.has(sectionKey)}
                           label={
-                            group.section
-                              ? `Refresh ${group.section}`
+                            resolvedSectionTitle
+                              ? `Refresh ${resolvedSectionTitle}`
                               : "Refresh section"
                           }
                         />

--- a/apps/csm-portal/webapp/src/layouts/AppLayout.tsx
+++ b/apps/csm-portal/webapp/src/layouts/AppLayout.tsx
@@ -38,6 +38,7 @@ import IdleTimeoutProvider from "@providers/IdleTimeoutProvider";
 import { useSyncRecentViewsIdentity } from "@features/csm-recent/hooks/useRecentViews";
 import GlobalNotificationBanner from "@components/notification-banner/GlobalNotificationBanner";
 import HtmlAnnouncementBanner from "@components/announcement-banner/HtmlAnnouncementBanner";
+import MobileAppBanner from "@components/mobile-app-banner/MobileAppBanner";
 import TopBanner from "@components/top-banner/TopBanner";
 import Header from "@components/header/Header";
 import CsmSideBar from "@components/side-nav-bar/CsmSideBar";
@@ -131,6 +132,7 @@ export default function AppLayout({ children }: AppLayoutProps): JSX.Element {
         }}
       >
         <TopBanner />
+        <MobileAppBanner />
         <GlobalNotificationBanner visible={notificationBannerConfig.visible} />
         <HtmlAnnouncementBanner />
         <AppShell sx={{ flex: 1, minHeight: 0, height: "auto" }}>

--- a/apps/csm-portal/webapp/src/types/mobileDevice.ts
+++ b/apps/csm-portal/webapp/src/types/mobileDevice.ts
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/** Mobile operating systems supported by the app-download banner. */
+export enum MobileOs {
+  Ios = "ios",
+  Android = "android",
+}
+
+/** Device form factor for mobile detection and copy. */
+export enum DeviceType {
+  Phone = "phone",
+  Tablet = "tablet",
+  Desktop = "desktop",
+}
+
+/** Navigator platform values used in device detection heuristics. */
+export enum NavigatorPlatform {
+  MacIntel = "MacIntel",
+}
+
+export interface MobileDeviceInfo {
+  os: MobileOs;
+  deviceType: DeviceType;
+}
+
+export interface DetectMobileDeviceOptions {
+  /** When false (default), only phones trigger the mobile-app banner. */
+  includeTablets?: boolean;
+}

--- a/apps/csm-portal/webapp/src/utils/deviceDetection.test.ts
+++ b/apps/csm-portal/webapp/src/utils/deviceDetection.test.ts
@@ -1,0 +1,140 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DeviceType, MobileOs, NavigatorPlatform } from "@/types/mobileDevice";
+import { detectMobileDevice, shouldPromptForMobileApp } from "@utils/deviceDetection";
+
+function mockNavigator(partial: Partial<Navigator> & { userAgent: string }): void {
+  vi.stubGlobal("navigator", {
+    platform: "iPhone",
+    maxTouchPoints: 1,
+    ...partial,
+  });
+}
+
+describe("detectMobileDevice", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("should detect iPhone as iOS phone", () => {
+    mockNavigator({
+      userAgent:
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15",
+    });
+
+    expect(detectMobileDevice()).toEqual({
+      os: MobileOs.Ios,
+      deviceType: DeviceType.Phone,
+    });
+  });
+
+  it("should ignore iPad by default", () => {
+    mockNavigator({
+      userAgent:
+        "Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) AppleWebKit/605.1.15",
+      platform: NavigatorPlatform.MacIntel,
+      maxTouchPoints: 5,
+    });
+
+    expect(detectMobileDevice()).toBeNull();
+  });
+
+  it("should detect iPad as iOS tablet when includeTablets is true", () => {
+    mockNavigator({
+      userAgent:
+        "Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) AppleWebKit/605.1.15",
+      platform: NavigatorPlatform.MacIntel,
+      maxTouchPoints: 5,
+    });
+
+    expect(detectMobileDevice({ includeTablets: true })).toEqual({
+      os: MobileOs.Ios,
+      deviceType: DeviceType.Tablet,
+    });
+  });
+
+  it("should detect Android phone when Mobile is present in user agent", () => {
+    mockNavigator({
+      userAgent:
+        "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 Mobile Safari/537.36",
+    });
+
+    expect(detectMobileDevice()).toEqual({
+      os: MobileOs.Android,
+      deviceType: DeviceType.Phone,
+    });
+  });
+
+  it("should ignore Android tablets by default", () => {
+    mockNavigator({
+      userAgent:
+        "Mozilla/5.0 (Linux; Android 14; SM-X900) AppleWebKit/537.36 Safari/537.36",
+    });
+
+    expect(detectMobileDevice()).toBeNull();
+  });
+
+  it("should detect Android tablets when includeTablets is true", () => {
+    mockNavigator({
+      userAgent:
+        "Mozilla/5.0 (Linux; Android 14; SM-X900) AppleWebKit/537.36 Safari/537.36",
+    });
+
+    expect(detectMobileDevice({ includeTablets: true })).toEqual({
+      os: MobileOs.Android,
+      deviceType: DeviceType.Tablet,
+    });
+  });
+
+  it("should return null for desktop Chrome", () => {
+    mockNavigator({
+      userAgent:
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/120.0.0.0 Safari/537.36",
+      platform: NavigatorPlatform.MacIntel,
+      maxTouchPoints: 0,
+    });
+
+    expect(detectMobileDevice()).toBeNull();
+  });
+});
+
+describe("shouldPromptForMobileApp", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns true when a mobile device is detected", () => {
+    mockNavigator({
+      userAgent:
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15",
+    });
+
+    expect(shouldPromptForMobileApp()).toBe(true);
+  });
+
+  it("returns false when no mobile device is detected", () => {
+    mockNavigator({
+      userAgent:
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/120.0.0.0 Safari/537.36",
+      platform: NavigatorPlatform.MacIntel,
+      maxTouchPoints: 0,
+    });
+
+    expect(shouldPromptForMobileApp()).toBe(false);
+  });
+});

--- a/apps/csm-portal/webapp/src/utils/deviceDetection.ts
+++ b/apps/csm-portal/webapp/src/utils/deviceDetection.ts
@@ -1,0 +1,109 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  DeviceType,
+  MobileOs,
+  NavigatorPlatform,
+  type DetectMobileDeviceOptions,
+  type MobileDeviceInfo,
+} from "@/types/mobileDevice";
+
+/**
+ * Returns true when the browser reports an iPad (including iPadOS desktop UA).
+ *
+ * @param {string} userAgent - Navigator user agent string.
+ * @returns {boolean} Whether the device is treated as an iPad.
+ */
+function isIPadUserAgent(userAgent: string): boolean {
+  if (/iPad/i.test(userAgent)) {
+    return true;
+  }
+
+  if (typeof navigator === "undefined") {
+    return false;
+  }
+
+  return (
+    navigator.platform === NavigatorPlatform.MacIntel &&
+    navigator.maxTouchPoints > 1 &&
+    !/iPhone|iPod/i.test(userAgent)
+  );
+}
+
+/**
+ * Classifies Android as phone or tablet using the Mobile token in the user agent.
+ *
+ * @param {string} userAgent - Navigator user agent string.
+ * @returns {DeviceType | null} phone, tablet, or null when not Android.
+ */
+function getAndroidDeviceType(userAgent: string): DeviceType | null {
+  if (!/Android/i.test(userAgent)) {
+    return null;
+  }
+
+  return /Mobile/i.test(userAgent) ? DeviceType.Phone : DeviceType.Tablet;
+}
+
+/**
+ * Detects iOS or Android mobile devices and distinguishes phones from tablets.
+ *
+ * @param {DetectMobileDeviceOptions} [options] - Detection options.
+ * @returns {MobileDeviceInfo | null} Device info for supported mobile OSes, else null.
+ */
+export function detectMobileDevice(
+  options: DetectMobileDeviceOptions = {},
+): MobileDeviceInfo | null {
+  if (typeof navigator === "undefined") {
+    return null;
+  }
+
+  const { includeTablets = false } = options;
+  const userAgent = navigator.userAgent;
+
+  if (/iPhone|iPod/i.test(userAgent)) {
+    return { os: MobileOs.Ios, deviceType: DeviceType.Phone };
+  }
+
+  if (isIPadUserAgent(userAgent)) {
+    if (!includeTablets) {
+      return null;
+    }
+    return { os: MobileOs.Ios, deviceType: DeviceType.Tablet };
+  }
+
+  const androidType = getAndroidDeviceType(userAgent);
+  if (androidType) {
+    if (androidType === DeviceType.Tablet && !includeTablets) {
+      return null;
+    }
+    return { os: MobileOs.Android, deviceType: androidType };
+  }
+
+  return null;
+}
+
+/**
+ * Returns true when the current device should see the mobile-app download banner.
+ *
+ * @param {DetectMobileDeviceOptions} [options] - Forwarded to {@link detectMobileDevice}.
+ * @returns {boolean} Whether the banner should be shown.
+ */
+export function shouldPromptForMobileApp(
+  options?: DetectMobileDeviceOptions,
+): boolean {
+  return detectMobileDevice(options) !== null;
+}


### PR DESCRIPTION
## Purpose
Two small, independent CSM Portal changes bundled into one PR:
1. The customer portal blocks phone browsers outright with a full-page "install the WSO2 Super App" prompt. CSM Portal had no equivalent, and CS engineers got no nudge that the app is available as a Super App micro-app when opening the portal on a phone.
2. A dashboard section title using the `{{currentTeam}}` text token (e.g. "Overall - {{currentTeam}}") showed the literal, unresolved token instead of the selected team's name — the token was only wired into individual widgets' own `displayName`/`description`, not into section headings.

## Goals
- Add a dismissible mobile-device banner to CSM Portal, unlike the customer portal's full-page block, since internal CS engineers may need emergency mobile access.
- Make section headings resolve `{{currentTeam}}` the same way individual widgets already do.

## Approach
**Mobile banner**: ported the customer portal's device-detection utilities (`detectMobileDevice`/`shouldPromptForMobileApp`, `MobileOs`/`DeviceType` types) into CSM Portal unchanged. Added an independent config surface with CSM-prefixed keys (`CSM_PORTAL_MOBILE_APP_PROMPT_ENABLED`/`_IOS_STORE_URL`/`_ANDROID_STORE_URL`/`_INCLUDE_TABLETS`), separate from the customer portal's own `CUSTOMER_PORTAL_MOBILE_APP_*` keys. Built the banner directly on MUI `Alert` rather than this app's `NotificationBanner` wrapper: `NotificationBanner`/`Alert` only auto-renders its own close icon when no custom `action` node is supplied, so a banner needing both a "Download" action and a close control has to pack both into `action` itself — matching the existing pattern already established in `ErrorBanner.tsx` for the same reason. Wired ahead of the existing maintenance banner (`GlobalNotificationBanner`) in `AppLayout.tsx` — the device nudge is per-session/dismissible, the maintenance banner is an admin-broadcast operational notice that should keep its position.

**Section-title token**: `resolveWidgetText` (already used for widget `displayName`/`description`) is now also applied to `AgentsLandingPagePilot`'s section heading and its refresh button's accessible label, using the same `selectedTeamLabel` already threaded into the component.

No screenshot included — item 1 is a small info-severity `Alert` banner consistent with the existing `ErrorBanner`/`GlobalNotificationBanner` visual pattern; item 2 is a one-line text-resolution fix with no visual/layout change beyond the text itself now resolving correctly.

## User stories
- As a CS engineer opening CSM Portal on a phone, I see a dismissible nudge toward the WSO2 Super App micro-app instead of no guidance at all, and can dismiss it and keep using the browser view if I need to.
- As a CS engineer viewing a team-based dashboard with a `{{currentTeam}}`-templated section title, I see the actual team name (or "All ABTs") instead of the literal template token.

## Release note
- Added a dismissible banner on CSM Portal nudging phone users toward the WSO2 Super App, configurable independently of the customer portal's own mobile-app prompt.
- Fixed dashboard section headings not resolving the `{{currentTeam}}` text token, so a section like "Overall - {{currentTeam}}" now correctly shows e.g. "Overall - Castor" or "Overall - All ABTs".

## Documentation
N/A — both changes are internal portal UI behavior, no external doc impact.

## Training
N/A — not training content.

## Certification
N/A — no certification exam impact.

## Marketing
N/A — internal UX addition and a bug fix, not marketable features.

## Automation tests
 - Unit tests
   Mobile banner: `deviceDetection.test.ts` (9 tests) + `MobileAppBanner.test.tsx` (7 tests), all passing. Section-title fix: new case in `AgentsLandingPagePilot.test.tsx` asserting `{{currentTeam}}` resolves in a section heading and the literal token never renders; full file re-run 7/7 passing. Full `csm-dashboard` suite re-verified on this branch after rebasing onto the now-merged `main`: 141/141 passing. `eslint`/`tsc -b`/`vite build` all clean.
 - Integration tests
   N/A — no e2e specs cover either interaction yet.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A for TypeScript — ran `eslint`/`tsc -b`, both clean
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes — `public/config.js.example` only documents the new mobile-app keys, the real `public/config.js` is gitignored and untouched

## Samples
N/A — no sample app impact.

## Related PRs
None (cs-tools#1362, which this branch was originally alongside, has since merged; this branch was rebased onto the resulting `main`).

## Migrations (if applicable)
N/A — no data/schema migration.

## Test environment
Verified locally on this branch (post-rebase onto merged `main`): `eslint` clean, `pnpm run build` (`tsc -b && vite build`) clean, `vitest run` on the mobile-banner tests (16/16) and the full `csm-dashboard` suite (141/141), all passing.

## Learning
Confirmed via MUI `Alert` source that it only auto-renders its own close button when `action` is unset — documented in `MobileAppBanner`'s own doc comment for future maintainers extending `NotificationBanner`-based banners with an action.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional, dismissible prompt encouraging mobile users to download the app.
  * Supports iOS and Android store links, with optional tablet targeting.
  * Invalid or unsafe store links are ignored.
* **Bug Fixes**
  * Resolved team placeholders in dashboard section headings and refresh labels.
* **Tests**
  * Added coverage for mobile device detection, banner behavior, dismissal, store links, security validation, and placeholder resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->