### PR TITLE
fix(support): recover the chat composer when the socket drops mid-send

### DIFF
--- a/apps/customer-portal/webapp/src/features/support/pages/ConversationDetailsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/ConversationDetailsPage.tsx
@@ -336,6 +336,14 @@ export default function ConversationDetailsPage(): JSX.Element {
   const [inputValue, setInputValueState] = useState("");
   const [resetTrigger, setResetTrigger] = useState(0);
   const [isSending, setIsSending] = useState(false);
+  // Mirrors isSending for the socket's onClose handler. The hook installs
+  // ws.onclose during connect(), so that closure captures the options object
+  // from whichever render connected — reading isSending directly there would
+  // see a stale value. A ref is always current.
+  const isSendingRef = useRef(false);
+  useEffect(() => {
+    isSendingRef.current = isSending;
+  }, [isSending]);
   const [isInputDisabled, setIsInputDisabled] = useState(false);
   const [newMessages, setNewMessages] = useState<Message[]>([]);
   const inputValueRef = useRef("");
@@ -548,6 +556,27 @@ export default function ConversationDetailsPage(): JSX.Element {
         isLoading: false,
         isError: true,
         text: "WebSocket connection error.",
+        thinkingSteps: [],
+        isStreaming: false,
+      }));
+      setIsSending(false);
+    },
+    // A close is not always an error — the socket can drop mid-exchange (gateway
+    // timeout, upstream reset) without onerror ever firing. Nothing else clears
+    // isSending, and both send paths are guarded by it, so leaving it set makes
+    // the composer permanently dead: the hook reconnects, isConnected flips back
+    // to true, and every later message is silently swallowed with the typing
+    // indicator still spinning. Recover only if a send was actually in flight,
+    // so an idle close does not mark a finished answer as failed.
+    onClose: () => {
+      if (!isSendingRef.current) return;
+      pendingFinalRef.current = null;
+      tokenQueueRef.current = [];
+      upsertActiveBotMessage((msg) => ({
+        ...msg,
+        isLoading: false,
+        isError: true,
+        text: "Connection lost before the answer arrived. Please try again.",
         thinkingSteps: [],
         isStreaming: false,
       }));

--- a/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
@@ -396,6 +396,14 @@ export default function NoveraChatPage(): JSX.Element {
   const piiGuard = usePiiGuard();
   const [resetTrigger, setResetTrigger] = useState(0);
   const [isSending, setIsSending] = useState(false);
+  // Mirrors isSending for the socket's onClose handler. The hook installs
+  // ws.onclose during connect(), so that closure captures the options object
+  // from whichever render connected — reading isSending directly there would
+  // see a stale value. A ref is always current.
+  const isSendingRef = useRef(false);
+  useEffect(() => {
+    isSendingRef.current = isSending;
+  }, [isSending]);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const activeBotMessageIdRef = useRef<string | null>(null);
   const initialMessageSentRef = useRef(false);
@@ -666,6 +674,27 @@ export default function NoveraChatPage(): JSX.Element {
         isLoading: false,
         isError: true,
         text: "WebSocket connection error.",
+        thinkingSteps: [],
+        isStreaming: false,
+      }));
+      setIsSending(false);
+    },
+    // A close is not always an error — the socket can drop mid-exchange (gateway
+    // timeout, upstream reset) without onerror ever firing. Nothing else clears
+    // isSending, and both send paths are guarded by it, so leaving it set makes
+    // the composer permanently dead: the hook reconnects, isConnected flips back
+    // to true, and every later message is silently swallowed with the typing
+    // indicator still spinning. Recover only if a send was actually in flight,
+    // so an idle close does not mark a finished answer as failed.
+    onClose: () => {
+      if (!isSendingRef.current) return;
+      pendingFinalRef.current = null;
+      tokenQueueRef.current = [];
+      upsertActiveBotMessage((msg) => ({
+        ...msg,
+        isLoading: false,
+        isError: true,
+        text: "Connection lost before the answer arrived. Please try again.",
         thinkingSteps: [],
         isStreaming: false,
       }));


### PR DESCRIPTION
## Symptom

The chat gets **permanently stuck**: typing indicator spinning forever, every subsequent message silently doing nothing. Reconnecting does not help, and the UI gives no indication anything is wrong.

## This is a frontend bug, not a backend one

From staging logs — the socket closes ~1s after each answer, and the *next* connection carries no traffic at all:

```
11:40:13  INFO:  connection open
          (nothing after this — no "Session created", no "User: ...")
```

The server logs both of those for every `user_message` it receives — it does exactly that at 11:36:34 and 11:39:40, answering in 3.8s and 3.3s. Neither line appears here, so **the portal never put the message on the wire.**

## Cause

`useChatWebSocket` fires `options.onClose` on `ws.onclose`:

```ts
ws.onclose = (event) => {
  setIsConnected(false);
  connectPromiseRef.current = null;
  options.onClose?.();      // <- nobody was listening
  ...
};
```

**Neither chat page supplied an `onClose`.** And `onerror` does *not* fire for an ordinary close, so `onError` — the only thing that resets `isSending` on a transport failure — never ran.

Both send paths are guarded by `isSending`:

```ts
if (isSending) return;                                // handleSend
if (!text || isSending || !projectId) return false;   // submit
```

So once a close landed mid-exchange, `isSending` stayed `true` forever and the composer was dead for good — while `isConnected` flipped back to `true` on reconnect, so everything looked healthy.

## Fix

Handle `onClose` on both pages: fail the in-flight answer and clear `isSending`, so the next message sends.

Guarded on `isSendingRef.current` so it only fires when a send was actually in flight — an idle close (navigating away, tab backgrounded) must not mark a finished answer as failed.

`isSending` is mirrored into a ref because the hook installs `ws.onclose` **inside `connect()`**, so that closure captures the `options` object from whichever render connected. Reading the state directly there would see a stale value from that render.

## Scope

This makes the UI *recover* from a mid-send close. It does not stop the close happening — something is still terminating the socket ~1s after each answer (gateway logs `upstream_reset_after_response_started`). Users will now see "Connection lost before the answer arrived. Please try again." and can retry, instead of a silent permanent freeze. The close itself is worth chasing separately.

## Verification

- `npx tsc --noEmit` → clean
- `npx eslint` on both changed files → clean, including `react-hooks/exhaustive-deps`
- `npx vitest run src/features/support` → 49 failed / 394 passed, **exactly the pre-existing baseline** on clean `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved chat recovery when the connection closes during an active response.
  - In-progress responses are now cleared and marked as failed instead of remaining stuck.
  - Idle connection closures are ignored, preventing unnecessary error states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->