### PR TITLE
[CSM Portal Microapp] Add a case-detail More menu and fix Log time /calendar and approver search issues

### DIFF
--- a/apps/csm-portal/microapp/src/components/case-detail/CaseMoreMenu.tsx
+++ b/apps/csm-portal/microapp/src/components/case-detail/CaseMoreMenu.tsx
@@ -1,0 +1,221 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useState, type JSX } from "react";
+import { Box, Button, Menu, MenuItem, Tooltip } from "@wso2/oxygen-ui";
+import {
+  AlertTriangle,
+  CalendarClock,
+  ChevronDown,
+  Clock,
+  Gauge,
+  GitBranch,
+  Link as LinkIcon,
+  ListChecks,
+  PauseCircle,
+  Pencil,
+  Play,
+  User,
+} from "@wso2/oxygen-ui-icons-react";
+import type { CaseDetail } from "@src/types";
+
+interface SecondaryItem {
+  key: string;
+  label: string;
+  icon: JSX.Element;
+  /** If true, render with a divider below in the menu. */
+  divider?: boolean;
+  disabled?: boolean;
+  /** Hover hint — explains why an item is disabled. */
+  tooltip?: string;
+  onClick?: () => void;
+}
+
+/**
+ * The overflow menu of state-independent case actions, mirroring the webapp's
+ * CaseActionBar "More" menu (see that file's buildSecondaryItems). "Copy case
+ * link" and "Hold auto-closure" are intentionally left out for now. Everything
+ * else appears in the same order/labels/icons as the webapp, but only "Change
+ * severity" and "Log time" are wired to real actions here — the rest have no
+ * microapp implementation yet and render disabled with a "not available yet"
+ * tooltip so they're ready to be wired up one at a time.
+ */
+function buildItems(
+  caseDetail: CaseDetail,
+  currentUserId: string | null | undefined,
+  onChangeSeverity: () => void,
+  onLogTime: () => void,
+): SecondaryItem[] {
+  const items: SecondaryItem[] = [];
+  const caseClosed = caseDetail.state === "closed";
+  const NOT_AVAILABLE = "Not available yet.";
+
+  if (caseDetail.assignedEngineer?.id === currentUserId && caseDetail.state === "work_in_progress") {
+    const ongoing = caseDetail.workState === "ongoing";
+    items.push({
+      key: "toggle_work_state",
+      label: ongoing ? "Pause work" : "Resume work",
+      icon: ongoing ? <PauseCircle size={16} /> : <Play size={16} />,
+      divider: true,
+      disabled: true,
+      tooltip: NOT_AVAILABLE,
+    });
+  }
+
+  items.push(
+    {
+      key: "raise_git_issue",
+      label: "Raise internal Git issue…",
+      icon: <GitBranch size={16} />,
+      divider: true,
+      disabled: true,
+      tooltip: NOT_AVAILABLE,
+    },
+    {
+      key: "reassign_engineer",
+      label: "Assign / reassign engineer…",
+      icon: <User size={16} />,
+      divider: true,
+      disabled: true,
+      tooltip: NOT_AVAILABLE,
+    },
+  );
+
+  // Only case-type items carry a severity — mirrors the caseDetail.severity
+  // check elsewhere on this page (service requests/security reports/etc. have
+  // no severity to change).
+  if (caseDetail.severity) {
+    items.push({
+      key: "change_severity",
+      label: "Change severity…",
+      icon: <Gauge size={16} />,
+      disabled: caseClosed,
+      tooltip: caseClosed ? "This case is closed — it's read-only." : undefined,
+      onClick: onChangeSeverity,
+    });
+  }
+
+  items.push(
+    {
+      key: "edit_case_details",
+      label: "Edit case details…",
+      icon: <Pencil size={16} />,
+      divider: true,
+      disabled: true,
+      tooltip: NOT_AVAILABLE,
+    },
+    {
+      key: "create_incident",
+      label: "Create incident from case…",
+      icon: <AlertTriangle size={16} />,
+      disabled: true,
+      tooltip: NOT_AVAILABLE,
+    },
+    {
+      key: "link_incident",
+      label: "Link to incident…",
+      icon: <LinkIcon size={16} />,
+      divider: true,
+      disabled: true,
+      tooltip: NOT_AVAILABLE,
+    },
+    {
+      key: "create_task",
+      label: "Create task…",
+      icon: <ListChecks size={16} />,
+      disabled: true,
+      tooltip: NOT_AVAILABLE,
+    },
+    {
+      key: "set_fix_eta",
+      label: "Set fix ETA…",
+      icon: <CalendarClock size={16} />,
+      divider: true,
+      disabled: true,
+      tooltip: NOT_AVAILABLE,
+    },
+    {
+      key: "log_time",
+      label: "Log time…",
+      icon: <Clock size={16} />,
+      onClick: onLogTime,
+    },
+  );
+
+  return items;
+}
+
+interface CaseMoreMenuProps {
+  caseDetail: CaseDetail;
+  currentUserId: string | null | undefined;
+  onChangeSeverity: () => void;
+  onLogTime: () => void;
+}
+
+export function CaseMoreMenu({ caseDetail, currentUserId, onChangeSeverity, onLogTime }: CaseMoreMenuProps) {
+  const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
+  const items = buildItems(caseDetail, currentUserId, onChangeSeverity, onLogTime);
+
+  return (
+    <>
+      <Button
+        size="small"
+        variant="outlined"
+        color="primary"
+        endIcon={<ChevronDown size={16} />}
+        onClick={(e) => setMenuAnchor(e.currentTarget)}
+        sx={{ borderRadius: 999, flexShrink: 0 }}
+      >
+        More
+      </Button>
+      <Menu anchorEl={menuAnchor} open={!!menuAnchor} onClose={() => setMenuAnchor(null)}>
+        {items.map((item) => {
+          const menuItem = (
+            <MenuItem
+              key={item.key}
+              disabled={item.disabled}
+              onClick={() => {
+                if (item.disabled) return;
+                setMenuAnchor(null);
+                item.onClick?.();
+              }}
+              sx={{ gap: 1.25, minHeight: 36 }}
+            >
+              {item.icon}
+              {item.label}
+            </MenuItem>
+          );
+          return [
+            // A disabled MenuItem has `pointer-events: none`, so a Tooltip only
+            // fires when it wraps a non-disabled span — wrap just the item here.
+            item.tooltip ? (
+              <Tooltip key={item.key} title={item.tooltip}>
+                <Box component="span" sx={{ display: "block" }}>
+                  {menuItem}
+                </Box>
+              </Tooltip>
+            ) : (
+              menuItem
+            ),
+            item.divider ? (
+              <Box key={`${item.key}-divider`} sx={{ borderTop: 1, borderColor: "divider", my: 0.25 }} />
+            ) : null,
+          ];
+        })}
+      </Menu>
+    </>
+  );
+}

