### PR TITLE
fix(customer-portal-backend-v2): add case attachments search, scope call-requests under /cases/{caseId}

### DIFF
--- a/apps/customer-portal/backend-v2/CLAUDE.md
+++ b/apps/customer-portal/backend-v2/CLAUDE.md
@@ -397,23 +397,56 @@ leak through it by default.
 **The DTO layer's job isn't only response trimming — it also absorbs entity-service's own request
 contract changes, so the frontend never has to know they happened.**
 `POST /projects/{id}/cases/search` is the example: entity-service redesigned its case-search
-filters from named fields (`types`, `states`, `projectIds`, ...) into a generic predicate array
-(`filters: [{field, op, values}]`, `internal/entity/types.go`'s `CaseFieldFilter`) and now rejects
-any request using the old shape outright (`decodeRequest`'s `DisallowUnknownFields`). The frontend
-was never updated — it still sends the old named-field shape — so
-`dto.CaseSearchRequest`/`CaseSearchFilters` keep that exact old shape as this backend's own stable,
-unchanged contract, and `dto.BuildEntitySearchCasesRequest` is the only place that builds an
-`entity.CaseFieldFilter` array, translating each portal filter field into the "field in/eq values"
-entry entity-service's `case_filters.go` expects (see that file for the authoritative field/op
-table if entity-service adds a new filter). `CreatedByMe` becomes a `createdBy`+`eq` filter carrying
-the literal string `"__current_user_email__"` — this must match entity-service's own
-`currentUserFilterPlaceholder` constant exactly, not just be "some sentinel". If entity-service ever
-changes another request contract this way, the fix is the same shape: keep the portal-facing dto
-type frozen at whatever the frontend already sends, and write a `BuildEntityXRequest` translator
-rather than pushing the new shape onto the frontend or, worse, decoding the incoming request
-directly into an `internal/entity` type (which is how this bug happened in the first place — there
-was no dto/entity separation on the request side for this one endpoint, unlike every response,
-which already goes through `dto.Map*`).
+filters from named fields into a generic predicate array (`filters: [{field, op, values}]`,
+`internal/entity/types.go`'s `CaseFieldFilter`) and now rejects any request using the old shape
+outright (`decodeRequest`'s `DisallowUnknownFields`). The frontend was never updated — it still
+sends the *old Ballerina backend's* named-field shape (`statusIds`, `severityIds`, `issueIds`,
+`caseTypes`, `engagementTypeKeys`, date-range fields — see `CaseSearchFilters` in
+`apps/customer-portal/webapp/src/features/support/types/cases.ts`, the one shared type every
+case-search call site imports), not entity-service's own vocabulary — so
+`dto.CaseSearchRequest`/`CaseSearchFilters` mirror *that* shape as this backend's own stable
+contract, frozen at whatever the frontend already sends, and `dto.BuildEntitySearchCasesRequest` is
+the only place that builds an `entity.CaseFieldFilter` array, translating each portal filter field
+into the "field in/eq/gte/lte values" entry entity-service's `case_filters.go` expects (see that
+file for the authoritative field/op table if entity-service adds a new filter). `CreatedByMe`
+becomes a `createdBy`+`eq` filter carrying the literal string `"__current_user_email__"` — this must
+match entity-service's own `currentUserFilterPlaceholder` constant exactly, not just be "some
+sentinel". If entity-service ever changes another request contract this way, the fix is the same
+shape: keep the portal-facing dto type frozen at whatever the frontend already sends, and write a
+`BuildEntityXRequest` translator rather than pushing the new shape onto the frontend or, worse,
+decoding the incoming request directly into an `internal/entity` type (which is how this bug
+happened in the first place — there was no dto/entity separation on the request side for this one
+endpoint, unlike every response, which already goes through `dto.Map*`).
+
+**Some fields need a second translation layer on top of the dto/entity split: ServiceNow numeric
+choice-list ids ⇄ entity-service's string enums.** The frontend was built against the old Ballerina
+backend, which forwarded ServiceNow's raw numeric choice-list keys (case status/severity/issue-type/
+engagement-type, call-request state) directly — it still sends and expects those exact numbers
+today, even though `cs-tools/entity-service`'s own contract is plain lowercase-snake-case string
+enums. `internal/dto/case_enum_mapping.go` and `internal/dto/call_request_enum_mapping.go` hold this
+backend's own copies of the numeric-id↔enum tables (mirroring entity-service's private
+`snStateIDMap`/`snSeverityIDMap`/`snIssueTypeIDMap`/`snEngagementTypeIDMap`/`callRequestKeyToState`
+in `internal/service/sn_case_service.go` and `sn_call_request_service.go` — these ids are
+ServiceNow's own stable configuration, not something entity-service computes, so duplicating them
+is safe, but if entity-service's copies ever change, update both). Two directions:
+- **Request → entity-service**: the frontend's numeric filter ids (`statusIds`, `severityIds`,
+  `issueIds`, `engagementTypeKeys`, `stateKeys`) translate via an id→enum map
+  (`caseIDsToEnums`/`callRequestStateKeyToEnum`) before reaching `BuildEntityXRequest`; an
+  unrecognized id is silently dropped (search) or produces an empty enum that entity-service's own
+  validation then rejects with 400 (update) — never forwarded to entity-service as a raw number,
+  which would always 400 anyway (entity-service only accepts its own enum vocabulary).
+- **Response → frontend**: entity-service's plain-string enum-valued fields (case search's `state`/
+  `severity`/`issueType`/`engagementType`, already ServiceNow's raw display *label* text for the
+  ServiceNow-backed search path, not a normalized enum — see `SearchCaseView`'s doc comment) become
+  `{id, label}` (`IDLabelRef`) via a label-parsing helper per field (`caseStatusRef`,
+  `caseSeverityRef`, etc.) that mirrors entity-service's own label-parsing functions
+  (`snCaseStateMap`, `snSeverityLabelMap`, `snIssueTypeToEnum`) closely enough to resolve the same
+  id, falling back to a label-only ref (empty id) for a label neither table recognizes rather than
+  dropping the field.
+
+If a future endpoint has this same problem (frontend still expects a legacy numeric id/label pair
+entity-service no longer speaks), follow this same two-file, two-direction pattern rather than
+inventing a new one per endpoint.
 
 **Project scoping via a `{id}` path parameter is the source of truth — never a client-settable body
 field, even when entity-service's own request struct has one.**

--- a/apps/customer-portal/backend-v2/CLAUDE.md
+++ b/apps/customer-portal/backend-v2/CLAUDE.md
@@ -550,8 +550,9 @@ constants).
 frontend's existing type before picking one.** The frontend's shared `PaginationResponse` type
 (`apps/customer-portal/webapp/src/types/common.ts`) is `{offset, limit, totalRecords}`, and some
 already-built frontend consumers (`GET /cases/{id}/attachments`,
-`POST /cases/{caseId}/call-requests/search`) read exactly that field name — so their dto response
-types use `totalRecords`, not this backend's more common `total`. This is not a house-style
+`POST /cases/{caseId}/call-requests/search`, `POST /projects/{id}/cases/search`) read exactly that
+field name — so their dto response types use `totalRecords`, not this backend's more common
+`total`. This is not a house-style
 migration in progress; new endpoints should still default to `total` unless porting one that a
 specific existing frontend hook already expects `totalRecords` from (check
 `apps/customer-portal/webapp/src/api/` and `src/features/*/api/` for the exact field the relevant

--- a/apps/customer-portal/backend-v2/CLAUDE.md
+++ b/apps/customer-portal/backend-v2/CLAUDE.md
@@ -25,7 +25,8 @@ all). Route list: `GET /health`, `GET`/`PATCH /users/me`, `POST /accounts/search
 `POST /comments`, `POST /comments/search`, `POST /change-requests`,
 `POST /change-requests/search`, `GET /change-requests/{id}`, `PATCH /change-requests/{id}`,
 `GET /change-requests/{id}/approvals`, `POST /change-requests/{id}/approvals/decision`,
-`POST /call-requests`, `POST /call-requests/search`, `PATCH /call-requests/{id}`,
+`POST /cases/{caseId}/call-requests`, `POST /cases/{caseId}/call-requests/search`,
+`PATCH /cases/{caseId}/call-requests/{id}`,
 `POST /cases/classify`, `POST /conversations/recommendations/search`,
 `POST /projects/{id}/conversations/search`, `POST /projects/{id}/conversations`,
 `GET /conversations/{id}`, `PATCH /conversations/{id}`, `GET /conversations/{id}/messages`,
@@ -37,7 +38,8 @@ all). Route list: `GET /health`, `GET`/`PATCH /users/me`, `POST /accounts/search
 `GET /projects/{id}/stats/support`, `GET /projects/{id}/stats/time-cards`,
 `GET /projects/{id}/stats/change-requests`, `POST /projects/{id}/cases/time-cards/search`,
 `GET /metadata`, `POST /search`, `GET /products/vulnerabilities/meta`,
-`GET /cases/{id}/feedback`, `POST /cases/{id}/feedback`, `GET /attachments/{id}`,
+`GET /cases/{id}/feedback`, `POST /cases/{id}/feedback`, `GET /cases/{id}/attachments`,
+`GET /attachments/{id}`,
 `PATCH /deployments/{deploymentId}/attachments/{attachmentId}`,
 `PATCH /cases/{caseId}/attachments/{attachmentId}`,
 `POST /deployments/{deploymentId}/products/{productId}/metrics/search`,
@@ -475,7 +477,7 @@ Two more examples, both in this same "restrict, don't mirror" category:
   `isCustomerApproved`/`isCustomerReviewed`/`requestApproval` fields (which *are* exposed, since
   they're literally the customer's own approval actions) rather than letting the customer set an
   arbitrary ServiceNow workflow state directly.
-- `PATCH /call-requests/{id}` (`dto.CallRequestUpdateRequest`) excludes `meetingDate`/`assignee`/
+- `PATCH /cases/{caseId}/call-requests/{id}` (`dto.CallRequestUpdateRequest`) excludes `meetingDate`/`assignee`/
   `notes`/`plan`/`attendees`/`actionItems`/`actualDurationMin` — entity-service's own doc comment
   labels these "agent-side fields, set when an engineer schedules or concludes the call." They're
   still exposed on the *read* side (`dto.CallRequestSummary`) since the customer should be able to
@@ -510,6 +512,26 @@ already treats `Severity`/`State` as plain strings) — skip re-declaring the co
 specific value needs to be checked in Go code (e.g. `ChangeRequestApprovalDecisionRequest.Decision`
 validation in the handler compares against literal `"approved"`/`"rejected"` strings, not enum
 constants).
+
+**Most pagination responses use `total`; a few deliberately use `totalRecords` instead — check the
+frontend's existing type before picking one.** The frontend's shared `PaginationResponse` type
+(`apps/customer-portal/webapp/src/types/common.ts`) is `{offset, limit, totalRecords}`, and some
+already-built frontend consumers (`GET /cases/{id}/attachments`,
+`POST /cases/{caseId}/call-requests/search`) read exactly that field name — so their dto response
+types use `totalRecords`, not this backend's more common `total`. This is not a house-style
+migration in progress; new endpoints should still default to `total` unless porting one that a
+specific existing frontend hook already expects `totalRecords` from (check
+`apps/customer-portal/webapp/src/api/` and `src/features/*/api/` for the exact field the relevant
+hook decodes before choosing).
+
+**Some routes nest a resource's own ID in the path purely for RESTful shape, not because the
+handler needs it.** `PATCH /cases/{caseId}/call-requests/{id}` is the example: entity-service's
+`UpdateCallRequest` is keyed on the call request's own `id` alone, so `caseId` is read from the URL
+only to make the path match the frontend's nesting (`/cases/{caseId}/call-requests/{id}`) — the
+handler never looks at it. Don't add a spurious "does this call request belong to this case" check
+just because the path implies one; that authorization already happens for `POST` and `POST .../search`
+on the same nested resource (`CaseID` is forced from the path there because entity-service's request
+struct actually carries it), and a stray extra check on `PATCH` would just be dead weight.
 
 ## Adding a new endpoint
 

