### PR TITLE
feat(entity-service): enable case tag management now that the backing service supports it

### DIFF
--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -1261,13 +1261,15 @@ type CaseView struct {
 	// CSM-engineer-facing only, never shared with the customer.
 	WorstCaseFixEta *string `json:"worstCaseFixEta"`
 	// Tags are the free-text labels attached to the case via ServiceNow's generic
-	// platform label/label_entry mechanism (not a case-specific column).
+	// platform label/label_entry mechanism (not a case-specific column). Tags
+	// themselves are managed out-of-band via AddCaseTag/RemoveCaseTag/SearchTags.
 	//
-	// Not yet available in the backing service: no Ballerina adapter exists yet
-	// for SN's generic label/label_entry tables. Confirmed real tag values exist in
-	// production (e.g. "micro-gw", "ws-policy", "node") but nothing in the current
-	// Choreo GET /cases/{id} contract returns them. This field is always nil until
-	// a Ballerina endpoint surfaces the case's tags.
+	// Not yet populated on the case detail read: the Choreo GET /cases/{id} contract
+	// does not inline a case's current tags, and there is no case-scoped "list tags
+	// for this case" endpoint yet either — only the case-agnostic GET /tags/search.
+	// Confirmed real tag values exist in production (e.g. "micro-gw", "ws-policy",
+	// "node") but this field is always nil until the backing service's case-detail
+	// response (or a case-scoped tags-list endpoint) surfaces them.
 	Tags []Tag `json:"tags"`
 }
 
@@ -1751,13 +1753,9 @@ type CreateCaseCommentRequest struct {
 	Content   string      `json:"content"`
 }
 
-// AddCaseTagRequest is the request body for POST /cases/{id}/tags.
-//
-// Not yet available in the backing service: SN's tagging is the generic platform
-// label/label_entry mechanism (table-agnostic, not a case column), so it needs an
-// entirely new Ballerina/Choreo adapter — nothing in the current contract creates
-// a label on a case. This request/the AddCaseTag service method are implemented so
-// the entity-service side is ready once Ballerina adds the endpoint.
+// AddCaseTagRequest is the request body for POST /cases/{id}/tags. SN's tagging is
+// the generic platform label/label_entry mechanism (table-agnostic, not a case
+// column).
 type AddCaseTagRequest struct {
 	CaseID string `json:"-"`
 	Label  string `json:"label"`

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -1264,12 +1264,12 @@ type CaseView struct {
 	// platform label/label_entry mechanism (not a case-specific column). Tags
 	// themselves are managed out-of-band via AddCaseTag/RemoveCaseTag/SearchTags.
 	//
-	// Not yet populated on the case detail read: the Choreo GET /cases/{id} contract
-	// does not inline a case's current tags, and there is no case-scoped "list tags
-	// for this case" endpoint yet either — only the case-agnostic GET /tags/search.
-	// Confirmed real tag values exist in production (e.g. "micro-gw", "ws-policy",
-	// "node") but this field is always nil until the backing service's case-detail
-	// response (or a case-scoped tags-list endpoint) surfaces them.
+	// Populated on the case detail read via a case-scoped tags-list lookup: the
+	// Choreo GET /cases/{id} contract still does not inline a case's current tags, so
+	// the case-detail read fetches them separately through the case-scoped "list tags
+	// for this case" endpoint. That lookup is best-effort — if it fails, the case
+	// detail read still succeeds and this field is left nil rather than failing the
+	// whole read.
 	Tags []Tag `json:"tags"`
 }
 

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -218,18 +218,13 @@ type CaseService interface {
 	DeleteCaseAttachment(ctx context.Context, req domain.DeleteAttachmentRequest) (domain.DeleteAttachmentResponse, error)
 	// AddCaseTag attaches a free-text label to the case identified by caseID.
 	// A ValidationError is returned for invalid input (e.g. malformed UUID, empty label).
-	// Not yet available in the backing service: no Ballerina adapter exists yet for
-	// ServiceNow's generic label/label_entry mechanism; see AddCaseTagRequest doc comment.
 	AddCaseTag(ctx context.Context, caseID, label string) (domain.Tag, error)
 	// RemoveCaseTag removes the tag identified by tagID from the case identified by caseID.
 	// A NotFoundError is returned if the tag does not exist on the case.
-	// Not yet available in the backing service: same gap as AddCaseTag above.
 	RemoveCaseTag(ctx context.Context, caseID, tagID string) error
 	// SearchTags returns the tags (not scoped to any single case) whose label matches query,
 	// for FE autocomplete when attaching a tag to a case. An empty query returns all known tags.
 	// limit caps the number of results (<=0 means use the downstream default).
-	// Not yet available in the backing service: no Ballerina/Choreo endpoint exists yet for a
-	// case-agnostic tag search; see SearchTags in sn_case_service.go for the requested contract.
 	SearchTags(ctx context.Context, query string, limit int) ([]domain.Tag, error)
 }
 

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -915,8 +915,12 @@ func (s *snCaseService) GetCaseByID(ctx context.Context, id string) (domain.Case
 	if c.WorstCaseFixEta != nil && *c.WorstCaseFixEta != "" {
 		cv.WorstCaseFixEta = c.WorstCaseFixEta
 	}
-	// Tags are not populated: not yet available in the backing service, see the
-	// CaseView.Tags doc comment. cv.Tags is left nil.
+	// Tags are not populated here: the Choreo GET /cases/{id} response (snCase above)
+	// still has no tags field, and case tags are managed via the dedicated
+	// AddCaseTag/RemoveCaseTag/SearchTags endpoints rather than being inlined on the
+	// case detail read. cv.Tags is left nil until the backing service's case-detail
+	// response (or a case-scoped tags-list endpoint) surfaces a case's current tags.
+	// See the CaseView.Tags doc comment.
 
 	return cv, nil
 }
@@ -2544,20 +2548,15 @@ func snWorkStateLabelToEnum(ws *snCaseLabel) *domain.CaseWorkState {
 	}
 }
 
