### PR TITLE
[Customer Portal] Render dropdown for service request variables with predefined choices

### DIFF
--- a/apps/customer-portal/backend/modules/entity/types.bal
+++ b/apps/customer-portal/backend/modules/entity/types.bal
@@ -2275,6 +2275,17 @@ public type CatalogSearchResponse record {|
     *Pagination;
 |};
 
+# Choice option for a catalog item variable.
+public type CatalogItemVariableChoice record {|
+    # Value submitted for this choice
+    string value;
+    # Display text for this choice
+    string text;
+    # Display order of the choice
+    int 'order;
+    json...;
+|};
+
 # Catalog item variable information.
 public type CatalogItemVariable record {|
     # Variable ID
@@ -2285,6 +2296,8 @@ public type CatalogItemVariable record {|
     int 'order;
     # Type of the variable (e.g., "Single Line Text", "Multi Line Text")
     string 'type;
+    # Available choices for the variable, when applicable (e.g., "Multiple Choice")
+    CatalogItemVariableChoice[]? choices?;
     json...;
 |};
 

--- a/apps/customer-portal/backend/openapi.yaml
+++ b/apps/customer-portal/backend/openapi.yaml
@@ -1790,6 +1790,10 @@ paths:
       responses:
         "200":
           description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CatalogItemVariablesResponse'
         "401":
           description: Unauthorized
         "500":
@@ -4186,6 +4190,64 @@ components:
           items:
             $ref: '#/components/schemas/ChoiceListItem'
       description: Cases trend by time unit.
+    CatalogItemVariable:
+      required:
+      - id
+      - order
+      - questionText
+      - type
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/IdString'
+        questionText:
+          type: string
+          description: Question text for the variable
+        order:
+          type: integer
+          description: Display order of the variable
+          format: int64
+        type:
+          type: string
+          description: "Type of the variable (e.g., \"Single Line Text\", \"Multi\
+            \ Line Text\")"
+        choices:
+          type: array
+          description: "Available choices for the variable, when applicable (e.g.,\
+            \ \"Multiple Choice\")"
+          nullable: true
+          items:
+            $ref: '#/components/schemas/CatalogItemVariableChoice'
+      description: Catalog item variable information.
+    CatalogItemVariableChoice:
+      required:
+      - order
+      - text
+      - value
+      type: object
+      properties:
+        value:
+          type: string
+          description: Value submitted for this choice
+        text:
+          type: string
+          description: Display text for this choice
+        order:
+          type: integer
+          description: Display order of the choice
+          format: int64
+      description: Choice option for a catalog item variable.
+    CatalogItemVariablesResponse:
+      required:
+      - variables
+      type: object
+      properties:
+        variables:
+          type: array
+          description: List of catalog item variables
+          items:
+            $ref: '#/components/schemas/CatalogItemVariable'
+      description: Catalog item variables response.
     CatalogSearchPayload:
       type: object
       properties:

--- a/apps/customer-portal/webapp/src/features/operations/components/service-requests/VariableFormFields.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/components/service-requests/VariableFormFields.tsx
@@ -311,6 +311,40 @@ export default function VariableFormFields({
     const titleLength = displayValue.trim().length;
     const isTitleTooLong = isTitle && titleLength > 160;
 
+    if (variable.choices && variable.choices.length > 0) {
+      const sortedChoices = [...variable.choices].sort(
+        (a, b) => a.order - b.order,
+      );
+      return (
+        <Grid key={variable.id} size={{ xs: 12 }}>
+          <Box sx={{ mb: 1 }}>
+            <FieldLabel questionText={variable.questionText ?? ""} />
+          </Box>
+          <FormControl fullWidth size="small">
+            <Select
+              value={value}
+              onChange={(e) => onChange(variable.id, e.target.value as string)}
+              displayEmpty
+              disabled={isContext}
+              renderValue={(v) =>
+                sortedChoices.find((c) => c.value === v)?.text ||
+                "Select..."
+              }
+            >
+              <MenuItem value="">
+                <em>Select...</em>
+              </MenuItem>
+              {sortedChoices.map((choice) => (
+                <MenuItem key={choice.value} value={choice.value}>
+                  {choice.text}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </Grid>
+      );
+    }
+
     if (
       type === VARIABLE_TYPE_SELECT ||
       type === VARIABLE_TYPE_RADIO ||

--- a/apps/customer-portal/webapp/src/features/operations/types/serviceRequests.ts
+++ b/apps/customer-portal/webapp/src/features/operations/types/serviceRequests.ts
@@ -55,12 +55,20 @@ export type CatalogSearchResponse = PaginationResponse & {
   catalogs: Catalog[];
 };
 
+/** Choice option for a catalog item variable. */
+export type CatalogItemVariableChoice = {
+  value: string;
+  text: string;
+  order: number;
+};
+
 /** Item type for a variable definition for a catalog item. */
 export type CatalogItemVariable = {
   id: string;
   questionText: string;
   order: number;
   type: string;
+  choices?: CatalogItemVariableChoice[] | null;
 };
 
 /** Response type for catalog item variables. */


### PR DESCRIPTION
## Summary
- Catalog item variables of type "Multiple Choice" (and similar) can carry a `choices` list (`value`/`text`/`order`) from the upstream entity service. Previously this was silently dropped/untyped, and the UI rendered these fields as a hardcoded Yes/No select regardless of the actual options.
- Backend: added `CatalogItemVariableChoice` and a `choices` field on `CatalogItemVariable` (`types.bal`), and documented the shape in `openapi.yaml` (new schemas + wired into the `GET /catalogs/{catalogId}/items/{itemId}` response, which previously had no documented response body).
- Frontend: mirrored the `choices` field on `CatalogItemVariable`, and updated `VariableFormFields` to render a real `Select` populated from `variable.choices` (sorted by `order`) whenever choices are present, falling back to existing behavior otherwise.

## Test plan
- [x] `bal build` passes for the backend module changes
- [x] `tsc --noEmit` passes for the frontend changes
- [ ] Manually create a service request against a catalog item whose variables include a "Multiple Choice" field with `choices` and confirm the dropdown lists the correct options and submits the selected `value`
- [ ] Confirm existing variable types (Single Line Text, Multi Line Text, description, attachment, date/time fields) still render unchanged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for catalog variables with predefined choices.
  * Choice-based fields now display ordered labels and values with a placeholder.
  * Context-dependent fields can be disabled when appropriate.
  * Catalog variable responses now include optional choice metadata through the API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->