### PR TITLE
fix(csm-portal-microapp): cap inline-image extraction from comment/description HTML

### DIFF
--- a/apps/csm-portal/microapp/src/components/home/CompositionDonut.tsx
+++ b/apps/csm-portal/microapp/src/components/home/CompositionDonut.tsx
@@ -96,7 +96,12 @@ export function CompositionDonut({
               data={pieData}
               colors={pieData.map((s) => s.color)}
               legend={{ show: false }}
-              tooltip={{ show: true }}
+              // Hover/tooltip doesn't map cleanly onto touch — a tap registers as "hover" first,
+              // leaving the tooltip stuck open over the center total until something else is
+              // tapped. This is a mobile-only WebView, so there's no real hover state to serve;
+              // tap already navigates directly via onSliceClick below. Matches customer-portal
+              // microapp's PieChartWidget, which disables the tooltip the same way.
+              tooltip={{ show: false }}
               width="100%"
               height={DONUT_SIZE}
               margin={{ top: 0, right: 0, bottom: 5, left: 0 }}

--- a/apps/csm-portal/microapp/src/components/timecards/TimeSheetCard.tsx
+++ b/apps/csm-portal/microapp/src/components/timecards/TimeSheetCard.tsx
@@ -116,10 +116,15 @@ function TimeCardRow({
 }) {
   const canDecide = onDecide && card.state === "submitted";
   return (
-    // A tinted background separates each card from its neighbors and from the sheet's own
-    // background — a plain gap between rows was indistinguishable in dark mode, where the
-    // accordion body and each card otherwise render as the same flat surface color.
-    <Stack gap={1} sx={{ p: 1.25, borderRadius: 1.5, bgcolor: "action.hover" }}>
+    // A visible border separates each card from its neighbors and from the sheet's own
+    // background — a plain Stack gap was indistinguishable in dark mode, where the accordion
+    // body and each card otherwise render as the same flat surface color. A translucent
+    // bgcolor (action.hover) isn't reliable here: this theme's Card surfaces are themselves
+    // semi-transparent (see theme/index.ts's MuiDialog override for the same "double
+    // transparency" issue), so a low-opacity fill on top of one can end up unnoticeable. A solid
+    // 1px border, the same pattern AttachmentsTab/CaseActivityFeed rows already use, doesn't have
+    // that problem.
+    <Stack gap={1} sx={{ p: 1.25, border: "1px solid", borderColor: "divider", borderRadius: 1 }}>
       <Stack direction="row" alignItems="center" justifyContent="space-between" gap={1}>
         <Box sx={{ minWidth: 0 }}>
           <Typography variant="body2" noWrap>

--- a/apps/csm-portal/microapp/src/components/timecards/TimeSheetCard.tsx
+++ b/apps/csm-portal/microapp/src/components/timecards/TimeSheetCard.tsx
@@ -116,7 +116,10 @@ function TimeCardRow({
 }) {
   const canDecide = onDecide && card.state === "submitted";
   return (
-    <Stack gap={1}>
+    // A tinted background separates each card from its neighbors and from the sheet's own
+    // background — a plain gap between rows was indistinguishable in dark mode, where the
+    // accordion body and each card otherwise render as the same flat surface color.
+    <Stack gap={1} sx={{ p: 1.25, borderRadius: 1.5, bgcolor: "action.hover" }}>
       <Stack direction="row" alignItems="center" justifyContent="space-between" gap={1}>
         <Box sx={{ minWidth: 0 }}>
           <Typography variant="body2" noWrap>

--- a/apps/csm-portal/microapp/src/components/timecards/TimeSheetCard.tsx
+++ b/apps/csm-portal/microapp/src/components/timecards/TimeSheetCard.tsx
@@ -116,15 +116,10 @@ function TimeCardRow({
 }) {
   const canDecide = onDecide && card.state === "submitted";
   return (
-    // A visible border separates each card from its neighbors and from the sheet's own
-    // background — a plain Stack gap was indistinguishable in dark mode, where the accordion
-    // body and each card otherwise render as the same flat surface color. A translucent
-    // bgcolor (action.hover) isn't reliable here: this theme's Card surfaces are themselves
-    // semi-transparent (see theme/index.ts's MuiDialog override for the same "double
-    // transparency" issue), so a low-opacity fill on top of one can end up unnoticeable. A solid
-    // 1px border, the same pattern AttachmentsTab/CaseActivityFeed rows already use, doesn't have
-    // that problem.
-    <Stack gap={1} sx={{ p: 1.25, border: "1px solid", borderColor: "divider", borderRadius: 1 }}>
+    <Stack
+      gap={1}
+      sx={{ p: 1.25, bgcolor: "action.hover", border: "1px solid", borderColor: "divider", borderRadius: 1 }}
+    >
       <Stack direction="row" alignItems="center" justifyContent="space-between" gap={1}>
         <Box sx={{ minWidth: 0 }}>
           <Typography variant="body2" noWrap>

--- a/apps/csm-portal/microapp/src/utils/inlineImages.ts
+++ b/apps/csm-portal/microapp/src/utils/inlineImages.ts
@@ -56,19 +56,27 @@ export function sysidToUuid(id: string): string {
   return `${id.slice(0, 8)}-${id.slice(8, 12)}-${id.slice(12, 16)}-${id.slice(16, 20)}-${id.slice(20, 32)}`;
 }
 
+// A comment/description with an unreasonable number of distinct inline images would otherwise
+// fire one parallel authenticated Blob fetch per image (see useResolvedInlineImageHtml) — this
+// caps how many unique ids are ever collected, so that stays bounded regardless of how much HTML
+// is thrown at it. Ids past the cap are simply never extracted, so replaceInlineImageSrcs treats
+// them the same as any other unresolved reference (stripped, not left pointing at an auth-gated
+// URL the WebView can't load).
+const MAX_INLINE_IMAGES = 20;
+
 /** Extracts every attachment id referenced by a `.iix` `<img>` src within an HTML string. */
 export function extractIixAttachmentIds(html: string): string[] {
-  const ids: string[] = [];
+  const ids = new Set<string>();
   let match;
   IMG_TAG_SRC.lastIndex = 0;
-  while ((match = IMG_TAG_SRC.exec(html)) !== null) {
+  while (ids.size < MAX_INLINE_IMAGES && (match = IMG_TAG_SRC.exec(html)) !== null) {
     const src = match[2] ?? match[3] ?? match[4] ?? "";
     if (src.includes(".iix")) {
       const id = extractInlineImageRefId(src);
-      if (id && !ids.includes(id)) ids.push(id);
+      if (id) ids.add(id);
     }
   }
-  return ids;
+  return Array.from(ids);
 }
 
 /**


### PR DESCRIPTION
## Summary
Follow-up to #1374 (already merged) — two CodeRabbit findings were re-verified against current upstream code:

- **Standalone `<img>` HTML detection (UpdatesPage.tsx)**: already fixed upstream as part of #1374 (commit 4c3e73317). No change needed.
- **Unbounded inline-image extraction (`inlineImages.ts`)**: still valid. `extractIixAttachmentIds` had no upper bound and deduped via an O(n) `ids.includes()` scan per match. `useResolvedInlineImageHtml` fires one parallel authenticated Blob fetch per id it returns, so a comment/description with an unreasonable number of distinct `.iix` images would fire an unbounded number of concurrent fetches. This PR caps collection at 20 unique ids (via a `Set`, also fixing the O(n) scan) — ids past the cap are simply never extracted, so they fall through the existing "unresolved reference" handling in `replaceInlineImageSrcs` (stripped, not left pointing at an auth-gated URL).

`useResolvedInlineImageHtml.ts` needed no changes — it already derives its queries, retries, and data-URL map entirely from `extractIixAttachmentIds`'s return value, so capping it there is sufficient.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx eslint .`
- [x] `npm run build`