### PR TITLE
[Customer Portal][Webapp]Guard against duplicate submits and unhandled errors during SRA attachment prep

### DIFF
--- a/apps/customer-portal/webapp/src/features/support/pages/CreateCasePage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/CreateCasePage.tsx
@@ -171,6 +171,7 @@ export default function CreateCasePage(): JSX.Element {
   const [attachments, setAttachments] = useState<AttachmentItem[]>([]);
   const attachmentNamesRef = useRef<Map<string, string>>(new Map());
   const attachmentIdCounterRef = useRef(0);
+  const isSubmittingRef = useRef(false);
   const [isPreparingAttachments, setIsPreparingAttachments] = useState(false);
   const [isAttachmentModalOpen, setIsAttachmentModalOpen] = useState(false);
   const deploymentsQuery = usePostProjectDeploymentsSearchInfinite(
@@ -950,14 +951,30 @@ export default function CreateCasePage(): JSX.Element {
       severityKey = parsedSeverity;
     }
 
+    if (isSubmittingRef.current) return;
+
     let inlineAttachments: Array<{ file: string; name: string }> | undefined;
     if (isSecurityReport) {
-      inlineAttachments = await Promise.all(
-        attachments.map(async (item) => ({
-          file: await fileToBase64Content(item.file),
-          name: attachmentNamesRef.current.get(item.id) || item.file.name,
-        })),
-      );
+      isSubmittingRef.current = true;
+      setIsPreparingAttachments(true);
+      const attachmentsSnapshot = attachments;
+      try {
+        inlineAttachments = await Promise.all(
+          attachmentsSnapshot.map(async (item) => ({
+            file: await fileToBase64Content(item.file),
+            name: attachmentNamesRef.current.get(item.id) || item.file.name,
+          })),
+        );
+      } catch (error) {
+        logger.error("Failed to read attachment file(s)", error);
+        showError(
+          "We couldn't read one or more attachments. Please try again.",
+        );
+        return;
+      } finally {
+        isSubmittingRef.current = false;
+        setIsPreparingAttachments(false);
+      }
     }
 
     const payload: CreateCaseRequest = {

--- a/apps/customer-portal/webapp/src/features/support/pages/CreateCasePage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/CreateCasePage.tsx
@@ -883,7 +883,7 @@ export default function CreateCasePage(): JSX.Element {
 
   const handleSubmit = async (e?: FormEvent, bypassPii = false) => {
     e?.preventDefault();
-    if (!projectId || isNavigatingAfterCreate) return;
+    if (!projectId || isNavigatingAfterCreate || isCreatePending) return;
     if (isProjectLoading || isProjectFeaturesLoading) return;
 
     const titlePlain = htmlToPlainText(title).trim();


### PR DESCRIPTION
## Summary
- Catch file-read failures from the security-report attachment base64 conversion before `postCase` is called — previously an unhandled rejection left the user with no error feedback and a stuck submit button.
- Guard against duplicate submissions while attachments are being converted (a window not covered by the existing `isNavigatingAfterCreate`/`isCreatePending` checks) using a synchronous ref, and visibly disable the submit button during that phase via the existing `isPreparingAttachments` state.
- Reviewed a third suggested fix (aggregate attachment size/file-count limit) and skipped it — no such limit exists anywhere in the codebase today, only a per-file cap enforced at selection time, and there's no known backend constraint to validate against.

## Test plan
- [ ] Submit a Security Report Analysis case with a valid attachment and confirm it still creates successfully with attachments inline.
- [ ] Simulate a file-read failure (e.g. corrupt/unreadable file) and confirm a clear error is shown and case creation does not proceed.
- [ ] Rapidly double-click submit on an SRA case with attachments and confirm only one case is created.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate support case submissions while a request is in progress.
  * Improved handling of security-report attachments during submission.
  * Added clearer loading and error states when attachments cannot be read.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->