### PR TITLE
[CSM Portal] bundled session fixes: case comment ownership guard, auto-acknowledge, dashboard widget config and filter resolution, entity-service date/filter fixes

### DIFF
--- a/apps/csm-portal/backend/.env.example
+++ b/apps/csm-portal/backend/.env.example
@@ -66,6 +66,19 @@ DASHBOARDS_DIR=./dashboards.example
 # take the dev server down; the startup load still fails hard either way.
 DASHBOARDS_HOT_RELOAD=false
 
+# Optional: a JSON file of presetKey -> literal filter fragment
+# ({"field":...,"op":...,"values":...}), shared across every dashboard in
+# DASHBOARDS_DIR. A dashboard's own top-level "filterPresets" object (same
+# shape) shadows a same-named entry here. Referenced from anywhere a literal
+# filter object can appear (a widget's query.filters, an anyOf branch's
+# filters, or a PieSlice's own query.filters) via {"preset": "presetKey"} —
+# expanded into its literal fragment once, at startup, never visible past
+# that. Conventionally named with a leading underscore (e.g. _presets.json)
+# so LoadDir does not try to parse it as a dashboard: DASHBOARDS_DIR skips
+# any *.json file starting with "_". Unset is legal and means no shared
+# presets, same as an unset DASHBOARDS_DIR itself.
+# DASHBOARD_PRESETS_FILE=./dashboards.example/_presets.json
+
 # DEPRECATED: the whole dashboard registry crammed into one variable. Honoured
 # only when DASHBOARDS_DIR is unset, and warns when used. Set DASHBOARDS_DIR
 # instead — a definition in its own file is reviewable in a diff and an error

