### PR TITLE
[Customer Portal] show system users as registered, fix service-token form wording

### DIFF
--- a/apps/customer-portal/microapp/src/services/users.ts
+++ b/apps/customer-portal/microapp/src/services/users.ts
@@ -114,7 +114,9 @@ function toUser(dto: UserDto): User {
     email: dto.email,
     firstName: dto.firstName,
     lastName: dto.lastName,
-    status: dto.membershipStatus === "REGISTERED" ? "registered" : "invited",
+    // System/integration users never go through the human registration flow, so
+    // membershipStatus stays INVITED indefinitely even though the account is fully active.
+    status: dto.isCsIntegrationUser || dto.membershipStatus === "REGISTERED" ? "registered" : "invited",
     roles: roles,
     lastActive: new Date(), // TODO: Replace this placeholder with actual last active date from backend when available
   };

--- a/apps/customer-portal/webapp/src/features/settings/components/GenerateTokenModal.tsx
+++ b/apps/customer-portal/webapp/src/features/settings/components/GenerateTokenModal.tsx
@@ -87,7 +87,7 @@ export default function GenerateTokenModal({
 
     let userErr: string | null = null;
     if (tokenType === RegistryTokenType.SERVICE && !selectedUser) {
-      userErr = "Please select an integration user for service tokens.";
+      userErr = "Please select a system user for service tokens.";
     }
     setCreatedForError(userErr);
 
@@ -237,7 +237,7 @@ export default function GenerateTokenModal({
             <Typography variant="body2" color="text.secondary">
               {tokenType === RegistryTokenType.USER
                 ? "Generate a personal registry token for WSO2 Updates 2.0 access. The token will be created for your account."
-                : "Generate a service registry token for automation and CI/CD pipelines. You must assign it to an integration user."}
+                : "Generate a service registry token for automation and CI/CD pipelines. You must assign it to a system user."}
             </Typography>
 
             <TextField
@@ -259,7 +259,7 @@ export default function GenerateTokenModal({
               }
             />
 
-            {/* Service token: select integration user */}
+            {/* Service token: select system user */}
             {tokenType === RegistryTokenType.SERVICE && (
               <Autocomplete
                 options={integrationUsers}
@@ -273,12 +273,12 @@ export default function GenerateTokenModal({
                 renderInput={(params) => (
                   <TextField
                     {...params}
-                    label="Integration User (Created For)"
+                    label="System User (Created For)"
                     required
                     error={!!createdForError}
                     helperText={
                       createdForError ??
-                      "Select the integration user this service token is created for."
+                      "Select the system user this service token is created for."
                     }
                     InputProps={{
                       ...params.InputProps,


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Two small consistency fixes in the customer portal's user management UI, both around the "System User" concept (machine-to-machine service accounts):

1. System users showed a "Invited" status in the users list even after being fully set up, because `membershipStatus` only flips to `REGISTERED` through the human email-registration flow, which system users never go through.
2. The "generate service token" form referred to the assignee as "integration user" (label, helper text, validation error) instead of "System User", the term used everywhere else in the product for this role.

## Goals
- System users always show as `registered` in the users list status column, regardless of their `membershipStatus`.
- The service-token form's copy consistently says "System User" instead of "integration user".

## Approach
1. `apps/customer-portal/microapp/src/services/users.ts` — `toUser()` now treats `isCsIntegrationUser` as `registered` before falling back to the existing `membershipStatus === "REGISTERED"` check. No backend or type change; purely a display-mapping fix.
2. `apps/customer-portal/webapp/src/features/settings/components/GenerateTokenModal.tsx` — updated the field label, helper text, validation error message, and a code comment from "integration user" to "System User". No behavioral change, copy only.

## User stories
As a project admin viewing the users list, a system/integration user's status should read "Registered" rather than "Invited", since it's not a person who needs to complete registration. As a project admin generating a service token, the form should consistently call the assignee a "System User".

## Release note
Fixed: system users now show as "Registered" in the users list instead of "Invited". Fixed: the generate service token form now consistently refers to "System User" instead of "integration user".

## Documentation
N/A — UI copy/display-logic fix, no product documentation describes this behavior.

## Automation tests
- Unit tests
  > No existing unit tests cover `toUser()` or this modal's copy; none added, this is a minimal, low-risk mapping/copy change verified by `tsc -b` and `eslint` on both touched packages.
- Integration tests
  > N/A

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — TypeScript/React change; `tsc -b` and `eslint` ran clean on both touched files instead.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
None

## Migrations (if applicable)
N/A — no data or schema change.

## Test environment
Verified via `tsc -b --noEmit` and `eslint` on both `apps/customer-portal/microapp` and `apps/customer-portal/webapp`, Node/npm as configured in each package's `package-lock.json`.

## Learning
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Integration users are now correctly recognized as registered regardless of membership status.
  * Other users continue to be classified based on their membership status.

* **UI Improvements**
  * Updated service-token terminology in the token-generation dialog to use “system user” consistently.
  * Token-generation behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->