### PR TITLE
fix(entity-service, csm-portal): show all linked change requests, incl. Linked Items tab count

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -1809,10 +1809,12 @@ export default function CsmCaseDetailPage(): JSX.Element {
                   t.id !== "time" &&
                   t.id !== "call-requests")),
           ).map((t) => {
-            // Counts shown only where the tab IS the list (unambiguous). Not
-            // shown for "related" — ChildCasesWidget runs its own scoped
-            // query for the child-case list, so no count is available here
-            // without an extra fetch.
+            // Counts shown only where the tab IS the list (unambiguous), or
+            // where the parent case-detail object already has the list in
+            // hand. "related" sums linkedChangeRequests + linkedServiceRequests
+            // (both already present on `c`); ChildCasesWidget is still
+            // excluded since it runs its own scoped query and would need an
+            // extra fetch to get a count.
             const count =
               t.id === "watchers"
                 ? c.watchers.length
@@ -1826,7 +1828,10 @@ export default function CsmCaseDetailPage(): JSX.Element {
                         ? callRequests?.length
                         : t.id === "tasks"
                           ? caseTasks?.total
-                          : undefined;
+                          : t.id === "related"
+                            ? (c.linkedChangeRequests?.length ?? 0) +
+                              (c.linkedServiceRequests?.length ?? 0)
+                            : undefined;
             return (
               <Tab
                 key={t.id}

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -75,8 +75,18 @@ type snCase struct {
 	LinkedServiceRequests []snLinkedServiceRequestRef `json:"linkedServiceRequests"`
 	// ChangeRequests carries the change requests raised from this case, keyed as
 	// `changeRequests` upstream. Only populated for service-request cases.
+	//
+	// Deprecated: the upstream `changeRequests` field is filtered to a subset of change
+	// request states by the backing service. Case mapping below reads ChangeRequestsAll
+	// instead, which is unfiltered. This field is kept only because it is still present
+	// on the upstream response; nothing in this service reads it.
 	ChangeRequests []snLinkedChangeRequestRef `json:"changeRequests"`
-	ResolutionCode *struct {
+	// ChangeRequestsAll carries the same change requests as ChangeRequests but unfiltered by
+	// state, keyed as `changeRequestsAll` upstream. Same item shape as `changeRequests`. Case
+	// mapping reads this field so linked change requests in New/Assess/Authorize states are
+	// no longer silently dropped before they reach the outward `linkedChangeRequests` field.
+	ChangeRequestsAll []snLinkedChangeRequestRef `json:"changeRequestsAll"`
+	ResolutionCode    *struct {
 		ID    json.Number `json:"id"`
 		Label string      `json:"label"`
 	} `json:"resolutionCode"`
@@ -844,9 +854,9 @@ func (s *snCaseService) GetCaseByID(ctx context.Context, id string) (domain.Case
 		}
 		cv.LinkedServiceRequests = lsr
 	}
-	if len(c.ChangeRequests) > 0 {
-		lcr := make([]domain.LinkedChangeRequestRef, 0, len(c.ChangeRequests))
-		for _, r := range c.ChangeRequests {
+	if len(c.ChangeRequestsAll) > 0 {
+		lcr := make([]domain.LinkedChangeRequestRef, 0, len(c.ChangeRequestsAll))
+		for _, r := range c.ChangeRequestsAll {
 			// An absent upstream subject becomes null, not "" — see the note on
 			// LinkedChangeRequestRef.Name.
 			var name *string

--- a/entity-service/internal/service/sn_case_service_test.go
+++ b/entity-service/internal/service/sn_case_service_test.go
@@ -1446,8 +1446,9 @@ func TestCaseService_SearchTags_ServiceUnavailable(t *testing.T) {
 }
 
 // TestSNCaseService_GetCaseByID_MapsLinkedChangeRequests covers the reverse side of the
-// service-request <-> change-request link. Upstream sends the list under `changeRequests`
-// with 32-hex ids; the domain exposes it as `linkedChangeRequests` with canonical UUIDs.
+// service-request <-> change-request link. Upstream sends the list under `changeRequestsAll`
+// (unfiltered by change-request state, unlike the older `changeRequests` field) with 32-hex
+// ids; the domain exposes it as `linkedChangeRequests` with canonical UUIDs.
 //
 // The cardinality cases matter: a service request can have several change requests (one per
 // environment the change is promoted to), so a single-value mapping would look correct
@@ -1470,7 +1471,7 @@ func TestSNCaseService_GetCaseByID_MapsLinkedChangeRequests(t *testing.T) {
 			"deployment": {"id": "", "name": ""},
 			"deployedProduct": {"id": "", "name": "", "version": ""},
 			"state": {"id": 1, "label": "Open"},
-			"changeRequests": ` + changeRequests + `
+			"changeRequestsAll": ` + changeRequests + `
 		}`
 	}
 


### PR DESCRIPTION
## Purpose

Two related changes bundled into one branch, same reviewer, same underlying bug:

1. The CSM portal's service-request detail page shows a linked change request's list as empty even when a change request has already been created and correctly linked. This happens because the backing data source filters out change requests that are still in their earliest workflow states, so a freshly created change request is invisible until it's manually advanced past those states elsewhere. A corresponding change to the underlying data source now returns an additional, unfiltered list of a case's linked change requests alongside the existing (filtered) one; this PR points the entity-service's case mapping at the unfiltered list.
2. The case-detail page's "Linked Items" tab was the only tab without an entry count in its label, unlike every other tab (Watchers, SLAs, Attachments, etc.). Two of the three widgets under that tab already have their data on hand with no extra fetch, so they're now summed into the tab badge.

## Goals

1. Show every change request linked to a service request on the CSM portal, regardless of its current workflow state, instead of only the subset that have progressed past initial triage.
2. Show a count on the "Linked Items" tab, consistent with every other case-detail tab.

## Approach

**Change-request visibility**: `entity-service/internal/service/sn_case_service.go` — the internal struct decoding the backing service's case-detail response gains a second field alongside the existing one, carrying the same item shape but sourced from the unfiltered list. `GetCaseByID`'s mapping logic is switched to read from that new field instead of the old one. The entity-service's own outward-facing response field (`linkedChangeRequests` on the case response, in both the Go struct and `openapi.yaml`) is completely unchanged — same name, same shape, same JSON tag. This is a pure internal data-source swap: nothing downstream (CSM backend, CSM webapp) needs to change, since they keep reading the same field they already read today.

**Linked Items tab count**: `apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx` — the existing per-tab count ternary gains a branch for the `related` ("Linked Items") tab, summing `c.linkedChangeRequests.length` and `c.linkedServiceRequests.length` (both already present on the fetched case-detail object). The third widget under that tab, `ChildCasesWidget`, still isn't counted — it runs its own scoped query and would need an extra fetch to expose a count, which is separate, larger follow-up work, not bundled here.

## User stories

As a CS engineer viewing a service request on the CSM portal, I want to see every change request linked to it, including ones just created and not yet triaged, so I don't lose track of work that's already been auto-generated but sits invisible.

As a CS engineer scanning a case's tabs, I want the "Linked Items" tab to show a count like every other tab, so I can tell at a glance whether there's anything there without clicking in.

## Release note

The CSM portal's service-request detail page now shows all linked change requests, including ones in early/untriaged workflow states that were previously hidden. The "Linked Items" tab now also shows an entry count, like every other case-detail tab.

## Documentation

N/A — internal data-mapping fix, no external-facing documentation to update.

## Training

N/A — no training content impact.

## Certification

N/A — no certification exam impact.

## Marketing

N/A — internal bug fix, no marketing content.

## Automation tests

- Unit tests
  > Updated the existing `TestSNCaseService_GetCaseByID_MapsLinkedChangeRequests` test (null/single/multiple-entry subtests) to send its fixture change-request list under the new upstream field name instead of the old one — same mapping logic, so no new test needed; the existing coverage already exercises null, single-entry, and multi-entry cases. No test suite exists yet for the case-detail page's tab-count logic (none of the other per-tab counts have one either); not adding one here for consistency with the existing pattern.
- Integration tests
  > `go build ./...` and `go test ./...` pass locally for the `entity-service` module; `tsc -b` and `eslint` clean for the webapp change. **Full live end-to-end verification completed** against real ServiceNow DEV data through the real webapp UI (real Asgardeo login, real backing-service data, not mocked): created a fresh service-request case, confirmed its auto-created change request (state New — exactly the class this fix targets) appears in the entity-service's `linkedChangeRequests` response, confirmed a direct call to the unpatched/old field would still exclude it (negative control, proving the fix — not coincidence — is what surfaces it), and confirmed the webapp's Linked Items tab shows both the change request itself and the "(1)" count badge live.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? Yes — no new logic, auth, or data handling introduced; a decode-source swap on an existing typed field.
- Ran FindSecurityBugs plugin and verified report? N/A — this is a Go module, not Java/FindSecurityBugs-applicable.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? Yes.

## Samples

N/A — no sample apps affected.

## Related PRs

A corresponding change in the private entity-service repo adds the additive unfiltered field this PR reads from (not linked here per this repo's convention of describing private-repo dependencies functionally rather than by reference).

## Migrations (if applicable)

N/A — no data migration; internal field-source swap only.

## Test environment

`go build`/`go test` run locally with the module's pinned Go toolchain; `tsc`/`eslint` run locally for the webapp. End-to-end verification run against the real ServiceNow DEV tenant, through a locally-run full stack (webapp → gateway-shim → BFF → this entity-service → local Ballerina carrying the corresponding upstream change → ServiceNow DEV), with a real Asgardeo login.

## Learning

N/A.

