### PR TITLE
fix(customer-portal-backend-v2): scope cases/deployments search under /projects/{id}

### DIFF
--- a/apps/customer-portal/backend-v2/CLAUDE.md
+++ b/apps/customer-portal/backend-v2/CLAUDE.md
@@ -12,9 +12,10 @@ service, the registry (robot-account) service, and the project-contact onboardin
 "The AI chat agent", "The product-consumption service", "The registry service", and "The
 project-contact onboarding service" below — none of the last four is entity-service-backed at
 all). Route list: `GET /health`, `GET`/`PATCH /users/me`, `POST /accounts/search`,
-`GET /accounts/{id}`, `POST /projects/search`, `GET /projects/{id}`, `POST /cases/search`,
+`GET /accounts/{id}`, `POST /projects/search`, `GET /projects/{id}`,
+`POST /projects/{id}/cases/search`,
 `GET /cases/{id}`, `POST /cases`, `PATCH /cases/{id}`, `POST /cases/{id}/comments`,
-`POST /cases/{id}/activities/search`, `POST /deployments/search`, `POST /deployments`,
+`POST /cases/{id}/activities/search`, `POST /projects/{id}/deployments/search`, `POST /deployments`,
 `PATCH /deployments/{id}`, `POST /deployed-products/search`, `POST /deployed-products`,
 `PATCH /deployed-products/{id}`, `POST /attachments`, `POST /attachments/search`,
 `GET /attachments/{id}/content`, `DELETE /attachments/{id}`, `POST /products/search`,
@@ -392,24 +393,38 @@ itself a design decision about what a customer should see, and entity-service's 
 leak through it by default.
 
 **The DTO layer's job isn't only response trimming — it also absorbs entity-service's own request
