### PR TITLE
[CSM Portal Microapp] Fix comment author showing as "Unknown" for every commenter

### DIFF
--- a/apps/csm-portal/microapp/src/types/case.dto.ts
+++ b/apps/csm-portal/microapp/src/types/case.dto.ts
@@ -181,16 +181,10 @@ export interface CaseViewDto {
 
 export type CaseCommentType = "work_note" | "comment" | "activity";
 
-// openapi.yaml declares `createdBy` as a plain string, but the live entity-service response
-// doesn't consistently match that — it comes back as a richer {id, firstName, lastName, fullName}
-// object for at least some comments (same createdBy string-vs-object drift already seen on
-// CaseSearchViewDto — see reference_csm_announcements memory). Modeled as a union and normalized
-// to a display string in `toComment` rather than trusted as a string at the DTO boundary.
 export interface CaseCommentAuthorDto {
-  id?: string;
-  firstName?: string;
-  lastName?: string;
-  fullName?: string;
+  id: string | null;
+  email: string;
+  name: string;
 }
 
 export interface CaseCommentDto {

--- a/apps/csm-portal/microapp/src/types/case.model.ts
+++ b/apps/csm-portal/microapp/src/types/case.model.ts
@@ -174,8 +174,8 @@ export function toCaseDetail(dto: CaseViewDto): CaseDetail {
 }
 function commentAuthorLabel(createdBy: CaseCommentDto["createdBy"] | null | undefined): string {
   if (!createdBy) return "Unknown";
-  if (typeof createdBy === "string") return createdBy;
-  return createdBy.name || createdBy.email || "Unknown";
+  if (typeof createdBy === "string") return createdBy.trim() || "Unknown";
+  return createdBy.name?.trim() || createdBy.email?.trim() || "Unknown";
 }
 
 export function toComment(dto: CaseCommentDto): Comment {

--- a/apps/csm-portal/microapp/src/types/case.model.ts
+++ b/apps/csm-portal/microapp/src/types/case.model.ts
@@ -172,16 +172,10 @@ export function toCaseDetail(dto: CaseViewDto): CaseDetail {
     nextStates: dto.nextStates,
   };
 }
-
-// See CaseCommentAuthorDto's comment: `createdBy` isn't reliably a string at runtime despite what
-// openapi.yaml declares, so this always normalizes to a display string before it reaches a
-// component — mirrors user.model.ts's fullName derivation (firstName + lastName, falling back
-// further since comments' author object carries no email to fall back to). Also guards against
-// createdBy being entirely absent — seen on some records regardless of what the DTO type claims.
 function commentAuthorLabel(createdBy: CaseCommentDto["createdBy"] | null | undefined): string {
   if (!createdBy) return "Unknown";
   if (typeof createdBy === "string") return createdBy;
-  return createdBy.fullName || [createdBy.firstName, createdBy.lastName].filter(Boolean).join(" ").trim() || "Unknown";
+  return createdBy.name || createdBy.email || "Unknown";
 }
 
 export function toComment(dto: CaseCommentDto): Comment {


### PR DESCRIPTION
## Summary
- `CaseCommentAuthorDto` declared `createdBy` as `{id?, firstName?, lastName?, fullName?}`, but the backend actually sends the canonical `UserReference` shape documented in `openapi.yaml` — `{id, email, name}`. Confirmed live: `{"id":"bcc4881f-...","email":"anuradhab@wso2.com","name":"Anuradha Basnayake ⓦ"}`.
- None of `fullName`/`firstName`/`lastName` exist on that object, so `commentAuthorLabel`'s lookup always came up empty and fell through to `"Unknown"` — for every comment, from any author (customer or internal), not intermittently.
- Fixed the DTO to match the real shape and updated `commentAuthorLabel` to read `createdBy.name` (falling back to `createdBy.email`, then `"Unknown"` only if genuinely absent).

## Test plan
- [x] `tsc --noEmit` passes
- [x] `eslint` passes
- [x] `npm run build` passes
- [x] Verified against a real `/cases/{id}/comments/search` response — `createdBy.name` now renders instead of falling through to "Unknown"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved case comment author information display by using the author’s name, with email shown as a fallback when needed.
  * Standardized comment author details for more consistent case views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->