### PR TITLE
feat(support): predefined reason tags alongside the answer rating

### DIFF
--- a/apps/customer-portal/webapp/src/features/support/components/novera-ai-assistant/novera-chat-page/ChatMessageBubble.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/novera-ai-assistant/novera-chat-page/ChatMessageBubble.tsx
@@ -33,6 +33,11 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { ChatSender } from "@features/support/types/conversations";
 import {
+  MAX_FEEDBACK_TAGS,
+  feedbackTagPrompt,
+  feedbackTagsFor,
+} from "@features/support/constants/feedbackTags";
+import {
   NOVERA_ANALYZING_PLACEHOLDER_TEXT,
   NOVERA_DISPLAY_NAME,
 } from "@features/support/constants/chatConstants";
@@ -143,6 +148,7 @@ export default function ChatMessageBubble({
   message,
   onThumbsUp,
   onThumbsDown,
+  onFeedbackTag,
   onRequestTokenIncrease,
 }: ChatMessageBubbleProps): JSX.Element {
   const isUser = message.sender === ChatSender.USER;
@@ -204,6 +210,20 @@ export default function ChatMessageBubble({
     !hideFeedbackRow &&
     !!message.feedbackMessageId &&
     (!!onThumbsUp || !!onThumbsDown);
+
+  /**
+   * Reason chips appear only once a rating exists, so giving the rating is never
+   * blocked by a second decision — the vote is the signal we most want, and it
+   * is already saved by the time these render. Gated on onFeedbackTag too, so
+   * they disappear with the thumbs when the socket closes.
+   */
+  const selectedTags = message.feedbackTags ?? [];
+  const showFeedbackTags =
+    showFeedbackRow && !!onFeedbackTag && !!message.feedbackRating;
+  const tagOptions = message.feedbackRating
+    ? feedbackTagsFor(message.feedbackRating)
+    : [];
+  const tagLimitReached = selectedTags.length >= MAX_FEEDBACK_TAGS;
 
   const streamBodyText = collapseStreamLineBreaks(displayText);
   const analyzingLeadText = "Novera is analyzing your request...";
@@ -491,6 +511,47 @@ export default function ChatMessageBubble({
                 </IconButton>
               </Tooltip>
             </Stack>
+          )}
+
+          {showFeedbackTags && (
+            <Box sx={{ mt: 0.5 }}>
+              <Typography
+                variant="caption"
+                color="text.secondary"
+                sx={{ display: "block", mb: 0.5 }}
+              >
+                {feedbackTagPrompt(message.feedbackRating as 1 | -1)}
+              </Typography>
+              <Stack direction="row" flexWrap="wrap" useFlexGap spacing={0.5}>
+                {tagOptions.map(({ slug, label }) => {
+                  const selected = selectedTags.includes(slug);
+                  return (
+                    <Button
+                      key={slug}
+                      size="small"
+                      variant={selected ? "contained" : "outlined"}
+                      color={message.feedbackRating === 1 ? "primary" : "error"}
+                      aria-pressed={selected}
+                      // Unselected chips go inert at the cap so the limit is
+                      // discoverable, rather than silently dropping the choice
+                      // server-side.
+                      disabled={!selected && tagLimitReached}
+                      onClick={() =>
+                        onFeedbackTag?.(message.feedbackMessageId as string, slug)
+                      }
+                      sx={{
+                        textTransform: "none",
+                        borderRadius: 4,
+                        py: 0.1,
+                        minWidth: 0,
+                      }}
+                    >
+                      {label}
+                    </Button>
+                  );
+                })}
+              </Stack>
+            </Box>
           )}
 
           {showTokenRequestCta && (

--- a/apps/customer-portal/webapp/src/features/support/components/novera-ai-assistant/novera-chat-page/ChatMessageList.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/novera-ai-assistant/novera-chat-page/ChatMessageList.tsx
@@ -34,6 +34,7 @@ export default function ChatMessageList({
   onCreateCase,
   onThumbsUp,
   onThumbsDown,
+  onFeedbackTag,
   onFetchOlder,
   isFetchingOlder = false,
   onSolutionWorked,
@@ -93,6 +94,7 @@ export default function ChatMessageList({
             onCreateCase={onCreateCase}
             onThumbsUp={onThumbsUp}
             onThumbsDown={onThumbsDown}
+            onFeedbackTag={onFeedbackTag}
             onSolutionWorked={onSolutionWorked}
             onRequestTokenIncrease={onRequestTokenIncrease}
           />

--- a/apps/customer-portal/webapp/src/features/support/components/novera-ai-assistant/novera-chat-page/__tests__/ChatMessageBubble.test.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/novera-ai-assistant/novera-chat-page/__tests__/ChatMessageBubble.test.tsx
@@ -173,4 +173,75 @@ describe("ChatMessageBubble", () => {
       expect(screen.queryByLabelText("Good response")).not.toBeInTheDocument();
     });
   });
+
+  describe("reason tags", () => {
+    const handlers = () => ({
+      onThumbsUp: vi.fn(),
+      onThumbsDown: vi.fn(),
+      onFeedbackTag: vi.fn(),
+    });
+
+    it("does not offer tags until the answer has been rated", () => {
+      renderBubble(botAnswer(), handlers());
+
+      expect(screen.queryByText("What went wrong?")).not.toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: "Inaccurate" })).not.toBeInTheDocument();
+    });
+
+    it("offers the negative vocabulary after a thumbs down", () => {
+      renderBubble(botAnswer({ feedbackRating: -1 }), handlers());
+
+      expect(screen.getByText("What went wrong?")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Inaccurate" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Too slow" })).toBeInTheDocument();
+      // Positive tags must not leak into the negative set.
+      expect(screen.queryByRole("button", { name: "Saved time" })).not.toBeInTheDocument();
+    });
+
+    it("offers the positive vocabulary after a thumbs up", () => {
+      renderBubble(botAnswer({ feedbackRating: 1 }), handlers());
+
+      expect(screen.getByText("What was good about it?")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Saved time" })).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: "Inaccurate" })).not.toBeInTheDocument();
+    });
+
+    it("reports the chosen tag and marks it pressed", () => {
+      const props = handlers();
+      renderBubble(
+        botAnswer({ feedbackRating: -1, feedbackTags: ["outdated"] }),
+        props,
+      );
+
+      expect(screen.getByRole("button", { name: "Outdated" })).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+      fireEvent.click(screen.getByRole("button", { name: "Incomplete" }));
+      expect(props.onFeedbackTag).toHaveBeenCalledWith("msg-123", "incomplete");
+    });
+
+    it("disables unselected tags once the cap is reached, keeping selected ones clickable", () => {
+      renderBubble(
+        botAnswer({
+          feedbackRating: -1,
+          feedbackTags: ["inaccurate", "incomplete", "irrelevant", "outdated"],
+        }),
+        handlers(),
+      );
+
+      expect(screen.getByRole("button", { name: "Too slow" })).toBeDisabled();
+      // Still removable, otherwise the user is stuck at the cap.
+      expect(screen.getByRole("button", { name: "Outdated" })).toBeEnabled();
+    });
+
+    it("hides tags when the socket is closed (no handler passed)", () => {
+      renderBubble(botAnswer({ feedbackRating: -1 }), {
+        onThumbsUp: vi.fn(),
+        onThumbsDown: vi.fn(),
+      });
+
+      expect(screen.queryByText("What went wrong?")).not.toBeInTheDocument();
+    });
+  });
 });

--- a/apps/customer-portal/webapp/src/features/support/constants/feedbackTags.ts
+++ b/apps/customer-portal/webapp/src/features/support/constants/feedbackTags.ts
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+ * Predefined reason tags offered after rating a Novera answer.
+ *
+ * Deliberately duplicated rather than fetched: the vocabulary changes rarely,
+ * and the backend is the authority — it validates against its own allow-list in
+ * `claude_chatbot/feedback_tags.py` and silently drops anything it does not
+ * recognise. So a client that drifts loses its tags, it cannot corrupt the data.
+ * Keep the slugs here in step with that file; the labels are ours alone.
+ */
+
+export interface FeedbackTagOption {
+  /** Wire value. Must match the backend allow-list exactly. */
+  slug: string;
+  /** What the customer reads. */
+  label: string;
+}
+
+export const NEGATIVE_FEEDBACK_TAGS: readonly FeedbackTagOption[] = [
+  { slug: "inaccurate", label: "Inaccurate" },
+  { slug: "incomplete", label: "Incomplete" },
+  { slug: "irrelevant", label: "Irrelevant" },
+  { slug: "outdated", label: "Outdated" },
+  { slug: "too_slow", label: "Too slow" },
+];
+
+export const POSITIVE_FEEDBACK_TAGS: readonly FeedbackTagOption[] = [
+  { slug: "accurate", label: "Accurate" },
+  { slug: "complete", label: "Complete" },
+  { slug: "clear", label: "Clear" },
+  { slug: "saved_time", label: "Saved time" },
+];
+
+/** Mirrors MAX_TAGS in claude_chatbot/feedback_tags.py — extra tags are dropped. */
+export const MAX_FEEDBACK_TAGS = 4;
+
+/** Prompt shown above the chips, which differs by rating. */
+export function feedbackTagPrompt(rating: 1 | -1): string {
+  return rating === 1 ? "What was good about it?" : "What went wrong?";
+}
+
+export function feedbackTagsFor(rating: 1 | -1): readonly FeedbackTagOption[] {
+  return rating === 1 ? POSITIVE_FEEDBACK_TAGS : NEGATIVE_FEEDBACK_TAGS;
+}

--- a/apps/customer-portal/webapp/src/features/support/pages/ConversationDetailsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/ConversationDetailsPage.tsx
@@ -497,8 +497,12 @@ export default function ConversationDetailsPage(): JSX.Element {
           const ackId = String(event.messageId ?? "");
           const ackRating =
             event.rating === 1 ? 1 : event.rating === -1 ? -1 : null;
-          // The server echoes what it actually stored, after dropping any tag
-          // it does not recognise — so adopt its list rather than ours.
+          // The server echoes what it actually stored, after dropping any tag it
+          // does not recognise — so adopt its list unconditionally. An absent
+          // `tags` field means it stored none (an older backend ignores the
+          // field entirely), so fall back to [] rather than keeping our
+          // optimistic value: showing chips as selected when nothing was saved
+          // tells the user something untrue.
           const ackTags = Array.isArray(event.tags)
             ? (event.tags as unknown[]).filter(
                 (t): t is string => typeof t === "string",
@@ -511,7 +515,7 @@ export default function ConversationDetailsPage(): JSX.Element {
                   ? {
                       ...m,
                       feedbackRating: ackRating,
-                      ...(ackTags ? { feedbackTags: ackTags } : {}),
+                      feedbackTags: ackTags ?? [],
                     }
                   : m,
               ),

--- a/apps/customer-portal/webapp/src/features/support/pages/ConversationDetailsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/ConversationDetailsPage.tsx
@@ -52,6 +52,7 @@ import type {
   ChatHistoryItem,
 } from "@features/support/types/conversations";
 import { ChatSender } from "@features/support/types/conversations";
+import { MAX_FEEDBACK_TAGS } from "@features/support/constants/feedbackTags";
 import ApiErrorState from "@components/error/ApiErrorState";
 import type { Message } from "@features/support/types/conversations";
 import ConversationKnowledgeRecommendations from "@features/support/components/knowledge-base/ConversationKnowledgeRecommendations";
@@ -496,11 +497,22 @@ export default function ConversationDetailsPage(): JSX.Element {
           const ackId = String(event.messageId ?? "");
           const ackRating =
             event.rating === 1 ? 1 : event.rating === -1 ? -1 : null;
+          // The server echoes what it actually stored, after dropping any tag
+          // it does not recognise — so adopt its list rather than ours.
+          const ackTags = Array.isArray(event.tags)
+            ? (event.tags as unknown[]).filter(
+                (t): t is string => typeof t === "string",
+              )
+            : undefined;
           if (ackId) {
             setNewMessages((prev) =>
               prev.map((m) =>
                 m.feedbackMessageId === ackId
-                  ? { ...m, feedbackRating: ackRating }
+                  ? {
+                      ...m,
+                      feedbackRating: ackRating,
+                      ...(ackTags ? { feedbackTags: ackTags } : {}),
+                    }
                   : m,
               ),
             );
@@ -619,7 +631,7 @@ export default function ConversationDetailsPage(): JSX.Element {
   const feedbackSeqRef = useRef<Map<string, number>>(new Map());
 
   const submitFeedback = useCallback(
-    (messageId: string, rating: 1 | -1) => {
+    (messageId: string, rating: 1 | -1, tags?: string[]) => {
       if (!projectId) return;
 
       // Mark this as the latest submission for the message. Clicking 👍 then
@@ -635,7 +647,11 @@ export default function ConversationDetailsPage(): JSX.Element {
         prev.map((m) => {
           if (m.feedbackMessageId !== messageId) return m;
           previousRating = m.feedbackRating ?? null;
-          return { ...m, feedbackRating: rating };
+          return {
+            ...m,
+            feedbackRating: rating,
+            ...(tags ? { feedbackTags: tags } : {}),
+          };
         }),
       );
 
@@ -647,6 +663,7 @@ export default function ConversationDetailsPage(): JSX.Element {
             rating,
             conversationId: conversationId ?? undefined,
             accountId: accountId || undefined,
+            ...(tags ? { tags } : {}),
           }),
         )
         .catch(() => {
@@ -661,6 +678,28 @@ export default function ConversationDetailsPage(): JSX.Element {
         });
     },
     [accountId, connect, conversationId, projectId, sendUserMessage],
+  );
+
+  /**
+   * Toggle a reason tag on an answer that has already been rated. Re-sends the
+   * same feedback event with the new list — the backend upserts on
+   * (conversation, message), so this replaces rather than accumulating rows.
+   * Capped client-side at MAX_FEEDBACK_TAGS; the server enforces the same limit.
+   */
+  const handleFeedbackTag = useCallback(
+    (messageId: string, tag: string) => {
+      const msg = newMessages.find((m) => m.feedbackMessageId === messageId);
+      if (!msg?.feedbackRating) return;
+      const current = msg.feedbackTags ?? [];
+      const next = current.includes(tag)
+        ? current.filter((t) => t !== tag)
+        : current.length >= MAX_FEEDBACK_TAGS
+          ? current
+          : [...current, tag];
+      if (next === current) return;
+      submitFeedback(messageId, msg.feedbackRating, next);
+    },
+    [newMessages, submitFeedback],
   );
 
   const handleThumbsUp = useCallback(
@@ -898,6 +937,7 @@ export default function ConversationDetailsPage(): JSX.Element {
                         message={m}
                         onThumbsUp={isConnected ? handleThumbsUp : undefined}
                         onThumbsDown={isConnected ? handleThumbsDown : undefined}
+                        onFeedbackTag={isConnected ? handleFeedbackTag : undefined}
                       />
                     ),
                   )}

--- a/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
@@ -60,6 +60,7 @@ import { htmlToPlainText } from "@features/support/utils/richTextEditor";
 import { usePiiGuard } from "@features/support/hooks/usePiiGuard";
 import PiiWarningDialog from "@features/support/components/dialogs/PiiWarningDialog";
 import { ChatSender } from "@features/support/types/conversations";
+import { MAX_FEEDBACK_TAGS } from "@features/support/constants/feedbackTags";
 import type {
   ChatNavState,
   Message,
@@ -614,11 +615,22 @@ export default function NoveraChatPage(): JSX.Element {
           const ackId = String(event.messageId ?? "");
           const ackRating =
             event.rating === 1 ? 1 : event.rating === -1 ? -1 : null;
+          // The server echoes what it actually stored, after dropping any tag
+          // it does not recognise — so adopt its list rather than ours.
+          const ackTags = Array.isArray(event.tags)
+            ? (event.tags as unknown[]).filter(
+                (t): t is string => typeof t === "string",
+              )
+            : undefined;
           if (ackId) {
             setMessages((prev) =>
               prev.map((m) =>
                 m.feedbackMessageId === ackId
-                  ? { ...m, feedbackRating: ackRating }
+                  ? {
+                      ...m,
+                      feedbackRating: ackRating,
+                      ...(ackTags ? { feedbackTags: ackTags } : {}),
+                    }
                   : m,
               ),
             );
@@ -745,7 +757,7 @@ export default function NoveraChatPage(): JSX.Element {
   const feedbackSeqRef = useRef<Map<string, number>>(new Map());
 
   const submitFeedback = useCallback(
-    (messageId: string, rating: 1 | -1) => {
+    (messageId: string, rating: 1 | -1, tags?: string[]) => {
       if (!projectId) return;
 
       // Mark this as the latest submission for the message. Clicking 👍 then
@@ -761,7 +773,11 @@ export default function NoveraChatPage(): JSX.Element {
         prev.map((m) => {
           if (m.feedbackMessageId !== messageId) return m;
           previousRating = m.feedbackRating ?? null;
-          return { ...m, feedbackRating: rating };
+          return {
+            ...m,
+            feedbackRating: rating,
+            ...(tags ? { feedbackTags: tags } : {}),
+          };
         }),
       );
 
@@ -773,6 +789,7 @@ export default function NoveraChatPage(): JSX.Element {
             rating,
             conversationId: conversationId ?? undefined,
             accountId: accountId || undefined,
+            ...(tags ? { tags } : {}),
           }),
         )
         .catch(() => {
@@ -787,6 +804,28 @@ export default function NoveraChatPage(): JSX.Element {
         });
     },
     [accountId, connect, conversationId, projectId, sendUserMessage],
+  );
+
+  /**
+   * Toggle a reason tag on an answer that has already been rated. Re-sends the
+   * same feedback event with the new list — the backend upserts on
+   * (conversation, message), so this replaces rather than accumulating rows.
+   * Capped client-side at MAX_FEEDBACK_TAGS; the server enforces the same limit.
+   */
+  const handleFeedbackTag = useCallback(
+    (messageId: string, tag: string) => {
+      const msg = messages.find((m) => m.feedbackMessageId === messageId);
+      if (!msg?.feedbackRating) return;
+      const current = msg.feedbackTags ?? [];
+      const next = current.includes(tag)
+        ? current.filter((t) => t !== tag)
+        : current.length >= MAX_FEEDBACK_TAGS
+          ? current
+          : [...current, tag];
+      if (next === current) return;
+      submitFeedback(messageId, msg.feedbackRating, next);
+    },
+    [messages, submitFeedback],
   );
 
   const handleThumbsUp = useCallback(
@@ -885,6 +924,7 @@ export default function NoveraChatPage(): JSX.Element {
               onCreateCase={handleCreateCase}
               onThumbsUp={isConnected ? handleThumbsUp : undefined}
               onThumbsDown={isConnected ? handleThumbsDown : undefined}
+            onFeedbackTag={isConnected ? handleFeedbackTag : undefined}
               onSolutionWorked={handleSolutionWorked}
               onRequestTokenIncrease={
                 tokenRequestEnabled

--- a/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
@@ -615,8 +615,12 @@ export default function NoveraChatPage(): JSX.Element {
           const ackId = String(event.messageId ?? "");
           const ackRating =
             event.rating === 1 ? 1 : event.rating === -1 ? -1 : null;
-          // The server echoes what it actually stored, after dropping any tag
-          // it does not recognise — so adopt its list rather than ours.
+          // The server echoes what it actually stored, after dropping any tag it
+          // does not recognise — so adopt its list unconditionally. An absent
+          // `tags` field means it stored none (an older backend ignores the
+          // field entirely), so fall back to [] rather than keeping our
+          // optimistic value: showing chips as selected when nothing was saved
+          // tells the user something untrue.
           const ackTags = Array.isArray(event.tags)
             ? (event.tags as unknown[]).filter(
                 (t): t is string => typeof t === "string",
@@ -629,7 +633,7 @@ export default function NoveraChatPage(): JSX.Element {
                   ? {
                       ...m,
                       feedbackRating: ackRating,
-                      ...(ackTags ? { feedbackTags: ackTags } : {}),
+                      feedbackTags: ackTags ?? [],
                     }
                   : m,
               ),

--- a/apps/customer-portal/webapp/src/features/support/types/conversations.ts
+++ b/apps/customer-portal/webapp/src/features/support/types/conversations.ts
@@ -216,6 +216,8 @@ export type Message = {
   feedbackMessageId?: string;
   /** The rating the user has given this answer, if any (+1 up / -1 down). */
   feedbackRating?: 1 | -1 | null;
+  /** Reason tags chosen alongside the rating. Slugs, not labels. */
+  feedbackTags?: string[];
   isLoading?: boolean;
   isError?: boolean;
   slotState?: SlotState;

--- a/apps/customer-portal/webapp/src/features/support/types/supportComponents.ts
+++ b/apps/customer-portal/webapp/src/features/support/types/supportComponents.ts
@@ -533,6 +533,8 @@ export type ChatMessageListProps = {
   onCreateCase?: () => void;
   onThumbsUp?: (messageId: string) => void;
   onThumbsDown?: (messageId: string) => void;
+  /** Toggle a reason tag on an already-rated answer. */
+  onFeedbackTag?: (messageId: string, tag: string) => void;
   onFetchOlder?: () => void;
   isFetchingOlder?: boolean;
   onSolutionWorked?: () => void;
@@ -545,6 +547,8 @@ export type ChatMessageBubbleProps = {
   onCreateCase?: () => void;
   onThumbsUp?: (messageId: string) => void;
   onThumbsDown?: (messageId: string) => void;
+  /** Toggle a reason tag on an already-rated answer. */
+  onFeedbackTag?: (messageId: string, tag: string) => void;
   onSolutionWorked?: () => void;
   /** When provided, usage-limit error bubbles show a "request token increase" CTA. */
   onRequestTokenIncrease?: () => void;


### PR DESCRIPTION
## What

Customer-portal side of the feedback **reason tags**. Follows #1401 (which added the 👍/👎 itself). The backend and dashboard half is `wso2-enterprise/digiops-cs#2714`.

A bare 👍/👎 records that an answer was good or bad but not *why*. After rating, the customer gets one-click reason chips:

| | |
| --- | --- |
| 👎 | Inaccurate · Incomplete · Irrelevant · Outdated · Too slow |
| 👍 | Accurate · Complete · Clear · Saved time |

## Design decisions worth reviewing

**Chips appear only after a rating exists.** The vote is the signal we most want, and it is already saved by the time the chips render — so giving it is never blocked by a second decision. Tagging is genuinely optional.

**Gated on the same `isConnected` check as the thumbs**, so they disappear with them when the socket closes. Feedback travels on the socket; a chip without one is a broken affordance.

**Selecting re-sends the same `feedback` event** with the new list. The backend upserts on (conversation, message), so this replaces rather than accumulating rows. `feedback_ack` echoes what was actually stored and we adopt **the server's list**, not ours — it drops anything it does not recognise, and the UI should reflect reality.

**At the cap (4, matching the server), unselected chips disable while selected ones stay clickable.** Otherwise a user who picked four could not correct a mistake. Making the limit visible beats silently dropping the extra server-side.

**The vocabulary is duplicated, not fetched.** `constants/feedbackTags.ts` mirrors `claude_chatbot/feedback_tags.py`. It changes rarely, and the backend validates against its own allow-list — so a client that drifts loses its tags but cannot corrupt the data. Both files carry a comment pointing at the other. The alternative (an endpoint) adds a request for data that changes once a year, and you specifically did not want new endpoints for the portal.

Built with `Button` rather than `Chip` — oxygen-ui 0.6.0 does not export one.

## Testing

`tsc --noEmit` clean. `ChatMessageBubble` tests **16 passed**, including 6 new ones covering:

- no chips before a rating
- correct per-rating vocabulary, and no leakage between the two sets
- the slug reported to the handler, and `aria-pressed`
- the cap disabling unselected chips while leaving selected ones enabled
- chips hidden when the socket is closed

`src/features/support` is unchanged at **49 pre-existing failures** across 16 files — identical to clean `origin/main`, verified by running the same suite on both. 394 passing vs 388, the 6 extra being these tests.

## Dependency

Needs `digiops-cs#2714` for the backend to store the tags. Until that merges the `tags` field is sent and ignored — harmless, but not verifiable end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added selectable feedback reasons for rated Novera answers.
  * Displays rating-specific positive or negative reason tags after feedback is submitted.
  * Supports selecting and deselecting up to four feedback tags.
  * Preserves selected feedback reasons when conversation responses are refreshed.

* **Bug Fixes**
  * Improved synchronization of feedback ratings and selected reasons with saved conversation data.

* **Tests**
  * Added coverage for tag visibility, rating-specific options, selection behavior, limits, and callback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->