-// snAddTagPayload is the Choreo POST /cases/{id}/tags request body.
-//
-// Not yet available in the backing service: no Ballerina/Choreo endpoint exists yet
-// for this. SN's tagging is the generic platform label/label_entry mechanism
-// (table-agnostic, not a case column), so a new adapter is needed -- ask: add
-// POST /cases/{id}/tags (body: {"label": string}) and
-// DELETE /cases/{id}/tags/{tagId} to the backing service's case API, backed by the
-// sys_label / label_entry tables scoped to
+// snAddTagPayload is the Choreo POST /cases/{id}/tags request body. SN's tagging is
+// the generic platform label/label_entry mechanism (table-agnostic, not a case
+// column), backed by the sys_label / label_entry tables scoped to
 // reference_table="sn_customerservice_case".
 type snAddTagPayload struct {
 	Label string `json:"label"`
 }
 
-// snTag mirrors the Choreo tag shape (once it exists).
+// snTag mirrors the Choreo tag shape.
 type snTag struct {
 	ID    string  `json:"id"`
 	Label string  `json:"label"`
@@ -2570,10 +2569,6 @@ type snAddTagResponse struct {
 }
 
 // AddCaseTag attaches a free-text label to the case identified by caseID.
-//
-// Not yet available in the backing service: see snAddTagPayload doc comment. This
-// is implemented so the entity-service side is ready the moment Ballerina adds it;
-// until then, calling it returns a downstream error (no such Choreo route today).
 func (s *snCaseService) AddCaseTag(ctx context.Context, caseID, label string) (domain.Tag, error) {
 	if err := validateUUIDs("id", []string{caseID}); err != nil {
 		return domain.Tag{}, err
@@ -2603,9 +2598,6 @@ func (s *snCaseService) AddCaseTag(ctx context.Context, caseID, label string) (d
 }
 
 // RemoveCaseTag removes the tag identified by tagID from the case identified by caseID.
-//
-// Not yet available in the backing service: see snAddTagPayload doc comment (no
-// such Choreo route today).
 func (s *snCaseService) RemoveCaseTag(ctx context.Context, caseID, tagID string) error {
 	if err := validateUUIDs("id", []string{caseID}); err != nil {
 		return err
@@ -2620,22 +2612,15 @@ func (s *snCaseService) RemoveCaseTag(ctx context.Context, caseID, tagID string)
 	return err
 }
 
-// snSearchTagsResponse mirrors the Choreo GET /tags/search response (once it exists).
+// snSearchTagsResponse mirrors the Choreo GET /tags/search response.
 type snSearchTagsResponse struct {
 	Tags []snTag `json:"tags"`
 }
 
 // SearchTags returns the tags (not scoped to any single case) whose label matches query, for
-// FE autocomplete when attaching a tag to a case.
-//
-// Not yet available in the backing service: no Ballerina/Choreo endpoint exists yet for this.
-// SN's tagging is the generic platform label mechanism (table-agnostic, not a case column), so
-// listing/searching existing labels needs a new adapter -- ask: add
-// GET /tags/search?q={query}&limit={limit} (response: {"tags": [{"id", "label", "color"}]}) to
-// the backing service's case API, backed by the sys_label table (optionally scoped to labels
-// used against reference_table="sn_customerservice_case" label_entry rows). This is so the
-// entity-service side is ready the moment Ballerina adds the endpoint; until then, calling it
-// returns a downstream error (no such Choreo route today).
+// FE autocomplete when attaching a tag to a case. SN's tagging is the generic platform label
+// mechanism (table-agnostic, not a case column), backed by the sys_label table (optionally
+// scoped to labels used against reference_table="sn_customerservice_case" label_entry rows).
 func (s *snCaseService) SearchTags(ctx context.Context, query string, limit int) ([]domain.Tag, error) {
 	token := middleware.UserIDTokenFromContext(ctx)
 

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -21,6 +21,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/url"
 	"strconv"
 	"strings"
@@ -915,12 +916,16 @@ func (s *snCaseService) GetCaseByID(ctx context.Context, id string) (domain.Case
 	if c.WorstCaseFixEta != nil && *c.WorstCaseFixEta != "" {
 		cv.WorstCaseFixEta = c.WorstCaseFixEta
 	}
-	// Tags are not populated here: the Choreo GET /cases/{id} response (snCase above)
-	// still has no tags field, and case tags are managed via the dedicated
-	// AddCaseTag/RemoveCaseTag/SearchTags endpoints rather than being inlined on the
-	// case detail read. cv.Tags is left nil until the backing service's case-detail
-	// response (or a case-scoped tags-list endpoint) surfaces a case's current tags.
-	// See the CaseView.Tags doc comment.
+	// The Choreo GET /cases/{id} response (snCase above) still has no inline tags field,
+	// so the case's current tags are fetched separately via the case-scoped
+	// GET /cases/{id}/tags resource. A failure here must not fail the whole case read
+	// (see CaseView.Tags doc comment): cv.Tags is left nil and the failure is logged.
+	tags, err := s.listCaseTags(ctx, id)
+	if err != nil {
+		slog.WarnContext(ctx, "sn get case: case tags lookup failed", "caseId", id, "error", err)
+	} else {
+		cv.Tags = tags
+	}
 
 	return cv, nil
 }
@@ -2612,9 +2617,36 @@ func (s *snCaseService) RemoveCaseTag(ctx context.Context, caseID, tagID string)
 	return err
 }
 
-// snSearchTagsResponse mirrors the Choreo GET /tags/search response.
+// snSearchTagsResponse mirrors the Choreo GET /tags/search response, and the shape of the
+// case-scoped GET /cases/{id}/tags response consumed by listCaseTags below.
 type snSearchTagsResponse struct {
 	Tags []snTag `json:"tags"`
+}
+
+// listCaseTags returns the tags currently attached to the case identified by caseID, via the
+// case-scoped GET /cases/{id}/tags resource.
+func (s *snCaseService) listCaseTags(ctx context.Context, caseID string) ([]domain.Tag, error) {
+	token := middleware.UserIDTokenFromContext(ctx)
+
+	raw, err := s.client.Get(ctx, "/cases/"+uuidToSysid(caseID)+"/tags", token)
+	if err != nil {
+		return nil, err
+	}
+
+	var snResp snSearchTagsResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return nil, fmt.Errorf("sn list case tags: parse response: %w", err)
+	}
+
+	tags := make([]domain.Tag, 0, len(snResp.Tags))
+	for _, t := range snResp.Tags {
+		tags = append(tags, domain.Tag{
+			ID:    sysidToUUID(t.ID),
+			Label: t.Label,
+			Color: t.Color,
+		})
+	}
+	return tags, nil
 }
 
 // SearchTags returns the tags (not scoped to any single case) whose label matches query, for

--- a/entity-service/internal/service/sn_case_service_test.go
+++ b/entity-service/internal/service/sn_case_service_test.go
@@ -1531,3 +1531,91 @@ func TestSNCaseService_GetCaseByID_MapsLinkedChangeRequests(t *testing.T) {
 		}
 	})
 }
