### PR TITLE
[Customer Portal][Webapp] Style choice-driven variable select with muted placeholder

### DIFF
--- a/apps/customer-portal/webapp/src/features/operations/components/service-requests/VariableFormFields.tsx
+++ b/apps/customer-portal/webapp/src/features/operations/components/service-requests/VariableFormFields.tsx
@@ -326,14 +326,16 @@ export default function VariableFormFields({
               onChange={(e) => onChange(variable.id, e.target.value as string)}
               displayEmpty
               disabled={isContext}
+              sx={{
+                "& .MuiSelect-select": {
+                  color: !value ? "text.secondary" : undefined,
+                },
+              }}
               renderValue={(v) =>
                 sortedChoices.find((c) => c.value === v)?.text ||
                 "Select..."
               }
             >
-              <MenuItem value="">
-                <em>Select...</em>
-              </MenuItem>
               {sortedChoices.map((choice) => (
                 <MenuItem key={choice.value} value={choice.value}>
                   {choice.text}


### PR DESCRIPTION
## Summary
- Choice-driven service request variables are mandatory, so remove the blank "Select..." menu item from the dropdown — it isn't a valid selectable value.
- Mute the placeholder text via `.MuiSelect-select` color (`text.secondary` until a value is chosen), matching the existing deployment/product select pattern used elsewhere in the app (`EditDeploymentModal.tsx`).

## Test plan
- [x] `tsc --noEmit` passes
- [ ] Manually open a service request with a "Multiple Choice" variable and confirm the placeholder renders muted/gray, no blank option appears in the list, and it turns to normal text color once a choice is selected


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the visual styling of unselected dropdown placeholders for better clarity.
* **Bug Fixes**
  * Removed redundant empty placeholder options while preserving placeholder display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->