### PR TITLE
[CSM Portal Microapp] fix case cards, fix tab-bar clipping, add attachment preview

### DIFF
--- a/apps/csm-portal/microapp/src/components/case-detail/AttachmentPreviewDialog.tsx
+++ b/apps/csm-portal/microapp/src/components/case-detail/AttachmentPreviewDialog.tsx
@@ -1,0 +1,445 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  Box,
+  Button,
+  ButtonGroup,
+  CircularProgress,
+  Dialog,
+  IconButton,
+  pxToRem,
+  Skeleton,
+  Stack,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { ChevronDown, ChevronUp, File, Image, Minus, Plus, X } from "@wso2/oxygen-ui-icons-react";
+import { TransformWrapper, TransformComponent, type ReactZoomPanPinchRef } from "react-zoom-pan-pinch";
+import { Document, Page, pdfjs } from "react-pdf";
+import "react-pdf/dist/Page/AnnotationLayer.css";
+import "react-pdf/dist/Page/TextLayer.css";
+import { PDF_JS_DIST_CDN } from "@config/endpoints";
+import { attachments as attachmentsService } from "@src/services/attachments";
+import { getAttachmentPreviewKind } from "@utils/attachmentPreview";
+import type { CaseAttachment } from "@src/types";
+
+pdfjs.GlobalWorkerOptions.workerSrc = new URL(PDF_JS_DIST_CDN(pdfjs.version)).toString();
+
+// Full-screen zoom/pan image + paginated PDF viewer — mirrors the customer-portal microapp's own
+// AttachmentPreviewDialog (components/shared/AttachmentPreviewDialog.tsx) UI, but sources bytes
+// the way the webapp does (attachments.getContent -> Blob -> object URL) rather than a JSON
+// base64 endpoint, since this backend's content route doesn't have that shape — see
+// attachments.ts's getAttachmentContent comment.
+
+interface PreviewHeaderProps {
+  fileName: string | undefined;
+  isTypeImage: boolean;
+  onClose: () => void;
+}
+
+function PreviewHeader({ fileName, isTypeImage, onClose }: PreviewHeaderProps) {
+  return (
+    <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mt: "var(--safe-top)", p: 1 }}>
+      <Stack direction="row" alignItems="center" flex={1} gap={1} sx={{ minWidth: 0 }}>
+        {isTypeImage ? <Image size={pxToRem(18)} /> : <File size={pxToRem(18)} />}
+        <Typography noWrap variant="subtitle1">
+          {fileName}
+        </Typography>
+      </Stack>
+      <IconButton size="small" onClick={onClose} aria-label="Close preview">
+        <X />
+      </IconButton>
+    </Stack>
+  );
+}
+
+function PreviewError({ message }: { message: string }) {
+  return (
+    <Stack
+      flex={1}
+      alignItems="center"
+      justifyContent="center"
+      gap={1}
+      sx={{ bgcolor: "background.default", p: 2, textAlign: "center" }}
+    >
+      <Typography variant="body2" color="error">
+        {message}
+      </Typography>
+    </Stack>
+  );
+}
+
+function UnsupportedPreview() {
+  return (
+    <Stack
+      alignItems="center"
+      gap={1}
+      sx={{
+        flex: 1,
+        justifyContent: "center",
+        color: "text.secondary",
+        bgcolor: "background.default",
+        textAlign: "center",
+        p: 2,
+      }}
+    >
+      <Box mb={1}>
+        <File size={pxToRem(48)} />
+      </Box>
+      <Typography variant="body1" lineHeight={0.6}>
+        Preview not available for this file type.
+      </Typography>
+      <Typography variant="caption">Use Download instead.</Typography>
+    </Stack>
+  );
+}
+
+interface ZoomControlsProps {
+  zoomIn: () => void;
+  zoomOut: () => void;
+  reset: () => void;
+}
+
+function ZoomControls({ zoomIn, zoomOut, reset }: ZoomControlsProps) {
+  return (
+    <Stack direction="row" alignItems="center" gap={1}>
+      <ButtonGroup variant="contained" color="inherit">
+        <IconButton onClick={zoomOut} aria-label="Zoom out">
+          <Minus />
+        </IconButton>
+        <IconButton onClick={zoomIn} aria-label="Zoom in">
+          <Plus />
+        </IconButton>
+      </ButtonGroup>
+      <Button variant="text" color="inherit" onClick={reset}>
+        Reset
+      </Button>
+    </Stack>
+  );
+}
+
+function ImageToolbar({ zoomIn, zoomOut, reset }: ZoomControlsProps) {
+  return (
+    <Stack
+      direction="row"
+      sx={{
+        bgcolor: "background.paper",
+        height: 50,
+        mb: "var(--safe-bottom)",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: 2,
+      }}
+    >
+      <ZoomControls zoomIn={zoomIn} zoomOut={zoomOut} reset={reset} />
+    </Stack>
+  );
+}
+
+interface PdfToolbarProps extends ZoomControlsProps {
+  currentPage: number;
+  numberOfPages: number;
+  goToPage: (page: number) => void;
+}
+
+function PdfToolbar({ currentPage, numberOfPages, goToPage, zoomIn, zoomOut, reset }: PdfToolbarProps) {
+  return (
+    <Stack
+      direction="row"
+      sx={{
+        bgcolor: "background.paper",
+        height: 50,
+        mb: "var(--safe-bottom)",
+        alignItems: "center",
+        justifyContent: "space-between",
+        gap: 2,
+        px: 1,
+      }}
+    >
+      <ZoomControls zoomIn={zoomIn} zoomOut={zoomOut} reset={reset} />
+      <Stack direction="row" alignItems="center" gap={1}>
+        <ButtonGroup variant="contained" color="inherit">
+          <IconButton disabled={currentPage <= 1} onClick={() => goToPage(currentPage - 1)} aria-label="Previous page">
+            <ChevronUp />
+          </IconButton>
+          <IconButton
+            disabled={currentPage >= numberOfPages}
+            onClick={() => goToPage(currentPage + 1)}
+            aria-label="Next page"
+          >
+            <ChevronDown />
+          </IconButton>
+        </ButtonGroup>
+        <Typography sx={{ minWidth: 60, textAlign: "center" }}>
+          {currentPage} / {numberOfPages}
+        </Typography>
+      </Stack>
+    </Stack>
+  );
+}
+
+function ImagePreview({ src }: { src: string }) {
+  const transformRef = useRef<ReactZoomPanPinchRef>(null);
+
+  return (
+    <>
+      <TransformWrapper
+        centerZoomedOut
+        centerOnInit
+        ref={transformRef}
+        initialScale={1}
+        minScale={0.5}
+        maxScale={5}
+        wheel={{ step: 0.2 }}
+        doubleClick={{ disabled: true }}
+      >
+        <Box
+          sx={{
+            flex: 1,
+            overflow: "hidden",
+            bgcolor: "background.default",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <TransformComponent
+            wrapperStyle={{ width: "100%", height: "100%" }}
+            contentStyle={{ width: "fit-content", height: "fit-content" }}
+          >
+            <Box
+              component="img"
+              src={src}
+              sx={{
+                maxWidth: "100%",
+                maxHeight: "100%",
+                objectFit: "contain",
+                userSelect: "none",
+                pointerEvents: "none",
+              }}
+            />
+          </TransformComponent>
+        </Box>
+      </TransformWrapper>
+
+      <ImageToolbar
+        zoomIn={() => transformRef.current?.zoomIn()}
+        zoomOut={() => transformRef.current?.zoomOut()}
+        reset={() => transformRef.current?.resetTransform()}
+      />
+    </>
+  );
+}
+
+function PdfPreview({ src }: { src: string }) {
+  const transformRef = useRef<ReactZoomPanPinchRef>(null);
+  const pageRefs = useRef<(HTMLDivElement | null)[]>([]);
+
+  const [containerWidth, setContainerWidth] = useState(0);
+  const [numberOfPages, setNumberOfPages] = useState(0);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [isError, setIsError] = useState(false);
+
+  const containerCallbackRef = useCallback((node: HTMLDivElement | null) => {
+    if (!node) return;
+    const observer = new ResizeObserver(([entry]) => {
+      const width = entry.contentRect.width;
+      if (width > 0) setContainerWidth(width);
+    });
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, []);
+
+  const handleOnLoadSuccess = ({ numPages }: { numPages: number }) => {
+    setNumberOfPages(numPages);
+    setTimeout(() => transformRef.current?.resetTransform(0), 100);
+  };
+
+  const goToPage = (page: number) => {
+    const clamped = Math.min(Math.max(page, 1), numberOfPages);
+    setCurrentPage(clamped);
+    pageRefs.current[clamped - 1]?.scrollIntoView({ behavior: "smooth" });
+  };
+
+  useEffect(() => {
+    if (!numberOfPages) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = entries.find((e) => e.isIntersecting);
+        if (visible) {
+          const index = pageRefs.current.indexOf(visible.target as HTMLDivElement);
+          if (index !== -1) setCurrentPage(index + 1);
+        }
+      },
+      { threshold: 0.5 },
+    );
+
+    pageRefs.current.forEach((page) => page && observer.observe(page));
+    return () => observer.disconnect();
+  }, [numberOfPages]);
+
+  if (isError) return <PreviewError message="Could not render this PDF." />;
+
+  return (
+    <>
+      <TransformWrapper
+        centerZoomedOut
+        ref={transformRef}
+        initialScale={1}
+        minScale={0.5}
+        maxScale={5}
+        wheel={{ step: 0.2 }}
+        doubleClick={{ disabled: true }}
+      >
+        <Box
+          ref={containerCallbackRef}
+          sx={{
+            flex: 1,
+            overflow: "hidden",
+            bgcolor: "background.default",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            position: "relative",
+          }}
+        >
+          <TransformComponent
+            wrapperStyle={{ width: "100%", height: "100%" }}
+            contentStyle={{ width: "fit-content", height: "fit-content" }}
+          >
+            <Document file={src} onLoadSuccess={handleOnLoadSuccess} onLoadError={() => setIsError(true)}>
+              <Stack gap={0.5}>
+                {Array.from({ length: numberOfPages }, (_, i) => (
+                  <Box
+                    key={i}
+                    ref={(el) => {
+                      pageRefs.current[i] = el as HTMLDivElement;
+                    }}
+                  >
+                    <Page width={containerWidth} pageNumber={i + 1} />
+                  </Box>
+                ))}
+              </Stack>
+            </Document>
+          </TransformComponent>
+
+          {numberOfPages === 0 && (
+            <Box sx={{ width: "100%", height: "100%", position: "absolute", bgcolor: "background.default" }}>
+              <Skeleton variant="rectangular" width="100%" height="100%" />
+            </Box>
+          )}
+        </Box>
+      </TransformWrapper>
+
+      <PdfToolbar
+        currentPage={currentPage}
+        numberOfPages={numberOfPages}
+        goToPage={goToPage}
+        zoomIn={() => transformRef.current?.zoomIn()}
+        zoomOut={() => transformRef.current?.zoomOut()}
+        reset={() => transformRef.current?.resetTransform()}
+      />
+    </>
+  );
+}
+
+function LoadingFallback() {
+  return (
+    <Stack flex={1} alignItems="center" justifyContent="center" sx={{ bgcolor: "background.default" }}>
+      <CircularProgress size={30} />
+    </Stack>
+  );
+}
+
+interface AttachmentPreviewDialogProps {
+  /** Attachment being previewed; the dialog is closed when this is null. */
+  attachment: CaseAttachment | null;
+  onClose: () => void;
+}
+
+export function AttachmentPreviewDialog({ attachment, onClose }: AttachmentPreviewDialogProps) {
+  const [objectUrl, setObjectUrl] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // Reconcile state *synchronously during render* the moment `attachment` changes (React's
+  // "adjusting state when a prop changes" pattern) — resetting from a useEffect instead leaves a
+  // frame where the dialog paints the *previous* attachment's stale objectUrl/error before the
+  // effect fires, a visible flash of the wrong preview.
+  const [renderedFor, setRenderedFor] = useState(attachment);
+  if (attachment !== renderedFor) {
+    setRenderedFor(attachment);
+    setObjectUrl(null);
+    setError(null);
+  }
+
+  useEffect(() => {
+    if (!attachment) return;
+
+    let cancelled = false;
+    let createdUrl: string | null = null;
+
+    attachmentsService
+      .getContent(attachment)
+      .then((blob) => {
+        if (cancelled) return;
+        createdUrl = URL.createObjectURL(blob);
+        setObjectUrl(createdUrl);
+      })
+      .catch(() => {
+        if (!cancelled) setError("Could not load the preview.");
+      });
+
+    return () => {
+      cancelled = true;
+      if (createdUrl) URL.revokeObjectURL(createdUrl);
+    };
+  }, [attachment]);
+
+  const kind = attachment ? getAttachmentPreviewKind(attachment.type) : null;
+  const open = !!attachment;
+  const loading = open && !objectUrl && !error;
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      fullScreen
+      fullWidth
+      slots={{ container: Box, paper: Box }}
+      slotProps={{
+        container: { sx: { bgcolor: "background.paper", height: "100dvh" } },
+        paper: { sx: { bgcolor: "background.paper", height: "100%", display: "flex", flexDirection: "column" } },
+      }}
+      aria-label={attachment ? `Preview ${attachment.name}` : "Preview"}
+    >
+      <PreviewHeader fileName={attachment?.name} isTypeImage={kind === "image"} onClose={onClose} />
+
+      {loading ? (
+        <LoadingFallback />
+      ) : error ? (
+        <PreviewError message={error} />
+      ) : (
+        <>
+          {kind === null && <UnsupportedPreview />}
+          {kind === "image" && objectUrl && <ImagePreview src={objectUrl} />}
+          {kind === "pdf" && objectUrl && <PdfPreview src={objectUrl} />}
+        </>
+      )}
+    </Dialog>
+  );
+}

