### PR TITLE
[CSM Portal Microapp]: app-wide crash isolation and a root error boundary

### DIFF
--- a/apps/csm-portal/microapp/src/components/case-detail/AttachmentsTab.tsx
+++ b/apps/csm-portal/microapp/src/components/case-detail/AttachmentsTab.tsx
@@ -21,6 +21,7 @@ import { Eye, FileText } from "@wso2/oxygen-ui-icons-react";
 import { attachments as attachmentsService } from "@src/services/attachments";
 import type { CaseAttachment } from "@src/types";
 import { ErrorBoundary } from "@components/common/ErrorBoundary";
+import { ListItemErrorBoundary } from "@components/common/ListItemErrorBoundary";
 import { ErrorState } from "@components/support/ErrorState";
 import { AttachmentsField } from "@components/support/AttachmentsField";
 import { formatBytes, type PendingAttachment } from "@utils/attachments";
@@ -112,7 +113,9 @@ function AttachmentsTabContent({ caseId }: { caseId: string }) {
       ) : (
         <Stack gap={1}>
           {caseAttachments.map((attachment) => (
-            <AttachmentRow key={attachment.id} attachment={attachment} onPreview={setPreviewTarget} />
+            <ListItemErrorBoundary key={attachment.id} context="attachment row">
+              <AttachmentRow attachment={attachment} onPreview={setPreviewTarget} />
+            </ListItemErrorBoundary>
           ))}
         </Stack>
       )}

--- a/apps/csm-portal/microapp/src/components/case-detail/CaseActivityFeed.tsx
+++ b/apps/csm-portal/microapp/src/components/case-detail/CaseActivityFeed.tsx
@@ -22,6 +22,7 @@ import { activities as activitiesService } from "@src/services/activities";
 import { attachments as attachmentsService } from "@src/services/attachments";
 import type { CaseAttachment, CaseAuditEntry, Comment } from "@src/types";
 import { ErrorBoundary } from "@components/common/ErrorBoundary";
+import { ListItemErrorBoundary } from "@components/common/ListItemErrorBoundary";
 import { ErrorState } from "@components/support/ErrorState";
 import { formatBytes } from "@utils/attachments";
 import { fromNow } from "@utils/dateTime";
