### PR TITLE
fix(customer-portal-backend-v2): align response/request types with the frontend and old Ballerina backend

### DIFF
--- a/apps/customer-portal/backend-v2/CLAUDE.md
+++ b/apps/customer-portal/backend-v2/CLAUDE.md
@@ -6,7 +6,7 @@ responses for the frontend. This is a rewrite of the existing backend at
 `apps/customer-portal/backend`, modeled on `apps/csm-portal/backend`'s conventions — read that
 backend's own CLAUDE.md too if something here is underspecified.
 
-**Status: in progress.** 101 routes are wired up so far, across seven upstream services:
+**Status: in progress.** 104 routes are wired up so far, across seven upstream services:
 entity-service, the WSO2 Updates service, SCIM, the AI chat agent, the product-consumption
 service, the registry (robot-account) service, and the project-contact onboarding service (see
 "The AI chat agent", "The product-consumption service", "The registry service", and "The
@@ -15,15 +15,19 @@ all). Route list: `GET /health`, `GET`/`PATCH /users/me`, `POST /accounts/search
 `GET /accounts/{id}`, `POST /projects/search`, `GET /projects/{id}`,
 `POST /projects/{id}/cases/search`,
 `GET /cases/{id}`, `POST /cases`, `PATCH /cases/{id}`, `POST /cases/{id}/comments`,
-`POST /cases/{id}/activities/search`, `POST /projects/{id}/deployments/search`, `POST /deployments`,
-`PATCH /deployments/{id}`, `POST /deployed-products/search`, `POST /deployed-products`,
-`PATCH /deployed-products/{id}`, `POST /attachments`, `POST /attachments/search`,
-`GET /attachments/{id}/content`, `DELETE /attachments/{id}`, `POST /products/search`,
+`POST /cases/{id}/activities/search`, `POST /cases/{id}/attachments`,
+`POST /projects/{id}/deployments/search`, `POST /projects/{id}/deployments`,
+`PATCH /projects/{projectId}/deployments/{id}`,
+`POST /deployments/{deploymentId}/products/search`, `POST /deployments/{deploymentId}/products`,
+`PATCH /deployments/{deploymentId}/products/{id}`, `POST /attachments`, `POST /attachments/search`,
+`GET /attachments/{id}/content`, `DELETE /attachments/{id}`, `GET /products`,
+`POST /products/search`,
 `POST /products/{id}/versions/search`, `POST /products/vulnerabilities/search`,
-`GET /products/vulnerabilities/{id}`, `POST /catalogs/search`,
-`GET /catalogs/{catalogId}/items/{catalogItemId}/variables`, `POST /time-cards/search`,
+`GET /products/vulnerabilities/{id}`,
+`POST /deployments/products/{deployedProductId}/catalogs/search`,
+`GET /catalogs/{catalogId}/items/{itemId}`, `POST /projects/{id}/time-cards/search`,
 `POST /comments`, `POST /comments/search`, `POST /change-requests`,
-`POST /change-requests/search`, `GET /change-requests/{id}`, `PATCH /change-requests/{id}`,
+`POST /projects/{id}/change-requests/search`, `GET /change-requests/{id}`, `PATCH /change-requests/{id}`,
 `GET /change-requests/{id}/approvals`, `POST /change-requests/{id}/approvals/decision`,
 `POST /cases/{caseId}/call-requests`, `POST /cases/{caseId}/call-requests/search`,
 `PATCH /cases/{caseId}/call-requests/{id}`,
@@ -353,12 +357,22 @@ Concretely:
 - `internal/dto` defines the portal's own response structs and one `Map*` function per entity type
   that translates entity → portal, dropping fields the customer portal has no business showing:
   - Salesforce/internal IDs (e.g. `ProjectDetailsView.SfID`)
-  - Internal feature-flags (e.g. `ProjectAccountRef.AgentEnabled`/`KbReferencesEnabled`)
   - CSM/WSO2-internal-only fields that entity-service itself documents as such (e.g.
-    `CaseView`'s `BestCaseFixEta`/`MostLikelyFixEta`/`WorstCaseFixEta`, `WatchList` — see the
-    comments in `entity-service/internal/domain/entity.go` on `CaseView`)
+    `CaseView`'s `BestCaseFixEta`/`MostLikelyFixEta`/`WorstCaseFixEta` — see the comments in
+    `entity-service/internal/domain/entity.go` on `CaseView`)
   - WSO2-internal team routing (e.g. `AccountRef.CreTeam`/`SreTeam`)
-  - Internal opaque identifiers not meaningful to a customer (e.g. `SearchCaseView.InternalID`)
+  - Internal opaque identifiers not meaningful to a customer (e.g. `SearchCaseView.InternalID`,
+    though `CaseDetails.internalId` on the single-case read path IS exposed — the frontend's own
+    `CaseDetails` type reads it directly, unlike the search-list item)
+
+  Not everything that looks internal-only actually is — `ProjectAccountRef.AgentEnabled`/
+  `KbReferencesEnabled` and `CaseView.WatchList` both looked like CSM/engineer-only fields from
+  their entity-service-side doc comments, but the frontend reads both directly
+  (`ProjectAccount.hasAgent`/`hasKbReferences`, `CaseDetails.watchList` — a customer's own
+  self-service watch-list, not an internal annotation) — see `internal/dto/project.go`'s
+  `ProjectAccount` and `internal/dto/case.go`'s `CaseDetails` for the corrected mapping. Verify
+  against the live frontend TypeScript, not just an entity-service doc comment, before excluding a
+  field as "obviously internal."
 - `internal/handler` calls the entity client, passes the result through the matching `dto.Map*`
   function, and writes the DTO with `writeJSONValue`.
 
@@ -385,7 +399,7 @@ is `time.Time` and the ServiceNow shape is a plain string, because a Go `*string
 JSON string value regardless of which the source type actually was.
 
 **When the frontend's contract expects a thinner shape than entity-service's own struct, match the
-frontend's contract, not entity-service.** `POST /time-cards/search`'s `dto.TimeCardSummary`
+frontend's contract, not entity-service.** `POST /projects/{id}/time-cards/search`'s `dto.TimeCardSummary`
 excludes entity-service's per-category time breakdowns (`timeAnalyzing`, `timeSettingUp`, etc.),
 `issueComplexity`, `workLogComment`, `rejectionReason`, and the eligible-approvers list — not
 because any of them are individually dangerous, but because the frontend's existing contract never
@@ -418,17 +432,26 @@ decoding the incoming request directly into an `internal/entity` type (which is 
 happened in the first place — there was no dto/entity separation on the request side for this one
 endpoint, unlike every response, which already goes through `dto.Map*`).
 
-**Some fields need a second translation layer on top of the dto/entity split: ServiceNow numeric
-choice-list ids ⇄ entity-service's string enums.** The frontend was built against the old Ballerina
-backend, which forwarded ServiceNow's raw numeric choice-list keys (case status/severity/issue-type/
-engagement-type, call-request state) directly — it still sends and expects those exact numbers
-today, even though `cs-tools/entity-service`'s own contract is plain lowercase-snake-case string
-enums. `internal/dto/case_enum_mapping.go` and `internal/dto/call_request_enum_mapping.go` hold this
-backend's own copies of the numeric-id↔enum tables (mirroring entity-service's private
-`snStateIDMap`/`snSeverityIDMap`/`snIssueTypeIDMap`/`snEngagementTypeIDMap`/`callRequestKeyToState`
-in `internal/service/sn_case_service.go` and `sn_call_request_service.go` — these ids are
-ServiceNow's own stable configuration, not something entity-service computes, so duplicating them
-is safe, but if entity-service's copies ever change, update both). Two directions:
+**Some fields need a second translation layer on top of the dto/entity split: ServiceNow/Choreo
+numeric choice-list ids ⇄ entity-service's string enums.** The frontend was built against the old
+Ballerina backend, which forwarded these raw numeric choice-list keys (case status/severity/
+issue-type/engagement-type, call-request state, change-request state/impact, conversation state,
+deployment type, product-vulnerability severity) directly — it still sends and expects those exact
+numbers today, even though `cs-tools/entity-service`'s own contract is plain lowercase-snake-case
+string enums (or, for conversation state, an upper-snake-case one). Six files hold this backend's
+own copies of the numeric-id↔enum tables, one pair of directions each:
+`internal/dto/case_enum_mapping.go` (mirrors `snStateIDMap`/`snSeverityIDMap`/`snIssueTypeIDMap`/
+`snEngagementTypeIDMap` in `internal/service/sn_case_service.go`),
+`internal/dto/call_request_enum_mapping.go` (mirrors `callRequestKeyToState` in
+`sn_call_request_service.go`), `internal/dto/change_request_enum_mapping.go` (mirrors
+`snCRStateIDMap`/`snCRImpactIDMap` in `sn_change_request_service.go`),
+`internal/dto/conversation_enum_mapping.go` (mirrors `snConversationStateKeyMap` in
+`sn_conversation_service.go`), `internal/dto/deployment_enum_mapping.go` (mirrors
+`deploymentTypeToKey` in `sn_deployment_service.go`), and
+`internal/dto/product_vulnerability_enum_mapping.go` (mirrors `vulnerabilityPriorityToSeverityID`
+in `sn_product_vulnerability_service.go`). These ids are each service's own stable upstream
+configuration, not something entity-service computes, so duplicating them is safe, but if
+entity-service's copies ever change, update the matching file here too. Two directions:
 - **Request → entity-service**: the frontend's numeric filter ids (`statusIds`, `severityIds`,
   `issueIds`, `engagementTypeKeys`, `stateKeys`) translate via an id→enum map
   (`caseIDsToEnums`/`callRequestStateKeyToEnum`) before reaching `BuildEntityXRequest`; an
@@ -523,13 +546,18 @@ Two more examples, both in this same "restrict, don't mirror" category:
   entries verbatim unless the caller filters them out, and those are internal WSO2 annotations that
   must never reach the customer regardless of which reference entity they're attached to.
 