--- a/apps/customer-portal/backend-v2/README.md
+++ b/apps/customer-portal/backend-v2/README.md
@@ -450,7 +450,7 @@ curl -H "x-jwt-assertion: $JWT" http://localhost:8080/projects/<project-id>/stat
 
 curl -X POST http://localhost:8080/projects/<project-id>/cases/search \
   -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
-  -d '{"pagination":{"limit":10,"offset":0},"filters":{"searchQuery":"login error"}}'
+  -d '{"pagination":{"limit":10,"offset":0},"filters":{"searchQuery":"login error","statusIds":[1,10],"severityIds":[11]}}'
 
 curl -H "x-jwt-assertion: $JWT" http://localhost:8080/cases/<case-id>
 
@@ -542,7 +542,7 @@ curl -X POST http://localhost:8080/cases/<case-id>/call-requests/search \
 
 curl -X PATCH http://localhost:8080/cases/<case-id>/call-requests/<call-request-id> \
   -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
-  -d '{"state":"customer_rejected","cancellationReason":"No longer needed"}'
+  -d '{"stateKey":4,"cancellationReason":"No longer needed"}'
 
 curl -X PATCH http://localhost:8080/deployments/<deployment-id> \
   -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \

--- a/apps/customer-portal/backend-v2/README.md
+++ b/apps/customer-portal/backend-v2/README.md
@@ -542,7 +542,7 @@ curl -X POST http://localhost:8080/cases/<case-id>/call-requests/search \
 
 curl -X PATCH http://localhost:8080/cases/<case-id>/call-requests/<call-request-id> \
   -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
-  -d '{"stateKey":4,"cancellationReason":"No longer needed"}'
+  -d '{"stateKey":6,"cancellationReason":"No longer needed"}'
 
 curl -X PATCH http://localhost:8080/deployments/<deployment-id> \
   -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \

--- a/apps/customer-portal/backend-v2/README.md
+++ b/apps/customer-portal/backend-v2/README.md
@@ -321,6 +321,7 @@ backend-v2/
 - `POST /cases/{id}/comments` — add a comment to a case (always a plain customer comment)
 - `GET /cases/{id}/feedback` — get feedback previously submitted for a case (ServiceNow data source only)
 - `POST /cases/{id}/feedback` — submit feedback for a case (ServiceNow data source only)
+- `GET /cases/{id}/attachments` — search a case's attachments, paginated via `limit`/`offset` query params
 - `PATCH /cases/{caseId}/attachments/{attachmentId}` — update a case attachment's name (description not supported on this route — see CLAUDE.md)
 - `POST /cases/{caseId}/escalations` — escalate or de-escalate a case (ServiceNow data source only)
 - `POST /cases/{caseId}/escalations/search` — search a case's escalations (ServiceNow data source only)
@@ -345,9 +346,9 @@ backend-v2/
 - `PATCH /change-requests/{id}` — update a change request (restricted, customer-safe field subset — see CLAUDE.md; ServiceNow data source only)
 - `GET /change-requests/{id}/approvals` — get a change request's approval stages (ServiceNow data source only)
 - `POST /change-requests/{id}/approvals/decision` — approve/reject the caller's own pending approval (ServiceNow data source only)
-- `POST /call-requests` — create a call request (ServiceNow data source only)
-- `POST /call-requests/search` — search call requests, scoped by caseId in the body (ServiceNow data source only)
-- `PATCH /call-requests/{id}` — update a call request (restricted, excludes agent-only fields — see CLAUDE.md; ServiceNow data source only)
+- `POST /cases/{caseId}/call-requests` — create a call request for a case (ServiceNow data source only)
+- `POST /cases/{caseId}/call-requests/search` — search a case's call requests (ServiceNow data source only)
+- `PATCH /cases/{caseId}/call-requests/{id}` — update a call request (restricted, excludes agent-only fields — see CLAUDE.md; ServiceNow data source only)
 - `POST /products/search` — search products
 - `POST /products/{id}/versions/search` — search a product's versions
 - `POST /products/vulnerabilities/search` — search product vulnerabilities
@@ -497,6 +498,8 @@ curl -H "x-jwt-assertion: $JWT" http://localhost:8080/attachments/<attachment-id
 
 curl -X DELETE -H "x-jwt-assertion: $JWT" http://localhost:8080/attachments/<attachment-id>
 
+curl -H "x-jwt-assertion: $JWT" "http://localhost:8080/cases/<case-id>/attachments?limit=10&offset=0"
+
 curl -X POST http://localhost:8080/cases/<case-id>/activities/search \
   -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
   -d '{"pagination":{"limit":20,"offset":0}}'
@@ -529,15 +532,15 @@ curl -X POST http://localhost:8080/change-requests/<change-request-id>/approvals
   -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
   -d '{"decision":"approved"}'
 
-curl -X POST http://localhost:8080/call-requests \
+curl -X POST http://localhost:8080/cases/<case-id>/call-requests \
   -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
-  -d '{"caseId":"<case-id>","reason":"Discuss workaround","utcTimes":["2026-08-05T10:00:00Z"],"durationInMinutes":30}'
+  -d '{"reason":"Discuss workaround","utcTimes":["2026-08-05T10:00:00Z"],"durationInMinutes":30}'
 
-curl -X POST http://localhost:8080/call-requests/search \
+curl -X POST http://localhost:8080/cases/<case-id>/call-requests/search \
   -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
-  -d '{"caseId":"<case-id>","pagination":{"limit":10,"offset":0}}'
+  -d '{"pagination":{"limit":10,"offset":0}}'
 
-curl -X PATCH http://localhost:8080/call-requests/<call-request-id> \
+curl -X PATCH http://localhost:8080/cases/<case-id>/call-requests/<call-request-id> \
   -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
   -d '{"state":"customer_rejected","cancellationReason":"No longer needed"}'
 

--- a/apps/customer-portal/backend-v2/cmd/server/main.go
+++ b/apps/customer-portal/backend-v2/cmd/server/main.go
@@ -228,6 +228,7 @@ func main() {
 	mux.HandleFunc("PATCH /cases/{id}", caseHandler.PatchCase)
 	mux.HandleFunc("POST /cases/{id}/comments", caseHandler.CreateCaseComment)
 	mux.HandleFunc("POST /cases/{id}/activities/search", caseHandler.SearchCaseActivities)
+	mux.HandleFunc("GET /cases/{id}/attachments", caseHandler.SearchCaseAttachments)
 	mux.HandleFunc("GET /cases/{id}/feedback", caseHandler.GetCaseFeedback)
 	mux.HandleFunc("POST /cases/{id}/feedback", caseHandler.SubmitCaseFeedback)
 	mux.HandleFunc("PATCH /cases/{caseId}/attachments/{attachmentId}", caseHandler.PatchCaseAttachment)
@@ -288,9 +289,9 @@ func main() {
 	mux.HandleFunc("GET /change-requests/{id}/approvals", changeRequestHandler.GetChangeRequestApprovals)
 	mux.HandleFunc("POST /change-requests/{id}/approvals/decision", changeRequestHandler.DecideChangeRequestApproval)
 
-	mux.HandleFunc("POST /call-requests", callRequestHandler.CreateCallRequest)
-	mux.HandleFunc("POST /call-requests/search", callRequestHandler.SearchCallRequests)
-	mux.HandleFunc("PATCH /call-requests/{id}", callRequestHandler.PatchCallRequest)
+	mux.HandleFunc("POST /cases/{caseId}/call-requests", callRequestHandler.CreateCallRequest)
+	mux.HandleFunc("POST /cases/{caseId}/call-requests/search", callRequestHandler.SearchCallRequests)
+	mux.HandleFunc("PATCH /cases/{caseId}/call-requests/{id}", callRequestHandler.PatchCallRequest)
 
 	mux.HandleFunc("POST /accounts/search", accountHandler.SearchAccounts)
 	mux.HandleFunc("GET /accounts/{id}", accountHandler.GetAccount)

--- a/apps/customer-portal/backend-v2/internal/dto/attachment.go
+++ b/apps/customer-portal/backend-v2/internal/dto/attachment.go
@@ -91,6 +91,45 @@ func MapSearchAttachments(r entity.SearchAttachmentsResponse) SearchAttachmentsR
 	}
 }
 
+// CaseAttachmentsResponse is the portal's response for
+// GET /cases/{id}/attachments. A distinct type from SearchAttachmentsResponse
+// (not just a reuse) because the frontend's pagination envelope for this
+// specific endpoint uses totalRecords, not total — see
+// PaginationResponse in apps/customer-portal/webapp/src/types/common.ts.
+type CaseAttachmentsResponse struct {
+	Attachments  []AttachmentSummary `json:"attachments"`
+	Offset       int                 `json:"offset"`
+	Limit        int                 `json:"limit"`
+	TotalRecords int                 `json:"totalRecords"`
+}
+
+// MapCaseAttachments builds the portal response from entity-service's
+// SearchAttachmentsResponse for GET /cases/{id}/attachments.
+func MapCaseAttachments(r entity.SearchAttachmentsResponse) CaseAttachmentsResponse {
+	items := make([]AttachmentSummary, 0, len(r.Attachments))
+	for _, a := range r.Attachments {
+		items = append(items, AttachmentSummary{
+			ID:            a.ID,
+			ReferenceID:   a.ReferenceID,
+			ReferenceType: string(a.ReferenceType),
+			Name:          a.Name,
+			Type:          a.Type,
+			SizeBytes:     a.SizeBytes,
+			Description:   a.Description,
+			CreatedBy:     a.CreatedBy,
+			CreatedOn:     a.CreatedOn,
+			DownloadURL:   a.DownloadURL,
+			PreviewURL:    a.PreviewURL,
+		})
+	}
+	return CaseAttachmentsResponse{
+		Attachments:  items,
+		Offset:       r.Offset,
+		Limit:        r.Limit,
+		TotalRecords: r.Total,
+	}
+}
+
 // DeleteResponse is the portal's response for DELETE /attachments/{id}.
 type DeleteResponse struct {
 	Message string `json:"message"`

--- a/apps/customer-portal/backend-v2/internal/dto/call_request.go
+++ b/apps/customer-portal/backend-v2/internal/dto/call_request.go
@@ -74,6 +74,47 @@ type CallRequestSummary struct {
 	ActualDurationMin  *int                 `json:"actualDurationMin,omitempty"`
 }
 
+// CallRequestSearchFilters holds the optional filter criteria for
+// POST /cases/{caseId}/call-requests/search — shaped to match the
+// frontend's request body (useGetCallRequests.ts's bodyObj.filters), which
+// sends numeric ServiceNow choice-list keys (stateKeys), not
+// entity-service's own string enum (see callRequestStateKeyToEnum for the
+// translation).
+type CallRequestSearchFilters struct {
+	StateKeys []int `json:"stateKeys,omitempty"`
+}
+
+// CallRequestSearchRequest is the portal's request body for
+// POST /cases/{caseId}/call-requests/search.
+type CallRequestSearchRequest struct {
+	Filters    CallRequestSearchFilters `json:"filters"`
+	Pagination entity.Pagination        `json:"pagination"`
+}
+
+// BuildEntitySearchCallRequestsRequest translates the portal's request into
+// entity-service's SearchCallRequestsRequest. caseID (the {caseId} path
+// parameter) is always forced, never taken from the request body — the
+// frontend's request body carries only filters/pagination. Unrecognized
+// state keys are silently skipped (same behavior as
+// caseIDsToEnums/BuildEntitySearchCasesRequest).
+func BuildEntitySearchCallRequestsRequest(caseID string, req CallRequestSearchRequest) entity.SearchCallRequestsRequest {
+	states := make([]string, 0, len(req.Filters.StateKeys))
+	for _, key := range req.Filters.StateKeys {
+		if enum, ok := callRequestStateKeyToEnum[key]; ok {
+			states = append(states, enum)
+		}
+	}
+	var filters *entity.SearchCallRequestsFilters
+	if len(states) > 0 {
+		filters = &entity.SearchCallRequestsFilters{States: states}
+	}
+	return entity.SearchCallRequestsRequest{
+		CaseID:     caseID,
+		Filters:    filters,
+		Pagination: req.Pagination,
+	}
+}
+
 // SearchCallRequestsResponse is the portal's response for
 // POST /cases/{caseId}/call-requests/search. TotalRecords (not Total) to
 // match the frontend's shared pagination envelope — see
@@ -119,14 +160,21 @@ func MapSearchCallRequests(r entity.SearchCallRequestsResponse) SearchCallReques
 }
 
 // CallRequestUpdateRequest is the portal's request shape for