@@ -95,84 +96,81 @@ export function CaseActivityFeed({ comments, audit, attachments }: CaseActivityF
       {entries.map((e) => {
         if (e.kind === "comment") {
           return (
-            <Stack
-              key={`c-${e.id}`}
-              gap={0.5}
-              sx={{ p: 1.5, border: "1px solid", borderColor: "divider", borderRadius: 1 }}
-            >
-              <Stack direction="row" justifyContent="space-between" alignItems="center" gap={1} flexWrap="wrap">
-                <Stack direction="row" alignItems="center" gap={1} sx={{ minWidth: 0 }}>
-                  <Typography variant="subtitle2" color="text.secondary" noWrap sx={{ minWidth: 0 }}>
-                    {e.comment.createdBy}
+            <ListItemErrorBoundary key={`c-${e.id}`} context="comment">
+              <Stack gap={0.5} sx={{ p: 1.5, border: "1px solid", borderColor: "divider", borderRadius: 1 }}>
+                <Stack direction="row" justifyContent="space-between" alignItems="center" gap={1} flexWrap="wrap">
+                  <Stack direction="row" alignItems="center" gap={1} sx={{ minWidth: 0 }}>
+                    <Typography variant="subtitle2" color="text.secondary" noWrap sx={{ minWidth: 0 }}>
+                      {e.comment.createdBy}
+                    </Typography>
+                    {e.comment.type === "work_note" && <Chip size="small" variant="outlined" label="Work note" />}
+                  </Stack>
+                  <Typography variant="subtitle2" color="text.secondary" noWrap sx={{ flexShrink: 0 }}>
+                    {fromNow(e.comment.createdOn)}
                   </Typography>
-                  {e.comment.type === "work_note" && <Chip size="small" variant="outlined" label="Work note" />}
                 </Stack>
-                <Typography variant="subtitle2" color="text.secondary" noWrap sx={{ flexShrink: 0 }}>
-                  {fromNow(e.comment.createdOn)}
-                </Typography>
+                <CommentBody content={e.comment.content} />
               </Stack>
-              <CommentBody content={e.comment.content} />
-            </Stack>
+            </ListItemErrorBoundary>
           );
         }
 
         if (e.kind === "audit") {
           return (
-            <Stack
-              key={`a-${e.id}`}
-              gap={0.75}
-              sx={{ p: 1.5, border: "1px solid", borderColor: "divider", borderRadius: 1 }}
-            >
-              <Stack direction="row" alignItems="center" gap={1} flexWrap="wrap">
-                <History size={14} />
-                <Typography variant="subtitle2">{e.entry.actor}</Typography>
-                <Chip size="small" variant="outlined" label="Lifecycle" />
-                <Typography variant="caption" color="text.secondary" sx={{ ml: "auto" }}>
-                  {fromNow(e.entry.createdOn)}
-                </Typography>
+            <ListItemErrorBoundary key={`a-${e.id}`} context="lifecycle entry">
+              <Stack gap={0.75} sx={{ p: 1.5, border: "1px solid", borderColor: "divider", borderRadius: 1 }}>
+                <Stack direction="row" alignItems="center" gap={1} flexWrap="wrap">
+                  <History size={14} />
+                  <Typography variant="subtitle2">{e.entry.actor}</Typography>
+                  <Chip size="small" variant="outlined" label="Lifecycle" />
+                  <Typography variant="caption" color="text.secondary" sx={{ ml: "auto" }}>
+                    {fromNow(e.entry.createdOn)}
+                  </Typography>
+                </Stack>
+                <Stack gap={0.25}>
+                  {e.entry.changes.map((change, i) => (
+                    <FieldChangeLine key={`${change.field}-${i}`} field={change} />
+                  ))}
+                </Stack>
               </Stack>
-              <Stack gap={0.25}>
-                {e.entry.changes.map((change, i) => (
-                  <FieldChangeLine key={`${change.field}-${i}`} field={change} />
-                ))}
-              </Stack>
-            </Stack>
+            </ListItemErrorBoundary>
           );
         }
 
         return (
-          <Stack
-            key={`f-${e.id}`}
-            direction="row"
-            alignItems="center"
-            justifyContent="space-between"
-            gap={1}
-            onClick={() => setPreviewTarget(e.attachment)}
-            sx={{ p: 1.5, border: "1px solid", borderColor: "divider", borderRadius: 1, cursor: "pointer" }}
-          >
-            <Stack direction="row" alignItems="center" gap={1} sx={{ minWidth: 0 }}>
-              <Paperclip size={16} />
-              <Stack sx={{ minWidth: 0 }}>
-                <Stack direction="row" alignItems="center" gap={1}>
-                  <Typography variant="subtitle2" noWrap>
-                    {e.attachment.createdBy}
+          <ListItemErrorBoundary key={`f-${e.id}`} context="attachment entry">
+            <Stack
+              direction="row"
+              alignItems="center"
+              justifyContent="space-between"
+              gap={1}
+              onClick={() => setPreviewTarget(e.attachment)}
+              sx={{ p: 1.5, border: "1px solid", borderColor: "divider", borderRadius: 1, cursor: "pointer" }}
+            >
+              <Stack direction="row" alignItems="center" gap={1} sx={{ minWidth: 0 }}>
+                <Paperclip size={16} />
+                <Stack sx={{ minWidth: 0 }}>
+                  <Stack direction="row" alignItems="center" gap={1}>
+                    <Typography variant="subtitle2" noWrap>
+                      {e.attachment.createdBy}
+                    </Typography>
+                    <Chip size="small" variant="outlined" label="Attachment" />
+                  </Stack>
+                  <Typography variant="body2" noWrap sx={{ fontWeight: 600 }}>
+                    {e.attachment.name}
                   </Typography>
-                  <Chip size="small" variant="outlined" label="Attachment" />
+                  <Typography variant="caption" color="text.secondary" noWrap>
+                    {formatBytes(e.attachment.sizeBytes)} · {fromNow(e.attachment.createdOn)}
+                  </Typography>
                 </Stack>
-                <Typography variant="body2" noWrap sx={{ fontWeight: 600 }}>
-                  {e.attachment.name}
-                </Typography>
-                <Typography variant="caption" color="text.secondary" noWrap>
-                  {formatBytes(e.attachment.sizeBytes)} · {fromNow(e.attachment.createdOn)}
-                </Typography>
               </Stack>
+              {/* Whole row opens Preview, same as AttachmentsTab/customer-portal microapp's
+                  AttachmentCard — no separate Download action (neither app's native bridge has a
+                  "save file to device" primitive). Unsupported types still open the dialog; it
+                  renders its own "Preview not available" state for those. */}
+              <Eye size={16} />
             </Stack>
-            {/* Whole row opens Preview, same as AttachmentsTab/customer-portal microapp's
-                AttachmentCard — no separate Download action (neither app's native bridge has a
-                "save file to device" primitive). Unsupported types still open the dialog; it
-                renders its own "Preview not available" state for those. */}
-            <Eye size={16} />
-          </Stack>
+          </ListItemErrorBoundary>
         );
       })}
 

--- a/apps/csm-portal/microapp/src/components/case-detail/CommentBody.tsx
+++ b/apps/csm-portal/microapp/src/components/case-detail/CommentBody.tsx
@@ -22,7 +22,8 @@ import { useResolvedInlineImageHtml } from "@utils/useResolvedInlineImageHtml";
 // Some comments (state-change audit entries, etc.) carry real HTML (`<br><p>...</p>`) rather than
 // plain text — rendering those as plain text shows the literal tags. Same sniff-then-sanitize
 // pattern as the webapp's UpdatesPage (apps/csm-portal/webapp), which hits the same ambiguity.
-const HTML_FORMAT_RE = /<\/?(p|span|div|ul|ol|li|strong|em|b|i|br|h[1-6]|a[\s>]|table|tr|td|th|code|pre|blockquote)\b/i;
+const HTML_FORMAT_RE =
+  /<\/?(p|span|div|ul|ol|li|strong|em|b|i|br|h[1-6]|a[\s>]|table|tr|td|th|code|pre|blockquote|img)\b/i;
 
 const HTML_CONTENT_SX = {
   fontSize: "0.875rem",

--- a/apps/csm-portal/microapp/src/components/common/AppErrorBoundary.tsx
+++ b/apps/csm-portal/microapp/src/components/common/AppErrorBoundary.tsx
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Component, type ErrorInfo, type ReactNode } from "react";
+import { Box, Button, Stack, Typography } from "@wso2/oxygen-ui";
+import { TriangleAlert } from "@wso2/oxygen-ui-icons-react";
+import { Logger } from "@utils/logger";
+
+interface AppErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface AppErrorBoundaryState {
+  hasError: boolean;
+}
+
+/**
+ * Last-resort boundary at the app root. Every other ErrorBoundary in this app is scoped to a
+ * single tab/section (AttachmentsTab, CaseActivityFeed, etc.) — but most pages (HomePage,
+ * AnnouncementsPage, MorePage, ...) and shared chrome (MainLayout, TopBar) have no boundary of
+ * their own. Without this one, an uncaught render error in any of those unmounts the *entire*
+ * React tree with nothing left to catch it — the WebView goes to a blank white screen with no
+ * way back short of force-quitting. That's not hypothetical: the createdBy UserReference bug
+ * that crashed the Announcements page this session threw at render time, inside a page with no
+ * boundary of its own and, at the time, no root boundary either — the "blank page" bug report was
+ * this exact failure mode. Mirrors the webapp's AppErrorBoundary, trimmed to this app's simpler
+ * recovery options (a WebView has no address bar to retype a URL into, so "reload" is the whole
+ * story).
+ */
+export class AppErrorBoundary extends Component<AppErrorBoundaryProps, AppErrorBoundaryState> {
+  state: AppErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): AppErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    Logger.error("Unhandled render error crashed the app", {
+      message: error.message,
+      componentStack: info.componentStack,
+    });
+  }
+
+  private handleReload = (): void => {
+    window.location.reload();
+  };
+
+  render(): ReactNode {
+    if (!this.state.hasError) return this.props.children;
+
+    return (
+      <Box sx={{ minHeight: "100vh", display: "flex", alignItems: "center", justifyContent: "center", px: 3 }}>
+        <Stack alignItems="center" gap={1.5} sx={{ maxWidth: 320, textAlign: "center" }}>
+          <TriangleAlert size={32} color="currentColor" />
+          <Typography variant="h6">Something went wrong</Typography>
+          <Typography variant="body2" color="text.secondary">
+            Please try reloading. If this keeps happening, let support know.
+          </Typography>
+          <Button variant="contained" onClick={this.handleReload} sx={{ mt: 1 }}>
+            Reload
+          </Button>
+        </Stack>
+      </Box>
+    );
+  }
+}

