### PR TITLE
fix(customer-portal): split product-consumption tracking base URL from subscription

### DIFF
--- a/apps/customer-portal/backend-v2/.env.example
+++ b/apps/customer-portal/backend-v2/.env.example
@@ -31,9 +31,14 @@ AI_CHAT_AGENT_WS_SCOPES=
 # local development only.
 WS_ALLOWED_ORIGINS=
 
-# Product-consumption service (deployment license provisioning + usage import) —
-# a separate service, not entity-service.
+# Product-consumption services — not entity-service. The Ballerina backend
+# configures these as two independently-configurable base URLs
+# (product_consumption_subscription vs product_consumption_tracking), so set
+# both here too. PRODUCT_CONSUMPTION_TRACKING_BASE_URL falls back to
+# PRODUCT_CONSUMPTION_BASE_URL when left unset — only needed if the two
+# services are hosted separately.
 PRODUCT_CONSUMPTION_BASE_URL=
+PRODUCT_CONSUMPTION_TRACKING_BASE_URL=
 PRODUCT_CONSUMPTION_SCOPES=
 
 # Registry service (robot-account / registry-token issuance, integration

--- a/apps/customer-portal/backend-v2/CLAUDE.md
+++ b/apps/customer-portal/backend-v2/CLAUDE.md
@@ -175,9 +175,14 @@ development only).
 
 `internal/productconsumption` is a fifth upstream client for **another separate service unrelated
 to entity-service** — see `apps/customer-portal/backend`'s `modules/product_consumption_subscription`
