### PR TITLE
[CSM Portal] drop the team filter entirely for "All ABTs"

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-dashboard/utils/teamFilterPlaceholder.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/utils/teamFilterPlaceholder.test.ts
@@ -101,7 +101,7 @@ describe("resolveTeamPlaceholder", () => {
     expect(resolveTeamPlaceholder(filters, "team-group-id")).toBe(filters);
   });
 
-  it("splices every groupId in an array into the placeholder's spot ('All ABTs')", () => {
+  it("drops the integrationCsTeam entry entirely when given an array with many ids ('All ABTs')", () => {
     const filters = {
       filters: [
         { field: "state", op: "in", values: ["open"] },
@@ -112,18 +112,11 @@ describe("resolveTeamPlaceholder", () => {
     const resolved = resolveTeamPlaceholder(filters, ["group-a", "group-b", "group-c"]);
 
     expect(resolved).toEqual({
-      filters: [
-        { field: "state", op: "in", values: ["open"] },
-        {
-          field: "integrationCsTeam",
-          op: "in",
-          values: ["group-a", "group-b", "group-c"],
-        },
-      ],
+      filters: [{ field: "state", op: "in", values: ["open"] }],
     });
   });
 
-  it("keeps a literal value alongside a spliced-in array, in position", () => {
+  it("drops the integrationCsTeam entry entirely when given an array with a single id", () => {
     const filters = {
       filters: [
         {
@@ -134,17 +127,9 @@ describe("resolveTeamPlaceholder", () => {
       ],
     };
 
-    const resolved = resolveTeamPlaceholder(filters, ["group-a", "group-b"]);
+    const resolved = resolveTeamPlaceholder(filters, ["group-a"]);
 
-    expect(resolved).toEqual({
-      filters: [
-        {
-          field: "integrationCsTeam",
-          op: "in",
-          values: ["some-literal-group-id", "group-a", "group-b"],
-        },
-      ],
-    });
+    expect(resolved).toEqual({ filters: [] });
   });
 
   it("drops the integrationCsTeam entry entirely when given an empty array", () => {

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/utils/teamFilterPlaceholder.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/utils/teamFilterPlaceholder.ts
@@ -51,31 +51,37 @@ const TEAM_FILTER_FIELD = "integrationCsTeam";
  * `resolveCurrentUserSentinels` already walk) with the selected team's own
  * `groupId` — the backing data source's assignment-group id reformatted as
  * this platform's UUID (`BeTeam.groupId`), never the team registry key
- * (`BeTeam.id`) that `integrationCsTeam` values are NOT keyed by.
+ * (`BeTeam.id`) that `integrationCsTeam` values are NOT keyed by. This only
+ * applies to a single selected team (`selectedTeamGroupId` a plain string).
  *
  * `selectedTeamGroupId` may also be an array of `groupId`s — the "All ABTs"
- * case (see {@link ALL_TEAMS_SENTINEL}): every team in the current
- * dashboard's family, OR'd together. The single placeholder occurrence in
- * `values` is then spliced out and replaced with all of them (`in` already
- * supports multiple values — no backend change needed), rather than the
- * 1:1 substitution a single string gets. An empty array is treated the same
- * as `undefined` (see below) — a family with no teams configured is no
- * different from no team selected at all.
+ * case (see {@link ALL_TEAMS_SENTINEL}). As of 2026-08-05 this is an
+ * explicit, deliberate product decision: the `integrationCsTeam` entry is
+ * DROPPED from the filter array entirely whenever `selectedTeamGroupId` is
+ * an array, regardless of its contents, rather than being replaced with the
+ * enumerated list of every team's `groupId` in the current dashboard's
+ * family. Dropping the filter widens the query to *every* team in the whole
+ * registry — including non-ABT teams (`cre`, `sre`, etc.) outside this
+ * dashboard's own family — which is broader than "every team in this
+ * family" and was previously avoided on purpose (see the removed "My ABT /
+ * All customers" toggle this replaced). That tradeoff was considered and
+ * accepted: "All ABTs" now means "no team filter at all", org-wide.
  *
- * If `selectedTeamGroupId` is undefined (or an empty array) — no team
- * selected yet, or the selected team has no group configured in the
- * deployment's team registry — the `integrationCsTeam` entry is DROPPED
- * from the filter array entirely, rather than either (a) sent with the
- * literal placeholder string, which the entity-service would either reject
- * with a 400 (not a valid UUID) or, worse, silently treat as a value that
- * matches nothing, or (b) sent with an empty `values` array, which the
- * entity-service also rejects for a non-`isEmpty`/`isNotEmpty` op. Dropping
- * the condition instead just widens the query back to "every team" — the
- * same result as if this filter had never been applied — which is the
- * safer failure mode for a dashboard tile: a count/list that's too broad is
- * visibly wrong (an obviously large number, or rows from other teams) and
- * gets noticed, where a query that silently matches zero rows reads as
- * "there's nothing to see here" and doesn't.
+ * If `selectedTeamGroupId` is undefined, or an array (see above) — no team
+ * selected yet, the selected team has no group configured in the
+ * deployment's team registry, or "All ABTs" is selected — the
+ * `integrationCsTeam` entry is DROPPED from the filter array entirely,
+ * rather than either (a) sent with the literal placeholder string, which
+ * the entity-service would either reject with a 400 (not a valid UUID) or,
+ * worse, silently treat as a value that matches nothing, or (b) sent with
+ * an empty `values` array, which the entity-service also rejects for a
+ * non-`isEmpty`/`isNotEmpty` op. Dropping the condition instead just widens
+ * the query back to "every team" — the same result as if this filter had
+ * never been applied — which is the safer failure mode for a dashboard
+ * tile: a count/list that's too broad is visibly wrong (an obviously large
+ * number, or rows from other teams) and gets noticed, where a query that
+ * silently matches zero rows reads as "there's nothing to see here" and
+ * doesn't.
  *
  * Every other filter entry, and every other resourceType's filters shape
  * (this only touches the case-search generic field/op/values DSL), passes
@@ -88,9 +94,8 @@ export function resolveTeamPlaceholder(
   const fieldFilters = filters.filters;
   if (!isCaseFieldFilterArray(fieldFilters)) return filters;
 
-  const hasReplacement =
-    selectedTeamGroupId !== undefined &&
-    (!Array.isArray(selectedTeamGroupId) || selectedTeamGroupId.length > 0);
+  const replacementGroupId =
+    typeof selectedTeamGroupId === "string" ? selectedTeamGroupId : undefined;
 
   let changed = false;
   const resolved: WidgetCaseFieldFilterLike[] = [];
@@ -101,19 +106,13 @@ export function resolveTeamPlaceholder(
       continue;
     }
     changed = true;
-    if (!hasReplacement) {
+    if (replacementGroupId === undefined) {
       // Drop the entry entirely — see the doc comment above.
       continue;
     }
     resolved.push({
       ...entry,
-      values: values.flatMap((v) =>
-        v === CURRENT_TEAM_PLACEHOLDER
-          ? Array.isArray(selectedTeamGroupId)
-            ? selectedTeamGroupId
-            : [selectedTeamGroupId as string]
-          : [v],
-      ),
+      values: values.flatMap((v) => (v === CURRENT_TEAM_PLACEHOLDER ? [replacementGroupId] : [v])),
     });
   }
 


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

The "All ABTs" option on a team-based dashboard's team picker currently substitutes the widget's `integrationCsTeam` filter with every team's `groupId` in the current dashboard's own family (e.g. every `cre-abt` team), keeping results scoped to that family. We want "All ABTs" to mean no team restriction at all, org-wide, not "every team in this family."

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

`resolveTeamPlaceholder` now drops the `integrationCsTeam` filter entry entirely when "All ABTs" is selected, the same way it already does when no team is selected, instead of enumerating the family's team ids into the filter's `values`.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

In `apps/csm-portal/webapp/src/features/csm-dashboard/utils/teamFilterPlaceholder.ts`, the array-valued `selectedTeamGroupId` case (the "All ABTs" sentinel resolves to an array of every family team's `groupId`) is now treated the same as the `undefined` case: the whole `integrationCsTeam` filter entry is dropped rather than spliced with the enumerated array. The single-team string substitution path is unchanged. Doc comment updated to state the new behavior plainly. No UI change — the picker option, its label, and the `{{currentTeam}}` display-text resolution are untouched; only the case-search filter DSL this produces changes.

## User stories
> Summary of user stories addressed by this change

As a CS engineer viewing a team-based ABT dashboard, when I select "All ABTs" I see data across every team, not just my dashboard's own family, so I'm not missing cases assigned to teams outside that family.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

"All ABTs" on a dashboard's team picker now shows data across every team, not just the dashboard's own team family.

## Documentation
N/A — internal dashboard filter behavior, no user-facing docs describe this level of detail.

## Training
N/A — not training content.

## Certification
N/A — no certification exam impact.

## Marketing
N/A — internal dashboard behavior change, not a marketed feature.

## Automation tests
 - Unit tests
   `teamFilterPlaceholder.test.ts` updated: single-id array, multi-id array, and empty array all now assert the filter is dropped. Full `csm-dashboard` feature suite (141 tests) passes.
 - Integration tests
   N/A — no integration test suite covers this path; verified via unit tests and `tsc`/`eslint`.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A for TypeScript — ran `eslint` and `tsc -b --noEmit` clean instead
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no sample code affected.

## Related PRs
None.

## Migrations (if applicable)
N/A — no data migration involved.

## Test environment
Vitest (jsdom), Node/pnpm toolchain as configured in the repo. No browser/OS/DB-specific behavior.

## Learning
N/A.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated team filtering so selecting multiple teams or all teams correctly widens results instead of creating separate team-specific filters.
  * Improved handling of mixed team filter selections, including single-team arrays and placeholder filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->