--- a/apps/csm-portal/microapp/src/components/common/ListItemErrorBoundary.tsx
+++ b/apps/csm-portal/microapp/src/components/common/ListItemErrorBoundary.tsx
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { ReactNode } from "react";
+import { Box, Typography } from "@wso2/oxygen-ui";
+import { TriangleAlert } from "@wso2/oxygen-ui-icons-react";
+import { Logger } from "@utils/logger";
+import { ErrorBoundary } from "./ErrorBoundary";
+
+interface ListItemErrorBoundaryProps {
+  /** Short label identifying what kind of item this wraps, for the log line only — never shown
+   * to the user, e.g. "comment", "attachment row", "case card". */
+  context: string;
+  children: ReactNode;
+}
+
+/**
+ * Wraps a single item in a list of externally-shaped data (a comment, an attachment row, a case
+ * card, ...) so a render error in *one* item degrades to a small inline placeholder instead of
+ * taking down the whole list. Without this, the list's own section-level ErrorBoundary (the
+ * existing convention — AttachmentsTab, CaseListErrorBoundary, ...) is the nearest boundary above
+ * a crashing item, and it unmounts *everything* below it, not just the offending item — every
+ * other case, comment, or attachment included. This is exactly how one attachment with a bad
+ * `createdBy` value took down the entire comments feed alongside it.
+ *
+ * Deliberately has no built-in retry: a render error here is a code/data-shape bug, not a
+ * transient failure a tap can fix, and the item is keyed by its own id at the call site — a
+ * corrected payload for that id (a refetch) still won't clear this boundary's error state until
+ * the page reloads, same as every other ErrorBoundary already in this app.
+ */
+export function ListItemErrorBoundary({ context, children }: ListItemErrorBoundaryProps) {
+  return (
+    <ErrorBoundary
+      onError={(error) => Logger.error(`Failed to render ${context}`, error)}
+      fallback={
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            gap: 1,
+            p: 1,
+            border: "1px dashed",
+            borderColor: "divider",
+            borderRadius: 1,
+            color: "text.disabled",
+          }}
+        >
+          <TriangleAlert size={14} />
+          <Typography variant="caption">Couldn't display this item.</Typography>
+        </Box>
+      }
+    >
+      {children}
+    </ErrorBoundary>
+  );
+}

