### PR TITLE
[CSM][Web] Add a Conversations sub-tab to a project's Work items

### DIFF
--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -987,6 +987,50 @@ export interface BeCommentSearchResponse extends BeSearchResponseBase {
 }
 
 // ---------------------------------------------------------------------------
+// Conversations (Novera chat sessions)
+// ---------------------------------------------------------------------------
+
+export type BeConversationState = "ACTIVE" | "RESOLVED";
+
+/**
+ * A chat session as returned by `POST /conversations/search` — the ServiceNow
+ * "conversation" record a case may originate from. `id`/`number`/`state` are
+ * nullable on the wire (a conversation that never resolved to a real SN
+ * record can have gaps); `case` is null for a chat that never became a case.
+ */
+export interface BeConversationView {
+  id: string | null;
+  number: string | null;
+  initialMessage: string | null;
+  messageCount: number;
+  project: BeEntityRef | null;
+  case: BeEntityRef | null;
+  state: BeConversationState | null;
+  createdOn: string;
+  createdBy: string;
+}
+
+export interface BeSearchConversationsFilters {
+  projectIds?: string[];
+  states?: BeConversationState[];
+}
+
+export interface BeSearchConversationsPayload {
+  filters?: BeSearchConversationsFilters;
+  sortBy?: { field: "createdOn" | "updatedOn"; order: "asc" | "desc" };
+  pagination?: BePagination;
+}
+
+/** No `hasMore` on this response (unlike {@link BeSearchResponseBase}) —
+ * `total` is the only continuation signal the entity service gives here. */
+export interface BeSearchConversationsResponse {
+  conversations: BeConversationView[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+// ---------------------------------------------------------------------------
 // Case activities (unified comment / attachment / field-change stream)
 // ---------------------------------------------------------------------------
 

--- a/apps/csm-portal/webapp/src/features/csm-projects/api/useSearchConversations.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/api/useSearchConversations.test.tsx
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+import { useSearchConversations } from "@features/csm-projects/api/useSearchConversations";
+import type { BackendApi } from "@api/backend/client";
+import type { BeSearchConversationsResponse } from "@api/backend/types";
+
+const postMock = vi.fn();
+
+vi.mock("@api/backend/client", () => ({
+  useBackendApi: (): Partial<BackendApi> => ({ post: postMock }),
+}));
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+describe("useSearchConversations", () => {
+  it("is disabled until a projectId is provided", () => {
+    const { result } = renderHook(
+      () => useSearchConversations(undefined, { page: 0, rowsPerPage: 20 }),
+      { wrapper },
+    );
+
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(postMock).not.toHaveBeenCalled();
+  });
+
+  it("searches by projectId, sorted most-recently-active first, and returns conversations + total", async () => {
+    const response: BeSearchConversationsResponse = {
+      conversations: [
+        {
+          id: "conv-1",
+          number: "CONV0000001",
+          initialMessage: "Hi, need help",
+          messageCount: 4,
+          project: { id: "proj-1", name: "Acme" },
+          case: null,
+          state: "ACTIVE",
+          createdOn: "2026-07-01T10:00:00Z",
+          createdBy: "Jane Doe",
+        },
+      ],
+      total: 1,
+      limit: 20,
+      offset: 0,
+    };
+    postMock.mockResolvedValue(response);
+
+    const { result } = renderHook(
+      () => useSearchConversations("proj-1", { page: 0, rowsPerPage: 20 }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(postMock).toHaveBeenCalledWith("/conversations/search", {
+      filters: { projectIds: ["proj-1"] },
+      sortBy: { field: "updatedOn", order: "desc" },
+      pagination: { limit: 20, offset: 0 },
+    });
+    expect(result.current.data?.total).toBe(1);
+    expect(result.current.data?.conversations[0].id).toBe("conv-1");
+  });
+
+  it("caps rowsPerPage at BE_MAX_PAGE_LIMIT and computes offset from the requested page", async () => {
+    postMock.mockResolvedValue({ conversations: [], total: 0, limit: 50, offset: 100 });
+
+    const { result } = renderHook(
+      () => useSearchConversations("proj-1", { page: 2, rowsPerPage: 200 }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(postMock).toHaveBeenCalledWith(
+      "/conversations/search",
+      expect.objectContaining({ pagination: { limit: 50, offset: 100 } }),
+    );
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-projects/api/useSearchConversations.ts
+++ b/apps/csm-portal/webapp/src/features/csm-projects/api/useSearchConversations.ts
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { ApiQueryKeys, BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
+import { useBackendApi } from "@api/backend/client";
+import type {
+  BeConversationView,
+  BeSearchConversationsPayload,
+  BeSearchConversationsResponse,
+} from "@api/backend/types";
+
+/** Zero-indexed page + page size, mirroring MUI `TablePagination`. */
+export interface ConversationPagination {
+  page: number;
+  rowsPerPage: number;
+}
+
+export interface ConversationSearchResult {
+  conversations: BeConversationView[];
+  total: number;
+}
+
+/**
+ * A project's chat sessions, via `POST /conversations/search`, sorted most
+ * recently active first. `rowsPerPage` is capped at {@link BE_MAX_PAGE_LIMIT}
+ * (the entity service's own documented max for this endpoint). Disabled until
+ * a project id is provided.
+ */
+export function useSearchConversations(
+  projectId: string | undefined,
+  pagination: ConversationPagination,
+): UseQueryResult<ConversationSearchResult, Error> {
+  const api = useBackendApi();
+  const limit = Math.min(pagination.rowsPerPage, BE_MAX_PAGE_LIMIT);
+  const offset = pagination.page * limit;
+
+  return useQuery<ConversationSearchResult, Error>({
+    queryKey: [ApiQueryKeys.CONVERSATIONS_SEARCH, projectId ?? "", pagination.page, limit],
+    queryFn: async (): Promise<ConversationSearchResult> => {
+      const res = await api.post<
+        BeSearchConversationsPayload,
+        BeSearchConversationsResponse
+      >("/conversations/search", {
+        filters: { projectIds: [projectId ?? ""] },
+        sortBy: { field: "updatedOn", order: "desc" },
+        pagination: { limit, offset },
+      });
+      return { conversations: res.conversations ?? [], total: res.total };
+    },
+    enabled: !!projectId,
+    staleTime: 30_000,
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/ConversationTranscriptDialog.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/ConversationTranscriptDialog.test.tsx
@@ -15,7 +15,7 @@
 // under the License.
 
 import { fireEvent, render, screen } from "@testing-library/react";
-import { MemoryRouter } from "react-router";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 import ConversationTranscriptDialog from "@features/csm-projects/components/ConversationTranscriptDialog";
@@ -46,6 +46,11 @@ function conversation(overrides: Partial<BeConversationView> = {}): BeConversati
     createdBy: "Jane Doe",
     ...overrides,
   };
+}
+
+function LocationProbe() {
+  const location = useLocation();
+  return <div data-testid="location-probe">{location.pathname}</div>;
 }
 
 function message(overrides: Partial<CsmCaseComment> = {}): CsmCaseComment {
@@ -147,6 +152,35 @@ describe("ConversationTranscriptDialog", () => {
 
     const link = screen.getByText("View case").closest("a");
     expect(link).toHaveAttribute("href", "/cases/case-1");
+  });
+
+  it("navigates to the linked case when 'View case' is clicked", () => {
+    mockUseGetCsmConversationMessages.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: false,
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/projects/proj-1"]}>
+        <Routes>
+          <Route
+            path="/projects/proj-1"
+            element={
+              <ConversationTranscriptDialog
+                conversation={conversation({ case: { id: "case-1", name: "CS0000001" } })}
+                onClose={vi.fn()}
+              />
+            }
+          />
+          <Route path="/cases/:caseId" element={<LocationProbe />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByText("View case"));
+
+    expect(screen.getByTestId("location-probe")).toHaveTextContent("/cases/case-1");
   });
 
   it("calls onClose when the Close button is clicked", () => {

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/ConversationTranscriptDialog.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/ConversationTranscriptDialog.test.tsx
@@ -1,0 +1,170 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import ConversationTranscriptDialog from "@features/csm-projects/components/ConversationTranscriptDialog";
+import type { BeConversationView } from "@api/backend/types";
+import type { CsmCaseComment } from "@features/csm-cases/types/csmCases";
+
+const mockUseGetCsmConversationMessages = vi.fn();
+
+vi.mock("@features/csm-cases/api/useCsmConversationMessages", () => ({
+  useGetCsmConversationMessages: (...args: unknown[]) =>
+    mockUseGetCsmConversationMessages(...args),
+}));
+
+vi.mock("@features/csm-cases/components/CsmCaseCommentBubble", () => ({
+  default: ({ comment }: { comment: CsmCaseComment }) => <div>Message: {comment.bodyHtml}</div>,
+}));
+
+function conversation(overrides: Partial<BeConversationView> = {}): BeConversationView {
+  return {
+    id: "conv-1",
+    number: "CONV0000001",
+    initialMessage: "Hi, need help",
+    messageCount: 1,
+    project: { id: "proj-1", name: "Acme" },
+    case: null,
+    state: "ACTIVE",
+    createdOn: "2026-07-01T10:00:00Z",
+    createdBy: "Jane Doe",
+    ...overrides,
+  };
+}
+
+function message(overrides: Partial<CsmCaseComment> = {}): CsmCaseComment {
+  return {
+    id: "msg-1",
+    caseId: "",
+    authorName: "Jane Doe",
+    authorRole: "customer",
+    bodyHtml: "Hi, need help",
+    createdAt: "2026-07-01T10:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("ConversationTranscriptDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the conversation's messages once loaded", () => {
+    mockUseGetCsmConversationMessages.mockReturnValue({
+      data: [message()],
+      isLoading: false,
+      isError: false,
+    });
+
+    render(
+      <MemoryRouter>
+        <ConversationTranscriptDialog conversation={conversation()} onClose={vi.fn()} />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("Message: Hi, need help")).toBeInTheDocument();
+  });
+
+  it("shows an empty state when the conversation has no messages", () => {
+    mockUseGetCsmConversationMessages.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: false,
+    });
+
+    render(
+      <MemoryRouter>
+        <ConversationTranscriptDialog conversation={conversation()} onClose={vi.fn()} />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("No messages in this conversation.")).toBeInTheDocument();
+  });
+
+  it("shows an error state when messages fail to load", () => {
+    mockUseGetCsmConversationMessages.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    });
+
+    render(
+      <MemoryRouter>
+        <ConversationTranscriptDialog conversation={conversation()} onClose={vi.fn()} />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("Could not load this conversation.")).toBeInTheDocument();
+  });
+
+  it("does not show a 'View case' link when the conversation never became a case", () => {
+    mockUseGetCsmConversationMessages.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: false,
+    });
+
+    render(
+      <MemoryRouter>
+        <ConversationTranscriptDialog conversation={conversation({ case: null })} onClose={vi.fn()} />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByText("View case")).not.toBeInTheDocument();
+  });
+
+  it("shows a 'View case' link to the linked case when one exists", () => {
+    mockUseGetCsmConversationMessages.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: false,
+    });
+
+    render(
+      <MemoryRouter>
+        <ConversationTranscriptDialog
+          conversation={conversation({ case: { id: "case-1", name: "CS0000001" } })}
+          onClose={vi.fn()}
+        />
+      </MemoryRouter>,
+    );
+
+    const link = screen.getByText("View case").closest("a");
+    expect(link).toHaveAttribute("href", "/cases/case-1");
+  });
+
+  it("calls onClose when the Close button is clicked", () => {
+    const onClose = vi.fn();
+    mockUseGetCsmConversationMessages.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: false,
+    });
+
+    render(
+      <MemoryRouter>
+        <ConversationTranscriptDialog conversation={conversation()} onClose={onClose} />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByText("Close"));
+
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/ConversationTranscriptDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/ConversationTranscriptDialog.tsx
@@ -1,0 +1,95 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Skeleton,
+  Stack,
+  Typography,
+} from "@wso2/oxygen-ui";
+import type { JSX } from "react";
+import { Link as RouterLink } from "react-router";
+import CsmCaseCommentBubble from "@features/csm-cases/components/CsmCaseCommentBubble";
+import { useGetCsmConversationMessages } from "@features/csm-cases/api/useCsmConversationMessages";
+import type { BeConversationView } from "@api/backend/types";
+
+interface ConversationTranscriptDialogProps {
+  conversation: BeConversationView;
+  onClose: () => void;
+}
+
+/**
+ * Read-only transcript of a single chat session, opened from a project's
+ * Conversations tab. Reuses `useGetCsmConversationMessages` and
+ * `CsmCaseCommentBubble` — the same hook and bubble the case-detail activity
+ * feed uses for the Novera transcript a case originated from — so message
+ * rendering (sanitisation, author role, etc.) stays identical wherever a
+ * transcript is shown.
+ */
+export default function ConversationTranscriptDialog({
+  conversation,
+  onClose,
+}: ConversationTranscriptDialogProps): JSX.Element {
+  const { data: messages, isLoading, isError } = useGetCsmConversationMessages(
+    conversation.id,
+  );
+
+  return (
+    <Dialog open onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>
+        Chat session {conversation.number ? `· ${conversation.number}` : ""}
+      </DialogTitle>
+      <DialogContent dividers sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+        {isLoading ? (
+          <Stack gap={1.5}>
+            <Skeleton variant="rounded" height={64} />
+            <Skeleton variant="rounded" height={64} />
+            <Skeleton variant="rounded" height={64} />
+          </Stack>
+        ) : isError ? (
+          <Typography variant="body2" color="error">
+            Could not load this conversation.
+          </Typography>
+        ) : !messages || messages.length === 0 ? (
+          <Typography variant="body2" color="text.secondary">
+            No messages in this conversation.
+          </Typography>
+        ) : (
+          <Stack gap={1.5}>
+            {messages.map((message) => (
+              <CsmCaseCommentBubble key={message.id} comment={message} />
+            ))}
+          </Stack>
+        )}
+      </DialogContent>
+      <DialogActions>
+        {conversation.case?.id && (
+          <Box sx={{ mr: "auto" }}>
+            <Button component={RouterLink} to={`/cases/${conversation.case.id}`} onClick={onClose}>
+              View case
+            </Button>
+          </Box>
+        )}
+        <Button onClick={onClose}>Close</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/ConversationsTab.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/ConversationsTab.test.tsx
@@ -1,0 +1,148 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import ConversationsTab from "@features/csm-projects/components/ConversationsTab";
+import type { BeConversationView } from "@api/backend/types";
+
+// QueryErrorState imports BackendApiError from @api/backend/client, whose
+// module reads window.config (via @config/apiConfig) at load time —
+// unavailable under vitest. Mock the config so that module evaluates cleanly;
+// useBackendApi itself is never called here (useSearchConversations is mocked
+// below), so it doesn't need its own mock.
+vi.mock("@config/apiConfig", () => ({
+  apiConfig: { backendUrl: "https://example.test" },
+}));
+
+const mockUseSearchConversations = vi.fn();
+
+vi.mock("@features/csm-projects/api/useSearchConversations", () => ({
+  useSearchConversations: (...args: unknown[]) => mockUseSearchConversations(...args),
+}));
+
+vi.mock("@features/csm-projects/components/ConversationTranscriptDialog", () => ({
+  default: ({
+    conversation,
+    onClose,
+  }: {
+    conversation: BeConversationView;
+    onClose: () => void;
+  }) => (
+    <div>
+      <div>Transcript for {conversation.id}</div>
+      <button onClick={onClose}>Close transcript</button>
+    </div>
+  ),
+}));
+
+function conversation(overrides: Partial<BeConversationView> = {}): BeConversationView {
+  return {
+    id: "conv-1",
+    number: "CONV0000001",
+    initialMessage: "Hi, need help",
+    messageCount: 4,
+    project: { id: "proj-1", name: "Acme" },
+    case: null,
+    state: "ACTIVE",
+    createdOn: "2026-07-01T10:00:00Z",
+    createdBy: "Jane Doe",
+    ...overrides,
+  };
+}
+
+describe("ConversationsTab", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows a loading skeleton while the search is in flight", () => {
+    mockUseSearchConversations.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+      error: null,
+    });
+
+    render(<ConversationsTab projectId="proj-1" />);
+
+    expect(screen.queryByText("No chat sessions found for this project.")).not.toBeInTheDocument();
+  });
+
+  it("shows an error state when the search fails", () => {
+    mockUseSearchConversations.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: new Error("boom"),
+    });
+
+    render(<ConversationsTab projectId="proj-1" />);
+
+    expect(screen.getByText("boom")).toBeInTheDocument();
+  });
+
+  it("shows an empty state when the project has no conversations", () => {
+    mockUseSearchConversations.mockReturnValue({
+      data: { conversations: [], total: 0 },
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    render(<ConversationsTab projectId="proj-1" />);
+
+    expect(screen.getByText("No chat sessions found for this project.")).toBeInTheDocument();
+  });
+
+  it("lists conversations and opens the transcript dialog when a row is clicked", () => {
+    mockUseSearchConversations.mockReturnValue({
+      data: { conversations: [conversation()], total: 1 },
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    render(<ConversationsTab projectId="proj-1" />);
+
+    expect(screen.getByText("Jane Doe")).toBeInTheDocument();
+    expect(screen.getByText("Active")).toBeInTheDocument();
+    expect(screen.queryByText("Transcript for conv-1")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Jane Doe"));
+
+    expect(screen.getByText("Transcript for conv-1")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Close transcript"));
+
+    expect(screen.queryByText("Transcript for conv-1")).not.toBeInTheDocument();
+  });
+
+  it("renders a dash for a conversation with no resolved state", () => {
+    mockUseSearchConversations.mockReturnValue({
+      data: { conversations: [conversation({ state: null })], total: 1 },
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    render(<ConversationsTab projectId="proj-1" />);
+
+    expect(screen.queryByText("Active")).not.toBeInTheDocument();
+    expect(screen.queryByText("Resolved")).not.toBeInTheDocument();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/ConversationsTab.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/ConversationsTab.test.tsx
@@ -145,4 +145,64 @@ describe("ConversationsTab", () => {
     expect(screen.queryByText("Active")).not.toBeInTheDocument();
     expect(screen.queryByText("Resolved")).not.toBeInTheDocument();
   });
+
+  it("opens the transcript dialog when a row is activated with Enter", () => {
+    mockUseSearchConversations.mockReturnValue({
+      data: { conversations: [conversation()], total: 1 },
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    render(<ConversationsTab projectId="proj-1" />);
+
+    const row = screen.getByRole("button", { name: "View chat session started by Jane Doe" });
+    expect(row).toHaveAttribute("tabIndex", "0");
+    fireEvent.keyDown(row, { key: "Enter" });
+
+    expect(screen.getByText("Transcript for conv-1")).toBeInTheDocument();
+  });
+
+  it("opens the transcript dialog when a row is activated with Space", () => {
+    mockUseSearchConversations.mockReturnValue({
+      data: { conversations: [conversation()], total: 1 },
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    render(<ConversationsTab projectId="proj-1" />);
+
+    const row = screen.getByRole("button", { name: "View chat session started by Jane Doe" });
+    fireEvent.keyDown(row, { key: " " });
+
+    expect(screen.getByText("Transcript for conv-1")).toBeInTheDocument();
+  });
+
+  it("resets pagination and closes any open transcript when projectId changes", () => {
+    mockUseSearchConversations.mockReturnValue({
+      data: { conversations: [conversation()], total: 100 },
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    const { rerender } = render(<ConversationsTab projectId="proj-1" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /next page/i }));
+    fireEvent.click(screen.getByText("Jane Doe"));
+    expect(screen.getByText("Transcript for conv-1")).toBeInTheDocument();
+    expect(mockUseSearchConversations).toHaveBeenLastCalledWith(
+      "proj-1",
+      expect.objectContaining({ page: 1 }),
+    );
+
+    rerender(<ConversationsTab projectId="proj-2" />);
+
+    expect(screen.queryByText("Transcript for conv-1")).not.toBeInTheDocument();
+    expect(mockUseSearchConversations).toHaveBeenLastCalledWith(
+      "proj-2",
+      expect.objectContaining({ page: 0 }),
+    );
+  });
 });

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/ConversationsTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/ConversationsTab.tsx
@@ -54,9 +54,21 @@ interface ConversationsTabProps {
  * through to it from there instead of duplicating that action inline here.
  */
 export default function ConversationsTab({ projectId }: ConversationsTabProps): JSX.Element {
+  // Guarded set during render (React's documented pattern for adjusting state
+  // from a changed prop, not an effect) — resets pagination and the open
+  // transcript when the surrounding page switches to a different project's
+  // Work items tab, rather than carrying over the previous project's page
+  // number or selected conversation into this one.
+  const [previousProjectId, setPreviousProjectId] = useState(projectId);
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_ROWS_PER_PAGE);
   const [selected, setSelected] = useState<BeConversationView | null>(null);
+
+  if (projectId !== previousProjectId) {
+    setPreviousProjectId(projectId);
+    setPage(0);
+    setSelected(null);
+  }
 
   const { data, isLoading, isError, error } = useSearchConversations(projectId, {
     page,
@@ -111,27 +123,39 @@ export default function ConversationsTab({ projectId }: ConversationsTabProps): 
                   </TableCell>
                 </TableRow>
               ) : (
-                conversations.map((c, i) => (
-                  <TableRow
-                    key={c.id ?? `${c.createdOn}-${i}`}
-                    hover
-                    onClick={() => setSelected(c)}
-                    sx={{ cursor: "pointer" }}
-                  >
-                    <TableCell>
-                      <RelativeTime iso={c.createdOn} />
-                    </TableCell>
-                    <TableCell>{c.createdBy || "—"}</TableCell>
-                    <TableCell>{c.messageCount}</TableCell>
-                    <TableCell>
-                      {c.state ? (
-                        <SemanticChip role={STATE_META[c.state].role} label={STATE_META[c.state].label} />
-                      ) : (
-                        "—"
-                      )}
-                    </TableCell>
-                  </TableRow>
-                ))
+                conversations.map((c, i) => {
+                  const open = (): void => setSelected(c);
+                  return (
+                    <TableRow
+                      key={c.id ?? `${c.createdOn}-${i}`}
+                      hover
+                      onClick={open}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          open();
+                        }
+                      }}
+                      tabIndex={0}
+                      role="button"
+                      aria-label={`View chat session started by ${c.createdBy || "unknown"}`}
+                      sx={{ cursor: "pointer" }}
+                    >
+                      <TableCell>
+                        <RelativeTime iso={c.createdOn} />
+                      </TableCell>
+                      <TableCell>{c.createdBy || "—"}</TableCell>
+                      <TableCell>{c.messageCount}</TableCell>
+                      <TableCell>
+                        {c.state ? (
+                          <SemanticChip role={STATE_META[c.state].role} label={STATE_META[c.state].label} />
+                        ) : (
+                          "—"
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  );
+                })
               )}
             </TableBody>
           </Table>

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/ConversationsTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/ConversationsTab.tsx
@@ -1,0 +1,160 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Paper,
+  Skeleton,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TablePagination,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { useState, type JSX } from "react";
+import RelativeTime from "@components/RelativeTime";
+import QueryErrorState from "@components/QueryErrorState";
+import SemanticChip from "@components/SemanticChip";
+import ConversationTranscriptDialog from "@features/csm-projects/components/ConversationTranscriptDialog";
+import { useSearchConversations } from "@features/csm-projects/api/useSearchConversations";
+import type { BeConversationState, BeConversationView } from "@api/backend/types";
+
+const COLUMN_COUNT = 4;
+const DEFAULT_ROWS_PER_PAGE = 20;
+const ROWS_PER_PAGE_OPTIONS = [10, DEFAULT_ROWS_PER_PAGE, 50];
+
+const STATE_META: Record<BeConversationState, { label: string; role: "info" | "success" }> = {
+  ACTIVE: { label: "Active", role: "info" },
+  RESOLVED: { label: "Resolved", role: "success" },
+};
+
+interface ConversationsTabProps {
+  projectId: string;
+}
+
+/**
+ * Lists a project's chat sessions (`POST /conversations/search`), most
+ * recently active first. Clicking a row opens the read-only transcript
+ * (`ConversationTranscriptDialog`); a conversation that became a case links
+ * through to it from there instead of duplicating that action inline here.
+ */
+export default function ConversationsTab({ projectId }: ConversationsTabProps): JSX.Element {
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_ROWS_PER_PAGE);
+  const [selected, setSelected] = useState<BeConversationView | null>(null);
+
+  const { data, isLoading, isError, error } = useSearchConversations(projectId, {
+    page,
+    rowsPerPage,
+  });
+  const conversations = data?.conversations ?? [];
+  const total = data?.total ?? 0;
+
+  return (
+    <>
+      <Paper variant="outlined">
+        <TableContainer>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Started</TableCell>
+                <TableCell>Started by</TableCell>
+                <TableCell>Messages</TableCell>
+                <TableCell>State</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {isLoading ? (
+                Array.from({ length: 3 }).map((_, i) => (
+                  <TableRow key={i}>
+                    {Array.from({ length: COLUMN_COUNT }).map((__, c) => (
+                      <TableCell key={c}>
+                        <Skeleton variant="rounded" width="70%" height={18} />
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                ))
+              ) : isError ? (
+                <TableRow>
+                  <TableCell colSpan={COLUMN_COUNT} align="center">
+                    <QueryErrorState
+                      message={
+                        error instanceof Error && error.message.trim()
+                          ? error.message
+                          : "Failed to load conversations."
+                      }
+                      error={error}
+                    />
+                  </TableCell>
+                </TableRow>
+              ) : conversations.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={COLUMN_COUNT} align="center" sx={{ py: 4 }}>
+                    <Typography variant="body2" color="text.secondary">
+                      No chat sessions found for this project.
+                    </Typography>
+                  </TableCell>
+                </TableRow>
+              ) : (
+                conversations.map((c, i) => (
+                  <TableRow
+                    key={c.id ?? `${c.createdOn}-${i}`}
+                    hover
+                    onClick={() => setSelected(c)}
+                    sx={{ cursor: "pointer" }}
+                  >
+                    <TableCell>
+                      <RelativeTime iso={c.createdOn} />
+                    </TableCell>
+                    <TableCell>{c.createdBy || "—"}</TableCell>
+                    <TableCell>{c.messageCount}</TableCell>
+                    <TableCell>
+                      {c.state ? (
+                        <SemanticChip role={STATE_META[c.state].role} label={STATE_META[c.state].label} />
+                      ) : (
+                        "—"
+                      )}
+                    </TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </TableContainer>
+
+        <TablePagination
+          component="div"
+          count={total}
+          page={page}
+          onPageChange={(_, newPage) => setPage(newPage)}
+          rowsPerPage={rowsPerPage}
+          onRowsPerPageChange={(e) => {
+            setRowsPerPage(parseInt(e.target.value, 10));
+            setPage(0);
+          }}
+          rowsPerPageOptions={ROWS_PER_PAGE_OPTIONS}
+          labelRowsPerPage="Conversations per page"
+        />
+      </Paper>
+
+      {selected && (
+        <ConversationTranscriptDialog conversation={selected} onClose={() => setSelected(null)} />
+      )}
+    </>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/WorkItemsTab.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/WorkItemsTab.test.tsx
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import WorkItemsTab from "@features/csm-projects/components/WorkItemsTab";
+
+const mockCsmIssuesView = vi.fn();
+
+vi.mock("@features/csm-cases/components/CsmIssuesView", () => ({
+  default: (props: Record<string, unknown>) => {
+    mockCsmIssuesView(props);
+    return <div>IssuesView: {props.entityNoun as string}</div>;
+  },
+}));
+
+vi.mock("@features/csm-projects/components/ConversationsTab", () => ({
+  default: ({ projectId }: { projectId: string }) => <div>Conversations for {projectId}</div>,
+}));
+
+describe("WorkItemsTab", () => {
+  it("defaults to the Cases sub-tab, locked to this project's case-type cases", () => {
+    render(<WorkItemsTab projectId="proj-1" />);
+
+    expect(screen.getByText("IssuesView: cases")).toBeInTheDocument();
+    expect(mockCsmIssuesView).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entityNoun: "cases",
+        lockedFilters: { projects: ["proj-1"], caseTypes: ["case"] },
+        hideProjectFilter: true,
+        hideTypeFilter: true,
+      }),
+    );
+  });
+
+  it("switches to the Service requests sub-tab, routed to the operations detail page", () => {
+    render(<WorkItemsTab projectId="proj-1" />);
+
+    fireEvent.click(screen.getByText("Service requests"));
+
+    expect(screen.getByText("IssuesView: service requests")).toBeInTheDocument();
+    expect(mockCsmIssuesView).toHaveBeenCalledWith(
+      expect.objectContaining({
+        lockedFilters: { projects: ["proj-1"], caseTypes: ["service_request"] },
+        detailBasePath: "/operations/service-requests",
+      }),
+    );
+  });
+
+  it("switches to the Security reports sub-tab with severity hidden", () => {
+    render(<WorkItemsTab projectId="proj-1" />);
+
+    fireEvent.click(screen.getByText("Security reports"));
+
+    expect(screen.getByText("IssuesView: security reports")).toBeInTheDocument();
+    expect(mockCsmIssuesView).toHaveBeenCalledWith(
+      expect.objectContaining({
+        lockedFilters: { projects: ["proj-1"], caseTypes: ["security_report_analysis"] },
+        hideSeverityColumn: true,
+        detailBasePath: "/security-center/security-reports",
+      }),
+    );
+  });
+
+  it("switches to the Engagements sub-tab with the engagement-type filter shown", () => {
+    render(<WorkItemsTab projectId="proj-1" />);
+
+    fireEvent.click(screen.getByText("Engagements"));
+
+    expect(screen.getByText("IssuesView: engagements")).toBeInTheDocument();
+    expect(mockCsmIssuesView).toHaveBeenCalledWith(
+      expect.objectContaining({
+        lockedFilters: { projects: ["proj-1"], caseTypes: ["engagement"] },
+        showEngagementTypeFilter: true,
+        hideSeverityColumn: true,
+        detailBasePath: "/engagements",
+      }),
+    );
+  });
+
+  it("switches to the Conversations sub-tab", () => {
+    render(<WorkItemsTab projectId="proj-1" />);
+
+    fireEvent.click(screen.getByText("Conversations"));
+
+    expect(screen.getByText("Conversations for proj-1")).toBeInTheDocument();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/WorkItemsTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/WorkItemsTab.tsx
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Box, Tab, Tabs } from "@wso2/oxygen-ui";
+import { useState, type JSX } from "react";
+import CsmIssuesView from "@features/csm-cases/components/CsmIssuesView";
+import ConversationsTab from "@features/csm-projects/components/ConversationsTab";
+
+type WorkItemSubTab =
+  | "cases"
+  | "serviceRequests"
+  | "securityReports"
+  | "engagements"
+  | "conversations";
+
+interface WorkItemsTabProps {
+  projectId: string;
+}
+
+/**
+ * A project's work items, categorized into per-type sub-tabs rather than one
+ * mixed list with a type filter — Cases / Service requests / Security reports
+ * / Engagements each lock `CsmIssuesView` to their own case type (mirroring
+ * the props each type's own standalone page already uses — `CsmCasesPage`,
+ * `OperationsPage`, `CsmSecurityCenterPage`, `CsmEngagementsPage` — so a row's
+ * severity column, detail route, and engagement-type filter all match what a
+ * user sees on that type's dedicated page). Conversations is the project's
+ * chat sessions (`ConversationsTab`), included here as its own sub-tab rather
+ * than as a separate top-level project tab.
+ */
+export default function WorkItemsTab({ projectId }: WorkItemsTabProps): JSX.Element {
+  const [subTab, setSubTab] = useState<WorkItemSubTab>("cases");
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+      <Tabs value={subTab} onChange={(_, v) => setSubTab(v as WorkItemSubTab)}>
+        <Tab value="cases" label="Cases" />
+        <Tab value="serviceRequests" label="Service requests" />
+        <Tab value="securityReports" label="Security reports" />
+        <Tab value="engagements" label="Engagements" />
+        <Tab value="conversations" label="Conversations" />
+      </Tabs>
+
+      {subTab === "cases" && (
+        <CsmIssuesView
+          entityNoun="cases"
+          lockedFilters={{ projects: [projectId], caseTypes: ["case"] }}
+          hideProjectFilter
+          hideTypeFilter
+        />
+      )}
+
+      {subTab === "serviceRequests" && (
+        <CsmIssuesView
+          entityNoun="service requests"
+          lockedFilters={{ projects: [projectId], caseTypes: ["service_request"] }}
+          hideProjectFilter
+          hideTypeFilter
+          detailBasePath="/operations/service-requests"
+        />
+      )}
+
+      {subTab === "securityReports" && (
+        <CsmIssuesView
+          entityNoun="security reports"
+          lockedFilters={{ projects: [projectId], caseTypes: ["security_report_analysis"] }}
+          hideProjectFilter
+          hideTypeFilter
+          hideSeverityColumn
+          detailBasePath="/security-center/security-reports"
+        />
+      )}
+
+      {subTab === "engagements" && (
+        <CsmIssuesView
+          entityNoun="engagements"
+          lockedFilters={{ projects: [projectId], caseTypes: ["engagement"] }}
+          hideProjectFilter
+          hideTypeFilter
+          showEngagementTypeFilter
+          hideSeverityColumn
+          detailBasePath="/engagements"
+        />
+      )}
+
+      {subTab === "conversations" && <ConversationsTab projectId={projectId} />}
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-projects/pages/CsmProjectDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/pages/CsmProjectDetailPage.tsx
@@ -30,23 +30,17 @@ import { ArrowLeft, ChevronDown, Plus } from "@wso2/oxygen-ui-icons-react";
 import { useState, type JSX, type MouseEvent, type ReactNode } from "react";
 import { Link as RouterLink, useLocation, useParams } from "react-router";
 import { useGetProject } from "@features/csm-projects/api/useGetProject";
-import CsmIssuesView from "@features/csm-cases/components/CsmIssuesView";
 import ClosureStateChip from "@features/csm-projects/components/ClosureStateChip";
-import ConversationsTab from "@features/csm-projects/components/ConversationsTab";
 import DeploymentsTab from "@features/csm-projects/components/DeploymentsTab";
 import ProjectContactsTab from "@features/csm-projects/components/ProjectContactsTab";
+import WorkItemsTab from "@features/csm-projects/components/WorkItemsTab";
 import {
   endDateLabel,
   startDateLabel,
 } from "@features/csm-projects/utils/projectLifecycle";
 import { useNavTransition } from "@hooks/useNavTransition";
 
-type ProjectTabId =
-  | "overview"
-  | "deployments"
-  | "contacts"
-  | "workItems"
-  | "conversations";
+type ProjectTabId = "overview" | "deployments" | "contacts" | "workItems";
 
 function formatDate(value?: string | null): string {
   if (!value) return "—";
@@ -271,7 +265,6 @@ export default function CsmProjectDetailPage(): JSX.Element {
           <Tab value="deployments" label="Deployments" />
           <Tab value="contacts" label="Project contacts" />
           <Tab value="workItems" label="Work items" />
-          <Tab value="conversations" label="Conversations" />
         </Tabs>
       </Box>
 
@@ -330,15 +323,7 @@ export default function CsmProjectDetailPage(): JSX.Element {
 
       {activeTab === "contacts" && <ProjectContactsTab projectId={p.id} />}
 
-      {activeTab === "workItems" && (
-        <CsmIssuesView
-          entityNoun="work items"
-          lockedFilters={{ projects: [p.id] }}
-          hideProjectFilter
-        />
-      )}
-
-      {activeTab === "conversations" && <ConversationsTab projectId={p.id} />}
+      {activeTab === "workItems" && <WorkItemsTab projectId={p.id} />}
     </Box>
   );
 }

--- a/apps/csm-portal/webapp/src/features/csm-projects/pages/CsmProjectDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/pages/CsmProjectDetailPage.tsx
@@ -32,6 +32,7 @@ import { Link as RouterLink, useLocation, useParams } from "react-router";
 import { useGetProject } from "@features/csm-projects/api/useGetProject";
 import CsmIssuesView from "@features/csm-cases/components/CsmIssuesView";
 import ClosureStateChip from "@features/csm-projects/components/ClosureStateChip";
+import ConversationsTab from "@features/csm-projects/components/ConversationsTab";
 import DeploymentsTab from "@features/csm-projects/components/DeploymentsTab";
 import ProjectContactsTab from "@features/csm-projects/components/ProjectContactsTab";
 import {
@@ -40,7 +41,12 @@ import {
 } from "@features/csm-projects/utils/projectLifecycle";
 import { useNavTransition } from "@hooks/useNavTransition";
 
-type ProjectTabId = "overview" | "deployments" | "contacts" | "workItems";
+type ProjectTabId =
+  | "overview"
+  | "deployments"
+  | "contacts"
+  | "workItems"
+  | "conversations";
 
 function formatDate(value?: string | null): string {
   if (!value) return "—";
@@ -265,6 +271,7 @@ export default function CsmProjectDetailPage(): JSX.Element {
           <Tab value="deployments" label="Deployments" />
           <Tab value="contacts" label="Project contacts" />
           <Tab value="workItems" label="Work items" />
+          <Tab value="conversations" label="Conversations" />
         </Tabs>
       </Box>
 
@@ -330,6 +337,8 @@ export default function CsmProjectDetailPage(): JSX.Element {
           hideProjectFilter
         />
       )}
+
+      {activeTab === "conversations" && <ConversationsTab projectId={p.id} />}
     </Box>
   );
 }


### PR DESCRIPTION
## Purpose
There was no way to view a customer's chat sessions scoped to a project — chat history was only reachable in the context of a case that originated from one. The backend already supports this end-to-end (entity-service `POST /conversations/search`, `csm-portal/backend`'s existing `GET /conversations/{id}/messages` proxy); nothing in the frontend called the search endpoint yet.

## Goals
- Let CS engineers browse and read a project's chat sessions.
- Reorganize the project's Work items tab into per-type sub-tabs (Cases / Service requests / Security reports / Engagements) instead of one mixed list with a type filter, and fold Conversations into that structure as a fifth sub-tab.

## Approach
- Added the `POST /conversations/search` wire types and a `useSearchConversations` hook (paginated, sorted most-recently-active first, scoped by `projectId`).
- `ConversationsTab` lists a project's chat sessions; clicking a row opens `ConversationTranscriptDialog`, which reuses the existing `useGetCsmConversationMessages` hook and `CsmCaseCommentBubble` renderer already used for a case's own Novera transcript — so message rendering stays identical wherever a transcript is shown. A conversation that became a case links through to it.
- Replaced the project detail page's single "Work items" `CsmIssuesView` (mixed types + a type filter) with a new `WorkItemsTab` component: five sub-tabs (Cases, Service requests, Security reports, Engagements, Conversations), each of the first four locking `CsmIssuesView` to its own case type with the same props that type's own standalone page already uses (detail route, severity column, engagement-type filter), so a row here matches what the same item looks like on its dedicated page.

## User stories
As a CS engineer, I can open a project, go to Work items, and switch to the Conversations sub-tab to see and read that project's chat sessions, including which ones became a case.

## Release note
Feature: a project's Work items tab is now split into Cases / Service requests / Security reports / Engagements / Conversations sub-tabs, adding the ability to view a project's chat sessions.

## Documentation
N/A — internal CSM portal UI, no external doc surface affected.

## Automation tests
- Unit tests: `useSearchConversations.test.tsx` (search payload/pagination), `ConversationsTab.test.tsx` (loading/error/empty states, row click opens transcript), `ConversationTranscriptDialog.test.tsx` (message rendering, empty/error states, linked-case link), `WorkItemsTab.test.tsx` (each sub-tab renders with the correct locked filters/props) — all passing.
- Verified against staging: not yet — only verified locally via `tsc -b`, `eslint`, and `vitest`; haven't run this against a live/staging environment in a browser.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (frontend-only change)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
- `apps/csm-portal/webapp`: `tsc -b`, `eslint`, and `vitest run` all passing locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a dedicated Work Items area with tabs for Cases, Service Requests, Security Reports, Engagements, and Conversations.
  - Added paginated conversation browsing with project filtering, status indicators, sorting, and loading, empty, or error states.
  - Added keyboard-accessible conversation selection and read-only transcript viewing, including related case navigation when available.

- **Tests**
  - Added coverage for conversation search, work-item navigation, transcript rendering, pagination, keyboard interaction, and empty or error states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->