### PR TITLE
[Customer Portal][Webapp] Show "Not Available" instead of a misleading "Portal User" badge for users with no role

### DIFF
--- a/apps/customer-portal/webapp/src/features/settings/components/SettingsUserManagement.tsx
+++ b/apps/customer-portal/webapp/src/features/settings/components/SettingsUserManagement.tsx
@@ -346,17 +346,26 @@ export default function SettingsUserManagement({
                   </TableCell>
                   <TableCell>
                     <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5 }}>
-                      {getRoleBadges(contact).map((badge) => (
-                        <Chip
-                          key={badge.label}
-                          size="small"
-                          icon={<badge.Icon size={12} />}
-                          label={badge.label}
-                          variant="outlined"
-                          color={badge.chipColor}
-                          sx={getRoleChipSx(badge.chipColor)}
-                        />
-                      ))}
+                      {getRoleBadges(contact).map((badge) => {
+                        const chip = (
+                          <Chip
+                            key={badge.label}
+                            size="small"
+                            icon={<badge.Icon size={12} />}
+                            label={badge.label}
+                            variant="outlined"
+                            color={badge.chipColor}
+                            sx={getRoleChipSx(badge.chipColor)}
+                          />
+                        );
+                        return badge.tooltip ? (
+                          <Tooltip key={badge.label} title={badge.tooltip}>
+                            <span>{chip}</span>
+                          </Tooltip>
+                        ) : (
+                          chip
+                        );
+                      })}
                     </Box>
                   </TableCell>
                   <TableCell>

--- a/apps/customer-portal/webapp/src/features/settings/types/settings.ts
+++ b/apps/customer-portal/webapp/src/features/settings/types/settings.ts
@@ -73,6 +73,8 @@ export type SettingsRoleBadge = {
   label: string;
   Icon: ComponentType<{ size?: number }>;
   chipColor: "primary" | "info" | "error" | "default" | "warning";
+  /** Tooltip shown on hover, e.g. to explain a "Not Available" role. */
+  tooltip?: string;
 };
 
 export type SettingsUserManagementProps = {

--- a/apps/customer-portal/webapp/src/features/settings/utils/settings.ts
+++ b/apps/customer-portal/webapp/src/features/settings/utils/settings.ts
@@ -15,7 +15,15 @@
 // under the License.
 
 import { colors } from "@wso2/oxygen-ui";
-import { Code, Crown, Monitor, Shield, Star, Users } from "@wso2/oxygen-ui-icons-react";
+import {
+  Code,
+  Crown,
+  Monitor,
+  Shield,
+  ShieldOff,
+  Star,
+  Users,
+} from "@wso2/oxygen-ui-icons-react";
 import {
   NULL_PLACEHOLDER,
   SETTINGS_AVATAR_BACKGROUND_COLORS,
@@ -50,7 +58,13 @@ export function getRoleBadges(contact: ProjectContact): SettingsRoleBadge[] {
       badges.push({ label: "Security User", Icon: Shield, chipColor: "error" });
     }
     if (!contact.isPortalUser && !contact.isSecurityContact) {
-      badges.push({ label: "Portal User", Icon: Monitor, chipColor: "default" });
+      badges.push({
+        label: "Not Available",
+        Icon: ShieldOff,
+        chipColor: "default",
+        tooltip:
+          "Please contact your customer admin or account manager to enable the required role(s).",
+      });
     }
   }
 


### PR DESCRIPTION
## Fix

- The no-role fallback now renders a distinct **"Not Available"** badge with a `ShieldOff` icon.
- Added an optional `tooltip` field to `SettingsRoleBadge` and wired it up in `SettingsUserManagement.tsx` so the badge shows: "Please contact your customer administrator or account manager to enable the required role(s)."

## Changes

- `features/settings/utils/settings.ts` — fallback badge relabeled to "Not Available" with tooltip text
- `features/settings/types/settings.ts` — added `tooltip?: string` to `SettingsRoleBadge`
- `features/settings/components/SettingsUserManagement.tsx` — wraps the chip in a `Tooltip` when `badge.tooltip` is set

## Test plan

- [ ] View a contact with no role flags set — confirm "Not Available" chip renders with hover tooltip
- [ ] View a contact with `isPortalUser: true` — confirm "Portal User" badge still renders correctly
- [ ] View a contact with `isSecurityContact: true` — confirm "Security User" badge still renders correctly
- [ ] Typecheck passes