--- a/apps/csm-portal/microapp/src/components/case-detail/AttachmentPreviewDialog.tsx
+++ b/apps/csm-portal/microapp/src/components/case-detail/AttachmentPreviewDialog.tsx
@@ -35,6 +35,7 @@ import "react-pdf/dist/Page/TextLayer.css";
 import { PDF_JS_DIST_CDN } from "@config/endpoints";
 import { attachments as attachmentsService } from "@src/services/attachments";
 import { getAttachmentPreviewKind } from "@utils/attachmentPreview";
+import { Logger } from "@utils/logger";
 import type { CaseAttachment } from "@src/types";
 
 pdfjs.GlobalWorkerOptions.workerSrc = new URL(PDF_JS_DIST_CDN(pdfjs.version)).toString();
@@ -100,9 +101,7 @@ function UnsupportedPreview() {
       <Box mb={1}>
         <File size={pxToRem(48)} />
       </Box>
-      <Typography variant="body1" lineHeight={0.6}>
-        Preview not available for this file type.
-      </Typography>
+      <Typography variant="body1">Preview not available for this file type.</Typography>
       <Typography variant="caption">Use Download instead.</Typography>
     </Stack>
   );
@@ -184,15 +183,19 @@ function PdfToolbar({ currentPage, numberOfPages, goToPage, zoomIn, zoomOut, res
             <ChevronDown />
           </IconButton>
         </ButtonGroup>
-        <Typography sx={{ minWidth: 60, textAlign: "center" }}>
-          {currentPage} / {numberOfPages}
-        </Typography>
+        {/* Hidden until the page count is known, rather than showing "1 / 0" while the PDF is
+            still loading. aria-live announces page changes as the user scrolls/paginates. */}
+        {numberOfPages > 0 && (
+          <Typography sx={{ minWidth: 60, textAlign: "center" }} aria-live="polite">
+            {currentPage} / {numberOfPages}
+          </Typography>
+        )}
       </Stack>
     </Stack>
   );
 }
 
