### PR TITLE
[CSM][Web] Fix dashboard-widget back navigation across all resource types

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-accounts/pages/CsmAccountsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-accounts/pages/CsmAccountsPage.tsx
@@ -16,6 +16,7 @@
 
 import {
   Box,
+  Button,
   Chip,
   Skeleton,
   Table,
@@ -28,7 +29,9 @@ import {
   TextField,
   Typography,
 } from "@wso2/oxygen-ui";
+import { ArrowLeft } from "@wso2/oxygen-ui-icons-react";
 import { useMemo, useState, type ChangeEvent, type JSX, type KeyboardEvent } from "react";
+import { useLocation } from "react-router";
 import QueryErrorState from "@components/QueryErrorState";
 import { useDebouncedValue } from "@hooks/useDebouncedValue";
 import { useNavTransition } from "@hooks/useNavTransition";
@@ -58,6 +61,10 @@ function formatDate(value?: string | null): string {
 
 export default function CsmAccountsPage(): JSX.Element {
   const navigate = useNavTransition();
+  const location = useLocation();
+  // Set by a dashboard widget's click-through, since this page has no
+  // dashboard context of its own.
+  const backState = location.state as { from?: string } | undefined;
   const [searchInput, setSearchInput] = useState("");
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_ROWS_PER_PAGE);
@@ -92,6 +99,18 @@ export default function CsmAccountsPage(): JSX.Element {
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
+      {backState?.from && (
+        <Button
+          variant="text"
+          size="small"
+          startIcon={<ArrowLeft size={16} />}
+          onClick={() => navigate(backState.from as string)}
+          sx={{ alignSelf: "flex-start" }}
+        >
+          Back
+        </Button>
+      )}
+
       <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 1 }}>
         <Typography variant="body2" color="text.secondary">
           Search across account name and Salesforce ID (case-insensitive).
@@ -159,7 +178,10 @@ export default function CsmAccountsPage(): JSX.Element {
               ) : (
                 accounts.map((a) => {
                   const tier = resolveAccountTier(a);
-                  const goToAccount = (): void => navigate(`/customers/accounts/${a.id}`);
+                  const goToAccount = (): void =>
+                    navigate(`/customers/accounts/${a.id}`, {
+                      state: { from: `${location.pathname}${location.search}` },
+                    });
                   const handleRowKeyDown = (e: KeyboardEvent<HTMLTableRowElement>): void => {
                     if (e.key === "Enter" || e.key === " ") {
                       e.preventDefault();

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardMiniTable.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardMiniTable.test.tsx
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router";
+import { describe, expect, it } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import DashboardMiniTable from "@features/csm-dashboard/components/DashboardMiniTable";
+
+function LocationProbe() {
+  const location = useLocation();
+  return (
+    <>
+      <div data-testid="location-probe">{location.pathname}</div>
+      <div data-testid="location-state-probe">{JSON.stringify(location.state ?? null)}</div>
+    </>
+  );
+}
+
+describe("DashboardMiniTable", () => {
+  it("carries a row's state prop through to the navigated destination", () => {
+    render(
+      <MemoryRouter initialEntries={["/dashboard"]}>
+        <Routes>
+          <Route
+            path="/dashboard"
+            element={
+              <DashboardMiniTable
+                isLoading={false}
+                emptyMessage="No rows."
+                columns={[{ label: "Number" }]}
+                rows={[
+                  {
+                    key: "row-1",
+                    href: "/operations/incidents/inc-1",
+                    state: { from: "/dashboard" },
+                    cells: [<span key="c">INC0000001</span>],
+                  },
+                ]}
+              />
+            }
+          />
+          <Route path="/operations/incidents/:id" element={<LocationProbe />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByText("INC0000001"));
+
+    expect(screen.getByTestId("location-probe")).toHaveTextContent(
+      "/operations/incidents/inc-1",
+    );
+    expect(screen.getByTestId("location-state-probe")).toHaveTextContent(
+      JSON.stringify({ from: "/dashboard" }),
+    );
+  });
+
+  it("navigates with no state when a row sets none", () => {
+    render(
+      <MemoryRouter initialEntries={["/dashboard"]}>
+        <Routes>
+          <Route
+            path="/dashboard"
+            element={
+              <DashboardMiniTable
+                isLoading={false}
+                emptyMessage="No rows."
+                columns={[{ label: "Number" }]}
+                rows={[
+                  {
+                    key: "row-1",
+                    href: "/operations/incidents/inc-1",
+                    cells: [<span key="c">INC0000001</span>],
+                  },
+                ]}
+              />
+            }
+          />
+          <Route path="/operations/incidents/:id" element={<LocationProbe />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByText("INC0000001"));
+
+    expect(screen.getByTestId("location-state-probe")).toHaveTextContent("null");
+  });
+
+  it("renders an onClick row (e.g. a task) without a state prop, since it never navigates", () => {
+    const onClick = () => {};
+    render(
+      <MemoryRouter>
+        <DashboardMiniTable
+          isLoading={false}
+          emptyMessage="No rows."
+          columns={[{ label: "Subject" }]}
+          rows={[{ key: "row-1", onClick, cells: [<span key="c">Task subject</span>] }]}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("Task subject")).toBeInTheDocument();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardMiniTable.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardMiniTable.tsx
@@ -34,6 +34,11 @@ export interface DashboardMiniTableRow {
    * — a row with no standalone detail *page* (e.g. a task, only ever shown
    * in a dialog) uses `onClick` instead. */
   href?: string;
+  /** Router state carried on `href`'s navigation — e.g. `{ from: <dashboard
+   * path> }`, so the destination page's own Back button can return here
+   * instead of falling through to a hardcoded/generic destination. Ignored
+   * when `href` is unset. */
+  state?: unknown;
   /** Opens something in place (a dialog) rather than navigating — for a
    * resource with no standalone detail route. See `href`'s doc comment for
    * when to use which. */
@@ -134,7 +139,7 @@ export default function DashboardMiniTable({
             <Box
               key={row.key}
               {...(row.href
-                ? { component: RouterLink, to: row.href }
+                ? { component: RouterLink, to: row.href, state: row.state }
                 : row.onClick
                   ? { onClick: row.onClick, role: "button", tabIndex: 0 }
                   : {})}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetListConfig.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetListConfig.tsx
@@ -53,7 +53,6 @@ import { resolveAccountTier, type Account } from "@features/csm-accounts/types/c
 import type { Project } from "@features/csm-projects/types/csmProjects";
 import ClosureStateChip from "@features/csm-projects/components/ClosureStateChip";
 import { normalizeUser, type User, type SnUser } from "@features/csm-users/types/csmUsers";
-import UserRefLink from "@components/UserRefLink";
 import { vulnerabilityPriorityColor } from "@features/csm-security-center/utils/vulnerabilities";
 import type { BeProductVulnerabilityView } from "@api/backend/types";
 import type { BeCallRequestView } from "@api/backend/types";
@@ -384,8 +383,16 @@ function UserWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.Elem
         key: u.id,
         href: `/people/${encodeURIComponent(u.id)}`,
         state: dashboardReturnState,
+        // Plain text, not `UserRefLink` — that renders its own nested
+        // RouterLink with no `state`, so clicking the name specifically
+        // (vs. elsewhere in the row) would silently drop `dashboardReturnState`
+        // and land on a plain default back target instead. The row itself
+        // is already the link (with state), matching every sibling widget's
+        // "name" cell (see AccountWidgetList/ProjectWidgetList above).
         cells: [
-          <UserRefLink key="user" name={u.userName} email={u.email} userId={u.id} />,
+          <Typography key="user" variant="body2" noWrap>
+            {u.userName}
+          </Typography>,
           <Typography key="email" variant="body2" noWrap>
             {u.email}
           </Typography>,

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetListConfig.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetListConfig.tsx
@@ -18,6 +18,7 @@
 
 import { Chip, Typography } from "@wso2/oxygen-ui";
 import { useState, type JSX } from "react";
+import { useLocation } from "react-router";
 import type {
   BeCaseSearchView,
   BeIncident,
@@ -63,6 +64,17 @@ import type { BeCallRequestView } from "@api/backend/types";
  * agnostic); each renderer below casts it to the same typed shape its own
  * tab already assumes, since it's the identical upstream response. */
 type WidgetItem = Record<string, unknown>;
+
+/** Router state carried on every list-shape widget row's navigation (every
+ * renderer below other than `CaseWidgetList`/`TimeCardWidgetList`, which
+ * embed their own tab's real list component and so already get this for
+ * free — see `CasesList`'s own `useLocation()` call), so the destination
+ * page's own Back button can return to this exact dashboard instead of
+ * falling through to a hardcoded/generic destination. */
+function useDashboardReturnState(): { from: string } {
+  const location = useLocation();
+  return { from: `${location.pathname}${location.search}` };
+}
 
 function formatDate(value?: string | null): string {
   return (
@@ -123,6 +135,7 @@ function TimeCardWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.
 
 function IncidentWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.Element {
   const incidents = items as unknown as BeIncident[];
+  const dashboardReturnState = useDashboardReturnState();
   return (
     <DashboardMiniTable
       isLoading={isLoading}
@@ -137,6 +150,7 @@ function IncidentWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.
       rows={incidents.map((incident, i) => ({
         key: incident.id ?? `incident-${i}`,
         href: incident.id ? `/operations/incidents/${incident.id}` : undefined,
+        state: dashboardReturnState,
         cells: [
           <Typography key="number" variant="body2" noWrap>
             {incident.number || "—"}
@@ -181,6 +195,7 @@ function IncidentWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.
 
 function ChangeRequestWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.Element {
   const changeRequests = items as unknown as BeChangeRequestSearchView[];
+  const dashboardReturnState = useDashboardReturnState();
   return (
     <DashboardMiniTable
       isLoading={isLoading}
@@ -195,6 +210,7 @@ function ChangeRequestWidgetList({ items, isLoading }: WidgetListRendererProps):
       rows={changeRequests.map((cr, i) => ({
         key: cr.id ?? `cr-${i}`,
         href: cr.id ? `/operations/change-requests/${cr.id}` : undefined,
+        state: dashboardReturnState,
         cells: [
           <Typography key="number" variant="body2" noWrap>
             {cr.number || "—"}
@@ -239,6 +255,7 @@ function ChangeRequestWidgetList({ items, isLoading }: WidgetListRendererProps):
 
 function ProblemWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.Element {
   const problems = items as unknown as BeProblemSearchView[];
+  const dashboardReturnState = useDashboardReturnState();
   return (
     <DashboardMiniTable
       isLoading={isLoading}
@@ -252,6 +269,7 @@ function ProblemWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.E
       rows={problems.map((problem, i) => ({
         key: problem.id ?? `problem-${i}`,
         href: problem.id ? `/operations/problems/${problem.id}` : undefined,
+        state: dashboardReturnState,
         cells: [
           <Typography key="number" variant="body2" noWrap>
             {problem.number || "—"}
@@ -283,6 +301,7 @@ function ProblemWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.E
 
 function AccountWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.Element {
   const accounts = items as unknown as Account[];
+  const dashboardReturnState = useDashboardReturnState();
   return (
     <DashboardMiniTable
       isLoading={isLoading}
@@ -297,6 +316,7 @@ function AccountWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.E
         return {
           key: a.id,
           href: `/customers/accounts/${a.id}`,
+          state: dashboardReturnState,
           cells: [
             <Typography key="name" variant="body2" noWrap title={a.name}>
               {a.name}
@@ -320,6 +340,7 @@ function AccountWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.E
 
 function ProjectWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.Element {
   const projects = items as unknown as Project[];
+  const dashboardReturnState = useDashboardReturnState();
   return (
     <DashboardMiniTable
       isLoading={isLoading}
@@ -332,6 +353,7 @@ function ProjectWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.E
       rows={projects.map((p) => ({
         key: p.id,
         href: `/customers/projects/${p.id}`,
+        state: dashboardReturnState,
         cells: [
           <Typography key="name" variant="body2" noWrap title={p.name}>
             {p.name}
@@ -348,6 +370,7 @@ function ProjectWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.E
 
 function UserWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.Element {
   const users = items.map((item) => normalizeUser(item as unknown as User | SnUser));
+  const dashboardReturnState = useDashboardReturnState();
   return (
     <DashboardMiniTable
       isLoading={isLoading}
@@ -360,6 +383,7 @@ function UserWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.Elem
       rows={users.map((u) => ({
         key: u.id,
         href: `/people/${encodeURIComponent(u.id)}`,
+        state: dashboardReturnState,
         cells: [
           <UserRefLink key="user" name={u.userName} email={u.email} userId={u.id} />,
           <Typography key="email" variant="body2" noWrap>
@@ -376,6 +400,7 @@ function UserWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.Elem
 
 function ProductVulnerabilityWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.Element {
   const vulnerabilities = items as unknown as BeProductVulnerabilityView[];
+  const dashboardReturnState = useDashboardReturnState();
   return (
     <DashboardMiniTable
       isLoading={isLoading}
@@ -388,6 +413,7 @@ function ProductVulnerabilityWidgetList({ items, isLoading }: WidgetListRenderer
       rows={vulnerabilities.map((vuln) => ({
         key: vuln.id,
         href: `/security-center/vulnerabilities/${encodeURIComponent(vuln.id)}`,
+        state: dashboardReturnState,
         cells: [
           <Typography key="cve" variant="body2" noWrap sx={{ fontFamily: "monospace" }}>
             {vuln.cveId || vuln.vulnerabilityId || "—"}
@@ -475,6 +501,7 @@ function TaskWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.Elem
  * opening a dialog. */
 function CallRequestWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.Element {
   const callRequests = items as unknown as BeCallRequestView[];
+  const dashboardReturnState = useDashboardReturnState();
   return (
     <DashboardMiniTable
       isLoading={isLoading}
@@ -488,6 +515,7 @@ function CallRequestWidgetList({ items, isLoading }: WidgetListRendererProps): J
       rows={callRequests.map((cr, i) => ({
         key: cr.id ?? `call-request-${i}`,
         href: cr.case?.id ? `/cases/${cr.case.id}` : undefined,
+        state: dashboardReturnState,
         cells: [
           <Typography key="number" variant="body2" noWrap>
             {cr.number || "—"}

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestsTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestsTab.tsx
@@ -30,7 +30,7 @@ import {
 } from "@wso2/oxygen-ui";
 import { Plus } from "@wso2/oxygen-ui-icons-react";
 import { useCallback, useMemo, useState, type ChangeEvent, type JSX } from "react";
-import { useSearchParams } from "react-router";
+import { useLocation, useSearchParams } from "react-router";
 import { useNavTransition } from "@hooks/useNavTransition";
 import QueryErrorState from "@components/QueryErrorState";
 import FilteredCsvExportButton from "@components/FilteredCsvExportButton";
@@ -90,6 +90,7 @@ function toISOEnd(date: string): string {
 export default function ChangeRequestsTab(): JSX.Element {
   const navigate = useNavTransition();
   const api = useBackendApi();
+  const location = useLocation();
   const [searchParams, setSearchParams] = useSearchParams();
   const filters = useMemo<ChangeRequestFilters>(
     () => readChangeRequestFiltersFromUrl(searchParams),
@@ -269,7 +270,11 @@ export default function ChangeRequestsTab(): JSX.Element {
                   <TableRow
                     key={cr.id}
                     hover
-                    onClick={() => navigate(`/operations/change-requests/${cr.id}`)}
+                    onClick={() =>
+                      navigate(`/operations/change-requests/${cr.id}`, {
+                        state: { from: `${location.pathname}${location.search}` },
+                      })
+                    }
                     sx={{ cursor: "pointer" }}
                   >
                     <TableCell>{cr.number || "—"}</TableCell>

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/IncidentsTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/IncidentsTab.tsx
@@ -30,7 +30,7 @@ import {
 } from "@wso2/oxygen-ui";
 import { Plus } from "@wso2/oxygen-ui-icons-react";
 import { useCallback, useMemo, useState, type ChangeEvent, type JSX } from "react";
-import { useSearchParams } from "react-router";
+import { useLocation, useSearchParams } from "react-router";
 import { useNavTransition } from "@hooks/useNavTransition";
 import QueryErrorState from "@components/QueryErrorState";
 import FilteredCsvExportButton from "@components/FilteredCsvExportButton";
@@ -80,6 +80,7 @@ function formatDate(value?: string | null): string {
 export default function IncidentsTab(): JSX.Element {
   const navigate = useNavTransition();
   const api = useBackendApi();
+  const location = useLocation();
   const [searchParams, setSearchParams] = useSearchParams();
   const filters = useMemo<IncidentFilters>(
     () => readIncidentFiltersFromUrl(searchParams),
@@ -256,7 +257,12 @@ export default function IncidentsTab(): JSX.Element {
                     // type allows) still get distinct React keys.
                     key={incident.id ?? `incident-${index}`}
                     hover
-                    onClick={() => incident.id && navigate(`/operations/incidents/${incident.id}`)}
+                    onClick={() =>
+                      incident.id &&
+                      navigate(`/operations/incidents/${incident.id}`, {
+                        state: { from: `${location.pathname}${location.search}` },
+                      })
+                    }
                     sx={{ cursor: "pointer" }}
                   >
                     <TableCell>{incident.number || "—"}</TableCell>

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ProblemsTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ProblemsTab.tsx
@@ -30,6 +30,7 @@ import {
 } from "@wso2/oxygen-ui";
 import { Plus } from "@wso2/oxygen-ui-icons-react";
 import { useMemo, useState, type ChangeEvent, type JSX } from "react";
+import { useLocation } from "react-router";
 import { useNavTransition } from "@hooks/useNavTransition";
 import QueryErrorState from "@components/QueryErrorState";
 import { useDebouncedValue } from "@hooks/useDebouncedValue";
@@ -53,6 +54,7 @@ const ROWS_PER_PAGE_OPTIONS = [10, 20, 50];
  */
 export default function ProblemsTab(): JSX.Element {
   const navigate = useNavTransition();
+  const location = useLocation();
   const [filters, setFilters] = useState<ProblemFilters>(DEFAULT_PROBLEM_FILTERS);
   const [isFiltersOpen, setIsFiltersOpen] = useState(true);
   const [page, setPage] = useState(0);
@@ -162,15 +164,16 @@ export default function ProblemsTab(): JSX.Element {
               ) : (
                 problems.map((problem) => {
                   const detailPath = `/operations/problems/${problem.id}`;
+                  const detailState = { from: `${location.pathname}${location.search}` };
                   return (
                   <TableRow
                     key={problem.id}
                     hover
-                    onClick={() => navigate(detailPath)}
+                    onClick={() => navigate(detailPath, { state: detailState })}
                     onKeyDown={(e) => {
                       if (e.key === "Enter" || e.key === " ") {
                         e.preventDefault();
-                        navigate(detailPath);
+                        navigate(detailPath, { state: detailState });
                       }
                     }}
                     tabIndex={0}

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/OperationsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/OperationsPage.tsx
@@ -15,8 +15,9 @@
 // under the License.
 
 import { Box, Button, Typography } from "@wso2/oxygen-ui";
-import { Plus } from "@wso2/oxygen-ui-icons-react";
+import { ArrowLeft, Plus } from "@wso2/oxygen-ui-icons-react";
 import { type JSX } from "react";
+import { useLocation } from "react-router";
 import SectionTabs from "@components/section-tabs/SectionTabs";
 import CsmIssuesView from "@features/csm-cases/components/CsmIssuesView";
 import ChangeRequestsTab from "@features/csm-operations/components/ChangeRequestsTab";
@@ -40,9 +41,27 @@ export default function OperationsPage(): JSX.Element {
   const tabs = useQueryTabs("operations");
   const activeTab = tabs.activeKey;
   const navigate = useNavTransition();
+  // Set by a dashboard widget's click-through (see DashboardWidgetTile /
+  // widgetListConfig.tsx), since this page has no dashboard context of its
+  // own. The service_requests tab renders its own Back button instead (via
+  // CsmIssuesView, which reads this same state) — skip here to avoid a
+  // duplicate.
+  const backState = useLocation().state as { from?: string } | undefined;
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
+      {backState?.from && activeTab !== "service_requests" && (
+        <Button
+          variant="text"
+          size="small"
+          startIcon={<ArrowLeft size={16} />}
+          onClick={() => navigate(backState.from as string)}
+          sx={{ alignSelf: "flex-start" }}
+        >
+          Back
+        </Button>
+      )}
+
       <Box>
         <Typography variant="h5">Operations</Typography>
         <Typography variant="body2" color="text.secondary">

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/ProblemDetailPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/ProblemDetailPage.test.tsx
@@ -22,9 +22,11 @@ import type { BeProblemDetail } from "@api/backend/types";
 
 const navigateMock = vi.fn();
 const useGetProblemMock = vi.fn();
+const useLocationMock = vi.fn<() => { state: { from?: string } | null }>(() => ({ state: null }));
 
 vi.mock("react-router", () => ({
   useParams: () => ({ id: "prb-1" }),
+  useLocation: () => useLocationMock(),
 }));
 vi.mock("@hooks/useNavTransition", () => ({
   useNavTransition: () => navigateMock,
@@ -148,10 +150,19 @@ describe("ProblemDetailPage", () => {
     expect(screen.getByText("Restart the pod.")).toBeInTheDocument();
   });
 
-  it("navigates back to the problems tab from the back button", () => {
+  it("navigates back to the problems tab from the back button when no origin is known", () => {
+    useLocationMock.mockReturnValue({ state: null });
     mockQueryResult({ data: BASE_PROBLEM });
     render(<ProblemDetailPage />);
     screen.getByRole("button", { name: /back to problems/i }).click();
     expect(navigateMock).toHaveBeenCalledWith("/operations?tab=problems");
+  });
+
+  it("navigates back to the captured origin (e.g. a dashboard widget) when one is known", () => {
+    useLocationMock.mockReturnValue({ state: { from: "/dashboard" } });
+    mockQueryResult({ data: BASE_PROBLEM });
+    render(<ProblemDetailPage />);
+    screen.getByRole("button", { name: /back to problems/i }).click();
+    expect(navigateMock).toHaveBeenCalledWith("/dashboard");
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/ProblemDetailPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/ProblemDetailPage.test.tsx
@@ -165,4 +165,14 @@ describe("ProblemDetailPage", () => {
     screen.getByRole("button", { name: /back to problems/i }).click();
     expect(navigateMock).toHaveBeenCalledWith("/dashboard");
   });
+
+  it("navigates back to a captured origin's exact pathname + search (e.g. the Operations tab's own filters)", () => {
+    useLocationMock.mockReturnValue({
+      state: { from: "/operations?tab=problems&state=closed" },
+    });
+    mockQueryResult({ data: BASE_PROBLEM });
+    render(<ProblemDetailPage />);
+    screen.getByRole("button", { name: /back to problems/i }).click();
+    expect(navigateMock).toHaveBeenCalledWith("/operations?tab=problems&state=closed");
+  });
 });

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/ProblemDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/ProblemDetailPage.tsx
@@ -17,7 +17,7 @@
 import { Box, Button, Card, Chip, Skeleton, Typography } from "@wso2/oxygen-ui";
 import { ArrowLeft, Link as LinkIcon } from "@wso2/oxygen-ui-icons-react";
 import { type JSX, type ReactNode, useEffect } from "react";
-import { useParams } from "react-router";
+import { useLocation, useParams } from "react-router";
 import { formatBackendTimestampForDisplay } from "@utils/dateTime";
 import { useGetProblem } from "@features/csm-operations/api/useGetProblem";
 import { problemStateColor, problemStateLabel } from "@features/csm-operations/utils/problems";
@@ -97,6 +97,11 @@ function ProblemRefItem({
 export default function ProblemDetailPage(): JSX.Element {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavTransition();
+  // Prefer the list URL the row link captured (if any) so "back" returns to
+  // the exact view the engineer came from, falling back to the bare tab path
+  // for a bookmarked or directly-linked problem.
+  const backState = useLocation().state as { from?: string } | undefined;
+  const backTarget = backState?.from ?? OPERATIONS_PROBLEMS_PATH;
   const { data, isLoading, isError } = useGetProblem(id);
 
   const recordView = useRecordRecentView();
@@ -114,7 +119,7 @@ export default function ProblemDetailPage(): JSX.Element {
   }, [data, recordView]);
 
   const back = (): void => {
-    navigate(OPERATIONS_PROBLEMS_PATH);
+    navigate(backTarget);
   };
 
   const BackButton = (

--- a/apps/csm-portal/webapp/src/features/csm-projects/pages/CsmProjectsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/pages/CsmProjectsPage.tsx
@@ -16,6 +16,7 @@
 
 import {
   Box,
+  Button,
   Skeleton,
   Table,
   TableBody,
@@ -27,7 +28,9 @@ import {
   TextField,
   Typography,
 } from "@wso2/oxygen-ui";
+import { ArrowLeft } from "@wso2/oxygen-ui-icons-react";
 import { useMemo, useState, type ChangeEvent, type JSX, type KeyboardEvent } from "react";
+import { useLocation } from "react-router";
 import QueryErrorState from "@components/QueryErrorState";
 import { useDebouncedValue } from "@hooks/useDebouncedValue";
 import { useNavTransition } from "@hooks/useNavTransition";
@@ -55,6 +58,10 @@ function formatDate(value?: string | null): string {
 
 export default function CsmProjectsPage(): JSX.Element {
   const navigate = useNavTransition();
+  const location = useLocation();
+  // Set by a dashboard widget's click-through, since this page has no
+  // dashboard context of its own.
+  const backState = location.state as { from?: string } | undefined;
   const [searchInput, setSearchInput] = useState("");
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_ROWS_PER_PAGE);
@@ -87,6 +94,18 @@ export default function CsmProjectsPage(): JSX.Element {
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
+      {backState?.from && (
+        <Button
+          variant="text"
+          size="small"
+          startIcon={<ArrowLeft size={16} />}
+          onClick={() => navigate(backState.from as string)}
+          sx={{ alignSelf: "flex-start" }}
+        >
+          Back
+        </Button>
+      )}
+
       <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 1 }}>
         <Typography variant="body2" color="text.secondary">
           Search across project name, project key, and subscription type.
@@ -151,7 +170,10 @@ export default function CsmProjectsPage(): JSX.Element {
                 </TableRow>
               ) : (
                 projects.map((p) => {
-                  const goToProject = (): void => navigate(`/customers/projects/${p.id}`);
+                  const goToProject = (): void =>
+                    navigate(`/customers/projects/${p.id}`, {
+                      state: { from: `${location.pathname}${location.search}` },
+                    });
                   const handleRowKeyDown = (e: KeyboardEvent<HTMLTableRowElement>): void => {
                     if (e.key === "Enter" || e.key === " ") {
                       e.preventDefault();

--- a/apps/csm-portal/webapp/src/features/csm-security-center/components/ProductVulnerabilitiesTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-security-center/components/ProductVulnerabilitiesTab.tsx
@@ -191,7 +191,17 @@ export default function ProductVulnerabilitiesTab(): JSX.Element {
                   const detailPath = `/security-center/vulnerabilities/${encodeURIComponent(
                     vuln.id,
                   )}`;
-                  const detailState = { from: `${location.pathname}${location.search}` };
+                  // `parentState` nests this tab's OWN inherited state (e.g.
+                  // `{ from: "/dashboard" }`, when this page was itself
+                  // reached from a dashboard widget) so the detail page can
+                  // restore it on its own way back — otherwise a
+                  // dashboard → here → detail → Back round trip would land
+                  // back on this tab with no `from`, silently dropping its
+                  // own Back button.
+                  const detailState = {
+                    from: `${location.pathname}${location.search}`,
+                    parentState: location.state ?? null,
+                  };
                   return (
                   <TableRow
                     key={vuln.id}

--- a/apps/csm-portal/webapp/src/features/csm-security-center/components/ProductVulnerabilitiesTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-security-center/components/ProductVulnerabilitiesTab.tsx
@@ -32,6 +32,7 @@ import {
 } from "@wso2/oxygen-ui";
 import { Search } from "@wso2/oxygen-ui-icons-react";
 import { useMemo, useState, type ChangeEvent, type JSX } from "react";
+import { useLocation } from "react-router";
 import QueryErrorState from "@components/QueryErrorState";
 import { useDebouncedValue } from "@hooks/useDebouncedValue";
 import { useSearchProductVulnerabilities } from "@features/csm-security-center/api/useSearchProductVulnerabilities";
@@ -54,6 +55,7 @@ const ROWS_PER_PAGE_OPTIONS = [10, 20, 50];
  */
 export default function ProductVulnerabilitiesTab(): JSX.Element {
   const navigate = useNavTransition();
+  const location = useLocation();
   const [searchInput, setSearchInput] = useState("");
   const [priorityFilter, setPriorityFilter] = useState<BeVulnerabilityPriority | "">("");
   const [page, setPage] = useState(0);
@@ -189,15 +191,16 @@ export default function ProductVulnerabilitiesTab(): JSX.Element {
                   const detailPath = `/security-center/vulnerabilities/${encodeURIComponent(
                     vuln.id,
                   )}`;
+                  const detailState = { from: `${location.pathname}${location.search}` };
                   return (
                   <TableRow
                     key={vuln.id}
                     hover
-                    onClick={() => navigate(detailPath)}
+                    onClick={() => navigate(detailPath, { state: detailState })}
                     onKeyDown={(e) => {
                       if (e.key === "Enter" || e.key === " ") {
                         e.preventDefault();
-                        navigate(detailPath);
+                        navigate(detailPath, { state: detailState });
                       }
                     }}
                     tabIndex={0}

--- a/apps/csm-portal/webapp/src/features/csm-security-center/pages/CsmSecurityCenterPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-security-center/pages/CsmSecurityCenterPage.tsx
@@ -15,8 +15,9 @@
 // under the License.
 
 import { Box, Button, Typography } from "@wso2/oxygen-ui";
-import { Plus } from "@wso2/oxygen-ui-icons-react";
+import { ArrowLeft, Plus } from "@wso2/oxygen-ui-icons-react";
 import { type JSX } from "react";
+import { useLocation } from "react-router";
 import SectionTabs from "@components/section-tabs/SectionTabs";
 import CsmIssuesView from "@features/csm-cases/components/CsmIssuesView";
 import ProductVulnerabilitiesTab from "@features/csm-security-center/components/ProductVulnerabilitiesTab";
@@ -36,9 +37,26 @@ export default function CsmSecurityCenterPage(): JSX.Element {
   const tabs = useQueryTabs("security-center");
   const activeTab = tabs.activeKey;
   const navigate = useNavTransition();
+  // Set by a dashboard widget's click-through, since this page has no
+  // dashboard context of its own. The security_reports tab renders its own
+  // Back button instead (via CsmIssuesView, which reads this same state) —
+  // skip here to avoid a duplicate.
+  const backState = useLocation().state as { from?: string } | undefined;
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
+      {backState?.from && activeTab !== "security_reports" && (
+        <Button
+          variant="text"
+          size="small"
+          startIcon={<ArrowLeft size={16} />}
+          onClick={() => navigate(backState.from as string)}
+          sx={{ alignSelf: "flex-start" }}
+        >
+          Back
+        </Button>
+      )}
+
       <Box>
         <Typography variant="h5">Security Center</Typography>
         <Typography variant="body2" color="text.secondary">

--- a/apps/csm-portal/webapp/src/features/csm-security-center/pages/ProductVulnerabilityDetailPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-security-center/pages/ProductVulnerabilityDetailPage.test.tsx
@@ -1,0 +1,91 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import type { UseQueryResult } from "@tanstack/react-query";
+import type { BeProductVulnerabilityView } from "@api/backend/types";
+
+const navigateMock = vi.fn();
+const useGetProductVulnerabilityMock = vi.fn();
+const useLocationMock = vi.fn<() => { state: { from?: string } | null }>(() => ({ state: null }));
+
+vi.mock("react-router", () => ({
+  useParams: () => ({ id: "vuln-1" }),
+  useLocation: () => useLocationMock(),
+}));
+vi.mock("@hooks/useNavTransition", () => ({
+  useNavTransition: () => navigateMock,
+}));
+vi.mock("@features/csm-security-center/api/useGetProductVulnerability", () => ({
+  useGetProductVulnerability: () => useGetProductVulnerabilityMock(),
+}));
+
+// Imported after the mocks above so the module picks them up.
+import ProductVulnerabilityDetailPage from "@features/csm-security-center/pages/ProductVulnerabilityDetailPage";
+
+const BASE_VULN: BeProductVulnerabilityView = {
+  id: "vuln-1",
+  cveId: "CVE-2026-0001",
+  vulnerabilityId: "VUL0001",
+  priority: "P1",
+  componentName: "libfoo",
+  version: "1.2.3",
+  componentType: "library",
+  productName: "Acme Gateway",
+  productVersion: "4.5",
+  type: "third_party",
+  updateLevel: "U1",
+};
+
+function mockQueryResult(
+  overrides: Partial<UseQueryResult<BeProductVulnerabilityView | null, Error>>,
+): void {
+  useGetProductVulnerabilityMock.mockReturnValue({
+    data: null,
+    isLoading: false,
+    isError: false,
+    error: null,
+    ...overrides,
+  });
+}
+
+describe("ProductVulnerabilityDetailPage", () => {
+  it("renders CVE id and priority for a loaded vulnerability", () => {
+    useLocationMock.mockReturnValue({ state: null });
+    mockQueryResult({ data: BASE_VULN });
+    render(<ProductVulnerabilityDetailPage />);
+    expect(screen.getAllByText("CVE-2026-0001").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("P1").length).toBeGreaterThan(0);
+  });
+
+  it("navigates back to the vulnerabilities tab from the back button when no origin is known", () => {
+    useLocationMock.mockReturnValue({ state: null });
+    mockQueryResult({ data: BASE_VULN });
+    render(<ProductVulnerabilityDetailPage />);
+    screen.getByRole("button", { name: /back to vulnerabilities/i }).click();
+    expect(navigateMock).toHaveBeenCalledWith("/security-center?tab=vulnerabilities");
+  });
+
+  it("navigates back to the captured origin (e.g. a dashboard widget) when one is known", () => {
+    useLocationMock.mockReturnValue({ state: { from: "/dashboard" } });
+    mockQueryResult({ data: BASE_VULN });
+    render(<ProductVulnerabilityDetailPage />);
+    screen.getByRole("button", { name: /back to vulnerabilities/i }).click();
+    expect(navigateMock).toHaveBeenCalledWith("/dashboard");
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-security-center/pages/ProductVulnerabilityDetailPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-security-center/pages/ProductVulnerabilityDetailPage.test.tsx
@@ -14,28 +14,20 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router";
 import { describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 import type { UseQueryResult } from "@tanstack/react-query";
 import type { BeProductVulnerabilityView } from "@api/backend/types";
 
-const navigateMock = vi.fn();
 const useGetProductVulnerabilityMock = vi.fn();
-const useLocationMock = vi.fn<() => { state: { from?: string } | null }>(() => ({ state: null }));
 
-vi.mock("react-router", () => ({
-  useParams: () => ({ id: "vuln-1" }),
-  useLocation: () => useLocationMock(),
-}));
-vi.mock("@hooks/useNavTransition", () => ({
-  useNavTransition: () => navigateMock,
-}));
 vi.mock("@features/csm-security-center/api/useGetProductVulnerability", () => ({
   useGetProductVulnerability: () => useGetProductVulnerabilityMock(),
 }));
 
-// Imported after the mocks above so the module picks them up.
+// Imported after the mock above so the module picks it up.
 import ProductVulnerabilityDetailPage from "@features/csm-security-center/pages/ProductVulnerabilityDetailPage";
 
 const BASE_VULN: BeProductVulnerabilityView = {
@@ -64,28 +56,77 @@ function mockQueryResult(
   });
 }
 
+/** Destination probe: renders wherever a Back click actually lands, showing
+ * both the resulting path and the location.state that came with it — so
+ * tests assert on real router navigation, not a mocked navigate function. */
+function LocationProbe() {
+  const location = useLocation();
+  return (
+    <>
+      <div data-testid="location-probe">{location.pathname + location.search}</div>
+      <div data-testid="location-state-probe">{JSON.stringify(location.state ?? null)}</div>
+    </>
+  );
+}
+
+function renderAt(initialEntry: { pathname: string; state?: unknown }) {
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <Routes>
+        <Route
+          path="/security-center/vulnerabilities/:id"
+          element={<ProductVulnerabilityDetailPage />}
+        />
+        <Route path="/security-center" element={<LocationProbe />} />
+        <Route path="/dashboard" element={<LocationProbe />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
 describe("ProductVulnerabilityDetailPage", () => {
   it("renders CVE id and priority for a loaded vulnerability", () => {
-    useLocationMock.mockReturnValue({ state: null });
     mockQueryResult({ data: BASE_VULN });
-    render(<ProductVulnerabilityDetailPage />);
+    renderAt({ pathname: "/security-center/vulnerabilities/vuln-1" });
     expect(screen.getAllByText("CVE-2026-0001").length).toBeGreaterThan(0);
     expect(screen.getAllByText("P1").length).toBeGreaterThan(0);
   });
 
   it("navigates back to the vulnerabilities tab from the back button when no origin is known", () => {
-    useLocationMock.mockReturnValue({ state: null });
     mockQueryResult({ data: BASE_VULN });
-    render(<ProductVulnerabilityDetailPage />);
-    screen.getByRole("button", { name: /back to vulnerabilities/i }).click();
-    expect(navigateMock).toHaveBeenCalledWith("/security-center?tab=vulnerabilities");
+    renderAt({ pathname: "/security-center/vulnerabilities/vuln-1" });
+    fireEvent.click(screen.getByRole("button", { name: /back to vulnerabilities/i }));
+    expect(screen.getByTestId("location-probe")).toHaveTextContent(
+      "/security-center?tab=vulnerabilities",
+    );
   });
 
   it("navigates back to the captured origin (e.g. a dashboard widget) when one is known", () => {
-    useLocationMock.mockReturnValue({ state: { from: "/dashboard" } });
     mockQueryResult({ data: BASE_VULN });
-    render(<ProductVulnerabilityDetailPage />);
-    screen.getByRole("button", { name: /back to vulnerabilities/i }).click();
-    expect(navigateMock).toHaveBeenCalledWith("/dashboard");
+    renderAt({
+      pathname: "/security-center/vulnerabilities/vuln-1",
+      state: { from: "/dashboard" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /back to vulnerabilities/i }));
+    expect(screen.getByTestId("location-probe")).toHaveTextContent("/dashboard");
+  });
+
+  it("restores the vulnerabilities tab's own dashboard-return state after a round trip (dashboard → tab → detail → Back)", () => {
+    mockQueryResult({ data: BASE_VULN });
+    renderAt({
+      pathname: "/security-center/vulnerabilities/vuln-1",
+      state: {
+        from: "/security-center?tab=vulnerabilities",
+        parentState: { from: "/dashboard" },
+      },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /back to vulnerabilities/i }));
+
+    expect(screen.getByTestId("location-probe")).toHaveTextContent(
+      "/security-center?tab=vulnerabilities",
+    );
+    expect(screen.getByTestId("location-state-probe")).toHaveTextContent(
+      JSON.stringify({ from: "/dashboard" }),
+    );
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-security-center/pages/ProductVulnerabilityDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-security-center/pages/ProductVulnerabilityDetailPage.tsx
@@ -24,7 +24,7 @@ import {
 } from "@wso2/oxygen-ui";
 import { ArrowLeft } from "@wso2/oxygen-ui-icons-react";
 import { type JSX, type ReactNode } from "react";
-import {  useParams } from "react-router";
+import { useLocation, useParams } from "react-router";
 import { useGetProductVulnerability } from "@features/csm-security-center/api/useGetProductVulnerability";
 import { useNavTransition } from "@hooks/useNavTransition";
 import {
@@ -78,10 +78,15 @@ function TextSection({ title, text }: { title: string; text?: string | null }): 
 export default function ProductVulnerabilityDetailPage(): JSX.Element {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavTransition();
+  // Prefer the list URL the row link captured (if any) so "back" returns to
+  // the exact view the engineer came from, falling back to the bare tab path
+  // for a bookmarked or directly-linked vulnerability.
+  const backState = useLocation().state as { from?: string } | undefined;
+  const backTarget = backState?.from ?? SECURITY_CENTER_VULN_PATH;
   const { data, isLoading, isError } = useGetProductVulnerability(id);
 
   const back = (): void => {
-    navigate(SECURITY_CENTER_VULN_PATH);
+    navigate(backTarget);
   };
 
   const BackButton = (

--- a/apps/csm-portal/webapp/src/features/csm-security-center/pages/ProductVulnerabilityDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-security-center/pages/ProductVulnerabilityDetailPage.tsx
@@ -80,13 +80,19 @@ export default function ProductVulnerabilityDetailPage(): JSX.Element {
   const navigate = useNavTransition();
   // Prefer the list URL the row link captured (if any) so "back" returns to
   // the exact view the engineer came from, falling back to the bare tab path
-  // for a bookmarked or directly-linked vulnerability.
-  const backState = useLocation().state as { from?: string } | undefined;
+  // for a bookmarked or directly-linked vulnerability. `parentState` is
+  // whatever state the list tab itself was carrying (e.g. `{ from:
+  // "/dashboard" }`) — forwarded back onto it below so a
+  // dashboard → tab → here → Back round trip restores the tab's own Back
+  // button instead of silently dropping it.
+  const backState = useLocation().state as
+    | { from?: string; parentState?: unknown }
+    | undefined;
   const backTarget = backState?.from ?? SECURITY_CENTER_VULN_PATH;
   const { data, isLoading, isError } = useGetProductVulnerability(id);
 
   const back = (): void => {
-    navigate(backTarget);
+    navigate(backTarget, { state: backState?.parentState ?? undefined });
   };
 
   const BackButton = (

--- a/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.test.tsx
@@ -90,16 +90,25 @@ function renderPageWithDestinations(
   );
 }
 
+/** Destination probe: renders wherever a navigation actually lands, showing
+ * both the resulting path and the location.state that came with it — so
+ * tests assert on real router navigation, not a static marker or a mocked
+ * navigate function. */
 function LocationProbe() {
   const location = useLocation();
-  return <div data-testid="location-state-probe">{JSON.stringify(location.state ?? null)}</div>;
+  return (
+    <>
+      <div data-testid="location-probe">{location.pathname + location.search}</div>
+      <div data-testid="location-state-probe">{JSON.stringify(location.state ?? null)}</div>
+    </>
+  );
 }
 
 /**
- * Same as {@link renderPageWithDestinations}, but the `/people/:id`
- * destination renders a probe of the navigated-to `location.state` instead
- * of a static marker — used to assert the row click actually carries the
- * `from` state forward, not just that it navigated somewhere.
+ * Same as {@link renderPageWithDestinations}, but `/people/:id` and
+ * `/dashboard` both render {@link LocationProbe} instead of a static marker
+ * — used to assert a navigation actually carries the right `location.state`
+ * forward, not just that it landed on the right page.
  */
 function renderPageWithLocationProbe(
   initialPath: string | { pathname: string; state?: unknown },
@@ -111,6 +120,7 @@ function renderPageWithLocationProbe(
         <Routes>
           <Route path="/admin/users" element={<CsmUsersPage />} />
           <Route path="/people/:id" element={<LocationProbe />} />
+          <Route path="/dashboard" element={<LocationProbe />} />
         </Routes>
       </MemoryRouter>
     </QueryClientProvider>,
@@ -322,7 +332,7 @@ describe("CsmUsersPage — role truncation and row navigation", () => {
     fireEvent.click(screen.getByText("John Smith").closest("tr") as HTMLElement);
 
     expect(await screen.findByTestId("location-state-probe")).toHaveTextContent(
-      JSON.stringify({ from: "/admin/users" }),
+      JSON.stringify({ from: "/admin/users", parentState: null }),
     );
   });
 
@@ -332,23 +342,26 @@ describe("CsmUsersPage — role truncation and row navigation", () => {
   });
 
   it("renders a Back button that returns to the dashboard when reached via a dashboard widget's `from` state", async () => {
-    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-    render(
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/admin/users", state: { from: "/dashboard" } }]}
-        >
-          <Routes>
-            <Route path="/admin/users" element={<CsmUsersPage />} />
-            <Route path="/dashboard" element={<div>Dashboard page</div>} />
-          </Routes>
-        </MemoryRouter>
-      </QueryClientProvider>,
-    );
+    renderPageWithLocationProbe({ pathname: "/admin/users", state: { from: "/dashboard" } });
 
     const backButton = await screen.findByRole("button", { name: "Back" });
     fireEvent.click(backButton);
 
-    expect(await screen.findByText("Dashboard page")).toBeInTheDocument();
+    expect(await screen.findByTestId("location-probe")).toHaveTextContent("/dashboard");
+  });
+
+  it("restores its own dashboard-return state after a round trip through a profile (dashboard → users → profile → users → dashboard)", async () => {
+    renderPageWithLocationProbe({ pathname: "/admin/users", state: { from: "/dashboard" } });
+
+    // Users list, reached from the dashboard, still shows its own Back button.
+    expect(await screen.findByRole("button", { name: "Back" })).toBeInTheDocument();
+
+    // Row click into a profile carries both this page's own URL (`from`) and
+    // the dashboard state it was itself carrying (`parentState`).
+    await waitFor(() => expect(screen.getByText("John Smith")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("John Smith").closest("tr") as HTMLElement);
+    expect(await screen.findByTestId("location-state-probe")).toHaveTextContent(
+      JSON.stringify({ from: "/admin/users", parentState: { from: "/dashboard" } }),
+    );
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.test.tsx
@@ -17,7 +17,7 @@
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import "@testing-library/jest-dom/vitest";
-import { MemoryRouter, Route, Routes } from "react-router";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 const authFetchMock = vi.fn();
@@ -84,6 +84,33 @@ function renderPageWithDestinations(
           <Route path="/admin/users" element={<CsmUsersPage />} />
           <Route path="/admin/roles/:id" element={<div>Role members page</div>} />
           <Route path="/people/:id" element={<div>User profile page</div>} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+function LocationProbe() {
+  const location = useLocation();
+  return <div data-testid="location-state-probe">{JSON.stringify(location.state ?? null)}</div>;
+}
+
+/**
+ * Same as {@link renderPageWithDestinations}, but the `/people/:id`
+ * destination renders a probe of the navigated-to `location.state` instead
+ * of a static marker — used to assert the row click actually carries the
+ * `from` state forward, not just that it navigated somewhere.
+ */
+function renderPageWithLocationProbe(
+  initialPath: string | { pathname: string; state?: unknown },
+): ReturnType<typeof render> {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[initialPath]}>
+        <Routes>
+          <Route path="/admin/users" element={<CsmUsersPage />} />
+          <Route path="/people/:id" element={<LocationProbe />} />
         </Routes>
       </MemoryRouter>
     </QueryClientProvider>,
@@ -286,5 +313,42 @@ describe("CsmUsersPage — role truncation and row navigation", () => {
     row.focus();
     fireEvent.keyDown(row, { key: "Enter" });
     expect(await screen.findByText("User profile page")).toBeInTheDocument();
+  });
+
+  it("carries this page's own URL forward as `from` when a row navigates to a profile", async () => {
+    renderPageWithLocationProbe("/admin/users");
+
+    await waitFor(() => expect(screen.getByText("John Smith")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("John Smith").closest("tr") as HTMLElement);
+
+    expect(await screen.findByTestId("location-state-probe")).toHaveTextContent(
+      JSON.stringify({ from: "/admin/users" }),
+    );
+  });
+
+  it("renders no Back button when it wasn't reached from a dashboard widget", () => {
+    renderPage("/admin/users");
+    expect(screen.queryByRole("button", { name: "Back" })).not.toBeInTheDocument();
+  });
+
+  it("renders a Back button that returns to the dashboard when reached via a dashboard widget's `from` state", async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/admin/users", state: { from: "/dashboard" } }]}
+        >
+          <Routes>
+            <Route path="/admin/users" element={<CsmUsersPage />} />
+            <Route path="/dashboard" element={<div>Dashboard page</div>} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const backButton = await screen.findByRole("button", { name: "Back" });
+    fireEvent.click(backButton);
+
+    expect(await screen.findByText("Dashboard page")).toBeInTheDocument();
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.tsx
@@ -392,9 +392,19 @@ export default function CsmUsersPage(): JSX.Element {
               ) : (
                 users.map((u) => {
                   const profilePath = `/people/${encodeURIComponent(u.id)}`;
+                  // `parentState` nests this page's OWN inherited state
+                  // (e.g. `{ from: "/dashboard" }`, when this page was
+                  // itself reached from a dashboard widget) so the profile
+                  // page can restore it on its own way back — otherwise a
+                  // dashboard → here → profile → Back round trip would land
+                  // back on this page with no `from`, silently dropping its
+                  // own Back button.
                   const goToProfile = (): void =>
                     navigate(profilePath, {
-                      state: { from: `${location.pathname}${location.search}` },
+                      state: {
+                        from: `${location.pathname}${location.search}`,
+                        parentState: backState ?? null,
+                      },
                     });
                   const handleRowKeyDown = (e: KeyboardEvent<HTMLTableRowElement>): void => {
                     if (e.key === "Enter" || e.key === " ") {

--- a/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.tsx
@@ -16,6 +16,7 @@
 
 import {
   Box,
+  Button,
   Checkbox,
   FormControl,
   IconButton,
@@ -38,9 +39,9 @@ import {
   Typography,
   type SelectChangeEvent,
 } from "@wso2/oxygen-ui";
-import { X } from "@wso2/oxygen-ui-icons-react";
+import { ArrowLeft, X } from "@wso2/oxygen-ui-icons-react";
 import { useMemo, useState, type ChangeEvent, type JSX, type KeyboardEvent } from "react";
-import { useSearchParams } from "react-router";
+import { useLocation, useSearchParams } from "react-router";
 import QueryErrorState from "@components/QueryErrorState";
 import UserRefLink from "@components/UserRefLink";
 import AsyncEntityMultiSelect from "@components/AsyncEntityMultiSelect";
@@ -80,6 +81,10 @@ const ROWS_PER_PAGE_OPTIONS = [10, 20, BE_MAX_PAGE_LIMIT];
  */
 export default function CsmUsersPage(): JSX.Element {
   const navigate = useNavTransition();
+  const location = useLocation();
+  // Set by a dashboard widget's click-through, since this page has no
+  // dashboard context of its own.
+  const backState = location.state as { from?: string } | undefined;
   const [searchParams, setSearchParams] = useSearchParams();
   const filters = useMemo(() => readUsersFiltersFromUrl(searchParams), [searchParams]);
 
@@ -156,6 +161,18 @@ export default function CsmUsersPage(): JSX.Element {
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
+      {backState?.from && (
+        <Button
+          variant="text"
+          size="small"
+          startIcon={<ArrowLeft size={16} />}
+          onClick={() => navigate(backState.from as string)}
+          sx={{ alignSelf: "flex-start" }}
+        >
+          Back
+        </Button>
+      )}
+
       <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 1 }}>
         <Typography variant="body2" color="text.secondary">
           Search across username and email (case-insensitive). Filter by role, group, team and
@@ -375,7 +392,10 @@ export default function CsmUsersPage(): JSX.Element {
               ) : (
                 users.map((u) => {
                   const profilePath = `/people/${encodeURIComponent(u.id)}`;
-                  const goToProfile = (): void => navigate(profilePath);
+                  const goToProfile = (): void =>
+                    navigate(profilePath, {
+                      state: { from: `${location.pathname}${location.search}` },
+                    });
                   const handleRowKeyDown = (e: KeyboardEvent<HTMLTableRowElement>): void => {
                     if (e.key === "Enter" || e.key === " ") {
                       e.preventDefault();

--- a/apps/csm-portal/webapp/src/features/csm-users/pages/UserProfilePage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/pages/UserProfilePage.test.tsx
@@ -14,23 +14,15 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
-import { MemoryRouter } from "react-router";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router";
 import { QueryClient, QueryClientProvider, type UseQueryResult } from "@tanstack/react-query";
 import type { NormalizedUserDetail } from "@features/csm-users/types/csmUsers";
 
-const navigateMock = vi.fn();
 const useGetUserByIdMock = vi.fn();
 
-vi.mock("react-router", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("react-router")>();
-  return { ...actual, useParams: () => ({ id: "user-1" }) };
-});
-vi.mock("@hooks/useNavTransition", () => ({
-  useNavTransition: () => navigateMock,
-}));
 // The backend client reads runtime config (`CSM_PORTAL_BACKEND_BASE_URL`) at
 // module load, which isn't present under vitest. `QueryErrorState` imports
 // `BackendApiError` from it directly, so stub the module with a real class
@@ -119,12 +111,31 @@ function mockQueryResult(
   });
 }
 
-function renderPage(routeState?: { from?: string }): ReturnType<typeof render> {
+/** Destination probe: renders wherever a Back click actually lands, showing
+ * both the resulting path and the location.state that came with it — so
+ * tests assert on real router navigation, not a mocked navigate function. */
+function LocationProbe() {
+  const location = useLocation();
+  return (
+    <>
+      <div data-testid="location-probe">{location.pathname + location.search}</div>
+      <div data-testid="location-state-probe">{JSON.stringify(location.state ?? null)}</div>
+    </>
+  );
+}
+
+function renderPage(
+  routeState?: { from?: string; parentState?: unknown },
+): ReturnType<typeof render> {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
     <QueryClientProvider client={queryClient}>
       <MemoryRouter initialEntries={[{ pathname: "/people/user-1", state: routeState ?? null }]}>
-        <UserProfilePage />
+        <Routes>
+          <Route path="/people/:id" element={<UserProfilePage />} />
+          <Route path="/admin/users" element={<LocationProbe />} />
+          <Route path="/dashboard" element={<LocationProbe />} />
+        </Routes>
       </MemoryRouter>
     </QueryClientProvider>,
   );
@@ -256,15 +267,47 @@ describe("UserProfilePage", () => {
 
   it("falls back to browser history when no origin was captured (e.g. a bookmarked/direct link)", () => {
     mockQueryResult({ data: INTERNAL_USER });
-    renderPage();
-    screen.getByRole("button", { name: "Back" }).click();
-    expect(navigateMock).toHaveBeenCalledWith(-1);
+    // Two history entries (unlike renderPage's single-entry default) so
+    // `navigate(-1)` has something real to pop back to — verified through
+    // the actual router, not a mocked navigate function.
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter
+          initialEntries={["/admin/users", "/people/user-1"]}
+          initialIndex={1}
+        >
+          <Routes>
+            <Route path="/people/:id" element={<UserProfilePage />} />
+            <Route path="/admin/users" element={<LocationProbe />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Back" }));
+
+    expect(screen.getByTestId("location-probe")).toHaveTextContent("/admin/users");
   });
 
   it("returns to the captured origin (e.g. a dashboard widget or an admin users list) when one is known", () => {
     mockQueryResult({ data: INTERNAL_USER });
     renderPage({ from: "/admin/users" });
-    screen.getByRole("button", { name: "Back" }).click();
-    expect(navigateMock).toHaveBeenCalledWith("/admin/users");
+
+    fireEvent.click(screen.getByRole("button", { name: "Back" }));
+
+    expect(screen.getByTestId("location-probe")).toHaveTextContent("/admin/users");
+  });
+
+  it("restores the users list's own dashboard-return state after a round trip (dashboard → users → profile → users → dashboard)", () => {
+    mockQueryResult({ data: INTERNAL_USER });
+    renderPage({ from: "/admin/users", parentState: { from: "/dashboard" } });
+
+    fireEvent.click(screen.getByRole("button", { name: "Back" }));
+
+    expect(screen.getByTestId("location-probe")).toHaveTextContent("/admin/users");
+    expect(screen.getByTestId("location-state-probe")).toHaveTextContent(
+      JSON.stringify({ from: "/dashboard" }),
+    );
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-users/pages/UserProfilePage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/pages/UserProfilePage.test.tsx
@@ -119,11 +119,11 @@ function mockQueryResult(
   });
 }
 
-function renderPage(): ReturnType<typeof render> {
+function renderPage(routeState?: { from?: string }): ReturnType<typeof render> {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
     <QueryClientProvider client={queryClient}>
-      <MemoryRouter>
+      <MemoryRouter initialEntries={[{ pathname: "/people/user-1", state: routeState ?? null }]}>
         <UserProfilePage />
       </MemoryRouter>
     </QueryClientProvider>,
@@ -252,5 +252,19 @@ describe("UserProfilePage", () => {
     mockQueryResult({ data: { ...BLOCKED_EXTERNAL_USER, active: false } });
     renderPage();
     expect(screen.getByText(/account is inactive/i)).toBeInTheDocument();
+  });
+
+  it("falls back to browser history when no origin was captured (e.g. a bookmarked/direct link)", () => {
+    mockQueryResult({ data: INTERNAL_USER });
+    renderPage();
+    screen.getByRole("button", { name: "Back" }).click();
+    expect(navigateMock).toHaveBeenCalledWith(-1);
+  });
+
+  it("returns to the captured origin (e.g. a dashboard widget or an admin users list) when one is known", () => {
+    mockQueryResult({ data: INTERNAL_USER });
+    renderPage({ from: "/admin/users" });
+    screen.getByRole("button", { name: "Back" }).click();
+    expect(navigateMock).toHaveBeenCalledWith("/admin/users");
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-users/pages/UserProfilePage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/pages/UserProfilePage.tsx
@@ -396,9 +396,17 @@ export default function UserProfilePage(): JSX.Element {
   // no single canonical "list" to fall back to the way other detail pages
   // have. Prefer the URL the row link captured (if any) so "back" returns to
   // the exact view the engineer came from; browser history otherwise, same
-  // as before this carried no `from` state at all.
-  const backState = useLocation().state as { from?: string } | undefined;
+  // as before this carried no `from` state at all. `parentState` is
+  // whatever state that captured list page was itself carrying (e.g.
+  // `{ from: "/dashboard" }`) — forwarded back onto it below so a
+  // dashboard → list → here → Back round trip restores the list's own Back
+  // button instead of silently dropping it. Ignored (harmlessly) when
+  // `backTarget` falls back to the numeric `-1` history pop.
+  const backState = useLocation().state as
+    | { from?: string; parentState?: unknown }
+    | undefined;
   const backTarget = backState?.from ?? -1;
+  const backNavState = backState?.parentState ?? undefined;
 
   const { data: user, isLoading, isError, error } = useGetUserById(id);
 
@@ -414,7 +422,7 @@ export default function UserProfilePage(): JSX.Element {
   if (isError) {
     return (
       <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
-        <BackButton onClick={() => navigate(backTarget)} />
+        <BackButton onClick={() => navigate(backTarget, { state: backNavState })} />
         <QueryErrorState
           message={error instanceof Error && error.message.trim() ? error.message : "Failed to load user."}
           error={error}
@@ -426,7 +434,7 @@ export default function UserProfilePage(): JSX.Element {
   if (!user) {
     return (
       <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
-        <BackButton onClick={() => navigate(backTarget)} />
+        <BackButton onClick={() => navigate(backTarget, { state: backNavState })} />
         <Typography variant="h5">User not found</Typography>
         <Typography variant="body2" color="text.secondary">
           No user with id <code>{id}</code>.
@@ -439,7 +447,7 @@ export default function UserProfilePage(): JSX.Element {
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 2.5 }}>
-      <BackButton onClick={() => navigate(backTarget)} />
+      <BackButton onClick={() => navigate(backTarget, { state: backNavState })} />
 
       <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
         <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, flexWrap: "wrap" }}>

--- a/apps/csm-portal/webapp/src/features/csm-users/pages/UserProfilePage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/pages/UserProfilePage.tsx
@@ -31,7 +31,7 @@ import {
 } from "@wso2/oxygen-ui";
 import { ArrowLeft } from "@wso2/oxygen-ui-icons-react";
 import { useMemo, type JSX, type ReactNode } from "react";
-import { Link as RouterLink, useParams } from "react-router";
+import { Link as RouterLink, useLocation, useParams } from "react-router";
 import QueryErrorState from "@components/QueryErrorState";
 import { useNavTransition } from "@hooks/useNavTransition";
 import { formatBackendTimestampForDisplay } from "@utils/dateTime";
@@ -391,6 +391,14 @@ function AccessibleProjectsCard({ user }: { user: NormalizedUserDetail }): JSX.E
 export default function UserProfilePage(): JSX.Element {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavTransition();
+  // This page is reachable from arbitrary contexts (any user reference —
+  // case creator/assignee, comment author, dashboard widget row), so there's
+  // no single canonical "list" to fall back to the way other detail pages
+  // have. Prefer the URL the row link captured (if any) so "back" returns to
+  // the exact view the engineer came from; browser history otherwise, same
+  // as before this carried no `from` state at all.
+  const backState = useLocation().state as { from?: string } | undefined;
+  const backTarget = backState?.from ?? -1;
 
   const { data: user, isLoading, isError, error } = useGetUserById(id);
 
@@ -406,7 +414,7 @@ export default function UserProfilePage(): JSX.Element {
   if (isError) {
     return (
       <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
-        <BackButton onClick={() => navigate(-1)} />
+        <BackButton onClick={() => navigate(backTarget)} />
         <QueryErrorState
           message={error instanceof Error && error.message.trim() ? error.message : "Failed to load user."}
           error={error}
@@ -418,7 +426,7 @@ export default function UserProfilePage(): JSX.Element {
   if (!user) {
     return (
       <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
-        <BackButton onClick={() => navigate(-1)} />
+        <BackButton onClick={() => navigate(backTarget)} />
         <Typography variant="h5">User not found</Typography>
         <Typography variant="body2" color="text.secondary">
           No user with id <code>{id}</code>.
@@ -431,7 +439,7 @@ export default function UserProfilePage(): JSX.Element {
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 2.5 }}>
-      <BackButton onClick={() => navigate(-1)} />
+      <BackButton onClick={() => navigate(backTarget)} />
 
       <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
         <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, flexWrap: "wrap" }}>


### PR DESCRIPTION
## Purpose
Back navigation from a page opened via a dashboard widget could land somewhere wrong — a hardcoded/generic destination instead of the page the user actually came from. This was reported for call requests specifically, but the same gap existed across nearly every dashboard widget resource type.

## Goals
- Every dashboard-originated page's Back button should return to the true previous page in the actual navigation chain, one hop at a time — never skip straight to the dashboard or a generic list unless that page really is the one right after the dashboard.

## Approach
- **Root mechanism**: `DashboardMiniTable`/`DashboardMiniTableRow` gained a `state` field, and every `widgetListConfig.tsx` row renderer (incident, change_request, problem, account, project, user, product_vulnerability, call_request) now sets `state: { from: <dashboard path> }` on its row link. Case and time-card widgets already worked correctly — they reuse the real `CasesList`/`TimeCardsTable` components, which already resolve their own location.
- **Three detail pages had no `from`-handling at all**, not just a missing row-level piece: `ProblemDetailPage`, `UserProfilePage`, and `ProductVulnerabilityDetailPage` were hardcoded or used `navigate(-1)`. Brought in line with the pattern already used by `CsmIncidentDetailPage` / `CsmChangeRequestDetailPage` / `CsmAccountDetailPage` / `CsmProjectDetailPage` / `CsmCaseDetailPage`.
- **Two-hop chains** (dashboard tile → intermediate list → detail page): `IncidentsTab` / `ChangeRequestsTab` / `ProblemsTab` (inside `OperationsPage`), `ProductVulnerabilitiesTab` (inside `CsmSecurityCenterPage`), `CsmAccountsPage`, `CsmProjectsPage`, and `CsmUsersPage` now forward *their own* current URL as `from` on their own row clicks, and each gained its own conditional Back button (shown only when reached via a `from` state) so a dashboard-originated visit can itself be backed out of.

## User stories
As a CS engineer, when I open any record (case, incident, change request, problem, account, project, user, vulnerability, call request) from a dashboard widget — directly or via an intermediate list — clicking Back always takes me to the page I was actually just on, until I reach the dashboard.

## Release note
Fix: Back navigation from a dashboard widget now returns to the correct previous page for every resource type, not just cases.

## Documentation
N/A — internal CSM portal UI, no external doc surface affected.

## Automation tests
- Unit tests: new `DashboardMiniTable.test.tsx` and `ProductVulnerabilityDetailPage.test.tsx`; extended `ProblemDetailPage.test.tsx`, `UserProfilePage.test.tsx`, and `CsmUsersPage.test.tsx` with back-button/state-forwarding coverage — all passing.
- Note: `IncidentsTab`, `ChangeRequestsTab`, `ProblemsTab`, `OperationsPage`, `CsmSecurityCenterPage`, `ProductVulnerabilitiesTab`, `CsmAccountsPage`, and `CsmProjectsPage` had no pre-existing test coverage; changes there are verified by `tsc`/`eslint`/code review only, not new tests.
- Verified against staging: not yet — only verified locally via `tsc -b`, `eslint`, and `vitest`; haven't run this against a live/staging environment in a browser.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (frontend-only change)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
- `apps/csm-portal/webapp`: `tsc -b`, `eslint .`, and `vitest run` all passing locally (2 pre-existing unrelated eslint issues and 8 pre-existing unrelated test failures confirmed present on `main` too, via stash comparison).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Back navigation when opening accounts, projects, users, operations, and security details from dashboard views.
  * Preserved originating pages, filters, and navigation context when moving between lists and detail pages.
  * Added fallback destinations for pages opened directly without an originating location.

* **Bug Fixes**
  * Improved return navigation across incidents, change requests, problems, vulnerabilities, and user profiles.

* **Tests**
  * Added coverage for navigation state, Back buttons, fallback behavior, and row interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->