-and `modules/product_consumption_tracking` for the Ballerina backend's two client modules, which
-this backend models as one Go package since both Ballerina modules point at the same upstream base
-URL in practice (confirmed in the Ballerina backend's `config.toml`).
+and `modules/product_consumption_tracking` for the Ballerina backend's two client modules. This
+backend models them as one Go package (one shared `*Client`, one OAuth2 app) but keeps their base
+URLs distinct: `Config.BaseURL` backs the subscription/license API, `Config.TrackingBaseURL` backs
+the usage-tracking API. They happen to point at the same host in the Ballerina backend's current
+`config.toml`, which is why `TrackingBaseURL` falls back to `BaseURL` when left unset — but they are
+two independently-configurable variables there (`productConsumptionBaseUrl` vs
+`productConsumptionTrackingBaseUrl`), not guaranteed to always match, so don't collapse them into a
+single field.
 
 It backs two routes:
 - `POST /projects/{projectId}/deployments/{deploymentId}/license` — provisions (or resumes

--- a/apps/customer-portal/backend-v2/CLAUDE.md
+++ b/apps/customer-portal/backend-v2/CLAUDE.md
@@ -510,7 +510,20 @@ constants).
    entity-client methods this handler needs; handler method sequence: auth check → path/body
    guards → call entity client → `mapUpstreamError` on failure → map to DTO → `writeJSONValue`.
 6. **Route** (`cmd/server/main.go`) — register using Go 1.22 method-prefixed patterns:
-   `"POST /cases/{id}/comments"`.
+   `"POST /cases/{id}/comments"`. **`net/http.ServeMux` panics at startup — crashing the whole
+   server — if a new pattern is ambiguous with an existing one** (neither is strictly more specific;
+   this can happen even with a different number of literal segments in a different position, e.g.
+   `/deployments/products/{id}/instances/metrics/search` vs.
+   `/deployments/{deploymentId}/products/{productId}/metrics/search`, which both match
+   `/deployments/products/products/instances/metrics/search`). Registration order does NOT matter
+   for this — the panic fires regardless of which one is registered first. This is NOT a
+   theoretical concern: it took the server down in production once already (see the merged fix for
+   exactly this pair of routes). Before opening a PR that adds a route with a wildcard segment,
+   sanity-check it against every other route sharing that many-or-fewer path segments; if two
+   patterns are ambiguous, merge them under one wildcard pattern and dispatch manually using
+   `r.SetPathValue` to inject the values each handler expects (see
+   `dispatchDeploymentsProductsMetricsSearch` in `main.go` for the pattern) rather than renaming
+   either route — the URL shapes themselves are an external contract with the frontend.
 7. **README** — add the endpoint under "API Endpoints" in `README.md`.
 8. **OpenAPI spec** (`openapi.yaml`) — add the path with `200`/`400`/`401`/`403`/`500` responses
    (`404` too for get-by-id, `413` too for endpoints with a request body); every endpoint must

--- a/apps/customer-portal/backend-v2/README.md
+++ b/apps/customer-portal/backend-v2/README.md
@@ -136,11 +136,14 @@ A separate Python service (not entity-service) — see [CLAUDE.md](./CLAUDE.md#t
 
 ### Product-consumption service
 
-A separate service (not entity-service) — see [CLAUDE.md](./CLAUDE.md#the-product-consumption-service).
+Not entity-service — see [CLAUDE.md](./CLAUDE.md#the-product-consumption-service). The Ballerina
+backend configures the subscription/license API and the usage-tracking API as two independently
+configurable base URLs, so set both here too.
 
 | Variable | Description |
 |---|---|
-| `PRODUCT_CONSUMPTION_BASE_URL` | Base URL of the product-consumption service |
+| `PRODUCT_CONSUMPTION_BASE_URL` | Base URL of the subscription/license API |
+| `PRODUCT_CONSUMPTION_TRACKING_BASE_URL` | Base URL of the usage-tracking API (optional — falls back to `PRODUCT_CONSUMPTION_BASE_URL` when unset) |
 | `PRODUCT_CONSUMPTION_SCOPES` | Comma-separated OAuth2 scopes (optional) |
 
 ### Registry service

--- a/apps/customer-portal/backend-v2/cmd/server/main.go
+++ b/apps/customer-portal/backend-v2/cmd/server/main.go
@@ -103,16 +103,21 @@ func main() {
 	}
 	aiChatAgentWsClient := aichatagent.NewWSClient(aiChatAgentWsCfg)
 
-	// The product-consumption service is a separate service (not
-	// entity-service) that provisions deployment licenses; it also
-	// authenticates as the same shared OAuth2 app (see the Ballerina
-	// backend's Config.toml).
+	// The product-consumption service(s) are separate services (not
+	// entity-service) that provision deployment licenses and import usage
+	// data; both authenticate as the same shared OAuth2 app. The Ballerina
+	// backend configures these as two independently-configurable base URLs
+	// (productConsumptionBaseUrl vs productConsumptionTrackingBaseUrl) —
+	// PRODUCT_CONSUMPTION_TRACKING_BASE_URL defaults to
+	// PRODUCT_CONSUMPTION_BASE_URL when unset, matching that backend's
+	// current config where both happen to point at the same host.
 	productConsumptionCfg := productconsumption.Config{
-		BaseURL:      mustEnv("PRODUCT_CONSUMPTION_BASE_URL"),
-		TokenURL:     oauth2TokenURL,
-		ClientID:     oauth2ClientID,
-		ClientSecret: oauth2ClientSecret,
-		Scopes:       splitComma(os.Getenv("PRODUCT_CONSUMPTION_SCOPES")),
+		BaseURL:         mustEnv("PRODUCT_CONSUMPTION_BASE_URL"),
+		TrackingBaseURL: os.Getenv("PRODUCT_CONSUMPTION_TRACKING_BASE_URL"),
+		TokenURL:        oauth2TokenURL,
+		ClientID:        oauth2ClientID,
+		ClientSecret:    oauth2ClientSecret,
+		Scopes:          splitComma(os.Getenv("PRODUCT_CONSUMPTION_SCOPES")),
 	}
 	productConsumptionClient := productconsumption.NewClient(productConsumptionCfg)
 

--- a/apps/customer-portal/backend-v2/cmd/server/main.go
+++ b/apps/customer-portal/backend-v2/cmd/server/main.go
@@ -256,10 +256,19 @@ func main() {
 	// ServiceNow data source — see internal/entity/deployed_products.go.
 	mux.HandleFunc("POST /deployed-products", deployedProductHandler.CreateDeployedProduct)
 	mux.HandleFunc("PATCH /deployed-products/{id}", deployedProductHandler.PatchDeployedProduct)
-	mux.HandleFunc("POST /deployments/{deploymentId}/products/{productId}/metrics/search", deployedProductHandler.SearchDeployedProductMetrics)
+	// POST /deployments/{deploymentId}/products/{productId}/metrics/search and
+	// POST /deployments/products/{id}/instances/metrics/search cannot both be
+	// registered as literal patterns: net/http.ServeMux (Go 1.22+) rejects
+	// them as ambiguous (neither is more specific than the other — e.g. both
+	// match "/deployments/products/products/instances/metrics/search") and
+	// panics at startup. Both path shapes are genuine, distinct Ballerina
+	// reference routes, so they're merged under one wildcard pattern and
+	// dispatched by dispatchDeploymentsProductsMetricsSearch below instead of
+	// renaming either one.
+	mux.HandleFunc("POST /deployments/{seg1}/{seg2}/{seg3}/metrics/search",
+		dispatchDeploymentsProductsMetricsSearch(instanceHandler, deployedProductHandler))
 	mux.HandleFunc("POST /deployments/{deploymentId}/products/{productId}/metrics/usage-counts/search", deployedProductHandler.SearchDeployedProductUsageCounts)
 	mux.HandleFunc("POST /deployments/products/{id}/instances/search", instanceHandler.SearchDeployedProductInstances)
-	mux.HandleFunc("POST /deployments/products/{id}/instances/metrics/search", instanceHandler.SearchDeployedProductInstanceMetrics)
 	mux.HandleFunc("POST /deployments/products/{id}/instances/usages/search", instanceHandler.SearchDeployedProductInstanceUsage)
 	mux.HandleFunc("POST /deployments/products/{id}/instances/stats/metrics/search", instanceHandler.SearchDeployedProductInstanceMetricsStats)
 	mux.HandleFunc("POST /deployments/products/{id}/instances/stats/usages/search", instanceHandler.SearchDeployedProductInstanceUsageStats)
@@ -374,6 +383,39 @@ func main() {
 		os.Exit(1)
 	}
 	slog.Info("Customer Portal Backend (v2) stopped")
+}
+
+// dispatchDeploymentsProductsMetricsSearch resolves the two distinct
+// Ballerina reference routes merged under the "POST
+// /deployments/{seg1}/{seg2}/{seg3}/metrics/search" pattern registered in
+// main() (see the comment at that registration for why they can't be
+// registered as separate literal patterns). Exactly one of the two shapes
+// can match a given request: seg1=="products" identifies the
+// deployed-product-scoped instances-metrics route (seg2 is the deployed
+// product ID, seg3 is the literal "instances"); otherwise seg2=="products"
+// identifies the deployed-product's own metrics route (seg1 is the
+// deployment ID, seg3 is the product ID). Path values are injected via
+// SetPathValue so the existing handler methods can read them exactly as
+// they would from their own literal pattern.
+func dispatchDeploymentsProductsMetricsSearch(instances *handler.InstanceHandler, deployedProducts *handler.DeployedProductHandler) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		seg1 := r.PathValue("seg1")
+		seg2 := r.PathValue("seg2")
+		seg3 := r.PathValue("seg3")
+
+		if seg1 == "products" && seg3 == "instances" {
+			r.SetPathValue("id", seg2)
+			instances.SearchDeployedProductInstanceMetrics(w, r)
+			return
+		}
+		if seg2 == "products" {
+			r.SetPathValue("deploymentId", seg1)
+			r.SetPathValue("productId", seg3)
+			deployedProducts.SearchDeployedProductMetrics(w, r)
+			return
+		}
+		http.NotFound(w, r)
+	}
 }
 
 func mustEnv(key string) string {

--- a/apps/customer-portal/backend-v2/internal/productconsumption/client.go
+++ b/apps/customer-portal/backend-v2/internal/productconsumption/client.go
@@ -15,13 +15,16 @@
 // under the License.
 
 // Package productconsumption is the HTTP client for the upstream
-// product-consumption service — a separate service (not entity-service)
-// that provisions WSO2 API Manager applications/subscriptions/credentials to
-// generate per-deployment product licenses, and imports deployment usage
+// product-consumption service(s) — separate services (not entity-service)
+// that provision WSO2 API Manager applications/subscriptions/credentials to
+// generate per-deployment product licenses, and import deployment usage
 // data. See apps/customer-portal/backend's modules/product_consumption_subscription
 // and modules/product_consumption_tracking for the Ballerina backend's
-// equivalent clients — both point at the same upstream base URL there, so
-// this package models them as one client rather than two.
+// equivalent clients: each has its own independently-configurable base URL
+// (productConsumptionBaseUrl vs productConsumptionTrackingBaseUrl) — they
+// happen to be set to the same value in that backend's current config, but
+// are not guaranteed to be, so this package keeps them as two distinct fields
+// rather than assuming they're always the same host.
 package productconsumption
 
 import (
@@ -48,24 +51,33 @@ func noRedirect(_ *http.Request, _ []*http.Request) error {
 	return http.ErrUseLastResponse
 }
 
-// Config holds the configuration for the product-consumption service client.
+// Config holds the configuration for the product-consumption service
+// clients. TrackingBaseURL defaults to BaseURL when left empty, matching
+// this Ballerina reference's current deployment where both configurable
+// base URLs happen to be set to the same value — set it explicitly once
+// the two services are hosted separately.
 type Config struct {
-	BaseURL      string
-	TokenURL     string
-	ClientID     string
-	ClientSecret string
-	Scopes       []string
+	BaseURL         string
+	TrackingBaseURL string
+	TokenURL        string
+	ClientID        string
+	ClientSecret    string
+	Scopes          []string
 }
 
-// Client is an HTTP client for the upstream product-consumption service,
-// authenticated via the OAuth2 client credentials grant.
+// Client is an HTTP client for the upstream product-consumption service(s),
+// authenticated via the OAuth2 client credentials grant. baseURL backs the
+// subscription/license API; trackingBaseURL backs the usage-import API —
+// two independently-configurable upstream services in the Ballerina
+// reference, kept distinct here even though they're often the same host.
 type Client struct {
-	http    *http.Client
-	baseURL string
+	http            *http.Client
+	baseURL         string
+	trackingBaseURL string
 }
 
 // NewClient constructs a Client that authenticates against the
-// product-consumption service using the OAuth2 client credentials grant type.
+// product-consumption service(s) using the OAuth2 client credentials grant type.
 func NewClient(cfg Config) *Client {
 	cc := clientcredentials.Config{
 		ClientID:     cfg.ClientID,
@@ -88,19 +100,25 @@ func NewClient(cfg Config) *Client {
 		CheckRedirect: noRedirect,
 	}
 
+	trackingBaseURL := cfg.TrackingBaseURL
+	if trackingBaseURL == "" {
+		trackingBaseURL = cfg.BaseURL
+	}
+
 	return &Client{
-		http:    httpClient,
-		baseURL: strings.TrimRight(cfg.BaseURL, "/"),
+		http:            httpClient,
+		baseURL:         strings.TrimRight(cfg.BaseURL, "/"),
+		trackingBaseURL: strings.TrimRight(trackingBaseURL, "/"),
 	}
 }
 
-func (c *Client) do(ctx context.Context, method, path, contentType string, body []byte) ([]byte, error) {
+func (c *Client) doAt(ctx context.Context, baseURL, method, path, contentType string, body []byte) ([]byte, error) {
 	var reqBody io.Reader
 	if len(body) > 0 {
 		reqBody = bytes.NewReader(body)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, reqBody)
+	req, err := http.NewRequestWithContext(ctx, method, baseURL+path, reqBody)
 	if err != nil {
 		return nil, fmt.Errorf("productconsumption: build request %s %s: %w", method, path, err)
 	}
@@ -135,12 +153,33 @@ func (c *Client) do(ctx context.Context, method, path, contentType string, body 
 	return respBody, nil
 }
 
+func (c *Client) do(ctx context.Context, method, path, contentType string, body []byte) ([]byte, error) {
+	return c.doAt(ctx, c.baseURL, method, path, contentType, body)
+}
+
 func (c *Client) postJSON(ctx context.Context, path string, reqBody, out any) error {
 	payload, err := json.Marshal(reqBody)
 	if err != nil {
 		return fmt.Errorf("productconsumption: encode request for POST %s: %w", path, err)
 	}
 	body, err := c.do(ctx, http.MethodPost, path, "application/json", payload)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(body, out); err != nil {
+		return fmt.Errorf("productconsumption: decode response for POST %s: %w", path, err)
+	}
+	return nil
+}
+
+// postJSONTracking is postJSON's counterpart for the usage-tracking service
+// — the only consumer of trackingBaseURL.
+func (c *Client) postJSONTracking(ctx context.Context, path string, reqBody, out any) error {
+	payload, err := json.Marshal(reqBody)
+	if err != nil {
+		return fmt.Errorf("productconsumption: encode request for POST %s: %w", path, err)
+	}
+	body, err := c.doAt(ctx, c.trackingBaseURL, http.MethodPost, path, "application/json", payload)
 	if err != nil {
 		return err
 	}

--- a/apps/customer-portal/backend-v2/internal/productconsumption/tracking.go
+++ b/apps/customer-portal/backend-v2/internal/productconsumption/tracking.go
@@ -21,14 +21,15 @@ import (
 	"encoding/base64"
 )
 
-// ImportDeploymentUsage calls POST /deployment-usages, base64-encoding
-// zipFile as the upstream service's contract requires.
+// ImportDeploymentUsage calls POST /deployment-usages against the tracking
+// service's own base URL, base64-encoding zipFile as the upstream service's
+// contract requires.
 func (c *Client) ImportDeploymentUsage(ctx context.Context, email string, zipFile []byte) (ImportUsageResponse, error) {
 	req := ImportUsageRequest{
 		Email: email,
 		Zip:   base64.StdEncoding.EncodeToString(zipFile),
 	}
 	var out ImportUsageResponse
-	err := c.postJSON(ctx, "/deployment-usages", req, &out)
+	err := c.postJSONTracking(ctx, "/deployment-usages", req, &out)
 	return out, err
 }


### PR DESCRIPTION
## Summary
- The Ballerina reference (`apps/customer-portal/backend`) configures `product_consumption_subscription` and `product_consumption_tracking` as two independently-configurable base URLs (`productConsumptionBaseUrl` vs `productConsumptionTrackingBaseUrl` in `config.toml`) — they only happen to be set to the same host in that backend's current config, not guaranteed by the module architecture.
- `backend-v2`'s `internal/productconsumption` package had collapsed this into a single `BaseURL`, silently assuming the two would always match.
- Adds `PRODUCT_CONSUMPTION_TRACKING_BASE_URL`, which the `usage-tracking` API (`ImportDeploymentUsage` / `POST /deployment-usages`) now uses instead of the subscription/license API's base URL. Falls back to `PRODUCT_CONSUMPTION_BASE_URL` when left unset, so existing deployments where both happen to coincide keep working unchanged.
- Updated `.env.example`, `README.md`, and `CLAUDE.md` accordingly.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` all clean
- [x] `gosec -fmt=text ./...` — 0 issues
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Product consumption integrations can now use separate base URLs for subscription/license and usage-tracking services.
  * Usage-tracking requests are routed to the configured tracking service.
  * Tracking service configuration falls back to the primary service URL when not provided.
  * Deployment-product metrics routes continue to support existing URL formats.

* **Documentation**
  * Updated setup guidance and configuration examples to explain the separate service URLs and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->