### PR TITLE
csm-portal: add exact-match caseNumber/wso2CaseId case search filters

### DIFF
--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -5271,6 +5271,8 @@ components:
             - taskSLABusinessElapsedPercent
             - escalationLevel
             - escalation
+            - number
+            - internalId
         op:
           type: string
           enum: [eq, in, notIn, isEmpty, isNotEmpty, gte, lte]
@@ -5358,6 +5360,12 @@ components:
         - **escalation** (isEmpty / isNotEmpty): values ignored; isEmpty
           matches cases with no active escalation, isNotEmpty matches cases
           with an active escalation.
+        - **number** (eq): a single case number (e.g. "CS0441174"); matches
+          exactly. Routed as a first-class filter rather than through the
+          free-text searchQuery scan.
+        - **internalId** (eq): a single WSO2 case id; matches exactly. Routed
+          as a first-class filter rather than through the free-text
+          searchQuery scan.
 
     CaseSearchFilters:
       type: object
@@ -8094,6 +8102,12 @@ components:
               type: string
               format: date-time
               description: Filter change requests closed on or before this UTC datetime (optional)
+            number:
+              type: string
+              description: >-
+                A single change request number (e.g. "CHG0010001"); matches
+                exactly. Routed as a first-class filter rather than through
+                the free-text searchQuery scan.
         sortBy:
           type: object
           properties:
@@ -9305,6 +9319,12 @@ components:
               items:
                 type: string
                 format: uuid
+            number:
+              type: string
+              description: >-
+                A single incident number (e.g. "INC0010001"); matches
+                exactly. Routed as a first-class filter rather than through
+                the free-text searchQuery scan.
         sortBy:
           type: object
           properties:
@@ -9755,6 +9775,12 @@ components:
           properties:
             searchQuery:
               type: string
+            number:
+              type: string
+              description: >-
+                A single problem number (e.g. "PRB0010001"); matches exactly.
+                Routed as a first-class filter rather than through the
+                free-text searchQuery scan.
         pagination:
           allOf:
             - $ref: '#/components/schemas/Pagination'

