### PR TITLE
[CSM Portal Microapp] Add a Linked Items tab to case details

### DIFF
--- a/apps/csm-portal/microapp/src/components/case-detail/LinkCaseDialog.tsx
+++ b/apps/csm-portal/microapp/src/components/case-detail/LinkCaseDialog.tsx
@@ -1,0 +1,214 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useMemo, useState } from "react";
+import {
+  alpha,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControlLabel,
+  Radio,
+  RadioGroup,
+  Skeleton,
+  Stack,
+  TextField,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { Search } from "@wso2/oxygen-ui-icons-react";
+import { useQuery } from "@tanstack/react-query";
+import { cases, QUICK_SEARCH_MIN_QUERY_LEN } from "@src/services/cases";
+import type { CaseSummary } from "@src/types";
+import { SeverityChip, StatusChip } from "@components/support/Chips";
+import { useDebouncedValue } from "@utils/useDebouncedValue";
+
+export type CaseLinkType = "parent" | "related";
+
+interface LinkCaseDialogProps {
+  /** The case being linked from — excluded from its own search results. */
+  currentCaseId: string;
+  /** True while a PATCH is in flight; disables the actions. */
+  isLinking: boolean;
+  onClose: () => void;
+  /** Link the current case to `targetCaseId` as either its parent or a related case. */
+  onLink: (targetCaseId: string, linkType: CaseLinkType) => void;
+}
+
+/**
+ * Search-and-select a case to link the current one to — either as its **parent** (`PATCH
+ * { parentId }`, the hierarchical major-case/child-case relationship) or as a **related case**
+ * (`PATCH { relatedCaseId }`, a looser cross-link). Mirrors the webapp's LinkCaseDialog: picking a
+ * search result doesn't link immediately — it shows a selected-case summary to confirm against
+ * first, with a "Change" button back to search; the PATCH only fires from "Link".
+ */
+export function LinkCaseDialog({ currentCaseId, isLinking, onClose, onLink }: LinkCaseDialogProps) {
+  const [linkType, setLinkType] = useState<CaseLinkType>("parent");
+  const [input, setInput] = useState("");
+  const [selected, setSelected] = useState<CaseSummary | null>(null);
+  const debouncedInput = useDebouncedValue(input.trim(), 300);
+  const { data, isFetching, isError } = useQuery(cases.quickSearch(debouncedInput));
+
+  const candidates = useMemo(() => (data ?? []).filter((c) => c.id !== currentCaseId), [data, currentCaseId]);
+
+  return (
+    <Dialog
+      open
+      onClose={isLinking ? undefined : onClose}
+      fullWidth
+      maxWidth="xs"
+      slotProps={{
+        paper: {
+          sx: {
+            backgroundImage: "none",
+            backgroundColor: "background.default",
+            // Same explicit cap as LogTimeCardDialog — keeps the search results scrollable within
+            // the dialog instead of letting the paper grow past the viewport.
+            display: "flex",
+            flexDirection: "column",
+            maxHeight: "85vh",
+          },
+        },
+      }}
+    >
+      <DialogTitle>Link to another case</DialogTitle>
+      <DialogContent dividers>
+        <Stack gap={1.5}>
+          <RadioGroup row value={linkType} onChange={(e) => setLinkType(e.target.value as CaseLinkType)}>
+            <FormControlLabel value="parent" disabled={isLinking} control={<Radio size="small" />} label="As parent" />
+            <FormControlLabel
+              value="related"
+              disabled={isLinking}
+              control={<Radio size="small" />}
+              label="As related case"
+            />
+          </RadioGroup>
+          <Typography variant="caption" color="text.secondary">
+            {linkType === "parent"
+              ? "The hierarchical major-case/child-case relationship — this case can't close while it has open children linked this way."
+              : "A looser cross-link; not subject to the child-case close restriction."}
+          </Typography>
+
+          {selected ? (
+            <Stack
+              direction="row"
+              alignItems="flex-start"
+              gap={1}
+              sx={(theme) => ({
+                px: 1.5,
+                py: 1,
+                borderRadius: 1,
+                border: "1px solid",
+                borderColor: "success.main",
+                bgcolor: alpha(theme.palette.success.main, 0.1),
+              })}
+            >
+              <Stack sx={{ minWidth: 0, flex: 1 }} gap={0.5}>
+                <Typography
+                  variant="body2"
+                  noWrap
+                  sx={{ fontWeight: 600 }}
+                  title={`${selected.number} — ${selected.subject}`}
+                >
+                  {selected.number} — {selected.subject}
+                </Typography>
+                <Stack direction="row" alignItems="center" gap={0.75} flexWrap="wrap">
+                  <StatusChip state={selected.state} />
+                  {selected.severity && <SeverityChip severity={selected.severity} />}
+                  {selected.assignedEngineer?.name && (
+                    <Typography variant="caption" color="text.secondary" noWrap>
+                      {selected.assignedEngineer.name}
+                    </Typography>
+                  )}
+                </Stack>
+              </Stack>
+              <Button size="small" variant="text" disabled={isLinking} onClick={() => setSelected(null)}>
+                Change
+              </Button>
+            </Stack>
+          ) : (
+            <Stack gap={0.75}>
+              <TextField
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                placeholder="Search by case number or subject…"
+                size="small"
+                fullWidth
+                autoFocus
+                slotProps={{ input: { startAdornment: <Search size={16} style={{ marginRight: 8 }} /> } }}
+              />
+              {input.trim().length < QUICK_SEARCH_MIN_QUERY_LEN ? (
+                <Typography variant="caption" color="text.secondary">
+                  Type at least {QUICK_SEARCH_MIN_QUERY_LEN} characters to search
+                </Typography>
+              ) : isFetching ? (
+                <Stack gap={0.5}>
+                  {[0, 1, 2].map((i) => (
+                    <Skeleton key={i} variant="rounded" height={44} />
+                  ))}
+                </Stack>
+              ) : isError ? (
+                <Typography variant="caption" color="error">
+                  Could not search cases. Try again.
+                </Typography>
+              ) : candidates.length === 0 ? (
+                <Typography variant="caption" color="text.secondary">
+                  No matching cases.
+                </Typography>
+              ) : (
+                <Stack>
+                  {candidates.map((hit) => (
+                    <Button
+                      key={hit.id}
+                      variant="text"
+                      color="inherit"
+                      disabled={isLinking}
+                      onClick={() => setSelected(hit)}
+                      sx={{ justifyContent: "flex-start", textTransform: "none", px: 1, py: 0.75, display: "flex" }}
+                    >
+                      <Stack sx={{ minWidth: 0, flex: 1, textAlign: "left" }} gap={0.25}>
+                        <Typography variant="body2" noWrap>
+                          {hit.number} — {hit.subject}
+                        </Typography>
+                        <Stack direction="row" gap={0.75}>
+                          <StatusChip state={hit.state} />
+                          {hit.severity && <SeverityChip severity={hit.severity} />}
+                        </Stack>
+                      </Stack>
+                    </Button>
+                  ))}
+                </Stack>
+              )}
+            </Stack>
+          )}
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button color="inherit" onClick={onClose} disabled={isLinking}>
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          disabled={!selected || isLinking}
+          onClick={() => selected && onLink(selected.id, linkType)}
+        >
+          {isLinking ? "Linking…" : "Link"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/csm-portal/microapp/src/components/case-detail/LinkedItemsTab.tsx
+++ b/apps/csm-portal/microapp/src/components/case-detail/LinkedItemsTab.tsx
@@ -1,0 +1,350 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useMemo, type JSX, type ReactNode } from "react";
+import { Box, Button, Card, Chip, Skeleton, Stack, Tooltip, Typography, pxToRem, useTheme } from "@wso2/oxygen-ui";
+import { ChevronRight, GitFork, GitPullRequest, Link as LinkIcon, Plus } from "@wso2/oxygen-ui-icons-react";
+import { Link } from "react-router-dom";
+import { useQueries, useQuery } from "@tanstack/react-query";
+import { cases, type ChildCaseRow } from "@src/services/cases";
+import { changeRequests } from "@src/services/changeRequests";
+import type { CaseDetail, CaseLinkRefDto } from "@src/types";
+import { SeverityChip, StatusChip } from "@components/support/Chips";
+import { changeRequestStateColor, changeRequestStateLabel } from "@components/operations/config";
+
+interface LinkedItemsTabProps {
+  caseId: string;
+  caseDetail: CaseDetail;
+  isClosed: boolean;
+  onLinkCase: () => void;
+  onCreateServiceRequest: () => void;
+}
+
+/**
+ * "Linked Items" tab — mirrors the webapp's CsmCaseDetailPage `related` tab (Child cases, Linked
+ * service requests, Linked change requests), adapted from its desktop tables to mobile cards. The
+ * webapp's per-widget refresh buttons are dropped — the microapp doesn't have that convention
+ * anywhere else in the case detail page, which already re-fetches the whole case on every mutation
+ * (see CaseDetailPage.tsx's invalidateCase).
+ */
+export function LinkedItemsTab({
+  caseId,
+  caseDetail,
+  isClosed,
+  onLinkCase,
+  onCreateServiceRequest,
+}: LinkedItemsTabProps) {
+  // Content-relevance, not a data-source gate: shown whenever this is a service request (the only
+  // case type that carries the link) or the list already has entries — mirrors the webapp.
+  const showLinkedChangeRequests = caseDetail.type === "service_request" || caseDetail.linkedChangeRequests.length > 0;
+
+  return (
+    <Stack gap={2}>
+      <Tooltip title={isClosed ? "This case is closed — it's read-only." : ""}>
+        <Box component="span" sx={{ alignSelf: "flex-start" }}>
+          <Button
+            size="small"
+            variant="outlined"
+            startIcon={<LinkIcon size={14} />}
+            onClick={onLinkCase}
+            disabled={isClosed}
+          >
+            Link to another case
+          </Button>
+        </Box>
+      </Tooltip>
+
+      <ChildCasesSection caseId={caseId} />
+
+      <LinkedServiceRequestsSection
+        caseId={caseId}
+        refs={caseDetail.linkedServiceRequests}
+        createDisabled={isClosed}
+        onCreateServiceRequest={onCreateServiceRequest}
+      />
+
+      {showLinkedChangeRequests && <LinkedChangeRequestsSection refs={caseDetail.linkedChangeRequests} />}
+    </Stack>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Shared row shell — a tappable case card compact enough to list several per
+// tab, unlike the full support/CaseCard.tsx (which needs fields these linked
+// refs don't always carry, e.g. wso2Id/updatedOn/type).
+// ---------------------------------------------------------------------------
+
+function LinkedItemsSection({
+  icon,
+  title,
+  count,
+  action,
+  emptyMessage,
+  children,
+}: {
+  icon: JSX.Element;
+  title: string;
+  count?: number;
+  action?: ReactNode;
+  emptyMessage: string;
+  children: ReactNode;
+}) {
+  const isEmpty = count === 0;
+  return (
+    <Card sx={{ p: 1.5 }}>
+      <Stack gap={1.25}>
+        <Stack direction="row" alignItems="center" justifyContent="space-between" gap={1} flexWrap="wrap">
+          <Stack direction="row" alignItems="center" gap={0.75}>
+            {icon}
+            <Typography variant="subtitle2">
+              {title}
+              {typeof count === "number" && count > 0 ? ` (${count})` : ""}
+            </Typography>
+          </Stack>
+          {action}
+        </Stack>
+        {isEmpty ? (
+          <Typography variant="body2" color="text.secondary">
+            {emptyMessage}
+          </Typography>
+        ) : (
+          <Stack gap={1}>{children}</Stack>
+        )}
+      </Stack>
+    </Card>
+  );
+}
+
+function CaseRow({
+  to,
+  label,
+  severity,
+  state,
+  assigneeName,
+  loading,
+}: {
+  to: string;
+  label: string;
+  severity?: CaseDetailSeverity;
+  state?: CaseDetailState;
+  assigneeName?: string | null;
+  /** True while enrichment (state/severity/assignee) is still resolving — shows skeletons for
+   * those fields instead of a bare "—", matching LinkedServiceRequestsSection's rows before the
+   * shared child-cases search resolves. */
+  loading?: boolean;
+}): JSX.Element {
+  const theme = useTheme();
+  return (
+    <Card component={Link} to={to} variant="outlined" sx={{ textDecoration: "none", p: 1, display: "block" }}>
+      <Stack direction="row" alignItems="center" gap={1}>
+        <Stack sx={{ minWidth: 0, flex: 1 }} gap={0.5}>
+          <Typography variant="body2" color="text.primary" noWrap title={label}>
+            {label}
+          </Typography>
+          <Stack direction="row" alignItems="center" gap={1} flexWrap="wrap">
+            {loading ? <Skeleton variant="rounded" width={64} height={20} /> : state && <StatusChip state={state} />}
+            {severity && <SeverityChip severity={severity} />}
+            {!loading && assigneeName && (
+              <Typography variant="caption" color="text.secondary" noWrap>
+                {assigneeName}
+              </Typography>
+            )}
+          </Stack>
+        </Stack>
+        <ChevronRight size={pxToRem(18)} color={theme.palette.text.secondary} style={{ flexShrink: 0 }} />
+      </Stack>
+    </Card>
+  );
+}
+
+// Narrow aliases so CaseRow's props stay readable above without importing the full CaseState/
+// CaseSeverity union names twice.
+type CaseDetailSeverity = NonNullable<CaseDetail["severity"]>;
+type CaseDetailState = CaseDetail["state"];
+
+// ---------------------------------------------------------------------------
+// 1. Child cases — cases whose own parentId points at this one.
+// ---------------------------------------------------------------------------
+
+function ChildCasesSection({ caseId }: { caseId: string }) {
+  const { data, isLoading, isError } = useQuery(cases.searchChildren(caseId));
+  const rows = data?.cases ?? [];
+
+  return (
+    <LinkedItemsSection
+      icon={<GitFork size={16} />}
+      title="Child cases"
+      count={isLoading ? undefined : rows.length}
+      emptyMessage="No child cases linked to this case."
+    >
+      {isError ? (
+        <Typography variant="body2" color="error">
+          Could not load child cases for this case.
+        </Typography>
+      ) : isLoading ? (
+        <Stack gap={1}>
+          {[0, 1].map((i) => (
+            <Skeleton key={i} variant="rounded" height={56} />
+          ))}
+        </Stack>
+      ) : (
+        rows.map((c) => <ChildCaseCardRow key={c.id} row={c} />)
+      )}
+    </LinkedItemsSection>
+  );
+}
+
+function ChildCaseCardRow({ row }: { row: ChildCaseRow }) {
+  return (
+    <CaseRow
+      to={`/cases/${encodeURIComponent(row.id)}`}
+      label={`${row.number} — ${row.subject}`}
+      severity={row.severity ?? undefined}
+      state={row.state}
+      assigneeName={row.assigneeName}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 2. Linked service requests — the case-detail payload's own refs, enriched
+//    with state/severity/assignee from the same child-cases search (shared
+//    cache entry — service requests are children too, just restricted to the
+//    ids the case-detail response already names).
+// ---------------------------------------------------------------------------
+
+function LinkedServiceRequestsSection({
+  caseId,
+  refs,
+  createDisabled,
+  onCreateServiceRequest,
+}: {
+  caseId: string;
+  refs: CaseLinkRefDto[];
+  createDisabled: boolean;
+  onCreateServiceRequest: () => void;
+}) {
+  const { data, isLoading, isError } = useQuery(cases.searchChildren(caseId));
+  const enrichedById = useMemo(() => {
+    const map = new Map<string, ChildCaseRow>();
+    for (const row of data?.cases ?? []) map.set(row.id, row);
+    return map;
+  }, [data]);
+  // isError means enrichment is unavailable, not pending — fall straight to a plain row instead
+  // of a skeleton that would spin forever.
+  const enriching = isLoading && !isError;
+
+  return (
+    <LinkedItemsSection
+      icon={<LinkIcon size={16} />}
+      title="Linked service requests"
+      count={refs.length}
+      emptyMessage="No service requests linked to this case."
+      action={
+        <Tooltip title={createDisabled ? "This case is closed — it's read-only." : ""}>
+          <Box component="span">
+            <Button
+              size="small"
+              variant="text"
+              startIcon={<Plus size={14} />}
+              onClick={onCreateServiceRequest}
+              disabled={createDisabled}
+              aria-label="Create service request"
+            >
+              Create
+            </Button>
+          </Box>
+        </Tooltip>
+      }
+    >
+      {refs.map((ref) => {
+        const enriched = enrichedById.get(ref.id);
+        return (
+          <CaseRow
+            key={ref.id}
+            to={`/cases/${encodeURIComponent(ref.id)}`}
+            label={[ref.number, ref.name].filter(Boolean).join(" — ")}
+            severity={enriched?.severity ?? undefined}
+            state={enriched?.state}
+            assigneeName={enriched?.assigneeName}
+            loading={!enriched && enriching}
+          />
+        );
+      })}
+    </LinkedItemsSection>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 3. Linked change requests — raised from this service request. Each ref only
+//    carries id/number/name; state and target environment are fetched per row
+//    (fanned out with useQueries, mirroring the webapp), so a slow or failed
+//    row never blocks or hides the others.
+// ---------------------------------------------------------------------------
+
+function LinkedChangeRequestsSection({ refs }: { refs: CaseLinkRefDto[] }) {
+  const queries = useQueries({
+    queries: refs.map((ref) => changeRequests.get(ref.id)),
+  });
+
+  return (
+    <LinkedItemsSection
+      icon={<GitPullRequest size={16} />}
+      title="Linked change requests"
+      count={refs.length}
+      emptyMessage="No change requests have been raised from this service request yet."
+    >
+      {refs.map((ref, i) => {
+        const query = queries[i];
+        const detail = query?.data;
+        const rowLoading = query?.isLoading ?? false;
+        return (
+          <Card
+            key={ref.id}
+            component={Link}
+            to={`/operations/change-requests/${encodeURIComponent(ref.id)}`}
+            variant="outlined"
+            sx={{ textDecoration: "none", p: 1, display: "block" }}
+          >
+            <Stack direction="row" alignItems="center" gap={1}>
+              <Stack sx={{ minWidth: 0, flex: 1 }} gap={0.5}>
+                <Typography variant="body2" color="text.primary" noWrap>
+                  {[ref.number, ref.name].filter(Boolean).join(" — ")}
+                </Typography>
+                <Stack direction="row" alignItems="center" gap={1} flexWrap="wrap">
+                  {rowLoading ? (
+                    <Skeleton variant="rounded" width={64} height={20} />
+                  ) : detail ? (
+                    <Chip
+                      size="small"
+                      color={changeRequestStateColor(detail.state)}
+                      label={changeRequestStateLabel(detail.state)}
+                    />
+                  ) : null}
+                  {!rowLoading && detail?.deployment?.name && (
+                    <Typography variant="caption" color="text.secondary" noWrap>
+                      {detail.deployment.name}
+                    </Typography>
+                  )}
+                </Stack>
+              </Stack>
+            </Stack>
+          </Card>
+        );
+      })}
+    </LinkedItemsSection>
+  );
+}

--- a/apps/csm-portal/microapp/src/components/case-detail/LinkedItemsTab.tsx
+++ b/apps/csm-portal/microapp/src/components/case-detail/LinkedItemsTab.tsx
@@ -187,7 +187,7 @@ function ChildCasesSection({ caseId }: { caseId: string }) {
     <LinkedItemsSection
       icon={<GitFork size={16} />}
       title="Child cases"
-      count={isLoading ? undefined : rows.length}
+      count={isLoading || isError ? undefined : rows.length}
       emptyMessage="No child cases linked to this case."
     >
       {isError ? (

--- a/apps/csm-portal/microapp/src/pages/CaseDetailPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/CaseDetailPage.tsx
@@ -15,7 +15,7 @@
 // under the License.
 
 import { Suspense, useRef, useState, type ReactNode } from "react";
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { Card, Divider, Grid, Skeleton, Stack, Tab, Tabs, Typography, pxToRem } from "@wso2/oxygen-ui";
 import {
   Building2,
@@ -54,6 +54,8 @@ import { TYPE_CONFIG } from "@components/support/config";
 import { CaseActionBar } from "@components/case-detail/CaseActionBar";
 import { CaseMoreMenu } from "@components/case-detail/CaseMoreMenu";
 import { ChangeSeverityDialog } from "@components/case-detail/ChangeSeverityDialog";
+import { LinkCaseDialog, type CaseLinkType } from "@components/case-detail/LinkCaseDialog";
+import { LinkedItemsTab } from "@components/case-detail/LinkedItemsTab";
 import { LogTimeCardDialog } from "@components/case-detail/LogTimeCardDialog";
 import { ResolutionDialog } from "@components/case-detail/ResolutionDialog";
 import { CommentComposer } from "@components/case-detail/CommentComposer";
@@ -63,16 +65,18 @@ import { SlaTab } from "@components/case-detail/SlaTab";
 import { AttachmentsTab } from "@components/case-detail/AttachmentsTab";
 import { CallRequestsTab } from "@components/case-detail/CallRequestsTab";
 import { TimeTrackingTab } from "@components/case-detail/TimeTrackingTab";
+import type { CreateServiceRequestFromCaseNavState } from "@pages/NewServiceRequestPage";
 import { formatDate } from "@utils/dateTime";
 import { Logger } from "@utils/logger";
 import { toApiError } from "@utils/ApiError";
 import type { PendingAttachment } from "@utils/attachments";
 
-type CaseTabId = "activities" | "details" | "sla" | "attachments" | "time" | "call-requests";
+type CaseTabId = "activities" | "details" | "related" | "sla" | "attachments" | "time" | "call-requests";
 
 const TAB_DEFS: Array<{ id: CaseTabId; label: string }> = [
   { id: "activities", label: "Activities" },
   { id: "details", label: "Details" },
+  { id: "related", label: "Linked Items" },
   { id: "sla", label: "SLAs" },
   { id: "attachments", label: "Attachments" },
   { id: "time", label: "Time tracking" },
@@ -96,6 +100,7 @@ export default function CaseDetailPage() {
 }
 
 function CaseDetailContent({ id }: { id: string }) {
+  const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { data: caseDetail } = useSuspenseQuery(cases.get(id));
   const { data: comments } = useSuspenseQuery(cases.comments(id));
@@ -119,9 +124,12 @@ function CaseDetailContent({ id }: { id: string }) {
   const [logTimeOpen, setLogTimeOpen] = useState(false);
   const [isLoggingTime, setIsLoggingTime] = useState(false);
   const [logTimeError, setLogTimeError] = useState<string | null>(null);
+  const [linkCaseOpen, setLinkCaseOpen] = useState(false);
+  const [isLinkingCase, setIsLinkingCase] = useState(false);
 
+  const ANNOUNCEMENT_HIDDEN_TABS: CaseTabId[] = ["related", "sla", "time", "call-requests"];
   const visibleTabDefs = isAnnouncement
-    ? TAB_DEFS.filter((tab) => tab.id !== "sla" && tab.id !== "time" && tab.id !== "call-requests")
+    ? TAB_DEFS.filter((tab) => !ANNOUNCEMENT_HIDDEN_TABS.includes(tab.id))
     : TAB_DEFS;
   // If a case turns out to be an announcement (only knowable once caseDetail
   // loads) while a tab hidden for announcements is active, fall back to
@@ -336,6 +344,32 @@ function CaseDetailContent({ id }: { id: string }) {
       .finally(() => setIsLoggingTime(false));
   };
 
+  const handleLinkCase = (targetCaseId: string, linkType: CaseLinkType): void => {
+    setIsLinkingCase(true);
+    setMutationError(null);
+    cases
+      .patch(id, linkType === "parent" ? { parentId: targetCaseId } : { relatedCaseId: targetCaseId })
+      .then(() => {
+        setLinkCaseOpen(false);
+        invalidateCase();
+      })
+      .catch(() => setMutationError("Could not link the case. Please try again."))
+      .finally(() => setIsLinkingCase(false));
+  };
+
+  // Pre-fills the create-service-request form and links the new SR back to this case in one step
+  // (see CreateServiceRequestFromCaseNavState) — no separate create-then-link round trip.
+  const handleCreateServiceRequest = (): void => {
+    const navState: CreateServiceRequestFromCaseNavState = {
+      projectId: caseDetail.project.id,
+      relatedCaseId: caseDetail.id,
+      relatedCaseNumber: caseDetail.number,
+      deploymentId: caseDetail.deployment?.id,
+      deployedProductId: caseDetail.deployedProduct?.id,
+    };
+    navigate("/operations/service-requests/new", { state: navState });
+  };
+
   // Text and inline attachments upload as separate requests (the backend's comment payload has no
   // file field — see CaseCommentCreatePayloadDto), mirroring NewCasePage's create-then-attach
   // pattern. An empty comment with attachments still sends: the case gets the files with no
@@ -440,6 +474,16 @@ function CaseDetailContent({ id }: { id: string }) {
         </Stack>
       )}
 
+      {effectiveTab === "related" && (
+        <LinkedItemsTab
+          caseId={id}
+          caseDetail={caseDetail}
+          isClosed={caseDetail.state === "closed"}
+          onLinkCase={() => setLinkCaseOpen(true)}
+          onCreateServiceRequest={handleCreateServiceRequest}
+        />
+      )}
+
       {effectiveTab === "sla" && <SlaTab caseId={id} />}
 
       {effectiveTab === "attachments" && <AttachmentsTab caseId={id} />}
@@ -496,6 +540,14 @@ function CaseDetailContent({ id }: { id: string }) {
             }
           }}
           onSubmit={handleLogTimeSubmit}
+        />
+      )}
+      {linkCaseOpen && (
+        <LinkCaseDialog
+          currentCaseId={id}
+          isLinking={isLinkingCase}
+          onClose={() => setLinkCaseOpen(false)}
+          onLink={handleLinkCase}
         />
       )}
     </Stack>

--- a/apps/csm-portal/microapp/src/pages/NewServiceRequestPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/NewServiceRequestPage.tsx
@@ -14,13 +14,14 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { useMemo, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useEffect, useMemo, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
 import { Button, FormControl, FormHelperText, InputLabel, MenuItem, Select, Stack, Typography } from "@wso2/oxygen-ui";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { cases } from "@src/services/cases";
 import { deployments } from "@src/services/deployments";
 import { catalogs } from "@src/services/catalogs";
+import { projects } from "@src/services/projects";
 import { attachments as attachmentsService } from "@src/services/attachments";
 import type { Project } from "@src/types";
 import { Logger } from "@utils/logger";
@@ -35,18 +36,32 @@ import {
 } from "@utils/catalogVariables";
 import type { PendingAttachment } from "@utils/attachments";
 
+// Router (`navigate(..., { state })`) payload carried from a case's "Create service request"
+// action (case detail's Linked Items tab) to this page, so the form can prefill from the
+// originating case and file the new SR as linked to it in one step. Mirrors the webapp's
+// CreateServiceRequestFromCaseNavState: `projectId` locks the Project field read-only;
+// `deploymentId`/`deployedProductId` are just starting values and stay fully editable.
+export interface CreateServiceRequestFromCaseNavState {
+  projectId: string;
+  relatedCaseId: string;
+  relatedCaseNumber?: string;
+  deploymentId?: string;
+  deployedProductId?: string;
+}
+
 // Ports the webapp's CreateServiceRequestPage.tsx (features/csm-operations/pages/): the same
 // cascading Project → Deployment → Deployed product → Catalog → Catalog item picker, driving a
 // dynamic form built from the chosen catalog item's ServiceNow variables. Layout follows this
-// app's own NewCasePage.tsx (single-column Stack, no locked-project entry point) rather than the
-// webapp's Grid/Card, and — like NewCasePage — the Description variable renders as a plain
-// multiline field rather than the rich-text editor (this app has no rich-text component).
+// app's own NewCasePage.tsx (single-column Stack) rather than the webapp's Grid/Card, and — like
+// NewCasePage — the Description variable renders as a plain multiline field rather than the
+// rich-text editor (this app has no rich-text component).
 export default function NewServiceRequestPage() {
   const navigate = useNavigate();
+  const fromCaseState = useLocation().state as CreateServiceRequestFromCaseNavState | undefined;
 
   const [project, setProject] = useState<Project | null>(null);
-  const [deploymentId, setDeploymentId] = useState("");
-  const [deployedProductId, setDeployedProductId] = useState("");
+  const [deploymentId, setDeploymentId] = useState(fromCaseState?.deploymentId ?? "");
+  const [deployedProductId, setDeployedProductId] = useState(fromCaseState?.deployedProductId ?? "");
   const [catalogId, setCatalogId] = useState("");
   const [catalogItemId, setCatalogItemId] = useState("");
   // Variable answers, keyed by variable id.
@@ -58,6 +73,16 @@ export default function NewServiceRequestPage() {
   // fire a duplicate submission. Tracks the whole handleSubmit lifecycle instead, same as
   // NewCasePage.tsx.
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // Resolves the full Project (ProjectSelect needs more than the nav state's bare id) once, to
+  // seed the locked field below — never re-runs once `project` is set, so it doesn't fight a
+  // user's own pick on a page that arrived without a related case.
+  const lockedProjectId = fromCaseState?.projectId;
+  const lockedProjectQuery = useQuery({ ...projects.get(lockedProjectId ?? ""), enabled: !!lockedProjectId });
+  useEffect(() => {
+    if (lockedProjectQuery.data && !project) setProject(lockedProjectQuery.data);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [lockedProjectQuery.data]);
 
   const deploymentsQuery = useQuery(deployments.byProject(project?.id ?? ""));
   const productsQuery = useQuery(deployments.productsByDeployment(deploymentId));
@@ -151,6 +176,7 @@ export default function NewServiceRequestPage() {
         catalogId,
         catalogItemId,
         variables: variablePayload,
+        ...(fromCaseState?.relatedCaseId ? { relatedCaseId: fromCaseState.relatedCaseId } : {}),
       });
 
       // The create endpoint doesn't attach files for service requests, so upload them to the new
@@ -183,9 +209,18 @@ export default function NewServiceRequestPage() {
   return (
     <Stack gap={2}>
       <Typography variant="h6">New Service Request</Typography>
+      {fromCaseState && (
+        <Typography variant="caption" color="text.secondary">
+          Creating from case {fromCaseState.relatedCaseNumber ?? fromCaseState.relatedCaseId}
+        </Typography>
+      )}
 
       <Stack gap={2}>
-        <ProjectSelect value={project} onChange={handleProjectChange} disabled={createCase.isPending || isSubmitting} />
+        <ProjectSelect
+          value={project}
+          onChange={handleProjectChange}
+          disabled={!!fromCaseState || createCase.isPending || isSubmitting}
+        />
 
         <FormControl
           size="small"

--- a/apps/csm-portal/microapp/src/pages/NewServiceRequestPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/NewServiceRequestPage.tsx
@@ -214,12 +214,20 @@ export default function NewServiceRequestPage() {
           Creating from case {fromCaseState.relatedCaseNumber ?? fromCaseState.relatedCaseId}
         </Typography>
       )}
+      {lockedProjectQuery.isError && (
+        <Typography variant="caption" color="error.main">
+          Could not load the case's project. Pick one below to continue.
+        </Typography>
+      )}
 
       <Stack gap={2}>
         <ProjectSelect
           value={project}
           onChange={handleProjectChange}
-          disabled={!!fromCaseState || createCase.isPending || isSubmitting}
+          // Stays locked only while the case's project is still expected to arrive — a failed
+          // lookup falls back to letting the engineer pick one manually instead of leaving the
+          // form permanently stuck on a null project with no way to proceed.
+          disabled={(!!fromCaseState && !lockedProjectQuery.isError) || createCase.isPending || isSubmitting}
         />
 
         <FormControl

--- a/apps/csm-portal/microapp/src/services/cases.ts
+++ b/apps/csm-portal/microapp/src/services/cases.ts
@@ -32,6 +32,8 @@ import type {
   CaseSearchFiltersDto,
   CaseSearchPayloadDto,
   CaseSearchResponseDto,
+  CaseSeverity,
+  CaseState,
   CaseType,
   CaseViewDto,
   CreatedCaseDto,
@@ -82,6 +84,7 @@ function toWireFilters(filters: CaseSearchFiltersDto = {}): { searchQuery?: stri
   if (filters.productNames?.length) fieldFilters.push({ field: "product", op: "in", values: filters.productNames });
   if (filters.createdByMe)
     fieldFilters.push({ field: "createdBy", op: "eq", values: [CURRENT_USER_FILTER_PLACEHOLDER] });
+  if (filters.parentId) fieldFilters.push({ field: "parentId", op: "eq", values: [filters.parentId] });
 
   return {
     ...(filters.searchQuery && { searchQuery: filters.searchQuery }),
@@ -276,6 +279,58 @@ const postComment = async (id: string, payload: CaseCommentCreatePayloadDto): Pr
 
 const CASES_PAGE_LIMIT = 20;
 
+export interface ChildCaseRow {
+  id: string;
+  number: string;
+  subject: string;
+  severity: CaseSeverity | null;
+  state: CaseState;
+  assigneeName: string | null;
+}
+
+const CHILD_CASES_LIMIT = 20;
+
+// Child cases of `parentCaseId` — cases whose own `parentId` points at it (the hierarchical
+// major-case/child-case relationship). Reuses the general cross-project search rather than a
+// dedicated endpoint, mirroring the webapp's useSearchChildCases. Single page (20 cases) — a case
+// with more children than that isn't expected, same assumption the webapp makes.
+const searchChildCases = async (parentCaseId: string): Promise<{ cases: ChildCaseRow[]; total: number }> => {
+  const result = await getAllCases({
+    filters: { types: ALL_CASE_TYPES, parentId: parentCaseId },
+    pagination: { offset: 0, limit: CHILD_CASES_LIMIT },
+  });
+  return {
+    cases: result.items.map((c) => ({
+      id: c.id,
+      number: c.number,
+      subject: c.subject,
+      severity: c.severity,
+      state: c.state,
+      assigneeName: c.assignedEngineer?.name ?? null,
+    })),
+    total: result.total,
+  };
+};
+
+// Don't fire LinkCaseDialog's search until the user has typed something searchable — mirrors the
+// webapp's QUICK_CASE_MIN_QUERY_LEN.
+export const QUICK_SEARCH_MIN_QUERY_LEN = 2;
+const QUICK_SEARCH_LIMIT = 8;
+
+// Free-text case lookup for LinkCaseDialog's search-and-pick — the same `/cases/search` the cases
+// list itself uses. Explicitly requests every case sub-type (mirrors the webapp's
+// useQuickCaseSearch): entity-service defaults `filters.types` to `["case"]` only when the caller
+// omits it, which would otherwise hide service requests/security reports/etc. from this search.
+const quickSearchCases = async (query: string): Promise<CaseSummary[]> => {
+  const trimmed = query.trim();
+  if (trimmed.length < QUICK_SEARCH_MIN_QUERY_LEN) return [];
+  const result = await getAllCases({
+    filters: { types: ALL_CASE_TYPES, searchQuery: trimmed },
+    pagination: { offset: 0, limit: QUICK_SEARCH_LIMIT },
+  });
+  return result.items;
+};
+
 export const cases = {
   all: (payload: CaseSearchPayloadDto = {}) =>
     queryOptions({
@@ -308,6 +363,26 @@ export const cases = {
     queryOptions({
       queryKey: ["case", id, "comments"],
       queryFn: () => getCaseComments(id),
+    }),
+
+  // Linked Items tab: child cases (own `parentId` pointing at this one) — shared by both the
+  // Child cases card and Linked service requests' enrichment (same underlying relationship, see
+  // that widget's own comment), so both queries dedupe against this one cache entry.
+  searchChildren: (caseId: string | undefined) =>
+    queryOptions({
+      queryKey: ["cases", "children", caseId ?? ""],
+      queryFn: () => (caseId ? searchChildCases(caseId) : Promise.resolve({ cases: [], total: 0 })),
+      enabled: !!caseId,
+      staleTime: 30_000,
+    }),
+
+  // Linked Items tab: LinkCaseDialog's search-and-pick.
+  quickSearch: (query: string) =>
+    queryOptions({
+      queryKey: ["cases", "quick-search", query.trim()],
+      queryFn: () => quickSearchCases(query),
+      enabled: query.trim().length >= QUICK_SEARCH_MIN_QUERY_LEN,
+      staleTime: 15_000,
     }),
 
   create: createCase,

--- a/apps/csm-portal/microapp/src/types/case.dto.ts
+++ b/apps/csm-portal/microapp/src/types/case.dto.ts
@@ -103,6 +103,9 @@ export interface CaseSearchFiltersDto {
   engagementTypes?: EngagementType[];
   /** Product family names (e.g. "API Manager"); matches all versions of each. */
   productNames?: string[];
+  /** UUID of the case whose children (their own `parentId` pointing here) to find — the
+   * hierarchical major-case/child-case relationship. Mirrors the webapp's useSearchChildCases. */
+  parentId?: string;
 }
 
 export interface CaseSearchPayloadDto {
@@ -170,6 +173,15 @@ export interface CaseSearchResponseDto {
   hasMore: boolean;
 }
 
+// A linked case/service-request/change-request reference on the case-detail response — only
+// id/number/name are ever carried (mirrors the webapp's BeLinkedServiceRequestRef/
+// BeLinkedChangeRequestRef); `name` is the target's subject, nullable on records without one.
+export interface CaseLinkRefDto {
+  id: string;
+  number: string;
+  name: string | null;
+}
+
 export interface CaseViewDto {
   id: string;
   number: string;
@@ -201,6 +213,8 @@ export interface CaseViewDto {
   relatedCase: CaseNumberRefDto | null;
   account: AccountRefDto | null;
   nextStates: CaseState[];
+  linkedServiceRequests?: CaseLinkRefDto[] | null;
+  linkedChangeRequests?: CaseLinkRefDto[] | null;
 }
 
 export type CaseCommentType = "work_note" | "comment" | "activity";
@@ -248,9 +262,10 @@ export interface CaseCommentCreateResponseDto {
   };
 }
 
-// Backend's UpdateCaseRequest: exactly one of state/severity/workState/assigneeEmail must be
-// provided per PATCH call (they're mutually exclusive `oneOf` branches in openapi.yaml) —
-// resolutionCode/cause/closeNotes are the exception, allowed alongside `state` only.
+// Backend's UpdateCaseRequest: exactly one of state/severity/workState/assigneeEmail/parentId/
+// relatedCaseId must be provided per PATCH call (they're mutually exclusive `oneOf` branches in
+// openapi.yaml) — resolutionCode/cause/closeNotes are the exception, allowed alongside `state`
+// only.
 export interface CasePatchPayloadDto {
   state?: CaseState;
   severity?: CaseSeverity;
@@ -259,6 +274,12 @@ export interface CasePatchPayloadDto {
   resolutionCode?: CaseResolutionCode;
   cause?: CaseCause;
   closeNotes?: string;
+  /** Links this case to another as its parent (the hierarchical major-case/child-case
+   * relationship) — this case can't close while it has open children linked this way. */
+  parentId?: string;
+  /** Cross-links this case to another as a related case — looser than `parentId`, not subject to
+   * the child-case close restriction. */
+  relatedCaseId?: string;
 }
 
 export interface UpdateCaseResponseDto {
@@ -353,6 +374,9 @@ export interface ServiceRequestCreatePayloadDto {
   catalogId: string;
   catalogItemId: string;
   variables: CaseVariableDto[];
+  /** UUID of the case this service request is filed from — links the new request back to it in
+   * the same create call, mirroring the webapp's CreateServiceRequestFromCaseNavState flow. */
+  relatedCaseId?: string;
 }
 
 export interface CreatedCaseDto {

--- a/apps/csm-portal/microapp/src/types/case.model.ts
+++ b/apps/csm-portal/microapp/src/types/case.model.ts
@@ -19,6 +19,7 @@ import type {
   AssignedEngineerRefDto,
   CaseCommentDto,
   CaseCommentType,
+  CaseLinkRefDto,
   CaseNumberRefDto,
   CaseSearchViewDto,
   CaseSeverity,
@@ -106,6 +107,8 @@ export interface CaseDetail {
   parentCase: CaseNumberRefDto | null;
   relatedCase: CaseNumberRefDto | null;
   nextStates: CaseState[];
+  linkedServiceRequests: CaseLinkRefDto[];
+  linkedChangeRequests: CaseLinkRefDto[];
 }
 
 export interface Comment {
@@ -181,6 +184,8 @@ export function toCaseDetail(dto: CaseViewDto): CaseDetail {
     parentCase: dto.parentCase,
     relatedCase: dto.relatedCase,
     nextStates: dto.nextStates,
+    linkedServiceRequests: dto.linkedServiceRequests ?? [],
+    linkedChangeRequests: dto.linkedChangeRequests ?? [],
   };
 }
 function commentAuthorLabel(createdBy: CaseCommentDto["createdBy"] | null | undefined): string {


### PR DESCRIPTION
## Summary

- Adds a **Linked Items** tab to the case detail page, mirroring the webapp's `related` tab — the backend already returns child cases, linked service requests, and linked change requests on the case-detail response, but none of it was surfaced anywhere in the microapp.
- **Child cases** and **Linked service requests** both page through a new `parentId`-scoped case search (`POST /cases/search { filters: { parentId } }`) — the same underlying relationship both lists share, so the two queries dedupe against one cache entry. Rows are tappable, navigating straight to that case/change request.
- **Linked change requests** fans out a per-row `GET /change-requests/{id}` (via `useQueries`) using the ids the case-detail response already carries, so state/target-environment resolve independently per row without blocking the others.
- Adapted from the webapp's desktop tables to mobile cards; dropped the webapp's per-widget refresh buttons since this page already refetches the whole case on every mutation.
- Adds **LinkCaseDialog** — search-and-pick a case to link the current one to as its parent or as a related case, with the same confirm-before-committing UX as the webapp (pick a result, review it, then confirm) before the PATCH fires.
- Threads a `CreateServiceRequestFromCaseNavState` through to `NewServiceRequestPage`, so "Create service request" from a case locks the Project field, pre-seeds deployment/deployed product, and links the new request back to the originating case in the same create call — no separate create-then-link round trip.

## Test plan

- [x] `tsc --noEmit` and `eslint` pass clean across every touched/new file.
- [x] exercised in a local browser session — the microapp authenticates via a native superapp bridge with no standalone fallback; verified by code review and close comparison against the webapp's working `related` tab, `useSearchChildCases`, `useQuickCaseSearch`, and `LinkCaseDialog`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Linked Items tab to case details.
  * Link cases as parent or related cases with search, review, and confirmation.
  * View linked service requests and change requests, including loading and error states.
  * Create pre-populated service requests directly from a case.
  * Added child-case search and quick case search across case types.
  * Linking and creation actions are disabled for closed cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->