### PR TITLE
feat(support): thumbs up/down feedback on Novera answers, while the session is live

### DIFF
--- a/apps/customer-portal/webapp/src/features/support/components/novera-ai-assistant/novera-chat-page/ChatMessageBubble.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/novera-ai-assistant/novera-chat-page/ChatMessageBubble.tsx
@@ -19,13 +19,15 @@ import {
   Avatar,
   Box,
   Button,
+  IconButton,
   Paper,
   Stack,
+  Tooltip,
   Typography,
   alpha,
   useTheme,
 } from "@wso2/oxygen-ui";
-import { Bot, User } from "@wso2/oxygen-ui-icons-react";
+import { Bot, ThumbsDown, ThumbsUp, User } from "@wso2/oxygen-ui-icons-react";
 import { type JSX, useEffect, useMemo, useRef } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -139,6 +141,8 @@ function MarkdownContent({ text }: { text: string }) {
  */
 export default function ChatMessageBubble({
   message,
+  onThumbsUp,
+  onThumbsDown,
   onRequestTokenIncrease,
 }: ChatMessageBubbleProps): JSX.Element {
   const isUser = message.sender === ChatSender.USER;
@@ -183,6 +187,18 @@ export default function ChatMessageBubble({
 
   /** Faded frame wraps analyzing, live thinking steps, and streamed tokens. */
   const showThinkingStreamFrame = hideFeedbackRow;
+
+  /**
+   * Show 👍/👎 on a completed assistant answer that carries a stable
+   * feedbackMessageId (from the WS `final` event). Never on user, error,
+   * streaming, or history messages that lack an id.
+   */
+  const showFeedbackRow =
+    message.sender === ChatSender.BOT &&
+    !message.isError &&
+    !hideFeedbackRow &&
+    !!message.feedbackMessageId &&
+    (!!onThumbsUp || !!onThumbsDown);
 
   const streamBodyText = collapseStreamLineBreaks(displayText);
   const analyzingLeadText = "Novera is analyzing your request...";
@@ -425,6 +441,52 @@ export default function ChatMessageBubble({
               </Box>
             )}
           </Box>
+
+          {showFeedbackRow && (
+            <Stack
+              direction="row"
+              alignItems="center"
+              spacing={0.5}
+              sx={{ mt: 0.25, ml: -0.75 }}
+            >
+              <Tooltip title="Good response">
+                <IconButton
+                  size="small"
+                  aria-label="Good response"
+                  aria-pressed={message.feedbackRating === 1}
+                  onClick={() =>
+                    onThumbsUp?.(message.feedbackMessageId as string)
+                  }
+                  sx={{
+                    color:
+                      message.feedbackRating === 1
+                        ? "primary.main"
+                        : "text.secondary",
+                  }}
+                >
+                  <ThumbsUp size={16} />
+                </IconButton>
+              </Tooltip>
+              <Tooltip title="Bad response">
+                <IconButton
+                  size="small"
+                  aria-label="Bad response"
+                  aria-pressed={message.feedbackRating === -1}
+                  onClick={() =>
+                    onThumbsDown?.(message.feedbackMessageId as string)
+                  }
+                  sx={{
+                    color:
+                      message.feedbackRating === -1
+                        ? "error.main"
+                        : "text.secondary",
+                  }}
+                >
+                  <ThumbsDown size={16} />
+                </IconButton>
+              </Tooltip>
+            </Stack>
+          )}
 
           {showTokenRequestCta && (
             <Box sx={{ mt: 1 }}>

--- a/apps/customer-portal/webapp/src/features/support/components/novera-ai-assistant/novera-chat-page/ChatMessageBubble.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/novera-ai-assistant/novera-chat-page/ChatMessageBubble.tsx
@@ -192,6 +192,11 @@ export default function ChatMessageBubble({
    * Show 👍/👎 on a completed assistant answer that carries a stable
    * feedbackMessageId (from the WS `final` event). Never on user, error,
    * streaming, or history messages that lack an id.
+   *
+   * Feedback is delivered over the chat socket, so it is only offered while
+   * that socket is open: the pages pass the handlers as undefined when
+   * disconnected, and the last clause below then hides the row. Hidden rather
+   * than disabled — a greyed-out thumb invites a click that cannot succeed.
    */
   const showFeedbackRow =
     message.sender === ChatSender.BOT &&

--- a/apps/customer-portal/webapp/src/features/support/components/novera-ai-assistant/novera-chat-page/__tests__/ChatMessageBubble.test.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/novera-ai-assistant/novera-chat-page/__tests__/ChatMessageBubble.test.tsx
@@ -14,10 +14,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { ThemeProvider, createTheme } from "@wso2/oxygen-ui";
 import ChatMessageBubble from "@features/support/components/novera-ai-assistant/novera-chat-page/ChatMessageBubble";
+import type { ChatMessageBubbleProps } from "@features/support/types/supportComponents";
 import {
   ChatSender,
   type Message,
@@ -29,13 +30,25 @@ vi.mock("react-markdown", () => ({
   ),
 }));
 
-function renderBubble(message: Message) {
+function renderBubble(
+  message: Message,
+  props: Partial<ChatMessageBubbleProps> = {},
+) {
   return render(
     <ThemeProvider theme={createTheme()}>
-      <ChatMessageBubble message={message} />
+      <ChatMessageBubble message={message} {...props} />
     </ThemeProvider>,
   );
 }
+
+const botAnswer = (over: Partial<Message> = {}): Message => ({
+  id: "bot-1",
+  text: "Here is your answer",
+  sender: ChatSender.BOT,
+  timestamp: new Date(),
+  feedbackMessageId: "msg-123",
+  ...over,
+});
 
 describe("ChatMessageBubble", () => {
   it("should render user message correctly", () => {
@@ -101,5 +114,63 @@ describe("ChatMessageBubble", () => {
     expect(
       screen.queryByText("NullPointerException at line 42"),
     ).not.toBeInTheDocument();
+  });
+
+  describe("answer feedback (👍/👎)", () => {
+    it("renders thumbs on a completed answer with a feedbackMessageId", () => {
+      renderBubble(botAnswer(), {
+        onThumbsUp: vi.fn(),
+        onThumbsDown: vi.fn(),
+      });
+
+      expect(screen.getByLabelText("Good response")).toBeInTheDocument();
+      expect(screen.getByLabelText("Bad response")).toBeInTheDocument();
+    });
+
+    it("calls onThumbsUp / onThumbsDown with the feedbackMessageId", () => {
+      const onThumbsUp = vi.fn();
+      const onThumbsDown = vi.fn();
+      renderBubble(botAnswer(), { onThumbsUp, onThumbsDown });
+
+      fireEvent.click(screen.getByLabelText("Good response"));
+      expect(onThumbsUp).toHaveBeenCalledWith("msg-123");
+
+      fireEvent.click(screen.getByLabelText("Bad response"));
+      expect(onThumbsDown).toHaveBeenCalledWith("msg-123");
+    });
+
+    it("reflects the chosen rating via aria-pressed", () => {
+      renderBubble(botAnswer({ feedbackRating: 1 }), {
+        onThumbsUp: vi.fn(),
+        onThumbsDown: vi.fn(),
+      });
+
+      expect(screen.getByLabelText("Good response")).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+      expect(screen.getByLabelText("Bad response")).toHaveAttribute(
+        "aria-pressed",
+        "false",
+      );
+    });
+
+    it("hides thumbs when there is no feedbackMessageId", () => {
+      renderBubble(botAnswer({ feedbackMessageId: undefined }), {
+        onThumbsUp: vi.fn(),
+        onThumbsDown: vi.fn(),
+      });
+
+      expect(screen.queryByLabelText("Good response")).not.toBeInTheDocument();
+    });
+
+    it("hides thumbs while the answer is still streaming", () => {
+      renderBubble(botAnswer({ isStreaming: true }), {
+        onThumbsUp: vi.fn(),
+        onThumbsDown: vi.fn(),
+      });
+
+      expect(screen.queryByLabelText("Good response")).not.toBeInTheDocument();
+    });
   });
 });

--- a/apps/customer-portal/webapp/src/features/support/pages/ConversationDetailsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/ConversationDetailsPage.tsx
@@ -381,7 +381,9 @@ export default function ConversationDetailsPage(): JSX.Element {
         const idx = prev.findIndex((m) => m.id === activeId);
         if (idx === -1) return prev;
         pendingFinalRef.current = null;
-        const { finalMessage } = pending;
+        const { finalMessage, payload } = pending;
+        const answerId =
+          typeof payload.messageId === "string" ? payload.messageId : undefined;
         const msg = prev[idx];
         const next = [...prev];
         next[idx] = {
@@ -389,6 +391,8 @@ export default function ConversationDetailsPage(): JSX.Element {
           isLoading: false,
           isError: false,
           text: finalMessage || msg.text,
+          showFeedbackActions: !!answerId,
+          feedbackMessageId: answerId,
           isStreaming: false,
           thinkingSteps: [],
           thinkingLabel: null,
@@ -486,6 +490,21 @@ export default function ConversationDetailsPage(): JSX.Element {
           const finalMessage = getFinalMessageFromPayload(payload);
           pendingFinalRef.current = { payload, finalMessage };
           flushPendingFinalIfReady();
+          break;
+        }
+        case "feedback_ack": {
+          const ackId = String(event.messageId ?? "");
+          const ackRating =
+            event.rating === 1 ? 1 : event.rating === -1 ? -1 : null;
+          if (ackId) {
+            setNewMessages((prev) =>
+              prev.map((m) =>
+                m.feedbackMessageId === ackId
+                  ? { ...m, feedbackRating: ackRating }
+                  : m,
+              ),
+            );
+          }
           break;
         }
         case "error":
@@ -592,6 +611,48 @@ export default function ConversationDetailsPage(): JSX.Element {
     await sendViaWebSocket(text);
     return true;
   }, [accountId, isSending, projectId, sendViaWebSocket, setInputValueAndRef]);
+
+  // Answer feedback (👍/👎) over the existing chat socket (#2534). Optimistic
+  // with revert-on-failure; feedback_ack confirms the persisted value.
+  const submitFeedback = useCallback(
+    (messageId: string, rating: 1 | -1) => {
+      if (!projectId) return;
+      setNewMessages((prev) =>
+        prev.map((m) =>
+          m.feedbackMessageId === messageId ? { ...m, feedbackRating: rating } : m,
+        ),
+      );
+      void connect(projectId)
+        .then(() =>
+          sendUserMessage({
+            type: "feedback",
+            messageId,
+            rating,
+            conversationId: conversationId ?? undefined,
+            accountId: accountId || undefined,
+          }),
+        )
+        .catch(() => {
+          setNewMessages((prev) =>
+            prev.map((m) =>
+              m.feedbackMessageId === messageId
+                ? { ...m, feedbackRating: null }
+                : m,
+            ),
+          );
+        });
+    },
+    [accountId, connect, conversationId, projectId, sendUserMessage],
+  );
+
+  const handleThumbsUp = useCallback(
+    (messageId: string) => submitFeedback(messageId, 1),
+    [submitFeedback],
+  );
+  const handleThumbsDown = useCallback(
+    (messageId: string) => submitFeedback(messageId, -1),
+    [submitFeedback],
+  );
 
   const conversationStatus = summary?.status;
   const conversationStatusLabel = conversationStatus ?? "--";
@@ -814,7 +875,12 @@ export default function ConversationDetailsPage(): JSX.Element {
                     m.isLoading ? (
                       <LoadingDotsBubble key={m.id} />
                     ) : (
-                      <ChatMessageBubble key={m.id} message={m} />
+                      <ChatMessageBubble
+                        key={m.id}
+                        message={m}
+                        onThumbsUp={handleThumbsUp}
+                        onThumbsDown={handleThumbsDown}
+                      />
                     ),
                   )}
                 </>

--- a/apps/customer-portal/webapp/src/features/support/pages/ConversationDetailsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/ConversationDetailsPage.tsx
@@ -432,7 +432,7 @@ export default function ConversationDetailsPage(): JSX.Element {
     return () => window.clearInterval(id);
   }, [dequeueOneTypedToken, flushPendingFinalIfReady]);
 
-  const { connect, sendUserMessage } = useChatWebSocket({
+  const { connect, sendUserMessage, isConnected } = useChatWebSocket({
     onEvent: (event) => {
       switch (event.type) {
         case "thinking_start":
@@ -878,8 +878,8 @@ export default function ConversationDetailsPage(): JSX.Element {
                       <ChatMessageBubble
                         key={m.id}
                         message={m}
-                        onThumbsUp={handleThumbsUp}
-                        onThumbsDown={handleThumbsDown}
+                        onThumbsUp={isConnected ? handleThumbsUp : undefined}
+                        onThumbsDown={isConnected ? handleThumbsDown : undefined}
                       />
                     ),
                   )}

--- a/apps/customer-portal/webapp/src/features/support/pages/ConversationDetailsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/ConversationDetailsPage.tsx
@@ -614,14 +614,31 @@ export default function ConversationDetailsPage(): JSX.Element {
 
   // Answer feedback (👍/👎) over the existing chat socket (#2534). Optimistic
   // with revert-on-failure; feedback_ack confirms the persisted value.
+  // Latest feedback submission per messageId, so a stale rejection cannot
+  // roll back a newer vote. A ref, not state: it must not trigger a render.
+  const feedbackSeqRef = useRef<Map<string, number>>(new Map());
+
   const submitFeedback = useCallback(
     (messageId: string, rating: 1 | -1) => {
       if (!projectId) return;
+
+      // Mark this as the latest submission for the message. Clicking 👍 then
+      // 👎 leaves two sends in flight; if the first rejects after the second
+      // resolved, its rollback must not undo the newer vote.
+      const seq = (feedbackSeqRef.current.get(messageId) ?? 0) + 1;
+      feedbackSeqRef.current.set(messageId, seq);
+
+      // Remember what was showing so a failure restores it, rather than
+      // clearing a rating the user had already given (and we had persisted).
+      let previousRating: 1 | -1 | null = null;
       setNewMessages((prev) =>
-        prev.map((m) =>
-          m.feedbackMessageId === messageId ? { ...m, feedbackRating: rating } : m,
-        ),
+        prev.map((m) => {
+          if (m.feedbackMessageId !== messageId) return m;
+          previousRating = m.feedbackRating ?? null;
+          return { ...m, feedbackRating: rating };
+        }),
       );
+
       void connect(projectId)
         .then(() =>
           sendUserMessage({
@@ -633,10 +650,11 @@ export default function ConversationDetailsPage(): JSX.Element {
           }),
         )
         .catch(() => {
+          if (feedbackSeqRef.current.get(messageId) !== seq) return;
           setNewMessages((prev) =>
             prev.map((m) =>
               m.feedbackMessageId === messageId
-                ? { ...m, feedbackRating: null }
+                ? { ...m, feedbackRating: previousRating }
                 : m,
             ),
           );

--- a/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
@@ -449,12 +449,16 @@ export default function NoveraChatPage(): JSX.Element {
           ? (payload.actions as NoveraAction[])
           : undefined;
         const next = [...prev];
+        const answerId =
+          typeof payload.messageId === "string" ? payload.messageId : undefined;
         next[idx] = {
           ...msg,
           isLoading: false,
           isError: false,
           text: finalMessage || msg.text,
           showCreateCaseAction: payload.actions != null,
+          showFeedbackActions: !!answerId,
+          feedbackMessageId: answerId,
           slotState: payload.slotState as SlotState | undefined,
           thinkingSteps: [],
           thinkingLabel: null,
@@ -606,6 +610,21 @@ export default function NoveraChatPage(): JSX.Element {
           }
           break;
         }
+        case "feedback_ack": {
+          const ackId = String(event.messageId ?? "");
+          const ackRating =
+            event.rating === 1 ? 1 : event.rating === -1 ? -1 : null;
+          if (ackId) {
+            setMessages((prev) =>
+              prev.map((m) =>
+                m.feedbackMessageId === ackId
+                  ? { ...m, feedbackRating: ackRating }
+                  : m,
+              ),
+            );
+          }
+          break;
+        }
         case "error":
           pendingFinalRef.current = null;
           tokenQueueRef.current = [];
@@ -718,6 +737,49 @@ export default function NoveraChatPage(): JSX.Element {
     void sendViaWebSocket("This Resolved My Issue");
   }, [isSending, sendViaWebSocket]);
 
+  // Answer feedback (👍/👎) over the existing chat socket (#2534). Optimistic:
+  // reflect the vote immediately, revert if the send fails. feedback_ack later
+  // confirms the persisted value.
+  const submitFeedback = useCallback(
+    (messageId: string, rating: 1 | -1) => {
+      if (!projectId) return;
+      setMessages((prev) =>
+        prev.map((m) =>
+          m.feedbackMessageId === messageId ? { ...m, feedbackRating: rating } : m,
+        ),
+      );
+      void connect(projectId)
+        .then(() =>
+          sendUserMessage({
+            type: "feedback",
+            messageId,
+            rating,
+            conversationId: conversationId ?? undefined,
+            accountId: accountId || undefined,
+          }),
+        )
+        .catch(() => {
+          setMessages((prev) =>
+            prev.map((m) =>
+              m.feedbackMessageId === messageId
+                ? { ...m, feedbackRating: null }
+                : m,
+            ),
+          );
+        });
+    },
+    [accountId, connect, conversationId, projectId, sendUserMessage],
+  );
+
+  const handleThumbsUp = useCallback(
+    (messageId: string) => submitFeedback(messageId, 1),
+    [submitFeedback],
+  );
+  const handleThumbsDown = useCallback(
+    (messageId: string) => submitFeedback(messageId, -1),
+    [submitFeedback],
+  );
+
   // Feature-flagged (config.js): request a token limit increase over the chat
   // WebSocket. Kept off until the backend handler is ready.
   const tokenRequestEnabled =
@@ -803,6 +865,8 @@ export default function NoveraChatPage(): JSX.Element {
               messages={messages}
               messagesEndRef={messagesEndRef}
               onCreateCase={handleCreateCase}
+              onThumbsUp={handleThumbsUp}
+              onThumbsDown={handleThumbsDown}
               onSolutionWorked={handleSolutionWorked}
               onRequestTokenIncrease={
                 tokenRequestEnabled

--- a/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
@@ -740,14 +740,31 @@ export default function NoveraChatPage(): JSX.Element {
   // Answer feedback (👍/👎) over the existing chat socket (#2534). Optimistic:
   // reflect the vote immediately, revert if the send fails. feedback_ack later
   // confirms the persisted value.
+  // Latest feedback submission per messageId, so a stale rejection cannot
+  // roll back a newer vote. A ref, not state: it must not trigger a render.
+  const feedbackSeqRef = useRef<Map<string, number>>(new Map());
+
   const submitFeedback = useCallback(
     (messageId: string, rating: 1 | -1) => {
       if (!projectId) return;
+
+      // Mark this as the latest submission for the message. Clicking 👍 then
+      // 👎 leaves two sends in flight; if the first rejects after the second
+      // resolved, its rollback must not undo the newer vote.
+      const seq = (feedbackSeqRef.current.get(messageId) ?? 0) + 1;
+      feedbackSeqRef.current.set(messageId, seq);
+
+      // Remember what was showing so a failure restores it, rather than
+      // clearing a rating the user had already given (and we had persisted).
+      let previousRating: 1 | -1 | null = null;
       setMessages((prev) =>
-        prev.map((m) =>
-          m.feedbackMessageId === messageId ? { ...m, feedbackRating: rating } : m,
-        ),
+        prev.map((m) => {
+          if (m.feedbackMessageId !== messageId) return m;
+          previousRating = m.feedbackRating ?? null;
+          return { ...m, feedbackRating: rating };
+        }),
       );
+
       void connect(projectId)
         .then(() =>
           sendUserMessage({
@@ -759,10 +776,11 @@ export default function NoveraChatPage(): JSX.Element {
           }),
         )
         .catch(() => {
+          if (feedbackSeqRef.current.get(messageId) !== seq) return;
           setMessages((prev) =>
             prev.map((m) =>
               m.feedbackMessageId === messageId
-                ? { ...m, feedbackRating: null }
+                ? { ...m, feedbackRating: previousRating }
                 : m,
             ),
           );

--- a/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
@@ -508,7 +508,7 @@ export default function NoveraChatPage(): JSX.Element {
     return () => window.clearInterval(id);
   }, [dequeueOneTypedToken, flushPendingFinalIfReady, TYPING_INTERVAL_MS]);
 
-  const { connect, sendUserMessage } = useChatWebSocket({
+  const { connect, sendUserMessage, isConnected } = useChatWebSocket({
     onEvent: (event) => {
       switch (event.type) {
         case "conversation_created": {
@@ -865,8 +865,8 @@ export default function NoveraChatPage(): JSX.Element {
               messages={messages}
               messagesEndRef={messagesEndRef}
               onCreateCase={handleCreateCase}
-              onThumbsUp={handleThumbsUp}
-              onThumbsDown={handleThumbsDown}
+              onThumbsUp={isConnected ? handleThumbsUp : undefined}
+              onThumbsDown={isConnected ? handleThumbsDown : undefined}
               onSolutionWorked={handleSolutionWorked}
               onRequestTokenIncrease={
                 tokenRequestEnabled

--- a/apps/customer-portal/webapp/src/features/support/types/conversations.ts
+++ b/apps/customer-portal/webapp/src/features/support/types/conversations.ts
@@ -212,6 +212,10 @@ export type Message = {
   createdOnRaw?: string;
   showFeedbackActions?: boolean;
   showCreateCaseAction?: boolean;
+  /** Stable id of this assistant answer (from the WS `final` event), used to rate it. */
+  feedbackMessageId?: string;
+  /** The rating the user has given this answer, if any (+1 up / -1 down). */
+  feedbackRating?: 1 | -1 | null;
   isLoading?: boolean;
   isError?: boolean;
   slotState?: SlotState;
@@ -252,6 +256,14 @@ export type ChatWebSocketPayload =
       accountId: string;
       reason: string;
       limitType: "session" | "monthly";
+    }
+  | {
+      type: "feedback";
+      messageId: string;
+      rating: 1 | -1;
+      conversationId?: string;
+      accountId?: string;
+      comment?: string;
     };
 
 // Model type for chat WebSocket hook options.


### PR DESCRIPTION
## What

Customer-portal side of **Novera answer feedback** — the 👍/👎 control on assistant answers in the Novera chat. This is the client half of `digiops-cs` epic #2529 (subtask #2534); the backend and analytics dashboard half is `wso2-enterprise/digiops-cs#2712`.

```
chat (this PR) ──{type:"feedback", messageId, rating}──▶ Novera backend ──▶ message_feedback
               ◀──{type:"feedback_ack", …}
```

## Transport: the existing chat WebSocket, no new REST call

Feedback is sent as a `feedback` event on the socket that is already open for the conversation. There is deliberately **no REST endpoint** for this — the backend PR drops the `PUT /feedback` that was originally proposed.

Behaviour: optimistic update on click, reconciled against `feedback_ack`, rolled back if the send fails. Re-rating replaces the previous vote (the backend upserts per `conversation_id` + `message_id`).

## Only offered while the session is live

The thumbs appear only when the socket is **open**. Both chat pages pass the handlers as `undefined` when disconnected, and the existing `(!!onThumbsUp || !!onThumbsDown)` clause in `ChatMessageBubble` hides the row.

**Hidden rather than disabled** — a greyed-out thumb invites a click that cannot succeed, and there is nothing the user can do about it. Since feedback travels on the socket, a control shown without one is simply a broken affordance.

`useChatWebSocket` already exposed `isConnected`, so no new state was needed.

The row is also hidden for user messages, errors, streaming/thinking messages, and history messages that carry no `feedbackMessageId`.

## Files

| File | Change |
| --- | --- |
| `ChatMessageBubble.tsx` | 👍/👎 buttons, `aria-pressed` reflecting the current rating |
| `NoveraChatPage.tsx` | send `feedback`, handle `feedback_ack`, gate on `isConnected` |
| `ConversationDetailsPage.tsx` | same, for the conversation view |
| `types/conversations.ts` | `feedbackMessageId` / `feedbackRating` on chat messages |
| `__tests__/ChatMessageBubble.test.tsx` | coverage for render conditions and rating state |

## Testing

- `tsc --noEmit` — clean
- `ChatMessageBubble.test.tsx` — **10 passed**

The wider `src/features/support` suite reports **49 failures across 16 files**. Those are **pre-existing**: I ran the identical suite on clean `origin/main` and got the same 16 files / 49 tests failing. This branch runs 437 tests vs 432 on main — the 5 extra are the new feedback tests, all passing, with no change to the failure count. Not addressed here, but worth someone looking at separately.

## Dependency

The backend only emits a stable `messageId` on assistant answers as part of `digiops-cs#2712`. Until that merges the control will not render (no `feedbackMessageId`), so this can merge safely in either order but is **not end-to-end testable** until both are in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added thumbs-up and thumbs-down feedback controls to completed AI responses.
  * Selected feedback ratings are visibly indicated.
  * Feedback is submitted through the active chat connection with immediate UI updates.
* **Bug Fixes**
  * Feedback changes now revert when submission fails.
  * Feedback controls are hidden during streaming, when unavailable, or without a valid response identifier.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->