### PR TITLE
[CSM Portal Microapp]: createdBy UserReference crashes on Announcements and Activities

### DIFF
--- a/apps/csm-portal/microapp/src/types/activity.dto.ts
+++ b/apps/csm-portal/microapp/src/types/activity.dto.ts
@@ -33,12 +33,21 @@ export interface CaseActivityFieldChangeDto {
  * are consumed from here, mirroring the webapp's useCsmCaseActivities.ts (it deliberately avoids
  * a second, divergent read path for comments/attachments).
  */
+/** The canonical {id, email, name} UserReference shape (openapi.yaml's CaseActivity.createdBy) —
+ * matches the webapp's own ground-truth useCsmCaseActivities.ts, which reads
+ * entry.createdBy?.name / ?.email throughout and never treats createdBy as a plain string. */
+export interface CaseActivityAuthorDto {
+  id?: string | null;
+  email?: string;
+  name?: string;
+}
+
 export interface CaseActivityEntryDto {
   id: string;
   type: CaseActivityType;
   content?: string;
   createdOn: string;
-  createdBy?: string;
+  createdBy?: CaseActivityAuthorDto | null;
   createdByFirstName?: string;
   createdByLastName?: string;
   createdByFullName?: string;

--- a/apps/csm-portal/microapp/src/types/activity.model.ts
+++ b/apps/csm-portal/microapp/src/types/activity.model.ts
@@ -32,8 +32,13 @@ export interface CaseAuditEntry {
   changes: CaseAuditFieldChange[];
 }
 
-/** Best display name off an activity entry's flat author fields — mirrors commentAuthorLabel's
- * fallback chain in case.model.ts, adapted to this endpoint's flat (non-nested) author fields. */
+/** Best display name off an activity entry's author fields — mirrors commentAuthorLabel's
+ * fallback chain in case.model.ts. The final fallback used to read entry.createdBy as a plain
+ * string (entry.createdBy?.trim()), but createdBy is actually the canonical {id, email, name}
+ * UserReference object per openapi.yaml and the webapp's own useCsmCaseActivities.ts (which reads
+ * entry.createdBy?.name / ?.email, never .trim() on createdBy itself) — calling .trim() on that
+ * object throws, which would have crashed this entry's render whenever createdByFullName and
+ * createdByFirstName/createdByLastName were all empty. */
 function activityAuthorLabel(entry: CaseActivityEntryDto): string {
   const full = entry.createdByFullName?.trim();
   if (full) return full;
@@ -42,7 +47,7 @@ function activityAuthorLabel(entry: CaseActivityEntryDto): string {
     .join(" ")
     .trim();
   if (composed) return composed;
-  return entry.createdBy?.trim() || "Unknown";
+  return entry.createdBy?.name?.trim() || entry.createdBy?.email?.trim() || "Unknown";
 }
 
 export function toCaseAuditEntry(dto: CaseActivityEntryDto): CaseAuditEntry {

--- a/apps/csm-portal/microapp/src/types/case.dto.ts
+++ b/apps/csm-portal/microapp/src/types/case.dto.ts
@@ -61,10 +61,15 @@ export interface UserIdEmailRefDto {
   email: string;
 }
 
+// CaseView/CaseSearchView.assignedEngineer both reference the canonical UserReference schema
+// (openapi.yaml) — {id: string|null, email: string, name: string} — not the separate,
+// differently-nullable AssignedEngineerRef schema used elsewhere (e.g. acknowledgedBy). Field
+// names already matched reality (no render crash), but id/email's nullability were backwards:
+// id can genuinely be null, email is always populated when assignedEngineer itself is non-null.
 export interface AssignedEngineerRefDto {
-  id: string;
+  id: string | null;
   name: string;
-  email: string | null;
+  email: string;
 }
 
 export interface CaseNumberRefDto {
@@ -138,9 +143,15 @@ export interface CaseSearchViewDto {
   createdOn?: string;
   updatedOn?: string;
   closedOn: string | null;
-  // The case-search view returns the creator's email as a plain string (unlike
-  // the by-id detail view, which returns a full user object).
-  createdBy: string;
+  // This comment used to claim the case-search view returns the creator's email as a plain
+  // string, unlike the by-id detail view. That was never true: openapi.yaml documents
+  // CaseSearchView.createdBy as the same nullable UserReference ({id, email, name}) as the
+  // detail view, and live data confirms it (e.g. {"id":null,"email":"hesara@wso2.com","name":""}).
+  // Rendering this directly as a string (AnnouncementCard.tsx, which shows CaseSummary.createdBy)
+  // crashed with "Objects are not valid as a React child" and nothing caught it, so the whole
+  // Announcements page went blank. Same bug class as CaseCommentDto/AttachmentViewDto/CaseViewDto's
+  // createdBy fields, just the one instance not caught in that earlier pass.
+  createdBy: string | UserRefDto | null;
   project: EntityRefDto;
   deployment: EntityRefDto | null;
   deployedProduct: EntityRefDto | null;

--- a/apps/csm-portal/microapp/src/types/case.model.ts
+++ b/apps/csm-portal/microapp/src/types/case.model.ts
@@ -70,7 +70,8 @@ export interface CaseSummary {
   createdOn: Date;
   updatedOn: Date;
   closedOn: Date | null;
-  /** Creator's email (the case-search view returns it as a plain string). */
+  /** Display-ready creator name, normalized from CaseSearchViewDto's raw UserReference/string/null
+   * by caseCreatorLabel — never render dto.createdBy directly, see that function's comment. */
   createdBy: string;
   project: EntityRefDto;
   deployment: EntityRefDto | null;
@@ -116,6 +117,16 @@ export interface Comment {
   createdOn: Date;
 }
 
+// CaseSearchViewDto's createdBy is the canonical {id, email, name} UserReference (see that
+// field's comment) — not the plain string this codebase used to assume. Rendering it directly
+// crashes React ("Objects are not valid as a React child"); normalize it here the same way
+// commentAuthorLabel/attachmentAuthorLabel do for the same underlying shape elsewhere.
+function caseCreatorLabel(createdBy: CaseSearchViewDto["createdBy"] | null | undefined): string {
+  if (!createdBy) return "Unknown";
+  if (typeof createdBy === "string") return createdBy.trim() || "Unknown";
+  return createdBy.name?.trim() || createdBy.email?.trim() || "Unknown";
+}
+
 export function toCaseSummary(dto: CaseSearchViewDto): CaseSummary {
   return {
     id: dto.id,
@@ -132,7 +143,7 @@ export function toCaseSummary(dto: CaseSearchViewDto): CaseSummary {
     createdOn: parseBackendTimestamp(dto.createdOn ?? ""),
     updatedOn: parseBackendTimestamp(dto.updatedOn ?? dto.createdOn ?? ""),
     closedOn: parseOptionalBackendTimestamp(dto.closedOn),
-    createdBy: dto.createdBy,
+    createdBy: caseCreatorLabel(dto.createdBy),
     project: dto.project,
     deployment: dto.deployment,
     product: dto.product,


### PR DESCRIPTION
## Summary
- `CaseSearchViewDto.createdBy` was typed as a plain `string`, but the backend actually sends the canonical `{id, email, name}` `UserReference` object (confirmed via `openapi.yaml` and a live payload: `{"id":null,"email":"...","name":""}`). Rendering it directly crashed with "Objects are not valid as a React child," blanking the entire Announcements page.
- `AssignedEngineerRefDto`'s `id`/`email` nullability was backwards relative to the `UserReference` schema it's based on (`id` can be `null`, `email` cannot).
- `CaseActivityEntryDto.createdBy` (Activities tab "Lifecycle" entries) had the same latent bug: `activityAuthorLabel`'s final fallback called `.trim()` directly on `createdBy`, which is also a `UserReference` object, not a string — would throw `TypeError` whenever the flat name fields were all empty.

Both fixes follow the same normalization pattern already used for `CaseCommentDto.createdBy` / `AttachmentViewDto.createdBy` / `CaseViewDto.createdBy` earlier in this app.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx eslint .`
- [x] `npm run build`
- [x] Verified against a live `/cases/search` payload showing `createdBy` as a `UserReference` object with an empty `name`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved display of case and activity creators when names or email addresses are missing.
  * Prevented rendering issues caused by incomplete author information.
  * Added a fallback to display “Unknown” when no creator details are available.

* **Improvements**
  * Creator information now supports names, email addresses, and user references from backend responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->