### PR TITLE
fix(customer-portal): stop a rating from jamming the chat WebSocket

### DIFF
--- a/apps/customer-portal/backend/modules/ai_chat_agent/ai_chat_agent.bal
+++ b/apps/customer-portal/backend/modules/ai_chat_agent/ai_chat_agent.bal
@@ -162,7 +162,13 @@ public isolated function streamChat(string sessionId, string payload, websocket:
 public isolated function sendSideChannelMessage(string sessionId, string payload,
         websocket:Caller caller) returns error? {
     websocket:Client agentClient = check createAiChatAgentWsClient(sessionId, SIDE_CHANNEL_READ_TIMEOUT);
-    check agentClient->writeTextMessage(payload);
+    // Not `check`: returning straight out of here would leave the connection we
+    // just opened dangling, which is the very thing this function exists to stop.
+    error? upstreamWriteErr = agentClient->writeTextMessage(payload);
+    if upstreamWriteErr is error {
+        closeUpstream(agentClient);
+        return upstreamWriteErr;
+    }
     boolean upstreamClosed = false;
     while true {
         string|error event = agentClient->readTextMessage();
@@ -196,10 +202,20 @@ public isolated function sendSideChannelMessage(string sessionId, string payload
         }
     }
     if !upstreamClosed {
-        error? closeErr = agentClient->close(1000, "acknowledged");
-        if closeErr is error {
-            log:printError("Failed to close upstream WebSocket connection", closeErr);
-        }
+        closeUpstream(agentClient);
     }
     return;
+}
+
+# Close a side-channel upstream connection, logging rather than raising if the
+# close itself fails. Every exit path from sendSideChannelMessage goes through
+# here, and each reaches it at most once, so the connection is always released
+# and never closed twice.
+#
+# + agentClient - The upstream AI chat agent connection to release
+isolated function closeUpstream(websocket:Client agentClient) {
+    error? closeErr = agentClient->close(1000, "acknowledged");
+    if closeErr is error {
+        log:printError("Failed to close upstream WebSocket connection", closeErr);
+    }
 }

--- a/apps/customer-portal/backend/modules/ai_chat_agent/ai_chat_agent.bal
+++ b/apps/customer-portal/backend/modules/ai_chat_agent/ai_chat_agent.bal
@@ -144,3 +144,62 @@ public isolated function streamChat(string sessionId, string payload, websocket:
     }
     return finalPayload;
 }
+
+# Forward a side-channel message — an answer rating, or a token-increase request —
+# to the upstream agent and pipe events back until it acknowledges.
+#
+# Deliberately separate from streamChat. These are not chat turns: the agent
+# answers them with a "*_ack" and never sends a "final". Routing them through
+# streamChat left it reading for an event that could not arrive, holding the
+# caller's streaming lock until the connection gave out — so the customer's next
+# real message was rejected with "A response is already being streamed" and never
+# forwarded upstream at all. The rating persisted; the conversation was dead.
+#
+# + sessionId - Conversation/session ID used to route to the upstream Python session
+# + payload - Raw JSON string (feedback or token_increase_request) to forward
+# + caller - The browser WebSocket caller to forward the acknowledgement back to
+# + return - Error if the upstream connection could not be opened or written to
+public isolated function sendSideChannelMessage(string sessionId, string payload,
+        websocket:Caller caller) returns error? {
+    websocket:Client agentClient = check createAiChatAgentWsClient(sessionId, SIDE_CHANNEL_READ_TIMEOUT);
+    check agentClient->writeTextMessage(payload);
+    boolean upstreamClosed = false;
+    while true {
+        string|error event = agentClient->readTextMessage();
+        if event is error {
+            if event is websocket:ConnectionClosureError {
+                upstreamClosed = true;
+            } else {
+                // Includes the read timeout. The rating may well have been stored
+                // — the write succeeded — so this is logged, not surfaced as a
+                // failure to the customer.
+                log:printError("Error reading acknowledgement from upstream AI chat agent", event);
+            }
+            break;
+        }
+        error? writeErr = caller->writeTextMessage(event);
+        if writeErr is error {
+            log:printError("Failed to forward acknowledgement to caller (client disconnected)", writeErr);
+            break;
+        }
+        json|error parsed = event.fromJsonString();
+        if parsed is error {
+            log:printError("Failed to parse upstream event as JSON", parsed);
+            continue;
+        }
+        if parsed is map<json> {
+            string evtType = (parsed[EVENT_TYPE_KEY] ?: "").toString();
+            if evtType == EVENT_FEEDBACK_ACK || evtType == EVENT_TOKEN_REQUEST_ACK
+                || evtType == EVENT_ERROR {
+                break;
+            }
+        }
+    }
+    if !upstreamClosed {
+        error? closeErr = agentClient->close(1000, "acknowledged");
+        if closeErr is error {
+            log:printError("Failed to close upstream WebSocket connection", closeErr);
+        }
+    }
+    return;
+}

