### PR TITLE
[Customer Portal][Webapp]Fix time tracking pagination fetching every intermediate page on jump

### DIFF
--- a/apps/customer-portal/webapp/src/features/project-details/components/time-tracking/ProjectTimeTracking.tsx
+++ b/apps/customer-portal/webapp/src/features/project-details/components/time-tracking/ProjectTimeTracking.tsx
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Box, Grid, Pagination, Typography } from "@wso2/oxygen-ui";
+import { Box, CircularProgress, Grid, Pagination, Typography } from "@wso2/oxygen-ui";
 import {
   useState,
   useEffect,
@@ -63,11 +63,11 @@ export default function ProjectTimeTracking({
     enabled: !!projectId,
   });
 
-  // Reset pagination when filters change
+  // Reset pagination when the project changes
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setPage(1);
-  }, [projectId, startDate, endDate]);
+  }, [projectId]);
 
   const paginatedTimeCards = data?.caseTimeCards ?? [];
   const totalItems = data?.totalRecords ?? 0;
@@ -77,7 +77,18 @@ export default function ProjectTimeTracking({
     setPage(value);
   };
 
+  const handleStartDateChange = (value: string) => {
+    setPage(1);
+    setStartDate(value);
+  };
+
+  const handleEndDateChange = (value: string) => {
+    setPage(1);
+    setEndDate(value);
+  };
+
   const handleClearDates = () => {
+    setPage(1);
     setStartDate("");
     setEndDate("");
   };
@@ -96,17 +107,22 @@ export default function ProjectTimeTracking({
         <TimeCardsDateFilter
           startDate={startDate}
           endDate={endDate}
-          onStartDateChange={setStartDate}
-          onEndDateChange={setEndDate}
+          onStartDateChange={handleStartDateChange}
+          onEndDateChange={handleEndDateChange}
           onClear={handleClearDates}
           hasFilters={hasDateFilters}
         />
       </Box>
 
       <Box sx={{ mb: 2, display: "flex", alignItems: "center", justifyContent: "space-between" }}>
-        <Typography variant="body2" color="text.secondary">
-          Showing {paginatedTimeCards.length} of {totalItems} time cards
-        </Typography>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+          <Typography variant="body2" color="text.secondary">
+            Showing {paginatedTimeCards.length} of {totalItems} time cards
+          </Typography>
+          {!isTimeCardsLoading && isTimeCardsFetching && (
+            <CircularProgress size={14} />
+          )}
+        </Box>
         <TimeCardsCsvExportButton
           projectId={projectId}
           projectName={project?.name}
@@ -126,7 +142,7 @@ export default function ProjectTimeTracking({
       ) : (
         <>
           <Grid container spacing={3}>
-            {isTimeCardsLoading || isTimeCardsFetching ? (
+            {isTimeCardsLoading ? (
               Array.from({ length: 7 }).map((_, index) => (
                 <Grid key={`skeleton-${index}`} size={12}>
                   <TimeTrackingCardSkeleton />

--- a/apps/customer-portal/webapp/src/features/project-details/components/time-tracking/ProjectTimeTracking.tsx
+++ b/apps/customer-portal/webapp/src/features/project-details/components/time-tracking/ProjectTimeTracking.tsx
@@ -16,7 +16,6 @@
 import { Box, Grid, Pagination, Typography } from "@wso2/oxygen-ui";
 import {
   useState,
-  useMemo,
   useEffect,
   type JSX,
   type ChangeEvent,
@@ -31,7 +30,6 @@ import EmptyState from "@components/empty-state/EmptyState";
 import TimeCardsCsvExportButton from "@time-tracking/TimeCardsCsvExportButton";
 
 import type { ProjectTimeTrackingProps } from "@features/project-details/types/projectDetailsComponents";
-import { paginateList } from "@features/project-details/utils/timeTrackingPage";
 
 /**
  * ProjectTimeTracking manages the display of time tracking statistics, date filter, and case time cards.
@@ -53,27 +51,17 @@ export default function ProjectTimeTracking({
   const {
     data,
     isLoading: isTimeCardsLoading,
+    isFetching: isTimeCardsFetching,
     isError: isTimeCardsError,
-    hasNextPage,
-    fetchNextPage,
-    isFetchingNextPage,
-    isFetchNextPageError,
   } = useSearchProjectCaseTimeCards({
     projectId,
     startDate,
     endDate,
     states: ["Approved"],
+    page,
+    pageSize,
     enabled: !!projectId,
   });
-
-  // Fetch the next page only once the current page needs data beyond what's loaded
-  useEffect(() => {
-    if (!data || !hasNextPage || isFetchingNextPage || isFetchNextPageError) return;
-    const loadedCount = data.pages.flatMap((p) => p.caseTimeCards).length;
-    if (page * pageSize > loadedCount) {
-      void fetchNextPage();
-    }
-  }, [page, pageSize, data, hasNextPage, isFetchingNextPage, isFetchNextPageError, fetchNextPage]);
 
   // Reset pagination when filters change
   useEffect(() => {
@@ -81,18 +69,8 @@ export default function ProjectTimeTracking({
     setPage(1);
   }, [projectId, startDate, endDate]);
 
-  const allTimeCards = useMemo(
-    () => data?.pages.flatMap((page) => page.caseTimeCards) ?? [],
-    [data],
-  );
-
-  const totalItems = data?.pages?.[0]?.totalRecords ?? allTimeCards.length;
-
-  const paginatedTimeCards = useMemo(
-    () => paginateList(allTimeCards, page, pageSize),
-    [allTimeCards, page, pageSize],
-  );
-
+  const paginatedTimeCards = data?.caseTimeCards ?? [];
+  const totalItems = data?.totalRecords ?? 0;
   const totalPages = Math.ceil(totalItems / pageSize);
 
   const handlePageChange = (_event: ChangeEvent<unknown>, value: number) => {
@@ -137,7 +115,7 @@ export default function ProjectTimeTracking({
             ...(endDate && { endDate }),
             states: ["Approved"],
           }}
-          prefetchedCards={allTimeCards}
+          prefetchedCards={paginatedTimeCards}
           totalRecords={totalItems}
           disabled={isTimeCardsLoading || isTimeCardsError || totalItems === 0}
         />
@@ -148,7 +126,7 @@ export default function ProjectTimeTracking({
       ) : (
         <>
           <Grid container spacing={3}>
-            {isTimeCardsLoading || isFetchingNextPage ? (
+            {isTimeCardsLoading || isTimeCardsFetching ? (
               Array.from({ length: 7 }).map((_, index) => (
                 <Grid key={`skeleton-${index}`} size={12}>
                   <TimeTrackingCardSkeleton />

--- a/apps/customer-portal/webapp/src/features/project-details/components/time-tracking/__tests__/ProjectTimeTracking.test.tsx
+++ b/apps/customer-portal/webapp/src/features/project-details/components/time-tracking/__tests__/ProjectTimeTracking.test.tsx
@@ -1,0 +1,165 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import ProjectTimeTracking from "@time-tracking/ProjectTimeTracking";
+
+const authFetchMock = vi.fn();
+
+vi.mock("@asgardeo/react", () => ({
+  useAsgardeo: () => ({ isSignedIn: true, isLoading: false }),
+}));
+
+vi.mock("@/hooks/useAuthApiClient", () => ({
+  useAuthApiClient: () => authFetchMock,
+}));
+
+vi.mock("@hooks/useLogger", () => ({
+  useLogger: () => ({ debug: vi.fn(), error: vi.fn() }),
+}));
+
+vi.mock("@time-tracking/ServiceHoursStatCards", () => ({
+  default: () => <div data-testid="service-hours-stat-cards" />,
+}));
+
+vi.mock("@time-tracking/TimeCardsCsvExportButton", () => ({
+  default: () => <div data-testid="csv-export-button" />,
+}));
+
+vi.mock("@time-tracking/TimeTrackingCard", () => ({
+  default: ({ card }: { card: { case: { id: string } } }) => (
+    <div data-testid="time-tracking-card">{card.case.id}</div>
+  ),
+}));
+
+vi.mock("@time-tracking/TimeTrackingCardSkeleton", () => ({
+  default: () => <div data-testid="time-tracking-card-skeleton" />,
+}));
+
+vi.mock("@time-tracking/TimeTrackingErrorState", () => ({
+  default: () => <div data-testid="time-tracking-error-state" />,
+}));
+
+vi.mock("@components/empty-state/EmptyState", () => ({
+  default: () => <div data-testid="empty-state" />,
+}));
+
+vi.mock("@wso2/oxygen-ui", async () => {
+  const actual = await vi.importActual<Record<string, unknown>>("@wso2/oxygen-ui");
+  return {
+    ...actual,
+    Pagination: ({
+      count,
+      onChange,
+    }: {
+      count: number;
+      onChange: (event: unknown, value: number) => void;
+    }) => (
+      <div data-testid="pagination">
+        {Array.from({ length: count }, (_, index) => index + 1).map((pageNumber) => (
+          <button
+            key={pageNumber}
+            type="button"
+            onClick={() => onChange(null, pageNumber)}
+          >
+            {pageNumber}
+          </button>
+        ))}
+      </div>
+    ),
+  };
+});
+
+function createWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+function makeCaseTimeCard(id: string) {
+  return {
+    case: { id, number: id, name: id, updatedOn: "2026-01-01", project: { id: "p1", label: "p1" } },
+    totalTime: 1,
+    totalCount: 1,
+    billable: { totalTime: 1, count: 1 },
+    nonBillable: { totalTime: 0, count: 0 },
+  };
+}
+
+describe("ProjectTimeTracking", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (
+      window as unknown as { config?: { CUSTOMER_PORTAL_BACKEND_BASE_URL?: string } }
+    ).config = { CUSTOMER_PORTAL_BACKEND_BASE_URL: "https://api.test" };
+
+    authFetchMock.mockImplementation(async (_url: string, init: RequestInit) => {
+      const body = JSON.parse(init.body as string) as {
+        pagination: { offset: number; limit: number };
+      };
+      const { offset, limit } = body.pagination;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          offset,
+          limit,
+          totalRecords: 25,
+          caseTimeCards: Array.from({ length: limit }, (_, i) =>
+            makeCaseTimeCard(`case-${offset + i}`),
+          ),
+        }),
+      };
+    });
+  });
+
+  it("requests offset 0 when a date filter changes from a later page", async () => {
+    render(<ProjectTimeTracking projectId="p1" />, { wrapper: createWrapper() });
+
+    await waitFor(() =>
+      expect(screen.getAllByTestId("time-tracking-card").length).toBeGreaterThan(0),
+    );
+
+    fireEvent.click(screen.getByText("2"));
+
+    await waitFor(() =>
+      expect(authFetchMock).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          body: expect.stringContaining("\"offset\":10"),
+        }),
+      ),
+    );
+
+    const startDateInput = screen.getByLabelText("From:");
+    fireEvent.change(startDateInput, { target: { value: "2026-01-01" } });
+
+    await waitFor(() =>
+      expect(authFetchMock).toHaveBeenLastCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          body: expect.stringContaining("\"offset\":0"),
+        }),
+      ),
+    );
+  });
+});

--- a/apps/customer-portal/webapp/src/features/usage-metrics/api/useSearchProjectCaseTimeCards.ts
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/api/useSearchProjectCaseTimeCards.ts
@@ -15,9 +15,9 @@
 // under the License.
 
 import {
-  useInfiniteQuery,
-  type UseInfiniteQueryResult,
-  type InfiniteData,
+  useQuery,
+  keepPreviousData,
+  type UseQueryResult,
 } from "@tanstack/react-query";
 import { useAsgardeo } from "@asgardeo/react";
 import { useAuthApiClient } from "@/hooks/useAuthApiClient";
@@ -30,39 +30,42 @@ import type {
 import type { UseSearchProjectTimeCardsParams } from "@features/usage-metrics/types/usageMetrics";
 
 /**
- * Searches case-level time cards via projects/:projectId/cases/time-cards/search.
+ * Searches case-level time cards via projects/:projectId/cases/time-cards/search,
+ * fetching exactly the requested page's offset directly.
  *
- * @param {UseSearchProjectTimeCardsParams} params - Project ID and optional filters.
- * @returns {UseInfiniteQueryResult} The infinite query result.
+ * @param {UseSearchProjectTimeCardsParams} params - Project ID, page, and optional filters.
+ * @returns {UseQueryResult} The query result for the requested page.
  */
 export default function useSearchProjectCaseTimeCards({
   projectId,
   startDate,
   endDate,
   states,
+  page = 1,
+  pageSize = 10,
   enabled,
-}: UseSearchProjectTimeCardsParams): UseInfiniteQueryResult<
-  InfiniteData<CaseTimeCardSearchResponse>,
+}: UseSearchProjectTimeCardsParams): UseQueryResult<
+  CaseTimeCardSearchResponse,
   Error
 > {
   const logger = useLogger();
   const { isSignedIn, isLoading: isAuthLoading } = useAsgardeo();
   const authFetch = useAuthApiClient();
+  const offset = (page - 1) * pageSize;
 
-  return useInfiniteQuery<CaseTimeCardSearchResponse, Error>({
+  return useQuery<CaseTimeCardSearchResponse, Error>({
     queryKey: [
       ApiQueryKeys.CASE_TIME_CARDS_SEARCH,
       projectId,
       startDate,
       endDate,
       states,
+      offset,
+      pageSize,
     ],
-    queryFn: async ({
-      pageParam = 0,
-      signal,
-    }): Promise<CaseTimeCardSearchResponse> => {
+    queryFn: async ({ signal }): Promise<CaseTimeCardSearchResponse> => {
       logger.debug(
-        `Searching case time cards for project ID: ${projectId}, offset: ${pageParam}`,
+        `Searching case time cards for project ID: ${projectId}, offset: ${offset}`,
       );
 
       const baseUrl = window.config?.CUSTOMER_PORTAL_BACKEND_BASE_URL;
@@ -78,7 +81,7 @@ export default function useSearchProjectCaseTimeCards({
 
       const body: TimeCardSearchRequest = {
         filters,
-        pagination: { limit: 10, offset: pageParam as number },
+        pagination: { limit: pageSize, offset },
       };
 
       const response = await authFetch(
@@ -94,12 +97,8 @@ export default function useSearchProjectCaseTimeCards({
       logger.debug("[useSearchProjectCaseTimeCards] Data received:", data);
       return data;
     },
-    initialPageParam: 0,
-    getNextPageParam: (lastPage) => {
-      const nextOffset = lastPage.offset + lastPage.limit;
-      return nextOffset < lastPage.totalRecords ? nextOffset : undefined;
-    },
     enabled: enabled !== false && !!projectId && isSignedIn && !isAuthLoading,
+    placeholderData: keepPreviousData,
     staleTime: 0,
   });
 }

--- a/apps/customer-portal/webapp/src/features/usage-metrics/api/useSearchProjectCaseTimeCards.ts
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/api/useSearchProjectCaseTimeCards.ts
@@ -51,7 +51,9 @@ export default function useSearchProjectCaseTimeCards({
   const logger = useLogger();
   const { isSignedIn, isLoading: isAuthLoading } = useAsgardeo();
   const authFetch = useAuthApiClient();
-  const offset = (page - 1) * pageSize;
+  const normalizedPage = Math.max(1, Math.floor(page));
+  const normalizedPageSize = Math.max(1, Math.floor(pageSize));
+  const offset = (normalizedPage - 1) * normalizedPageSize;
 
   return useQuery<CaseTimeCardSearchResponse, Error>({
     queryKey: [
@@ -61,7 +63,7 @@ export default function useSearchProjectCaseTimeCards({
       endDate,
       states,
       offset,
-      pageSize,
+      normalizedPageSize,
     ],
     queryFn: async ({ signal }): Promise<CaseTimeCardSearchResponse> => {
       logger.debug(
@@ -81,7 +83,7 @@ export default function useSearchProjectCaseTimeCards({
 
       const body: TimeCardSearchRequest = {
         filters,
-        pagination: { limit: pageSize, offset },
+        pagination: { limit: normalizedPageSize, offset },
       };
 
       const response = await authFetch(

--- a/apps/customer-portal/webapp/src/features/usage-metrics/types/usageMetrics.ts
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/types/usageMetrics.ts
@@ -162,6 +162,8 @@ export type UseSearchProjectTimeCardsParams = {
   startDate?: string;
   endDate?: string;
   states?: string[];
+  page?: number;
+  pageSize?: number;
   enabled?: boolean;
 };
 


### PR DESCRIPTION
## Summary
- `useSearchProjectCaseTimeCards` previously used `useInfiniteQuery`, whose `fetchNextPage()` can only advance sequentially from the last loaded page. Jumping to a distant page (e.g. page 33) triggered the pagination effect to replay every intermediate page fetch in sequence to catch up, firing dozens of duplicate `/cases/time-cards/search` requests.
- Replaced it with a plain per-page `useQuery` that requests the exact `offset` for the selected page directly (the API already supports arbitrary offsets), with `keepPreviousData` to avoid a blank flash between page changes.
- Simplified `ProjectTimeTracking.tsx` accordingly — removed the page-accumulation state and the auto-fetch-next-page effect; the component now just renders whatever page the query returns.

## Test plan
- [ ] Open the Time Tracking tab and click through pages 1 → 2 → 3 sequentially; confirm one request per page
- [ ] Jump directly to a distant page (e.g. last page); confirm only one request fires, not one per intermediate page
- [ ] Apply a date range filter and confirm pagination resets to page 1 and refetches correctly
- [ ] Export CSV/PDF and confirm it still exports the full filtered dataset, not just the current page
- [ ] `npx vitest run` on `useSearchProjectCaseTimeCards.test.tsx` and `timeTrackingPage.test.ts` — both pass unchanged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated project time tracking to use server-side pagination for faster, more efficient navigation.
  * Time-card results now display the selected page and total available records directly from the service.
  * Loading indicators remain responsive while new pages are fetched.
  * CSV exports now include the currently displayed page of time cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->