### PR TITLE
[CSM Portal] keep the cases Product filter paging in the background past a monopolized first page

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useProductSearch.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useProductSearch.test.tsx
@@ -1,0 +1,112 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { ReactNode } from "react";
+import type { BeProduct, BeProductSearchResponse } from "@api/backend/types";
+
+const postMock = vi.fn();
+
+// The real client reads runtime config at module load, which isn't present
+// under vitest (same approach as useQuickCaseSearch.test.tsx).
+vi.mock("@api/backend/client", () => ({
+  useBackendApi: () => ({ post: postMock }),
+}));
+
+import { useInfiniteProductSearch } from "@features/csm-cases/api/useProductSearch";
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+/** Builds a page of `count` rows all sharing `name`, matching the real
+ * catalogue shape where one family can monopolize many consecutive rows. */
+function page(
+  name: string,
+  count: number,
+  hasMore: boolean,
+  offset: number,
+): BeProductSearchResponse {
+  const products: BeProduct[] = Array.from({ length: count }, (_, i) => ({
+    id: `${name}-${offset + i}`,
+    name,
+  }));
+  return { products, total: 117, limit: count, offset, hasMore };
+}
+
+describe("useInfiniteProductSearch", () => {
+  beforeEach(() => {
+    postMock.mockReset();
+  });
+
+  it("keeps paging in the background past a first page monopolized by one family, without a manual scroll fetch", async () => {
+    // Mirrors the live DEV-tenant bug: the first 50-row page is entirely one
+    // family ("API Manager"), so the dropdown would render only 1 distinct
+    // name and have nothing to scroll unless something else keeps fetching.
+    postMock
+      .mockResolvedValueOnce(page("API Manager", 50, true, 0))
+      .mockResolvedValueOnce(page("API Manager", 50, true, 50))
+      .mockResolvedValueOnce(page("Identity Server", 17, false, 100));
+
+    const { result } = renderHook(() => useInfiniteProductSearch("", true), {
+      wrapper,
+    });
+
+    // Without calling fetchNextPage manually, the background effect should
+    // still walk every page until hasMore is false.
+    await waitFor(() =>
+      expect(result.current.productNames).toEqual([
+        "API Manager",
+        "Identity Server",
+      ]),
+    );
+    await waitFor(() => expect(result.current.hasNextPage).toBe(false));
+    expect(postMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not fetch at all while disabled (dropdown closed)", () => {
+    postMock.mockResolvedValue(page("API Manager", 50, true, 0));
+
+    renderHook(() => useInfiniteProductSearch("", false), { wrapper });
+
+    expect(postMock).not.toHaveBeenCalled();
+  });
+
+  it("stops auto-fetching at the safety cap even if the catalogue has more pages", async () => {
+    // 21 pages of 50 rows each, every one reporting hasMore: true — well
+    // past MAX_AUTO_PAGES (20). The background effect must not spin forever.
+    postMock.mockImplementation(() =>
+      Promise.resolve(page("API Manager", 50, true, 0)),
+    );
+
+    const { result } = renderHook(() => useInfiniteProductSearch("", true), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(postMock).toHaveBeenCalledTimes(20));
+    // Give the effect a chance to fire once more if it were unbounded.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(postMock).toHaveBeenCalledTimes(20);
+    expect(result.current.hasNextPage).toBe(true);
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useProductSearch.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useProductSearch.ts
@@ -15,7 +15,7 @@
 // under the License.
 
 import { keepPreviousData, useInfiniteQuery } from "@tanstack/react-query";
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { ApiQueryKeys, BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
 import { useBackendApi } from "@api/backend/client";
 import type { BeProductSearchPayload, BeProductSearchResponse } from "@api/backend/types";
@@ -28,6 +28,21 @@ import type { BeProductSearchPayload, BeProductSearchResponse } from "@api/backe
  * would risk the first page surfacing only a couple of distinct names.
  */
 export const PRODUCT_PAGE_SIZE = BE_MAX_PAGE_LIMIT;
+
+/**
+ * Hard cap on pages auto-fetched in the background per open/query (see the
+ * effect in {@link useInfiniteProductSearch}), so a future catalogue size
+ * increase can't turn this into an unbounded fetch loop. `/products/search`
+ * rows aren't deduplicated or sorted by family name — live-verified against
+ * the DEV tenant, a single family ("API Manager") occupies the first 117 of
+ * 367 rows before any other distinct name appears — so relying on
+ * scroll-to-load-more alone can leave the dropdown stuck: with only 1-2
+ * distinct names rendered, the listbox has nothing to scroll, so the
+ * scroll-triggered fetch of {@link ProductNameMultiSelect} never fires. 20
+ * pages (1,000 rows) comfortably covers today's 367-row, 65-family catalogue
+ * with headroom to spare.
+ */
+const MAX_AUTO_PAGES = 20;
 
 /** Flattened, deduplicated, paginated result for the lazy-loaded product filter. */
 export interface InfiniteProductSearch {
@@ -45,11 +60,14 @@ export interface InfiniteProductSearch {
 /**
  * Paginated product-family-name search for the cases product filter. Loads
  * the first {@link PRODUCT_PAGE_SIZE} product rows as soon as it is enabled
- * (the dropdown opens) — no typing required — and pages through the rest on
- * demand via {@link InfiniteProductSearch.fetchNextPage} (wired to the
- * listbox scroll). An empty query lists the whole catalogue a page at a
- * time; a typed query narrows it (`searchQuery` matches ServiceNow's
- * `product.name`) and re-pages from the first match.
+ * (the dropdown opens) — no typing required — the dropdown shows this page
+ * immediately. Further pages then continue loading in the background (see
+ * the effect below, capped at {@link MAX_AUTO_PAGES}) without blocking the
+ * UI, so the option list fills in progressively; {@link
+ * InfiniteProductSearch.fetchNextPage} (wired to the listbox scroll) remains
+ * as a fallback for paging past the cap. An empty query lists the whole
+ * catalogue a page at a time; a typed query narrows it (`searchQuery`
+ * matches ServiceNow's `product.name`) and re-pages from the first match.
  *
  * Pagination tracks raw rows (matching the backend's own `hasMore`/offset
  * contract), while the returned `productNames` is a deduplicated view over
@@ -88,6 +106,27 @@ export function useInfiniteProductSearch(
     placeholderData: keepPreviousData,
     staleTime: 60_000,
   });
+
+  const pageCount = result.data?.pages.length ?? 0;
+  const { hasNextPage, isFetching, isFetchingNextPage, fetchNextPage: fetchNext } = result;
+
+  // Keep paging in the background — without blocking the dropdown, which
+  // already renders the first page — until the catalogue is exhausted or
+  // MAX_AUTO_PAGES is hit. Needed because scroll-triggered paging alone can
+  // never fire when the accumulated distinct names are too few to make the
+  // listbox scrollable in the first place (the exact symptom this hook
+  // exists to fix).
+  useEffect(() => {
+    if (
+      enabled &&
+      hasNextPage &&
+      !isFetching &&
+      !isFetchingNextPage &&
+      pageCount < MAX_AUTO_PAGES
+    ) {
+      void fetchNext();
+    }
+  }, [enabled, hasNextPage, isFetching, isFetchingNextPage, pageCount, fetchNext]);
 
   const productNames = useMemo(() => {
     const names = new Set<string>();

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/ProductNameMultiSelect.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/ProductNameMultiSelect.tsx
@@ -38,9 +38,12 @@ interface ProductNameMultiSelectProps {
 /**
  * Product filter for the cases list — the product-name twin of
  * {@link AsyncProjectMultiSelect}. Loads the first page of distinct product
- * family names on open (no typing needed) and pages through the rest on
- * scroll, narrowing server-side as the user types, instead of paging through
- * the entire product catalogue up front. The selected values ARE the names,
+ * family names on open (no typing needed); {@link useInfiniteProductSearch}
+ * then continues paging the rest in the background (bounded, see
+ * `MAX_AUTO_PAGES`) so the list fills in without the user needing to scroll
+ * first — `handleListboxScroll` below is a scroll-triggered fallback for
+ * paging past that cap. Narrows server-side as the user types. The selected
+ * values ARE the names,
  * which flow straight into `filters.productNames` (ServiceNow matches
  * `product.name`, so every version of a product is included) — unlike
  * Project/Assignee there's no id to resolve to a display name, so an


### PR DESCRIPTION
## Purpose
The Cases list's Product filter (made lazy/async in a prior PR) can get stuck showing only 1-2 options when a single product family monopolizes the first page of results — live-verified against a real tenant where one family occupies the first 100+ of 367 rows before another distinct name appears. Scroll-triggered paging alone can't recover from this: with only 1-2 distinct names rendered, the listbox has nothing to scroll, so the "load more" fetch never fires and the dropdown gets stuck.

## Goals
- Keep the Product filter dropdown filling in with more names even when scroll-triggered paging can't fire
- Do this without blocking the UI, and without turning into an unbounded fetch loop if the catalogue grows

## Approach
- `useProductSearch.ts`: `useInfiniteProductSearch` gains a background effect that auto-continues fetching pages (non-blocking — the dropdown already shows the first page immediately) once enabled, capped by a new `MAX_AUTO_PAGES` (20) safety valve, until the catalogue is exhausted or the cap is hit.
- Scroll-triggered fetching (`ProductNameMultiSelect`'s existing `handleListboxScroll`) stays in place as a fallback for paging past that cap.
- New test file (`useProductSearch.test.tsx`) covers: the exact monopolized-first-page scenario (background paging recovers without any scroll), no fetching at all while the dropdown is closed, and the safety cap actually stopping the loop rather than fetching forever.

## User stories
As a CSM agent filtering cases by product, I can see more than one product family option in the filter dropdown even when the catalogue's first page happens to be dominated by a single family.

## Release note
Fix the Cases list's Product filter getting stuck with too few options when one product family dominates the first page of results.

## Documentation
N/A — internal CSM portal UI, no external doc surface affected.

## Automation tests
- Unit tests: 3 new tests in `useProductSearch.test.tsx`, all passing.
- Full suite via `./node_modules/.bin/vitest run`: 2 pre-existing failures (`CaseActionBar.test.tsx`, `LinkCaseDialog.test.tsx`) confirmed unrelated — neither file is touched by this change.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (frontend-only change)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
- `./node_modules/.bin/tsc -b`, `./node_modules/.bin/eslint`, `./node_modules/.bin/vitest run`, `./node_modules/.bin/vite build` all passing locally.