--- a/apps/customer-portal/backend/modules/ai_chat_agent/client.bal
+++ b/apps/customer-portal/backend/modules/ai_chat_agent/client.bal
@@ -39,10 +39,15 @@ final http:Client aiChatAgentClient = check new (aiChatAgentBaseUrl, {
     }
 });
 
-isolated function createAiChatAgentWsClient(string sessionId) returns websocket:Client|error {
-    return new (string `${aiChatAgentWsBaseUrl}/ws?sessionId=${sessionId}`, {
+isolated function createAiChatAgentWsClient(string sessionId, decimal? readTimeout = ())
+        returns websocket:Client|error {
+    websocket:ClientConfiguration config = {
         auth: {
             ...clientCredentialsOauth2ConfigWs
         }
-    });
+    };
+    if readTimeout is decimal {
+        config.readTimeout = readTimeout;
+    }
+    return new (string `${aiChatAgentWsBaseUrl}/ws?sessionId=${sessionId}`, config);
 }

--- a/apps/customer-portal/backend/modules/ai_chat_agent/constants.bal
+++ b/apps/customer-portal/backend/modules/ai_chat_agent/constants.bal
@@ -25,3 +25,22 @@ const string EVENT_TYPE_KEY = "type";
 
 # JSON key for the payload field in the final upstream WebSocket event.
 const string EVENT_PAYLOAD_KEY = "payload";
+
+# WebSocket event acknowledging a stored answer rating.
+const string EVENT_FEEDBACK_ACK = "feedback_ack";
+
+# WebSocket event acknowledging a token-increase request.
+const string EVENT_TOKEN_REQUEST_ACK = "token_request_ack";
+
+# Inbound message type carrying a thumbs up/down on an answer.
+public const string MSG_TYPE_FEEDBACK = "feedback";
+
+# Inbound message type asking support to raise a token limit.
+public const string MSG_TYPE_TOKEN_INCREASE_REQUEST = "token_increase_request";
+
+# How long to wait for a side-channel acknowledgement before giving up.
+#
+# The upstream answers these in well under a second. A bound matters because the
+# alternative is an upstream connection parked indefinitely: the websocket client
+# is otherwise created with no read timeout at all.
+const decimal SIDE_CHANNEL_READ_TIMEOUT = 30.0;

--- a/apps/customer-portal/backend/service.bal
+++ b/apps/customer-portal/backend/service.bal
@@ -6887,6 +6887,46 @@ isolated service class WsProxyService {
             check caller->writeTextMessage(string `{"type":"pong","ts":${ts}}`);
             return;
         }
+
+        // Side-channel messages: an answer rating, or a request to raise a token
+        // limit. Handled before everything below, because none of it applies to
+        // them and all of it causes harm:
+        //
+        //   - the streaming lock: the agent answers these with a "*_ack" and
+        //     never a "final", so the chat-turn path held the lock until the
+        //     upstream connection gave out. The customer's next message was then
+        //     rejected with "a response is already being streamed" and never
+        //     forwarded — the chat looked dead while the socket was fine.
+        //   - conversation creation: a rating carries no "message", so a rating
+        //     arriving before the id was known minted a conversation with an
+        //     empty initial message.
+        //   - the post-stream bookkeeping: persisting the "user query" and
+        //     updating conversation state makes no sense for a rating.
+        string inboundType = parsed is map<json> ? (parsed["type"] ?: "").toString() : "";
+        if inboundType == ai_chat_agent:MSG_TYPE_FEEDBACK
+            || inboundType == ai_chat_agent:MSG_TYPE_TOKEN_INCREASE_REQUEST {
+            string sideChannelConvId;
+            lock {
+                sideChannelConvId = self.conversationId ?: "";
+            }
+            if sideChannelConvId.length() == 0 {
+                // Fall back to the id the client names. It knows which answer it
+                // is rating even when this connection has not carried a turn yet.
+                sideChannelConvId = parsed is map<json>
+                    ? (parsed["conversationId"] ?: "").toString() : "";
+            }
+            if sideChannelConvId.length() == 0 {
+                log:printError(string `Discarding ${inboundType}: no conversation id available`);
+                return;
+            }
+            error? sideChannelErr = ai_chat_agent:sendSideChannelMessage(
+                    string `${self.projectId}:${sideChannelConvId}`, data, caller);
+            if sideChannelErr is error {
+                log:printError(string `Failed to forward ${inboundType} upstream`, sideChannelErr);
+            }
+            return;
+        }
+
         boolean alreadyStreaming;
         lock {
             alreadyStreaming = self.streaming;


### PR DESCRIPTION
## Symptom

Rating an answer killed the conversation. The rating itself worked — the customer saw the acknowledgement — but the next message got **no reply**, and the chat stayed dead for minutes.

The chatbot logged **nothing at all** for that next message. Not a stall, not an error — it never arrived.

## Root cause: the rating holds the streaming lock

[`onMessage`](apps/customer-portal/backend/service.bal#L6880) special-cases only `ping`, and puts everything else through the chat-turn path:

```ballerina
lock { alreadyStreaming = self.streaming;
       if !alreadyStreaming { self.streaming = true; } }
if alreadyStreaming {
    caller->writeTextMessage({"type":"error","message":"A response is already being streamed..."});
    return;                                   // ← never forwarded upstream
}
result = ai_chat_agent:streamChat(sessionId, enrichedPayload, caller);
```

And `streamChat` exits on exactly two events:

```ballerina
if evtType == EVENT_FINAL { break; }
if evtType == EVENT_ERROR { break; }
```

A rating is answered with **`feedback_ack`** — neither. So:

1. `feedback` arrives → `self.streaming = true`.
2. `streamChat` forwards the ack to the browser. **This is why the customer sees it work.**
3. The loop reads on, waiting for a `final` that cannot come. The websocket client is created with **no read timeout**, so nothing bounds that wait.
4. The next real message hits the "already being streamed" branch and returns — **never forwarded upstream**.

From the browser the socket looks fine. From the chatbot, nothing happened. `token_increase_request` has the identical shape (`token_request_ack`) and the identical result.

### Everything this accounts for

| Observation | Cause |
|---|---|
| `feedback_ack` arrives normally | step 2 |
| Next message never reaches the chatbot, zero logs | step 4 |
| Chat recovers on its own after minutes | the upstream connection finally gives out, releasing the lock |
| Choreo `upstream_reset_after_response_started`, `Duration=100528` / `866637` | upstream connections parked in step 3 |

## Fix

Handle both side-channel types **before any of the chat-turn machinery** — none of it applies to them, and each part does harm:

- **the streaming lock** — per above;
- **conversation creation** — a rating carries no `message`, so one arriving before the conversation id was known created a conversation with an *empty* initial message;
- **the post-stream bookkeeping** — persisting the "user query" and updating conversation state is meaningless for a rating.

New `sendSideChannelMessage()` forwards the frame and returns on the matching ack, and gives that upstream client a **30s read timeout** so a missing ack can never park a connection again.

## Why the fix is here and not in the chatbot

I ran the chatbot locally against real Redis and Postgres and drove the exact frame sequence:

```
1. user_message 'hi'             -> [thinking_start, error, thinking_end, final]
2. feedback                      -> [feedback_ack]
3. user_message AFTER feedback   -> [thinking_start, error, thinking_end, final]
```

The agent handles it correctly. Nothing sat between the frames in that test — this proxy is what sits between them in staging.

## Verification

`bal build` clean against Swan Lake Update 13.1 (`Dependencies.toml` churn from the build reverted, so the diff is only the fix).

Not covered locally: this needs a staging smoke test — rate an answer, then send another message and confirm it replies immediately rather than after a multi-minute stall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for sending feedback and token-increase requests through a dedicated real-time channel.
  * Side-channel requests now receive upstream acknowledgements or errors.
  * Added handling for active session and message-based conversation identification.

* **Bug Fixes**
  * Side-channel requests no longer interrupt or interfere with normal chat streaming.
  * Added handling for connection failures, timeouts, and invalid requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->