-function ImagePreview({ src }: { src: string }) {
+function ImagePreview({ src, alt, onError }: { src: string; alt: string; onError: () => void }) {
   const transformRef = useRef<ReactZoomPanPinchRef>(null);
 
   return (
@@ -224,6 +227,8 @@ function ImagePreview({ src }: { src: string }) {
             <Box
               component="img"
               src={src}
+              alt={alt}
+              onError={onError}
               sx={{
                 maxWidth: "100%",
                 maxHeight: "100%",
@@ -324,21 +329,25 @@ function PdfPreview({ src }: { src: string }) {
           >
             <Document file={src} onLoadSuccess={handleOnLoadSuccess} onLoadError={() => setIsError(true)}>
               <Stack gap={0.5}>
-                {Array.from({ length: numberOfPages }, (_, i) => (
-                  <Box
-                    key={i}
-                    ref={(el) => {
-                      pageRefs.current[i] = el as HTMLDivElement;
-                    }}
-                  >
-                    <Page width={containerWidth} pageNumber={i + 1} />
-                  </Box>
-                ))}
+                {/* Don't render pages until the container's real width is measured — Document's
+                    onLoadSuccess can fire before the ResizeObserver's first callback, and a Page
+                    given width={0} renders collapsed/broken until the next re-render. */}
+                {containerWidth > 0 &&
+                  Array.from({ length: numberOfPages }, (_, i) => (
+                    <Box
+                      key={i}
+                      ref={(el) => {
+                        pageRefs.current[i] = el as HTMLDivElement;
+                      }}
+                    >
+                      <Page width={containerWidth} pageNumber={i + 1} />
+                    </Box>
+                  ))}
               </Stack>
             </Document>
           </TransformComponent>
 
-          {numberOfPages === 0 && (
+          {(numberOfPages === 0 || containerWidth === 0) && (
             <Box sx={{ width: "100%", height: "100%", position: "absolute", bgcolor: "background.default" }}>
               <Skeleton variant="rectangular" width="100%" height="100%" />
             </Box>
@@ -387,8 +396,14 @@ export function AttachmentPreviewDialog({ attachment, onClose }: AttachmentPrevi
     setError(null);
   }
 
+  const kind = attachment ? getAttachmentPreviewKind(attachment.type) : null;
+
   useEffect(() => {
-    if (!attachment) return;
+    // Both callers only ever open this dialog for a previewable kind (see AttachmentsTab.tsx /
+    // CaseActivityFeed.tsx's own getAttachmentPreviewKind-gated Preview button), but guard here
+    // too rather than trust that invariant — fetching content that can only ever render
+    // UnsupportedPreview would be a wasted request.
+    if (!attachment || !kind) return;
 
     let cancelled = false;
     let createdUrl: string | null = null;
@@ -400,17 +415,18 @@ export function AttachmentPreviewDialog({ attachment, onClose }: AttachmentPrevi
         createdUrl = URL.createObjectURL(blob);
         setObjectUrl(createdUrl);
       })
-      .catch(() => {
-        if (!cancelled) setError("Could not load the preview.");
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        Logger.error(`Failed to load attachment preview for ${attachment.id}`, err);
+        setError("Could not load the preview.");
       });
 
     return () => {
       cancelled = true;
       if (createdUrl) URL.revokeObjectURL(createdUrl);
     };
-  }, [attachment]);
+  }, [attachment, kind]);
 
-  const kind = attachment ? getAttachmentPreviewKind(attachment.type) : null;
   const open = !!attachment;
   const loading = open && !objectUrl && !error;
 
@@ -436,7 +452,13 @@ export function AttachmentPreviewDialog({ attachment, onClose }: AttachmentPrevi
       ) : (
         <>
           {kind === null && <UnsupportedPreview />}
-          {kind === "image" && objectUrl && <ImagePreview src={objectUrl} />}
+          {kind === "image" && objectUrl && (
+            <ImagePreview
+              src={objectUrl}
+              alt={attachment?.name ?? "Attachment preview"}
+              onError={() => setError("Could not display this image.")}
+            />
+          )}
           {kind === "pdf" && objectUrl && <PdfPreview src={objectUrl} />}
         </>
       )}

--- a/apps/csm-portal/microapp/src/components/case-detail/AttachmentsTab.tsx
+++ b/apps/csm-portal/microapp/src/components/case-detail/AttachmentsTab.tsx
@@ -150,23 +150,27 @@ function AttachmentRow({
           </Typography>
         </Stack>
       </Stack>
-      {attachment.downloadUrl && (
+      {(attachment.downloadUrl || getAttachmentPreviewKind(attachment.type)) && (
         <Stack direction="row" gap={2} sx={{ flexShrink: 0 }}>
-          {/* Only for content types the in-app viewer actually renders (images/PDFs) — matches
-              the webapp's own conditional Preview button (CaseActivitiesFeed.tsx). Everything
-              else is download-only. */}
+          {/* Preview doesn't depend on downloadUrl — it fetches via GET /attachments/{id}/content,
+              a different mechanism entirely — so it must not be gated behind downloadUrl being
+              present. Only for content types the in-app viewer actually renders (images/PDFs) —
+              matches the webapp's own conditional Preview button (CaseActivitiesFeed.tsx).
+              Everything else is download-only. */}
           {getAttachmentPreviewKind(attachment.type) && (
             <IconButton size="small" aria-label={`Preview ${attachment.name}`} onClick={() => onPreview(attachment)}>
               <Eye size={16} />
             </IconButton>
           )}
-          <IconButton
-            size="small"
-            aria-label={`Download ${attachment.name}`}
-            onClick={() => openUrl({ url: attachment.downloadUrl as string, presentationStyle: "fullScreen" })}
-          >
-            <Download size={16} />
-          </IconButton>
+          {attachment.downloadUrl && (
+            <IconButton
+              size="small"
+              aria-label={`Download ${attachment.name}`}
+              onClick={() => openUrl({ url: attachment.downloadUrl as string, presentationStyle: "fullScreen" })}
+            >
+              <Download size={16} />
+            </IconButton>
+          )}
         </Stack>
       )}
     </Stack>

--- a/apps/csm-portal/microapp/src/components/case-detail/AttachmentsTab.tsx
+++ b/apps/csm-portal/microapp/src/components/case-detail/AttachmentsTab.tsx
@@ -24,9 +24,11 @@ import { ErrorBoundary } from "@components/common/ErrorBoundary";
 import { ErrorState } from "@components/support/ErrorState";
 import { AttachmentsField } from "@components/support/AttachmentsField";
 import { formatBytes, type PendingAttachment } from "@utils/attachments";
+import { getAttachmentPreviewKind } from "@utils/attachmentPreview";
 import { formatDate } from "@utils/dateTime";
 import { openUrl } from "@components/microapp-bridge";
 import { Logger } from "@utils/logger";
+import { AttachmentPreviewDialog } from "./AttachmentPreviewDialog";
 
 /**
  * Full attachment list + upload for a case — the standalone flow (10 MB cap), distinct from the
@@ -48,6 +50,7 @@ function AttachmentsTabContent({ caseId }: { caseId: string }) {
   const [pending, setPending] = useState<PendingAttachment[]>([]);
   const [isUploading, setIsUploading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [previewTarget, setPreviewTarget] = useState<CaseAttachment | null>(null);
 
   const handleUpload = async () => {
     if (pending.length === 0) return;
@@ -111,15 +114,23 @@ function AttachmentsTabContent({ caseId }: { caseId: string }) {
       ) : (
         <Stack gap={1}>
           {caseAttachments.map((attachment) => (
-            <AttachmentRow key={attachment.id} attachment={attachment} />
+            <AttachmentRow key={attachment.id} attachment={attachment} onPreview={setPreviewTarget} />
           ))}
         </Stack>
       )}
+
+      <AttachmentPreviewDialog attachment={previewTarget} onClose={() => setPreviewTarget(null)} />
     </Stack>
   );
 }
 
-function AttachmentRow({ attachment }: { attachment: CaseAttachment }) {
+function AttachmentRow({
+  attachment,
+  onPreview,
+}: {
+  attachment: CaseAttachment;
+  onPreview: (attachment: CaseAttachment) => void;
+}) {
   return (
     <Stack
       direction="row"
@@ -141,13 +152,14 @@ function AttachmentRow({ attachment }: { attachment: CaseAttachment }) {
       </Stack>
       {attachment.downloadUrl && (
         <Stack direction="row" gap={2} sx={{ flexShrink: 0 }}>
-          <IconButton
-            size="small"
-            aria-label={`Open ${attachment.name}`}
-            onClick={() => openUrl({ url: attachment.downloadUrl as string, presentationStyle: "fullScreen" })}
-          >
-            <Eye size={16} />
-          </IconButton>
+          {/* Only for content types the in-app viewer actually renders (images/PDFs) — matches
+              the webapp's own conditional Preview button (CaseActivitiesFeed.tsx). Everything
+              else is download-only. */}
+          {getAttachmentPreviewKind(attachment.type) && (
+            <IconButton size="small" aria-label={`Preview ${attachment.name}`} onClick={() => onPreview(attachment)}>
+              <Eye size={16} />
+            </IconButton>
+          )}
           <IconButton
             size="small"
             aria-label={`Download ${attachment.name}`}

--- a/apps/csm-portal/microapp/src/components/case-detail/CaseActivityFeed.tsx
+++ b/apps/csm-portal/microapp/src/components/case-detail/CaseActivityFeed.tsx
@@ -14,9 +14,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Suspense, useMemo, type ReactNode } from "react";
+import { Suspense, useMemo, useState, type ReactNode } from "react";
 import { Chip, IconButton, Skeleton, Stack, Typography } from "@wso2/oxygen-ui";
-import { Eye, History, Paperclip } from "@wso2/oxygen-ui-icons-react";
+import { Download, Eye, History, Paperclip } from "@wso2/oxygen-ui-icons-react";
 import { useQueryErrorResetBoundary, useSuspenseQuery } from "@tanstack/react-query";
 import { activities as activitiesService } from "@src/services/activities";
 import { attachments as attachmentsService } from "@src/services/attachments";
@@ -24,8 +24,10 @@ import type { CaseAttachment, CaseAuditEntry, Comment } from "@src/types";
 import { ErrorBoundary } from "@components/common/ErrorBoundary";
 import { ErrorState } from "@components/support/ErrorState";
 import { formatBytes } from "@utils/attachments";
+import { getAttachmentPreviewKind } from "@utils/attachmentPreview";
 import { fromNow } from "@utils/dateTime";
 import { openUrl } from "@components/microapp-bridge";
+import { AttachmentPreviewDialog } from "./AttachmentPreviewDialog";
 import { CommentBody } from "./CommentBody";
 
 interface CaseActivityFeedProps {
@@ -73,6 +75,8 @@ function FieldChangeLine({ field }: { field: CaseAuditEntry["changes"][number] }
  * category filter/sort-order chips — everything is always shown here.
  */
 export function CaseActivityFeed({ comments, audit, attachments }: CaseActivityFeedProps) {
+  const [previewTarget, setPreviewTarget] = useState<CaseAttachment | null>(null);
+
   const entries = useMemo(() => {
     const out: FeedEntry[] = [];
     for (const c of comments) out.push({ kind: "comment", at: c.createdOn, id: c.id, comment: c });
@@ -165,22 +169,32 @@ export function CaseActivityFeed({ comments, audit, attachments }: CaseActivityF
               </Stack>
             </Stack>
             {e.attachment.downloadUrl && (
-              // Only "Open" — the native bridge exposes a single `openUrl` action (open in the
-              // in-app browser), no distinct "save to device" primitive. A "Download" button
-              // that called the same thing was misleading rather than offering real download
-              // behavior.
-              <IconButton
-                size="small"
-                aria-label={`Open ${e.attachment.name}`}
-                onClick={() => openUrl({ url: e.attachment.downloadUrl as string, presentationStyle: "fullScreen" })}
-                sx={{ flexShrink: 0 }}
-              >
-                <Eye size={16} />
-              </IconButton>
+              <Stack direction="row" gap={0.5} sx={{ flexShrink: 0 }}>
+                {/* In-app zoom/pan viewer, same as AttachmentsTab — only for content types it
+                    actually renders (images/PDFs); everything else is download-only. */}
+                {getAttachmentPreviewKind(e.attachment.type) && (
+                  <IconButton
+                    size="small"
+                    aria-label={`Preview ${e.attachment.name}`}
+                    onClick={() => setPreviewTarget(e.attachment)}
+                  >
+                    <Eye size={16} />
+                  </IconButton>
+                )}
+                <IconButton
+                  size="small"
+                  aria-label={`Download ${e.attachment.name}`}
+                  onClick={() => openUrl({ url: e.attachment.downloadUrl as string, presentationStyle: "fullScreen" })}
+                >
+                  <Download size={16} />
+                </IconButton>
+              </Stack>
             )}
           </Stack>
         );
       })}
+
+      <AttachmentPreviewDialog attachment={previewTarget} onClose={() => setPreviewTarget(null)} />
     </Stack>
   );
 }

--- a/apps/csm-portal/microapp/src/components/case-detail/CaseActivityFeed.tsx
+++ b/apps/csm-portal/microapp/src/components/case-detail/CaseActivityFeed.tsx
@@ -168,10 +168,13 @@ export function CaseActivityFeed({ comments, audit, attachments }: CaseActivityF
                 </Typography>
               </Stack>
             </Stack>
-            {e.attachment.downloadUrl && (
+            {(e.attachment.downloadUrl || getAttachmentPreviewKind(e.attachment.type)) && (
               <Stack direction="row" gap={0.5} sx={{ flexShrink: 0 }}>
-                {/* In-app zoom/pan viewer, same as AttachmentsTab — only for content types it
-                    actually renders (images/PDFs); everything else is download-only. */}
+                {/* Preview doesn't depend on downloadUrl — it fetches via
+                    GET /attachments/{id}/content, a different mechanism entirely — so it must not
+                    be gated behind downloadUrl being present. Same in-app zoom/pan viewer as
+                    AttachmentsTab, only for content types it actually renders (images/PDFs);
+                    everything else is download-only. */}
                 {getAttachmentPreviewKind(e.attachment.type) && (
                   <IconButton
                     size="small"
@@ -181,13 +184,17 @@ export function CaseActivityFeed({ comments, audit, attachments }: CaseActivityF
                     <Eye size={16} />
                   </IconButton>
                 )}
-                <IconButton
-                  size="small"
-                  aria-label={`Download ${e.attachment.name}`}
-                  onClick={() => openUrl({ url: e.attachment.downloadUrl as string, presentationStyle: "fullScreen" })}
-                >
-                  <Download size={16} />
-                </IconButton>
+                {e.attachment.downloadUrl && (
+                  <IconButton
+                    size="small"
+                    aria-label={`Download ${e.attachment.name}`}
+                    onClick={() =>
+                      openUrl({ url: e.attachment.downloadUrl as string, presentationStyle: "fullScreen" })
+                    }
+                  >
+                    <Download size={16} />
+                  </IconButton>
+                )}
               </Stack>
             )}
           </Stack>

--- a/apps/csm-portal/microapp/src/components/layout/MainLayout.tsx
+++ b/apps/csm-portal/microapp/src/components/layout/MainLayout.tsx
@@ -26,7 +26,8 @@ export default function MainLayout() {
   return (
     <>
       <TopBar />
-      <Box component="main" flexGrow={1} p={2} pb="calc(var(--tab-bar-height, 120px) + 24px)">
+
+      <Box component="main" flexGrow={1} p={2} pb={15}>
         <Outlet />
       </Box>
       <TabBar />

--- a/apps/csm-portal/microapp/src/components/support/CaseCard.tsx
+++ b/apps/csm-portal/microapp/src/components/support/CaseCard.tsx
@@ -33,6 +33,14 @@ export function CaseCard({ item }: { item: CaseSummary }) {
           <Stack direction="row" alignItems="center" gap={1}>
             <Icon size={pxToRem(16)} color={color} />
             <Typography variant="subtitle2" color="text.secondary">
+              {/* wso2Id then number, "|"-separated — matches the customer-portal microapp's
+                  ItemCard list convention and this same case's own detail-page header. */}
+              {item.wso2Id && (
+                <>
+                  {item.wso2Id}
+                  <span style={{ opacity: 0.5, margin: "0 4px" }}>|</span>
+                </>
+              )}
               {item.number}
             </Typography>
           </Stack>

--- a/apps/csm-portal/microapp/src/config/endpoints.ts
+++ b/apps/csm-portal/microapp/src/config/endpoints.ts
@@ -68,6 +68,11 @@ export const CATALOG_ITEM_VARIABLES_ENDPOINT = (catalogId: string, catalogItemId
 
 export const ATTACHMENTS_ENDPOINT = "/attachments";
 export const ATTACHMENTS_SEARCH_ENDPOINT = "/attachments/search";
+export const ATTACHMENT_CONTENT_ENDPOINT = (id: string) => `/attachments/${id}/content`;
+
+// react-pdf's worker script — mirrors the customer-portal microapp's own PDF_JS_DIST_CDN
+// (config/endpoints.ts), which points at the pdfjs-dist version react-pdf was built against.
+export const PDF_JS_DIST_CDN = (version: string) => `https://unpkg.com/pdfjs-dist@${version}/build/pdf.worker.min.mjs`;
 
 export const TIME_CARDS_ENDPOINT = "/time-cards";
 export const TIME_CARDS_SEARCH_ENDPOINT = "/time-cards/search";

--- a/apps/csm-portal/microapp/src/pages/CaseDetailPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/CaseDetailPage.tsx
@@ -490,10 +490,19 @@ function CaseSummarySection({
         <Stack direction="row" alignItems="center" gap={0.5}>
           <Icon size={pxToRem(18)} color={color} />
           <Typography variant="subtitle2" color="text.secondary">
+            {/* wso2Id then number, "|"-separated — matches the customer-portal microapp's
+                OverlineSlot/ItemCard convention (ids={[internalId, number]}). Copy button below
+                copies only the number (not wso2Id) — that's the value Support's search box
+                actually matches on, so copying it lets you paste straight into a case search. */}
+            {caseDetail.wso2Id && (
+              <>
+                {caseDetail.wso2Id}
+                <span style={{ opacity: 0.5, margin: "0 4px" }}>|</span>
+              </>
+            )}
             {caseDetail.number}
-            {caseDetail.wso2Id ? ` · ${caseDetail.wso2Id}` : ""}
           </Typography>
-          <CopyIconButton value={caseDetail.wso2Id || caseDetail.number} aria-label="Copy case ID" />
+          <CopyIconButton value={caseDetail.number} aria-label="Copy case ID" />
         </Stack>
 
         <Typography variant="h6">{caseDetail.subject}</Typography>

--- a/apps/csm-portal/microapp/src/services/attachments.ts
+++ b/apps/csm-portal/microapp/src/services/attachments.ts
@@ -15,7 +15,7 @@
 // under the License.
 
 import { queryOptions } from "@tanstack/react-query";
-import { ATTACHMENTS_ENDPOINT, ATTACHMENTS_SEARCH_ENDPOINT } from "@config/endpoints";
+import { ATTACHMENT_CONTENT_ENDPOINT, ATTACHMENTS_ENDPOINT, ATTACHMENTS_SEARCH_ENDPOINT } from "@config/endpoints";
 import type {
   AttachmentCreatePayloadDto,
   AttachmentCreateResponseDto,
@@ -24,6 +24,7 @@ import type {
   AttachmentSearchResponseDto,
 } from "@src/types";
 import { toCaseAttachment, type CaseAttachment } from "@src/types";
+import { isSafeAttachmentContentType } from "@utils/attachmentPreview";
 import apiClient from "./apiClient";
 
 const createAttachment = async (payload: AttachmentCreatePayloadDto): Promise<AttachmentDetailDto> => {
@@ -43,6 +44,25 @@ const searchAttachments = async (
   return (data.attachments ?? []).map(toCaseAttachment);
 };
 
+// Fetches an attachment's raw bytes via `GET /attachments/{id}/content`, for the preview dialog.
+// The content endpoint always responds with `Content-Disposition: attachment` and streams behind
+// auth, so it's fetched as a Blob rather than pointed at directly (a plain `openUrl`/`<img src>`
+// would miss the auth headers and would force a download instead of rendering inline) — mirrors
+// the webapp's useGetCsmCaseAttachmentContent (useCsmCaseAttachments.ts).
+//
+// The response's Content-Type is only forwarded as-is for the backend's safe-content-type
+// allowlist (case_handler.go) — anything else is coerced to application/octet-stream server-side
+// to block a stored-XSS via a crafted upstream type. The attachment's own `type` from
+// /attachments/search list metadata is whatever the uploader claimed, unverified — so it's only
+// used to relabel the fetched blob when that metadata type is itself in the same allowlist
+// (mirrored client-side as isSafeAttachmentContentType); otherwise the blob is left as
+// application/octet-stream, matching what the backend already coerced it to.
+const getAttachmentContent = async (attachment: CaseAttachment): Promise<Blob> => {
+  const { data } = await apiClient.get<Blob>(ATTACHMENT_CONTENT_ENDPOINT(attachment.id), { responseType: "blob" });
+  if (!isSafeAttachmentContentType(attachment.type)) return data;
+  return data.type === attachment.type ? data : data.slice(0, data.size, attachment.type);
+};
+
 export const attachments = {
   create: createAttachment,
   forCase: (caseId: string) =>
@@ -50,4 +70,5 @@ export const attachments = {
       queryKey: ["case", caseId, "attachments"],
       queryFn: () => searchAttachments(caseId, "case"),
     }),
+  getContent: getAttachmentContent,
 };

--- a/apps/csm-portal/microapp/src/services/attachments.ts
+++ b/apps/csm-portal/microapp/src/services/attachments.ts
@@ -24,7 +24,7 @@ import type {
   AttachmentSearchResponseDto,
 } from "@src/types";
 import { toCaseAttachment, type CaseAttachment } from "@src/types";
-import { isSafeAttachmentContentType } from "@utils/attachmentPreview";
+import { isSafeAttachmentContentType, normalizeContentType } from "@utils/attachmentPreview";
 import apiClient from "./apiClient";
 
 const createAttachment = async (payload: AttachmentCreatePayloadDto): Promise<AttachmentDetailDto> => {
@@ -60,7 +60,10 @@ const searchAttachments = async (
 const getAttachmentContent = async (attachment: CaseAttachment): Promise<Blob> => {
   const { data } = await apiClient.get<Blob>(ATTACHMENT_CONTENT_ENDPOINT(attachment.id), { responseType: "blob" });
   if (!isSafeAttachmentContentType(attachment.type)) return data;
-  return data.type === attachment.type ? data : data.slice(0, data.size, attachment.type);
+  // Compare/relabel with the normalized form, not the raw uploader-provided string — a stray
+  // ";charset=..." parameter would otherwise make it into the relabeled blob's type verbatim.
+  const safeType = normalizeContentType(attachment.type);
+  return data.type === safeType ? data : data.slice(0, data.size, safeType);
 };
 
 export const attachments = {

--- a/apps/csm-portal/microapp/src/types/case.dto.ts
+++ b/apps/csm-portal/microapp/src/types/case.dto.ts
@@ -115,7 +115,13 @@ export interface CaseSearchPayloadDto {
 export interface CaseSearchViewDto {
   id: string;
   number: string;
-  wso2Id: string;
+  // openapi.yaml's CaseSearchView documents this field as `wso2Id`, but the live /cases/search
+  // response sends it as `internalId` (confirmed live: {"id":"20d3964f-...","internalId":"CPPSUB-175",
+  // "number":"CS0441016",...}) — same spec-vs-reality drift already documented elsewhere in this
+  // file. `wso2Id` is kept as the app-facing name in case.model.ts's CaseSummary/CaseDetail (it's
+  // the concept name used throughout the UI); only this wire-level DTO field is renamed to match
+  // what actually arrives.
+  internalId: string;
   subject: string;
   description: string;
   // Only meaningful for the "case" type — null for service_request/security_report_analysis/etc.
@@ -156,7 +162,9 @@ export interface CaseSearchResponseDto {
 export interface CaseViewDto {
   id: string;
   number: string;
-  wso2Id: string;
+  // See CaseSearchViewDto's internalId comment — same spec-vs-reality field-name drift, confirmed
+  // by this same symptom (case detail header not showing a second id) on the by-id detail view.
+  internalId: string;
   subject: string;
   description: string;
   severity: string | null;
@@ -340,11 +348,6 @@ export interface CreatedCaseDto {
   id: string;
 }
 
-// POST /cases wraps the created case in a { message, case } envelope rather than returning it
-// flat — confirmed against the webapp's usePostCsmCase.ts (BeCaseCreateResponse/BeCreatedCase),
-// which unwraps res.case for exactly this reason. openapi.yaml's postCases 201 response
-// ($ref: Case) doesn't reflect the envelope; trust the webapp's actual working code over the spec
-// here, same doc-vs-reality gap seen elsewhere in this backend family.
 export interface CaseCreateResponseDto {
   message?: string;
   case: CreatedCaseDto;

--- a/apps/csm-portal/microapp/src/types/case.model.ts
+++ b/apps/csm-portal/microapp/src/types/case.model.ts
@@ -120,7 +120,7 @@ export function toCaseSummary(dto: CaseSearchViewDto): CaseSummary {
   return {
     id: dto.id,
     number: dto.number,
-    wso2Id: dto.wso2Id,
+    wso2Id: dto.internalId,
     subject: dto.subject,
     description: dto.description,
     severity: normalizeSeverity(dto.severity),
@@ -147,7 +147,7 @@ export function toCaseDetail(dto: CaseViewDto): CaseDetail {
   return {
     id: dto.id,
     number: dto.number,
-    wso2Id: dto.wso2Id,
+    wso2Id: dto.internalId,
     subject: dto.subject,
     description: dto.description,
     severity: normalizeSeverity(dto.severity),

--- a/apps/csm-portal/microapp/src/utils/attachmentPreview.ts
+++ b/apps/csm-portal/microapp/src/utils/attachmentPreview.ts
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Ported from the webapp's attachmentPreview.ts (apps/csm-portal/webapp/src/features/csm-cases/utils/attachmentPreview.ts) —
+// keep this in lockstep with that file and with the entity-service's safeAttachmentTypes allowlist
+// (case_handler.go).
+
+/** The content-type families the attachment preview dialog knows how to render inline. */
+export type AttachmentPreviewKind = "image" | "pdf";
+
+/**
+ * `GET /attachments/{id}/content` only forwards the stored `Content-Type` as-is for a type in
+ * this set — anything else (including every `video/*` type, which has no entry at all) is
+ * coerced to `application/octet-stream` by the backend as a deliberate stored-XSS control. The
+ * attachment's `type` from `/attachments/search` list metadata reflects whatever the uploader
+ * claimed, uncoerced, so the FE must re-check it against this same allowlist before trusting it
+ * for anything (relabeling a fetched blob, or offering an inline preview) — otherwise a spoofed
+ * metadata `type` re-enables exactly what the backend control is meant to block. Keep this list
+ * in lockstep with the backend's; do not add an entry here that isn't also in `safeAttachmentTypes`.
+ */
+const SAFE_ATTACHMENT_CONTENT_TYPES: ReadonlySet<string> = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+  "application/pdf",
+  "text/plain",
+  "application/zip",
+  "application/x-zip-compressed",
+  "application/msword",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  "application/vnd.ms-excel",
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+]);
+
+/**
+ * Normalizes a content type the same way the backend does before its allowlist check: strip any
+ * `;`-parameters, trim, lowercase.
+ */
+function normalizeContentType(contentType: string): string {
+  return contentType.split(";")[0].trim().toLowerCase();
+}
+
+/**
+ * True when `contentType` is a member of the backend's safe-content-type allowlist (after the
+ * same normalization the backend applies). Anything outside this set must be treated as
+ * untrusted for rendering/relabeling purposes, even though it is a perfectly valid attachment to
+ * store/download.
+ */
+export function isSafeAttachmentContentType(contentType: string): boolean {
+  return SAFE_ATTACHMENT_CONTENT_TYPES.has(normalizeContentType(contentType));
+}
+
+/**
+ * Classify an attachment's content type into a previewable kind, or `null` when it has no inline
+ * preview (docs, archives, video, etc. stay download-only).
+ *
+ * Gated on {@link isSafeAttachmentContentType}: a type the backend's content endpoint would
+ * coerce to `application/octet-stream` can never be offered a preview, regardless of what the
+ * (uploader-controlled) metadata claims. Of the allowlisted types, only images and PDFs make
+ * sense as *inline* preview; `text/plain` and the archive/office types stay download-only.
+ */
+export function getAttachmentPreviewKind(contentType: string): AttachmentPreviewKind | null {
+  const type = normalizeContentType(contentType);
+  if (!SAFE_ATTACHMENT_CONTENT_TYPES.has(type)) return null;
+  if (type === "image/png" || type === "image/jpeg" || type === "image/gif" || type === "image/webp") return "image";
+  if (type === "application/pdf") return "pdf";
+  return null;
+}

--- a/apps/csm-portal/microapp/src/utils/attachmentPreview.ts
+++ b/apps/csm-portal/microapp/src/utils/attachmentPreview.ts
@@ -48,9 +48,11 @@ const SAFE_ATTACHMENT_CONTENT_TYPES: ReadonlySet<string> = new Set([
 
 /**
  * Normalizes a content type the same way the backend does before its allowlist check: strip any
- * `;`-parameters, trim, lowercase.
+ * `;`-parameters, trim, lowercase. Exported for attachments.ts's getAttachmentContent, which
+ * relabels a fetched Blob with this same normalized form rather than the raw uploader-provided
+ * string.
  */
-function normalizeContentType(contentType: string): string {
+export function normalizeContentType(contentType: string): string {
   return contentType.split(";")[0].trim().toLowerCase();
 }
 


### PR DESCRIPTION
## Summary
- **Case ID display**: `openapi.yaml` documents this field as `wso2Id`, but the live `/cases/search` and by-id detail responses actually send it as `internalId` (confirmed live: `{"id":"20d3964f-...","internalId":"CPPSUB-175","number":"CS0441016",...}`) — reading `dto.wso2Id` was always `undefined`, so the case detail header and Support/Home case cards silently showed only the case number. 

- Renamed the wire-level DTO field to `internalId` (app-facing `wso2Id` name unchanged in `case.model.ts`). Case detail header and case cards now show `wso2Id | number`, matching the customer-portal microapp's `OverlineSlot`/`ItemCard` convention. Copy button copies just the number — the value Support's search box actually matches on.

- **Tab bar clipping**: `MainLayout` trusted a dynamically-measured `--tab-bar-height` CSS var for bottom padding, which isn't reliably up to date on every render path — the last item in scrollable content (e.g. the last comment on a case) could get clipped behind the fixed tab bar. Switched to a flat, generous padding, same fix customer-portal microapp already uses for the same problem.

- **Real in-app attachment preview**: "Preview" previously opened `downloadUrl` externally, which ServiceNow serves with `&download=true` — forcing a download instead of rendering, making Preview and Download functionally identical. 

- Built a proper in-app viewer (pinch-zoom/pan images, paginated PDFs via `react-pdf` + `react-zoom-pan-pinch`, both already in `package.json` but never wired up), matching customer-portal microapp's UI. 

- Sources bytes the way the webapp does — `GET /attachments/{id}/content` fetched as an authenticated Blob and turned into an object URL — since this backend's content endpoint always sets `Content-Disposition: attachment` and has no JSON-wrapped alternative like customer-portal's backend does (`Content-Disposition` only affects direct browser navigation, not programmatic Blob fetches, so this works fine). 

- Content-type allowlist ported from the webapp, kept in lockstep with the entity-service's `safeAttachmentTypes` security control.

## Test plan
- [x] `tsc --noEmit` passes
- [x] `eslint` passes (4 pre-existing errors remain in untouched files, unrelated to this PR)
- [x] `npm run build` passes
- [x] Verified live: case detail header and Support/Home cards show `wso2Id | number`; copy button copies just the number; scrolling to the bottom of a case's Activities tab no longer clips the last comment; previewing an image/PDF attachment now zooms/pans/paginates in-app instead of opening externally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added full-screen previews for supported image and PDF attachments.
  * Images support zoom, pan, and reset controls; PDFs support page navigation.
  * Added separate Preview and Download actions for attachments.
  * Case displays now include the available WSO2 ID alongside the case number.

* **Bug Fixes**
  * Unsupported or unsafe attachment types remain download-only.
  * Copying a case now consistently copies the case number.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->