### PR TITLE
Fix Activities tab crash on attachments + case Created By name, remove purple gradient

### DIFF
--- a/apps/csm-portal/microapp/src/pages/CaseDetailPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/CaseDetailPage.tsx
@@ -589,7 +589,10 @@ function CaseMetadataSection({ caseDetail }: { caseDetail: CaseDetail }) {
       {
         icon: PenLine,
         label: "Created By",
-        value: caseDetail.createdBy?.name || caseDetail.createdBy?.email,
+        // Falls back to "Unknown" rather than leaving this undefined — this section's groups are
+        // filtered to only fields with a truthy value, so an undefined here would silently drop
+        // the whole "Created By" row instead of showing that the creator is unknown.
+        value: caseDetail.createdBy?.name || caseDetail.createdBy?.email || "Unknown",
       },
     ],
     [

--- a/apps/csm-portal/microapp/src/pages/CaseDetailPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/CaseDetailPage.tsx
@@ -589,7 +589,7 @@ function CaseMetadataSection({ caseDetail }: { caseDetail: CaseDetail }) {
       {
         icon: PenLine,
         label: "Created By",
-        value: caseDetail.createdBy?.displayName || caseDetail.createdBy?.email,
+        value: caseDetail.createdBy?.name || caseDetail.createdBy?.email,
       },
     ],
     [

--- a/apps/csm-portal/microapp/src/theme/index.ts
+++ b/apps/csm-portal/microapp/src/theme/index.ts
@@ -39,6 +39,20 @@ const theme = extendTheme(AcrylicPurpleTheme, {
         }),
       },
     },
+    // AcrylicPurpleTheme (unlike AcrylicOrangeTheme, which has no such override — see the
+    // customer-portal microapp's theme/index.ts) paints a radial-gradient onto <body>, keyed to
+    // fixed focal points (e.g. "circle at 65% 30%") that fade back to background.default
+    // elsewhere. With background-attachment: fixed, that reads as tinted near those points and
+    // plain white/black everywhere else — inconsistent rather than a deliberate design choice
+    // here. Same selectors @wso2/oxygen-ui's own override uses (dist/index.js), just dropping the
+    // image so the page falls back to the flat background.default color everywhere, matching how
+    // the orange theme already looks.
+    MuiCssBaseline: {
+      styleOverrides: {
+        "html[data-color-scheme='dark'] body": { backgroundImage: "none" },
+        "html[data-color-scheme='light'] body": { backgroundImage: "none" },
+      },
+    },
   },
 }) as OxygenTheme;
 

--- a/apps/csm-portal/microapp/src/types/attachment.dto.ts
+++ b/apps/csm-portal/microapp/src/types/attachment.dto.ts
@@ -36,6 +36,16 @@ export interface AttachmentCreateResponseDto {
   attachment: AttachmentDetailDto;
 }
 
