### PR TITLE
[CSM Portal Microapp] Fix case time cards to scope by caseId and show properly styled entries

### DIFF
--- a/apps/csm-portal/microapp/src/components/case-detail/TimeTrackingTab.tsx
+++ b/apps/csm-portal/microapp/src/components/case-detail/TimeTrackingTab.tsx
@@ -14,11 +14,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Box, Button, Divider, Skeleton, Stack, Typography } from "@wso2/oxygen-ui";
 import { Plus } from "@wso2/oxygen-ui-icons-react";
-import { useNavigate } from "react-router-dom";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
 import { timecards } from "@src/services/timecards";
 import type { CaseSeverity, CreateTimeCardInput, CsmTimeCard } from "@src/types";
 import { cardDateLabel, formatMinutes } from "@utils/timecard";
@@ -33,41 +32,69 @@ interface TimeTrackingTabProps {
   projectName: string;
 }
 
+// A bordered, tinted box per entry — mirrors the webapp's CaseTimeCardsPanel row
+// (border + rounded corners) and this app's own TimeSheetCard's inner
+// TimeCardRow (same treatment, plus the `action.hover` tint), so a logged card
+// reads as a distinct entry instead of a bare line of text in the list.
 function TimeCardRow({ card }: { card: CsmTimeCard }) {
   return (
-    <Stack direction="row" alignItems="center" justifyContent="space-between" gap={1}>
-      <Typography variant="body2" noWrap sx={{ minWidth: 0 }}>
-        {card.userName}
-      </Typography>
-      <Stack alignItems="flex-end" gap={0.5} flexShrink={0}>
-        <TimeCardStateChip state={card.state} />
-        <Typography variant="caption" color="text.secondary">
-          {cardDateLabel(card.createdOn)} · {formatMinutes(card.totalMinutes)}
-          {card.billable ? "" : " · Non-billable"}
+    <Stack
+      gap={0.5}
+      sx={{ p: 1.25, bgcolor: "action.hover", border: "1px solid", borderColor: "divider", borderRadius: 1 }}
+    >
+      <Stack direction="row" alignItems="center" justifyContent="space-between" gap={1}>
+        <Typography variant="body2" noWrap sx={{ minWidth: 0 }}>
+          {card.userName}
         </Typography>
+        <Stack direction="row" alignItems="center" gap={1} flexShrink={0}>
+          <Typography variant="body2">{formatMinutes(card.totalMinutes)}</Typography>
+          <TimeCardStateChip state={card.state} />
+        </Stack>
       </Stack>
+      <Typography variant="caption" color="text.secondary">
+        {card.billable ? "Billable" : "Non-billable"} · {cardDateLabel(card.createdOn)}
+      </Typography>
     </Stack>
   );
 }
 
 /**
- * `caseId` is confirmed non-functional live as a `/time-cards/search` filter (see
- * services/timecards.ts's fetchCaseTimeCards), so this list is scoped to the case's
- * project server-side and filtered to the case client-side, same workaround the
- * webapp's CaseTimeCardsPanel uses. Only the first page of the project's cards is
- * fetched — a single case logging more than a page's worth of time isn't expected —
- * so a truncated notice covers the rare case where it does.
+ * Scoped server-side by `filters.caseId` (see services/timecards.ts's `forCase`
+ * and BeSearchTimeCardsFilters.caseId's comment on the backend fix this relies
+ * on), paged the same way the "Time cards" > All tab is — an IntersectionObserver
+ * sentinel fetches the next page as it scrolls into view — for the rare case
+ * whose entries outnumber one page. There's no separate "Open Time Cards" entry
+ * point to leave for any of the case's own cards, since this tab shows all of
+ * them.
  */
 export function TimeTrackingTab({ caseId, caseNumber, caseSeverity, projectId, projectName }: TimeTrackingTabProps) {
-  const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [logTimeOpen, setLogTimeOpen] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const { data, isLoading, isError } = useQuery(timecards.forCase(caseId, projectId));
-  const cards = data?.cards ?? [];
+  const { data, isLoading, isError, hasNextPage, isFetchingNextPage, fetchNextPage } = useInfiniteQuery(
+    timecards.forCase(caseId),
+  );
+  const cards = data ?? [];
   const total = cards.reduce((sum, c) => sum + c.totalMinutes, 0);
+
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const el = sentinelRef.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry?.isIntersecting && hasNextPage && !isFetchingNextPage) {
+          void fetchNextPage();
+        }
+      },
+      { threshold: 0.1 },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
   const handleSubmit = (input: CreateTimeCardInput) => {
     setIsSubmitting(true);
@@ -103,12 +130,6 @@ export function TimeTrackingTab({ caseId, caseNumber, caseSeverity, projectId, p
 
       <Divider />
 
-      {!isError && data?.truncated && (
-        <Typography variant="caption" color="text.secondary">
-          Some entries on this case may not be shown.
-        </Typography>
-      )}
-
       {isLoading ? (
         <Stack gap={1}>
           {[0, 1].map((i) => (
@@ -119,7 +140,7 @@ export function TimeTrackingTab({ caseId, caseNumber, caseSeverity, projectId, p
         <Typography variant="body2" color="error">
           Could not load time cards.
         </Typography>
-      ) : cards.length === 0 ? (
+      ) : cards.length === 0 && !hasNextPage ? (
         <Typography variant="body2" color="text.secondary">
           No time logged on this case yet.
         </Typography>
@@ -128,12 +149,14 @@ export function TimeTrackingTab({ caseId, caseNumber, caseSeverity, projectId, p
           {cards.map((c) => (
             <TimeCardRow key={c.id} card={c} />
           ))}
+
+          {/* IntersectionObserver can miss a zero-height target, so give the sentinel 1px to
+           * observe. Kept mounted even once every card is in — cheap and avoids a layout jump. */}
+          <div ref={sentinelRef} style={{ height: 1 }} />
+
+          {(isFetchingNextPage || (cards.length === 0 && hasNextPage)) && <Skeleton variant="rounded" height={48} />}
         </Stack>
       )}
-
-      <Button variant="outlined" size="small" onClick={() => navigate("/more/time-cards")} sx={{ alignSelf: "start" }}>
-        Open Time Cards
-      </Button>
 
       {logTimeOpen && (
         <LogTimeCardDialog

--- a/apps/csm-portal/microapp/src/components/case-detail/TimeTrackingTab.tsx
+++ b/apps/csm-portal/microapp/src/components/case-detail/TimeTrackingTab.tsx
@@ -73,10 +73,11 @@ export function TimeTrackingTab({ caseId, caseNumber, caseSeverity, projectId, p
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const { data, isLoading, isError, hasNextPage, isFetchingNextPage, fetchNextPage } = useInfiniteQuery(
+  const { data, isLoading, isError, hasNextPage, isFetching, isFetchingNextPage, fetchNextPage } = useInfiniteQuery(
     timecards.forCase(caseId),
   );
-  const cards = data ?? [];
+  const cards = data?.cards ?? [];
+  const totalCount = data?.total ?? cards.length;
   const total = cards.reduce((sum, c) => sum + c.totalMinutes, 0);
 
   const sentinelRef = useRef<HTMLDivElement>(null);
@@ -86,7 +87,11 @@ export function TimeTrackingTab({ caseId, caseNumber, caseSeverity, projectId, p
 
     const observer = new IntersectionObserver(
       ([entry]) => {
-        if (entry?.isIntersecting && hasNextPage && !isFetchingNextPage) {
+        // Also gated on `!isFetching` (not just `!isFetchingNextPage`) so the sentinel can't fire
+        // a next-page fetch while a *different* fetch is already in flight for this query — e.g.
+        // the background refetch invalidateQueries triggers right after logging time reloads the
+        // already-loaded pages, during which isFetchingNextPage is false but isFetching is true.
+        if (entry?.isIntersecting && hasNextPage && !isFetching) {
           void fetchNextPage();
         }
       },
@@ -94,7 +99,7 @@ export function TimeTrackingTab({ caseId, caseNumber, caseSeverity, projectId, p
     );
     observer.observe(el);
     return () => observer.disconnect();
-  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+  }, [hasNextPage, isFetching, fetchNextPage]);
 
   const handleSubmit = (input: CreateTimeCardInput) => {
     setIsSubmitting(true);
@@ -120,7 +125,11 @@ export function TimeTrackingTab({ caseId, caseNumber, caseSeverity, projectId, p
             {formatMinutes(total)}
           </Typography>
           <Typography variant="caption" color="text.secondary">
-            Across {cards.length} {cards.length === 1 ? "entry" : "entries"}
+            {/* While more pages are still to come, say so explicitly rather than letting the
+             * loaded-so-far count read as the case's whole total. */}
+            {hasNextPage
+              ? `${cards.length} of ${totalCount} ${totalCount === 1 ? "entry" : "entries"} loaded so far`
+              : `Across ${cards.length} ${cards.length === 1 ? "entry" : "entries"}`}
           </Typography>
         </Box>
         <Button variant="contained" size="small" startIcon={<Plus size={14} />} onClick={() => setLogTimeOpen(true)}>

--- a/apps/csm-portal/microapp/src/services/timecards.ts
+++ b/apps/csm-portal/microapp/src/services/timecards.ts
@@ -30,7 +30,7 @@
 // flattened, then grouped into weekly sheets in one pass — so a week that spans a
 // page boundary stays a single sheet, rather than being split per page.
 
-import { infiniteQueryOptions, queryOptions, type InfiniteData } from "@tanstack/react-query";
+import { infiniteQueryOptions, type InfiniteData } from "@tanstack/react-query";
 import { TIME_CARDS_ENDPOINT, TIME_CARDS_SEARCH_ENDPOINT, TIME_CARD_ENDPOINT } from "@config/endpoints";
 import type {
   BeCreateTimeCardPayload,
@@ -56,9 +56,9 @@ import {
 import apiClient from "./apiClient";
 
 // Server-side filters honored by the search endpoint. `states` is filtered
-// client-side (combining it with a large `projectIds` array 500s the backend),
-// and there is deliberately no `caseId` (non-functional live — see the DTO).
+// client-side (combining it with a large `projectIds` array 500s the backend).
 interface TimeCardSearchFilters {
+  caseId?: string;
   projectIds?: string[];
   userId?: string;
   approverId?: string;
@@ -97,6 +97,7 @@ const EMPTY_PAGE: TimeCardPage = { cards: [], total: 0, nextOffset: 0, hasMore: 
 async function searchTimeCardsPage(filters: TimeCardSearchFilters, offset: number): Promise<TimeCardPage> {
   const payload: BeSearchTimeCardsPayload = {
     filters: {
+      ...(filters.caseId ? { caseId: filters.caseId } : {}),
       ...(filters.projectIds?.length ? { projectIds: filters.projectIds } : {}),
       ...(filters.userId ? { userId: filters.userId } : {}),
       ...(filters.approverId ? { approverId: filters.approverId } : {}),
@@ -113,26 +114,6 @@ async function searchTimeCardsPage(filters: TimeCardSearchFilters, offset: numbe
   const nextOffset = data.offset + raw.length;
   const cards = filters.states?.length ? raw.filter((c) => filters.states!.includes(c.state)) : raw;
   return { cards, total: data.total, nextOffset, hasMore: raw.length > 0 && nextOffset < data.total };
-}
-
-// A case's time cards from the first TIME_CARD_MAX_PAGE_LIMIT cards in its
-// project, plus whether that one page fell short of the project's full
-// `total` — some of the case's cards may not have been fetched if so. No
-// pagination UI (a single case logging more than a page's worth of time is
-// not expected). Mirrors the webapp's useCaseTimeCards: `caseId` itself is
-// non-functional as a search filter (see the interface note above), so this
-// scopes to the case's own project instead and filters client-side.
-export interface CaseTimeCardsResult {
-  cards: CsmTimeCard[];
-  truncated: boolean;
-}
-
-async function fetchCaseTimeCards(caseId: string, projectId: string): Promise<CaseTimeCardsResult> {
-  const { cards, total } = await searchTimeCardsPage({ projectIds: [projectId] }, 0);
-  return {
-    cards: cards.filter((c) => c.caseId === caseId),
-    truncated: cards.length < total,
-  };
 }
 
 // Flatten every loaded page's cards, derive the client-filter option lists from
@@ -293,16 +274,19 @@ export const timecards = {
   decide: decideCard,
   create: createCard,
 
-  // A single case's logged time cards (Time Tracking tab). See fetchCaseTimeCards
-  // for the projectIds-scoped + client-filtered workaround this relies on.
-  forCase: (caseId: string | undefined, projectId: string | undefined) =>
-    queryOptions({
-      queryKey: ["timecards", "case", caseId ?? "", projectId ?? ""],
-      queryFn: () =>
-        caseId && projectId
-          ? fetchCaseTimeCards(caseId, projectId)
-          : Promise.resolve<CaseTimeCardsResult>({ cards: [], truncated: false }),
-      enabled: !!caseId && !!projectId,
+  // A single case's logged time cards (Time Tracking tab), scoped server-side by
+  // `filters.caseId` (see BeSearchTimeCardsFilters.caseId's comment) — an
+  // infinite query, paged the same way as the "Time cards" > All tab (the
+  // caller drains it with a scroll sentinel), for the rare case whose entries
+  // outnumber one page, rather than a hard-coded single fetch.
+  forCase: (caseId: string | undefined) =>
+    infiniteQueryOptions({
+      queryKey: ["timecards", "case", caseId ?? ""],
+      queryFn: ({ pageParam }) => (caseId ? searchTimeCardsPage({ caseId }, pageParam) : Promise.resolve(EMPTY_PAGE)),
+      initialPageParam: 0,
+      getNextPageParam,
+      enabled: !!caseId,
       staleTime: 5_000,
+      select: (data) => data.pages.flatMap((p) => p.cards),
     }),
 };

--- a/apps/csm-portal/microapp/src/services/timecards.ts
+++ b/apps/csm-portal/microapp/src/services/timecards.ts
@@ -287,6 +287,13 @@ export const timecards = {
       getNextPageParam,
       enabled: !!caseId,
       staleTime: 5_000,
-      select: (data) => data.pages.flatMap((p) => p.cards),
+      // Carries `total` (the backend's real count for the case, unaffected by
+      // client-side filtering — this query applies none) alongside the loaded
+      // cards, so the caller can tell "every card is in" from "more pages remain"
+      // instead of the loaded-so-far count silently reading as the whole total.
+      select: (data) => ({
+        cards: data.pages.flatMap((p) => p.cards),
+        total: data.pages[0]?.total ?? 0,
+      }),
     }),
 };

--- a/apps/csm-portal/microapp/src/types/timecard.dto.ts
+++ b/apps/csm-portal/microapp/src/types/timecard.dto.ts
@@ -47,12 +47,14 @@ export interface BeTimeCardView {
   case?: BeTimeCardCaseRef;
 }
 
-// `caseId` is deliberately omitted here: it's documented in entity-service's
-// openapi.yaml and implemented end-to-end, but confirmed non-functional live
-// (always returns total: 0). Case scoping goes through `projectIds` plus a
-// client-side filter instead. `states` is filtered client-side too — combining
-// it with a large `projectIds` array 500s the backend.
+// `states` is filtered client-side — combining it with a large `projectIds`
+// array 500s the backend.
 export interface BeSearchTimeCardsFilters {
+  /** Confirmed live (2026-08): scopes correctly and returns an accurate `total`, mirroring the
+   * webapp's own filters.caseId — see useCaseTimeCards's comment for the backend fix (PR #1133)
+   * this now relies on. Previously worked around via `projectIds` plus a client-side filter,
+   * back when this filter unconditionally returned `total: 0`. */
+  caseId?: string;
   projectIds?: string[];
   /** Only time cards submitted by this user. */
   userId?: string;


### PR DESCRIPTION
## Summary

- The case detail **Time Tracking** tab believed `BeSearchTimeCardsFilters.caseId` was non-functional against `/time-cards/search` (a stale assumption — it used to always return `total: 0`), so it worked around that by scoping to the case's project and filtering client-side, capped at a single page with a "some entries may not be shown" notice and a separate "Open Time Cards" button as the escape hatch.
- A live payload capture confirmed `caseId` now scopes correctly and returns an accurate `total` — the webapp's `useCaseTimeCards` already switched to it, with its own comment pointing at the backend fix (PR #1133) this relies on. Dropped the project-scoped workaround for the direct `caseId` filter.
- The tab now pages through the case's own cards the same way the "Time cards" > All tab does — an `IntersectionObserver` scroll sentinel fetches further pages for the rare case with more than one page's worth of entries — instead of stopping at a fixed first page. The truncation notice and "Open Time Cards" navigation button are gone; the tab is now the complete list on its own.
- Each logged entry now gets a proper bordered, tinted card treatment (matching this app's own `TimeSheetCard` row and the webapp's `CaseTimeCardsPanel`) instead of rendering as a bare, borderless line of text.

## Test plan

- [x] `tsc --noEmit` and `eslint` pass clean.
- [x] Not exercised in a local browser session — the microapp authenticates via a native superapp bridge with no standalone fallback; verification relied on a live payload capture and code review against the webapp's already-fixed equivalent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Time cards now load directly for the selected case with reliable server-side filtering.
  * Additional time cards load automatically as you scroll.
  * Counts now reflect partially loaded results as more records are retrieved.

* **UI Improvements**
  * Updated time-card rows with bordered, tinted cards and improved metadata layout.
  * Added loading skeletons during pagination.
  * Improved empty-state behavior while pages are still loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->