+
+// caseDetailBody is a minimal, valid GET /cases/{id} response body for the given sysid,
+// used by the tags-population tests below where only the tags side-fetch is under test.
+func caseDetailBody(caseSysid string) string {
+	return `{
+		"id": "` + caseSysid + `",
+		"internalId": "WSO2-001",
+		"number": "CS0001001",
+		"title": "Case subject",
+		"description": "Case description",
+		"createdOn": "2026-01-01 10:00:00",
+		"project": {"id": "` + testProjectSysid + `", "name": "Project A"},
+		"deployment": {"id": "", "name": ""},
+		"deployedProduct": {"id": "", "name": "", "version": ""},
+		"state": {"id": 1, "label": "Open"}
+	}`
+}
+
+// TestSNCaseService_GetCaseByID_PopulatesTags verifies GetCaseByID fetches the case's
+// current tags from the case-scoped GET /cases/{id}/tags resource and maps them onto
+// CaseView.Tags, the same way SearchTags/AddCaseTag map the shared snTag shape.
+func TestSNCaseService_GetCaseByID_PopulatesTags(t *testing.T) {
+	var gotTagsPath string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/cases/"+testCaseSysid, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(caseDetailBody(testCaseSysid)))
+	})
+	mux.HandleFunc("/cases/"+testCaseSysid+"/tags", func(w http.ResponseWriter, r *http.Request) {
+		gotTagsPath = r.URL.Path
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"tags": []map[string]any{
+				{"id": testTagSysid, "label": "micro-gw", "color": "#f97316"},
+			},
+		})
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowCaseService(client, nil)
+
+	cv, err := svc.GetCaseByID(contextWithUserIDToken("token"), testCaseUUID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotTagsPath != "/cases/"+testCaseSysid+"/tags" {
+		t.Fatalf("tags endpoint not called, got path %q", gotTagsPath)
+	}
+	if len(cv.Tags) != 1 {
+		t.Fatalf("expected 1 tag, got %d: %+v", len(cv.Tags), cv.Tags)
+	}
+	if cv.Tags[0].ID != testTagUUID || cv.Tags[0].Label != "micro-gw" {
+		t.Fatalf("unexpected tag mapping: %+v", cv.Tags[0])
+	}
+	if cv.Tags[0].Color == nil || *cv.Tags[0].Color != "#f97316" {
+		t.Fatalf("tag.Color = %v, want #f97316", cv.Tags[0].Color)
+	}
+}
+
+// TestSNCaseService_GetCaseByID_TagsFetchFailureDoesNotFailRead verifies that a failing
+// tags lookup is soft-failed: the case detail read still succeeds (matching this file's
+// established soft-fail convention for supplementary side-fetches, e.g.
+// resolveUserGroups/resolveProjectAccess in sn_user_service.go), with CaseView.Tags left
+// nil rather than the whole GetCaseByID call returning an error.
+func TestSNCaseService_GetCaseByID_TagsFetchFailureDoesNotFailRead(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/cases/"+testCaseSysid, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(caseDetailBody(testCaseSysid)))
+	})
+	mux.HandleFunc("/cases/"+testCaseSysid+"/tags", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message": "internal error"}`))
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowCaseService(client, nil)
+
+	cv, err := svc.GetCaseByID(contextWithUserIDToken("token"), testCaseUUID)
+	if err != nil {
+		t.Fatalf("expected GetCaseByID to succeed despite the tags-lookup failure, got: %v", err)
+	}
+	if cv.Tags != nil {
+		t.Fatalf("expected Tags to stay nil on a fetch failure, got %+v", cv.Tags)
+	}
+	if cv.Number != "CS0001001" {
+		t.Fatalf("expected the rest of the case detail to still be populated, got %+v", cv)
+	}
+}

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -5284,6 +5284,15 @@ components:
           description: >-
             Internal-only worst-case fix-commitment date (date-only, YYYY-MM-DD), visible to
             CSM engineers only. Populated for ServiceNow cases; null otherwise.