--- a/apps/csm-portal/webapp/src/App.tsx
+++ b/apps/csm-portal/webapp/src/App.tsx
@@ -180,7 +180,14 @@ const CsmAnnouncementsPage = lazy(
 function RootLanding(): JSX.Element | null {
   const pending = sessionStorage.getItem(POST_LOGIN_REDIRECT_KEY);
   const [searchParams] = useSearchParams();
-  const hasDeepLinkSearch = searchParams.has("goto") || searchParams.has("q");
+  // A present-but-empty `?q=`/`?goto=` (e.g. a link with a blank query) must
+  // not defer the redirect forever: QuickNav's own initial-params effect
+  // already no-ops on an empty value (`if (!q && !goto) return`), so nothing
+  // would ever clear the param and this component would sit blank
+  // indefinitely on `.has()` alone. Require an actual non-blank value.
+  const hasDeepLinkSearch = ["goto", "q"].some((key) =>
+    Boolean(searchParams.get(key)?.trim()),
+  );
   return pending || hasDeepLinkSearch ? null : <Navigate to="/dashboard" replace />;
 }
 

--- a/apps/csm-portal/webapp/src/App.tsx
+++ b/apps/csm-portal/webapp/src/App.tsx
@@ -15,7 +15,15 @@
 // under the License.
 
 import { type JSX, lazy } from "react";
-import { Navigate, Outlet, Route, Routes, useLocation, useParams } from "react-router";
+import {
+  Navigate,
+  Outlet,
+  Route,
+  Routes,
+  useLocation,
+  useParams,
+  useSearchParams,
+} from "react-router";
 import AuthGuard from "@layouts/AuthGuard";
 import { SectionIndexRedirect } from "@components/section-tabs/SectionTabs";
 import { navNodeForPath } from "@config/csmNavItems";
@@ -152,13 +160,28 @@ const CsmAnnouncementsPage = lazy(
 
 /**
  * Landing for `/`. Defers to AuthGuard's post-login deep-link restore when a
- * redirect is pending (rendering nothing so it doesn't race the restore);
- * otherwise sends the user to the default `/dashboard` landing. A pure read of
- * sessionStorage — AuthGuard owns clearing the key.
+ * redirect is pending (rendering nothing so it doesn't race the restore).
+ *
+ * Also defers — rendering nothing rather than navigating to `/dashboard` —
+ * while a `?goto=`/`?q=` deep link is still being resolved by `QuickNav`
+ * (mounted in the persistent header, above this route's `Outlet`). Without
+ * this, `/?goto=CS0441150` would navigate straight to `/dashboard` and start
+ * fetching every dashboard widget in the background, purely to sit behind
+ * the search palette while it resolves — wasted work for a link whose whole
+ * point is to jump straight to one record. `QuickNav` clears `goto`/`q` from
+ * the URL itself once it actually navigates away (the single-match case) or
+ * once the user closes the palette without picking anything (see its
+ * `close()`); either way, this component naturally proceeds to the normal
+ * `/dashboard` redirect on its next render once the params are gone.
+ *
+ * A pure read of sessionStorage/search params — AuthGuard and QuickNav own
+ * clearing their respective keys.
  */
 function RootLanding(): JSX.Element | null {
   const pending = sessionStorage.getItem(POST_LOGIN_REDIRECT_KEY);
-  return pending ? null : <Navigate to="/dashboard" replace />;
+  const [searchParams] = useSearchParams();
+  const hasDeepLinkSearch = searchParams.has("goto") || searchParams.has("q");
+  return pending || hasDeepLinkSearch ? null : <Navigate to="/dashboard" replace />;
 }
 
 /**

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -801,7 +801,9 @@ export type BeCaseFieldFilterField =
   | "parentId"
   | "taskSLABusinessElapsedPercent"
   | "escalationLevel"
-  | "escalation";
+  | "escalation"
+  | "number"
+  | "internalId";
 
 /**
  * `op` enum accepted by {@link BeCaseFieldFilter}, independent of `field` —
@@ -2210,6 +2212,12 @@ export interface BeChangeRequestSearchPayload {
     impacts?: BeChangeRequestImpact[];
     closedStartDate?: string;
     closedEndDate?: string;
+    /**
+     * A single change request number (e.g. "CHG0038721"); matches exactly.
+     * Routed as a first-class filter rather than through the free-text
+     * searchQuery scan.
+     */
+    number?: string;
   };
   sortBy?: {
     field?: "createdOn" | "updatedOn";
@@ -2458,6 +2466,12 @@ export interface BeIncidentSearchPayload {
      * categories — filtering by this misses roughly half of all incidents.
      */
     productNames?: string[];
+    /**
+     * A single incident number (e.g. "INC0090472"); matches exactly. Routed
+     * as a first-class filter rather than through the free-text searchQuery
+     * scan.
+     */
+    number?: string;
   };
   sortBy?: {
     field?: "createdOn" | "updatedOn" | "openedOn";
@@ -2523,6 +2537,11 @@ export interface BeProblemSearchFilters {
    * control from `ProblemsFilterBar`.
    */
   states?: BeProblemState[];
+  /**
+   * A single problem number (e.g. "PRB0040192"); matches exactly. Routed as
+   * a first-class filter rather than through the free-text searchQuery scan.
+   */
+  number?: string;
 }
 
 export interface BeProblemSearchPayload {

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useQuickCaseSearch.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useQuickCaseSearch.test.tsx
@@ -27,7 +27,10 @@ vi.mock("@api/backend/client", () => ({
   useBackendApi: () => ({ post: postMock }),
 }));
 
-import { useQuickCaseSearch } from "@features/csm-cases/api/useQuickCaseSearch";
+import {
+  classifyQuickCaseQuery,
+  useQuickCaseSearch,
+} from "@features/csm-cases/api/useQuickCaseSearch";
 import { ALL_CASE_TYPES } from "@features/csm-cases/utils/caseType";
 
 function wrapper({ children }: { children: ReactNode }) {
@@ -46,7 +49,9 @@ describe("useQuickCaseSearch", () => {
   });
 
   it("requests every known case sub-type, not just the default 'case' type", async () => {
-    const { result } = renderHook(() => useQuickCaseSearch("ABC-123"), {
+    // "free text" query — doesn't match the number/internalId patterns,
+    // so this goes through the free-text `searchQuery` path.
+    const { result } = renderHook(() => useQuickCaseSearch("printer jam"), {
       wrapper,
     });
 
@@ -56,7 +61,7 @@ describe("useQuickCaseSearch", () => {
       "/cases/search",
       expect.objectContaining({
         filters: expect.objectContaining({
-          searchQuery: "ABC-123",
+          searchQuery: "printer jam",
           filters: [{ field: "type", op: "in", values: ALL_CASE_TYPES }],
         }),
       }),
@@ -77,5 +82,80 @@ describe("useQuickCaseSearch", () => {
   it("does not fire a search until the query reaches the minimum length", () => {
     renderHook(() => useQuickCaseSearch("a"), { wrapper });
     expect(postMock).not.toHaveBeenCalled();
+  });
+
+  it("routes a CS case number to an exact-match number filter, not searchQuery", async () => {
+    const { result } = renderHook(() => useQuickCaseSearch("CS0441174"), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const body = postMock.mock.calls[0][1];
+    expect(body.filters.searchQuery).toBeUndefined();
+    expect(body.filters.filters).toEqual([
+      { field: "type", op: "in", values: ALL_CASE_TYPES },
+      { field: "number", op: "eq", values: ["CS0441174"] },
+    ]);
+  });
+
+  it("routes a WSO2 case id to an exact-match internalId filter, not searchQuery", async () => {
+    const { result } = renderHook(() => useQuickCaseSearch("SOMEID-4"), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const body = postMock.mock.calls[0][1];
+    expect(body.filters.searchQuery).toBeUndefined();
+    expect(body.filters.filters).toEqual([
+      { field: "type", op: "in", values: ALL_CASE_TYPES },
+      { field: "internalId", op: "eq", values: ["SOMEID-4"] },
+    ]);
+  });
+
+  it("falls back to free-text search when forceFreeText is set, even for a matching query", async () => {
+    const { result } = renderHook(
+      () => useQuickCaseSearch("CS0441174", { forceFreeText: true }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(postMock).toHaveBeenCalledWith(
+      "/cases/search",
+      expect.objectContaining({
+        filters: expect.objectContaining({
+          searchQuery: "CS0441174",
+          filters: [{ field: "type", op: "in", values: ALL_CASE_TYPES }],
+        }),
+      }),
+    );
+  });
+
+  describe("classifyQuickCaseQuery", () => {
+    it("classifies a CS case number", () => {
+      expect(classifyQuickCaseQuery("CS0441174")).toBe("number");
+    });
+
+    it("classifies a WSO2 case id", () => {
+      expect(classifyQuickCaseQuery("SOMEID-4")).toBe("internalId");
+      expect(classifyQuickCaseQuery("ABC-123")).toBe("internalId");
+      expect(classifyQuickCaseQuery("wso2-1")).toBe("internalId");
+    });
+
+    it("classifies free text as text", () => {
+      expect(classifyQuickCaseQuery("printer jam")).toBe("text");
+      // Wrong digit count for a case number.
+      expect(classifyQuickCaseQuery("CS044117")).toBe("text");
+      expect(classifyQuickCaseQuery("CS04411745")).toBe("text");
+      // Too many digits after the hyphen for a WSO2 case id.
+      expect(classifyQuickCaseQuery("SOMEID-12345")).toBe("text");
+      // No digits after the hyphen at all.
+      expect(classifyQuickCaseQuery("SOMEID-")).toBe("text");
+      // Lowercase "cs" prefix fails the strict, case-sensitive case-number
+      // shape, and there's no hyphen for it to match the internalId shape.
+      expect(classifyQuickCaseQuery("cs0441174")).toBe("text");
+    });
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useQuickCaseSearch.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useQuickCaseSearch.ts
@@ -19,6 +19,8 @@ import { ApiQueryKeys } from "@constants/apiConstants";
 import { useBackendApi } from "@api/backend/client";
 import { severityFromPriority, uiStateFromBe } from "@api/backend/mappers";
 import type {
+  BeCaseFieldFilter,
+  BeCaseSearchFilters,
   BeCaseSearchPayload,
   BeCaseSearchResponse,
   BeCaseType,
@@ -35,6 +37,40 @@ export const QUICK_CASE_MIN_QUERY_LEN = 2;
 
 /** A small result page — the palette only shows the top few hits. */
 const QUICK_CASE_LIMIT = 8;
+
+/** A CS case number, e.g. "CS0441174" — always "CS" plus exactly 7 digits. */
+const CASE_NUMBER_RE = /^CS\d{7}$/;
+
+/**
+ * A WSO2 case id, e.g. "SOMEID-4" — an alphanumeric project/product prefix, a
+ * hyphen, then 1-4 digits. Deliberately looser than {@link CASE_NUMBER_RE}
+ * (no fixed prefix), so it's checked second, after the case-number pattern
+ * has already had first refusal.
+ */
+const WSO2_CASE_ID_RE = /^[a-zA-Z0-9]+-\d{1,4}$/;
+
+/**
+ * What kind of lookup a typed quick-search string should run as:
+ * - `"number"` / `"internalId"`: an exact-match, first-class filter — the
+ *   entity-service resolves these against an indexed column instead of the
+ *   free-text `searchQuery` scan. Named to match the response field names
+ *   (`BeCaseSearchView.number` / `.internalId`), not a UI-facing label.
+ * - `"text"`: the existing free-text search across subject/description
+ *   (and number/internalId, case-insensitively) — unchanged behavior.
+ */
+export type QuickCaseSearchScope = "number" | "internalId" | "text";
+
+/**
+ * Classifies a typed (already-trimmed) quick-search string into the scope
+ * {@link useQuickCaseSearch} should route it through. Order matters: a case
+ * number is checked first since `CS\d{7}` is a strict subset of the looser
+ * WSO2-case-id shape.
+ */
+export function classifyQuickCaseQuery(query: string): QuickCaseSearchScope {
+  if (CASE_NUMBER_RE.test(query)) return "number";
+  if (WSO2_CASE_ID_RE.test(query)) return "internalId";
+  return "text";
+}
 
 /**
  * One hit from the global-search case lookup. Carries the UUID `id` (for the
@@ -57,10 +93,14 @@ export interface QuickCaseHit {
 }
 
 /**
- * Free-text case lookup for the global quick-nav palette. Calls
- * `POST /cases/search` with the typed text as `searchQuery` (the same search the
- * cases list uses), so a CS/WSO2 case id — or any subject text — resolves to
- * matching cases the user can jump straight into.
+ * Case lookup for the global quick-nav palette. Calls `POST /cases/search`,
+ * routing the typed text one of three ways (see {@link classifyQuickCaseQuery}):
+ * a `CS\d{7}` case number or a `<prefix>-<digits>` WSO2 case id goes through
+ * as an exact-match, first-class field filter (an indexed lookup); anything
+ * else falls back to the same free-text `searchQuery` search the cases list
+ * uses. Pass `forceFreeText` to opt back into the free-text path even when
+ * the query matches one of the exact patterns — the quick-nav palette's
+ * "search in subject and description too" affordance uses this to widen a scoped result.
  *
  * Explicitly requests every known case sub-type ({@link ALL_CASE_TYPES}) —
  * `entity-service`'s `/cases/search` defaults `filters.types` to `["case"]`
@@ -72,21 +112,34 @@ export interface QuickCaseHit {
  */
 export function useQuickCaseSearch(
   query: string,
+  options?: { forceFreeText?: boolean },
 ): UseQueryResult<QuickCaseHit[], Error> {
   const api = useBackendApi();
   const q = query.trim();
+  const scope = options?.forceFreeText ? "text" : classifyQuickCaseQuery(q);
 
   return useQuery<QuickCaseHit[], Error>({
-    queryKey: [ApiQueryKeys.CSM_CASES, "quick-search", q],
+    queryKey: [ApiQueryKeys.CSM_CASES, "quick-search", q, scope],
     queryFn: async (): Promise<QuickCaseHit[]> => {
+      const typeFilter: BeCaseFieldFilter = {
+        field: "type",
+        op: "in",
+        values: ALL_CASE_TYPES,
+      };
+      const filters: BeCaseSearchFilters =
+        scope === "text"
+          ? { searchQuery: q, filters: [typeFilter] }
+          : {
+              filters: [
+                typeFilter,
+                { field: scope, op: "eq", values: [q] },
+              ],
+            };
       const res = await api.post<BeCaseSearchPayload, BeCaseSearchResponse>(
         "/cases/search",
         {
           pagination: { offset: 0, limit: QUICK_CASE_LIMIT },
-          filters: {
-            searchQuery: q,
-            filters: [{ field: "type", op: "in", values: ALL_CASE_TYPES }],
-          },
+          filters,
         },
       );
       return (res.cases ?? []).map((c) => ({

--- a/apps/csm-portal/webapp/src/features/csm-operations/api/useQuickChangeRequestSearch.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/api/useQuickChangeRequestSearch.test.tsx
@@ -1,0 +1,116 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { ReactNode } from "react";
+
+const postMock = vi.fn();
+
+// The real client reads runtime config at module load, which isn't present
+// under vitest (same approach as useQuickCaseSearch.test.tsx).
+vi.mock("@api/backend/client", () => ({
+  useBackendApi: () => ({ post: postMock }),
+}));
+
+import {
+  classifyQuickChangeRequestQuery,
+  useQuickChangeRequestSearch,
+} from "@features/csm-operations/api/useQuickChangeRequestSearch";
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe("useQuickChangeRequestSearch", () => {
+  beforeEach(() => {
+    postMock.mockReset();
+    postMock.mockResolvedValue({ changeRequests: [] });
+  });
+
+  it("sends free text as searchQuery for a non-number-shaped query", async () => {
+    const { result } = renderHook(
+      () => useQuickChangeRequestSearch("upgrade gateway"),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(postMock).toHaveBeenCalledWith(
+      "/change-requests/search",
+      expect.objectContaining({
+        filters: { searchQuery: "upgrade gateway" },
+      }),
+    );
+  });
+
+  it("does not fire a search until the query reaches the minimum length", () => {
+    renderHook(() => useQuickChangeRequestSearch("a"), { wrapper });
+    expect(postMock).not.toHaveBeenCalled();
+  });
+
+  it("routes a CHG number to an exact-match number filter, not searchQuery", async () => {
+    const { result } = renderHook(
+      () => useQuickChangeRequestSearch("CHG0038721"),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const body = postMock.mock.calls[0][1];
+    expect(body.filters).toEqual({ number: "CHG0038721" });
+  });
+
+  it("falls back to free-text search when forceFreeText is set, even for a matching query", async () => {
+    const { result } = renderHook(
+      () =>
+        useQuickChangeRequestSearch("CHG0038721", { forceFreeText: true }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(postMock).toHaveBeenCalledWith(
+      "/change-requests/search",
+      expect.objectContaining({
+        filters: { searchQuery: "CHG0038721" },
+      }),
+    );
+  });
+
+  describe("classifyQuickChangeRequestQuery", () => {
+    it("classifies a CHG number", () => {
+      expect(classifyQuickChangeRequestQuery("CHG0038721")).toBe("number");
+    });
+
+    it("classifies free text as text", () => {
+      expect(classifyQuickChangeRequestQuery("upgrade gateway")).toBe("text");
+      // Wrong digit count for a change-request number.
+      expect(classifyQuickChangeRequestQuery("CHG003872")).toBe("text");
+      expect(classifyQuickChangeRequestQuery("CHG00387212")).toBe("text");
+      // Lowercase "chg" prefix fails the strict, case-sensitive shape.
+      expect(classifyQuickChangeRequestQuery("chg0038721")).toBe("text");
+      // A different prefix entirely.
+      expect(classifyQuickChangeRequestQuery("PRB0040192")).toBe("text");
+    });
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-operations/api/useQuickChangeRequestSearch.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/api/useQuickChangeRequestSearch.ts
@@ -28,6 +28,27 @@ export const QUICK_CHANGE_REQUEST_MIN_QUERY_LEN = 2;
 /** A small result page — the palette only shows the top few hits. */
 const QUICK_CHANGE_REQUEST_LIMIT = 5;
 
+/** A change request number, e.g. "CHG0038721" — always "CHG" plus exactly 7 digits. */
+const CHANGE_REQUEST_NUMBER_RE = /^CHG\d{7}$/;
+
+/**
+ * What kind of lookup a typed quick-search string should run as — mirrors
+ * {@link "@features/csm-cases/api/useQuickCaseSearch".QuickCaseSearchScope},
+ * just without the internalId variant cases have (change requests have only
+ * one exact-match identifier).
+ */
+export type QuickChangeRequestSearchScope = "number" | "text";
+
+/**
+ * Classifies a typed (already-trimmed) quick-search string into the scope
+ * {@link useQuickChangeRequestSearch} should route it through.
+ */
+export function classifyQuickChangeRequestQuery(
+  query: string,
+): QuickChangeRequestSearchScope {
+  return CHANGE_REQUEST_NUMBER_RE.test(query) ? "number" : "text";
+}
+
 /** One hit from the global-search change-request lookup, enough for the palette's result row. */
 export interface QuickChangeRequestHit {
   id: string;
@@ -40,11 +61,18 @@ export interface QuickChangeRequestHit {
 }
 
 /**
- * Free-text change-request lookup for the global quick-nav palette. Calls
- * `POST /change-requests/search` with the typed text as `searchQuery`
- * (ServiceNow data source only) — same endpoint `useSearchChangeRequests`
- * uses for the Operations tab's listing, just capped to a handful of hits and
- * shaped for the palette instead of a paginated table.
+ * Change-request lookup for the global quick-nav palette. Calls
+ * `POST /change-requests/search` (ServiceNow data source only) — same
+ * endpoint `useSearchChangeRequests` uses for the Operations tab's listing,
+ * just capped to a handful of hits and shaped for the palette instead of a
+ * paginated table. Routes the typed text one of two ways (see
+ * {@link classifyQuickChangeRequestQuery}): a `CHG\d{7}` change-request
+ * number goes through as an exact-match, first-class field filter (an
+ * indexed lookup); anything else falls back to the same free-text
+ * `searchQuery` search the change-requests list uses. Pass `forceFreeText`
+ * to opt back into the free-text path even when the query matches the exact
+ * pattern — the quick-nav palette's "search in subject and description too" affordance
+ * uses this to widen a scoped result.
  *
  * Disabled until the trimmed text reaches
  * {@link QUICK_CHANGE_REQUEST_MIN_QUERY_LEN}, so opening the palette costs no
@@ -52,19 +80,23 @@ export interface QuickChangeRequestHit {
  */
 export function useQuickChangeRequestSearch(
   query: string,
+  options?: { forceFreeText?: boolean },
 ): UseQueryResult<QuickChangeRequestHit[], Error> {
   const api = useBackendApi();
   const q = query.trim();
+  const scope = options?.forceFreeText
+    ? "text"
+    : classifyQuickChangeRequestQuery(q);
 
   return useQuery<QuickChangeRequestHit[], Error>({
-    queryKey: [ApiQueryKeys.CHANGE_REQUESTS, "quick-search", q],
+    queryKey: [ApiQueryKeys.CHANGE_REQUESTS, "quick-search", q, scope],
     queryFn: async (): Promise<QuickChangeRequestHit[]> => {
       const res = await api.post<
         BeChangeRequestSearchPayload,
         BeChangeRequestSearchResponse
       >("/change-requests/search", {
         pagination: { offset: 0, limit: QUICK_CHANGE_REQUEST_LIMIT },
-        filters: { searchQuery: q },
+        filters: scope === "number" ? { number: q } : { searchQuery: q },
       });
       return (res.changeRequests ?? []).map((cr) => ({
         id: cr.id,

--- a/apps/csm-portal/webapp/src/features/csm-operations/api/useQuickIncidentSearch.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/api/useQuickIncidentSearch.test.tsx
@@ -1,0 +1,116 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { ReactNode } from "react";
+
+const postMock = vi.fn();
+
+// The real client reads runtime config at module load, which isn't present
+// under vitest (same approach as useQuickCaseSearch.test.tsx).
+vi.mock("@api/backend/client", () => ({
+  useBackendApi: () => ({ post: postMock }),
+}));
+
+import {
+  classifyQuickIncidentQuery,
+  useQuickIncidentSearch,
+} from "@features/csm-operations/api/useQuickIncidentSearch";
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe("useQuickIncidentSearch", () => {
+  beforeEach(() => {
+    postMock.mockReset();
+    postMock.mockResolvedValue({ incidents: [] });
+  });
+
+  it("sends free text as searchQuery for a non-number-shaped query", async () => {
+    const { result } = renderHook(
+      () => useQuickIncidentSearch("cluster down"),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(postMock).toHaveBeenCalledWith(
+      "/incidents/search",
+      expect.objectContaining({
+        filters: { searchQuery: "cluster down" },
+      }),
+    );
+  });
+
+  it("does not fire a search until the query reaches the minimum length", () => {
+    renderHook(() => useQuickIncidentSearch("a"), { wrapper });
+    expect(postMock).not.toHaveBeenCalled();
+  });
+
+  it("routes an INC number to an exact-match number filter, not searchQuery", async () => {
+    const { result } = renderHook(
+      () => useQuickIncidentSearch("INC0090472"),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const body = postMock.mock.calls[0][1];
+    expect(body.filters).toEqual({ number: "INC0090472" });
+  });
+
+  it("falls back to free-text search when forceFreeText is set, even for a matching query", async () => {
+    const { result } = renderHook(
+      () =>
+        useQuickIncidentSearch("INC0090472", { forceFreeText: true }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(postMock).toHaveBeenCalledWith(
+      "/incidents/search",
+      expect.objectContaining({
+        filters: { searchQuery: "INC0090472" },
+      }),
+    );
+  });
+
+  describe("classifyQuickIncidentQuery", () => {
+    it("classifies an INC number", () => {
+      expect(classifyQuickIncidentQuery("INC0090472")).toBe("number");
+    });
+
+    it("classifies free text as text", () => {
+      expect(classifyQuickIncidentQuery("cluster down")).toBe("text");
+      // Wrong digit count for an incident number.
+      expect(classifyQuickIncidentQuery("INC009047")).toBe("text");
+      expect(classifyQuickIncidentQuery("INC00904720")).toBe("text");
+      // Lowercase "inc" prefix fails the strict, case-sensitive shape.
+      expect(classifyQuickIncidentQuery("inc0090472")).toBe("text");
+      // A different prefix entirely.
+      expect(classifyQuickIncidentQuery("CS0441174")).toBe("text");
+    });
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-operations/api/useQuickIncidentSearch.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/api/useQuickIncidentSearch.ts
@@ -29,6 +29,27 @@ export const QUICK_INCIDENT_MIN_QUERY_LEN = 2;
 /** A small result page — the palette only shows the top few hits. */
 const QUICK_INCIDENT_LIMIT = 5;
 
+/** An incident number, e.g. "INC0090472" — always "INC" plus exactly 7 digits. */
+const INCIDENT_NUMBER_RE = /^INC\d{7}$/;
+
+/**
+ * What kind of lookup a typed quick-search string should run as — mirrors
+ * {@link "@features/csm-cases/api/useQuickCaseSearch".QuickCaseSearchScope},
+ * just without the internalId variant cases have (incidents have only one
+ * exact-match identifier).
+ */
+export type QuickIncidentSearchScope = "number" | "text";
+
+/**
+ * Classifies a typed (already-trimmed) quick-search string into the scope
+ * {@link useQuickIncidentSearch} should route it through.
+ */
+export function classifyQuickIncidentQuery(
+  query: string,
+): QuickIncidentSearchScope {
+  return INCIDENT_NUMBER_RE.test(query) ? "number" : "text";
+}
+
 /** One hit from the global-search incident lookup, enough for the palette's result row. */
 export interface QuickIncidentHit {
   id: string;
@@ -41,29 +62,36 @@ export interface QuickIncidentHit {
 }
 
 /**
- * Free-text incident lookup for the global quick-nav palette. Calls
- * `POST /incidents/search` with the typed text as `searchQuery` (ServiceNow
- * data source only) — same endpoint `useSearchIncidents` uses for the
- * Operations tab's listing, just capped to a handful of hits and shaped for
- * the palette instead of a paginated table.
+ * Incident lookup for the global quick-nav palette. Calls
+ * `POST /incidents/search` (ServiceNow data source only) — same endpoint
+ * `useSearchIncidents` uses for the Operations tab's listing, just capped to
+ * a handful of hits and shaped for the palette instead of a paginated table.
+ * Routes the typed text one of two ways (see {@link classifyQuickIncidentQuery}):
+ * an `INC\d{7}` incident number goes through as an exact-match, first-class
+ * field filter (an indexed lookup); anything else falls back to the same
+ * free-text `searchQuery` search the incidents list uses. Pass
+ * `forceFreeText` to opt back into the free-text path even when the query
+ * matches the exact pattern — the quick-nav palette's "search in subject and description too" affordance uses this to widen a scoped result.
  *
  * Disabled until the trimmed text reaches {@link QUICK_INCIDENT_MIN_QUERY_LEN},
  * so opening the palette costs no network.
  */
 export function useQuickIncidentSearch(
   query: string,
+  options?: { forceFreeText?: boolean },
 ): UseQueryResult<QuickIncidentHit[], Error> {
   const api = useBackendApi();
   const q = query.trim();
+  const scope = options?.forceFreeText ? "text" : classifyQuickIncidentQuery(q);
 
   return useQuery<QuickIncidentHit[], Error>({
-    queryKey: [ApiQueryKeys.INCIDENTS, "quick-search", q],
+    queryKey: [ApiQueryKeys.INCIDENTS, "quick-search", q, scope],
     queryFn: async (): Promise<QuickIncidentHit[]> => {
       const res = await api.post<BeIncidentSearchPayload, BeIncidentSearchResponse>(
         "/incidents/search",
         {
           pagination: { offset: 0, limit: QUICK_INCIDENT_LIMIT },
-          filters: { searchQuery: q },
+          filters: scope === "number" ? { number: q } : { searchQuery: q },
         },
       );
       return (res.incidents ?? [])

--- a/apps/csm-portal/webapp/src/features/csm-operations/api/useQuickProblemSearch.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/api/useQuickProblemSearch.test.tsx
@@ -1,0 +1,113 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { ReactNode } from "react";
+
+const postMock = vi.fn();
+
+// The real client reads runtime config at module load, which isn't present
+// under vitest (same approach as useQuickCaseSearch.test.tsx).
+vi.mock("@api/backend/client", () => ({
+  useBackendApi: () => ({ post: postMock }),
+}));
+
+import {
+  classifyQuickProblemQuery,
+  useQuickProblemSearch,
+} from "@features/csm-operations/api/useQuickProblemSearch";
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe("useQuickProblemSearch", () => {
+  beforeEach(() => {
+    postMock.mockReset();
+    postMock.mockResolvedValue({ problems: [] });
+  });
+
+  it("sends free text as searchQuery for a non-number-shaped query", async () => {
+    const { result } = renderHook(() => useQuickProblemSearch("disk full"), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(postMock).toHaveBeenCalledWith(
+      "/problems/search",
+      expect.objectContaining({
+        filters: { searchQuery: "disk full" },
+      }),
+    );
+  });
+
+  it("does not fire a search until the query reaches the minimum length", () => {
+    renderHook(() => useQuickProblemSearch("a"), { wrapper });
+    expect(postMock).not.toHaveBeenCalled();
+  });
+
+  it("routes a PRB number to an exact-match number filter, not searchQuery", async () => {
+    const { result } = renderHook(() => useQuickProblemSearch("PRB0040192"), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const body = postMock.mock.calls[0][1];
+    expect(body.filters).toEqual({ number: "PRB0040192" });
+  });
+
+  it("falls back to free-text search when forceFreeText is set, even for a matching query", async () => {
+    const { result } = renderHook(
+      () => useQuickProblemSearch("PRB0040192", { forceFreeText: true }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(postMock).toHaveBeenCalledWith(
+      "/problems/search",
+      expect.objectContaining({
+        filters: { searchQuery: "PRB0040192" },
+      }),
+    );
+  });
+
+  describe("classifyQuickProblemQuery", () => {
+    it("classifies a PRB number", () => {
+      expect(classifyQuickProblemQuery("PRB0040192")).toBe("number");
+    });
+
+    it("classifies free text as text", () => {
+      expect(classifyQuickProblemQuery("disk full")).toBe("text");
+      // Wrong digit count for a problem number.
+      expect(classifyQuickProblemQuery("PRB004019")).toBe("text");
+      expect(classifyQuickProblemQuery("PRB004019212")).toBe("text");
+      // Lowercase "prb" prefix fails the strict, case-sensitive shape.
+      expect(classifyQuickProblemQuery("prb0040192")).toBe("text");
+      // A different prefix entirely.
+      expect(classifyQuickProblemQuery("INC0090472")).toBe("text");
+    });
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-operations/api/useQuickProblemSearch.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/api/useQuickProblemSearch.ts
@@ -28,6 +28,27 @@ export const QUICK_PROBLEM_MIN_QUERY_LEN = 2;
 /** A small result page — the palette only shows the top few hits. */
 const QUICK_PROBLEM_LIMIT = 5;
 
+/** A problem number, e.g. "PRB0040192" — always "PRB" plus exactly 7 digits. */
+const PROBLEM_NUMBER_RE = /^PRB\d{7}$/;
+
+/**
+ * What kind of lookup a typed quick-search string should run as — mirrors
+ * {@link "@features/csm-cases/api/useQuickCaseSearch".QuickCaseSearchScope},
+ * just without the internalId variant cases have (problems have only one
+ * exact-match identifier).
+ */
+export type QuickProblemSearchScope = "number" | "text";
+
+/**
+ * Classifies a typed (already-trimmed) quick-search string into the scope
+ * {@link useQuickProblemSearch} should route it through.
+ */
+export function classifyQuickProblemQuery(
+  query: string,
+): QuickProblemSearchScope {
+  return PROBLEM_NUMBER_RE.test(query) ? "number" : "text";
+}
+
 /** One hit from the global-search problem lookup, enough for the palette's result row. */
 export interface QuickProblemHit {
   id: string;
@@ -38,29 +59,36 @@ export interface QuickProblemHit {
 }
 
 /**
- * Free-text problem lookup for the global quick-nav palette. Calls
- * `POST /problems/search` with the typed text as `searchQuery` (ServiceNow
- * data source only) — same endpoint `useSearchProblems` uses for the
- * Operations tab's listing, just capped to a handful of hits and shaped for
- * the palette instead of a paginated table.
+ * Problem lookup for the global quick-nav palette. Calls
+ * `POST /problems/search` (ServiceNow data source only) — same endpoint
+ * `useSearchProblems` uses for the Operations tab's listing, just capped to
+ * a handful of hits and shaped for the palette instead of a paginated table.
+ * Routes the typed text one of two ways (see {@link classifyQuickProblemQuery}):
+ * a `PRB\d{7}` problem number goes through as an exact-match, first-class
+ * field filter (an indexed lookup); anything else falls back to the same
+ * free-text `searchQuery` search the problems list uses. Pass
+ * `forceFreeText` to opt back into the free-text path even when the query
+ * matches the exact pattern — the quick-nav palette's "search in subject and description too" affordance uses this to widen a scoped result.
  *
  * Disabled until the trimmed text reaches {@link QUICK_PROBLEM_MIN_QUERY_LEN},
  * so opening the palette costs no network.
  */
 export function useQuickProblemSearch(
   query: string,
+  options?: { forceFreeText?: boolean },
 ): UseQueryResult<QuickProblemHit[], Error> {
   const api = useBackendApi();
   const q = query.trim();
+  const scope = options?.forceFreeText ? "text" : classifyQuickProblemQuery(q);
 
   return useQuery<QuickProblemHit[], Error>({
-    queryKey: [ApiQueryKeys.PROBLEMS, "quick-search", q],
+    queryKey: [ApiQueryKeys.PROBLEMS, "quick-search", q, scope],
     queryFn: async (): Promise<QuickProblemHit[]> => {
       const res = await api.post<BeProblemSearchPayload, BeProblemSearchResponse>(
         "/problems/search",
         {
           pagination: { offset: 0, limit: QUICK_PROBLEM_LIMIT },
-          filters: { searchQuery: q },
+          filters: scope === "number" ? { number: q } : { searchQuery: q },
         },
       );
       return (res.problems ?? []).map((p) => ({

--- a/apps/csm-portal/webapp/src/features/csm-recent/components/QuickNav.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-recent/components/QuickNav.test.tsx
@@ -34,25 +34,50 @@ vi.mock("@config/featureFlags", () => ({
 const quickCaseSearchMock = vi.fn();
 vi.mock("@features/csm-cases/api/useQuickCaseSearch", () => ({
   QUICK_CASE_MIN_QUERY_LEN: 2,
-  useQuickCaseSearch: (q: string) => quickCaseSearchMock(q),
+  useQuickCaseSearch: (q: string, options?: { forceFreeText?: boolean }) =>
+    quickCaseSearchMock(q, options),
+  // A same-module-shape stand-in for the real `classifyQuickCaseQuery` —
+  // duplicated here (rather than pulled in via `importOriginal`) because the
+  // real module transitively imports the backend API client, which reads
+  // runtime config unavailable under vitest. Mirrors the two patterns in
+  // `useQuickCaseSearch.ts` exactly; if those patterns change, the matching
+  // assertions below (and this copy) must change too.
+  classifyQuickCaseQuery: (query: string): "number" | "internalId" | "text" => {
+    if (/^CS\d{7}$/.test(query)) return "number";
+    if (/^[a-zA-Z0-9]+-\d{1,4}$/.test(query)) return "internalId";
+    return "text";
+  },
 }));
 
+// Same "same-module-shape stand-in" reasoning as `classifyQuickCaseQuery`
+// above applies to the three classify functions below.
 const quickIncidentSearchMock = vi.fn();
 vi.mock("@features/csm-operations/api/useQuickIncidentSearch", () => ({
   QUICK_INCIDENT_MIN_QUERY_LEN: 2,
-  useQuickIncidentSearch: (q: string) => quickIncidentSearchMock(q),
+  useQuickIncidentSearch: (q: string, options?: { forceFreeText?: boolean }) =>
+    quickIncidentSearchMock(q, options),
+  classifyQuickIncidentQuery: (query: string): "number" | "text" =>
+    /^INC\d{7}$/.test(query) ? "number" : "text",
 }));
 
 const quickChangeRequestSearchMock = vi.fn();
 vi.mock("@features/csm-operations/api/useQuickChangeRequestSearch", () => ({
   QUICK_CHANGE_REQUEST_MIN_QUERY_LEN: 2,
-  useQuickChangeRequestSearch: (q: string) => quickChangeRequestSearchMock(q),
+  useQuickChangeRequestSearch: (
+    q: string,
+    options?: { forceFreeText?: boolean },
+  ) => quickChangeRequestSearchMock(q, options),
+  classifyQuickChangeRequestQuery: (query: string): "number" | "text" =>
+    /^CHG\d{7}$/.test(query) ? "number" : "text",
 }));
 
 const quickProblemSearchMock = vi.fn();
 vi.mock("@features/csm-operations/api/useQuickProblemSearch", () => ({
   QUICK_PROBLEM_MIN_QUERY_LEN: 2,
-  useQuickProblemSearch: (q: string) => quickProblemSearchMock(q),
+  useQuickProblemSearch: (q: string, options?: { forceFreeText?: boolean }) =>
+    quickProblemSearchMock(q, options),
+  classifyQuickProblemQuery: (query: string): "number" | "text" =>
+    /^PRB\d{7}$/.test(query) ? "number" : "text",
 }));
 
 const navigateMock = vi.fn();
@@ -72,15 +97,35 @@ function renderQuickNav(initialEntries?: string[]) {
   );
 }
 
+/**
+ * Which of the four search hooks a given query actually gets routed to as
+ * its real (non-suppressed) query — mirrors `QuickNav`'s own suppression
+ * logic (only the entity kind whose exact-match shape the query matches
+ * gets the real query; the other three get `""` and never fire). A query
+ * matching none of the four shapes routes to all four, so waiting on the
+ * case mock is representative there too.
+ */
+function primaryMockFor(query: string) {
+  if (/^INC\d{7}$/.test(query)) return quickIncidentSearchMock;
+  if (/^PRB\d{7}$/.test(query)) return quickProblemSearchMock;
+  if (/^CHG\d{7}$/.test(query)) return quickChangeRequestSearchMock;
+  return quickCaseSearchMock;
+}
+
 async function openAndType(query: string) {
   renderQuickNav();
   fireEvent.click(screen.getByLabelText("Search or jump to (open quick nav)"));
   const input = await screen.findByLabelText("Quick nav search");
   fireEvent.change(input, { target: { value: query } });
   // Wait past the 180ms debounce for the search hooks to be called with the
-  // settled query.
+  // settled query — waiting on whichever hook the query actually routes to
+  // (see `primaryMockFor`), since an exact-match-shaped query suppresses the
+  // other three down to an empty, disabled query.
   await waitFor(() =>
-    expect(quickCaseSearchMock).toHaveBeenLastCalledWith(query),
+    expect(primaryMockFor(query)).toHaveBeenLastCalledWith(
+      query,
+      expect.objectContaining({ forceFreeText: false }),
+    ),
   );
 }
 
@@ -154,7 +199,10 @@ describe("QuickNav", () => {
     const input = await screen.findByLabelText("Quick nav search");
     expect(input).toHaveValue("CS0440883");
     await waitFor(() =>
-      expect(quickCaseSearchMock).toHaveBeenLastCalledWith("CS0440883"),
+      expect(quickCaseSearchMock).toHaveBeenLastCalledWith(
+        "CS0440883",
+        expect.objectContaining({ forceFreeText: false }),
+      ),
     );
   });
 
@@ -183,10 +231,263 @@ describe("QuickNav", () => {
 
     const input = await screen.findByLabelText("Quick nav search");
     await waitFor(() =>
-      expect(quickCaseSearchMock).toHaveBeenLastCalledWith("NOPE0000"),
+      expect(quickCaseSearchMock).toHaveBeenLastCalledWith(
+        "NOPE0000",
+        expect.objectContaining({ forceFreeText: false }),
+      ),
     );
     await waitFor(() => expect(screen.getByText("No matches.")).toBeInTheDocument());
     expect(input).toBeInTheDocument();
     expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it("shows an exact-match banner for a case-number-shaped query, with a widen affordance", async () => {
+    quickCaseSearchMock.mockReturnValue(idleResult);
+
+    await openAndType("CS0441174");
+
+    expect(
+      await screen.findByText(/Showing an exact match for case number/),
+    ).toBeInTheDocument();
+    const widenButton = screen.getByRole("button", { name: "Search in subject and description too" });
+
+    fireEvent.click(widenButton);
+
+    await waitFor(() =>
+      expect(quickCaseSearchMock).toHaveBeenLastCalledWith(
+        "CS0441174",
+        expect.objectContaining({ forceFreeText: true }),
+      ),
+    );
+    // Widening clears the banner — the search is no longer scoped.
+    expect(
+      screen.queryByText(/Showing an exact match for case number/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows an exact-match banner for a WSO2-case-id-shaped query", async () => {
+    quickCaseSearchMock.mockReturnValue(idleResult);
+
+    await openAndType("SOMEID-4");
+
+    expect(
+      await screen.findByText(/Showing an exact match for WSO2 case id/),
+    ).toBeInTheDocument();
+  });
+
+  it("does not show the exact-match banner for a free-text query", async () => {
+    quickCaseSearchMock.mockReturnValue(idleResult);
+
+    await openAndType("printer jam");
+
+    expect(screen.queryByText(/Showing an exact match/)).not.toBeInTheDocument();
+  });
+
+  it("shows an exact-match banner for an incident-number-shaped query, with a widen affordance", async () => {
+    await openAndType("INC0090472");
+
+    expect(
+      await screen.findByText(/Showing an exact match for incident number/),
+    ).toBeInTheDocument();
+    const widenButton = screen.getByRole("button", { name: "Search in subject and description too" });
+
+    fireEvent.click(widenButton);
+
+    // Widening re-enables and searches ALL FOUR entity types as free text —
+    // not just the incident search that was originally scoped.
+    await waitFor(() =>
+      expect(quickIncidentSearchMock).toHaveBeenLastCalledWith(
+        "INC0090472",
+        expect.objectContaining({ forceFreeText: true }),
+      ),
+    );
+    expect(quickCaseSearchMock).toHaveBeenLastCalledWith(
+      "INC0090472",
+      expect.objectContaining({ forceFreeText: true }),
+    );
+    expect(quickProblemSearchMock).toHaveBeenLastCalledWith(
+      "INC0090472",
+      expect.objectContaining({ forceFreeText: true }),
+    );
+    expect(quickChangeRequestSearchMock).toHaveBeenLastCalledWith(
+      "INC0090472",
+      expect.objectContaining({ forceFreeText: true }),
+    );
+    expect(
+      screen.queryByText(/Showing an exact match for incident number/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows an exact-match banner for a problem-number-shaped query", async () => {
+    await openAndType("PRB0040192");
+
+    expect(
+      await screen.findByText(/Showing an exact match for problem number/),
+    ).toBeInTheDocument();
+  });
+
+  it("shows an exact-match banner for a change-request-number-shaped query", async () => {
+    await openAndType("CHG0038721");
+
+    expect(
+      await screen.findByText(/Showing an exact match for change request number/),
+    ).toBeInTheDocument();
+  });
+
+  it.each([
+    ["INC0090472", quickIncidentSearchMock, "incident"],
+    ["PRB0040192", quickProblemSearchMock, "problem"],
+    ["CHG0038721", quickChangeRequestSearchMock, "change request"],
+    ["CS0441174", quickCaseSearchMock, "case"],
+  ] as const)(
+    "routes a %s-shaped query only to the %s search, suppressing the other three entirely",
+    async (query, matchingMock, _label) => {
+      await openAndType(query);
+
+      // The matching type gets the real query, in exact-match mode.
+      expect(matchingMock).toHaveBeenLastCalledWith(
+        query,
+        expect.objectContaining({ forceFreeText: false }),
+      );
+
+      // The other three are passed an empty query — not the typed text, not
+      // even as a free-text search — so their own `enabled` gate (`q.length
+      // >= MIN_LEN`) keeps them from firing at all.
+      const allMocks = [
+        quickCaseSearchMock,
+        quickIncidentSearchMock,
+        quickProblemSearchMock,
+        quickChangeRequestSearchMock,
+      ];
+      for (const mock of allMocks) {
+        if (mock === matchingMock) continue;
+        expect(mock).toHaveBeenLastCalledWith(
+          "",
+          expect.objectContaining({ forceFreeText: false }),
+        );
+      }
+    },
+  );
+
+  it("runs all four searches as free text for a query that matches none of the exact-match patterns", async () => {
+    await openAndType("printer jam");
+
+    for (const mock of [
+      quickCaseSearchMock,
+      quickIncidentSearchMock,
+      quickProblemSearchMock,
+      quickChangeRequestSearchMock,
+    ]) {
+      expect(mock).toHaveBeenLastCalledWith(
+        "printer jam",
+        expect.objectContaining({ forceFreeText: false }),
+      );
+    }
+  });
+
+  it("renders the exact-match banner after the result sections, not before them", async () => {
+    quickIncidentSearchMock.mockReturnValue({
+      data: [
+        {
+          id: "inc-1",
+          number: "INC0090472",
+          subject: "Prod cluster down",
+          state: "IN_PROGRESS",
+        },
+      ],
+      isFetching: false,
+    });
+
+    await openAndType("INC0090472");
+
+    const banner = await screen.findByText(
+      /Showing an exact match for incident number/,
+    );
+    const incidentsHeading = screen.getByText("Incidents");
+
+    // DOM order, not just presence: the banner must come after the results,
+    // not above them.
+    expect(
+      incidentsHeading.compareDocumentPosition(banner) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it("shows a low-key 'didn't match a known pattern' hint while a free-text search is in flight, and hides the exact-match banner at the same time", async () => {
+    quickCaseSearchMock.mockReturnValue({ data: undefined, isFetching: true });
+
+    await openAndType("printer jam");
+
+    expect(
+      await screen.findByText(
+        /Didn't match a known number pattern.*searching all fields/,
+      ),
+    ).toBeInTheDocument();
+    // The two messages are mutually exclusive — a free-text query never
+    // matches an exact-match shape, so the banner never renders alongside
+    // the hint.
+    expect(screen.queryByText(/Showing an exact match/)).not.toBeInTheDocument();
+  });
+
+  it("keeps showing the 'didn't match a known pattern' hint (settled wording) once the free-text search has settled with zero hits", async () => {
+    // Regression: this hint used to be gated on isFetching and disappeared
+    // the moment the search settled — so a query like "cs123" (doesn't
+    // match the exact-match shape, free-text search finds nothing) landed
+    // on a bare "No matches." with zero explanation of why it didn't get
+    // the fast exact-match path. The hint must persist through a settled
+    // zero-hit result, just with past-tense wording instead of the
+    // in-flight "searching..." phrasing.
+    quickCaseSearchMock.mockReturnValue(idleResult);
+
+    await openAndType("printer jam");
+
+    expect(
+      await screen.findByText(/Didn't match a known number pattern.*searched all fields\./),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/searching all fields, this may take a moment/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not flash 'No matches.' for a scoped CHG query while the (only relevant) change-request search is still fetching", async () => {
+    // A CHG-shaped query suppresses case/incident/problem entirely (their
+    // hooks are passed "" and settle to idle immediately), so `casesLoading`
+    // alone would already read `false` here — the regression this guards:
+    // the empty state must keep waiting on the change-request search
+    // specifically, not on the (irrelevant, already-idle) case search.
+    quickChangeRequestSearchMock.mockReturnValue({
+      data: undefined,
+      isFetching: true,
+    });
+
+    await openAndType("CHG0038721");
+
+    expect(screen.queryByText("No matches.")).not.toBeInTheDocument();
+  });
+
+  it("shows both 'No matches.' and the exact-match banner once a scoped CHG query genuinely settles with zero hits", async () => {
+    quickChangeRequestSearchMock.mockReturnValue({ data: [], isFetching: false });
+
+    await openAndType("CHG0038721");
+
+    const emptyState = await screen.findByText("No matches.");
+    const banner = await screen.findByText(
+      /Showing an exact match for change request number/,
+    );
+    expect(emptyState).toBeInTheDocument();
+    expect(banner).toBeInTheDocument();
+    // The banner is a footnote below the empty state, not competing with it.
+    expect(
+      emptyState.compareDocumentPosition(banner) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    // And the widen affordance still works from this zero-hit state.
+    fireEvent.click(screen.getByRole("button", { name: "Search in subject and description too" }));
+    await waitFor(() =>
+      expect(quickChangeRequestSearchMock).toHaveBeenLastCalledWith(
+        "CHG0038721",
+        expect.objectContaining({ forceFreeText: true }),
+      ),
+    );
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-recent/components/QuickNav.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-recent/components/QuickNav.tsx
@@ -15,7 +15,9 @@
 // under the License.
 
 import {
+  Alert,
   Box,
+  Button,
   ButtonBase,
   Form,
   InputBase,
@@ -40,6 +42,7 @@ import QuickNavEntityCard from "@features/csm-recent/components/QuickNavEntityCa
 import QuickNavResultSkeleton from "@features/csm-recent/components/QuickNavResultSkeleton";
 import SearchNoResultsIcon from "@components/empty-state/SearchNoResultsIcon";
 import {
+  classifyQuickCaseQuery,
   QUICK_CASE_MIN_QUERY_LEN,
   useQuickCaseSearch,
   type QuickCaseHit,
@@ -47,14 +50,17 @@ import {
 import { caseIdLabel } from "@features/csm-cases/utils/caseIdentity";
 import { useNavTransition } from "@hooks/useNavTransition";
 import {
+  classifyQuickIncidentQuery,
   QUICK_INCIDENT_MIN_QUERY_LEN,
   useQuickIncidentSearch,
 } from "@features/csm-operations/api/useQuickIncidentSearch";
 import {
+  classifyQuickChangeRequestQuery,
   QUICK_CHANGE_REQUEST_MIN_QUERY_LEN,
   useQuickChangeRequestSearch,
 } from "@features/csm-operations/api/useQuickChangeRequestSearch";
 import {
+  classifyQuickProblemQuery,
   QUICK_PROBLEM_MIN_QUERY_LEN,
   useQuickProblemSearch,
 } from "@features/csm-operations/api/useQuickProblemSearch";
@@ -92,6 +98,28 @@ interface Result {
 
 const RECENT_LIMIT = 8;
 
+/**
+ * Which entity kind's exact-match search actually ran for the current query
+ * — drives the shared "showing an exact match" banner. A typed query only
+ * ever matches one of these shapes (CS/INC/PRB/CHG are distinct prefixes,
+ * all followed by exactly 7 digits), so at most one is ever non-null.
+ */
+type ExactMatchKind =
+  | "caseNumber"
+  | "caseInternalId"
+  | "incidentNumber"
+  | "problemNumber"
+  | "changeRequestNumber"
+  | null;
+
+const EXACT_MATCH_LABELS: Record<Exclude<ExactMatchKind, null>, string> = {
+  caseNumber: "case number",
+  caseInternalId: "WSO2 case id",
+  incidentNumber: "incident number",
+  problemNumber: "problem number",
+  changeRequestNumber: "change request number",
+};
+
 const isMac =
   typeof navigator !== "undefined" && /Mac|iPhone|iPad/.test(navigator.platform);
 
@@ -106,6 +134,17 @@ export default function QuickNav(): JSX.Element | null {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
   const [active, setActive] = useState(0);
+  // Set only via the "Search in subject and description too" affordance below — opts a
+  // query that matched one of the case/incident/problem/change-request
+  // exact-match number (or WSO2-id) patterns back into free-text search for
+  // all four entity searches at once. Cleared whenever the query text itself
+  // changes, so widening one search never silently sticks for the next one
+  // typed. Shared across all four rather than one flag per type: a typed
+  // query only ever matches one of the four exact-match shapes (they have
+  // distinct prefixes — CS/INC/PRB/CHG — so widening always targets exactly
+  // the one search that was actually scoped; passing it to the other three
+  // hooks is a no-op since they're already on the free-text path).
+  const [forceFreeText, setForceFreeText] = useState(false);
 
   // Shareable-link support: `?q=` opens the palette pre-filled with a search
   // (e.g. a link like `/?q=CS0440883` someone pastes to a colleague), and
@@ -126,9 +165,109 @@ export default function QuickNav(): JSX.Element | null {
   // results stay clickable during the debounce window or after the input shrinks.
   const caseHitsSettled = trimmedQuery === debouncedQuery.trim();
 
+  // Whether the query the API actually ran (the debounced one) would be
+  // routed as an exact-match filter rather than free-text search, for each
+  // of the four searchable entity kinds — drives the shared "showing an
+  // exact match" banner below. Computed off the debounced (not live) query
+  // so the banner only reflects the search that actually ran, not what's
+  // mid-typing.
+  const caseSearchScope = classifyQuickCaseQuery(debouncedQuery.trim());
+  const incidentSearchScope = classifyQuickIncidentQuery(debouncedQuery.trim());
+  const problemSearchScope = classifyQuickProblemQuery(debouncedQuery.trim());
+  const changeRequestSearchScope = classifyQuickChangeRequestQuery(
+    debouncedQuery.trim(),
+  );
+
+  // This picks whichever of the four searches would run in exact-match mode
+  // (see {@link ExactMatchKind}), to drive both a single shared banner
+  // instead of one per entity kind (the palette is one search box, not four)
+  // and — below — which of the four hooks actually get to search at all.
+  // Computed off the classifications above (themselves off the debounced
+  // query), so this doesn't depend on any of the hooks' own results.
+  const exactMatchKind: ExactMatchKind =
+    caseSearchScope === "number"
+      ? "caseNumber"
+      : caseSearchScope === "internalId"
+        ? "caseInternalId"
+        : incidentSearchScope === "number"
+          ? "incidentNumber"
+          : problemSearchScope === "number"
+            ? "problemNumber"
+            : changeRequestSearchScope === "number"
+              ? "changeRequestNumber"
+              : null;
+
+  // Whether each of the four searches should actually run for the current
+  // debounced query. When the query matches exactly one entity kind's
+  // exact-match shape (`exactMatchKind !== null`), only that one kind's hook
+  // runs — the other three would otherwise burn a free-text request against
+  // entity types the query obviously doesn't belong to (e.g. typing a CHG
+  // number shouldn't also run a case/incident/problem search for the literal
+  // string "CHG0038721"). `forceFreeText` (the "Search in subject and description too" widen
+  // affordance) overrides this for all four at once, since widening is
+  // meant to broaden the search across every entity kind, not just the one
+  // that was originally scoped.
+  const caseSearchShouldRun =
+    forceFreeText ||
+    exactMatchKind === null ||
+    exactMatchKind === "caseNumber" ||
+    exactMatchKind === "caseInternalId";
+  const incidentSearchShouldRun =
+    forceFreeText || exactMatchKind === null || exactMatchKind === "incidentNumber";
+  const problemSearchShouldRun =
+    forceFreeText || exactMatchKind === null || exactMatchKind === "problemNumber";
+  const changeRequestSearchShouldRun =
+    forceFreeText ||
+    exactMatchKind === null ||
+    exactMatchKind === "changeRequestNumber";
+
   // API-backed case lookup: a CS/WSO2 id (or any subject text) resolves to real
-  // cases. Disabled until the query is long enough (see the hook).
-  const caseSearch = useQuickCaseSearch(open ? debouncedQuery : "");
+  // cases. Routed to an exact-match field filter when the debounced query
+  // matches the case-number/WSO2-id shape (see `classifyQuickCaseQuery`),
+  // unless the user asked to widen it via `forceFreeText`. Passed an empty
+  // query (same as when the palette is closed) when `caseSearchShouldRun` is
+  // false — that's the same `enabled: q.length >= MIN_LEN` gate the hook
+  // already uses to skip a request while the palette is closed, reused here
+  // to skip it while the query belongs to a different entity kind.
+  const caseSearch = useQuickCaseSearch(
+    open && caseSearchShouldRun ? debouncedQuery : "",
+    { forceFreeText },
+  );
+
+  // Same debounced query string fans out to the other searchable entity
+  // kinds — one shared debounce (above) rather than each hook debouncing its
+  // own copy, so a keystroke costs at most one query-string change, not four.
+  // Each is routed to its own exact-match number filter the same way cases
+  // are (see `classifyQuickIncidentQuery`/`classifyQuickProblemQuery`/
+  // `classifyQuickChangeRequestQuery`), also gated on the same shared
+  // `forceFreeText` widen flag and the same should-run suppression as cases
+  // above. Incidents/CRs/problems are ServiceNow-only and comparatively rare
+  // hits, so — unlike Cases — these don't get a dedicated skeleton: their
+  // sections simply appear once data lands, same as Pinned/Recent/Pages.
+  const incidentSearch = useQuickIncidentSearch(
+    open && incidentSearchShouldRun ? debouncedQuery : "",
+    { forceFreeText },
+  );
+  const changeRequestSearch = useQuickChangeRequestSearch(
+    open && changeRequestSearchShouldRun ? debouncedQuery : "",
+    { forceFreeText },
+  );
+  const problemSearch = useQuickProblemSearch(
+    open && problemSearchShouldRun ? debouncedQuery : "",
+    { forceFreeText },
+  );
+
+  // Only shown once every search this query feeds has actually settled (not
+  // while any is still fetching) and hasn't already been widened by the
+  // user.
+  const showExactMatchBanner =
+    !forceFreeText &&
+    exactMatchKind !== null &&
+    caseHitsSettled &&
+    !caseSearch.isFetching &&
+    !incidentSearch.isFetching &&
+    !changeRequestSearch.isFetching &&
+    !problemSearch.isFetching;
   // True while a case search is in flight (or its result is for a stale
   // query) — drives the "Cases" section's skeleton independently of whether
   // Pinned/Recent/Pages already have matches to show.
@@ -141,18 +280,46 @@ export default function QuickNav(): JSX.Element | null {
   // `caseSearch.data` still holds the previous results. Without this,
   // the skeleton block and the real "Cases" section would render together.
   const showCasesSkeleton = casesLoading && !caseSearch.data;
-
-  // Same debounced query string fans out to the other searchable entity
-  // kinds — one shared debounce (above) rather than each hook debouncing its
-  // own copy, so a keystroke costs at most one query-string change, not four.
-  // Incidents/CRs/problems are ServiceNow-only and comparatively rare hits,
-  // so — unlike Cases — these don't get a dedicated skeleton: their sections
-  // simply appear once data lands, same as Pinned/Recent/Pages.
-  const incidentSearch = useQuickIncidentSearch(open ? debouncedQuery : "");
-  const changeRequestSearch = useQuickChangeRequestSearch(
-    open ? debouncedQuery : "",
-  );
-  const problemSearch = useQuickProblemSearch(open ? debouncedQuery : "");
+  // True while any of the four searches this query feeds is actually
+  // in-flight — used below to show a quiet "didn't match a known number
+  // pattern" hint only for the duration of the wait, not once results have
+  // settled (settled-with-nothing already gets the "No matches." empty
+  // state, and settled-with-hits speaks for itself). A suppressed hook
+  // (passed an empty query per `*SearchShouldRun` above) settles to
+  // `isFetching === false` almost immediately, so this naturally reflects
+  // only whichever search(es) the current query actually feeds — no
+  // separate "which hooks are enabled" bookkeeping needed here.
+  const anySearchFetching =
+    caseSearch.isFetching ||
+    incidentSearch.isFetching ||
+    changeRequestSearch.isFetching ||
+    problemSearch.isFetching;
+  // Gates the "No matches." empty state below. `casesLoading` alone isn't
+  // enough here: it only reflects the case search, so when the query is
+  // scoped to (say) a CHG number — case search suppressed entirely per
+  // `caseSearchShouldRun` — `caseSearch.isFetching` goes false almost
+  // immediately (it isn't even running), and "No matches." would render
+  // while the change-request search that's actually relevant is still in
+  // flight. Reuses `anySearchFetching` (any of the four still fetching,
+  // which for a suppressed hook is trivially false) alongside the shared
+  // `caseHitsSettled` debounce check, so the empty state waits for BOTH
+  // "the debounce settled" AND "nothing still fetching" before it can
+  // render — same two-part wait `showExactMatchBanner` already does below.
+  const resultsSettling =
+    trimmedQuery.length >= QUICK_CASE_MIN_QUERY_LEN &&
+    (!caseHitsSettled || anySearchFetching);
+  // Passive, low-key heads-up shown for genuinely free-text queries (none of
+  // the four exact-match patterns matched) — mutually exclusive with
+  // `showExactMatchBanner` by construction: this requires
+  // `exactMatchKind === null`, that requires `exactMatchKind !== null`.
+  // Deliberately NOT gated on `anySearchFetching`/`resultsSettling`: it
+  // needs to stay visible through a settled zero-hit result too (e.g.
+  // typing "cs123" — doesn't match the exact-match shape, free-text search
+  // finds nothing), not just disappear the moment the search finishes,
+  // which would leave "No matches." with no explanation of why a plain-
+  // looking query didn't get the fast exact-match path.
+  const showNoPatternHint =
+    !forceFreeText && exactMatchKind === null && trimmedQuery.length > 0;
 
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -357,10 +524,31 @@ export default function QuickNav(): JSX.Element | null {
   // the end (avoids a setState-in-effect cascade).
   const safeActive = results.length ? Math.min(active, results.length - 1) : 0;
 
+  // Strips `q`/`goto` from the URL if either is present. Called whenever the
+  // palette stops being the reason `/` shouldn't redirect to `/dashboard`
+  // yet (see `RootLanding` in App.tsx) — on manual close without picking a
+  // result, and (separately, in the goto-resolution effect below) once a
+  // `?goto=` link actually resolves to a single match and navigates away.
+  const clearDeepLinkParams = () => {
+    if (!searchParams.has("q") && !searchParams.has("goto")) return;
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        next.delete("q");
+        next.delete("goto");
+        return next;
+      },
+      { replace: true },
+    );
+  };
+
   const close = () => {
     setOpen(false);
     setQuery("");
     setActive(0);
+    setForceFreeText(false);
+    setGotoTarget(null);
+    clearDeepLinkParams();
   };
 
   const choose = (r: Result | undefined) => {
@@ -414,17 +602,16 @@ export default function QuickNav(): JSX.Element | null {
 
     /* eslint-disable react-hooks/set-state-in-effect -- syncs palette state to the external goto/search resolution outcome, a one-shot action once the search settles */
     setGotoTarget(null);
-    setSearchParams(
-      (prev) => {
-        const next = new URLSearchParams(prev);
-        next.delete("q");
-        next.delete("goto");
-        return next;
-      },
-      { replace: true },
-    );
 
     if (matches.length === 1) {
+      // Only clear `q`/`goto` from the URL — and only here, on the single-
+      // match path. Leaving them in place for the 0-or-multiple-match case
+      // below is deliberate: RootLanding (App.tsx) reads their presence to
+      // keep deferring its `/dashboard` redirect, so the background stays
+      // blank behind the still-open palette instead of a dashboard loading
+      // in underneath it. They get cleared once the user either picks a
+      // result (route changes away from `/` entirely) or closes the palette
+      // manually (see `close()`, which calls `clearDeepLinkParams`).
       close();
       navigate(matches[0]);
     }
@@ -568,6 +755,7 @@ export default function QuickNav(): JSX.Element | null {
                 onChange={(e) => {
                   setQuery(e.target.value);
                   setActive(0);
+                  setForceFreeText(false);
                 }}
                 inputProps={{ "aria-label": "Quick nav search" }}
               />
@@ -587,7 +775,7 @@ export default function QuickNav(): JSX.Element | null {
                 </Box>
               )}
               {results.length === 0 ? (
-                casesLoading ? null : (
+                resultsSettling ? null : (
                   <Box
                     sx={{
                       display: "flex",
@@ -683,6 +871,51 @@ export default function QuickNav(): JSX.Element | null {
                     </Box>
                   );
                 })
+              )}
+              {/*
+                Both the exact-match banner and the no-pattern-match hint
+                render below every result section, not above them — they're
+                a footnote about how the search ran, not something that
+                should push the actual results down the page. They're
+                mutually exclusive by construction (`showExactMatchBanner`
+                requires `exactMatchKind !== null`, `showNoPatternHint`
+                requires it to be `null`), so at most one renders here.
+              */}
+              {showExactMatchBanner && exactMatchKind && (
+                <Alert severity="info" sx={{ mt: results.length ? 2 : 0 }}>
+                  {/* The widen button sits on its own row below the message,
+                      not MUI's inline `action` slot — "Search in subject
+                      and description too" is long enough that the inline
+                      layout wrapped the message and button onto two
+                      cramped, misaligned rows instead. */}
+                  <Box>
+                    Showing an exact match for {EXACT_MATCH_LABELS[exactMatchKind]}
+                    &nbsp;"{debouncedQuery.trim()}".
+                  </Box>
+                  <Button
+                    size="small"
+                    sx={{ mt: 1 }}
+                    onClick={() => setForceFreeText(true)}
+                  >
+                    Search in subject and description too
+                  </Button>
+                </Alert>
+              )}
+              {showNoPatternHint && (
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  sx={{
+                    display: "block",
+                    mt: results.length ? 2 : 0,
+                    textAlign: "center",
+                  }}
+                >
+                  Didn&apos;t match a known number pattern —{" "}
+                  {anySearchFetching
+                    ? "searching all fields, this may take a moment."
+                    : "searched all fields."}
+                </Typography>
               )}
             </Box>
           </Box>

--- a/apps/csm-portal/webapp/src/features/csm-recent/components/QuickNav.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-recent/components/QuickNav.tsx
@@ -318,8 +318,17 @@ export default function QuickNav(): JSX.Element | null {
   // finds nothing), not just disappear the moment the search finishes,
   // which would leave "No matches." with no explanation of why a plain-
   // looking query didn't get the fast exact-match path.
+  //
+  // Gated on the free-text path's minimum query length (all four hooks'
+  // MIN_QUERY_LEN happen to be the same value, 2 — using the case one as
+  // the representative constant), not just `> 0`: below that length every
+  // hook is disabled (`enabled: q.length >= MIN_LEN`) and no search runs at
+  // all, so the hint's "searched all fields" framing would be describing a
+  // request that was never made.
   const showNoPatternHint =
-    !forceFreeText && exactMatchKind === null && trimmedQuery.length > 0;
+    !forceFreeText &&
+    exactMatchKind === null &&
+    trimmedQuery.length >= QUICK_CASE_MIN_QUERY_LEN;
 
   const inputRef = useRef<HTMLInputElement>(null);
 

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -2221,7 +2221,7 @@ type SearchChangeRequestsFilters struct {
 	// "CHG0010001") exactly matches (optional). Exact match against
 	// ServiceNow's `number` column, routed as a first-class filter rather
 	// than through the free-text SearchQuery scan.
-	Number string `json:"number"`
+	Number *string `json:"number,omitempty"`
 }
 
 // SearchChangeRequestsRequest is the input for a change request search operation.
@@ -3267,7 +3267,7 @@ type SearchIncidentsFilters struct {
 	// "INC0010001") exactly matches (optional). Exact match against
 	// ServiceNow's `number` column, routed as a first-class filter rather
 	// than through the free-text SearchQuery scan.
-	Number string `json:"number"`
+	Number *string `json:"number,omitempty"`
 }
 
 // SearchIncidentsRequest is the input for POST /incidents/search.
@@ -3531,7 +3531,7 @@ type SearchProblemsFilters struct {
 	// "PRB0010001") exactly matches (optional). Exact match against
 	// ServiceNow's `number` column, routed as a first-class filter rather
 	// than through the free-text SearchQuery scan.
-	Number string `json:"number"`
+	Number *string `json:"number,omitempty"`
 }
 
 // SearchProblemsRequest is the input for POST /problems/search.

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -1362,6 +1362,16 @@ type ParsedCaseFilters struct {
 	// child-case relationship set via the case PATCH parentId field). Not yet
 	// available in the backing service.
 	ParentID *string
+	// Number filters to the case whose human-readable case number (e.g.
+	// "CS0441174") exactly matches (optional). Exact match against ServiceNow's
+	// `number` column, routed as a first-class filter rather than through the
+	// free-text SearchQuery scan.
+	Number *string
+	// InternalID filters to the case whose WSO2 case id exactly matches
+	// (optional). Exact match against ServiceNow's `u_wso2_case_id` column,
+	// routed as a first-class filter rather than through the free-text
+	// SearchQuery scan.
+	InternalID *string
 	// ProjectOnboardingStatuses filters to cases whose parent project's onboarding
 	// status is one of these values (optional; free-text SN choice labels, e.g.
 	// "Completed", "Not-Applicable" -- not a closed enum at this layer).
@@ -2207,6 +2217,11 @@ type SearchChangeRequestsFilters struct {
 	Impacts         []ChangeRequestImpact `json:"impacts"`
 	ClosedStartDate *time.Time            `json:"closedStartDate"`
 	ClosedEndDate   *time.Time            `json:"closedEndDate"`
+	// Number filters to the change request whose human-readable number (e.g.
+	// "CHG0010001") exactly matches (optional). Exact match against
+	// ServiceNow's `number` column, routed as a first-class filter rather
+	// than through the free-text SearchQuery scan.
+	Number string `json:"number"`
 }
 
 // SearchChangeRequestsRequest is the input for a change request search operation.
@@ -3248,6 +3263,11 @@ type SearchIncidentsFilters struct {
 	SearchQuery string             `json:"searchQuery"`
 	Priorities  []IncidentPriority `json:"priorities"`
 	ParentIDs   []string           `json:"parentIds"`
+	// Number filters to the incident whose human-readable number (e.g.
+	// "INC0010001") exactly matches (optional). Exact match against
+	// ServiceNow's `number` column, routed as a first-class filter rather
+	// than through the free-text SearchQuery scan.
+	Number string `json:"number"`
 }
 
 // SearchIncidentsRequest is the input for POST /incidents/search.
@@ -3507,6 +3527,11 @@ type IncidentView struct {
 // SearchProblemsFilters holds all optional filter criteria for a problem search.
 type SearchProblemsFilters struct {
 	SearchQuery string `json:"searchQuery"`
+	// Number filters to the problem whose human-readable number (e.g.
+	// "PRB0010001") exactly matches (optional). Exact match against
+	// ServiceNow's `number` column, routed as a first-class filter rather
+	// than through the free-text SearchQuery scan.
+	Number string `json:"number"`
 }
 
 // SearchProblemsRequest is the input for POST /problems/search.

--- a/entity-service/internal/service/case_filters.go
+++ b/entity-service/internal/service/case_filters.go
@@ -44,7 +44,7 @@ var caseFilterFieldSet = map[string]bool{
 	"createdOn": true, "updatedOn": true, "closedOn": true, "product": true,
 	"projectOnboardingStatus": true, "projectType": true, "integrationCsTeam": true,
 	"resolutionNotes": true, "parentId": true, "taskSLABusinessElapsedPercent": true,
-	"escalationLevel": true, "escalation": true,
+	"escalationLevel": true, "escalation": true, "number": true, "internalId": true,
 }
 
 // caseFilterOpSet is the exact set of CaseFieldFilter.Op values accepted by
@@ -503,6 +503,32 @@ func ParseCaseFieldFilters(filters []domain.CaseFieldFilter, callerEmail string,
 			id := f.Values[0]
 			p.ParentID = &id
 
+		case "number":
+			if f.Op != "eq" {
+				return domain.ParsedCaseFilters{}, badCaseFilterCombo(f)
+			}
+			if err := requireCaseFilterValues(f); err != nil {
+				return domain.ParsedCaseFilters{}, err
+			}
+			if len(f.Values) != 1 {
+				return domain.ParsedCaseFilters{}, &apierror.ValidationError{Msg: "filters: number eq requires exactly one value"}
+			}
+			number := f.Values[0]
+			p.Number = &number
+
+		case "internalId":
+			if f.Op != "eq" {
+				return domain.ParsedCaseFilters{}, badCaseFilterCombo(f)
+			}
+			if err := requireCaseFilterValues(f); err != nil {
+				return domain.ParsedCaseFilters{}, err
+			}
+			if len(f.Values) != 1 {
+				return domain.ParsedCaseFilters{}, &apierror.ValidationError{Msg: "filters: internalId eq requires exactly one value"}
+			}
+			internalID := f.Values[0]
+			p.InternalID = &internalID
+
 		case "taskSLABusinessElapsedPercent":
 			if err := requireCaseFilterValues(f); err != nil {
 				return domain.ParsedCaseFilters{}, err
@@ -645,6 +671,10 @@ func rejectUnsupportedOrGroupFields(parsed domain.ParsedCaseFilters) error {
 		return &apierror.ValidationError{Msg: "anyOf: field \"tag\" is not supported inside an OR group"}
 	case parsed.ParentID != nil:
 		return &apierror.ValidationError{Msg: "anyOf: field \"parentId\" is not supported inside an OR group"}
+	case parsed.Number != nil:
+		return &apierror.ValidationError{Msg: "anyOf: field \"number\" is not supported inside an OR group"}
+	case parsed.InternalID != nil:
+		return &apierror.ValidationError{Msg: "anyOf: field \"internalId\" is not supported inside an OR group"}
 	case len(parsed.CreatedBy) > 0 || parsed.CreatedByMe:
 		return &apierror.ValidationError{Msg: "anyOf: field \"createdBy\" is not supported inside an OR group"}
 	case parsed.ClosedStartDate != nil || parsed.ClosedEndDate != nil:

--- a/entity-service/internal/service/case_filters_test.go
+++ b/entity-service/internal/service/case_filters_test.go
@@ -148,6 +148,24 @@ func TestParseCaseFieldFilters_NamedFieldTranslations(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "number eq",
+			in:   []domain.CaseFieldFilter{{Field: "number", Op: "eq", Values: []string{"CS0441174"}}},
+			check: func(t *testing.T, p domain.ParsedCaseFilters) {
+				if p.Number == nil || *p.Number != "CS0441174" {
+					t.Fatalf("Number = %v", p.Number)
+				}
+			},
+		},
+		{
+			name: "internalId eq",
+			in:   []domain.CaseFieldFilter{{Field: "internalId", Op: "eq", Values: []string{"12345"}}},
+			check: func(t *testing.T, p domain.ParsedCaseFilters) {
+				if p.InternalID == nil || *p.InternalID != "12345" {
+					t.Fatalf("InternalID = %v", p.InternalID)
+				}
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -174,6 +192,8 @@ func TestParseCaseFieldFilters_Rejections(t *testing.T) {
 		{name: "resolutionNotes isNotEmpty unsupported", in: []domain.CaseFieldFilter{{Field: "resolutionNotes", Op: "isNotEmpty"}}},
 		{name: "createdBy eq non-placeholder literal", in: []domain.CaseFieldFilter{{Field: "createdBy", Op: "eq", Values: []string{"someone@example.com"}}}},
 		{name: "createdOn bad date format", in: []domain.CaseFieldFilter{{Field: "createdOn", Op: "gte", Values: []string{"not-a-date"}}}},
+		{name: "number in unsupported", in: []domain.CaseFieldFilter{{Field: "number", Op: "in", Values: []string{"CS0441174"}}}},
+		{name: "internalId in unsupported", in: []domain.CaseFieldFilter{{Field: "internalId", Op: "in", Values: []string{"12345"}}}},
 	}
 
 	for _, tc := range cases {

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -341,7 +341,15 @@ type snCaseFilters struct {
 	// declares it). See domain.ParsedCaseFilters.ExcludeTags.
 	ExcludeTags []string `json:"excludeTags,omitempty"`
 	// ParentID: see domain.SearchCasesFilters.ParentID doc comment.
-	ParentID                  string   `json:"parentId,omitempty"`
+	ParentID string `json:"parentId,omitempty"`
+	// Number: see domain.ParsedCaseFilters.Number doc comment. Exact
+	// match against ServiceNow's `number` column -- not part of the free-text
+	// SearchQuery scan.
+	Number string `json:"number,omitempty"`
+	// InternalID: see domain.ParsedCaseFilters.InternalID doc comment. Exact
+	// match against ServiceNow's `u_wso2_case_id` column -- not part of the
+	// free-text SearchQuery scan.
+	InternalID                string   `json:"internalId,omitempty"`
 	ProjectOnboardingStatuses []string `json:"projectOnboardingStatuses,omitempty"`
 	ProjectTypeIDs            []string `json:"projectTypeIds,omitempty"`
 	IntegrationCsTeamIDs      []string `json:"integrationCsTeamIds,omitempty"`
@@ -2121,6 +2129,8 @@ func buildSNCaseFilters(parsed domain.ParsedCaseFilters, searchQuery string) snC
 		Tags:                      parsed.Tags,
 		ExcludeTags:               parsed.ExcludeTags,
 		ParentID:                  snParentIDFilter(parsed.ParentID),
+		Number:                    stringPtrValue(parsed.Number),
+		InternalID:                stringPtrValue(parsed.InternalID),
 		ProjectOnboardingStatuses: parsed.ProjectOnboardingStatuses,
 		ProjectTypeIDs:            uuidsToSysids(parsed.ProjectTypeIDs),
 		IntegrationCsTeamIDs:      uuidsToSysids(parsed.IntegrationCsTeamIDs),

--- a/entity-service/internal/service/sn_change_request_service.go
+++ b/entity-service/internal/service/sn_change_request_service.go
@@ -88,6 +88,10 @@ type snChangeRequestFilters struct {
 	ImpactKeys      []int    `json:"impactKeys,omitempty"`
 	ClosedStartDate string   `json:"closedStartDate,omitempty"`
 	ClosedEndDate   string   `json:"closedEndDate,omitempty"`
+	// Number: see domain.SearchChangeRequestsFilters.Number doc comment.
+	// Exact match against ServiceNow's `number` column -- not part of the
+	// free-text SearchQuery scan.
+	Number string `json:"number,omitempty"`
 }
 
 // snCRTypeIDMap maps domain ChangeRequestType enums to SN numeric type IDs.
@@ -288,6 +292,7 @@ func (s *snChangeRequestService) SearchChangeRequests(ctx context.Context, req d
 			ImpactKeys:      domainCRImpactsToSNIDs(req.Filters.Impacts),
 			ClosedStartDate: formatSNDateTimeUTC(req.Filters.ClosedStartDate),
 			ClosedEndDate:   formatSNDateTimeUTC(req.Filters.ClosedEndDate),
+			Number:          req.Filters.Number,
 		},
 		SortBy:     snSortBy,
 		Pagination: snProjectPagination{Limit: req.Pagination.Limit, Offset: req.Pagination.Offset},

--- a/entity-service/internal/service/sn_change_request_service.go
+++ b/entity-service/internal/service/sn_change_request_service.go
@@ -246,6 +246,9 @@ func (s *snChangeRequestService) SearchChangeRequests(ctx context.Context, req d
 	if err := validateSearchQuery(req.Filters.SearchQuery); err != nil {
 		return domain.SearchChangeRequestsResponse{}, err
 	}
+	if err := validateExactNumber("number", req.Filters.Number); err != nil {
+		return domain.SearchChangeRequestsResponse{}, err
+	}
 
 	if req.Filters.ClosedEndDate != nil && req.Filters.ClosedStartDate != nil &&
 		req.Filters.ClosedEndDate.Before(*req.Filters.ClosedStartDate) {
@@ -292,7 +295,7 @@ func (s *snChangeRequestService) SearchChangeRequests(ctx context.Context, req d
 			ImpactKeys:      domainCRImpactsToSNIDs(req.Filters.Impacts),
 			ClosedStartDate: formatSNDateTimeUTC(req.Filters.ClosedStartDate),
 			ClosedEndDate:   formatSNDateTimeUTC(req.Filters.ClosedEndDate),
-			Number:          req.Filters.Number,
+			Number:          stringPtrValue(req.Filters.Number),
 		},
 		SortBy:     snSortBy,
 		Pagination: snProjectPagination{Limit: req.Pagination.Limit, Offset: req.Pagination.Offset},

--- a/entity-service/internal/service/sn_change_request_service_test.go
+++ b/entity-service/internal/service/sn_change_request_service_test.go
@@ -144,7 +144,7 @@ func TestSNChangeRequestService_SearchChangeRequests_NumberFilterPassedThrough(t
 	svc := NewServiceNowChangeRequestService(client)
 
 	req := domain.SearchChangeRequestsRequest{
-		Filters: domain.SearchChangeRequestsFilters{Number: "CHG0010001"},
+		Filters: domain.SearchChangeRequestsFilters{Number: strPtr("CHG0010001")},
 	}
 	if _, err := svc.SearchChangeRequests(contextWithUserIDToken("token"), req); err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/entity-service/internal/service/sn_change_request_service_test.go
+++ b/entity-service/internal/service/sn_change_request_service_test.go
@@ -19,9 +19,11 @@ package service
 import (
 	"encoding/json"
 	"errors"
+	"net/http"
 	"testing"
 
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
 )
 
 // TestToDownstreamUTCDateTime covers the create-path datetime conversion: the
@@ -118,5 +120,44 @@ func TestNormalizePaginationCapMatchesDownstream(t *testing.T) {
 
 	if maxLimit != 50 {
 		t.Fatalf("maxLimit is %d; the downstream layer rejects anything above 50", maxLimit)
+	}
+}
+
+// TestSNChangeRequestService_SearchChangeRequests_NumberFilterPassedThrough verifies
+// the exact-match Number filter reaches the outgoing payload under the "number" key
+// unchanged, alongside the untouched free-text searchQuery.
+func TestSNChangeRequestService_SearchChangeRequests_NumberFilterPassedThrough(t *testing.T) {
+	var gotBody map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/change-requests/search", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", r.Method)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"changeRequests": [], "totalRecords": 0, "offset": 0, "limit": 20}`))
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowChangeRequestService(client)
+
+	req := domain.SearchChangeRequestsRequest{
+		Filters: domain.SearchChangeRequestsFilters{Number: "CHG0010001"},
+	}
+	if _, err := svc.SearchChangeRequests(contextWithUserIDToken("token"), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	gotFilters, ok := gotBody["filters"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected filters object in payload, got %+v", gotBody["filters"])
+	}
+	if gotFilters["number"] != "CHG0010001" {
+		t.Fatalf("filters.number: got %v, want %q", gotFilters["number"], "CHG0010001")
+	}
+	if _, hasSearchQuery := gotFilters["searchQuery"]; hasSearchQuery {
+		t.Fatalf("filters.searchQuery: expected omitted (empty), got %v", gotFilters["searchQuery"])
 	}
 }

--- a/entity-service/internal/service/sn_id.go
+++ b/entity-service/internal/service/sn_id.go
@@ -45,6 +45,17 @@ func snParentIDFilter(uuid *string) string {
 	return uuidToSysid(*uuid)
 }
 
+// stringPtrValue dereferences an optional string filter value, returning ""
+// (omitted via omitempty) when nil. Unlike snParentIDFilter, no sysid
+// conversion applies: number and internalId are opaque ServiceNow values,
+// not UUIDs.
+func stringPtrValue(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
 // uuidsToSysids converts a slice of UUID strings to sysids.
 // Returns the original slice unchanged if it is empty.
 func uuidsToSysids(uuids []string) []string {

--- a/entity-service/internal/service/sn_id.go
+++ b/entity-service/internal/service/sn_id.go
@@ -16,6 +16,35 @@
 
 package service
 
+import (
+	"fmt"
+	"unicode/utf8"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
+)
+
+// maxExactNumberLen bounds an exact-match record-number filter
+// (incident/problem/change-request `number`) before it reaches the
+// ServiceNow client. Deliberately a length cap only, not a format/prefix
+// check: the case search's own number/internalId filters (case_filters.go)
+// don't validate format either, and every entity type's real number prefix
+// is an SN configuration detail this layer shouldn't hardcode assumptions
+// about.
+const maxExactNumberLen = 50
+
+// validateExactNumber checks an optional exact-match number filter value,
+// returning nil for an absent (nil) filter. Mirrors validateSearchQuery's
+// length-cap style (user_service.go) for the free-text path.
+func validateExactNumber(fieldName string, number *string) error {
+	if number == nil {
+		return nil
+	}
+	if utf8.RuneCountInString(*number) > maxExactNumberLen {
+		return &apierror.ValidationError{Msg: fmt.Sprintf("%s cannot exceed %d characters", fieldName, maxExactNumberLen)}
+	}
+	return nil
+}
+
 // sysidToUUID converts a 32-character ServiceNow sysid to a standard UUID by
 // inserting hyphens at the canonical 8-4-4-4-12 positions.
 // Returns the input unchanged if it is not exactly 32 hex characters.

--- a/entity-service/internal/service/sn_incident_service.go
+++ b/entity-service/internal/service/sn_incident_service.go
@@ -85,6 +85,10 @@ type snIncidentFilters struct {
 	SearchQuery  string   `json:"searchQuery,omitempty"`
 	PriorityKeys []int    `json:"priorityKeys,omitempty"` // SN expects int keys
 	ParentIDs    []string `json:"parentIds,omitempty"`
+	// Number: see domain.SearchIncidentsFilters.Number doc comment. Exact
+	// match against ServiceNow's `number` column -- not part of the
+	// free-text SearchQuery scan.
+	Number string `json:"number,omitempty"`
 }
 
 // snIncidentPriorityKeyMap maps domain IncidentPriority enums to SN numeric priority keys.
@@ -210,6 +214,7 @@ func (s *snIncidentService) SearchIncidents(ctx context.Context, req domain.Sear
 			SearchQuery:  req.Filters.SearchQuery,
 			PriorityKeys: priorityKeys,
 			ParentIDs:    uuidsToSysids(req.Filters.ParentIDs),
+			Number:       req.Filters.Number,
 		},
 		SortBy:     snSortBy,
 		Pagination: snProjectPagination{Limit: req.Pagination.Limit, Offset: req.Pagination.Offset},

--- a/entity-service/internal/service/sn_incident_service.go
+++ b/entity-service/internal/service/sn_incident_service.go
@@ -178,6 +178,9 @@ func (s *snIncidentService) SearchIncidents(ctx context.Context, req domain.Sear
 	if err := validateSearchQuery(req.Filters.SearchQuery); err != nil {
 		return domain.SearchIncidentsResponse{}, err
 	}
+	if err := validateExactNumber("number", req.Filters.Number); err != nil {
+		return domain.SearchIncidentsResponse{}, err
+	}
 	if req.SortBy.Field != "" && !validIncidentSortField[req.SortBy.Field] {
 		return domain.SearchIncidentsResponse{}, &apierror.ValidationError{Msg: "sortBy.field contains invalid value: " + string(req.SortBy.Field)}
 	}
@@ -214,7 +217,7 @@ func (s *snIncidentService) SearchIncidents(ctx context.Context, req domain.Sear
 			SearchQuery:  req.Filters.SearchQuery,
 			PriorityKeys: priorityKeys,
 			ParentIDs:    uuidsToSysids(req.Filters.ParentIDs),
-			Number:       req.Filters.Number,
+			Number:       stringPtrValue(req.Filters.Number),
 		},
 		SortBy:     snSortBy,
 		Pagination: snProjectPagination{Limit: req.Pagination.Limit, Offset: req.Pagination.Offset},

--- a/entity-service/internal/service/sn_incident_service_test.go
+++ b/entity-service/internal/service/sn_incident_service_test.go
@@ -169,3 +169,42 @@ func TestSNIncidentService_UpdateIncident_WatchList_InvalidUUID(t *testing.T) {
 		t.Fatalf("expected *apierror.ValidationError, got %T: %v", err, err)
 	}
 }
+
+// TestSNIncidentService_SearchIncidents_NumberFilterPassedThrough verifies the
+// exact-match Number filter reaches the outgoing payload under the "number" key
+// unchanged, alongside the untouched free-text searchQuery.
+func TestSNIncidentService_SearchIncidents_NumberFilterPassedThrough(t *testing.T) {
+	var gotBody map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/incidents/search", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", r.Method)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"incidents": [], "totalRecords": 0, "offset": 0, "limit": 20}`))
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowIncidentService(client)
+
+	req := domain.SearchIncidentsRequest{
+		Filters: domain.SearchIncidentsFilters{Number: "INC0010001"},
+	}
+	if _, err := svc.SearchIncidents(contextWithUserIDToken("token"), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	gotFilters, ok := gotBody["filters"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected filters object in payload, got %+v", gotBody["filters"])
+	}
+	if gotFilters["number"] != "INC0010001" {
+		t.Fatalf("filters.number: got %v, want %q", gotFilters["number"], "INC0010001")
+	}
+	if _, hasSearchQuery := gotFilters["searchQuery"]; hasSearchQuery {
+		t.Fatalf("filters.searchQuery: expected omitted (empty), got %v", gotFilters["searchQuery"])
+	}
+}

--- a/entity-service/internal/service/sn_incident_service_test.go
+++ b/entity-service/internal/service/sn_incident_service_test.go
@@ -191,7 +191,7 @@ func TestSNIncidentService_SearchIncidents_NumberFilterPassedThrough(t *testing.
 	svc := NewServiceNowIncidentService(client)
 
 	req := domain.SearchIncidentsRequest{
-		Filters: domain.SearchIncidentsFilters{Number: "INC0010001"},
+		Filters: domain.SearchIncidentsFilters{Number: strPtr("INC0010001")},
 	}
 	if _, err := svc.SearchIncidents(contextWithUserIDToken("token"), req); err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/entity-service/internal/service/sn_problem_service.go
+++ b/entity-service/internal/service/sn_problem_service.go
@@ -53,6 +53,10 @@ type snProblemSearchPayload struct {
 
 type snProblemFilters struct {
 	SearchQuery string `json:"searchQuery,omitempty"`
+	// Number: see domain.SearchProblemsFilters.Number doc comment. Exact
+	// match against ServiceNow's `number` column -- not part of the
+	// free-text SearchQuery scan.
+	Number string `json:"number,omitempty"`
 }
 
 type snProblemService struct {
@@ -75,7 +79,7 @@ func (s *snProblemService) SearchProblems(ctx context.Context, req domain.Search
 	token := middleware.UserIDTokenFromContext(ctx)
 
 	payload := snProblemSearchPayload{
-		Filters:    snProblemFilters{SearchQuery: req.Filters.SearchQuery},
+		Filters:    snProblemFilters{SearchQuery: req.Filters.SearchQuery, Number: req.Filters.Number},
 		Pagination: snProjectPagination{Limit: req.Pagination.Limit, Offset: req.Pagination.Offset},
 	}
 

--- a/entity-service/internal/service/sn_problem_service.go
+++ b/entity-service/internal/service/sn_problem_service.go
@@ -75,11 +75,14 @@ func (s *snProblemService) SearchProblems(ctx context.Context, req domain.Search
 	if err := validateSearchQuery(req.Filters.SearchQuery); err != nil {
 		return domain.SearchProblemsResponse{}, err
 	}
+	if err := validateExactNumber("number", req.Filters.Number); err != nil {
+		return domain.SearchProblemsResponse{}, err
+	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
 
 	payload := snProblemSearchPayload{
-		Filters:    snProblemFilters{SearchQuery: req.Filters.SearchQuery, Number: req.Filters.Number},
+		Filters:    snProblemFilters{SearchQuery: req.Filters.SearchQuery, Number: stringPtrValue(req.Filters.Number)},
 		Pagination: snProjectPagination{Limit: req.Pagination.Limit, Offset: req.Pagination.Offset},
 	}
 

--- a/entity-service/internal/service/sn_problem_service_test.go
+++ b/entity-service/internal/service/sn_problem_service_test.go
@@ -19,8 +19,10 @@ package service
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 	"testing"
 
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
 )
 
@@ -45,7 +47,7 @@ func TestSNProblemService_SearchProblems_NumberFilterPassedThrough(t *testing.T)
 	svc := NewServiceNowProblemService(client)
 
 	req := domain.SearchProblemsRequest{
-		Filters: domain.SearchProblemsFilters{Number: "PRB0010001"},
+		Filters: domain.SearchProblemsFilters{Number: strPtr("PRB0010001")},
 	}
 	if _, err := svc.SearchProblems(contextWithUserIDToken("token"), req); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -60,5 +62,37 @@ func TestSNProblemService_SearchProblems_NumberFilterPassedThrough(t *testing.T)
 	}
 	if _, hasSearchQuery := gotFilters["searchQuery"]; hasSearchQuery {
 		t.Fatalf("filters.searchQuery: expected omitted (empty), got %v", gotFilters["searchQuery"])
+	}
+}
+
+// TestSNProblemService_SearchProblems_RejectsOverlongNumber verifies an
+// oversized exact-match Number filter is rejected as a *apierror.ValidationError
+// before the ServiceNow client is ever called.
+func TestSNProblemService_SearchProblems_RejectsOverlongNumber(t *testing.T) {
+	called := false
+	mux := http.NewServeMux()
+	mux.HandleFunc("/problems/search", func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"problems": [], "totalRecords": 0, "offset": 0, "limit": 20}`))
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowProblemService(client)
+
+	req := domain.SearchProblemsRequest{
+		Filters: domain.SearchProblemsFilters{Number: strPtr(strings.Repeat("x", maxExactNumberLen+1))},
+	}
+	_, err := svc.SearchProblems(contextWithUserIDToken("token"), req)
+
+	var valErr *apierror.ValidationError
+	if err == nil {
+		t.Fatal("expected a validation error, got nil")
+	}
+	if ok := asValidationError(err, &valErr); !ok {
+		t.Fatalf("expected *apierror.ValidationError, got %T: %v", err, err)
+	}
+	if called {
+		t.Fatal("ServiceNow client was called despite the invalid filter")
 	}
 }

--- a/entity-service/internal/service/sn_problem_service_test.go
+++ b/entity-service/internal/service/sn_problem_service_test.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package service
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+)
+
+// TestSNProblemService_SearchProblems_NumberFilterPassedThrough verifies the
+// exact-match Number filter reaches the outgoing payload under the "number" key
+// unchanged, alongside the untouched free-text searchQuery.
+func TestSNProblemService_SearchProblems_NumberFilterPassedThrough(t *testing.T) {
+	var gotBody map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/problems/search", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", r.Method)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"problems": [], "totalRecords": 0, "offset": 0, "limit": 20}`))
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowProblemService(client)
+
+	req := domain.SearchProblemsRequest{
+		Filters: domain.SearchProblemsFilters{Number: "PRB0010001"},
+	}
+	if _, err := svc.SearchProblems(contextWithUserIDToken("token"), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	gotFilters, ok := gotBody["filters"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected filters object in payload, got %+v", gotBody["filters"])
+	}
+	if gotFilters["number"] != "PRB0010001" {
+		t.Fatalf("filters.number: got %v, want %q", gotFilters["number"], "PRB0010001")
+	}
+	if _, hasSearchQuery := gotFilters["searchQuery"]; hasSearchQuery {
+		t.Fatalf("filters.searchQuery: expected omitted (empty), got %v", gotFilters["searchQuery"])
+	}
+}

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -4781,6 +4781,8 @@ components:
             - taskSLABusinessElapsedPercent
             - escalationLevel
             - escalation
+            - number
+            - internalId
         op:
           type: string
           enum: [eq, in, notIn, isEmpty, isNotEmpty, gte, lte]
@@ -4870,6 +4872,12 @@ components:
         - **escalation** (isEmpty / isNotEmpty): values ignored; isEmpty
           matches cases with no active escalation, isNotEmpty matches cases
           with an active escalation.
+        - **number** (eq): a single case number (e.g. "CS0441174"); matches
+          exactly. Routed as a first-class filter rather than through the
+          free-text searchQuery scan.
+        - **internalId** (eq): a single WSO2 case id; matches exactly. Routed
+          as a first-class filter rather than through the free-text
+          searchQuery scan.
 
     CaseFilterBranch:
       type: object
@@ -5801,6 +5809,12 @@ components:
               type: string
               format: date-time
               description: "ISO-8601 UTC datetime (YYYY-MM-DDTHH:MM:SSZ)"
+            number:
+              type: string
+              description: >-
+                A single change request number (e.g. "CHG0010001"); matches
+                exactly. Routed as a first-class filter rather than through
+                the free-text searchQuery scan.
         sortBy:
           type: object
           required: [field, order]
@@ -7749,6 +7763,12 @@ components:
               items:
                 type: string
                 format: uuid
+            number:
+              type: string
+              description: >-
+                A single incident number (e.g. "INC0010001"); matches
+                exactly. Routed as a first-class filter rather than through
+                the free-text searchQuery scan.
         sortBy:
           type: object
           properties:
@@ -8181,6 +8201,12 @@ components:
           properties:
             searchQuery:
               type: string
+            number:
+              type: string
+              description: >-
+                A single problem number (e.g. "PRB0010001"); matches exactly.
+                Routed as a first-class filter rather than through the
+                free-text searchQuery scan.
         pagination:
           $ref: '#/components/schemas/Pagination'
 


### PR DESCRIPTION
## Purpose
The CSM portal's global case search was slow (multiple seconds in production for a single case-number lookup). Case number and WSO2 case id were only reachable through the free-text `searchQuery` filter, which the backing ServiceNow data source evaluates as an unindexed scan across four columns (case number, WSO2 case id, subject, description) -- expensive regardless of how precise the typed value is, and worse for the CSM portal than for the customer portal because the CSM search has no per-account scoping to narrow the candidate set first.

## Goals
Add `caseNumber` and `wso2CaseId` as first-class, exact-match case-search filters (mirroring how every other simple case attribute -- state, severity, project, parentId, etc. -- already works), and route the CSM portal's global quick-search palette to use them automatically when the typed text looks like a case number or a WSO2 case id, instead of always going through the free-text scan.

## Approach
Three layers, bottom-up:
- **entity-service**: added `caseNumber`/`wso2CaseId` to the case-search field-filter allowlist (`eq`-only, single value, same pattern as the existing `parentId` filter), threaded end-to-end into the request sent to the backing data source. Documented in `openapi.yaml`.
- **csm-portal backend**: this service's case-search path is a pure byte passthrough (no typed request struct), so no Go code change was needed -- only its own independently-maintained `openapi.yaml` was updated to keep the documented contract in sync.
- **csm-portal webapp**: the global quick-search palette (`QuickNav`) now classifies the typed query -- a `CS` + 7-digit pattern routes to the `caseNumber` filter, a `<prefix>-<1-4 digits>` pattern routes to `wso2CaseId`, anything else keeps using the existing free-text search unchanged. When a scoped exact-match search runs, an inline banner tells the user the search was narrowed to that attribute, with a "Search all fields" action to re-run the same query as free text -- narrowing is never silent, and widening is always the user's explicit choice.

A corresponding change to the entity-service's backing data source (additive, gated behind the two new optional filter keys, verified live against a non-production environment) has already landed separately.

## User stories
As a CS engineer using the CSM portal's quick-search, when I type a known case number or WSO2 case id, I want the matching case to come back near-instantly instead of waiting several seconds, since this is the most common thing I search for during a support call.

## Release note
Case search now supports exact-match filtering by case number (`caseNumber`) and WSO2 case id (`wso2CaseId`), in addition to the existing free-text search. The CSM portal's global quick-search automatically uses the faster exact-match path when the typed text looks like a case number or WSO2 case id, with an option to widen back to a full-text search.

## Documentation
N/A -- internal API filter addition, no external-facing documentation to update.

## Training
N/A -- no training content impact.

## Certification
N/A -- no certification exam impact.

## Marketing
N/A -- internal performance fix, no marketing content.

## Automation tests
 - Unit tests
   > entity-service: added `ParseCaseFieldFilters` parse/rejection tests for both new fields (`entity-service/internal/service/case_filters_test.go`), following the existing `parentId` test pattern. Full `go test ./...` passes for both `entity-service` and `apps/csm-portal/backend`.
 - Integration tests
   > csm-portal webapp: added routing tests for `classifyQuickCaseQuery` (both regexes' edge cases) and `useQuickCaseSearch` (all three routing branches, including the `forceFreeText` widen override), plus `QuickNav` tests for the new "exact match" banner and its widen action. Full `vitest` suite passes with no regressions (986 passed / 8 pre-existing unrelated failures, confirmed present on `main` before this change).

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A -- Go and TypeScript changes only, no Java in this PR.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A -- no sample apps affected.

## Related PRs
A corresponding backing-data-source contract change has already landed separately (tracked internally, not linked here as it lives in a private repo).

## Migrations (if applicable)
N/A -- additive filter fields, no data migration.

## Test environment
Verified via `go build`/`go vet`/`go test` (entity-service, csm-portal backend) and `tsc -b`/`vitest` (csm-portal webapp) locally. No browser-specific behavior introduced.

## Learning
N/A.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Quick navigation now recognizes exact case, change request, incident, and problem numbers.
  - Case searches also support exact internal ID matching.
  - Exact matches search identifiers directly for more precise results.
  - Added an option to broaden exact-match searches to free text.
  - Added clearer search messages, exact-match indicators, widening actions, and format guidance.
  - Improved deep-link handling, loading states, and empty-state behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->