--- a/apps/csm-portal/microapp/src/main.tsx
+++ b/apps/csm-portal/microapp/src/main.tsx
@@ -20,6 +20,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { OxygenUIThemeProvider } from "@wso2/oxygen-ui";
 import axios from "axios";
 import App from "@src/App";
+import { AppErrorBoundary } from "@components/common/AppErrorBoundary";
 import theme from "./theme";
 import "@src/index.css";
 
@@ -44,7 +45,9 @@ createRoot(container).render(
   <StrictMode>
     <OxygenUIThemeProvider theme={theme}>
       <QueryClientProvider client={queryClient}>
-        <App />
+        <AppErrorBoundary>
+          <App />
+        </AppErrorBoundary>
       </QueryClientProvider>
     </OxygenUIThemeProvider>
   </StrictMode>,

--- a/apps/csm-portal/microapp/src/pages/AnnouncementsPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/AnnouncementsPage.tsx
@@ -28,6 +28,7 @@ import {
 } from "@utils/announcements";
 import { SearchBar } from "@components/support/SearchBar";
 import { EmptyState } from "@components/support/EmptyState";
+import { ListItemErrorBoundary } from "@components/common/ListItemErrorBoundary";
 import { ErrorState } from "@components/support/ErrorState";
 import { AnnouncementCard, AnnouncementCardSkeleton } from "@components/announcements/AnnouncementCard";
 import { AnnouncementFiltersSheet } from "@components/announcements/AnnouncementFiltersSheet";
@@ -104,7 +105,9 @@ export default function AnnouncementsPage() {
           </Typography>
 
           {items.map((item) => (
-            <AnnouncementCard key={item.id} item={item} />
+            <ListItemErrorBoundary key={item.id} context="announcement card">
+              <AnnouncementCard item={item} />
+            </ListItemErrorBoundary>
           ))}
 
           {/* IntersectionObserver can miss a zero-height target, so give the sentinel 1px to observe. */}

--- a/apps/csm-portal/microapp/src/pages/SupportPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/SupportPage.tsx
@@ -23,6 +23,7 @@ import { cases } from "@src/services/cases";
 import { currentUser } from "@src/services/currentUser";
 import type { CaseState } from "@src/types";
 import { ErrorBoundary } from "@components/common/ErrorBoundary";
+import { ListItemErrorBoundary } from "@components/common/ListItemErrorBoundary";
 import { CaseCard, CaseCardSkeleton } from "@components/support/CaseCard";
 import { EmptyState } from "@components/support/EmptyState";
 import { ErrorState } from "@components/support/ErrorState";
@@ -197,7 +198,9 @@ function CaseListContent({
       </Typography>
 
       {items.map((item) => (
-        <CaseCard key={item.id} item={item} />
+        <ListItemErrorBoundary key={item.id} context="case card">
+          <CaseCard item={item} />
+        </ListItemErrorBoundary>
       ))}
 
       {/* IntersectionObserver can miss a zero-height target, so give the sentinel 1px to observe. */}

--- a/apps/csm-portal/microapp/src/pages/UpdatesPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/UpdatesPage.tsx
@@ -54,7 +54,8 @@ const INITIAL_FILTER: FilterState = { productName: "", productVersion: "", start
 // Real HTML tags that warrant sanitized HTML rendering vs a plain-text fallback
 // — update descriptions come back as HTML sometimes and plain text other
 // times, from the same upstream field (see the webapp's identical gotcha).
-const HTML_FORMAT_RE = /<\/?(p|span|div|ul|ol|li|strong|em|b|i|br|h[1-6]|a[\s>]|table|tr|td|th|code|pre|blockquote)\b/i;
+const HTML_FORMAT_RE =
+  /<\/?(p|span|div|ul|ol|li|strong|em|b|i|br|h[1-6]|a[\s>]|table|tr|td|th|code|pre|blockquote|img)\b/i;
 
 function HtmlOrText({ content }: { content: string }) {
   const isHtml = HTML_FORMAT_RE.test(content);

--- a/apps/csm-portal/microapp/src/utils/inlineImages.ts
+++ b/apps/csm-portal/microapp/src/utils/inlineImages.ts
@@ -56,19 +56,27 @@ export function sysidToUuid(id: string): string {
   return `${id.slice(0, 8)}-${id.slice(8, 12)}-${id.slice(12, 16)}-${id.slice(16, 20)}-${id.slice(20, 32)}`;
 }
 
+// A comment/description with an unreasonable number of distinct inline images would otherwise
+// fire one parallel authenticated Blob fetch per image (see useResolvedInlineImageHtml) — this
+// caps how many unique ids are ever collected, so that stays bounded regardless of how much HTML
+// is thrown at it. Ids past the cap are simply never extracted, so replaceInlineImageSrcs treats
+// them the same as any other unresolved reference (stripped, not left pointing at an auth-gated
+// URL the WebView can't load).
+const MAX_INLINE_IMAGES = 20;
+
 /** Extracts every attachment id referenced by a `.iix` `<img>` src within an HTML string. */
 export function extractIixAttachmentIds(html: string): string[] {
-  const ids: string[] = [];
+  const ids = new Set<string>();
   let match;
   IMG_TAG_SRC.lastIndex = 0;
-  while ((match = IMG_TAG_SRC.exec(html)) !== null) {
+  while (ids.size < MAX_INLINE_IMAGES && (match = IMG_TAG_SRC.exec(html)) !== null) {
     const src = match[2] ?? match[3] ?? match[4] ?? "";
     if (src.includes(".iix")) {
       const id = extractInlineImageRefId(src);
-      if (id && !ids.includes(id)) ids.push(id);
+      if (id) ids.add(id);
     }
   }
-  return ids;
+  return Array.from(ids);
 }
 
 /**


### PR DESCRIPTION
## Summary
Two gaps found while auditing this app's error-boundary coverage (webapp checked for reference — its `AppErrorBoundary` covers the root-level gap the same way, but has no per-item isolation either, so that part is new here):

- **No boundary above the page level anywhere.** `App.tsx`, `main.tsx`, `MainLayout.tsx` had none, and several pages (`AnnouncementsPage`, `HomePage`, `MorePage`, ...) have no boundary of their own. An uncaught render error in any of those unmounted the entire React tree to a blank screen with no recovery. This is almost certainly what the Announcements "white space" bug actually was — a render-time throw with nothing above it to catch it. Added `AppErrorBoundary` at the root (`main.tsx`), mirroring the webapp's version, trimmed to a simple themed "Something went wrong / Reload" screen.
- **No isolation *within* a list.** Four lists render backend-shaped data per item — `CaseActivityFeed` (comments/lifecycle/attachments merged), `AttachmentsTab`'s rows, `SupportPage`'s case cards, `AnnouncementsPage`'s announcement cards — all under one list-level `ErrorBoundary`. A render error in *one* item was caught by that shared boundary, which unmounts everything below it, not just the offending item. This is exactly how one bad attachment took down the entire comments feed alongside it. Added `ListItemErrorBoundary`, wrapping each individual item in these four lists so a crash degrades to a small inline "Couldn't display this item" placeholder instead.

No changes to any data access, optional chaining, or field-level fallbacks — this is purely containment for whatever still slips through.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx eslint .`
- [x] `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability by isolating errors in individual case, announcement, update, comment, audit, and attachment items.
  * Added a full-page recovery screen for unexpected application errors, with an option to reload.
  * Improved rendering of comments and updates containing inline images.
  * Limited inline image processing to 20 unique images to help prevent excessive loading.

* **User Experience**
  * Lists now remain available when a single item cannot be displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->