+        tags:
+          type: array
+          nullable: true
+          items:
+            $ref: '#/components/schemas/Tag'
+          description: >-
+            Tags currently attached to the case, fetched via a best-effort lookup against the
+            backing data source. null if that lookup failed; the rest of the case detail is
+            still valid in that case, not an indication the case has no tags.
 
     CaseSearchView:
       type: object


### PR DESCRIPTION
## Purpose
Case tag management (add, remove, search, and — as of this update — listing a case's current tags) for a case in the CSM Portal has been unreachable end-to-end: the entity-service side was implemented ahead of its backing-service dependency, so the code carried "not yet available" stubs and doc comments. That dependency now exists and is live. This PR removes the now-stale stubbing and wires up case-detail reads to actually surface a case's current tags.

## Goals
- Enable `POST /cases/{id}/tags`, `DELETE /cases/{id}/tags/{tagId}`, and `GET /tags/search` to actually work end-to-end instead of returning a "not yet available" state, by dropping doc comments that no longer reflect reality now that the backing-service route exists.
- Populate `CaseView.Tags` on `GET /cases/{id}` reads, using a new case-scoped tags-list lookup against the backing service — previously always `nil` because no such lookup existed.

## Approach
First commit: comment-only cleanup in `entity-service/internal/service/sn_case_service.go`, `interfaces.go`, and `internal/domain/entity.go` — no behavioral/logic changes. The HTTP calls to the backing service were already correctly implemented and already covered by existing passing unit tests; only the doc comments claiming the downstream route didn't exist yet were stale and removed/corrected.

Second commit: `GetCaseByID` now fetches a case's current tags via a case-scoped lookup and populates `CaseView.Tags`. This is a **best-effort, soft-fail** call — if the tags lookup fails, the case detail read still succeeds with `Tags` left `nil` rather than failing the whole read, matching this file's existing soft-fail convention for supplementary side-fetches (e.g. `resolveUserGroups`/`resolveProjectAccess`). Sequential, not concurrent with the rest of the case-detail assembly — `GetCaseByID` has no existing concurrency pattern to extend, and one field didn't warrant introducing a new one.

Third commit: documents the new `tags` field on `CaseView` in `openapi.yaml`, reusing the existing `Tag` schema already defined for `/tags/search` — this field was previously undocumented in the published contract even though the Go type always had it.

## User stories
As a CS engineer, I can add, remove, search for, and see the tags currently attached to a case from the CSM Portal.

## Release note
Case tag management (add/remove/search/list) is now functional in the CSM Portal.

## Documentation
`openapi.yaml`'s `CaseView` schema now documents the `tags` field (nullable array of `Tag`, reusing the existing `Tag` schema from `/tags/search`). No external user-facing docs to update beyond that.

## Automation tests
- Unit tests: existing tests for `AddCaseTag`, `RemoveCaseTag`, and `SearchTags` continue to pass unchanged. Two new tests added for the tags-population behavior: one confirming a successful lookup maps onto `CaseView.Tags` correctly, one confirming a failing lookup doesn't fail the case read. `go test ./...` clean across the module.
- Integration tests: not run against a live backing-service instance in this environment; verified at build/vet/unit-test level only. The underlying ServiceNow-side contract this relies on (an additive `caseId` filter on the existing tag-search endpoint) was independently live-verified against the DEV tenant before the Ballerina/Go code was written against it.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A for Go — `go vet ./...` ran clean instead.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no new samples.

## Related PRs
Depends on a corresponding Ballerina entity-service change in the private digiops-cs repo (tracked separately) that added the case-scoped tags endpoint this PR's second commit calls.

## Migrations (if applicable)
N/A — no schema/migration changes.

## Test environment
Verified with `go build ./...`, `go vet ./...`, and `go test ./...` locally (Go toolchain per `go.mod`).

## Learning
N/A.