-// PATCH /call-requests/{id} — a deliberately restricted subset of
-// entity-service's UpdateCallRequestRequest. Excluded fields are agent-side
-// actions entity-service itself documents as "set when an engineer schedules
-// or concludes the call" — MeetingDate, Assignee, Notes, Plan, Attendees,
-// ActionItems, ActualDurationMin — none of which a customer should be able
-// to set on their own call request.
+// PATCH /cases/{caseId}/call-requests/{id} — a deliberately restricted
+// subset of entity-service's UpdateCallRequestRequest. Excluded fields are
+// agent-side actions entity-service itself documents as "set when an
+// engineer schedules or concludes the call" — MeetingDate, Assignee, Notes,
+// Plan, Attendees, ActionItems, ActualDurationMin — none of which a customer
+// should be able to set on their own call request. StateKey (not State):
+// the frontend was built against the old Ballerina backend and still sends
+// ServiceNow's numeric choice-list key, not entity-service's own string
+// enum — see callRequestStateKeyToEnum for the translation. Reason is
+// excluded too: the frontend's PatchCallRequest carries an optional reason
+// field, but entity-service's UpdateCallRequestRequest has no equivalent —
+// there's no code path to forward it to, so it's silently dropped rather
+// than worked around.
 type CallRequestUpdateRequest struct {
-	State              string   `json:"state"`
+	StateKey           int      `json:"stateKey"`
 	CancellationReason *string  `json:"cancellationReason,omitempty"`
 	UTCTimes           []string `json:"utcTimes,omitempty"`
 	DurationMinutes    *int     `json:"durationInMinutes,omitempty"`
@@ -134,10 +182,13 @@ type CallRequestUpdateRequest struct {
 
 // BuildEntityUpdateCallRequestRequest converts the portal's restricted update
 // request into entity-service's full request shape, leaving every excluded
-// (agent-side) field nil.
+// (agent-side) field nil. An unrecognized StateKey (including the zero value
+// for an absent field) translates to an empty State, which entity-service's
+// own validCallRequestStates check then rejects with a 400 — this backend
+// doesn't duplicate that validation itself.
 func BuildEntityUpdateCallRequestRequest(req CallRequestUpdateRequest) entity.UpdateCallRequestRequest {
 	return entity.UpdateCallRequestRequest{
-		State:              req.State,
+		State:              callRequestStateKeyToEnum[req.StateKey],
 		CancellationReason: req.CancellationReason,
 		UTCTimes:           req.UTCTimes,
 		DurationMinutes:    req.DurationMinutes,

--- a/apps/customer-portal/backend-v2/internal/dto/call_request.go
+++ b/apps/customer-portal/backend-v2/internal/dto/call_request.go
@@ -74,10 +74,13 @@ type CallRequestSummary struct {
 	ActualDurationMin  *int                 `json:"actualDurationMin,omitempty"`
 }
 
-// SearchCallRequestsResponse is the portal's response for POST /call-requests/search.
+// SearchCallRequestsResponse is the portal's response for
+// POST /cases/{caseId}/call-requests/search. TotalRecords (not Total) to
+// match the frontend's shared pagination envelope — see
+// PaginationResponse in apps/customer-portal/webapp/src/types/common.ts.
 type SearchCallRequestsResponse struct {
 	CallRequests []CallRequestSummary `json:"callRequests"`
-	Total        int                  `json:"total"`
+	TotalRecords int                  `json:"totalRecords"`
 	Offset       int                  `json:"offset"`
 	Limit        int                  `json:"limit"`
 }
@@ -109,7 +112,7 @@ func MapSearchCallRequests(r entity.SearchCallRequestsResponse) SearchCallReques
 	}
 	return SearchCallRequestsResponse{
 		CallRequests: items,
-		Total:        r.Total,
+		TotalRecords: r.Total,
 		Offset:       r.Offset,
 		Limit:        r.Limit,
 	}

--- a/apps/customer-portal/backend-v2/internal/dto/call_request_enum_mapping.go
+++ b/apps/customer-portal/backend-v2/internal/dto/call_request_enum_mapping.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dto
+
+// callRequestStateKeyToEnum mirrors entity-service's private
+// callRequestKeyToState (internal/service/sn_call_request_service.go) —
+// ServiceNow's own numeric choice-list key for each call-request state. The
+// frontend was built against the old Ballerina backend, which forwarded
+// this exact key as stateKey; it still sends it today
+// (PATCH .../call-requests/{id}'s body, POST .../call-requests/search's
+// filters.stateKeys) even though entity-service's own contract is the
+// plain string enum (see domain.CallRequestStateType). If entity-service's
+// copy ever changes, this one must be updated too.
+var callRequestStateKeyToEnum = map[int]string{
+	1: "pending_on_customer",
+	2: "pending_on_wso2",
+	3: "scheduled",
+	4: "customer_rejected",
+	5: "wso2_rejected",
+	6: "canceled",
+	7: "notes_pending",
+	8: "concluded",
+}

--- a/apps/customer-portal/backend-v2/internal/dto/call_request_test.go
+++ b/apps/customer-portal/backend-v2/internal/dto/call_request_test.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dto
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+)
+
+// TestBuildEntityUpdateCallRequestRequest_StateKeyTranslatesToEnum guards
+// against reintroducing the bug where this backend expected a "state" string
+// enum field the frontend never sends — the frontend (built against the old
+// Ballerina backend) sends stateKey as a ServiceNow numeric choice-list key.
+func TestBuildEntityUpdateCallRequestRequest_StateKeyTranslatesToEnum(t *testing.T) {
+	got := BuildEntityUpdateCallRequestRequest(CallRequestUpdateRequest{StateKey: 6})
+
+	if got.State != "canceled" {
+		t.Fatalf("State = %q, want %q", got.State, "canceled")
+	}
+}
+
+// TestBuildEntityUpdateCallRequestRequest_UnrecognizedStateKeyProducesEmptyState
+// verifies an unrecognized (or absent, zero-value) stateKey translates to an
+// empty State rather than panicking or forwarding the raw number —
+// entity-service's own validCallRequestStates check then rejects an empty
+// state with 400.
+func TestBuildEntityUpdateCallRequestRequest_UnrecognizedStateKeyProducesEmptyState(t *testing.T) {
+	got := BuildEntityUpdateCallRequestRequest(CallRequestUpdateRequest{StateKey: 999})
+
+	if got.State != "" {
+		t.Fatalf("State = %q, want empty string for an unrecognized stateKey", got.State)
+	}
+}
+
+// TestBuildEntitySearchCallRequestsRequest_CaseIDFromPathAndStateKeysTranslated
+// verifies caseID always comes from the path parameter (never the body,
+// which the frontend never sends one in) and that filters.stateKeys
+// translates to entity-service's own states string enum.
+func TestBuildEntitySearchCallRequestsRequest_CaseIDFromPathAndStateKeysTranslated(t *testing.T) {
+	req := CallRequestSearchRequest{
+		Filters:    CallRequestSearchFilters{StateKeys: []int{3, 8, 999}},
+		Pagination: entity.Pagination{Limit: 10, Offset: 0},
+	}
+
+	got := BuildEntitySearchCallRequestsRequest("case-1", req)
+
+	if got.CaseID != "case-1" {
+		t.Fatalf("CaseID = %q, want %q", got.CaseID, "case-1")
+	}
+	if got.Filters == nil {
+		t.Fatal("expected non-nil Filters")
+	}
+	want := []string{"scheduled", "concluded"}
+	if !reflect.DeepEqual(got.Filters.States, want) {
+		t.Fatalf("States = %+v, want %+v (999 has no mapping and must be dropped)", got.Filters.States, want)
+	}
+	if got.Pagination != req.Pagination {
+		t.Fatalf("Pagination = %+v, want %+v", got.Pagination, req.Pagination)
+	}
+}
+
+// TestBuildEntitySearchCallRequestsRequest_NoStateKeysLeavesFiltersNil
+// verifies an empty/absent stateKeys filter produces a nil Filters, matching
+// entity.SearchCallRequestsRequest.Filters's omitempty/optional contract,
+// rather than an empty-but-present filters object.
+func TestBuildEntitySearchCallRequestsRequest_NoStateKeysLeavesFiltersNil(t *testing.T) {
+	got := BuildEntitySearchCallRequestsRequest("case-1", CallRequestSearchRequest{})
+
+	if got.Filters != nil {
+		t.Fatalf("Filters = %+v, want nil", got.Filters)
+	}
+}

--- a/apps/customer-portal/backend-v2/internal/dto/case.go
+++ b/apps/customer-portal/backend-v2/internal/dto/case.go
@@ -50,37 +50,60 @@ func mapNumberRef(r *entity.CaseNumberRef) *NumberRef {
 }
 
 // CaseSummary is one item of the portal's response for
-// POST /projects/{id}/cases/search.
-//
-// Deliberately excludes entity-service's InternalID (internal-only
-// identifier), Catalog/CatalogItem (CMDB implementation detail), Conversation,
-// DeployedProduct, AssignedEngineer, ParentCase/RelatedCase — kept minimal for
-// the list view; the full picture is available via GET /cases/{id}.
+// POST /projects/{id}/cases/search — shaped to match the frontend's
+// CaseListItem type (apps/customer-portal/webapp/src/features/support/types/
+// cases.ts) field-for-field, not entity-service's own SearchCaseView. Every
+// enum-valued field (status, severity, issueType, engagementType, type) is
+// an IDLabelRef, not a plain string, and status/severity/issueType/
+// engagementType's .id is a ServiceNow numeric choice-list key the frontend
+// still expects — see case_enum_mapping.go for the translation. Deliberately
+// excludes entity-service's Catalog/CatalogItem (CMDB implementation
+// detail), ParentCase/RelatedCase, Conversation — CaseListItem has no
+// equivalent fields; the full picture is available via GET /cases/{id}.
 type CaseSummary struct {
-	ID             string  `json:"id"`
-	Number         string  `json:"number"`
-	Subject        *string `json:"subject,omitempty"`
-	Description    *string `json:"description,omitempty"`
-	State          string  `json:"state"`
-	Severity       *string `json:"severity,omitempty"`
-	IssueType      *string `json:"issueType,omitempty"`
-	EngagementType *string `json:"engagementType,omitempty"`
-	WorkState      *string `json:"workState,omitempty"`
-	Type           string  `json:"type"`
-	CreatedOn      string  `json:"createdOn"`
-	Project        Ref     `json:"project"`
-	Deployment     *Ref    `json:"deployment,omitempty"`
-	Product        *Ref    `json:"product,omitempty"`
-	AssignedTeam   *Ref    `json:"assignedTeam,omitempty"`
+	ID               string      `json:"id"`
+	InternalID       string      `json:"internalId,omitempty"`
+	Number           string      `json:"number"`
+	Title            *string     `json:"title,omitempty"`
+	Description      *string     `json:"description,omitempty"`
+	AssignedEngineer *IDLabelRef `json:"assignedEngineer,omitempty"`
+	Project          IDLabelRef  `json:"project"`
+	IssueType        *IDLabelRef `json:"issueType,omitempty"`
+	EngagementType   *IDLabelRef `json:"engagementType,omitempty"`
+	DeployedProduct  *IDLabelRef `json:"deployedProduct,omitempty"`
+	Deployment       *IDLabelRef `json:"deployment,omitempty"`
+	Severity         *IDLabelRef `json:"severity,omitempty"`
+	Status           *IDLabelRef `json:"status,omitempty"`
+	Type             *IDLabelRef `json:"type,omitempty"`
+	CaseTypes        *IDLabelRef `json:"caseTypes,omitempty"`
+	CreatedOn        string      `json:"createdOn,omitempty"`
+	UpdatedOn        string      `json:"updatedOn,omitempty"`
+	CreatedBy        string      `json:"createdBy,omitempty"`
 }
 
 // SearchCasesResponse is the portal's response for
-// POST /projects/{id}/cases/search.
+// POST /projects/{id}/cases/search. TotalRecords (not Total) to match the
+// frontend's shared pagination envelope — see PaginationResponse in
+// apps/customer-portal/webapp/src/types/common.ts.
 type SearchCasesResponse struct {
-	Cases  []CaseSummary `json:"cases"`
-	Total  int           `json:"total"`
-	Limit  int           `json:"limit"`
-	Offset int           `json:"offset"`
+	Cases        []CaseSummary `json:"cases"`
+	TotalRecords int           `json:"totalRecords"`
+	Limit        int           `json:"limit"`
+	Offset       int           `json:"offset"`
+}
+
+func entityRefToIDLabel(r *entity.EntityRef) *IDLabelRef {
+	if r == nil {
+		return nil
+	}
+	return &IDLabelRef{ID: r.ID, Label: r.Name}
+}
+
+func assignedEngineerToIDLabel(r *entity.AssignedEngineerRef) *IDLabelRef {
+	if r == nil {
+		return nil
+	}
+	return &IDLabelRef{ID: r.ID, Label: r.Name}
 }
 
 // MapSearchCases builds the portal response from entity-service's SearchCasesResponse.
@@ -88,28 +111,31 @@ func MapSearchCases(r entity.SearchCasesResponse) SearchCasesResponse {
 	cases := make([]CaseSummary, 0, len(r.Cases))
 	for _, c := range r.Cases {
 		cases = append(cases, CaseSummary{
-			ID:             c.ID,
-			Number:         c.Number,
-			Subject:        c.Subject,
-			Description:    c.Description,
-			State:          c.State,
-			Severity:       c.Severity,
-			IssueType:      c.IssueType,
-			EngagementType: c.EngagementType,
-			WorkState:      c.WorkState,
-			Type:           c.Type,
-			CreatedOn:      c.CreatedOn,
-			Project:        Ref{ID: c.Project.ID, Name: c.Project.Name},
-			Deployment:     mapRef(c.Deployment),
-			Product:        mapRef(c.Product),
-			AssignedTeam:   mapRef(c.AssignedTeam),
+			ID:               c.ID,
+			InternalID:       c.InternalID,
+			Number:           c.Number,
+			Title:            c.Subject,
+			Description:      c.Description,
+			AssignedEngineer: assignedEngineerToIDLabel(c.AssignedEngineer),
+			Project:          IDLabelRef{ID: c.Project.ID, Label: c.Project.Name},
+			IssueType:        caseIssueTypeRef(c.IssueType),
+			EngagementType:   caseEngagementTypeRef(c.EngagementType),
+			DeployedProduct:  entityRefToIDLabel(c.DeployedProduct),
+			Deployment:       entityRefToIDLabel(c.Deployment),
+			Severity:         caseSeverityRef(c.Severity),
+			Status:           caseStatusRef(c.State),
+			Type:             caseTypeRef(c.Type),
+			CaseTypes:        caseTypeRef(c.Type),
+			CreatedOn:        c.CreatedOn,
+			UpdatedOn:        c.UpdatedOn,
+			CreatedBy:        c.CreatedBy,
 		})
 	}
 	return SearchCasesResponse{
-		Cases:  cases,
-		Total:  r.Total,
-		Limit:  r.Limit,
-		Offset: r.Offset,
+		Cases:        cases,
+		TotalRecords: r.Total,
+		Limit:        r.Limit,
+		Offset:       r.Offset,
 	}
 }
 
@@ -120,13 +146,17 @@ func MapSearchCases(r entity.SearchCasesResponse) SearchCasesResponse {
 const currentUserFilterPlaceholder = "__current_user_email__"
 
 // CaseSearchFilters holds the optional filter criteria for
-// POST /projects/{id}/cases/search. This is the portal's own request
-// contract, unchanged from before entity-service redesigned its case-search
-// wire format into a generic filter-predicate array (matching what the
-// frontend has always sent) — only the fields the portal currently exposes
-// are included; extend as needed when more filters are surfaced to the
-// frontend. See BuildEntitySearchCasesRequest for the translation into
-// entity-service's current contract.
+// POST /projects/{id}/cases/search — shaped to match the frontend's own
+// CaseSearchFilters type (apps/customer-portal/webapp/src/features/support/
+// types/cases.ts) field-for-field, the same type every case-search call site
+// in the frontend shares. StatusIDs/SeverityIDs/IssueIDs/EngagementTypeKeys
+// carry ServiceNow's numeric choice-list ids (the frontend was built against
+// the old Ballerina backend, which forwarded these ids as-is) — see
+// case_enum_mapping.go for how they're translated into entity-service's own
+// enum vocabulary. CaseTypes needs no translation: entity-service's own
+// "type"+"in" filter already accepts "default_case" as an alias for "case"
+// (case_service.go's caseTypeAliases), and every other case type value is
+// identical between the two.
 //
 // No ProjectIDs field: project scoping comes exclusively from the {id} path
 // parameter (see BuildEntitySearchCasesRequest's projectID parameter), never
@@ -135,20 +165,21 @@ const currentUserFilterPlaceholder = "__current_user_email__"
 // CreatedBy/CreatedByMe had (a body projectIds disagreeing with the path
 // silently returning an empty result instead of erroring or being ignored).
 type CaseSearchFilters struct {
-	Types           []string `json:"types,omitempty"`
-	SearchQuery     string   `json:"searchQuery,omitempty"`
-	DeploymentIDs   []string `json:"deploymentIds,omitempty"`
-	States          []string `json:"states,omitempty"`
-	Severities      []string `json:"severities,omitempty"`
-	IssueTypes      []string `json:"issueTypes,omitempty"`
-	EngagementTypes []string `json:"engagementTypes,omitempty"`
-	CreatedBy       []string `json:"createdBy,omitempty"`
-	CreatedByMe     bool     `json:"createdByMe,omitempty"`
-	WorkStates      []string `json:"workStates,omitempty"`
-	AssignedUserIDs []string `json:"assignedUserIds,omitempty"`
-	ProductNames    []string `json:"productNames,omitempty"`
-	Tags            []string `json:"tags,omitempty"`
-	ParentID        *string  `json:"parentId,omitempty"`
+	SearchQuery        string   `json:"searchQuery,omitempty"`
+	StatusIDs          []int    `json:"statusIds,omitempty"`
+	CaseTypes          []string `json:"caseTypes,omitempty"`
+	SeverityIDs        []int    `json:"severityIds,omitempty"`
+	IssueIDs           []int    `json:"issueIds,omitempty"`
+	DeploymentIDs      []string `json:"deploymentIds,omitempty"`
+	CreatedByMe        bool     `json:"createdByMe,omitempty"`
+	CreatedBy          []string `json:"createdBy,omitempty"`
+	EngagementTypeKeys []int    `json:"engagementTypeKeys,omitempty"`
+	ClosedStartDate    string   `json:"closedStartDate,omitempty"`
+	ClosedEndDate      string   `json:"closedEndDate,omitempty"`
+	StartCreatedDate   string   `json:"startCreatedDate,omitempty"`
+	EndCreatedDate     string   `json:"endCreatedDate,omitempty"`
+	StartUpdatedDate   string   `json:"startUpdatedDate,omitempty"`
+	EndUpdatedDate     string   `json:"endUpdatedDate,omitempty"`
 }
 
 // CaseSearchRequest is the portal's request body for
@@ -162,7 +193,7 @@ type CaseSearchRequest struct {
 // BuildEntitySearchCasesRequest translates the portal's named-filter-field
 // request into entity-service's current generic filter-predicate array
 // contract (see entity.CaseFieldFilter) — every filter the portal exposes
-// becomes one "field in/eq values" entry; SearchQuery, SortBy, and
+// becomes one "field in/eq/gte/lte values" entry; SearchQuery, SortBy, and
 // Pagination pass straight through unchanged. projectID (the {id} path
 // parameter from POST /projects/{id}/cases/search — never the request body)
 // always becomes a projectId+in filter with that single value, scoping every
@@ -183,22 +214,26 @@ func BuildEntitySearchCasesRequest(projectID string, req CaseSearchRequest) enti
 			filters = append(filters, entity.CaseFieldFilter{Field: field, Op: "in", Values: values})
 		}
 	}
-
-	addIn("type", req.Filters.Types)
-	filters = append(filters, entity.CaseFieldFilter{Field: "projectId", Op: "in", Values: []string{projectID}})
-	addIn("deploymentId", req.Filters.DeploymentIDs)
-	addIn("state", req.Filters.States)
-	addIn("severity", req.Filters.Severities)
-	addIn("issueType", req.Filters.IssueTypes)
-	addIn("engagementType", req.Filters.EngagementTypes)
-	addIn("workState", req.Filters.WorkStates)
-	addIn("assignedUserId", req.Filters.AssignedUserIDs)
-	addIn("product", req.Filters.ProductNames)
-	addIn("tag", req.Filters.Tags)
-
-	if req.Filters.ParentID != nil {
-		filters = append(filters, entity.CaseFieldFilter{Field: "parentId", Op: "eq", Values: []string{*req.Filters.ParentID}})
+	addDateRange := func(field, gte, lte string) {
+		if gte != "" {
+			filters = append(filters, entity.CaseFieldFilter{Field: field, Op: "gte", Values: []string{gte}})
+		}
+		if lte != "" {
+			filters = append(filters, entity.CaseFieldFilter{Field: field, Op: "lte", Values: []string{lte}})
+		}
 	}
+
+	filters = append(filters, entity.CaseFieldFilter{Field: "projectId", Op: "in", Values: []string{projectID}})
+	addIn("type", req.Filters.CaseTypes)
+	addIn("state", caseIDsToEnums(req.Filters.StatusIDs, caseStateIDToEnum))
+	addIn("severity", caseIDsToEnums(req.Filters.SeverityIDs, caseSeverityIDToEnum))
+	addIn("issueType", caseIDsToEnums(req.Filters.IssueIDs, caseIssueTypeIDToEnum))
+	addIn("engagementType", caseIDsToEnums(req.Filters.EngagementTypeKeys, caseEngagementTypeIDToEnum))
+	addIn("deploymentId", req.Filters.DeploymentIDs)
+	addDateRange("createdOn", req.Filters.StartCreatedDate, req.Filters.EndCreatedDate)
+	addDateRange("updatedOn", req.Filters.StartUpdatedDate, req.Filters.EndUpdatedDate)
+	addDateRange("closedOn", req.Filters.ClosedStartDate, req.Filters.ClosedEndDate)
+
 	// CreatedByMe takes precedence over CreatedBy: entity-service's filters
 	// array is AND-only (case_filters.go), so a createdBy+in filter and a
 	// createdBy+eq filter together could never both match (barring CreatedBy

--- a/apps/customer-portal/backend-v2/internal/dto/case_enum_mapping.go
+++ b/apps/customer-portal/backend-v2/internal/dto/case_enum_mapping.go
@@ -1,0 +1,253 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dto
+
+import (
+	"strconv"
+	"strings"
+)
+
+// This file mirrors, on the portal side, four numeric-id⇄string-enum
+// mapping tables that live privately inside entity-service
+// (internal/service/sn_case_service.go's snStateIDMap/snSeverityIDMap/
+// snIssueTypeIDMap/snEngagementTypeIDMap and their label-parsing
+// counterparts snCaseStateMap/snSeverityLabelMap/snIssueTypeToEnum). Those
+// ids are ServiceNow's own choice-list keys — stable configuration, not
+// something entity-service computes — so duplicating them here is safe, but
+// if entity-service's copies ever change, this file must be updated too.
+//
+// The frontend (apps/customer-portal/webapp) was built against the old
+// Ballerina backend, which forwarded these exact ServiceNow numeric ids
+// directly. It still sends them today (POST /projects/{id}/cases/search's
+// filters.statusIds/severityIds/issueIds/engagementTypeKeys) and still
+// expects them back on read (CaseListItem's status/severity/issueType/
+// engagementType: IdLabelRef, whose .id these tables populate) — even though
+// cs-tools/entity-service's own contract is plain lowercase-snake-case
+// domain enums (see case_filters.go). This file is the translation layer:
+// caseXxxIDs (enum -> id) builds the .id half of an IdLabelRef from
+// entity-service's response; caseXxxIDToEnum (id -> enum, the reverse) turns
+// the frontend's numeric filter values back into entity-service's own enum
+// vocabulary before they reach BuildEntitySearchCasesRequest.
+
+// caseStateIDs mirrors entity-service's private snStateIDMap.
+var caseStateIDs = map[string]string{
+	"open":              "1",
+	"work_in_progress":  "10",
+	"awaiting_info":     "18",
+	"waiting_on_wso2":   "1003",
+	"reopened":          "1006",
+	"solution_proposed": "6",
+	"closed":            "3",
+}
+
+// caseSeverityIDs mirrors entity-service's private snSeverityIDMap.
+var caseSeverityIDs = map[string]string{
+	"catastrophic": "14",
+	"critical":     "10",
+	"high":         "11",
+	"medium":       "12",
+	"low":          "13",
+}
+
+// caseIssueTypeIDs mirrors entity-service's private snIssueTypeIDMap.
+var caseIssueTypeIDs = map[string]string{
+	"total_outage":            "1",
+	"partial_outage":          "2",
+	"performance_degradation": "3",
+	"question":                "4",
+	"security_or_compliance":  "5",
+	"error":                   "6",
+}
+
+// caseEngagementTypeIDs mirrors entity-service's private snEngagementTypeIDMap.
+var caseEngagementTypeIDs = map[string]string{
+	"migration":               "1",
+	"consultancy":             "2",
+	"new_feature_improvement": "3",
+	"follow_up":               "4",
+	"onboarding":              "5",
+}
+
+func reverseStringMap(m map[string]string) map[string]string {
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		out[v] = k
+	}
+	return out
+}
+
+var (
+	caseStateIDToEnum          = reverseStringMap(caseStateIDs)
+	caseSeverityIDToEnum       = reverseStringMap(caseSeverityIDs)
+	caseIssueTypeIDToEnum      = reverseStringMap(caseIssueTypeIDs)
+	caseEngagementTypeIDToEnum = reverseStringMap(caseEngagementTypeIDs)
+)
+
+// caseStateLabelWords mirrors entity-service's private snCaseStateMap: the
+// full (lowercased) ServiceNow state label, not a scanned word — state
+// labels are short and consistent ("Open", "Work In Progress"), unlike
+// severity labels.
+var caseStateLabelWords = map[string]string{
+	"open":              "open",
+	"work in progress":  "work_in_progress",
+	"waiting on wso2":   "waiting_on_wso2",
+	"awaiting info":     "awaiting_info",
+	"reopened":          "reopened",
+	"solution proposed": "solution_proposed",
+	"closed":            "closed",
+}
+
+// caseSeverityLabelWords mirrors entity-service's private snSeverityLabelMap:
+// a single priority word scanned out of the full label, since severity
+// labels vary in format ("Low (P4)", "2 - High", "3 - Moderate").
+var caseSeverityLabelWords = map[string]string{
+	"catastrophic": "catastrophic",
+	"critical":     "critical",
+	"high":         "high",
+	"moderate":     "medium",
+	"medium":       "medium",
+	"low":          "low",
+}
+
+// caseIDsToEnums converts the frontend's numeric filter ids (statusIds,
+// severityIds, issueIds, engagementTypeKeys) to entity-service's own enum
+// vocabulary via idToEnum, silently skipping any id with no known mapping —
+// consistent with entity-service's own domainStatesToSNIDs/
+// domainSeveritiesToSNIDs/domainIssueTypesToSNIDs, which do the same in the
+// opposite direction.
+func caseIDsToEnums(ids []int, idToEnum map[string]string) []string {
+	out := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if enum, ok := idToEnum[strconv.Itoa(id)]; ok {
+			out = append(out, enum)
+		}
+	}
+	return out
+}
+
+// IDLabelRef is a compact {id, label} reference, matching the frontend's
+// shared IdLabelRef type (apps/customer-portal/webapp/src/types/common.ts) —
+// used only by the case-search response, where entity-service's enum-valued
+// fields (state, severity, issueType, engagementType, type) must round-trip
+// as an id/label pair instead of the plain string entity-service itself
+// returns. Every other dto in this package keeps using Ref{id, name} for
+// entity references; don't reuse this type there.
+type IDLabelRef struct {
+	ID    string `json:"id,omitempty"`
+	Label string `json:"label"`
+}
+
+// caseStatusRef builds the {id, label} the frontend's CaseListItem.status
+// expects from entity-service's plain State label string. entity-service's
+// ServiceNow-backed case search returns the raw SN label directly (e.g.
+// "Work In Progress"), not a normalized enum, so label is used verbatim; id
+// is resolved by matching the full lowercased label against
+// caseStateLabelWords. Falls back to a label-only ref (empty id) for a label
+// this table doesn't recognize, rather than dropping the field entirely —
+// the frontend still renders unrecognized labels, just without a usable id.
+func caseStatusRef(label string) *IDLabelRef {
+	if label == "" {
+		return nil
+	}
+	if enum, ok := caseStateLabelWords[strings.ToLower(strings.TrimSpace(label))]; ok {
+		return &IDLabelRef{ID: caseStateIDs[enum], Label: label}
+	}
+	return &IDLabelRef{Label: label}
+}
+
+// caseSeverityRef mirrors caseStatusRef for severity, scanning label words
+// (see caseSeverityLabelWords) rather than matching the full label, since
+// severity label formats vary.
+func caseSeverityRef(label *string) *IDLabelRef {
+	if label == nil || *label == "" {
+		return nil
+	}
+	for _, word := range strings.Fields(*label) {
+		w := strings.ToLower(strings.Trim(word, "(),"))
+		if enum, ok := caseSeverityLabelWords[w]; ok {
+			return &IDLabelRef{ID: caseSeverityIDs[enum], Label: *label}
+		}
+	}
+	return &IDLabelRef{Label: *label}
+}
+
+// caseIssueTypeRef mirrors caseStatusRef for issue type, matching
+// entity-service's own snIssueTypeToEnum transform (lowercase, spaces to
+// underscores) rather than a lookup table of raw labels.
+func caseIssueTypeRef(label *string) *IDLabelRef {
+	if label == nil || *label == "" {
+		return nil
+	}
+	enum := strings.ToLower(strings.ReplaceAll(*label, " ", "_"))
+	if id, ok := caseIssueTypeIDs[enum]; ok {
+		return &IDLabelRef{ID: id, Label: *label}
+	}
+	return &IDLabelRef{Label: *label}
+}
+
+// caseEngagementTypeRef mirrors caseStatusRef for engagement type.
+// entity-service has no equivalent label-parsing helper for this field (its
+// SN search response passes the raw label straight through, unparsed) — this
+// transform (lowercase, spaces and slashes to underscores) is this backend's
+// own best-effort match against caseEngagementTypeIDs's domain.EngagementType
+// keys, not a mirror of an existing entity-service function.
+func caseEngagementTypeRef(label *string) *IDLabelRef {
+	if label == nil || *label == "" {
+		return nil
+	}
+	enum := strings.ToLower(strings.NewReplacer(" ", "_", "/", "_").Replace(*label))
+	if id, ok := caseEngagementTypeIDs[enum]; ok {
+		return &IDLabelRef{ID: id, Label: *label}
+	}
+	return &IDLabelRef{Label: *label}
+}
+
+// caseTypeLabels supplies portal-facing display text for entity-service's
+// case type domain values — these never come from ServiceNow as a label at
+// all (Type is entity-service's own domain string, e.g. "case",
+// "service_request"), so there's nothing to parse; this is just this
+// backend's own presentation text.
+var caseTypeLabels = map[string]string{
+	"case":                     "Case",
+	"service_request":          "Service Request",
+	"security_report_analysis": "Security Report Analysis",
+	"engagement":               "Engagement",
+	"announcement":             "Announcement",
+}
+
+// caseTypeRef builds the {id, label} the frontend's CaseListItem.type/
+// caseTypes expect. id is entity-service's Type value, EXCEPT "case" is
+// translated to "default_case" — entity-service's own canonical value ties
+// to its Postgres case_type_enum (see case_service.go's caseTypeAliases doc
+// comment), but the frontend's CaseType.DEFAULT_CASE constant (and code that
+// compares type.id against it directly, e.g. support.ts's isSecurityReportCase-
+// style helpers) was built against ServiceNow's raw "default_case" wire
+// value and has no knowledge of "case" at all.
+func caseTypeRef(caseType string) *IDLabelRef {
+	if caseType == "" {
+		return nil
+	}
+	id := caseType
+	if id == "case" {
+		id = "default_case"
+	}
+	label := caseTypeLabels[caseType]
+	if label == "" {
+		label = caseType
+	}
+	return &IDLabelRef{ID: id, Label: label}
+}

--- a/apps/customer-portal/backend-v2/internal/dto/case_test.go
+++ b/apps/customer-portal/backend-v2/internal/dto/case_test.go
@@ -24,29 +24,30 @@ import (
 )
 
 // TestBuildEntitySearchCasesRequest_AllFiltersTranslate guards against
-// reintroducing the bug where this backend sent entity-service's old
-// named-filter-field case-search shape directly instead of building the
-// generic filter-predicate array entity-service's current
+// reintroducing the bug where this backend sent entity-service's own
+// named-filter-field case-search shape (or an invented one) directly instead
+// of building the generic filter-predicate array entity-service's current
 // /cases/search requires (which rejects unknown fields outright) — every
-// filter the portal exposes must produce exactly the CaseFieldFilter entry
+// filter the portal exposes, using the frontend's actual field names and
+// ServiceNow numeric ids, must produce exactly the CaseFieldFilter entry
 // entity-service's case_filters.go expects.
 func TestBuildEntitySearchCasesRequest_AllFiltersTranslate(t *testing.T) {
-	parentID := "parent-id-1"
 	req := CaseSearchRequest{
 		Filters: CaseSearchFilters{
-			Types:           []string{"case", "engagement"},
-			SearchQuery:     "login issue",
-			DeploymentIDs:   []string{"dep-1"},
-			States:          []string{"open"},
-			Severities:      []string{"high"},
-			IssueTypes:      []string{"question"},
-			EngagementTypes: []string{"migration"},
-			CreatedBy:       []string{"user-1"},
-			WorkStates:      []string{"ongoing"},
-			AssignedUserIDs: []string{"eng-1"},
-			ProductNames:    []string{"API Manager"},
-			Tags:            []string{"urgent"},
-			ParentID:        &parentID,
+			SearchQuery:        "login issue",
+			StatusIDs:          []int{1}, // open
+			CaseTypes:          []string{"default_case", "engagement"},
+			SeverityIDs:        []int{11}, // high
+			IssueIDs:           []int{4},  // question
+			DeploymentIDs:      []string{"dep-1"},
+			CreatedBy:          []string{"user-1"},
+			EngagementTypeKeys: []int{1}, // migration
+			StartCreatedDate:   "2026-01-01",
+			EndCreatedDate:     "2026-01-31",
+			StartUpdatedDate:   "2026-02-01",
+			EndUpdatedDate:     "2026-02-28",
+			ClosedStartDate:    "2026-03-01",
+			ClosedEndDate:      "2026-03-31",
 		},
 		SortBy:     entity.CaseSort{Field: "createdOn", Order: "desc"},
 		Pagination: entity.Pagination{Limit: 20, Offset: 0},
@@ -65,22 +66,41 @@ func TestBuildEntitySearchCasesRequest_AllFiltersTranslate(t *testing.T) {
 	}
 
 	want := []entity.CaseFieldFilter{
-		{Field: "type", Op: "in", Values: []string{"case", "engagement"}},
 		{Field: "projectId", Op: "in", Values: []string{"proj-1"}},
-		{Field: "deploymentId", Op: "in", Values: []string{"dep-1"}},
+		{Field: "type", Op: "in", Values: []string{"default_case", "engagement"}},
 		{Field: "state", Op: "in", Values: []string{"open"}},
 		{Field: "severity", Op: "in", Values: []string{"high"}},
 		{Field: "issueType", Op: "in", Values: []string{"question"}},
 		{Field: "engagementType", Op: "in", Values: []string{"migration"}},
-		{Field: "workState", Op: "in", Values: []string{"ongoing"}},
-		{Field: "assignedUserId", Op: "in", Values: []string{"eng-1"}},
-		{Field: "product", Op: "in", Values: []string{"API Manager"}},
-		{Field: "tag", Op: "in", Values: []string{"urgent"}},
-		{Field: "parentId", Op: "eq", Values: []string{"parent-id-1"}},
+		{Field: "deploymentId", Op: "in", Values: []string{"dep-1"}},
+		{Field: "createdOn", Op: "gte", Values: []string{"2026-01-01"}},
+		{Field: "createdOn", Op: "lte", Values: []string{"2026-01-31"}},
+		{Field: "updatedOn", Op: "gte", Values: []string{"2026-02-01"}},
+		{Field: "updatedOn", Op: "lte", Values: []string{"2026-02-28"}},
+		{Field: "closedOn", Op: "gte", Values: []string{"2026-03-01"}},
+		{Field: "closedOn", Op: "lte", Values: []string{"2026-03-31"}},
 		{Field: "createdBy", Op: "in", Values: []string{"user-1"}},
 	}
 	if !reflect.DeepEqual(got.Filters.Filters, want) {
 		t.Fatalf("Filters = %+v,\nwant     %+v", got.Filters.Filters, want)
+	}
+}
+
+// TestBuildEntitySearchCasesRequest_UnrecognizedNumericIDsSkipped verifies an
+// id with no entry in the caseXxxIDToEnum tables is silently dropped rather
+// than sent to entity-service verbatim (which would 400, since entity-service
+// only accepts its own lowercase-snake-case enum values, never a raw
+// ServiceNow numeric id).
+func TestBuildEntitySearchCasesRequest_UnrecognizedNumericIDsSkipped(t *testing.T) {
+	req := CaseSearchRequest{Filters: CaseSearchFilters{StatusIDs: []int{999999}}}
+
+	got := BuildEntitySearchCasesRequest("proj-1", req)
+
+	want := []entity.CaseFieldFilter{
+		{Field: "projectId", Op: "in", Values: []string{"proj-1"}},
+	}
+	if !reflect.DeepEqual(got.Filters.Filters, want) {
+		t.Fatalf("Filters = %+v, want %+v (unrecognized status id must be dropped, not forwarded)", got.Filters.Filters, want)
 	}
 }
 
@@ -142,5 +162,99 @@ func TestBuildEntitySearchCasesRequest_CreatedByMeTakesPrecedenceOverCreatedBy(t
 	}
 	if !reflect.DeepEqual(got.Filters.Filters, want) {
 		t.Fatalf("Filters = %+v, want %+v", got.Filters.Filters, want)
+	}
+}
+
+// TestMapSearchCases_MatchesFrontendCaseListItemShape verifies the full
+// response translation: entity-service's plain-string/label fields become
+// {id, label} refs, title comes from Subject, status comes from State, and
+// TotalRecords (not Total) carries the response's pagination envelope — the
+// exact set of mismatches that left the case list rendering "--" for every
+// column and "0-0 of 0" for pagination despite a successful 200 response.
+func TestMapSearchCases_MatchesFrontendCaseListItemShape(t *testing.T) {
+	assignee := "engineer@example.com"
+	subject := "Login error"
+	description := "Cannot log in"
+	severity := "High (P2)"
+	issueType := "Question"
+
+	r := entity.SearchCasesResponse{
+		Total:  878,
+		Offset: 0,
+		Limit:  5,
+		Cases: []entity.SearchCaseView{
+			{
+				ID:               "case-1",
+				InternalID:       "internal-1",
+				Number:           "CS0440883",
+				CreatedOn:        "2026-07-27 08:39:48",
+				UpdatedOn:        "2026-08-01 10:00:00",
+				CreatedBy:        "customer@example.com",
+				Subject:          &subject,
+				Description:      &description,
+				State:            "Work In Progress",
+				Severity:         &severity,
+				IssueType:        &issueType,
+				Type:             "case",
+				Project:          entity.EntityRef{ID: "proj-1", Name: "Customer Project"},
+				Deployment:       &entity.EntityRef{ID: "dep-1", Name: "Primary Production"},
+				DeployedProduct:  &entity.EntityRef{ID: "dp-1", Name: "WSO2 API Manager 4.5.0"},
+				AssignedEngineer: &entity.AssignedEngineerRef{ID: "eng-1", Name: "Jane Engineer", Email: &assignee},
+			},
+		},
+	}
+
+	got := MapSearchCases(r)
+
+	if got.TotalRecords != 878 {
+		t.Fatalf("TotalRecords = %d, want 878", got.TotalRecords)
+	}
+	if len(got.Cases) != 1 {
+		t.Fatalf("expected 1 case, got %d", len(got.Cases))
+	}
+	c := got.Cases[0]
+
+	if c.Title == nil || *c.Title != "Login error" {
+		t.Fatalf("Title = %v, want \"Login error\" (from entity-service's Subject field)", c.Title)
+	}
+	if c.UpdatedOn != "2026-08-01 10:00:00" {
+		t.Fatalf("UpdatedOn = %q, want the entity-service updatedOn value", c.UpdatedOn)
+	}
+	if c.CreatedBy != "customer@example.com" {
+		t.Fatalf("CreatedBy = %q, want the entity-service createdBy value", c.CreatedBy)
+	}
+	if c.Project.ID != "proj-1" || c.Project.Label != "Customer Project" {
+		t.Fatalf("Project = %+v, want {id: proj-1, label: Customer Project}", c.Project)
+	}
+	if c.Status == nil || c.Status.Label != "Work In Progress" || c.Status.ID != "10" {
+		t.Fatalf("Status = %+v, want {id: 10, label: Work In Progress}", c.Status)
+	}
+	if c.Severity == nil || c.Severity.Label != "High (P2)" || c.Severity.ID != "11" {
+		t.Fatalf("Severity = %+v, want {id: 11, label: High (P2)}", c.Severity)
+	}
+	if c.IssueType == nil || c.IssueType.Label != "Question" || c.IssueType.ID != "4" {
+		t.Fatalf("IssueType = %+v, want {id: 4, label: Question}", c.IssueType)
+	}
+	if c.AssignedEngineer == nil || c.AssignedEngineer.Label != "Jane Engineer" || c.AssignedEngineer.ID != "eng-1" {
+		t.Fatalf("AssignedEngineer = %+v, want {id: eng-1, label: Jane Engineer}", c.AssignedEngineer)
+	}
+	if c.DeployedProduct == nil || c.DeployedProduct.Label != "WSO2 API Manager 4.5.0" {
+		t.Fatalf("DeployedProduct = %+v, want label WSO2 API Manager 4.5.0", c.DeployedProduct)
+	}
+	if c.Deployment == nil || c.Deployment.Label != "Primary Production" {
+		t.Fatalf("Deployment = %+v, want label Primary Production", c.Deployment)
+	}
+	if c.Type == nil || c.Type.ID != "default_case" {
+		t.Fatalf("Type = %+v, want id \"default_case\" (entity-service's canonical \"case\" translated for the frontend's CaseType.DEFAULT_CASE)", c.Type)
+	}
+}
+
+// TestCaseIDsToEnums_UnknownIDsSkipped verifies unrecognized numeric ids
+// don't produce an empty-string enum entry.
+func TestCaseIDsToEnums_UnknownIDsSkipped(t *testing.T) {
+	got := caseIDsToEnums([]int{11, 999}, caseSeverityIDToEnum)
+	want := []string{"high"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("caseIDsToEnums = %+v, want %+v", got, want)
 	}
 }

--- a/apps/customer-portal/backend-v2/internal/entity/types.go
+++ b/apps/customer-portal/backend-v2/internal/entity/types.go
@@ -502,6 +502,7 @@ type SearchCaseView struct {
 	InternalID       string               `json:"internalId"`
 	Number           string               `json:"number"`
 	CreatedOn        string               `json:"createdOn"`
+	UpdatedOn        string               `json:"updatedOn"`
 	CreatedBy        string               `json:"createdBy"`
 	Subject          *string              `json:"subject"`
 	Description      *string              `json:"description"`

--- a/apps/customer-portal/backend-v2/internal/handler/call_requests.go
+++ b/apps/customer-portal/backend-v2/internal/handler/call_requests.go
@@ -48,11 +48,17 @@ func NewCallRequestHandler(entity entityCallRequestClient) *CallRequestHandler {
 	return &CallRequestHandler{entity: entity}
 }
 
-// CreateCallRequest handles POST /call-requests.
+// CreateCallRequest handles POST /cases/{caseId}/call-requests.
 func (h *CallRequestHandler) CreateCallRequest(w http.ResponseWriter, r *http.Request) {
 	user := middleware.UserInfoFromContext(r.Context())
 	if user == nil {
 		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	caseID := r.PathValue("caseId")
+	if caseID == "" || !uuidRe.MatchString(caseID) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
 
@@ -66,7 +72,11 @@ func (h *CallRequestHandler) CreateCallRequest(w http.ResponseWriter, r *http.Re
 		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
 		return
 	}
-	if !uuidRe.MatchString(req.CaseID) || req.Reason == "" || len(req.UTCTimes) == 0 || req.DurationMinutes <= 0 {
+	// CaseID is always forced to the {caseId} path parameter, never a
+	// client-supplied body field — the frontend's request body carries only
+	// reason/utcTimes/durationInMinutes, no caseId at all.
+	req.CaseID = caseID
+	if req.Reason == "" || len(req.UTCTimes) == 0 || req.DurationMinutes <= 0 {
 		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
 		return
 	}
@@ -81,11 +91,17 @@ func (h *CallRequestHandler) CreateCallRequest(w http.ResponseWriter, r *http.Re
 	writeJSONValue(w, http.StatusCreated, dto.MapCallRequestCreate(result))
 }
 
-// SearchCallRequests handles POST /call-requests/search.
+// SearchCallRequests handles POST /cases/{caseId}/call-requests/search.
 func (h *CallRequestHandler) SearchCallRequests(w http.ResponseWriter, r *http.Request) {
 	user := middleware.UserInfoFromContext(r.Context())
 	if user == nil {
 		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	caseID := r.PathValue("caseId")
+	if caseID == "" || !uuidRe.MatchString(caseID) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
 
@@ -99,10 +115,10 @@ func (h *CallRequestHandler) SearchCallRequests(w http.ResponseWriter, r *http.R
 		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
 		return
 	}
-	if !uuidRe.MatchString(req.CaseID) {
-		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
-		return
-	}
+	// CaseID is always forced to the {caseId} path parameter, never a
+	// client-supplied body field — the frontend's request body carries only
+	// filters/pagination, no caseId at all.
+	req.CaseID = caseID
 
 	result, err := h.entity.SearchCallRequests(r.Context(), req)
 	if err != nil {
@@ -114,7 +130,10 @@ func (h *CallRequestHandler) SearchCallRequests(w http.ResponseWriter, r *http.R
 	writeJSONValue(w, http.StatusOK, dto.MapSearchCallRequests(result))
 }
 
-// PatchCallRequest handles PATCH /call-requests/{id}.
+// PatchCallRequest handles PATCH /cases/{caseId}/call-requests/{id}. caseId
+// is part of the URL only for RESTful nesting — entity-service's
+// UpdateCallRequest is keyed on the call request's own id alone, so caseId
+// is never read here.
 func (h *CallRequestHandler) PatchCallRequest(w http.ResponseWriter, r *http.Request) {
 	user := middleware.UserInfoFromContext(r.Context())
 	if user == nil {

--- a/apps/customer-portal/backend-v2/internal/handler/call_requests.go
+++ b/apps/customer-portal/backend-v2/internal/handler/call_requests.go
@@ -110,17 +110,13 @@ func (h *CallRequestHandler) SearchCallRequests(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	var req entity.SearchCallRequestsRequest
+	var req dto.CallRequestSearchRequest
 	if err := json.Unmarshal(body, &req); err != nil {
 		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
 		return
 	}
-	// CaseID is always forced to the {caseId} path parameter, never a
-	// client-supplied body field — the frontend's request body carries only
-	// filters/pagination, no caseId at all.
-	req.CaseID = caseID
 
-	result, err := h.entity.SearchCallRequests(r.Context(), req)
+	result, err := h.entity.SearchCallRequests(r.Context(), dto.BuildEntitySearchCallRequestsRequest(caseID, req))
 	if err != nil {
 		slog.ErrorContext(r.Context(), "entity SearchCallRequests failed", "userID", user.UserID, "err", summarizeErr(err))
 		mapUpstreamError(w, err, "Failed to search call requests.")
@@ -157,7 +153,7 @@ func (h *CallRequestHandler) PatchCallRequest(w http.ResponseWriter, r *http.Req
 		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
 		return
 	}
-	if req.State == "" {
+	if req.StateKey == 0 {
 		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
 		return
 	}

--- a/apps/customer-portal/backend-v2/internal/handler/case_attachments_call_requests_test.go
+++ b/apps/customer-portal/backend-v2/internal/handler/case_attachments_call_requests_test.go
@@ -1,0 +1,193 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+)
+
+const testCaseID = "22222222-2222-2222-2222-222222222222"
+
+func (f *fakeEntityCaseClient) SearchAttachments(ctx context.Context, req entity.SearchAttachmentsRequest) (entity.SearchAttachmentsResponse, error) {
+	f.gotSearchAttachmentsReq = req
+	return entity.SearchAttachmentsResponse{Total: 3}, nil
+}
+
+// TestSearchCaseAttachments_RouteAndQueryParams is an end-to-end check,
+// through a real http.ServeMux registered with the exact pattern main.go
+// uses ("GET /cases/{id}/attachments"), that the {id} path value and the
+// limit/offset query params reach entity-service correctly, and that the
+// response uses totalRecords — the frontend's
+// apps/customer-portal/webapp/src/types/common.ts PaginationResponse field
+// name, not entity-service's own "total".
+func TestSearchCaseAttachments_RouteAndQueryParams(t *testing.T) {
+	fake := &fakeEntityCaseClient{}
+	h := NewCaseHandler(fake)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /cases/{id}/attachments", h.SearchCaseAttachments)
+
+	req := authedRequest(http.MethodGet, "/cases/"+testCaseID+"/attachments?limit=10&offset=5", "")
+	rec := httptest.NewRecorder()
+
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	want := entity.SearchAttachmentsRequest{
+		ReferenceID:   testCaseID,
+		ReferenceType: entity.ReferenceTypeCase,
+		Pagination:    entity.Pagination{Limit: 10, Offset: 5},
+	}
+	if fake.gotSearchAttachmentsReq != want {
+		t.Fatalf("entity-service SearchAttachments request = %+v, want %+v", fake.gotSearchAttachmentsReq, want)
+	}
+
+	var body struct {
+		TotalRecords int `json:"totalRecords"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.TotalRecords != 3 {
+		t.Fatalf("totalRecords = %d, want 3 (response must use totalRecords, not total)", body.TotalRecords)
+	}
+}
+
+// fakeEntityCallRequestClient records the requests it was called with.
+// entityCallRequestClient is embedded (nil) so only the methods under test
+// need implementing.
+type fakeEntityCallRequestClient struct {
+	entityCallRequestClient
+	gotCreateReq entity.CreateCallRequestRequest
+	gotSearchReq entity.SearchCallRequestsRequest
+}
+
+func (f *fakeEntityCallRequestClient) CreateCallRequest(ctx context.Context, req entity.CreateCallRequestRequest) (entity.CreateCallRequestResponse, error) {
+	f.gotCreateReq = req
+	return entity.CreateCallRequestResponse{}, nil
+}
+
+func (f *fakeEntityCallRequestClient) SearchCallRequests(ctx context.Context, req entity.SearchCallRequestsRequest) (entity.SearchCallRequestsResponse, error) {
+	f.gotSearchReq = req
+	return entity.SearchCallRequestsResponse{Total: 7}, nil
+}
+
+func (f *fakeEntityCallRequestClient) UpdateCallRequest(ctx context.Context, id string, req entity.UpdateCallRequestRequest) (entity.UpdateCallRequestResponse, error) {
+	return entity.UpdateCallRequestResponse{CallRequest: entity.CallRequestUpdated{ID: id}}, nil
+}
+
+// TestCreateCallRequest_CaseIDFromPath verifies POST /cases/{caseId}/call-requests
+// forces CaseID from the path — the frontend's request body carries only
+// reason/utcTimes/durationInMinutes, never a caseId field.
+func TestCreateCallRequest_CaseIDFromPath(t *testing.T) {
+	fake := &fakeEntityCallRequestClient{}
+	h := NewCallRequestHandler(fake)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /cases/{caseId}/call-requests", h.CreateCallRequest)
+
+	req := authedRequest(http.MethodPost, "/cases/"+testCaseID+"/call-requests",
+		`{"reason":"discuss migration","utcTimes":["2026-08-10T10:00:00Z"],"durationInMinutes":30}`)
+	rec := httptest.NewRecorder()
+
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if fake.gotCreateReq.CaseID != testCaseID {
+		t.Fatalf("CaseID = %q, want %q", fake.gotCreateReq.CaseID, testCaseID)
+	}
+}
+
+// TestSearchCallRequests_CaseIDFromPath verifies
+// POST /cases/{caseId}/call-requests/search forces CaseID from the path
+// rather than requiring (or trusting) it in the body, and that the response
+// uses totalRecords for pagination.
+func TestSearchCallRequests_CaseIDFromPath(t *testing.T) {
+	fake := &fakeEntityCallRequestClient{}
+	h := NewCallRequestHandler(fake)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /cases/{caseId}/call-requests/search", h.SearchCallRequests)
+
+	req := authedRequest(http.MethodPost, "/cases/"+testCaseID+"/call-requests/search",
+		`{"pagination":{"limit":10,"offset":0}}`)
+	rec := httptest.NewRecorder()
+
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if fake.gotSearchReq.CaseID != testCaseID {
+		t.Fatalf("CaseID = %q, want %q", fake.gotSearchReq.CaseID, testCaseID)
+	}
+
+	var body struct {
+		TotalRecords int `json:"totalRecords"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.TotalRecords != 7 {
+		t.Fatalf("totalRecords = %d, want 7 (response must use totalRecords, not total)", body.TotalRecords)
+	}
+}
+
+// TestPatchCallRequest_ExtraCaseIDPathSegmentDoesNotBreakRouting verifies
+// PATCH /cases/{caseId}/call-requests/{id} still resolves {id} correctly now
+// that the pattern has an extra leading {caseId} segment for RESTful
+// nesting — caseId itself is never read by the handler, since
+// entity-service's UpdateCallRequest is keyed on the call request's own id.
+func TestPatchCallRequest_ExtraCaseIDPathSegmentDoesNotBreakRouting(t *testing.T) {
+	fake := &fakeEntityCallRequestClient{}
+	h := NewCallRequestHandler(fake)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("PATCH /cases/{caseId}/call-requests/{id}", h.PatchCallRequest)
+
+	callRequestID := "33333333-3333-3333-3333-333333333333"
+	req := authedRequest(http.MethodPatch, "/cases/"+testCaseID+"/call-requests/"+callRequestID,
+		`{"state":"canceled"}`)
+	rec := httptest.NewRecorder()
+
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var body struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.ID != callRequestID {
+		t.Fatalf("id = %q, want %q (the {id} segment, not {caseId})", body.ID, callRequestID)
+	}
+}

--- a/apps/customer-portal/backend-v2/internal/handler/case_attachments_call_requests_test.go
+++ b/apps/customer-portal/backend-v2/internal/handler/case_attachments_call_requests_test.go
@@ -172,7 +172,7 @@ func TestPatchCallRequest_ExtraCaseIDPathSegmentDoesNotBreakRouting(t *testing.T
 
 	callRequestID := "33333333-3333-3333-3333-333333333333"
 	req := authedRequest(http.MethodPatch, "/cases/"+testCaseID+"/call-requests/"+callRequestID,
-		`{"state":"canceled"}`)
+		`{"stateKey":6}`)
 	rec := httptest.NewRecorder()
 
 	mux.ServeHTTP(rec, req)

--- a/apps/customer-portal/backend-v2/internal/handler/cases.go
+++ b/apps/customer-portal/backend-v2/internal/handler/cases.go
@@ -40,6 +40,7 @@ type entityCaseClient interface {
 	UpdateAttachment(ctx context.Context, id string, req entity.UpdateAttachmentRequest) (entity.UpdateAttachmentResponse, error)
 	CreateEscalation(ctx context.Context, req entity.CreateEscalationRequest) (entity.CreateEscalationResponse, error)
 	SearchEscalations(ctx context.Context, req entity.SearchEscalationsRequest) (entity.SearchEscalationsResponse, error)
+	SearchAttachments(ctx context.Context, req entity.SearchAttachmentsRequest) (entity.SearchAttachmentsResponse, error)
 }
 
 // CaseHandler handles HTTP requests for case operations.
@@ -85,6 +86,39 @@ func (h *CaseHandler) SearchCases(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSONValue(w, http.StatusOK, dto.MapSearchCases(result))
+}
+
+// SearchCaseAttachments handles GET /cases/{id}/attachments?limit=&offset=.
+func (h *CaseHandler) SearchCaseAttachments(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	id := r.PathValue("id")
+	if id == "" || !uuidRe.MatchString(id) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	limit, offset, ok := parseLimitOffset(w, r)
+	if !ok {
+		return
+	}
+
+	result, err := h.entity.SearchAttachments(r.Context(), entity.SearchAttachmentsRequest{
+		ReferenceID:   id,
+		ReferenceType: entity.ReferenceTypeCase,
+		Pagination:    entity.Pagination{Limit: limit, Offset: offset},
+	})
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity SearchAttachments failed", "userID", user.UserID, "caseID", id, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to retrieve case attachments.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusOK, dto.MapCaseAttachments(result))
 }
 
 // GetCase handles GET /cases/{id}.

--- a/apps/customer-portal/backend-v2/internal/handler/project_scoped_search_test.go
+++ b/apps/customer-portal/backend-v2/internal/handler/project_scoped_search_test.go
@@ -36,7 +36,8 @@ const testProjectID = "11111111-1111-1111-1111-111111111111"
 // never call one.
 type fakeEntityCaseClient struct {
 	entityCaseClient
-	gotSearchCasesReq entity.SearchCasesRequest
+	gotSearchCasesReq       entity.SearchCasesRequest
+	gotSearchAttachmentsReq entity.SearchAttachmentsRequest
 }
 
 func (f *fakeEntityCaseClient) SearchCases(ctx context.Context, req entity.SearchCasesRequest) (entity.SearchCasesResponse, error) {

--- a/apps/customer-portal/backend-v2/openapi.yaml
+++ b/apps/customer-portal/backend-v2/openapi.yaml
@@ -2076,11 +2076,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
-  /call-requests:
+  /cases/{caseId}/call-requests:
     post:
-      summary: Create a call request.
+      summary: Create a call request for a case.
       description: Only entity-service's ServiceNow data source supports this route.
-      operationId: postCallRequests
+      operationId: postCasesCaseIdCallRequests
+      parameters:
+        - name: caseId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -2125,13 +2132,21 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
-  /call-requests/search:
+  /cases/{caseId}/call-requests/search:
     post:
-      summary: Search call requests.
+      summary: Search a case's call requests.
       description: >
-        Scoped by caseId in the request body (not a path segment). Only
-        entity-service's ServiceNow data source supports this route.
-      operationId: postCallRequestsSearch
+        caseId is set server-side from the path parameter — the request body
+        carries only filters/pagination. Only entity-service's ServiceNow
+        data source supports this route.
+      operationId: postCasesCaseIdCallRequestsSearch
+      parameters:
+        - name: caseId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -2176,7 +2191,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
-  /call-requests/{id}:
+  /cases/{caseId}/call-requests/{id}:
     patch:
       summary: Update a call request.
       description: >
@@ -2184,9 +2199,16 @@ paths:
         plan, attendees, actionItems, actualDurationMin) are read-only for
         the customer and not accepted here — see CallRequestSummary for
         viewing them. Only entity-service's ServiceNow data source supports
-        this route.
-      operationId: patchCallRequestsId
+        this route. caseId is part of the URL only for RESTful nesting — the
+        call request is looked up by id alone.
+      operationId: patchCasesCaseIdCallRequestsId
       parameters:
+        - name: caseId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
         - name: id
           in: path
           required: true
@@ -3542,6 +3564,61 @@ paths:
                 $ref: '#/components/schemas/ErrorPayload'
         "413":
           description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /cases/{id}/attachments:
+    get:
+      summary: Search a case's attachments.
+      operationId: getCasesIdAttachments
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 20
+        - name: offset
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 0
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CaseAttachmentsResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
           content:
             application/json:
               schema:
@@ -6611,6 +6688,24 @@ components:
         hasMore:
           type: boolean
 
+    CaseAttachmentsResponse:
+      description: >
+        totalRecords (not total) to match the frontend's shared pagination
+        envelope — see PaginationResponse in
+        apps/customer-portal/webapp/src/types/common.ts.
+      type: object
+      properties:
+        attachments:
+          type: array
+          items:
+            $ref: '#/components/schemas/AttachmentSummary'
+        offset:
+          type: integer
+        limit:
+          type: integer
+        totalRecords:
+          type: integer
+
     DeleteResponse:
       type: object
       properties:
@@ -7630,12 +7725,10 @@ components:
     # ---- call requests ----
 
     CreateCallRequestRequest:
+      description: caseId is not part of this body — it's set server-side from the {caseId} path parameter.
       type: object
-      required: [caseId, reason, utcTimes, durationInMinutes]
+      required: [reason, utcTimes, durationInMinutes]
       properties:
-        caseId:
-          type: string
-          format: uuid
         reason:
           type: string
         utcTimes:
@@ -7656,12 +7749,9 @@ components:
           type: string
 
     SearchCallRequestsRequest:
+      description: caseId is not part of this body — it's set server-side from the {caseId} path parameter.
       type: object
-      required: [caseId]
       properties:
-        caseId:
-          type: string
-          format: uuid
         filters:
           type: object
           properties:
@@ -7737,13 +7827,17 @@ components:
           type: integer
 
     SearchCallRequestsResponse:
+      description: >
+        totalRecords (not total) to match the frontend's shared pagination
+        envelope — see PaginationResponse in
+        apps/customer-portal/webapp/src/types/common.ts.
       type: object
       properties:
         callRequests:
           type: array
           items:
             $ref: '#/components/schemas/CallRequestSummary'
-        total:
+        totalRecords:
           type: integer
         offset:
           type: integer

--- a/apps/customer-portal/backend-v2/openapi.yaml
+++ b/apps/customer-portal/backend-v2/openapi.yaml
@@ -6031,6 +6031,13 @@ components:
     # ---- cases ----
 
     SearchCasesRequest:
+      description: >
+        filters uses the frontend's own field names and ServiceNow numeric
+        choice-list ids (statusIds/severityIds/issueIds/engagementTypeKeys),
+        not entity-service's own lowercase-snake-case string enums — this
+        backend translates between the two (see case_enum_mapping.go). There
+        is no projectIds filter: project scope comes exclusively from the
+        {id} path parameter.
       type: object
       properties:
         pagination:
@@ -6045,99 +6052,116 @@ components:
         filters:
           type: object
           properties:
-            types:
-              type: array
-              items:
-                type: string
             searchQuery:
               type: string
+            statusIds:
+              type: array
+              items:
+                type: integer
+            caseTypes:
+              type: array
+              items:
+                type: string
+            severityIds:
+              type: array
+              items:
+                type: integer
+            issueIds:
+              type: array
+              items:
+                type: integer
             deploymentIds:
-              type: array
-              items:
-                type: string
-            states:
-              type: array
-              items:
-                type: string
-            severities:
-              type: array
-              items:
-                type: string
-            issueTypes:
-              type: array
-              items:
-                type: string
-            engagementTypes:
-              type: array
-              items:
-                type: string
-            createdBy:
               type: array
               items:
                 type: string
             createdByMe:
               type: boolean
-            workStates:
+            createdBy:
               type: array
               items:
                 type: string
-            assignedUserIds:
+            engagementTypeKeys:
               type: array
               items:
-                type: string
-            productNames:
-              type: array
-              items:
-                type: string
-            tags:
-              type: array
-              items:
-                type: string
-            parentId:
+                type: integer
+            closedStartDate:
               type: string
+            closedEndDate:
+              type: string
+            startCreatedDate:
+              type: string
+            endCreatedDate:
+              type: string
+            startUpdatedDate:
+              type: string
+            endUpdatedDate:
+              type: string
+
+    IdLabelRef:
+      description: >
+        {id, label} pair. For case-search enum fields (status/severity/
+        issueType/engagementType/type), id is a ServiceNow numeric
+        choice-list key (as a string) matching what the frontend's
+        CaseType/statusIds/etc already use — see case_enum_mapping.go.
+      type: object
+      properties:
+        id:
+          type: string
+        label:
+          type: string
 
     CaseSummary:
       type: object
       properties:
         id:
           type: string
+        internalId:
+          type: string
         number:
           type: string
-        subject:
+        title:
           type: string
         description:
           type: string
-        state:
-          type: string
-        severity:
-          type: string
+        assignedEngineer:
+          $ref: '#/components/schemas/IdLabelRef'
+        project:
+          $ref: '#/components/schemas/IdLabelRef'
         issueType:
-          type: string
+          $ref: '#/components/schemas/IdLabelRef'
         engagementType:
-          type: string
-        workState:
-          type: string
+          $ref: '#/components/schemas/IdLabelRef'
+        deployedProduct:
+          $ref: '#/components/schemas/IdLabelRef'
+        deployment:
+          $ref: '#/components/schemas/IdLabelRef'
+        severity:
+          $ref: '#/components/schemas/IdLabelRef'
+        status:
+          $ref: '#/components/schemas/IdLabelRef'
         type:
-          type: string
+          $ref: '#/components/schemas/IdLabelRef'
+        caseTypes:
+          $ref: '#/components/schemas/IdLabelRef'
         createdOn:
           type: string
-        project:
-          $ref: '#/components/schemas/Ref'
-        deployment:
-          $ref: '#/components/schemas/Ref'
-        product:
-          $ref: '#/components/schemas/Ref'
-        assignedTeam:
-          $ref: '#/components/schemas/Ref'
+        updatedOn:
+          type: string
+        createdBy:
+          type: string
 
     SearchCasesResponse:
+      description: >
+        totalRecords (not total) to match the frontend's shared pagination
+        envelope — see PaginationResponse in
+        apps/customer-portal/webapp/src/types/common.ts.
       type: object
       properties:
         cases:
           type: array
           items:
             $ref: '#/components/schemas/CaseSummary'
-        total:
+        totalRecords:
           type: integer
         limit:
           type: integer
@@ -7749,16 +7773,21 @@ components:
           type: string
 
     SearchCallRequestsRequest:
-      description: caseId is not part of this body — it's set server-side from the {caseId} path parameter.
+      description: >
+        caseId is not part of this body — it's set server-side from the
+        {caseId} path parameter. filters.stateKeys carries ServiceNow's own
+        numeric choice-list keys (the frontend was built against the old
+        Ballerina backend and still sends these, not entity-service's own
+        string enum) — see callRequestStateKeyToEnum for the translation.
       type: object
       properties:
         filters:
           type: object
           properties:
-            states:
+            stateKeys:
               type: array
               items:
-                type: string
+                type: integer
         pagination:
           $ref: '#/components/schemas/Pagination'
 
@@ -7848,12 +7877,17 @@ components:
       description: >
         Agent-side fields (meetingDate, assignee, notes, plan, attendees,
         actionItems, actualDurationMin) are read-only for the customer and
-        not accepted here.
+        not accepted here. stateKey carries ServiceNow's own numeric
+        choice-list key (the frontend was built against the old Ballerina
+        backend and still sends this, not entity-service's own string enum)
+        — see callRequestStateKeyToEnum for the translation. reason is also
+        not accepted: entity-service's UpdateCallRequestRequest has no
+        equivalent field to forward it to.
       type: object
-      required: [state]
+      required: [stateKey]
       properties:
-        state:
-          type: string
+        stateKey:
+          type: integer
         cancellationReason:
           type: string
         utcTimes:


### PR DESCRIPTION
## Summary

- `GET /cases/{id}/attachments?limit=&offset=` didn't exist at all — the frontend calls it directly (`apps/customer-portal/webapp`'s `useGetCaseAttachments.ts`), but this backend only had a generic `POST /attachments/search`. Added the dedicated route, backed by the same `entity-service` `SearchAttachments` call scoped to `referenceType=case`.
- All three call-request routes were registered flat with `caseId` expected in the body (`POST /call-requests`, `POST /call-requests/search`, `PATCH /call-requests/{id}`), but the frontend calls all three nested under `/cases/{caseId}/call-requests` — every request was either 404ing, or (for search) relying on a `caseId` body field the frontend never actually sends. Moved all three under `/cases/{caseId}/call-requests...`, with `caseId` always derived from the path.

## Field-shape translation (the deeper fix)

Getting the routes reachable wasn't enough — `apps/customer-portal/webapp` was built against the old Ballerina backend and still sends/expects **ServiceNow's raw numeric choice-list ids and `{id, label}` pairs**, not `cs-tools/entity-service`'s plain lowercase-snake-case string enums. Concretely, every case-search request's filters (`statusIds`, `severityIds`, `issueIds`, `caseTypes`, `engagementTypeKeys`) were being silently ignored as unknown JSON fields, and every response field the case list actually renders (`title`, `status`, `severity`, `issueType`, `assignedEngineer`, `deployedProduct`, `updatedOn`, `createdBy`, `totalRecords`) was either named differently or shaped differently — so the UI rendered `--` for every column and `0-0 of 0` for pagination despite a successful 200 response.

- Added `internal/dto/case_enum_mapping.go` and `call_request_enum_mapping.go` — this backend's own copies of entity-service's *private* numeric-id⇄enum tables (`snStateIDMap`/`snSeverityIDMap`/`snIssueTypeIDMap`/`snEngagementTypeIDMap`/`callRequestKeyToState` in `sn_case_service.go`/`sn_call_request_service.go` — ServiceNow's own stable choice-list configuration, safe to duplicate) plus label-parsing helpers that translate both directions: numeric filter ids → entity-service's enums on requests, entity-service's plain-string labels → `{id, label}` on responses.
- `CaseSearchFilters` and `CallRequestUpdateRequest`/`CallRequestSearchFilters` rewritten to match the frontend's actual field names exactly, dropping the previously-invented field names (`types`, `states`, `severities`, etc.) no real caller ever sent.
- `CaseSummary` rewritten to match the frontend's `CaseListItem` field-for-field.
- `entity.SearchCaseView` gained `UpdatedOn` — entity-service's own response already carries it, this backend's mirror struct was just missing it.
- Both new/changed responses (case attachments, call-request search) use `totalRecords` instead of this backend's more common `total`, matching the frontend's exact `PaginationResponse` field name — documented in `CLAUDE.md` as a deliberate per-endpoint exception.
- One deliberate, unfixable gap: the frontend's `PatchCallRequest` carries an optional `reason` field with no equivalent on entity-service's `UpdateCallRequestRequest` — no code path to forward it to, so it's dropped rather than worked around.
- `openapi.yaml`, `README.md`, `CLAUDE.md` updated to match.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` all clean
- [x] `go test ./...` passes, including end-to-end route tests and new dto-level tests covering every numeric-id⇄enum translation direction (request and response, recognized and unrecognized ids)
- [x] `gosec -fmt=text ./...` reports 0 issues
- [x] Verified `openapi.yaml` is valid YAML with no duplicate path/schema keys
- [x] Verified all 101 registered route patterns still register on a real `http.ServeMux` with no ambiguity panic

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added paginated case attachment search.
  * Expanded case search with numeric status, severity, issue, engagement, case-type, and date-range filters.
  * Case results now include richer fields, labeled references, updated timestamps, and `totalRecords` pagination totals.
* **Changes**
  * Moved call-request operations under case-specific routes.
  * Call-request state inputs now use numeric state keys.
  * Call-request and case-search responses use `totalRecords` for pagination consistency.
* **Documentation**
  * Updated API documentation and examples for revised routes, filters, request fields, and response formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->