### PR TITLE
feat(customer portal): send the chat reference with answer feedback

### DIFF
--- a/apps/customer-portal/webapp/src/features/support/pages/ConversationDetailsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/ConversationDetailsPage.tsx
@@ -702,6 +702,7 @@ export default function ConversationDetailsPage(): JSX.Element {
             // loaded for this page, so this costs no extra request.
             accountName: projectDetails?.account?.name || undefined,
             projectName: projectDetails?.name || undefined,
+            conversationName: summary?.chatNumber || undefined,
             ...(tags ? { tags } : {}),
           }),
         )
@@ -723,6 +724,7 @@ export default function ConversationDetailsPage(): JSX.Element {
       projectId,
       projectDetails?.account?.name,
       projectDetails?.name,
+      summary?.chatNumber,
       sendUserMessage,
     ],
   );

--- a/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
@@ -828,6 +828,7 @@ export default function NoveraChatPage(): JSX.Element {
             // loaded for this page, so this costs no extra request.
             accountName: projectDetails?.account?.name || undefined,
             projectName: projectDetails?.name || undefined,
+            conversationName: chatNumber || undefined,
             ...(tags ? { tags } : {}),
           }),
         )
@@ -849,6 +850,7 @@ export default function NoveraChatPage(): JSX.Element {
       projectId,
       projectDetails?.account?.name,
       projectDetails?.name,
+      chatNumber,
       sendUserMessage,
     ],
   );

--- a/apps/customer-portal/webapp/src/features/support/types/conversations.ts
+++ b/apps/customer-portal/webapp/src/features/support/types/conversations.ts
@@ -279,6 +279,13 @@ export type ChatWebSocketPayload =
        */
       accountName?: string;
       projectName?: string;
+      /**
+       * The chat's own reference as shown in the UI, e.g. CHAT000002755, so the
+       * analytics drill-down can name the conversation a rating came from rather
+       * than showing a raw id. Absent when this page was deep-linked or
+       * refreshed, since the reference arrives in router state.
+       */
+      conversationName?: string;
     };
 
 // Model type for chat WebSocket hook options.


### PR DESCRIPTION
## Why

The analytics drill-down can name the **account** and **project** a rating came from, but not the **chat** — it had only the conversation id, a 32-character hex string that appears nowhere a customer or an agent can see. Which chat a rating was about is the most useful thing on that page.

The UI already shows the chat as **"Chat CHAT000002755"**, and both pages that offer a rating already hold that reference:

| Page | Source |
|---|---|
| `NoveraChatPage` | `navState?.chatNumber` (router state) |
| `ConversationDetailsPage` | `summary?.chatNumber` (conversation summary) |

So it just sends it. **No new request.**

```ts
conversationName: chatNumber || undefined,
```

## Naming

`conversationName` rather than `chatNumber`, matching the existing `accountName`/`projectName` fields — it is whatever label the portal shows for the conversation, and the field should keep making sense if that label ever stops being a CHAT-prefixed number.

## Absent sometimes, by design

The reference arrives in router state, so a **deep-linked or refreshed** chat page rates without one. The backend `COALESCE`s the column, so a later rating on the same message fills it in. The dashboard falls back to showing the conversation id.

## Ordering

Needs digiops-cs **#2727** to store and display it. Until that ships the field is accepted and ignored, so this is safe to merge in either order.

## Verification

- `npx tsc --noEmit` → clean
- `npx eslint` on all three changed files → clean, including `react-hooks/exhaustive-deps` (both `useCallback` dep arrays updated)
- `npx vitest run src/features/support` → 49 failed / 394 passed, **exactly the pre-existing baseline** on clean `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Feedback submissions now include the relevant chat reference number.
  * Chat reference information is available for analytics and display across support conversations.
  * Feedback details remain synchronized with the latest conversation information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->