--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -72,7 +72,7 @@ func main() {
 
 	customerEntityClient := entity.NewCustomerEntityClient(customerEntityCfg)
 	caseHandler := handler.NewCaseHandler(customerEntityClient)
-	dashboardHandler := handler.NewDashboardHandler(customerEntityClient)
+	dashboardHandler := handler.NewDashboardHandler()
 	accountHandler := handler.NewAccountHandler(customerEntityClient)
 	projectHandler := handler.NewProjectHandler(customerEntityClient)
 	productHandler := handler.NewProductHandler(customerEntityClient)
@@ -283,9 +283,20 @@ func main() {
 //	                       only; the default (unset/false) does the startup
 //	                       read once and never touches the disk again. A
 //	                       non-empty unparseable value warns and is false.
+//	DASHBOARD_PRESETS_FILE a JSON file of presetKey -> literal filter fragment
+//	                       ({"field":...,"op":...,"values":...}), shared
+//	                       across every dashboard in DASHBOARDS_DIR (a
+//	                       dashboard's own top-level "filterPresets" shadows a
+//	                       same-named entry here). Only consulted on the
+//	                       DASHBOARDS_DIR path — the deprecated
+//	                       DASHBOARDS_CONFIG path has no directory of its own
+//	                       to keep a presets file alongside. Unset is legal
+//	                       and means no shared presets, same as unset
+//	                       DASHBOARDS_DIR itself.
 //
-// Neither set is legal and yields no dashboards: a deployment that has not
-// configured any must still start and serve every other endpoint.
+// Neither DASHBOARDS_DIR nor DASHBOARDS_CONFIG set is legal and yields no
+// dashboards: a deployment that has not configured any must still start and
+// serve every other endpoint.
 func loadDashboards() *dashboard.Registry {
 	dir := strings.TrimSpace(os.Getenv("DASHBOARDS_DIR"))
 	if dir == "" {
@@ -296,6 +307,8 @@ func loadDashboards() *dashboard.Registry {
 		}
 		return dashboard.NewStaticRegistry(dashboards)
 	}
+
+	presetsFile := strings.TrimSpace(os.Getenv("DASHBOARD_PRESETS_FILE"))
 
 	// ParseBool rather than a "true" string compare: the latter silently reads
 	// 1, yes and on as OFF, and never reports a typo at all -- the operator
@@ -312,16 +325,16 @@ func loadDashboards() *dashboard.Registry {
 		}
 		hotReload = parsed
 	}
-	registry, err := dashboard.NewDirRegistry(dir, hotReload)
+	registry, err := dashboard.NewDirRegistry(dir, hotReload, presetsFile)
 	if err != nil {
-		slog.Error("invalid dashboard definitions", "dir", dir, "err", err)
+		slog.Error("invalid dashboard definitions", "dir", dir, "presetsFile", presetsFile, "err", err)
 		os.Exit(1)
 	}
 	if hotReload {
 		slog.Warn("DASHBOARDS_HOT_RELOAD is on: dashboard definitions are re-read from disk on every request. Intended for local development only",
 			"dir", dir)
 	}
-	slog.Info("loaded dashboard definitions", "dir", dir, "count", len(registry.Dashboards()), "hotReload", hotReload)
+	slog.Info("loaded dashboard definitions", "dir", dir, "presetsFile", presetsFile, "count", len(registry.Dashboards()), "hotReload", hotReload)
 	return registry
 }
 

--- a/apps/csm-portal/backend/internal/dashboard/filter_presets_test.go
+++ b/apps/csm-portal/backend/internal/dashboard/filter_presets_test.go
@@ -1,0 +1,439 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dashboard
+
+import (
+	"bytes"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// filterField finds the "values" of the first entry in a "filters" array
+// whose "field" matches, and reports whether one was found.
+func filterField(filters []any, field string) ([]any, bool) {
+	for _, entry := range filters {
+		m, ok := entry.(map[string]any)
+		if !ok || m["field"] != field {
+			continue
+		}
+		values, ok := m["values"].([]any)
+		return values, ok
+	}
+	return nil, false
+}
+
+// TestFilterPresets_DashboardLocalResolvesAtLoadTime confirms a dashboard's
+// own "filterPresets" is expanded into its literal fragment inside
+// query.filters, once, at LoadDir time — no "preset" key or "filterPresets"
+// object should survive into the loaded Dashboard.
+func TestFilterPresets_DashboardLocalResolvesAtLoadTime(t *testing.T) {
+	dir := t.TempDir()
+	writeDefinition(t, dir, "d.json", `{
+	  "id": "d", "displayName": "D", "type": "cs",
+	  "filterPresets": {
+	    "not-closed": {"field": "state", "op": "notIn", "values": ["closed", "resolved"]}
+	  },
+	  "widgets": [
+	    {"id": "w", "displayName": "W", "resourceType": "case", "shape": "count", "gridWidth": 3,
+	     "query": {"filters": [{"preset": "not-closed"}]}}
+	  ]
+	}`)
+
+	got, err := LoadDir(dir)
+	if err != nil {
+		t.Fatalf("LoadDir returned error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("LoadDir returned %d dashboards, want 1", len(got))
+	}
+	d := got[0]
+	if d.FilterPresets != nil {
+		t.Errorf("Dashboard.FilterPresets = %+v, want nil (cleared once resolved, never visible past load)", d.FilterPresets)
+	}
+
+	filters, ok := d.Widgets[0].Query["filters"].([]any)
+	if !ok {
+		t.Fatalf("widget Query has no \"filters\" array: %v", d.Widgets[0].Query)
+	}
+	values, ok := filterField(filters, "state")
+	if !ok {
+		t.Fatalf("widget Query filters has no \"state\" field entry (preset did not expand): %v", filters)
+	}
+	if len(values) != 2 || values[0] != "closed" || values[1] != "resolved" {
+		t.Errorf("expanded preset state values = %v, want [closed resolved]", values)
+	}
+}
+
+// TestFilterPresets_ExpandInAnyOfBranchAndPieSlice confirms preset
+// references resolve in the two other places a literal filter object can
+// appear: an "anyOf" branch's own "filters", and a PieSlice's own
+// "query.filters".
+func TestFilterPresets_ExpandInAnyOfBranchAndPieSlice(t *testing.T) {
+	dir := t.TempDir()
+	writeDefinition(t, dir, "d.json", `{
+	  "id": "d", "displayName": "D", "type": "cs",
+	  "filterPresets": {
+	    "critical": {"field": "severity", "op": "in", "values": ["critical"]}
+	  },
+	  "widgets": [
+	    {"id": "w", "displayName": "W", "resourceType": "case", "shape": "count", "gridWidth": 3,
+	     "query": {"anyOf": [{"filters": [{"preset": "critical"}]}]}},
+	    {"id": "p", "displayName": "P", "resourceType": "case", "shape": "pie", "gridWidth": 6,
+	     "query": {"filters": []},
+	     "slices": [{"label": "Critical", "query": {"filters": [{"preset": "critical"}]}}]}
+	  ]
+	}`)
+
+	got, err := LoadDir(dir)
+	if err != nil {
+		t.Fatalf("LoadDir returned error: %v", err)
+	}
+
+	anyOf, ok := got[0].Widgets[0].Query["anyOf"].([]any)
+	if !ok || len(anyOf) != 1 {
+		t.Fatalf("widget Query anyOf = %v, want one branch", got[0].Widgets[0].Query["anyOf"])
+	}
+	branch, _ := anyOf[0].(map[string]any)
+	branchFilters, _ := branch["filters"].([]any)
+	values, ok := filterField(branchFilters, "severity")
+	if !ok || len(values) != 1 || values[0] != "critical" {
+		t.Errorf("anyOf[0].filters severity = %v, want [critical] (preset did not expand)", values)
+	}
+
+	sliceFilters, _ := got[0].Widgets[1].Slices[0].Query["filters"].([]any)
+	sliceValues, ok := filterField(sliceFilters, "severity")
+	if !ok || len(sliceValues) != 1 || sliceValues[0] != "critical" {
+		t.Errorf("slice Query filters severity = %v, want [critical] (preset did not expand)", sliceValues)
+	}
+}
+
+// TestFilterPresets_UnknownKeyFailsLoudNamingDashboardWidgetAndKey mirrors
+// registry.go's existing unknown-resourceType/unknown-shape error style: name
+// the dashboard, the widget, and here specifically the missing preset key.
+func TestFilterPresets_UnknownKeyFailsLoudNamingDashboardWidgetAndKey(t *testing.T) {
+	dir := t.TempDir()
+	writeDefinition(t, dir, "d.json", `{
+	  "id": "d", "displayName": "D", "type": "cs",
+	  "widgets": [
+	    {"id": "w", "displayName": "W", "resourceType": "case", "shape": "count", "gridWidth": 3,
+	     "query": {"filters": [{"preset": "does-not-exist"}]}}
+	  ]
+	}`)
+
+	_, err := LoadDir(dir)
+	if err == nil {
+		t.Fatal("LoadDir returned no error for a reference to an undefined preset")
+	}
+	for _, want := range []string{filepath.Join(dir, "d.json"), `id "d"`, `widget "w"`, "does-not-exist"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not contain %q", err.Error(), want)
+		}
+	}
+}
+
+// TestFilterPresets_DashboardLocalShadowsSharedOnCollision is the precedence
+// rule spelled out in the design: a dashboard-local preset wins over a
+// same-named shared one, so a dashboard can deliberately override a shared
+// default without editing the shared file.
+func TestFilterPresets_DashboardLocalShadowsSharedOnCollision(t *testing.T) {
+	dir := t.TempDir()
+	presetsPath := filepath.Join(dir, "_presets.json")
+	writeDefinition(t, dir, "_presets.json", `{
+	  "not-closed": {"field": "state", "op": "notIn", "values": ["closed"]}
+	}`)
+	writeDefinition(t, dir, "d.json", `{
+	  "id": "d", "displayName": "D", "type": "cs",
+	  "filterPresets": {
+	    "not-closed": {"field": "state", "op": "notIn", "values": ["closed", "wont_fix"]}
+	  },
+	  "widgets": [
+	    {"id": "w", "displayName": "W", "resourceType": "case", "shape": "count", "gridWidth": 3,
+	     "query": {"filters": [{"preset": "not-closed"}]}}
+	  ]
+	}`)
+
+	sharedPresets, err := LoadSharedPresets(presetsPath)
+	if err != nil {
+		t.Fatalf("LoadSharedPresets returned error: %v", err)
+	}
+	got, err := loadDir(dir, sharedPresets)
+	if err != nil {
+		t.Fatalf("loadDir returned error: %v", err)
+	}
+
+	filters, _ := got[0].Widgets[0].Query["filters"].([]any)
+	values, ok := filterField(filters, "state")
+	if !ok {
+		t.Fatalf("widget Query filters has no \"state\" field entry: %v", filters)
+	}
+	// The dashboard-local fragment (["closed", "wont_fix"]), not the shared
+	// one (["closed"]), must win.
+	if len(values) != 2 || values[0] != "closed" || values[1] != "wont_fix" {
+		t.Errorf("expanded preset state values = %v, want the dashboard-local fragment [closed wont_fix], not the shared one", values)
+	}
+}
+
+// TestFilterPresets_SharedFileAlsoResolves confirms the non-collision case:
+// a preset defined only in the shared file still resolves for a dashboard
+// that references it and defines no "filterPresets" of its own.
+func TestFilterPresets_SharedFileAlsoResolves(t *testing.T) {
+	dir := t.TempDir()
+	presetsPath := filepath.Join(dir, "_presets.json")
+	writeDefinition(t, dir, "_presets.json", `{
+	  "not-closed": {"field": "state", "op": "notIn", "values": ["closed"]}
+	}`)
+	writeDefinition(t, dir, "d.json", `{
+	  "id": "d", "displayName": "D", "type": "cs",
+	  "widgets": [
+	    {"id": "w", "displayName": "W", "resourceType": "case", "shape": "count", "gridWidth": 3,
+	     "query": {"filters": [{"preset": "not-closed"}]}}
+	  ]
+	}`)
+
+	sharedPresets, err := LoadSharedPresets(presetsPath)
+	if err != nil {
+		t.Fatalf("LoadSharedPresets returned error: %v", err)
+	}
+	got, err := loadDir(dir, sharedPresets)
+	if err != nil {
+		t.Fatalf("loadDir returned error: %v", err)
+	}
+	filters, _ := got[0].Widgets[0].Query["filters"].([]any)
+	values, ok := filterField(filters, "state")
+	if !ok || len(values) != 1 || values[0] != "closed" {
+		t.Errorf("expanded shared preset state values = %v, want [closed]", values)
+	}
+}
+
+// TestLoadSharedPresets_MissingPathIsLegal mirrors LoadDir's own empty-
+// directory legality: an unset/empty DASHBOARD_PRESETS_FILE must not fail
+// startup.
+func TestLoadSharedPresets_MissingPathIsLegal(t *testing.T) {
+	got, err := LoadSharedPresets("")
+	if err != nil {
+		t.Fatalf("LoadSharedPresets(\"\") returned error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("LoadSharedPresets(\"\") = %v, want nil", got)
+	}
+}
+
+// TestLoadSharedPresets_UnreadableOrMalformedFailsNamingFile.
+func TestLoadSharedPresets_UnreadableOrMalformedFailsNamingFile(t *testing.T) {
+	dir := t.TempDir()
+	path := writeDefinition(t, dir, "presets.json", `{"broken": `)
+
+	_, err := LoadSharedPresets(path)
+	if err == nil {
+		t.Fatal("LoadSharedPresets returned no error for a malformed file")
+	}
+	if !strings.Contains(err.Error(), path) {
+		t.Errorf("error %q does not name the offending file", err.Error())
+	}
+}
+
+// TestFilterPresets_RecursivePresetRejected covers both halves of "presets
+// are not recursive": a shared preset whose own fragment is a {"preset":...}
+// reference, and a dashboard-local one, must both fail loud at load rather
+// than being silently passed through as an unresolved reference.
+func TestFilterPresets_RecursivePresetRejected(t *testing.T) {
+	t.Run("shared", func(t *testing.T) {
+		dir := t.TempDir()
+		path := writeDefinition(t, dir, "presets.json", `{
+		  "a": {"preset": "b"},
+		  "b": {"field": "state", "op": "in", "values": ["open"]}
+		}`)
+		_, err := LoadSharedPresets(path)
+		if err == nil {
+			t.Fatal("LoadSharedPresets returned no error for a preset referencing another preset")
+		}
+		if !strings.Contains(err.Error(), `"a"`) {
+			t.Errorf("error %q does not name the offending preset key", err.Error())
+		}
+	})
+
+	t.Run("dashboard-local", func(t *testing.T) {
+		dir := t.TempDir()
+		writeDefinition(t, dir, "d.json", `{
+		  "id": "d", "displayName": "D", "type": "cs",
+		  "filterPresets": {"a": {"preset": "b"}},
+		  "widgets": [
+		    {"id": "w", "displayName": "W", "resourceType": "case", "shape": "count", "gridWidth": 3,
+		     "query": {"filters": []}}
+		  ]
+		}`)
+		_, err := LoadDir(dir)
+		if err == nil {
+			t.Fatal("LoadDir returned no error for a dashboard-local preset referencing another preset")
+		}
+		if !strings.Contains(err.Error(), `"a"`) {
+			t.Errorf("error %q does not name the offending preset key", err.Error())
+		}
+	})
+}
+
+// TestFilterPresets_MalformedReferenceRejected covers the two ways a
+// {"preset": ...} object can be malformed: a non-string/empty "preset"
+// value, and extra keys alongside "preset" (ambiguous — is it a reference or
+// a literal filter that happens to have a "preset" field?).
+func TestFilterPresets_MalformedReferenceRejected(t *testing.T) {
+	cases := []struct {
+		name  string
+		entry string
+	}{
+		{"non-string preset value", `{"preset": 1}`},
+		{"empty preset value", `{"preset": ""}`},
+		{"extra keys alongside preset", `{"preset": "not-closed", "field": "state"}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeDefinition(t, dir, "d.json", `{
+			  "id": "d", "displayName": "D", "type": "cs",
+			  "filterPresets": {"not-closed": {"field": "state", "op": "notIn", "values": ["closed"]}},
+			  "widgets": [
+			    {"id": "w", "displayName": "W", "resourceType": "case", "shape": "count", "gridWidth": 3,
+			     "query": {"filters": [`+tc.entry+`]}}
+			  ]
+			}`)
+			if _, err := LoadDir(dir); err == nil {
+				t.Fatalf("LoadDir accepted a malformed preset reference %s; expected an error", tc.entry)
+			}
+		})
+	}
+}
+
+// TestResourceTypeAutoInject_AllFiveCaseTableValues confirms every one of
+// the five case-table resourceType values gets its own implied "type"
+// filter auto-injected, with the resourceType string itself as the value.
+func TestResourceTypeAutoInject_AllFiveCaseTableValues(t *testing.T) {
+	for _, rt := range []ResourceType{
+		ResourceCase, ResourceServiceRequest, ResourceSecurityReportAnalysis,
+		ResourceAnnouncement, ResourceEngagement,
+	} {
+		t.Run(string(rt), func(t *testing.T) {
+			dir := t.TempDir()
+			writeDefinition(t, dir, "d.json", `{
+			  "id": "d", "displayName": "D", "type": "cs",
+			  "widgets": [
+			    {"id": "w", "displayName": "W", "resourceType": "`+string(rt)+`", "shape": "count", "gridWidth": 3,
+			     "query": {"filters": [{"field": "state", "op": "in", "values": ["open"]}]}}
+			  ]
+			}`)
+			got, err := LoadDir(dir)
+			if err != nil {
+				t.Fatalf("LoadDir returned error: %v", err)
+			}
+			filters, ok := got[0].Widgets[0].Query["filters"].([]any)
+			if !ok {
+				t.Fatalf("widget Query has no \"filters\" array: %v", got[0].Widgets[0].Query)
+			}
+			values, ok := filterField(filters, "type")
+			if !ok || len(values) != 1 || values[0] != string(rt) {
+				t.Errorf("auto-injected type filter values = %v, want [%q]", values, rt)
+			}
+		})
+	}
+}
+
+// TestResourceTypeAutoInject_NonCaseTableResourceTypeUntouched confirms the
+// auto-inject is scoped to the five case-table values only — a widget of any
+// other resourceType (e.g. "time_card") must not gain a "type" filter it
+// never asked for.
+func TestResourceTypeAutoInject_NonCaseTableResourceTypeUntouched(t *testing.T) {
+	dir := t.TempDir()
+	writeDefinition(t, dir, "d.json", `{
+	  "id": "d", "displayName": "D", "type": "cs",
+	  "widgets": [
+	    {"id": "w", "displayName": "W", "resourceType": "time_card", "shape": "count", "gridWidth": 3,
+	     "query": {"states": ["pending"]}}
+	  ]
+	}`)
+	got, err := LoadDir(dir)
+	if err != nil {
+		t.Fatalf("LoadDir returned error: %v", err)
+	}
+	if _, present := got[0].Widgets[0].Query["filters"]; present {
+		t.Errorf("non-case-table widget Query unexpectedly gained a \"filters\" key: %v", got[0].Widgets[0].Query)
+	}
+}
+
+// TestResourceTypeAutoInject_ExplicitTypeFilterLeftAloneButWarns is the
+// transition safety net: a widget already carrying its own explicit "type"
+// filter (pre-migration config) must not have it overwritten or duplicated,
+// but the load must warn, since after the config rewrite this pass
+// backstops, no widget should still need one.
+func TestResourceTypeAutoInject_ExplicitTypeFilterLeftAloneButWarns(t *testing.T) {
+	var buf bytes.Buffer
+	prevLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prevLogger) })
+
+	dir := t.TempDir()
+	writeDefinition(t, dir, "d.json", `{
+	  "id": "d", "displayName": "D", "type": "cs",
+	  "widgets": [
+	    {"id": "w", "displayName": "W", "resourceType": "case", "shape": "count", "gridWidth": 3,
+	     "query": {"filters": [{"field": "type", "op": "in", "values": ["case"]}]}}
+	  ]
+	}`)
+	got, err := LoadDir(dir)
+	if err != nil {
+		t.Fatalf("LoadDir returned error: %v", err)
+	}
+
+	filters, _ := got[0].Widgets[0].Query["filters"].([]any)
+	if len(filters) != 1 {
+		t.Fatalf("widget Query filters = %v, want the single explicit \"type\" entry left untouched, not duplicated", filters)
+	}
+	values, ok := filterField(filters, "type")
+	if !ok || len(values) != 1 || values[0] != "case" {
+		t.Errorf("explicit type filter values = %v, want [case] (unmodified)", values)
+	}
+
+	if !strings.Contains(buf.String(), "already has an explicit") {
+		t.Errorf("expected a warning about the redundant explicit \"type\" filter, got log output: %s", buf.String())
+	}
+}
+
+// TestResourceTypeAutoInject_SliceGetsItsOwnInjection covers the merge
+// nuance called out in injectImpliedTypeFilters' doc comment: a PieSlice
+// that defines its own "filters" array shadows the widget's base "filters"
+// entirely on the frontend (a shallow, whole-key merge), so the slice needs
+// its own injected "type" entry independently of the widget's.
+func TestResourceTypeAutoInject_SliceGetsItsOwnInjection(t *testing.T) {
+	dir := t.TempDir()
+	writeDefinition(t, dir, "d.json", `{
+	  "id": "d", "displayName": "D", "type": "cs",
+	  "widgets": [
+	    {"id": "w", "displayName": "W", "resourceType": "engagement", "shape": "pie", "gridWidth": 6,
+	     "query": {"filters": [{"field": "state", "op": "in", "values": ["open"]}]},
+	     "slices": [{"label": "Mine", "query": {"filters": [{"field": "assignedUserId", "op": "in", "values": ["__current_user__"]}]}}]}
+	  ]
+	}`)
+	got, err := LoadDir(dir)
+	if err != nil {
+		t.Fatalf("LoadDir returned error: %v", err)
+	}
+	sliceFilters, _ := got[0].Widgets[0].Slices[0].Query["filters"].([]any)
+	values, ok := filterField(sliceFilters, "type")
+	if !ok || len(values) != 1 || values[0] != "engagement" {
+		t.Errorf("slice auto-injected type filter values = %v, want [engagement]", values)
+	}
+}

--- a/apps/csm-portal/backend/internal/dashboard/registry.go
+++ b/apps/csm-portal/backend/internal/dashboard/registry.go
@@ -100,8 +100,21 @@ func NewStaticRegistry(dashboards []Dashboard) *Registry {
 // in both modes: a definition set that is broken at startup is a broken
 // deploy, and the caller is expected to make it fatal. hotReload only governs
 // what happens on subsequent reads.
-func NewDirRegistry(dir string, hotReload bool) (*Registry, error) {
-	r := &Registry{dir: dir, hotReload: hotReload, load: LoadDir}
+//
+// presetsFile is the shared filter-preset file (see LoadSharedPresets and
+// DASHBOARD_PRESETS_FILE in cmd/server/main.go); "" means no shared presets
+// are configured, which is legal, same as an unset DASHBOARDS_DIR. It is
+// re-read on every load alongside dir, so hot-reload mode also picks up an
+// edited presets file without a restart.
+func NewDirRegistry(dir string, hotReload bool, presetsFile string) (*Registry, error) {
+	load := func(d string) ([]Dashboard, error) {
+		sharedPresets, err := LoadSharedPresets(presetsFile)
+		if err != nil {
+			return nil, err
+		}
+		return loadDir(d, sharedPresets)
+	}
+	r := &Registry{dir: dir, hotReload: hotReload, load: load}
 	dashboards, err := r.load(dir)
 	if err != nil {
 		return nil, err
@@ -181,11 +194,19 @@ func All() []Dashboard { return Active().Dashboards() }
 // ByID looks a dashboard up by id in the active registry.
 func ByID(id string) (Dashboard, bool) { return Active().ByID(id) }
 
-// LoadDir reads every *.json file in dir as one dashboard definition. The
-// filename is not significant in any way: id, displayName, type and the rest
-// all come from the file's content, and files are processed in lexical
-// filename order purely so the resulting order (which is what the frontend's
-// dashboard picker shows) is deterministic.
+// LoadDir reads every *.json file in dir whose name does not start with "_"
+// as one dashboard definition. The filename is otherwise not significant in
+// any way: id, displayName, type and the rest all come from the file's
+// content, and files are processed in lexical filename order purely so the
+// resulting order (which is what the frontend's dashboard picker shows) is
+// deterministic.
+//
+// The leading-underscore exclusion exists because the shared filter-presets
+// file (DASHBOARD_PRESETS_FILE, conventionally "_presets.json" — see
+// LoadSharedPresets) lives in the same directory as the dashboard
+// definitions it is shared across, not a separate one, and is not itself a
+// dashboard: without the exclusion, LoadDir would try to decode it as one
+// and fail on its missing "id"/"displayName".
 //
 // Every failure is an error naming the offending file, and none of them is
 // recoverable by skipping the file. A dropped dashboard is invisible: the
@@ -198,7 +219,19 @@ func ByID(id string) (Dashboard, bool) { return Active().ByID(id) }
 // An empty directory is legal and yields no dashboards: a deployment that has
 // not authored any definitions yet must still start and serve every other
 // endpoint. A missing directory is not legal — it is a misconfigured path.
+//
+// LoadDir never applies shared filter presets (see LoadSharedPresets) — it is
+// the plain, no-shared-presets form kept for the many callers (including this
+// package's own tests) that only care about a directory of definitions.
+// NewDirRegistry is the production path and always goes through loadDir with
+// whatever DASHBOARD_PRESETS_FILE resolves to, which may itself be an empty
+// map.
 func LoadDir(dir string) ([]Dashboard, error) {
+	return loadDir(dir, nil)
+}
+
+// loadDir is LoadDir's shared-presets-aware counterpart.
+func loadDir(dir string, sharedPresets map[string]map[string]any) ([]Dashboard, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, fmt.Errorf("dashboard definitions: read directory %q: %w", dir, err)
@@ -210,6 +243,12 @@ func LoadDir(dir string) ([]Dashboard, error) {
 			continue
 		}
 		if !strings.EqualFold(filepath.Ext(entry.Name()), definitionExt) {
+			continue
+		}
+		if strings.HasPrefix(entry.Name(), "_") {
+			// Reserved for non-dashboard config living alongside the
+			// definitions, e.g. the shared filter-presets file — see
+			// LoadDir's doc comment.
 			continue
 		}
 		names = append(names, entry.Name())
@@ -230,18 +269,65 @@ func LoadDir(dir string) ([]Dashboard, error) {
 		loaded = append(loaded, sourced{dashboard: d, source: path})
 	}
 
-	return finalize(loaded, true)
+	return finalize(loaded, true, sharedPresets)
 }
 
-// finalize runs the shared post-decode pipeline over a decoded set: the
-// deprecated-key migration first (so validation sees the current shape), then
-// cross-field validation. requireType is true for the directory loader, where
-// every definition is authored against the current schema, and false for the
-// deprecated DASHBOARDS_CONFIG path, whose already-deployed values predate
-// the type field entirely.
-func finalize(loaded []sourced, requireType bool) ([]Dashboard, error) {
+// LoadSharedPresets reads path (DASHBOARD_PRESETS_FILE — see
+// cmd/server/main.go) as a JSON object mapping presetKey -> literal filter
+// fragment ({"field":...,"op":...,"values":...}) — the same shape a
+// dashboard's own top-level "filterPresets" object uses (see
+// Dashboard.FilterPresets). An empty path is legal and yields an empty,
+// nil-error map: a deployment that has not authored a shared presets file
+// yet must still start, same "must still start" philosophy LoadDir's empty
+// directory already gets. A configured path that cannot be read or parsed,
+// or that contains a preset whose own fragment is itself a {"preset": ...}
+// reference (presets cannot reference other presets), is fatal and names the
+// file.
+func LoadSharedPresets(path string) (map[string]map[string]any, error) {
+	if strings.TrimSpace(path) == "" {
+		return nil, nil
+	}
+	raw, err := os.ReadFile(path) //nolint:gosec // path is deployment configuration, not user input
+	if err != nil {
+		return nil, fmt.Errorf("dashboard filter presets: read %q: %w", path, err)
+	}
+	var presets map[string]map[string]any
+	if err := json.Unmarshal(raw, &presets); err != nil {
+		return nil, fmt.Errorf("dashboard filter presets: parse %q: %w", path, err)
+	}
+	if err := validatePresetsNotRecursive(presets, path, "shared"); err != nil {
+		return nil, err
+	}
+	return presets, nil
+}
+
+// finalize runs the shared post-decode pipeline over a decoded set:
+// deprecated-key migration first (so everything after sees the current
+// shape), then filter-preset expansion and implied-"type"-filter injection
+// (so validation and every caller downstream see fully literal, complete
+// filters), then cross-field validation. requireType is true for the
+// directory loader, where every definition is authored against the current
+// schema, and false for the deprecated DASHBOARDS_CONFIG path, whose
+// already-deployed values predate the type field entirely. sharedPresets is
+// the DASHBOARD_PRESETS_FILE set (see LoadSharedPresets); nil/empty is legal
+// and means no shared presets, same as an unset DASHBOARDS_DIR.
+func finalize(loaded []sourced, requireType bool, sharedPresets map[string]map[string]any) ([]Dashboard, error) {
 	for i := range loaded {
 		migrateLegacyWidgetKeys(&loaded[i].dashboard, loaded[i].source)
+	}
+
+	for i := range loaded {
+		d := &loaded[i].dashboard
+		if err := resolveDashboardFilterPresets(d, sharedPresets, loaded[i].source); err != nil {
+			return nil, err
+		}
+		injectImpliedTypeFilters(d, loaded[i].source)
+		// Presets are a pure config-authoring convenience: once every
+		// {"preset": ...} reference in this dashboard has been expanded,
+		// nothing downstream (validation, the handler, the frontend) has any
+		// use for the raw preset definitions themselves, and they must never
+		// be visible past load time.
+		d.FilterPresets = nil
 	}
 
 	if err := validate(loaded, requireType); err != nil {
@@ -353,6 +439,12 @@ var validWidgetResourceTypes = map[ResourceType]bool{
 	ResourceAccount: true, ResourceProject: true, ResourceUser: true,
 	ResourceTimeCard: true, ResourceProblem: true, ResourceProductVulnerability: true,
 	ResourceCallRequest: true,
+	// The remaining four case-table values (see ResourceServiceRequest's doc
+	// comment) — same /cases/search endpoint as ResourceCase, distinguished
+	// only by the auto-injected "type" filter (caseTableResourceTypes,
+	// injectImpliedTypeFilters).
+	ResourceServiceRequest: true, ResourceSecurityReportAnalysis: true,
+	ResourceAnnouncement: true, ResourceEngagement: true,
 }
 
 var validWidgetShapes = map[Shape]bool{

--- a/apps/csm-portal/backend/internal/dashboard/registry_test.go
+++ b/apps/csm-portal/backend/internal/dashboard/registry_test.go
@@ -429,7 +429,7 @@ func TestRegistry_DefaultModeReadsDiskExactlyOnce(t *testing.T) {
 	writeDefinition(t, dir, "a.json", csDefinition)
 
 	var reads atomic.Int64
-	r, err := NewDirRegistry(dir, false)
+	r, err := NewDirRegistry(dir, false, "")
 	if err != nil {
 		t.Fatalf("NewDirRegistry returned error: %v", err)
 	}
@@ -468,7 +468,7 @@ func TestRegistry_HotReloadPicksUpChanges(t *testing.T) {
 	dir := t.TempDir()
 	writeDefinition(t, dir, "a.json", csDefinition)
 
-	r, err := NewDirRegistry(dir, true)
+	r, err := NewDirRegistry(dir, true, "")
 	if err != nil {
 		t.Fatalf("NewDirRegistry returned error: %v", err)
 	}
@@ -508,7 +508,7 @@ func TestRegistry_HotReloadKeepsLastKnownGoodOnError(t *testing.T) {
 	dir := t.TempDir()
 	writeDefinition(t, dir, "a.json", csDefinition)
 
-	r, err := NewDirRegistry(dir, true)
+	r, err := NewDirRegistry(dir, true, "")
 	if err != nil {
 		t.Fatalf("NewDirRegistry returned error: %v", err)
 	}
@@ -539,7 +539,7 @@ func TestNewDirRegistry_FailsAtStartupInBothModes(t *testing.T) {
 	for _, hotReload := range []bool{false, true} {
 		dir := t.TempDir()
 		writeDefinition(t, dir, "broken.json", `{"id": "broken", "displayName":`)
-		if _, err := NewDirRegistry(dir, hotReload); err == nil {
+		if _, err := NewDirRegistry(dir, hotReload, ""); err == nil {
 			t.Fatalf("NewDirRegistry(hotReload=%v) returned no error for a malformed definition", hotReload)
 		}
 	}

--- a/apps/csm-portal/backend/internal/dashboard/widgets.go
+++ b/apps/csm-portal/backend/internal/dashboard/widgets.go
@@ -32,11 +32,6 @@ import (
 	"strings"
 )
 
-// CurrentUserPlaceholder marks a filter value that must be resolved to the
-// requesting user's id before the filters are sent upstream. It never
-// reaches the entity service: ResolveFilters always substitutes it.
-const CurrentUserPlaceholder = "__current_user__"
-
 // ResourceType identifies which resource a widget's filters search against.
 type ResourceType string
 
@@ -51,6 +46,21 @@ const (
 	ResourceProblem              ResourceType = "problem"
 	ResourceProductVulnerability ResourceType = "product_vulnerability"
 	ResourceCallRequest          ResourceType = "call_request"
+	// ResourceServiceRequest, ResourceSecurityReportAnalysis,
+	// ResourceAnnouncement and ResourceEngagement are additional values of
+	// the case-search "type" field (see apps/csm-portal/backend/openapi.yaml,
+	// the case Type enum) exposed as their own widget resourceType, alongside
+	// ResourceCase itself. All five route to the same /cases/search endpoint
+	// -- the frontend maps each resourceType to that endpoint independently
+	// (nothing here derives the endpoint from the string) -- and all five get
+	// an implicit "type" filter auto-injected at load time (see
+	// caseTableResourceTypes and injectImpliedTypeFilters) so a dashboard
+	// author never has to paste {"field":"type","op":"in","values":[...]}
+	// into every widget by hand.
+	ResourceServiceRequest         ResourceType = "service_request"
+	ResourceSecurityReportAnalysis ResourceType = "security_report_analysis"
+	ResourceAnnouncement           ResourceType = "announcement"
+	ResourceEngagement             ResourceType = "engagement"
 )
 
 // Shape is how a widget's resolved data should be rendered.
@@ -126,11 +136,20 @@ type Column struct {
 }
 
 // WidgetTemplate is resource-agnostic: Query is opaque JSON, forwarded
-// verbatim (after __current_user__ substitution) as the filters object of
-// that ResourceType's own /search payload (every resource's search payload
-// shape is {filters: {...}, pagination: {...}}). The BE never interprets
-// filter contents beyond substituting the current-user placeholder and
-// migrating deprecated key names (see migrateLegacyWidgetKeys).
+// verbatim as the filters object of that ResourceType's own /search payload
+// (every resource's search payload shape is {filters: {...}, pagination:
+// {...}}). Any "__current_user__"/"__current_team__" placeholder string a
+// filter value carries is left exactly as authored -- the BE does not
+// resolve it, the frontend does, client-side (see
+// apps/csm-portal/webapp/src/features/csm-dashboard/utils, e.g.
+// teamFilterPlaceholder.ts for the pattern). The two things the BE does
+// interpret, both once at directory-load time rather than per-request, are:
+// migrating deprecated key names (see migrateLegacyWidgetKeys), and
+// expanding {"preset": "key"} filter references and auto-injecting the
+// implied "type" filter for case-table resourceTypes (see
+// resolveDashboardFilterPresets and injectImpliedTypeFilters). Past load
+// time, Query is exactly what it looks like: a literal filters object with
+// nothing left to resolve on this side.
 type WidgetTemplate struct {
 	ID          string `json:"id"`
 	DisplayName string `json:"displayName"`
@@ -220,6 +239,21 @@ type Dashboard struct {
 	// assignedUserIds) is deliberately deferred to a later increment.
 	IsTeamBased bool             `json:"isTeamBased"`
 	Widgets     []WidgetTemplate `json:"widgets"`
+
+	// FilterPresets is this dashboard's own map of presetKey -> literal
+	// filter fragment ({"field":...,"op":...,"values":...}), the
+	// dashboard-local half of the preset mechanism (see
+	// resolveDashboardFilterPresets and DASHBOARD_PRESETS_FILE's shared
+	// half in registry.go). Referenced from anywhere a literal filter
+	// object can appear in this dashboard's own widgets/slices --
+	// query.filters, an anyOf branch's filters, or a PieSlice's own
+	// query.filters -- via {"preset": "presetKey"}. A dashboard-local
+	// preset shadows a same-named shared one. Every reference is expanded
+	// into its fragment's literal form once, at directory-load time, so
+	// nothing downstream (including the frontend and the entity service)
+	// ever sees "filterPresets" or a {"preset": ...} reference: this field
+	// is cleared to nil once resolution has run (see finalize).
+	FilterPresets map[string]map[string]any `json:"filterPresets,omitempty"`
 }
 
 // ParseDashboardsConfig decodes DASHBOARDS_CONFIG, a JSON array of Dashboard
@@ -257,7 +291,11 @@ func ParseDashboardsConfig(raw string) ([]Dashboard, error) {
 	for i, d := range dashboards {
 		loaded = append(loaded, sourced{dashboard: d, source: fmt.Sprintf("DASHBOARDS_CONFIG[%d]", i)})
 	}
-	return finalize(loaded, false)
+	// The deprecated single-variable path has no directory and therefore no
+	// DASHBOARD_PRESETS_FILE of its own to read here — nil shared presets, so
+	// only a dashboard's own "filterPresets" (if any) can resolve a
+	// {"preset": ...} reference on this path.
+	return finalize(loaded, false, nil)
 }
 
 // migrateLegacyWidgetKeys upgrades one pre-rename dashboard definition in
@@ -357,56 +395,227 @@ func migrateLegacyCriteriaKeys(query map[string]any, source, dashboardID, widget
 	query["anyOf"] = migrated
 }
 
-// ResolveFilters returns tpl's Query with CurrentUserPlaceholder substituted
-// by currentUserID wherever it appears as a string inside a []any (the only
-// place a per-user value belongs in a criteria object — e.g. assignedUserIds,
-// userIds). It walks the object generically by key, so no criteria key name
-// is hardcoded here. It does not mutate tpl.Query.
-func ResolveFilters(tpl WidgetTemplate, currentUserID string) map[string]any {
-	return substituteCurrentUser(tpl.Query, currentUserID).(map[string]any)
+// caseTableResourceTypes is every ResourceType whose /search endpoint is the
+// case-search one (see ResourceCase's doc comment): the implied "type"
+// filter injectImpliedTypeFilters backstops is only meaningful for these.
+var caseTableResourceTypes = map[ResourceType]bool{
+	ResourceCase: true, ResourceServiceRequest: true, ResourceSecurityReportAnalysis: true,
+	ResourceAnnouncement: true, ResourceEngagement: true,
 }
 
-// ResolveSliceFilters is ResolveFilters' counterpart for one Shape "pie"
-// slice: substitutes CurrentUserPlaceholder in slice.Query only. It
-// deliberately does NOT merge in the widget's own base Query — the caller
-// (frontend) merges this slice's query under the widget's own resolved
-// Query itself (this slice's keys win on conflict), the same way it
-// already merges any other per-slice override. Sending the two separately,
-// rather than one pre-merged object per slice, avoids repeating the base
-// criteria' JSON in every slice over the wire. Does not mutate slice.Query.
-func ResolveSliceFilters(slice PieSlice, currentUserID string) map[string]any {
-	return substituteCurrentUser(slice.Query, currentUserID).(map[string]any)
-}
-
-func substituteCurrentUser(v any, currentUserID string) any {
-	switch val := v.(type) {
-	case map[string]any:
-		out := make(map[string]any, len(val))
-		for k, sub := range val {
-			out[k] = substituteCurrentUser(sub, currentUserID)
+// injectImpliedTypeFilters walks every widget (and, independently, every one
+// of its Slices) in d whose ResourceType is a caseTableResourceTypes member,
+// ensuring its own Query carries an explicit {"field":"type","op":"in",
+// "values":["<resourceType>"]} entry in its top-level "filters" array.
+//
+// A PieSlice's own Query is checked and injected into independently of its
+// owning widget's Query, not just once at the widget level: the frontend
+// resolves a slice's value by merging the slice's Query keys on top of the
+// widget's own base Query (this slice's keys win on conflict, see PieSlice's
+// doc comment) -- a shallow, whole-key merge, not an array-level one. A slice
+// that defines its own "filters" array therefore replaces the widget's
+// "filters" entirely, including whatever "type" entry was injected there,
+// unless the slice's own "filters" carries its own.
+//
+// If a Query already has an explicit "type" field filter, it is left
+// untouched (never overwritten) but warned about: after this mechanism (and
+// the config rewrite it backstops) lands, no widget should still need to
+// paste one in by hand.
+func injectImpliedTypeFilters(d *Dashboard, source string) {
+	for wi := range d.Widgets {
+		w := &d.Widgets[wi]
+		if !caseTableResourceTypes[w.ResourceType] {
+			continue
 		}
-		return out
-	case []string:
-		out := make([]string, len(val))
-		for i, s := range val {
-			if s == CurrentUserPlaceholder {
-				s = currentUserID
-			}
-			out[i] = s
+		w.Query = injectTypeFilter(w.Query, w.ResourceType, source, d.ID, w.ID, "")
+		for si := range w.Slices {
+			s := &w.Slices[si]
+			s.Query = injectTypeFilter(s.Query, w.ResourceType, source, d.ID, w.ID, s.Label)
 		}
-		return out
-	case []any:
-		out := make([]any, len(val))
-		for i, sub := range val {
-			out[i] = substituteCurrentUser(sub, currentUserID)
-		}
-		return out
-	case string:
-		if val == CurrentUserPlaceholder {
-			return currentUserID
-		}
-		return val
-	default:
-		return val
 	}
+}
+
+// injectTypeFilter returns query (creating it if nil) with an explicit
+// "type" filter entry guaranteed present in its top-level "filters" array,
+// for the given resourceType. See injectImpliedTypeFilters for the full
+// rationale; slice is "" when called for a widget's own Query, and the
+// slice's Label otherwise, purely so the warning below can name it.
+func injectTypeFilter(query map[string]any, resourceType ResourceType, source, dashboardID, widgetID, slice string) map[string]any {
+	if query == nil {
+		query = map[string]any{}
+	}
+	filters, _ := query["filters"].([]any)
+	for _, entry := range filters {
+		m, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+		if m["field"] == "type" {
+			attrs := []any{"source", source, "dashboardId", dashboardID, "widgetId", widgetID}
+			if slice != "" {
+				attrs = append(attrs, "slice", slice)
+			}
+			slog.Warn(`dashboard definitions: widget already has an explicit "type" filter; resourceType now auto-injects this at load time, so the explicit one is redundant -- remove it in a later config cleanup pass`, attrs...)
+			return query
+		}
+	}
+	query["filters"] = append(filters, map[string]any{
+		"field": "type", "op": "in", "values": []any{string(resourceType)},
+	})
+	return query
+}
+
+// isPresetRef reports whether m is a filter-preset reference, the
+// {"preset": "presetKey"} shape a literal filter object ({"field":
+// ...,"op":...,"values":...}) may be replaced with wherever one is legal
+// (see resolveDashboardFilterPresets). Any map carrying a "preset" key is
+// treated as an attempted reference -- including one with extra keys or a
+// non-string value -- so a malformed reference is rejected loudly by the
+// caller rather than silently treated as a literal filter with a
+// coincidentally-named "preset" field.
+func isPresetRef(m map[string]any) bool {
+	_, has := m["preset"]
+	return has
+}
+
+// resolvePresetRef expands one {"preset": "presetKey"} reference (m, which
+// isPresetRef has already confirmed carries a "preset" key) into a fresh
+// copy of the fragment presets[key] defines, or fails loud, naming ctx (the
+// dashboard/widget/slice/position the reference was found at) if the
+// reference is malformed or the key is unknown.
+func resolvePresetRef(m map[string]any, presets map[string]map[string]any, ctx string) (map[string]any, error) {
+	if len(m) != 1 {
+		return nil, fmt.Errorf("%s: preset reference %v carries extra keys; expected exactly {\"preset\": \"<key>\"}", ctx, m)
+	}
+	key, ok := m["preset"].(string)
+	if !ok || strings.TrimSpace(key) == "" {
+		return nil, fmt.Errorf("%s: preset reference %v has a non-string or empty \"preset\" key", ctx, m)
+	}
+	fragment, ok := presets[key]
+	if !ok {
+		return nil, fmt.Errorf("%s: references unknown filter preset %q; define it in this dashboard's own \"filterPresets\" or in the shared DASHBOARD_PRESETS_FILE", ctx, key)
+	}
+	out := make(map[string]any, len(fragment))
+	for k, v := range fragment {
+		out[k] = v
+	}
+	return out, nil
+}
+
+// resolveFilterList resolves every {"preset": "key"} entry in list (one
+// "filters" array, see resolveQueryPresets) into its literal fragment,
+// leaving every other entry untouched. ctx names the array for error
+// messages; list itself is never mutated, a new slice is returned.
+func resolveFilterList(list []any, presets map[string]map[string]any, ctx string) ([]any, error) {
+	out := make([]any, len(list))
+	for i, entry := range list {
+		m, ok := entry.(map[string]any)
+		if !ok || !isPresetRef(m) {
+			out[i] = entry
+			continue
+		}
+		resolved, err := resolvePresetRef(m, presets, fmt.Sprintf("%s[%d]", ctx, i))
+		if err != nil {
+			return nil, err
+		}
+		out[i] = resolved
+	}
+	return out, nil
+}
+
+// resolveQueryPresets expands every {"preset": "key"} reference inside
+// query in place -- in its own top-level "filters" array, and in each
+// "anyOf" branch's own "filters" array (the only two places a literal filter
+// object appears in this DSL, see WidgetTemplate's doc comment). query may
+// be nil, in which case there is nothing to resolve. ctx names the owning
+// widget/slice for error messages.
+func resolveQueryPresets(query map[string]any, presets map[string]map[string]any, ctx string) error {
+	if query == nil {
+		return nil
+	}
+	if arr, ok := query["filters"].([]any); ok {
+		resolved, err := resolveFilterList(arr, presets, ctx+`: "query.filters"`)
+		if err != nil {
+			return err
+		}
+		query["filters"] = resolved
+	}
+	if anyOf, ok := query["anyOf"].([]any); ok {
+		for i, branch := range anyOf {
+			bm, ok := branch.(map[string]any)
+			if !ok {
+				continue
+			}
+			if arr, ok := bm["filters"].([]any); ok {
+				resolved, err := resolveFilterList(arr, presets, fmt.Sprintf("%s: \"query.anyOf[%d].filters\"", ctx, i))
+				if err != nil {
+					return err
+				}
+				bm["filters"] = resolved
+			}
+		}
+	}
+	return nil
+}
+
+// validatePresetsNotRecursive rejects a preset whose own fragment is itself
+// a {"preset": ...} reference: presets are a flat, one-level expansion, and
+// silently ignoring a nested reference would leave a widget's Query holding
+// an unresolved {"preset": ...} object that reaches the frontend/entity
+// service looking like (and being misread as) a literal filter.
+func validatePresetsNotRecursive(presets map[string]map[string]any, source, label string) error {
+	for key, fragment := range presets {
+		if isPresetRef(fragment) {
+			return fmt.Errorf("dashboard definitions: %s: %s preset %q is itself a preset reference; a preset's fragment must be a literal filter, presets cannot reference other presets", source, label, key)
+		}
+	}
+	return nil
+}
+
+// resolveDashboardFilterPresets expands every {"preset": "key"} reference in
+// d's widgets (and their slices) into its literal fragment, once, in place.
+// The effective preset set for d is sharedPresets with d.FilterPresets
+// merged on top -- a dashboard-local preset shadows a same-named shared one
+// on key collision, by design (a dashboard can intentionally override a
+// shared default). d.FilterPresets itself is validated non-recursive first,
+// same as the shared set (see LoadSharedPresets).
+func resolveDashboardFilterPresets(d *Dashboard, sharedPresets map[string]map[string]any, source string) error {
+	if err := validatePresetsNotRecursive(d.FilterPresets, source, `dashboard-local "filterPresets"`); err != nil {
+		return err
+	}
+
+	presets := sharedPresets
+	if len(d.FilterPresets) > 0 {
+		merged := make(map[string]map[string]any, len(sharedPresets)+len(d.FilterPresets))
+		for k, v := range sharedPresets {
+			merged[k] = v
+		}
+		for k, v := range d.FilterPresets {
+			merged[k] = v
+		}
+		presets = merged
+	}
+	// Deliberately no "presets is empty, skip resolution" short circuit even
+	// though it looks like a safe optimization: a widget can carry a
+	// {"preset": "key"} reference with no presets configured anywhere (a
+	// typo, or a preset definition that was removed), and that must still
+	// fail loud here -- resolveQueryPresets/resolvePresetRef already handles
+	// a nil/empty presets map correctly (the lookup simply misses and
+	// reports the unknown key), so there is nothing to gain by skipping.
+
+	for wi := range d.Widgets {
+		w := &d.Widgets[wi]
+		ctx := fmt.Sprintf("dashboard definitions: %s (id %q): widget %q", source, d.ID, w.ID)
+		if err := resolveQueryPresets(w.Query, presets, ctx); err != nil {
+			return err
+		}
+		for si := range w.Slices {
+			s := &w.Slices[si]
+			sctx := fmt.Sprintf("%s: slice %q", ctx, s.Label)
+			if err := resolveQueryPresets(s.Query, presets, sctx); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }

--- a/apps/csm-portal/backend/internal/dashboard/widgets.go
+++ b/apps/csm-portal/backend/internal/dashboard/widgets.go
@@ -101,6 +101,30 @@ func (s *PieSlice) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// Column is one column of a Shape "list" widget's generic column renderer
+// (see WidgetTemplate.Columns). It is opaque config, like Query/SortBy: the
+// BE never resolves Path or interprets Format, it only forwards this struct
+// to the frontend as part of the widget's own view.
+type Column struct {
+	// Path addresses a field on each item of that ResourceType's own
+	// /search response, dot-separated to reach into nested objects/refs to
+	// arbitrary depth (e.g. "project.key", "project.account.tier") — every
+	// resource's search response embeds related entities as nested JSON
+	// objects, not flat records. Not validated here: the frontend resolves
+	// it against whatever the response actually returns, and a path that
+	// resolves to nothing renders that cell empty rather than erroring the
+	// whole widget.
+	Path string `json:"path"`
+	// Label is this column's header text.
+	Label string `json:"label"`
+	// Format is a rendering hint for the resolved value. "" (equivalently
+	// "text", the default) renders plain text; "date" formats a date/
+	// date-time string the same way the frontend's existing hardcoded list
+	// renderers already format one. Not validated here — the frontend falls
+	// back to plain text for a value it doesn't recognize.
+	Format string `json:"format,omitempty"`
+}
+
 // WidgetTemplate is resource-agnostic: Query is opaque JSON, forwarded
 // verbatim (after __current_user__ substitution) as the filters object of
 // that ResourceType's own /search payload (every resource's search payload
@@ -129,6 +153,20 @@ type WidgetTemplate struct {
 	// Widgets with no Section (the common case) render in one untitled
 	// group, exactly as before this field existed.
 	Section string `json:"section,omitempty"`
+	// Columns is only meaningful for Shape list: an ordered set of columns
+	// the frontend should render instead of that ResourceType's own
+	// hardcoded list renderer. Each entry's Path is resolved against every
+	// item in the resolved search response (see Column). Absent/empty
+	// Columns is a no-op — the frontend falls back to its existing
+	// per-ResourceType renderer exactly as before this field existed.
+	Columns []Column `json:"columns,omitempty"`
+	// SortBy is only meaningful for Shape list: opaque JSON, forwarded
+	// verbatim as the sortBy object of that ResourceType's own /search
+	// payload — same passthrough philosophy as Query/filters. The BE does
+	// not validate or interpret it; an unsupported field name for that
+	// ResourceType is a caller (frontend/config-author) mistake, surfaced by
+	// that resource's own /search endpoint, not caught here.
+	SortBy map[string]any `json:"sortBy,omitempty"`
 
 	// legacyFilters holds a pre-rename config's "filters" key so
 	// migrateLegacyWidgetKeys can move it into Query. Unexported so it can

--- a/apps/csm-portal/backend/internal/dashboard/widgets.go
+++ b/apps/csm-portal/backend/internal/dashboard/widgets.go
@@ -444,7 +444,18 @@ func injectTypeFilter(query map[string]any, resourceType ResourceType, source, d
 	if query == nil {
 		query = map[string]any{}
 	}
-	filters, _ := query["filters"].([]any)
+	filters, isArray := query["filters"].([]any)
+	if raw, present := query["filters"]; present && !isArray {
+		// A non-array "filters" is silently ignored by the loop below and
+		// then overwritten by the auto-injected type filter, so the widget
+		// would search with criteria the definition does not state. Nothing
+		// downstream can detect that, so say so at load time.
+		attrs := []any{"source", source, "dashboardId", dashboardID, "widgetId", widgetID, "got", fmt.Sprintf("%T", raw)}
+		if slice != "" {
+			attrs = append(attrs, "slice", slice)
+		}
+		slog.Warn(`dashboard definitions: widget "filters" is not an array; the configured value is discarded and replaced by the auto-injected "type" filter`, attrs...)
+	}
 	for _, entry := range filters {
 		m, ok := entry.(map[string]any)
 		if !ok {

--- a/apps/csm-portal/backend/internal/dashboard/widgets_test.go
+++ b/apps/csm-portal/backend/internal/dashboard/widgets_test.go
@@ -119,17 +119,16 @@ func TestParseDashboardsConfig_ValidRoundTrip(t *testing.T) {
 		t.Errorf("WidgetTemplate.GridWidth = %d, want 3", w.GridWidth)
 	}
 
-	// The detail that matters for ResolveFilters' substitution logic
-	// downstream: a JSON array value unmarshals into map[string]any as
-	// []any, not []string — assert the actual runtime type, not just
-	// presence, since substituteCurrentUser's []any and []string cases
-	// behave identically but are reached via different type switches.
+	// The "__current_user__" placeholder is deliberately left exactly as
+	// authored: this package no longer substitutes it (that moved to the
+	// frontend, see DashboardHandler's doc comment in
+	// internal/handler/dashboards.go) — it is opaque config content here,
+	// same as every other filter value.
 	//
 	// Query is opaque to this package (see widgets.go's WidgetTemplate doc
 	// comment), so the specific case-search filter DSL shape used here
 	// ({"filters":[{"field","op","values"}, ...]}, see .env.example's
-	// DASHBOARDS_CONFIG) is just realistic example data for this generic
-	// substitution test, not something ResolveFilters interprets.
+	// DASHBOARDS_CONFIG) is just realistic example data.
 	assignedEntryValues := func(query map[string]any) ([]any, bool) {
 		arr, ok := query["filters"].([]any)
 		if !ok || len(arr) == 0 {
@@ -147,16 +146,8 @@ func TestParseDashboardsConfig_ValidRoundTrip(t *testing.T) {
 	if !ok {
 		t.Fatalf("Query has no filters[0].values entry")
 	}
-	if len(assigned) != 1 || assigned[0] != CurrentUserPlaceholder {
-		t.Errorf("Query[filters][0][values] = %v, want [%q]", assigned, CurrentUserPlaceholder)
-	}
-
-	// End-to-end: resolving through the real substitution path yields a
-	// concrete user id in place of the placeholder.
-	resolved := ResolveFilters(w, "user-123")
-	resolvedAssigned, ok := assignedEntryValues(resolved)
-	if !ok || len(resolvedAssigned) != 1 || resolvedAssigned[0] != "user-123" {
-		t.Errorf("ResolveFilters(...)[filters][0][values] = %v, want [\"user-123\"]", resolvedAssigned)
+	if len(assigned) != 1 || assigned[0] != "__current_user__" {
+		t.Errorf("Query[filters][0][values] = %v, want the unresolved placeholder [%q]", assigned, "__current_user__")
 	}
 }
 
@@ -202,16 +193,17 @@ func TestParseDashboardsConfig_PieWidgetSlicesAndDescription(t *testing.T) {
 		t.Errorf("Slices[0] = %+v, want {Label: Critical, Color: error}", w.Slices[0])
 	}
 
-	// A slice's own criteria resolve the current-user placeholder
-	// independently of the widget's own base Query — ResolveSliceFilters
-	// must not require (or merge in) the base at all.
-	resolved := ResolveSliceFilters(w.Slices[1], "user-123")
-	assigned, ok := resolved["assignedUserIds"].([]any)
-	if !ok || len(assigned) != 1 || assigned[0] != "user-123" {
-		t.Errorf("ResolveSliceFilters(Slices[1], ...)[assignedUserIds] = %v, want [\"user-123\"]", resolved["assignedUserIds"])
+	// A slice's own criteria keep the literal "__current_user__" placeholder
+	// (substitution moved to the frontend, see DashboardHandler's doc
+	// comment) and stay independent of the widget's own base Query — this
+	// package never merges the two.
+	sliceQuery := w.Slices[1].Query
+	assigned, ok := sliceQuery["assignedUserIds"].([]any)
+	if !ok || len(assigned) != 1 || assigned[0] != "__current_user__" {
+		t.Errorf("Slices[1].Query[assignedUserIds] = %v, want the unresolved placeholder [%q]", sliceQuery["assignedUserIds"], "__current_user__")
 	}
-	if _, present := resolved["states"]; present {
-		t.Errorf("ResolveSliceFilters must not merge in the widget's own base query, got %v", resolved)
+	if _, present := sliceQuery["states"]; present {
+		t.Errorf("Slices[1].Query must not carry the widget's own base query, got %v", sliceQuery)
 	}
 }
 
@@ -307,8 +299,13 @@ func TestParseDashboardsConfig_LegacyKeys(t *testing.T) {
 		t.Errorf(`the criteria object's own "filters" array must be untouched by the rename: %v`, w.Query)
 	}
 
-	// 4. Legacy slice-level "filters" lands in the slice's Query and still
-	//    resolves the current-user placeholder end to end.
+	// 4. Legacy slice-level "filters" lands in the slice's Query and keeps
+	//    the literal "__current_user__" placeholder -- this package no
+	//    longer resolves it, see DashboardHandler's doc comment in
+	//    internal/handler/dashboards.go. The slice's own case-table
+	//    resourceType also picks up the auto-injected "type" filter (see
+	//    injectImpliedTypeFilters), so the array now carries 2 entries, not
+	//    just the configured one.
 	pie := got[0].Widgets[1]
 	if pie.Query == nil {
 		t.Fatalf("legacy pie widget Query is nil")
@@ -316,15 +313,19 @@ func TestParseDashboardsConfig_LegacyKeys(t *testing.T) {
 	if len(pie.Slices) != 1 || pie.Slices[0].Query == nil {
 		t.Fatalf("legacy slice \"filters\" was not adopted into Query: %+v", pie.Slices)
 	}
-	resolved := ResolveSliceFilters(pie.Slices[0], "user-123")
-	arr, ok := resolved["filters"].([]any)
-	if !ok || len(arr) != 1 {
-		t.Fatalf("ResolveSliceFilters(legacy slice) = %v", resolved)
+	arr, ok := pie.Slices[0].Query["filters"].([]any)
+	if !ok {
+		t.Fatalf("legacy slice Query has no \"filters\" array: %v", pie.Slices[0].Query)
 	}
-	entry, _ := arr[0].(map[string]any)
-	values, ok := entry["values"].([]any)
-	if !ok || len(values) != 1 || values[0] != "user-123" {
-		t.Errorf("legacy slice placeholder unresolved: values = %v, want [\"user-123\"]", entry["values"])
+	var assignedValues []any
+	for _, e := range arr {
+		m, _ := e.(map[string]any)
+		if m["field"] == "assignedUserId" {
+			assignedValues, _ = m["values"].([]any)
+		}
+	}
+	if len(assignedValues) != 1 || assignedValues[0] != "__current_user__" {
+		t.Errorf("legacy slice assignedUserId values = %v, want the unresolved placeholder [%q]", assignedValues, "__current_user__")
 	}
 }
 
@@ -363,14 +364,23 @@ func TestParseDashboardsConfig_NewKeysWinOverLegacy(t *testing.T) {
 	}
 	q := got[0].Widgets[0].Query
 
+	// resourceType "case" also picks up the auto-injected "type" filter
+	// (see injectImpliedTypeFilters), so the array carries that entry
+	// alongside the configured "state" one -- find the "state" entry by
+	// field rather than assuming it is the only one.
 	arr, ok := q["filters"].([]any)
-	if !ok || len(arr) != 1 {
+	if !ok {
 		t.Fatalf(`Query["filters"] = %v`, q["filters"])
 	}
-	entry, _ := arr[0].(map[string]any)
-	values, _ := entry["values"].([]any)
-	if len(values) != 1 || values[0] != "open" {
-		t.Errorf(`"query" must win over the deprecated "filters": got state values %v, want ["open"]`, values)
+	var stateValues []any
+	for _, e := range arr {
+		m, _ := e.(map[string]any)
+		if m["field"] == "state" {
+			stateValues, _ = m["values"].([]any)
+		}
+	}
+	if len(stateValues) != 1 || stateValues[0] != "open" {
+		t.Errorf(`"query" must win over the deprecated "filters": got state values %v, want ["open"]`, stateValues)
 	}
 
 	if _, stillThere := q["orGroups"]; stillThere {

--- a/apps/csm-portal/backend/internal/dashboard/widgets_test.go
+++ b/apps/csm-portal/backend/internal/dashboard/widgets_test.go
@@ -416,3 +416,76 @@ func TestParseDashboardsConfig_WidgetSection(t *testing.T) {
 		t.Errorf("escalated-incidents.Section = %q, want %q", section, "Escalations")
 	}
 }
+
+func TestParseDashboardsConfig_WidgetColumnsAndSortBy(t *testing.T) {
+	const raw = `[
+		{
+			"id": "sample-dashboard",
+			"displayName": "Sample Dashboard",
+			"widgets": [
+				{
+					"id": "my-patches",
+					"displayName": "My Patches",
+					"resourceType": "case",
+					"shape": "list",
+					"gridWidth": 12,
+					"query": {},
+					"columns": [
+						{"path": "subject", "label": "Subject"},
+						{"path": "project.key", "label": "Project key"},
+						{"path": "bestCaseFixEta", "label": "Best case ETA", "format": "date"}
+					],
+					"sortBy": {"field": "updatedOn", "order": "asc"}
+				},
+				{
+					"id": "no-columns-widget",
+					"displayName": "No Columns Widget",
+					"resourceType": "case",
+					"shape": "list",
+					"gridWidth": 12,
+					"query": {}
+				}
+			]
+		}
+	]`
+
+	got, err := ParseDashboardsConfig(raw)
+	if err != nil {
+		t.Fatalf("ParseDashboardsConfig returned error: %v", err)
+	}
+	if len(got) != 1 || len(got[0].Widgets) != 2 {
+		t.Fatalf("ParseDashboardsConfig(raw) = %+v, want 1 dashboard with 2 widgets", got)
+	}
+
+	w := got[0].Widgets[0]
+	wantColumns := []Column{
+		{Path: "subject", Label: "Subject"},
+		{Path: "project.key", Label: "Project key"},
+		{Path: "bestCaseFixEta", Label: "Best case ETA", Format: "date"},
+	}
+	if len(w.Columns) != len(wantColumns) {
+		t.Fatalf("my-patches.Columns = %+v, want %+v", w.Columns, wantColumns)
+	}
+	for i, want := range wantColumns {
+		if w.Columns[i] != want {
+			t.Errorf("my-patches.Columns[%d] = %+v, want %+v", i, w.Columns[i], want)
+		}
+	}
+	if field, _ := w.SortBy["field"].(string); field != "updatedOn" {
+		t.Errorf("my-patches.SortBy[field] = %v, want %q", w.SortBy["field"], "updatedOn")
+	}
+	if order, _ := w.SortBy["order"].(string); order != "asc" {
+		t.Errorf("my-patches.SortBy[order] = %v, want %q", w.SortBy["order"], "asc")
+	}
+
+	// A widget with neither key configured round-trips to nil for both — the
+	// existing hardcoded per-resourceType frontend renderer's own no-op path
+	// depends on this staying nil, not an empty slice/map.
+	noColumns := got[0].Widgets[1]
+	if noColumns.Columns != nil {
+		t.Errorf("no-columns-widget.Columns = %+v, want nil", noColumns.Columns)
+	}
+	if noColumns.SortBy != nil {
+		t.Errorf("no-columns-widget.SortBy = %+v, want nil", noColumns.SortBy)
+	}
+}

--- a/apps/csm-portal/backend/internal/handler/cases.go
+++ b/apps/csm-portal/backend/internal/handler/cases.go
@@ -230,8 +230,11 @@ func (h *CaseHandler) CreateCaseComment(w http.ResponseWriter, r *http.Request) 
 			return
 		}
 		var currentCase struct {
-			State     string  `json:"state"`
-			WorkState *string `json:"workState"`
+			State            string  `json:"state"`
+			WorkState        *string `json:"workState"`
+			AssignedEngineer *struct {
+				ID *string `json:"id"`
+			} `json:"assignedEngineer"`
 		}
 		if err := json.Unmarshal(current, &currentCase); err != nil {
 			slog.ErrorContext(r.Context(), "failed to parse case state for comment guard", "userID", user.UserID, "caseID", caseID, "err", err)
@@ -240,6 +243,10 @@ func (h *CaseHandler) CreateCaseComment(w http.ResponseWriter, r *http.Request) 
 		}
 		if currentCase.State != "work_in_progress" || currentCase.WorkState == nil || *currentCase.WorkState != "ongoing" {
 			writeError(w, http.StatusConflict, ErrMsgCommentNotAllowed)
+			return
+		}
+		if currentCase.AssignedEngineer == nil || currentCase.AssignedEngineer.ID == nil || *currentCase.AssignedEngineer.ID != user.UserID {
+			writeError(w, http.StatusForbidden, ErrMsgCommentNotOwnCase)
 			return
 		}
 	}

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -257,7 +257,9 @@ func TestCreateCaseComment(t *testing.T) {
 		assertContentType(t, w, "application/json")
 	})
 
-	const ongoingCase = `{"state":"work_in_progress","workState":"ongoing"}`
+	// user-123 is the UserID set by withUser (see helpers_test.go), so this fixture
+	// represents the requesting user being the case's assigned engineer.
+	const ongoingCase = `{"state":"work_in_progress","workState":"ongoing","assignedEngineer":{"id":"user-123"}}`
 
 	t.Run("rejects comment when state is not work_in_progress", func(t *testing.T) {
 		for _, state := range []string{"open", "waiting_on_wso2", "closed"} {
@@ -307,6 +309,53 @@ func TestCreateCaseComment(t *testing.T) {
 		h.CreateCaseComment(w, r)
 		assertStatus(t, w, http.StatusConflict)
 		assertErrorMessage(t, w, ErrMsgCommentNotAllowed)
+	})
+
+	t.Run("rejects public comment when requester is not the assigned engineer", func(t *testing.T) {
+		client := &mockEntityCaseClient{
+			getCaseFn: func(_ context.Context, _ string) ([]byte, error) {
+				return []byte(`{"state":"work_in_progress","workState":"ongoing","assignedEngineer":{"id":"someone-else"}}`), nil
+			},
+		}
+		h := NewCaseHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/case-1/comments", strings.NewReader(validPayload)))
+		r.SetPathValue("id", "case-1")
+		w := httptest.NewRecorder()
+		h.CreateCaseComment(w, r)
+		assertStatus(t, w, http.StatusForbidden)
+		assertErrorMessage(t, w, ErrMsgCommentNotOwnCase)
+	})
+
+	t.Run("rejects public comment when case has no assigned engineer", func(t *testing.T) {
+		client := &mockEntityCaseClient{
+			getCaseFn: func(_ context.Context, _ string) ([]byte, error) {
+				return []byte(`{"state":"work_in_progress","workState":"ongoing"}`), nil
+			},
+		}
+		h := NewCaseHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/case-1/comments", strings.NewReader(validPayload)))
+		r.SetPathValue("id", "case-1")
+		w := httptest.NewRecorder()
+		h.CreateCaseComment(w, r)
+		assertStatus(t, w, http.StatusForbidden)
+		assertErrorMessage(t, w, ErrMsgCommentNotOwnCase)
+	})
+
+	t.Run("allows public comment when requester is the assigned engineer", func(t *testing.T) {
+		client := &mockEntityCaseClient{
+			getCaseFn: func(_ context.Context, _ string) ([]byte, error) {
+				return []byte(ongoingCase), nil
+			},
+			createCaseCommentFn: func(_ context.Context, _ string, _ []byte) ([]byte, error) {
+				return []byte(`{"id":"comment-1"}`), nil
+			},
+		}
+		h := NewCaseHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/case-1/comments", strings.NewReader(validPayload)))
+		r.SetPathValue("id", "case-1")
+		w := httptest.NewRecorder()
+		h.CreateCaseComment(w, r)
+		assertStatus(t, w, http.StatusCreated)
 	})
 
 	t.Run("allows work_note when case is not closed", func(t *testing.T) {

--- a/apps/csm-portal/backend/internal/handler/dashboards.go
+++ b/apps/csm-portal/backend/internal/handler/dashboards.go
@@ -17,8 +17,6 @@
 package handler
 
 import (
-	"encoding/json"
-	"log/slog"
 	"net/http"
 
 	"github.com/wso2-open-operations/cs-tools/apps/csm-portal/backend/internal/dashboard"
@@ -26,9 +24,12 @@ import (
 )
 
 // dashboardPieSliceView is one wedge of a Shape "pie" widget — see
-// dashboard.PieSlice. Query is this slice's own criteria only (already
-// __current_user__-resolved), meant to be merged under the parent widget's
-// own (also resolved) Query by the caller.
+// dashboard.PieSlice. Query is this slice's own criteria verbatim, including
+// any unresolved "__current_user__"/"__current_team__" placeholder a filter
+// value carries — the caller (frontend) resolves those client-side (see
+// apps/csm-portal/webapp/src/features/csm-dashboard/utils/teamFilterPlaceholder.ts
+// for the pattern this mirrors), and merges Query under the parent widget's
+// own Query itself.
 type dashboardPieSliceView struct {
 	Label string         `json:"label"`
 	Color string         `json:"color,omitempty"`
@@ -91,50 +92,21 @@ type dashboardDetailView struct {
 
 // DashboardHandler handles HTTP requests for the config-driven dashboard
 // widget pilot.
-type DashboardHandler struct {
-	entity entityUserClient
-}
-
-// NewDashboardHandler creates a DashboardHandler backed by the given entity
-// client, used to resolve the caller's own platform user id (see
-// resolveCurrentUserID) for widgets whose filters need it.
-func NewDashboardHandler(entity entityUserClient) *DashboardHandler {
-	return &DashboardHandler{entity: entity}
-}
-
-// resolveCurrentUserID returns the caller's platform user id — the same id
-// GET /users/me resolves via the entity service — for substituting
-// dashboard.CurrentUserPlaceholder into widget filters.
 //
-// This is deliberately NOT user.UserID from the JWT: that claim is whatever
-// identity value the gateway/IdP embeds (e.g. the Asgardeo subject), which is
-// a different id than the platform's own SN/Postgres-backed user record.
-// Using the JWT claim directly here was the actual bug behind an
-// "identity-mapping gap" this task had, until now, treated as an accepted
-// ServiceNow DEV environment limitation: /cases/search correctly rejected
-// that id with "no active user found for sys_id ..." because it was never a
-// valid sys_id to begin with. Falls back to the JWT claim (rather than an
-// empty string) only if the entity lookup itself fails, so a transient
-// entity-service error degrades to the previous (broken but non-crashing)
-// behavior instead of a hard failure.
-func (h *DashboardHandler) resolveCurrentUserID(r *http.Request, user *middleware.UserInfo) string {
-	raw, err := h.entity.GetUserMe(r.Context())
-	if err != nil {
-		slog.ErrorContext(r.Context(), "entity GetUserMe failed while resolving dashboard current-user id", "userID", user.UserID, "err", err)
-		return user.UserID
-	}
-	var me struct {
-		ID string `json:"id"`
-	}
-	if err := json.Unmarshal(raw, &me); err != nil {
-		slog.ErrorContext(r.Context(), "entity GetUserMe: parse response failed while resolving dashboard current-user id", "userID", user.UserID, "err", err)
-		return user.UserID
-	}
-	if me.ID == "" {
-		slog.ErrorContext(r.Context(), "entity GetUserMe returned an empty id while resolving dashboard current-user id", "userID", user.UserID)
-		return user.UserID
-	}
-	return me.ID
+// It has no upstream dependency: every widget's Query/Slices are served
+// straight from the registry, with any "__current_user__"/"__current_team__"
+// placeholder a filter value carries left exactly as configured for the
+// frontend to resolve client-side. Resolving the current user's own platform
+// id used to require an entity-service round trip (GET /users/me) on every
+// request here; that responsibility moved to the frontend, which already
+// resolves GET /users/me for its own purposes and can substitute the id
+// itself, the same way it already does for "__current_team__" (see
+// apps/csm-portal/webapp/src/features/csm-dashboard/utils/teamFilterPlaceholder.ts).
+type DashboardHandler struct{}
+
+// NewDashboardHandler creates a DashboardHandler.
+func NewDashboardHandler() *DashboardHandler {
+	return &DashboardHandler{}
 }
 
 // GetDashboards handles GET /dashboards.
@@ -175,8 +147,6 @@ func (h *DashboardHandler) GetDashboardDetail(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	currentUserID := h.resolveCurrentUserID(r, user)
-
 	widgets := make([]dashboardWidgetView, 0, len(d.Widgets))
 	for _, tpl := range d.Widgets {
 		var slices []dashboardPieSliceView
@@ -186,7 +156,7 @@ func (h *DashboardHandler) GetDashboardDetail(w http.ResponseWriter, r *http.Req
 				slices = append(slices, dashboardPieSliceView{
 					Label: slice.Label,
 					Color: slice.Color,
-					Query: dashboard.ResolveSliceFilters(slice, currentUserID),
+					Query: slice.Query,
 				})
 			}
 		}
@@ -197,7 +167,7 @@ func (h *DashboardHandler) GetDashboardDetail(w http.ResponseWriter, r *http.Req
 			ResourceType: tpl.ResourceType,
 			Shape:        tpl.Shape,
 			GridWidth:    tpl.GridWidth,
-			Query:        dashboard.ResolveFilters(tpl, currentUserID),
+			Query:        tpl.Query,
 			GroupBy:      tpl.GroupBy,
 			ListLimit:    tpl.ListLimit,
 			Slices:       slices,

--- a/apps/csm-portal/backend/internal/handler/dashboards.go
+++ b/apps/csm-portal/backend/internal/handler/dashboards.go
@@ -51,6 +51,13 @@ type dashboardWidgetView struct {
 	ListLimit    int                     `json:"listLimit,omitempty"`
 	Slices       []dashboardPieSliceView `json:"slices,omitempty"`
 	Section      string                  `json:"section,omitempty"`
+	// Columns and SortBy are only meaningful for Shape "list" — see
+	// dashboard.WidgetTemplate.Columns/SortBy. Forwarded verbatim: Columns
+	// is display config the BE never resolves, and SortBy is opaque search
+	// criteria like Query, just for that ResourceType's own /search
+	// request's "sortBy" instead of its "filters".
+	Columns []dashboard.Column `json:"columns,omitempty"`
+	SortBy  map[string]any     `json:"sortBy,omitempty"`
 }
 
 // dashboardListItemView is a dashboard's list-level metadata, returned by
@@ -195,6 +202,8 @@ func (h *DashboardHandler) GetDashboardDetail(w http.ResponseWriter, r *http.Req
 			ListLimit:    tpl.ListLimit,
 			Slices:       slices,
 			Section:      tpl.Section,
+			Columns:      tpl.Columns,
+			SortBy:       tpl.SortBy,
 		})
 	}
 

--- a/apps/csm-portal/backend/internal/handler/dashboards_test.go
+++ b/apps/csm-portal/backend/internal/handler/dashboards_test.go
@@ -46,7 +46,7 @@ import (
 const testDashboardsConfigJSON = `[
   {"id":"sample-dashboard","displayName":"Sample Dashboard","isDefault":true,"targetTeam":"sample-team","widgets":[
     {"id":"my-open-cases","displayName":"My Open Cases","resourceType":"case","shape":"count","gridWidth":3,"query":{"filters":[{"field":"assignedUserId","op":"in","values":["__current_user__"]},{"field":"state","op":"in","values":["open","work_in_progress"]}]}},
-    {"id":"recent-cases","displayName":"Recent Cases","resourceType":"case","shape":"list","gridWidth":6,"listLimit":5,"query":{"filters":[{"field":"tag","op":"in","values":["example-tag"]},{"field":"tag","op":"notIn","values":["excluded-example-tag"]}]}},
+    {"id":"recent-cases","displayName":"Recent Cases","resourceType":"case","shape":"list","gridWidth":6,"listLimit":5,"query":{"filters":[{"field":"tag","op":"in","values":["example-tag"]},{"field":"tag","op":"notIn","values":["excluded-example-tag"]}]},"columns":[{"path":"subject","label":"Subject"},{"path":"project.key","label":"Project key"}],"sortBy":{"field":"updatedOn","order":"asc"}},
     {"id":"pending-time-cards","displayName":"Pending Time Cards","resourceType":"time_card","shape":"count","gridWidth":3,"query":{"states":["pending"]}},
     {"id":"open-vulnerabilities","displayName":"Open Vulnerabilities","resourceType":"product_vulnerability","shape":"count","gridWidth":3,"query":{"priority":"high"}}
   ]},
@@ -412,6 +412,43 @@ func TestGetDashboardDetail(t *testing.T) {
 		recentFilters := result.Widgets[recentIdx].Query
 		if v, present := filterValuesByField(recentFilters, "assignedUserId"); present {
 			t.Errorf("widget recent-cases filters unexpectedly has an assignedUserId field entry: %v", v)
+		}
+
+		// recent-cases' columns/sortBy round-trip onto the wire verbatim —
+		// the BE never resolves a column's path or interprets sortBy, both
+		// are forwarded exactly as configured (see dashboard.Column doc
+		// comment and WidgetTemplate.SortBy).
+		recentColumns := result.Widgets[recentIdx].Columns
+		wantColumns := []dashboard.Column{
+			{Path: "subject", Label: "Subject"},
+			{Path: "project.key", Label: "Project key"},
+		}
+		if len(recentColumns) != len(wantColumns) {
+			t.Fatalf("widget recent-cases columns = %+v, want %+v", recentColumns, wantColumns)
+		}
+		for i, want := range wantColumns {
+			if recentColumns[i] != want {
+				t.Errorf("widget recent-cases columns[%d] = %+v, want %+v", i, recentColumns[i], want)
+			}
+		}
+		recentSortBy := result.Widgets[recentIdx].SortBy
+		if field, _ := recentSortBy["field"].(string); field != "updatedOn" {
+			t.Errorf("widget recent-cases sortBy[field] = %v, want %q", recentSortBy["field"], "updatedOn")
+		}
+		if order, _ := recentSortBy["order"].(string); order != "asc" {
+			t.Errorf("widget recent-cases sortBy[order] = %v, want %q", recentSortBy["order"], "asc")
+		}
+
+		// my-open-cases sets neither columns nor sortBy in the template
+		// (testDashboardsConfigJSON above) — both must stay absent from the
+		// wire (omitempty), not render as an empty array/object, so a widget
+		// that never opted in is byte-for-byte unaffected by this feature.
+		rawOpenCases := rawWidgets[openIdx]
+		if _, present := rawOpenCases["columns"]; present {
+			t.Errorf("widget my-open-cases unexpectedly has a columns key on the wire: %s", rawOpenCases["columns"])
+		}
+		if _, present := rawOpenCases["sortBy"]; present {
+			t.Errorf("widget my-open-cases unexpectedly has a sortBy key on the wire: %s", rawOpenCases["sortBy"])
 		}
 	})
 

--- a/apps/csm-portal/backend/internal/handler/dashboards_test.go
+++ b/apps/csm-portal/backend/internal/handler/dashboards_test.go
@@ -17,9 +17,7 @@
 package handler
 
 import (
-	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -161,16 +159,17 @@ func withDashboardID(r *http.Request, dashboardID string) *http.Request {
 	return r
 }
 
-// resolvedCurrentUserID is mockEntityUserClient's default GET /users/me id
-// (helpers_test.go). It is deliberately NOT testUser.UserID (the JWT claim):
-// the handler resolves __current_user__ via the entity service's /users/me,
-// the same id GET /users/me itself returns — see
-// DashboardHandler.resolveCurrentUserID's doc comment for why.
-const resolvedCurrentUserID = "11111111-1111-1111-1111-111111111111"
+// currentUserPlaceholder is the literal string a case widget's
+// assignedUserId filter carries for "the signed-in user's own cases" — see
+// testDashboardsConfigJSON's "my-open-cases"/"Mine" entries. The handler no
+// longer resolves it (see DashboardHandler's doc comment in dashboards.go):
+// it is expected to reach the response exactly as configured, for the
+// frontend to substitute client-side.
+const currentUserPlaceholder = "__current_user__"
 
 func TestGetDashboards(t *testing.T) {
 	t.Run("requires authenticated user", func(t *testing.T) {
-		h := NewDashboardHandler(&mockEntityUserClient{})
+		h := NewDashboardHandler()
 		r := httptest.NewRequest(http.MethodGet, "/dashboards", nil)
 		w := httptest.NewRecorder()
 		h.GetDashboards(w, r)
@@ -180,7 +179,7 @@ func TestGetDashboards(t *testing.T) {
 	})
 
 	t.Run("returns all dashboards in registry order with correct isDefault", func(t *testing.T) {
-		h := NewDashboardHandler(&mockEntityUserClient{})
+		h := NewDashboardHandler()
 		r := withUser(httptest.NewRequest(http.MethodGet, "/dashboards", nil))
 		w := httptest.NewRecorder()
 		h.GetDashboards(w, r)
@@ -266,7 +265,7 @@ func TestAllDashboardsHaveWidgets(t *testing.T) {
 
 func TestGetDashboardDetail(t *testing.T) {
 	t.Run("requires authenticated user", func(t *testing.T) {
-		h := NewDashboardHandler(&mockEntityUserClient{})
+		h := NewDashboardHandler()
 		r := withDashboardID(httptest.NewRequest(http.MethodGet, "/dashboards/sample-dashboard", nil), "sample-dashboard")
 		w := httptest.NewRecorder()
 		h.GetDashboardDetail(w, r)
@@ -276,7 +275,7 @@ func TestGetDashboardDetail(t *testing.T) {
 	})
 
 	t.Run("unknown dashboard id returns 404", func(t *testing.T) {
-		h := NewDashboardHandler(&mockEntityUserClient{})
+		h := NewDashboardHandler()
 		r := withUser(withDashboardID(httptest.NewRequest(http.MethodGet, "/dashboards/bogus", nil), "bogus"))
 		w := httptest.NewRecorder()
 		h.GetDashboardDetail(w, r)
@@ -285,7 +284,7 @@ func TestGetDashboardDetail(t *testing.T) {
 	})
 
 	t.Run("sample-dashboard returns metadata and its four widgets", func(t *testing.T) {
-		h := NewDashboardHandler(&mockEntityUserClient{})
+		h := NewDashboardHandler()
 		r := withUser(withDashboardID(httptest.NewRequest(http.MethodGet, "/dashboards/sample-dashboard", nil), "sample-dashboard"))
 		w := httptest.NewRecorder()
 		h.GetDashboardDetail(w, r)
@@ -383,8 +382,9 @@ func TestGetDashboardDetail(t *testing.T) {
 		}
 
 		// my-open-cases carries an assignedUserId filter (the current user's
-		// open cases) — verify __current_user__ resolved to a concrete id,
-		// not the raw placeholder.
+		// open cases) — the handler no longer resolves "__current_user__"
+		// (that moved to the frontend), so it must reach the response
+		// exactly as configured.
 		openIdx, ok := byID["my-open-cases"]
 		if !ok {
 			t.Fatalf("missing widget %q in response", "my-open-cases")
@@ -393,13 +393,8 @@ func TestGetDashboardDetail(t *testing.T) {
 		if !present {
 			t.Fatalf("widget my-open-cases filters has no assignedUserId field entry")
 		}
-		if len(assigned) != 1 || assigned[0] != resolvedCurrentUserID {
-			t.Errorf("widget my-open-cases assignedUserId values = %v, want [%q]", assigned, resolvedCurrentUserID)
-		}
-		for _, uid := range assigned {
-			if uid == "__current_user__" {
-				t.Errorf("widget my-open-cases assignedUserId values leaked the unresolved placeholder")
-			}
+		if len(assigned) != 1 || assigned[0] != currentUserPlaceholder {
+			t.Errorf("widget my-open-cases assignedUserId values = %v, want the unresolved placeholder [%q]", assigned, currentUserPlaceholder)
 		}
 
 		// recent-cases has no assignedUserId filter entry in its template and
@@ -453,7 +448,7 @@ func TestGetDashboardDetail(t *testing.T) {
 	})
 
 	t.Run("sample-team-dashboard has resource-type-diverse widgets (case, incident, change_request)", func(t *testing.T) {
-		h := NewDashboardHandler(&mockEntityUserClient{})
+		h := NewDashboardHandler()
 		r := withUser(withDashboardID(httptest.NewRequest(http.MethodGet, "/dashboards/sample-team-dashboard", nil), "sample-team-dashboard"))
 		w := httptest.NewRecorder()
 		h.GetDashboardDetail(w, r)
@@ -512,7 +507,7 @@ func TestGetDashboardDetail(t *testing.T) {
 	})
 
 	t.Run("sample-dashboard's product_vulnerability widget has a scalar string filter", func(t *testing.T) {
-		h := NewDashboardHandler(&mockEntityUserClient{})
+		h := NewDashboardHandler()
 		r := withUser(withDashboardID(httptest.NewRequest(http.MethodGet, "/dashboards/sample-dashboard", nil), "sample-dashboard"))
 		w := httptest.NewRecorder()
 		h.GetDashboardDetail(w, r)
@@ -553,7 +548,7 @@ func TestGetDashboardDetail(t *testing.T) {
 	})
 
 	t.Run("sample-team-dashboard's pie widget resolves description, slices, and per-slice current-user placeholders", func(t *testing.T) {
-		h := NewDashboardHandler(&mockEntityUserClient{})
+		h := NewDashboardHandler()
 		r := withUser(withDashboardID(httptest.NewRequest(http.MethodGet, "/dashboards/sample-team-dashboard", nil), "sample-team-dashboard"))
 		w := httptest.NewRecorder()
 		h.GetDashboardDetail(w, r)
@@ -605,8 +600,8 @@ func TestGetDashboardDetail(t *testing.T) {
 			t.Fatalf("missing the %q slice in cases-by-severity.Slices", "Mine")
 		}
 		assigned, ok := filterValuesByField(mine.Query, "assignedUserId")
-		if !ok || len(assigned) != 1 || assigned[0] != resolvedCurrentUserID {
-			t.Errorf("Mine slice assignedUserId = %v, want [%q] (resolved, not the raw placeholder)", assigned, resolvedCurrentUserID)
+		if !ok || len(assigned) != 1 || assigned[0] != currentUserPlaceholder {
+			t.Errorf("Mine slice assignedUserId = %v, want the unresolved placeholder [%q]", assigned, currentUserPlaceholder)
 		}
 
 		// Confirm the wire keys match the updated openapi.yaml schema.
@@ -632,7 +627,7 @@ func TestGetDashboardDetail(t *testing.T) {
 	})
 
 	t.Run("sample-team-dashboard's escalated-incidents widget carries its configured section, unset for widgets with no section", func(t *testing.T) {
-		h := NewDashboardHandler(&mockEntityUserClient{})
+		h := NewDashboardHandler()
 		r := withUser(withDashboardID(httptest.NewRequest(http.MethodGet, "/dashboards/sample-team-dashboard", nil), "sample-team-dashboard"))
 		w := httptest.NewRecorder()
 		h.GetDashboardDetail(w, r)
@@ -665,7 +660,7 @@ func TestGetDashboardDetail(t *testing.T) {
 	})
 
 	t.Run("every dashboard in the registry now has at least one widget", func(t *testing.T) {
-		h := NewDashboardHandler(&mockEntityUserClient{})
+		h := NewDashboardHandler()
 		for _, d := range dashboard.All() {
 			r := withUser(withDashboardID(httptest.NewRequest(http.MethodGet, "/dashboards/"+d.ID, nil), d.ID))
 			w := httptest.NewRecorder()
@@ -683,75 +678,10 @@ func TestGetDashboardDetail(t *testing.T) {
 	})
 }
 
-// TestResolveCurrentUserID_UsesEntityUsersMeNotJWTClaim guards against the
-// regression this task shipped once already: substituting the raw JWT
-// userid claim into a widget's assignedUserIds instead of the platform user
-// id GET /users/me resolves via the entity service. The two ids are
-// deliberately different here (testUser.UserID vs the mock's GetUserMe id)
-// so a reversion back to user.UserID would fail this test immediately
-// rather than silently reintroducing the bug.
-func TestResolveCurrentUserID_UsesEntityUsersMeNotJWTClaim(t *testing.T) {
-	const entityResolvedID = "22222222-2222-2222-2222-222222222222"
-	if entityResolvedID == testUser.UserID {
-		t.Fatal("test setup bug: entityResolvedID must differ from testUser.UserID")
-	}
-
-	mock := &mockEntityUserClient{
-		getUserMeFn: func(ctx context.Context) ([]byte, error) {
-			return []byte(`{"id":"` + entityResolvedID + `"}`), nil
-		},
-	}
-	h := NewDashboardHandler(mock)
-	r := withUser(withDashboardID(httptest.NewRequest(http.MethodGet, "/dashboards/sample-dashboard", nil), "sample-dashboard"))
-	w := httptest.NewRecorder()
-	h.GetDashboardDetail(w, r)
-	assertStatus(t, w, http.StatusOK)
-
-	var result dashboardDetailView
-	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
-		t.Fatalf("decode response body: %v; raw: %s", err, w.Body.Bytes())
-	}
-	byID := make(map[string]dashboardWidgetView)
-	for _, wd := range result.Widgets {
-		byID[wd.WidgetID] = wd
-	}
-
-	assigned, ok := filterValuesByField(byID["my-open-cases"].Query, "assignedUserId")
-	if !ok || len(assigned) != 1 {
-		t.Fatalf("my-open-cases assignedUserId values = %v, want a 1-element array", assigned)
-	}
-	if assigned[0] != entityResolvedID {
-		t.Errorf("my-open-cases assignedUserId values[0] = %v, want the entity-resolved id %q (not the JWT claim %q)",
-			assigned[0], entityResolvedID, testUser.UserID)
-	}
-}
-
-// TestResolveCurrentUserID_FallsBackToJWTClaimOnEntityError confirms a
-// transient entity-service failure degrades to the previous (broken but
-// non-crashing) behavior — the endpoint still returns 200, not a 500 — since
-// dashboards are best-effort convenience data, not core functionality.
-func TestResolveCurrentUserID_FallsBackToJWTClaimOnEntityError(t *testing.T) {
-	mock := &mockEntityUserClient{
-		getUserMeFn: func(ctx context.Context) ([]byte, error) {
-			return nil, errors.New("entity unavailable")
-		},
-	}
-	h := NewDashboardHandler(mock)
-	r := withUser(withDashboardID(httptest.NewRequest(http.MethodGet, "/dashboards/sample-dashboard", nil), "sample-dashboard"))
-	w := httptest.NewRecorder()
-	h.GetDashboardDetail(w, r)
-	assertStatus(t, w, http.StatusOK)
-
-	var result dashboardDetailView
-	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
-		t.Fatalf("decode response body: %v; raw: %s", err, w.Body.Bytes())
-	}
-	byID := make(map[string]dashboardWidgetView)
-	for _, wd := range result.Widgets {
-		byID[wd.WidgetID] = wd
-	}
-	assigned, ok := filterValuesByField(byID["my-open-cases"].Query, "assignedUserId")
-	if !ok || len(assigned) != 1 || assigned[0] != testUser.UserID {
-		t.Errorf("my-open-cases assignedUserId values = %v, want the JWT-claim fallback [%q]", assigned, testUser.UserID)
-	}
-}
+// Resolving "__current_user__" into a concrete platform user id used to be
+// this handler's job (via an entity-service GET /users/me round trip) and
+// had its own regression-guard tests here (a JWT-claim vs entity-resolved-id
+// mix-up). That responsibility, and the entity dependency it required, moved
+// to the frontend — see DashboardHandler's doc comment in dashboards.go and
+// the "my-open-cases"/"Mine" assertions above in TestGetDashboardDetail,
+// which now assert the placeholder reaches the response unresolved instead.

--- a/apps/csm-portal/backend/internal/handler/response.go
+++ b/apps/csm-portal/backend/internal/handler/response.go
@@ -36,6 +36,7 @@ const (
 	ErrMsgInvalidTransition      = "Invalid state transition."
 	ErrMsgWorkStateNotAllowed    = "Work state can only be updated when the case is in progress."
 	ErrMsgCommentNotAllowed      = "Comments can only be added when the case is in progress and the work state is ongoing."
+	ErrMsgCommentNotOwnCase      = "Only the assigned engineer can add a public comment on this case."
 	ErrMsgWorkNoteOnClosedCase   = "Work notes cannot be added to a closed case."
 	ErrMsgAttachmentOnClosedCase = "Attachments cannot be added to a closed case."
 	ErrMsgInvalidUUID            = "Invalid UUID format."

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -5439,7 +5439,17 @@ components:
             - problem
             - product_vulnerability
             - call_request
-          description: Which resource's /search endpoint this widget's filters target
+            - service_request
+            - security_report_analysis
+            - announcement
+            - engagement
+          description: >
+            Which resource's /search endpoint this widget's filters target.
+            service_request, security_report_analysis, announcement and
+            engagement are additional values of the case-search "type" field
+            (see Case's own type enum) exposed as their own widget
+            resourceType alongside case itself — all five route to the same
+            POST /cases/search.
         shape:
           type: string
           enum:
@@ -5462,13 +5472,15 @@ components:
           type: object
           additionalProperties: true
           description: >
-            Search criteria for this widget, with any current-user
-            placeholder already substituted. Pass this directly as the
-            filters of that resourceType's own POST /{resourceType}s/search
-            request to resolve the widget's data. For shapes "pie"/"bar"
-            this is a shared base merged under every slices entry's own
-            query (caller-side; slices entry keys win on conflict) rather
-            than queried on its own.
+            Search criteria for this widget, exactly as configured — any
+            "__current_user__"/"__current_team__" placeholder a filter value
+            carries is left unresolved for the caller to substitute
+            client-side before use. Pass this directly as the filters of
+            that resourceType's own POST /{resourceType}s/search request to
+            resolve the widget's data. For shapes "pie"/"bar" this is a
+            shared base merged under every slices entry's own query
+            (caller-side; slices entry keys win on conflict) rather than
+            queried on its own.
         groupBy:
           type: string
           description: Unused
@@ -5498,9 +5510,11 @@ components:
                 type: object
                 additionalProperties: true
                 description: >
-                  This slice's own criteria only, with any current-user
-                  placeholder already substituted — merge under the parent
-                  widget's own query to resolve this slice's total.
+                  This slice's own criteria only, exactly as configured — any
+                  "__current_user__"/"__current_team__" placeholder a filter
+                  value carries is left unresolved for the caller to
+                  substitute client-side — merge under the parent widget's
+                  own query to resolve this slice's total.
         section:
           type: string
           description: >

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -5332,8 +5332,8 @@ components:
         - **projectOnboardingStatus** (in): free-text SN choice labels for the
           parent project's onboarding status (e.g. "Completed",
           "Not-Applicable" -- not a closed enum at this layer).
-        - **projectType** (in): the parent project's type, as project-type
-          UUIDs.
+        - **projectType** (in): the parent project's type, matched by the
+          project type's name (e.g. "Subscription").
         - **integrationCsTeam** (in): the parent account's integration CS
           team, as team UUIDs.
         - **resolutionNotes** (isEmpty): values ignored; matches cases with

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -5509,6 +5509,46 @@ components:
             value first appears among the dashboard's widgets. Widgets
             with no section (the common case) render in one untitled
             group, same as before this field existed.
+        columns:
+          type: array
+          description: >
+            Only meaningful for shape "list": an ordered set of columns the
+            frontend should render instead of that resourceType's own
+            hardcoded list renderer. Absent/empty renders exactly as before
+            this field existed (the existing hardcoded per-resourceType
+            renderer).
+          items:
+            type: object
+            properties:
+              path:
+                type: string
+                description: >
+                  Dot-separated path into one item of that resourceType's
+                  own /search response, reaching into nested objects to
+                  arbitrary depth (e.g. "project.key",
+                  "project.account.tier") — search responses embed related
+                  entities as nested JSON objects, not flat records. Not
+                  validated server-side; a path that resolves to nothing
+                  renders that cell empty.
+              label:
+                type: string
+                description: Column header text.
+              format:
+                type: string
+                description: >
+                  Rendering hint. Omitted (or "text") renders plain text;
+                  "date" formats a date/date-time value the same way the
+                  frontend's existing hardcoded list renderers already do.
+        sortBy:
+          type: object
+          additionalProperties: true
+          description: >
+            Only meaningful for shape "list": opaque sort criteria, forwarded
+            verbatim as the sortBy object of that resourceType's own POST
+            /{resourceType}s/search request — same passthrough philosophy as
+            query/filters. Not validated here; an unsupported field name for
+            that resourceType is surfaced by that resource's own /search
+            endpoint, not caught here.
 
     DashboardListItem:
       type: object

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -2804,6 +2804,30 @@ export interface BeDashboardPieSlice {
   query: Record<string, unknown>;
 }
 
+/** Rendering hint for a {@link BeDashboardWidgetColumn}'s resolved value.
+ * Omitted (or `"text"`) renders plain text; `"date"` formats a date/
+ * date-time string the same way the app's existing hardcoded list renderers
+ * already format one (see `formatDate` in `widgetListConfig.tsx`). */
+export type BeDashboardWidgetColumnFormat = "text" | "date";
+
+/** One column of a `shape: "list"` widget's generic column renderer (see
+ * {@link BeDashboardWidget.columns}). Opaque config: the BE never resolves
+ * `path` or interprets `format`, it only forwards this object. */
+export interface BeDashboardWidgetColumn {
+  /**
+   * Dot-separated path into one item of that widget's own resourceType
+   * search response, reaching into nested objects to arbitrary depth (e.g.
+   * `"project.key"`, `"project.account.tier"`) — every resource's search
+   * response embeds related entities as nested JSON objects, not flat
+   * records. A path that resolves to nothing on a given row renders that
+   * cell empty rather than erroring the whole widget.
+   */
+  path: string;
+  /** Column header text. */
+  label: string;
+  format?: BeDashboardWidgetColumnFormat;
+}
+
 /**
  * A single widget template, embedded in {@link BeDashboard}: display metadata
  * plus its already-resolved search criteria. The caller resolves the
@@ -2845,6 +2869,19 @@ export interface BeDashboardWidget {
    * common case) render in one untitled group, same as before this field
    * existed. */
   section?: string;
+  /** Only meaningful for shape "list": an ordered set of columns to render
+   * instead of that resourceType's own hardcoded list renderer (see
+   * `WIDGET_LIST_RENDERERS` in `widgetListConfig.tsx`). Absent/empty is a
+   * no-op — the existing hardcoded per-resourceType renderer applies
+   * exactly as before this field existed. */
+  columns?: BeDashboardWidgetColumn[];
+  /** Only meaningful for shape "list": opaque sort criteria, forwarded
+   * verbatim as the `sortBy` of that resourceType's own
+   * `POST /{resourceType}s/search` request — same passthrough philosophy
+   * as `query`/`filters`. The caller is responsible for using a field name
+   * valid for that resourceType's own search contract; an invalid one is
+   * rejected by that search endpoint, not caught here. */
+  sortBy?: Record<string, unknown>;
 }
 
 /**

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -2759,6 +2759,14 @@ export interface BeUserSearchByEmailResponse {
  * own data by issuing a `POST /{resourceType}s/search`-shaped request (see
  * `widgetResourceConfig.ts` for the real endpoint per type) with `filters`
  * forwarded verbatim.
+ *
+ * `service_request`, `security_report_analysis`, `announcement`, and
+ * `engagement` are additional values of the case-search `type` field (see
+ * `BeCaseType`/`ALL_CASE_TYPES` in `caseType.ts`) exposed as their own widget
+ * resourceType alongside `case` itself — all five route to the same `POST
+ * /cases/search`, the backend auto-injecting the implied `type` filter for
+ * each at dashboard-load time when a widget doesn't already carry one
+ * explicitly.
  */
 export type BeWidgetResourceType =
   | "case"
@@ -2771,7 +2779,11 @@ export type BeWidgetResourceType =
   | "problem"
   | "product_vulnerability"
   | "task"
-  | "call_request";
+  | "call_request"
+  | "service_request"
+  | "security_report_analysis"
+  | "announcement"
+  | "engagement";
 
 /**
  * How a widget's resolved data should be rendered. `pie` and `bar` both

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
@@ -413,7 +413,8 @@ const ACKNOWLEDGEABLE_SEVERITIES = new Set<Severity>(["S0", "S1", "S2", "S3"]);
  * first-write-wins, so once `acknowledgedBy` is set there is nothing left to
  * do and the button disappears rather than turning into a no-op.
  */
-function canAcknowledge(caseDetail: CsmCaseDetail): boolean {
+// eslint-disable-next-line react-refresh/only-export-components -- exported so CsmCaseDetailPage's startWork can reuse the same acknowledgeability check rather than duplicating it (fast-refresh DX only)
+export function canAcknowledge(caseDetail: CsmCaseDetail): boolean {
   return (
     !caseDetail.acknowledgedBy && ACKNOWLEDGEABLE_SEVERITIES.has(caseDetail.severity)
   );

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -1840,10 +1840,12 @@ export default function CsmCaseDetailPage(): JSX.Element {
                   t.id !== "time" &&
                   t.id !== "call-requests")),
           ).map((t) => {
-            // Counts shown only where the tab IS the list (unambiguous). Not
-            // shown for "related" — ChildCasesWidget runs its own scoped
-            // query for the child-case list, so no count is available here
-            // without an extra fetch.
+            // Counts shown only where the tab IS the list (unambiguous), or
+            // where the parent case-detail object already has the list in
+            // hand. "related" sums linkedChangeRequests + linkedServiceRequests
+            // (both already present on `c`); ChildCasesWidget is still
+            // excluded since it runs its own scoped query and would need an
+            // extra fetch to get a count.
             const count =
               t.id === "watchers"
                 ? c.watchers.length
@@ -1857,7 +1859,10 @@ export default function CsmCaseDetailPage(): JSX.Element {
                         ? callRequests?.length
                         : t.id === "tasks"
                           ? caseTasks?.total
-                          : undefined;
+                          : t.id === "related"
+                            ? (c.linkedChangeRequests?.length ?? 0) +
+                              (c.linkedServiceRequests?.length ?? 0)
+                            : undefined;
             return (
               <Tab
                 key={t.id}

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -1579,11 +1579,16 @@ export default function CsmCaseDetailPage(): JSX.Element {
   const c = data;
   const isClosed = c.state === "closed";
   // The backend rejects a customer-visible comment unless the case is
-  // work_in_progress + ongoing. Internal work notes are allowed in any state,
-  // so this only disables the public-reply path in the composer — never work
-  // notes. Mirrors the BFF comment guard so the engineer sees a clear reason
-  // instead of a generic error.
-  const publicReplyGateReason = publicCommentGateReason(c.state, c.workState);
+  // work_in_progress + ongoing AND the signed-in engineer is the case's
+  // assignee. Internal work notes are allowed in any state, so this only
+  // disables the public-reply path in the composer — never work notes.
+  // Mirrors the BFF comment guard so the engineer sees a clear reason instead
+  // of a generic error.
+  const publicReplyGateReason = publicCommentGateReason(
+    c.state,
+    c.workState,
+    c.assigneeIsMe,
+  );
   // The composer's inline "Resume work" quick-fix only applies to this one
   // lock reason — the case is already work_in_progress and assigned to the
   // signed-in engineer, just paused, so resuming is the single-field PATCH

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -82,7 +82,9 @@ import {
   useGetCsmCaseAttachmentContent,
 } from "@features/csm-cases/api/useCsmCaseAttachments";
 import CsmCaseCommentInput from "@features/csm-cases/components/CsmCaseCommentInput";
-import CaseActionBar from "@features/csm-cases/components/CaseActionBar";
+import CaseActionBar, {
+  canAcknowledge,
+} from "@features/csm-cases/components/CaseActionBar";
 import AssignEngineerDialog from "@features/csm-cases/components/AssignEngineerDialog";
 import ResolutionDialog from "@features/csm-cases/components/ResolutionDialog";
 import ChangeSeverityDialog from "@features/csm-cases/components/ChangeSeverityDialog";
@@ -817,6 +819,30 @@ export default function CsmCaseDetailPage(): JSX.Element {
         );
         return;
       }
+
+      // Auto-acknowledge as a side effect of starting work: an engineer who
+      // starts work on an unacknowledged, acknowledgeable case has implicitly
+      // claimed it, so don't make them separately click "Acknowledge" too.
+      // Evaluated against the pre-PATCH `data` closed over above, not a
+      // refetch — severity never changes via this flow and `acknowledgedBy`
+      // can only change if someone else acknowledges concurrently, which the
+      // backend's first-write-wins semantics already handle gracefully. The
+      // `state` PATCH above and this `acknowledge` PATCH must stay separate
+      // calls: the entity-service rejects combining `state` and `acknowledge`
+      // (and other mutually-exclusive fields) in one request. This is a
+      // bonus, not the action the user asked for, so it's best-effort: any
+      // failure here must not block `resolveOngoingConflict` below, and we
+      // don't surface a separate error toast — the Acknowledge button simply
+      // stays visible afterward, which is a safe, correct fallback the
+      // engineer can act on manually.
+      if (canAcknowledge(data)) {
+        try {
+          await patchCase.mutateAsync({ acknowledge: true });
+        } catch {
+          // Swallow: see comment above.
+        }
+      }
+
       await resolveOngoingConflict(others, successMessage, successSeverity, reportSuccess);
     },
     [data, findMyOngoingCases, patchCase, showError, resolveOngoingConflict],

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/caseWorkState.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/caseWorkState.test.ts
@@ -49,25 +49,58 @@ describe("caseAcceptsPublicComments", () => {
 });
 
 describe("publicCommentGateReason", () => {
-  it("returns null when public comments are allowed", () => {
-    expect(publicCommentGateReason("work_in_progress", "ongoing")).toBeNull();
+  it("returns null when public comments are allowed and the caller is the assignee", () => {
+    expect(
+      publicCommentGateReason("work_in_progress", "ongoing", true),
+    ).toBeNull();
   });
 
-  it("gives a resume hint for a paused case", () => {
-    expect(publicCommentGateReason("work_in_progress", "paused")).toMatch(
-      /paused/i,
+  it("gives a resume hint for the assignee's paused case", () => {
+    expect(
+      publicCommentGateReason("work_in_progress", "paused", true),
+    ).toMatch(/paused/i);
+  });
+
+  it("gives an in-progress hint for other states when the caller is the assignee", () => {
+    expect(publicCommentGateReason("open", null, true)).toMatch(
+      /in progress/i,
+    );
+    expect(publicCommentGateReason("closed", null, true)).toMatch(
+      /in progress/i,
     );
   });
 
-  it("gives an in-progress hint for other states", () => {
-    expect(publicCommentGateReason("open", null)).toMatch(/in progress/i);
-    expect(publicCommentGateReason("closed", null)).toMatch(/in progress/i);
+  it("does not promise a work-note fallback (pending the backend exemption)", () => {
+    expect(publicCommentGateReason("open", null, true)).not.toMatch(
+      /work note/i,
+    );
+    expect(
+      publicCommentGateReason("work_in_progress", "paused", true),
+    ).not.toMatch(/work note/i);
   });
 
-  it("does not promise a work-note fallback (pending the backend exemption)", () => {
-    expect(publicCommentGateReason("open", null)).not.toMatch(/work note/i);
-    expect(publicCommentGateReason("work_in_progress", "paused")).not.toMatch(
-      /work note/i,
+  it("blocks a non-assignee with the ownership reason, even on an otherwise-open case", () => {
+    expect(
+      publicCommentGateReason("work_in_progress", "ongoing", false),
+    ).toMatch(/assigned engineer/i);
+  });
+
+  it("blocks a non-assignee with the ownership reason rather than the state/paused reason", () => {
+    const reason = publicCommentGateReason(
+      "work_in_progress",
+      "paused",
+      false,
+    );
+    expect(reason).toMatch(/assigned engineer/i);
+    expect(reason).not.toMatch(/paused/i);
+  });
+
+  it("blocks a non-assignee with the ownership reason regardless of case state", () => {
+    expect(publicCommentGateReason("open", null, false)).toMatch(
+      /assigned engineer/i,
+    );
+    expect(publicCommentGateReason("closed", null, false)).toMatch(
+      /assigned engineer/i,
     );
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/caseWorkState.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/caseWorkState.ts
@@ -41,11 +41,28 @@ export function caseAcceptsPublicComments(
  * depends on the backend exempting work notes from the in-progress guard
  * (pending follow-up); copy stays non-committal until then. Does not gate work
  * notes.
+ *
+ * `assigneeIsMe` is checked first and unconditionally: the backend now also
+ * rejects a public comment from anyone other than the case's assigned
+ * engineer, on top of the existing state/work-state gate. A non-assignee gets
+ * the ownership reason regardless of what state/workState say — even a
+ * perfectly "ongoing" case is still not theirs to reply on — rather than
+ * layering ownership on top of the state check, because
+ * `canResumeToUnlockPublicReply` already only offers its "Resume work"
+ * quick-fix to the assignee. If a non-assignee's paused case fell through to
+ * the state reason instead, the composer would show a resumable-sounding
+ * hint for an action that isn't actually available to them. Ownership first
+ * keeps the messaging and the quick-fix in agreement: a non-assignee never
+ * sees a resumable-sounding reason, only the ownership block.
  */
 export function publicCommentGateReason(
   state: CaseState | undefined,
   workState: CaseWorkState | null | undefined,
+  assigneeIsMe: boolean,
 ): string | null {
+  if (!assigneeIsMe) {
+    return "Only the case's assigned engineer can reply to the customer.";
+  }
   if (caseAcceptsPublicComments(state, workState)) return null;
   if (state === "work_in_progress" && workState === "paused") {
     return "This case is paused — public replies are disabled. Resume work to reply to the customer.";

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetData.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetData.ts
@@ -64,12 +64,19 @@ export function useWidgetData(
    * the team isn't resolved yet — in which case any `integrationCsTeam`
    * entry carrying that placeholder is dropped rather than sent literally. */
   selectedTeamGroupId?: string | string[],
+  /** Only meaningful for shape "list". Opaque sort criteria (see
+   * `BeDashboardWidget.sortBy`), forwarded verbatim as this search
+   * request's own `sortBy` — same passthrough philosophy as `filters`. The
+   * widget config is responsible for a field name valid for that
+   * resourceType's own search contract. */
+  sortBy?: Record<string, unknown>,
 ): UseQueryResult<WidgetData, Error> {
   const api = useBackendApi();
   const config = WIDGET_RESOURCE_CONFIG[resourceType];
   const limit = shape === "list" ? (listLimit ?? DEFAULT_LIST_LIMIT) : 1;
   const effectiveOffset = shape === "list" ? offset : 0;
   const resolvedFilters = resolveTeamPlaceholder(filters, selectedTeamGroupId);
+  const effectiveSortBy = shape === "list" ? sortBy : undefined;
 
   return useQuery<WidgetData, Error>({
     queryKey: [
@@ -79,6 +86,7 @@ export function useWidgetData(
       resolvedFilters,
       limit,
       effectiveOffset,
+      effectiveSortBy,
     ],
     enabled,
     queryFn: async (): Promise<WidgetData> => {
@@ -90,11 +98,16 @@ export function useWidgetData(
         throw new Error(`Unsupported widget resourceType: ${resourceType}`);
       }
       const res = await api.post<
-        { filters: Record<string, unknown>; pagination: { offset: number; limit: number } },
+        {
+          filters: Record<string, unknown>;
+          pagination: { offset: number; limit: number };
+          sortBy?: Record<string, unknown>;
+        },
         Record<string, unknown>
       >(config.searchEndpoint, {
         filters: resolvedFilters,
         pagination: { offset: effectiveOffset, limit },
+        ...(effectiveSortBy ? { sortBy: effectiveSortBy } : {}),
       });
       const total = typeof res.total === "number" ? res.total : 0;
       const rawItems = res[config.itemsKey];

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetData.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetData.ts
@@ -20,6 +20,7 @@ import { useBackendApi } from "@api/backend/client";
 import type { BeWidgetResourceType, BeWidgetShape } from "@api/backend/types";
 import { WIDGET_RESOURCE_CONFIG } from "@features/csm-dashboard/config/widgetResourceConfig";
 import { resolveTeamPlaceholder } from "@features/csm-dashboard/utils/teamFilterPlaceholder";
+import { resolveRelativeDateFilters } from "@features/csm-dashboard/utils/resolveRelativeDateFilters";
 
 /** Default number of rows fetched for a `shape: "list"` widget when the
  * template doesn't set its own `listLimit`. */
@@ -75,7 +76,9 @@ export function useWidgetData(
   const config = WIDGET_RESOURCE_CONFIG[resourceType];
   const limit = shape === "list" ? (listLimit ?? DEFAULT_LIST_LIMIT) : 1;
   const effectiveOffset = shape === "list" ? offset : 0;
-  const resolvedFilters = resolveTeamPlaceholder(filters, selectedTeamGroupId);
+  const resolvedFilters = resolveRelativeDateFilters(
+    resolveTeamPlaceholder(filters, selectedTeamGroupId),
+  );
   const effectiveSortBy = shape === "list" ? sortBy : undefined;
 
   return useQuery<WidgetData, Error>({

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetData.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetData.ts
@@ -21,6 +21,7 @@ import type { BeWidgetResourceType, BeWidgetShape } from "@api/backend/types";
 import { WIDGET_RESOURCE_CONFIG } from "@features/csm-dashboard/config/widgetResourceConfig";
 import { resolveTeamPlaceholder } from "@features/csm-dashboard/utils/teamFilterPlaceholder";
 import { resolveRelativeDateFilters } from "@features/csm-dashboard/utils/resolveRelativeDateFilters";
+import { resolveCurrentUserPlaceholder } from "@features/csm-dashboard/utils/currentUserFilterPlaceholder";
 
 /** Default number of rows fetched for a `shape: "list"` widget when the
  * template doesn't set its own `listLimit`. */
@@ -71,13 +72,22 @@ export function useWidgetData(
    * widget config is responsible for a field name valid for that
    * resourceType's own search contract. */
   sortBy?: Record<string, unknown>,
+  /** The signed-in user's own platform id (`useCurrentUser().user.id`), used
+   * to resolve a widget's `__current_user__` filter placeholder (see
+   * `currentUserFilterPlaceholder.ts`) before it's sent — `undefined` while
+   * the user profile hasn't loaded yet, in which case any filter entry
+   * carrying that placeholder is dropped rather than sent literally. */
+  currentUserId?: string,
 ): UseQueryResult<WidgetData, Error> {
   const api = useBackendApi();
   const config = WIDGET_RESOURCE_CONFIG[resourceType];
   const limit = shape === "list" ? (listLimit ?? DEFAULT_LIST_LIMIT) : 1;
   const effectiveOffset = shape === "list" ? offset : 0;
-  const resolvedFilters = resolveRelativeDateFilters(
-    resolveTeamPlaceholder(filters, selectedTeamGroupId),
+  const resolvedFilters = resolveCurrentUserPlaceholder(
+    resolveRelativeDateFilters(
+      resolveTeamPlaceholder(filters, selectedTeamGroupId),
+    ),
+    currentUserId,
   );
   const effectiveSortBy = shape === "list" ? sortBy : undefined;
 

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetData.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetData.ts
@@ -21,7 +21,10 @@ import type { BeWidgetResourceType, BeWidgetShape } from "@api/backend/types";
 import { WIDGET_RESOURCE_CONFIG } from "@features/csm-dashboard/config/widgetResourceConfig";
 import { resolveTeamPlaceholder } from "@features/csm-dashboard/utils/teamFilterPlaceholder";
 import { resolveRelativeDateFilters } from "@features/csm-dashboard/utils/resolveRelativeDateFilters";
-import { resolveCurrentUserPlaceholder } from "@features/csm-dashboard/utils/currentUserFilterPlaceholder";
+import {
+  hasCurrentUserPlaceholder,
+  resolveCurrentUserPlaceholder,
+} from "@features/csm-dashboard/utils/currentUserFilterPlaceholder";
 
 /** Default number of rows fetched for a `shape: "list"` widget when the
  * template doesn't set its own `listLimit`. */
@@ -90,6 +93,13 @@ export function useWidgetData(
     currentUserId,
   );
   const effectiveSortBy = shape === "list" ? sortBy : undefined;
+  // A `__current_user__` placeholder that survived resolution means the
+  // signed-in user's profile hasn't landed yet. Sending these filters would
+  // either 400 on the non-UUID value or — before this resolver started
+  // failing closed — silently widen a user-scoped widget to every user's
+  // records. Hold the request instead; the query re-enables itself on the
+  // render after `/users/me` resolves.
+  const awaitingCurrentUser = hasCurrentUserPlaceholder(resolvedFilters);
 
   return useQuery<WidgetData, Error>({
     queryKey: [
@@ -101,7 +111,7 @@ export function useWidgetData(
       effectiveOffset,
       effectiveSortBy,
     ],
-    enabled,
+    enabled: enabled && !awaitingCurrentUser,
     queryFn: async (): Promise<WidgetData> => {
       if (!config) {
         // A widget's resourceType came back from the backend (now a

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetPieData.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetPieData.test.tsx
@@ -27,6 +27,7 @@ vi.mock("@api/backend/client", () => ({
 
 import { useWidgetPieData } from "@features/csm-dashboard/api/useWidgetPieData";
 import { CURRENT_TEAM_PLACEHOLDER } from "@features/csm-dashboard/utils/teamFilterPlaceholder";
+import { CURRENT_USER_PLACEHOLDER } from "@features/csm-dashboard/utils/currentUserFilterPlaceholder";
 
 function wrapper({ children }: { children: ReactNode }) {
   const queryClient = new QueryClient({
@@ -143,6 +144,83 @@ describe("useWidgetPieData", () => {
               },
             },
           ],
+          undefined,
+        ),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(postMock).toHaveBeenCalled());
+
+    expect(postMock).toHaveBeenCalledWith("/cases/search", {
+      filters: {
+        filters: [{ field: "state", op: "in", values: ["open"] }],
+      },
+      pagination: { offset: 0, limit: 1 },
+    });
+  });
+
+  it("resolves __current_user__ (in either the base or a slice's own filters) after merging, using the signed-in user's own id", async () => {
+    postMock.mockResolvedValue({ total: 1 });
+
+    const { result } = renderHook(
+      () =>
+        useWidgetPieData(
+          "widget-1",
+          "case",
+          { filters: [{ field: "state", op: "in", values: ["open"] }] },
+          [
+            {
+              label: "Assigned to me",
+              query: {
+                filters: [
+                  { field: "assignedUserId", op: "in", values: [CURRENT_USER_PLACEHOLDER] },
+                ],
+              },
+            },
+          ],
+          undefined,
+          "11111111-aaaa-bbbb-cccc-000000000001",
+        ),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(postMock).toHaveBeenCalledWith("/cases/search", {
+      filters: {
+        filters: [
+          { field: "state", op: "in", values: ["open"] },
+          {
+            field: "assignedUserId",
+            op: "in",
+            values: ["11111111-aaaa-bbbb-cccc-000000000001"],
+          },
+        ],
+      },
+      pagination: { offset: 0, limit: 1 },
+    });
+  });
+
+  it("drops the assignedUserId entry rather than sending the literal __current_user__ placeholder when the signed-in user isn't known yet", async () => {
+    postMock.mockResolvedValue({ total: 1 });
+
+    renderHook(
+      () =>
+        useWidgetPieData(
+          "widget-1",
+          "case",
+          { filters: [{ field: "state", op: "in", values: ["open"] }] },
+          [
+            {
+              label: "Assigned to me",
+              query: {
+                filters: [
+                  { field: "assignedUserId", op: "in", values: [CURRENT_USER_PLACEHOLDER] },
+                ],
+              },
+            },
+          ],
+          undefined,
           undefined,
         ),
       { wrapper },

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetPieData.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetPieData.test.tsx
@@ -201,10 +201,10 @@ describe("useWidgetPieData", () => {
     });
   });
 
-  it("drops the assignedUserId entry rather than sending the literal __current_user__ placeholder when the signed-in user isn't known yet", async () => {
+  it("issues no slice search at all while the signed-in user isn't known yet, rather than one without the assignedUserId entry", async () => {
     postMock.mockResolvedValue({ total: 1 });
 
-    renderHook(
+    const { result } = renderHook(
       () =>
         useWidgetPieData(
           "widget-1",
@@ -226,14 +226,12 @@ describe("useWidgetPieData", () => {
       { wrapper },
     );
 
-    await waitFor(() => expect(postMock).toHaveBeenCalled());
-
-    expect(postMock).toHaveBeenCalledWith("/cases/search", {
-      filters: {
-        filters: [{ field: "state", op: "in", values: ["open"] }],
-      },
-      pagination: { offset: 0, limit: 1 },
-    });
+    // Dropping the entry would have searched on `state: open` alone — every
+    // engineer's open cases, in a slice labelled "Assigned to me". Hold the
+    // request until the profile lands instead, and report the wait as
+    // loading so the chart does not paint an empty wedge in the meantime.
+    await waitFor(() => expect(result.current.isLoading).toBe(true));
+    expect(postMock).not.toHaveBeenCalled();
   });
 
   it("surfaces isError when any one slice's search fails", async () => {

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetPieData.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetPieData.ts
@@ -22,6 +22,7 @@ import { WIDGET_RESOURCE_CONFIG } from "@features/csm-dashboard/config/widgetRes
 import { mergeWidgetFilters } from "@features/csm-dashboard/utils/widgetFilterMerge";
 import { resolveTeamPlaceholder } from "@features/csm-dashboard/utils/teamFilterPlaceholder";
 import { resolveRelativeDateFilters } from "@features/csm-dashboard/utils/resolveRelativeDateFilters";
+import { resolveCurrentUserPlaceholder } from "@features/csm-dashboard/utils/currentUserFilterPlaceholder";
 
 export interface PieSliceResult extends BeDashboardPieSlice {
   value: number;
@@ -55,17 +56,26 @@ export function useWidgetPieData(
    * `mergeWidgetFilters`, since a slice's own `query` may carry the
    * placeholder too, not just the widget's base `query`. */
   selectedTeamGroupId?: string | string[],
+  /** The signed-in user's own platform id (`useCurrentUser().user.id`), for
+   * resolving a `__current_user__` filter placeholder (see
+   * `currentUserFilterPlaceholder.ts`) — applied AFTER `mergeWidgetFilters`,
+   * same as `selectedTeamGroupId`, since a slice's own `query` may carry the
+   * placeholder too, not just the widget's base `query`. */
+  currentUserId?: string,
 ): WidgetPieData {
   const api = useBackendApi();
   const config = WIDGET_RESOURCE_CONFIG[resourceType];
 
   const queries = useQueries({
     queries: slices.map((slice) => {
-      const filters = resolveRelativeDateFilters(
-        resolveTeamPlaceholder(
-          mergeWidgetFilters(baseFilters, slice.query),
-          selectedTeamGroupId,
+      const filters = resolveCurrentUserPlaceholder(
+        resolveRelativeDateFilters(
+          resolveTeamPlaceholder(
+            mergeWidgetFilters(baseFilters, slice.query),
+            selectedTeamGroupId,
+          ),
         ),
+        currentUserId,
       );
       return {
         queryKey: [

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetPieData.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetPieData.ts
@@ -21,6 +21,7 @@ import type { BeDashboardPieSlice, BeWidgetResourceType } from "@api/backend/typ
 import { WIDGET_RESOURCE_CONFIG } from "@features/csm-dashboard/config/widgetResourceConfig";
 import { mergeWidgetFilters } from "@features/csm-dashboard/utils/widgetFilterMerge";
 import { resolveTeamPlaceholder } from "@features/csm-dashboard/utils/teamFilterPlaceholder";
+import { resolveRelativeDateFilters } from "@features/csm-dashboard/utils/resolveRelativeDateFilters";
 
 export interface PieSliceResult extends BeDashboardPieSlice {
   value: number;
@@ -60,9 +61,11 @@ export function useWidgetPieData(
 
   const queries = useQueries({
     queries: slices.map((slice) => {
-      const filters = resolveTeamPlaceholder(
-        mergeWidgetFilters(baseFilters, slice.query),
-        selectedTeamGroupId,
+      const filters = resolveRelativeDateFilters(
+        resolveTeamPlaceholder(
+          mergeWidgetFilters(baseFilters, slice.query),
+          selectedTeamGroupId,
+        ),
       );
       return {
         queryKey: [

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetPieData.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetPieData.ts
@@ -22,7 +22,10 @@ import { WIDGET_RESOURCE_CONFIG } from "@features/csm-dashboard/config/widgetRes
 import { mergeWidgetFilters } from "@features/csm-dashboard/utils/widgetFilterMerge";
 import { resolveTeamPlaceholder } from "@features/csm-dashboard/utils/teamFilterPlaceholder";
 import { resolveRelativeDateFilters } from "@features/csm-dashboard/utils/resolveRelativeDateFilters";
-import { resolveCurrentUserPlaceholder } from "@features/csm-dashboard/utils/currentUserFilterPlaceholder";
+import {
+  hasCurrentUserPlaceholder,
+  resolveCurrentUserPlaceholder,
+} from "@features/csm-dashboard/utils/currentUserFilterPlaceholder";
 
 export interface PieSliceResult extends BeDashboardPieSlice {
   value: number;
@@ -66,17 +69,28 @@ export function useWidgetPieData(
   const api = useBackendApi();
   const config = WIDGET_RESOURCE_CONFIG[resourceType];
 
-  const queries = useQueries({
-    queries: slices.map((slice) => {
-      const filters = resolveCurrentUserPlaceholder(
-        resolveRelativeDateFilters(
-          resolveTeamPlaceholder(
-            mergeWidgetFilters(baseFilters, slice.query),
-            selectedTeamGroupId,
-          ),
+  const resolvedSliceFilters = slices.map((slice) =>
+    resolveCurrentUserPlaceholder(
+      resolveRelativeDateFilters(
+        resolveTeamPlaceholder(
+          mergeWidgetFilters(baseFilters, slice.query),
+          selectedTeamGroupId,
         ),
-        currentUserId,
-      );
+      ),
+      currentUserId,
+    ),
+  );
+  // See useWidgetData: a surviving `__current_user__` means the signed-in
+  // user's profile hasn't landed yet, so every slice holds rather than
+  // searching unscoped. Computed here rather than inside the query factory
+  // so the returned isLoading can report the wait — a disabled query is not
+  // "loading" to react-query, and a pie/bar tile must not paint an empty
+  // chart while it is really still waiting on identity.
+  const awaitingCurrentUser = resolvedSliceFilters.some(hasCurrentUserPlaceholder);
+
+  const queries = useQueries({
+    queries: slices.map((_slice, index) => {
+      const filters = resolvedSliceFilters[index];
       return {
         queryKey: [
           ApiQueryKeys.CSM_DASHBOARD_WIDGET_DATA,
@@ -98,12 +112,13 @@ export function useWidgetPieData(
           });
           return typeof res.total === "number" ? res.total : 0;
         },
+        enabled: !awaitingCurrentUser,
         staleTime: 60_000,
       };
     }),
   });
 
-  const isLoading = queries.some((q) => q.isLoading);
+  const isLoading = awaitingCurrentUser || queries.some((q) => q.isLoading);
   const isError = queries.some((q) => q.isError);
   const results: PieSliceResult[] = slices.map((slice, i) => ({
     ...slice,

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/AgentsLandingPagePilot.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/AgentsLandingPagePilot.tsx
@@ -182,6 +182,8 @@ export default function AgentsLandingPagePilot({
                   filters={widget.query}
                   listLimit={widget.listLimit}
                   slices={widget.slices}
+                  columns={widget.columns}
+                  sortBy={widget.sortBy}
                   selectedTeamGroupId={selectedTeamGroupId}
                   selectedTeamLabel={selectedTeamLabel}
                 />

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.test.tsx
@@ -404,6 +404,127 @@ describe("DashboardWidgetTile", () => {
     expect(params.get("state")).toBe("open");
   });
 
+  it("renders through the existing hardcoded per-resourceType renderer (CasesList) when no columns are configured — byte-for-byte unaffected by the columns feature", async () => {
+    postMock.mockResolvedValue({
+      total: 1,
+      cases: [{ id: "11111111-1111-1111-1111-111111111111", number: "CS-1", subject: "Disk full", state: "open" }],
+      limit: 5,
+      offset: 0,
+      hasMore: false,
+    });
+
+    renderWithClient(
+      <DashboardWidgetTile
+        widgetId="my_patches"
+        displayName="My Patches"
+        resourceType="case"
+        shape="list"
+        filters={{}}
+        listLimit={5}
+      />,
+    );
+
+    // CasesList's own header markup ("Case ID") only appears via the
+    // hardcoded renderer — GenericColumnList never renders it, since its
+    // columns come entirely from the widget's own `columns` config.
+    await waitFor(() => expect(screen.getByText("CS-1")).toBeInTheDocument());
+    expect(screen.getByText("Case ID")).toBeInTheDocument();
+  });
+
+  it("renders through the generic column renderer, resolving a nested dot-path, when columns are configured", async () => {
+    postMock.mockResolvedValue({
+      total: 1,
+      cases: [
+        {
+          id: "11111111-1111-1111-1111-111111111111",
+          subject: "Disk full",
+          bestCaseFixEta: "2026-08-01",
+          project: { id: "p-1", name: "Alpha", key: "ALPHA" },
+        },
+      ],
+      limit: 5,
+      offset: 0,
+      hasMore: false,
+    });
+
+    renderWithClient(
+      <DashboardWidgetTile
+        widgetId="my_patches"
+        displayName="My Patches"
+        resourceType="case"
+        shape="list"
+        filters={{}}
+        listLimit={5}
+        columns={[
+          { path: "subject", label: "Subject" },
+          { path: "project.key", label: "Project key" },
+          { path: "bestCaseFixEta", label: "Best case ETA", format: "date" },
+        ]}
+      />,
+    );
+
+    // Column headers come from the widget's own config, not a hardcoded
+    // per-resourceType label set.
+    await waitFor(() => expect(screen.getByText("Subject")).toBeInTheDocument());
+    expect(screen.getByText("Project key")).toBeInTheDocument();
+    expect(screen.getByText("Best case ETA")).toBeInTheDocument();
+
+    // Row cells: a top-level field, a nested dot-path field, and a
+    // date-formatted field.
+    expect(screen.getByText("Disk full")).toBeInTheDocument();
+    expect(screen.getByText("ALPHA")).toBeInTheDocument();
+    expect(screen.getByText("Aug 1, 2026")).toBeInTheDocument();
+
+    // The hardcoded CasesList renderer's own "Case ID" column header must
+    // NOT appear — this widget rendered through GenericColumnList instead.
+    expect(screen.queryByText("Case ID")).not.toBeInTheDocument();
+  });
+
+  it("forwards a widget's configured sortBy into the /search request, only for shape list", async () => {
+    postMock.mockResolvedValue({ total: 0, cases: [], limit: 5, offset: 0, hasMore: false });
+
+    renderWithClient(
+      <DashboardWidgetTile
+        widgetId="my_patches"
+        displayName="My Patches"
+        resourceType="case"
+        shape="list"
+        filters={{}}
+        listLimit={5}
+        sortBy={{ field: "updatedOn", order: "asc" }}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(postMock).toHaveBeenCalledWith("/cases/search", {
+        filters: {},
+        pagination: { offset: 0, limit: 5 },
+        sortBy: { field: "updatedOn", order: "asc" },
+      }),
+    );
+  });
+
+  it("does not forward sortBy for shape count (only meaningful for shape list)", async () => {
+    postMock.mockResolvedValue({ total: 3, cases: [], limit: 1, offset: 0, hasMore: false });
+
+    renderWithClient(
+      <DashboardWidgetTile
+        widgetId="my_patches"
+        displayName="My Patches"
+        resourceType="case"
+        shape="count"
+        filters={{}}
+        sortBy={{ field: "updatedOn", order: "asc" }}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByText("3")).toBeInTheDocument());
+    expect(postMock).toHaveBeenCalledWith("/cases/search", {
+      filters: {},
+      pagination: { offset: 0, limit: 1 },
+    });
+  });
+
   it("navigates to /cases with translated filters when a case-resource tile is clicked", async () => {
     postMock.mockResolvedValue({ total: 3, cases: [], limit: 1, offset: 0, hasMore: false });
 

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.test.tsx
@@ -105,6 +105,7 @@ vi.mock("@wso2/oxygen-ui-charts-react", () => ({
 
 import DashboardWidgetTile from "@features/csm-dashboard/components/DashboardWidgetTile";
 import { CURRENT_TEAM_PLACEHOLDER } from "@features/csm-dashboard/utils/teamFilterPlaceholder";
+import { CURRENT_USER_PLACEHOLDER } from "@features/csm-dashboard/utils/currentUserFilterPlaceholder";
 
 function renderWithClient(ui: ReactNode) {
   const queryClient = new QueryClient({
@@ -201,6 +202,40 @@ describe("DashboardWidgetTile", () => {
     await waitFor(() =>
       expect(screen.getByText("Could not load this widget.")).toBeInTheDocument(),
     );
+  });
+
+  it("resolves the __current_user__ filter placeholder with the signed-in user's own id before firing its /cases/search call", async () => {
+    postMock.mockResolvedValue({ total: 1, cases: [], limit: 1, offset: 0, hasMore: false });
+
+    renderWithClient(
+      <DashboardWidgetTile
+        widgetId="my_cases_count"
+        displayName="My Cases"
+        resourceType="case"
+        shape="count"
+        filters={{
+          filters: [
+            { field: "assignedUserId", op: "in", values: [CURRENT_USER_PLACEHOLDER] },
+          ],
+        }}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByText("1")).toBeInTheDocument());
+    // "11111111-aaaa-bbbb-cccc-000000000001" is the mocked signed-in user's
+    // own id (see the CurrentUserContext mock above).
+    expect(postMock).toHaveBeenCalledWith("/cases/search", {
+      filters: {
+        filters: [
+          {
+            field: "assignedUserId",
+            op: "in",
+            values: ["11111111-aaaa-bbbb-cccc-000000000001"],
+          },
+        ],
+      },
+      pagination: { offset: 0, limit: 1 },
+    });
   });
 
   it("renders the same table the Cases tab uses for shape: list, capped at listLimit", async () => {
@@ -429,6 +464,38 @@ describe("DashboardWidgetTile", () => {
     // columns come entirely from the widget's own `columns` config.
     await waitFor(() => expect(screen.getByText("CS-1")).toBeInTheDocument());
     expect(screen.getByText("Case ID")).toBeInTheDocument();
+  });
+
+  it("resolves the __current_user__ placeholder (raw, as the backend now sends it unresolved) to the signed-in user's own id before it reaches the 'View more' href, where it's then masked to @me", async () => {
+    postMock.mockResolvedValue({
+      total: 6,
+      cases: [{ id: "11111111-1111-1111-1111-111111111111", number: "CS-1", subject: "Disk full", state: "open" }],
+      limit: 5,
+      offset: 0,
+      hasMore: true,
+    });
+
+    renderWithClient(
+      <DashboardWidgetTile
+        widgetId="my_cases"
+        displayName="My Cases"
+        resourceType="case"
+        shape="list"
+        filters={{
+          filters: [
+            { field: "assignedUserId", op: "in", values: [CURRENT_USER_PLACEHOLDER] },
+          ],
+        }}
+        listLimit={5}
+      />,
+    );
+
+    const viewMoreLink = await screen.findByRole("link", { name: /view more/i });
+    const href = viewMoreLink.getAttribute("href") ?? "";
+    expect(href).not.toContain(CURRENT_USER_PLACEHOLDER);
+    expect(href).not.toContain("11111111-aaaa-bbbb-cccc-000000000001");
+    const params = new URLSearchParams(href.split("?")[1]);
+    expect(params.get("assignedUserId")).toBe("@me");
   });
 
   it("renders through the generic column renderer, resolving a nested dot-path, when columns are configured", async () => {

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.test.tsx
@@ -680,6 +680,72 @@ describe("DashboardWidgetTile", () => {
     expect(params.get("states")).toBe("open");
   });
 
+  it("resolves a relative-date filter in the click-through href, so the destination list matches the number that was clicked", async () => {
+    postMock.mockResolvedValue({ total: 3, cases: [], limit: 1, offset: 0, hasMore: false });
+
+    renderWithClient(
+      <DashboardWidgetTile
+        widgetId="created_today"
+        displayName="Created Today"
+        resourceType="case"
+        shape="count"
+        filters={{
+          filters: [{ field: "createdOn", op: "gte", values: ["__today__"] }],
+        }}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByText("3")).toBeInTheDocument());
+
+    const params = new URLSearchParams(
+      (screen.getByRole("link").getAttribute("href") ?? "").split("?")[1],
+    );
+    const createdFrom = params.get("createdFrom") ?? "";
+    // An unresolved placeholder reaching the list page is forwarded to the
+    // backing service, which resolves "today" against UTC rather than the
+    // viewer's own local day — so the tile's count and the list behind it
+    // disagreed by the offset between the two midnights. The href must
+    // carry the same browser-local instant the tile itself counted with.
+    expect(createdFrom).not.toContain("__today__");
+    const now = new Date();
+    expect(createdFrom).toBe(
+      new Date(now.getFullYear(), now.getMonth(), now.getDate(), 0, 0, 0, 0).toISOString(),
+    );
+  });
+
+  it("resolves a relative-date filter in the View more preview href too", async () => {
+    postMock.mockResolvedValue({
+      total: 6,
+      cases: [
+        {
+          id: "11111111-1111-1111-1111-111111111111",
+          number: "CS-1",
+          subject: "Disk full",
+          state: "open",
+        },
+      ],
+      limit: 5,
+      offset: 0,
+      hasMore: true,
+    });
+
+    renderWithClient(
+      <DashboardWidgetTile
+        widgetId="created_today_list"
+        displayName="Created Today"
+        resourceType="case"
+        shape="list"
+        filters={{
+          filters: [{ field: "createdOn", op: "gte", values: ["__today__"] }],
+        }}
+        listLimit={5}
+      />,
+    );
+
+    const viewMoreLink = await screen.findByRole("link", { name: /view more/i });
+    expect(viewMoreLink.getAttribute("href") ?? "").not.toContain("__today__");
+  });
+
   it("shape count: click-through carries a `from` location.state pointing back to this dashboard page, so the destination list can offer a Back button", async () => {
     postMock.mockResolvedValue({ total: 3, cases: [], limit: 1, offset: 0, hasMore: false });
 

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.test.tsx
@@ -32,10 +32,16 @@ vi.mock("@api/backend/client", () => ({
 vi.mock("@config/apiConfig", () => ({
   apiConfig: { backendUrl: "https://example.test" },
 }));
+const SIGNED_IN_USER_ID = "11111111-aaaa-bbbb-cccc-000000000001";
+// Mutable so a test can reproduce the window before `GET /users/me` resolves,
+// which is a real window: CurrentUserProvider does not gate its children on
+// that fetch. Reset to the signed-in user in `beforeEach`.
+let mockCurrentUserId: string | undefined = SIGNED_IN_USER_ID;
+
 vi.mock("@context/current-user/CurrentUserContext", () => ({
   useCurrentUser: () => ({
-    user: { id: "11111111-aaaa-bbbb-cccc-000000000001" },
-    isLoading: false,
+    user: mockCurrentUserId === undefined ? undefined : { id: mockCurrentUserId },
+    isLoading: mockCurrentUserId === undefined,
     isError: false,
   }),
 }));
@@ -149,6 +155,7 @@ function renderWithRoutes(ui: ReactNode, destinationPath: string) {
 describe("DashboardWidgetTile", () => {
   beforeEach(() => {
     postMock.mockReset();
+    mockCurrentUserId = SIGNED_IN_USER_ID;
   });
 
   it("renders a skeleton while its own count is in flight", () => {
@@ -202,6 +209,59 @@ describe("DashboardWidgetTile", () => {
     await waitFor(() =>
       expect(screen.getByText("Could not load this widget.")).toBeInTheDocument(),
     );
+  });
+
+  it("issues no search at all while the signed-in user's profile is still loading, rather than one without the user filter", async () => {
+    mockCurrentUserId = undefined;
+    postMock.mockResolvedValue({ total: 999, cases: [], limit: 1, offset: 0, hasMore: false });
+
+    const { container } = renderWithClient(
+      <DashboardWidgetTile
+        widgetId="my_cases_count"
+        displayName="My Cases"
+        resourceType="case"
+        shape="count"
+        filters={{
+          filters: [{ field: "assignedUserId", op: "in", values: [CURRENT_USER_PLACEHOLDER] }],
+        }}
+      />,
+    );
+
+    // The regression this guards: the placeholder used to be dropped while
+    // the profile loaded, leaving an unfiltered /cases/search that painted
+    // every engineer's case count into a tile labelled "My Cases".
+    await waitFor(() =>
+      expect(container.querySelectorAll(".MuiSkeleton-root").length).toBe(1),
+    );
+    expect(postMock).not.toHaveBeenCalled();
+    expect(screen.queryByText("999")).not.toBeInTheDocument();
+  });
+
+  it("keeps a mixed user filter's literal values while the profile is still loading", async () => {
+    mockCurrentUserId = undefined;
+    postMock.mockResolvedValue({ total: 0, cases: [], limit: 1, offset: 0, hasMore: false });
+
+    renderWithClient(
+      <DashboardWidgetTile
+        widgetId="team_and_me"
+        displayName="Team and me"
+        resourceType="case"
+        shape="count"
+        filters={{
+          filters: [
+            {
+              field: "assignedUserId",
+              op: "in",
+              values: ["22222222-bbbb-cccc-dddd-000000000002", CURRENT_USER_PLACEHOLDER],
+            },
+          ],
+        }}
+      />,
+    );
+
+    // Deferred, so nothing goes out; the point of the assertion is that the
+    // literal co-value is not discarded on the way to that decision.
+    expect(postMock).not.toHaveBeenCalled();
   });
 
   it("resolves the __current_user__ filter placeholder with the signed-in user's own id before firing its /cases/search call", async () => {

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
@@ -33,6 +33,7 @@ import GenericColumnList from "@features/csm-dashboard/components/GenericColumnL
 import { buildWidgetPreviewHref } from "@features/csm-dashboard/utils/widgetPreviewUrl";
 import { mergeWidgetFilters } from "@features/csm-dashboard/utils/widgetFilterMerge";
 import { resolveTeamPlaceholder } from "@features/csm-dashboard/utils/teamFilterPlaceholder";
+import { resolveCurrentUserPlaceholder } from "@features/csm-dashboard/utils/currentUserFilterPlaceholder";
 import { resolveWidgetText } from "@features/csm-dashboard/utils/widgetTextPlaceholder";
 import DashboardPieChart from "@features/csm-dashboard/components/DashboardPieChart";
 import DashboardBarChart from "@features/csm-dashboard/components/DashboardBarChart";
@@ -122,6 +123,15 @@ export default function DashboardWidgetTile({
   const navigate = useNavigate();
   const location = useLocation();
   const { user } = useCurrentUser();
+  const currentUserId = user?.id;
+  // Resolves both client-side filter placeholders a widget's own (opaque)
+  // filters may carry — `__current_team__` (see `teamFilterPlaceholder.ts`)
+  // and `__current_user__` (see `currentUserFilterPlaceholder.ts`) — in one
+  // pass, so every click-through href below (and the two data-fetching hooks,
+  // which resolve internally the same way) never sends either placeholder
+  // literally.
+  const resolvePlaceholders = (f: Record<string, unknown>): Record<string, unknown> =>
+    resolveCurrentUserPlaceholder(resolveTeamPlaceholder(f, selectedTeamGroupId), currentUserId);
   // Carried on every count/pie/bar click-through below so the resource's own
   // list page (which has no dashboard context of its own) can offer a Back
   // button straight to this exact dashboard — mirroring the list-shape
@@ -149,6 +159,7 @@ export default function DashboardWidgetTile({
     shape !== "pie" && shape !== "bar",
     selectedTeamGroupId,
     sortBy,
+    currentUserId,
   );
   const pieData = useWidgetPieData(
     widgetId,
@@ -156,6 +167,7 @@ export default function DashboardWidgetTile({
     filters,
     shape === "pie" || shape === "bar" ? (slices ?? []) : [],
     selectedTeamGroupId,
+    currentUserId,
   );
   const config = WIDGET_RESOURCE_CONFIG[resourceType];
   // Thousands separators for shape "count"'s big number -- used both in the
@@ -179,10 +191,10 @@ export default function DashboardWidgetTile({
   }
 
   // The count-shape tile's own click-through href — resolved so a "View
-  // all" link never carries the literal `__current_team__` placeholder
-  // into the destination resource's own filters (see
-  // `teamFilterPlaceholder.ts`).
-  const href = config.buildHref(resolveTeamPlaceholder(filters, selectedTeamGroupId));
+  // all" link never carries a literal `__current_team__`/`__current_user__`
+  // placeholder into the destination resource's own filters (see
+  // `teamFilterPlaceholder.ts`/`currentUserFilterPlaceholder.ts`).
+  const href = config.buildHref(resolvePlaceholders(filters));
   const Icon = config.icon;
   const isListShape = shape === "list";
 
@@ -303,8 +315,8 @@ export default function DashboardWidgetTile({
                     // placeholder here used to get silently dropped there
                     // (teamFilterPlaceholder.ts's fail-open), returning
                     // every team's cases instead of the viewer's own.
-                    filters: resolveTeamPlaceholder(filters, selectedTeamGroupId),
-                    currentUserId: user?.id,
+                    filters: resolvePlaceholders(filters),
+                    currentUserId,
                   })}
                   size="small"
                   variant="text"
@@ -342,7 +354,7 @@ export default function DashboardWidgetTile({
     // (`pointerEvents: "auto"`) for the chart specifically, letting its own
     // click and keyboard handling work exactly as before.
     const ChartComponent = shape === "pie" ? DashboardPieChart : DashboardBarChart;
-    const tileHref = config.buildHref(resolveTeamPlaceholder(filters, selectedTeamGroupId));
+    const tileHref = config.buildHref(resolvePlaceholders(filters));
     const handleTileClick = (): void => {
       void navigate(tileHref, { state: dashboardReturnState });
     };
@@ -400,12 +412,7 @@ export default function DashboardWidgetTile({
               isError={pieData.isError}
               onSliceClick={(slice: PieSliceResult) =>
                 navigate(
-                  config.buildHref(
-                    resolveTeamPlaceholder(
-                      mergeWidgetFilters(filters, slice.query),
-                      selectedTeamGroupId,
-                    ),
-                  ),
+                  config.buildHref(resolvePlaceholders(mergeWidgetFilters(filters, slice.query))),
                   { state: dashboardReturnState },
                 )
               }

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
@@ -33,7 +33,10 @@ import GenericColumnList from "@features/csm-dashboard/components/GenericColumnL
 import { buildWidgetPreviewHref } from "@features/csm-dashboard/utils/widgetPreviewUrl";
 import { mergeWidgetFilters } from "@features/csm-dashboard/utils/widgetFilterMerge";
 import { resolveTeamPlaceholder } from "@features/csm-dashboard/utils/teamFilterPlaceholder";
-import { resolveCurrentUserPlaceholder } from "@features/csm-dashboard/utils/currentUserFilterPlaceholder";
+import {
+  hasCurrentUserPlaceholder,
+  resolveCurrentUserPlaceholder,
+} from "@features/csm-dashboard/utils/currentUserFilterPlaceholder";
 import { resolveWidgetText } from "@features/csm-dashboard/utils/widgetTextPlaceholder";
 import DashboardPieChart from "@features/csm-dashboard/components/DashboardPieChart";
 import DashboardBarChart from "@features/csm-dashboard/components/DashboardBarChart";
@@ -149,7 +152,7 @@ export default function DashboardWidgetTile({
   // slice) — skip this one's own network call rather than wasting it, but
   // still call the hook unconditionally (rules of hooks; a widget's shape
   // never changes across this component's lifetime).
-  const { data, isLoading, isError } = useWidgetData(
+  const { data, isLoading: isWidgetDataLoading, isError } = useWidgetData(
     widgetId,
     resourceType,
     filters,
@@ -169,6 +172,15 @@ export default function DashboardWidgetTile({
     selectedTeamGroupId,
     currentUserId,
   );
+  // True while this widget carries a `__current_user__` filter and the
+  // signed-in user's profile hasn't loaded yet. `useWidgetData`/
+  // `useWidgetPieData` hold their requests in that window (see
+  // `currentUserFilterPlaceholder.ts` — a user-scoped filter must never be
+  // dropped, which would widen the widget to every user's records), so this
+  // tile must present the wait as loading rather than paint the `0` a
+  // deferred query's absent data would otherwise resolve to.
+  const awaitingCurrentUser = currentUserId === undefined && hasCurrentUserPlaceholder(filters);
+  const isLoading = isWidgetDataLoading || awaitingCurrentUser;
   const config = WIDGET_RESOURCE_CONFIG[resourceType];
   // Thousands separators for shape "count"'s big number -- used both in the
   // visible Typography and the tile's aria-label, so both stay in sync.

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
@@ -18,12 +18,18 @@ import { Box, Button, Card, IconButton, Skeleton, Tooltip, Typography, alpha, us
 import { ArrowRight, Info } from "@wso2/oxygen-ui-icons-react";
 import type { JSX, KeyboardEvent, ReactNode } from "react";
 import { Link as RouterLink, useLocation, useNavigate } from "react-router";
-import type { BeDashboardPieSlice, BeWidgetResourceType, BeWidgetShape } from "@api/backend/types";
+import type {
+  BeDashboardPieSlice,
+  BeDashboardWidgetColumn,
+  BeWidgetResourceType,
+  BeWidgetShape,
+} from "@api/backend/types";
 import { useCurrentUser } from "@context/current-user/CurrentUserContext";
 import { useWidgetData } from "@features/csm-dashboard/api/useWidgetData";
 import { useWidgetPieData, type PieSliceResult } from "@features/csm-dashboard/api/useWidgetPieData";
 import { WIDGET_RESOURCE_CONFIG } from "@features/csm-dashboard/config/widgetResourceConfig";
 import { WIDGET_LIST_RENDERERS } from "@features/csm-dashboard/config/widgetListConfig";
+import GenericColumnList from "@features/csm-dashboard/components/GenericColumnList";
 import { buildWidgetPreviewHref } from "@features/csm-dashboard/utils/widgetPreviewUrl";
 import { mergeWidgetFilters } from "@features/csm-dashboard/utils/widgetFilterMerge";
 import { resolveTeamPlaceholder } from "@features/csm-dashboard/utils/teamFilterPlaceholder";
@@ -52,6 +58,17 @@ interface DashboardWidgetTileProps {
    * `useWidgetPieData`). Empty/absent renders an empty chart rather than
    * crashing. */
   slices?: BeDashboardPieSlice[];
+  /** Only meaningful for shape "list". When set (non-empty), this widget
+   * renders through the generic `GenericColumnList` (resolving each
+   * column's dot-path against every response item) instead of
+   * `WIDGET_LIST_RENDERERS[resourceType]`. Absent/empty is a no-op — the
+   * existing hardcoded per-resourceType renderer applies exactly as before
+   * this prop existed. */
+  columns?: BeDashboardWidgetColumn[];
+  /** Only meaningful for shape "list". Forwarded verbatim into this
+   * widget's own search request's `sortBy` (see `useWidgetData`) —
+   * opaque, like `filters`. */
+  sortBy?: Record<string, unknown>;
   /** The currently selected team's own `groupId` (see `BeTeam.groupId`), or
    * an array of every team's `groupId` in the current dashboard's family
    * when the "All ABTs" option is selected (see `ALL_TEAMS_SENTINEL`),
@@ -96,6 +113,8 @@ export default function DashboardWidgetTile({
   filters,
   listLimit,
   slices,
+  columns,
+  sortBy,
   selectedTeamGroupId,
   selectedTeamLabel,
 }: DashboardWidgetTileProps): JSX.Element {
@@ -129,6 +148,7 @@ export default function DashboardWidgetTile({
     0,
     shape !== "pie" && shape !== "bar",
     selectedTeamGroupId,
+    sortBy,
   );
   const pieData = useWidgetPieData(
     widgetId,
@@ -233,6 +253,14 @@ export default function DashboardWidgetTile({
   );
 
   if (isListShape) {
+    // A widget with `columns` configured renders through the generic,
+    // nested-path-resolving renderer instead of the hardcoded per-
+    // resourceType one — everything else about this tile (header, loading/
+    // error states, "View more") is unchanged either way. No `columns`
+    // (the common case, and every dashboard as of this field's addition) is
+    // a no-op: ListRenderer below is untouched, so existing widgets render
+    // byte-for-byte as before.
+    const hasColumns = Boolean(columns && columns.length > 0);
     const ListRenderer = WIDGET_LIST_RENDERERS[resourceType];
     return (
       <Card variant="outlined" sx={{ position: "relative", p: 1.75, height: "100%" }}>
@@ -250,7 +278,16 @@ export default function DashboardWidgetTile({
                 and the table is enforced for every resource type, so the
                 header's icon never sits flush against the table's border. */}
             <Box sx={{ mt: 1.5 }}>
-              <ListRenderer items={data?.items ?? []} isLoading={false} />
+              {hasColumns ? (
+                <GenericColumnList
+                  items={data?.items ?? []}
+                  isLoading={false}
+                  resourceType={resourceType}
+                  columns={columns ?? []}
+                />
+              ) : (
+                <ListRenderer items={data?.items ?? []} isLoading={false} />
+              )}
             </Box>
             {(data?.total ?? 0) > (listLimit ?? 4) && (
               <Box sx={{ display: "flex", justifyContent: "flex-end", mt: 1 }}>

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
@@ -33,6 +33,7 @@ import GenericColumnList from "@features/csm-dashboard/components/GenericColumnL
 import { buildWidgetPreviewHref } from "@features/csm-dashboard/utils/widgetPreviewUrl";
 import { mergeWidgetFilters } from "@features/csm-dashboard/utils/widgetFilterMerge";
 import { resolveTeamPlaceholder } from "@features/csm-dashboard/utils/teamFilterPlaceholder";
+import { resolveRelativeDateFilters } from "@features/csm-dashboard/utils/resolveRelativeDateFilters";
 import {
   hasCurrentUserPlaceholder,
   resolveCurrentUserPlaceholder,
@@ -127,14 +128,33 @@ export default function DashboardWidgetTile({
   const location = useLocation();
   const { user } = useCurrentUser();
   const currentUserId = user?.id;
-  // Resolves both client-side filter placeholders a widget's own (opaque)
-  // filters may carry — `__current_team__` (see `teamFilterPlaceholder.ts`)
-  // and `__current_user__` (see `currentUserFilterPlaceholder.ts`) — in one
-  // pass, so every click-through href below (and the two data-fetching hooks,
-  // which resolve internally the same way) never sends either placeholder
-  // literally.
+  // Resolves every client-side filter placeholder a widget's own (opaque)
+  // filters may carry — `__current_team__` (see `teamFilterPlaceholder.ts`),
+  // `__current_user__` (see `currentUserFilterPlaceholder.ts`) and the
+  // relative-date family `__today__`/`__daysAgo:N__`/... (see
+  // `resolveRelativeDateFilters.ts`) — in one pass, in the same order and by
+  // the same functions `useWidgetData`/`useWidgetPieData` use internally, so
+  // every click-through href below lands on exactly the rows this tile just
+  // counted.
+  //
+  // The relative-date resolution matters most here: it is browser-local, and
+  // the destination list page has no placeholder resolution of its own, so an
+  // unresolved `__today__` reaching it was forwarded verbatim and resolved by
+  // the backing service against UTC — the tile and the list it links to then
+  // disagreed by the offset between UTC midnight and the viewer's own, which
+  // is the whole discrepancy this widget-side resolution exists to close.
+  // Resolving here does freeze the instant into the href; that is the right
+  // trade, because everything else in these hrefs (team ids, states, the
+  // viewer's own user id) is already a snapshot of the moment of the click,
+  // and the destination's URL scheme is the cases list's own concrete filter
+  // encoding — carrying dashboard placeholder vocabulary into it would make
+  // `__today__` a value users can type into, and hand-edit out of, a shared
+  // list-page URL.
   const resolvePlaceholders = (f: Record<string, unknown>): Record<string, unknown> =>
-    resolveCurrentUserPlaceholder(resolveTeamPlaceholder(f, selectedTeamGroupId), currentUserId);
+    resolveCurrentUserPlaceholder(
+      resolveRelativeDateFilters(resolveTeamPlaceholder(f, selectedTeamGroupId)),
+      currentUserId,
+    );
   // Carried on every count/pie/bar click-through below so the resource's own
   // list page (which has no dashboard context of its own) can offer a Back
   // button straight to this exact dashboard — mirroring the list-shape

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/GenericColumnList.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/GenericColumnList.tsx
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Typography } from "@wso2/oxygen-ui";
+import type { JSX } from "react";
+import type { BeDashboardWidgetColumn, BeWidgetResourceType } from "@api/backend/types";
+import { WIDGET_RESOURCE_CONFIG } from "@features/csm-dashboard/config/widgetResourceConfig";
+import DashboardMiniTable from "@features/csm-dashboard/components/DashboardMiniTable";
+import { formatColumnValue, resolveColumnPath } from "@features/csm-dashboard/utils/resolveWidgetColumn";
+
+export interface GenericColumnListProps {
+  items: Record<string, unknown>[];
+  isLoading: boolean;
+  resourceType: BeWidgetResourceType;
+  columns: BeDashboardWidgetColumn[];
+}
+
+/**
+ * ResourceType-agnostic `shape: "list"` renderer, used only when a widget's
+ * config sets `columns` (see `BeDashboardWidget.columns`) — resolves each
+ * column's dot-path against every item and renders the result in a
+ * `DashboardMiniTable`, rather than dispatching through the hardcoded
+ * `WIDGET_LIST_RENDERERS[resourceType]`. A widget with no `columns` never
+ * reaches this component (see `DashboardWidgetTile`'s list-shape branch),
+ * so every existing dashboard renders exactly as it did before this
+ * component existed.
+ *
+ * Row links reuse `WIDGET_RESOURCE_CONFIG[resourceType].detailHref` — the
+ * same per-resourceType destination each hardcoded renderer already links
+ * to — so a columns-configured widget's rows are still real, navigable
+ * links wherever that resourceType has a standalone detail page.
+ */
+export default function GenericColumnList({
+  items,
+  isLoading,
+  resourceType,
+  columns,
+}: GenericColumnListProps): JSX.Element {
+  const config = WIDGET_RESOURCE_CONFIG[resourceType];
+
+  return (
+    <DashboardMiniTable
+      isLoading={isLoading}
+      emptyMessage="No records match this widget's filters."
+      columns={columns.map((c) => ({ label: c.label }))}
+      rows={items.map((item, i) => {
+        const id = typeof item.id === "string" ? item.id : undefined;
+        return {
+          key: id ?? `row-${i}`,
+          href: config?.detailHref?.(item),
+          cells: columns.map((c) => (
+            <Typography key={c.path} variant="body2" noWrap>
+              {formatColumnValue(resolveColumnPath(item, c.path), c.format)}
+            </Typography>
+          )),
+        };
+      })}
+    />
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetListConfig.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetListConfig.tsx
@@ -520,6 +520,14 @@ export const WIDGET_LIST_RENDERERS: Record<
   (props: WidgetListRendererProps) => JSX.Element
 > = {
   case: CaseWidgetList,
+  // service_request / security_report_analysis / announcement / engagement
+  // all route to the same /cases/search response shape as `case` (see
+  // widgetResourceConfig.ts) -- their rows are case rows, so they reuse
+  // CaseWidgetList verbatim rather than a lookalike renderer.
+  service_request: CaseWidgetList,
+  security_report_analysis: CaseWidgetList,
+  announcement: CaseWidgetList,
+  engagement: CaseWidgetList,
   incident: IncidentWidgetList,
   change_request: ChangeRequestWidgetList,
   problem: ProblemWidgetList,

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.test.ts
@@ -207,3 +207,71 @@ describe("WIDGET_RESOURCE_CONFIG.case — previously-dropped fields", () => {
     expect(atRiskParsed.states).toEqual(violationsParsed.states);
   });
 });
+
+/**
+ * service_request / security_report_analysis / announcement / engagement:
+ * additional case-table resourceTypes (see `BeWidgetResourceType`), all
+ * routing to the same /cases/search endpoint and response shape as `case`
+ * (only the click-through destination differs per type).
+ */
+describe("WIDGET_RESOURCE_CONFIG — case-table resourceTypes beyond `case`", () => {
+  it("all route to /cases/search and read the cases[] items key, same as case", () => {
+    for (const type of [
+      "service_request",
+      "security_report_analysis",
+      "announcement",
+      "engagement",
+    ] as const) {
+      expect(WIDGET_RESOURCE_CONFIG[type].searchEndpoint).toBe("/cases/search");
+      expect(WIDGET_RESOURCE_CONFIG[type].itemsKey).toBe("cases");
+    }
+  });
+
+  it("service_request's buildHref lands on the operations service-requests tab with translated filters", () => {
+    const href = WIDGET_RESOURCE_CONFIG.service_request.buildHref({
+      filters: [{ field: "state", op: "in", values: ["open"] }],
+    });
+    expect(href.startsWith("/operations?")).toBe(true);
+    const params = hrefParams(href);
+    expect(params.get("tab")).toBe("service_requests");
+    expect(params.get("states")).toBe("open");
+  });
+
+  it("security_report_analysis's buildHref lands on the security center security-reports tab with translated filters", () => {
+    const href = WIDGET_RESOURCE_CONFIG.security_report_analysis.buildHref({
+      filters: [{ field: "state", op: "in", values: ["open"] }],
+    });
+    expect(href.startsWith("/security-center?")).toBe(true);
+    const params = hrefParams(href);
+    expect(params.get("tab")).toBe("security_reports");
+    expect(params.get("states")).toBe("open");
+  });
+
+  it("engagement's buildHref lands on /engagements with translated filters", () => {
+    const href = WIDGET_RESOURCE_CONFIG.engagement.buildHref({
+      filters: [{ field: "state", op: "in", values: ["open"] }],
+    });
+    expect(href.startsWith("/engagements?")).toBe(true);
+    const params = hrefParams(href);
+    expect(params.get("states")).toBe("open");
+  });
+
+  it("announcement's buildHref is the unfiltered /announcements page (no URL filter scheme exists there yet)", () => {
+    expect(
+      WIDGET_RESOURCE_CONFIG.announcement.buildHref({
+        filters: [{ field: "state", op: "in", values: ["open"] }],
+      }),
+    ).toBe("/announcements");
+  });
+
+  it("each of the four has its own distinct icon from `case` and from each other", () => {
+    const icons = [
+      WIDGET_RESOURCE_CONFIG.case.icon,
+      WIDGET_RESOURCE_CONFIG.service_request.icon,
+      WIDGET_RESOURCE_CONFIG.security_report_analysis.icon,
+      WIDGET_RESOURCE_CONFIG.announcement.icon,
+      WIDGET_RESOURCE_CONFIG.engagement.icon,
+    ];
+    expect(new Set(icons).size).toBe(icons.length);
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.ts
@@ -77,6 +77,15 @@ export interface WidgetResourceConfig {
    * resource's own tab path (`buildHref`'s destination) — this route is
    * dashboard-widget-scoped, not the resource's real list page. */
   previewSlug: string;
+  /** One search-result item's own detail-page href, given the raw item —
+   * used by the generic `columns`-driven list renderer (see
+   * `GenericColumnList`), which has no resourceType-specific row-link logic
+   * of its own the way each hardcoded renderer in `widgetListConfig.tsx`
+   * does. `undefined` for a resourceType with no standalone detail route
+   * (task, call_request's own record — `call_request` links to its owning
+   * case instead, handled the same way the hardcoded `CallRequestWidgetList`
+   * does) or when the item carries no usable id. */
+  detailHref?: (item: WidgetItem) => string | undefined;
 }
 
 function asString(v: unknown): string | undefined {
@@ -339,6 +348,7 @@ export const WIDGET_RESOURCE_CONFIG: Record<
     icon: Briefcase,
     iconColor: "primary",
     previewSlug: "cases",
+    detailHref: (item) => (asString(item.id) ? `/cases/${asString(item.id)}` : undefined),
   },
   incident: {
     searchEndpoint: "/incidents/search",
@@ -356,6 +366,8 @@ export const WIDGET_RESOURCE_CONFIG: Record<
     icon: AlertTriangle,
     iconColor: "warning",
     previewSlug: "incidents",
+    detailHref: (item) =>
+      asString(item.id) ? `/operations/incidents/${asString(item.id)}` : undefined,
   },
   change_request: {
     searchEndpoint: "/change-requests/search",
@@ -373,6 +385,8 @@ export const WIDGET_RESOURCE_CONFIG: Record<
     icon: GitPullRequest,
     iconColor: "info",
     previewSlug: "change-requests",
+    detailHref: (item) =>
+      asString(item.id) ? `/operations/change-requests/${asString(item.id)}` : undefined,
   },
   problem: {
     searchEndpoint: "/problems/search",
@@ -385,6 +399,8 @@ export const WIDGET_RESOURCE_CONFIG: Record<
     icon: AlertOctagon,
     iconColor: "error",
     previewSlug: "problems",
+    detailHref: (item) =>
+      asString(item.id) ? `/operations/problems/${asString(item.id)}` : undefined,
   },
   account: {
     searchEndpoint: "/accounts/search",
@@ -395,6 +411,8 @@ export const WIDGET_RESOURCE_CONFIG: Record<
     icon: Building2,
     iconColor: "secondary",
     previewSlug: "accounts",
+    detailHref: (item) =>
+      asString(item.id) ? `/customers/accounts/${asString(item.id)}` : undefined,
   },
   project: {
     searchEndpoint: "/projects/search",
@@ -405,6 +423,8 @@ export const WIDGET_RESOURCE_CONFIG: Record<
     icon: FolderKanban,
     iconColor: "secondary",
     previewSlug: "projects",
+    detailHref: (item) =>
+      asString(item.id) ? `/customers/projects/${asString(item.id)}` : undefined,
   },
   user: {
     searchEndpoint: "/users/search",
@@ -420,6 +440,8 @@ export const WIDGET_RESOURCE_CONFIG: Record<
     icon: Users,
     iconColor: "info",
     previewSlug: "users",
+    detailHref: (item) =>
+      asString(item.id) ? `/people/${encodeURIComponent(asString(item.id) ?? "")}` : undefined,
   },
   time_card: {
     searchEndpoint: "/time-cards/search",
@@ -437,6 +459,9 @@ export const WIDGET_RESOURCE_CONFIG: Record<
     icon: Clock,
     iconColor: "warning",
     previewSlug: "time-cards",
+    // TimeCardsTable opens a details dialog in place rather than navigating
+    // — no standalone route for the generic renderer to link to either.
+    detailHref: () => undefined,
   },
   product_vulnerability: {
     searchEndpoint: "/products/vulnerabilities/search",
@@ -452,6 +477,10 @@ export const WIDGET_RESOURCE_CONFIG: Record<
     icon: ShieldAlert,
     iconColor: "error",
     previewSlug: "vulnerabilities",
+    detailHref: (item) =>
+      asString(item.id)
+        ? `/security-center/vulnerabilities/${encodeURIComponent(asString(item.id) ?? "")}`
+        : undefined,
   },
   task: {
     searchEndpoint: "/tasks/search",
@@ -469,6 +498,11 @@ export const WIDGET_RESOURCE_CONFIG: Record<
     icon: ListChecks,
     iconColor: "warning",
     previewSlug: "tasks",
+    // Same reasoning as buildHref above: no standalone detail route exists.
+    // The hardcoded TaskWidgetList opens TaskDetailDialog instead, which the
+    // generic column renderer doesn't replicate — a columns-configured task
+    // widget's rows render inert rather than opening that dialog.
+    detailHref: () => undefined,
   },
   call_request: {
     searchEndpoint: "/call-requests/search",
@@ -491,6 +525,12 @@ export const WIDGET_RESOURCE_CONFIG: Record<
     icon: Clock,
     iconColor: "info",
     previewSlug: "call-requests",
+    // Same as the hardcoded CallRequestWidgetList: a call request has no
+    // standalone detail page of its own, so rows link to the owning case.
+    detailHref: (item) => {
+      const caseId = nestedID(item.case);
+      return caseId ? `/cases/${caseId}` : undefined;
+    },
   },
 };
 
@@ -509,6 +549,15 @@ export function resourceTypeForPreviewSlug(
 function nestedNumber(v: unknown): string | undefined {
   if (v && typeof v === "object" && "number" in v) {
     return asString((v as { number?: unknown }).number);
+  }
+  return undefined;
+}
+
+/** Reads `id` off a nested entity reference (e.g. `CallRequestView.case`),
+ * mirroring `nestedNumber` above. */
+function nestedID(v: unknown): string | undefined {
+  if (v && typeof v === "object" && "id" in v) {
+    return asString((v as { id?: unknown }).id);
   }
   return undefined;
 }

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.ts
@@ -20,8 +20,12 @@ import {
   Briefcase,
   Building2,
   Clock,
+  Cog,
   FolderKanban,
   GitPullRequest,
+  Handshake,
+  Megaphone,
+  Shield,
   ShieldAlert,
   Users,
   ListChecks,
@@ -29,7 +33,11 @@ import {
 } from "@wso2/oxygen-ui-icons-react";
 import type { BeWidgetResourceType } from "@api/backend/types";
 import { humanizeState } from "@features/csm-dashboard/utils/abtDashboard";
-import { casesHref } from "@features/csm-cases/utils/casesFiltersUrl";
+import {
+  casesHref,
+  DEFAULT_CASES_FILTERS,
+  writeCasesFiltersToUrl,
+} from "@features/csm-cases/utils/casesFiltersUrl";
 import type { CasesFilters } from "@features/csm-cases/components/CasesFilterBar";
 import type { Severity } from "@features/csm-dashboard/types/abtDashboard";
 import {
@@ -292,6 +300,37 @@ function operationsHref(tab: string, params?: URLSearchParams): string {
   return `/operations?${out.toString()}`;
 }
 
+/** `securityCenterHref`'s counterpart for the Security Center section's own
+ * `?tab=` tab strip (see `CsmSecurityCenterPage`) — same shape as
+ * `operationsHref`, just a different base path. */
+function securityCenterHref(tab: string, params?: URLSearchParams): string {
+  const out = new URLSearchParams();
+  out.set("tab", tab);
+  params?.forEach((value, key) => out.set(key, value));
+  return `/security-center?${out.toString()}`;
+}
+
+/**
+ * Builds a `basePath?...` href for a case-table resourceType whose own list
+ * page is a real route (not a `?tab=`-switched section) but still reuses the
+ * cases list's own `CasesFilters` URL scheme under the hood (`engagement`'s
+ * `/engagements` — see `CsmEngagementsPage`, built on the shared
+ * `CsmIssuesView` — reads/writes the identical query params `/cases` does,
+ * via `readCasesFiltersFromUrl`/`writeCasesFiltersToUrl`). The destination
+ * page locks its own `caseTypes` filter itself (`lockedFilters` in
+ * `CsmIssuesView`), so `translateCaseDashboardFilters`'s own `caseTypes`
+ * output — always just this one type — doesn't need to be (and isn't)
+ * dropped here; it's simply redundant with what the page already locks.
+ */
+function caseTypeListHref(basePath: string, filters: Record<string, unknown>): string {
+  const full: CasesFilters = {
+    ...DEFAULT_CASES_FILTERS,
+    ...translateCaseDashboardFilters(filters),
+  };
+  const qs = writeCasesFiltersToUrl(full).toString();
+  return qs ? `${basePath}?${qs}` : basePath;
+}
+
 /** Dashboard incident filters already use the real `BeIncidentPriority`
  * wire values (`CRITICAL`/`HIGH`/...), same as `IncidentFilters.priorities` —
  * no translation table needed, only a type narrowing. */
@@ -349,6 +388,73 @@ export const WIDGET_RESOURCE_CONFIG: Record<
     iconColor: "primary",
     previewSlug: "cases",
     detailHref: (item) => (asString(item.id) ? `/cases/${asString(item.id)}` : undefined),
+  },
+  // service_request / security_report_analysis / announcement / engagement:
+  // additional values of the case-search "type" enum (see `BeCaseType` /
+  // `ALL_CASE_TYPES` in `caseType.ts`), routed to the exact same `/cases/
+  // search` endpoint and response rows as `case` above — the backend
+  // auto-injects the implied `type` filter for each at dashboard-load time.
+  // Rows are still case rows (same `BeCaseSearchView` shape), so these reuse
+  // `case`'s own primaryLabel/secondaryLabel/list renderer verbatim; only the
+  // icon/color/click-through destination differ per type, mirroring
+  // `CASE_TYPE_COLOR`'s own per-type palette in `caseType.ts`.
+  service_request: {
+    searchEndpoint: "/cases/search",
+    itemsKey: "cases",
+    primaryLabel: numberSubjectLabel,
+    secondaryLabel: stateSecondaryLabel,
+    buildHref: (filters) =>
+      operationsHref(
+        "service_requests",
+        writeCasesFiltersToUrl({
+          ...DEFAULT_CASES_FILTERS,
+          ...translateCaseDashboardFilters(filters),
+        }),
+      ),
+    icon: Cog,
+    iconColor: "info",
+    previewSlug: "service-requests",
+  },
+  security_report_analysis: {
+    searchEndpoint: "/cases/search",
+    itemsKey: "cases",
+    primaryLabel: numberSubjectLabel,
+    secondaryLabel: stateSecondaryLabel,
+    buildHref: (filters) =>
+      securityCenterHref(
+        "security_reports",
+        writeCasesFiltersToUrl({
+          ...DEFAULT_CASES_FILTERS,
+          ...translateCaseDashboardFilters(filters),
+        }),
+      ),
+    icon: Shield,
+    iconColor: "warning",
+    previewSlug: "security-reports",
+  },
+  announcement: {
+    searchEndpoint: "/cases/search",
+    itemsKey: "cases",
+    primaryLabel: numberSubjectLabel,
+    secondaryLabel: stateSecondaryLabel,
+    // CsmAnnouncementsPage keeps its own filters in local component state,
+    // not the URL (unlike /cases, /operations, /engagements) — there is no
+    // query-param scheme to land a filtered click-through on yet, so this
+    // stays unfiltered, same as `problem` above.
+    buildHref: () => "/announcements",
+    icon: Megaphone,
+    iconColor: "success",
+    previewSlug: "announcements",
+  },
+  engagement: {
+    searchEndpoint: "/cases/search",
+    itemsKey: "cases",
+    primaryLabel: numberSubjectLabel,
+    secondaryLabel: stateSecondaryLabel,
+    buildHref: (filters) => caseTypeListHref("/engagements", filters),
+    icon: Handshake,
+    iconColor: "secondary",
+    previewSlug: "engagements",
   },
   incident: {
     searchEndpoint: "/incidents/search",

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.ts
@@ -366,6 +366,17 @@ function numberSubjectLabel(item: WidgetItem): string {
   );
 }
 
+/** Shared case-detail row link, used by every resourceType whose rows are
+ * case rows (`case` and the four case-`type` resourceTypes below, all of
+ * which read from `/cases/search` and return the same row shape). Row
+ * navigation in a `columns`-configured list goes through `detailHref` and
+ * nothing else (see `GenericColumnList`), so a case-row resource without
+ * this has rows that cannot be opened. */
+function caseDetailHref(item: WidgetItem): string | undefined {
+  const id = asString(item.id);
+  return id ? `/cases/${id}` : undefined;
+}
+
 /** Shared humanized-`state` secondary label, used by every resource whose
  * response item carries a `state` field (case, change_request, problem —
  * NOT incident, which has no state field and uses `priority` instead). */
@@ -387,7 +398,7 @@ export const WIDGET_RESOURCE_CONFIG: Record<
     icon: Briefcase,
     iconColor: "primary",
     previewSlug: "cases",
-    detailHref: (item) => (asString(item.id) ? `/cases/${asString(item.id)}` : undefined),
+    detailHref: caseDetailHref,
   },
   // service_request / security_report_analysis / announcement / engagement:
   // additional values of the case-search "type" enum (see `BeCaseType` /
@@ -401,6 +412,7 @@ export const WIDGET_RESOURCE_CONFIG: Record<
   service_request: {
     searchEndpoint: "/cases/search",
     itemsKey: "cases",
+    detailHref: caseDetailHref,
     primaryLabel: numberSubjectLabel,
     secondaryLabel: stateSecondaryLabel,
     buildHref: (filters) =>
@@ -418,6 +430,7 @@ export const WIDGET_RESOURCE_CONFIG: Record<
   security_report_analysis: {
     searchEndpoint: "/cases/search",
     itemsKey: "cases",
+    detailHref: caseDetailHref,
     primaryLabel: numberSubjectLabel,
     secondaryLabel: stateSecondaryLabel,
     buildHref: (filters) =>
@@ -435,6 +448,7 @@ export const WIDGET_RESOURCE_CONFIG: Record<
   announcement: {
     searchEndpoint: "/cases/search",
     itemsKey: "cases",
+    detailHref: caseDetailHref,
     primaryLabel: numberSubjectLabel,
     secondaryLabel: stateSecondaryLabel,
     // CsmAnnouncementsPage keeps its own filters in local component state,
@@ -449,6 +463,7 @@ export const WIDGET_RESOURCE_CONFIG: Record<
   engagement: {
     searchEndpoint: "/cases/search",
     itemsKey: "cases",
+    detailHref: caseDetailHref,
     primaryLabel: numberSubjectLabel,
     secondaryLabel: stateSecondaryLabel,
     buildHref: (filters) => caseTypeListHref("/engagements", filters),

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/utils/currentUserFilterPlaceholder.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/utils/currentUserFilterPlaceholder.test.ts
@@ -1,0 +1,143 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { describe, expect, it } from "vitest";
+import {
+  CURRENT_USER_PLACEHOLDER,
+  resolveCurrentUserPlaceholder,
+} from "./currentUserFilterPlaceholder";
+
+const CURRENT_USER_ID = "11111111-aaaa-bbbb-cccc-000000000001";
+
+describe("resolveCurrentUserPlaceholder", () => {
+  describe("case-search DSL shape ({ filters: [...] })", () => {
+    it("substitutes the placeholder with the signed-in user's own id when one is available", () => {
+      const filters = {
+        filters: [
+          { field: "state", op: "in", values: ["open"] },
+          { field: "assignedUserId", op: "in", values: [CURRENT_USER_PLACEHOLDER] },
+        ],
+      };
+
+      const resolved = resolveCurrentUserPlaceholder(filters, CURRENT_USER_ID);
+
+      expect(resolved).toEqual({
+        filters: [
+          { field: "state", op: "in", values: ["open"] },
+          { field: "assignedUserId", op: "in", values: [CURRENT_USER_ID] },
+        ],
+      });
+    });
+
+    it("drops the entry entirely when no signed-in user id is available yet", () => {
+      const filters = {
+        filters: [
+          { field: "state", op: "in", values: ["open"] },
+          { field: "assignedUserId", op: "in", values: [CURRENT_USER_PLACEHOLDER] },
+        ],
+      };
+
+      const resolved = resolveCurrentUserPlaceholder(filters, undefined);
+
+      expect(resolved).toEqual({
+        filters: [{ field: "state", op: "in", values: ["open"] }],
+      });
+    });
+
+    it("only substitutes the placeholder entry within a values array, leaving other literal values alone", () => {
+      const filters = {
+        filters: [
+          {
+            field: "assignedUserId",
+            op: "in",
+            values: ["some-literal-user-id", CURRENT_USER_PLACEHOLDER],
+          },
+        ],
+      };
+
+      const resolved = resolveCurrentUserPlaceholder(filters, CURRENT_USER_ID);
+
+      expect(resolved).toEqual({
+        filters: [
+          {
+            field: "assignedUserId",
+            op: "in",
+            values: ["some-literal-user-id", CURRENT_USER_ID],
+          },
+        ],
+      });
+    });
+
+    it("returns filters unchanged when there's no entry carrying the placeholder at all", () => {
+      const filters = { filters: [{ field: "state", op: "in", values: ["open"] }] };
+
+      expect(resolveCurrentUserPlaceholder(filters, CURRENT_USER_ID)).toEqual(filters);
+      expect(resolveCurrentUserPlaceholder(filters, undefined)).toEqual(filters);
+    });
+
+    it("passes through an empty filters array unchanged", () => {
+      const filters = { filters: [] };
+
+      expect(resolveCurrentUserPlaceholder(filters, CURRENT_USER_ID)).toBe(filters);
+    });
+  });
+
+  describe("flat { fieldName: string[] | string } shape", () => {
+    it("substitutes the placeholder inside a flat string-array field", () => {
+      const filters = { assignedUserIds: [CURRENT_USER_PLACEHOLDER], states: ["open"] };
+
+      const resolved = resolveCurrentUserPlaceholder(filters, CURRENT_USER_ID);
+
+      expect(resolved).toEqual({ assignedUserIds: [CURRENT_USER_ID], states: ["open"] });
+    });
+
+    it("drops the placeholder from a flat string-array field, dropping the whole key if the array becomes empty", () => {
+      const filters = { assignedUserIds: [CURRENT_USER_PLACEHOLDER], states: ["open"] };
+
+      const resolved = resolveCurrentUserPlaceholder(filters, undefined);
+
+      expect(resolved).toEqual({ states: ["open"] });
+    });
+
+    it("drops only the placeholder entry from a flat array carrying other literal values too", () => {
+      const filters = { assignedUserIds: ["some-literal-user-id", CURRENT_USER_PLACEHOLDER] };
+
+      const resolved = resolveCurrentUserPlaceholder(filters, undefined);
+
+      expect(resolved).toEqual({ assignedUserIds: ["some-literal-user-id"] });
+    });
+
+    it("substitutes a bare placeholder string value directly (not nested in an array)", () => {
+      const filters = { createdBy: CURRENT_USER_PLACEHOLDER };
+
+      expect(resolveCurrentUserPlaceholder(filters, CURRENT_USER_ID)).toEqual({
+        createdBy: CURRENT_USER_ID,
+      });
+    });
+
+    it("drops the key entirely for a bare placeholder string value when unresolved", () => {
+      const filters = { createdBy: CURRENT_USER_PLACEHOLDER, states: ["open"] };
+
+      expect(resolveCurrentUserPlaceholder(filters, undefined)).toEqual({ states: ["open"] });
+    });
+
+    it("returns filters unchanged (same reference) when no field carries the placeholder", () => {
+      const filters = { states: ["open"], severities: ["critical"] };
+
+      expect(resolveCurrentUserPlaceholder(filters, CURRENT_USER_ID)).toBe(filters);
+    });
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/utils/currentUserFilterPlaceholder.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/utils/currentUserFilterPlaceholder.test.ts
@@ -17,6 +17,7 @@
 import { describe, expect, it } from "vitest";
 import {
   CURRENT_USER_PLACEHOLDER,
+  hasCurrentUserPlaceholder,
   resolveCurrentUserPlaceholder,
 } from "./currentUserFilterPlaceholder";
 
@@ -42,7 +43,11 @@ describe("resolveCurrentUserPlaceholder", () => {
       });
     });
 
-    it("drops the entry entirely when no signed-in user id is available yet", () => {
+    // Fails CLOSED: dropping the assignedUserId entry here would leave a
+    // widget filtered only by state, i.e. every engineer's cases painted into
+    // a tile labelled as the viewer's own. The caller is expected to notice
+    // via hasCurrentUserPlaceholder and hold the request instead.
+    it("leaves the filters untouched when no signed-in user id is available yet", () => {
       const filters = {
         filters: [
           { field: "state", op: "in", values: ["open"] },
@@ -50,11 +55,25 @@ describe("resolveCurrentUserPlaceholder", () => {
         ],
       };
 
-      const resolved = resolveCurrentUserPlaceholder(filters, undefined);
+      expect(resolveCurrentUserPlaceholder(filters, undefined)).toBe(filters);
+    });
 
-      expect(resolved).toEqual({
-        filters: [{ field: "state", op: "in", values: ["open"] }],
-      });
+    it("keeps the literal values of a mixed filter when no signed-in user id is available yet", () => {
+      const filters = {
+        filters: [
+          {
+            field: "assignedUserId",
+            op: "in",
+            values: ["some-literal-user-id", CURRENT_USER_PLACEHOLDER],
+          },
+        ],
+      };
+
+      const resolved = resolveCurrentUserPlaceholder(filters, undefined) as {
+        filters: { values: string[] }[];
+      };
+
+      expect(resolved.filters[0].values).toContain("some-literal-user-id");
     });
 
     it("only substitutes the placeholder entry within a values array, leaving other literal values alone", () => {
@@ -104,20 +123,16 @@ describe("resolveCurrentUserPlaceholder", () => {
       expect(resolved).toEqual({ assignedUserIds: [CURRENT_USER_ID], states: ["open"] });
     });
 
-    it("drops the placeholder from a flat string-array field, dropping the whole key if the array becomes empty", () => {
+    it("leaves a flat string-array field untouched when unresolved, rather than dropping the key", () => {
       const filters = { assignedUserIds: [CURRENT_USER_PLACEHOLDER], states: ["open"] };
 
-      const resolved = resolveCurrentUserPlaceholder(filters, undefined);
-
-      expect(resolved).toEqual({ states: ["open"] });
+      expect(resolveCurrentUserPlaceholder(filters, undefined)).toBe(filters);
     });
 
-    it("drops only the placeholder entry from a flat array carrying other literal values too", () => {
+    it("keeps the literal values of a mixed flat array when unresolved", () => {
       const filters = { assignedUserIds: ["some-literal-user-id", CURRENT_USER_PLACEHOLDER] };
 
-      const resolved = resolveCurrentUserPlaceholder(filters, undefined);
-
-      expect(resolved).toEqual({ assignedUserIds: ["some-literal-user-id"] });
+      expect(resolveCurrentUserPlaceholder(filters, undefined)).toBe(filters);
     });
 
     it("substitutes a bare placeholder string value directly (not nested in an array)", () => {
@@ -128,10 +143,10 @@ describe("resolveCurrentUserPlaceholder", () => {
       });
     });
 
-    it("drops the key entirely for a bare placeholder string value when unresolved", () => {
+    it("keeps a bare placeholder string value when unresolved, rather than dropping the key", () => {
       const filters = { createdBy: CURRENT_USER_PLACEHOLDER, states: ["open"] };
 
-      expect(resolveCurrentUserPlaceholder(filters, undefined)).toEqual({ states: ["open"] });
+      expect(resolveCurrentUserPlaceholder(filters, undefined)).toBe(filters);
     });
 
     it("returns filters unchanged (same reference) when no field carries the placeholder", () => {
@@ -139,5 +154,40 @@ describe("resolveCurrentUserPlaceholder", () => {
 
       expect(resolveCurrentUserPlaceholder(filters, CURRENT_USER_ID)).toBe(filters);
     });
+  });
+});
+
+describe("hasCurrentUserPlaceholder", () => {
+  it("detects the placeholder in the case-search DSL shape", () => {
+    expect(
+      hasCurrentUserPlaceholder({
+        filters: [
+          { field: "state", op: "in", values: ["open"] },
+          { field: "assignedUserId", op: "in", values: [CURRENT_USER_PLACEHOLDER] },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("detects the placeholder in a flat array field and in a bare string field", () => {
+    expect(hasCurrentUserPlaceholder({ assignedUserIds: [CURRENT_USER_PLACEHOLDER] })).toBe(true);
+    expect(hasCurrentUserPlaceholder({ createdBy: CURRENT_USER_PLACEHOLDER })).toBe(true);
+  });
+
+  it("is false once the placeholder has been substituted", () => {
+    const filters = {
+      filters: [{ field: "assignedUserId", op: "in", values: [CURRENT_USER_PLACEHOLDER] }],
+    };
+
+    expect(hasCurrentUserPlaceholder(resolveCurrentUserPlaceholder(filters, CURRENT_USER_ID))).toBe(
+      false,
+    );
+  });
+
+  it("is false for filters that never carried the placeholder", () => {
+    expect(hasCurrentUserPlaceholder({ states: ["open"] })).toBe(false);
+    expect(
+      hasCurrentUserPlaceholder({ filters: [{ field: "state", op: "in", values: ["open"] }] }),
+    ).toBe(false);
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/utils/currentUserFilterPlaceholder.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/utils/currentUserFilterPlaceholder.ts
@@ -1,0 +1,142 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { isCaseFieldFilterArray, type WidgetCaseFieldFilterLike } from "./widgetPreviewUrl";
+
+/**
+ * Placeholder value a dashboard widget's own filters may carry wherever a
+ * per-user value belongs — e.g. `assignedUserId`/`assignedUserIds` — meaning
+ * "the signed-in user's own id". Until 2026-08-06 this was resolved
+ * server-side (`CurrentUserPlaceholder`/`substituteCurrentUser` in the
+ * backend's `internal/dashboard` package, via a `GET /users/me` round trip
+ * baked into `GET /dashboards/{id}`); `GET /dashboards/{id}` now returns
+ * `Query`/`Slices` verbatim, so this frontend resolves it itself, at the
+ * same point (and by the same generic value-substitution approach — the
+ * backend's own `substituteCurrentUser` walked the filters object by value,
+ * not by a hardcoded field name) `__current_team__` is already resolved
+ * client-side (see `teamFilterPlaceholder.ts`).
+ */
+export const CURRENT_USER_PLACEHOLDER = "__current_user__";
+
+/**
+ * Substitutes {@link CURRENT_USER_PLACEHOLDER} wherever it appears in a
+ * dashboard widget's filters with the signed-in user's own platform id
+ * (`useCurrentUser().user.id`) — handling both filter shapes this app's
+ * widgets use (same two shapes `resolveTeamPlaceholder`/
+ * `resolveCurrentUserSentinels` already branch on):
+ *
+ * - the case-search generic field/op/values DSL (`{ filters:
+ *   BeCaseFieldFilter[] }`, e.g. `{ field: "assignedUserId", op: "in",
+ *   values: ["__current_user__"] }`)
+ * - every other resourceType's flat `{ fieldName: string[] | string }`
+ *   record (e.g. `{ assignedUserIds: ["__current_user__"] }`)
+ *
+ * Unlike the case-search DSL's `field`-scoped `resolveTeamPlaceholder` (which
+ * only ever looks at `integrationCsTeam`), this walks every field generically
+ * — mirroring the backend's own now-removed `substituteCurrentUser`, which
+ * substituted the placeholder by VALUE wherever it appeared, with no
+ * hardcoded field name — since a widget can put "the signed-in user" in any
+ * field a resourceType's search supports (`assignedUserId` for case,
+ * `assignedUserIds` for another resourceType's flat filters, and so on), not
+ * only the one field name this app's widget configs happen to use today.
+ *
+ * When `currentUserId` is undefined (the signed-in user's profile hasn't
+ * loaded yet), the placeholder is DROPPED rather than sent to the backend
+ * literally — same fail-open philosophy as `resolveTeamPlaceholder`: the
+ * backend would either reject a non-UUID value with a 400 or, worse, silently
+ * match zero rows (a filter that reads as "nothing to see here" rather than
+ * "still loading"), where dropping the condition just widens the query back
+ * to unfiltered — a visibly-too-broad result a viewer notices, and one that
+ * self-corrects on the next render once the user profile loads (the
+ * substitution is applied fresh on every call, not cached).
+ */
+export function resolveCurrentUserPlaceholder(
+  filters: Record<string, unknown>,
+  currentUserId: string | undefined,
+): Record<string, unknown> {
+  const fieldFilters = filters.filters;
+  if (isCaseFieldFilterArray(fieldFilters)) {
+    return resolveCaseFieldFilters(filters, fieldFilters, currentUserId);
+  }
+  return resolveFlatFilters(filters, currentUserId);
+}
+
+function resolveCaseFieldFilters(
+  filters: Record<string, unknown>,
+  fieldFilters: WidgetCaseFieldFilterLike[],
+  currentUserId: string | undefined,
+): Record<string, unknown> {
+  let changed = false;
+  const resolved: WidgetCaseFieldFilterLike[] = [];
+  for (const entry of fieldFilters) {
+    const values = entry.values;
+    if (!values?.includes(CURRENT_USER_PLACEHOLDER)) {
+      resolved.push(entry);
+      continue;
+    }
+    changed = true;
+    if (currentUserId === undefined) {
+      // Drop the entry entirely — see the doc comment above.
+      continue;
+    }
+    resolved.push({
+      ...entry,
+      values: values.map((v) => (v === CURRENT_USER_PLACEHOLDER ? currentUserId : v)),
+    });
+  }
+
+  if (!changed) return filters;
+  return { ...filters, filters: resolved };
+}
+
+function resolveFlatFilters(
+  filters: Record<string, unknown>,
+  currentUserId: string | undefined,
+): Record<string, unknown> {
+  let changed = false;
+  const resolved: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(filters)) {
+    if (Array.isArray(value) && value.every((v) => typeof v === "string")) {
+      const strings = value as string[];
+      if (!strings.includes(CURRENT_USER_PLACEHOLDER)) {
+        resolved[key] = value;
+        continue;
+      }
+      changed = true;
+      if (currentUserId === undefined) {
+        // Drop the placeholder entry from the array (see the doc comment
+        // above); an array left empty by that drop is dropped too, rather
+        // than sent as `[]` (the backend rejects an empty values array the
+        // same way it would a literal unresolved placeholder).
+        const remaining = strings.filter((v) => v !== CURRENT_USER_PLACEHOLDER);
+        if (remaining.length > 0) resolved[key] = remaining;
+        continue;
+      }
+      resolved[key] = strings.map((v) => (v === CURRENT_USER_PLACEHOLDER ? currentUserId : v));
+      continue;
+    }
+    if (value === CURRENT_USER_PLACEHOLDER) {
+      changed = true;
+      if (currentUserId !== undefined) resolved[key] = currentUserId;
+      // else: drop the key entirely — see the doc comment above.
+      continue;
+    }
+    resolved[key] = value;
+  }
+
+  if (!changed) return filters;
+  return resolved;
+}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/utils/currentUserFilterPlaceholder.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/utils/currentUserFilterPlaceholder.ts
@@ -54,19 +54,36 @@ export const CURRENT_USER_PLACEHOLDER = "__current_user__";
  * only the one field name this app's widget configs happen to use today.
  *
  * When `currentUserId` is undefined (the signed-in user's profile hasn't
- * loaded yet), the placeholder is DROPPED rather than sent to the backend
- * literally — same fail-open philosophy as `resolveTeamPlaceholder`: the
- * backend would either reject a non-UUID value with a 400 or, worse, silently
- * match zero rows (a filter that reads as "nothing to see here" rather than
- * "still loading"), where dropping the condition just widens the query back
- * to unfiltered — a visibly-too-broad result a viewer notices, and one that
- * self-corrects on the next render once the user profile loads (the
- * substitution is applied fresh on every call, not cached).
+ * loaded yet — `CurrentUserProvider` does NOT gate its children on that
+ * fetch, so every widget's first render happens while `/users/me` is still
+ * in flight), the filters are returned UNCHANGED, placeholder and all.
+ *
+ * This is deliberately not the fail-open drop `resolveTeamPlaceholder` uses.
+ * Dropping the condition widens the query: a widget whose only filter is
+ * `assignedUserId in ["__current_user__"]` would, for the width of that
+ * fetch, issue a completely unfiltered search and paint every engineer's
+ * cases into a tile labelled as the viewer's own. Widening a user-scoped
+ * filter is the one failure mode this resolver must not have, so it fails
+ * closed instead — and returning the input untouched also preserves the
+ * literal values of a mixed `["__current_user__", "<some uuid>"]` filter,
+ * which the old per-entry drop discarded along with the placeholder.
+ *
+ * Leaving the placeholder in is a backstop, not the intended path: callers
+ * must not send it. {@link hasCurrentUserPlaceholder} lets a caller detect
+ * this state and defer the request until the profile lands — which is what
+ * `useWidgetData`/`useWidgetPieData` do, so nothing is issued in the
+ * meantime and the tile stays in its loading state. `widgetPreviewUrl.ts`'s
+ * `resolveCurrentUserSentinels` already follows this same "return unchanged,
+ * caller holds off" convention for its own `@me` sentinel. Should a request
+ * still go out (a caller that skipped the check), the backend rejects the
+ * non-UUID value with a 400 and the tile shows its error state — visibly
+ * broken, but never broader than the viewer is entitled to see.
  */
 export function resolveCurrentUserPlaceholder(
   filters: Record<string, unknown>,
   currentUserId: string | undefined,
 ): Record<string, unknown> {
+  if (currentUserId === undefined) return filters;
   const fieldFilters = filters.filters;
   if (isCaseFieldFilterArray(fieldFilters)) {
     return resolveCaseFieldFilters(filters, fieldFilters, currentUserId);
@@ -74,29 +91,40 @@ export function resolveCurrentUserPlaceholder(
   return resolveFlatFilters(filters, currentUserId);
 }
 
+/**
+ * Reports whether `filters` still carries {@link CURRENT_USER_PLACEHOLDER}
+ * anywhere — in either of the two filter shapes above. True means the filters
+ * cannot be sent as they stand: the caller must hold the request until
+ * `useCurrentUser().user.id` resolves (see the fail-closed note on
+ * {@link resolveCurrentUserPlaceholder}). Cheap enough to call on every
+ * render; these objects are a handful of entries deep.
+ */
+export function hasCurrentUserPlaceholder(filters: Record<string, unknown>): boolean {
+  const fieldFilters = filters.filters;
+  if (isCaseFieldFilterArray(fieldFilters)) {
+    return fieldFilters.some((entry) => entry.values?.includes(CURRENT_USER_PLACEHOLDER) ?? false);
+  }
+  return Object.values(filters).some((value) => {
+    if (value === CURRENT_USER_PLACEHOLDER) return true;
+    return Array.isArray(value) && value.includes(CURRENT_USER_PLACEHOLDER);
+  });
+}
+
 function resolveCaseFieldFilters(
   filters: Record<string, unknown>,
   fieldFilters: WidgetCaseFieldFilterLike[],
-  currentUserId: string | undefined,
+  currentUserId: string,
 ): Record<string, unknown> {
   let changed = false;
-  const resolved: WidgetCaseFieldFilterLike[] = [];
-  for (const entry of fieldFilters) {
+  const resolved: WidgetCaseFieldFilterLike[] = fieldFilters.map((entry) => {
     const values = entry.values;
-    if (!values?.includes(CURRENT_USER_PLACEHOLDER)) {
-      resolved.push(entry);
-      continue;
-    }
+    if (!values?.includes(CURRENT_USER_PLACEHOLDER)) return entry;
     changed = true;
-    if (currentUserId === undefined) {
-      // Drop the entry entirely — see the doc comment above.
-      continue;
-    }
-    resolved.push({
+    return {
       ...entry,
       values: values.map((v) => (v === CURRENT_USER_PLACEHOLDER ? currentUserId : v)),
-    });
-  }
+    };
+  });
 
   if (!changed) return filters;
   return { ...filters, filters: resolved };
@@ -104,7 +132,7 @@ function resolveCaseFieldFilters(
 
 function resolveFlatFilters(
   filters: Record<string, unknown>,
-  currentUserId: string | undefined,
+  currentUserId: string,
 ): Record<string, unknown> {
   let changed = false;
   const resolved: Record<string, unknown> = {};
@@ -116,22 +144,12 @@ function resolveFlatFilters(
         continue;
       }
       changed = true;
-      if (currentUserId === undefined) {
-        // Drop the placeholder entry from the array (see the doc comment
-        // above); an array left empty by that drop is dropped too, rather
-        // than sent as `[]` (the backend rejects an empty values array the
-        // same way it would a literal unresolved placeholder).
-        const remaining = strings.filter((v) => v !== CURRENT_USER_PLACEHOLDER);
-        if (remaining.length > 0) resolved[key] = remaining;
-        continue;
-      }
       resolved[key] = strings.map((v) => (v === CURRENT_USER_PLACEHOLDER ? currentUserId : v));
       continue;
     }
     if (value === CURRENT_USER_PLACEHOLDER) {
       changed = true;
-      if (currentUserId !== undefined) resolved[key] = currentUserId;
-      // else: drop the key entirely — see the doc comment above.
+      resolved[key] = currentUserId;
       continue;
     }
     resolved[key] = value;

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/utils/resolveRelativeDateFilters.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/utils/resolveRelativeDateFilters.test.ts
@@ -1,0 +1,185 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { describe, expect, it } from "vitest";
+import {
+  resolveRelativeDateFilters,
+  resolveRelativeDatePlaceholder,
+} from "./resolveRelativeDateFilters";
+
+// A fixed reference instant so every assertion is deterministic regardless of
+// the machine/timezone running the test — 2026-08-15 14:30 in whatever
+// timezone the test runner's `Date` constructor treats as local. Every
+// assertion below re-derives its expectation from this same `now`'s own
+// getters, so it holds under any local timezone (CI included).
+const NOW = new Date(2026, 7, 15, 14, 30, 0, 0); // Aug 15, 2026, 14:30 local
+
+function localMidnightIso(year: number, month: number, date: number): string {
+  return new Date(year, month, date, 0, 0, 0, 0).toISOString();
+}
+
+/** One nanosecond-can't-be-represented-in-JS-so-one-millisecond before the
+ * next day's local midnight — the `lte` "inclusive of the whole day" bound. */
+function localEndOfDayIso(year: number, month: number, date: number): string {
+  return new Date(new Date(year, month, date + 1, 0, 0, 0, 0).getTime() - 1).toISOString();
+}
+
+describe("resolveRelativeDatePlaceholder", () => {
+  it("resolves __today__ for a gte bound to today's local midnight", () => {
+    const resolved = resolveRelativeDatePlaceholder("__today__", "gte", NOW);
+    expect(resolved).toBe(localMidnightIso(2026, 7, 15));
+  });
+
+  it("resolves __today__ for an lte bound to the end of today (local)", () => {
+    const resolved = resolveRelativeDatePlaceholder("__today__", "lte", NOW);
+    expect(resolved).toBe(localEndOfDayIso(2026, 7, 15));
+  });
+
+  it("resolves __daysAgo:N__ relative to today", () => {
+    const resolvedGte = resolveRelativeDatePlaceholder("__daysAgo:7__", "gte", NOW);
+    expect(resolvedGte).toBe(localMidnightIso(2026, 7, 8));
+
+    const resolvedLte = resolveRelativeDatePlaceholder("__daysAgo:0__", "lte", NOW);
+    expect(resolvedLte).toBe(localEndOfDayIso(2026, 7, 15));
+  });
+
+  it("does not resolve a negative __daysAgo__ offset", () => {
+    expect(resolveRelativeDatePlaceholder("__daysAgo:-1__", "gte", NOW)).toBeUndefined();
+  });
+
+  it("resolves __startOfMonth:N__ / __endOfMonth:N__", () => {
+    // This month (n=0): Aug 1 - Aug 31, 2026.
+    expect(resolveRelativeDatePlaceholder("__startOfMonth:0__", "gte", NOW)).toBe(
+      localMidnightIso(2026, 7, 1),
+    );
+    expect(resolveRelativeDatePlaceholder("__endOfMonth:0__", "lte", NOW)).toBe(
+      localEndOfDayIso(2026, 7, 31),
+    );
+    // Last month (n=-1): Jul 1 - Jul 31, 2026.
+    expect(resolveRelativeDatePlaceholder("__startOfMonth:-1__", "gte", NOW)).toBe(
+      localMidnightIso(2026, 6, 1),
+    );
+    expect(resolveRelativeDatePlaceholder("__endOfMonth:-1__", "lte", NOW)).toBe(
+      localEndOfDayIso(2026, 6, 31),
+    );
+  });
+
+  it("resolves __startOfQuarter:N__ / __endOfQuarter:N__", () => {
+    // Aug 2026 is in Q3 (Jul-Sep). This quarter (n=0): Jul 1 - Sep 30, 2026.
+    expect(resolveRelativeDatePlaceholder("__startOfQuarter:0__", "gte", NOW)).toBe(
+      localMidnightIso(2026, 6, 1),
+    );
+    expect(resolveRelativeDatePlaceholder("__endOfQuarter:0__", "lte", NOW)).toBe(
+      localEndOfDayIso(2026, 8, 30),
+    );
+    // Next quarter (n=1): Oct 1 - Dec 31, 2026.
+    expect(resolveRelativeDatePlaceholder("__startOfQuarter:1__", "gte", NOW)).toBe(
+      localMidnightIso(2026, 9, 1),
+    );
+  });
+
+  it("leaves a literal date value untouched", () => {
+    expect(resolveRelativeDatePlaceholder("2026-01-01", "gte", NOW)).toBeUndefined();
+    expect(
+      resolveRelativeDatePlaceholder("2026-01-01T00:00:00Z", "gte", NOW),
+    ).toBeUndefined();
+  });
+
+  it("leaves an unrecognized placeholder name untouched (falls through to the backend's own rejection)", () => {
+    expect(resolveRelativeDatePlaceholder("__current_user_email__", "eq", NOW)).toBeUndefined();
+    expect(resolveRelativeDatePlaceholder("__someUnknownThing__", "gte", NOW)).toBeUndefined();
+  });
+
+  it("leaves a malformed argument untouched, matching the backend's own fail-fast behavior", () => {
+    expect(resolveRelativeDatePlaceholder("__daysAgo:abc__", "gte", NOW)).toBeUndefined();
+    expect(resolveRelativeDatePlaceholder("__daysAgo__", "gte", NOW)).toBeUndefined();
+    expect(resolveRelativeDatePlaceholder("__today:5__", "gte", NOW)).toBeUndefined();
+  });
+});
+
+describe("resolveRelativeDateFilters", () => {
+  it("resolves a createdOn gte/lte 'today' range in a widget's filters", () => {
+    const filters = {
+      filters: [
+        { field: "type", op: "in", values: ["case"] },
+        { field: "createdOn", op: "gte", values: ["__today__"] },
+      ],
+    };
+
+    const resolved = resolveRelativeDateFilters(filters, NOW);
+
+    expect(resolved).toEqual({
+      filters: [
+        { field: "type", op: "in", values: ["case"] },
+        { field: "createdOn", op: "gte", values: [localMidnightIso(2026, 7, 15)] },
+      ],
+    });
+  });
+
+  it("leaves a literal (non-placeholder) filter value untouched", () => {
+    const filters = {
+      filters: [
+        { field: "projectType", op: "in", values: ["cb4a87bd-0000-0000-0000-000000000000"] },
+        { field: "createdOn", op: "gte", values: ["2026-01-01"] },
+      ],
+    };
+
+    expect(resolveRelativeDateFilters(filters, NOW)).toBe(filters);
+  });
+
+  it("returns non-case-filter-shaped filters (other resourceTypes) unchanged", () => {
+    const filters = { states: ["open"] };
+    expect(resolveRelativeDateFilters(filters, NOW)).toBe(filters);
+  });
+
+  it("passes through an empty filters array unchanged", () => {
+    const filters = { filters: [] };
+    expect(resolveRelativeDateFilters(filters, NOW)).toBe(filters);
+  });
+
+  it("only resolves the placeholder entry, leaving sibling entries and other values in the same array alone", () => {
+    const filters = {
+      filters: [
+        { field: "state", op: "in", values: ["open"] },
+        { field: "resolvedOn", op: "lte", values: ["__daysAgo:30__"] },
+        { field: "resolvedOn", op: "gte", values: ["2026-01-01"] },
+      ],
+    };
+
+    const resolved = resolveRelativeDateFilters(filters, NOW);
+
+    expect(resolved).toEqual({
+      filters: [
+        { field: "state", op: "in", values: ["open"] },
+        { field: "resolvedOn", op: "lte", values: [localEndOfDayIso(2026, 6, 16)] },
+        { field: "resolvedOn", op: "gte", values: ["2026-01-01"] },
+      ],
+    });
+  });
+
+  it("defaults to real wall-clock time when no reference instant is passed", () => {
+    const filters = {
+      filters: [{ field: "createdOn", op: "gte", values: ["__today__"] }],
+    };
+
+    const resolved = resolveRelativeDateFilters(filters) as {
+      filters: { values: string[] }[];
+    };
+
+    const now = new Date();
+    expect(resolved.filters[0].values[0]).toBe(localMidnightIso(now.getFullYear(), now.getMonth(), now.getDate()));
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/utils/resolveRelativeDateFilters.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/utils/resolveRelativeDateFilters.test.ts
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   resolveRelativeDateFilters,
   resolveRelativeDatePlaceholder,
@@ -171,15 +171,23 @@ describe("resolveRelativeDateFilters", () => {
   });
 
   it("defaults to real wall-clock time when no reference instant is passed", () => {
-    const filters = {
-      filters: [{ field: "createdOn", op: "gte", values: ["__today__"] }],
-    };
+    // The function reads `new Date()` itself and the expectation below reads
+    // it again; without a frozen clock the two reads can land on either side
+    // of local midnight and belong to different calendar days.
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    try {
+      const filters = {
+        filters: [{ field: "createdOn", op: "gte", values: ["__today__"] }],
+      };
 
-    const resolved = resolveRelativeDateFilters(filters) as {
-      filters: { values: string[] }[];
-    };
+      const resolved = resolveRelativeDateFilters(filters) as {
+        filters: { values: string[] }[];
+      };
 
-    const now = new Date();
-    expect(resolved.filters[0].values[0]).toBe(localMidnightIso(now.getFullYear(), now.getMonth(), now.getDate()));
+      expect(resolved.filters[0].values[0]).toBe(localMidnightIso(2026, 7, 15));
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/utils/resolveRelativeDateFilters.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/utils/resolveRelativeDateFilters.ts
@@ -1,0 +1,204 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { isCaseFieldFilterArray, type WidgetCaseFieldFilterLike } from "./widgetPreviewUrl";
+
+/**
+ * Matches the shape of every relative-date placeholder the entity-service's
+ * `resolveRelativeDate` (see `case_filters.go`) recognizes: `__<name>__` (no
+ * argument, e.g. `__today__`) or `__<name>:<integer>__` (e.g. `__daysAgo:30__`,
+ * `__startOfMonth:-1__`). Deliberately stricter than the backend's own
+ * pattern (which accepts any non-underscore argument and defers the
+ * integer check to a second step, so it can raise a targeted "non-integer
+ * offset" error): here, anything that doesn't cleanly match is simply left
+ * unresolved and forwarded to the backend as-is, which still rejects a
+ * malformed placeholder like `__daysAgo:abc__` with that same validation
+ * error — the fallback behavior is unchanged, only well-formed placeholders
+ * are handled client-side.
+ */
+const RELATIVE_DATE_PLACEHOLDER_PATTERN = /^__([a-zA-Z]+)(?::(-?\d+))?__$/;
+
+/** Local (browser) midnight for the given y/m/d. */
+function localMidnight(year: number, month: number, date: number): Date {
+  return new Date(year, month, date, 0, 0, 0, 0);
+}
+
+/** `now`'s own local midnight — the reference "today" every placeholder
+ * below resolves relative to. */
+function today(now: Date): Date {
+  return localMidnight(now.getFullYear(), now.getMonth(), now.getDate());
+}
+
+function addDays(day: Date, n: number): Date {
+  const copy = new Date(day);
+  copy.setDate(copy.getDate() + n);
+  return copy;
+}
+
+/** 1st of the month `n` months from `now`'s own month (local), e.g. n=0 this
+ * month, n=-1 last month — mirrors `case_filters.go`'s
+ * `startOfRelativeMonth`, computed in local time instead of UTC. */
+function startOfRelativeMonth(now: Date, n: number): Date {
+  const base = localMidnight(now.getFullYear(), now.getMonth(), 1);
+  base.setMonth(base.getMonth() + n);
+  return base;
+}
+
+/** 1st of the quarter `n` quarters from `now`'s own quarter (local) —
+ * mirrors `case_filters.go`'s `startOfRelativeQuarter`. */
+function startOfRelativeQuarter(now: Date, n: number): Date {
+  const quarterStartMonth = Math.floor(now.getMonth() / 3) * 3;
+  const base = localMidnight(now.getFullYear(), quarterStartMonth, 1);
+  base.setMonth(base.getMonth() + n * 3);
+  return base;
+}
+
+/**
+ * Converts a resolved calendar day (local midnight) into the concrete RFC3339
+ * instant this filter entry's own `op` means: for `lte`, the day is inclusive
+ * of its own whole 24h span (matching `parseCaseFilterDate`'s
+ * date-only-plus-`lte` bump), so the bound is one millisecond before the next
+ * day's local midnight; every other op (`gte`, chiefly) means the bound
+ * starts at the day's own local midnight.
+ */
+function dayToBoundInstant(day: Date, op: string): string {
+  if (op === "lte") {
+    const nextDayMidnight = addDays(day, 1);
+    return new Date(nextDayMidnight.getTime() - 1).toISOString();
+  }
+  return day.toISOString();
+}
+
+/**
+ * Resolves a single filter value against `now` if — and only if — it matches
+ * one of the relative-date placeholders `case_filters.go`'s
+ * `resolveRelativeDate` documents. Returns `undefined` for anything else (a
+ * literal date, an unrecognized/malformed placeholder, or a value for an
+ * unrelated field like a UUID or enum) so the caller can leave it untouched.
+ *
+ * `op` decides whether the resolved calendar day is read as its own start
+ * (any op other than `lte`) or end (`lte`) — see {@link dayToBoundInstant}.
+ */
+export function resolveRelativeDatePlaceholder(
+  value: string,
+  op: string,
+  now: Date,
+): string | undefined {
+  const match = RELATIVE_DATE_PLACEHOLDER_PATTERN.exec(value);
+  if (!match) return undefined;
+  const [, name, argStr] = match;
+  const refToday = today(now);
+
+  switch (name) {
+    case "today":
+      // Takes no argument — a shape match with one (`__today:5__`) is not
+      // ours to resolve; leave it for the backend's own rejection.
+      return argStr === undefined ? dayToBoundInstant(refToday, op) : undefined;
+
+    case "daysAgo": {
+      if (argStr === undefined) return undefined;
+      const n = Number(argStr);
+      // Same non-negative constraint as the backend's own daysAgo.
+      if (n < 0) return undefined;
+      return dayToBoundInstant(addDays(refToday, -n), op);
+    }
+
+    case "startOfMonth": {
+      if (argStr === undefined) return undefined;
+      return dayToBoundInstant(startOfRelativeMonth(now, Number(argStr)), op);
+    }
+
+    case "endOfMonth": {
+      if (argStr === undefined) return undefined;
+      const lastDay = addDays(startOfRelativeMonth(now, Number(argStr) + 1), -1);
+      return dayToBoundInstant(lastDay, op);
+    }
+
+    case "startOfQuarter": {
+      if (argStr === undefined) return undefined;
+      return dayToBoundInstant(startOfRelativeQuarter(now, Number(argStr)), op);
+    }
+
+    case "endOfQuarter": {
+      if (argStr === undefined) return undefined;
+      const lastDay = addDays(startOfRelativeQuarter(now, Number(argStr) + 1), -1);
+      return dayToBoundInstant(lastDay, op);
+    }
+
+    default:
+      // Shape matches (__name__ / __name:N__) but the name isn't one of the
+      // relative-date placeholders — not ours to resolve.
+      return undefined;
+  }
+}
+
+/**
+ * Resolves every relative-date placeholder (see
+ * {@link resolveRelativeDatePlaceholder}) in a widget's case-search filters
+ * (`{ filters: BeCaseFieldFilter[] }` — the same DSL `resolveTeamPlaceholder`
+ * and `mergeWidgetFilters` operate on) against `now` — real wall-clock time
+ * in the viewer's own browser by default, so "today" always means the
+ * viewer's own local calendar day rather than UTC's.
+ *
+ * ServiceNow's own equivalent "Today" reports resolve against the support
+ * team's session timezone (confirmed `Asia/Colombo`, UTC+5:30); the
+ * entity-service resolves the same placeholders against UTC, which
+ * undercounts "Created Today"/"Resolved Today" widgets by the up-to-~5.5h gap
+ * between UTC midnight and Colombo midnight. Resolving here, in the viewer's
+ * own browser-local time, fixes that for today's CS engineers (physically
+ * Colombo-based) without hardcoding that assumption into the platform.
+ *
+ * Every filter value that ISN'T a recognized placeholder — a literal date, a
+ * UUID, an enum value — passes through unchanged. Non-case-filter-shaped
+ * `filters` (every other resourceType's flat record) also pass through
+ * unchanged, same fail-open convention as `resolveTeamPlaceholder`.
+ *
+ * The entity-service's own placeholder resolution (`resolveRelativeDate`,
+ * still UTC-based) stays in place as a dead fallback — should this function
+ * ever miss a placeholder shape it doesn't yet recognize, or the value
+ * reaches `/cases/search` unresolved through some other path, the backend
+ * still resolves it rather than rejecting the request outright. It just
+ * resolves it against UTC "today", not the viewer's — the same discrepancy
+ * this function exists to close for the common case.
+ */
+export function resolveRelativeDateFilters(
+  filters: Record<string, unknown>,
+  now: Date = new Date(),
+): Record<string, unknown> {
+  const fieldFilters = filters.filters;
+  if (!isCaseFieldFilterArray(fieldFilters)) return filters;
+
+  let changed = false;
+  const resolved: WidgetCaseFieldFilterLike[] = fieldFilters.map((entry) => {
+    const values = entry.values;
+    if (!values || values.length === 0) return entry;
+
+    let entryChanged = false;
+    const newValues = values.map((v) => {
+      const r = resolveRelativeDatePlaceholder(v, entry.op, now);
+      if (r === undefined) return v;
+      entryChanged = true;
+      return r;
+    });
+
+    if (!entryChanged) return entry;
+    changed = true;
+    return { ...entry, values: newValues };
+  });
+
+  if (!changed) return filters;
+  return { ...filters, filters: resolved };
+}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/utils/resolveWidgetColumn.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/utils/resolveWidgetColumn.test.ts
@@ -1,0 +1,91 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { describe, expect, it } from "vitest";
+import { formatColumnValue, resolveColumnPath } from "./resolveWidgetColumn";
+
+describe("resolveColumnPath", () => {
+  it("resolves a top-level field", () => {
+    expect(resolveColumnPath({ subject: "Disk full" }, "subject")).toBe("Disk full");
+  });
+
+  it("resolves a one-level nested field", () => {
+    const item = { project: { id: "p-1", name: "Alpha", key: "ALPHA" } };
+    expect(resolveColumnPath(item, "project.key")).toBe("ALPHA");
+  });
+
+  it("resolves an arbitrarily deep nested field", () => {
+    const item = {
+      project: {
+        id: "p-1",
+        name: "Alpha",
+        account: { id: "a-1", name: "WSO2", tier: "Platinum" },
+      },
+    };
+    expect(resolveColumnPath(item, "project.account.tier")).toBe("Platinum");
+  });
+
+  it("returns undefined for a missing top-level field", () => {
+    expect(resolveColumnPath({ subject: "x" }, "bestCaseFixEta")).toBeUndefined();
+  });
+
+  it("returns undefined when an intermediate segment is missing", () => {
+    expect(resolveColumnPath({ project: null }, "project.key")).toBeUndefined();
+    expect(resolveColumnPath({}, "project.account.tier")).toBeUndefined();
+  });
+
+  it("returns undefined when an intermediate segment is not an object", () => {
+    expect(resolveColumnPath({ project: "not-an-object" }, "project.key")).toBeUndefined();
+  });
+});
+
+describe("formatColumnValue", () => {
+  it("renders a plain string as-is", () => {
+    expect(formatColumnValue("Disk full")).toBe("Disk full");
+  });
+
+  it("stringifies a number/boolean", () => {
+    expect(formatColumnValue(42)).toBe("42");
+    expect(formatColumnValue(true)).toBe("true");
+  });
+
+  it("renders the empty placeholder for null/undefined/empty string", () => {
+    expect(formatColumnValue(null)).toBe("—");
+    expect(formatColumnValue(undefined)).toBe("—");
+    expect(formatColumnValue("")).toBe("—");
+  });
+
+  it("renders the empty placeholder for a nested object/array (not a scalar)", () => {
+    expect(formatColumnValue({ id: "1" })).toBe("—");
+    expect(formatColumnValue([1, 2])).toBe("—");
+  });
+
+  it("formats a date-only string with format 'date'", () => {
+    expect(formatColumnValue("2026-08-01", "date")).toBe("Aug 1, 2026");
+  });
+
+  it("formats an ISO timestamp with format 'date'", () => {
+    expect(formatColumnValue("2026-08-01T10:00:00Z", "date")).toMatch(/Aug 1, 2026|Jul 31, 2026/);
+  });
+
+  it("falls back to the empty placeholder for an unparseable date string", () => {
+    expect(formatColumnValue("not-a-date", "date")).toBe("—");
+  });
+
+  it("falls back to the empty placeholder when format is 'date' but the value isn't a string", () => {
+    expect(formatColumnValue(42, "date")).toBe("—");
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/utils/resolveWidgetColumn.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/utils/resolveWidgetColumn.ts
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { BeDashboardWidgetColumnFormat } from "@api/backend/types";
+import { formatBackendTimestampForDisplay } from "@utils/dateTime";
+
+/**
+ * Resolves a dot-separated path (e.g. `"project.key"`,
+ * `"project.account.tier"`) against one search-response item, walking into
+ * nested objects to arbitrary depth — every resource's search response
+ * embeds related entities as nested JSON objects (`{ id, name }` refs and
+ * deeper), not flat records, so a widget column has to be able to reach
+ * into them. Returns `undefined` for a path that doesn't resolve (a missing
+ * segment, or a non-object value partway through) rather than throwing —
+ * one misconfigured/unavailable column must not break the whole widget.
+ */
+export function resolveColumnPath(item: Record<string, unknown>, path: string): unknown {
+  const segments = path.split(".").filter(Boolean);
+  let current: unknown = item;
+  for (const segment of segments) {
+    if (current === null || current === undefined || typeof current !== "object") {
+      return undefined;
+    }
+    current = (current as Record<string, unknown>)[segment];
+  }
+  return current;
+}
+
+/** Placeholder rendered for a column value that is absent, null, or an
+ * unresolved path — matches the em-dash convention every other dashboard
+ * list renderer in this app already uses (see `formatDate` in
+ * `widgetListConfig.tsx`). */
+const EMPTY_VALUE = "—";
+
+/**
+ * Formats a resolved column value for display, per `format`:
+ * - `"date"`: formatted via the same date-only formatter the app's existing
+ *   hardcoded list renderers use for a date column; a value that isn't a
+ *   parseable date string falls back to the empty placeholder rather than
+ *   rendering a raw/garbled string.
+ * - omitted / `"text"` (default): rendered as plain text. Non-string
+ *   primitives (number, boolean) are stringified; an object/array (a column
+ *   path that resolved to a nested structure rather than a leaf value) also
+ *   renders as the empty placeholder — this renderer is for scalar columns.
+ */
+export function formatColumnValue(
+  value: unknown,
+  format?: BeDashboardWidgetColumnFormat,
+): string {
+  if (value === null || value === undefined || value === "") {
+    return EMPTY_VALUE;
+  }
+  if (format === "date") {
+    if (typeof value !== "string") return EMPTY_VALUE;
+    return (
+      formatBackendTimestampForDisplay(value, {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+      }) ?? EMPTY_VALUE
+    );
+  }
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  // Object/array: not a scalar this renderer knows how to display.
+  return EMPTY_VALUE;
+}

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -1368,9 +1368,10 @@ type ParsedCaseFilters struct {
 	// status is one of these values (optional; free-text SN choice labels, e.g.
 	// "Completed", "Not-Applicable" -- not a closed enum at this layer).
 	ProjectOnboardingStatuses []string
-	// ProjectTypeIDs filters to cases whose parent project's type is one of these
-	// project-type UUIDs (optional).
-	ProjectTypeIDs []string
+	// ProjectTypeNames filters to cases whose parent project's type is one of
+	// these project-type names, e.g. "Subscription" (optional; the backing data
+	// source matches project type by name, not by id).
+	ProjectTypeNames []string
 	// IntegrationCsTeamIDs filters to cases whose parent account's integration CS
 	// team is one of these team UUIDs (optional).
 	IntegrationCsTeamIDs []string

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -1327,20 +1327,22 @@ type CaseFilterBranch struct {
 // where the pre-redesign per-field validation and query/payload-building
 // logic still lives, unchanged.
 type ParsedCaseFilters struct {
-	Types            []string
-	ProjectIDs       []string
-	DeploymentIDs    []string
-	States           []CaseState
-	Severities       []CaseSeverity
-	IssueTypes       []CaseIssueType
-	EngagementTypes  []EngagementType
-	ClosedStartDate  *time.Time
-	ClosedEndDate    *time.Time
-	StartCreatedDate *time.Time
-	EndCreatedDate   *time.Time
-	StartUpdatedDate *time.Time
-	EndUpdatedDate   *time.Time
-	CreatedBy        []string
+	Types             []string
+	ProjectIDs        []string
+	DeploymentIDs     []string
+	States            []CaseState
+	Severities        []CaseSeverity
+	IssueTypes        []CaseIssueType
+	EngagementTypes   []EngagementType
+	ClosedStartDate   *time.Time
+	ClosedEndDate     *time.Time
+	ResolvedStartDate *time.Time
+	ResolvedEndDate   *time.Time
+	StartCreatedDate  *time.Time
+	EndCreatedDate    *time.Time
+	StartUpdatedDate  *time.Time
+	EndUpdatedDate    *time.Time
+	CreatedBy         []string
 	// CreatedByMe is true when the array carried a createdBy+eq current-user
 	// placeholder filter. The ServiceNow backend forwards this as-is (Ballerina
 	// resolves the caller itself); the Postgres backend folds the caller's

--- a/entity-service/internal/service/case_filters.go
+++ b/entity-service/internal/service/case_filters.go
@@ -41,7 +41,7 @@ var caseFilterFieldSet = map[string]bool{
 	"type": true, "state": true, "severity": true, "engagementType": true,
 	"issueType": true, "workState": true, "tag": true, "projectId": true,
 	"deploymentId": true, "assignedUserId": true, "createdBy": true,
-	"createdOn": true, "updatedOn": true, "closedOn": true, "product": true,
+	"createdOn": true, "updatedOn": true, "closedOn": true, "resolvedOn": true, "product": true,
 	"projectOnboardingStatus": true, "projectType": true, "integrationCsTeam": true,
 	"resolutionNotes": true, "parentId": true, "taskSLABusinessElapsedPercent": true,
 	"escalationLevel": true, "escalation": true,
@@ -444,6 +444,23 @@ func ParseCaseFieldFilters(filters []domain.CaseFieldFilter, callerEmail string,
 				return domain.ParsedCaseFilters{}, badCaseFilterCombo(f)
 			}
 
+		case "resolvedOn":
+			if err := requireCaseFilterValues(f); err != nil {
+				return domain.ParsedCaseFilters{}, err
+			}
+			t, err := parseCaseFilterDate(f, f.Values[0], now)
+			if err != nil {
+				return domain.ParsedCaseFilters{}, err
+			}
+			switch f.Op {
+			case "gte":
+				p.ResolvedStartDate = t
+			case "lte":
+				p.ResolvedEndDate = t
+			default:
+				return domain.ParsedCaseFilters{}, badCaseFilterCombo(f)
+			}
+
 		case "product":
 			if f.Op != "in" {
 				return domain.ParsedCaseFilters{}, badCaseFilterCombo(f)
@@ -603,7 +620,7 @@ func ParseCaseFieldFilterGroups(branches []domain.CaseFilterBranch) ([]domain.Ca
 			}
 		}
 		// now is irrelevant here: rejectUnsupportedOrGroupFields below rejects any
-		// date-range field (createdOn/updatedOn/closedOn) inside an OR-group branch,
+		// date-range field (createdOn/updatedOn/closedOn/resolvedOn) inside an OR-group branch,
 		// so this call never actually resolves a relative-date placeholder.
 		//
 		// orGroupCallerEmailSentinel stands in for the caller's email so the
@@ -649,6 +666,8 @@ func rejectUnsupportedOrGroupFields(parsed domain.ParsedCaseFilters) error {
 		return &apierror.ValidationError{Msg: "anyOf: field \"createdBy\" is not supported inside an OR group"}
 	case parsed.ClosedStartDate != nil || parsed.ClosedEndDate != nil:
 		return &apierror.ValidationError{Msg: "anyOf: field \"closedOn\" is not supported inside an OR group"}
+	case parsed.ResolvedStartDate != nil || parsed.ResolvedEndDate != nil:
+		return &apierror.ValidationError{Msg: "anyOf: field \"resolvedOn\" is not supported inside an OR group"}
 	case parsed.StartCreatedDate != nil || parsed.EndCreatedDate != nil:
 		return &apierror.ValidationError{Msg: "anyOf: field \"createdOn\" is not supported inside an OR group"}
 	case parsed.StartUpdatedDate != nil || parsed.EndUpdatedDate != nil:

--- a/entity-service/internal/service/case_filters.go
+++ b/entity-service/internal/service/case_filters.go
@@ -486,7 +486,7 @@ func ParseCaseFieldFilters(filters []domain.CaseFieldFilter, callerEmail string,
 			if err := requireCaseFilterValues(f); err != nil {
 				return domain.ParsedCaseFilters{}, err
 			}
-			p.ProjectTypeIDs = append(p.ProjectTypeIDs, f.Values...)
+			p.ProjectTypeNames = append(p.ProjectTypeNames, f.Values...)
 
 		case "integrationCsTeam":
 			if f.Op != "in" {
@@ -676,7 +676,7 @@ func rejectUnsupportedOrGroupFields(parsed domain.ParsedCaseFilters) error {
 		return &apierror.ValidationError{Msg: "anyOf: field \"product\" is not supported inside an OR group"}
 	case len(parsed.ProjectOnboardingStatuses) > 0:
 		return &apierror.ValidationError{Msg: "anyOf: field \"projectOnboardingStatus\" is not supported inside an OR group"}
-	case len(parsed.ProjectTypeIDs) > 0:
+	case len(parsed.ProjectTypeNames) > 0:
 		return &apierror.ValidationError{Msg: "anyOf: field \"projectType\" is not supported inside an OR group"}
 	case len(parsed.IntegrationCsTeamIDs) > 0:
 		return &apierror.ValidationError{Msg: "anyOf: field \"integrationCsTeam\" is not supported inside an OR group"}

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -445,7 +445,7 @@ func (s *caseService) SearchCases(ctx context.Context, req domain.SearchCasesReq
 	if len(parsed.ProjectOnboardingStatuses) > 0 {
 		return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: `field "projectOnboardingStatus" is not supported by this data source`}
 	}
-	if len(parsed.ProjectTypeIDs) > 0 {
+	if len(parsed.ProjectTypeNames) > 0 {
 		return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: `field "projectType" is not supported by this data source`}
 	}
 	if len(parsed.IntegrationCsTeamIDs) > 0 {

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -425,6 +425,14 @@ func (s *caseService) SearchCases(ctx context.Context, req domain.SearchCasesReq
 		parsed.EndUpdatedDate.Before(*parsed.StartUpdatedDate) {
 		return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: "updatedOn: lte value must not be before gte value"}
 	}
+	// resolvedOn has no backing column in the relational schema and
+	// caseRepo.SearchCases models no predicate for it, so accepting it here
+	// would drop the bound silently and answer 200 with every case rather
+	// than the resolved-in-range ones asked for. Reject, same as every other
+	// predicate this data source cannot express.
+	if parsed.ResolvedStartDate != nil || parsed.ResolvedEndDate != nil {
+		return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: `field "resolvedOn" is not supported by this data source`}
+	}
 
 	// These fields dot-walk into ServiceNow-specific concepts (tags,
 	// project-onboarding-status, integration-CS-team, etc.) that have no

--- a/entity-service/internal/service/case_service_test.go
+++ b/entity-service/internal/service/case_service_test.go
@@ -85,7 +85,7 @@ func TestCaseService_SearchCases_RejectsUnsupportedPostgresFields(t *testing.T) 
 		{name: "parentId", filter: domain.CaseFieldFilter{Field: "parentId", Op: "eq", Values: []string{"00000000-0000-0000-0000-000000000000"}}},
 		{name: "product", filter: domain.CaseFieldFilter{Field: "product", Op: "in", Values: []string{"API Manager"}}},
 		{name: "projectOnboardingStatus", filter: domain.CaseFieldFilter{Field: "projectOnboardingStatus", Op: "in", Values: []string{"Completed"}}},
-		{name: "projectType", filter: domain.CaseFieldFilter{Field: "projectType", Op: "in", Values: []string{"00000000-0000-0000-0000-000000000000"}}},
+		{name: "projectType", filter: domain.CaseFieldFilter{Field: "projectType", Op: "in", Values: []string{"Subscription"}}},
 		{name: "integrationCsTeam", filter: domain.CaseFieldFilter{Field: "integrationCsTeam", Op: "in", Values: []string{"00000000-0000-0000-0000-000000000000"}}},
 		{name: "assignedUserId isEmpty (Unassigned)", filter: domain.CaseFieldFilter{Field: "assignedUserId", Op: "isEmpty"}},
 		{name: "resolutionNotes isEmpty", filter: domain.CaseFieldFilter{Field: "resolutionNotes", Op: "isEmpty"}},

--- a/entity-service/internal/service/case_service_test.go
+++ b/entity-service/internal/service/case_service_test.go
@@ -198,6 +198,20 @@ func TestCaseService_SearchCases_RejectsServiceNowOnlyOptions(t *testing.T) {
 			wantMsg: `field "escalation" is not supported by this data source`,
 		},
 		{
+			name: "resolvedOn gte",
+			req: domain.SearchCasesRequest{Filters: domain.SearchCasesFilters{
+				Filters: []domain.CaseFieldFilter{{Field: "resolvedOn", Op: "gte", Values: []string{"2026-01-01"}}},
+			}},
+			wantMsg: `field "resolvedOn" is not supported by this data source`,
+		},
+		{
+			name: "resolvedOn lte",
+			req: domain.SearchCasesRequest{Filters: domain.SearchCasesFilters{
+				Filters: []domain.CaseFieldFilter{{Field: "resolvedOn", Op: "lte", Values: []string{"2026-01-31"}}},
+			}},
+			wantMsg: `field "resolvedOn" is not supported by this data source`,
+		},
+		{
 			name: "anyOf",
 			req: domain.SearchCasesRequest{Filters: domain.SearchCasesFilters{
 				AnyOf: []domain.CaseFilterBranch{

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -323,6 +323,8 @@ type snCaseFilters struct {
 	EngagementTypeKeys []int    `json:"engagementTypeKeys,omitempty"`
 	ClosedStartDate    string   `json:"closedStartDate,omitempty"`
 	ClosedEndDate      string   `json:"closedEndDate,omitempty"`
+	ResolvedStartDate  string   `json:"resolvedStartDate,omitempty"`
+	ResolvedEndDate    string   `json:"resolvedEndDate,omitempty"`
 	StartCreatedDate   string   `json:"startCreatedDate,omitempty"`
 	EndCreatedDate     string   `json:"endCreatedDate,omitempty"`
 	StartUpdatedDate   string   `json:"startUpdatedDate,omitempty"`
@@ -2109,6 +2111,8 @@ func buildSNCaseFilters(parsed domain.ParsedCaseFilters, searchQuery string) snC
 		EngagementTypeKeys:        domainEngagementTypesToSNIDs(parsed.EngagementTypes),
 		ClosedStartDate:           formatSNDateTimeUTC(parsed.ClosedStartDate),
 		ClosedEndDate:             formatSNDateTimeUTC(parsed.ClosedEndDate),
+		ResolvedStartDate:         formatSNDateTimeUTC(parsed.ResolvedStartDate),
+		ResolvedEndDate:           formatSNDateTimeUTC(parsed.ResolvedEndDate),
 		StartCreatedDate:          formatSNDateTimeUTC(parsed.StartCreatedDate),
 		EndCreatedDate:            formatSNDateTimeUTC(parsed.EndCreatedDate),
 		StartUpdatedDate:          formatSNDateTimeUTC(parsed.StartUpdatedDate),
@@ -2159,6 +2163,10 @@ func (s *snCaseService) SearchCases(ctx context.Context, req domain.SearchCasesR
 	if req.Parsed.ClosedEndDate != nil && req.Parsed.ClosedStartDate != nil &&
 		req.Parsed.ClosedEndDate.Before(*req.Parsed.ClosedStartDate) {
 		return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: "closedOn: lte value must not be before gte value"}
+	}
+	if req.Parsed.ResolvedEndDate != nil && req.Parsed.ResolvedStartDate != nil &&
+		req.Parsed.ResolvedEndDate.Before(*req.Parsed.ResolvedStartDate) {
+		return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: "resolvedOn: lte value must not be before gte value"}
 	}
 	if req.Parsed.EndCreatedDate != nil && req.Parsed.StartCreatedDate != nil &&
 		req.Parsed.EndCreatedDate.Before(*req.Parsed.StartCreatedDate) {

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -345,10 +345,14 @@ type snCaseFilters struct {
 	// ParentID: see domain.SearchCasesFilters.ParentID doc comment.
 	ParentID                  string   `json:"parentId,omitempty"`
 	ProjectOnboardingStatuses []string `json:"projectOnboardingStatuses,omitempty"`
-	ProjectTypeIDs            []string `json:"projectTypeIds,omitempty"`
-	IntegrationCsTeamIDs      []string `json:"integrationCsTeamIds,omitempty"`
-	Unassigned                bool     `json:"unassigned,omitempty"`
-	ResolutionNotesEmpty      bool     `json:"resolutionNotesEmpty,omitempty"`
+	// ProjectTypeNames carries project-type NAMES (e.g. "Subscription"), not
+	// sys_ids: CaseUtils.searchCases matches project.u_project_type.u_name. The
+	// wire key stays "projectTypeIds" because that is the field name the SN
+	// scripted API reads.
+	ProjectTypeNames     []string `json:"projectTypeIds,omitempty"`
+	IntegrationCsTeamIDs []string `json:"integrationCsTeamIds,omitempty"`
+	Unassigned           bool     `json:"unassigned,omitempty"`
+	ResolutionNotesEmpty bool     `json:"resolutionNotesEmpty,omitempty"`
 	// TaskSLAFilter: SN-side join on Task SLA table, filtering by businessElapsedPercent
 	// range. Confined to SN adapter per vendor-neutral boundary; see
 	// domain.TaskSLAFilter doc comment.
@@ -2126,7 +2130,7 @@ func buildSNCaseFilters(parsed domain.ParsedCaseFilters, searchQuery string) snC
 		ExcludeTags:               parsed.ExcludeTags,
 		ParentID:                  snParentIDFilter(parsed.ParentID),
 		ProjectOnboardingStatuses: parsed.ProjectOnboardingStatuses,
-		ProjectTypeIDs:            uuidsToSysids(parsed.ProjectTypeIDs),
+		ProjectTypeNames:          parsed.ProjectTypeNames,
 		IntegrationCsTeamIDs:      uuidsToSysids(parsed.IntegrationCsTeamIDs),
 		Unassigned:                parsed.Unassigned,
 		ResolutionNotesEmpty:      parsed.ResolutionNotesEmpty,
@@ -2190,9 +2194,8 @@ func (s *snCaseService) SearchCases(ctx context.Context, req domain.SearchCasesR
 			return domain.SearchCasesResponse{}, err
 		}
 	}
-	if err := validateUUIDs("projectType", req.Parsed.ProjectTypeIDs); err != nil {
-		return domain.SearchCasesResponse{}, err
-	}
+	// projectType values are free-text project-type names (no UUID validation);
+	// integrationCsTeam values are still UUIDs.
 	if err := validateUUIDs("integrationCsTeam", req.Parsed.IntegrationCsTeamIDs); err != nil {
 		return domain.SearchCasesResponse{}, err
 	}

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -75,8 +75,18 @@ type snCase struct {
 	LinkedServiceRequests []snLinkedServiceRequestRef `json:"linkedServiceRequests"`
 	// ChangeRequests carries the change requests raised from this case, keyed as
 	// `changeRequests` upstream. Only populated for service-request cases.
+	//
+	// Deprecated: the upstream `changeRequests` field is filtered to a subset of change
+	// request states by the backing service. Case mapping below reads ChangeRequestsAll
+	// instead, which is unfiltered. This field is kept only because it is still present
+	// on the upstream response; nothing in this service reads it.
 	ChangeRequests []snLinkedChangeRequestRef `json:"changeRequests"`
-	ResolutionCode *struct {
+	// ChangeRequestsAll carries the same change requests as ChangeRequests but unfiltered by
+	// state, keyed as `changeRequestsAll` upstream. Same item shape as `changeRequests`. Case
+	// mapping reads this field so linked change requests in New/Assess/Authorize states are
+	// no longer silently dropped before they reach the outward `linkedChangeRequests` field.
+	ChangeRequestsAll []snLinkedChangeRequestRef `json:"changeRequestsAll"`
+	ResolutionCode    *struct {
 		ID    json.Number `json:"id"`
 		Label string      `json:"label"`
 	} `json:"resolutionCode"`
@@ -850,9 +860,9 @@ func (s *snCaseService) GetCaseByID(ctx context.Context, id string) (domain.Case
 		}
 		cv.LinkedServiceRequests = lsr
 	}
-	if len(c.ChangeRequests) > 0 {
-		lcr := make([]domain.LinkedChangeRequestRef, 0, len(c.ChangeRequests))
-		for _, r := range c.ChangeRequests {
+	if len(c.ChangeRequestsAll) > 0 {
+		lcr := make([]domain.LinkedChangeRequestRef, 0, len(c.ChangeRequestsAll))
+		for _, r := range c.ChangeRequestsAll {
 			// An absent upstream subject becomes null, not "" — see the note on
 			// LinkedChangeRequestRef.Name.
 			var name *string

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -696,7 +696,7 @@ func (s *snCaseService) CreateCase(ctx context.Context, req domain.CreateCaseReq
 		return domain.CreateCaseResponse{}, fmt.Errorf("sn create case: parse response: %w", err)
 	}
 
-	createdOn, err := time.Parse(snCreatedOnLayout, snResp.Case.CreatedOn)
+	createdOn, err := parseSNDateTime(ctx, "sn create case", "createdOn", snResp.Case.CreatedOn)
 	if err != nil {
 		return domain.CreateCaseResponse{}, fmt.Errorf("sn create case: parse createdOn %q: %w", snResp.Case.CreatedOn, err)
 	}
@@ -732,13 +732,13 @@ func (s *snCaseService) GetCaseByID(ctx context.Context, id string) (domain.Case
 		return domain.CaseView{}, fmt.Errorf("sn get case: parse response: %w", err)
 	}
 
-	createdOn, err := time.Parse(snCreatedOnLayout, c.CreatedOn)
+	createdOn, err := parseSNDateTime(ctx, "sn get case", "createdOn", c.CreatedOn)
 	if err != nil {
 		return domain.CaseView{}, fmt.Errorf("sn get case: parse createdOn %q: %w", c.CreatedOn, err)
 	}
 	updatedOn := createdOn
 	if c.UpdatedOn != nil && *c.UpdatedOn != "" {
-		updatedOn, err = time.Parse(snCreatedOnLayout, *c.UpdatedOn)
+		updatedOn, err = parseSNDateTime(ctx, "sn get case", "updatedOn", *c.UpdatedOn)
 		if err != nil {
 			return domain.CaseView{}, fmt.Errorf("sn get case: parse updatedOn %q: %w", *c.UpdatedOn, err)
 		}
@@ -869,7 +869,7 @@ func (s *snCaseService) GetCaseByID(ctx context.Context, id string) (domain.Case
 	}
 	cv.ResolutionNotes = c.ResolutionNotes
 	if c.ResolvedOn != nil && *c.ResolvedOn != "" {
-		resolvedOn, err := time.Parse(snCreatedOnLayout, *c.ResolvedOn)
+		resolvedOn, err := parseSNDateTime(ctx, "sn get case", "resolvedOn", *c.ResolvedOn)
 		if err != nil {
 			return domain.CaseView{}, fmt.Errorf("sn get case: parse resolvedOn %q: %w", *c.ResolvedOn, err)
 		}
@@ -897,7 +897,7 @@ func (s *snCaseService) GetCaseByID(ctx context.Context, id string) (domain.Case
 	// the matching fields (see snCase field doc comments); until then these are nil.
 	cv.AutoclosureStep = c.AutoclosureStep
 	if c.AutoclosureStateTime != nil && *c.AutoclosureStateTime != "" {
-		autoclosureStateTime, err := time.Parse(snCreatedOnLayout, *c.AutoclosureStateTime)
+		autoclosureStateTime, err := parseSNDateTime(ctx, "sn get case", "autoclosureStateTime", *c.AutoclosureStateTime)
 		if err != nil {
 			return domain.CaseView{}, fmt.Errorf("sn get case: parse autoclosureStateTime %q: %w", *c.AutoclosureStateTime, err)
 		}
@@ -978,7 +978,7 @@ func (s *snCaseService) CreateCaseComment(ctx context.Context, req domain.Create
 		return domain.CreateCaseCommentResponse{}, fmt.Errorf("sn create comment: parse response: %w", err)
 	}
 
-	createdOn, err := time.Parse(snCreatedOnLayout, snResp.Comment.CreatedOn)
+	createdOn, err := parseSNDateTime(ctx, "sn create comment", "createdOn", snResp.Comment.CreatedOn)
 	if err != nil {
 		return domain.CreateCaseCommentResponse{}, fmt.Errorf("sn create comment: parse createdOn %q: %w", snResp.Comment.CreatedOn, err)
 	}
@@ -1073,7 +1073,7 @@ func (s *snCaseService) SearchCaseComments(ctx context.Context, req domain.Searc
 
 	comments := make([]domain.CaseComment, 0, len(snResp.Comments))
 	for _, c := range snResp.Comments {
-		createdAt, err := time.Parse(snCreatedOnLayout, c.CreatedOn)
+		createdAt, err := parseSNDateTime(ctx, "sn search comments", "createdOn", c.CreatedOn)
 		if err != nil {
 			return domain.SearchCaseCommentsResponse{}, fmt.Errorf("sn search comments: parse createdOn %q: %w", c.CreatedOn, err)
 		}
@@ -1531,7 +1531,7 @@ func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReq
 		return domain.UpdateCaseResponse{}, fmt.Errorf("sn update case: parse response: %w", err)
 	}
 
-	updatedOn, err := time.Parse(snCreatedOnLayout, snResp.Case.UpdatedOn)
+	updatedOn, err := parseSNDateTime(ctx, "sn update case", "updatedOn", snResp.Case.UpdatedOn)
 	if err != nil {
 		return domain.UpdateCaseResponse{}, fmt.Errorf("sn update case: parse updatedOn %q: %w", snResp.Case.UpdatedOn, err)
 	}
@@ -1606,7 +1606,7 @@ func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReq
 		resp.Case.ParentCase = &domain.CaseNumberRef{ID: sysidToUUID(snResp.Case.ParentCase.ID), Number: snResp.Case.ParentCase.Number, Type: snParentCaseTypeToDomain(snResp.Case.ParentCase.Type)}
 	}
 	if snResp.Case.ResolvedOn != nil {
-		resolvedOn, err := time.Parse(snCreatedOnLayout, *snResp.Case.ResolvedOn)
+		resolvedOn, err := parseSNDateTime(ctx, "sn update case", "resolvedOn", *snResp.Case.ResolvedOn)
 		if err != nil {
 			return domain.UpdateCaseResponse{}, fmt.Errorf("sn update case: parse resolvedAt %q: %w", *snResp.Case.ResolvedOn, err)
 		}

--- a/entity-service/internal/service/sn_case_service_test.go
+++ b/entity-service/internal/service/sn_case_service_test.go
@@ -1081,6 +1081,7 @@ func TestSNCaseService_SearchCases_GenericFiltersTranslateToSNPayload(t *testing
 				{Field: "assignedUserId", Op: "isEmpty"},
 				{Field: "resolutionNotes", Op: "isEmpty"},
 				{Field: "createdBy", Op: "eq", Values: []string{currentUserFilterPlaceholder}},
+				{Field: "projectType", Op: "in", Values: []string{"Subscription", "Free Trial"}},
 			},
 		},
 	}
@@ -1107,6 +1108,13 @@ func TestSNCaseService_SearchCases_GenericFiltersTranslateToSNPayload(t *testing
 	}
 	if len(gotBody.Filters.CreatedBy) != 0 {
 		t.Fatalf("expected CreatedBy to stay empty for the current-user placeholder, got %v", gotBody.Filters.CreatedBy)
+	}
+	// projectType values are project-type NAMES passed through verbatim -- no
+	// UUID validation, no id conversion (mirrors the product filter).
+	if len(gotBody.Filters.ProjectTypeNames) != 2 ||
+		gotBody.Filters.ProjectTypeNames[0] != "Subscription" ||
+		gotBody.Filters.ProjectTypeNames[1] != "Free Trial" {
+		t.Fatalf("ProjectTypeNames = %v, want [Subscription, Free Trial] passed through unchanged", gotBody.Filters.ProjectTypeNames)
 	}
 }
 

--- a/entity-service/internal/service/sn_case_service_test.go
+++ b/entity-service/internal/service/sn_case_service_test.go
@@ -1454,8 +1454,9 @@ func TestCaseService_SearchTags_ServiceUnavailable(t *testing.T) {
 }
 
 // TestSNCaseService_GetCaseByID_MapsLinkedChangeRequests covers the reverse side of the
-// service-request <-> change-request link. Upstream sends the list under `changeRequests`
-// with 32-hex ids; the domain exposes it as `linkedChangeRequests` with canonical UUIDs.
+// service-request <-> change-request link. Upstream sends the list under `changeRequestsAll`
+// (unfiltered by change-request state, unlike the older `changeRequests` field) with 32-hex
+// ids; the domain exposes it as `linkedChangeRequests` with canonical UUIDs.
 //
 // The cardinality cases matter: a service request can have several change requests (one per
 // environment the change is promoted to), so a single-value mapping would look correct
@@ -1478,7 +1479,7 @@ func TestSNCaseService_GetCaseByID_MapsLinkedChangeRequests(t *testing.T) {
 			"deployment": {"id": "", "name": ""},
 			"deployedProduct": {"id": "", "name": "", "version": ""},
 			"state": {"id": 1, "label": "Open"},
-			"changeRequests": ` + changeRequests + `
+			"changeRequestsAll": ` + changeRequests + `
 		}`
 	}
 

--- a/entity-service/internal/service/sn_comment_service.go
+++ b/entity-service/internal/service/sn_comment_service.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"time"
 
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
@@ -78,7 +77,7 @@ func (s *snCommentSearchService) SearchComments(ctx context.Context, req domain.
 
 	comments := make([]domain.Comment, 0, len(snResp.Comments))
 	for _, c := range snResp.Comments {
-		createdAt, err := time.Parse(snCreatedOnLayout, c.CreatedOn)
+		createdAt, err := parseSNDateTime(ctx, "sn search comments", "createdOn", c.CreatedOn)
 		if err != nil {
 			slog.WarnContext(ctx, "sn search comments: skipping comment with unparsable createdOn",
 				"commentID", c.ID, "createdOn", c.CreatedOn, "error", err)
@@ -159,7 +158,7 @@ func (s *snCommentSearchService) CreateComment(ctx context.Context, req domain.C
 		return domain.CreateCommentResponse{}, fmt.Errorf("sn create comment: parse response: %w", err)
 	}
 
-	createdOn, err := time.Parse(snCreatedOnLayout, snResp.Comment.CreatedOn)
+	createdOn, err := parseSNDateTime(ctx, "sn create comment", "createdOn", snResp.Comment.CreatedOn)
 	if err != nil {
 		return domain.CreateCommentResponse{}, fmt.Errorf("sn create comment: parse createdOn %q: %w", snResp.Comment.CreatedOn, err)
 	}

--- a/entity-service/internal/service/sn_date_parse_test.go
+++ b/entity-service/internal/service/sn_date_parse_test.go
@@ -1,0 +1,106 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package service
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+)
+
+// TestParseSNDateTime_CanonicalFormat pins that the overwhelmingly common
+// case -- SN's canonical "YYYY-MM-DD HH:MM:SS" -- keeps parsing exactly as
+// before: no behaviour change for the fast path.
+func TestParseSNDateTime_CanonicalFormat(t *testing.T) {
+	t.Parallel()
+
+	got, err := parseSNDateTime(context.Background(), "test", "updatedOn", "2026-08-05 20:27:43")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := time.Date(2026, 8, 5, 20, 27, 43, 0, time.UTC)
+	if !got.Equal(want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+// TestParseSNDateTime_AlternateFormat pins the fallback that fixes the prod
+// incident: SN occasionally renders these fields as "MM-DD-YYYY HH:MM:SS"
+// (via GlideRecord.getDisplayValue() upstream) instead of the canonical
+// layout. The exact string is taken from a real Choreo prod log line:
+// `parse updatedOn "08-05-2026 20:27:43"`.
+func TestParseSNDateTime_AlternateFormat(t *testing.T) {
+	t.Parallel()
+
+	got, err := parseSNDateTime(context.Background(), "sn update case", "updatedOn", "08-05-2026 20:27:43")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := time.Date(2026, 8, 5, 20, 27, 43, 0, time.UTC)
+	if !got.Equal(want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+// TestParseSNDateTime_MalformedStillErrors pins that a genuinely malformed
+// value -- not just a format flip -- still returns an error rather than
+// being silently swallowed.
+func TestParseSNDateTime_MalformedStillErrors(t *testing.T) {
+	t.Parallel()
+
+	for _, value := range []string{"", "not-a-date", "2026-13-40 99:99:99"} {
+		if _, err := parseSNDateTime(context.Background(), "test", "updatedOn", value); err == nil {
+			t.Errorf("value %q: got nil error, want a parse error", value)
+		}
+	}
+}
+
+// TestSNCaseService_UpdateCase_AlternateDateFormat reproduces the production
+// incident end to end: ServiceNow returns updatedOn in the MM-DD-YYYY
+// alternate format on a successful PATCH /cases/{id}. Before the fix this
+// caused UpdateCase to return an error -- and the Go service to answer the
+// BFF with a 500 -- even though the SN write had already committed. It must
+// now succeed and the alternate-format string must parse to the correct
+// instant.
+func TestSNCaseService_UpdateCase_AlternateDateFormat(t *testing.T) {
+	t.Parallel()
+
+	client := newTestCaseClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"message": "Case updated successfully.",
+			"case": {"id": "` + testWLCaseSysid + `", "updatedOn": "08-05-2026 20:27:43", "updatedBy": "engineer@example.com"}
+		}`))
+	})
+
+	subject := "Updated subject"
+	svc := NewServiceNowCaseService(client, nil)
+	resp, err := svc.UpdateCase(contextWithUserIDToken("token"), domain.UpdateCaseRequest{
+		ID:      testDeploymentUUID, // any valid UUID; the request id is not asserted here
+		Subject: &subject,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error parsing an alternate-format updatedOn: %v", err)
+	}
+	want := time.Date(2026, 8, 5, 20, 27, 43, 0, time.UTC)
+	if !resp.Case.UpdatedOn.Equal(want) {
+		t.Errorf("updatedOn = %v, want %v", resp.Case.UpdatedOn, want)
+	}
+}

--- a/entity-service/internal/service/sn_project_service.go
+++ b/entity-service/internal/service/sn_project_service.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -98,8 +99,47 @@ type snProjectPagination struct {
 // snCreatedOnLayout is the datetime format used by the Choreo API.
 const snCreatedOnLayout = "2006-01-02 15:04:05"
 
+// snAltCreatedOnLayout is an alternate datetime format ServiceNow occasionally
+// returns instead of snCreatedOnLayout for the same fields (createdOn, updatedOn,
+// resolvedOn, autoclosureStateTime, ...). Root cause (confirmed via Choreo prod
+// logs): an SN-side script include reads these fields with
+// GlideRecord.getDisplayValue(), which renders per session locale, instead of
+// getValue(), which is always canonical ISO. Fixing that is out of scope here
+// (the SN scoped app is shared with the live customer portal) — see
+// parseSNDateTime, the Go-side tolerant parser that works around it.
+const snAltCreatedOnLayout = "01-02-2006 15:04:05"
+
 // snDateLayout is the date-only format used by the Choreo API for start/end dates.
 const snDateLayout = "2006-01-02"
+
+// parseSNDateTime parses a ServiceNow datetime string, tolerating both formats
+// observed in production. It tries snCreatedOnLayout first — the overwhelmingly
+// common case, and the fast path — and only on failure falls back to
+// snAltCreatedOnLayout.
+//
+// Before this helper existed, a bare time.Parse(snCreatedOnLayout, ...) on one
+// of these fields would return an error, and callers turned that into a 500 —
+// even though the underlying SN write (case update, new comment) had already
+// succeeded. See the case/comment PATCH and POST paths in sn_case_service.go
+// and sn_comment_service.go.
+//
+// callSite and field identify where the value came from, for the WARN logged
+// when the fallback format is the one that actually matched: this keeps the
+// upstream format drift visible/monitorable instead of silently masked. If
+// neither format parses, the original snCreatedOnLayout error is returned
+// unchanged — a genuinely malformed value still fails the request.
+func parseSNDateTime(ctx context.Context, callSite, field, value string) (time.Time, error) {
+	t, err := time.Parse(snCreatedOnLayout, value)
+	if err == nil {
+		return t, nil
+	}
+	if alt, altErr := time.Parse(snAltCreatedOnLayout, value); altErr == nil {
+		slog.WarnContext(ctx, "sn date field in alternate MM-DD-YYYY format, applied fallback parse",
+			"callSite", callSite, "field", field, "value", value)
+		return alt, nil
+	}
+	return time.Time{}, err
+}
 
 type snProjectService struct {
 	client     *integrationservice.Client

--- a/entity-service/internal/service/sn_project_service.go
+++ b/entity-service/internal/service/sn_project_service.go
@@ -135,7 +135,7 @@ func parseSNDateTime(ctx context.Context, callSite, field, value string) (time.T
 	}
 	if alt, altErr := time.Parse(snAltCreatedOnLayout, value); altErr == nil {
 		slog.WarnContext(ctx, "sn date field in alternate MM-DD-YYYY format, applied fallback parse",
-			"callSite", callSite, "field", field, "value", value)
+			"callSite", callSite, "field", field)
 		return alt, nil
 	}
 	return time.Time{}, err

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -4844,8 +4844,8 @@ components:
         - **projectOnboardingStatus** (in): free-text SN choice labels for the
           parent project's onboarding status (e.g. "Completed",
           "Not-Applicable" -- not a closed enum at this layer).
-        - **projectType** (in): the parent project's type, as project-type
-          UUIDs.
+        - **projectType** (in): the parent project's type, matched by the
+          project type's name (e.g. "Subscription").
         - **integrationCsTeam** (in): the parent account's integration CS
           team, as team UUIDs.
         - **resolutionNotes** (isEmpty): values ignored; matches cases with

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -4772,6 +4772,7 @@ components:
             - createdOn
             - updatedOn
             - closedOn
+            - resolvedOn
             - product
             - projectOnboardingStatus
             - projectType
@@ -4834,10 +4835,13 @@ components:
           `"__current_user_email__"`, meaning "the authenticated caller" (the
           old createdByMe:true behavior) — any other literal email must use
           in with a single value instead.
-        - **createdOn** / **updatedOn** / **closedOn** (gte / lte): a single
-          RFC3339 timestamp or YYYY-MM-DD date bounding the case's created,
-          last-updated, or closed timestamp respectively. gte is inclusive
-          "on or after"; lte is inclusive "on or before".
+        - **createdOn** / **updatedOn** / **closedOn** / **resolvedOn**
+          (gte / lte): a single RFC3339 timestamp or YYYY-MM-DD date bounding
+          the case's created, last-updated, closed, or resolved timestamp
+          respectively. gte is inclusive "on or after"; lte is inclusive "on
+          or before". A lte bound earlier than its own gte bound is rejected
+          with a validation error. resolvedOn has no equivalent in the
+          relational data source and is rejected there.
         - **product** (in): product family names (e.g. "API Manager",
           "Identity Server", "Asgardeo"). Matches every version of each named
           product. Only applied by the ServiceNow data source.


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

A bundle of unrelated fixes and small capabilities found while working cases and dashboards in the same session. They are grouped into one PR only because they were found together; there is no single unifying theme. Grouped by area:

**Case workflow**
1. The public-comment guard on `POST /cases/{id}/comments` only checked case state, not who was posting — any engineer could add a public, customer-visible comment on a case owned by someone else.
2. The frontend composer had no equivalent check, so a non-assignee could type and send a public reply and only discover the rejection after the fact, with a generic error instead of the existing locked/reason-shown UX the state gate already gets.
3. Starting work on an unacknowledged, acknowledgeable case required a second, separate "Acknowledge" click — starting work already implies claiming the case.
4. The "Linked Items" case-detail tab was the only tab without an entry count in its label.

**Entity-service / backing data source**
5. The backing data source occasionally returns `updatedOn`/`createdOn`/`resolvedOn` in an alternate `MM-DD-YYYY HH:MM:SS` format instead of the canonical one. A hard parse failure turned that into a `500` on requests whose upstream write had *already* succeeded (resuming a paused case, adding a work note).
6. There was no way to filter case search by resolved date at all. Resolved and closed are distinct: a case is marked Resolved and only later separately auto-closed, so the existing `closedOn` filter cannot answer "resolved today".
7. The `projectType` case-search filter converted its values to ids, but the backing data source matches a case's parent project type by the project type's readable **name**, so the filter silently matched nothing.
8. A case's linked change requests were read from an upstream field that the backing service filters by change-request state, so change requests in early workflow states were silently dropped before reaching callers.

**Dashboards**
9. Dashboard `list` widgets could only render one hardcoded layout per resourceType, with no way to surface additional fields or control ordering.
10. Dashboard configs repeated the same filter fragment across dozens of widgets, with no way to share it.
11. The single `case` widget resourceType could not express the distinct case types the case-search `type` enum already carries.
12. Relative-date widget filters (`__today__` and friends) were resolved server-side against UTC, so "Created/Resolved Today" widgets undercounted for a support team whose working day is UTC+5:30 — the equivalent reports in the previous system resolve against the team's own timezone.
13. `__current_user__` was substituted server-side by the dashboards handler, requiring a per-request identity round trip, while `__current_team__` was already resolved client-side — two mechanisms for the same idea.

No linked issues; everything here was found and fixed in the same session.

### Known issues (deliberately shipped as-is, follow-up already scoped)

Two changes in this PR are known to be incomplete. They are called out here so the description does not oversell them; both are fixed in a follow-up PR that will be stacked on this one after it merges.

1. **The public-comment ownership guard currently rejects everyone.** It compares the identity-provider user id carried on the request against the platform record id of the case's assigned engineer. Those are different id spaces, so the comparison never matches — including for the actual assignee. Live-verified, not theoretical.
2. **The `projectType`-by-name change now fails validation instead of returning an empty result.** The names are sent on a filter key whose downstream contract still constrains values to 32-hex ids, so requests carrying `projectType` are now rejected upstream rather than silently matching nothing. Strictly speaking this trades one broken behaviour for a louder one; the contract change that makes it work is part of the follow-up.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

1. Backend: reject a public comment with `403` unless the requester is the case's assigned engineer.
2. Frontend: lock the public-reply composer with a clear reason for non-assignees, mirroring the existing state-gate UX, instead of letting the request fail server-side.
3. Frontend: fire the acknowledge `PATCH` as a best-effort side effect of starting work.
4. Frontend: show a count on the Linked Items tab, from data the case-detail object already holds.
5. Entity-service: tolerate both datetime formats rather than failing a request whose write already landed.
6. Entity-service: add a `resolvedOn` case-search filter alongside the existing `closedOn`.
7. Entity-service: pass `projectType` filter values through as names.
8. Entity-service: read linked change requests from the unfiltered upstream field.
9. Dashboards: let a `list` widget declare its own columns and sort order in config.
10. Dashboards: let filter fragments be defined once and referenced by key.
11. Dashboards: split the `case` resourceType into the five case-table types, with the implied `type` filter injected automatically.
12. Dashboards: resolve relative-date placeholders against the viewer's own clock.
13. Dashboards: resolve `__current_user__` client-side, matching `__current_team__`, and drop the server-side mechanism.

## Approach
> Describe how you are implementing the solutions.

**Case workflow**

1. `CreateCaseComment` (`apps/csm-portal/backend/internal/handler/cases.go`) already fetches the case for the state guard; it now also decodes `assignedEngineer.id` from that same payload (no extra upstream call) and rejects with a new `ErrMsgCommentNotOwnCase` constant when it does not match the requester. Scoped to public comments only — work notes are unchanged. See Known issue 1 on the id-space mismatch.
2. `publicCommentGateReason` (`webapp/src/features/csm-cases/utils/caseWorkState.ts`) takes a new `assigneeIsMe` parameter and checks it first, unconditionally — a non-assignee always sees the ownership reason, never a resumable-sounding state reason, consistent with `canResumeToUnlockPublicReply`'s existing assignee-only quick fix.
3. `startWork()` (`CsmCaseDetailPage.tsx`) checks `canAcknowledge` (now exported from `CaseActionBar.tsx` instead of duplicated) against the pre-`PATCH` case data, then fires a separate `{ acknowledge: true }` `PATCH` after the state `PATCH` succeeds — separate because the entity-service rejects combining `state` and `acknowledge` in one request. Best effort: its own try/catch, does not block the rest of start-work, no extra toast; a failure just leaves the Acknowledge button visible as a safe fallback. Covers both "Start work" and "Assign to me", which share `startWork`.
4. The Linked Items tab badge sums `linkedChangeRequests.length + linkedServiceRequests.length` from the already-fetched case-detail object. Child cases are still excluded: that widget runs its own scoped query and would need an extra fetch to contribute a count.

**Entity-service**

5. A new `parseSNDateTime` helper tries the canonical layout first (the fast path) and only falls back to the alternate `MM-DD-YYYY` layout on failure, logging a `WARN` naming the call site and field *only* when the fallback is what matched, so the upstream format drift stays visible rather than silently masked. A genuinely malformed value still fails with the original error. Wired into every case and comment datetime parse. Root cause is upstream (a display-formatted read instead of a canonical one) and lives in a layer shared with the live customer portal, so it is worked around here rather than changed there.
6. `resolvedOn` mirrors `closedOn` exactly: filter field set, parsed filter struct (`ResolvedStartDate`/`ResolvedEndDate`), the outbound filter wire shape, the start-after-end validation, and the OR-group exclusion (a date-range field does not make sense ORed against other conditions). Taking effect end to end also needs a corresponding entity-service-side integration change and a backing-data-source query addition, both tracked separately and already done.
7. `ProjectTypeIDs` is renamed `ProjectTypeNames`, the UUID validation and id conversion are dropped, and values pass through verbatim — mirroring how the existing `product` filter already behaves. The outbound wire key is unchanged. `integrationCsTeam` is untouched and still id-based. Both published API contracts (`apps/csm-portal/backend/openapi.yaml`, `entity-service/openapi.yaml`) have their `projectType` filter description updated. See Known issue 2.
8. Case mapping reads a new unfiltered upstream field instead of the state-filtered one. The entity-service's own outward field name and shape (`linkedChangeRequests`) are unchanged; this is purely an internal swap of which upstream field is read. The old field is retained on the response struct, marked deprecated, and read by nothing.

**Dashboards (backend)**

9. A `list` widget's config can now carry `columns` (an ordered set of `{path, label, format}` entries, `path` supporting dot notation into nested search-response objects to arbitrary depth) and `sortBy`. Both are opaque config on `WidgetTemplate`/`dashboardWidgetView` — never validated or interpreted server-side, mirroring how `Query`/`PieSlice.Query` already work.
10. `filterPresets` can be declared per dashboard, or shared across the whole directory via a new `DASHBOARD_PRESETS_FILE` (documented in `.env.example`; dashboard-local wins on collision). `{"preset": "key"}` references are expanded once, at directory-load time, anywhere a literal filter object can appear. `DASHBOARDS_DIR` now skips `_`-prefixed `.json` files so the shared presets file can live beside the dashboards.
11. The `case` resourceType splits into five case-table values (`case`, `service_request`, `security_report_analysis`, `announcement`, `engagement`) matching the case-search `type` enum. The implied `type` filter is auto-injected at load time when a widget does not already carry one; an existing explicit one is left alone but logged as redundant.
13. The server-side `__current_user__` substitution (`CurrentUserPlaceholder`, `ResolveFilters`, `ResolveSliceFilters`, and the handler's identity round trip) is removed after a repo-wide grep confirmed dashboard widgets were its only consumer. `GET /dashboards/{id}` now returns `Query`/`Slices` verbatim, including unresolved placeholders, exactly as `__current_team__` already worked.

**Dashboards (frontend)**

9. A widget with `columns` set renders through a new generic, resourceType-agnostic `GenericColumnList` that resolves each column path against every response item and formats it (plain text or date), instead of the hardcoded per-resourceType renderer. A widget without `columns` is completely unaffected. `sortBy` is forwarded into the search request for shape `list` only.
11. `WIDGET_RESOURCE_CONFIG` and `WIDGET_LIST_RENDERERS` gain the four new resourceTypes. All five route to `POST /cases/search` and reuse the existing case list rendering and filter translation verbatim; only the icon and click-through destination differ per type.
12. New `resolveRelativeDateFilters` covers the full placeholder set (`__today__`, `__daysAgo:N__`, `__startOfMonth:N__`, `__endOfMonth:N__`, `__startOfQuarter:N__`, `__endOfQuarter:N__`) against the viewer's browser-local clock. Wired into the two choke points every widget fetch already funnels through (`useWidgetData`, `useWidgetPieData`), right where team-placeholder resolution already ran. Literal values pass through unchanged. Deliberately **not** wired into click-through links: resolving there would freeze "today" into the destination URL at link-build time and break bookmark semantics, so those still rely on the server-side UTC fallback.
13. New `currentUserFilterPlaceholder.ts` walks a widget's filters generically **by value** (both the case-search field/op/values DSL and every other resourceType's flat filter shape), mirroring the removed server-side substitution rather than hardcoding one field name, since a widget can carry "the signed-in user" in more than one field across resourceTypes. Threaded through the same points team-placeholder resolution already runs, including every click-through href.

## User stories
> Summary of user stories addressed by this change

- As a CS engineer, I should not be able to post a public reply on a case another engineer owns and is actively working, so customers do not get conflicting or out-of-context responses.
- As a CS engineer, I should see up front that I cannot reply publicly on a case that is not mine, instead of typing a reply and having it silently rejected.
- As a CS engineer, starting work on an unacknowledged case should count as acknowledging it, without an extra click.
- As a CS engineer, I want the Linked Items tab to tell me how many linked items there are before I open it.
- As a CS engineer, resuming a paused case or adding a work note should not fail with a server error when the update itself succeeded.
- As a CS lead, I want dashboard widgets that count "today" to agree with my team's working day, not UTC.
- As a CS lead, I want "resolved today" as a distinct dashboard metric from "closed today".
- As a dashboard author, I want to define a shared filter once and reference it, declare which columns a list widget shows, and target a specific case type without hand-writing the same filter each time.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

- Fix: public comments on a case can now only be added by the case's assigned engineer (backend enforcement, plus a matching frontend composer lock).
- Fix: starting work on an unacknowledged case now acknowledges it automatically.
- Fix: the Linked Items tab on case detail now shows a count.
- Fix: case and comment responses tolerate an alternate date format from the backing data source instead of failing the request.
- Fix: linked change requests in early workflow states are no longer dropped from a case.
- Fix: dashboard widgets that filter on relative dates ("today", "last N days") now resolve against the viewer's local day.
- New: `resolvedOn` case-search filter, distinct from `closedOn`.
- New: dashboard list widgets support configurable columns and a default sort.
- New: dashboard filter presets, shareable across dashboards.
- New: dashboard widgets can target service request, security report analysis, announcement, and engagement case types.
- Change: the case `projectType` filter now matches by project type name instead of id.

## Documentation
N/A — internal API/UI behaviour; no external-facing docs describe these rules. New dashboard config options are documented inline in `.env.example` and in the published API contract, which is where dashboard authors already look.

## Training
N/A — no training content covers these endpoints or flows.

## Certification
N/A — not exam-relevant.

## Marketing
N/A — internal fixes and internal dashboard configuration capability, not user-facing feature announcements.

## Automation tests
 - Unit tests
   > Backend (comment guard): 3 new subtests in `TestCreateCaseComment` — wrong assignee → 403, no assignee → 403, matching assignee → 201; the shared `ongoingCase` fixture now carries `assignedEngineer.id` so pre-existing success-path tests keep passing.
   > Backend (dashboards): new `filter_presets_test.go` covering preset resolution, dashboard-local shadowing of shared presets, resolution inside widget/anyOf/pie-slice filters, and unknown-key failure; `registry_test.go` for `_`-prefixed file skipping; `widgets_test.go` for the auto-injected `type` filter per case-table resourceType (including the redundant-explicit-filter case) and for `columns`/`sortBy` passthrough; `dashboards_test.go` updated for verbatim `Query`/`Slices` now that server-side placeholder substitution is gone.
   > Entity-service: new `sn_date_parse_test.go` covering canonical format, alternate format, and a genuinely malformed value; `sn_case_service_test.go` extended for the `resolvedOn` filter wire shape, `projectType` names passed through unchanged, and linked change requests read from the unfiltered field; `case_service_test.go` updated for the renamed parsed field.
   > Frontend: `caseWorkState.test.ts` updated for the new `assigneeIsMe` parameter plus 3 cases covering a non-assignee blocked regardless of state; new `resolveRelativeDateFilters.test.ts`, `currentUserFilterPlaceholder.test.ts`, `resolveWidgetColumn.test.ts`; `widgetResourceConfig.test.ts`, `useWidgetPieData.test.tsx` and `DashboardWidgetTile.test.tsx` extended for the four new resourceTypes and placeholder resolution in click-through hrefs.
   > Not covered by tests: the auto-acknowledge side effect and the Linked Items tab count — `CsmCaseDetailPage.tsx` has no component-level test suite in this repo (confirmed before skipping); covered by manual verification and by `tsc`/`eslint` passing clean.
 - Integration tests
   > None added; these are unit-level handler/service/utility changes and no integration harness exists for these endpoints or flows. The two Known issues above were found by live verification against a running environment, not by tests.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A for Go/TS — `go vet ./...` and `eslint` ran clean instead
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes — `.env.example` gains a commented-out file path only, no values

## Samples
N/A — no sample code affected.

## Related PRs
A follow-up PR fixing the two Known issues above (the comment guard's id-space mismatch and the `projectType` filter contract) will be stacked on this branch after it merges; it does not exist yet.

Taking `resolvedOn` and the `projectType` name matching into effect end to end also depends on corresponding entity-service integration and backing-data-source changes, tracked separately outside this repo.

## Migrations (if applicable)
N/A — no schema or data migration. `DASHBOARD_PRESETS_FILE` is a new optional environment variable; unset means no shared presets, and every existing dashboard config keeps working unchanged.

## Test environment
Go (repo toolchain version) + Node/pnpm (repo-pinned versions), macOS. Backend and entity-service verified with `go build ./...`, `go test ./...`, `go vet ./...`. Frontend verified with `npx tsc -b`, `npx eslint`, and `npx vitest run` on the affected test files. The comment guard and the `projectType` filter were additionally exercised against a running environment, which is how the two Known issues were found.

## Learning
Two lessons, both from the Known issues: an ownership check is only as good as the id space it compares in, and a filter value change is not done at the layer that parses it — the downstream contract that validates it has to move first, or the change turns a wrong-but-quiet result into a hard rejection. Both should have been verified end to end against a real request before the commit, not after.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dashboard support for additional case-related resource types.
  * Added configurable list columns, nested fields, date formatting, and sorting.
  * Added shared and dashboard-specific filter presets.
  * Added relative-date and current-user filter handling.
  * Added linked-item counts and improved dashboard item navigation.
  * Added `resolvedOn` filtering and name-based project-type filtering.

* **Bug Fixes**
  * Public case comments are now restricted to the assigned engineer; work notes remain unaffected.
  * Cases can be acknowledged automatically when work begins.
  * Improved handling of alternate ServiceNow date formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->