### PR TITLE
[CSM Portal] Inline resume-work quick-fix for the locked public-reply toggle

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasePreviewDrawer.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasePreviewDrawer.tsx
@@ -34,6 +34,7 @@ import WorkStateChip from "@components/WorkStateChip";
 import CsmCaseCommentBubble from "@features/csm-cases/components/CsmCaseCommentBubble";
 import { useGetCsmCaseComments } from "@features/csm-cases/api/useCsmCaseComments";
 import { caseTypeDetailBasePath, caseTypeHasSeverity } from "@features/csm-cases/utils/caseType";
+import { effectiveWorkState } from "@features/csm-cases/utils/caseWorkState";
 import type { CsmCaseRow } from "@features/csm-cases/types/csmCases";
 
 // "The last few at least" — deliberately not the full thread (that's the
@@ -108,8 +109,8 @@ export default function CasePreviewDrawer({ row, onClose }: CasePreviewDrawerPro
             </Box>
             <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
               <StateChip state={row.state} variant="outlined" />
-              {row.state === "work_in_progress" && row.workState && (
-                <WorkStateChip workState={row.workState} />
+              {row.state === "work_in_progress" && (
+                <WorkStateChip workState={effectiveWorkState(row.workState)} />
               )}
               {caseTypeHasSeverity(row.caseType) && <SeverityChip severity={row.severity} />}
             </Box>

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.tsx
@@ -42,6 +42,7 @@ import {
   caseTypeDetailBasePath,
   caseTypeHasSeverity,
 } from "@features/csm-cases/utils/caseType";
+import { effectiveWorkState } from "@features/csm-cases/utils/caseWorkState";
 
 interface CasesListProps {
   cases: CsmCaseRow[];
@@ -362,8 +363,8 @@ export default function CasesList({
                 }}
               >
                 <StateChip state={c.state} variant="outlined" clickable />
-                {c.state === "work_in_progress" && c.workState && (
-                  <WorkStateChip workState={c.workState} />
+                {c.state === "work_in_progress" && (
+                  <WorkStateChip workState={effectiveWorkState(c.workState)} />
                 )}
               </Box>
               <Typography variant="caption" color="text.secondary" noWrap>

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentInput.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentInput.test.tsx
@@ -1,0 +1,137 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+
+// The real client reads runtime config at module load, which isn't present
+// under vitest (same approach as CaseActivitiesFeed.test.tsx). Pulled in
+// transitively via CsmUploadAttachmentModal -> useCsmCaseAttachments, just
+// for its MAX_ATTACHMENT_SIZE_BYTES constant — the mock only exists to keep
+// that import chain from throwing on missing runtime config.
+vi.mock("@api/backend/client", () => ({
+  useBackendApi: () => ({ post: vi.fn() }),
+}));
+
+import CsmCaseCommentInput from "@features/csm-cases/components/CsmCaseCommentInput";
+
+// This component isn't under test here; stub it to a plain textarea (same
+// technique EditCaseDetailsDialog.test.tsx uses for the same dependency).
+vi.mock("@components/rich-text-editor/Editor", () => ({
+  default: ({
+    value,
+    onChange,
+  }: {
+    value: string;
+    onChange: (v: string) => void;
+  }) => (
+    <textarea
+      aria-label="comment-editor"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  ),
+}));
+
+const PAUSED_REASON =
+  "This case is paused — customer replies are disabled. Resume work to reply to the customer.";
+const NOT_STARTED_REASON =
+  "Customer replies are disabled unless the case is actively in progress.";
+
+describe("CsmCaseCommentInput — resume-work quick-fix", () => {
+  it("shows the inline resume link when the only lock reason is paused work, and calls onResumeWork", () => {
+    const onResumeWork = vi.fn();
+    render(
+      <CsmCaseCommentInput
+        onSubmit={vi.fn()}
+        publicCommentDisabledReason={PAUSED_REASON}
+        canResumeToUnlockPublicReply
+        onResumeWork={onResumeWork}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Resume work" }));
+    expect(onResumeWork).toHaveBeenCalledTimes(1);
+  });
+
+  it("doesn't also repeat the raw lock reason in the send-row status line once the quick-fix covers it", () => {
+    render(
+      <CsmCaseCommentInput
+        onSubmit={vi.fn()}
+        publicCommentDisabledReason={PAUSED_REASON}
+        canResumeToUnlockPublicReply
+        onResumeWork={vi.fn()}
+      />,
+    );
+
+    // The quick-fix's own sentence is present once...
+    expect(
+      screen.getByText("Only resumed work can send public replies to the customer.", {
+        exact: false,
+      }),
+    ).toBeInTheDocument();
+    // ...and the send-row status line falls back to the normal hint instead
+    // of repeating the raw backend reason a second time.
+    expect(screen.queryByText(PAUSED_REASON)).not.toBeInTheDocument();
+    expect(screen.getByText("Ctrl/Cmd + Enter to send.")).toBeInTheDocument();
+  });
+
+  it("does not show the resume link when the case hasn't started yet (not just paused)", () => {
+    render(
+      <CsmCaseCommentInput
+        onSubmit={vi.fn()}
+        publicCommentDisabledReason={NOT_STARTED_REASON}
+        canResumeToUnlockPublicReply={false}
+        onResumeWork={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Resume work" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText(NOT_STARTED_REASON)).toBeInTheDocument();
+  });
+
+  it("does not show the resume link when public replies are already allowed", () => {
+    render(
+      <CsmCaseCommentInput
+        onSubmit={vi.fn()}
+        publicCommentDisabledReason={null}
+        canResumeToUnlockPublicReply
+        onResumeWork={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Resume work" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("disables the resume link and shows a pending label while resuming", () => {
+    render(
+      <CsmCaseCommentInput
+        onSubmit={vi.fn()}
+        publicCommentDisabledReason={PAUSED_REASON}
+        canResumeToUnlockPublicReply
+        onResumeWork={vi.fn()}
+        isResumingWork
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Resuming…" })).toBeDisabled();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentInput.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentInput.tsx
@@ -19,6 +19,7 @@ import {
   Button,
   FormControlLabel,
   IconButton,
+  Link,
   Switch,
   TextField,
   Tooltip,
@@ -64,6 +65,26 @@ interface CsmCaseCommentInputProps {
    * are always allowed. `null`/absent = public replies allowed.
    */
   publicCommentDisabledReason?: string | null;
+  /**
+   * True when the *only* thing blocking a public reply is paused work — i.e.
+   * the case is already `work_in_progress` and assigned, just not `ongoing`,
+   * so resuming (a single click, no reassignment or state change needed)
+   * would unlock it right away. Drives the inline "Resume work" quick-fix
+   * shown next to the Internal note toggle; omit/false when the case isn't
+   * even in progress yet, where "resume" doesn't apply. Ignored unless
+   * `publicCommentDisabledReason` and `onResumeWork` are both set.
+   */
+  canResumeToUnlockPublicReply?: boolean;
+  /** Resumes work on the case (`workState` paused → ongoing). Runs the same
+   * single-active-case conflict check as the case header's own Resume
+   * action — see CsmCaseDetailPage's `onAction("toggle_work_state")`. Once it
+   * succeeds, `publicCommentDisabledReason` clears on its own (the case
+   * detail query refetches) and the Internal note toggle unlocks — this
+   * doesn't flip it or send anything by itself. */
+  onResumeWork?: () => void;
+  /** True while a resume (or any other case mutation sharing the same
+   * pending flag) is in flight; disables the quick-fix link. */
+  isResumingWork?: boolean;
   /** Focus the editor as soon as it mounts (e.g. when the composer opens). */
   autoFocus?: boolean;
 }
@@ -91,6 +112,9 @@ export default function CsmCaseCommentInput({
   onSubmit,
   disabled = false,
   publicCommentDisabledReason = null,
+  canResumeToUnlockPublicReply = false,
+  onResumeWork,
+  isResumingWork = false,
   autoFocus = false,
 }: CsmCaseCommentInputProps): JSX.Element {
   const [html, setHtml] = useState<string>("");
@@ -209,6 +233,16 @@ export default function CsmCaseCommentInput({
     if (publicReplyLocked && !internal) setInternal(true);
   }, [publicReplyLocked, internal]);
 
+  // One reason, shown once. When resuming would unlock public replies, the
+  // quick-fix next to Internal note covers it (with the actionable link) —
+  // the send-row status line below falls back to its normal hint instead of
+  // repeating the same reason a second time. Otherwise (the case hasn't even
+  // started) there's no quick fix to offer, so the send-row line is the only
+  // place the reason shows.
+  const showResumeQuickFix =
+    publicReplyLocked && canResumeToUnlockPublicReply && !!onResumeWork;
+  const showBottomLockReason = publicReplyLocked && !showResumeQuickFix;
+
   const toggleSourceMode = useCallback(
     (nextSource: boolean) => {
       setSourceMode(nextSource);
@@ -316,6 +350,26 @@ export default function CsmCaseCommentInput({
         </Box>
       </Box>
 
+      {/* Quick-fix for the most common lock reason (paused work): resuming
+          is a single click here, unlike the other lock reason (case not
+          started yet), which needs the full assign/start flow and isn't
+          offered inline. */}
+      {showResumeQuickFix && (
+        <Typography variant="caption" color="text.secondary">
+          Only resumed work can send public replies to the customer.{" "}
+          <Link
+            component="button"
+            type="button"
+            variant="caption"
+            onClick={onResumeWork}
+            disabled={isResumingWork}
+          >
+            {isResumingWork ? "Resuming…" : "Resume work"}
+          </Link>{" "}
+          to publish this as a public comment.
+        </Typography>
+      )}
+
       {sourceMode ? (
         <TextField
           value={html}
@@ -380,14 +434,14 @@ export default function CsmCaseCommentInput({
           color={
             sizeError || error
               ? "error"
-              : publicReplyLocked
+              : showBottomLockReason
                 ? "warning.main"
                 : "text.secondary"
           }
         >
           {sizeError ??
             error ??
-            (publicReplyLocked
+            (showBottomLockReason
               ? publicCommentDisabledReason
               : sourceMode
                 ? "Output is sent as-is. Use this to fix paste-formatting or insert tables."

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -139,6 +139,7 @@ import {
 } from "@utils/sanitizeHtml";
 import { useDarkMode } from "@utils/useDarkMode";
 import {
+  canResumeToUnlockPublicReply as computeCanResumeToUnlockPublicReply,
   publicCommentGateReason,
   WORK_STATE_LABEL,
 } from "@features/csm-cases/utils/caseWorkState";
@@ -1583,12 +1584,17 @@ export default function CsmCaseDetailPage(): JSX.Element {
   // instead of a generic error.
   const publicReplyGateReason = publicCommentGateReason(c.state, c.workState);
   // The composer's inline "Resume work" quick-fix only applies to this one
-  // lock reason — the case is already work_in_progress and assigned, just
-  // paused, so resuming is the single-field PATCH `onAction` already runs
-  // for "toggle_work_state" below. The other lock reason (not started yet)
-  // needs the full assign/start flow, which doesn't belong in the composer.
-  const canResumeToUnlockPublicReply =
-    c.state === "work_in_progress" && c.workState !== "ongoing";
+  // lock reason — the case is already work_in_progress and assigned to the
+  // signed-in engineer, just paused, so resuming is the single-field PATCH
+  // `onAction` already runs for "toggle_work_state" below. The other lock
+  // reason (not started yet) needs the full assign/start flow, which doesn't
+  // belong in the composer; `assigneeIsMe` also excludes another engineer's
+  // paused case, matching CaseActionBar's own gate on the same action.
+  const canResumeToUnlockPublicReply = computeCanResumeToUnlockPublicReply(
+    c.state,
+    c.workState,
+    c.assigneeIsMe,
+  );
   // FE-only, advisory close-gate: warn when the case has an open task, so the
   // engineer isn't surprised by a close rejection. Best-effort — the task
   // *list* (`POST /cases/{id}/tasks/search`) returns `BeTaskSummary`, which

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -140,6 +140,7 @@ import {
 import { useDarkMode } from "@utils/useDarkMode";
 import {
   canResumeToUnlockPublicReply as computeCanResumeToUnlockPublicReply,
+  effectiveWorkState,
   publicCommentGateReason,
   WORK_STATE_LABEL,
 } from "@features/csm-cases/utils/caseWorkState";
@@ -1717,12 +1718,12 @@ export default function CsmCaseDetailPage(): JSX.Element {
                   sx={{ fontWeight: 600 }}
                 />
               )}
-            {!isAnnouncement && c.state === "work_in_progress" && c.workState && (
+            {!isAnnouncement && c.state === "work_in_progress" && (
               <Chip
                 size="small"
                 variant="outlined"
-                color={c.workState === "paused" ? "warning" : "default"}
-                label={WORK_STATE_LABEL[c.workState]}
+                color={effectiveWorkState(c.workState) === "paused" ? "warning" : "default"}
+                label={WORK_STATE_LABEL[effectiveWorkState(c.workState)]}
                 sx={{ fontWeight: 600 }}
               />
             )}

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -1582,6 +1582,13 @@ export default function CsmCaseDetailPage(): JSX.Element {
   // notes. Mirrors the BFF comment guard so the engineer sees a clear reason
   // instead of a generic error.
   const publicReplyGateReason = publicCommentGateReason(c.state, c.workState);
+  // The composer's inline "Resume work" quick-fix only applies to this one
+  // lock reason — the case is already work_in_progress and assigned, just
+  // paused, so resuming is the single-field PATCH `onAction` already runs
+  // for "toggle_work_state" below. The other lock reason (not started yet)
+  // needs the full assign/start flow, which doesn't belong in the composer.
+  const canResumeToUnlockPublicReply =
+    c.state === "work_in_progress" && c.workState !== "ongoing";
   // FE-only, advisory close-gate: warn when the case has an open task, so the
   // engineer isn't surprised by a close rejection. Best-effort — the task
   // *list* (`POST /cases/{id}/tasks/search`) returns `BeTaskSummary`, which
@@ -1860,6 +1867,9 @@ export default function CsmCaseDetailPage(): JSX.Element {
               <CsmCaseCommentInput
                 disabled={!caseId || isClosed}
                 publicCommentDisabledReason={publicReplyGateReason}
+                canResumeToUnlockPublicReply={canResumeToUnlockPublicReply}
+                onResumeWork={() => onAction({ secondary: "toggle_work_state" })}
+                isResumingWork={patchCase.isPending}
                 autoFocus
                 onSubmit={async (bodyHtml, internal, commentAttachments) => {
                   if (!caseId) return;

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/caseWorkState.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/caseWorkState.test.ts
@@ -18,6 +18,7 @@ import { describe, expect, it } from "vitest";
 import {
   canResumeToUnlockPublicReply,
   caseAcceptsPublicComments,
+  effectiveWorkState,
   publicCommentGateReason,
 } from "./caseWorkState";
 
@@ -93,5 +94,17 @@ describe("canResumeToUnlockPublicReply", () => {
   it("is false when the case hasn't started yet, regardless of assignee", () => {
     expect(canResumeToUnlockPublicReply("open", null, true)).toBe(false);
     expect(canResumeToUnlockPublicReply("open", null, false)).toBe(false);
+  });
+});
+
+describe("effectiveWorkState", () => {
+  it("passes through an explicit work state as-is", () => {
+    expect(effectiveWorkState("ongoing")).toBe("ongoing");
+    expect(effectiveWorkState("paused")).toBe("paused");
+  });
+
+  it("treats a never-set work state as paused", () => {
+    expect(effectiveWorkState(null)).toBe("paused");
+    expect(effectiveWorkState(undefined)).toBe("paused");
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/caseWorkState.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/caseWorkState.test.ts
@@ -16,6 +16,7 @@
 
 import { describe, expect, it } from "vitest";
 import {
+  canResumeToUnlockPublicReply,
   caseAcceptsPublicComments,
   publicCommentGateReason,
 } from "./caseWorkState";
@@ -67,5 +68,30 @@ describe("publicCommentGateReason", () => {
     expect(publicCommentGateReason("work_in_progress", "paused")).not.toMatch(
       /work note/i,
     );
+  });
+});
+
+describe("canResumeToUnlockPublicReply", () => {
+  it("is true for the engineer's own paused, work_in_progress case", () => {
+    expect(
+      canResumeToUnlockPublicReply("work_in_progress", "paused", true),
+    ).toBe(true);
+  });
+
+  it("is false when the case isn't assigned to the signed-in engineer, even if paused", () => {
+    expect(
+      canResumeToUnlockPublicReply("work_in_progress", "paused", false),
+    ).toBe(false);
+  });
+
+  it("is false once the case is already ongoing (nothing to resume)", () => {
+    expect(
+      canResumeToUnlockPublicReply("work_in_progress", "ongoing", true),
+    ).toBe(false);
+  });
+
+  it("is false when the case hasn't started yet, regardless of assignee", () => {
+    expect(canResumeToUnlockPublicReply("open", null, true)).toBe(false);
+    expect(canResumeToUnlockPublicReply("open", null, false)).toBe(false);
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/caseWorkState.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/caseWorkState.test.ts
@@ -95,6 +95,23 @@ describe("canResumeToUnlockPublicReply", () => {
     expect(canResumeToUnlockPublicReply("open", null, true)).toBe(false);
     expect(canResumeToUnlockPublicReply("open", null, false)).toBe(false);
   });
+
+  // A null/undefined workState on a work_in_progress case is a real, expected
+  // state (e.g. data predating the work-state feature), not just "open"'s
+  // absent-workState case above — and it's resumable, matching
+  // CaseActionBar's own deliberate handling of the same case (see its
+  // "anything else (paused OR a null work-state in-progress case) is
+  // resumable" comment in buildSecondaryItems). Requiring workState ===
+  // "paused" exactly here would hide this quick-fix for a case where the
+  // action bar's own "Resume work" item is still shown and functional.
+  it("is true for a work_in_progress case with a null or undefined work state", () => {
+    expect(canResumeToUnlockPublicReply("work_in_progress", null, true)).toBe(
+      true,
+    );
+    expect(
+      canResumeToUnlockPublicReply("work_in_progress", undefined, true),
+    ).toBe(true);
+  });
 });
 
 describe("effectiveWorkState", () => {

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/caseWorkState.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/caseWorkState.ts
@@ -76,6 +76,24 @@ export function canResumeToUnlockPublicReply(
   );
 }
 
+/**
+ * The work sub-state a `work_in_progress` case should be *shown* as having,
+ * treating a never-set `workState` (`null`/`undefined`) the same as
+ * `paused` — the same "anything but ongoing behaves like paused" rule
+ * `canResumeToUnlockPublicReply` already applies to behavior (resuming,
+ * unlocking public replies). Without this, the work-state chip on the cases
+ * list / case header / preview drawer silently renders nothing at all for
+ * such a case, reading as "no status" rather than the paused state it
+ * actually is. Only meaningful once the caller already knows `state` is
+ * `work_in_progress` — callers still gate on that themselves, same as the
+ * other functions here.
+ */
+export function effectiveWorkState(
+  workState: CaseWorkState | null | undefined,
+): CaseWorkState {
+  return workState ?? "paused";
+}
+
 /** Short label for the work sub-state chip on the case header / list. */
 export const WORK_STATE_LABEL: Record<CaseWorkState, string> = {
   ongoing: "Ongoing",

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/caseWorkState.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/caseWorkState.ts
@@ -65,6 +65,15 @@ export function publicCommentGateReason(
  * see a "Resume work" quick-fix that isn't actually theirs to use. The other
  * lock reason (case not started at all) needs the full assign/start flow
  * instead, so it's never resumable this way regardless of assignee.
+ *
+ * Deliberately `workState !== "ongoing"`, not `workState === "paused"`: a
+ * null/undefined work state on a work_in_progress case is real (e.g. data
+ * predating the work-state feature) and is resumable too, matching
+ * CaseActionBar's own handling of the exact same case — see its "anything
+ * else (paused OR a null work-state in-progress case) is resumable" comment
+ * in `buildSecondaryItems`. Narrowing this to `=== "paused"` would hide the
+ * quick-fix for a case where the action bar's own "Resume work" item is
+ * still shown and functional.
  */
 export function canResumeToUnlockPublicReply(
   state: CaseState | undefined,

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/caseWorkState.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/caseWorkState.ts
@@ -53,6 +53,29 @@ export function publicCommentGateReason(
   return "Customer replies are disabled unless the case is actively in progress.";
 }
 
+/**
+ * Whether resuming work — a single-field PATCH, no reassignment or state
+ * change — would be enough to unlock a public reply right now. True only for
+ * the one lock reason that's actually a single click away: the case is
+ * already `work_in_progress` and assigned to the signed-in engineer, just not
+ * `ongoing`. `assigneeIsMe` matters because pausing/resuming is only offered
+ * to the case's own assignee elsewhere in the UI (see CaseActionBar's own
+ * `assigneeIsMe && state === "work_in_progress"` gate on the same action) —
+ * without this check, an engineer viewing someone else's paused case would
+ * see a "Resume work" quick-fix that isn't actually theirs to use. The other
+ * lock reason (case not started at all) needs the full assign/start flow
+ * instead, so it's never resumable this way regardless of assignee.
+ */
+export function canResumeToUnlockPublicReply(
+  state: CaseState | undefined,
+  workState: CaseWorkState | null | undefined,
+  assigneeIsMe: boolean,
+): boolean {
+  return (
+    assigneeIsMe && state === "work_in_progress" && workState !== "ongoing"
+  );
+}
+
 /** Short label for the work sub-state chip on the case header / list. */
 export const WORK_STATE_LABEL: Record<CaseWorkState, string> = {
   ongoing: "Ongoing",


### PR DESCRIPTION
## Purpose
The reply composer already disables the public-comment toggle when the case isn't in a state
that accepts customer-visible replies, but gives no way to act on it — an engineer with a paused
case just sees a disabled switch and has to leave the composer, find the "Resume work" control
elsewhere on the page, then come back.

## Goals
When the *specific* reason a public reply is locked is paused work (not "the case hasn't started
at all"), let the engineer resume and unlock it from right where they're already typing, instead
of hunting for the fix elsewhere.

## Approach
`CsmCaseCommentInput` gets three new optional props: `canResumeToUnlockPublicReply`,
`onResumeWork`, `isResumingWork`. When the reply is locked *and* resuming would unlock it, a line
appears next to the Internal note toggle: "Only resumed work can send public replies to the
customer. **Resume work** to publish this as a public comment." — with "Resume work" as a real
button styled as a link.

Scoped deliberately to just that one lock reason. The other one (case not started yet) needs the
full assign/start flow with its own single-active-case conflict dialog, which doesn't belong
squeezed into a reply box — it keeps its existing plain-text explanation with no link.

`CsmCaseDetailPage` computes `canResumeToUnlockPublicReply` (case is `work_in_progress` and
already assigned, just not `ongoing`) and wires `onResumeWork` straight to the existing
`onAction({ secondary: "toggle_work_state" })` handler — the same one the case header's own
Resume control calls, including its single-active-case conflict check. Nothing about that flow
is reimplemented in the composer.

Also merges what became two copies of the same message once the quick-fix landed: the send-row
status line used to always echo the raw lock reason, which would have doubled up with the new
line above it. It now only shows the reason when there's no quick-fix already covering it,
falling back to the normal "Ctrl/Cmd + Enter to send." hint otherwise.

Resuming only resumes — it never flips the Internal note toggle or sends anything on its own.
Once it succeeds, the case-detail query refetches, the lock clears, and the toggle unlocks; the
engineer still explicitly toggles to public and hits Send themselves.

## User stories
As a CS engineer with a paused case, I can resume work and send a public reply without leaving
the composer to find the resume control elsewhere on the page.

## Release note
The case reply composer now explains *why* the public-reply toggle is disabled next to the
toggle itself, and — when resuming the case's work would fix it — offers a one-click way to do
that inline.

## Documentation
N/A — no published documentation covers this internal UI behavior.

## Training
N/A.

## Certification
N/A.

## Marketing
N/A.

## Automation tests
- Unit tests: first test file for `CsmCaseCommentInput` (previously untested) — 5 tests covering
  the quick-fix's visibility conditions, its click behavior, its pending state, and the
  no-duplicate-message fix. Mocks `@api/backend/client` (pulled in transitively via
  `CsmUploadAttachmentModal` → `useCsmCaseAttachments`) and stubs the rich-text `Editor` to a
  plain textarea, matching `EditCaseDetailsDialog.test.tsx`'s precedent for the same dependency.
- `tsc -b`, `eslint` clean on all three touched files.
- `vitest run src/features/csm-cases`: passes except the 2 pre-existing `LinkCaseDialog.test.tsx`
  failures and `CaseActionBar.test.tsx`'s missing-config error, both confirmed unrelated via
  `git stash` earlier in the same working session (unrelated to this change).
- Production `vite build` clean.
- Integration tests: none — no integration-test harness exists for this app. **Not manually
  verified in a browser** — no live backend/Asgardeo session available in this environment.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? no — TypeScript/React only, nothing for a JVM tool to analyse.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
None.

## Migrations (if applicable)
N/A — no schema or data change, UI-only.

## Test environment
- Node.js, pnpm (via `./node_modules/.bin/*` directly — the `pnpm` CLI itself errors with
  "packages field missing or empty" in this environment).
- macOS.
- `tsc -b`, `eslint`, `vitest`, `vite build` — all clean as noted above.
- Not manually verified in a browser against a live backend in this session.

## Learning
N/A.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a **Resume work** action to the public reply composer when work is paused.
  - Resuming work unlocks public replies and shows a disabled pending state while processing.
  - Improved work-state status display for paused cases, including cases with missing status information.
  - Prevented duplicate lock reasons from appearing when the quick action is available.

- **Tests**
  - Added coverage for resume-work availability, button states, callback handling, and lock-reason scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->