--- a/apps/csm-portal/microapp/src/components/case-detail/CaseMoreMenu.tsx
+++ b/apps/csm-portal/microapp/src/components/case-detail/CaseMoreMenu.tsx
@@ -63,7 +63,10 @@ function buildItems(
   const caseClosed = caseDetail.state === "closed";
   const NOT_AVAILABLE = "Not available yet.";
 
-  if (caseDetail.assignedEngineer?.id === currentUserId && caseDetail.state === "work_in_progress") {
+  // Guard on `currentUserId` being present first: `assignedEngineer?.id` is `undefined` for an
+  // unassigned case, which would otherwise equal an `undefined` currentUserId (an unidentified
+  // caller) and wrongly show the toggle for a case nobody — including the viewer — is assigned to.
+  if (currentUserId && caseDetail.assignedEngineer?.id === currentUserId && caseDetail.state === "work_in_progress") {
     const ongoing = caseDetail.workState === "ongoing";
     items.push({
       key: "toggle_work_state",

--- a/apps/csm-portal/microapp/src/components/case-detail/LogTimeCardDialog.tsx
+++ b/apps/csm-portal/microapp/src/components/case-detail/LogTimeCardDialog.tsx
@@ -18,6 +18,8 @@ import { useMemo, useState } from "react";
 import {
   AdapterDateFns,
   Autocomplete,
+  Avatar,
+  Box,
   Button,
   Chip,
   DatePickers,
@@ -27,6 +29,7 @@ import {
   DialogTitle,
   Divider,
   FormControlLabel,
+  LinearProgress,
   MenuItem,
   Stack,
   Switch,
@@ -40,10 +43,14 @@ import { useUserStore } from "@src/store/user";
 import type {
   ActivityBreakdown,
   ActivityKey,
+  CaseSeverity,
   CreateTimeCardInput,
   IssueComplexity,
   TimeCardApprover,
 } from "@src/types";
+import { SEVERITY_LABELS } from "@components/support/config";
+import { TimeCardStateChip } from "@components/timecards/TimeCardStateChip";
+import { initialsOf } from "@utils/initials";
 import { useDebouncedValue } from "@utils/useDebouncedValue";
 import {
   ACTIVITY_BUCKETS,
@@ -51,6 +58,7 @@ import {
   DEFAULT_ISSUE_COMPLEXITY,
   ISSUE_COMPLEXITY_OPTIONS,
   MAX_MINUTES_PER_DAY,
+  NON_BILLABLE_SEVERITIES,
   WORK_LOG_MAX,
   emptyBreakdown,
   timeCardDraftErrors,
@@ -82,11 +90,65 @@ interface ApproverOption {
   email?: string;
 }
 
+/** One activity row: a labelled whole-minutes input plus a proportion bar (relative to the
+ * current logged total, so each bar shows share-of-work, not share-of-day). Mirrors the webapp's
+ * ActivityRow. */
+function ActivityRow({
+  label,
+  value,
+  total,
+  onChange,
+  onBlur,
+}: {
+  label: string;
+  value: number;
+  total: number;
+  onChange: (next: number) => void;
+  onBlur: () => void;
+}) {
+  const pct = total > 0 ? Math.min(100, (value / total) * 100) : 0;
+  return (
+    <Box sx={{ display: "grid", gridTemplateColumns: "1fr 96px", alignItems: "center", columnGap: 1.5, rowGap: 0.5 }}>
+      <Typography variant="body2">{label}</Typography>
+      <TextField
+        // Stays type="number" — a manually-filtered type="text" turned out unreliable to type
+        // into on the microapp's mobile WebView (some builds never fired onChange for digit
+        // keys). The native number input is what's actually well-supported for typing everywhere,
+        // and already keeps the value numeric; only the increment/decrement spinner is unwanted
+        // here, so that's hidden via CSS below instead of swapping the input type.
+        type="number"
+        size="small"
+        value={Number.isFinite(value) ? value : 0}
+        onChange={(e) => onChange(Math.max(0, Math.round(Number(e.target.value) || 0)))}
+        onBlur={onBlur}
+        slotProps={{
+          htmlInput: { min: 0, max: MAX_MINUTES_PER_DAY, step: 1, inputMode: "numeric", "aria-label": label },
+        }}
+        sx={{
+          width: 96,
+          "& input[type=number]": { MozAppearance: "textfield" },
+          "& input[type=number]::-webkit-outer-spin-button, & input[type=number]::-webkit-inner-spin-button": {
+            WebkitAppearance: "none",
+            margin: 0,
+          },
+        }}
+      />
+      <Box sx={{ gridColumn: "1 / -1", mt: -0.25 }}>
+        <LinearProgress variant="determinate" value={pct} sx={{ height: 4, borderRadius: 2 }} />
+      </Box>
+    </Box>
+  );
+}
+
 interface LogTimeCardDialogProps {
   /** The case the time was spent on — always known, this dialog only opens
-   * from a case's Time Tracking tab. */
+   * from a case's Time Tracking tab or its "More" menu. */
   caseId: string;
   caseNumber: string;
+  /** Determines whether the billable switch is editable — see NON_BILLABLE_SEVERITIES. A null/
+   * missing severity (e.g. a case type that doesn't carry one) is treated the same as a
+   * non-billable severity, since only "low" (S4) is ever left editable. */
+  caseSeverity: CaseSeverity | null;
   projectId: string;
   projectName: string;
   /** True while the create mutation is in flight. */
@@ -106,6 +168,7 @@ interface LogTimeCardDialogProps {
 export function LogTimeCardDialog({
   caseId,
   caseNumber,
+  caseSeverity,
   projectId,
   projectName,
   isSubmitting,
@@ -115,9 +178,11 @@ export function LogTimeCardDialog({
 }: LogTimeCardDialogProps) {
   const me = useUserStore((s) => s.user);
 
+  const isAlwaysNonBillable = !caseSeverity || NON_BILLABLE_SEVERITIES.includes(caseSeverity);
+
   const [date, setDate] = useState(todayIso());
   const [issueComplexity, setIssueComplexity] = useState<IssueComplexity>(DEFAULT_ISSUE_COMPLEXITY);
-  const [billable, setBillable] = useState<boolean>(DEFAULT_BILLABLE);
+  const [billable, setBillable] = useState<boolean>(isAlwaysNonBillable ? false : DEFAULT_BILLABLE);
   const [breakdown, setBreakdown] = useState<ActivityBreakdown>(emptyBreakdown());
   const [workLogComment, setWorkLogComment] = useState("");
   const [approver, setApprover] = useState<TimeCardApprover | null>(null);
@@ -177,11 +242,35 @@ export function LogTimeCardDialog({
       onClose={isSubmitting ? undefined : onClose}
       fullWidth
       maxWidth="xs"
-      slotProps={{ paper: { sx: { backgroundImage: "none", backgroundColor: "background.default" } } }}
+      slotProps={{
+        paper: {
+          sx: {
+            backgroundImage: "none",
+            backgroundColor: "background.default",
+            // Explicit cap (rather than relying on the default `calc(100% - 64px)`) so the dialog
+            // never grows taller than the visible viewport in the microapp's WebView — without it,
+            // the last field(s) and the action buttons can end up clipped below the fold with no
+            // way to scroll to them.
+            display: "flex",
+            flexDirection: "column",
+            maxHeight: "85vh",
+          },
+        },
+      }}
     >
       <DialogTitle>Log time · {caseNumber}</DialogTitle>
       <DialogContent dividers>
         <Stack gap={2}>
+          <Stack direction="row" alignItems="center" justifyContent="space-between" gap={1}>
+            <Stack direction="row" alignItems="center" gap={1}>
+              <Avatar src={me?.avatarUrl} sx={{ width: 28, height: 28, fontSize: "0.75rem" }}>
+                {initialsOf(me?.name ?? "")}
+              </Avatar>
+              <Typography variant="body2">{me?.name}</Typography>
+            </Stack>
+            <TimeCardStateChip state="submitted" />
+          </Stack>
+
           <Typography variant="body2" color="text.secondary">
             {projectName || "—"}
           </Typography>
@@ -190,6 +279,11 @@ export function LogTimeCardDialog({
             <DatePicker
               label="Date"
               value={fromIsoDate(date)}
+              // Time can only be logged for today or earlier, never in advance. Both props are
+              // set: `disableFuture` is MUI's dedicated flag for this exact rule (robust to any
+              // `maxDate`/"now" edge case), `maxDate` pins the same boundary explicitly.
+              disableFuture
+              maxDate={new Date()}
               onChange={(next) => {
                 setDate(next instanceof Date && !Number.isNaN(next.getTime()) ? format(next, ISO_DATE) : "");
                 touch("date");
@@ -224,23 +318,14 @@ export function LogTimeCardDialog({
           )}
           <Stack gap={1.25}>
             {ACTIVITY_BUCKETS.map((b) => (
-              <Stack key={b.key} direction="row" alignItems="center" justifyContent="space-between" gap={1.5}>
-                <Typography variant="body2">{b.label}</Typography>
-                <TextField
-                  type="number"
-                  size="small"
-                  value={Number.isFinite(breakdown[b.key]) ? breakdown[b.key] : 0}
-                  onChange={(e) =>
-                    setActivity(
-                      b.key,
-                      Math.min(MAX_MINUTES_PER_DAY, Math.max(0, Math.round(Number(e.target.value) || 0))),
-                    )
-                  }
-                  onBlur={() => touch("minutes")}
-                  slotProps={{ htmlInput: { min: 0, max: MAX_MINUTES_PER_DAY, step: 1, "aria-label": b.label } }}
-                  sx={{ width: 96 }}
-                />
-              </Stack>
+              <ActivityRow
+                key={b.key}
+                label={b.label}
+                value={breakdown[b.key]}
+                total={total}
+                onChange={(next) => setActivity(b.key, Math.min(MAX_MINUTES_PER_DAY, next))}
+                onBlur={() => touch("minutes")}
+              />
             ))}
           </Stack>
 
@@ -260,19 +345,41 @@ export function LogTimeCardDialog({
                 </MenuItem>
               ))}
             </TextField>
-            <FormControlLabel
-              control={<Switch checked={billable} onChange={(e) => setBillable(e.target.checked)} />}
-              label={billable ? "Billable" : "Non-billable"}
-              labelPlacement="start"
-              sx={{ ml: 0 }}
-            />
+            <Stack alignItems="flex-end" gap={0.25}>
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={billable}
+                    disabled={isAlwaysNonBillable}
+                    onChange={(e) => setBillable(e.target.checked)}
+                  />
+                }
+                label={billable ? "Billable" : "Non-billable"}
+                labelPlacement="start"
+                sx={{ ml: 0 }}
+              />
+              {isAlwaysNonBillable && (
+                <Typography variant="caption" color="text.secondary">
+                  Always non-billable{caseSeverity ? ` for ${SEVERITY_LABELS[caseSeverity]} cases` : ""}.
+                </Typography>
+              )}
+            </Stack>
           </Stack>
 
           <TextField
+            // No `placeholder` here: MUI forces an outlined field's label into a permanently
+            // shrunk state whenever a placeholder is also set (so the two never overlap), which
+            // reads as the label crowding the top border on this field's theme — every other
+            // multiline field in the app (Close notes, lead comment) sticks to label-only for the
+            // same reason, so this matches that established, correctly-spaced look.
             label="Work log comment"
             required
             multiline
             minRows={3}
+            // Caps how tall the field can grow before it scrolls internally instead — without
+            // this a long comment keeps pushing the rest of the form (and the Submit button)
+            // further down, which is what made the field clip off-screen in the first place.
+            maxRows={6}
             fullWidth
             value={workLogComment}
             onChange={(e) => setWorkLogComment(e.target.value.slice(0, WORK_LOG_MAX))}

--- a/apps/csm-portal/microapp/src/components/case-detail/TimeTrackingTab.tsx
+++ b/apps/csm-portal/microapp/src/components/case-detail/TimeTrackingTab.tsx
@@ -20,7 +20,7 @@ import { Plus } from "@wso2/oxygen-ui-icons-react";
 import { useNavigate } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { timecards } from "@src/services/timecards";
-import type { CreateTimeCardInput, CsmTimeCard } from "@src/types";
+import type { CaseSeverity, CreateTimeCardInput, CsmTimeCard } from "@src/types";
 import { cardDateLabel, formatMinutes } from "@utils/timecard";
 import { TimeCardStateChip } from "@components/timecards/TimeCardStateChip";
 import { LogTimeCardDialog } from "./LogTimeCardDialog";
@@ -28,6 +28,7 @@ import { LogTimeCardDialog } from "./LogTimeCardDialog";
 interface TimeTrackingTabProps {
   caseId: string;
   caseNumber: string;
+  caseSeverity: CaseSeverity | null;
   projectId: string;
   projectName: string;
 }
@@ -57,7 +58,7 @@ function TimeCardRow({ card }: { card: CsmTimeCard }) {
  * fetched — a single case logging more than a page's worth of time isn't expected —
  * so a truncated notice covers the rare case where it does.
  */
-export function TimeTrackingTab({ caseId, caseNumber, projectId, projectName }: TimeTrackingTabProps) {
+export function TimeTrackingTab({ caseId, caseNumber, caseSeverity, projectId, projectName }: TimeTrackingTabProps) {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [logTimeOpen, setLogTimeOpen] = useState(false);
@@ -138,6 +139,7 @@ export function TimeTrackingTab({ caseId, caseNumber, projectId, projectName }: 
         <LogTimeCardDialog
           caseId={caseId}
           caseNumber={caseNumber}
+          caseSeverity={caseSeverity}
           projectId={projectId}
           projectName={projectName}
           isSubmitting={isSubmitting}

--- a/apps/csm-portal/microapp/src/components/settings/filters.ts
+++ b/apps/csm-portal/microapp/src/components/settings/filters.ts
@@ -30,7 +30,7 @@ export function countActiveUsersFilters(filters: UsersFilters): number {
 export function toUserSearchFilters(search: string, filters: UsersFilters): UserSearchFiltersDto {
   return {
     ...(search.length > 0 && { searchQuery: search }),
-    ...(filters.roles.length > 0 && { roles: filters.roles }),
+    ...(filters.roles.length > 0 && { roleIds: filters.roles }),
     ...(filters.active !== "all" && { active: filters.active === "active" }),
   };
 }

--- a/apps/csm-portal/microapp/src/pages/CaseDetailPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/CaseDetailPage.tsx
@@ -16,20 +16,7 @@
 
 import { Suspense, useRef, useState, type ReactNode } from "react";
 import { useParams } from "react-router-dom";
-import {
-  Card,
-  Divider,
-  FormControl,
-  Grid,
-  MenuItem,
-  Select,
-  Skeleton,
-  Stack,
-  Tab,
-  Tabs,
-  Typography,
-  pxToRem,
-} from "@wso2/oxygen-ui";
+import { Card, Divider, Grid, Skeleton, Stack, Tab, Tabs, Typography, pxToRem } from "@wso2/oxygen-ui";
 import {
   Building2,
   CheckCircle,
@@ -46,6 +33,7 @@ import { useQueryClient, useQueryErrorResetBoundary, useSuspenseQuery } from "@t
 import { cases, parseOngoingConflictCaseNumber, type MyOngoingCase } from "@src/services/cases";
 import { currentUser } from "@src/services/currentUser";
 import { attachments as attachmentsService } from "@src/services/attachments";
+import { timecards } from "@src/services/timecards";
 import { useUserStore } from "@src/store/user";
 import type {
   CaseCause,
@@ -56,13 +44,17 @@ import type {
   CaseState,
   CaseWorkState,
   Comment,
+  CreateTimeCardInput,
 } from "@src/types";
 import { ErrorBoundary } from "@components/common/ErrorBoundary";
 import { CopyIconButton } from "@components/common/CopyIconButton";
 import { SeverityChip, StatusChip } from "@components/support/Chips";
 import { ErrorState } from "@components/support/ErrorState";
-import { ALL_SEVERITIES, SEVERITY_LABELS, TYPE_CONFIG } from "@components/support/config";
+import { TYPE_CONFIG } from "@components/support/config";
 import { CaseActionBar } from "@components/case-detail/CaseActionBar";
+import { CaseMoreMenu } from "@components/case-detail/CaseMoreMenu";
+import { ChangeSeverityDialog } from "@components/case-detail/ChangeSeverityDialog";
+import { LogTimeCardDialog } from "@components/case-detail/LogTimeCardDialog";
 import { ResolutionDialog } from "@components/case-detail/ResolutionDialog";
 import { CommentComposer } from "@components/case-detail/CommentComposer";
 import { CaseActivitiesTab } from "@components/case-detail/CaseActivityFeed";
@@ -123,6 +115,10 @@ function CaseDetailContent({ id }: { id: string }) {
   const [isPostingComment, setIsPostingComment] = useState(false);
   const [activeTab, setActiveTab] = useState<CaseTabId>("activities");
   const [pauseConflict, setPauseConflict] = useState<MyOngoingCase[] | null>(null);
+  const [severityDialogOpen, setSeverityDialogOpen] = useState(false);
+  const [logTimeOpen, setLogTimeOpen] = useState(false);
+  const [isLoggingTime, setIsLoggingTime] = useState(false);
+  const [logTimeError, setLogTimeError] = useState<string | null>(null);
 
   const visibleTabDefs = isAnnouncement
     ? TAB_DEFS.filter((tab) => tab.id !== "sla" && tab.id !== "time" && tab.id !== "call-requests")
@@ -317,9 +313,27 @@ function CaseDetailContent({ id }: { id: string }) {
     setMutationError(null);
     cases
       .patch(id, { severity: next })
-      .then(invalidateCase)
+      .then(() => {
+        setSeverityDialogOpen(false);
+        invalidateCase();
+      })
       .catch(() => setMutationError("Could not change the severity. Please try again."))
       .finally(() => setIsMutating(false));
+  };
+
+  const handleLogTimeSubmit = (input: CreateTimeCardInput): void => {
+    setIsLoggingTime(true);
+    setLogTimeError(null);
+    timecards
+      .create(input)
+      .then(() => {
+        setLogTimeOpen(false);
+        // Root key — one invalidate refreshes every time-cards view (My sheets, All, Approvals,
+        // and this case's own list), same as TimeTrackingTab's own log-time flow.
+        void queryClient.invalidateQueries({ queryKey: ["timecards"] });
+      })
+      .catch(() => setLogTimeError("Could not log time. Please try again."))
+      .finally(() => setIsLoggingTime(false));
   };
 
   // Text and inline attachments upload as separate requests (the backend's comment payload has no
@@ -398,7 +412,8 @@ function CaseDetailContent({ id }: { id: string }) {
         onTransition={handleTransition}
         onAssignAndStart={handleAssignAndStart}
         onNeedsResolution={setResolutionTarget}
-        onChangeSeverity={handleSeveritySubmit}
+        onOpenChangeSeverity={() => setSeverityDialogOpen(true)}
+        onOpenLogTime={() => setLogTimeOpen(true)}
       />
 
       <Tabs value={effectiveTab} variant="scrollable" onChange={(_, value: CaseTabId) => setActiveTab(value)}>
@@ -433,6 +448,7 @@ function CaseDetailContent({ id }: { id: string }) {
         <TimeTrackingTab
           caseId={id}
           caseNumber={caseDetail.number}
+          caseSeverity={caseDetail.severity}
           projectId={caseDetail.project?.id ?? ""}
           projectName={caseDetail.project?.name ?? ""}
         />
@@ -456,6 +472,32 @@ function CaseDetailContent({ id }: { id: string }) {
           onDecline={handleDeclinePauseConflict}
         />
       )}
+      {severityDialogOpen && caseDetail.severity && (
+        <ChangeSeverityDialog
+          currentSeverity={caseDetail.severity}
+          isSubmitting={isMutating}
+          onClose={() => setSeverityDialogOpen(false)}
+          onSubmit={handleSeveritySubmit}
+        />
+      )}
+      {logTimeOpen && (
+        <LogTimeCardDialog
+          caseId={id}
+          caseNumber={caseDetail.number}
+          caseSeverity={caseDetail.severity}
+          projectId={caseDetail.project?.id ?? ""}
+          projectName={caseDetail.project?.name ?? ""}
+          isSubmitting={isLoggingTime}
+          error={logTimeError}
+          onClose={() => {
+            if (!isLoggingTime) {
+              setLogTimeOpen(false);
+              setLogTimeError(null);
+            }
+          }}
+          onSubmit={handleLogTimeSubmit}
+        />
+      )}
     </Stack>
   );
 }
@@ -469,7 +511,8 @@ function CaseSummarySection({
   onTransition,
   onAssignAndStart,
   onNeedsResolution,
-  onChangeSeverity,
+  onOpenChangeSeverity,
+  onOpenLogTime,
 }: {
   caseDetail: CaseDetail;
   currentUserId: string | null;
@@ -479,10 +522,10 @@ function CaseSummarySection({
   onTransition: (target: CaseState) => void;
   onAssignAndStart: () => void;
   onNeedsResolution: (target: "closed" | "solution_proposed") => void;
-  onChangeSeverity: (next: CaseSeverity) => void;
+  onOpenChangeSeverity: () => void;
+  onOpenLogTime: () => void;
 }) {
   const { icon: Icon, color } = TYPE_CONFIG[caseDetail.type ?? "case"] ?? TYPE_CONFIG.case;
-  const canChangeSeverity = !isAnnouncement && caseDetail.severity && caseDetail.state !== "closed";
 
   return (
     <Stack gap={1.5}>
@@ -518,8 +561,10 @@ function CaseSummarySection({
       </Stack>
 
       {/* Actions live in their own row, visually separated from the identity block above so the
-       * primary "what can I do" affordance isn't read as part of the case's own metadata. */}
-      {!isAnnouncement && (caseDetail.nextStates.length > 0 || canChangeSeverity) && (
+       * primary "what can I do" affordance isn't read as part of the case's own metadata. The
+       * More menu always renders alongside a lifecycle button (mirrors the webapp's action bar) —
+       * it has case-independent items (e.g. Log time) that apply regardless of `nextStates`. */}
+      {!isAnnouncement && (
         <Stack
           direction="row"
           gap={1}
@@ -535,35 +580,12 @@ function CaseSummarySection({
             onAssignAndStart={onAssignAndStart}
             onNeedsResolution={onNeedsResolution}
           />
-          {/* Closed is read-only, same rule the webapp applies to comments/attachments/severity. */}
-          {canChangeSeverity && (
-            <FormControl size="small" sx={{ minWidth: 150, flexShrink: 0 }}>
-              <Select
-                value=""
-                displayEmpty
-                disabled={isMutating}
-                renderValue={() => "Change severity"}
-                onChange={(e) => onChangeSeverity(e.target.value as CaseSeverity)}
-                sx={{
-                  borderRadius: 999,
-                  color: "primary.main",
-                  "& .MuiOutlinedInput-notchedOutline": { borderColor: "primary.main", borderRadius: 999 },
-                  "&:hover .MuiOutlinedInput-notchedOutline": { borderColor: "primary.main" },
-                  "&.Mui-focused .MuiOutlinedInput-notchedOutline": { borderColor: "primary.main" },
-                  "&.Mui-disabled": {
-                    color: "action.disabled",
-                    "& .MuiOutlinedInput-notchedOutline": { borderColor: "action.disabledBackground" },
-                  },
-                }}
-              >
-                {ALL_SEVERITIES.map((severity) => (
-                  <MenuItem key={severity} value={severity} disabled={severity === caseDetail.severity}>
-                    {SEVERITY_LABELS[severity]}
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
-          )}
+          <CaseMoreMenu
+            caseDetail={caseDetail}
+            currentUserId={currentUserId}
+            onChangeSeverity={onOpenChangeSeverity}
+            onLogTime={onOpenLogTime}
+          />
         </Stack>
       )}
 

--- a/apps/csm-portal/microapp/src/services/adminUsers.ts
+++ b/apps/csm-portal/microapp/src/services/adminUsers.ts
@@ -68,7 +68,7 @@ export const adminUsers = {
       queryKey: ["admin-users", "search", searchQuery],
       queryFn: () =>
         searchUsers({
-          filters: { searchQuery, roles: APPROVER_ROLES, active: true },
+          filters: { searchQuery, roleIds: APPROVER_ROLES, active: true },
           pagination: { offset: 0, limit: APPROVER_SEARCH_LIMIT },
         }),
       enabled: searchQuery.trim().length > 0,

--- a/apps/csm-portal/microapp/src/types/adminUser.dto.ts
+++ b/apps/csm-portal/microapp/src/types/adminUser.dto.ts
@@ -63,8 +63,10 @@ export interface SnUserDto {
 
 export interface UserSearchFiltersDto {
   searchQuery?: string;
-  /** ServiceNow data source only. */
-  roles?: AdminUserRole[];
+  /** ServiceNow data source only. Named `roleIds` (not `roles`) to match the backend contract —
+   * a role's "id" is its key (e.g. "agent"), not a separate numeric identifier. Mirrors the
+   * webapp's UserSearchFilters.roleIds. */
+  roleIds?: AdminUserRole[];
   /** ServiceNow data source only. */
   active?: boolean;
 }

--- a/apps/csm-portal/microapp/src/utils/timecard.ts
+++ b/apps/csm-portal/microapp/src/utils/timecard.ts
@@ -18,6 +18,7 @@ import type { ChipProps } from "@wso2/oxygen-ui";
 import type {
   ActivityBreakdown,
   ActivityKey,
+  CaseSeverity,
   CsmTimeCard,
   CsmTimeSheet,
   IssueComplexity,
@@ -259,6 +260,15 @@ export const DEFAULT_ISSUE_COMPLEXITY: IssueComplexity = "N/A";
  * billable; the engineer can flip it per card. */
 export const DEFAULT_BILLABLE = true;
 
+/**
+ * Severities ServiceNow always treats as non-billable, regardless of what a time card's
+ * create/update request sends: an unconditional `after` business rule forces the card back to
+ * non-billable for cases of these severities. Mirrors the webapp's NON_BILLABLE_SEVERITIES — the
+ * FE billable switch is disabled rather than left silently overridden after submit. Only "low"
+ * (S4) is left editable.
+ */
+export const NON_BILLABLE_SEVERITIES: CaseSeverity[] = ["catastrophic", "critical", "high", "medium"];
+
 /** Character cap mirroring the ServiceNow work-log field. */
 export const WORK_LOG_MAX = 4000;
 
@@ -288,6 +298,15 @@ export function hasLoggedTime(breakdown: ActivityBreakdown): boolean {
   return ACTIVITY_KEYS.some((key) => (breakdown[key] || 0) > 0);
 }
 
+/** Today's date as `yyyy-MM-dd`, in local time — comparable lexicographically against another
+ * `yyyy-MM-dd` string since both are zero-padded and share that format. */
+function todayIsoDate(): string {
+  const d = new Date();
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  return `${d.getFullYear()}-${mm}-${dd}`;
+}
+
 /** Field-level validation errors for the log dialog, keyed by field name. */
 export interface TimeCardDraftErrors {
   date?: string;
@@ -310,7 +329,13 @@ export interface TimeCardDraft {
  */
 export function timeCardDraftErrors(draft: TimeCardDraft): TimeCardDraftErrors {
   const errors: TimeCardDraftErrors = {};
-  if (!draft.date) errors.date = "Pick a date.";
+  if (!draft.date) {
+    errors.date = "Pick a date.";
+  } else if (draft.date > todayIsoDate()) {
+    // Backstop for the DatePicker's own `maxDate` (e.g. a manually typed date) — time can only be
+    // logged for today or earlier, never in advance.
+    errors.date = "Date can't be in the future.";
+  }
   if (!hasLoggedTime(draft.breakdown)) {
     errors.minutes = "Log time against at least one activity.";
   } else if (


### PR DESCRIPTION
## Summary

- Replaces the case-detail "Change severity" pill button with a webapp-style **More** overflow menu (`CaseMoreMenu`). It lists every state-independent case action the webapp's `CaseActionBar` offers, in the same order/icons — except "Copy case link" and "Hold auto-closure", left out for now. Only **Change severity** and **Log time** are wired to real actions today (the microapp already had dialogs for both); every other item (reassign engineer, edit case details, create incident, link to incident, create task, set fix ETA, raise Git issue, pause/resume work) renders disabled with a "Not available yet" tooltip, so the menu shape doesn't need to change as each one gets wired up in a follow-up.
- Along the way, the **Log time** dialog picked up several fixes surfaced while testing on a real device:
  - The billable switch is now only editable for **S4** cases — ServiceNow force-reverts it to non-billable for S0–S3 server-side via an unconditional business rule, so the switch mirrors that instead of silently lying about it (matches the webapp's `NON_BILLABLE_SEVERITIES`).
  - The date picker can no longer select a **future date** (`disableFuture` + `maxDate`, with a matching validation backstop).
  - The activity-breakdown inputs now show a **proportion bar** under each field, like the webapp's `ActivityRow`.
  - Those same inputs no longer show the native number spinner arrows (hidden via CSS) — a hand-filtered `type="text"` input was tried first but turned out unreliable to type into on the microapp's mobile WebView, so it stayed `type="number"` with the spinner hidden instead.
  - The dialog's height is now capped so a long work-log comment (or the approver search results) can't push the Submit button off-screen in the WebView — this is what was causing the "Work log comment" field to render clipped/unreachable.
  - Added the avatar/name/status header row and matched the "Work log comment" field's placeholder-vs-label behavior to avoid MUI forcing the label into an oddly-spaced permanent-shrink state.
- Separately: **user/approver search was broken** — `UserSearchFiltersDto` sent the role filter as `roles`, but the backend contract actually names it `roleIds` (confirmed against the webapp's working request payload for the same endpoint). The backend was silently ignoring the mismatched field, breaking both the Log time dialog's approver search and the Settings → Users role filter — both are fixed now that the field name matches.

## Test plan

- [x] `tsc --noEmit` and `eslint` pass clean.
- [x] Manually verified on a real device (via the reporting engineer): More menu renders and opens Change severity / Log time dialogs; billable toggle is disabled for non-S4 severities; future dates are blocked; numeric inputs are typable with no spinner arrows; Work log comment is fully reachable/scrollable; approver search returns results.
- [ ] Could not be exercised in a local browser session end-to-end — the microapp authenticates via a native superapp bridge with no standalone fallback, so this relied on the device testing above rather than an automated run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a case overflow menu with actions for work status, severity, and time logging.
  - Added dedicated dialogs for changing severity and recording time.
  - Time logging now supports activity tracking, billability rules, progress indicators, and submission feedback.
  - Future dates are blocked when recording time.

- **Bug Fixes**
  - Corrected user and approver role filtering to return accurate results.
  - Severity changes are unavailable for closed cases and unsupported actions provide guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->