-**Not every field worth restricting is a security decision — some are just an unenforced entity-service
-scoping convenience.** `PATCH /deployed-products/{id}`'s `deploymentId` field looks similar to the
-fields above (an id referencing another resource) but isn't restricted, because entity-service
-documents it as an IDOR-style scope guard the caller supplies voluntarily (verify the deployed
-product belongs to this deployment before mutating it), not a way to relink the resource. Read the
-entity-service doc comment on the field before deciding which category it falls into — don't
-pattern-match on field name alone (e.g. "any ID field" or "any assignee-shaped field").
+**Not every field worth restricting is a security decision — some are just an entity-service scoping
+convenience, and the path (not the body) is the more reliable source for it.**
+`PATCH /deployments/{deploymentId}/products/{id}`'s `deploymentId` field is an IDOR-style scope
+guard entity-service documents (verify the deployed product belongs to this deployment before
+mutating it), not a way to relink the resource — but the frontend's own `PatchDeploymentProductRequest`
+body never actually carries a `deploymentId` field, so trusting the body would leave the guard
+permanently unset. `dto.BuildEntityUpdateDeployedProductRequest` always injects it from the URL's
+`{deploymentId}` path segment instead, the same way project/deployment scoping is forced from the
+path everywhere else in this backend (see "Project scoping via a `{id}` path parameter" below). Read
+the entity-service doc comment on a field like this before deciding whether path-injection or
+body-passthrough is the right source — don't pattern-match on field name alone (e.g. "any ID field"
+or "any assignee-shaped field").
 
 **"Exactly one" vs. "at least one" is per-entity, read entity-service's own doc comment.**
 `PATCH /cases/{id}` requires *exactly one* of its primary fields (entity-service's doc comment says
@@ -546,17 +574,18 @@ specific value needs to be checked in Go code (e.g. `ChangeRequestApprovalDecisi
 validation in the handler compares against literal `"approved"`/`"rejected"` strings, not enum
 constants).
 
-**Most pagination responses use `total`; a few deliberately use `totalRecords` instead — check the
-frontend's existing type before picking one.** The frontend's shared `PaginationResponse` type
-(`apps/customer-portal/webapp/src/types/common.ts`) is `{offset, limit, totalRecords}`, and some
-already-built frontend consumers (`GET /cases/{id}/attachments`,
-`POST /cases/{caseId}/call-requests/search`, `POST /projects/{id}/cases/search`) read exactly that
-field name — so their dto response types use `totalRecords`, not this backend's more common
-`total`. This is not a house-style
-migration in progress; new endpoints should still default to `total` unless porting one that a
-specific existing frontend hook already expects `totalRecords` from (check
-`apps/customer-portal/webapp/src/api/` and `src/features/*/api/` for the exact field the relevant
-hook decodes before choosing).
+**Most pagination responses use `totalRecords`; a handful of not-yet-audited endpoints still use
+`total` — check the frontend's existing type before picking one.** The frontend's shared
+`PaginationResponse` type (`apps/customer-portal/webapp/src/types/common.ts`) is
+`{offset, limit, totalRecords}`, and the large majority of this backend's paginated responses were
+renamed to match it during a full request/response type-alignment pass against the old Ballerina
+backend and the live frontend (see git history for `fix/customer-portal-v2-align-response-types`).
+A few endpoints not yet touched by that pass (`internal/dto/account.go`, `attachment.go`,
+`escalation.go`, `project_stats.go`) still send `total` — this is leftover drift, not a deliberate
+split, and each should be renamed to `totalRecords` the next time one of them is revisited. New
+endpoints should default to `totalRecords`; verify against the specific frontend hook's decoded
+field name before assuming (check `apps/customer-portal/webapp/src/api/` and
+`src/features/*/api/`).
 
 **Some routes nest a resource's own ID in the path purely for RESTful shape, not because the
 handler needs it.** `PATCH /cases/{caseId}/call-requests/{id}` is the example: entity-service's

--- a/apps/customer-portal/backend-v2/README.md
+++ b/apps/customer-portal/backend-v2/README.md
@@ -5,7 +5,7 @@ Rewrite of the existing backend at `apps/customer-portal/backend`. It is a backe
 [`entity-service`](../../../entity-service) (this repo's `cs-tools/entity-service`, not the
 `digiops-cs/entity-service` the existing backend targets), and shapes the responses for the frontend.
 
-This is a work in progress — only the 101 routes listed below are implemented so far, across
+This is a work in progress — only the 104 routes listed below are implemented so far, across
 entity-service, the WSO2 Updates service, SCIM, the AI chat agent, the product-consumption
 service, the registry (robot-account) service, and the project-contact onboarding service (six
 more separate services — see [CLAUDE.md](./CLAUDE.md#the-ai-chat-agent),
@@ -272,13 +272,13 @@ backend-v2/
 │       ├── projects.go          # POST /projects/search, GET /projects/{id}
 │       ├── project_stats.go     # project filters/features/dashboard-stats (composite, some graceful-degradation), case-grouped time-cards
 │       ├── cases.go             # cases search/get/create/update/comment/activities/feedback/escalations, case-scoped attachment update
-│       ├── deployments.go       # POST /projects/{id}/deployments/search, POST /deployments, PATCH /deployments/{id}, deployment-scoped attachment update
-│       ├── deployed_products.go # deployed-product search/create/update + per-deployed-product metrics/usage-counts
+│       ├── deployments.go       # POST /projects/{id}/deployments/search, POST /projects/{id}/deployments, PATCH /projects/{projectId}/deployments/{id}, deployment-scoped attachment update
+│       ├── deployed_products.go # deployed-product search/create/update (scoped under /deployments/{deploymentId}/products) + per-deployed-product metrics/usage-counts
 │       ├── attachments.go       # attachment create/search/download/get/delete
-│       ├── products.go          # POST /products/search, POST /products/{id}/versions/search
+│       ├── products.go          # GET /products, POST /products/search, POST /products/{id}/versions/search
 │       ├── product_vulnerabilities.go # vulnerability search/get
-│       ├── catalogs.go          # catalog search, catalog item variables
-│       ├── time_cards.go        # POST /time-cards/search
+│       ├── catalogs.go          # catalog search (scoped under /deployments/products/{deployedProductId}), catalog item variables
+│       ├── time_cards.go        # POST /projects/{id}/time-cards/search
 │       ├── comments.go          # generic comment create/search
 │       ├── ai_chat.go           # case classification, recommendations, conversation create/get/update/search/messages/summary
 │       ├── websocket.go         # GET /ws — real-time AI chat proxy
@@ -322,16 +322,17 @@ backend-v2/
 - `GET /cases/{id}/feedback` — get feedback previously submitted for a case (ServiceNow data source only)
 - `POST /cases/{id}/feedback` — submit feedback for a case (ServiceNow data source only)
 - `GET /cases/{id}/attachments` — search a case's attachments, paginated via `limit`/`offset` query params
+- `POST /cases/{id}/attachments` — add an attachment to a case
 - `PATCH /cases/{caseId}/attachments/{attachmentId}` — update a case attachment's name (description not supported on this route — see CLAUDE.md)
 - `POST /cases/{caseId}/escalations` — escalate or de-escalate a case (ServiceNow data source only)
 - `POST /cases/{caseId}/escalations/search` — search a case's escalations (ServiceNow data source only)
 - `POST /projects/{id}/deployments/search` — search a project's deployments
-- `POST /deployments` — create a deployment (ServiceNow data source only)
-- `PATCH /deployments/{id}` — update a deployment's name/type/description, or deactivate it
+- `POST /projects/{id}/deployments` — create a deployment (ServiceNow data source only)
+- `PATCH /projects/{projectId}/deployments/{id}` — update a deployment's name/type/description, or deactivate it
 - `PATCH /deployments/{deploymentId}/attachments/{attachmentId}` — update a deployment attachment's name/description
-- `POST /deployed-products/search` — search deployed products
-- `POST /deployed-products` — create a deployed product (ServiceNow data source only)
-- `PATCH /deployed-products/{id}` — update a deployed product's cores/tps/description, or deactivate it (ServiceNow data source only)
+- `POST /deployments/{deploymentId}/products/search` — search a deployment's deployed products
+- `POST /deployments/{deploymentId}/products` — create a deployed product (ServiceNow data source only)
+- `PATCH /deployments/{deploymentId}/products/{id}` — update a deployed product's cores/tps/description, or deactivate it (ServiceNow data source only)
 - `POST /deployments/{deploymentId}/products/{productId}/metrics/search` — get core-count metrics for a deployed product over a date range (`productId` is the deployed product's own ID; ServiceNow data source only)
 - `POST /deployments/{deploymentId}/products/{productId}/metrics/usage-counts/search` — get usage-count metrics for a deployed product over a date range (ServiceNow data source only)
 - `POST /attachments` — create an attachment
@@ -341,7 +342,7 @@ backend-v2/
 - `DELETE /attachments/{id}` — delete an attachment
 - `POST /cases/{id}/activities/search` — search a case's activity feed (comments, attachments, field changes)
 - `POST /change-requests` — create a change request (ServiceNow data source only)
-- `POST /change-requests/search` — search change requests (ServiceNow data source only)
+- `POST /projects/{id}/change-requests/search` — search a project's change requests (ServiceNow data source only)
 - `GET /change-requests/{id}` — get change request by ID (ServiceNow data source only)
 - `PATCH /change-requests/{id}` — update a change request (restricted, customer-safe field subset — see CLAUDE.md; ServiceNow data source only)
 - `GET /change-requests/{id}/approvals` — get a change request's approval stages (ServiceNow data source only)
@@ -349,14 +350,15 @@ backend-v2/
 - `POST /cases/{caseId}/call-requests` — create a call request for a case (ServiceNow data source only)
 - `POST /cases/{caseId}/call-requests/search` — search a case's call requests (ServiceNow data source only)
 - `PATCH /cases/{caseId}/call-requests/{id}` — update a call request (restricted, excludes agent-only fields — see CLAUDE.md; ServiceNow data source only)
+- `GET /products` — browse products, paginated via `class`/`offset`/`limit` query params (`class` is accepted but not forwarded — entity-service has no class filter)
 - `POST /products/search` — search products
 - `POST /products/{id}/versions/search` — search a product's versions
 - `POST /products/vulnerabilities/search` — search product vulnerabilities
 - `GET /products/vulnerabilities/{id}` — get a product vulnerability by ID
 - `GET /products/vulnerabilities/meta` — get valid vulnerability severity choices
-- `POST /catalogs/search` — search service catalogs, scoped by deployedProductId
-- `GET /catalogs/{catalogId}/items/{catalogItemId}/variables` — get a catalog item's form variables
-- `POST /time-cards/search` — search time cards (read-only; ServiceNow data source only)
+- `POST /deployments/products/{deployedProductId}/catalogs/search` — search service catalogs available for a deployed product
+- `GET /catalogs/{catalogId}/items/{itemId}` — get a catalog item's form variables
+- `POST /projects/{id}/time-cards/search` — search a project's time cards (read-only; ServiceNow data source only)
 - `POST /projects/{id}/cases/time-cards/search` — search time cards rolled up by case for a project (ServiceNow data source only)
 - `POST /comments` — add a comment to any reference entity (case, conversation, change_request, deployment, incident) — always a plain customer comment
 - `POST /comments/search` — search comments on a reference entity — always filtered to plain customer comments
@@ -470,19 +472,19 @@ curl -X POST http://localhost:8080/projects/<project-id>/deployments/search \
   -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
   -d '{"pagination":{"limit":10,"offset":0}}'
 
-curl -X POST http://localhost:8080/deployments \
+curl -X POST http://localhost:8080/projects/<project-id>/deployments \
   -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
-  -d '{"projectId":"<project-id>","name":"Production"}'
+  -d '{"name":"Production","deploymentTypeKey":6,"description":"Primary production"}'
 
-curl -X POST http://localhost:8080/deployed-products/search \
+curl -X POST http://localhost:8080/deployments/<deployment-id>/products/search \
   -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
-  -d '{"pagination":{"limit":10,"offset":0},"deploymentIds":["<deployment-id>"]}'
+  -d '{"pagination":{"limit":10,"offset":0}}'
 
-curl -X POST http://localhost:8080/deployed-products \
+curl -X POST http://localhost:8080/deployments/<deployment-id>/products \
   -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
-  -d '{"projectId":"<project-id>","deploymentId":"<deployment-id>","productId":"<product-id>","versionId":"<version-id>"}'
+  -d '{"projectId":"<project-id>","productId":"<product-id>","versionId":"<version-id>"}'
 
-curl -X PATCH http://localhost:8080/deployed-products/<deployed-product-id> \
+curl -X PATCH http://localhost:8080/deployments/<deployment-id>/products/<deployed-product-id> \
   -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
   -d '{"cores":4}'
 
@@ -504,6 +506,8 @@ curl -X POST http://localhost:8080/cases/<case-id>/activities/search \
   -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
   -d '{"pagination":{"limit":20,"offset":0}}'
 
+curl -H "x-jwt-assertion: $JWT" "http://localhost:8080/products?class=product_model&offset=0&limit=10"
+
 curl -X POST http://localhost:8080/products/search \
   -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
   -d '{"pagination":{"limit":10,"offset":0},"searchQuery":"wso2am"}'
@@ -516,7 +520,7 @@ curl -X POST http://localhost:8080/change-requests \
   -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
   -d '{"subject":"Upgrade WSO2 API Manager to 4.3.0"}'
 
-curl -X POST http://localhost:8080/change-requests/search \
+curl -X POST http://localhost:8080/projects/<project-id>/change-requests/search \
   -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
   -d '{"pagination":{"limit":10,"offset":0}}'
 
@@ -544,7 +548,7 @@ curl -X PATCH http://localhost:8080/cases/<case-id>/call-requests/<call-request-
   -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
   -d '{"stateKey":6,"cancellationReason":"No longer needed"}'
 
-curl -X PATCH http://localhost:8080/deployments/<deployment-id> \
+curl -X PATCH http://localhost:8080/projects/<project-id>/deployments/<deployment-id> \
   -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
   -d '{"name":"Production (EU)"}'
 
@@ -554,15 +558,15 @@ curl -X POST http://localhost:8080/products/vulnerabilities/search \
 
 curl -H "x-jwt-assertion: $JWT" http://localhost:8080/products/vulnerabilities/<vulnerability-id>
 
-curl -X POST http://localhost:8080/catalogs/search \
+curl -X POST http://localhost:8080/deployments/products/<deployed-product-id>/catalogs/search \
   -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
-  -d '{"deployedProductId":"<deployed-product-id>","pagination":{"limit":10,"offset":0}}'
+  -d '{"pagination":{"limit":10,"offset":0}}'
 
-curl -H "x-jwt-assertion: $JWT" http://localhost:8080/catalogs/<catalog-id>/items/<catalog-item-id>/variables
+curl -H "x-jwt-assertion: $JWT" http://localhost:8080/catalogs/<catalog-id>/items/<item-id>
 
-curl -X POST http://localhost:8080/time-cards/search \
+curl -X POST http://localhost:8080/projects/<project-id>/time-cards/search \
   -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \
-  -d '{"pagination":{"limit":10,"offset":0},"filters":{"projectIds":["<project-id>"]}}'
+  -d '{"pagination":{"limit":10,"offset":0}}'
 
 curl -X POST http://localhost:8080/comments \
   -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \

--- a/apps/customer-portal/backend-v2/cmd/server/main.go
+++ b/apps/customer-portal/backend-v2/cmd/server/main.go
@@ -229,6 +229,7 @@ func main() {
 	mux.HandleFunc("POST /cases/{id}/comments", caseHandler.CreateCaseComment)
 	mux.HandleFunc("POST /cases/{id}/activities/search", caseHandler.SearchCaseActivities)
 	mux.HandleFunc("GET /cases/{id}/attachments", caseHandler.SearchCaseAttachments)
+	mux.HandleFunc("POST /cases/{id}/attachments", caseHandler.CreateCaseAttachment)
 	mux.HandleFunc("GET /cases/{id}/feedback", caseHandler.GetCaseFeedback)
 	mux.HandleFunc("POST /cases/{id}/feedback", caseHandler.SubmitCaseFeedback)
 	mux.HandleFunc("PATCH /cases/{caseId}/attachments/{attachmentId}", caseHandler.PatchCaseAttachment)
@@ -236,10 +237,10 @@ func main() {
 	mux.HandleFunc("POST /cases/{caseId}/escalations/search", caseHandler.SearchCaseEscalations)
 
 	mux.HandleFunc("POST /projects/{id}/deployments/search", deploymentHandler.SearchDeployments)
-	// POST /deployments only succeeds against entity-service's ServiceNow
-	// data source — see internal/entity/deployments.go.
-	mux.HandleFunc("POST /deployments", deploymentHandler.CreateDeployment)
-	mux.HandleFunc("PATCH /deployments/{id}", deploymentHandler.PatchDeployment)
+	// POST /projects/{id}/deployments only succeeds against entity-service's
+	// ServiceNow data source — see internal/entity/deployments.go.
+	mux.HandleFunc("POST /projects/{id}/deployments", deploymentHandler.CreateDeployment)
+	mux.HandleFunc("PATCH /projects/{projectId}/deployments/{id}", deploymentHandler.PatchDeployment)
 	mux.HandleFunc("PATCH /deployments/{deploymentId}/attachments/{attachmentId}", deploymentHandler.PatchDeploymentAttachment)
 	mux.HandleFunc("POST /deployments/{id}/instances/search", instanceHandler.SearchDeploymentInstances)
 	mux.HandleFunc("POST /deployments/{id}/instances/metrics/search", instanceHandler.SearchDeploymentInstanceMetrics)
@@ -247,11 +248,11 @@ func main() {
 	mux.HandleFunc("POST /deployments/{id}/instances/stats/metrics/search", instanceHandler.SearchDeploymentInstanceMetricsStats)
 	mux.HandleFunc("POST /deployments/{id}/instances/stats/usages/search", instanceHandler.SearchDeploymentInstanceUsageStats)
 
-	mux.HandleFunc("POST /deployed-products/search", deployedProductHandler.SearchDeployedProducts)
-	// POST/PATCH /deployed-products only succeed against entity-service's
+	mux.HandleFunc("POST /deployments/{deploymentId}/products/search", deployedProductHandler.SearchDeployedProducts)
+	// POST/PATCH .../products only succeed against entity-service's
 	// ServiceNow data source — see internal/entity/deployed_products.go.
-	mux.HandleFunc("POST /deployed-products", deployedProductHandler.CreateDeployedProduct)
-	mux.HandleFunc("PATCH /deployed-products/{id}", deployedProductHandler.PatchDeployedProduct)
+	mux.HandleFunc("POST /deployments/{deploymentId}/products", deployedProductHandler.CreateDeployedProduct)
+	mux.HandleFunc("PATCH /deployments/{deploymentId}/products/{id}", deployedProductHandler.PatchDeployedProduct)
 	// POST /deployments/{deploymentId}/products/{productId}/metrics/search and
 	// POST /deployments/products/{id}/instances/metrics/search cannot both be
 	// registered as literal patterns: net/http.ServeMux (Go 1.22+) rejects
@@ -276,6 +277,7 @@ func main() {
 	mux.HandleFunc("GET /attachments/{id}", attachmentHandler.GetAttachment)
 	mux.HandleFunc("DELETE /attachments/{id}", attachmentHandler.DeleteAttachment)
 
+	mux.HandleFunc("GET /products", productHandler.GetProducts)
 	mux.HandleFunc("POST /products/search", productHandler.SearchProducts)
 	mux.HandleFunc("POST /products/{id}/versions/search", productHandler.SearchProductVersions)
 
@@ -283,7 +285,7 @@ func main() {
 	// ServiceNow data source — see internal/entity/change_requests.go and
 	// internal/entity/call_requests.go.
 	mux.HandleFunc("POST /change-requests", changeRequestHandler.CreateChangeRequest)
-	mux.HandleFunc("POST /change-requests/search", changeRequestHandler.SearchChangeRequests)
+	mux.HandleFunc("POST /projects/{id}/change-requests/search", changeRequestHandler.SearchChangeRequests)
 	mux.HandleFunc("GET /change-requests/{id}", changeRequestHandler.GetChangeRequest)
 	mux.HandleFunc("PATCH /change-requests/{id}", changeRequestHandler.PatchChangeRequest)
 	mux.HandleFunc("GET /change-requests/{id}/approvals", changeRequestHandler.GetChangeRequestApprovals)
@@ -306,12 +308,12 @@ func main() {
 	mux.HandleFunc("GET /metadata", globalHandler.GetMetadata)
 	mux.HandleFunc("POST /search", globalHandler.GlobalSearch)
 
-	mux.HandleFunc("POST /catalogs/search", catalogHandler.SearchCatalogs)
-	mux.HandleFunc("GET /catalogs/{catalogId}/items/{catalogItemId}/variables", catalogHandler.GetCatalogItemVariables)
+	mux.HandleFunc("POST /deployments/products/{deployedProductId}/catalogs/search", catalogHandler.SearchCatalogs)
+	mux.HandleFunc("GET /catalogs/{catalogId}/items/{itemId}", catalogHandler.GetCatalogItemVariables)
 
 	// entity-service only supports time cards on its ServiceNow data source —
 	// see internal/entity/time_cards.go.
-	mux.HandleFunc("POST /time-cards/search", timeCardHandler.SearchTimeCards)
+	mux.HandleFunc("POST /projects/{id}/time-cards/search", timeCardHandler.SearchTimeCards)
 
 	// AI chat feature: case classification and KB recommendations call the
 	// upstream AI chat agent directly; conversation search/messages/summary

--- a/apps/customer-portal/backend-v2/internal/dto/ai_chat.go
+++ b/apps/customer-portal/backend-v2/internal/dto/ai_chat.go
@@ -209,23 +209,29 @@ func MapConversationSummary(r aichatagent.ConversationSummaryResponse) Conversat
 }
 
 // ConversationSummary is one item of the portal's response for
-// POST /projects/{id}/conversations/search.
+// POST /projects/{id}/conversations/search — shaped to match the frontend's
+// own Conversation type (apps/customer-portal/webapp/src/features/support/
+// types/conversations.ts) field-for-field: State and Project as IDLabelRef
+// (not a plain string / not missing) — see conversation_enum_mapping.go for
+// the State translation.
 type ConversationSummary struct {
-	ID             string `json:"id"`
-	Number         string `json:"number,omitempty"`
-	InitialMessage string `json:"initialMessage,omitempty"`
-	MessageCount   int    `json:"messageCount"`
-	Case           *Ref   `json:"case,omitempty"`
-	State          string `json:"state,omitempty"`
-	CreatedOn      string `json:"createdOn"`
-	CreatedBy      string `json:"createdBy"`
+	ID             string      `json:"id"`
+	Number         string      `json:"number,omitempty"`
+	InitialMessage string      `json:"initialMessage,omitempty"`
+	MessageCount   int         `json:"messageCount"`
+	Project        *IDLabelRef `json:"project,omitempty"`
+	Case           *IDLabelRef `json:"case,omitempty"`
+	State          *IDLabelRef `json:"state,omitempty"`
+	CreatedOn      string      `json:"createdOn"`
+	CreatedBy      string      `json:"createdBy"`
 }
 
 // SearchConversationsResponse is the portal's response for
-// POST /projects/{id}/conversations/search.
+// POST /projects/{id}/conversations/search. TotalRecords (not Total) to
+// match the frontend's shared pagination envelope.
 type SearchConversationsResponse struct {
 	Conversations []ConversationSummary `json:"conversations"`
-	Total         int                   `json:"total"`
+	TotalRecords  int                   `json:"totalRecords"`
 	Limit         int                   `json:"limit"`
 	Offset        int                   `json:"offset"`
 }
@@ -237,7 +243,9 @@ func MapSearchConversations(r entity.SearchConversationsResponse) SearchConversa
 	for _, c := range r.Conversations {
 		summary := ConversationSummary{
 			MessageCount: c.MessageCount,
-			Case:         mapRef(c.Case),
+			Project:      entityRefToIDLabel(c.Project),
+			Case:         entityRefToIDLabel(c.Case),
+			State:        conversationStateRef(c.State),
 			CreatedOn:    c.CreatedOn,
 			CreatedBy:    c.CreatedBy,
 		}
@@ -250,15 +258,50 @@ func MapSearchConversations(r entity.SearchConversationsResponse) SearchConversa
 		if c.InitialMessage != nil {
 			summary.InitialMessage = *c.InitialMessage
 		}
-		if c.State != nil {
-			summary.State = *c.State
-		}
 		items = append(items, summary)
 	}
 	return SearchConversationsResponse{
 		Conversations: items,
-		Total:         r.Total,
+		TotalRecords:  r.Total,
 		Limit:         r.Limit,
 		Offset:        r.Offset,
+	}
+}
+
+// ConversationSearchFilters holds the optional filter criteria for
+// POST /projects/{id}/conversations/search — shaped to match the frontend's
+// actual request body. StateKeys carries ServiceNow's numeric choice-list
+// ids (the frontend was built against the old Ballerina backend and still
+// sends these, not entity-service's own string enum) — see
+// conversation_enum_mapping.go for the translation. No ProjectIDs field:
+// project scoping comes exclusively from the {id} path parameter.
+type ConversationSearchFilters struct {
+	StateKeys   []int  `json:"stateKeys,omitempty"`
+	SearchQuery string `json:"searchQuery,omitempty"`
+	CreatedByMe bool   `json:"createdByMe,omitempty"`
+}
+
+// ConversationSearchRequest is the portal's request body for
+// POST /projects/{id}/conversations/search.
+type ConversationSearchRequest struct {
+	Filters    ConversationSearchFilters `json:"filters"`
+	SortBy     entity.ConversationSort   `json:"sortBy"`
+	Pagination entity.Pagination         `json:"pagination"`
+}
+
+// BuildEntitySearchConversationsRequest translates the portal's request
+// into entity-service's SearchConversationsRequest. projectID (the {id}
+// path parameter) always populates Filters.ProjectIDs — never the request
+// body.
+func BuildEntitySearchConversationsRequest(projectID string, req ConversationSearchRequest) entity.SearchConversationsRequest {
+	return entity.SearchConversationsRequest{
+		Filters: entity.SearchConversationsFilters{
+			ProjectIDs:  []string{projectID},
+			States:      conversationIDsToEnums(req.Filters.StateKeys),
+			SearchQuery: req.Filters.SearchQuery,
+			CreatedByMe: req.Filters.CreatedByMe,
+		},
+		SortBy:     req.SortBy,
+		Pagination: req.Pagination,
 	}
 }

--- a/apps/customer-portal/backend-v2/internal/dto/attachment.go
+++ b/apps/customer-portal/backend-v2/internal/dto/attachment.go
@@ -22,6 +22,34 @@ import (
 	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
 )
 
+// CreateCaseAttachmentRequest is the portal's request body for
+// POST /cases/{id}/attachments, matching the frontend's own
+// PostCaseAttachmentRequest type
+// (apps/customer-portal/webapp/src/features/support/types/attachments.ts)
+// field-for-field. There's no referenceId field: the case is scoped by the
+// {id} path parameter, never the body.
+type CreateCaseAttachmentRequest struct {
+	Name        string  `json:"name"`
+	Type        string  `json:"type"`
+	Content     string  `json:"content"`
+	Description *string `json:"description,omitempty"`
+}
+
+// BuildEntityCreateCaseAttachmentRequest translates the portal's request
+// into entity-service's CreateAttachmentRequest, forcing ReferenceID (from
+// the {id} path parameter) and ReferenceType to case, and renaming
+// Content->File to match entity-service's own field name.
+func BuildEntityCreateCaseAttachmentRequest(caseID string, req CreateCaseAttachmentRequest) entity.CreateAttachmentRequest {
+	return entity.CreateAttachmentRequest{
+		ReferenceID:   caseID,
+		ReferenceType: entity.ReferenceTypeCase,
+		Name:          req.Name,
+		Type:          req.Type,
+		File:          req.Content,
+		Description:   req.Description,
+	}
+}
+
 // AttachmentCreateResponse is the portal's response for POST /attachments.
 type AttachmentCreateResponse struct {
 	ID          string    `json:"id"`

--- a/apps/customer-portal/backend-v2/internal/dto/case.go
+++ b/apps/customer-portal/backend-v2/internal/dto/case.go
@@ -591,6 +591,17 @@ func MapCaseCreate(r entity.CreateCaseResponse) CaseCreateResponse {
 // translation. entity-service requires exactly one of State/WatchList (of
 // the fields this portal DTO exposes) to be set — StateKey counts as State
 // for that check.
+//
+// WatchList cannot be used to clear every watcher via an explicit empty
+// array — this is a genuine end-to-end platform limitation, not something
+// fixable in this dto layer: entity-service's own ServiceNow implementation
+// checks `len(req.WatchList) > 0` before forwarding it upstream at all (see
+// sn_case_service.go), so even an explicit `{"watchList": []}` would be
+// silently dropped several layers up, regardless of whether this struct
+// distinguished absent from empty. Validating watchList as "must be
+// non-empty to count as provided" (see the handler) is therefore accurate,
+// not a bug — don't change this to a `*[]string` to "fix" an empty-array
+// case that entity-service can't honor anyway.
 type UpdateCaseRequest struct {
 	StateKey  *int     `json:"stateKey,omitempty"`
 	WatchList []string `json:"watchList,omitempty"`

--- a/apps/customer-portal/backend-v2/internal/dto/case.go
+++ b/apps/customer-portal/backend-v2/internal/dto/case.go
@@ -17,6 +17,7 @@
 package dto
 
 import (
+	"strconv"
 	"time"
 
 	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
@@ -279,62 +280,129 @@ type CaseTag struct {
 	Color *string `json:"color,omitempty"`
 }
 
-// CaseDetails is the portal's response for GET /cases/{id}.
+// CaseDetailsAccount is the account reference embedded in CaseDetails,
+// matching the frontend's own CaseDetailsAccount type ({type, id, label}).
+type CaseDetailsAccount struct {
+	Type  string `json:"type"`
+	ID    string `json:"id"`
+	Label string `json:"label"`
+}
+
+// CaseDetailsAssignedEngineer matches the frontend's own
+// CaseDetailsAssignedEngineer type.
+type CaseDetailsAssignedEngineer struct {
+	ID    string `json:"id"`
+	Label string `json:"label,omitempty"`
+	Name  string `json:"name,omitempty"`
+}
+
+// CaseWatchListUser is one entry of CaseDetails.WatchList, matching the
+// frontend's inline watchList item shape.
+type CaseWatchListUser struct {
+	ID       string `json:"id,omitempty"`
+	UserName string `json:"userName,omitempty"`
+	Name     string `json:"name,omitempty"`
+	Email    string `json:"email,omitempty"`
+}
+
+// CaseDetails is the portal's response for GET /cases/{id} — shaped to
+// match the frontend's own CaseDetails type
+// (apps/customer-portal/webapp/src/features/support/types/cases.ts)
+// field-for-field: Title (not Subject), Status (not State), every
+// enum-valued field as IDLabelRef, every reference field as IDLabelRef (not
+// Ref), plus InternalID/Account/ChangeRequests/WatchList, which
+// entity-service's CaseView already carries but this dto previously left
+// unmapped (some under an inaccurate "CSM-engineer-only" doc comment — see
+// entity.CaseView's own doc comment on WatchList, which says otherwise).
 //
-// Deliberately excludes entity-service's InternalID, Catalog/CatalogItem
-// (CMDB detail), WatchList, AutoclosureStep/AutoclosureStateTime, and
-// BestCaseFixEta/MostLikelyFixEta/WorstCaseFixEta — entity-service documents
-// the Fix-ETA trio and WatchList as CSM-engineer-facing only, and autoclosure
-// state is internal ServiceNow workflow detail not surfaced to entity-service's
-// decoded CaseView in the first place (see internal/entity/types.go).
+// Deliberately excludes entity-service's AutoclosureStep/AutoclosureStateTime
+// and BestCaseFixEta/MostLikelyFixEta/WorstCaseFixEta — genuinely
+// CSM-engineer-facing only. SlaResponseTime, CsManager, ClosedBy,
+// CloseNotes (on this read path — it does exist on the PATCH response),
+// HasAutoClosed, FindingsResolved/FindingsTotal, EscalationLevel/
+// IsEscalated, Duration, EngagementStartDate/EngagementEndDate, and
+// Variables are all present on the frontend's type but have no
+// entity-service equivalent at all on CaseView — not fixable in this dto
+// layer alone.
 type CaseDetails struct {
-	ID                    string                 `json:"id"`
-	Number                string                 `json:"number"`
-	Subject               string                 `json:"subject"`
-	Description           string                 `json:"description"`
-	Severity              string                 `json:"severity"`
-	IssueType             string                 `json:"issueType"`
-	State                 string                 `json:"state"`
-	WorkState             *string                `json:"workState,omitempty"`
-	Type                  *string                `json:"type,omitempty"`
-	EngagementType        *string                `json:"engagementType,omitempty"`
-	CreatedOn             time.Time              `json:"createdOn"`
-	UpdatedOn             time.Time              `json:"updatedOn"`
-	ClosedOn              *time.Time             `json:"closedOn,omitempty"`
-	CreatedBy             PersonRef              `json:"createdBy"`
-	Project               Ref                    `json:"project"`
-	Deployment            *Ref                   `json:"deployment,omitempty"`
-	DeployedProduct       *Ref                   `json:"deployedProduct,omitempty"`
-	Product               *Ref                   `json:"product,omitempty"`
-	AssignedTeam          *Ref                   `json:"assignedTeam,omitempty"`
-	Conversation          *Ref                   `json:"conversation,omitempty"`
-	AssignedEngineer      *PersonRef             `json:"assignedEngineer,omitempty"`
-	ParentCase            *NumberRef             `json:"parentCase,omitempty"`
-	RelatedCase           *NumberRef             `json:"relatedCase,omitempty"`
-	LinkedServiceRequests []LinkedServiceRequest `json:"linkedServiceRequests,omitempty"`
-	ResolvedOn            *time.Time             `json:"resolvedOn,omitempty"`
-	ResolutionCode        *string                `json:"resolutionCode,omitempty"`
-	Cause                 *string                `json:"cause,omitempty"`
-	ResolutionNotes       *string                `json:"resolutionNotes,omitempty"`
-	FixEta                *time.Time             `json:"fixEta,omitempty"`
-	Tags                  []CaseTag              `json:"tags,omitempty"`
+	ID                    string                       `json:"id"`
+	InternalID            string                       `json:"internalId"`
+	Number                string                       `json:"number"`
+	Title                 string                       `json:"title"`
+	Description           string                       `json:"description"`
+	Product               *IDLabelRef                  `json:"product,omitempty"`
+	Account               *CaseDetailsAccount          `json:"account,omitempty"`
+	AssignedEngineer      *CaseDetailsAssignedEngineer `json:"assignedEngineer,omitempty"`
+	EngineerEmail         *string                      `json:"engineerEmail,omitempty"`
+	Project               *IDLabelRef                  `json:"project,omitempty"`
+	Type                  *IDLabelRef                  `json:"type,omitempty"`
+	DeployedProduct       *IDLabelRef                  `json:"deployedProduct,omitempty"`
+	RelatedCase           *IDLabelRef                  `json:"relatedCase,omitempty"`
+	Conversation          *IDLabelRef                  `json:"conversation,omitempty"`
+	IssueType             *IDLabelRef                  `json:"issueType,omitempty"`
+	EngagementType        *IDLabelRef                  `json:"engagementType,omitempty"`
+	Catalog               *IDLabelRef                  `json:"catalog,omitempty"`
+	CatalogItem           *IDLabelRef                  `json:"catalogItem,omitempty"`
+	ChangeRequests        []IDLabelRef                 `json:"changeRequests,omitempty"`
+	AssignedTeam          *IDLabelRef                  `json:"assignedTeam,omitempty"`
+	Deployment            *IDLabelRef                  `json:"deployment,omitempty"`
+	Severity              *IDLabelRef                  `json:"severity,omitempty"`
+	Status                *IDLabelRef                  `json:"status,omitempty"`
+	WorkState             *string                      `json:"workState,omitempty"`
+	CreatedOn             time.Time                    `json:"createdOn"`
+	UpdatedOn             time.Time                    `json:"updatedOn"`
+	ClosedOn              *time.Time                   `json:"closedOn,omitempty"`
+	CreatedBy             string                       `json:"createdBy"`
+	ParentCase            *NumberRef                   `json:"parentCase,omitempty"`
+	LinkedServiceRequests []LinkedServiceRequest       `json:"linkedServiceRequests,omitempty"`
+	ResolvedOn            *time.Time                   `json:"resolvedOn,omitempty"`
+	ResolutionCode        *string                      `json:"resolutionCode,omitempty"`
+	Cause                 *string                      `json:"cause,omitempty"`
+	ResolutionNotes       *string                      `json:"resolutionNotes,omitempty"`
+	WatchList             []CaseWatchListUser          `json:"watchList,omitempty"`
+	FixEta                *time.Time                   `json:"fixEta,omitempty"`
+	Tags                  []CaseTag                    `json:"tags,omitempty"`
 }
 
 // MapCaseDetails builds the portal response from entity-service's CaseView.
 func MapCaseDetails(c entity.CaseView) CaseDetails {
-	var deployedProduct *Ref
-	if c.DeployedProductDetails != nil {
-		deployedProduct = &Ref{ID: c.DeployedProductDetails.ID, Name: c.DeployedProductDetails.DisplayName}
+	var account *CaseDetailsAccount
+	if c.AccountDetails != nil {
+		account = &CaseDetailsAccount{Type: c.AccountDetails.Type, ID: c.AccountDetails.ID, Label: c.AccountDetails.Name}
 	}
 
-	var assignedEngineer *PersonRef
+	var assignedEngineer *CaseDetailsAssignedEngineer
+	var engineerEmail *string
 	if c.AssignedEngineer != nil {
-		assignedEngineer = &PersonRef{Name: c.AssignedEngineer.Name, Email: c.AssignedEngineer.Email}
+		assignedEngineer = &CaseDetailsAssignedEngineer{ID: c.AssignedEngineer.ID, Label: c.AssignedEngineer.Name, Name: c.AssignedEngineer.Name}
+		engineerEmail = c.AssignedEngineer.Email
+	}
+
+	var relatedCase *IDLabelRef
+	if c.RelatedCase != nil {
+		relatedCase = &IDLabelRef{ID: c.RelatedCase.ID, Label: c.RelatedCase.Number}
+	}
+
+	changeRequests := make([]IDLabelRef, 0, len(c.LinkedChangeRequests))
+	for _, cr := range c.LinkedChangeRequests {
+		label := cr.Number
+		if cr.Name != nil {
+			label = *cr.Name
+		}
+		changeRequests = append(changeRequests, IDLabelRef{ID: cr.ID, Label: label})
 	}
 
 	linked := make([]LinkedServiceRequest, 0, len(c.LinkedServiceRequests))
 	for _, lsr := range c.LinkedServiceRequests {
 		linked = append(linked, LinkedServiceRequest{ID: lsr.ID, Number: lsr.Number, Name: lsr.Name})
+	}
+
+	var watchList []CaseWatchListUser
+	if len(c.WatchList) > 0 {
+		watchList = make([]CaseWatchListUser, 0, len(c.WatchList))
+		for _, w := range c.WatchList {
+			watchList = append(watchList, CaseWatchListUser{ID: w.ID, UserName: w.UserName, Name: w.Name, Email: w.Email})
+		}
 	}
 
 	var tags []CaseTag
@@ -345,103 +413,203 @@ func MapCaseDetails(c entity.CaseView) CaseDetails {
 		}
 	}
 
-	email := c.CreatedByDetails.Email
 	return CaseDetails{
-		ID:              c.ID,
-		Number:          c.Number,
-		Subject:         c.Subject,
-		Description:     c.Description,
-		Severity:        c.Severity,
-		IssueType:       c.IssueType,
-		State:           c.State,
-		WorkState:       c.WorkState,
-		Type:            c.Type,
-		EngagementType:  c.EngagementType,
-		CreatedOn:       c.CreatedOn,
-		UpdatedOn:       c.UpdatedOn,
-		ClosedOn:        c.ClosedOn,
-		CreatedBy:       PersonRef{Name: c.CreatedByDetails.Name, Email: &email},
-		Project:         Ref{ID: c.ProjectDetails.ID, Name: c.ProjectDetails.Name},
-		Deployment:      mapRef(c.DeploymentDetails),
-		DeployedProduct: deployedProduct,
-		Product:         mapRef(c.ProductDetails),
-		AssignedTeam:    mapRef(c.AssignedTeam),
-		Conversation:    mapRef(c.Conversation),
-
+		ID:                    c.ID,
+		InternalID:            c.InternalID,
+		Number:                c.Number,
+		Title:                 c.Subject,
+		Description:           c.Description,
+		Product:               entityRefToIDLabel(c.ProductDetails),
+		Account:               account,
 		AssignedEngineer:      assignedEngineer,
+		EngineerEmail:         engineerEmail,
+		Project:               &IDLabelRef{ID: c.ProjectDetails.ID, Label: c.ProjectDetails.Name},
+		Type:                  caseTypeRefFromPointer(c.Type),
+		DeployedProduct:       deployedProductRefToIDLabel(c.DeployedProductDetails),
+		RelatedCase:           relatedCase,
+		Conversation:          entityRefToIDLabel(c.Conversation),
+		IssueType:             caseIssueTypeRef(&c.IssueType),
+		EngagementType:        caseEngagementTypeRef(c.EngagementType),
+		Catalog:               entityRefToIDLabel(c.Catalog),
+		CatalogItem:           entityRefToIDLabel(c.CatalogItem),
+		ChangeRequests:        changeRequests,
+		AssignedTeam:          entityRefToIDLabel(c.AssignedTeam),
+		Deployment:            entityRefToIDLabel(c.DeploymentDetails),
+		Severity:              caseSeverityRef(&c.Severity),
+		Status:                caseStatusRef(c.State),
+		WorkState:             c.WorkState,
+		CreatedOn:             c.CreatedOn,
+		UpdatedOn:             c.UpdatedOn,
+		ClosedOn:              c.ClosedOn,
+		CreatedBy:             c.CreatedByDetails.Name,
 		ParentCase:            mapNumberRef(c.ParentCase),
-		RelatedCase:           mapNumberRef(c.RelatedCase),
 		LinkedServiceRequests: linked,
 		ResolvedOn:            c.ResolvedOn,
 		ResolutionCode:        c.ResolutionCode,
 		Cause:                 c.Cause,
 		ResolutionNotes:       c.ResolutionNotes,
+		WatchList:             watchList,
 		FixEta:                c.FixEta,
 		Tags:                  tags,
 	}
 }
 
-// CaseCreateResponse is the portal's response for POST /cases. Deliberately
-// excludes entity-service's InternalID, consistent with the other case DTOs.
-type CaseCreateResponse struct {
-	ID        string    `json:"id"`
-	Number    string    `json:"number"`
-	CreatedOn time.Time `json:"createdOn"`
-	State     string    `json:"state"`
+// caseTypeRefFromPointer mirrors caseTypeRef for CaseView.Type, which is a
+// *string (nullable) unlike SearchCaseView.Type (always present).
+func caseTypeRefFromPointer(t *string) *IDLabelRef {
+	if t == nil {
+		return nil
+	}
+	return caseTypeRef(*t)
 }
 
-// MapCaseCreate builds the portal response from entity-service's CreateCaseResponse.
-func MapCaseCreate(r entity.CreateCaseResponse) CaseCreateResponse {
-	return CaseCreateResponse{
-		ID:        r.Case.ID,
-		Number:    r.Case.Number,
-		CreatedOn: r.Case.CreatedOn,
-		State:     r.Case.State,
+// deployedProductRefToIDLabel maps entity-service's DeployedProductRef
+// (id + displayName, where displayName is a "product name + version"
+// concatenation with no separately-addressable version field) to an
+// IDLabelRef. The frontend's CaseDetailsDeployedProduct type additionally
+// declares an optional version field, but there's no clean, lossless way to
+// split it back out of DisplayName, so it's left unset rather than guessed.
+func deployedProductRefToIDLabel(r *entity.DeployedProductRef) *IDLabelRef {
+	if r == nil {
+		return nil
+	}
+	return &IDLabelRef{ID: r.ID, Label: r.DisplayName}
+}
+
+// CaseCreateAttachment is one file attached at case-creation time, matching
+// the frontend's CreateCaseRequest.attachments entry ({file, name}) — the
+// same shape as entity.CaseAttachment, kept as its own type only for this
+// package's "always mirror the frontend's own type name" convention.
+type CaseCreateAttachment struct {
+	Name string `json:"name"`
+	File string `json:"file"`
+}
+
+// CreateCaseRequest is the portal's request body for POST /cases — shaped to
+// match the frontend's own CreateCaseRequest type
+// (apps/customer-portal/webapp/src/features/support/types/cases.ts)
+// field-for-field. SeverityKey/IssueTypeKey carry ServiceNow's numeric
+// choice-list ids (the frontend was built against the old Ballerina backend
+// and still sends these, not entity-service's own string enum) — see
+// case_enum_mapping.go for the translation. CatalogID/CatalogItemID/
+// Variables aren't in the frontend's current CreateCaseRequest TS type (no
+// caller creates a service_request case today), but are kept here as
+// optional fields matching entity-service's/the old Ballerina backend's
+// CaseCreatePayload contract (modules/entity/types.bal), so that flow works
+// unmodified if the frontend adds it later.
+type CreateCaseRequest struct {
+	Title             string                 `json:"title"`
+	Type              string                 `json:"type,omitempty"`
+	ProjectID         string                 `json:"projectId"`
+	DeploymentID      string                 `json:"deploymentId"`
+	DeployedProductID string                 `json:"deployedProductId,omitempty"`
+	Description       string                 `json:"description"`
+	SeverityKey       *int                   `json:"severityKey,omitempty"`
+	IssueTypeKey      *int                   `json:"issueTypeKey,omitempty"`
+	CatalogID         string                 `json:"catalogId,omitempty"`
+	CatalogItemID     string                 `json:"catalogItemId,omitempty"`
+	Variables         []entity.Variable      `json:"variables,omitempty"`
+	RelatedCaseID     string                 `json:"relatedCaseId,omitempty"`
+	ConversationID    string                 `json:"conversationId,omitempty"`
+	WatchList         []string               `json:"watchList,omitempty"`
+	Attachments       []CaseCreateAttachment `json:"attachments,omitempty"`
+}
+
+// BuildEntityCreateCaseRequest translates the portal's request into
+// entity-service's CreateCaseRequest. An unrecognized (or absent)
+// SeverityKey/IssueTypeKey translates to an empty Severity/IssueType, which
+// entity-service's own validation then rejects with 400 for case types that
+// require them — this backend doesn't duplicate that validation itself.
+func BuildEntityCreateCaseRequest(req CreateCaseRequest) entity.CreateCaseRequest {
+	var severity, issueType string
+	if req.SeverityKey != nil {
+		severity = caseSeverityIDToEnum[strconv.Itoa(*req.SeverityKey)]
+	}
+	if req.IssueTypeKey != nil {
+		issueType = caseIssueTypeIDToEnum[strconv.Itoa(*req.IssueTypeKey)]
+	}
+	attachments := make([]entity.CaseAttachment, 0, len(req.Attachments))
+	for _, a := range req.Attachments {
+		attachments = append(attachments, entity.CaseAttachment{Name: a.Name, File: a.File})
+	}
+	return entity.CreateCaseRequest{
+		Type:              req.Type,
+		ProjectID:         req.ProjectID,
+		DeploymentID:      req.DeploymentID,
+		DeployedProductID: req.DeployedProductID,
+		Subject:           req.Title,
+		Description:       req.Description,
+		Severity:          severity,
+		IssueType:         issueType,
+		CatalogID:         req.CatalogID,
+		CatalogItemID:     req.CatalogItemID,
+		Variables:         req.Variables,
+		RelatedCaseID:     req.RelatedCaseID,
+		ConversationID:    req.ConversationID,
+		WatchList:         req.WatchList,
+		Attachments:       attachments,
 	}
 }
 
-// UpdateCaseRequest is the portal's request shape for PATCH /cases/{id} — a
-// deliberately restricted subset of entity-service's UpdateCaseRequest.
-// Excluded fields are internal WSO2 support operations, not customer
-// self-service actions: WorkState (CSM engineer work-in-progress tracking),
-// AssigneeEmail (support engineer assignment), ParentID/RelatedCaseID/
-// DeploymentID/DeployedProductID (case relinking), AutocloseHoldUntil
-// (ServiceNow auto-closure workflow control), and FixEta/BestCaseFixEta/
-// MostLikelyFixEta/WorstCaseFixEta (fix-commitment dates set by support
-// engineers, not the customer). entity-service requires exactly one of
-// State/Severity/WorkState/WatchList/AssigneeEmail/ParentID/RelatedCaseID/
-// AutocloseHoldUntil/Subject/Description/DeploymentID/DeployedProductID/
-// FixEta/BestCaseFixEta/MostLikelyFixEta/WorstCaseFixEta to be set (see
-// entity.UpdateCaseRequest's doc comment) — since this portal DTO only
-// exposes State/Severity/Subject/Description/WatchList of that set, exactly
-// one of those five must be set here too. ResolutionCode/Cause/CloseNotes
-// are secondary fields, only accepted alongside a closing State transition,
-// and don't count toward the exactly-one rule.
+// CaseCreateResponse is the portal's response for POST /cases, matching the
+// frontend's CreateCaseResponse type field-for-field.
+type CaseCreateResponse struct {
+	ID         string      `json:"id"`
+	InternalID string      `json:"internalId,omitempty"`
+	Number     string      `json:"number"`
+	CreatedOn  time.Time   `json:"createdOn"`
+	State      *IDLabelRef `json:"state,omitempty"`
+	Type       *IDLabelRef `json:"type,omitempty"`
+}
+
+// MapCaseCreate builds the portal response from entity-service's
+// CreateCaseResponse. Type is left nil: entity-service's CreateCaseDetails
+// doesn't return the case type at all, so there's nothing to translate.
+func MapCaseCreate(r entity.CreateCaseResponse) CaseCreateResponse {
+	return CaseCreateResponse{
+		ID:         r.Case.ID,
+		InternalID: r.Case.InternalID,
+		Number:     r.Case.Number,
+		CreatedOn:  r.Case.CreatedOn,
+		State:      caseStatusRef(r.Case.State),
+	}
+}
+
+// UpdateCaseRequest is the portal's request shape for PATCH /cases/{id} —
+// matches the frontend's own PatchCaseRequest type
+// (apps/customer-portal/webapp/src/features/support/types/cases.ts) and the
+// old Ballerina backend's CaseUpdatePayload (modules/entity/types.bal)
+// exactly: only stateKey and watchList. Every other field
+// entity.UpdateCaseRequest supports (severity, subject, description,
+// resolutionCode, cause, closeNotes, and every internal WSO2 support
+// operation — workState, assigneeEmail, case relinking, autocloseHoldUntil,
+// fix-commitment dates) is neither sent by the frontend today nor part of
+// this endpoint's real contract; don't reintroduce them speculatively.
+// StateKey carries ServiceNow's numeric choice-list id (the frontend was
+// built against the old Ballerina backend and still sends this, not
+// entity-service's own string enum) — see case_enum_mapping.go for the
+// translation. entity-service requires exactly one of State/WatchList (of
+// the fields this portal DTO exposes) to be set — StateKey counts as State
+// for that check.
 type UpdateCaseRequest struct {
-	State          *string  `json:"state,omitempty"`
-	Severity       *string  `json:"severity,omitempty"`
-	Subject        *string  `json:"subject,omitempty"`
-	Description    *string  `json:"description,omitempty"`
-	WatchList      []string `json:"watchList,omitempty"`
-	ResolutionCode *string  `json:"resolutionCode,omitempty"`
-	Cause          *string  `json:"cause,omitempty"`
-	CloseNotes     *string  `json:"closeNotes,omitempty"`
+	StateKey  *int     `json:"stateKey,omitempty"`
+	WatchList []string `json:"watchList,omitempty"`
 }
 
 // BuildEntityUpdateCaseRequest converts the portal's restricted update
 // request into entity-service's full request shape, leaving every excluded
-// field zero/nil.
+// field zero/nil. An unrecognized StateKey translates to an empty State,
+// which entity-service's own validation then rejects with 400.
 func BuildEntityUpdateCaseRequest(id string, req UpdateCaseRequest) entity.UpdateCaseRequest {
+	var state *string
+	if req.StateKey != nil {
+		s := caseStateIDToEnum[strconv.Itoa(*req.StateKey)]
+		state = &s
+	}
 	return entity.UpdateCaseRequest{
-		ID:             id,
-		State:          req.State,
-		Severity:       req.Severity,
-		Subject:        req.Subject,
-		Description:    req.Description,
-		WatchList:      req.WatchList,
-		ResolutionCode: req.ResolutionCode,
-		Cause:          req.Cause,
-		CloseNotes:     req.CloseNotes,
+		ID:        id,
+		State:     state,
+		WatchList: req.WatchList,
 	}
 }
 
@@ -552,30 +720,38 @@ type CaseFieldChange struct {
 
 // CaseActivity is one entry in the portal's response for
 // POST /cases/{id}/activities/search — a discriminated union on Type, like
-// entity-service's CaseActivity. Deliberately excludes entity-service's
-// CreatedByFirstName/CreatedByLastName (redundant with CreatedBy, which
-// carries the full name) and the raw internal actor ID.
+// entity-service's CaseActivity. CreatedByFirstName/CreatedByLastName/
+// CreatedByFullName are all read as distinct fields by the frontend
+// (useGetCaseCommentsInfinite.ts), so all three are carried through — not
+// redundant despite an earlier assumption here. Deliberately excludes the
+// raw internal actor ID.
 type CaseActivity struct {
-	ID          string            `json:"id"`
-	Type        string            `json:"type"`
-	Content     string            `json:"content,omitempty"`
-	CreatedOn   time.Time         `json:"createdOn"`
-	CreatedBy   string            `json:"createdBy"`
-	CommentType *string           `json:"commentType,omitempty"`
-	FileName    string            `json:"fileName,omitempty"`
-	ContentType string            `json:"contentType,omitempty"`
-	SizeBytes   int               `json:"sizeBytes,omitempty"`
-	DownloadURL string            `json:"downloadUrl,omitempty"`
-	Changes     []CaseFieldChange `json:"changes,omitempty"`
+	ID                 string            `json:"id"`
+	Type               string            `json:"type"`
+	Content            string            `json:"content,omitempty"`
+	CreatedOn          time.Time         `json:"createdOn"`
+	CreatedBy          string            `json:"createdBy"`
+	CreatedByFirstName string            `json:"createdByFirstName,omitempty"`
+	CreatedByLastName  string            `json:"createdByLastName,omitempty"`
+	CreatedByFullName  string            `json:"createdByFullName,omitempty"`
+	CommentType        *string           `json:"commentType,omitempty"`
+	FileName           string            `json:"fileName,omitempty"`
+	ContentType        string            `json:"contentType,omitempty"`
+	SizeBytes          int               `json:"sizeBytes,omitempty"`
+	DownloadURL        string            `json:"downloadUrl,omitempty"`
+	Changes            []CaseFieldChange `json:"changes,omitempty"`
 }
 
-// SearchCaseActivitiesResponse is the portal's response for POST /cases/{id}/activities/search.
+// SearchCaseActivitiesResponse is the portal's response for
+// POST /cases/{id}/activities/search — Activities (not Activity) and
+// TotalRecords (not Total) to match the frontend's actual read sites
+// (useGetCaseCommentsInfinite.ts reads data.activities/data.totalRecords).
 type SearchCaseActivitiesResponse struct {
-	Activity []CaseActivity `json:"activity"`
-	Total    int            `json:"total"`
-	Limit    int            `json:"limit"`
-	Offset   int            `json:"offset"`
-	HasMore  bool           `json:"hasMore"`
+	Activities   []CaseActivity `json:"activities"`
+	TotalRecords int            `json:"totalRecords"`
+	Limit        int            `json:"limit"`
+	Offset       int            `json:"offset"`
+	HasMore      bool           `json:"hasMore"`
 }
 
 // MapSearchCaseActivities builds the portal response from entity-service's SearchCaseActivitiesResponse.
@@ -602,24 +778,27 @@ func MapSearchCaseActivities(r entity.SearchCaseActivitiesResponse) SearchCaseAc
 		}
 
 		items = append(items, CaseActivity{
-			ID:          a.ID,
-			Type:        string(a.Type),
-			Content:     a.Content,
-			CreatedOn:   a.CreatedOn,
-			CreatedBy:   a.CreatedByFullName,
-			CommentType: commentType,
-			FileName:    a.FileName,
-			ContentType: a.ContentType,
-			SizeBytes:   a.SizeBytes,
-			DownloadURL: a.DownloadURL,
-			Changes:     changes,
+			ID:                 a.ID,
+			Type:               string(a.Type),
+			Content:            a.Content,
+			CreatedOn:          a.CreatedOn,
+			CreatedBy:          a.CreatedByFullName,
+			CreatedByFirstName: a.CreatedByFirstName,
+			CreatedByLastName:  a.CreatedByLastName,
+			CreatedByFullName:  a.CreatedByFullName,
+			CommentType:        commentType,
+			FileName:           a.FileName,
+			ContentType:        a.ContentType,
+			SizeBytes:          a.SizeBytes,
+			DownloadURL:        a.DownloadURL,
+			Changes:            changes,
 		})
 	}
 	return SearchCaseActivitiesResponse{
-		Activity: items,
-		Total:    r.Total,
-		Limit:    r.Limit,
-		Offset:   r.Offset,
-		HasMore:  r.HasMore,
+		Activities:   items,
+		TotalRecords: r.Total,
+		Limit:        r.Limit,
+		Offset:       r.Offset,
+		HasMore:      r.HasMore,
 	}
 }

--- a/apps/customer-portal/backend-v2/internal/dto/case_time_cards.go
+++ b/apps/customer-portal/backend-v2/internal/dto/case_time_cards.go
@@ -71,10 +71,15 @@ type CaseTimeCard struct {
 }
 
 // CaseTimeCardSearchResponse is the portal's response for
-// POST /projects/{id}/cases/time-cards/search.
+// POST /projects/{id}/cases/time-cards/search. TotalRecords (not Total) to
+// match the frontend's shared PaginationResponse envelope —
+// useSearchProjectCaseTimeCards.ts's getNextPageParam and
+// fetchAllCaseTimeCards.ts's export pagination both read totalRecords, so a
+// mismatch here stalls "load more" and truncates CSV/PDF exports to the
+// first page.
 type CaseTimeCardSearchResponse struct {
 	CaseTimeCards []CaseTimeCard `json:"caseTimeCards"`
-	Total         int            `json:"total"`
+	TotalRecords  int            `json:"totalRecords"`
 	Offset        int            `json:"offset"`
 	Limit         int            `json:"limit"`
 }
@@ -103,7 +108,7 @@ func MapCaseTimeCardSearchResponse(r entity.SearchCaseTimeCardsResponse) CaseTim
 	}
 	return CaseTimeCardSearchResponse{
 		CaseTimeCards: items,
-		Total:         r.Total,
+		TotalRecords:  r.Total,
 		Offset:        r.Offset,
 		Limit:         r.Limit,
 	}

--- a/apps/customer-portal/backend-v2/internal/dto/catalog.go
+++ b/apps/customer-portal/backend-v2/internal/dto/catalog.go
@@ -18,25 +18,34 @@ package dto
 
 import "github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
 
-// CatalogItem is a single selectable item within a service catalog.
+// CatalogItem is a single selectable item within a service catalog — Label
+// (not Name) to match the frontend's own CatalogItem type
+// (apps/customer-portal/webapp/src/features/operations/types/
+// serviceRequests.ts: CatalogItem = MetadataItem = {id, label}). Note the
+// catalog container itself (Catalog.Name below) keeps Name — only items
+// need Label.
 type CatalogItem struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
+	ID    string `json:"id"`
+	Label string `json:"label"`
 }
 
-// Catalog is one item of the portal's response for POST /catalogs/search.
+// Catalog is one item of the portal's response for
+// POST /deployments/products/{deployedProductId}/catalogs/search.
 type Catalog struct {
 	ID           string        `json:"id"`
 	Name         string        `json:"name"`
 	CatalogItems []CatalogItem `json:"catalogItems"`
 }
 
-// SearchCatalogsResponse is the portal's response for POST /catalogs/search.
+// SearchCatalogsResponse is the portal's response for
+// POST /deployments/products/{deployedProductId}/catalogs/search.
+// TotalRecords (not Total) to match the frontend's shared pagination
+// envelope.
 type SearchCatalogsResponse struct {
-	Catalogs []Catalog `json:"catalogs"`
-	Total    int       `json:"total"`
-	Limit    int       `json:"limit"`
-	Offset   int       `json:"offset"`
+	Catalogs     []Catalog `json:"catalogs"`
+	TotalRecords int       `json:"totalRecords"`
+	Limit        int       `json:"limit"`
+	Offset       int       `json:"offset"`
 }
 
 // MapSearchCatalogs builds the portal response from entity-service's SearchCatalogsResponse.
@@ -45,7 +54,7 @@ func MapSearchCatalogs(r entity.SearchCatalogsResponse) SearchCatalogsResponse {
 	for _, c := range r.Catalogs {
 		items := make([]CatalogItem, 0, len(c.CatalogItems))
 		for _, item := range c.CatalogItems {
-			items = append(items, CatalogItem{ID: item.ID, Name: item.Name})
+			items = append(items, CatalogItem{ID: item.ID, Label: item.Name})
 		}
 		catalogs = append(catalogs, Catalog{
 			ID:           c.ID,
@@ -54,10 +63,27 @@ func MapSearchCatalogs(r entity.SearchCatalogsResponse) SearchCatalogsResponse {
 		})
 	}
 	return SearchCatalogsResponse{
-		Catalogs: catalogs,
-		Total:    r.Total,
-		Limit:    r.Limit,
-		Offset:   r.Offset,
+		Catalogs:     catalogs,
+		TotalRecords: r.Total,
+		Limit:        r.Limit,
+		Offset:       r.Offset,
+	}
+}
+
+// SearchCatalogsRequest is the portal's request body for
+// POST /deployments/products/{deployedProductId}/catalogs/search.
+type SearchCatalogsRequest struct {
+	Pagination entity.Pagination `json:"pagination"`
+}
+
+// BuildEntitySearchCatalogsRequest translates the portal's search request
+// into entity-service's request shape, always scoping to the deployed
+// product in the URL — never a client-settable body field (same reasoning
+// as BuildEntitySearchCasesRequest's projectID parameter).
+func BuildEntitySearchCatalogsRequest(deployedProductID string, req SearchCatalogsRequest) entity.SearchCatalogsRequest {
+	return entity.SearchCatalogsRequest{
+		DeployedProductID: deployedProductID,
+		Pagination:        req.Pagination,
 	}
 }
 

--- a/apps/customer-portal/backend-v2/internal/dto/change_request.go
+++ b/apps/customer-portal/backend-v2/internal/dto/change_request.go
@@ -92,56 +92,71 @@ func MapChangeRequestCreate(r entity.CreateChangeRequestResponse) ChangeRequestC
 }
 
 // ChangeRequestSummary is one item of the portal's response for
-// POST /change-requests/search.
+// POST /projects/{id}/change-requests/search — shaped to match the
+// frontend's own ChangeRequestItem type
+// (apps/customer-portal/webapp/src/features/operations/types/
+// changeRequests.ts) field-for-field: Title (not Subject), StartDate/
+// EndDate (not PlannedStartOn/PlannedEndOn), every reference field as
+// IDLabelRef (not Ref), and Impact/State/Type as IDLabelRef too — see
+// change_request_enum_mapping.go for the translation. InternalID and
+// HasServiceOutage are in the frontend's type but have no entity-service
+// equivalent at all (entity.SearchChangeRequestView carries neither) — not
+// fixable in this DTO layer alone.
 type ChangeRequestSummary struct {
-	ID               string  `json:"id"`
-	Number           string  `json:"number"`
-	Subject          *string `json:"subject,omitempty"`
-	Description      *string `json:"description,omitempty"`
-	Project          Ref     `json:"project"`
-	Case             *Ref    `json:"case,omitempty"`
-	Deployment       *Ref    `json:"deployment,omitempty"`
-	DeployedProduct  *Ref    `json:"deployedProduct,omitempty"`
-	Product          *Ref    `json:"product,omitempty"`
-	AssignedEngineer *Ref    `json:"assignedEngineer,omitempty"`
-	AssignedTeam     *Ref    `json:"assignedTeam,omitempty"`
-	PlannedStartOn   *string `json:"plannedStartOn,omitempty"`
-	PlannedEndOn     *string `json:"plannedEndOn,omitempty"`
-	Duration         *string `json:"duration,omitempty"`
-	Impact           *string `json:"impact,omitempty"`
-	State            *string `json:"state,omitempty"`
-	Type             *string `json:"type,omitempty"`
-	CreatedOn        string  `json:"createdOn"`
-	UpdatedOn        string  `json:"updatedOn"`
+	ID               string      `json:"id"`
+	Number           string      `json:"number"`
+	Title            string      `json:"title"`
+	Description      *string     `json:"description,omitempty"`
+	Project          IDLabelRef  `json:"project"`
+	Case             *IDLabelRef `json:"case,omitempty"`
+	Deployment       *IDLabelRef `json:"deployment,omitempty"`
+	DeployedProduct  *IDLabelRef `json:"deployedProduct,omitempty"`
+	Product          *IDLabelRef `json:"product,omitempty"`
+	AssignedEngineer *IDLabelRef `json:"assignedEngineer,omitempty"`
+	AssignedTeam     *IDLabelRef `json:"assignedTeam,omitempty"`
+	StartDate        *string     `json:"startDate,omitempty"`
+	EndDate          *string     `json:"endDate,omitempty"`
+	Duration         *string     `json:"duration,omitempty"`
+	Impact           *IDLabelRef `json:"impact,omitempty"`
+	State            *IDLabelRef `json:"state,omitempty"`
+	Type             *IDLabelRef `json:"type,omitempty"`
+	CreatedOn        string      `json:"createdOn"`
+	UpdatedOn        string      `json:"updatedOn"`
 }
 
-// SearchChangeRequestsResponse is the portal's response for POST /change-requests/search.
+// SearchChangeRequestsResponse is the portal's response for
+// POST /projects/{id}/change-requests/search. TotalRecords (not Total) to
+// match the frontend's shared pagination envelope.
 type SearchChangeRequestsResponse struct {
 	ChangeRequests []ChangeRequestSummary `json:"changeRequests"`
-	Total          int                    `json:"total"`
+	TotalRecords   int                    `json:"totalRecords"`
 	Offset         int                    `json:"offset"`
 	Limit          int                    `json:"limit"`
 }
 
 func mapChangeRequestSummary(v entity.SearchChangeRequestView) ChangeRequestSummary {
+	var title string
+	if v.Subject != nil {
+		title = *v.Subject
+	}
 	return ChangeRequestSummary{
 		ID:               v.ID,
 		Number:           v.Number,
-		Subject:          v.Subject,
+		Title:            title,
 		Description:      v.Description,
-		Project:          Ref{ID: v.Project.ID, Name: v.Project.Name},
-		Case:             mapRef(v.Case),
-		Deployment:       mapRef(v.Deployment),
-		DeployedProduct:  mapRef(v.DeployedProduct),
-		Product:          mapRef(v.Product),
-		AssignedEngineer: mapRef(v.AssignedEngineer),
-		AssignedTeam:     mapRef(v.AssignedTeam),
-		PlannedStartOn:   v.PlannedStartOn,
-		PlannedEndOn:     v.PlannedEndOn,
+		Project:          IDLabelRef{ID: v.Project.ID, Label: v.Project.Name},
+		Case:             entityRefToIDLabel(v.Case),
+		Deployment:       entityRefToIDLabel(v.Deployment),
+		DeployedProduct:  entityRefToIDLabel(v.DeployedProduct),
+		Product:          entityRefToIDLabel(v.Product),
+		AssignedEngineer: entityRefToIDLabel(v.AssignedEngineer),
+		AssignedTeam:     entityRefToIDLabel(v.AssignedTeam),
+		StartDate:        v.PlannedStartOn,
+		EndDate:          v.PlannedEndOn,
 		Duration:         v.Duration,
-		Impact:           v.Impact,
-		State:            v.State,
-		Type:             v.Type,
+		Impact:           crImpactRef(v.Impact),
+		State:            crStateRef(v.State),
+		Type:             crTypeRef(v.Type),
 		CreatedOn:        v.CreatedOn,
 		UpdatedOn:        v.UpdatedOn,
 	}
@@ -155,9 +170,53 @@ func MapSearchChangeRequests(r entity.SearchChangeRequestsResponse) SearchChange
 	}
 	return SearchChangeRequestsResponse{
 		ChangeRequests: items,
-		Total:          r.Total,
+		TotalRecords:   r.Total,
 		Offset:         r.Offset,
 		Limit:          r.Limit,
+	}
+}
+
+// ChangeRequestSearchFilters holds the optional filter criteria for
+// POST /projects/{id}/change-requests/search — shaped to match the
+// frontend's own ChangeRequestSearchFilters type. StateKeys/ImpactKeys
+// carry ServiceNow's numeric choice-list ids (the frontend was built
+// against the old Ballerina backend and still sends these, not
+// entity-service's own string enum) — see change_request_enum_mapping.go
+// for the translation. No ProjectIDs field: project scoping comes
+// exclusively from the {id} path parameter, same reasoning as
+// dto.CaseSearchFilters.
+type ChangeRequestSearchFilters struct {
+	SearchQuery     string  `json:"searchQuery,omitempty"`
+	StateKeys       []int   `json:"stateKeys,omitempty"`
+	ImpactKeys      []int   `json:"impactKeys,omitempty"`
+	ClosedStartDate *string `json:"closedStartDate,omitempty"`
+	ClosedEndDate   *string `json:"closedEndDate,omitempty"`
+}
+
+// ChangeRequestSearchRequest is the portal's request body for
+// POST /projects/{id}/change-requests/search.
+type ChangeRequestSearchRequest struct {
+	Filters    ChangeRequestSearchFilters `json:"filters"`
+	SortBy     entity.ChangeRequestSort   `json:"sortBy"`
+	Pagination entity.Pagination          `json:"pagination"`
+}
+
+// BuildEntitySearchChangeRequestsRequest translates the portal's request
+// into entity-service's SearchChangeRequestsRequest. projectID (the {id}
+// path parameter) always populates Filters.ProjectIDs — never the request
+// body, which the frontend never sends one in.
+func BuildEntitySearchChangeRequestsRequest(projectID string, req ChangeRequestSearchRequest) entity.SearchChangeRequestsRequest {
+	return entity.SearchChangeRequestsRequest{
+		Filters: entity.SearchChangeRequestsFilters{
+			ProjectIDs:      []string{projectID},
+			SearchQuery:     req.Filters.SearchQuery,
+			States:          crIDsToEnums(req.Filters.StateKeys, crStateIDToEnum),
+			Impacts:         crIDsToEnums(req.Filters.ImpactKeys, crImpactIDToEnum),
+			ClosedStartDate: req.Filters.ClosedStartDate,
+			ClosedEndDate:   req.Filters.ClosedEndDate,
+		},
+		SortBy:     req.SortBy,
+		Pagination: req.Pagination,
 	}
 }
 
@@ -165,18 +224,18 @@ func MapSearchChangeRequests(r entity.SearchChangeRequestsResponse) SearchChange
 // and PATCH /change-requests/{id}.
 type ChangeRequestDetails struct {
 	ChangeRequestSummary
-	CreatedBy           string   `json:"createdBy"`
-	Justification       *string  `json:"justification,omitempty"`
-	ImpactDescription   *string  `json:"impactDescription,omitempty"`
-	ServiceOutage       *string  `json:"serviceOutage,omitempty"`
-	CommunicationPlan   *string  `json:"communicationPlan,omitempty"`
-	RollbackPlan        *string  `json:"rollbackPlan,omitempty"`
-	TestPlan            *string  `json:"testPlan,omitempty"`
-	HasCustomerApproved bool     `json:"hasCustomerApproved"`
-	HasCustomerReviewed bool     `json:"hasCustomerReviewed"`
-	ApprovedBy          *Ref     `json:"approvedBy,omitempty"`
-	ApprovedOn          *string  `json:"approvedOn,omitempty"`
-	LegalNextStates     []string `json:"legalNextStates,omitempty"`
+	CreatedBy           string      `json:"createdBy"`
+	Justification       *string     `json:"justification,omitempty"`
+	ImpactDescription   *string     `json:"impactDescription,omitempty"`
+	ServiceOutage       *string     `json:"serviceOutage,omitempty"`
+	CommunicationPlan   *string     `json:"communicationPlan,omitempty"`
+	RollbackPlan        *string     `json:"rollbackPlan,omitempty"`
+	TestPlan            *string     `json:"testPlan,omitempty"`
+	HasCustomerApproved bool        `json:"hasCustomerApproved"`
+	HasCustomerReviewed bool        `json:"hasCustomerReviewed"`
+	ApprovedBy          *IDLabelRef `json:"approvedBy,omitempty"`
+	ApprovedOn          *string     `json:"approvedOn,omitempty"`
+	LegalNextStates     []string    `json:"legalNextStates,omitempty"`
 }
 
 // MapChangeRequestDetails builds the portal response from entity-service's ChangeRequest.
@@ -192,7 +251,7 @@ func MapChangeRequestDetails(r entity.ChangeRequest) ChangeRequestDetails {
 		TestPlan:             r.TestPlan,
 		HasCustomerApproved:  r.HasCustomerApproved,
 		HasCustomerReviewed:  r.HasCustomerReviewed,
-		ApprovedBy:           mapRef(r.ApprovedBy),
+		ApprovedBy:           entityRefToIDLabel(r.ApprovedBy),
 		ApprovedOn:           r.ApprovedOn,
 		LegalNextStates:      r.LegalNextStates,
 	}

--- a/apps/customer-portal/backend-v2/internal/dto/change_request_enum_mapping.go
+++ b/apps/customer-portal/backend-v2/internal/dto/change_request_enum_mapping.go
@@ -1,0 +1,123 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dto
+
+import "strconv"
+
+// crStateIDs mirrors entity-service's private snCRStateIDMap
+// (internal/service/sn_change_request_service.go) — ServiceNow's own
+// numeric choice-list key for each change-request state. Unlike case
+// search, entity-service's change-request search response already
+// normalizes State/Impact to these exact domain enum strings (see
+// snCRStateLabelToString/snCRImpactLabelToString), so no label-word-parsing
+// is needed here — just a direct enum lookup, both directions.
+var crStateIDs = map[string]string{
+	"customer_approval": "5",
+	"scheduled":         "-2",
+	"implement":         "-1",
+	"review":            "0",
+	"customer_review":   "1",
+	"rollback":          "2",
+	"closed":            "3",
+	"canceled":          "4",
+}
+
+// crImpactIDs mirrors entity-service's private snCRImpactIDMap.
+var crImpactIDs = map[string]string{
+	"high":   "1",
+	"medium": "2",
+	"low":    "3",
+}
+
+var (
+	crStateIDToEnum  = reverseStringMap(crStateIDs)
+	crImpactIDToEnum = reverseStringMap(crImpactIDs)
+)
+
+// crStateLabels/crImpactLabels supply portal-facing display text for these
+// enum values — entity-service's change-request search response carries the
+// domain enum string only (not ServiceNow's own display label, unlike case
+// search's SN-backed path), so this is this backend's own presentation
+// text, not a mirror of anything entity-service or ServiceNow provides.
+var crStateLabels = map[string]string{
+	"customer_approval": "Customer Approval",
+	"scheduled":         "Scheduled",
+	"implement":         "Implement",
+	"review":            "Review",
+	"customer_review":   "Customer Review",
+	"rollback":          "Rollback",
+	"closed":            "Closed",
+	"canceled":          "Canceled",
+}
+
+var crImpactLabels = map[string]string{
+	"high":   "High",
+	"medium": "Medium",
+	"low":    "Low",
+}
+
+// crIDsToEnums converts the frontend's numeric filter ids (stateKeys,
+// impactKeys) to entity-service's own enum vocabulary, silently skipping
+// any id with no known mapping.
+func crIDsToEnums(ids []int, idToEnum map[string]string) []string {
+	out := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if enum, ok := idToEnum[strconv.Itoa(id)]; ok {
+			out = append(out, enum)
+		}
+	}
+	return out
+}
+
+// crStateRef builds the {id, label} the frontend's ChangeRequestSummary.state
+// expects from entity-service's already-normalized State enum string.
+func crStateRef(state *string) *IDLabelRef {
+	if state == nil || *state == "" {
+		return nil
+	}
+	label := crStateLabels[*state]
+	if label == "" {
+		label = *state
+	}
+	return &IDLabelRef{ID: crStateIDs[*state], Label: label}
+}
+
+// crImpactRef mirrors crStateRef for impact.
+func crImpactRef(impact *string) *IDLabelRef {
+	if impact == nil || *impact == "" {
+		return nil
+	}
+	label := crImpactLabels[*impact]
+	if label == "" {
+		label = *impact
+	}
+	return &IDLabelRef{ID: crImpactIDs[*impact], Label: label}
+}
+
+// crTypeRef builds a label-only {label} ref (no id) for entity-service's
+// Type field: unlike State/Impact, entity-service's change-request search
+// response passes ServiceNow's raw type label straight through unnormalized
+// (see snCRTypeLabelToString), and there's no label-parsing table available
+// to resolve it back to a numeric id the way case search's fuzzy word-match
+// does for severity — a label-only ref still renders correctly, just
+// without an id a caller could round-trip into a filter.
+func crTypeRef(t *string) *IDLabelRef {
+	if t == nil || *t == "" {
+		return nil
+	}
+	return &IDLabelRef{Label: *t}
+}

--- a/apps/customer-portal/backend-v2/internal/dto/comment.go
+++ b/apps/customer-portal/backend-v2/internal/dto/comment.go
@@ -83,21 +83,33 @@ func BuildEntitySearchCommentsRequest(req CommentSearchRequest) entity.SearchCom
 	}
 }
 
-// CommentView is one item of the portal's response for POST /comments/search.
+// CommentView is one item of the portal's response for POST /comments/search
+// (also shared by GET /conversations/{id}/messages, which decodes the same
+// shape as its ConversationMessage type). Type and CreatedByFirstName/
+// CreatedByLastName are read by the chat-history view to distinguish the
+// AI's replies from the customer's own messages and to build a display
+// name — see apps/customer-portal/webapp/src/features/support/pages/
+// ConversationDetailsPage.tsx.
 type CommentView struct {
-	ID        string    `json:"id"`
-	Content   string    `json:"content"`
-	CreatedOn time.Time `json:"createdOn"`
-	CreatedBy string    `json:"createdBy"`
+	ID                 string    `json:"id"`
+	Content            string    `json:"content"`
+	Type               string    `json:"type,omitempty"`
+	CreatedOn          time.Time `json:"createdOn"`
+	CreatedBy          string    `json:"createdBy"`
+	CreatedByFirstName string    `json:"createdByFirstName,omitempty"`
+	CreatedByLastName  string    `json:"createdByLastName,omitempty"`
 }
 
-// SearchCommentsResponse is the portal's response for POST /comments/search.
+// SearchCommentsResponse is the portal's response for POST /comments/search
+// and GET /conversations/{id}/messages. TotalRecords (not Total) to match
+// the frontend's shared pagination envelope — useGetConversationMessages.ts's
+// getNextPageParam reads totalRecords to decide whether more pages remain.
 type SearchCommentsResponse struct {
-	Comments []CommentView `json:"comments"`
-	Total    int           `json:"total"`
-	Limit    int           `json:"limit"`
-	Offset   int           `json:"offset"`
-	HasMore  bool          `json:"hasMore"`
+	Comments     []CommentView `json:"comments"`
+	TotalRecords int           `json:"totalRecords"`
+	Limit        int           `json:"limit"`
+	Offset       int           `json:"offset"`
+	HasMore      bool          `json:"hasMore"`
 }
 
 // MapSearchComments builds the portal response from entity-service's SearchCommentsResponse.
@@ -105,17 +117,20 @@ func MapSearchComments(r entity.SearchCommentsResponse) SearchCommentsResponse {
 	comments := make([]CommentView, 0, len(r.Comments))
 	for _, c := range r.Comments {
 		comments = append(comments, CommentView{
-			ID:        c.ID,
-			Content:   c.Content,
-			CreatedOn: c.CreatedOn,
-			CreatedBy: c.CreatedBy.FullName,
+			ID:                 c.ID,
+			Content:            c.Content,
+			Type:               string(c.Type),
+			CreatedOn:          c.CreatedOn,
+			CreatedBy:          c.CreatedBy.FullName,
+			CreatedByFirstName: c.CreatedBy.FirstName,
+			CreatedByLastName:  c.CreatedBy.LastName,
 		})
 	}
 	return SearchCommentsResponse{
-		Comments: comments,
-		Total:    r.Total,
-		Limit:    r.Limit,
-		Offset:   r.Offset,
-		HasMore:  r.HasMore,
+		Comments:     comments,
+		TotalRecords: r.Total,
+		Limit:        r.Limit,
+		Offset:       r.Offset,
+		HasMore:      r.HasMore,
 	}
 }

--- a/apps/customer-portal/backend-v2/internal/dto/conversation_enum_mapping.go
+++ b/apps/customer-portal/backend-v2/internal/dto/conversation_enum_mapping.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dto
+
+import "strconv"
+
+// conversationStateIDs mirrors entity-service's private
+// snConversationStateKeyMap (internal/service/sn_conversation_service.go) —
+// ServiceNow's own numeric choice-list key for each conversation state.
+// entity-service's search response already normalizes State to these exact
+// domain enum strings (see snConversationStateLabelMap), so no
+// label-word-parsing is needed, just a direct enum lookup both directions.
+var conversationStateIDs = map[string]string{
+	"ACTIVE":    "2",
+	"RESOLVED":  "3",
+	"CONVERTED": "4",
+	"ABANDONED": "5",
+	"CLOSED":    "6",
+}
+
+var conversationStateIDToEnum = reverseStringMap(conversationStateIDs)
+
+// conversationStateLabels supplies portal-facing display text for these enum
+// values — entity-service's response carries the domain enum string only,
+// not a ServiceNow display label, so this is this backend's own
+// presentation text.
+var conversationStateLabels = map[string]string{
+	"ACTIVE":    "Active",
+	"RESOLVED":  "Resolved",
+	"CONVERTED": "Converted",
+	"ABANDONED": "Abandoned",
+	"CLOSED":    "Closed",
+}
+
+// conversationStateRef builds the {id, label} the frontend's
+// Conversation.state expects from entity-service's already-normalized State
+// enum string.
+func conversationStateRef(state *string) *IDLabelRef {
+	if state == nil || *state == "" {
+		return nil
+	}
+	label := conversationStateLabels[*state]
+	if label == "" {
+		label = *state
+	}
+	return &IDLabelRef{ID: conversationStateIDs[*state], Label: label}
+}
+
+// conversationIDsToEnums converts the frontend's numeric stateKeys filter to
+// entity-service's own enum vocabulary, silently skipping any id with no
+// known mapping.
+func conversationIDsToEnums(ids []int) []string {
+	out := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if enum, ok := conversationStateIDToEnum[strconv.Itoa(id)]; ok {
+			out = append(out, enum)
+		}
+	}
+	return out
+}

--- a/apps/customer-portal/backend-v2/internal/dto/deployed_product.go
+++ b/apps/customer-portal/backend-v2/internal/dto/deployed_product.go
@@ -17,37 +17,53 @@
 package dto
 
 import (
+	"encoding/json"
+	"strconv"
 	"time"
 
 	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
 )
 
-// DeployedProductVersion is the version reference embedded in a deployed product.
+// DeployedProductVersion is the version reference embedded in a deployed
+// product — Label (not Name), ReleasedOn/EndOfLifeOn (not ReleasedDate/
+// SupportEoLDate) to match the frontend's IdLabelRef shape
+// (apps/customer-portal/webapp/src/types/common.ts), read directly off this
+// field by DeploymentProductList.tsx.
 type DeployedProductVersion struct {
-	ID             string     `json:"id"`
-	Name           string     `json:"name"`
-	ReleasedDate   *time.Time `json:"releasedDate,omitempty"`
-	SupportEoLDate *time.Time `json:"supportEoLDate,omitempty"`
+	ID          string     `json:"id"`
+	Label       string     `json:"label"`
+	ReleasedOn  *time.Time `json:"releasedOn,omitempty"`
+	EndOfLifeOn *time.Time `json:"endOfLifeOn,omitempty"`
 }
 
 // DeployedProductSummary is one item of the portal's response for
-// POST /deployed-products/search.
+// POST /deployments/{deploymentId}/products/search — Deployment/Product as
+// IDLabelRef (not Ref) and Cores/TPS as numbers (not strings) to match the
+// frontend's own DeploymentProductItem type
+// (apps/customer-portal/webapp/src/features/project-details/types/deployments.ts:
+// cores?: number | null; tps?: number | null;). entity-service's own wire
+// format sends Cores/TPS as ServiceNow strings (see DeployedProductView's
+// doc comment in entity-service/internal/domain/entity.go) — parsed here
+// rather than passed through, since the frontend's contract is this
+// backend's to define, not entity-service's ServiceNow quirk to propagate.
 type DeployedProductSummary struct {
 	ID         string                  `json:"id"`
-	Deployment Ref                     `json:"deployment"`
-	Product    Ref                     `json:"product"`
+	Deployment *IDLabelRef             `json:"deployment,omitempty"`
+	Product    *IDLabelRef             `json:"product,omitempty"`
 	Version    *DeployedProductVersion `json:"version,omitempty"`
-	Cores      *string                 `json:"cores,omitempty"`
-	TPS        *string                 `json:"tps,omitempty"`
+	Cores      *int                    `json:"cores,omitempty"`
+	TPS        *float64                `json:"tps,omitempty"`
 	Category   *string                 `json:"category,omitempty"`
 	CreatedOn  time.Time               `json:"createdOn"`
 	UpdatedOn  time.Time               `json:"updatedOn"`
 }
 
-// SearchDeployedProductsResponse is the portal's response for POST /deployed-products/search.
+// SearchDeployedProductsResponse is the portal's response for
+// POST /deployments/{deploymentId}/products/search. TotalRecords (not
+// Total) to match the frontend's shared pagination envelope.
 type SearchDeployedProductsResponse struct {
 	DeployedProducts []DeployedProductSummary `json:"deployedProducts"`
-	Total            int                      `json:"total"`
+	TotalRecords     int                      `json:"totalRecords"`
 	Limit            int                      `json:"limit"`
 	Offset           int                      `json:"offset"`
 	HasMore          bool                     `json:"hasMore"`
@@ -58,11 +74,38 @@ func mapDeployedProductVersion(v *entity.DeployedProductVersionRef) *DeployedPro
 		return nil
 	}
 	return &DeployedProductVersion{
-		ID:             v.ID,
-		Name:           v.Name,
-		ReleasedDate:   v.ReleasedDate,
-		SupportEoLDate: v.SupportEoLDate,
+		ID:          v.ID,
+		Label:       v.Name,
+		ReleasedOn:  v.ReleasedDate,
+		EndOfLifeOn: v.SupportEoLDate,
 	}
+}
+
+// parseCores parses entity-service's ServiceNow-string Cores field into a
+// number; an unparseable or absent value maps to nil rather than 0, so the
+// frontend's `typeof item.cores === "number"` checks correctly treat it as
+// unknown.
+func parseCores(s *string) *int {
+	if s == nil {
+		return nil
+	}
+	n, err := strconv.Atoi(*s)
+	if err != nil {
+		return nil
+	}
+	return &n
+}
+
+// parseTPS parses entity-service's ServiceNow-string TPS field into a number.
+func parseTPS(s *string) *float64 {
+	if s == nil {
+		return nil
+	}
+	n, err := strconv.ParseFloat(*s, 64)
+	if err != nil {
+		return nil
+	}
+	return &n
 }
 
 // MapSearchDeployedProducts builds the portal response from entity-service's SearchDeployedProductsResponse.
@@ -71,11 +114,11 @@ func MapSearchDeployedProducts(r entity.SearchDeployedProductsResponse) SearchDe
 	for _, d := range r.DeployedProducts {
 		items = append(items, DeployedProductSummary{
 			ID:         d.ID,
-			Deployment: Ref{ID: d.Deployment.ID, Name: d.Deployment.Name},
-			Product:    Ref{ID: d.Product.ID, Name: d.Product.Name},
+			Deployment: entityRefToIDLabel(&d.Deployment),
+			Product:    entityRefToIDLabel(&d.Product),
 			Version:    mapDeployedProductVersion(d.Version),
-			Cores:      d.Cores,
-			TPS:        d.TPS,
+			Cores:      parseCores(d.Cores),
+			TPS:        parseTPS(d.TPS),
 			Category:   d.Category,
 			CreatedOn:  d.CreatedOn,
 			UpdatedOn:  d.UpdatedOn,
@@ -83,14 +126,59 @@ func MapSearchDeployedProducts(r entity.SearchDeployedProductsResponse) SearchDe
 	}
 	return SearchDeployedProductsResponse{
 		DeployedProducts: items,
-		Total:            r.Total,
+		TotalRecords:     r.Total,
 		Limit:            r.Limit,
 		Offset:           r.Offset,
 		HasMore:          r.HasMore,
 	}
 }
 
-// DeployedProductCreateResponse is the portal's response for POST /deployed-products.
+// DeployedProductSearchRequest is the portal's request body for
+// POST /deployments/{deploymentId}/products/search.
+type DeployedProductSearchRequest struct {
+	Pagination entity.Pagination `json:"pagination"`
+}
+
+// BuildEntitySearchDeployedProductsRequest translates the portal's search
+// request into entity-service's request shape, always scoping to the
+// deployment in the URL — never a client-settable body field (same
+// reasoning as BuildEntitySearchCasesRequest's projectID parameter).
+func BuildEntitySearchDeployedProductsRequest(deploymentID string, req DeployedProductSearchRequest) entity.SearchDeployedProductsRequest {
+	return entity.SearchDeployedProductsRequest{
+		Pagination:    req.Pagination,
+		DeploymentIDs: []string{deploymentID},
+	}
+}
+
+// DeployedProductCreateRequest is the portal's request body for
+// POST /deployments/{deploymentId}/products, matching the frontend's
+// PostDeploymentProductRequest type.
+type DeployedProductCreateRequest struct {
+	ProductID   string   `json:"productId"`
+	VersionID   string   `json:"versionId"`
+	ProjectID   string   `json:"projectId"`
+	Cores       *int     `json:"cores,omitempty"`
+	TPS         *float64 `json:"tps,omitempty"`
+	Description *string  `json:"description,omitempty"`
+}
+
+// BuildEntityCreateDeployedProductRequest translates the portal's create
+// request into entity-service's request shape, forcing DeploymentID from
+// the path.
+func BuildEntityCreateDeployedProductRequest(deploymentID string, req DeployedProductCreateRequest) entity.CreateDeployedProductRequest {
+	return entity.CreateDeployedProductRequest{
+		ProjectID:    req.ProjectID,
+		DeploymentID: deploymentID,
+		ProductID:    req.ProductID,
+		VersionID:    req.VersionID,
+		Cores:        req.Cores,
+		TPS:          req.TPS,
+		Description:  req.Description,
+	}
+}
+
+// DeployedProductCreateResponse is the portal's response for
+// POST /deployments/{deploymentId}/products.
 type DeployedProductCreateResponse struct {
 	ID        string    `json:"id"`
 	CreatedOn time.Time `json:"createdOn"`
@@ -104,9 +192,45 @@ func MapDeployedProductCreate(r entity.CreateDeployedProductResponse) DeployedPr
 	}
 }
 
-// DeployedProductUpdateResponse is the portal's response for PATCH /deployed-products/{id}.
-// Deliberately excludes entity-service's UpdatedBy (internal actor identity),
-// consistent with the other update responses in this package.
+// DeployedProductUpdateRequest is the portal's request body for
+// PATCH /deployments/{deploymentId}/products/{id}, matching the frontend's
+// PatchDeploymentProductRequest type. Updates (a ProductUpdate[] list) is
+// not exposed here — entity-service's UpdateDeployedProductRequest has no
+// equivalent field, a genuine gap, not fixable in this dto layer alone.
+type DeployedProductUpdateRequest struct {
+	Cores       *int     `json:"cores,omitempty"`
+	TPS         *float64 `json:"tps,omitempty"`
+	Description *string  `json:"description,omitempty"`
+	Active      *bool    `json:"active,omitempty"`
+}
+
+// BuildEntityUpdateDeployedProductRequest translates the portal's update
+// request into entity-service's request shape, forcing DeploymentID from
+// the path — entity-service documents this field as an IDOR-style scope
+// guard ("the deployed product must belong to this deployment"), which the
+// frontend's own request body never carries, so the path is the only
+// reliable source (see PatchDeployment's doc comment on entityDeployment
+// Client for the same reasoning).
+func BuildEntityUpdateDeployedProductRequest(id, deploymentID string, req DeployedProductUpdateRequest) entity.UpdateDeployedProductRequest {
+	out := entity.UpdateDeployedProductRequest{
+		ID:           id,
+		DeploymentID: &deploymentID,
+		Cores:        req.Cores,
+		TPS:          req.TPS,
+		Active:       req.Active,
+	}
+	if req.Description != nil {
+		if raw, err := json.Marshal(*req.Description); err == nil {
+			out.Description = raw
+		}
+	}
+	return out
+}
+
+// DeployedProductUpdateResponse is the portal's response for
+// PATCH /deployments/{deploymentId}/products/{id}. Deliberately excludes
+// entity-service's UpdatedBy (internal actor identity), consistent with the
+// other update responses in this package.
 type DeployedProductUpdateResponse struct {
 	ID        string    `json:"id"`
 	UpdatedOn time.Time `json:"updatedOn"`

--- a/apps/customer-portal/backend-v2/internal/dto/deployment.go
+++ b/apps/customer-portal/backend-v2/internal/dto/deployment.go
@@ -17,33 +17,37 @@
 package dto
 
 import (
+	"encoding/json"
 	"time"
 
 	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
 )
 
 // DeploymentSummary is one item of the portal's response for
-// POST /projects/{id}/deployments/search.
+// POST /projects/{id}/deployments/search — Type and Project as IDLabelRef
+// to match the frontend's own ProjectDeploymentItem type
+// (apps/customer-portal/webapp/src/features/project-details/types/deployments.ts).
 type DeploymentSummary struct {
-	ID          string    `json:"id"`
-	Number      string    `json:"number"`
-	Name        string    `json:"name"`
-	Type        string    `json:"type"`
-	Description *string   `json:"description,omitempty"`
-	CreatedBy   *Ref      `json:"createdBy,omitempty"`
-	Project     Ref       `json:"project"`
-	CreatedOn   time.Time `json:"createdOn"`
-	UpdatedOn   time.Time `json:"updatedOn"`
+	ID          string      `json:"id"`
+	Number      string      `json:"number"`
+	Name        string      `json:"name"`
+	Type        *IDLabelRef `json:"type,omitempty"`
+	Description *string     `json:"description,omitempty"`
+	CreatedBy   *Ref        `json:"createdBy,omitempty"`
+	Project     *IDLabelRef `json:"project,omitempty"`
+	CreatedOn   time.Time   `json:"createdOn"`
+	UpdatedOn   time.Time   `json:"updatedOn"`
 }
 
 // SearchDeploymentsResponse is the portal's response for
-// POST /projects/{id}/deployments/search.
+// POST /projects/{id}/deployments/search. TotalRecords (not Total) to match
+// the frontend's shared pagination envelope.
 type SearchDeploymentsResponse struct {
-	Deployments []DeploymentSummary `json:"deployments"`
-	Total       int                 `json:"total"`
-	Limit       int                 `json:"limit"`
-	Offset      int                 `json:"offset"`
-	HasMore     bool                `json:"hasMore"`
+	Deployments  []DeploymentSummary `json:"deployments"`
+	TotalRecords int                 `json:"totalRecords"`
+	Limit        int                 `json:"limit"`
+	Offset       int                 `json:"offset"`
+	HasMore      bool                `json:"hasMore"`
 }
 
 // MapSearchDeployments builds the portal response from entity-service's SearchDeploymentsResponse.
@@ -54,21 +58,74 @@ func MapSearchDeployments(r entity.SearchDeploymentsResponse) SearchDeploymentsR
 			ID:          d.ID,
 			Number:      d.Number,
 			Name:        d.Name,
-			Type:        d.Type,
+			Type:        deploymentTypeRef(d.Type),
 			Description: d.Description,
 			CreatedBy:   mapRef(d.CreatedBy),
-			Project:     Ref{ID: d.Project.ID, Name: d.Project.Name},
+			Project:     entityRefToIDLabel(&d.Project),
 			CreatedOn:   d.CreatedOn,
 			UpdatedOn:   d.UpdatedOn,
 		})
 	}
 	return SearchDeploymentsResponse{
-		Deployments: deployments,
-		Total:       r.Total,
-		Limit:       r.Limit,
-		Offset:      r.Offset,
-		HasMore:     r.HasMore,
+		Deployments:  deployments,
+		TotalRecords: r.Total,
+		Limit:        r.Limit,
+		Offset:       r.Offset,
+		HasMore:      r.HasMore,
 	}
+}
+
+// DeploymentCreateRequest is the portal's request body for
+// POST /projects/{id}/deployments — DeploymentTypeKey is the ServiceNow
+// numeric choice-list key the frontend sends (CreateDeploymentRequest.
+// deploymentTypeKey), translated to entity-service's string enum by
+// BuildEntityCreateDeploymentRequest.
+type DeploymentCreateRequest struct {
+	DeploymentTypeKey int    `json:"deploymentTypeKey"`
+	Description       string `json:"description"`
+	Name              string `json:"name"`
+}
+
+// BuildEntityCreateDeploymentRequest translates the portal's create request
+// into entity-service's request shape, forcing ProjectID from the path.
+func BuildEntityCreateDeploymentRequest(projectID string, req DeploymentCreateRequest) entity.CreateDeploymentRequest {
+	return entity.CreateDeploymentRequest{
+		ProjectID:   projectID,
+		Name:        req.Name,
+		Type:        deploymentTypeIDToEnumPtr(req.DeploymentTypeKey),
+		Description: req.Description,
+	}
+}
+
+// DeploymentUpdateRequest is the portal's request body for
+// PATCH /projects/{id}/deployments/{deploymentId} — TypeKey is the
+// ServiceNow numeric choice-list key the frontend sends
+// (PatchDeploymentRequest.typeKey), translated to entity-service's string
+// enum by BuildEntityUpdateDeploymentRequest.
+type DeploymentUpdateRequest struct {
+	Active      *bool   `json:"active,omitempty"`
+	Description *string `json:"description,omitempty"`
+	Name        *string `json:"name,omitempty"`
+	TypeKey     *int    `json:"typeKey,omitempty"`
+}
+
+// BuildEntityUpdateDeploymentRequest translates the portal's update request
+// into entity-service's request shape.
+func BuildEntityUpdateDeploymentRequest(id string, req DeploymentUpdateRequest) entity.UpdateDeploymentRequest {
+	out := entity.UpdateDeploymentRequest{
+		ID:     id,
+		Name:   req.Name,
+		Active: req.Active,
+	}
+	if req.TypeKey != nil {
+		out.Type = deploymentTypeIDToEnumPtr(*req.TypeKey)
+	}
+	if req.Description != nil {
+		if raw, err := json.Marshal(*req.Description); err == nil {
+			out.Description = raw
+		}
+	}
+	return out
 }
 
 // DeploymentCreateResponse is the portal's response for POST /deployments.

--- a/apps/customer-portal/backend-v2/internal/dto/deployment.go
+++ b/apps/customer-portal/backend-v2/internal/dto/deployment.go
@@ -101,29 +101,31 @@ func BuildEntityCreateDeploymentRequest(projectID string, req DeploymentCreateRe
 // PATCH /projects/{id}/deployments/{deploymentId} — TypeKey is the
 // ServiceNow numeric choice-list key the frontend sends
 // (PatchDeploymentRequest.typeKey), translated to entity-service's string
-// enum by BuildEntityUpdateDeploymentRequest.
+// enum by BuildEntityUpdateDeploymentRequest. Description is json.RawMessage
+// (not *string) to preserve the three-state absent/null/value semantic
+// entity-service's own UpdateDeploymentRequest.Description expects — a
+// *string can't distinguish an omitted field from an explicit
+// {"description": null}, which would silently drop a customer's attempt to
+// clear the description (see the analogous convention already documented
+// for UpdateDeployedProductRequest.Description in this backend's CLAUDE.md).
 type DeploymentUpdateRequest struct {
-	Active      *bool   `json:"active,omitempty"`
-	Description *string `json:"description,omitempty"`
-	Name        *string `json:"name,omitempty"`
-	TypeKey     *int    `json:"typeKey,omitempty"`
+	Active      *bool           `json:"active,omitempty"`
+	Description json.RawMessage `json:"description,omitempty"`
+	Name        *string         `json:"name,omitempty"`
+	TypeKey     *int            `json:"typeKey,omitempty"`
 }
 
 // BuildEntityUpdateDeploymentRequest translates the portal's update request
 // into entity-service's request shape.
 func BuildEntityUpdateDeploymentRequest(id string, req DeploymentUpdateRequest) entity.UpdateDeploymentRequest {
 	out := entity.UpdateDeploymentRequest{
-		ID:     id,
-		Name:   req.Name,
-		Active: req.Active,
+		ID:          id,
+		Name:        req.Name,
+		Active:      req.Active,
+		Description: req.Description,
 	}
 	if req.TypeKey != nil {
 		out.Type = deploymentTypeIDToEnumPtr(*req.TypeKey)
-	}
-	if req.Description != nil {
-		if raw, err := json.Marshal(*req.Description); err == nil {
-			out.Description = raw
-		}
 	}
 	return out
 }

--- a/apps/customer-portal/backend-v2/internal/dto/deployment_enum_mapping.go
+++ b/apps/customer-portal/backend-v2/internal/dto/deployment_enum_mapping.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dto
+
+import "strconv"
+
+// deploymentTypeIDs mirrors entity-service's private deploymentTypeToKey
+// table (internal/service/sn_deployment_service.go) — the ServiceNow
+// choice-list integer key for each DeploymentType enum value. The frontend
+// was built against the old Ballerina backend, which forwarded this raw
+// numeric key (deploymentTypeKey/typeKey) directly; entity-service's own
+// contract is the plain string enum, so this backend translates both ways,
+// same pattern as case_enum_mapping.go.
+var deploymentTypeIDs = map[string]int{
+	"development":        1,
+	"qa":                 2,
+	"staging":            3,
+	"stress":             4,
+	"uat":                5,
+	"primary_production": 6,
+}
+
+var deploymentTypeIDToEnum = func() map[int]string {
+	m := make(map[int]string, len(deploymentTypeIDs))
+	for enum, id := range deploymentTypeIDs {
+		m[id] = enum
+	}
+	return m
+}()
+
+// deploymentTypeLabels are portal-owned display labels for each deployment
+// type enum value.
+var deploymentTypeLabels = map[string]string{
+	"development":        "Development",
+	"qa":                 "QA",
+	"staging":            "Staging",
+	"stress":             "Stress",
+	"uat":                "UAT",
+	"primary_production": "Primary Production",
+}
+
+// deploymentTypeRef converts entity-service's string enum into an
+// {id, label} pair, id being the ServiceNow numeric key as a string.
+func deploymentTypeRef(enum string) *IDLabelRef {
+	if enum == "" {
+		return nil
+	}
+	label := deploymentTypeLabels[enum]
+	if label == "" {
+		label = enum
+	}
+	id := ""
+	if key, ok := deploymentTypeIDs[enum]; ok {
+		id = strconv.Itoa(key)
+	}
+	return &IDLabelRef{ID: id, Label: label}
+}
+
+// deploymentTypeIDToEnumPtr translates a frontend-supplied numeric
+// deployment-type key into entity-service's string enum, returning nil for
+// an unrecognized id (never forwarded to entity-service as a raw number).
+func deploymentTypeIDToEnumPtr(key int) *string {
+	enum, ok := deploymentTypeIDToEnum[key]
+	if !ok {
+		return nil
+	}
+	return &enum
+}

--- a/apps/customer-portal/backend-v2/internal/dto/instance.go
+++ b/apps/customer-portal/backend-v2/internal/dto/instance.go
@@ -33,14 +33,23 @@ func toOptionalRef(r *entity.ReferenceTableItem) *ReferenceItem {
 	return &ReferenceItem{ID: r.ID, Label: r.Name}
 }
 
+// InstanceSearchDateFilters holds the optional date-range filter nested
+// under InstanceSearchRequest.Filters, matching the frontend's own
+// InstanceSearchFilters type (apps/customer-portal/webapp/src/features/
+// project-details/types/usage.ts: filters?: { startDate?, endDate? }) —
+// the frontend sends these nested, not top-level.
+type InstanceSearchDateFilters struct {
+	StartDate *string `json:"startDate,omitempty"`
+	EndDate   *string `json:"endDate,omitempty"`
+}
+
 // InstanceSearchRequest is the portal's request body for the three
 // instances/search routes. Exactly one path param (project/deployment/
 // deployed-product ID) is injected server-side into the corresponding
 // entity filter field by the calling handler.
 type InstanceSearchRequest struct {
-	StartDate  *string           `json:"startDate,omitempty"`
-	EndDate    *string           `json:"endDate,omitempty"`
-	Pagination entity.Pagination `json:"pagination"`
+	Filters    *InstanceSearchDateFilters `json:"filters,omitempty"`
+	Pagination entity.Pagination          `json:"pagination"`
 }
 
 // InstanceMetadata is the portal's own copy of entity.InstanceMetadata.
@@ -86,12 +95,14 @@ type Instance struct {
 	Metadata        *InstanceMetadata `json:"metadata"`
 }
 
-// InstanceSearchResponse is the portal's response for the three instances/search routes.
+// InstanceSearchResponse is the portal's response for the three
+// instances/search routes. TotalRecords (not Total) to match the frontend's
+// shared pagination envelope (InstancesResponse extends PaginationResponse).
 type InstanceSearchResponse struct {
-	Instances []Instance `json:"instances"`
-	Total     int        `json:"total"`
-	Offset    int        `json:"offset"`
-	Limit     int        `json:"limit"`
+	Instances    []Instance `json:"instances"`
+	TotalRecords int        `json:"totalRecords"`
+	Offset       int        `json:"offset"`
+	Limit        int        `json:"limit"`
 }
 
 // MapInstanceSearchResponse builds the portal response from entity-service's
@@ -111,7 +122,7 @@ func MapInstanceSearchResponse(r entity.SearchInstancesResponse) InstanceSearchR
 			Metadata:        toOptionalInstanceMetadata(i.Metadata),
 		})
 	}
-	return InstanceSearchResponse{Instances: items, Total: r.Total, Offset: r.Offset, Limit: r.Limit}
+	return InstanceSearchResponse{Instances: items, TotalRecords: r.Total, Offset: r.Offset, Limit: r.Limit}
 }
 
 // InstanceDateRangeRequest is the portal's request body for the
@@ -269,13 +280,15 @@ type InstanceMetricSummary struct {
 }
 
 // InstanceMetricsStatsResponse is the portal's response for the
-// instances/stats/metrics/search routes.
+// instances/stats/metrics/search routes. TotalRecords (not Total) for
+// consistency with InstanceUsageStatsResponse, which the frontend's own
+// type confirms reads totalRecords.
 type InstanceMetricsStatsResponse struct {
-	Stats     map[string]map[string]int `json:"stats"`
-	Summary   InstanceMetricSummary     `json:"summary"`
-	Total     int                       `json:"total"`
-	StartDate string                    `json:"startDate"`
-	EndDate   string                    `json:"endDate"`
+	Stats        map[string]map[string]int `json:"stats"`
+	Summary      InstanceMetricSummary     `json:"summary"`
+	TotalRecords int                       `json:"totalRecords"`
+	StartDate    string                    `json:"startDate"`
+	EndDate      string                    `json:"endDate"`
 }
 
 // MapInstanceMetricsStatsResponse builds the portal response from
@@ -289,29 +302,30 @@ func MapInstanceMetricsStatsResponse(r entity.InstanceMetricsStatsResponse) Inst
 			Max:     r.Summary.Max,
 			Avg:     r.Summary.Avg,
 		},
-		Total:     r.Total,
-		StartDate: r.StartDate,
-		EndDate:   r.EndDate,
+		TotalRecords: r.Total,
+		StartDate:    r.StartDate,
+		EndDate:      r.EndDate,
 	}
 }
 
 // InstanceUsageStatsResponse is the portal's response for the
 // instances/stats/usages/search routes. Unlike InstanceMetricsStatsResponse,
-// there is no summary block, by design.
+// there is no summary block, by design. TotalRecords (not Total) to match
+// the frontend's own InstanceUsageStatsResponse type.
 type InstanceUsageStatsResponse struct {
-	Stats     map[string]map[string]int `json:"stats"`
-	Total     int                       `json:"total"`
-	StartDate string                    `json:"startDate"`
-	EndDate   string                    `json:"endDate"`
+	Stats        map[string]map[string]int `json:"stats"`
+	TotalRecords int                       `json:"totalRecords"`
+	StartDate    string                    `json:"startDate"`
+	EndDate      string                    `json:"endDate"`
 }
 
 // MapInstanceUsageStatsResponse builds the portal response from
 // entity-service's InstanceUsageStatsResponse.
 func MapInstanceUsageStatsResponse(r entity.InstanceUsageStatsResponse) InstanceUsageStatsResponse {
 	return InstanceUsageStatsResponse{
-		Stats:     r.Stats,
-		Total:     r.Total,
-		StartDate: r.StartDate,
-		EndDate:   r.EndDate,
+		Stats:        r.Stats,
+		TotalRecords: r.Total,
+		StartDate:    r.StartDate,
+		EndDate:      r.EndDate,
 	}
 }

--- a/apps/customer-portal/backend-v2/internal/dto/product.go
+++ b/apps/customer-portal/backend-v2/internal/dto/product.go
@@ -27,13 +27,15 @@ type ProductSummary struct {
 	UpdatedOn *string `json:"updatedOn,omitempty"`
 }
 
-// SearchProductsResponse is the portal's response for POST /products/search.
+// SearchProductsResponse is the portal's response for POST /products/search
+// and GET /products. TotalRecords (not Total) to match the frontend's
+// shared pagination envelope.
 type SearchProductsResponse struct {
-	Products []ProductSummary `json:"products"`
-	Total    int              `json:"total"`
-	Limit    int              `json:"limit"`
-	Offset   int              `json:"offset"`
-	HasMore  bool             `json:"hasMore"`
+	Products     []ProductSummary `json:"products"`
+	TotalRecords int              `json:"totalRecords"`
+	Limit        int              `json:"limit"`
+	Offset       int              `json:"offset"`
+	HasMore      bool             `json:"hasMore"`
 }
 
 // MapSearchProducts builds the portal response from entity-service's SearchProductsResponse.
@@ -49,12 +51,29 @@ func MapSearchProducts(r entity.SearchProductsResponse) SearchProductsResponse {
 		})
 	}
 	return SearchProductsResponse{
-		Products: items,
-		Total:    r.Total,
-		Limit:    r.Limit,
-		Offset:   r.Offset,
-		HasMore:  r.HasMore,
+		Products:     items,
+		TotalRecords: r.Total,
+		Limit:        r.Limit,
+		Offset:       r.Offset,
+		HasMore:      r.HasMore,
 	}
+}
+
+// GetProductsRequest is the portal's translated request for GET /products —
+// built from the offset/limit query params by the handler. entity-service's
+// SearchProductsRequest has no class filter at all (unlike the old
+// Ballerina backend's target service, which accepted filters.class), so the
+// frontend's `class=product_model` query param has no server-side
+// equivalent here — a genuine entity-service gap, not fixable in this dto
+// layer alone.
+type GetProductsRequest struct {
+	Pagination entity.Pagination
+}
+
+// BuildEntitySearchProductsRequestFromQuery translates GET /products' query
+// params into entity-service's POST /products/search request shape.
+func BuildEntitySearchProductsRequestFromQuery(req GetProductsRequest) entity.SearchProductsRequest {
+	return entity.SearchProductsRequest{Pagination: req.Pagination}
 }
 
 // ProductVersionSummary is one item of the portal's response for
@@ -71,13 +90,17 @@ type ProductVersionSummary struct {
 	UpdatedOn                      *string `json:"updatedOn,omitempty"`
 }
 
-// SearchProductVersionsResponse is the portal's response for POST /products/{id}/versions/search.
+// SearchProductVersionsResponse is the portal's response for
+// POST /products/{id}/versions/search — Versions (not ProductVersions) and
+// TotalRecords (not Total) to match the frontend's own
+// ProductVersionsSearchResponse type (apps/customer-portal/webapp/src/
+// features/project-details/types/products.ts).
 type SearchProductVersionsResponse struct {
-	ProductVersions []ProductVersionSummary `json:"productVersions"`
-	Total           int                     `json:"total"`
-	Limit           int                     `json:"limit"`
-	Offset          int                     `json:"offset"`
-	HasMore         bool                    `json:"hasMore"`
+	Versions     []ProductVersionSummary `json:"versions"`
+	TotalRecords int                     `json:"totalRecords"`
+	Limit        int                     `json:"limit"`
+	Offset       int                     `json:"offset"`
+	HasMore      bool                    `json:"hasMore"`
 }
 
 // MapSearchProductVersions builds the portal response from entity-service's SearchProductVersionsResponse.
@@ -96,10 +119,10 @@ func MapSearchProductVersions(r entity.SearchProductVersionsResponse) SearchProd
 		})
 	}
 	return SearchProductVersionsResponse{
-		ProductVersions: items,
-		Total:           r.Total,
-		Limit:           r.Limit,
-		Offset:          r.Offset,
-		HasMore:         r.HasMore,
+		Versions:     items,
+		TotalRecords: r.Total,
+		Limit:        r.Limit,
+		Offset:       r.Offset,
+		HasMore:      r.HasMore,
 	}
 }

--- a/apps/customer-portal/backend-v2/internal/dto/product.go
+++ b/apps/customer-portal/backend-v2/internal/dto/product.go
@@ -16,7 +16,11 @@
 
 package dto
 
-import "github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+import (
+	"strings"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+)
 
 // ProductSummary is one item of the portal's response for POST /products/search.
 type ProductSummary struct {
@@ -60,20 +64,53 @@ func MapSearchProducts(r entity.SearchProductsResponse) SearchProductsResponse {
 }
 
 // GetProductsRequest is the portal's translated request for GET /products —
-// built from the offset/limit query params by the handler. entity-service's
-// SearchProductsRequest has no class filter at all (unlike the old
-// Ballerina backend's target service, which accepted filters.class), so the
-// frontend's `class=product_model` query param has no server-side
-// equivalent here — a genuine entity-service gap, not fixable in this dto
-// layer alone.
+// built from the class/offset/limit query params by the handler.
+// entity-service's SearchProductsRequest has no class filter parameter at
+// all (unlike the old Ballerina backend's target service, which accepted
+// filters.class server-side), so Class can't be forwarded upstream — see
+// FilterProductsByClass, which applies it after the fact instead of
+// silently dropping it.
 type GetProductsRequest struct {
 	Pagination entity.Pagination
+	Class      string
 }
 
 // BuildEntitySearchProductsRequestFromQuery translates GET /products' query
-// params into entity-service's POST /products/search request shape.
+// params into entity-service's POST /products/search request shape. Class
+// is intentionally not forwarded — entity-service has nowhere to put it.
 func BuildEntitySearchProductsRequestFromQuery(req GetProductsRequest) entity.SearchProductsRequest {
 	return entity.SearchProductsRequest{Pagination: req.Pagination}
+}
+
+// FilterProductsByClass keeps only products whose Class matches want
+// (case-insensitive), applied after MapSearchProducts since entity-service
+// can't filter by class server-side (see GetProductsRequest's doc comment).
+// This is necessarily best-effort: TotalRecords/HasMore still describe
+// entity-service's unfiltered page, since entity-service computed pagination
+// before this backend ever saw (or could exclude) an off-class item — a
+// page can come back with fewer than Limit on-class items even when more
+// exist on a later page. A product with no Class at all (nil) never
+// matches, so it's excluded rather than kept as "unknown". On the Postgres
+// data source, entity-service's Class vocabulary is only "software"/
+// "service" (see domain.ProductClass in entity-service/internal/domain/
+// entity.go) — the frontend's own class value ("product_model") only ever
+// matches something on the ServiceNow data source, whose Class field is a
+// free-form passthrough label; requesting this endpoint against a
+// Postgres-mode deployment will therefore always return zero products, the
+// same "ServiceNow data source only" limitation documented elsewhere in
+// this backend.
+func FilterProductsByClass(r SearchProductsResponse, want string) SearchProductsResponse {
+	if want == "" {
+		return r
+	}
+	filtered := make([]ProductSummary, 0, len(r.Products))
+	for _, p := range r.Products {
+		if p.Class != nil && strings.EqualFold(*p.Class, want) {
+			filtered = append(filtered, p)
+		}
+	}
+	r.Products = filtered
+	return r
 }
 
 // ProductVersionSummary is one item of the portal's response for

--- a/apps/customer-portal/backend-v2/internal/dto/product_vulnerability.go
+++ b/apps/customer-portal/backend-v2/internal/dto/product_vulnerability.go
@@ -20,22 +20,27 @@ import "github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2
 
 // ProductVulnerability is the portal's shape for a single vulnerability,
 // used both for GET /products/vulnerabilities/{id} and as one item of
-// POST /products/vulnerabilities/search's response.
+// POST /products/vulnerabilities/search's response. Severity (not Priority)
+// as an IDLabelRef to match the frontend's own ProductVulnerability type
+// (apps/customer-portal/webapp/src/features/security/types/security.ts:
+// severity: MetadataItem). Status is not exposed — entity-service's
+// ProductVulnerabilityView has no equivalent field at all, a genuine gap,
+// not fixable in this dto layer alone.
 type ProductVulnerability struct {
-	ID              string  `json:"id"`
-	CveID           string  `json:"cveId"`
-	VulnerabilityID string  `json:"vulnerabilityId"`
-	Priority        string  `json:"priority"`
-	ProductName     *string `json:"productName,omitempty"`
-	ProductVersion  *string `json:"productVersion,omitempty"`
-	ComponentName   string  `json:"componentName"`
-	Version         string  `json:"version"`
-	Type            string  `json:"type"`
-	ComponentType   *string `json:"componentType,omitempty"`
-	UpdateLevel     *string `json:"updateLevel,omitempty"`
-	UseCase         *string `json:"useCase,omitempty"`
-	Justification   *string `json:"justification,omitempty"`
-	Resolution      *string `json:"resolution,omitempty"`
+	ID              string      `json:"id"`
+	CveID           string      `json:"cveId"`
+	VulnerabilityID string      `json:"vulnerabilityId"`
+	Severity        *IDLabelRef `json:"severity,omitempty"`
+	ProductName     *string     `json:"productName,omitempty"`
+	ProductVersion  *string     `json:"productVersion,omitempty"`
+	ComponentName   string      `json:"componentName"`
+	Version         string      `json:"version"`
+	Type            string      `json:"type"`
+	ComponentType   *string     `json:"componentType,omitempty"`
+	UpdateLevel     *string     `json:"updateLevel,omitempty"`
+	UseCase         *string     `json:"useCase,omitempty"`
+	Justification   *string     `json:"justification,omitempty"`
+	Resolution      *string     `json:"resolution,omitempty"`
 }
 
 // MapProductVulnerability builds the portal shape from entity-service's ProductVulnerabilityView.
@@ -44,7 +49,7 @@ func MapProductVulnerability(v entity.ProductVulnerabilityView) ProductVulnerabi
 		ID:              v.ID,
 		CveID:           v.CveID,
 		VulnerabilityID: v.VulnerabilityID,
-		Priority:        v.Priority,
+		Severity:        vulnerabilitySeverityRef(v.Priority),
 		ProductName:     v.ProductName,
 		ProductVersion:  v.ProductVersion,
 		ComponentName:   v.ComponentName,
@@ -59,10 +64,11 @@ func MapProductVulnerability(v entity.ProductVulnerabilityView) ProductVulnerabi
 }
 
 // SearchProductVulnerabilitiesResponse is the portal's response for
-// POST /products/vulnerabilities/search.
+// POST /products/vulnerabilities/search. TotalRecords (not Total) to match
+// the frontend's shared pagination envelope.
 type SearchProductVulnerabilitiesResponse struct {
 	ProductVulnerabilities []ProductVulnerability `json:"productVulnerabilities"`
-	Total                  int                    `json:"total"`
+	TotalRecords           int                    `json:"totalRecords"`
 	Limit                  int                    `json:"limit"`
 	Offset                 int                    `json:"offset"`
 }
@@ -76,8 +82,47 @@ func MapSearchProductVulnerabilities(r entity.SearchProductVulnerabilitiesRespon
 	}
 	return SearchProductVulnerabilitiesResponse{
 		ProductVulnerabilities: items,
-		Total:                  r.Total,
+		TotalRecords:           r.Total,
 		Limit:                  r.Limit,
 		Offset:                 r.Offset,
 	}
+}
+
+// SearchProductVulnerabilitiesFilters holds the optional filter criteria
+// for POST /products/vulnerabilities/search, matching the frontend's own
+// ProductVulnerabilitiesSearchFilters type. StatusID has no entity-service
+// equivalent at all (a genuine gap — SearchProductVulnerabilitiesFilters
+// has no status field) and is accepted but not forwarded.
+type SearchProductVulnerabilitiesFilters struct {
+	SearchQuery    string `json:"searchQuery,omitempty"`
+	SeverityID     *int   `json:"severityId,omitempty"`
+	StatusID       *int   `json:"statusId,omitempty"`
+	ProductName    string `json:"productName,omitempty"`
+	ProductVersion string `json:"productVersion,omitempty"`
+}
+
+// SearchProductVulnerabilitiesRequest is the portal's request body for
+// POST /products/vulnerabilities/search.
+type SearchProductVulnerabilitiesRequest struct {
+	Filters    *SearchProductVulnerabilitiesFilters `json:"filters,omitempty"`
+	Pagination entity.Pagination                    `json:"pagination"`
+}
+
+// BuildEntitySearchProductVulnerabilitiesRequest translates the portal's
+// request into entity-service's request shape, translating SeverityID into
+// entity-service's lowercase enum string.
+func BuildEntitySearchProductVulnerabilitiesRequest(req SearchProductVulnerabilitiesRequest) entity.SearchProductVulnerabilitiesRequest {
+	out := entity.SearchProductVulnerabilitiesRequest{Pagination: req.Pagination}
+	if req.Filters == nil {
+		return out
+	}
+	out.Filters = &entity.SearchProductVulnerabilitiesFilters{
+		SearchQuery:    req.Filters.SearchQuery,
+		ProductName:    req.Filters.ProductName,
+		ProductVersion: req.Filters.ProductVersion,
+	}
+	if req.Filters.SeverityID != nil {
+		out.Filters.Priority = vulnerabilitySeverityIDToEnumPtr(*req.Filters.SeverityID)
+	}
+	return out
 }

--- a/apps/customer-portal/backend-v2/internal/dto/product_vulnerability.go
+++ b/apps/customer-portal/backend-v2/internal/dto/product_vulnerability.go
@@ -90,13 +90,17 @@ func MapSearchProductVulnerabilities(r entity.SearchProductVulnerabilitiesRespon
 
 // SearchProductVulnerabilitiesFilters holds the optional filter criteria
 // for POST /products/vulnerabilities/search, matching the frontend's own
-// ProductVulnerabilitiesSearchFilters type. StatusID has no entity-service
-// equivalent at all (a genuine gap — SearchProductVulnerabilitiesFilters
-// has no status field) and is accepted but not forwarded.
+// ProductVulnerabilitiesSearchFilters type minus statusId: entity-service's
+// ProductVulnerabilityView carries no status field anywhere in its
+// response (unlike Priority/severity, which does have a numeric-id mirror
+// table), so there's no data to filter or even post-filter client-side by —
+// a genuine, currently unimplementable gap. statusId is deliberately not
+// declared here (rather than accepted and silently dropped) so this
+// backend's own contract doesn't advertise a filter it can't honor; add it
+// back once entity-service exposes vulnerability status.
 type SearchProductVulnerabilitiesFilters struct {
 	SearchQuery    string `json:"searchQuery,omitempty"`
 	SeverityID     *int   `json:"severityId,omitempty"`
-	StatusID       *int   `json:"statusId,omitempty"`
 	ProductName    string `json:"productName,omitempty"`
 	ProductVersion string `json:"productVersion,omitempty"`
 }

--- a/apps/customer-portal/backend-v2/internal/dto/product_vulnerability_enum_mapping.go
+++ b/apps/customer-portal/backend-v2/internal/dto/product_vulnerability_enum_mapping.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dto
+
+import (
+	"strconv"
+	"strings"
+)
+
+// vulnerabilitySeverityIDs mirrors entity-service's private
+// vulnerabilityPriorityToSeverityID table
+// (internal/service/sn_product_vulnerability_service.go) — the ServiceNow/
+// Choreo integer severity id for each VulnerabilityPriority enum value. The
+// frontend's severityId filter is this numeric id, but entity-service's own
+// SearchProductVulnerabilitiesFilters.Priority takes the lowercase enum
+// string, so this backend translates both ways, same pattern as
+// case_enum_mapping.go.
+var vulnerabilitySeverityIDs = map[string]int{
+	"info":     0,
+	"low":      1,
+	"medium":   2,
+	"high":     3,
+	"critical": 4,
+	"unknown":  5,
+}
+
+var vulnerabilitySeverityIDToEnum = func() map[int]string {
+	m := make(map[int]string, len(vulnerabilitySeverityIDs))
+	for enum, id := range vulnerabilitySeverityIDs {
+		m[id] = enum
+	}
+	return m
+}()
+
+// vulnerabilitySeverityLabels are portal-owned display labels for each
+// severity enum value.
+var vulnerabilitySeverityLabels = map[string]string{
+	"info":     "Info",
+	"low":      "Low",
+	"medium":   "Medium",
+	"high":     "High",
+	"critical": "Critical",
+	"unknown":  "Unknown",
+}
+
+// vulnerabilitySeverityRef converts entity-service's response Priority field
+// (the raw upstream label, e.g. "High" — see ProductVulnerabilityView's doc
+// comment) into an {id, label} pair. The label is matched case-insensitively
+// against the known enum names directly (unlike case_enum_mapping.go's
+// caseStatusRef, no fuzzy multi-word matching is needed here since this
+// field is always a single severity word), falling back to a label-only ref
+// for an unrecognized value rather than dropping the field.
+func vulnerabilitySeverityRef(rawLabel string) *IDLabelRef {
+	if rawLabel == "" {
+		return nil
+	}
+	enum := strings.ToLower(strings.TrimSpace(rawLabel))
+	id, ok := vulnerabilitySeverityIDs[enum]
+	if !ok {
+		return &IDLabelRef{Label: rawLabel}
+	}
+	label := vulnerabilitySeverityLabels[enum]
+	if label == "" {
+		label = rawLabel
+	}
+	return &IDLabelRef{ID: strconv.Itoa(id), Label: label}
+}
+
+// vulnerabilitySeverityIDToEnumPtr translates a frontend-supplied numeric
+// severityId into entity-service's lowercase enum string, returning nil for
+// an unrecognized id (never forwarded to entity-service as a raw number).
+func vulnerabilitySeverityIDToEnumPtr(id int) *string {
+	enum, ok := vulnerabilitySeverityIDToEnum[id]
+	if !ok {
+		return nil
+	}
+	return &enum
+}

--- a/apps/customer-portal/backend-v2/internal/dto/project.go
+++ b/apps/customer-portal/backend-v2/internal/dto/project.go
@@ -33,18 +33,21 @@ type ProjectSummary struct {
 	Name             string     `json:"name"`
 	Key              string     `json:"key"`
 	SubscriptionType string     `json:"subscriptionType"`
+	StartDate        *time.Time `json:"startDate,omitempty"`
 	EndDate          *time.Time `json:"endDate,omitempty"`
 	CreatedOn        time.Time  `json:"createdOn"`
 	ClosureState     *string    `json:"closureState,omitempty"`
 }
 
 // SearchProjectsResponse is the portal's response for POST /projects/search.
+// TotalRecords (not Total) to match the frontend's shared pagination
+// envelope.
 type SearchProjectsResponse struct {
-	Projects []ProjectSummary `json:"projects"`
-	Total    int              `json:"total"`
-	Limit    int              `json:"limit"`
-	Offset   int              `json:"offset"`
-	HasMore  bool             `json:"hasMore"`
+	Projects     []ProjectSummary `json:"projects"`
+	TotalRecords int              `json:"totalRecords"`
+	Limit        int              `json:"limit"`
+	Offset       int              `json:"offset"`
+	HasMore      bool             `json:"hasMore"`
 }
 
 // MapSearchProjects builds the portal response from entity-service's SearchProjectsResponse.
@@ -56,30 +59,59 @@ func MapSearchProjects(r entity.SearchProjectsResponse) SearchProjectsResponse {
 			Name:             p.Name,
 			Key:              p.Key,
 			SubscriptionType: p.SubscriptionType,
+			StartDate:        p.StartDate,
 			EndDate:          p.EndDate,
 			CreatedOn:        p.CreatedOn,
 			ClosureState:     p.ClosureState,
 		})
 	}
 	return SearchProjectsResponse{
-		Projects: projects,
-		Total:    r.Total,
-		Limit:    r.Limit,
-		Offset:   r.Offset,
-		HasMore:  r.HasMore,
+		Projects:     projects,
+		TotalRecords: r.Total,
+		Limit:        r.Limit,
+		Offset:       r.Offset,
+		HasMore:      r.HasMore,
 	}
 }
 
-// ProjectAccount is the account summary embedded in ProjectDetails.
-//
-// Deliberately excludes entity-service's AgentEnabled/KbReferencesEnabled
-// (internal feature-flags gating WSO2 agent behavior, not customer-facing)
-// and ActivationDate (redundant with the project's own dates for this view).
+// SearchProjectsFilters holds the optional filter criteria for
+// POST /projects/search, matching the frontend's nested filters.searchQuery
+// body shape (apps/customer-portal/webapp/src/api/useGetProjects.ts) rather
+// than entity-service's own flat SearchQuery field.
+type SearchProjectsFilters struct {
+	SearchQuery string `json:"searchQuery,omitempty"`
+}
+
+// SearchProjectsRequest is the portal's request body for POST /projects/search.
+type SearchProjectsRequest struct {
+	Pagination entity.Pagination     `json:"pagination"`
+	Filters    SearchProjectsFilters `json:"filters"`
+}
+
+// BuildEntitySearchProjectsRequest translates the portal's nested-filters
+// request into entity-service's flat SearchProjectsRequest.
+func BuildEntitySearchProjectsRequest(req SearchProjectsRequest) entity.SearchProjectsRequest {
+	return entity.SearchProjectsRequest{
+		Pagination:  req.Pagination,
+		SearchQuery: req.Filters.SearchQuery,
+	}
+}
+
+// ProjectAccount is the account summary embedded in ProjectDetails —
+// SupportTier (not Tier) to match the frontend's read site
+// (ProjectInformationCard.tsx: project?.account?.supportTier). HasAgent/
+// HasKbReferences/ActivationDate are read as a fallback path (e.g.
+// DashboardPage.tsx, SettingsAiAssistant.tsx: project.hasAgent ??
+// project.account?.hasAgent) — not actually internal-only despite this
+// struct's earlier doc comment claiming so.
 type ProjectAccount struct {
-	ID     string  `json:"id"`
-	Name   string  `json:"name"`
-	Tier   string  `json:"tier"`
-	Region *string `json:"region,omitempty"`
+	ID              string     `json:"id"`
+	Name            string     `json:"name"`
+	SupportTier     string     `json:"supportTier"`
+	Region          *string    `json:"region,omitempty"`
+	HasAgent        bool       `json:"hasAgent"`
+	HasKbReferences bool       `json:"hasKbReferences"`
+	ActivationDate  *time.Time `json:"activationDate,omitempty"`
 }
 
 // ProjectDetails is the portal's response for GET /projects/{id}.
@@ -105,10 +137,13 @@ func MapProjectDetails(p entity.ProjectDetailsView) ProjectDetails {
 	return ProjectDetails{
 		ID: p.ID,
 		Account: ProjectAccount{
-			ID:     p.Account.ID,
-			Name:   p.Account.Name,
-			Tier:   p.Account.Tier,
-			Region: p.Account.Region,
+			ID:              p.Account.ID,
+			Name:            p.Account.Name,
+			SupportTier:     p.Account.Tier,
+			Region:          p.Account.Region,
+			HasAgent:        p.Account.AgentEnabled,
+			HasKbReferences: p.Account.KbReferencesEnabled,
+			ActivationDate:  p.Account.ActivationDate,
 		},
 		Name:             p.Name,
 		Key:              p.Key,

--- a/apps/customer-portal/backend-v2/internal/dto/registry.go
+++ b/apps/customer-portal/backend-v2/internal/dto/registry.go
@@ -44,14 +44,17 @@ type RegistryTokenCreateRequest struct {
 
 // RegistryTokenCreateResponse is the portal's response for
 // POST /projects/{id}/registry-tokens and POST /registry-tokens/{id}/regenerate.
+// Name is read by both GenerateTokenModal.tsx and RegenerateTokenModal.tsx
+// to display the server-assigned token name after creation.
 type RegistryTokenCreateResponse struct {
-	Secret string `json:"secret"`
+	Secret string  `json:"secret"`
+	Name   *string `json:"name,omitempty"`
 }
 
 // MapRegistryTokenCreateResponse builds the portal response from the
 // registry service's TokenCreationResponse.
 func MapRegistryTokenCreateResponse(r registry.TokenCreationResponse) RegistryTokenCreateResponse {
-	return RegistryTokenCreateResponse{Secret: r.Secret}
+	return RegistryTokenCreateResponse{Secret: r.Secret, Name: r.Name}
 }
 
 // RegistryPermission is one access grant on a registry token.
@@ -59,16 +62,22 @@ type RegistryPermission struct {
 	Namespace string `json:"namespace"`
 }
 
-// RegistryToken is a registry token as returned to the portal.
+// RegistryToken is a registry token as returned to the portal. ID and
+// ExpiresAt are numeric (not string) — the real registry service sends
+// them as JSON numbers (confirmed against the old Ballerina backend's
+// registry:Token{int id?; ...; int expiresAt?; ...}), and the frontend's
+// RegistryToken type reads them as numbers directly (registryTokens.ts:
+// registryTokenExpiresWithinDays does `token.expiresAt < nowSec`). A
+// *string here would fail to unmarshal the real response entirely.
 type RegistryToken struct {
-	ID           *string              `json:"id,omitempty"`
+	ID           *int64               `json:"id,omitempty"`
 	Name         string               `json:"name"`
 	DisplayName  *string              `json:"displayName,omitempty"`
 	CreationTime *string              `json:"creationTime,omitempty"`
 	TokenType    *registry.TokenType  `json:"tokenType,omitempty"`
 	CreatedFor   *string              `json:"createdFor,omitempty"`
 	CreatedBy    *string              `json:"createdBy,omitempty"`
-	ExpiresAt    *string              `json:"expiresAt,omitempty"`
+	ExpiresAt    *int64               `json:"expiresAt,omitempty"`
 	Disable      bool                 `json:"disable"`
 	Duration     int                  `json:"duration"`
 	Permissions  []RegistryPermission `json:"permissions"`

--- a/apps/customer-portal/backend-v2/internal/dto/time_card.go
+++ b/apps/customer-portal/backend-v2/internal/dto/time_card.go
@@ -18,14 +18,47 @@ package dto
 
 import "github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
 
-// TimeCardCaseRef is a reference to the case associated with a time card.
+// timeCardStateLabels supplies portal-facing display text for
+// entity-service's TimeCardState enum. Unlike case status/severity, the
+// frontend's time-card state filter already sends/expects the plain enum
+// string itself as the id (webapp's TimeCardSearchFilters.states: string[]
+// — no ServiceNow numeric key involved here), so no id-lookup table is
+// needed, just display text for the {id, label} pair.
+var timeCardStateLabels = map[string]string{
+	"pending":   "Pending",
+	"submitted": "Submitted",
+	"approved":  "Approved",
+	"rejected":  "Rejected",
+	"processed": "Processed",
+	"recalled":  "Recalled",
+}
+
+func timeCardStateRef(state *string) *IDLabelRef {
+	if state == nil || *state == "" {
+		return nil
+	}
+	label := timeCardStateLabels[*state]
+	if label == "" {
+		label = *state
+	}
+	return &IDLabelRef{ID: *state, Label: label}
+}
+
+// TimeCardCaseRef is a reference to the case associated with a time card —
+// the frontend's TimeCard.case type is IdLabelRef intersected with a
+// required number field.
 type TimeCardCaseRef struct {
 	ID     string `json:"id"`
-	Name   string `json:"name"`
+	Label  string `json:"label"`
 	Number string `json:"number"`
 }
 
-// TimeCardSummary is one item of the portal's response for POST /time-cards/search.
+// TimeCardSummary is one item of the portal's response for
+// POST /projects/{id}/time-cards/search — shaped to match the frontend's
+// own TimeCard type (apps/customer-portal/webapp/src/features/usage-metrics/
+// types/timeTracking.ts) field-for-field: CreatedOn (not WorkDate),
+// ReportedBy (not User), and State/ApprovedBy/Project/Case all as
+// IDLabelRef.
 //
 // Deliberately excludes entity-service's per-category time breakdowns
 // (timeAnalyzing, timeSettingUp, timeReproducingDebugging,
@@ -35,57 +68,97 @@ type TimeCardCaseRef struct {
 type TimeCardSummary struct {
 	ID          string           `json:"id"`
 	TotalTime   float64          `json:"totalTime"`
-	WorkDate    string           `json:"workDate"`
+	CreatedOn   string           `json:"createdOn"`
 	HasBillable bool             `json:"hasBillable"`
-	State       *string          `json:"state,omitempty"`
-	User        *Ref             `json:"user,omitempty"`
-	ApprovedBy  *Ref             `json:"approvedBy,omitempty"`
-	Project     *Ref             `json:"project,omitempty"`
+	State       *IDLabelRef      `json:"state,omitempty"`
+	ReportedBy  *IDLabelRef      `json:"reportedBy,omitempty"`
+	ApprovedBy  *IDLabelRef      `json:"approvedBy,omitempty"`
+	Project     *IDLabelRef      `json:"project,omitempty"`
 	Case        *TimeCardCaseRef `json:"case,omitempty"`
 }
 
-// SearchTimeCardsResponse is the portal's response for POST /time-cards/search.
+// SearchTimeCardsResponse is the portal's response for
+// POST /projects/{id}/time-cards/search. TotalRecords (not Total) to match
+// the frontend's shared pagination envelope.
 type SearchTimeCardsResponse struct {
-	TimeCards []TimeCardSummary `json:"timeCards"`
-	Total     int               `json:"total"`
-	Limit     int               `json:"limit"`
-	Offset    int               `json:"offset"`
+	TimeCards    []TimeCardSummary `json:"timeCards"`
+	TotalRecords int               `json:"totalRecords"`
+	Limit        int               `json:"limit"`
+	Offset       int               `json:"offset"`
 }
 
-// MapSearchTimeCards builds the portal response from entity-service's SearchTimeCardsResponse.
+// MapSearchTimeCards builds the portal response from entity-service's
+// SearchTimeCardsResponse. CreatedOn is populated from WorkDate —
+// entity-service's own TimeCardView.CreatedOn is documented as "a
+// deprecated alias that always mirrors WorkDate", so reading WorkDate
+// directly is equivalent and avoids depending on the deprecated field.
 func MapSearchTimeCards(r entity.SearchTimeCardsResponse) SearchTimeCardsResponse {
 	items := make([]TimeCardSummary, 0, len(r.TimeCards))
 	for _, t := range r.TimeCards {
 		items = append(items, TimeCardSummary{
 			ID:          t.ID,
 			TotalTime:   t.TotalTime,
-			WorkDate:    t.WorkDate,
+			CreatedOn:   t.WorkDate,
 			HasBillable: t.HasBillable,
-			State:       t.State,
-			User:        mapTimeCardRef(t.User),
-			ApprovedBy:  mapTimeCardRef(t.ApprovedBy),
-			Project:     mapTimeCardRef(t.Project),
+			State:       timeCardStateRef(t.State),
+			ReportedBy:  timeCardRefToIDLabel(t.User),
+			ApprovedBy:  timeCardRefToIDLabel(t.ApprovedBy),
+			Project:     timeCardRefToIDLabel(t.Project),
 			Case:        mapTimeCardCaseRef(t.Case),
 		})
 	}
 	return SearchTimeCardsResponse{
-		TimeCards: items,
-		Total:     r.Total,
-		Limit:     r.Limit,
-		Offset:    r.Offset,
+		TimeCards:    items,
+		TotalRecords: r.Total,
+		Limit:        r.Limit,
+		Offset:       r.Offset,
 	}
 }
 
-func mapTimeCardRef(r *entity.TimeCardRef) *Ref {
+func timeCardRefToIDLabel(r *entity.TimeCardRef) *IDLabelRef {
 	if r == nil {
 		return nil
 	}
-	return &Ref{ID: r.ID, Name: r.Name}
+	return &IDLabelRef{ID: r.ID, Label: r.Name}
 }
 
 func mapTimeCardCaseRef(r *entity.TimeCardCaseRef) *TimeCardCaseRef {
 	if r == nil {
 		return nil
 	}
-	return &TimeCardCaseRef{ID: r.ID, Name: r.Name, Number: r.Number}
+	return &TimeCardCaseRef{ID: r.ID, Label: r.Name, Number: r.Number}
+}
+
+// TimeCardSearchFilters holds the optional filter criteria for
+// POST /projects/{id}/time-cards/search, matching the frontend's own
+// TimeCardSearchFilters type. No ProjectIDs field: project scoping comes
+// exclusively from the {id} path parameter.
+type TimeCardSearchFilters struct {
+	StartDate *string  `json:"startDate,omitempty"`
+	EndDate   *string  `json:"endDate,omitempty"`
+	States    []string `json:"states,omitempty"`
+}
+
+// TimeCardSearchRequest is the portal's request body for
+// POST /projects/{id}/time-cards/search.
+type TimeCardSearchRequest struct {
+	Filters    TimeCardSearchFilters `json:"filters"`
+	SortBy     entity.TimeCardSort   `json:"sortBy"`
+	Pagination entity.Pagination     `json:"pagination"`
+}
+
+// BuildEntitySearchTimeCardsRequest translates the portal's request into
+// entity-service's SearchTimeCardsRequest. projectID (the {id} path
+// parameter) always populates Filters.ProjectIDs — never the request body.
+func BuildEntitySearchTimeCardsRequest(projectID string, req TimeCardSearchRequest) entity.SearchTimeCardsRequest {
+	return entity.SearchTimeCardsRequest{
+		Filters: &entity.TimeCardFilters{
+			ProjectIDs: []string{projectID},
+			StartDate:  req.Filters.StartDate,
+			EndDate:    req.Filters.EndDate,
+			States:     req.Filters.States,
+		},
+		SortBy:     req.SortBy,
+		Pagination: req.Pagination,
+	}
 }

--- a/apps/customer-portal/backend-v2/internal/dto/type_alignment_test.go
+++ b/apps/customer-portal/backend-v2/internal/dto/type_alignment_test.go
@@ -282,3 +282,58 @@ func TestMapRegistryToken_NumericIDAndExpiresAt(t *testing.T) {
 		t.Fatalf("ExpiresAt = %v, want %d", got.ExpiresAt, expiresAt)
 	}
 }
+
+// TestFilterProductsByClass_KeepsOnlyMatchingCaseInsensitive verifies
+// GET /products' post-fetch class filter (entity-service has no class
+// filter parameter to forward to, see FilterProductsByClass's doc comment)
+// matches case-insensitively and drops products with no Class at all rather
+// than treating them as a match.
+func TestFilterProductsByClass_KeepsOnlyMatchingCaseInsensitive(t *testing.T) {
+	software := "software"
+	service := "Service"
+	r := SearchProductsResponse{
+		Products: []ProductSummary{
+			{ID: "p1", Class: &software},
+			{ID: "p2", Class: &service},
+			{ID: "p3", Class: nil},
+		},
+		TotalRecords: 3,
+	}
+
+	got := FilterProductsByClass(r, "service")
+	if len(got.Products) != 1 || got.Products[0].ID != "p2" {
+		t.Fatalf("Products = %+v, want only p2 (case-insensitive match on Service)", got.Products)
+	}
+
+	// An empty want (no ?class= supplied) must pass every product through
+	// unfiltered, not exclude everything.
+	unfiltered := FilterProductsByClass(r, "")
+	if len(unfiltered.Products) != 3 {
+		t.Fatalf("FilterProductsByClass with empty want dropped items: got %d, want 3", len(unfiltered.Products))
+	}
+}
+
+// TestBuildEntityUpdateDeploymentRequest_PreservesExplicitNullDescription
+// guards against collapsing an explicit {"description": null} into "field
+// absent" — entity-service's own UpdateDeploymentRequest.Description is
+// json.RawMessage specifically to distinguish the three states (absent /
+// null / value); a *string on this portal's request DTO couldn't represent
+// the null case at all.
+func TestBuildEntityUpdateDeploymentRequest_PreservesExplicitNullDescription(t *testing.T) {
+	var absent DeploymentUpdateRequest
+	if len(BuildEntityUpdateDeploymentRequest("dep-1", absent).Description) != 0 {
+		t.Fatalf("absent Description must not populate entity.UpdateDeploymentRequest.Description")
+	}
+
+	explicitNull := DeploymentUpdateRequest{Description: []byte("null")}
+	gotNull := BuildEntityUpdateDeploymentRequest("dep-1", explicitNull)
+	if string(gotNull.Description) != "null" {
+		t.Fatalf("Description = %q, want the literal JSON null preserved through", string(gotNull.Description))
+	}
+
+	withValue := DeploymentUpdateRequest{Description: []byte(`"Updated description"`)}
+	gotValue := BuildEntityUpdateDeploymentRequest("dep-1", withValue)
+	if string(gotValue.Description) != `"Updated description"` {
+		t.Fatalf("Description = %q, want the raw JSON string value preserved through", string(gotValue.Description))
+	}
+}

--- a/apps/customer-portal/backend-v2/internal/dto/type_alignment_test.go
+++ b/apps/customer-portal/backend-v2/internal/dto/type_alignment_test.go
@@ -1,0 +1,284 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dto
+
+import (
+	"testing"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/registry"
+)
+
+// TestBuildEntityCreateCaseRequest_SeverityAndIssueTypeKeysTranslate guards
+// the case-create numeric-key translation added when aligning this backend's
+// response/request shapes to the old Ballerina backend's contract.
+func TestBuildEntityCreateCaseRequest_SeverityAndIssueTypeKeysTranslate(t *testing.T) {
+	sev, issue := 11, 4 // high, question
+	got := BuildEntityCreateCaseRequest(CreateCaseRequest{
+		Title:        "Cannot log in",
+		ProjectID:    "proj-1",
+		SeverityKey:  &sev,
+		IssueTypeKey: &issue,
+	})
+	if got.Severity != "high" {
+		t.Fatalf("Severity = %q, want \"high\"", got.Severity)
+	}
+	if got.IssueType != "question" {
+		t.Fatalf("IssueType = %q, want \"question\"", got.IssueType)
+	}
+	if got.Subject != "Cannot log in" {
+		t.Fatalf("Subject = %q, want title passthrough", got.Subject)
+	}
+}
+
+// TestBuildEntityCreateCaseRequest_UnrecognizedKeysProduceEmptyEnum verifies
+// an unrecognized numeric key never leaks through as a raw number.
+func TestBuildEntityCreateCaseRequest_UnrecognizedKeysProduceEmptyEnum(t *testing.T) {
+	bad := 999999
+	got := BuildEntityCreateCaseRequest(CreateCaseRequest{SeverityKey: &bad})
+	if got.Severity != "" {
+		t.Fatalf("Severity = %q, want empty for unrecognized key", got.Severity)
+	}
+}
+
+// TestBuildEntityUpdateCaseRequest_StateKeyTranslates verifies PATCH
+// /cases/{id}'s stateKey (the only mutation field besides watchList) maps to
+// entity-service's enum string.
+func TestBuildEntityUpdateCaseRequest_StateKeyTranslates(t *testing.T) {
+	state := 10 // work_in_progress
+	got := BuildEntityUpdateCaseRequest("case-1", UpdateCaseRequest{StateKey: &state, WatchList: []string{"a@x.com"}})
+	if got.ID != "case-1" {
+		t.Fatalf("ID = %q, want case-1", got.ID)
+	}
+	if got.State == nil || *got.State != "work_in_progress" {
+		t.Fatalf("State = %v, want work_in_progress", got.State)
+	}
+	if len(got.WatchList) != 1 || got.WatchList[0] != "a@x.com" {
+		t.Fatalf("WatchList = %v", got.WatchList)
+	}
+}
+
+// TestBuildEntitySearchChangeRequestsRequest_ScopesProjectAndTranslatesKeys
+// verifies the change-request search translator forces project scope from
+// the path and translates stateKeys/impactKeys via the numeric-id mirror
+// table (entity-service's change-request search response is pre-normalized,
+// unlike case search, so this is a direct lookup, not fuzzy label matching).
+func TestBuildEntitySearchChangeRequestsRequest_ScopesProjectAndTranslatesKeys(t *testing.T) {
+	got := BuildEntitySearchChangeRequestsRequest("proj-9", ChangeRequestSearchRequest{
+		Filters: ChangeRequestSearchFilters{StateKeys: []int{5}, ImpactKeys: []int{1}}, // customer_approval, high
+	})
+	if len(got.Filters.ProjectIDs) != 1 || got.Filters.ProjectIDs[0] != "proj-9" {
+		t.Fatalf("ProjectIDs = %v, want [proj-9]", got.Filters.ProjectIDs)
+	}
+	if len(got.Filters.States) != 1 || got.Filters.States[0] != "customer_approval" {
+		t.Fatalf("States = %v, want [customer_approval]", got.Filters.States)
+	}
+	if len(got.Filters.Impacts) != 1 || got.Filters.Impacts[0] != "high" {
+		t.Fatalf("Impacts = %v, want [high]", got.Filters.Impacts)
+	}
+}
+
+// TestCrStateRef_KnownAndUnknownValues verifies the response-side {id,label}
+// translation for change-request state.
+func TestCrStateRef_KnownAndUnknownValues(t *testing.T) {
+	state := "customer_approval"
+	got := crStateRef(&state)
+	if got == nil || got.ID != "5" || got.Label != "Customer Approval" {
+		t.Fatalf("crStateRef(customer_approval) = %+v, want {id: 5, label: Customer Approval}", got)
+	}
+	if crStateRef(nil) != nil {
+		t.Fatalf("crStateRef(nil) should be nil")
+	}
+}
+
+// TestBuildEntitySearchConversationsRequest_ScopesProjectAndTranslatesStateKeys
+// guards the fix for stateKeys being a complete no-op (the handler
+// previously decoded straight into entity.SearchConversationsRequest, whose
+// field names never matched the frontend's body at all).
+func TestBuildEntitySearchConversationsRequest_ScopesProjectAndTranslatesStateKeys(t *testing.T) {
+	got := BuildEntitySearchConversationsRequest("proj-3", ConversationSearchRequest{
+		Filters: ConversationSearchFilters{StateKeys: []int{2}, CreatedByMe: true}, // ACTIVE
+	})
+	if len(got.Filters.ProjectIDs) != 1 || got.Filters.ProjectIDs[0] != "proj-3" {
+		t.Fatalf("ProjectIDs = %v, want [proj-3]", got.Filters.ProjectIDs)
+	}
+	if len(got.Filters.States) != 1 || got.Filters.States[0] != "ACTIVE" {
+		t.Fatalf("States = %v, want [ACTIVE]", got.Filters.States)
+	}
+	if !got.Filters.CreatedByMe {
+		t.Fatalf("CreatedByMe = false, want true")
+	}
+}
+
+// TestMapSearchTimeCards_WorkDateBecomesCreatedOn verifies the frontend's
+// TimeCard.createdOn is sourced from entity-service's WorkDate field, and
+// state/reportedBy/approvedBy/project all become {id,label} refs.
+func TestMapSearchTimeCards_WorkDateBecomesCreatedOn(t *testing.T) {
+	state := "approved"
+	r := entity.SearchTimeCardsResponse{
+		Total: 1,
+		TimeCards: []entity.TimeCardView{
+			{ID: "tc-1", TotalTime: 3.5, WorkDate: "2026-01-15", State: &state},
+		},
+	}
+	got := MapSearchTimeCards(r)
+	if got.TotalRecords != 1 {
+		t.Fatalf("TotalRecords = %d, want 1", got.TotalRecords)
+	}
+	if len(got.TimeCards) != 1 || got.TimeCards[0].CreatedOn != "2026-01-15" {
+		t.Fatalf("TimeCards[0].CreatedOn = %q, want entity-service's WorkDate value", got.TimeCards[0].CreatedOn)
+	}
+}
+
+// TestBuildEntitySearchProjectsRequest_NestedFiltersUnwrapped verifies the
+// frontend's nested filters.searchQuery body translates to entity-service's
+// flat SearchQuery field.
+func TestBuildEntitySearchProjectsRequest_NestedFiltersUnwrapped(t *testing.T) {
+	got := BuildEntitySearchProjectsRequest(SearchProjectsRequest{
+		Filters: SearchProjectsFilters{SearchQuery: "acme"},
+	})
+	if got.SearchQuery != "acme" {
+		t.Fatalf("SearchQuery = %q, want acme", got.SearchQuery)
+	}
+}
+
+// TestDeploymentTypeIDToEnumPtr_KnownAndUnknown verifies the deployment-type
+// numeric-key translation used by both create and patch deployment.
+func TestDeploymentTypeIDToEnumPtr_KnownAndUnknown(t *testing.T) {
+	got := deploymentTypeIDToEnumPtr(6) // primary_production
+	if got == nil || *got != "primary_production" {
+		t.Fatalf("deploymentTypeIDToEnumPtr(6) = %v, want primary_production", got)
+	}
+	if deploymentTypeIDToEnumPtr(9999) != nil {
+		t.Fatalf("deploymentTypeIDToEnumPtr(9999) should be nil for an unrecognized key")
+	}
+}
+
+// TestBuildEntityCreateDeploymentRequest_ForcesProjectIDAndTranslatesType
+// verifies POST /projects/{id}/deployments always scopes to the path's
+// project id and translates deploymentTypeKey.
+func TestBuildEntityCreateDeploymentRequest_ForcesProjectIDAndTranslatesType(t *testing.T) {
+	got := BuildEntityCreateDeploymentRequest("proj-7", DeploymentCreateRequest{
+		Name: "Prod", DeploymentTypeKey: 6, Description: "primary env",
+	})
+	if got.ProjectID != "proj-7" {
+		t.Fatalf("ProjectID = %q, want proj-7", got.ProjectID)
+	}
+	if got.Type == nil || *got.Type != "primary_production" {
+		t.Fatalf("Type = %v, want primary_production", got.Type)
+	}
+}
+
+// TestParseCoresAndTPS_ParsesServiceNowStrings verifies entity-service's
+// ServiceNow string Cores/TPS fields parse into numbers for the frontend's
+// `typeof item.cores === "number"` checks, and that an absent/unparseable
+// value maps to nil rather than 0 or a truncated garbage value.
+func TestParseCoresAndTPS_ParsesServiceNowStrings(t *testing.T) {
+	cores := "4"
+	tps := "12.5"
+	if got := parseCores(&cores); got == nil || *got != 4 {
+		t.Fatalf("parseCores(4) = %v, want 4", got)
+	}
+	if got := parseTPS(&tps); got == nil || *got != 12.5 {
+		t.Fatalf("parseTPS(12.5) = %v, want 12.5", got)
+	}
+	if parseCores(nil) != nil {
+		t.Fatalf("parseCores(nil) should be nil")
+	}
+	bad := "not-a-number"
+	if parseCores(&bad) != nil {
+		t.Fatalf("parseCores(%q) should be nil, not a garbage parse", bad)
+	}
+}
+
+// TestVulnerabilitySeverityRef_MatchesKnownLabelCaseInsensitively verifies
+// the product-vulnerability severity translation resolves entity-service's
+// raw upstream label (e.g. "High") to the numeric ServiceNow severity id
+// mirrored from vulnerabilityPriorityToSeverityID.
+func TestVulnerabilitySeverityRef_MatchesKnownLabelCaseInsensitively(t *testing.T) {
+	got := vulnerabilitySeverityRef("High")
+	if got == nil || got.ID != "3" || got.Label != "High" {
+		t.Fatalf("vulnerabilitySeverityRef(High) = %+v, want {id: 3, label: High}", got)
+	}
+	if got := vulnerabilitySeverityRef("Unrecognized"); got == nil || got.ID != "" || got.Label != "Unrecognized" {
+		t.Fatalf("vulnerabilitySeverityRef(Unrecognized) = %+v, want a label-only fallback ref", got)
+	}
+}
+
+// TestBuildEntitySearchProductVulnerabilitiesRequest_SeverityIDTranslates
+// verifies the frontend's numeric severityId filter becomes entity-service's
+// lowercase Priority enum string.
+func TestBuildEntitySearchProductVulnerabilitiesRequest_SeverityIDTranslates(t *testing.T) {
+	sevID := 3 // high
+	got := BuildEntitySearchProductVulnerabilitiesRequest(SearchProductVulnerabilitiesRequest{
+		Filters: &SearchProductVulnerabilitiesFilters{SeverityID: &sevID},
+	})
+	if got.Filters == nil || got.Filters.Priority == nil || *got.Filters.Priority != "high" {
+		t.Fatalf("Priority = %v, want high", got.Filters.Priority)
+	}
+}
+
+// TestBuildEntitySearchCatalogsRequest_ScopesDeployedProductID verifies the
+// catalog search translator always scopes to the deployed product in the
+// URL, matching the corrected route
+// POST /deployments/products/{deployedProductId}/catalogs/search.
+func TestBuildEntitySearchCatalogsRequest_ScopesDeployedProductID(t *testing.T) {
+	got := BuildEntitySearchCatalogsRequest("dp-1", SearchCatalogsRequest{Pagination: entity.Pagination{Limit: 10}})
+	if got.DeployedProductID != "dp-1" {
+		t.Fatalf("DeployedProductID = %q, want dp-1", got.DeployedProductID)
+	}
+	if got.Pagination.Limit != 10 {
+		t.Fatalf("Pagination.Limit = %d, want 10", got.Pagination.Limit)
+	}
+}
+
+// TestMapSearchCatalogs_ItemsUseLabelNotName verifies catalog items map to
+// {id, label} (matching the frontend's CatalogItem = MetadataItem type)
+// while the catalog container itself keeps its Name field.
+func TestMapSearchCatalogs_ItemsUseLabelNotName(t *testing.T) {
+	got := MapSearchCatalogs(entity.SearchCatalogsResponse{
+		Total: 1,
+		Catalogs: []entity.CatalogView{
+			{ID: "cat-1", Name: "Support Catalog", CatalogItems: []entity.CatalogItem{{ID: "item-1", Name: "Restart Service"}}},
+		},
+	})
+	if got.TotalRecords != 1 {
+		t.Fatalf("TotalRecords = %d, want 1", got.TotalRecords)
+	}
+	if got.Catalogs[0].Name != "Support Catalog" {
+		t.Fatalf("Catalog.Name = %q, want passthrough", got.Catalogs[0].Name)
+	}
+	if len(got.Catalogs[0].CatalogItems) != 1 || got.Catalogs[0].CatalogItems[0].Label != "Restart Service" {
+		t.Fatalf("CatalogItems[0].Label = %q, want Restart Service", got.Catalogs[0].CatalogItems[0].Label)
+	}
+}
+
+// TestMapRegistryToken_NumericIDAndExpiresAt verifies the registry token's
+// ID/ExpiresAt fields decode as numbers, matching the frontend's
+// RegistryToken type (registryTokenExpiresWithinDays does `token.expiresAt <
+// nowSec`, which requires a number, not a string).
+func TestMapRegistryToken_NumericIDAndExpiresAt(t *testing.T) {
+	id := int64(42)
+	expiresAt := int64(1893456000)
+	got := MapRegistryToken(registry.Token{ID: &id, Name: "robot-1", ExpiresAt: &expiresAt})
+	if got.ID == nil || *got.ID != 42 {
+		t.Fatalf("ID = %v, want 42", got.ID)
+	}
+	if got.ExpiresAt == nil || *got.ExpiresAt != expiresAt {
+		t.Fatalf("ExpiresAt = %v, want %d", got.ExpiresAt, expiresAt)
+	}
+}

--- a/apps/customer-portal/backend-v2/internal/dto/user.go
+++ b/apps/customer-portal/backend-v2/internal/dto/user.go
@@ -22,18 +22,19 @@ package dto
 
 import "github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
 
-// UserMeResponse is the portal's response for GET /users/me. PhoneNumber is
-// not part of entity-service's response — the handler sets it separately from
-// the SCIM client's result, since phone numbers are sourced from SCIM, not
-// entity-service.
+// UserMeResponse is the portal's response for GET /users/me. PhoneNumber and
+// LastPasswordUpdateTime are not part of entity-service's response — the
+// handler sets them separately from the SCIM client's result, since both are
+// sourced from SCIM, not entity-service.
 type UserMeResponse struct {
-	ID          string   `json:"id"`
-	Email       string   `json:"email"`
-	FirstName   *string  `json:"firstName,omitempty"`
-	LastName    string   `json:"lastName"`
-	TimeZone    *string  `json:"timeZone,omitempty"`
-	Roles       []string `json:"roles"`
-	PhoneNumber *string  `json:"phoneNumber,omitempty"`
+	ID                     string   `json:"id"`
+	Email                  string   `json:"email"`
+	FirstName              *string  `json:"firstName,omitempty"`
+	LastName               string   `json:"lastName"`
+	TimeZone               *string  `json:"timeZone,omitempty"`
+	Roles                  []string `json:"roles"`
+	PhoneNumber            *string  `json:"phoneNumber,omitempty"`
+	LastPasswordUpdateTime *string  `json:"lastPasswordUpdateTime,omitempty"`
 }
 
 // MapUserMe builds the portal response from entity-service's GetUserMeResponse.

--- a/apps/customer-portal/backend-v2/internal/entity/types.go
+++ b/apps/customer-portal/backend-v2/internal/entity/types.go
@@ -93,6 +93,7 @@ type ProjectView struct {
 	Name             string     `json:"name"`
 	Key              string     `json:"key"`
 	SubscriptionType string     `json:"subscriptionType"`
+	StartDate        *time.Time `json:"startDate"`
 	EndDate          *time.Time `json:"endDate"`
 	CreatedOn        time.Time  `json:"createdOn"`
 	ProjectClosureFields
@@ -466,6 +467,14 @@ type LinkedServiceRequestRef struct {
 	Name   string `json:"name"`
 }
 
+// LinkedChangeRequestRef is a compact reference to a change request raised
+// from a service-request case.
+type LinkedChangeRequestRef struct {
+	ID     string  `json:"id"`
+	Number string  `json:"number"`
+	Name   *string `json:"name"`
+}
+
 // AccountRef is a compact reference to an account.
 type AccountRef struct {
 	ID      string     `json:"id"`
@@ -712,11 +721,18 @@ type CaseView struct {
 	RelatedCase            *CaseNumberRef            `json:"relatedCase"`
 	AccountDetails         *AccountRef               `json:"account"`
 	LinkedServiceRequests  []LinkedServiceRequestRef `json:"linkedServiceRequests"`
-	ResolvedOn             *time.Time                `json:"resolvedOn"`
-	ResolutionCode         *string                   `json:"resolutionCode"`
-	Cause                  *string                   `json:"cause"`
-	ResolutionNotes        *string                   `json:"resolutionNotes"`
-	// WatchList, AutoclosureStep/AutoclosureStateTime and the Best/MostLikely/
+	// LinkedChangeRequests lists the change requests raised from this case
+	// (populated for service-request cases only; empty otherwise).
+	LinkedChangeRequests []LinkedChangeRequestRef `json:"linkedChangeRequests"`
+	ResolvedOn           *time.Time               `json:"resolvedOn"`
+	ResolutionCode       *string                  `json:"resolutionCode"`
+	Cause                *string                  `json:"cause"`
+	ResolutionNotes      *string                  `json:"resolutionNotes"`
+	// WatchList is the set of users watching the case (ServiceNow data
+	// source only) — a customer self-service feature (the customer's own
+	// PATCH /cases/{id} request can set it), not CSM-engineer-only.
+	WatchList []WatchListUser `json:"watchList,omitempty"`
+	// AutoclosureStep/AutoclosureStateTime and the Best/MostLikely/
 	// WorstCaseFixEta fields are intentionally NOT decoded here — entity-service
 	// documents them as CSM-engineer-facing only (see entity.go comments on
 	// CaseView), and the customer portal must not surface internal WSO2 support

--- a/apps/customer-portal/backend-v2/internal/handler/ai_chat.go
+++ b/apps/customer-portal/backend-v2/internal/handler/ai_chat.go
@@ -140,14 +140,13 @@ func (h *AIChatHandler) SearchConversations(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	var req entity.SearchConversationsRequest
+	var req dto.ConversationSearchRequest
 	if err := json.Unmarshal(body, &req); err != nil {
 		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
 		return
 	}
-	req.Filters.ProjectIDs = []string{projectID}
 
-	result, err := h.entity.SearchConversations(r.Context(), req)
+	result, err := h.entity.SearchConversations(r.Context(), dto.BuildEntitySearchConversationsRequest(projectID, req))
 	if err != nil {
 		slog.ErrorContext(r.Context(), "entity SearchConversations failed", "userID", user.UserID, "projectID", projectID, "err", summarizeErr(err))
 		mapUpstreamError(w, err, "Failed to retrieve conversations.")

--- a/apps/customer-portal/backend-v2/internal/handler/cases.go
+++ b/apps/customer-portal/backend-v2/internal/handler/cases.go
@@ -41,6 +41,7 @@ type entityCaseClient interface {
 	CreateEscalation(ctx context.Context, req entity.CreateEscalationRequest) (entity.CreateEscalationResponse, error)
 	SearchEscalations(ctx context.Context, req entity.SearchEscalationsRequest) (entity.SearchEscalationsResponse, error)
 	SearchAttachments(ctx context.Context, req entity.SearchAttachmentsRequest) (entity.SearchAttachmentsResponse, error)
+	CreateAttachment(ctx context.Context, req entity.CreateAttachmentRequest) (entity.CreateAttachmentResponse, error)
 }
 
 // CaseHandler handles HTTP requests for case operations.
@@ -121,6 +122,41 @@ func (h *CaseHandler) SearchCaseAttachments(w http.ResponseWriter, r *http.Reque
 	writeJSONValue(w, http.StatusOK, dto.MapCaseAttachments(result))
 }
 
+// CreateCaseAttachment handles POST /cases/{id}/attachments.
+func (h *CaseHandler) CreateCaseAttachment(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	id := r.PathValue("id")
+	if id == "" || !uuidRe.MatchString(id) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	body, ok := readJSONBody(w, r)
+	if !ok {
+		return
+	}
+
+	var req dto.CreateCaseAttachmentRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.CreateAttachment(r.Context(), dto.BuildEntityCreateCaseAttachmentRequest(id, req))
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity CreateAttachment failed", "userID", user.UserID, "caseID", id, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to create case attachment.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusCreated, dto.MapAttachmentCreate(result))
+}
+
 // GetCase handles GET /cases/{id}.
 func (h *CaseHandler) GetCase(w http.ResponseWriter, r *http.Request) {
 	user := middleware.UserInfoFromContext(r.Context())
@@ -158,17 +194,18 @@ func (h *CaseHandler) CreateCase(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var req entity.CreateCaseRequest
+	var req dto.CreateCaseRequest
 	if err := json.Unmarshal(body, &req); err != nil {
 		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
 		return
 	}
+	entityReq := dto.BuildEntityCreateCaseRequest(req)
 	// CreatedBy is server-set from the authenticated caller, never from the
 	// request body (the struct's json:"-" tag means a client-supplied value
 	// would be silently dropped anyway, but set it explicitly for clarity).
-	req.CreatedBy = user.Email
+	entityReq.CreatedBy = user.Email
 
-	result, err := h.entity.CreateCase(r.Context(), req)
+	result, err := h.entity.CreateCase(r.Context(), entityReq)
 	if err != nil {
 		slog.ErrorContext(r.Context(), "entity CreateCase failed", "userID", user.UserID, "err", summarizeErr(err))
 		mapUpstreamError(w, err, "Failed to create case.")
@@ -205,13 +242,13 @@ func (h *CaseHandler) PatchCase(w http.ResponseWriter, r *http.Request) {
 	// entity-service requires exactly one of these primary fields per PATCH —
 	// see dto.UpdateCaseRequest's doc comment.
 	primaryFieldsSet := 0
-	for _, set := range []bool{req.State != nil, req.Severity != nil, req.Subject != nil, req.Description != nil, len(req.WatchList) > 0} {
+	for _, set := range []bool{req.StateKey != nil, len(req.WatchList) > 0} {
 		if set {
 			primaryFieldsSet++
 		}
 	}
 	if primaryFieldsSet != 1 {
-		writeError(w, http.StatusBadRequest, "Exactly one of state, severity, subject, description, or watchList must be provided.")
+		writeError(w, http.StatusBadRequest, "Exactly one of stateKey or watchList must be provided.")
 		return
 	}
 

--- a/apps/customer-portal/backend-v2/internal/handler/catalogs.go
+++ b/apps/customer-portal/backend-v2/internal/handler/catalogs.go
@@ -43,11 +43,18 @@ func NewCatalogHandler(entity entityCatalogClient) *CatalogHandler {
 	return &CatalogHandler{entity: entity}
 }
 
-// SearchCatalogs handles POST /catalogs/search.
+// SearchCatalogs handles
+// POST /deployments/products/{deployedProductId}/catalogs/search.
 func (h *CatalogHandler) SearchCatalogs(w http.ResponseWriter, r *http.Request) {
 	user := middleware.UserInfoFromContext(r.Context())
 	if user == nil {
 		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	deployedProductID := r.PathValue("deployedProductId")
+	if !uuidRe.MatchString(deployedProductID) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
 
@@ -56,17 +63,13 @@ func (h *CatalogHandler) SearchCatalogs(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	var req entity.SearchCatalogsRequest
+	var req dto.SearchCatalogsRequest
 	if err := json.Unmarshal(body, &req); err != nil {
 		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
 		return
 	}
-	if !uuidRe.MatchString(req.DeployedProductID) {
-		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
-		return
-	}
 
-	result, err := h.entity.SearchCatalogs(r.Context(), req)
+	result, err := h.entity.SearchCatalogs(r.Context(), dto.BuildEntitySearchCatalogsRequest(deployedProductID, req))
 	if err != nil {
 		slog.ErrorContext(r.Context(), "entity SearchCatalogs failed", "userID", user.UserID, "err", summarizeErr(err))
 		mapUpstreamError(w, err, "Failed to search catalogs.")
@@ -76,7 +79,7 @@ func (h *CatalogHandler) SearchCatalogs(w http.ResponseWriter, r *http.Request) 
 	writeJSONValue(w, http.StatusOK, dto.MapSearchCatalogs(result))
 }
 
-// GetCatalogItemVariables handles GET /catalogs/{catalogId}/items/{catalogItemId}/variables.
+// GetCatalogItemVariables handles GET /catalogs/{catalogId}/items/{itemId}.
 func (h *CatalogHandler) GetCatalogItemVariables(w http.ResponseWriter, r *http.Request) {
 	user := middleware.UserInfoFromContext(r.Context())
 	if user == nil {
@@ -85,7 +88,7 @@ func (h *CatalogHandler) GetCatalogItemVariables(w http.ResponseWriter, r *http.
 	}
 
 	catalogID := r.PathValue("catalogId")
-	catalogItemID := r.PathValue("catalogItemId")
+	catalogItemID := r.PathValue("itemId")
 	if !uuidRe.MatchString(catalogID) || !uuidRe.MatchString(catalogItemID) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return

--- a/apps/customer-portal/backend-v2/internal/handler/change_requests.go
+++ b/apps/customer-portal/backend-v2/internal/handler/change_requests.go
@@ -84,11 +84,17 @@ func (h *ChangeRequestHandler) CreateChangeRequest(w http.ResponseWriter, r *htt
 	writeJSONValue(w, http.StatusCreated, dto.MapChangeRequestCreate(result))
 }
 
-// SearchChangeRequests handles POST /change-requests/search.
+// SearchChangeRequests handles POST /projects/{id}/change-requests/search.
 func (h *ChangeRequestHandler) SearchChangeRequests(w http.ResponseWriter, r *http.Request) {
 	user := middleware.UserInfoFromContext(r.Context())
 	if user == nil {
 		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	projectID := r.PathValue("id")
+	if projectID == "" || !uuidRe.MatchString(projectID) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
 
@@ -97,13 +103,13 @@ func (h *ChangeRequestHandler) SearchChangeRequests(w http.ResponseWriter, r *ht
 		return
 	}
 
-	var req entity.SearchChangeRequestsRequest
+	var req dto.ChangeRequestSearchRequest
 	if err := json.Unmarshal(body, &req); err != nil {
 		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
 		return
 	}
 
-	result, err := h.entity.SearchChangeRequests(r.Context(), req)
+	result, err := h.entity.SearchChangeRequests(r.Context(), dto.BuildEntitySearchChangeRequestsRequest(projectID, req))
 	if err != nil {
 		slog.ErrorContext(r.Context(), "entity SearchChangeRequests failed", "userID", user.UserID, "err", summarizeErr(err))
 		mapUpstreamError(w, err, "Failed to search change requests.")

--- a/apps/customer-portal/backend-v2/internal/handler/deployed_products.go
+++ b/apps/customer-portal/backend-v2/internal/handler/deployed_products.go
@@ -47,11 +47,18 @@ func NewDeployedProductHandler(entity entityDeployedProductClient) *DeployedProd
 	return &DeployedProductHandler{entity: entity}
 }
 
-// SearchDeployedProducts handles POST /deployed-products/search.
+// SearchDeployedProducts handles
+// POST /deployments/{deploymentId}/products/search.
 func (h *DeployedProductHandler) SearchDeployedProducts(w http.ResponseWriter, r *http.Request) {
 	user := middleware.UserInfoFromContext(r.Context())
 	if user == nil {
 		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	deploymentID := r.PathValue("deploymentId")
+	if deploymentID == "" || !uuidRe.MatchString(deploymentID) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
 
@@ -60,13 +67,13 @@ func (h *DeployedProductHandler) SearchDeployedProducts(w http.ResponseWriter, r
 		return
 	}
 
-	var req entity.SearchDeployedProductsRequest
+	var req dto.DeployedProductSearchRequest
 	if err := json.Unmarshal(body, &req); err != nil {
 		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
 		return
 	}
 
-	result, err := h.entity.SearchDeployedProducts(r.Context(), req)
+	result, err := h.entity.SearchDeployedProducts(r.Context(), dto.BuildEntitySearchDeployedProductsRequest(deploymentID, req))
 	if err != nil {
 		slog.ErrorContext(r.Context(), "entity SearchDeployedProducts failed", "userID", user.UserID, "err", summarizeErr(err))
 		mapUpstreamError(w, err, "Failed to search deployed products.")
@@ -76,7 +83,7 @@ func (h *DeployedProductHandler) SearchDeployedProducts(w http.ResponseWriter, r
 	writeJSONValue(w, http.StatusOK, dto.MapSearchDeployedProducts(result))
 }
 
-// CreateDeployedProduct handles POST /deployed-products.
+// CreateDeployedProduct handles POST /deployments/{deploymentId}/products.
 //
 // NOTE: entity-service only supports this route on its ServiceNow data
 // source — see internal/entity/deployed_products.go.
@@ -87,18 +94,24 @@ func (h *DeployedProductHandler) CreateDeployedProduct(w http.ResponseWriter, r 
 		return
 	}
 
+	deploymentID := r.PathValue("deploymentId")
+	if deploymentID == "" || !uuidRe.MatchString(deploymentID) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
 	body, ok := readJSONBody(w, r)
 	if !ok {
 		return
 	}
 
-	var req entity.CreateDeployedProductRequest
+	var req dto.DeployedProductCreateRequest
 	if err := json.Unmarshal(body, &req); err != nil {
 		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
 		return
 	}
 
-	result, err := h.entity.CreateDeployedProduct(r.Context(), req)
+	result, err := h.entity.CreateDeployedProduct(r.Context(), dto.BuildEntityCreateDeployedProductRequest(deploymentID, req))
 	if err != nil {
 		slog.ErrorContext(r.Context(), "entity CreateDeployedProduct failed", "userID", user.UserID, "err", summarizeErr(err))
 		mapUpstreamError(w, err, "Failed to create deployed product.")
@@ -108,7 +121,11 @@ func (h *DeployedProductHandler) CreateDeployedProduct(w http.ResponseWriter, r 
 	writeJSONValue(w, http.StatusCreated, dto.MapDeployedProductCreate(result))
 }
 
-// PatchDeployedProduct handles PATCH /deployed-products/{id}.
+// PatchDeployedProduct handles
+// PATCH /deployments/{deploymentId}/products/{id}. DeploymentID is always
+// injected from the path (entity-service documents it as an IDOR-style
+// scope guard) — the frontend's own request body never carries it, so the
+// path is the only reliable source.
 //
 // NOTE: entity-service only supports this route on its ServiceNow data
 // source — see internal/entity/deployed_products.go.
@@ -119,8 +136,9 @@ func (h *DeployedProductHandler) PatchDeployedProduct(w http.ResponseWriter, r *
 		return
 	}
 
+	deploymentID := r.PathValue("deploymentId")
 	id := r.PathValue("id")
-	if id == "" || !uuidRe.MatchString(id) {
+	if deploymentID == "" || !uuidRe.MatchString(deploymentID) || id == "" || !uuidRe.MatchString(id) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -130,19 +148,12 @@ func (h *DeployedProductHandler) PatchDeployedProduct(w http.ResponseWriter, r *
 		return
 	}
 
-	// Decoded directly into entity-service's request struct (no restricted
-	// portal DTO) — every field here is customer-appropriate, including
-	// DeploymentID: per entity-service's own doc comment on
-	// UpdateDeployedProductRequest, it isn't a mutation field but an
-	// IDOR-style scope guard ("the deployed product must belong to that
-	// deployment or the operation returns a NotFoundError") — a legitimate
-	// safety check for the frontend to supply, unlike the case-update
-	// endpoint's genuinely internal-only fields (see dto.UpdateCaseRequest).
-	var req entity.UpdateDeployedProductRequest
-	if err := json.Unmarshal(body, &req); err != nil {
+	var portalReq dto.DeployedProductUpdateRequest
+	if err := json.Unmarshal(body, &portalReq); err != nil {
 		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
 		return
 	}
+	req := dto.BuildEntityUpdateDeployedProductRequest(id, deploymentID, portalReq)
 	// entity-service requires exactly one of the detail-fields group
 	// (cores/tps/description) or active=false — never both, never neither.
 	detailFieldsSet := req.Cores != nil || req.TPS != nil || len(req.Description) > 0

--- a/apps/customer-portal/backend-v2/internal/handler/deployments.go
+++ b/apps/customer-portal/backend-v2/internal/handler/deployments.go
@@ -86,7 +86,7 @@ func (h *DeploymentHandler) SearchDeployments(w http.ResponseWriter, r *http.Req
 	writeJSONValue(w, http.StatusOK, dto.MapSearchDeployments(result))
 }
 
-// CreateDeployment handles POST /deployments.
+// CreateDeployment handles POST /projects/{id}/deployments.
 //
 // NOTE: entity-service only supports this route on its ServiceNow data
 // source — a Postgres-mode deployment returns 400 for every call, which
@@ -98,18 +98,24 @@ func (h *DeploymentHandler) CreateDeployment(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
+	projectID := r.PathValue("id")
+	if projectID == "" || !uuidRe.MatchString(projectID) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
 	body, ok := readJSONBody(w, r)
 	if !ok {
 		return
 	}
 
-	var req entity.CreateDeploymentRequest
+	var req dto.DeploymentCreateRequest
 	if err := json.Unmarshal(body, &req); err != nil {
 		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
 		return
 	}
 
-	result, err := h.entity.CreateDeployment(r.Context(), req)
+	result, err := h.entity.CreateDeployment(r.Context(), dto.BuildEntityCreateDeploymentRequest(projectID, req))
 	if err != nil {
 		slog.ErrorContext(r.Context(), "entity CreateDeployment failed", "userID", user.UserID, "err", summarizeErr(err))
 		mapUpstreamError(w, err, "Failed to create deployment.")
@@ -119,7 +125,11 @@ func (h *DeploymentHandler) CreateDeployment(w http.ResponseWriter, r *http.Requ
 	writeJSONValue(w, http.StatusCreated, dto.MapDeploymentCreate(result))
 }
 
-// PatchDeployment handles PATCH /deployments/{id}.
+// PatchDeployment handles PATCH /projects/{projectId}/deployments/{id}.
+// projectId is read from the URL only to match the frontend's nesting — the
+// handler never uses it, since entity-service's UpdateDeployment is keyed on
+// the deployment's own id alone (same pattern as
+// PATCH /cases/{caseId}/call-requests/{id} — see this backend's CLAUDE.md).
 func (h *DeploymentHandler) PatchDeployment(w http.ResponseWriter, r *http.Request) {
 	user := middleware.UserInfoFromContext(r.Context())
 	if user == nil {
@@ -138,14 +148,12 @@ func (h *DeploymentHandler) PatchDeployment(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	// Decoded directly into entity-service's request struct (no restricted
-	// portal DTO) — every field here (name/type/description/active) is
-	// customer-appropriate, matching the deployed-product update endpoint.
-	var req entity.UpdateDeploymentRequest
-	if err := json.Unmarshal(body, &req); err != nil {
+	var portalReq dto.DeploymentUpdateRequest
+	if err := json.Unmarshal(body, &portalReq); err != nil {
 		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
 		return
 	}
+	req := dto.BuildEntityUpdateDeploymentRequest(id, portalReq)
 	// entity-service requires exactly one of the detail-fields group
 	// (name/type/description) or active=false — never both, never neither.
 	detailFieldsSet := req.Name != nil || req.Type != nil || len(req.Description) > 0

--- a/apps/customer-portal/backend-v2/internal/handler/instances.go
+++ b/apps/customer-portal/backend-v2/internal/handler/instances.go
@@ -94,10 +94,14 @@ func (h *InstanceHandler) searchInstances(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	var startDate, endDate *string
+	if req.Filters != nil {
+		startDate, endDate = req.Filters.StartDate, req.Filters.EndDate
+	}
 	entityReq := entity.SearchInstancesRequest{
 		Filters: &entity.InstanceSearchFilters{
-			StartDate:          req.StartDate,
-			EndDate:            req.EndDate,
+			StartDate:          startDate,
+			EndDate:            endDate,
 			ProjectIDs:         scope.projectIDs,
 			DeploymentIDs:      scope.deploymentIDs,
 			DeployedProductIDs: scope.deployedProductIDs,

--- a/apps/customer-portal/backend-v2/internal/handler/product_vulnerabilities.go
+++ b/apps/customer-portal/backend-v2/internal/handler/product_vulnerabilities.go
@@ -57,13 +57,13 @@ func (h *ProductVulnerabilityHandler) SearchProductVulnerabilities(w http.Respon
 		return
 	}
 
-	var req entity.SearchProductVulnerabilitiesRequest
+	var req dto.SearchProductVulnerabilitiesRequest
 	if err := json.Unmarshal(body, &req); err != nil {
 		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
 		return
 	}
 
-	result, err := h.entity.SearchProductVulnerabilities(r.Context(), req)
+	result, err := h.entity.SearchProductVulnerabilities(r.Context(), dto.BuildEntitySearchProductVulnerabilitiesRequest(req))
 	if err != nil {
 		slog.ErrorContext(r.Context(), "entity SearchProductVulnerabilities failed", "userID", user.UserID, "err", summarizeErr(err))
 		mapUpstreamError(w, err, "Failed to search product vulnerabilities.")

--- a/apps/customer-portal/backend-v2/internal/handler/products.go
+++ b/apps/customer-portal/backend-v2/internal/handler/products.go
@@ -21,10 +21,16 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
+	"strconv"
 
 	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/dto"
 	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
 	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/middleware"
+)
+
+const (
+	defaultProductsOffset = 0
+	defaultProductsLimit  = 10
 )
 
 // entityProductClient abstracts the entity-service product operations used by ProductHandler.
@@ -41,6 +47,50 @@ type ProductHandler struct {
 // NewProductHandler creates a ProductHandler backed by the given entity client.
 func NewProductHandler(entity entityProductClient) *ProductHandler {
 	return &ProductHandler{entity: entity}
+}
+
+// GetProducts handles GET /products?class=&offset=&limit= — the frontend's
+// live product-browsing flow (matching the old Ballerina backend's own
+// GET /products). entity-service has no GET /products route at all, only
+// POST /products/search, so this translates the query params into that
+// call; class is accepted but not forwarded — entity-service's
+// SearchProductsRequest has no class filter (a genuine gap, see
+// dto.GetProductsRequest's doc comment).
+func (h *ProductHandler) GetProducts(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	offset := defaultProductsOffset
+	if v := r.URL.Query().Get("offset"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 0 {
+			writeError(w, http.StatusBadRequest, "offset must be a non-negative integer.")
+			return
+		}
+		offset = n
+	}
+	limit := defaultProductsLimit
+	if v := r.URL.Query().Get("limit"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 1 {
+			writeError(w, http.StatusBadRequest, "limit must be a positive integer.")
+			return
+		}
+		limit = n
+	}
+
+	req := dto.GetProductsRequest{Pagination: entity.Pagination{Offset: offset, Limit: limit}}
+	result, err := h.entity.SearchProducts(r.Context(), dto.BuildEntitySearchProductsRequestFromQuery(req))
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity SearchProducts failed", "userID", user.UserID, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to retrieve products.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusOK, dto.MapSearchProducts(result))
 }
 
 // SearchProducts handles POST /products/search.

--- a/apps/customer-portal/backend-v2/internal/handler/products.go
+++ b/apps/customer-portal/backend-v2/internal/handler/products.go
@@ -53,9 +53,11 @@ func NewProductHandler(entity entityProductClient) *ProductHandler {
 // live product-browsing flow (matching the old Ballerina backend's own
 // GET /products). entity-service has no GET /products route at all, only
 // POST /products/search, so this translates the query params into that
-// call; class is accepted but not forwarded — entity-service's
-// SearchProductsRequest has no class filter (a genuine gap, see
-// dto.GetProductsRequest's doc comment).
+// call; class can't be forwarded as a request filter — entity-service's
+// SearchProductsRequest has no such parameter — so it's applied afterward
+// against each returned item's own Class field instead (see
+// dto.FilterProductsByClass's doc comment, including the pagination and
+// Postgres-data-source caveats).
 func (h *ProductHandler) GetProducts(w http.ResponseWriter, r *http.Request) {
 	user := middleware.UserInfoFromContext(r.Context())
 	if user == nil {
@@ -82,7 +84,8 @@ func (h *ProductHandler) GetProducts(w http.ResponseWriter, r *http.Request) {
 		limit = n
 	}
 
-	req := dto.GetProductsRequest{Pagination: entity.Pagination{Offset: offset, Limit: limit}}
+	class := r.URL.Query().Get("class")
+	req := dto.GetProductsRequest{Pagination: entity.Pagination{Offset: offset, Limit: limit}, Class: class}
 	result, err := h.entity.SearchProducts(r.Context(), dto.BuildEntitySearchProductsRequestFromQuery(req))
 	if err != nil {
 		slog.ErrorContext(r.Context(), "entity SearchProducts failed", "userID", user.UserID, "err", summarizeErr(err))
@@ -90,7 +93,7 @@ func (h *ProductHandler) GetProducts(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSONValue(w, http.StatusOK, dto.MapSearchProducts(result))
+	writeJSONValue(w, http.StatusOK, dto.FilterProductsByClass(dto.MapSearchProducts(result), class))
 }
 
 // SearchProducts handles POST /products/search.

--- a/apps/customer-portal/backend-v2/internal/handler/projects.go
+++ b/apps/customer-portal/backend-v2/internal/handler/projects.go
@@ -56,13 +56,13 @@ func (h *ProjectHandler) SearchProjects(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	var req entity.SearchProjectsRequest
+	var req dto.SearchProjectsRequest
 	if err := json.Unmarshal(body, &req); err != nil {
 		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
 		return
 	}
 
-	result, err := h.entity.SearchProjects(r.Context(), req)
+	result, err := h.entity.SearchProjects(r.Context(), dto.BuildEntitySearchProjectsRequest(req))
 	if err != nil {
 		slog.ErrorContext(r.Context(), "entity SearchProjects failed", "userID", user.UserID, "err", summarizeErr(err))
 		mapUpstreamError(w, err, "Failed to search projects.")

--- a/apps/customer-portal/backend-v2/internal/handler/time_cards.go
+++ b/apps/customer-portal/backend-v2/internal/handler/time_cards.go
@@ -48,11 +48,17 @@ func NewTimeCardHandler(entity entityTimeCardClient) *TimeCardHandler {
 	return &TimeCardHandler{entity: entity}
 }
 
-// SearchTimeCards handles POST /time-cards/search.
+// SearchTimeCards handles POST /projects/{id}/time-cards/search.
 func (h *TimeCardHandler) SearchTimeCards(w http.ResponseWriter, r *http.Request) {
 	user := middleware.UserInfoFromContext(r.Context())
 	if user == nil {
 		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	projectID := r.PathValue("id")
+	if projectID == "" || !uuidRe.MatchString(projectID) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
 
@@ -61,13 +67,13 @@ func (h *TimeCardHandler) SearchTimeCards(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	var req entity.SearchTimeCardsRequest
+	var req dto.TimeCardSearchRequest
 	if err := json.Unmarshal(body, &req); err != nil {
 		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
 		return
 	}
 
-	result, err := h.entity.SearchTimeCards(r.Context(), req)
+	result, err := h.entity.SearchTimeCards(r.Context(), dto.BuildEntitySearchTimeCardsRequest(projectID, req))
 	if err != nil {
 		slog.ErrorContext(r.Context(), "entity SearchTimeCards failed", "userID", user.UserID, "err", summarizeErr(err))
 		mapUpstreamError(w, err, "Failed to search time cards.")

--- a/apps/customer-portal/backend-v2/internal/handler/users.go
+++ b/apps/customer-portal/backend-v2/internal/handler/users.go
@@ -87,6 +87,7 @@ func (h *UserHandler) GetMe(w http.ResponseWriter, r *http.Request) {
 		slog.WarnContext(r.Context(), "no SCIM user found", "userID", user.UserID)
 	} else {
 		resp.PhoneNumber = scimInfo.PhoneNumber
+		resp.LastPasswordUpdateTime = scimInfo.LastPasswordUpdateTime
 	}
 
 	writeJSONValue(w, http.StatusOK, resp)

--- a/apps/customer-portal/backend-v2/internal/registry/types.go
+++ b/apps/customer-portal/backend-v2/internal/registry/types.go
@@ -41,7 +41,8 @@ type TokenCreatePayload struct {
 // — an open record upstream; Secret is the only field this backend reads
 // directly, the rest is passed through as-is.
 type TokenCreationResponse struct {
-	Secret string `json:"secret"`
+	Secret string  `json:"secret"`
+	Name   *string `json:"name,omitempty"`
 }
 
 // Permission is one access grant on a registry token.
@@ -51,7 +52,7 @@ type Permission struct {
 
 // Token is a registry token as returned by the registry service.
 type Token struct {
-	ID           *string      `json:"id,omitempty"`
+	ID           *int64       `json:"id,omitempty"`
 	Name         string       `json:"name"`
 	DisplayName  *string      `json:"displayName,omitempty"`
 	Description  string       `json:"description"`
@@ -59,7 +60,7 @@ type Token struct {
 	TokenType    *TokenType   `json:"tokenType,omitempty"`
 	CreatedFor   *string      `json:"createdFor,omitempty"`
 	CreatedBy    *string      `json:"createdBy,omitempty"`
-	ExpiresAt    *string      `json:"expiresAt,omitempty"`
+	ExpiresAt    *int64       `json:"expiresAt,omitempty"`
 	Disable      bool         `json:"disable"`
 	Duration     int          `json:"duration"`
 	Permissions  []Permission `json:"permissions"`

--- a/apps/customer-portal/backend-v2/openapi.yaml
+++ b/apps/customer-portal/backend-v2/openapi.yaml
@@ -825,10 +825,10 @@ paths:
     patch:
       summary: Update a case.
       description: >
-        Exactly one of state/severity/subject/description/watchList is
-        required. This is a deliberately restricted subset of
-        entity-service's update contract — internal WSO2 support fields
-        (work state, engineer assignment, fix-ETA dates, case relinking,
+        Exactly one of stateKey or watchList is required. This is a
+        deliberately restricted subset of entity-service's update contract
+        — internal WSO2 support fields (severity, subject, description,
+        work state, engineer assignment, fix-ETA dates, case relinking,
         auto-closure control) are not customer-settable.
       operationId: patchCasesId
       parameters:
@@ -1117,13 +1117,21 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
-  /deployments:
+  /projects/{id}/deployments:
     post:
       summary: Create a deployment.
       description: >
-        Only entity-service's ServiceNow data source supports this route —
-        a Postgres-mode deployment always returns 400.
-      operationId: postDeployments
+        projectId is set server-side from the path parameter. Only
+        entity-service's ServiceNow data source supports this route — a
+        Postgres-mode deployment always returns 400.
+      operationId: postProjectsIdDeployments
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -1168,10 +1176,20 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
-  /deployed-products/search:
+  /deployments/{deploymentId}/products/search:
     post:
       summary: Search deployed products.
-      operationId: postDeployedProductsSearch
+      description: >
+        Always scoped to the deployment in the path — the request body
+        carries no deploymentId field.
+      operationId: postDeploymentsDeploymentIdProductsSearch
+      parameters:
+        - name: deploymentId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -1216,13 +1234,21 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
-  /deployed-products:
+  /deployments/{deploymentId}/products:
     post:
       summary: Create a deployed product.
       description: >
-        Only entity-service's ServiceNow data source supports this route —
-        a Postgres-mode deployment always returns 400.
-      operationId: postDeployedProducts
+        deploymentId is set server-side from the path parameter. Only
+        entity-service's ServiceNow data source supports this route — a
+        Postgres-mode deployment always returns 400.
+      operationId: postDeploymentsDeploymentIdProducts
+      parameters:
+        - name: deploymentId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -1267,15 +1293,24 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
-  /deployed-products/{id}:
+  /deployments/{deploymentId}/products/{id}:
     patch:
       summary: Update a deployed product.
       description: >
         Provide either cores/tps/description or active=false, but not both.
-        Only entity-service's ServiceNow data source supports this route —
-        a Postgres-mode deployment always returns 400.
-      operationId: patchDeployedProductsId
+        deploymentId is set server-side from the path parameter (an
+        IDOR-style scope guard — the deployed product must belong to this
+        deployment), not the request body. Only entity-service's ServiceNow
+        data source supports this route — a Postgres-mode deployment always
+        returns 400.
+      operationId: patchDeploymentsDeploymentIdProductsId
       parameters:
+        - name: deploymentId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
         - name: id
           in: path
           required: true
@@ -1643,6 +1678,63 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
+  /products:
+    get:
+      summary: List products.
+      description: >
+        class is accepted but not forwarded — entity-service's
+        SearchProductsRequest has no class filter (a genuine gap).
+      operationId: getProducts
+      parameters:
+        - name: class
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: offset
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 0
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 10
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchProductsResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
   /products/search:
     post:
       summary: Search products.
@@ -1801,11 +1893,21 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
-  /change-requests/search:
+  /projects/{id}/change-requests/search:
     post:
       summary: Search change requests.
-      description: Only entity-service's ServiceNow data source supports this route.
-      operationId: postChangeRequestsSearch
+      description: >
+        projectId is set server-side from the path parameter — any
+        client-supplied value in the request body is ignored. Only
+        entity-service's ServiceNow data source supports this route.
+      operationId: postProjectsIdChangeRequestsSearch
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -2353,13 +2455,22 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
-  /deployments/{id}:
+  /projects/{projectId}/deployments/{id}:
     patch:
       summary: Update a deployment.
       description: >
-        Provide either name/type/description or active=false, but not both.
-      operationId: patchDeploymentsId
+        Provide either name/typeKey/description or active=false, but not
+        both. projectId is read from the URL only to match the frontend's
+        nesting — entity-service's update is keyed on the deployment's own
+        id alone.
+      operationId: patchProjectsProjectIdDeploymentsId
       parameters:
+        - name: projectId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
         - name: id
           in: path
           required: true
@@ -2616,10 +2727,20 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
-  /catalogs/search:
+  /deployments/products/{deployedProductId}/catalogs/search:
     post:
       summary: Search service catalogs.
-      operationId: postCatalogsSearch
+      description: >
+        Always scoped to the deployed product in the path — the request
+        body carries no deployedProductId field.
+      operationId: postDeploymentsProductsDeployedProductIdCatalogsSearch
+      parameters:
+        - name: deployedProductId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -2664,10 +2785,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
-  /catalogs/{catalogId}/items/{catalogItemId}/variables:
+  /catalogs/{catalogId}/items/{itemId}:
     get:
       summary: Get a catalog item's variables.
-      operationId: getCatalogsCatalogIdItemsCatalogItemIdVariables
+      operationId: getCatalogsCatalogIdItemsItemId
       parameters:
         - name: catalogId
           in: path
@@ -2675,7 +2796,7 @@ paths:
           schema:
             type: string
             format: uuid
-        - name: catalogItemId
+        - name: itemId
           in: path
           required: true
           schema:
@@ -2719,14 +2840,23 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
-  /time-cards/search:
+  /projects/{id}/time-cards/search:
     post:
       summary: Search time cards.
       description: >
-        Only entity-service's ServiceNow data source supports this route —
-        a Postgres-mode deployment 404s. Excludes internal WSO2 per-category
+        projectId is set server-side from the path parameter — any
+        client-supplied value in the request body is ignored. Only
+        entity-service's ServiceNow data source supports this route — a
+        Postgres-mode deployment 404s. Excludes internal WSO2 per-category
         time breakdowns and notes — see this backend's CLAUDE.md.
-      operationId: postTimeCardsSearch
+      operationId: postProjectsIdTimeCardsSearch
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         content:
           application/json:
@@ -3619,6 +3749,62 @@ paths:
                 $ref: '#/components/schemas/ErrorPayload'
         "403":
           description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+    post:
+      summary: Create a case attachment.
+      description: >
+        The case is scoped by the {id} path parameter — there is no
+        referenceId field in the request body.
+      operationId: postCasesIdAttachments
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateCaseAttachmentRequest'
+        required: true
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AttachmentCreateResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
           content:
             application/json:
               schema:
@@ -5828,6 +6014,8 @@ components:
             type: string
         phoneNumber:
           type: string
+        lastPasswordUpdateTime:
+          type: string
 
     UserUpdateRequest:
       type: object
@@ -5940,23 +6128,22 @@ components:
 
     # ---- projects ----
 
+    SearchProjectsFilters:
+      type: object
+      properties:
+        searchQuery:
+          type: string
+
     SearchProjectsRequest:
+      description: >
+        filters is nested, matching the frontend's own request shape — not
+        entity-service's flat searchQuery field.
       type: object
       properties:
         pagination:
           $ref: '#/components/schemas/Pagination'
-        searchQuery:
-          type: string
-        closureStatus:
-          type: string
-        endDateFrom:
-          type: string
-        endDateTo:
-          type: string
-        sortBy:
-          type: string
-        sortOrder:
-          type: string
+        filters:
+          $ref: '#/components/schemas/SearchProjectsFilters'
 
     ProjectSummary:
       type: object
@@ -5969,6 +6156,8 @@ components:
           type: string
         subscriptionType:
           type: string
+        startDate:
+          type: string
         endDate:
           type: string
         createdOn:
@@ -5977,13 +6166,16 @@ components:
           type: string
 
     SearchProjectsResponse:
+      description: >
+        totalRecords (not total) to match the frontend's shared pagination
+        envelope.
       type: object
       properties:
         projects:
           type: array
           items:
             $ref: '#/components/schemas/ProjectSummary'
-        total:
+        totalRecords:
           type: integer
         limit:
           type: integer
@@ -5993,15 +6185,23 @@ components:
           type: boolean
 
     ProjectAccount:
+      description: >
+        supportTier (not tier) to match the frontend's read site.
       type: object
       properties:
         id:
           type: string
         name:
           type: string
-        tier:
+        supportTier:
           type: string
         region:
+          type: string
+        hasAgent:
+          type: boolean
+        hasKbReferences:
+          type: boolean
+        activationDate:
           type: string
 
     ProjectDetails:
@@ -6186,28 +6386,90 @@ components:
         name:
           type: string
 
+    CaseDetailsAccount:
+      type: object
+      properties:
+        type:
+          type: string
+        id:
+          type: string
+        label:
+          type: string
+
+    CaseDetailsAssignedEngineer:
+      type: object
+      properties:
+        id:
+          type: string
+        label:
+          type: string
+        name:
+          type: string
+
+    CaseWatchListUser:
+      type: object
+      properties:
+        id:
+          type: string
+        userName:
+          type: string
+        name:
+          type: string
+        email:
+          type: string
+
     CaseDetails:
       type: object
       properties:
         id:
           type: string
+        internalId:
+          type: string
         number:
           type: string
-        subject:
+        title:
           type: string
         description:
           type: string
-        severity:
+        product:
+          $ref: '#/components/schemas/IdLabelRef'
+        account:
+          $ref: '#/components/schemas/CaseDetailsAccount'
+        assignedEngineer:
+          $ref: '#/components/schemas/CaseDetailsAssignedEngineer'
+        engineerEmail:
           type: string
-        issueType:
-          type: string
-        state:
-          type: string
-        workState:
-          type: string
+        project:
+          $ref: '#/components/schemas/IdLabelRef'
         type:
-          type: string
+          $ref: '#/components/schemas/IdLabelRef'
+        deployedProduct:
+          $ref: '#/components/schemas/IdLabelRef'
+        relatedCase:
+          $ref: '#/components/schemas/IdLabelRef'
+        conversation:
+          $ref: '#/components/schemas/IdLabelRef'
+        issueType:
+          $ref: '#/components/schemas/IdLabelRef'
         engagementType:
+          $ref: '#/components/schemas/IdLabelRef'
+        catalog:
+          $ref: '#/components/schemas/IdLabelRef'
+        catalogItem:
+          $ref: '#/components/schemas/IdLabelRef'
+        changeRequests:
+          type: array
+          items:
+            $ref: '#/components/schemas/IdLabelRef'
+        assignedTeam:
+          $ref: '#/components/schemas/IdLabelRef'
+        deployment:
+          $ref: '#/components/schemas/IdLabelRef'
+        severity:
+          $ref: '#/components/schemas/IdLabelRef'
+        status:
+          $ref: '#/components/schemas/IdLabelRef'
+        workState:
           type: string
         createdOn:
           type: string
@@ -6216,24 +6478,8 @@ components:
         closedOn:
           type: string
         createdBy:
-          $ref: '#/components/schemas/PersonRef'
-        project:
-          $ref: '#/components/schemas/Ref'
-        deployment:
-          $ref: '#/components/schemas/Ref'
-        deployedProduct:
-          $ref: '#/components/schemas/Ref'
-        product:
-          $ref: '#/components/schemas/Ref'
-        assignedTeam:
-          $ref: '#/components/schemas/Ref'
-        conversation:
-          $ref: '#/components/schemas/Ref'
-        assignedEngineer:
-          $ref: '#/components/schemas/PersonRef'
+          type: string
         parentCase:
-          $ref: '#/components/schemas/NumberRef'
-        relatedCase:
           $ref: '#/components/schemas/NumberRef'
         linkedServiceRequests:
           type: array
@@ -6247,6 +6493,10 @@ components:
           type: string
         resolutionNotes:
           type: string
+        watchList:
+          type: array
+          items:
+            $ref: '#/components/schemas/CaseWatchListUser'
         fixEta:
           type: string
         tags:
@@ -6256,8 +6506,10 @@ components:
 
     CaseCreateRequest:
       type: object
-      required: [type, projectId, deploymentId, subject, description, severity, issueType]
+      required: [title, projectId, deploymentId, description]
       properties:
+        title:
+          type: string
         type:
           type: string
           description: "\"case\", \"service_request\", or \"security_report_analysis\""
@@ -6270,14 +6522,14 @@ components:
         deployedProductId:
           type: string
           format: uuid
-        subject:
-          type: string
         description:
           type: string
-        severity:
-          type: string
-        issueType:
-          type: string
+        severityKey:
+          type: integer
+          description: ServiceNow numeric choice-list id — see case_enum_mapping.go.
+        issueTypeKey:
+          type: integer
+          description: ServiceNow numeric choice-list id — see case_enum_mapping.go.
         catalogId:
           type: string
           description: Required when type is "service_request".
@@ -6320,38 +6572,30 @@ components:
       properties:
         id:
           type: string
+        internalId:
+          type: string
         number:
           type: string
         createdOn:
           type: string
         state:
-          type: string
+          $ref: '#/components/schemas/IdLabelRef'
+        type:
+          $ref: '#/components/schemas/IdLabelRef'
 
     CaseUpdateRequest:
       description: >
-        Exactly one of state/severity/subject/description/watchList is
-        required. resolutionCode/cause/closeNotes are only accepted
-        alongside a closing state transition.
+        Exactly one of stateKey or watchList is required. stateKey carries
+        ServiceNow's numeric choice-list id (see case_enum_mapping.go), not
+        entity-service's own string enum.
       type: object
       properties:
-        state:
-          type: string
-        severity:
-          type: string
-        subject:
-          type: string
-        description:
-          type: string
+        stateKey:
+          type: integer
         watchList:
           type: array
           items:
             type: string
-        resolutionCode:
-          type: string
-        cause:
-          type: string
-        closeNotes:
-          type: string
 
     CaseUpdateResponse:
       type: object
@@ -6433,26 +6677,29 @@ components:
         name:
           type: string
         type:
-          type: string
+          $ref: '#/components/schemas/IdLabelRef'
         description:
           type: string
         createdBy:
           $ref: '#/components/schemas/Ref'
         project:
-          $ref: '#/components/schemas/Ref'
+          $ref: '#/components/schemas/IdLabelRef'
         createdOn:
           type: string
         updatedOn:
           type: string
 
     SearchDeploymentsResponse:
+      description: >
+        totalRecords (not total) to match the frontend's shared pagination
+        envelope.
       type: object
       properties:
         deployments:
           type: array
           items:
             $ref: '#/components/schemas/DeploymentSummary'
-        total:
+        totalRecords:
           type: integer
         limit:
           type: integer
@@ -6462,17 +6709,18 @@ components:
           type: boolean
 
     CreateDeploymentRequest:
+      description: >
+        projectId is set server-side from the {id} path parameter — the
+        request body carries no projectId field. deploymentTypeKey carries
+        ServiceNow's numeric choice-list id (see deployment_enum_mapping.go).
       type: object
-      required: [projectId, name]
+      required: [deploymentTypeKey, description, name]
       properties:
-        projectId:
-          type: string
-          format: uuid
-        name:
-          type: string
-        type:
-          type: string
+        deploymentTypeKey:
+          type: integer
         description:
+          type: string
+        name:
           type: string
 
     DeploymentCreateResponse:
@@ -6484,18 +6732,21 @@ components:
           type: string
 
     UpdateDeploymentRequest:
-      description: Provide either name/type/description or active=false, but not both.
+      description: >
+        Provide either name/typeKey/description or active=false, but not
+        both. typeKey carries ServiceNow's numeric choice-list id (see
+        deployment_enum_mapping.go).
       type: object
       properties:
-        name:
-          type: string
-        type:
-          type: string
+        active:
+          type: boolean
         description:
           type: string
           nullable: true
-        active:
-          type: boolean
+        name:
+          type: string
+        typeKey:
+          type: integer
 
     DeploymentUpdateResponse:
       type: object
@@ -6508,42 +6759,47 @@ components:
     # ---- deployed products ----
 
     SearchDeployedProductsRequest:
+      description: >
+        Always scoped to the deployment in the {deploymentId} path
+        parameter — the request body carries no deploymentId field.
       type: object
       properties:
         pagination:
           $ref: '#/components/schemas/Pagination'
-        deploymentIds:
-          type: array
-          items:
-            type: string
 
     DeployedProductVersion:
+      description: >
+        label (not name), releasedOn/endOfLifeOn (not releasedDate/
+        supportEoLDate) to match the frontend's IdLabelRef shape.
       type: object
       properties:
         id:
           type: string
-        name:
+        label:
           type: string
-        releasedDate:
+        releasedOn:
           type: string
-        supportEoLDate:
+        endOfLifeOn:
           type: string
 
     DeployedProductSummary:
+      description: >
+        cores/tps are numbers (not strings) — parsed from entity-service's
+        ServiceNow-string wire format.
       type: object
       properties:
         id:
           type: string
         deployment:
-          $ref: '#/components/schemas/Ref'
+          $ref: '#/components/schemas/IdLabelRef'
         product:
-          $ref: '#/components/schemas/Ref'
+          $ref: '#/components/schemas/IdLabelRef'
         version:
           $ref: '#/components/schemas/DeployedProductVersion'
         cores:
-          type: string
+          type: integer
         tps:
-          type: string
+          type: number
         category:
           type: string
         createdOn:
@@ -6552,13 +6808,16 @@ components:
           type: string
 
     SearchDeployedProductsResponse:
+      description: >
+        totalRecords (not total) to match the frontend's shared pagination
+        envelope.
       type: object
       properties:
         deployedProducts:
           type: array
           items:
             $ref: '#/components/schemas/DeployedProductSummary'
-        total:
+        totalRecords:
           type: integer
         limit:
           type: integer
@@ -6568,13 +6827,13 @@ components:
           type: boolean
 
     CreateDeployedProductRequest:
+      description: >
+        deploymentId is set server-side from the {deploymentId} path
+        parameter — the request body carries no deploymentId field.
       type: object
-      required: [projectId, deploymentId, productId, versionId]
+      required: [projectId, productId, versionId]
       properties:
         projectId:
-          type: string
-          format: uuid
-        deploymentId:
           type: string
           format: uuid
         productId:
@@ -6599,13 +6858,13 @@ components:
           type: string
 
     UpdateDeployedProductRequest:
-      description: Provide either cores/tps/description or active=false, but not both.
+      description: >
+        Provide either cores/tps/description or active=false, but not both.
+        deploymentId is always injected server-side from the
+        {deploymentId} path parameter (an IDOR-style scope guard) — the
+        request body carries no deploymentId field.
       type: object
       properties:
-        deploymentId:
-          type: string
-          format: uuid
-          description: Optional — scopes the update to this deployment.
         cores:
           type: integer
         tps:
@@ -6624,6 +6883,24 @@ components:
           type: string
 
     # ---- attachments ----
+
+    CreateCaseAttachmentRequest:
+      description: >
+        The case is scoped by the {id} path parameter — referenceId/
+        referenceType are injected server-side, not client-supplied.
+      type: object
+      required: [name, type, content]
+      properties:
+        name:
+          type: string
+        type:
+          type: string
+          description: MIME/content type of the file.
+        content:
+          type: string
+          description: Base64-encoded file content.
+        description:
+          type: string
 
     CreateAttachmentRequest:
       type: object
@@ -6768,6 +7045,12 @@ components:
           type: string
         createdBy:
           type: string
+        createdByFirstName:
+          type: string
+        createdByLastName:
+          type: string
+        createdByFullName:
+          type: string
         commentType:
           type: string
         fileName:
@@ -6793,13 +7076,16 @@ components:
           description: When false or omitted, only comment and attachment entries are returned.
 
     SearchCaseActivitiesResponse:
+      description: >
+        activities (not activity) and totalRecords (not total) to match the
+        frontend's actual read sites.
       type: object
       properties:
-        activity:
+        activities:
           type: array
           items:
             $ref: '#/components/schemas/CaseActivity'
-        total:
+        totalRecords:
           type: integer
         limit:
           type: integer
@@ -6856,25 +7142,39 @@ components:
           $ref: '#/components/schemas/Pagination'
 
     CommentView:
+      description: >
+        Shared by POST /comments/search and GET /conversations/{id}/messages.
+        type/createdByFirstName/createdByLastName let the chat-history view
+        distinguish the AI's replies from the customer's own messages.
       type: object
       properties:
         id:
           type: string
         content:
           type: string
+        type:
+          type: string
         createdOn:
           type: string
         createdBy:
           type: string
+        createdByFirstName:
+          type: string
+        createdByLastName:
+          type: string
 
     SearchCommentsResponse:
+      description: >
+        totalRecords (not total) to match the frontend's shared pagination
+        envelope. Shared by POST /comments/search and
+        GET /conversations/{id}/messages.
       type: object
       properties:
         comments:
           type: array
           items:
             $ref: '#/components/schemas/CommentView'
-        total:
+        totalRecords:
           type: integer
         limit:
           type: integer
@@ -6908,13 +7208,16 @@ components:
           type: string
 
     SearchProductsResponse:
+      description: >
+        totalRecords (not total) to match the frontend's shared pagination
+        envelope. Shared by POST /products/search and GET /products.
       type: object
       properties:
         products:
           type: array
           items:
             $ref: '#/components/schemas/ProductSummary'
-        total:
+        totalRecords:
           type: integer
         limit:
           type: integer
@@ -6952,13 +7255,16 @@ components:
           type: string
 
     SearchProductVersionsResponse:
+      description: >
+        versions (not productVersions) and totalRecords (not total) to
+        match the frontend's own ProductVersionsSearchResponse type.
       type: object
       properties:
-        productVersions:
+        versions:
           type: array
           items:
             $ref: '#/components/schemas/ProductVersionSummary'
-        total:
+        totalRecords:
           type: integer
         limit:
           type: integer
@@ -6970,6 +7276,10 @@ components:
     # ---- product vulnerabilities ----
 
     SearchProductVulnerabilitiesRequest:
+      description: >
+        statusId is accepted but not forwarded — entity-service's
+        SearchProductVulnerabilitiesFilters has no status field (a genuine
+        gap).
       type: object
       properties:
         filters:
@@ -6977,9 +7287,11 @@ components:
           properties:
             searchQuery:
               type: string
-            priority:
-              type: string
-              enum: [info, low, medium, high, critical, unknown]
+            severityId:
+              type: integer
+              description: ServiceNow numeric choice-list id — see product_vulnerability_enum_mapping.go.
+            statusId:
+              type: integer
             productName:
               type: string
             productVersion:
@@ -6988,6 +7300,9 @@ components:
           $ref: '#/components/schemas/Pagination'
 
     ProductVulnerability:
+      description: >
+        severity (not priority) as an IdLabelRef to match the frontend's
+        own ProductVulnerability type.
       type: object
       properties:
         id:
@@ -6996,8 +7311,8 @@ components:
           type: string
         vulnerabilityId:
           type: string
-        priority:
-          type: string
+        severity:
+          $ref: '#/components/schemas/IdLabelRef'
         productName:
           type: string
           nullable: true
@@ -7027,13 +7342,16 @@ components:
           nullable: true
 
     SearchProductVulnerabilitiesResponse:
+      description: >
+        totalRecords (not total) to match the frontend's shared pagination
+        envelope.
       type: object
       properties:
         productVulnerabilities:
           type: array
           items:
             $ref: '#/components/schemas/ProductVulnerability'
-        total:
+        totalRecords:
           type: integer
         limit:
           type: integer
@@ -7043,22 +7361,22 @@ components:
     # ---- catalogs ----
 
     SearchCatalogsRequest:
-      description: Scopes the search to catalogs available for the given deployed product.
+      description: >
+        Always scoped to the deployed product in the {deployedProductId}
+        path parameter — the request body carries no deployedProductId
+        field.
       type: object
-      required: [deployedProductId]
       properties:
-        deployedProductId:
-          type: string
-          format: uuid
         pagination:
           $ref: '#/components/schemas/Pagination'
 
     CatalogItem:
+      description: label (not name) to match the frontend's own CatalogItem type.
       type: object
       properties:
         id:
           type: string
-        name:
+        label:
           type: string
 
     Catalog:
@@ -7074,13 +7392,16 @@ components:
             $ref: '#/components/schemas/CatalogItem'
 
     SearchCatalogsResponse:
+      description: >
+        totalRecords (not total) to match the frontend's shared pagination
+        envelope.
       type: object
       properties:
         catalogs:
           type: array
           items:
             $ref: '#/components/schemas/Catalog'
-        total:
+        totalRecords:
           type: integer
         limit:
           type: integer
@@ -7111,21 +7432,17 @@ components:
 
     SearchTimeCardsRequest:
       description: >
-        entity-service also accepts userId/approverId/approvedById/userIds
-        filters that scope results to a specific WSO2 engineer — deliberately
-        not exposed here since the portal has no notion of a customer
-        selecting a WSO2 engineer to filter by.
+        projectId is set server-side from the {id} path parameter — the
+        request body carries no projectIds/caseId field. entity-service
+        also accepts userId/approverId/approvedById/userIds filters that
+        scope results to a specific WSO2 engineer — deliberately not
+        exposed here since the portal has no notion of a customer selecting
+        a WSO2 engineer to filter by.
       type: object
       properties:
         filters:
           type: object
           properties:
-            projectIds:
-              type: array
-              items:
-                type: string
-            caseId:
-              type: string
             startDate:
               type: string
             endDate:
@@ -7149,7 +7466,7 @@ components:
       properties:
         id:
           type: string
-        name:
+        label:
           type: string
         number:
           type: string
@@ -7159,37 +7476,40 @@ components:
         Deliberately excludes entity-service's per-category time breakdowns,
         issueComplexity, workLogComment, rejectionReason, and the
         eligible-approvers list — internal WSO2 support bookkeeping never
-        exposed to the customer portal.
+        exposed to the customer portal. createdOn (not workDate), and
+        state/reportedBy/approvedBy/project as IdLabelRef.
       type: object
       properties:
         id:
           type: string
         totalTime:
           type: number
-        workDate:
+        createdOn:
           type: string
         hasBillable:
           type: boolean
         state:
-          type: string
-          nullable: true
-        user:
-          $ref: '#/components/schemas/Ref'
+          $ref: '#/components/schemas/IdLabelRef'
+        reportedBy:
+          $ref: '#/components/schemas/IdLabelRef'
         approvedBy:
-          $ref: '#/components/schemas/Ref'
+          $ref: '#/components/schemas/IdLabelRef'
         project:
-          $ref: '#/components/schemas/Ref'
+          $ref: '#/components/schemas/IdLabelRef'
         case:
           $ref: '#/components/schemas/TimeCardCaseRef'
 
     SearchTimeCardsResponse:
+      description: >
+        totalRecords (not total) to match the frontend's shared pagination
+        envelope.
       type: object
       properties:
         timeCards:
           type: array
           items:
             $ref: '#/components/schemas/TimeCardSummary'
-        total:
+        totalRecords:
           type: integer
         limit:
           type: integer
@@ -7414,20 +7734,18 @@ components:
     SearchConversationsRequest:
       description: >
         projectIds is set server-side from the path parameter and any
-        client-supplied value in filters.projectIds is ignored.
+        client-supplied value in filters.projectIds is ignored. stateKeys
+        carries ServiceNow's numeric choice-list ids (see
+        conversation_enum_mapping.go), not entity-service's own string enum.
       type: object
       properties:
         filters:
           type: object
           properties:
-            projectIds:
+            stateKeys:
               type: array
               items:
-                type: string
-            states:
-              type: array
-              items:
-                type: string
+                type: integer
             searchQuery:
               type: string
             createdByMe:
@@ -7443,6 +7761,7 @@ components:
           $ref: '#/components/schemas/Pagination'
 
     ConversationSummary:
+      description: project/case/state as IdLabelRef.
       type: object
       properties:
         id:
@@ -7453,23 +7772,28 @@ components:
           type: string
         messageCount:
           type: integer
+        project:
+          $ref: '#/components/schemas/IdLabelRef'
         case:
-          $ref: '#/components/schemas/Ref'
+          $ref: '#/components/schemas/IdLabelRef'
         state:
-          type: string
+          $ref: '#/components/schemas/IdLabelRef'
         createdOn:
           type: string
         createdBy:
           type: string
 
     SearchConversationsResponse:
+      description: >
+        totalRecords (not total) to match the frontend's shared pagination
+        envelope.
       type: object
       properties:
         conversations:
           type: array
           items:
             $ref: '#/components/schemas/ConversationSummary'
-        total:
+        totalRecords:
           type: integer
         limit:
           type: integer
@@ -7533,25 +7857,27 @@ components:
           type: string
 
     SearchChangeRequestsRequest:
+      description: >
+        projectId is set server-side from the {id} path parameter — the
+        request body carries no projectIds field. stateKeys/impactKeys
+        carry ServiceNow's numeric choice-list ids (see
+        change_request_enum_mapping.go), not entity-service's own string
+        enum.
       type: object
       properties:
         filters:
           type: object
           properties:
-            projectIds:
-              type: array
-              items:
-                type: string
             searchQuery:
               type: string
-            states:
+            stateKeys:
               type: array
               items:
-                type: string
-            impacts:
+                type: integer
+            impactKeys:
               type: array
               items:
-                type: string
+                type: integer
             closedStartDate:
               type: string
             closedEndDate:
@@ -7567,55 +7893,62 @@ components:
           $ref: '#/components/schemas/Pagination'
 
     ChangeRequestSummary:
+      description: >
+        title (not subject), startDate/endDate (not plannedStartOn/
+        plannedEndOn), and every reference field as IdLabelRef to match the
+        frontend's own ChangeRequestItem type.
       type: object
       properties:
         id:
           type: string
         number:
           type: string
-        subject:
+        title:
           type: string
         description:
           type: string
         project:
-          $ref: '#/components/schemas/Ref'
+          $ref: '#/components/schemas/IdLabelRef'
         case:
-          $ref: '#/components/schemas/Ref'
+          $ref: '#/components/schemas/IdLabelRef'
         deployment:
-          $ref: '#/components/schemas/Ref'
+          $ref: '#/components/schemas/IdLabelRef'
         deployedProduct:
-          $ref: '#/components/schemas/Ref'
+          $ref: '#/components/schemas/IdLabelRef'
         product:
-          $ref: '#/components/schemas/Ref'
+          $ref: '#/components/schemas/IdLabelRef'
         assignedEngineer:
-          $ref: '#/components/schemas/Ref'
+          $ref: '#/components/schemas/IdLabelRef'
         assignedTeam:
-          $ref: '#/components/schemas/Ref'
-        plannedStartOn:
+          $ref: '#/components/schemas/IdLabelRef'
+        startDate:
           type: string
-        plannedEndOn:
+        endDate:
           type: string
         duration:
           type: string
         impact:
-          type: string
+          $ref: '#/components/schemas/IdLabelRef'
         state:
-          type: string
+          $ref: '#/components/schemas/IdLabelRef'
         type:
-          type: string
+          $ref: '#/components/schemas/IdLabelRef'
         createdOn:
           type: string
         updatedOn:
           type: string
 
     SearchChangeRequestsResponse:
+      description: >
+        totalRecords (not total) to match the frontend's shared pagination
+        envelope.
       type: object
       properties:
         changeRequests:
           type: array
           items:
             $ref: '#/components/schemas/ChangeRequestSummary'
-        total:
+        totalRecords:
           type: integer
         offset:
           type: integer
@@ -7646,7 +7979,7 @@ components:
             hasCustomerReviewed:
               type: boolean
             approvedBy:
-              $ref: '#/components/schemas/Ref'
+              $ref: '#/components/schemas/IdLabelRef'
             approvedOn:
               type: string
             legalNextStates:
@@ -9194,14 +9527,17 @@ components:
           $ref: '#/components/schemas/CaseTimeCardBillingInfo'
 
     CaseTimeCardSearchResponse:
+      description: >
+        totalRecords (not total) to match the frontend's shared
+        PaginationResponse envelope.
       type: object
-      required: [caseTimeCards, total, offset, limit]
+      required: [caseTimeCards, totalRecords, offset, limit]
       properties:
         caseTimeCards:
           type: array
           items:
             $ref: '#/components/schemas/CaseTimeCard'
-        total:
+        totalRecords:
           type: integer
         offset:
           type: integer
@@ -9214,14 +9550,18 @@ components:
     InstanceSearchRequest:
       description: >-
         Exactly one path-scoped ID filter (project/deployment/deployed
-        product) is injected server-side by the calling handler.
+        product) is injected server-side by the calling handler. startDate/
+        endDate are nested under filters, not top-level.
       type: object
       required: [pagination]
       properties:
-        startDate:
-          type: string
-        endDate:
-          type: string
+        filters:
+          type: object
+          properties:
+            startDate:
+              type: string
+            endDate:
+              type: string
         pagination:
           $ref: '#/components/schemas/Pagination'
 
@@ -9288,14 +9628,17 @@ components:
             - $ref: '#/components/schemas/InstanceMetadata'
 
     InstanceSearchResponse:
+      description: >-
+        totalRecords (not total) to match the frontend's shared pagination
+        envelope.
       type: object
-      required: [instances, total, offset, limit]
+      required: [instances, totalRecords, offset, limit]
       properties:
         instances:
           type: array
           items:
             $ref: '#/components/schemas/Instance'
-        total:
+        totalRecords:
           type: integer
         offset:
           type: integer
@@ -9466,8 +9809,11 @@ components:
           type: number
 
     InstanceMetricsStatsResponse:
+      description: >-
+        totalRecords (not total) to match the frontend's shared pagination
+        envelope.
       type: object
-      required: [stats, summary, total, startDate, endDate]
+      required: [stats, summary, totalRecords, startDate, endDate]
       properties:
         stats:
           description: Keyed by instance ID, then by metric bucket.
@@ -9478,7 +9824,7 @@ components:
               type: integer
         summary:
           $ref: '#/components/schemas/InstanceMetricSummary'
-        total:
+        totalRecords:
           type: integer
         startDate:
           type: string
@@ -9488,8 +9834,10 @@ components:
     InstanceUsageStatsResponse:
       description: >-
         Unlike InstanceMetricsStatsResponse, there is no summary block.
+        totalRecords (not total) to match the frontend's own
+        InstanceUsageStatsResponse type.
       type: object
-      required: [stats, total, startDate, endDate]
+      required: [stats, totalRecords, startDate, endDate]
       properties:
         stats:
           description: Keyed by instance ID, then by usage bucket.
@@ -9498,7 +9846,7 @@ components:
             type: object
             additionalProperties:
               type: integer
-        total:
+        totalRecords:
           type: integer
         startDate:
           type: string
@@ -9526,10 +9874,16 @@ components:
           type: string
 
     RegistryTokenCreateResponse:
+      description: >-
+        name is read by both GenerateTokenModal.tsx and
+        RegenerateTokenModal.tsx to display the server-assigned token name
+        after creation.
       type: object
       required: [secret]
       properties:
         secret:
+          type: string
+        name:
           type: string
 
     RegistryPermission:
@@ -9543,12 +9897,14 @@ components:
       description: >-
         Description is deliberately omitted — it's an internal encoding the
         backend uses to recover project/type/owner for authorization, not
-        something the frontend should render.
+        something the frontend should render. id and expiresAt are numeric
+        (not string) — the real registry service sends them as JSON numbers.
       type: object
       required: [name, disable, duration, permissions]
       properties:
         id:
-          type: string
+          type: integer
+          format: int64
         name:
           type: string
         displayName:
@@ -9563,7 +9919,8 @@ components:
         createdBy:
           type: string
         expiresAt:
-          type: string
+          type: integer
+          format: int64
         disable:
           type: boolean
         duration:

--- a/apps/customer-portal/backend-v2/openapi.yaml
+++ b/apps/customer-portal/backend-v2/openapi.yaml
@@ -825,11 +825,16 @@ paths:
     patch:
       summary: Update a case.
       description: >
-        Exactly one of stateKey or watchList is required. This is a
-        deliberately restricted subset of entity-service's update contract
-        — internal WSO2 support fields (severity, subject, description,
-        work state, engineer assignment, fix-ETA dates, case relinking,
-        auto-closure control) are not customer-settable.
+        Exactly one of stateKey or watchList is required; watchList must be
+        a non-empty array — an empty array does not count as "provided" and
+        is rejected the same as an omitted field. This is not a bug in this
+        endpoint: entity-service's own ServiceNow implementation only
+        forwards watchList upstream when it is non-empty, so there is
+        currently no way to clear every watcher via this API at all, at any
+        layer. This is a deliberately restricted subset of entity-service's
+        update contract — internal WSO2 support fields (severity, subject,
+        description, work state, engineer assignment, fix-ETA dates, case
+        relinking, auto-closure control) are not customer-settable.
       operationId: patchCasesId
       parameters:
         - name: id
@@ -1682,8 +1687,17 @@ paths:
     get:
       summary: List products.
       description: >
-        class is accepted but not forwarded — entity-service's
-        SearchProductsRequest has no class filter (a genuine gap).
+        class cannot be forwarded to entity-service as a request filter —
+        SearchProductsRequest has no such parameter — so it is instead
+        applied server-side against each returned product's own class
+        field, case-insensitively, after the page is fetched. Because
+        entity-service computes offset/limit/totalRecords before this
+        filter is applied, a page can come back with fewer than limit
+        matching items even when more exist on a later page. On the
+        Postgres data source, class is only ever "software" or "service"
+        (entity-service's own domain.ProductClass enum) — this endpoint is
+        effectively ServiceNow-data-source-only for any other class value
+        such as the frontend's "product_model".
       operationId: getProducts
       parameters:
         - name: class
@@ -6743,6 +6757,9 @@ components:
         description:
           type: string
           nullable: true
+          description: >
+            Three states: omit the field to leave the description
+            unchanged, send null to clear it, send a string to set it.
         name:
           type: string
         typeKey:
@@ -7277,9 +7294,11 @@ components:
 
     SearchProductVulnerabilitiesRequest:
       description: >
-        statusId is accepted but not forwarded — entity-service's
-        SearchProductVulnerabilitiesFilters has no status field (a genuine
-        gap).
+        statusId is deliberately not a supported field — entity-service's
+        ProductVulnerabilityView has no status data anywhere in its response
+        (unlike severity/priority, which does have a numeric-id mirror
+        table), so there is nothing to filter or even post-filter by. It is
+        not accepted by this endpoint.
       type: object
       properties:
         filters:
@@ -7290,8 +7309,6 @@ components:
             severityId:
               type: integer
               description: ServiceNow numeric choice-list id — see product_vulnerability_enum_mapping.go.
-            statusId:
-              type: integer
             productName:
               type: string
             productVersion:


### PR DESCRIPTION
## Summary

Continues the type-alignment audit started in #1388 (case search / call requests) to cover every remaining `customer-portal-backend-v2` endpoint, cross-checked against the live frontend TypeScript and the old Ballerina backend (`apps/customer-portal/backend`) as the reference contract.

- **`total` → `totalRecords`** renamed across deployments, deployed products, instances (search + 2 stats variants), products, product versions, product vulnerabilities, catalogs, change requests, time cards, conversations, comments, and case activities — matching the frontend's shared `PaginationResponse` type.
- **Numeric-id ⇄ enum translation** added for change-request state/impact, conversation state, deployment type, and product-vulnerability severity (mirroring entity-service's own private ServiceNow/Choreo numeric-choice-list tables), following the same two-file pattern established for case fields in #1388.
- **Route re-scoping** — `deployments`, `deployed-products` (now under `/deployments/{deploymentId}/products`), `catalogs` (now under `/deployments/products/{deployedProductId}/catalogs`), `time-cards`, and `change-requests` search/mutation routes now scope to their owning path parameter instead of trusting a client-supplied body field.
- **Response reshapes** — case details, change request, time card, and deployed product responses rewritten to match the frontend's `IdLabelRef`-based contract (`{id, label}` instead of plain strings or `{id, name}` refs).
- **Missing fields added** where entity-service's own domain type already carried the data but this backend's mirror struct didn't: `project.startDate`, `project.account.{hasAgent,hasKbReferences,activationDate}`, `case.{watchList,changeRequests}`, `users/me.lastPasswordUpdateTime`, registry token `name`.
- **Type fixes** — registry token `id`/`expiresAt` now decode as numbers (previously strings, which didn't match either the real upstream response or the frontend's own type).
- **New routes** — `GET /products` (frontend's live product-browsing flow, translated to entity-service's `POST /products/search`) and `POST /cases/{id}/attachments`.

Everywhere a field genuinely doesn't exist on entity-service's own domain type (verified against `cs-tools/entity-service/internal/domain/entity.go`, not assumed), it's left out rather than fabricated — those gaps are documented with doc comments at each call site.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l` — clean
- [x] `go test ./...` — all existing tests pass, plus 16 new tests added covering the translation logic introduced in this PR (`internal/dto/type_alignment_test.go`)
- [x] `gosec -fmt=text ./...` — 0 issues
- [x] `openapi.yaml`, `README.md`, `CLAUDE.md` updated to match every route/schema change
- [ ] Manual smoke test against a running frontend (not done in this session — recommend before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added product browsing through `GET /products`.
  * Added case attachment creation.
  * Added project- and deployment-scoped operations for deployments, deployed products, catalogs, change requests, and time cards.
  * Added richer case, project, account, comment, conversation, vulnerability, and registry-token details.

* **Improvements**
  * Standardized pagination responses with `totalRecords`.
  * Updated API responses with clearer labels, references, dates, and numeric choice values.
  * User profile responses now include the last password update time.

* **Documentation**
  * Updated API documentation and examples to reflect 104 available routes and the revised endpoint structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->