+// The canonical {id, email, name} UserReference shape (openapi.yaml) — confirmed live:
+// {"id":"bcc4881f-...","email":"anuradhab@wso2.com","name":"Anuradha Basnayake ⓦ"}. Same shape
+// as CaseCommentAuthorDto in case.dto.ts; kept separate per this codebase's convention of one
+// type per DTO file rather than a shared cross-file import for it.
+export interface AttachmentAuthorDto {
+  id: string | null;
+  email: string;
+  name: string;
+}
+
 // List/search view — mirrors openapi.yaml's Attachment schema (the full record, as opposed to
 // AttachmentDetailDto's thin create-response ack).
 export interface AttachmentViewDto {
@@ -46,7 +56,7 @@ export interface AttachmentViewDto {
   type: string;
   sizeBytes: number;
   description: string | null;
-  createdBy: string;
+  createdBy: string | AttachmentAuthorDto;
   createdOn: string;
   downloadUrl: string | null;
   previewUrl: string | null;

--- a/apps/csm-portal/microapp/src/types/attachment.dto.ts
+++ b/apps/csm-portal/microapp/src/types/attachment.dto.ts
@@ -36,10 +36,9 @@ export interface AttachmentCreateResponseDto {
   attachment: AttachmentDetailDto;
 }
 
-// The canonical {id, email, name} UserReference shape (openapi.yaml) — confirmed live:
-// {"id":"bcc4881f-...","email":"anuradhab@wso2.com","name":"Anuradha Basnayake ⓦ"}. Same shape
-// as CaseCommentAuthorDto in case.dto.ts; kept separate per this codebase's convention of one
-// type per DTO file rather than a shared cross-file import for it.
+// The canonical {id, email, name} UserReference shape (openapi.yaml) — confirmed live against a
+// real response. Same shape as CaseCommentAuthorDto in case.dto.ts; kept separate per this
+// codebase's convention of one type per DTO file rather than a shared cross-file import for it.
 export interface AttachmentAuthorDto {
   id: string | null;
   email: string;
@@ -56,7 +55,10 @@ export interface AttachmentViewDto {
   type: string;
   sizeBytes: number;
   description: string | null;
-  createdBy: string | AttachmentAuthorDto;
+  // openapi.yaml marks this nullable — null is handled defensively in attachmentAuthorLabel
+  // (attachment.model.ts) already, but the type should say so too rather than let a future,
+  // non-defensive read assume it's always present.
+  createdBy: string | AttachmentAuthorDto | null;
   createdOn: string;
   downloadUrl: string | null;
   previewUrl: string | null;

--- a/apps/csm-portal/microapp/src/types/attachment.model.ts
+++ b/apps/csm-portal/microapp/src/types/attachment.model.ts
@@ -28,6 +28,18 @@ export interface CaseAttachment {
   downloadUrl: string | null;
 }
 
+// createdBy used to be assumed a plain string; the live shape is the {id, email, name}
+// UserReference object (see AttachmentAuthorDto) — rendering that object directly as a string,
+// as this codebase did before this fix, crashes React ("Objects are not valid as a React
+// child"), which is what tripped CaseActivityFeed's error boundary for the whole Activities tab
+// the moment an attachment with this shape entered the render. Mirrors commentAuthorLabel in
+// case.model.ts (same fallback chain the webapp's authorDisplayName uses).
+function attachmentAuthorLabel(createdBy: AttachmentViewDto["createdBy"] | null | undefined): string {
+  if (!createdBy) return "Unknown";
+  if (typeof createdBy === "string") return createdBy.trim() || "Unknown";
+  return createdBy.name?.trim() || createdBy.email?.trim() || "Unknown";
+}
+
 export function toCaseAttachment(dto: AttachmentViewDto): CaseAttachment {
   return {
     id: dto.id,
@@ -35,7 +47,7 @@ export function toCaseAttachment(dto: AttachmentViewDto): CaseAttachment {
     type: dto.type,
     sizeBytes: dto.sizeBytes,
     description: dto.description,
-    createdBy: dto.createdBy,
+    createdBy: attachmentAuthorLabel(dto.createdBy),
     createdOn: parseBackendTimestamp(dto.createdOn),
     downloadUrl: dto.downloadUrl,
   };

--- a/apps/csm-portal/microapp/src/types/case.dto.ts
+++ b/apps/csm-portal/microapp/src/types/case.dto.ts
@@ -44,11 +44,15 @@ export interface EntityRefDto {
   name: string;
 }
 
+// The canonical {id, email, name} UserReference shape (openapi.yaml), used for CaseViewDto's
+// createdBy — confirmed live: {"id":"bcc4881f-...","email":"anuradhab@wso2.com","name":"Anuradha
+// Basnayake ⓦ"}. Previously modeled as {id, displayName, userId, email}, none of which (besides
+// id/email) exist on the real object — CaseDetailPage's `displayName` read always came up empty
+// and silently fell back to rendering the email instead of the name.
 export interface UserRefDto {
-  id: string;
-  displayName: string;
-  userId: string;
+  id: string | null;
   email: string;
+  name: string;
 }
 
 export interface UserIdEmailRefDto {

--- a/apps/csm-portal/microapp/src/types/case.dto.ts
+++ b/apps/csm-portal/microapp/src/types/case.dto.ts
@@ -45,10 +45,11 @@ export interface EntityRefDto {
 }
 
 // The canonical {id, email, name} UserReference shape (openapi.yaml), used for CaseViewDto's
-// createdBy — confirmed live: {"id":"bcc4881f-...","email":"anuradhab@wso2.com","name":"Anuradha
-// Basnayake ⓦ"}. Previously modeled as {id, displayName, userId, email}, none of which (besides
-// id/email) exist on the real object — CaseDetailPage's `displayName` read always came up empty
-// and silently fell back to rendering the email instead of the name.
+// createdBy — confirmed live against a real response. Previously modeled as {id, displayName,
+// userId, email}, none of which (besides id/email) exist on the real object — CaseDetailPage's
+// `displayName` read always came up empty and silently fell back to rendering the email instead
+// of the name. openapi.yaml marks both UserReference and CaseView.createdBy nullable, so callers
+// must not assume a CaseViewDto always has one.
 export interface UserRefDto {
   id: string | null;
   email: string;
@@ -167,7 +168,7 @@ export interface CaseViewDto {
   createdOn?: string;
   updatedOn?: string;
   closedOn: string | null;
-  createdBy: UserRefDto;
+  createdBy: UserRefDto | null;
   project: EntityRefDto;
   deployment: EntityRefDto | null;
   deployedProduct: DeployedProductRefDto | null;

--- a/apps/csm-portal/microapp/src/types/case.model.ts
+++ b/apps/csm-portal/microapp/src/types/case.model.ts
@@ -95,7 +95,7 @@ export interface CaseDetail {
   createdOn: Date;
   updatedOn: Date;
   closedOn: Date | null;
-  createdBy: UserRefDto;
+  createdBy: UserRefDto | null;
   project: EntityRefDto;
   deployment: EntityRefDto | null;
   deployedProduct: DeployedProductRefDto | null;


### PR DESCRIPTION
## Summary
Two more instances of the same root bug as the already-merged comment-author fix (#1367), plus an unrelated theme cleanup:

- **`Attachment.createdBy` (crash)**: `AttachmentViewDto` claimed a plain string, but the backend sends the canonical `{id, email, name}` UserReference (confirmed live). `CaseActivityFeed` rendered it directly as a string (`{e.attachment.createdBy}`) - React throws "Objects are not valid as a React child" when that's actually an object, which crashed the whole Activities tab's error boundary (comments and audit entries included) the moment a newly-created attachment entered the render. 

this is very likely the real explanation for "some comments not shown" reports - not selective filtering, but the entire tab crashing whenever an attachment with this shape was present. Normalized via a new `attachmentAuthorLabel()`, mirroring `commentAuthorLabel`'s fallback chain.

- **`CaseView.createdBy` (wrong name)**: `UserRefDto` claimed `{id, displayName, userId, email}`; the real object has neither `displayName` nor `userId`. The case Details tab's "Created By" field always fell back to rendering the email instead of the name.

- Both now match the webapp's own canonical `BeUserReference`/`authorDisplayName` pattern: `name`, falling back to `email`, falling back to `"Unknown"`.

- **Theme**: removed `AcrylicPurpleTheme`'s baked-in radial-gradient `<body>` background (a `MuiCssBaseline` override from `@wso2/oxygen-ui`, not present in `AcrylicOrangeTheme`) — it read as tinted near its fixed focal points and plain white/black elsewhere, not a deliberate look. Neutralized the same way the existing `MuiDialog` override already handles a different unwanted base-theme style.

## Test plan
- [x] `tsc --noEmit` passes
- [x] `eslint` passes (4 pre-existing errors remain in untouched files, unrelated to this PR)
- [x] `npm run build` passes
- [x] Verified live: posting a comment with an attachment on a real case no longer crashes the Activities tab; the attachment now renders its actual author name instead of "Unknown"; case Details tab's "Created By" shows the name instead of the email

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Creator information now remains visible using the person’s name, email, or “Unknown” when details are unavailable.
  - Attachment authors are displayed consistently, including when author details are incomplete or provided in different formats.
  - Case and attachment details now handle missing creator information without display issues.

- **Style**
  - Removed radial-gradient backgrounds from light and dark themes for a consistent flat background appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->