-contract changes, so the frontend never has to know they happened.** `POST /cases/search` is the
-example: entity-service redesigned its case-search filters from named fields (`types`, `states`,
-`projectIds`, ...) into a generic predicate array (`filters: [{field, op, values}]`,
-`internal/entity/types.go`'s `CaseFieldFilter`) and now rejects any request using the old shape
-outright (`decodeRequest`'s `DisallowUnknownFields`). The frontend was never updated — it still
-sends the old named-field shape — so `dto.CaseSearchRequest`/`CaseSearchFilters` keep that exact old
-shape as this backend's own stable, unchanged contract, and `dto.BuildEntitySearchCasesRequest` is
-the only place that builds an `entity.CaseFieldFilter` array, translating each portal filter field
-into the "field in/eq values" entry entity-service's `case_filters.go` expects (see that file for
-the authoritative field/op table if entity-service adds a new filter). `CreatedByMe` becomes a
-`createdBy`+`eq` filter carrying the literal string `"__current_user_email__"` — this must match
-entity-service's own `currentUserFilterPlaceholder` constant exactly, not just be "some sentinel".
-If entity-service ever changes another request contract this way, the fix is the same shape: keep
-the portal-facing dto type frozen at whatever the frontend already sends, and write a
-`BuildEntityXRequest` translator rather than pushing the new shape onto the frontend or, worse,
-decoding the incoming request directly into an `internal/entity` type (which is how this bug
-happened in the first place — there was no dto/entity separation on the request side for this one
-endpoint, unlike every response, which already goes through `dto.Map*`).
+contract changes, so the frontend never has to know they happened.**
+`POST /projects/{id}/cases/search` is the example: entity-service redesigned its case-search
+filters from named fields (`types`, `states`, `projectIds`, ...) into a generic predicate array
+(`filters: [{field, op, values}]`, `internal/entity/types.go`'s `CaseFieldFilter`) and now rejects
+any request using the old shape outright (`decodeRequest`'s `DisallowUnknownFields`). The frontend
+was never updated — it still sends the old named-field shape — so
+`dto.CaseSearchRequest`/`CaseSearchFilters` keep that exact old shape as this backend's own stable,
+unchanged contract, and `dto.BuildEntitySearchCasesRequest` is the only place that builds an
+`entity.CaseFieldFilter` array, translating each portal filter field into the "field in/eq values"
+entry entity-service's `case_filters.go` expects (see that file for the authoritative field/op
+table if entity-service adds a new filter). `CreatedByMe` becomes a `createdBy`+`eq` filter carrying
+the literal string `"__current_user_email__"` — this must match entity-service's own
+`currentUserFilterPlaceholder` constant exactly, not just be "some sentinel". If entity-service ever
+changes another request contract this way, the fix is the same shape: keep the portal-facing dto
+type frozen at whatever the frontend already sends, and write a `BuildEntityXRequest` translator
+rather than pushing the new shape onto the frontend or, worse, decoding the incoming request
+directly into an `internal/entity` type (which is how this bug happened in the first place — there
+was no dto/entity separation on the request side for this one endpoint, unlike every response,
+which already goes through `dto.Map*`).
+
+**Project scoping via a `{id}` path parameter is the source of truth — never a client-settable body
+field, even when entity-service's own request struct has one.**
+`POST /projects/{id}/cases/search` and `POST /projects/{id}/deployments/search` both scope every
+search to the one project in the URL: `dto.CaseSearchFilters` has no `projectIds` field at all (the
+frontend has never sent one), and `dto.BuildEntitySearchCasesRequest(projectID, req)` always adds a
+`projectId`+`in` filter carrying that path value. `entity.SearchDeploymentsRequest` does still have
+a `ProjectIDs` field (it mirrors entity-service's own struct 1:1, per the no-DTO-layer exception for
+this endpoint — see "Response shaping" below), but the handler forcibly overwrites it with the path
+value right after decoding, the same way `AIChatHandler.SearchConversations` already does for
+`entity.SearchConversationsRequest.Filters.ProjectIDs`. Letting the body set project scope
+independently of the path would both be a needless IDOR surface and risk the same
+unsatisfiable-AND-filter bug `CreatedBy`/`CreatedByMe` had if the two values ever disagreed.
 
 **`json.RawMessage` on a request field usually means "preserve three states," not "skip validation."**
 `entity.UpdateDeployedProductRequest.Description` is `json.RawMessage` specifically so entity-service

--- a/apps/customer-portal/backend-v2/README.md
+++ b/apps/customer-portal/backend-v2/README.md
@@ -272,7 +272,7 @@ backend-v2/
 │       ├── projects.go          # POST /projects/search, GET /projects/{id}
 │       ├── project_stats.go     # project filters/features/dashboard-stats (composite, some graceful-degradation), case-grouped time-cards
 │       ├── cases.go             # cases search/get/create/update/comment/activities/feedback/escalations, case-scoped attachment update
-│       ├── deployments.go       # POST /deployments/search, POST /deployments, PATCH /deployments/{id}, deployment-scoped attachment update
+│       ├── deployments.go       # POST /projects/{id}/deployments/search, POST /deployments, PATCH /deployments/{id}, deployment-scoped attachment update
 │       ├── deployed_products.go # deployed-product search/create/update + per-deployed-product metrics/usage-counts
 │       ├── attachments.go       # attachment create/search/download/get/delete
 │       ├── products.go          # POST /products/search, POST /products/{id}/versions/search
@@ -314,7 +314,7 @@ backend-v2/
 - `GET /projects/{id}/stats/support` — get a project's combined support statistics (case + conversation; partial failures are tolerated)
 - `GET /projects/{id}/stats/time-cards` — get a project's time-card statistics, optionally filtered by `startDate`/`endDate`
 - `GET /projects/{id}/stats/change-requests` — get a project's change-request statistics
-- `POST /cases/search` — search cases
+- `POST /projects/{id}/cases/search` — search a project's cases
 - `GET /cases/{id}` — get case by ID
 - `POST /cases` — create a case
 - `PATCH /cases/{id}` — update a case (restricted, customer-safe field subset — see CLAUDE.md)
@@ -324,7 +324,7 @@ backend-v2/
 - `PATCH /cases/{caseId}/attachments/{attachmentId}` — update a case attachment's name (description not supported on this route — see CLAUDE.md)
 - `POST /cases/{caseId}/escalations` — escalate or de-escalate a case (ServiceNow data source only)
 - `POST /cases/{caseId}/escalations/search` — search a case's escalations (ServiceNow data source only)
-- `POST /deployments/search` — search deployments
+- `POST /projects/{id}/deployments/search` — search a project's deployments
 - `POST /deployments` — create a deployment (ServiceNow data source only)
 - `PATCH /deployments/{id}` — update a deployment's name/type/description, or deactivate it
 - `PATCH /deployments/{deploymentId}/attachments/{attachmentId}` — update a deployment attachment's name/description
@@ -447,7 +447,7 @@ curl -H "x-jwt-assertion: $JWT" "http://localhost:8080/projects/<project-id>/sta
 
 curl -H "x-jwt-assertion: $JWT" http://localhost:8080/projects/<project-id>/stats/change-requests
 
-curl -X POST http://localhost:8080/cases/search \
+curl -X POST http://localhost:8080/projects/<project-id>/cases/search \
   -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
   -d '{"pagination":{"limit":10,"offset":0},"filters":{"searchQuery":"login error"}}'
 
@@ -465,7 +465,7 @@ curl -X POST http://localhost:8080/cases/<case-id>/comments \
   -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
   -d '{"content":"Any update on this?"}'
 
-curl -X POST http://localhost:8080/deployments/search \
+curl -X POST http://localhost:8080/projects/<project-id>/deployments/search \
   -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
   -d '{"pagination":{"limit":10,"offset":0}}'
 

--- a/apps/customer-portal/backend-v2/cmd/server/main.go
+++ b/apps/customer-portal/backend-v2/cmd/server/main.go
@@ -222,7 +222,7 @@ func main() {
 	mux.HandleFunc("DELETE /registry-tokens/{id}", registryHandler.DeleteRegistryToken)
 	mux.HandleFunc("POST /registry-tokens/{id}/regenerate", registryHandler.RegenerateRegistryToken)
 
-	mux.HandleFunc("POST /cases/search", caseHandler.SearchCases)
+	mux.HandleFunc("POST /projects/{id}/cases/search", caseHandler.SearchCases)
 	mux.HandleFunc("GET /cases/{id}", caseHandler.GetCase)
 	mux.HandleFunc("POST /cases", caseHandler.CreateCase)
 	mux.HandleFunc("PATCH /cases/{id}", caseHandler.PatchCase)
@@ -234,7 +234,7 @@ func main() {
 	mux.HandleFunc("POST /cases/{caseId}/escalations", caseHandler.CreateCaseEscalation)
 	mux.HandleFunc("POST /cases/{caseId}/escalations/search", caseHandler.SearchCaseEscalations)
 
-	mux.HandleFunc("POST /deployments/search", deploymentHandler.SearchDeployments)
+	mux.HandleFunc("POST /projects/{id}/deployments/search", deploymentHandler.SearchDeployments)
 	// POST /deployments only succeeds against entity-service's ServiceNow
 	// data source — see internal/entity/deployments.go.
 	mux.HandleFunc("POST /deployments", deploymentHandler.CreateDeployment)

--- a/apps/customer-portal/backend-v2/internal/dto/case.go
+++ b/apps/customer-portal/backend-v2/internal/dto/case.go
@@ -49,7 +49,8 @@ func mapNumberRef(r *entity.CaseNumberRef) *NumberRef {
 	return &NumberRef{ID: r.ID, Number: r.Number}
 }
 
-// CaseSummary is one item of the portal's response for POST /cases/search.
+// CaseSummary is one item of the portal's response for
+// POST /projects/{id}/cases/search.
 //
 // Deliberately excludes entity-service's InternalID (internal-only
 // identifier), Catalog/CatalogItem (CMDB implementation detail), Conversation,
@@ -73,7 +74,8 @@ type CaseSummary struct {
 	AssignedTeam   *Ref    `json:"assignedTeam,omitempty"`
 }
 
-// SearchCasesResponse is the portal's response for POST /cases/search.
+// SearchCasesResponse is the portal's response for
+// POST /projects/{id}/cases/search.
 type SearchCasesResponse struct {
 	Cases  []CaseSummary `json:"cases"`
 	Total  int           `json:"total"`
@@ -117,18 +119,24 @@ func MapSearchCases(r entity.SearchCasesResponse) SearchCasesResponse {
 // caller".
 const currentUserFilterPlaceholder = "__current_user_email__"
 
-// CaseSearchFilters holds the optional filter criteria for POST /cases/search.
-// This is the portal's own request contract, unchanged from before
-// entity-service redesigned its case-search wire format into a generic
-// filter-predicate array (matching what the frontend has always sent) —
-// only the fields
-// the portal currently exposes are included; extend as needed when more
-// filters are surfaced to the frontend. See BuildEntitySearchCasesRequest
-// for the translation into entity-service's current contract.
+// CaseSearchFilters holds the optional filter criteria for
+// POST /projects/{id}/cases/search. This is the portal's own request
+// contract, unchanged from before entity-service redesigned its case-search
+// wire format into a generic filter-predicate array (matching what the
+// frontend has always sent) — only the fields the portal currently exposes
+// are included; extend as needed when more filters are surfaced to the
+// frontend. See BuildEntitySearchCasesRequest for the translation into
+// entity-service's current contract.
+//
+// No ProjectIDs field: project scoping comes exclusively from the {id} path
+// parameter (see BuildEntitySearchCasesRequest's projectID parameter), never
+// from the request body — the frontend has never sent one, and letting the
+// body set it would invite exactly the kind of unsatisfiable-AND-filter bug
+// CreatedBy/CreatedByMe had (a body projectIds disagreeing with the path
+// silently returning an empty result instead of erroring or being ignored).
 type CaseSearchFilters struct {
 	Types           []string `json:"types,omitempty"`
 	SearchQuery     string   `json:"searchQuery,omitempty"`
-	ProjectIDs      []string `json:"projectIds,omitempty"`
 	DeploymentIDs   []string `json:"deploymentIds,omitempty"`
 	States          []string `json:"states,omitempty"`
 	Severities      []string `json:"severities,omitempty"`
@@ -143,7 +151,8 @@ type CaseSearchFilters struct {
 	ParentID        *string  `json:"parentId,omitempty"`
 }
 
-// CaseSearchRequest is the portal's request body for POST /cases/search.
+// CaseSearchRequest is the portal's request body for
+// POST /projects/{id}/cases/search.
 type CaseSearchRequest struct {
 	Filters    CaseSearchFilters `json:"filters"`
 	SortBy     entity.CaseSort   `json:"sortBy"`
@@ -154,16 +163,19 @@ type CaseSearchRequest struct {
 // request into entity-service's current generic filter-predicate array
 // contract (see entity.CaseFieldFilter) — every filter the portal exposes
 // becomes one "field in/eq values" entry; SearchQuery, SortBy, and
-// Pagination pass straight through unchanged. CreatedByMe becomes a
-// createdBy+eq filter carrying currentUserFilterPlaceholder, exactly as
-// entity-service's own case_filters.go expects, resolving the caller's
-// identity server-side from the forwarded x-user-id-token. CreatedByMe takes
-// precedence over CreatedBy when both are set: entity-service's filters
-// array is AND-only, so a createdBy+in filter and a createdBy+eq filter
-// together could never both match (barring CreatedBy coincidentally
-// containing the caller's own email), silently returning an empty result
-// set — CreatedBy is dropped entirely rather than combined.
-func BuildEntitySearchCasesRequest(req CaseSearchRequest) entity.SearchCasesRequest {
+// Pagination pass straight through unchanged. projectID (the {id} path
+// parameter from POST /projects/{id}/cases/search — never the request body)
+// always becomes a projectId+in filter with that single value, scoping every
+// search to the one project in the URL. CreatedByMe becomes a createdBy+eq
+// filter carrying currentUserFilterPlaceholder, exactly as entity-service's
+// own case_filters.go expects, resolving the caller's identity server-side
+// from the forwarded x-user-id-token. CreatedByMe takes precedence over
+// CreatedBy when both are set: entity-service's filters array is AND-only,
+// so a createdBy+in filter and a createdBy+eq filter together could never
+// both match (barring CreatedBy coincidentally containing the caller's own
+// email), silently returning an empty result set — CreatedBy is dropped
+// entirely rather than combined.
+func BuildEntitySearchCasesRequest(projectID string, req CaseSearchRequest) entity.SearchCasesRequest {
 	var filters []entity.CaseFieldFilter
 
 	addIn := func(field string, values []string) {
@@ -173,7 +185,7 @@ func BuildEntitySearchCasesRequest(req CaseSearchRequest) entity.SearchCasesRequ
 	}
 
 	addIn("type", req.Filters.Types)
-	addIn("projectId", req.Filters.ProjectIDs)
+	filters = append(filters, entity.CaseFieldFilter{Field: "projectId", Op: "in", Values: []string{projectID}})
 	addIn("deploymentId", req.Filters.DeploymentIDs)
 	addIn("state", req.Filters.States)
 	addIn("severity", req.Filters.Severities)

--- a/apps/customer-portal/backend-v2/internal/dto/case_test.go
+++ b/apps/customer-portal/backend-v2/internal/dto/case_test.go
@@ -26,9 +26,9 @@ import (
 // TestBuildEntitySearchCasesRequest_AllFiltersTranslate guards against
 // reintroducing the bug where this backend sent entity-service's old
 // named-filter-field case-search shape directly instead of building the
-// generic filter-predicate array entity-service's current /cases/search
-// requires (which rejects unknown fields outright) — every filter the
-// portal exposes must produce exactly the CaseFieldFilter entry
+// generic filter-predicate array entity-service's current
+// /cases/search requires (which rejects unknown fields outright) — every
+// filter the portal exposes must produce exactly the CaseFieldFilter entry
 // entity-service's case_filters.go expects.
 func TestBuildEntitySearchCasesRequest_AllFiltersTranslate(t *testing.T) {
 	parentID := "parent-id-1"
@@ -36,7 +36,6 @@ func TestBuildEntitySearchCasesRequest_AllFiltersTranslate(t *testing.T) {
 		Filters: CaseSearchFilters{
 			Types:           []string{"case", "engagement"},
 			SearchQuery:     "login issue",
-			ProjectIDs:      []string{"proj-1"},
 			DeploymentIDs:   []string{"dep-1"},
 			States:          []string{"open"},
 			Severities:      []string{"high"},
@@ -53,7 +52,7 @@ func TestBuildEntitySearchCasesRequest_AllFiltersTranslate(t *testing.T) {
 		Pagination: entity.Pagination{Limit: 20, Offset: 0},
 	}
 
-	got := BuildEntitySearchCasesRequest(req)
+	got := BuildEntitySearchCasesRequest("proj-1", req)
 
 	if got.Filters.SearchQuery != "login issue" {
 		t.Fatalf("SearchQuery = %q", got.Filters.SearchQuery)
@@ -85,6 +84,25 @@ func TestBuildEntitySearchCasesRequest_AllFiltersTranslate(t *testing.T) {
 	}
 }
 
+// TestBuildEntitySearchCasesRequest_ProjectIDAlwaysScoped verifies the
+// projectID parameter (the POST /projects/{id}/cases/search path value) is
+// always translated into a projectId+in filter, regardless of what the
+// request body's filters contain — CaseSearchFilters has no client-settable
+// projectIds field at all, so this is the only source of project scoping.
+func TestBuildEntitySearchCasesRequest_ProjectIDAlwaysScoped(t *testing.T) {
+	got := BuildEntitySearchCasesRequest("proj-42", CaseSearchRequest{})
+
+	want := []entity.CaseFieldFilter{
+		{Field: "projectId", Op: "in", Values: []string{"proj-42"}},
+	}
+	if !reflect.DeepEqual(got.Filters.Filters, want) {
+		t.Fatalf("Filters = %+v, want %+v", got.Filters.Filters, want)
+	}
+	if got.Filters.SearchQuery != "" {
+		t.Fatalf("expected empty SearchQuery, got %q", got.Filters.SearchQuery)
+	}
+}
+
 // TestBuildEntitySearchCasesRequest_CreatedByMe verifies CreatedByMe becomes
 // a createdBy+eq filter carrying entity-service's exact current-user
 // placeholder string — a mismatch here would make entity-service reject it
@@ -93,9 +111,10 @@ func TestBuildEntitySearchCasesRequest_AllFiltersTranslate(t *testing.T) {
 func TestBuildEntitySearchCasesRequest_CreatedByMe(t *testing.T) {
 	req := CaseSearchRequest{Filters: CaseSearchFilters{CreatedByMe: true}}
 
-	got := BuildEntitySearchCasesRequest(req)
+	got := BuildEntitySearchCasesRequest("proj-1", req)
 
 	want := []entity.CaseFieldFilter{
+		{Field: "projectId", Op: "in", Values: []string{"proj-1"}},
 		{Field: "createdBy", Op: "eq", Values: []string{"__current_user_email__"}},
 	}
 	if !reflect.DeepEqual(got.Filters.Filters, want) {
@@ -115,28 +134,13 @@ func TestBuildEntitySearchCasesRequest_CreatedByMeTakesPrecedenceOverCreatedBy(t
 		CreatedByMe: true,
 	}}
 
-	got := BuildEntitySearchCasesRequest(req)
+	got := BuildEntitySearchCasesRequest("proj-1", req)
 
 	want := []entity.CaseFieldFilter{
+		{Field: "projectId", Op: "in", Values: []string{"proj-1"}},
 		{Field: "createdBy", Op: "eq", Values: []string{"__current_user_email__"}},
 	}
 	if !reflect.DeepEqual(got.Filters.Filters, want) {
 		t.Fatalf("Filters = %+v, want %+v", got.Filters.Filters, want)
-	}
-}
-
-// TestBuildEntitySearchCasesRequest_EmptyFiltersProduceNoPredicates verifies
-// an empty/default CaseSearchRequest builds a request with no filter
-// predicates at all -- entity-service's own case search already treats a
-// missing "type" filter (etc.) as "no restriction", so this must not
-// fabricate empty-but-present filter entries.
-func TestBuildEntitySearchCasesRequest_EmptyFiltersProduceNoPredicates(t *testing.T) {
-	got := BuildEntitySearchCasesRequest(CaseSearchRequest{})
-
-	if len(got.Filters.Filters) != 0 {
-		t.Fatalf("expected no filter predicates for an empty request, got %+v", got.Filters.Filters)
-	}
-	if got.Filters.SearchQuery != "" {
-		t.Fatalf("expected empty SearchQuery, got %q", got.Filters.SearchQuery)
 	}
 }

--- a/apps/customer-portal/backend-v2/internal/dto/deployment.go
+++ b/apps/customer-portal/backend-v2/internal/dto/deployment.go
@@ -22,7 +22,8 @@ import (
 	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
 )
 
-// DeploymentSummary is one item of the portal's response for POST /deployments/search.
+// DeploymentSummary is one item of the portal's response for
+// POST /projects/{id}/deployments/search.
 type DeploymentSummary struct {
 	ID          string    `json:"id"`
 	Number      string    `json:"number"`
@@ -35,7 +36,8 @@ type DeploymentSummary struct {
 	UpdatedOn   time.Time `json:"updatedOn"`
 }
 
-// SearchDeploymentsResponse is the portal's response for POST /deployments/search.
+// SearchDeploymentsResponse is the portal's response for
+// POST /projects/{id}/deployments/search.
 type SearchDeploymentsResponse struct {
 	Deployments []DeploymentSummary `json:"deployments"`
 	Total       int                 `json:"total"`

--- a/apps/customer-portal/backend-v2/internal/handler/cases.go
+++ b/apps/customer-portal/backend-v2/internal/handler/cases.go
@@ -52,11 +52,17 @@ func NewCaseHandler(entity entityCaseClient) *CaseHandler {
 	return &CaseHandler{entity: entity}
 }
 
-// SearchCases handles POST /cases/search.
+// SearchCases handles POST /projects/{id}/cases/search.
 func (h *CaseHandler) SearchCases(w http.ResponseWriter, r *http.Request) {
 	user := middleware.UserInfoFromContext(r.Context())
 	if user == nil {
 		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	projectID := r.PathValue("id")
+	if projectID == "" || !uuidRe.MatchString(projectID) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
 
@@ -71,7 +77,7 @@ func (h *CaseHandler) SearchCases(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	result, err := h.entity.SearchCases(r.Context(), dto.BuildEntitySearchCasesRequest(req))
+	result, err := h.entity.SearchCases(r.Context(), dto.BuildEntitySearchCasesRequest(projectID, req))
 	if err != nil {
 		slog.ErrorContext(r.Context(), "entity SearchCases failed", "userID", user.UserID, "err", summarizeErr(err))
 		mapUpstreamError(w, err, "Failed to search cases.")

--- a/apps/customer-portal/backend-v2/internal/handler/deployments.go
+++ b/apps/customer-portal/backend-v2/internal/handler/deployments.go
@@ -46,11 +46,17 @@ func NewDeploymentHandler(entity entityDeploymentClient) *DeploymentHandler {
 	return &DeploymentHandler{entity: entity}
 }
 
-// SearchDeployments handles POST /deployments/search.
+// SearchDeployments handles POST /projects/{id}/deployments/search.
 func (h *DeploymentHandler) SearchDeployments(w http.ResponseWriter, r *http.Request) {
 	user := middleware.UserInfoFromContext(r.Context())
 	if user == nil {
 		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	projectID := r.PathValue("id")
+	if projectID == "" || !uuidRe.MatchString(projectID) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
 
@@ -64,6 +70,11 @@ func (h *DeploymentHandler) SearchDeployments(w http.ResponseWriter, r *http.Req
 		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
 		return
 	}
+	// ProjectIDs is always forced to the {id} path parameter, never the
+	// client-supplied body: project scoping comes exclusively from the URL,
+	// same reasoning as dto.BuildEntitySearchCasesRequest's projectID
+	// parameter for POST /projects/{id}/cases/search.
+	req.ProjectIDs = []string{projectID}
 
 	result, err := h.entity.SearchDeployments(r.Context(), req)
 	if err != nil {


### PR DESCRIPTION
## Summary
- `POST /cases/search` and `POST /deployments/search` in `apps/customer-portal/backend-v2` were registered as flat, project-agnostic routes, but the actual frontend (`apps/customer-portal/webapp`) calls `POST /projects/{id}/cases/search` and `POST /projects/{id}/deployments/search` — confirmed against the webapp's API hooks and the existing Ballerina backend, which folds the path project ID into the entity-service query the same way. Every request from the frontend to these two endpoints was 404ing.
- Fixed by re-registering both routes under `/projects/{id}/...` and deriving project scope exclusively from the `{id}` path parameter.
- `dto.CaseSearchFilters` drops its `ProjectIDs` field entirely (the frontend never sent one in the body); `dto.BuildEntitySearchCasesRequest` now takes the path-derived `projectID` directly and always adds a `projectId`+`in` filter from it.
- The deployments handler forces `entity.SearchDeploymentsRequest.ProjectIDs` from the path after decoding the body, the same pattern `AIChatHandler.SearchConversations` already uses for conversations — project scope should never be a client-settable body field, both to avoid an IDOR-ish surface and to avoid the same unsatisfiable-AND-filter class of bug fixed for `createdBy`/`createdByMe` earlier.
- Updated `CLAUDE.md`/`README.md` route docs and curl examples to match.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` all clean
- [x] `go test ./...` passes, including new/updated dto tests covering the always-applied `projectId` filter
- [x] `gosec -fmt=text ./...` reports 0 issues
- [x] Verified all 100 registered route patterns still register on a real `http.ServeMux` with no ambiguity panic
- [ ] Manual smoke test against a running entity-service instance (not done in this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Case and deployment searches are now scoped to a specific project.
  * Project scope is provided through the project URL and takes precedence over request-body values.
* **Bug Fixes**
  * Invalid or missing project identifiers now return a clear `400 Bad Request` response.
* **Documentation**
  * Updated API documentation and examples to reflect the new project-scoped search endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->