### PR TITLE
[Customer Portal][Webapp] Fix duplicate search request storms on cases list and time tracking pages

### DIFF
--- a/apps/customer-portal/webapp/src/features/project-details/components/time-tracking/ProjectTimeTracking.tsx
+++ b/apps/customer-portal/webapp/src/features/project-details/components/time-tracking/ProjectTimeTracking.tsx
@@ -56,6 +56,7 @@ export default function ProjectTimeTracking({
     isError: isTimeCardsError,
     hasNextPage,
     fetchNextPage,
+    isFetchingNextPage,
   } = useSearchProjectCaseTimeCards({
     projectId,
     startDate,
@@ -64,11 +65,14 @@ export default function ProjectTimeTracking({
     enabled: !!projectId,
   });
 
-  // Auto-fetch all remaining pages in background
+  // Fetch the next page only once the current page needs data beyond what's loaded
   useEffect(() => {
-    if (!data || !hasNextPage) return;
-    void fetchNextPage();
-  }, [data, hasNextPage, fetchNextPage]);
+    if (!data || !hasNextPage || isFetchingNextPage) return;
+    const loadedCount = data.pages.flatMap((p) => p.caseTimeCards).length;
+    if (page * pageSize > loadedCount) {
+      void fetchNextPage();
+    }
+  }, [page, pageSize, data, hasNextPage, isFetchingNextPage, fetchNextPage]);
 
   // Reset pagination when filters change
   useEffect(() => {

--- a/apps/customer-portal/webapp/src/features/project-details/components/time-tracking/ProjectTimeTracking.tsx
+++ b/apps/customer-portal/webapp/src/features/project-details/components/time-tracking/ProjectTimeTracking.tsx
@@ -57,6 +57,7 @@ export default function ProjectTimeTracking({
     hasNextPage,
     fetchNextPage,
     isFetchingNextPage,
+    isFetchNextPageError,
   } = useSearchProjectCaseTimeCards({
     projectId,
     startDate,
@@ -67,12 +68,12 @@ export default function ProjectTimeTracking({
 
   // Fetch the next page only once the current page needs data beyond what's loaded
   useEffect(() => {
-    if (!data || !hasNextPage || isFetchingNextPage) return;
+    if (!data || !hasNextPage || isFetchingNextPage || isFetchNextPageError) return;
     const loadedCount = data.pages.flatMap((p) => p.caseTimeCards).length;
     if (page * pageSize > loadedCount) {
       void fetchNextPage();
     }
-  }, [page, pageSize, data, hasNextPage, isFetchingNextPage, fetchNextPage]);
+  }, [page, pageSize, data, hasNextPage, isFetchingNextPage, isFetchNextPageError, fetchNextPage]);
 
   // Reset pagination when filters change
   useEffect(() => {
@@ -147,7 +148,7 @@ export default function ProjectTimeTracking({
       ) : (
         <>
           <Grid container spacing={3}>
-            {isTimeCardsLoading ? (
+            {isTimeCardsLoading || isFetchingNextPage ? (
               Array.from({ length: 7 }).map((_, index) => (
                 <Grid key={`skeleton-${index}`} size={12}>
                   <TimeTrackingCardSkeleton />

--- a/apps/customer-portal/webapp/src/features/support/pages/AllCasesPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/AllCasesPage.tsx
@@ -28,6 +28,7 @@ import {
   type ChangeEvent,
 } from "react";
 import { useSessionState } from "@hooks/useSessionState";
+import { useDebouncedValue } from "@hooks/useDebouncedValue";
 import { useLoader } from "@context/linear-loader/LoaderContext";
 import { Stack, Divider } from "@wso2/oxygen-ui";
 import useGetProjectDetails from "@api/useGetProjectDetails";
@@ -81,6 +82,7 @@ export default function AllCasesPage(): JSX.Element {
 
   const sessionPrefix = `${projectId ?? "unknown"}-cases`;
   const [searchTerm, setSearchTerm] = useSessionState(`${sessionPrefix}-search`, "", undefined, { popOnly: true });
+  const debouncedSearchTerm = useDebouncedValue(searchTerm, 300);
   const [filters, setFilters] = useSessionState<AllCasesFilterValues>(
     `${sessionPrefix}-filters`,
     initialSeverityId ? { severityIds: [initialSeverityId] } : {},
@@ -166,7 +168,7 @@ export default function AllCasesPage(): JSX.Element {
           deploymentIds: permissions.hasDeployments
             ? (filters.deploymentIds as string[] | undefined)
             : undefined,
-          searchQuery: searchTerm,
+          searchQuery: debouncedSearchTerm,
           createdByMe: createdByMe || undefined,
           createdBy: filters.createdBy as string[] | undefined,
           caseStates: filterMetadata?.caseStates,
@@ -190,7 +192,7 @@ export default function AllCasesPage(): JSX.Element {
       hideSearchPanel,
       statusFilter,
       filters,
-      searchTerm,
+      debouncedSearchTerm,
       sortField,
       sortOrder,
       createdByMe,
@@ -198,7 +200,6 @@ export default function AllCasesPage(): JSX.Element {
       filterMetadata?.caseStates,
       isDashboardSeverityNavigation,
       initialSeverityId,
-      contactsList,
     ],
   );
 


### PR DESCRIPTION
## Summary
- Fix `AllCasesPage.tsx` refiring `/cases/search` on nearly every render — `contactsList` was listed as a dependency of the `caseSearchRequest` memo but never used inside it, so its new array identity each render invalidated the memo and triggered a fresh query. Also debounce the search input (300ms) so typing doesn't fire a request per keystroke.
- Fix `ProjectTimeTracking.tsx` eagerly draining the entire timecards infinite query (all ~33 pages for 328 records) on mount/filter change instead of only fetching the page the user is actually viewing.

Both surfaced as 30+ duplicate "search" network calls in DevTools despite no pagination interaction from the user.

## Test plan
- [ ] Open All Cases page, confirm only one `/cases/search` request fires per filter/search change (with debounce delay) instead of repeating on every render
- [ ] Type in the case search box and confirm requests are debounced, not fired per keystroke
- [ ] Open Project Time Tracking tab, confirm only the requests needed for the visible page fire (not all ~33 pages upfront)
- [ ] Paginate through time cards and confirm additional pages fetch on demand as needed
- [ ] Verify CSV export on both pages still exports the full dataset correctly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project time-tracking pagination to load additional entries only when needed.
  * Reduced unnecessary background data loading.
  * Added a delay before searching support cases to prevent excessive requests while typing.
  * Improved search result consistency by using the latest entered search term.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->