### PR TITLE
[CSM Portal] comment ownership guard, state notIn, project-type by name, tag search POST; plus fix ETAs, change request from a service request, and time card editing

### DIFF
--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -151,6 +151,10 @@ func main() {
 	mux.HandleFunc("POST /cases/{id}/tags", caseHandler.AddCaseTag)
 	mux.HandleFunc("DELETE /cases/{id}/tags/{tagId}", caseHandler.RemoveCaseTag)
 	mux.HandleFunc("POST /tags/search", caseHandler.SearchTags)
+	// Deprecated: the query-parameter form of tag search, kept for one release
+	// so this service and its callers can be deployed independently. Remove it
+	// (and CaseHandler.SearchTagsQuery) once every caller is on the POST.
+	mux.HandleFunc("GET /tags/search", caseHandler.SearchTagsQuery)
 	mux.HandleFunc("POST /cases/search", caseHandler.SearchCases)
 	mux.HandleFunc("GET /dashboards", dashboardHandler.GetDashboards)
 	mux.HandleFunc("GET /dashboards/{dashboardId}", dashboardHandler.GetDashboardDetail)

--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -154,6 +154,7 @@ func main() {
 	// Deprecated: the query-parameter form of tag search, kept for one release
 	// so this service and its callers can be deployed independently. Remove it
 	// (and CaseHandler.SearchTagsQuery) once every caller is on the POST.
+	//nolint:staticcheck // SA1019: intentional one-release compatibility route; remove with the handler.
 	mux.HandleFunc("GET /tags/search", caseHandler.SearchTagsQuery)
 	mux.HandleFunc("POST /cases/search", caseHandler.SearchCases)
 	mux.HandleFunc("GET /dashboards", dashboardHandler.GetDashboards)

--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -150,7 +150,7 @@ func main() {
 	mux.HandleFunc("POST /cases/{id}/github-issues", caseHandler.CreateCaseGithubIssue)
 	mux.HandleFunc("POST /cases/{id}/tags", caseHandler.AddCaseTag)
 	mux.HandleFunc("DELETE /cases/{id}/tags/{tagId}", caseHandler.RemoveCaseTag)
-	mux.HandleFunc("GET /tags/search", caseHandler.SearchTags)
+	mux.HandleFunc("POST /tags/search", caseHandler.SearchTags)
 	mux.HandleFunc("POST /cases/search", caseHandler.SearchCases)
 	mux.HandleFunc("GET /dashboards", dashboardHandler.GetDashboards)
 	mux.HandleFunc("GET /dashboards/{dashboardId}", dashboardHandler.GetDashboardDetail)

--- a/apps/csm-portal/backend/internal/entity/customer.go
+++ b/apps/csm-portal/backend/internal/entity/customer.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"strconv"
 )
 
 // CreateCase calls POST /cases on the entity service.
@@ -470,19 +469,8 @@ func (c *CustomerEntityClient) RemoveCaseTag(ctx context.Context, caseID, tagID 
 	return c.do(ctx, http.MethodDelete, fmt.Sprintf("/cases/%s/tags/%s", url.PathEscape(caseID), url.PathEscape(tagID)), nil)
 }
 
-// SearchTags calls GET /tags/search on the entity service.
-// Response is returned as raw JSON; typed response structs are deferred.
-func (c *CustomerEntityClient) SearchTags(ctx context.Context, query string, limit int) ([]byte, error) {
-	params := url.Values{}
-	if query != "" {
-		params.Set("q", query)
-	}
-	if limit > 0 {
-		params.Set("limit", strconv.Itoa(limit))
-	}
-	path := "/tags/search"
-	if len(params) > 0 {
-		path += "?" + params.Encode()
-	}
-	return c.do(ctx, http.MethodGet, path, nil)
+// SearchTags calls POST /tags/search on the entity service.
+// The request body is forwarded verbatim; the response is returned as raw JSON.
+func (c *CustomerEntityClient) SearchTags(ctx context.Context, body []byte) ([]byte, error) {
+	return c.do(ctx, http.MethodPost, "/tags/search", body)
 }

--- a/apps/csm-portal/backend/internal/entity/customer_client_test.go
+++ b/apps/csm-portal/backend/internal/entity/customer_client_test.go
@@ -18,6 +18,7 @@ package entity
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -57,5 +58,58 @@ func TestTokenFetchTimeout(t *testing.T) {
 	// Should fail well within 1 s (configured at 100 ms); allow 2 s for CI jitter.
 	if elapsed > 2*time.Second {
 		t.Errorf("token fetch took %v; expected <2s with 100ms timeout", elapsed)
+	}
+}
+
+// TestSearchTagsSendsPostWithBody pins the entity-service call shape for tag
+// search: a POST to /tags/search carrying the caller's body byte-for-byte. The
+// old contract was a GET with `q`/`limit` query params and is gone; asserting
+// on the raw bytes (rather than decoding through a struct) is what makes this
+// test able to catch a silent key rename.
+func TestSearchTagsSendsPostWithBody(t *testing.T) {
+	t.Parallel()
+
+	const reqBody = `{"filters":{"searchQuery":"micro"},"limit":20}`
+
+	var gotMethod, gotPath, gotRawQuery string
+	var gotBody []byte
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/token", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"test-token","token_type":"Bearer","expires_in":3600}`))
+	})
+	mux.HandleFunc("/tags/search", func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotRawQuery = r.URL.RawQuery
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"tags":[]}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	client := NewCustomerEntityClient(CustomerEntityConfig{
+		BaseURL:      srv.URL,
+		TokenURL:     srv.URL + "/token",
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+	})
+
+	if _, err := client.SearchTags(context.Background(), []byte(reqBody)); err != nil {
+		t.Fatalf("SearchTags: %v", err)
+	}
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	if gotPath != "/tags/search" {
+		t.Errorf("path = %q, want /tags/search", gotPath)
+	}
+	if gotRawQuery != "" {
+		t.Errorf("query string = %q, want empty (the query moved into the body)", gotRawQuery)
+	}
+	if string(gotBody) != reqBody {
+		t.Errorf("body = %s, want %s", gotBody, reqBody)
 	}
 }

--- a/apps/csm-portal/backend/internal/handler/cases.go
+++ b/apps/csm-portal/backend/internal/handler/cases.go
@@ -24,6 +24,7 @@ import (
 	"log/slog"
 	"net/http"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/wso2-open-operations/cs-tools/apps/csm-portal/backend/internal/middleware"
@@ -708,9 +709,63 @@ func (h *CaseHandler) SearchTags(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	h.forwardTagSearch(w, r, user.UserID, body)
+}
+
+// tagSearchRequest is the request body of POST /tags/search. It exists only so
+// the deprecated GET alias can build the exact same bytes the POST forwards;
+// the POST itself never decodes the body, it passes it through untouched.
+type tagSearchRequest struct {
+	Filters struct {
+		SearchQuery string `json:"searchQuery"`
+	} `json:"filters"`
+	Limit int `json:"limit"`
+}
+
+// SearchTagsQuery handles GET /tags/search?q={query}&limit={limit}, the
+// query-parameter form tag search used before it moved to a JSON body. The
+// parameters are translated into the POST body and forwarded through the same
+// client call, so only one request shape ever leaves this service.
+//
+// Deprecated: use POST /tags/search instead. This alias exists only to bridge
+// one release, so callers still on the GET do not get a 405 while this service
+// and its callers are deployed separately. Delete it once that release has
+// shipped.
+func (h *CaseHandler) SearchTagsQuery(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	var req tagSearchRequest
+	req.Filters.SearchQuery = r.URL.Query().Get("q")
+	if raw := r.URL.Query().Get("limit"); raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+			return
+		}
+		// Bounds are enforced upstream, as they are for the POST; a value that
+		// is merely out of range is forwarded and rejected there.
+		req.Limit = parsed
+	}
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	h.forwardTagSearch(w, r, user.UserID, body)
+}
+
+// forwardTagSearch is the single outbound path shared by POST /tags/search and
+// its deprecated GET alias.
+func (h *CaseHandler) forwardTagSearch(w http.ResponseWriter, r *http.Request, userID string, body []byte) {
 	result, err := h.entity.SearchTags(r.Context(), body)
 	if err != nil {
-		slog.ErrorContext(r.Context(), "entity SearchTags failed", "userID", user.UserID, "err", err)
+		slog.ErrorContext(r.Context(), "entity SearchTags failed", "userID", userID, "err", err)
 		mapUpstreamErrorGeneric(w, err, "Failed to search tags.")
 		return
 	}

--- a/apps/csm-portal/backend/internal/handler/cases.go
+++ b/apps/csm-portal/backend/internal/handler/cases.go
@@ -24,7 +24,6 @@ import (
 	"log/slog"
 	"net/http"
 	"regexp"
-	"strconv"
 	"strings"
 
 	"github.com/wso2-open-operations/cs-tools/apps/csm-portal/backend/internal/middleware"
@@ -88,7 +87,7 @@ type entityCaseClient interface {
 	CreateCaseGithubIssue(ctx context.Context, caseID string, body []byte) ([]byte, error)
 	AddCaseTag(ctx context.Context, caseID string, body []byte) ([]byte, error)
 	RemoveCaseTag(ctx context.Context, caseID, tagID string) ([]byte, error)
-	SearchTags(ctx context.Context, query string, limit int) ([]byte, error)
+	SearchTags(ctx context.Context, body []byte) ([]byte, error)
 	// GetUserMe resolves the caller's own platform user record — the same
 	// call that backs GET /users/me. Needed by the public-comment ownership
 	// guard; see CaseHandler.resolveCurrentUserID.
@@ -682,9 +681,10 @@ func (h *CaseHandler) RemoveCaseTag(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// SearchTags handles GET /tags/search.
-// Forwards the q and limit query parameters to the entity service and returns
-// the raw response verbatim.
+// SearchTags handles POST /tags/search.
+// The JSON body ({filters:{searchQuery}, limit}) is forwarded to the entity
+// service verbatim, and the raw response returned as-is. Limit bounds are
+// enforced upstream, so there is nothing to re-validate here.
 func (h *CaseHandler) SearchTags(w http.ResponseWriter, r *http.Request) {
 	user := middleware.UserInfoFromContext(r.Context())
 	if user == nil {
@@ -692,19 +692,23 @@ func (h *CaseHandler) SearchTags(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	q := r.URL.Query().Get("q")
-
-	var limit int
-	if limitStr := r.URL.Query().Get("limit"); limitStr != "" {
-		parsed, err := strconv.Atoi(limitStr)
-		if err != nil || parsed < 0 || parsed > 100 {
-			writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		if _, ok := err.(*http.MaxBytesError); ok {
+			writeError(w, http.StatusRequestEntityTooLarge, ErrMsgTooLarge)
 			return
 		}
-		limit = parsed
+		writeError(w, http.StatusBadRequest, errMsgReadBody)
+		return
 	}
 
-	result, err := h.entity.SearchTags(r.Context(), q, limit)
+	if !json.Valid(body) {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.SearchTags(r.Context(), body)
 	if err != nil {
 		slog.ErrorContext(r.Context(), "entity SearchTags failed", "userID", user.UserID, "err", err)
 		mapUpstreamErrorGeneric(w, err, "Failed to search tags.")

--- a/apps/csm-portal/backend/internal/handler/cases.go
+++ b/apps/csm-portal/backend/internal/handler/cases.go
@@ -89,6 +89,10 @@ type entityCaseClient interface {
 	AddCaseTag(ctx context.Context, caseID string, body []byte) ([]byte, error)
 	RemoveCaseTag(ctx context.Context, caseID, tagID string) ([]byte, error)
 	SearchTags(ctx context.Context, query string, limit int) ([]byte, error)
+	// GetUserMe resolves the caller's own platform user record — the same
+	// call that backs GET /users/me. Needed by the public-comment ownership
+	// guard; see CaseHandler.resolveCurrentUserID.
+	GetUserMe(ctx context.Context) ([]byte, error)
 }
 
 // CaseHandler handles HTTP requests for case operations, delegating to the
@@ -100,6 +104,40 @@ type CaseHandler struct {
 // NewCaseHandler creates a CaseHandler backed by the given entity client.
 func NewCaseHandler(entity entityCaseClient) *CaseHandler {
 	return &CaseHandler{entity: entity}
+}
+
+// resolveCurrentUserID returns the caller's platform user id — the id
+// GET /users/me resolves via the entity service — for comparing against a
+// platform record's own user references (e.g. a case's assigned engineer).
+//
+// This is deliberately NOT user.UserID from the JWT: that claim is whatever
+// identity value the gateway/identity provider embeds, an identifier from a
+// completely different space than the platform's own user record id. The two
+// are never equal, so comparing them always fails. The dashboard
+// "__current_user__" placeholder had exactly this bug and was fixed the same
+// way, by resolving the caller through GET /users/me instead of trusting the
+// raw claim.
+//
+// Returns an empty id when the lookup fails or yields nothing, so callers
+// gating on it fail closed rather than falling back to an id that can never
+// match.
+func (h *CaseHandler) resolveCurrentUserID(r *http.Request, user *middleware.UserInfo) string {
+	raw, err := h.entity.GetUserMe(r.Context())
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity GetUserMe failed while resolving the caller's platform user id", "userID", user.UserID, "err", err)
+		return ""
+	}
+	var me struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(raw, &me); err != nil {
+		slog.ErrorContext(r.Context(), "entity GetUserMe: parse response failed while resolving the caller's platform user id", "userID", user.UserID, "err", err)
+		return ""
+	}
+	if me.ID == "" {
+		slog.ErrorContext(r.Context(), "entity GetUserMe returned an empty id while resolving the caller's platform user id", "userID", user.UserID)
+	}
+	return me.ID
 }
 
 // maxRequestBodyBytes caps incoming request bodies at 1 MiB to prevent memory DoS.
@@ -245,7 +283,20 @@ func (h *CaseHandler) CreateCaseComment(w http.ResponseWriter, r *http.Request) 
 			writeError(w, http.StatusConflict, ErrMsgCommentNotAllowed)
 			return
 		}
-		if currentCase.AssignedEngineer == nil || currentCase.AssignedEngineer.ID == nil || *currentCase.AssignedEngineer.ID != user.UserID {
+		// Ownership check. assignedEngineer.id is a platform user record id, so
+		// it can only be compared against the caller's own platform id — never
+		// against the identity provider's user id on the JWT. Resolved here,
+		// after the state gate, so the extra lookup is only paid on a request
+		// that would otherwise be accepted.
+		currentUserID := h.resolveCurrentUserID(r, user)
+		if currentUserID == "" {
+			// The caller's identity could not be established, so ownership
+			// cannot be decided either way: fail closed, but as a server-side
+			// failure rather than a misleading "you are not the assignee".
+			writeError(w, http.StatusInternalServerError, ErrMsgInternal)
+			return
+		}
+		if currentCase.AssignedEngineer == nil || currentCase.AssignedEngineer.ID == nil || *currentCase.AssignedEngineer.ID != currentUserID {
 			writeError(w, http.StatusForbidden, ErrMsgCommentNotOwnCase)
 			return
 		}

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -2460,7 +2460,7 @@ func TestSearchCasesPassesThroughNewFixEtaFields(t *testing.T) {
 func TestSearchTags(t *testing.T) {
 	t.Run("requires authenticated user", func(t *testing.T) {
 		h := NewCaseHandler(&mockEntityCaseClient{})
-		r := httptest.NewRequest(http.MethodGet, "/tags/search?q=micro&limit=10", nil)
+		r := httptest.NewRequest(http.MethodPost, "/tags/search", strings.NewReader(`{"filters":{"searchQuery":"micro"}}`))
 		w := httptest.NewRecorder()
 		h.SearchTags(w, r)
 		assertStatus(t, w, http.StatusUnauthorized)
@@ -2468,9 +2468,9 @@ func TestSearchTags(t *testing.T) {
 		assertContentType(t, w, "application/json")
 	})
 
-	t.Run("rejects a non-numeric limit", func(t *testing.T) {
+	t.Run("rejects a malformed JSON body", func(t *testing.T) {
 		h := NewCaseHandler(&mockEntityCaseClient{})
-		r := withUser(httptest.NewRequest(http.MethodGet, "/tags/search?q=micro&limit=abc", nil))
+		r := withUser(httptest.NewRequest(http.MethodPost, "/tags/search", strings.NewReader(`{"filters":`)))
 		w := httptest.NewRecorder()
 		h.SearchTags(w, r)
 		assertStatus(t, w, http.StatusBadRequest)
@@ -2478,56 +2478,28 @@ func TestSearchTags(t *testing.T) {
 		assertContentType(t, w, "application/json")
 	})
 
-	t.Run("rejects a limit above the documented maximum", func(t *testing.T) {
-		h := NewCaseHandler(&mockEntityCaseClient{})
-		r := withUser(httptest.NewRequest(http.MethodGet, "/tags/search?q=micro&limit=101", nil))
-		w := httptest.NewRecorder()
-		h.SearchTags(w, r)
-		assertStatus(t, w, http.StatusBadRequest)
-		assertErrorMessage(t, w, ErrMsgBadRequest)
-		assertContentType(t, w, "application/json")
-	})
-
-	t.Run("accepts a limit of exactly 100", func(t *testing.T) {
-		var capturedLimit int
+	// The BFF is a pass-through here: it must hand the entity service the exact
+	// bytes it received. Asserting on the raw body (not a struct decoded through
+	// the same json tags) is what actually pins the wire format -- a decode-based
+	// check agrees with whichever key the payload happens to carry.
+	t.Run("forwards the request body byte-for-byte", func(t *testing.T) {
+		const reqBody = `{"filters":{"searchQuery":"micro"},"limit":20}`
+		var capturedBody []byte
 		client := &mockEntityCaseClient{
-			searchTagsFn: func(_ context.Context, _ string, limit int) ([]byte, error) {
-				capturedLimit = limit
-				return []byte(`{"tags":[]}`), nil
-			},
-		}
-		h := NewCaseHandler(client)
-		r := withUser(httptest.NewRequest(http.MethodGet, "/tags/search?q=micro&limit=100", nil))
-		w := httptest.NewRecorder()
-		h.SearchTags(w, r)
-		assertStatus(t, w, http.StatusOK)
-		if capturedLimit != 100 {
-			t.Errorf("upstream received limit %d, want 100", capturedLimit)
-		}
-	})
-
-	t.Run("forwards q and limit verbatim, returns 200 with matching tags", func(t *testing.T) {
-		var capturedQuery string
-		var capturedLimit int
-		client := &mockEntityCaseClient{
-			searchTagsFn: func(_ context.Context, query string, limit int) ([]byte, error) {
-				capturedQuery = query
-				capturedLimit = limit
+			searchTagsFn: func(_ context.Context, body []byte) ([]byte, error) {
+				capturedBody = body
 				return []byte(`{"tags":[{"id":"22222222-2222-2222-2222-222222222222","label":"micro-gw","color":null}]}`), nil
 			},
 		}
 		h := NewCaseHandler(client)
-		r := withUser(httptest.NewRequest(http.MethodGet, "/tags/search?q=micro&limit=10", nil))
+		r := withUser(httptest.NewRequest(http.MethodPost, "/tags/search", strings.NewReader(reqBody)))
 		w := httptest.NewRecorder()
 		h.SearchTags(w, r)
 
 		assertStatus(t, w, http.StatusOK)
 		assertContentType(t, w, "application/json")
-		if capturedQuery != "micro" {
-			t.Errorf("upstream received q %q, want %q", capturedQuery, "micro")
-		}
-		if capturedLimit != 10 {
-			t.Errorf("upstream received limit %d, want %d", capturedLimit, 10)
+		if string(capturedBody) != reqBody {
+			t.Errorf("upstream received body %s, want %s", capturedBody, reqBody)
 		}
 
 		var body struct {
@@ -2545,20 +2517,18 @@ func TestSearchTags(t *testing.T) {
 		}
 	})
 
-	t.Run("works with no query parameters", func(t *testing.T) {
-		var capturedQuery string
-		var capturedLimit int
+	t.Run("works with an empty filter object", func(t *testing.T) {
+		var capturedBody []byte
 		var called bool
 		client := &mockEntityCaseClient{
-			searchTagsFn: func(_ context.Context, query string, limit int) ([]byte, error) {
+			searchTagsFn: func(_ context.Context, body []byte) ([]byte, error) {
 				called = true
-				capturedQuery = query
-				capturedLimit = limit
+				capturedBody = body
 				return []byte(`{"tags":[]}`), nil
 			},
 		}
 		h := NewCaseHandler(client)
-		r := withUser(httptest.NewRequest(http.MethodGet, "/tags/search", nil))
+		r := withUser(httptest.NewRequest(http.MethodPost, "/tags/search", strings.NewReader(`{}`)))
 		w := httptest.NewRecorder()
 		h.SearchTags(w, r)
 
@@ -2566,11 +2536,8 @@ func TestSearchTags(t *testing.T) {
 		if !called {
 			t.Fatal("expected entity SearchTags to be called")
 		}
-		if capturedQuery != "" {
-			t.Errorf("upstream received q %q, want empty", capturedQuery)
-		}
-		if capturedLimit != 0 {
-			t.Errorf("upstream received limit %d, want 0", capturedLimit)
+		if string(capturedBody) != `{}` {
+			t.Errorf("upstream received body %s, want {}", capturedBody)
 		}
 	})
 
@@ -2579,12 +2546,12 @@ func TestSearchTags(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 				client := &mockEntityCaseClient{
-					searchTagsFn: func(_ context.Context, _ string, _ int) ([]byte, error) {
+					searchTagsFn: func(_ context.Context, _ []byte) ([]byte, error) {
 						return nil, tc.err
 					},
 				}
 				h := NewCaseHandler(client)
-				r := withUser(httptest.NewRequest(http.MethodGet, "/tags/search?q=micro", nil))
+				r := withUser(httptest.NewRequest(http.MethodPost, "/tags/search", strings.NewReader(`{"filters":{"searchQuery":"micro"}}`)))
 				w := httptest.NewRecorder()
 				h.SearchTags(w, r)
 				assertStatus(t, w, tc.wantCode)

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -257,9 +257,12 @@ func TestCreateCaseComment(t *testing.T) {
 		assertContentType(t, w, "application/json")
 	})
 
-	// user-123 is the UserID set by withUser (see helpers_test.go), so this fixture
-	// represents the requesting user being the case's assigned engineer.
-	const ongoingCase = `{"state":"work_in_progress","workState":"ongoing","assignedEngineer":{"id":"user-123"}}`
+	// testPlatformUserID is the id GET /users/me resolves for the requesting
+	// user (see helpers_test.go), so this fixture represents that user being
+	// the case's assigned engineer. Note it is NOT testUser.UserID: assignee
+	// ids live in the platform's id space, the token claim in the identity
+	// provider's, and the guard must compare within the former.
+	const ongoingCase = `{"state":"work_in_progress","workState":"ongoing","assignedEngineer":{"id":"` + testPlatformUserID + `"}}`
 
 	t.Run("rejects comment when state is not work_in_progress", func(t *testing.T) {
 		for _, state := range []string{"open", "waiting_on_wso2", "closed"} {
@@ -341,10 +344,20 @@ func TestCreateCaseComment(t *testing.T) {
 		assertErrorMessage(t, w, ErrMsgCommentNotOwnCase)
 	})
 
+	// Regression guard for the ownership check comparing two unrelated id
+	// spaces. The assignee id on a case is a platform user record id; the
+	// caller's identity on the request is the identity provider's user id.
+	// Comparing them denied everyone, the assignee included. The fixtures below
+	// deliberately keep the two values distinct so that bug cannot come back.
 	t.Run("allows public comment when requester is the assigned engineer", func(t *testing.T) {
+		var getUserMeCalls int
 		client := &mockEntityCaseClient{
 			getCaseFn: func(_ context.Context, _ string) ([]byte, error) {
 				return []byte(ongoingCase), nil
+			},
+			getUserMeFn: func(_ context.Context) ([]byte, error) {
+				getUserMeCalls++
+				return []byte(`{"id":"` + testPlatformUserID + `","email":"agent@example.com"}`), nil
 			},
 			createCaseCommentFn: func(_ context.Context, _ string, _ []byte) ([]byte, error) {
 				return []byte(`{"id":"comment-1"}`), nil
@@ -356,6 +369,105 @@ func TestCreateCaseComment(t *testing.T) {
 		w := httptest.NewRecorder()
 		h.CreateCaseComment(w, r)
 		assertStatus(t, w, http.StatusCreated)
+		if getUserMeCalls != 1 {
+			t.Errorf("GetUserMe calls = %d, want 1: the caller's own id must be resolved, once", getUserMeCalls)
+		}
+	})
+
+	t.Run("rejects public comment when the assignee id equals the token user id", func(t *testing.T) {
+		// The identity provider's user id must never satisfy the ownership
+		// check: a case whose assignee id happens to hold that value is not
+		// assigned to the caller.
+		client := &mockEntityCaseClient{
+			getCaseFn: func(_ context.Context, _ string) ([]byte, error) {
+				return []byte(`{"state":"work_in_progress","workState":"ongoing","assignedEngineer":{"id":"` + testUser.UserID + `"}}`), nil
+			},
+		}
+		h := NewCaseHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/case-1/comments", strings.NewReader(validPayload)))
+		r.SetPathValue("id", "case-1")
+		w := httptest.NewRecorder()
+		h.CreateCaseComment(w, r)
+		assertStatus(t, w, http.StatusForbidden)
+		assertErrorMessage(t, w, ErrMsgCommentNotOwnCase)
+	})
+
+	t.Run("fails closed when the caller's own id cannot be resolved", func(t *testing.T) {
+		for _, tc := range []struct {
+			name string
+			fn   func(context.Context) ([]byte, error)
+		}{
+			{"lookup error", func(context.Context) ([]byte, error) { return nil, errors.New("entity unavailable") }},
+			{"unparseable response", func(context.Context) ([]byte, error) { return []byte(`{not json`), nil }},
+			{"empty id", func(context.Context) ([]byte, error) { return []byte(`{"id":""}`), nil }},
+		} {
+			tc := tc
+			t.Run(tc.name, func(t *testing.T) {
+				var commentCreated bool
+				client := &mockEntityCaseClient{
+					getCaseFn: func(_ context.Context, _ string) ([]byte, error) {
+						return []byte(ongoingCase), nil
+					},
+					getUserMeFn: tc.fn,
+					createCaseCommentFn: func(_ context.Context, _ string, _ []byte) ([]byte, error) {
+						commentCreated = true
+						return []byte(`{"id":"comment-1"}`), nil
+					},
+				}
+				h := NewCaseHandler(client)
+				r := withUser(httptest.NewRequest(http.MethodPost, "/cases/case-1/comments", strings.NewReader(validPayload)))
+				r.SetPathValue("id", "case-1")
+				w := httptest.NewRecorder()
+				h.CreateCaseComment(w, r)
+				assertStatus(t, w, http.StatusInternalServerError)
+				assertErrorMessage(t, w, ErrMsgInternal)
+				if commentCreated {
+					t.Error("comment was created despite the caller's identity being unresolvable")
+				}
+			})
+		}
+	})
+
+	t.Run("does not resolve the caller's id for a work_note", func(t *testing.T) {
+		// Work notes are internal-only and exempt from the ownership guard, so
+		// they must not pay the extra lookup either.
+		client := &mockEntityCaseClient{
+			getCaseFn: func(_ context.Context, _ string) ([]byte, error) {
+				return []byte(`{"state":"work_in_progress"}`), nil
+			},
+			getUserMeFn: func(_ context.Context) ([]byte, error) {
+				t.Error("GetUserMe must not be called for a work note")
+				return nil, errors.New("unexpected call")
+			},
+			createCaseCommentFn: func(_ context.Context, _ string, _ []byte) ([]byte, error) {
+				return []byte(`{"id":"wn-1"}`), nil
+			},
+		}
+		h := NewCaseHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/case-1/comments", strings.NewReader(`{"type":"work_note","content":"internal note"}`)))
+		r.SetPathValue("id", "case-1")
+		w := httptest.NewRecorder()
+		h.CreateCaseComment(w, r)
+		assertStatus(t, w, http.StatusCreated)
+	})
+
+	t.Run("does not resolve the caller's id when the state gate already rejects", func(t *testing.T) {
+		client := &mockEntityCaseClient{
+			getCaseFn: func(_ context.Context, _ string) ([]byte, error) {
+				return []byte(`{"state":"work_in_progress","workState":"paused","assignedEngineer":{"id":"` + testPlatformUserID + `"}}`), nil
+			},
+			getUserMeFn: func(_ context.Context) ([]byte, error) {
+				t.Error("GetUserMe must not be called once the state gate has rejected the request")
+				return nil, errors.New("unexpected call")
+			},
+		}
+		h := NewCaseHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/case-1/comments", strings.NewReader(validPayload)))
+		r.SetPathValue("id", "case-1")
+		w := httptest.NewRecorder()
+		h.CreateCaseComment(w, r)
+		assertStatus(t, w, http.StatusConflict)
+		assertErrorMessage(t, w, ErrMsgCommentNotAllowed)
 	})
 
 	t.Run("allows work_note when case is not closed", func(t *testing.T) {

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -2561,3 +2561,122 @@ func TestSearchTags(t *testing.T) {
 		}
 	})
 }
+
+// TestSearchTagsQuery covers the deprecated GET /tags/search alias. It is kept
+// for one release so this service and its callers can be deployed independently
+// rather than in lockstep; delete these tests with the handler.
+func TestSearchTagsQuery(t *testing.T) {
+	t.Run("requires authenticated user", func(t *testing.T) {
+		h := NewCaseHandler(&mockEntityCaseClient{})
+		r := httptest.NewRequest(http.MethodGet, "/tags/search?q=micro&limit=5", nil)
+		w := httptest.NewRecorder()
+		h.SearchTagsQuery(w, r)
+		assertStatus(t, w, http.StatusUnauthorized)
+		assertErrorMessage(t, w, ErrMsgUnauthorized)
+		assertContentType(t, w, "application/json")
+	})
+
+	// The whole point of the alias: whichever form a caller uses, exactly one
+	// request shape leaves this service. Asserting on the raw outbound bytes
+	// (not a struct decoded through the same json tags) is what pins that -- a
+	// decode-based check would agree with whichever key the payload carries.
+	t.Run("sends the same body as the equivalent POST", func(t *testing.T) {
+		const postBody = `{"filters":{"searchQuery":"micro"},"limit":5}`
+
+		var postCaptured []byte
+		postClient := &mockEntityCaseClient{
+			searchTagsFn: func(_ context.Context, body []byte) ([]byte, error) {
+				postCaptured = body
+				return []byte(`{"tags":[]}`), nil
+			},
+		}
+		pr := withUser(httptest.NewRequest(http.MethodPost, "/tags/search", strings.NewReader(postBody)))
+		pw := httptest.NewRecorder()
+		NewCaseHandler(postClient).SearchTags(pw, pr)
+		assertStatus(t, pw, http.StatusOK)
+
+		var getCaptured []byte
+		getClient := &mockEntityCaseClient{
+			searchTagsFn: func(_ context.Context, body []byte) ([]byte, error) {
+				getCaptured = body
+				return []byte(`{"tags":[]}`), nil
+			},
+		}
+		gr := withUser(httptest.NewRequest(http.MethodGet, "/tags/search?q=micro&limit=5", nil))
+		gw := httptest.NewRecorder()
+		NewCaseHandler(getClient).SearchTagsQuery(gw, gr)
+		assertStatus(t, gw, http.StatusOK)
+		assertContentType(t, gw, "application/json")
+
+		if string(postCaptured) != postBody {
+			t.Fatalf("POST forwarded %s, want %s", postCaptured, postBody)
+		}
+		if string(getCaptured) != string(postCaptured) {
+			t.Errorf("GET alias forwarded %s, want the POST's %s", getCaptured, postCaptured)
+		}
+		if gw.Body.String() != pw.Body.String() {
+			t.Errorf("GET alias returned %s, want the POST's %s", gw.Body.String(), pw.Body.String())
+		}
+	})
+
+	t.Run("omitted parameters send the zero body", func(t *testing.T) {
+		var captured []byte
+		client := &mockEntityCaseClient{
+			searchTagsFn: func(_ context.Context, body []byte) ([]byte, error) {
+				captured = body
+				return []byte(`{"tags":[]}`), nil
+			},
+		}
+		h := NewCaseHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodGet, "/tags/search", nil))
+		w := httptest.NewRecorder()
+		h.SearchTagsQuery(w, r)
+
+		assertStatus(t, w, http.StatusOK)
+		const want = `{"filters":{"searchQuery":""},"limit":0}`
+		if string(captured) != want {
+			t.Errorf("upstream received body %s, want %s", captured, want)
+		}
+	})
+
+	t.Run("rejects a non-numeric limit", func(t *testing.T) {
+		var called bool
+		client := &mockEntityCaseClient{
+			searchTagsFn: func(_ context.Context, _ []byte) ([]byte, error) {
+				called = true
+				return []byte(`{"tags":[]}`), nil
+			},
+		}
+		h := NewCaseHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodGet, "/tags/search?q=micro&limit=abc", nil))
+		w := httptest.NewRecorder()
+		h.SearchTagsQuery(w, r)
+
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+		if called {
+			t.Error("expected the request to be rejected before the upstream call")
+		}
+	})
+
+	t.Run("upstream errors are mapped correctly", func(t *testing.T) {
+		for _, tc := range upstreamErrorsGeneric("Failed to search tags.") {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				client := &mockEntityCaseClient{
+					searchTagsFn: func(_ context.Context, _ []byte) ([]byte, error) {
+						return nil, tc.err
+					},
+				}
+				h := NewCaseHandler(client)
+				r := withUser(httptest.NewRequest(http.MethodGet, "/tags/search?q=micro", nil))
+				w := httptest.NewRecorder()
+				h.SearchTagsQuery(w, r)
+				assertStatus(t, w, tc.wantCode)
+				assertErrorMessage(t, w, tc.wantMsg)
+				assertContentType(t, w, "application/json")
+			})
+		}
+	})
+}

--- a/apps/csm-portal/backend/internal/handler/helpers_test.go
+++ b/apps/csm-portal/backend/internal/handler/helpers_test.go
@@ -113,7 +113,7 @@ type mockEntityCaseClient struct {
 	createCaseGithubIssueFn    func(ctx context.Context, caseID string, body []byte) ([]byte, error)
 	addCaseTagFn               func(ctx context.Context, caseID string, body []byte) ([]byte, error)
 	removeCaseTagFn            func(ctx context.Context, caseID, tagID string) ([]byte, error)
-	searchTagsFn               func(ctx context.Context, query string, limit int) ([]byte, error)
+	searchTagsFn               func(ctx context.Context, body []byte) ([]byte, error)
 	getUserMeFn                func(ctx context.Context) ([]byte, error)
 }
 
@@ -253,9 +253,9 @@ func (m *mockEntityCaseClient) RemoveCaseTag(ctx context.Context, caseID, tagID 
 	return nil, nil
 }
 
-func (m *mockEntityCaseClient) SearchTags(ctx context.Context, query string, limit int) ([]byte, error) {
+func (m *mockEntityCaseClient) SearchTags(ctx context.Context, body []byte) ([]byte, error) {
 	if m.searchTagsFn != nil {
-		return m.searchTagsFn(ctx, query, limit)
+		return m.searchTagsFn(ctx, body)
 	}
 	return []byte(`{"tags":[]}`), nil
 }

--- a/apps/csm-portal/backend/internal/handler/helpers_test.go
+++ b/apps/csm-portal/backend/internal/handler/helpers_test.go
@@ -29,12 +29,21 @@ import (
 	"github.com/wso2-open-operations/cs-tools/apps/csm-portal/backend/internal/updates"
 )
 
-// testUser is the authenticated user injected into request contexts.
+// testUser is the authenticated user injected into request contexts. UserID is
+// the identity provider's user id carried on the gateway-validated token — it
+// is NOT the platform's own user record id (see testPlatformUserID).
 var testUser = &middleware.UserInfo{
 	Email:  "agent@example.com",
-	UserID: "user-123",
+	UserID: "f2d9bf5b-7067-43dc-8578-802c8623af5d",
 	Groups: []string{"csm-agents"},
 }
+
+// testPlatformUserID is the id GET /users/me resolves for testUser: the
+// platform's own user record id, from a different id space than
+// testUser.UserID. Any check comparing a platform record's user reference
+// against the caller must use this one; the two values are deliberately kept
+// distinct here so a regression back to the token claim fails the tests.
+const testPlatformUserID = "94a1b01b-1b3c-f050-cb68-98aebd4bcb27"
 
 // withUser returns r with testUser stored in its context.
 func withUser(r *http.Request) *http.Request {
@@ -105,6 +114,17 @@ type mockEntityCaseClient struct {
 	addCaseTagFn               func(ctx context.Context, caseID string, body []byte) ([]byte, error)
 	removeCaseTagFn            func(ctx context.Context, caseID, tagID string) ([]byte, error)
 	searchTagsFn               func(ctx context.Context, query string, limit int) ([]byte, error)
+	getUserMeFn                func(ctx context.Context) ([]byte, error)
+}
+
+// GetUserMe defaults to the platform user record for testUser: note the id is
+// deliberately NOT testUser.UserID, mirroring production where the identity
+// provider's user id and the platform's own record id are unrelated values.
+func (m *mockEntityCaseClient) GetUserMe(ctx context.Context) ([]byte, error) {
+	if m.getUserMeFn != nil {
+		return m.getUserMeFn(ctx)
+	}
+	return []byte(`{"id":"` + testPlatformUserID + `","email":"` + testUser.Email + `"}`), nil
 }
 
 func (m *mockEntityCaseClient) CreateCase(ctx context.Context, body []byte) ([]byte, error) {

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -2660,27 +2660,35 @@ paths:
                 $ref: '#/components/schemas/ErrorPayload'
 
   /tags/search:
-    get:
-      summary: Search existing free-text tags by label (ServiceNow data source only).
+    post:
+      summary: Search existing free-text tags by label.
       description: >
-        Forwards the q and limit query parameters to the integration service as-is and
-        returns the matching tags.
+        Forwards the request body to the integration service as-is and returns the
+        matching tags. Only supported when the backing data source provides tags.
       operationId: searchTags
       security:
         - bearerAuth: []
-      parameters:
-        - name: q
-          in: query
-          required: false
-          description: Free-text search query matched against tag labels.
-          schema:
-            type: string
-        - name: limit
-          in: query
-          required: false
-          description: Maximum number of tags to return.
-          schema:
-            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                filters:
+                  type: object
+                  properties:
+                    searchQuery:
+                      type: string
+                      description: >
+                        Free-text query matched partially and case-insensitively against
+                        tag labels. Omit or leave empty to return all known tags.
+                limit:
+                  type: integer
+                  default: 20
+                  minimum: 0
+                  maximum: 100
+                  description: Maximum number of tags to return. Omit or 0 to use the default.
       responses:
         "200":
           description: Matching tags.

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -2680,9 +2680,11 @@ paths:
                   properties:
                     searchQuery:
                       type: string
+                      maxLength: 200
                       description: >
                         Free-text query matched partially and case-insensitively against
                         tag labels. Omit or leave empty to return all known tags.
+                        A longer value is rejected upstream with a validation error.
                 limit:
                   type: integer
                   default: 20
@@ -2744,9 +2746,11 @@ paths:
           required: false
           schema:
             type: string
+            maxLength: 200
           description: >
             Free-text query matched partially and case-insensitively against tag labels.
             Equivalent to `filters.searchQuery` on the POST. Omit to return all known tags.
+            A longer value is rejected upstream with a validation error.
         - name: limit
           in: query
           required: false

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -2726,6 +2726,73 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
+    get:
+      summary: Search existing free-text tags by label (deprecated query-parameter form).
+      description: >
+        Deprecated: use `POST /tags/search` instead. This alias accepts the old
+        `q`/`limit` query parameters, translates them into the POST request body and
+        forwards that upstream, so the response is identical. It exists only to bridge
+        one release so this service and its callers can be deployed independently, and
+        is removed after that.
+      operationId: searchTagsByQuery
+      deprecated: true
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: q
+          in: query
+          required: false
+          schema:
+            type: string
+          description: >
+            Free-text query matched partially and case-insensitively against tag labels.
+            Equivalent to `filters.searchQuery` on the POST. Omit to return all known tags.
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 20
+            minimum: 0
+            maximum: 100
+          description: Maximum number of tags to return. Equivalent to `limit` on the POST.
+      responses:
+        "200":
+          description: Matching tags.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [tags]
+                properties:
+                  tags:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Tag'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
 
   /change-requests/{id}:
     patch:

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -5297,8 +5297,12 @@ components:
 
         - **type** (in): case type, one of case/service_request/
           security_report_analysis/announcement/engagement.
-        - **state** (in): one of open/work_in_progress/waiting_on_wso2/
-          awaiting_info/reopened/solution_proposed/closed.
+        - **state** (in / notIn): one of open/work_in_progress/
+          waiting_on_wso2/awaiting_info/reopened/solution_proposed/closed. in
+          matches cases in any of the given states; notIn matches cases in
+          none of them. The two are independent and may be combined. notIn is
+          not supported inside an anyOf branch, and not supported by the
+          relational data source.
         - **severity** (in): one of catastrophic/critical/high/medium/low.
           Only applicable when a type filter includes case.
         - **engagementType** (in): one of migration/consultancy/

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -2687,12 +2687,14 @@ export interface BeTimeCardCaseRef {
 }
 
 /**
- * A time card as returned by search and the mutation endpoints. The backend
- * never echoes back category / issue complexity / hour breakdown / lead
- * comment, even though those are accepted on write — see
- * {@link BeCreateTimeCardPayload}. `workLogComment` is the one write field
- * that IS echoed back — confirmed live; it was previously assumed missing
- * and left unmapped, but the wire response does include it.
+ * A time card as returned by search and the mutation endpoints. Previously
+ * documented as never echoing back category / issue complexity / hour
+ * breakdown / lead comment, even though those are accepted on write — that
+ * was wrong for issue complexity and the hour breakdown: confirmed live
+ * against the real entity-service (`POST /time-cards/search`) that both come
+ * back on every card, not just the one just created. `workLogComment` is also
+ * echoed back — confirmed live separately. "Category" and any lead comment
+ * other than {@link rejectionReason} are still write-only/unconfirmed.
  */
 export interface BeTimeCardView {
   id: string;
@@ -2737,6 +2739,15 @@ export interface BeTimeCardView {
    * list, regardless of team-lead status.
    */
   approvers?: BeTimeCardRef[];
+  /** Per-activity whole minutes — confirmed live on `POST /time-cards/search`
+   * responses, both for a just-created card and a pre-existing one. */
+  timeAnalyzing?: number;
+  timeSettingUp?: number;
+  timeReproducingDebugging?: number;
+  timeProvidingSolution?: number;
+  timePatching?: number;
+  /** Confirmed live on `POST /time-cards/search` responses. */
+  issueComplexity?: string;
 }
 
 /**
@@ -2799,13 +2810,24 @@ export interface BeCreateTimeCardPayload {
 /**
  * Either editable fields (no `state`), or a state transition (`state`:
  * "approved", or "rejected" with a `leadComment`) — mutually exclusive, per
- * the backend contract. The portal only ever sends the state-transition form
- * (see ISSU-009 Edit-card gap: editable fields can't be safely round-tripped
- * since reads never return them).
+ * the backend contract, and enforced server-side as submitter-only +
+ * `submitted`-state-only (matches ServiceNow's own edit-in-place behavior).
+ * Confirmed live: a content-fields PATCH with no `state` key persists and
+ * round-trips correctly on the next search.
  */
 export interface BeUpdateTimeCardPayload {
   state?: Extract<BeTimeCardState, "approved" | "rejected">;
   leadComment?: string;
+  /** ISO 8601 date (YYYY-MM-DD). */
+  date?: string;
+  isBillable?: boolean;
+  issueComplexity?: string;
+  workLogComment?: string;
+  timeAnalyzing?: number;
+  timeSettingUp?: number;
+  timeReproducingDebugging?: number;
+  timeProvidingSolution?: number;
+  timePatching?: number;
 }
 
 export interface BeTimeCardMutationResponse {

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -424,7 +424,17 @@ export interface BeAddCaseTagPayload {
   label: string;
 }
 
-/** `GET /tags/search?q=&limit=` response: existing free-text tag labels matching the query. */
+/** `POST /tags/search` request body. */
+export interface BeSearchTagsPayload {
+  filters?: {
+    /** Partial, case-insensitive match against tag labels. Empty returns all known tags. */
+    searchQuery?: string;
+  };
+  /** Maximum number of tags to return; defaults to 20 upstream, capped at 100. */
+  limit?: number;
+}
+
+/** `POST /tags/search` response: existing free-text tag labels matching the query. */
 export interface BeSearchTagsResponse {
   tags?: BeTag[];
   total?: number;

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useSearchTags.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useSearchTags.test.tsx
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { ReactNode } from "react";
+
+const postMock = vi.fn();
+const getMock = vi.fn();
+
+// The real client reads runtime config at module load, which isn't present
+// under vitest (same approach as useQuickCaseSearch.test.tsx).
+vi.mock("@api/backend/client", () => ({
+  useBackendApi: () => ({ post: postMock, get: getMock }),
+}));
+
+import { useSearchTags } from "@features/csm-cases/api/useSearchTags";
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe("useSearchTags", () => {
+  beforeEach(() => {
+    postMock.mockReset();
+    getMock.mockReset();
+    postMock.mockResolvedValue({ tags: [] });
+  });
+
+  // Serialising the captured payload is deliberate: comparing against the exact
+  // JSON that goes on the wire catches a silent key rename, which an
+  // objectContaining match on a decoded shape would happily accept.
+  it("POSTs the query nested under filters.searchQuery with a top-level limit", async () => {
+    const { result } = renderHook(() => useSearchTags("micro", true), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(getMock).not.toHaveBeenCalled();
+    expect(postMock).toHaveBeenCalledTimes(1);
+    const [path, payload] = postMock.mock.calls[0];
+    expect(path).toBe("/tags/search");
+    expect(JSON.stringify(payload)).toBe(
+      '{"filters":{"searchQuery":"micro"},"limit":20}',
+    );
+  });
+
+  it("sends an empty searchQuery rather than omitting the filters object", async () => {
+    const { result } = renderHook(() => useSearchTags("   ", true), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(JSON.stringify(postMock.mock.calls[0][1])).toBe(
+      '{"filters":{"searchQuery":""},"limit":20}',
+    );
+  });
+
+  it("returns the tags array from the unchanged {tags:[...]} response envelope", async () => {
+    postMock.mockResolvedValue({
+      tags: [{ id: "t1", label: "micro-gw", color: "#f97316" }],
+    });
+
+    const { result } = renderHook(() => useSearchTags("micro", true), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([
+      { id: "t1", label: "micro-gw", color: "#f97316" },
+    ]);
+  });
+
+  it("does not call the backend while disabled", () => {
+    renderHook(() => useSearchTags("micro", false), { wrapper });
+    expect(postMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useSearchTags.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useSearchTags.ts
@@ -20,15 +20,19 @@ import {
   type UseQueryResult,
 } from "@tanstack/react-query";
 import { useBackendApi } from "@api/backend/client";
-import type { BeSearchTagsResponse, BeTag } from "@api/backend/types";
+import type {
+  BeSearchTagsPayload,
+  BeSearchTagsResponse,
+  BeTag,
+} from "@api/backend/types";
 
 /** Cap on how many matching tags a search returns — this is a type-ahead list, not a paged browse. */
 const TAG_SEARCH_LIMIT = 20;
 
 /**
- * Searches existing free-text tag labels via `GET /tags/search?q=&limit=`, for
+ * Searches existing free-text tag labels via `POST /tags/search`, for
  * the {@link AddTagDialog} type-ahead. Tags are genuinely free-text on the
- * backing data source (SN's generic label mechanism) — this only offers
+ * backing data source's generic label mechanism — this only offers
  * already-used labels as suggestions; the dialog still allows creating a
  * label with no match. Runs even for an empty query (lists recently/commonly
  * used tags) while `enabled` — callers gate that on the dialog being open.
@@ -43,11 +47,9 @@ export function useSearchTags(
   return useQuery<BeTag[], Error>({
     queryKey: ["csm-tags-search", q],
     queryFn: async (): Promise<BeTag[]> => {
-      const params = new URLSearchParams();
-      if (q) params.set("q", q);
-      params.set("limit", String(TAG_SEARCH_LIMIT));
-      const res = await api.get<BeSearchTagsResponse>(
-        `/tags/search?${params.toString()}`,
+      const res = await api.post<BeSearchTagsPayload, BeSearchTagsResponse>(
+        "/tags/search",
+        { filters: { searchQuery: q }, limit: TAG_SEARCH_LIMIT },
       );
       return res?.tags ?? [];
     },

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/AddTagDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/AddTagDialog.tsx
@@ -42,7 +42,7 @@ interface AddTagDialogProps {
 /**
  * Add a tag to a case (`POST /cases/{id}/tags`). Tags are a curated,
  * pre-existing vocabulary, not free text — this is search-and-SELECT only:
- * it searches existing labels via `GET /tags/search` as the user types
+ * it searches existing labels via `POST /tags/search` as the user types
  * (debounced), but there is no "create a new tag" fallback for typed text
  * with no match. ServiceNow-source only; the caller surfaces a rejection on
  * another source.

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.test.tsx
@@ -567,6 +567,54 @@ describe("CaseActionBar — Change severity is blocked on a closed case", () => 
   });
 });
 
+describe("CaseActionBar — Create change request (service requests only)", () => {
+  it("is offered for a service request", () => {
+    const onAction = vi.fn();
+    render(
+      <CaseActionBar
+        caseDetail={{
+          ...caseInState("awaiting_info", ["waiting_on_wso2"]),
+          caseType: "service_request",
+        }}
+        onAction={onAction}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /more/i }));
+    const item = screen.getByRole("menuitem", { name: /create change request/i });
+    expect(item).not.toHaveAttribute("aria-disabled", "true");
+    fireEvent.click(item);
+    expect(onAction).toHaveBeenCalledWith({ secondary: "create_change_request" });
+  });
+
+  it("is not offered for a plain case", () => {
+    render(
+      <CaseActionBar
+        caseDetail={{ ...caseInState("awaiting_info", ["waiting_on_wso2"]), caseType: "case" }}
+        onAction={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /more/i }));
+    expect(
+      screen.queryByRole("menuitem", { name: /create change request/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("disables it once the service request is closed", () => {
+    const onAction = vi.fn();
+    render(
+      <CaseActionBar
+        caseDetail={{ ...caseInState("closed", []), caseType: "service_request" }}
+        onAction={onAction}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /more/i }));
+    const item = screen.getByRole("menuitem", { name: /create change request/i });
+    expect(item).toHaveAttribute("aria-disabled", "true");
+    fireEvent.click(item);
+    expect(onAction).not.toHaveBeenCalled();
+  });
+});
+
 describe("acknowledge action", () => {
   const renderBar = (
     overrides: Partial<CsmCaseDetail>,

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
@@ -33,6 +33,7 @@ import {
   Copy,
   Gauge,
   GitBranch,
+  GitPullRequest,
   Inbox,
   Link as LinkIcon,
   ListChecks,
@@ -209,6 +210,10 @@ interface SecondaryItem {
  *   - Link to incident               → ISSU-021 (PATCH /cases/{id} { parentId }, see
  *                                       LinkIncidentDialog.tsx)
  *   - Raise Git issue                → ISSU-020
+ *   - Create change request          → service-request-only. Navigates to the change-request
+ *                                       create form pre-filled with this service request as the
+ *                                       "Originating service request" (POST /change-requests, then
+ *                                       PATCH { caseId } — see CreateChangeRequestPage.tsx).
  *   - Create task                    → ISSU-025 (POST /cases/{caseId}/tasks, see CreateTaskDialog.tsx).
  *                                       Kept here even though a Tasks tab exists: that tab is
  *                                       still `hidden` in CsmCaseDetailPage's TAB_DEFS, so this
@@ -284,6 +289,21 @@ function buildSecondaryItems(caseDetail: CsmCaseDetail): SecondaryItem[] {
   const gitIssueStateBlocked = !GIT_ISSUE_ALLOWED_STATES.includes(
     caseDetail.state,
   );
+
+  // Only a service request can be the "Originating service request" a change
+  // request links back to (see the create form's picker), so the action is
+  // offered only there — mirrors the same `caseType === "service_request"`
+  // gate the Related tab already applies to LinkedChangeRequestsWidget.
+  if (caseDetail.caseType === "service_request") {
+    items.push({
+      key: "create_change_request",
+      label: "Create change request…",
+      icon: <GitPullRequest size={16} />,
+      divider: true,
+      disabled: caseClosed,
+      tooltip: caseClosed ? "This case is closed — it's read-only." : undefined,
+    });
+  }
 
   items.push(
     {

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseMetaBand.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseMetaBand.test.tsx
@@ -1,0 +1,137 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router";
+import "@testing-library/jest-dom/vitest";
+
+// `UserRefLink` (rendered for "Created by"/"Assignee") resolves an unknown id
+// through `useResolvedUserId`, which needs the real API client — same
+// approach as CaseDetailWidgets.test.tsx.
+vi.mock("@api/backend/client", () => ({
+  useBackendApi: () => ({ post: vi.fn().mockResolvedValue({ users: [] }) }),
+}));
+
+import CaseMetaBand from "@features/csm-cases/components/CaseMetaBand";
+import type { CsmCaseDetail } from "@features/csm-cases/types/csmCases";
+
+/** A complete, minimal case-detail fixture; tests override the fix-ETA fields. */
+const BASE_CASE: CsmCaseDetail = {
+  id: "case-1001",
+  caseNumber: "CS-1001",
+  wso2CaseId: "ACMESUB-1001",
+  subject: "Identity Server token issuance latency spike",
+  customer: "Acme Financial",
+  accountId: "acc-001",
+  projectId: "prj-acme-iam-prod",
+  projectName: "IAM Production",
+  product: "WSO2 Identity Server",
+  severity: "S1",
+  state: "work_in_progress",
+  workState: "ongoing",
+  assignee: "Jane Doe",
+  assigneeIsMe: true,
+  slaClockType: "first_response",
+  minutesToBreach: 120,
+  hasSla: false,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T01:00:00.000Z",
+  description: "Token issuance latency has spiked.",
+  assignmentGroup: "grp.cre_team",
+  customerContext: {
+    accountName: "Acme Financial",
+    tier: "enterprise",
+    region: "us-east-1",
+    primaryContact: "Jane Doe",
+    primaryContactEmail: "jane.doe@example.com",
+    accountManager: "John Roe",
+    openCases: 1,
+  },
+  productContext: {
+    product: "WSO2 Identity Server",
+    version: "7.1.0",
+    deployment: "IAM Production",
+    environment: "prod",
+  },
+  watchers: [],
+  linkedItems: [],
+  tags: [],
+  timeLogs: [],
+  audit: [],
+  attachments: [],
+  isWatching: false,
+};
+
+function renderBand(overrides: Partial<CsmCaseDetail>): ReturnType<typeof render> {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <CaseMetaBand
+          detail={{ ...BASE_CASE, ...overrides }}
+          collapsed={false}
+          onToggleCollapsed={() => {}}
+        />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("CaseMetaBand — fix ETA cells", () => {
+  it("renders all three fix ETA cells when all three values are set", () => {
+    renderBand({
+      bestCaseFixEta: "2026-08-01",
+      mostLikelyFixEta: "2026-08-05",
+      worstCaseFixEta: "2026-08-10",
+    });
+
+    expect(screen.getByText("Best case fix ETA")).toBeInTheDocument();
+    expect(screen.getByText("Aug 1, 2026")).toBeInTheDocument();
+    expect(screen.getByText("Most likely fix ETA")).toBeInTheDocument();
+    expect(screen.getByText("Aug 5, 2026")).toBeInTheDocument();
+    expect(screen.getByText("Worst case fix ETA")).toBeInTheDocument();
+    expect(screen.getByText("Aug 10, 2026")).toBeInTheDocument();
+  });
+
+  it("renders no fix ETA cells when all three values are absent", () => {
+    renderBand({
+      bestCaseFixEta: null,
+      mostLikelyFixEta: null,
+      worstCaseFixEta: null,
+    });
+
+    expect(screen.queryByText("Best case fix ETA")).not.toBeInTheDocument();
+    expect(screen.queryByText("Most likely fix ETA")).not.toBeInTheDocument();
+    expect(screen.queryByText("Worst case fix ETA")).not.toBeInTheDocument();
+  });
+
+  it("renders only the fix ETA cells with a value when only a subset is set", () => {
+    renderBand({
+      bestCaseFixEta: "2026-08-01",
+      mostLikelyFixEta: null,
+      worstCaseFixEta: undefined,
+    });
+
+    expect(screen.getByText("Best case fix ETA")).toBeInTheDocument();
+    expect(screen.getByText("Aug 1, 2026")).toBeInTheDocument();
+    expect(screen.queryByText("Most likely fix ETA")).not.toBeInTheDocument();
+    expect(screen.queryByText("Worst case fix ETA")).not.toBeInTheDocument();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseMetaBand.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseMetaBand.tsx
@@ -27,6 +27,7 @@ import DeploymentDetailsDialog from "@features/csm-projects/components/Deploymen
 import type { BeDeploymentType } from "@api/backend/types";
 import { announcementStateRole } from "@features/csm-announcements/utils/announcementState";
 import { STATE_LABEL } from "@features/csm-dashboard/utils/abtDashboard";
+import { formatDateOnlyForDisplay } from "@utils/dateTime";
 
 interface CaseMetaBandProps {
   detail: CsmCaseDetail;
@@ -402,6 +403,27 @@ export default function CaseMetaBand({
                       </Typography>
                     </Tooltip>
                   )}
+                </Cell>
+              )}
+              {c.bestCaseFixEta != null && (
+                <Cell label="Best case fix ETA">
+                  <Typography variant="body2" noWrap>
+                    {formatDateOnlyForDisplay(c.bestCaseFixEta)}
+                  </Typography>
+                </Cell>
+              )}
+              {c.mostLikelyFixEta != null && (
+                <Cell label="Most likely fix ETA">
+                  <Typography variant="body2" noWrap>
+                    {formatDateOnlyForDisplay(c.mostLikelyFixEta)}
+                  </Typography>
+                </Cell>
+              )}
+              {c.worstCaseFixEta != null && (
+                <Cell label="Worst case fix ETA">
+                  <Typography variant="body2" noWrap>
+                    {formatDateOnlyForDisplay(c.worstCaseFixEta)}
+                  </Typography>
                 </Cell>
               )}
             </>

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.test.tsx
@@ -1,0 +1,403 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import type { CsmCaseDetail } from "@features/csm-cases/types/csmCases";
+import type { CsmTimeCard } from "@features/csm-timecards/types/timeCards";
+
+// The backend client reads runtime config at module load, which isn't
+// present under vitest. The page imports `BackendApiError` from it directly,
+// so stub the module with a real class (so `instanceof` still works) — same
+// approach as CsmChangeRequestDetailPage.test.tsx.
+vi.mock("@api/backend/client", () => ({
+  BackendApiError: class BackendApiError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+      super(message);
+      this.status = status;
+    }
+  },
+}));
+
+// `currentCaseId` is read by the react-router mock below on every render, so
+// the test can move the page from one case to another by mutating it and
+// calling `rerender`. `vi.hoisted` is required because `vi.mock` factories
+// are hoisted above regular module-scope declarations.
+const { getCurrentCaseId, setCurrentCaseId } = vi.hoisted(() => {
+  let caseId = "case-1";
+  return {
+    getCurrentCaseId: () => caseId,
+    setCurrentCaseId: (next: string) => {
+      caseId = next;
+    },
+  };
+});
+
+vi.mock("react-router", () => ({
+  useParams: () => ({ caseId: getCurrentCaseId() }),
+  useLocation: () => ({
+    pathname: `/cases/${getCurrentCaseId()}`,
+    search: "",
+    hash: "",
+    state: undefined,
+  }),
+}));
+
+const navigateMock = vi.fn();
+vi.mock("@hooks/useNavTransition", () => ({
+  useNavTransition: () => navigateMock,
+}));
+
+vi.mock("@hooks/useIdTokenClaims", () => ({
+  useIdTokenClaims: () => ({
+    email: "jane.doe@example.com",
+    name: "Jane Doe",
+  }),
+}));
+
+vi.mock("@context/error-banner/ErrorBannerContext", () => ({
+  useErrorBanner: () => ({ showError: vi.fn() }),
+}));
+vi.mock("@context/success-banner/SuccessBannerContext", () => ({
+  useSuccessBanner: () => ({ showSuccess: vi.fn() }),
+}));
+vi.mock("@features/csm-recent/hooks/useRecentViews", () => ({
+  useRecordRecentView: () => vi.fn(),
+}));
+vi.mock("@utils/useDarkMode", () => ({
+  useDarkMode: () => false,
+}));
+
+// Builds a minimal but valid CsmCaseDetail whose `id` tracks the currently
+// mutated case id, so the page gets past its loading/error gates (the
+// `isLoading`/`isError`/`!data` early returns) for whichever case is active.
+function buildCase(id: string): CsmCaseDetail {
+  return {
+    id,
+    caseNumber: `CS-${id}`,
+    subject: "Sample case subject",
+    customer: "Acme Corp",
+    accountId: "account-1",
+    projectId: "project-1",
+    projectName: "Acme Project",
+    product: "WSO2 Identity Server",
+    severity: "S2",
+    state: "open",
+    assignee: "Unassigned",
+    assigneeIsMe: false,
+    slaClockType: "resolution",
+    minutesToBreach: 120,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    description: "<p>Sample description</p>",
+    assignmentGroup: "Support Team",
+    customerContext: {
+      accountName: "Acme Corp",
+      tier: "enterprise",
+      region: "US",
+      primaryContact: "Jane Doe",
+      primaryContactEmail: "jane.doe@example.com",
+      accountManager: "John Smith",
+      openCases: 1,
+    },
+    productContext: {
+      product: "WSO2 Identity Server",
+      version: "7.0",
+      deployment: "prod-cluster",
+      environment: "prod",
+    },
+    watchers: [],
+    linkedItems: [],
+    tags: [],
+    timeLogs: [],
+    audit: [],
+    attachments: [],
+    isWatching: false,
+  };
+}
+
+const useGetCsmCaseDetailMock = vi.fn();
+vi.mock("@features/csm-cases/api/useGetCsmCaseDetail", () => ({
+  useGetCsmCaseDetail: (id: string | undefined) => useGetCsmCaseDetailMock(id),
+}));
+useGetCsmCaseDetailMock.mockImplementation((id: string | undefined) => ({
+  data: id ? buildCase(id) : undefined,
+  isLoading: false,
+  isError: false,
+  error: null,
+  refetch: vi.fn(),
+  isFetching: false,
+  dataUpdatedAt: 0,
+}));
+
+vi.mock("@features/csm-cases/api/usePatchCsmCase", () => ({
+  usePatchCsmCase: () => ({
+    mutate: vi.fn(),
+    mutateAsync: vi.fn(),
+    isPending: false,
+  }),
+  usePatchCsmCaseById: () => vi.fn(),
+}));
+vi.mock("@features/csm-cases/api/useFindMyOngoingCases", () => ({
+  useFindMyOngoingCases: () => vi.fn(),
+}));
+vi.mock("@features/csm-cases/api/useCsmCaseComments", () => ({
+  useGetCsmCaseComments: () => ({
+    data: [],
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+    isFetching: false,
+  }),
+  usePostCsmCaseComment: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+vi.mock("@features/csm-cases/api/useCsmConversationMessages", () => ({
+  useGetCsmConversationMessages: () => ({
+    data: undefined,
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+    isFetching: false,
+  }),
+}));
+vi.mock("@features/csm-cases/api/useCsmCaseActivities", () => ({
+  useGetCsmCaseActivities: () => ({
+    data: undefined,
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+    isFetching: false,
+  }),
+}));
+vi.mock("@features/csm-cases/api/useCsmCaseAttachments", () => ({
+  useGetCsmCaseAttachments: () => ({
+    data: undefined,
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+    isFetching: false,
+    dataUpdatedAt: 0,
+  }),
+  usePostCsmCaseAttachment: () => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+    isError: false,
+    error: null,
+  }),
+  useDownloadCsmCaseAttachment: () => vi.fn(),
+  useDeleteCsmCaseAttachment: () => ({ mutate: vi.fn(), isPending: false }),
+  useGetCsmCaseAttachmentContent: () => vi.fn(),
+}));
+vi.mock("@features/csm-cases/api/useCsmCaseCallRequests", () => ({
+  useGetCsmCaseCallRequests: () => ({
+    data: undefined,
+    refetch: vi.fn(),
+    isFetching: false,
+  }),
+}));
+vi.mock("@features/csm-cases/api/useSearchCaseTasks", () => ({
+  useSearchCaseTasks: () => ({ data: undefined }),
+}));
+vi.mock("@features/csm-cases/api/useSearchDeployments", () => ({
+  useSearchDeployments: () => ({
+    data: undefined,
+    isLoading: false,
+    refetch: vi.fn(),
+    isFetching: false,
+  }),
+}));
+vi.mock("@features/csm-projects/api/useGetProject", () => ({
+  useGetProject: () => ({
+    data: undefined,
+    isLoading: false,
+    refetch: vi.fn(),
+    isFetching: false,
+  }),
+}));
+vi.mock("@features/csm-cases/api/useGetCsmCaseSlas", () => ({
+  useGetCsmCaseSlas: () => ({ data: undefined }),
+}));
+vi.mock("@features/csm-cases/api/useCreateCaseTask", () => ({
+  useCreateCaseTask: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+vi.mock("@features/csm-cases/api/useCaseTags", () => ({
+  useAddCaseTag: () => ({ mutate: vi.fn(), isPending: false }),
+  useRemoveCaseTag: () => ({
+    mutate: vi.fn(),
+    isPending: false,
+    variables: undefined,
+  }),
+}));
+vi.mock("@features/csm-cases/api/useCsmCaseGithubIssue", () => ({
+  usePostCaseGithubIssue: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+vi.mock("@features/csm-timecards/api/useTimeCards", () => ({
+  usePostTimeCard: () => ({ mutate: vi.fn(), isPending: false }),
+  useUpdateTimeCard: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+// Simple presentational stubs — none of this test's assertions touch these.
+vi.mock("@features/csm-cases/components/CsmCaseCommentInput", () => ({
+  default: () => null,
+}));
+vi.mock("@features/csm-cases/components/CaseActionBar", () => ({
+  default: () => null,
+  canAcknowledge: () => false,
+}));
+vi.mock("@features/csm-cases/components/AssignEngineerDialog", () => ({
+  default: () => null,
+}));
+vi.mock("@features/csm-cases/components/ResolutionDialog", () => ({
+  default: () => null,
+}));
+vi.mock("@features/csm-cases/components/ChangeSeverityDialog", () => ({
+  default: () => null,
+}));
+vi.mock("@features/csm-cases/components/SetAutocloseHoldDialog", () => ({
+  default: () => null,
+}));
+vi.mock("@features/csm-cases/components/EditCaseDetailsDialog", () => ({
+  default: () => null,
+}));
+vi.mock("@features/csm-cases/components/LinkIncidentDialog", () => ({
+  default: () => null,
+}));
+vi.mock("@features/csm-cases/components/LinkCaseDialog", () => ({
+  default: () => null,
+}));
+vi.mock("@features/csm-cases/components/SetFixEtaDialog", () => ({
+  default: () => null,
+}));
+vi.mock("@features/csm-cases/components/CreateTaskDialog", () => ({
+  default: () => null,
+}));
+vi.mock("@features/csm-cases/components/AddTagDialog", () => ({
+  default: () => null,
+}));
+vi.mock("@features/csm-cases/components/ChildCasesWidget", () => ({
+  ChildCasesWidget: () => null,
+}));
+vi.mock("@features/csm-cases/components/LinkedServiceRequestsWidget", () => ({
+  LinkedServiceRequestsWidget: () => null,
+}));
+vi.mock("@features/csm-cases/components/LinkedChangeRequestsWidget", () => ({
+  LinkedChangeRequestsWidget: () => null,
+}));
+vi.mock("@features/csm-cases/components/CreateGithubIssueDialog", () => ({
+  CreateGithubIssueDialog: () => null,
+}));
+vi.mock("@features/csm-cases/components/CaseActivitiesFeed", () => ({
+  default: () => null,
+}));
+vi.mock("@features/csm-cases/components/CaseMetaBand", () => ({
+  default: () => null,
+}));
+vi.mock("@features/csm-cases/components/CaseDetailWidgets", () => ({
+  AttachmentsWidget: () => null,
+  CustomerContextWidget: () => null,
+  ProductContextWidget: () => null,
+  TagsWidget: () => null,
+  WatchersWidget: () => null,
+}));
+vi.mock("@features/csm-cases/components/CallRequestsWidget", () => ({
+  CallRequestsWidget: () => null,
+}));
+vi.mock("@features/csm-cases/components/TasksWidget", () => ({
+  TasksWidget: () => null,
+}));
+vi.mock("@features/csm-cases/components/CaseSlaTable", () => ({
+  CaseSlaTable: () => null,
+}));
+
+// The two components at the center of this regression: CaseTimeCardsPanel is
+// stubbed to a button that opens the edit dialog for a fake card (mirroring
+// the real `onEditTimeCard={setEditTimeCard}` wiring), and LogTimeCardDialog
+// is stubbed to a probe that renders the `editingCard` id and `caseId` it was
+// actually given — so the test can see whether the dialog is still mounted,
+// and against which case, after a route change.
+const FAKE_CARD: CsmTimeCard = {
+  id: "card-1",
+  caseId: "case-1",
+  caseNumber: "CS-case-1",
+  projectId: "project-1",
+  projectName: "Acme Project",
+  workDate: "2026-01-01",
+  userId: "user-1",
+  userName: "Jane Doe",
+  state: "submitted",
+  billable: true,
+  totalMinutes: 60,
+} as CsmTimeCard;
+
+vi.mock("@features/csm-timecards/components/CaseTimeCardsPanel", () => ({
+  default: ({
+    onEditTimeCard,
+  }: {
+    onEditTimeCard: (card: CsmTimeCard) => void;
+  }) => (
+    <button type="button" onClick={() => onEditTimeCard(FAKE_CARD)}>
+      Edit fake time card
+    </button>
+  ),
+}));
+vi.mock("@features/csm-timecards/components/LogTimeCardDialog", () => ({
+  default: ({
+    caseId,
+    editingCard,
+  }: {
+    caseId: string;
+    editingCard?: CsmTimeCard;
+  }) => (
+    <div data-testid="log-time-card-dialog-probe">
+      {`editingCardId=${editingCard?.id ?? "none"} caseId=${caseId}`}
+    </div>
+  ),
+}));
+
+// Imported after the mocks above so the module picks them up.
+import CsmCaseDetailPage from "@features/csm-cases/pages/CsmCaseDetailPage";
+
+describe("CsmCaseDetailPage — time-card edit dialog reset on case change", () => {
+  it("stops showing the previous case's edit dialog once the route moves to a new case", () => {
+    setCurrentCaseId("case-1");
+    const { rerender } = render(<CsmCaseDetailPage />);
+
+    // Switch to the "Time tracking" tab, where CaseTimeCardsPanel (stubbed
+    // above) lives, and open the edit dialog for a card on case-1.
+    fireEvent.click(screen.getByRole("tab", { name: /time tracking/i }));
+    fireEvent.click(
+      screen.getByRole("button", { name: /edit fake time card/i }),
+    );
+
+    expect(screen.getByTestId("log-time-card-dialog-probe")).toHaveTextContent(
+      "editingCardId=card-1 caseId=case-1",
+    );
+
+    // Navigate to a different case (same route, only :caseId changes — this
+    // page stays mounted, so the render-time reset block is what has to run).
+    setCurrentCaseId("case-2");
+    rerender(<CsmCaseDetailPage />);
+
+    // Without `setEditTimeCard(null)` in the reset block, the dialog would
+    // still be mounted here, showing case-1's card while the rest of the
+    // page has already moved on to case-2.
+    expect(
+      screen.queryByTestId("log-time-card-dialog-probe"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.test.tsx
@@ -16,9 +16,19 @@
 
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
+import type { JSX } from "react";
+import { MemoryRouter, Route, Routes, useLocation, useNavigate } from "react-router";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import "@testing-library/jest-dom/vitest";
 import type { CsmCaseDetail } from "@features/csm-cases/types/csmCases";
 import type { CsmTimeCard } from "@features/csm-timecards/types/timeCards";
+
+// `@api/backend/client` -> `useAuthApiClient` -> `@config/apiConfig`, which
+// throws at module load when `window.config` isn't set — not present under
+// vitest. Same stub other page tests use (e.g. CsmAccountDetailPage.test.tsx).
+vi.mock("@config/apiConfig", () => ({
+  apiConfig: { backendUrl: "https://example.test" },
+}));
 
 // The backend client reads runtime config at module load, which isn't
 // present under vitest. The page imports `BackendApiError` from it directly,
@@ -32,30 +42,6 @@ vi.mock("@api/backend/client", () => ({
       this.status = status;
     }
   },
-}));
-
-// `currentCaseId` is read by the react-router mock below on every render, so
-// the test can move the page from one case to another by mutating it and
-// calling `rerender`. `vi.hoisted` is required because `vi.mock` factories
-// are hoisted above regular module-scope declarations.
-const { getCurrentCaseId, setCurrentCaseId } = vi.hoisted(() => {
-  let caseId = "case-1";
-  return {
-    getCurrentCaseId: () => caseId,
-    setCurrentCaseId: (next: string) => {
-      caseId = next;
-    },
-  };
-});
-
-vi.mock("react-router", () => ({
-  useParams: () => ({ caseId: getCurrentCaseId() }),
-  useLocation: () => ({
-    pathname: `/cases/${getCurrentCaseId()}`,
-    search: "",
-    hash: "",
-    state: undefined,
-  }),
 }));
 
 const navigateMock = vi.fn();
@@ -372,10 +358,51 @@ vi.mock("@features/csm-timecards/components/LogTimeCardDialog", () => ({
 // Imported after the mocks above so the module picks them up.
 import CsmCaseDetailPage from "@features/csm-cases/pages/CsmCaseDetailPage";
 
+// Renders the real route pathname, so the test can assert the router itself
+// actually transitioned (not just that the page re-rendered) — same
+// convention as CsmAccountDetailPage.test.tsx's `LocationProbe`.
+function LocationProbe(): JSX.Element {
+  const location = useLocation();
+  return <div data-testid="location-probe">{location.pathname}</div>;
+}
+
+// Fires a real `navigate("/cases/case-2")` from inside the router, the same
+// way an in-app link (e.g. the sidebar's recent-cases list) would move the
+// user from one case to another without unmounting this page — the route
+// pattern is identical, only the `:caseId` param changes.
+function NavigateToCaseTwoButton(): JSX.Element {
+  const navigate = useNavigate();
+  return (
+    <button type="button" onClick={() => navigate("/cases/case-2")}>
+      Go to case 2
+    </button>
+  );
+}
+
+function renderPage(): ReturnType<typeof render> {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={["/cases/case-1"]}>
+        <NavigateToCaseTwoButton />
+        <LocationProbe />
+        <Routes>
+          <Route path="/cases/:caseId" element={<CsmCaseDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
 describe("CsmCaseDetailPage — time-card edit dialog reset on case change", () => {
   it("stops showing the previous case's edit dialog once the route moves to a new case", () => {
-    setCurrentCaseId("case-1");
-    const { rerender } = render(<CsmCaseDetailPage />);
+    renderPage();
+
+    expect(screen.getByTestId("location-probe")).toHaveTextContent(
+      "/cases/case-1",
+    );
 
     // Switch to the "Time tracking" tab, where CaseTimeCardsPanel (stubbed
     // above) lives, and open the edit dialog for a card on case-1.
@@ -388,10 +415,14 @@ describe("CsmCaseDetailPage — time-card edit dialog reset on case change", () 
       "editingCardId=card-1 caseId=case-1",
     );
 
-    // Navigate to a different case (same route, only :caseId changes — this
-    // page stays mounted, so the render-time reset block is what has to run).
-    setCurrentCaseId("case-2");
-    rerender(<CsmCaseDetailPage />);
+    // Navigate to a different case through a real router transition (same
+    // route, only :caseId changes — this page stays mounted, so the
+    // render-time reset block is what has to run).
+    fireEvent.click(screen.getByRole("button", { name: /go to case 2/i }));
+
+    expect(screen.getByTestId("location-probe")).toHaveTextContent(
+      "/cases/case-2",
+    );
 
     // Without `setEditTimeCard(null)` in the reset block, the dialog would
     // still be mounted here, showing case-1's card while the rest of the

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -159,6 +159,7 @@ import type {
   CaseAttachment,
   CaseLifecycleAction,
   CaseWatcher,
+  CreateChangeRequestFromCaseNavState,
   CreateIncidentFromCaseNavState,
   CreateRelatedCaseNavState,
   CreateServiceRequestFromCaseNavState,
@@ -1000,6 +1001,22 @@ export default function CsmCaseDetailPage(): JSX.Element {
             : stripHtmlTags(data.description),
         };
         navigate("/operations/incidents/new", { state: navState });
+        return;
+      }
+
+      // Create change request navigates to the change-request create form,
+      // pre-filled with this service request as the new change request's
+      // "Originating service request" — mirrors the create_incident handler
+      // above. Only offered for a service request (see CaseActionBar's
+      // caseType gate on this menu item).
+      if (action.secondary === "create_change_request" && data) {
+        const navState: CreateChangeRequestFromCaseNavState = {
+          caseId: data.id,
+          caseNumber: data.caseNumber,
+          caseSubject: data.subject,
+          projectId: data.projectId,
+        };
+        navigate("/operations/change-requests/new", { state: navState });
         return;
       }
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -571,6 +571,10 @@ export default function CsmCaseDetailPage(): JSX.Element {
     setResolutionDialog(null);
     setSeverityOpen(false);
     setLogTimeOpen(false);
+    // Not just cosmetic: the edit dialog renders on editTimeCard alone, so a
+    // card left open here would stay mounted against the new case and submit
+    // a PATCH for the *previous* case's card.
+    setEditTimeCard(null);
     setGithubIssueOpen(false);
     setGithubIssueError(null);
     setGithubIssueResult(null);

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -130,7 +130,8 @@ import { CaseSlaTable } from "@features/csm-cases/components/CaseSlaTable";
 import { useGetCsmCaseSlas } from "@features/csm-cases/api/useGetCsmCaseSlas";
 import CaseTimeCardsPanel from "@features/csm-timecards/components/CaseTimeCardsPanel";
 import LogTimeCardDialog from "@features/csm-timecards/components/LogTimeCardDialog";
-import { usePostTimeCard } from "@features/csm-timecards/api/useTimeCards";
+import { usePostTimeCard, useUpdateTimeCard } from "@features/csm-timecards/api/useTimeCards";
+import type { CsmTimeCard } from "@features/csm-timecards/types/timeCards";
 import { caseIdLabel } from "@features/csm-cases/utils/caseIdentity";
 import { formatAbsoluteForUser } from "@utils/dateTime";
 import {
@@ -525,6 +526,9 @@ export default function CsmCaseDetailPage(): JSX.Element {
   } | null>(null);
   const [severityOpen, setSeverityOpen] = useState(false);
   const [logTimeOpen, setLogTimeOpen] = useState(false);
+  // The card being edited, if any — mutually exclusive with logTimeOpen
+  // (create); LogTimeCardDialog is rendered once for whichever is set.
+  const [editTimeCard, setEditTimeCard] = useState<CsmTimeCard | null>(null);
   const [githubIssueOpen, setGithubIssueOpen] = useState(false);
   // Inline error shown inside the Git-issue dialog (e.g. the SN routing 422 /
   // state 409). Cleared when the dialog opens or a submit is retried.
@@ -535,6 +539,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
     useState<BeCreateCaseGithubIssueResponse | null>(null);
   const postGithubIssue = usePostCaseGithubIssue();
   const postTimeCard = usePostTimeCard();
+  const updateTimeCard = useUpdateTimeCard();
   // Attachment pending delete confirmation (drives the confirm dialog).
   const [pendingDelete, setPendingDelete] = useState<CaseAttachment | null>(
     null,
@@ -2310,6 +2315,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
           <CaseTimeCardsPanel
             caseId={c.id}
             onLogTime={() => setLogTimeOpen(true)}
+            onEditTimeCard={setEditTimeCard}
           />
         </Box>
       )}
@@ -2439,16 +2445,42 @@ export default function CsmCaseDetailPage(): JSX.Element {
         />
       )}
 
-      {logTimeOpen && (
+      {(logTimeOpen || editTimeCard) && (
         <LogTimeCardDialog
           caseId={c.id}
           caseNumber={c.caseNumber ?? c.id}
           caseSeverity={c.severity}
           projectId={c.projectId}
           projectName={c.projectName}
-          isSubmitting={postTimeCard.isPending}
-          onClose={() => setLogTimeOpen(false)}
-          onSubmit={(input) =>
+          editingCard={editTimeCard ?? undefined}
+          isSubmitting={editTimeCard ? updateTimeCard.isPending : postTimeCard.isPending}
+          onClose={() => {
+            setLogTimeOpen(false);
+            setEditTimeCard(null);
+          }}
+          onSubmit={(input) => {
+            // "cardId" only exists on an edit submission — see
+            // LogTimeCardSubmit's doc comment.
+            if ("cardId" in input) {
+              updateTimeCard.mutate(input, {
+                onSuccess: () => {
+                  setEditTimeCard(null);
+                  setFeedback({
+                    message: "Time card updated.",
+                    severity: "success",
+                    sticky: false,
+                  });
+                },
+                onError: (err) => {
+                  const msg =
+                    err instanceof BackendApiError && err.status < 500 && err.message
+                      ? err.message
+                      : "Could not save your changes.";
+                  showError(msg, err);
+                },
+              });
+              return;
+            }
             postTimeCard.mutate(input, {
               onSuccess: () => {
                 setLogTimeOpen(false);
@@ -2469,8 +2501,8 @@ export default function CsmCaseDetailPage(): JSX.Element {
                     : "Could not log time.";
                 showError(msg, err);
               },
-            })
-          }
+            });
+          }}
         />
       )}
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
@@ -421,6 +421,28 @@ export interface CreateServiceRequestFromCaseNavState {
 }
 
 /**
+ * Router (`navigate(..., { state })`) payload carried from a service
+ * request's "Create change request…" action (case detail action bar) to
+ * `/operations/change-requests/new`, so the create-change-request form's
+ * "Originating service request" picker can pre-select the service request the
+ * action was opened from and scope its search to the same project — see
+ * CsmCaseDetailPage.tsx's `create_change_request` handler and
+ * CreateChangeRequestPage.tsx's read of `useLocation().state`. Distinct from
+ * ChangeRequestsTab.tsx's own "Create change request" button, which navigates
+ * to the same route with no state at all — that entry point has no service
+ * request to prefill or scope by, so its picker searches the whole system
+ * exactly as it always has. `projectId` is optional here (unlike the sibling
+ * nav states above) because a legacy case row can omit it; the picker simply
+ * skips scoping when it's absent.
+ */
+export interface CreateChangeRequestFromCaseNavState {
+  caseId: string;
+  caseNumber?: string;
+  caseSubject?: string;
+  projectId?: string;
+}
+
+/**
  * Router (`navigate(..., { state })`) payload carried from a case's "Create
  * incident from case…" action to `/operations/incidents/new`, so the
  * create-incident form can prefill from the originating case without a

--- a/apps/csm-portal/webapp/src/features/csm-operations/api/useSearchServiceRequestsForSelect.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/api/useSearchServiceRequestsForSelect.test.tsx
@@ -1,0 +1,130 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { ReactNode } from "react";
+
+const postMock = vi.fn();
+
+// The real client reads runtime config at module load, which isn't present
+// under vitest (same approach as useSearchGroups.test.tsx).
+vi.mock("@api/backend/client", () => ({
+  useBackendApi: () => ({ post: postMock }),
+}));
+
+import { useSearchServiceRequestsForSelect } from "@features/csm-operations/api/useSearchServiceRequestsForSelect";
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe("useSearchServiceRequestsForSelect", () => {
+  beforeEach(() => {
+    postMock.mockReset();
+  });
+
+  it("searches unscoped (type filter only) when no projectId is given", async () => {
+    postMock.mockResolvedValue({
+      cases: [{ id: "sr-1", number: "CS-0001", subject: "Reset admin password" }],
+    });
+
+    const { result } = renderHook(
+      () => useSearchServiceRequestsForSelect("reset", true),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(postMock).toHaveBeenCalledTimes(1);
+    expect(postMock).toHaveBeenCalledWith(
+      "/cases/search",
+      expect.objectContaining({
+        filters: expect.objectContaining({
+          searchQuery: "reset",
+          filters: [{ field: "type", op: "in", values: ["service_request"] }],
+        }),
+      }),
+    );
+    expect(result.current.data).toEqual([
+      { id: "sr-1", number: "CS-0001", subject: "Reset admin password" },
+    ]);
+  });
+
+  it("scopes the first search to projectId when given, and does not fall back when it finds matches", async () => {
+    postMock.mockResolvedValue({
+      cases: [{ id: "sr-1", number: "CS-0001", subject: "In-project match" }],
+    });
+
+    const { result } = renderHook(
+      () => useSearchServiceRequestsForSelect("", true, "prj-1"),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(postMock).toHaveBeenCalledTimes(1);
+    expect(postMock).toHaveBeenCalledWith(
+      "/cases/search",
+      expect.objectContaining({
+        filters: expect.objectContaining({
+          filters: [
+            { field: "type", op: "in", values: ["service_request"] },
+            { field: "projectId", op: "in", values: ["prj-1"] },
+          ],
+        }),
+      }),
+    );
+    expect(result.current.data).toEqual([
+      { id: "sr-1", number: "CS-0001", subject: "In-project match" },
+    ]);
+  });
+
+  it("falls back to the unscoped, system-wide search when the projectId-scoped search finds nothing", async () => {
+    postMock
+      .mockResolvedValueOnce({ cases: [] })
+      .mockResolvedValueOnce({
+        cases: [{ id: "sr-9", number: "CS-0009", subject: "Different project" }],
+      });
+
+    const { result } = renderHook(
+      () => useSearchServiceRequestsForSelect("", true, "prj-1"),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // Scoped attempt first, then the unscoped fallback — never excludes a
+    // real match just because it sits outside the scoped project.
+    expect(postMock).toHaveBeenCalledTimes(2);
+    expect(postMock.mock.calls[0][1].filters.filters).toEqual([
+      { field: "type", op: "in", values: ["service_request"] },
+      { field: "projectId", op: "in", values: ["prj-1"] },
+    ]);
+    expect(postMock.mock.calls[1][1].filters.filters).toEqual([
+      { field: "type", op: "in", values: ["service_request"] },
+    ]);
+    expect(result.current.data).toEqual([
+      { id: "sr-9", number: "CS-0009", subject: "Different project" },
+    ]);
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-operations/api/useSearchServiceRequestsForSelect.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/api/useSearchServiceRequestsForSelect.ts
@@ -18,6 +18,7 @@ import { keepPreviousData, useQuery, type UseQueryResult } from "@tanstack/react
 import { ApiQueryKeys } from "@constants/apiConstants";
 import { useBackendApi } from "@api/backend/client";
 import type {
+  BeCaseFieldFilter,
   BeCaseSearchPayload,
   BeCaseSearchResponse,
   BeCaseSearchView,
@@ -26,36 +27,64 @@ import type {
 /** A single page of matches is plenty for a type-ahead picker. */
 const SERVICE_REQUEST_SEARCH_LIMIT = 20;
 
+const TYPE_FILTER: BeCaseFieldFilter = {
+  field: "type",
+  op: "in",
+  values: ["service_request"],
+};
+
 /**
  * Type-ahead service-request search (`POST /cases/search`,
  * `filters.searchQuery`) for the change-request create form's "Originating
- * service request" picker. Matches the `(query, enabled) => {data,
+ * service request" picker. Matches the `(query, enabled, extra?) => {data,
  * isFetching, isError}` shape `AsyncEntitySelect` expects — same template as
  * `useSearchCasesForSelect`. Pinned to `types: ["service_request"]` since the
  * picker links a change request back to the service request it was raised
  * from, never a plain case.
+ *
+ * `projectId` (threaded through `AsyncEntitySelect`'s `searchExtra`) narrows
+ * to service requests on the same project as the case the create form was
+ * opened from — set only when the create form was reached via a service
+ * request's own "Create change request" action, which is the only entry
+ * point today that carries any project context (the create form has no
+ * project field of its own to seed it otherwise). This is deliberately not a
+ * hard filter: `/cases/search`'s field-filter DSL has no `accountId` field
+ * (only `projectId` — see `BeCaseFieldFilterField`), and a project-scoped
+ * search that comes back empty falls straight through to the same unscoped,
+ * system-wide search this hook has always run, so an incomplete or
+ * mismatched `projectId` can narrow the *default* suggestions but never
+ * exclude a real match the unscoped search would have found.
  */
 export function useSearchServiceRequestsForSelect(
   query: string,
   enabled: boolean,
+  projectId?: string,
 ): UseQueryResult<BeCaseSearchView[], Error> {
   const api = useBackendApi();
   const q = query.trim();
 
   return useQuery<BeCaseSearchView[], Error>({
-    queryKey: [ApiQueryKeys.SERVICE_REQUESTS_SEARCH_FOR_SELECT, q],
+    queryKey: [ApiQueryKeys.SERVICE_REQUESTS_SEARCH_FOR_SELECT, q, projectId ?? ""],
     queryFn: async (): Promise<BeCaseSearchView[]> => {
-      const res = await api.post<BeCaseSearchPayload, BeCaseSearchResponse>(
-        "/cases/search",
-        {
-          filters: {
-            searchQuery: q,
-            filters: [{ field: "type", op: "in", values: ["service_request"] }],
+      const search = async (filters: BeCaseFieldFilter[]): Promise<BeCaseSearchView[]> => {
+        const res = await api.post<BeCaseSearchPayload, BeCaseSearchResponse>(
+          "/cases/search",
+          {
+            filters: { searchQuery: q, filters },
+            pagination: { offset: 0, limit: SERVICE_REQUEST_SEARCH_LIMIT },
           },
-          pagination: { offset: 0, limit: SERVICE_REQUEST_SEARCH_LIMIT },
-        },
-      );
-      return res.cases ?? [];
+        );
+        return res.cases ?? [];
+      };
+
+      if (projectId) {
+        const scoped = await search([
+          TYPE_FILTER,
+          { field: "projectId", op: "in", values: [projectId] },
+        ]);
+        if (scoped.length > 0) return scoped;
+      }
+      return search([TYPE_FILTER]);
     },
     enabled,
     placeholderData: keepPreviousData,

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateChangeRequestPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateChangeRequestPage.test.tsx
@@ -18,6 +18,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import "@testing-library/jest-dom/vitest";
 import type { CloneChangeRequestNavState } from "@features/csm-operations/utils/changeRequests";
+import type { CreateChangeRequestFromCaseNavState } from "@features/csm-cases/types/csmCases";
 
 const navigateMock = vi.fn();
 const postChangeRequestMutateMock = vi.fn();
@@ -25,7 +26,10 @@ const patchChangeRequestMutateMock = vi.fn();
 const showErrorMock = vi.fn();
 const postIsPending = false;
 const patchIsPending = false;
-let locationState: CloneChangeRequestNavState | undefined;
+let locationState:
+  | CloneChangeRequestNavState
+  | CreateChangeRequestFromCaseNavState
+  | undefined;
 
 vi.mock("react-router", () => ({
   useNavigate: () => navigateMock,
@@ -244,5 +248,58 @@ describe("CreateChangeRequestPage — originating service request", () => {
       "Could not create the change request. Please try again.",
       expect.any(Error),
     );
+  });
+});
+
+describe("CreateChangeRequestPage — opened from a service request's own 'Create change request…' action", () => {
+  beforeEach(() => {
+    navigateMock.mockReset();
+    postChangeRequestMutateMock.mockReset();
+    patchChangeRequestMutateMock.mockReset();
+    showErrorMock.mockReset();
+  });
+
+  it("pre-selects the originating service request and surfaces a banner naming it", () => {
+    locationState = {
+      caseId: "sr-789",
+      caseNumber: "CS-4321",
+      caseSubject: "Cluster is unresponsive",
+      projectId: "prj-1",
+    };
+    render(<CreateChangeRequestPage />);
+    expect(screen.getByLabelText(/originating service request/i)).toHaveValue("sr-789");
+    expect(screen.getByText(/linking to cs-4321/i)).toBeInTheDocument();
+  });
+
+  it("still lets the pre-selected service request be changed or cleared", () => {
+    locationState = { caseId: "sr-789", caseNumber: "CS-4321" };
+    render(<CreateChangeRequestPage />);
+    fireEvent.change(screen.getByLabelText(/originating service request/i), {
+      target: { value: "" },
+    });
+    expect(screen.getByLabelText(/originating service request/i)).toHaveValue("");
+  });
+
+  it("PATCHes the created change request with the pre-selected caseId on submit", () => {
+    locationState = { caseId: "sr-789", caseNumber: "CS-4321" };
+    render(<CreateChangeRequestPage />);
+    fillSubject();
+    fireEvent.click(screen.getByRole("button", { name: /create change request/i }));
+
+    const [, postOptions] = postChangeRequestMutateMock.mock.calls[0];
+    postOptions.onSuccess({ changeRequest: { id: "chg-2", number: "CHG0000002" } });
+
+    expect(patchChangeRequestMutateMock).toHaveBeenCalledWith(
+      { id: "chg-2", patch: { caseId: "sr-789" } },
+      expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) }),
+    );
+  });
+
+  it("shows no clone banner and no service-request banner when opened directly", () => {
+    locationState = undefined;
+    render(<CreateChangeRequestPage />);
+    expect(screen.queryByText(/cloned from/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/linking to/i)).not.toBeInTheDocument();
+    expect(screen.getByLabelText(/originating service request/i)).toHaveValue("");
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateChangeRequestPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateChangeRequestPage.tsx
@@ -56,6 +56,7 @@ import {
   CLONE_SOURCE_GAP_MESSAGE,
   type CloneChangeRequestNavState,
 } from "@features/csm-operations/utils/changeRequests";
+import type { CreateChangeRequestFromCaseNavState } from "@features/csm-cases/types/csmCases";
 import type {
   BeChangeRequestCategory,
   BeChangeRequestImpact,
@@ -212,14 +213,29 @@ export default function CreateChangeRequestPage(): JSX.Element {
   const postChangeRequest = usePostChangeRequest();
   const patchChangeRequest = usePatchChangeRequest();
 
-  // Set when opened from a change request's "Clone" action, which navigates
-  // here with router state (not query params) — see
-  // CsmChangeRequestDetailPage.tsx's cloneChangeRequest and
-  // buildCloneChangeRequestNavState's doc comment for exactly which fields
-  // this can and can't carry over. Read once: this form's state is what the
-  // user edits from here on, so a later change to the *source* record must
-  // not reach back in and overwrite what they've typed.
-  const cloneState = useLocation().state as CloneChangeRequestNavState | undefined;
+  // This form can be opened two ways, each carrying its own router state
+  // (not query params) — read once: this form's state is what the user edits
+  // from here on, so a later change to the *source* record must not reach
+  // back in and overwrite what they've typed. The two shapes are mutually
+  // exclusive; narrow on `caseId`, the field only the latter carries.
+  //   - Clone, from a change request's "Clone" action — see
+  //     CsmChangeRequestDetailPage.tsx's cloneChangeRequest and
+  //     buildCloneChangeRequestNavState's doc comment for exactly which
+  //     fields this can and can't carry over.
+  //   - A service request's own "Create change request…" action — see
+  //     CsmCaseDetailPage.tsx's create_change_request handler and
+  //     CreateChangeRequestFromCaseNavState's doc comment. Carries the
+  //     originating service request (and its project, for scoping the
+  //     picker's search) so the "Originating service request" field below
+  //     starts pre-selected rather than blank.
+  const locationState = useLocation().state as
+    | CloneChangeRequestNavState
+    | CreateChangeRequestFromCaseNavState
+    | undefined;
+  const cloneState =
+    locationState && !("caseId" in locationState) ? locationState : undefined;
+  const fromCaseState =
+    locationState && "caseId" in locationState ? locationState : undefined;
 
   // Slice on seed as well as on change: a source record at or beyond the cap
   // would otherwise load untrimmed, show a negative characters-left count, and
@@ -260,7 +276,22 @@ export default function CreateChangeRequestPage(): JSX.Element {
   const [requestedById, setRequestedById] = useState("");
   // The service request this change request was raised from, when picked.
   // Not part of BeCreateChangeRequestPayload — see handleSubmit's comment.
-  const [caseId, setCaseId] = useState("");
+  // Pre-selected when opened from that service request's own "Create change
+  // request…" action; stays fully editable from there — the field remains a
+  // normal AsyncEntitySelect, not a locked/read-only control, so a wrong
+  // pre-fill (or a genuine need to link a different service request instead)
+  // can still be corrected without leaving the form.
+  const [caseId, setCaseId] = useState(fromCaseState?.caseId ?? "");
+  // Display label for the pre-filled `caseId` above until a fresh search for
+  // the same id resolves one from the backend (see AsyncEntitySelect's
+  // `knownLabel`).
+  const fromCaseKnownLabel = fromCaseState
+    ? caseSearchLabel({
+        id: fromCaseState.caseId,
+        number: fromCaseState.caseNumber,
+        subject: fromCaseState.caseSubject,
+      })
+    : undefined;
 
   // Defaults "Requested by" to the signed-in user, matching the legacy
   // ServiceNow form's own behaviour (usePostChangeRequest.ts/BE doesn't do
@@ -443,6 +474,13 @@ export default function CreateChangeRequestPage(): JSX.Element {
           {CLONE_SOURCE_GAP_MESSAGE}
         </Alert>
       )}
+      {fromCaseState && (
+        <Alert severity="info" sx={{ mb: 2 }}>
+          Linking to {fromCaseState.caseNumber ?? "the service request"} — its id is
+          carried through automatically as the Originating service request below (see
+          "More options").
+        </Alert>
+      )}
 
       <Card variant="outlined" sx={{ p: 3 }}>
         <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
@@ -569,9 +607,11 @@ export default function CreateChangeRequestPage(): JSX.Element {
               fields most requests won't need up front. */}
           <Accordion
             disableGutters
-            // Auto-expanded when cloning and an engineer carried over, so
-            // the prefilled value isn't hidden behind a collapsed section.
-            defaultExpanded={!!cloneState?.assignedEngineerId}
+            // Auto-expanded when cloning and an engineer carried over, or
+            // when opened from a service request with its id pre-filled
+            // below, so the prefilled value isn't hidden behind a collapsed
+            // section.
+            defaultExpanded={!!cloneState?.assignedEngineerId || !!fromCaseState}
             sx={{ "&:before": { display: "none" }, mt: 1 }}
           >
             <AccordionSummary expandIcon={<ChevronDown size={16} />}>
@@ -681,13 +721,26 @@ export default function CreateChangeRequestPage(): JSX.Element {
                     value={caseId}
                     onChange={setCaseId}
                     disabled={isSubmitting}
-                    // This form carries no account/project field, so there's
-                    // no context available to narrow suggestions — the search
-                    // is across all service requests by number/subject.
+                    // Opened from a service request's own "Create change
+                    // request…" action: its project is threaded through as
+                    // `searchExtra` so the search prefers service requests
+                    // from the same project first (see
+                    // useSearchServiceRequestsForSelect's doc comment for how
+                    // that stays additive, not a hard filter). Opened any
+                    // other way (this page's own "New change request" entry
+                    // point, or a Clone) there's no case context at all, so
+                    // `searchExtra` is undefined and the search stays exactly
+                    // the unscoped, system-wide search it's always been.
                     useSearch={useSearchServiceRequestsForSelect}
+                    searchExtra={fromCaseState?.projectId}
                     getId={(c) => c.id}
                     getLabel={caseSearchLabel}
-                    helperText="Links this change request back to the service request it was raised from."
+                    knownLabel={fromCaseKnownLabel}
+                    helperText={
+                      fromCaseState
+                        ? "Pre-filled from the service request you opened this from — change it if that's not right."
+                        : "Links this change request back to the service request it was raised from."
+                    }
                   />
                 </Box>
               </Box>

--- a/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeCards.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeCards.ts
@@ -35,10 +35,12 @@ import { useBackendApi } from "@api/backend/client";
 import type {
   BeCreateTimeCardPayload,
   BeTimeCardMutationResponse,
+  BeUpdateTimeCardPayload,
 } from "@api/backend/types";
 import type {
   CreateTimeCardInput,
   CsmTimeCard,
+  UpdateTimeCardInput,
 } from "@features/csm-timecards/types/timeCards";
 import {
   invalidateTimecards,
@@ -131,3 +133,43 @@ export function usePostTimeCard(): UseMutationResult<
  * they can't drift again.
  */
 export const useDecideTimeCard = useDecideCard;
+
+/**
+ * Edit an already-submitted card's own content (no `state` key — a content
+ * PATCH is mutually exclusive with the decide flow, see
+ * {@link BeUpdateTimeCardPayload}). The backend enforces submitter-only +
+ * `submitted`-state-only server-side; `LogTimeCardDialog`'s edit mode only
+ * ever offers this to the card's own owner while `submitted` (see
+ * `cardActions`), matching that same rule client-side.
+ */
+export function useUpdateTimeCard(): UseMutationResult<
+  CsmTimeCard,
+  Error,
+  UpdateTimeCardInput
+> {
+  const api = useBackendApi();
+  const queryClient = useQueryClient();
+  return useMutation<CsmTimeCard, Error, UpdateTimeCardInput>({
+    mutationFn: async (input): Promise<CsmTimeCard> => {
+      const payload: BeUpdateTimeCardPayload = {
+        date: input.date,
+        isBillable: input.billable,
+        issueComplexity: input.issueComplexity,
+        workLogComment: input.workLogComment,
+        // Same defensive round as usePostTimeCard's create payload — the
+        // form already collects minutes as whole numbers.
+        timeAnalyzing: Math.round(input.breakdown.analysisDebugging),
+        timeSettingUp: Math.round(input.breakdown.settingUp),
+        timeReproducingDebugging: Math.round(input.breakdown.reproduce),
+        timeProvidingSolution: Math.round(input.breakdown.providingSolution),
+        timePatching: Math.round(input.breakdown.answering),
+      };
+      const res = await api.patch<BeUpdateTimeCardPayload, BeTimeCardMutationResponse>(
+        `/time-cards/${encodeURIComponent(input.cardId)}`,
+        payload,
+      );
+      return mapTimeCard(res.timeCard);
+    },
+    onSuccess: () => invalidateTimecards(queryClient),
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeSheets.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeSheets.test.ts
@@ -15,7 +15,7 @@
 // under the License.
 
 import { describe, expect, it, vi } from "vitest";
-import { searchTimeCards } from "@features/csm-timecards/api/useTimeSheets";
+import { mapTimeCard, searchTimeCards } from "@features/csm-timecards/api/useTimeSheets";
 import type { BackendApi } from "@api/backend/client";
 import type {
   BeSearchTimeCardsPayload,
@@ -70,6 +70,51 @@ function mockApi(page: BeSearchTimeCardsResponse): { api: BackendApi; post: Retu
 function lastPayload(post: ReturnType<typeof vi.fn>): BeSearchTimeCardsPayload {
   return post.mock.calls.at(-1)![1] as BeSearchTimeCardsPayload;
 }
+
+describe("mapTimeCard", () => {
+  // Confirmed live against the real entity-service (POST /time-cards/search):
+  // the per-activity minute breakdown and issue complexity ARE echoed back on
+  // read, both for a just-created card and a pre-existing one — a previously
+  // documented "write-only" claim that turned out to be wrong.
+  it("maps the per-activity minute breakdown and issue complexity through from the wire, when present", () => {
+    const withBreakdown: BeTimeCardView = {
+      ...beCard("a", "submitted"),
+      timeAnalyzing: 11,
+      timeSettingUp: 22,
+      timeReproducingDebugging: 33,
+      timeProvidingSolution: 44,
+      timePatching: 55,
+      issueComplexity: "High",
+    };
+
+    const result = mapTimeCard(withBreakdown);
+
+    expect(result.breakdown).toEqual({
+      analysisDebugging: 11,
+      settingUp: 22,
+      reproduce: 33,
+      providingSolution: 44,
+      answering: 55,
+    });
+    expect(result.issueComplexity).toBe("High");
+  });
+
+  it("leaves breakdown/issueComplexity undefined when the wire response has none (a card logged before these fields were mapped)", () => {
+    const result = mapTimeCard(beCard("a", "submitted"));
+
+    expect(result.breakdown).toBeUndefined();
+    expect(result.issueComplexity).toBeUndefined();
+  });
+
+  it("treats an unrecognized issueComplexity value as undefined rather than passing it through uncast", () => {
+    const result = mapTimeCard({
+      ...beCard("a", "submitted"),
+      issueComplexity: "Some Future Value",
+    });
+
+    expect(result.issueComplexity).toBeUndefined();
+  });
+});
 
 describe("searchTimeCards", () => {
   it("makes a single request and returns the response as-is", async () => {

--- a/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeSheets.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeSheets.ts
@@ -90,6 +90,12 @@ export function invalidateTimecards(queryClient: QueryClient): void {
   }
 }
 
+/** Wire `issueComplexity` values the entity-service is confirmed to return
+ * (see `IssueComplexity`) — anything else (an older/renamed value) maps to
+ * `undefined` rather than a bogus cast, since the edit form's `<select>`
+ * would otherwise silently show nothing selected for an unrecognized value. */
+const KNOWN_ISSUE_COMPLEXITIES: readonly string[] = ["N/A", "Low", "Medium", "High"];
+
 /**
  * Map the backend's `TimeCardView` to the portal's `CsmTimeCard`. `totalTime`
  * is already whole minutes on the wire (see `usePostTimeCard`'s note on why),
@@ -101,8 +107,20 @@ export function invalidateTimecards(queryClient: QueryClient): void {
  * read the same underlying value, so the fallback is a no-op in practice.
  * `approvedBy` / `rejectionReason` are mutually exclusive: only one of them is
  * ever populated (see {@link CsmTimeCard}).
+ *
+ * `breakdown`/`issueComplexity` are only set when the wire response actually
+ * carries the per-activity minute fields — confirmed live to be present on
+ * every real card, but a defensive per-field fallback (rather than assuming
+ * the whole group is always there) costs nothing and matches how the rest of
+ * this mapper already treats every other optional wire field.
  */
 export function mapTimeCard(v: BeTimeCardView): CsmTimeCard {
+  const hasBreakdown =
+    v.timeAnalyzing !== undefined ||
+    v.timeSettingUp !== undefined ||
+    v.timeReproducingDebugging !== undefined ||
+    v.timeProvidingSolution !== undefined ||
+    v.timePatching !== undefined;
   return {
     id: v.id,
     caseId: v.case?.id ?? "",
@@ -120,6 +138,19 @@ export function mapTimeCard(v: BeTimeCardView): CsmTimeCard {
     rejectionReason: v.rejectionReason ?? undefined,
     approvers: v.approvers,
     workLogComment: v.workLogComment ?? undefined,
+    breakdown: hasBreakdown
+      ? {
+          analysisDebugging: v.timeAnalyzing ?? 0,
+          reproduce: v.timeReproducingDebugging ?? 0,
+          settingUp: v.timeSettingUp ?? 0,
+          providingSolution: v.timeProvidingSolution ?? 0,
+          answering: v.timePatching ?? 0,
+        }
+      : undefined,
+    issueComplexity:
+      v.issueComplexity && KNOWN_ISSUE_COMPLEXITIES.includes(v.issueComplexity)
+        ? (v.issueComplexity as CsmTimeCard["issueComplexity"])
+        : undefined,
   };
 }
 

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/CaseTimeCardsPanel.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/CaseTimeCardsPanel.tsx
@@ -23,7 +23,7 @@ import {
   Skeleton,
   Typography,
 } from "@wso2/oxygen-ui";
-import { Clock, Plus } from "@wso2/oxygen-ui-icons-react";
+import { Clock, Pencil, Plus } from "@wso2/oxygen-ui-icons-react";
 import RelativeTime from "@components/RelativeTime";
 import { useCaseTimeCards, useDecideTimeCard } from "@features/csm-timecards/api/useTimeCards";
 import { useCurrentEngineer } from "@features/csm-timecards/api/useTimeSheets";
@@ -42,6 +42,10 @@ interface CaseTimeCardsPanelProps {
   caseId: string;
   /** Opens the log-time dialog (owned by the page so the action bar can trigger it). */
   onLogTime: () => void;
+  /** Opens the edit dialog for one of this panel's own cards (owned by the
+   * page, same as `onLogTime` — both open the same `LogTimeCardDialog`
+   * instance, just in different modes). */
+  onEditTimeCard: (card: CsmTimeCard) => void;
 }
 
 /**
@@ -53,6 +57,7 @@ interface CaseTimeCardsPanelProps {
 export default function CaseTimeCardsPanel({
   caseId,
   onLogTime,
+  onEditTimeCard,
 }: CaseTimeCardsPanelProps): JSX.Element {
   const { data, isLoading, isError, refetch, isFetching, dataUpdatedAt } =
     useCaseTimeCards(caseId);
@@ -175,6 +180,19 @@ export default function CaseTimeCardsPanel({
                 <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
                   <Typography variant="body2">{c.totalMinutes} min</Typography>
                   <TimeCardStatusChip state={c.state} />
+                  {/* Own card, still submitted: only the submitter can edit
+                   its content, matching the backend's own submitter-only +
+                   submitted-state-only enforcement (see cardActions). */}
+                  {c.state === "submitted" && !!me.id && c.userId === me.id && (
+                    <Button
+                      size="small"
+                      variant="outlined"
+                      startIcon={<Pencil size={14} />}
+                      onClick={() => onEditTimeCard(c)}
+                    >
+                      Edit
+                    </Button>
+                  )}
                   {/* Never shown on your own card: the backend 403s a
                    self-decide regardless of approver status, so a card you
                    submitted yourself can never actually be reviewed by you.

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/LogTimeCardDialog.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/LogTimeCardDialog.test.tsx
@@ -1,0 +1,204 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import LogTimeCardDialog from "@features/csm-timecards/components/LogTimeCardDialog";
+import { useSearchUsers } from "@features/csm-users/api/useSearchUsers";
+import type { CsmTimeCard } from "@features/csm-timecards/types/timeCards";
+
+// Not under test here — stubbed to a plain textarea, same technique used by
+// EditCaseDetailsDialog.test.tsx for the same dependency.
+vi.mock("@components/rich-text-editor/Editor", () => ({
+  default: ({
+    value,
+    onChange,
+  }: {
+    value: string;
+    onChange: (v: string) => void;
+  }) => (
+    <textarea
+      aria-label="work-log-editor"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  ),
+}));
+vi.mock("@hooks/useIdTokenClaims", () => ({
+  useIdTokenClaims: () => ({ email: "engineer@example.test", given_name: "Jane" }),
+}));
+vi.mock("@features/csm-users/api/useSearchUsers", () => ({
+  useSearchUsers: vi.fn(),
+}));
+
+const mockedUseSearchUsers = vi.mocked(useSearchUsers);
+mockedUseSearchUsers.mockReturnValue({
+  data: { users: [] },
+} as unknown as ReturnType<typeof useSearchUsers>);
+
+const EDITING_CARD: CsmTimeCard = {
+  id: "card-1",
+  caseId: "case-1",
+  caseNumber: "CS0000001",
+  projectId: "proj-1",
+  projectName: "Acme",
+  workDate: "2026-07-13",
+  userId: "user-1",
+  userName: "Jane Doe",
+  state: "submitted",
+  billable: true,
+  totalMinutes: 165,
+  approvers: [{ id: "lead-1", name: "Lead Approver" }],
+  workLogComment: "<p>Investigated the reported latency issue.</p>",
+  issueComplexity: "High",
+  breakdown: {
+    analysisDebugging: 11,
+    reproduce: 33,
+    settingUp: 22,
+    providingSolution: 44,
+    answering: 55,
+  },
+};
+
+describe("LogTimeCardDialog — create mode", () => {
+  it("shows the log-time title and submit label, with an editable approver search", () => {
+    render(
+      <LogTimeCardDialog
+        caseId="case-1"
+        caseNumber="CS0000001"
+        caseSeverity="S3"
+        projectId="proj-1"
+        projectName="Acme"
+        isSubmitting={false}
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Log time · CS0000001")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Submit for review" })).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText("Search engineers by name or email…"),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("LogTimeCardDialog — edit mode", () => {
+  it("shows the edit title and Save changes label instead of the create ones", () => {
+    render(
+      <LogTimeCardDialog
+        caseId={EDITING_CARD.caseId}
+        caseNumber={EDITING_CARD.caseNumber}
+        projectId={EDITING_CARD.projectId}
+        projectName={EDITING_CARD.projectName}
+        editingCard={EDITING_CARD}
+        isSubmitting={false}
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Edit time card · CS0000001")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Save changes" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Submit for review" })).not.toBeInTheDocument();
+  });
+
+  it("prefills the activity breakdown and work-log comment from the card being edited", () => {
+    render(
+      <LogTimeCardDialog
+        caseId={EDITING_CARD.caseId}
+        caseNumber={EDITING_CARD.caseNumber}
+        projectId={EDITING_CARD.projectId}
+        projectName={EDITING_CARD.projectName}
+        editingCard={EDITING_CARD}
+        isSubmitting={false}
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByLabelText("Analysis and debugging")).toHaveValue(11);
+    expect(screen.getByLabelText("Reproduce")).toHaveValue(33);
+    expect(screen.getByLabelText("Setting up")).toHaveValue(22);
+    expect(screen.getByLabelText("Providing solution")).toHaveValue(44);
+    expect(screen.getByLabelText("Answering")).toHaveValue(55);
+    expect(screen.getByLabelText("work-log-editor")).toHaveValue(
+      "<p>Investigated the reported latency issue.</p>",
+    );
+    expect(screen.getByText(`${11 + 33 + 22 + 44 + 55} min total`)).toBeInTheDocument();
+  });
+
+  it("shows the approver read-only, with no delete affordance and no search box", () => {
+    render(
+      <LogTimeCardDialog
+        caseId={EDITING_CARD.caseId}
+        caseNumber={EDITING_CARD.caseNumber}
+        projectId={EDITING_CARD.projectId}
+        projectName={EDITING_CARD.projectName}
+        editingCard={EDITING_CARD}
+        isSubmitting={false}
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Lead Approver")).toBeInTheDocument();
+    expect(
+      screen.queryByPlaceholderText("Search engineers by name or email…"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("submits an UpdateTimeCardInput (cardId set, no approver field) on Save changes", () => {
+    const onSubmit = vi.fn();
+    render(
+      <LogTimeCardDialog
+        caseId={EDITING_CARD.caseId}
+        caseNumber={EDITING_CARD.caseNumber}
+        projectId={EDITING_CARD.projectId}
+        projectName={EDITING_CARD.projectName}
+        editingCard={EDITING_CARD}
+        isSubmitting={false}
+        onClose={vi.fn()}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("work-log-editor"), {
+      target: { value: "<p>Updated comment.</p>" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    const input = onSubmit.mock.calls[0][0];
+    expect(input).toMatchObject({
+      cardId: "card-1",
+      date: "2026-07-13",
+      billable: true,
+      issueComplexity: "High",
+      workLogComment: "<p>Updated comment.</p>",
+      breakdown: {
+        analysisDebugging: 11,
+        reproduce: 33,
+        settingUp: 22,
+        providingSolution: 44,
+        answering: 55,
+      },
+    });
+    expect(input).not.toHaveProperty("approver");
+    expect(input).not.toHaveProperty("caseId");
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/LogTimeCardDialog.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/LogTimeCardDialog.test.tsx
@@ -201,4 +201,42 @@ describe("LogTimeCardDialog — edit mode", () => {
     expect(input).not.toHaveProperty("approver");
     expect(input).not.toHaveProperty("caseId");
   });
+
+  // Regression: approvers is optional on a card. Requiring an approver in edit
+  // mode made the form invalid and then disabled Save, blocking the edit
+  // outright for a submitted card that has no mapped approver — even though the
+  // field is read-only here and never sent.
+  it("still saves a card that came back with no approver", () => {
+    const onSubmit = vi.fn();
+    const { approvers: _omitted, ...cardWithoutApprover } = EDITING_CARD;
+    render(
+      <LogTimeCardDialog
+        caseId={EDITING_CARD.caseId}
+        caseNumber={EDITING_CARD.caseNumber}
+        projectId={EDITING_CARD.projectId}
+        projectName={EDITING_CARD.projectName}
+        editingCard={cardWithoutApprover as CsmTimeCard}
+        isSubmitting={false}
+        onClose={vi.fn()}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("work-log-editor"), {
+      target: { value: "<p>Updated with no approver on the card.</p>" },
+    });
+
+    const save = screen.getByRole("button", { name: "Save changes" });
+    expect(save).not.toBeDisabled();
+
+    fireEvent.click(save);
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    const input = onSubmit.mock.calls[0][0];
+    expect(input).toMatchObject({
+      cardId: "card-1",
+      workLogComment: "<p>Updated with no approver on the card.</p>",
+    });
+    expect(input).not.toHaveProperty("approver");
+  });
 });

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/LogTimeCardDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/LogTimeCardDialog.tsx
@@ -64,8 +64,10 @@ import type {
   ActivityBreakdown,
   ActivityKey,
   CreateTimeCardInput,
+  CsmTimeCard,
   IssueComplexity,
   TimeCardApprover,
+  UpdateTimeCardInput,
 } from "@features/csm-timecards/types/timeCards";
 import {
   emptyBreakdown,
@@ -75,6 +77,11 @@ import {
 import { localTodayIso } from "@features/csm-timecards/utils/timeSheetWeek";
 import { formatDateOnly, parseDateOnly } from "@utils/dateTime";
 
+/** Either a create ({@link CreateTimeCardInput}, POST) or an edit
+ * ({@link UpdateTimeCardInput}, PATCH) submission — the caller distinguishes
+ * by checking for `cardId`, present only on the edit shape. */
+export type LogTimeCardSubmit = CreateTimeCardInput | UpdateTimeCardInput;
+
 interface LogTimeCardDialogProps {
   /** The case the time was spent on — always known, this dialog only opens
    * from a case's Time tracking tab (the backend requires a real case UUID,
@@ -82,14 +89,30 @@ interface LogTimeCardDialogProps {
   caseId: string;
   caseNumber: string;
   /** Determines whether the billable switch is editable — see
-   * NON_BILLABLE_SEVERITIES. */
-  caseSeverity: Severity;
+   * NON_BILLABLE_SEVERITIES. Optional because a caller editing a card from a
+   * cross-case context (the Time cards page's "My time sheets" tab) has no
+   * severity to hand in; the switch stays enabled there rather than being
+   * force-disabled on a guess, and the backend's own business rule still
+   * enforces the real non-billable-severities constraint server-side either
+   * way (see NON_BILLABLE_SEVERITIES's doc comment). */
+  caseSeverity?: Severity;
   projectId: string;
   projectName: string;
-  /** True while the create mutation is in flight. */
+  /** True while the create/edit mutation is in flight. */
   isSubmitting: boolean;
+  /**
+   * When set, the dialog opens in **edit mode** for this already-submitted
+   * card instead of logging a new one: every field prefills from the card's
+   * current values (see `CsmTimeCard.breakdown`/`issueComplexity`, confirmed
+   * live to round-trip), the approver becomes read-only (matching
+   * ServiceNow's own UX once a card is submitted — see `UpdateTimeCardInput`),
+   * the title/submit label change, and `onSubmit` is called with an
+   * {@link UpdateTimeCardInput} (`cardId` set) instead of a
+   * {@link CreateTimeCardInput}.
+   */
+  editingCard?: CsmTimeCard;
   onClose: () => void;
-  onSubmit: (input: CreateTimeCardInput) => void;
+  onSubmit: (input: LogTimeCardSubmit) => void;
 }
 
 interface ApproverOption {
@@ -152,15 +175,17 @@ function ActivityRow({
 }
 
 /**
- * "Log time" form. Mirrors the ServiceNow fields (date, the five activity
- * buckets, work-log comment, issue complexity, approver) with a live
+ * "Log time" form, doubling as the **edit** form for an already-submitted
+ * card (see `editingCard`). Mirrors the ServiceNow fields (date, the five
+ * activity buckets, work-log comment, issue complexity, approver) with a live
  * running total, per-activity proportion bars, and inline validation. There
  * was a "Category" field here too, but it was never actually sent anywhere
  * (`usePostTimeCard`'s payload has no such field) — removed rather than kept
  * as a choice that silently did nothing.
  * Creating a card submits it immediately — the backend has no draft step, so
- * there is no "Pending" status and no edit-after-create (see the module-level
- * note in `types/timeCards.ts` on why edit isn't supported).
+ * there is no "Pending" status. Editing is only offered (see `cardActions`)
+ * to the card's own submitter while it's still `submitted`, matching what
+ * the backend itself enforces server-side.
  */
 export default function LogTimeCardDialog({
   caseId,
@@ -169,23 +194,35 @@ export default function LogTimeCardDialog({
   projectId,
   projectName,
   isSubmitting,
+  editingCard,
   onClose,
   onSubmit,
 }: LogTimeCardDialogProps): JSX.Element {
   const me = resolveUserInfo(useIdTokenClaims());
+  const isEditMode = !!editingCard;
 
-  const isAlwaysNonBillable = NON_BILLABLE_SEVERITIES.includes(caseSeverity);
+  const isAlwaysNonBillable =
+    !!caseSeverity && NON_BILLABLE_SEVERITIES.includes(caseSeverity);
 
-  const [date, setDate] = useState(localTodayIso());
+  const [date, setDate] = useState(editingCard?.workDate ?? localTodayIso());
   const [issueComplexity, setIssueComplexity] = useState<IssueComplexity>(
-    DEFAULT_ISSUE_COMPLEXITY,
+    editingCard?.issueComplexity ?? DEFAULT_ISSUE_COMPLEXITY,
   );
   const [billable, setBillable] = useState<boolean>(
-    isAlwaysNonBillable ? false : DEFAULT_BILLABLE,
+    editingCard ? editingCard.billable : isAlwaysNonBillable ? false : DEFAULT_BILLABLE,
   );
-  const [breakdown, setBreakdown] = useState<ActivityBreakdown>(emptyBreakdown());
-  const [workLogComment, setWorkLogComment] = useState("");
-  const [approver, setApprover] = useState<TimeCardApprover | null>(null);
+  const [breakdown, setBreakdown] = useState<ActivityBreakdown>(
+    editingCard?.breakdown ?? emptyBreakdown(),
+  );
+  // workLogComment is rich-text HTML (see Editor below); an edited card's
+  // existing comment is already HTML on the wire, so it loads straight in.
+  const [workLogComment, setWorkLogComment] = useState(editingCard?.workLogComment ?? "");
+  // The approver is read-only once editing (see UpdateTimeCardInput's doc
+  // comment) — this state only exists to satisfy timeCardDraftErrors'
+  // approver-required check and is never sent on an edit submit.
+  const [approver, setApprover] = useState<TimeCardApprover | null>(
+    editingCard?.approvers?.[0] ?? null,
+  );
   const [approverInput, setApproverInput] = useState("");
   const [touched, setTouched] = useState<Set<string>>(new Set());
   const touch = (field: string): void =>
@@ -243,6 +280,17 @@ export default function LogTimeCardDialog({
       setTouched(new Set(ALL_FIELDS));
       return;
     }
+    if (isEditMode && editingCard) {
+      onSubmit({
+        cardId: editingCard.id,
+        date,
+        breakdown,
+        billable,
+        workLogComment: workLogComment.trim(),
+        issueComplexity,
+      });
+      return;
+    }
     onSubmit({
       caseId,
       caseNumber,
@@ -275,7 +323,9 @@ export default function LogTimeCardDialog({
 
   return (
     <Dialog open onClose={onClose} maxWidth="sm" fullWidth>
-      <DialogTitle>Log time · {caseNumber}</DialogTitle>
+      <DialogTitle>
+        {isEditMode ? "Edit time card" : "Log time"} · {caseNumber}
+      </DialogTitle>
       <DialogContent dividers>
         <Box
           onKeyDown={handleKeyDown}
@@ -297,7 +347,9 @@ export default function LogTimeCardDialog({
               >
                 {initialsOf(me.fullName)}
               </Avatar>
-              <Typography variant="body2">{me.fullName}</Typography>
+              <Typography variant="body2">
+                {isEditMode ? editingCard.userName : me.fullName}
+              </Typography>
             </Box>
             <TimeCardStatusChip state="submitted" />
           </Box>
@@ -457,10 +509,15 @@ export default function LogTimeCardDialog({
             </Typography>
           </Box>
 
-          {/* Approver */}
+          {/* Approver — read-only once editing: ServiceNow's own UX locks
+              this field after submit, and the portal follows that rather
+              than letting an edit silently reassign the approver even
+              though the backend would technically accept the change. */}
           <Box sx={{ display: "flex", flexDirection: "column", gap: 0.75 }}>
             <Typography variant="subtitle2">Approver (team lead)</Typography>
-            {approver ? (
+            {isEditMode ? (
+              <Chip label={approver?.name ?? "—"} sx={{ alignSelf: "flex-start" }} />
+            ) : approver ? (
               <Chip
                 label={approver.name}
                 onDelete={() => setApprover(null)}
@@ -569,7 +626,7 @@ export default function LogTimeCardDialog({
           onClick={handleSubmit}
           disabled={isSubmitting || (touched.size > 0 && !isValid)}
         >
-          Submit for review
+          {isEditMode ? "Save changes" : "Submit for review"}
         </Button>
       </DialogActions>
     </Dialog>

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/LogTimeCardDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/LogTimeCardDialog.tsx
@@ -235,6 +235,11 @@ export default function LogTimeCardDialog({
     breakdown,
     workLogComment,
     approverId: approver?.id,
+    // approvers is optional on a card, so an edited card may legitimately have
+    // none. The field is read-only in edit mode and never sent, so requiring it
+    // here would only make Save invalid and then disabled, blocking the edit
+    // outright for exactly those cards.
+    requireApprover: !isEditMode,
   });
   const isValid = Object.keys(errors).length === 0;
 
@@ -276,7 +281,7 @@ export default function LogTimeCardDialog({
 
   const ALL_FIELDS = ["date", "minutes", "workLogComment", "approver"];
   const handleSubmit = (): void => {
-    if (!isValid || !approver) {
+    if (!isValid) {
       setTouched(new Set(ALL_FIELDS));
       return;
     }
@@ -289,6 +294,12 @@ export default function LogTimeCardDialog({
         workLogComment: workLogComment.trim(),
         issueComplexity,
       });
+      return;
+    }
+    // Create only: an approver is mandatory here, and isValid already covers
+    // it (requireApprover is true outside edit mode). This narrows the type.
+    if (!approver) {
+      setTouched(new Set(ALL_FIELDS));
       return;
     }
     onSubmit({

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardsTable.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardsTable.test.tsx
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 import TimeCardsTable from "@features/csm-timecards/components/TimeCardsTable";
@@ -76,5 +76,74 @@ describe("TimeCardsTable column visibility", () => {
 
     expect(screen.getByText("CS0352584")).toBeInTheDocument();
     expect(screen.getByText("Jane Doe")).toBeInTheDocument();
+  });
+});
+
+describe("TimeCardsTable edit action", () => {
+  it("shows the edit icon for the card's own owner on a submitted card, and calls onCardAction with \"edit\"", () => {
+    const onCardAction = vi.fn();
+    render(
+      <TimeCardsTable
+        cards={[CARD]}
+        isLoading={false}
+        emptyText="No cards"
+        groupBy="case"
+        roleFor={() => ({ isOwner: true, isApprover: false, isAdmin: false })}
+        onCardAction={onCardAction}
+      />,
+    );
+
+    const editButton = screen.getByTestId(`timecard-edit-${CARD.id}`);
+    expect(editButton).toBeInTheDocument();
+    fireEvent.click(editButton);
+    expect(onCardAction).toHaveBeenCalledWith(CARD, "edit");
+  });
+
+  it("shows the edit icon regardless of showActionsColumn (unlike approve/reject)", () => {
+    render(
+      <TimeCardsTable
+        cards={[CARD]}
+        isLoading={false}
+        emptyText="No cards"
+        groupBy="case"
+        showActionsColumn={false}
+        roleFor={() => ({ isOwner: true, isApprover: false, isAdmin: false })}
+        onCardAction={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId(`timecard-edit-${CARD.id}`)).toBeInTheDocument();
+  });
+
+  it("hides the edit icon for a non-owner (e.g. an approver viewing someone else's card)", () => {
+    render(
+      <TimeCardsTable
+        cards={[CARD]}
+        isLoading={false}
+        emptyText="No cards"
+        groupBy="case"
+        showActionsColumn
+        roleFor={() => ({ isOwner: false, isApprover: true, isAdmin: false })}
+        onCardAction={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByTestId(`timecard-edit-${CARD.id}`)).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Approve" })).toBeInTheDocument();
+  });
+
+  it("hides the edit icon once the card is no longer submitted, even for the owner", () => {
+    render(
+      <TimeCardsTable
+        cards={[{ ...CARD, state: "approved" }]}
+        isLoading={false}
+        emptyText="No cards"
+        groupBy="case"
+        roleFor={() => ({ isOwner: true, isApprover: false, isAdmin: false })}
+        onCardAction={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByTestId(`timecard-edit-${CARD.id}`)).not.toBeInTheDocument();
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardsTable.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardsTable.tsx
@@ -16,7 +16,7 @@
 
 import { Fragment, useState, type JSX } from "react";
 import { Box, Button, IconButton, Skeleton, Tooltip, Typography } from "@wso2/oxygen-ui";
-import { Check, Eye, X } from "@wso2/oxygen-ui-icons-react";
+import { Check, Eye, Pencil, X } from "@wso2/oxygen-ui-icons-react";
 import RelativeTime from "@components/RelativeTime";
 import TimeCardDetailModal from "@features/csm-timecards/components/TimeCardDetailModal";
 import TimeCardStatusChip from "@features/csm-timecards/components/TimeCardStatusChip";
@@ -60,8 +60,11 @@ interface TimeCardsTableProps {
   onCardAction: (card: CsmTimeCard, action: TimecardAction) => void;
 }
 
+// "edit" isn't in here — unlike approve/reject, it renders as its own icon
+// button (matching the Eye view icon) shown unconditionally when a card is
+// editable, not as a text button gated by showActionsColumn (see below).
 const ACTION_BUTTONS: Record<
-  TimecardAction,
+  Exclude<TimecardAction, "edit">,
   { label: string; color: "success" | "error"; variant: "contained" | "outlined"; icon: JSX.Element }
 > = {
   approve: { label: "Approve", color: "success", variant: "outlined", icon: <Check size={14} /> },
@@ -252,22 +255,38 @@ export default function TimeCardsTable({
                   >
                     <Eye size={16} />
                   </IconButton>
+                  {/* Own actionable button regardless of showActionsColumn —
+                      unlike approve/reject, editing is offered to the card's
+                      own owner on every tab it can appear on (My time
+                      sheets, All), not just the Approvals queue. */}
+                  {actions.includes("edit") && (
+                    <IconButton
+                      size="small"
+                      aria-label="Edit time card"
+                      data-testid={`timecard-edit-${c.id}`}
+                      onClick={() => onCardAction(c, "edit")}
+                    >
+                      <Pencil size={16} />
+                    </IconButton>
+                  )}
                   {showActionsColumn &&
-                    actions.map((a) => {
-                      const b = ACTION_BUTTONS[a];
-                      return (
-                        <Button
-                          key={a}
-                          size="small"
-                          color={b.color}
-                          variant={b.variant}
-                          startIcon={b.icon}
-                          onClick={() => onCardAction(c, a)}
-                        >
-                          {b.label}
-                        </Button>
-                      );
-                    })}
+                    actions
+                      .filter((a): a is Exclude<TimecardAction, "edit"> => a !== "edit")
+                      .map((a) => {
+                        const b = ACTION_BUTTONS[a];
+                        return (
+                          <Button
+                            key={a}
+                            size="small"
+                            color={b.color}
+                            variant={b.variant}
+                            startIcon={b.icon}
+                            onClick={() => onCardAction(c, a)}
+                          >
+                            {b.label}
+                          </Button>
+                        );
+                      })}
                 </Box>
               </Box>
             );

--- a/apps/csm-portal/webapp/src/features/csm-timecards/constants/timeCardConstants.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/constants/timeCardConstants.ts
@@ -30,8 +30,9 @@ export interface ActivityBucket {
 
 /**
  * The five fixed activity categories, in display order — the activity types
- * from the Time Management requirement (ISSU-009). Write-only: the backend
- * accepts these hours on create but never returns them on read.
+ * from the Time Management requirement (ISSU-009). Shapes the log/edit-time
+ * form; the backend echoes these minutes back on read too (see
+ * `CsmTimeCard.breakdown`), which is what makes the edit form's prefill safe.
  */
 export const ACTIVITY_BUCKETS: ActivityBucket[] = [
   { key: "analysisDebugging", label: "Analysis and debugging" },
@@ -41,7 +42,7 @@ export const ACTIVITY_BUCKETS: ActivityBucket[] = [
   { key: "answering", label: "Answering" },
 ];
 
-/** Issue-complexity options (the ServiceNow "Issue Complexity" field). Write-only. */
+/** Issue-complexity options (the ServiceNow "Issue Complexity" field). */
 export const ISSUE_COMPLEXITY_OPTIONS: readonly IssueComplexity[] = [
   "N/A",
   "Low",

--- a/apps/csm-portal/webapp/src/features/csm-timecards/pages/CsmTimeCardsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/pages/CsmTimeCardsPage.tsx
@@ -61,6 +61,7 @@ import {
   useMyTimeCards,
   type TimeCardPagination,
 } from "@features/csm-timecards/api/useTimeSheets";
+import { useUpdateTimeCard } from "@features/csm-timecards/api/useTimeCards";
 import AsyncProjectMultiSelect from "@features/csm-cases/components/AsyncProjectMultiSelect";
 import { BackendApiError } from "@api/backend/client";
 import { BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
@@ -71,6 +72,7 @@ import RefreshButton from "@components/RefreshButton";
 import { useTimecardRole } from "@features/csm-timecards/hooks/useTimecardRole";
 import TimeCardsTable from "@features/csm-timecards/components/TimeCardsTable";
 import TimeCardReviewDialog from "@features/csm-timecards/components/TimeCardReviewDialog";
+import LogTimeCardDialog from "@features/csm-timecards/components/LogTimeCardDialog";
 import SearchableMultiSelect from "@components/SearchableMultiSelect";
 import { exportTimeCardsCsv } from "@features/csm-timecards/utils/timeCardCsvExport";
 import type { TimecardAction, TimecardRoleCtx } from "@features/csm-timecards/utils/timeSheetState";
@@ -149,10 +151,13 @@ type TabId = "mine" | "all" | "approvals";
 /**
  * Time cards workspace. Three tabs: **My time sheets** (own cards only),
  * **All** (everyone's cards, read only — visibility, not action), and
- * **Approvals** (approver/admin: approve/reject a submitted card). Logging
- * time happens from a case's Time tracking tab, not here. There's no
- * sheet-level bulk action, delegation, or reports — the backend has no
- * endpoints for those (see the module-level notes in `types/timeCards.ts`).
+ * **Approvals** (approver/admin: approve/reject a submitted card). Logging a
+ * *new* card still only happens from a case's Time tracking tab (this page
+ * has no case context to log against) — but editing an own still-`submitted`
+ * card is available from here too (My time sheets / All), via the same Edit
+ * action `TimeCardsTable` offers there. There's no sheet-level bulk action,
+ * delegation, or reports — the backend has no endpoints for those (see the
+ * module-level notes in `types/timeCards.ts`).
  */
 export default function CsmTimeCardsPage(): JSX.Element {
   const role = useTimecardRole();
@@ -169,6 +174,11 @@ export default function CsmTimeCardsPage(): JSX.Element {
   // the list), so the dialog reflects that one decision instead of asking
   // again — see TimeCardReviewDialog's `action` prop.
   const [review, setReview] = useState<{ card: CsmTimeCard; action: TimecardAction } | null>(null);
+  // The card open in the edit dialog, if any — this page has no case
+  // context of its own, so LogTimeCardDialog's caseId/caseNumber/projectId/
+  // projectName all come from the card being edited (see the render below).
+  const [editingCard, setEditingCard] = useState<CsmTimeCard | null>(null);
+  const updateTimeCard = useUpdateTimeCard();
 
   // How the table clusters its rows — a display-only choice (see
   // `groupTimeCards`), independent of the server-side filters below. Only
@@ -285,6 +295,7 @@ export default function CsmTimeCardsPage(): JSX.Element {
 
   const handleCardAction = (card: CsmTimeCard, action: TimecardAction): void => {
     if (action === "approve" || action === "reject") setReview({ card, action });
+    else if (action === "edit") setEditingCard(card);
   };
 
   // "All" shows everyone's cards, own included, and is always read-only
@@ -645,6 +656,34 @@ export default function CsmTimeCardsPage(): JSX.Element {
             </>
           )}
         </Box>
+      )}
+
+      {editingCard && (
+        <LogTimeCardDialog
+          caseId={editingCard.caseId}
+          caseNumber={editingCard.caseNumber}
+          projectId={editingCard.projectId}
+          projectName={editingCard.projectName}
+          editingCard={editingCard}
+          isSubmitting={updateTimeCard.isPending}
+          onClose={() => setEditingCard(null)}
+          onSubmit={(input) => {
+            if (!("cardId" in input)) return; // always the edit shape here
+            updateTimeCard.mutate(input, {
+              onSuccess: () => {
+                setEditingCard(null);
+                showSuccess("Time card updated.");
+              },
+              onError: (err) => {
+                const msg =
+                  err instanceof BackendApiError && err.status < 500 && err.message
+                    ? err.message
+                    : "Could not save your changes.";
+                showError(msg, err);
+              },
+            });
+          }}
+        />
       )}
 
       {review && (

--- a/apps/csm-portal/webapp/src/features/csm-timecards/types/timeCards.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/types/timeCards.ts
@@ -32,9 +32,9 @@ export type TimeCardState =
 /**
  * The fixed activity buckets a time card splits its time across — the
  * activity categories from the Time Management requirement (ISSU-009).
- * Write-only: the backend accepts these on create (`timeAnalyzing`,
- * `timeSettingUp`, …) but never returns them on read, so they shape the
- * log-time form only, not {@link CsmTimeCard}.
+ * Shapes the log/edit-time form; also the shape `CsmTimeCard.breakdown` reads
+ * an existing card's minutes into (see `mapTimeCard` in `useTimeSheets.ts`),
+ * now that the backend is confirmed to echo these back on read.
  */
 export const ACTIVITY_KEYS = [
   "analysisDebugging",
@@ -56,17 +56,18 @@ export interface TimeCardApprover {
   name: string;
 }
 
-/** Issue-complexity options (the ServiceNow "Issue Complexity" field). Write-only. */
+/** Issue-complexity options (the ServiceNow "Issue Complexity" field). */
 export type IssueComplexity = "N/A" | "Low" | "Medium" | "High";
 
 /**
  * A time card as returned by `POST /time-cards/search` and the mutation
- * endpoints (the backend's `TimeCardView`). This is the complete set of
- * fields the backend ever returns for a card — `issueComplexity`, the
- * per-activity minute breakdown, and any lead comment (other than
- * {@link rejectionReason}) are accepted on write but never read back, so
- * editing an existing card isn't supported (it would silently blank those
- * fields). `workLogComment` IS read back — confirmed live.
+ * endpoints (the backend's `TimeCardView`). `breakdown` and
+ * `issueComplexity` are confirmed live to round-trip: a card's per-activity
+ * minutes and issue complexity come back unchanged on the next search after
+ * being set, which is what makes editing an existing card (see
+ * `LogTimeCardDialog`'s edit mode) safe — prefilling the edit form from these
+ * fields shows the card's real current values, not stale zeros. A lead
+ * comment other than {@link rejectionReason} is still write-only/unconfirmed.
  */
 export interface CsmTimeCard {
   id: string;
@@ -120,6 +121,12 @@ export interface CsmTimeCard {
    * ServiceNow rich-text HTML — sanitize with `sanitizeRichTextHtml` before
    * rendering. Absent on a card logged before this field was mapped. */
   workLogComment?: string;
+  /** Per-activity minute breakdown — absent on a card logged before this
+   * field was mapped, otherwise always present alongside `totalMinutes`. */
+  breakdown?: ActivityBreakdown;
+  /** The "Issue Complexity" picked when the card was logged (or last
+   * edited). Absent on a card logged before this field was mapped. */
+  issueComplexity?: IssueComplexity;
 }
 
 /**
@@ -140,6 +147,24 @@ export interface CreateTimeCardInput {
   workLogComment: string;
   issueComplexity: IssueComplexity;
   approver: TimeCardApprover;
+}
+
+/**
+ * Payload to edit an already-submitted card's own content — the backend
+ * enforces submitter-only + `submitted`-state-only server-side (matching
+ * ServiceNow's own edit-in-place behavior), so this is only ever offered to
+ * the card's own submitter while it's still `submitted` (see `cardActions`).
+ * No `approver` field: the approver is shown read-only in the edit form
+ * (matching ServiceNow's own UX once a card is submitted) even though the
+ * backend would technically accept a change.
+ */
+export interface UpdateTimeCardInput {
+  cardId: string;
+  date: string;
+  breakdown: ActivityBreakdown;
+  billable: boolean;
+  workLogComment: string;
+  issueComplexity: IssueComplexity;
 }
 
 /** Payload for a lead's accept/reject decision. */

--- a/apps/csm-portal/webapp/src/features/csm-timecards/utils/__tests__/timeCardTotals.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/utils/__tests__/timeCardTotals.test.ts
@@ -70,6 +70,24 @@ describe("timeCardTotals", () => {
       expect(errors.approver).toBeDefined();
     });
 
+    // Regression: a card's approvers list is optional, and on an edit the
+    // approver is read-only and never sent. Requiring it there made the form
+    // permanently invalid, which disabled Save and blocked the edit entirely.
+    it("does not require an approver when requireApprover is false", () => {
+      const errors = timeCardDraftErrors({
+        ...valid,
+        approverId: undefined,
+        requireApprover: false,
+      });
+      expect(errors.approver).toBeUndefined();
+      expect(errors).toEqual({});
+    });
+
+    it("still requires an approver by default", () => {
+      const errors = timeCardDraftErrors({ ...valid, approverId: undefined });
+      expect(errors.approver).toBeDefined();
+    });
+
     it("flags a work log comment over WORK_LOG_MAX", () => {
       const errors = timeCardDraftErrors({
         ...valid,

--- a/apps/csm-portal/webapp/src/features/csm-timecards/utils/__tests__/timeSheetState.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/utils/__tests__/timeSheetState.test.ts
@@ -23,8 +23,8 @@ const ADMIN = { isOwner: false, isApprover: false, isAdmin: true };
 const NONE = { isOwner: false, isApprover: false, isAdmin: false };
 
 describe("cardActions", () => {
-  it("owner never has actions, even on a submitted card", () => {
-    expect(cardActions("submitted", OWNER)).toEqual([]);
+  it("owner can edit their own submitted card", () => {
+    expect(cardActions("submitted", OWNER)).toEqual(["edit"]);
   });
   it("approver approves/rejects a submitted card that isn't their own", () => {
     expect(cardActions("submitted", APPROVER)).toEqual(["approve", "reject"]);
@@ -35,8 +35,10 @@ describe("cardActions", () => {
   it("no actions for a non-approver, non-owner", () => {
     expect(cardActions("submitted", NONE)).toEqual([]);
   });
-  it("no actions once decided (approved/rejected)", () => {
+  it("no actions once decided (approved/rejected), even for the owner", () => {
     expect(cardActions("approved", APPROVER)).toEqual([]);
     expect(cardActions("rejected", APPROVER)).toEqual([]);
+    expect(cardActions("approved", OWNER)).toEqual([]);
+    expect(cardActions("rejected", OWNER)).toEqual([]);
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-timecards/utils/timeCardTotals.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/utils/timeCardTotals.ts
@@ -55,12 +55,20 @@ export interface TimeCardDraft {
   breakdown: ActivityBreakdown;
   workLogComment: string;
   approverId?: string;
+  /**
+   * Whether an approver must be chosen. True (the default) when creating a
+   * card. False when editing an existing one: the approver is fixed at
+   * submission time, shown read-only, and never sent on an edit — and a card
+   * may come back with no approver at all, which must not block the edit.
+   */
+  requireApprover?: boolean;
 }
 
 /**
  * Validate a log-time draft. Returns an errors object; an empty object means the
- * draft is submittable. Mirrors the ServiceNow required fields (Date, Task —
- * preset from the case, Work Log Comment, Approver) plus a "log some time" rule.
+ * draft is submittable. Mirrors the required fields of the backing work-log
+ * record (Date, Task — preset from the case, Work Log Comment, and Approver on
+ * create) plus a "log some time" rule.
  */
 export function timeCardDraftErrors(draft: TimeCardDraft): TimeCardDraftErrors {
   const errors: TimeCardDraftErrors = {};
@@ -78,6 +86,8 @@ export function timeCardDraftErrors(draft: TimeCardDraft): TimeCardDraftErrors {
   } else if (draft.workLogComment.length > WORK_LOG_MAX) {
     errors.workLogComment = `Comment must be ${WORK_LOG_MAX} characters or fewer.`;
   }
-  if (!draft.approverId) errors.approver = "Choose an approver.";
+  if (draft.requireApprover !== false && !draft.approverId) {
+    errors.approver = "Choose an approver.";
+  }
   return errors;
 }

--- a/apps/csm-portal/webapp/src/features/csm-timecards/utils/timeSheetState.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/utils/timeSheetState.ts
@@ -17,13 +17,14 @@
 import type { TimeCardState } from "@features/csm-timecards/types/timeCards";
 
 /**
- * Actions that can be taken on a card. The backend only supports a
- * state-transition PATCH (`approved` / `rejected`) — there's no submit
- * (cards are created already submitted), no edit (reads never return the
- * fields needed to safely round-trip an edit), no recall, and no process.
- * There's also no bulk/sheet-level endpoint, so there are no sheet actions.
+ * Actions that can be taken on a card. The backend supports a state-transition
+ * PATCH (`approved` / `rejected`) and a content-only PATCH — `edit` — while a
+ * card is still `submitted` and the caller is its own submitter (matching
+ * ServiceNow's own edit-in-place behavior). There's no submit (cards are
+ * created already submitted), no recall, and no process. There's also no
+ * bulk/sheet-level endpoint, so there are no sheet actions.
  */
-export type TimecardAction = "approve" | "reject";
+export type TimecardAction = "approve" | "reject" | "edit";
 
 /** The capabilities of the current user relative to a card. */
 export interface TimecardRoleCtx {
@@ -37,14 +38,17 @@ export interface TimecardRoleCtx {
 
 /**
  * Allowed actions on a single card given its state and the user's role.
- * Single source of truth for which buttons render. Only an approver/admin
- * acting on a `submitted` card (not their own) has any action — the owner
- * has none, matching what the backend actually supports today.
+ * Single source of truth for which buttons render. On a `submitted` card,
+ * the owner can only edit it (never approve/reject their own — the backend
+ * 403s a self-decide regardless of approver status) and an approver/admin
+ * can only decide it (never edit someone else's card). Once decided
+ * (approved/rejected), nobody has any action.
  */
 export function cardActions(
   state: TimeCardState,
   role: TimecardRoleCtx,
 ): TimecardAction[] {
-  if (state !== "submitted" || role.isOwner) return [];
+  if (state !== "submitted") return [];
+  if (role.isOwner) return ["edit"];
   return role.isApprover || role.isAdmin ? ["approve", "reject"] : [];
 }

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -1481,22 +1481,25 @@ type SearchCaseView struct {
 	// CreatedBy is the canonical user reference for the case creator. Its id is
 	// populated only where the backing data source already supplies one, and
 	// null otherwise: see UserReference.
-	CreatedBy       *UserReference `json:"createdBy"`
-	Subject         *string        `json:"subject"`
-	Description     *string        `json:"description"`
-	IssueType       *string        `json:"issueType"`
-	State           string         `json:"state"`
-	Severity        *string        `json:"severity"`
-	Catalog         *EntityRef     `json:"catalog"`
-	CatalogItem     *EntityRef     `json:"catalogItem"`
-	AssignedTeam    *EntityRef     `json:"assignedTeam"`
-	Product         *EntityRef     `json:"product"`
-	EngagementType  *string        `json:"engagementType"`
-	WorkState       *string        `json:"workState"`
-	Type            string         `json:"type"`
-	Project         EntityRef      `json:"project"`
-	Deployment      *EntityRef     `json:"deployment"`
-	DeployedProduct *EntityRef     `json:"deployedProduct"`
+	CreatedBy      *UserReference `json:"createdBy"`
+	Subject        *string        `json:"subject"`
+	Description    *string        `json:"description"`
+	IssueType      *string        `json:"issueType"`
+	State          string         `json:"state"`
+	Severity       *string        `json:"severity"`
+	Catalog        *EntityRef     `json:"catalog"`
+	CatalogItem    *EntityRef     `json:"catalogItem"`
+	AssignedTeam   *EntityRef     `json:"assignedTeam"`
+	Product        *EntityRef     `json:"product"`
+	EngagementType *string        `json:"engagementType"`
+	WorkState      *string        `json:"workState"`
+	Type           string         `json:"type"`
+	Project        EntityRef      `json:"project"`
+	// ProjectKey is the project's short human-readable key (e.g. "TESTQUERYSUB").
+	// Populated for the ServiceNow data source only; null otherwise.
+	ProjectKey      *string    `json:"projectKey"`
+	Deployment      *EntityRef `json:"deployment"`
+	DeployedProduct *EntityRef `json:"deployedProduct"`
 	// AssignedEngineer is the canonical user reference for the assigned
 	// engineer. Its id is populated from the assignee id the response already
 	// carries. Null when unassigned.
@@ -1504,6 +1507,24 @@ type SearchCaseView struct {
 	ParentCase       *EntityRef     `json:"parentCase"`
 	RelatedCase      *EntityRef     `json:"relatedCase"`
 	Conversation     *EntityRef     `json:"conversation"`
+	// AccountDetails is the case's account reference, including support tier
+	// (Type). Populated for the ServiceNow data source only; null otherwise.
+	AccountDetails *AccountRef `json:"account"`
+	// BestCaseFixEta is the internal-only best-case fix-commitment date, as a
+	// date-only "YYYY-MM-DD" string. Populated for the ServiceNow data source
+	// only; null otherwise. CSM-engineer-facing only, never shared with the
+	// customer.
+	BestCaseFixEta *string `json:"bestCaseFixEta"`
+	// MostLikelyFixEta is the internal-only most-likely fix-commitment date, as
+	// a date-only "YYYY-MM-DD" string. Populated for the ServiceNow data source
+	// only; null otherwise. CSM-engineer-facing only, never shared with the
+	// customer.
+	MostLikelyFixEta *string `json:"mostLikelyFixEta"`
+	// WorstCaseFixEta is the internal-only worst-case fix-commitment date, as a
+	// date-only "YYYY-MM-DD" string. Populated for the ServiceNow data source
+	// only; null otherwise. CSM-engineer-facing only, never shared with the
+	// customer.
+	WorstCaseFixEta *string `json:"worstCaseFixEta"`
 }
 
 // SearchCasesResponse is the paginated result of a case search. When the

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -1781,6 +1781,20 @@ type AddCaseTagRequest struct {
 	Label  string `json:"label"`
 }
 
+// SearchTagsFilters holds the optional filters for a tag search.
+type SearchTagsFilters struct {
+	// SearchQuery matches tag labels partially, case-insensitively. Empty
+	// returns all known tags.
+	SearchQuery string `json:"searchQuery"`
+}
+
+// SearchTagsRequest is the request body for POST /tags/search. Limit caps the
+// number of results (<=0 means use the backing data source's default of 20).
+type SearchTagsRequest struct {
+	Filters SearchTagsFilters `json:"filters"`
+	Limit   int               `json:"limit"`
+}
+
 // CreateCaseCommentResponse is the response for creating a new case comment.
 type CreateCaseCommentResponse struct {
 	Message string            `json:"message"`

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -1352,6 +1352,13 @@ type ParsedCaseFilters struct {
 	WorkStates      []CaseWorkState
 	AssignedUserIDs []string
 	ProductNames    []string
+	// ExcludeStates filters to cases whose state is NOT one of these values
+	// (optional). Inverse of States, and the two are independent: a request may
+	// carry either, both, or neither. Only the backing data source that models
+	// case state supports it; the relational backend rejects it rather than
+	// dropping the predicate, since silently ignoring an exclusion widens the
+	// result set instead of narrowing it.
+	ExcludeStates []CaseState
 	// Tags filters cases by attached free-text label. Works end-to-end: ServiceNow's
 	// CaseUtils.searchCases honors filters.tags, and Ballerina's CaseSearchFilters
 	// forwards it.

--- a/entity-service/internal/handler/case_handler.go
+++ b/entity-service/internal/handler/case_handler.go
@@ -20,7 +20,6 @@ package handler
 import (
 	"encoding/json"
 	"net/http"
-	"strconv"
 	"strings"
 
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
@@ -34,6 +33,10 @@ import (
 // The generic maxRequestBodySize (1 MiB) is far too small for this endpoint
 // and rejects legitimate small attachments (e.g. a 2 MB file).
 const maxAttachmentBodySize = int64(15 << 20)
+
+// maxTagSearchLimit caps POST /tags/search results. Tag search backs a
+// type-ahead, not a paged browse, so the ceiling is deliberately low.
+const maxTagSearchLimit = 100
 
 // attachmentTooLargeMsg is deliberately expressed as the file-size limit (10
 // MB) a caller actually cares about, not the raw request-body cap above — the
@@ -275,22 +278,23 @@ func (h *CaseHandler) RemoveCaseTag(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// SearchTags handles GET /tags/search?q={query}&limit={limit}. Not scoped to a single case; used
+// SearchTags handles POST /tags/search. Not scoped to a single case; used
 // for FE autocomplete when attaching a tag.
 func (h *CaseHandler) SearchTags(w http.ResponseWriter, r *http.Request) {
-	query := r.URL.Query().Get("q")
-
-	limit := 0
-	if raw := r.URL.Query().Get("limit"); raw != "" {
-		parsed, err := strconv.Atoi(raw)
-		if err != nil || parsed < 0 {
-			writeServiceError(w, r, &apierror.ValidationError{Msg: "limit must be a non-negative integer"})
-			return
-		}
-		limit = parsed
+	var req domain.SearchTagsRequest
+	if !decodeRequest(w, r, &req) {
+		return
+	}
+	if req.Limit < 0 {
+		writeServiceError(w, r, &apierror.ValidationError{Msg: "limit must be a non-negative integer"})
+		return
+	}
+	if req.Limit > maxTagSearchLimit {
+		writeServiceError(w, r, &apierror.ValidationError{Msg: "limit must not exceed 100"})
+		return
 	}
 
-	tags, err := h.svc.SearchTags(r.Context(), query, limit)
+	tags, err := h.svc.SearchTags(r.Context(), req)
 	if err != nil {
 		writeServiceError(w, r, err)
 		return

--- a/entity-service/internal/handler/case_handler.go
+++ b/entity-service/internal/handler/case_handler.go
@@ -20,6 +20,7 @@ package handler
 import (
 	"encoding/json"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
@@ -285,6 +286,35 @@ func (h *CaseHandler) SearchTags(w http.ResponseWriter, r *http.Request) {
 	if !decodeRequest(w, r, &req) {
 		return
 	}
+	h.searchTags(w, r, req)
+}
+
+// SearchTagsQuery handles GET /tags/search?q={query}&limit={limit}, the
+// query-parameter form tag search used before it moved to a JSON body.
+//
+// Deprecated: use POST /tags/search instead. This alias exists only so the
+// services in front of this one can be rolled out over the following release
+// instead of having to deploy in lockstep with it; a caller still on the GET
+// would otherwise get a 405. Delete it once that release has shipped.
+func (h *CaseHandler) SearchTagsQuery(w http.ResponseWriter, r *http.Request) {
+	req := domain.SearchTagsRequest{
+		Filters: domain.SearchTagsFilters{SearchQuery: r.URL.Query().Get("q")},
+	}
+	if raw := r.URL.Query().Get("limit"); raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		if err != nil {
+			writeServiceError(w, r, &apierror.ValidationError{Msg: "limit must be a non-negative integer"})
+			return
+		}
+		req.Limit = parsed
+	}
+	h.searchTags(w, r, req)
+}
+
+// searchTags is the single path both /tags/search forms run through: validation,
+// the service call, and the response envelope all live here so the deprecated
+// GET alias cannot drift from the POST.
+func (h *CaseHandler) searchTags(w http.ResponseWriter, r *http.Request, req domain.SearchTagsRequest) {
 	if req.Limit < 0 {
 		writeServiceError(w, r, &apierror.ValidationError{Msg: "limit must be a non-negative integer"})
 		return

--- a/entity-service/internal/handler/case_handler_test.go
+++ b/entity-service/internal/handler/case_handler_test.go
@@ -38,6 +38,11 @@ type stubCaseService struct {
 	createAttachmentCalled bool
 	createAttachmentResp   domain.CreateAttachmentResponse
 	createAttachmentErr    error
+
+	searchTagsCalled bool
+	searchTagsReq    domain.SearchTagsRequest
+	searchTagsTags   []domain.Tag
+	searchTagsErr    error
 }
 
 func (s *stubCaseService) CreateCaseAttachment(_ context.Context, _ domain.CreateAttachmentRequest) (domain.CreateAttachmentResponse, error) {
@@ -128,5 +133,112 @@ func TestCreateCaseAttachment_OverNewLimit(t *testing.T) {
 	}
 	if strings.Contains(rec.Body.String(), "request body too large") {
 		t.Fatalf("expected the generic message to be replaced by the attachment-specific one, got: %s", rec.Body.String())
+	}
+}
+
+// searchTagsCalled/searchTagsReq capture what the handler passes down, so the
+// tests below can assert the JSON body is decoded into the documented shape.
+func (s *stubCaseService) SearchTags(_ context.Context, req domain.SearchTagsRequest) ([]domain.Tag, error) {
+	s.searchTagsCalled = true
+	s.searchTagsReq = req
+	return s.searchTagsTags, s.searchTagsErr
+}
+
+// TestSearchTags_DecodesFiltersSearchQuery pins the request shape: the query
+// lives under filters.searchQuery and limit is top level. Asserting on the
+// decoded request here is safe only because the raw wire format one layer down
+// is separately pinned in the service package's tests.
+func TestSearchTags_DecodesFiltersSearchQuery(t *testing.T) {
+	stub := &stubCaseService{searchTagsTags: []domain.Tag{{ID: "t1", Label: "micro-gw"}}}
+	h := NewCaseHandler(stub)
+
+	req := httptest.NewRequest(http.MethodPost, "/tags/search",
+		strings.NewReader(`{"filters":{"searchQuery":"micro"},"limit":20}`))
+	rec := httptest.NewRecorder()
+
+	h.SearchTags(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !stub.searchTagsCalled {
+		t.Fatalf("expected SearchTags to reach the service layer")
+	}
+	if stub.searchTagsReq.Filters.SearchQuery != "micro" {
+		t.Fatalf("SearchQuery = %q, want micro", stub.searchTagsReq.Filters.SearchQuery)
+	}
+	if stub.searchTagsReq.Limit != 20 {
+		t.Fatalf("Limit = %d, want 20", stub.searchTagsReq.Limit)
+	}
+	if !strings.Contains(rec.Body.String(), `"tags"`) {
+		t.Fatalf("response must keep the {tags:[...]} envelope, got: %s", rec.Body.String())
+	}
+}
+
+// TestSearchTags_RejectsLegacyQueryParamShape proves the old GET contract is
+// gone: `q` is now an unknown field and the decoder rejects it outright.
+func TestSearchTags_RejectsLegacyQueryParamShape(t *testing.T) {
+	stub := &stubCaseService{}
+	h := NewCaseHandler(stub)
+
+	req := httptest.NewRequest(http.MethodPost, "/tags/search", strings.NewReader(`{"q":"micro"}`))
+	rec := httptest.NewRecorder()
+
+	h.SearchTags(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for the legacy q key, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if stub.searchTagsCalled {
+		t.Fatalf("expected the request to be rejected before the service layer")
+	}
+}
+
+func TestSearchTags_RejectsOutOfRangeLimit(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+	}{
+		{"negative", `{"limit":-1}`},
+		{"over max", `{"limit":101}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stub := &stubCaseService{}
+			h := NewCaseHandler(stub)
+
+			req := httptest.NewRequest(http.MethodPost, "/tags/search", strings.NewReader(tc.body))
+			rec := httptest.NewRecorder()
+
+			h.SearchTags(rec, req)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+			}
+			if stub.searchTagsCalled {
+				t.Fatalf("expected the request to be rejected before the service layer")
+			}
+		})
+	}
+}
+
+// TestSearchTags_EmptyBodyIsValid keeps the "list all known tags" behaviour the
+// old GET had when q and limit were both omitted.
+func TestSearchTags_EmptyBodyIsValid(t *testing.T) {
+	stub := &stubCaseService{}
+	h := NewCaseHandler(stub)
+
+	req := httptest.NewRequest(http.MethodPost, "/tags/search", strings.NewReader(`{}`))
+	rec := httptest.NewRecorder()
+
+	h.SearchTags(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !stub.searchTagsCalled {
+		t.Fatalf("expected SearchTags to reach the service layer")
+	}
+	if stub.searchTagsReq.Filters.SearchQuery != "" || stub.searchTagsReq.Limit != 0 {
+		t.Fatalf("expected a zero request, got %#v", stub.searchTagsReq)
 	}
 }

--- a/entity-service/internal/handler/case_handler_test.go
+++ b/entity-service/internal/handler/case_handler_test.go
@@ -242,3 +242,86 @@ func TestSearchTags_EmptyBodyIsValid(t *testing.T) {
 		t.Fatalf("expected a zero request, got %#v", stub.searchTagsReq)
 	}
 }
+
+// TestSearchTagsQuery_MatchesPostRequest is the guarantee the deprecated GET
+// alias exists for: `GET /tags/search?q=micro&limit=5` must reach the service
+// layer as the exact same domain.SearchTagsRequest as
+// `POST /tags/search {"filters":{"searchQuery":"micro"},"limit":5}`. Because the
+// upstream wire body is derived from that request and separately pinned against
+// raw bytes in the service package's tests, request equality here means the two
+// forms are byte-identical on the wire too.
+func TestSearchTagsQuery_MatchesPostRequest(t *testing.T) {
+	postStub := &stubCaseService{}
+	postReq := httptest.NewRequest(http.MethodPost, "/tags/search",
+		strings.NewReader(`{"filters":{"searchQuery":"micro"},"limit":5}`))
+	postRec := httptest.NewRecorder()
+	NewCaseHandler(postStub).SearchTags(postRec, postReq)
+	if postRec.Code != http.StatusOK {
+		t.Fatalf("POST: expected 200, got %d: %s", postRec.Code, postRec.Body.String())
+	}
+
+	getStub := &stubCaseService{}
+	getReq := httptest.NewRequest(http.MethodGet, "/tags/search?q=micro&limit=5", nil)
+	getRec := httptest.NewRecorder()
+	NewCaseHandler(getStub).SearchTagsQuery(getRec, getReq)
+	if getRec.Code != http.StatusOK {
+		t.Fatalf("GET: expected 200, got %d: %s", getRec.Code, getRec.Body.String())
+	}
+
+	if !getStub.searchTagsCalled {
+		t.Fatalf("expected the GET alias to reach the service layer")
+	}
+	if getStub.searchTagsReq != postStub.searchTagsReq {
+		t.Fatalf("GET alias produced %#v, want the POST's %#v", getStub.searchTagsReq, postStub.searchTagsReq)
+	}
+	if getRec.Body.String() != postRec.Body.String() {
+		t.Fatalf("GET alias response %s, want the POST's %s", getRec.Body.String(), postRec.Body.String())
+	}
+}
+
+// TestSearchTagsQuery_NoParams keeps the "list all known tags" behaviour when q
+// and limit are both omitted.
+func TestSearchTagsQuery_NoParams(t *testing.T) {
+	stub := &stubCaseService{}
+	rec := httptest.NewRecorder()
+
+	NewCaseHandler(stub).SearchTagsQuery(rec, httptest.NewRequest(http.MethodGet, "/tags/search", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !stub.searchTagsCalled {
+		t.Fatalf("expected SearchTags to reach the service layer")
+	}
+	if (stub.searchTagsReq != domain.SearchTagsRequest{}) {
+		t.Fatalf("expected a zero request, got %#v", stub.searchTagsReq)
+	}
+}
+
+// TestSearchTagsQuery_RejectsBadLimit covers the two limit values the alias must
+// refuse: one it cannot parse, and ones outside the range the POST enforces. The
+// bounds check is shared code, so this also proves the alias runs through it.
+func TestSearchTagsQuery_RejectsBadLimit(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		url  string
+	}{
+		{"non-numeric", "/tags/search?q=micro&limit=abc"},
+		{"negative", "/tags/search?q=micro&limit=-1"},
+		{"over max", "/tags/search?q=micro&limit=101"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stub := &stubCaseService{}
+			rec := httptest.NewRecorder()
+
+			NewCaseHandler(stub).SearchTagsQuery(rec, httptest.NewRequest(http.MethodGet, tc.url, nil))
+
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+			}
+			if stub.searchTagsCalled {
+				t.Fatalf("expected the request to be rejected before the service layer")
+			}
+		})
+	}
+}

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -278,7 +278,7 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 	mux.HandleFunc("DELETE /attachments/{id}", caseHandler.DeleteCaseAttachment)
 	mux.HandleFunc("POST /cases/{id}/tags", caseHandler.AddCaseTag)
 	mux.HandleFunc("DELETE /cases/{id}/tags/{tagId}", caseHandler.RemoveCaseTag)
-	mux.HandleFunc("GET /tags/search", caseHandler.SearchTags)
+	mux.HandleFunc("POST /tags/search", caseHandler.SearchTags)
 
 	if callRequestHandler != nil {
 		mux.HandleFunc("POST /call-requests", callRequestHandler.CreateCallRequest)

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -279,6 +279,10 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 	mux.HandleFunc("POST /cases/{id}/tags", caseHandler.AddCaseTag)
 	mux.HandleFunc("DELETE /cases/{id}/tags/{tagId}", caseHandler.RemoveCaseTag)
 	mux.HandleFunc("POST /tags/search", caseHandler.SearchTags)
+	// Deprecated: the query-parameter form of tag search, kept for one release
+	// so callers can be rolled out independently of this service. Remove it
+	// (and CaseHandler.SearchTagsQuery) once they are all on the POST.
+	mux.HandleFunc("GET /tags/search", caseHandler.SearchTagsQuery)
 
 	if callRequestHandler != nil {
 		mux.HandleFunc("POST /call-requests", callRequestHandler.CreateCallRequest)

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -282,6 +282,7 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 	// Deprecated: the query-parameter form of tag search, kept for one release
 	// so callers can be rolled out independently of this service. Remove it
 	// (and CaseHandler.SearchTagsQuery) once they are all on the POST.
+	//nolint:staticcheck // SA1019: intentional one-release compatibility route; remove with the handler.
 	mux.HandleFunc("GET /tags/search", caseHandler.SearchTagsQuery)
 
 	if callRequestHandler != nil {

--- a/entity-service/internal/service/case_filters.go
+++ b/entity-service/internal/service/case_filters.go
@@ -262,14 +262,23 @@ func ParseCaseFieldFilters(filters []domain.CaseFieldFilter, callerEmail string,
 			p.Types = append(p.Types, f.Values...)
 
 		case "state":
-			if f.Op != "in" {
+			switch f.Op {
+			case "in":
+				if err := requireCaseFilterValues(f); err != nil {
+					return domain.ParsedCaseFilters{}, err
+				}
+				for _, v := range f.Values {
+					p.States = append(p.States, domain.CaseState(v))
+				}
+			case "notIn":
+				if err := requireCaseFilterValues(f); err != nil {
+					return domain.ParsedCaseFilters{}, err
+				}
+				for _, v := range f.Values {
+					p.ExcludeStates = append(p.ExcludeStates, domain.CaseState(v))
+				}
+			default:
 				return domain.ParsedCaseFilters{}, badCaseFilterCombo(f)
-			}
-			if err := requireCaseFilterValues(f); err != nil {
-				return domain.ParsedCaseFilters{}, err
-			}
-			for _, v := range f.Values {
-				p.States = append(p.States, domain.CaseState(v))
 			}
 
 		case "severity":
@@ -710,6 +719,10 @@ func rejectUnsupportedOrGroupFields(parsed domain.ParsedCaseFilters) error {
 		return &apierror.ValidationError{Msg: "anyOf: field \"projectType\" is not supported inside an OR group"}
 	case len(parsed.IntegrationCsTeamIDs) > 0:
 		return &apierror.ValidationError{Msg: "anyOf: field \"integrationCsTeam\" is not supported inside an OR group"}
+	case len(parsed.ExcludeStates) > 0:
+		// state+in is supported inside a branch (CaseFilterGroup.States);
+		// state+notIn is not modeled there.
+		return &apierror.ValidationError{Msg: "anyOf: field \"state\" (notIn) is not supported inside an OR group"}
 	case parsed.Unassigned:
 		return &apierror.ValidationError{Msg: "anyOf: field \"assignedUserId\" (isEmpty) is not supported inside an OR group"}
 	case parsed.ResolutionNotesEmpty:

--- a/entity-service/internal/service/case_filters_test.go
+++ b/entity-service/internal/service/case_filters_test.go
@@ -77,6 +77,53 @@ func TestParseCaseFieldFilters_NamedFieldTranslations(t *testing.T) {
 			},
 		},
 		{
+			name: "state in maps to States",
+			in:   []domain.CaseFieldFilter{{Field: "state", Op: "in", Values: []string{"open", "reopened"}}},
+			check: func(t *testing.T, p domain.ParsedCaseFilters) {
+				if len(p.States) != 2 || p.States[0] != "open" || p.States[1] != "reopened" {
+					t.Fatalf("States = %v", p.States)
+				}
+				if len(p.ExcludeStates) != 0 {
+					t.Fatalf("ExcludeStates = %v, want empty", p.ExcludeStates)
+				}
+			},
+		},
+		{
+			name: "state notIn maps to ExcludeStates",
+			in:   []domain.CaseFieldFilter{{Field: "state", Op: "notIn", Values: []string{"awaiting_info", "solution_proposed", "closed"}}},
+			check: func(t *testing.T, p domain.ParsedCaseFilters) {
+				want := []domain.CaseState{"awaiting_info", "solution_proposed", "closed"}
+				if len(p.ExcludeStates) != len(want) {
+					t.Fatalf("ExcludeStates = %v, want %v", p.ExcludeStates, want)
+				}
+				for i, w := range want {
+					if p.ExcludeStates[i] != w {
+						t.Fatalf("ExcludeStates = %v, want %v", p.ExcludeStates, want)
+					}
+				}
+				// notIn must never be folded into the positive allowlist: that
+				// would silently invert the predicate's meaning.
+				if len(p.States) != 0 {
+					t.Fatalf("States = %v, want empty: notIn must not populate the in list", p.States)
+				}
+			},
+		},
+		{
+			name: "state in and notIn are independent and may be combined",
+			in: []domain.CaseFieldFilter{
+				{Field: "state", Op: "in", Values: []string{"open", "work_in_progress"}},
+				{Field: "state", Op: "notIn", Values: []string{"closed"}},
+			},
+			check: func(t *testing.T, p domain.ParsedCaseFilters) {
+				if len(p.States) != 2 {
+					t.Fatalf("States = %v, want 2 entries", p.States)
+				}
+				if len(p.ExcludeStates) != 1 || p.ExcludeStates[0] != "closed" {
+					t.Fatalf("ExcludeStates = %v, want [closed]", p.ExcludeStates)
+				}
+			},
+		},
+		{
 			name: "assignedUserId isEmpty maps to Unassigned",
 			in:   []domain.CaseFieldFilter{{Field: "assignedUserId", Op: "isEmpty"}},
 			check: func(t *testing.T, p domain.ParsedCaseFilters) {
@@ -409,6 +456,39 @@ func TestParseCaseFieldFilterGroups_CreatedByRejectedAsValidationError(t *testin
 				t.Errorf("Msg = %q, want %q", ve.Msg, want)
 			}
 		})
+	}
+}
+
+// state+in is one of the fields an OR branch does model, but state+notIn is
+// not: CaseFilterGroup has no exclusion field, so accepting it would drop the
+// predicate and widen the branch's result set.
+func TestParseCaseFieldFilterGroups_RejectsStateNotIn(t *testing.T) {
+	branch := domain.CaseFilterBranch{
+		Filters: []domain.CaseFieldFilter{{Field: "state", Op: "notIn", Values: []string{"closed"}}},
+	}
+	_, err := ParseCaseFieldFilterGroups([]domain.CaseFilterBranch{branch})
+	var ve *apierror.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("err = %v (%T), want *apierror.ValidationError", err, err)
+	}
+	const want = `anyOf: field "state" (notIn) is not supported inside an OR group`
+	if ve.Msg != want {
+		t.Errorf("Msg = %q, want %q", ve.Msg, want)
+	}
+}
+
+// state+in stays accepted inside a branch -- the rejection above must not
+// have caught the positive form too.
+func TestParseCaseFieldFilterGroups_AcceptsStateIn(t *testing.T) {
+	branch := domain.CaseFilterBranch{
+		Filters: []domain.CaseFieldFilter{{Field: "state", Op: "in", Values: []string{"open"}}},
+	}
+	groups, err := ParseCaseFieldFilterGroups([]domain.CaseFilterBranch{branch})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(groups) != 1 || len(groups[0].States) != 1 || groups[0].States[0] != "open" {
+		t.Fatalf("groups = %+v, want one branch with States [open]", groups)
 	}
 }
 

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -548,6 +548,6 @@ func (s *caseService) RemoveCaseTag(_ context.Context, _, _ string) error {
 	return &apierror.ServiceUnavailableError{Msg: "case tags are only supported for the ServiceNow data source"}
 }
 
-func (s *caseService) SearchTags(_ context.Context, _ string, _ int) ([]domain.Tag, error) {
+func (s *caseService) SearchTags(_ context.Context, _ domain.SearchTagsRequest) ([]domain.Tag, error) {
 	return nil, &apierror.ServiceUnavailableError{Msg: "case tags are only supported for the ServiceNow data source"}
 }

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -444,6 +444,11 @@ func (s *caseService) SearchCases(ctx context.Context, req domain.SearchCasesReq
 	if len(parsed.ExcludeTags) > 0 {
 		return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: `field "tag" (notIn) is not supported by this data source`}
 	}
+	// state+in is supported here; state+notIn has no repository query support,
+	// and dropping an exclusion silently would widen the result set.
+	if len(parsed.ExcludeStates) > 0 {
+		return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: `field "state" (notIn) is not supported by this data source`}
+	}
 	if parsed.ParentID != nil {
 		return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: `field "parentId" is not supported by this data source`}
 	}

--- a/entity-service/internal/service/case_service_test.go
+++ b/entity-service/internal/service/case_service_test.go
@@ -89,6 +89,8 @@ func TestCaseService_SearchCases_RejectsUnsupportedPostgresFields(t *testing.T) 
 		{name: "integrationCsTeam", filter: domain.CaseFieldFilter{Field: "integrationCsTeam", Op: "in", Values: []string{"00000000-0000-0000-0000-000000000000"}}},
 		{name: "assignedUserId isEmpty (Unassigned)", filter: domain.CaseFieldFilter{Field: "assignedUserId", Op: "isEmpty"}},
 		{name: "resolutionNotes isEmpty", filter: domain.CaseFieldFilter{Field: "resolutionNotes", Op: "isEmpty"}},
+		// state+in IS supported by this backend; only the exclusion is not.
+		{name: "state notIn", filter: domain.CaseFieldFilter{Field: "state", Op: "notIn", Values: []string{"closed"}}},
 	}
 
 	for _, tc := range cases {

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -222,10 +222,11 @@ type CaseService interface {
 	// RemoveCaseTag removes the tag identified by tagID from the case identified by caseID.
 	// A NotFoundError is returned if the tag does not exist on the case.
 	RemoveCaseTag(ctx context.Context, caseID, tagID string) error
-	// SearchTags returns the tags (not scoped to any single case) whose label matches query,
-	// for FE autocomplete when attaching a tag to a case. An empty query returns all known tags.
-	// limit caps the number of results (<=0 means use the downstream default).
-	SearchTags(ctx context.Context, query string, limit int) ([]domain.Tag, error)
+	// SearchTags returns the tags (not scoped to any single case) whose label matches
+	// req.Filters.SearchQuery, for FE autocomplete when attaching a tag to a case. An empty
+	// query returns all known tags. req.Limit caps the number of results (<=0 means use the
+	// downstream default).
+	SearchTags(ctx context.Context, req domain.SearchTagsRequest) ([]domain.Tag, error)
 }
 
 // CaseGithubIssueService defines the operation for filing a GitHub issue from a case.

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -2672,7 +2671,21 @@ func (s *snCaseService) RemoveCaseTag(ctx context.Context, caseID, tagID string)
 	return err
 }
 
-// snSearchTagsResponse mirrors the Choreo GET /tags/search response, and the shape of the
+// snSearchTagsFilters holds the filter fields of the Choreo POST /tags/search request body.
+// CaseID scopes the search to labels already used on one case; the entity service never sets
+// it (nothing upstream consumes the case-scoped variant), but it is part of the wire contract.
+type snSearchTagsFilters struct {
+	SearchQuery string `json:"searchQuery,omitempty"`
+	CaseID      string `json:"caseId,omitempty"`
+}
+
+// snSearchTagsPayload is the Choreo POST /tags/search request body.
+type snSearchTagsPayload struct {
+	Filters snSearchTagsFilters `json:"filters"`
+	Limit   int                 `json:"limit,omitempty"`
+}
+
+// snSearchTagsResponse mirrors the Choreo POST /tags/search response, and the shape of the
 // case-scoped GET /cases/{id}/tags response consumed by listCaseTags below.
 type snSearchTagsResponse struct {
 	Tags []snTag `json:"tags"`
@@ -2708,22 +2721,21 @@ func (s *snCaseService) listCaseTags(ctx context.Context, caseID string) ([]doma
 // FE autocomplete when attaching a tag to a case. SN's tagging is the generic platform label
 // mechanism (table-agnostic, not a case column), backed by the sys_label table (optionally
 // scoped to labels used against reference_table="sn_customerservice_case" label_entry rows).
-func (s *snCaseService) SearchTags(ctx context.Context, query string, limit int) ([]domain.Tag, error) {
+func (s *snCaseService) SearchTags(ctx context.Context, req domain.SearchTagsRequest) ([]domain.Tag, error) {
+	if err := validateSearchQuery(req.Filters.SearchQuery); err != nil {
+		return nil, err
+	}
+
 	token := middleware.UserIDTokenFromContext(ctx)
 
-	q := url.Values{}
-	if query != "" {
-		q.Set("q", query)
+	payload := snSearchTagsPayload{
+		Filters: snSearchTagsFilters{SearchQuery: req.Filters.SearchQuery},
 	}
-	if limit > 0 {
-		q.Set("limit", strconv.Itoa(limit))
-	}
-	path := "/tags/search"
-	if len(q) > 0 {
-		path += "?" + q.Encode()
+	if req.Limit > 0 {
+		payload.Limit = req.Limit
 	}
 
-	raw, err := s.client.Get(ctx, path, token)
+	raw, err := s.client.Post(ctx, "/tags/search", token, payload)
 	if err != nil {
 		return nil, err
 	}

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -52,7 +52,7 @@ type snCase struct {
 	UpdatedOn             *string                     `json:"updatedOn"`
 	CreatedBy             string                      `json:"createdBy"`
 	CreatedByFullName     string                      `json:"createdByFullName"`
-	Project               snCaseEntityRef             `json:"project"`
+	Project               snCaseProjectRef            `json:"project"`
 	Deployment            snCaseEntityRef             `json:"deployment"`
 	DeployedProduct       snCaseDeployedProduct       `json:"deployedProduct"`
 	Product               *snCaseEntityRef            `json:"product"`
@@ -111,22 +111,22 @@ type snCase struct {
 	// "eligible again after" date for a held case).
 	AutoclosureStateTime *string `json:"autoclosureStateTime"`
 	// BestCaseFixEta is the internal-only best-case fix-commitment date
-	// (u_best_case_fix_eta). Not yet available in the backing service: no Ballerina
-	// field currently surfaces this — the Choreo GET /cases/{id} response does not
-	// include a "bestCaseFixEta" key today, so this always unmarshals to nil. Ask:
-	// add a "bestCaseFixEta" (glide_date) field to the case response.
+	// (u_best_case_fix_eta). Populated on the Choreo GET /cases/{id} response
+	// unconditionally, and on POST /cases/search rows only when the search
+	// request set includeExtendedFields — nil otherwise, so this must tolerate
+	// absence.
 	BestCaseFixEta *string `json:"bestCaseFixEta"`
 	// MostLikelyFixEta is the internal-only most-likely fix-commitment date
-	// (u_most_likely_fix_eta). Not yet available in the backing service: no Ballerina
-	// field currently surfaces this — the Choreo GET /cases/{id} response does not
-	// include a "mostLikelyFixEta" key today, so this always unmarshals to nil. Ask:
-	// add a "mostLikelyFixEta" (glide_date) field to the case response.
+	// (u_most_likely_fix_eta). Populated on the Choreo GET /cases/{id} response
+	// unconditionally, and on POST /cases/search rows only when the search
+	// request set includeExtendedFields — nil otherwise, so this must tolerate
+	// absence.
 	MostLikelyFixEta *string `json:"mostLikelyFixEta"`
 	// WorstCaseFixEta is the internal-only worst-case fix-commitment date
-	// (u_worst_case_fix_eta). Not yet available in the backing service: no Ballerina
-	// field currently surfaces this — the Choreo GET /cases/{id} response does not
-	// include a "worstCaseFixEta" key today, so this always unmarshals to nil. Ask:
-	// add a "worstCaseFixEta" (glide_date) field to the case response.
+	// (u_worst_case_fix_eta). Populated on the Choreo GET /cases/{id} response
+	// unconditionally, and on POST /cases/search rows only when the search
+	// request set includeExtendedFields — nil otherwise, so this must tolerate
+	// absence.
 	WorstCaseFixEta *string `json:"worstCaseFixEta"`
 }
 
@@ -143,6 +143,15 @@ type snWatchListUser struct {
 type snCaseEntityRef struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
+}
+
+// snCaseProjectRef is the case's project reference. Key is the project's short
+// human-readable key (e.g. "TESTQUERYSUB"); it is only present on search rows when
+// the search request set includeExtendedFields, so it must tolerate absence.
+type snCaseProjectRef struct {
+	ID   string  `json:"id"`
+	Name string  `json:"name"`
+	Key  *string `json:"key"`
 }
 
 type snCaseDeployedProduct struct {
@@ -206,6 +215,13 @@ type snCaseSearchPayload struct {
 	Filters    snCaseFilters       `json:"filters,omitempty"`
 	SortBy     *snCaseSort         `json:"sortBy,omitempty"`
 	Pagination snProjectPagination `json:"pagination"`
+	// IncludeExtendedFields opts a search row into the account reference, project
+	// key, and fix-ETA fields (see snCase's Account/Project/BestCaseFixEta/
+	// MostLikelyFixEta/WorstCaseFixEta doc comments). Left unset (false) on the
+	// group-count fan-out in searchCasesGroupCount, which reads only
+	// totalRecords and never touches a row's fields, to keep that call as
+	// lightweight as it is today. SearchCases itself always sets this to true.
+	IncludeExtendedFields bool `json:"includeExtendedFields,omitempty"`
 }
 
 type snCaseSort struct {
@@ -2357,6 +2373,9 @@ func (s *snCaseService) SearchCases(ctx context.Context, req domain.SearchCasesR
 		Filters:    snFilters,
 		SortBy:     snSortBy,
 		Pagination: snProjectPagination{Limit: req.Pagination.Limit, Offset: req.Pagination.Offset},
+		// Requests the account reference, project key, and fix-ETA fields on every
+		// row (see snCaseSearchPayload.IncludeExtendedFields doc comment).
+		IncludeExtendedFields: true,
 	}
 
 	raw, err := s.client.Post(ctx, "/cases/search", token, payload)
@@ -2410,6 +2429,16 @@ func (s *snCaseService) SearchCases(ctx context.Context, req domain.SearchCasesR
 			WorkState:      workStateLabel,
 			Type:           caseTypeDomain,
 			Project:        domain.EntityRef{ID: sysidToUUID(c.Project.ID), Name: c.Project.Name},
+			ProjectKey:     c.Project.Key,
+			// BestCaseFixEta/MostLikelyFixEta/WorstCaseFixEta are already date-only
+			// "YYYY-MM-DD" strings on both sides, so no parsing/reformatting is
+			// needed — nil when includeExtendedFields data is absent from a row.
+			BestCaseFixEta:   c.BestCaseFixEta,
+			MostLikelyFixEta: c.MostLikelyFixEta,
+			WorstCaseFixEta:  c.WorstCaseFixEta,
+		}
+		if c.Account != nil {
+			cv.AccountDetails = &domain.AccountRef{ID: sysidToUUID(c.Account.ID), Name: c.Account.Name, Type: c.Account.Type}
 		}
 		if depID := sysidToUUID(c.Deployment.ID); depID != "" {
 			cv.Deployment = &domain.EntityRef{ID: depID, Name: c.Deployment.Name}

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -375,10 +375,14 @@ type snCaseFilters struct {
 	InternalID                string   `json:"internalId,omitempty"`
 	ProjectOnboardingStatuses []string `json:"projectOnboardingStatuses,omitempty"`
 	// ProjectTypeNames carries project-type NAMES (e.g. "Subscription"), not
-	// sys_ids: CaseUtils.searchCases matches project.u_project_type.u_name. The
-	// wire key stays "projectTypeIds" because that is the field name the SN
-	// scripted API reads.
-	ProjectTypeNames     []string `json:"projectTypeIds,omitempty"`
+	// sys_ids: CaseUtils.searchCases matches project.u_project_type.u_name.
+	// It goes out under its own key, "projectTypes", rather than reusing the
+	// old id-based "projectTypeIds": that key is typed as a 32-hex-character
+	// sys_id array in the Ballerina contract, so a name sent through it is
+	// rejected outright by request validation. "projectTypeIds" has no
+	// remaining producer or consumer on either portal and is being retired
+	// from the contract alongside this change.
+	ProjectTypeNames     []string `json:"projectTypes,omitempty"`
 	IntegrationCsTeamIDs []string `json:"integrationCsTeamIds,omitempty"`
 	Unassigned           bool     `json:"unassigned,omitempty"`
 	ResolutionNotesEmpty bool     `json:"resolutionNotesEmpty,omitempty"`

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -328,6 +328,17 @@ type snCaseFilters struct {
 	DeploymentIDs      []string `json:"deploymentIds,omitempty"`
 	DeployedProductIDs []string `json:"deployedProductIds,omitempty"`
 	StateKeys          []int    `json:"stateKeys,omitempty"`
+	// ExcludeStates is the inverse of StateKeys: cases whose state is none of
+	// these. It carries the same numeric state keys StateKeys does, produced by
+	// the same domainStatesToSNIDs conversion, because that is the form
+	// ServiceNow's `state` column is queried in -- a list of state names would
+	// match nothing. See domain.ParsedCaseFilters.ExcludeStates.
+	//
+	// Not honored downstream yet: CaseUtils.searchCases does not read
+	// filters.excludeStateKeys and Ballerina's CaseSearchFilters does not
+	// declare it, so until both land the key is dropped and the search behaves
+	// as if no exclusion had been requested.
+	ExcludeStates      []int    `json:"excludeStateKeys,omitempty"`
 	SeverityKeys       []int    `json:"severityKeys,omitempty"`
 	IssueTypeKeys      []int    `json:"issueTypeKeys,omitempty"`
 	EngagementTypeKeys []int    `json:"engagementTypeKeys,omitempty"`
@@ -2128,6 +2139,7 @@ func buildSNCaseFilters(parsed domain.ParsedCaseFilters, searchQuery string) snC
 		ProjectIDs:                uuidsToSysids(parsed.ProjectIDs),
 		DeploymentIDs:             uuidsToSysids(parsed.DeploymentIDs),
 		StateKeys:                 domainStatesToSNIDs(parsed.States),
+		ExcludeStates:             domainStatesToSNIDs(parsed.ExcludeStates),
 		SeverityKeys:              domainSeveritiesToSNIDs(parsed.Severities),
 		IssueTypeKeys:             domainIssueTypesToSNIDs(parsed.IssueTypes),
 		EngagementTypeKeys:        domainEngagementTypesToSNIDs(parsed.EngagementTypes),
@@ -2248,6 +2260,14 @@ func (s *snCaseService) SearchCases(ctx context.Context, req domain.SearchCasesR
 	for _, st := range req.Parsed.States {
 		if !validCaseState[st] {
 			return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: "state contains invalid value: " + string(st)}
+		}
+	}
+	// Same reasoning as States above, and it matters more here: an exclusion
+	// value that got silently dropped would widen the result set rather than
+	// narrow it, which is the harder failure to notice.
+	for _, st := range req.Parsed.ExcludeStates {
+		if !validCaseState[st] {
+			return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: "state (notIn) contains invalid value: " + string(st)}
 		}
 	}
 	for _, sv := range req.Parsed.Severities {

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -349,10 +349,15 @@ type snCaseFilters struct {
 	// ServiceNow's `state` column is queried in -- a list of state names would
 	// match nothing. See domain.ParsedCaseFilters.ExcludeStates.
 	//
-	// Not honored downstream yet: CaseUtils.searchCases does not read
-	// filters.excludeStateKeys and Ballerina's CaseSearchFilters does not
-	// declare it, so until both land the key is dropped and the search behaves
-	// as if no exclusion had been requested.
+	// Deployment ordering: the downstream service must be deployed before this
+	// one. Its search-filter record is closed, so an undeclared key is
+	// rejected outright rather than ignored -- if this service ships first, a
+	// search carrying a state exclusion fails loudly instead of quietly
+	// returning an unfiltered result set. That is the intended direction: a
+	// dropped exclusion widens the result set, which is the harder failure to
+	// notice. omitempty keeps the key off the wire entirely unless a
+	// `state notIn` filter was actually requested, so no search that does not
+	// use one is affected by the ordering.
 	ExcludeStates      []int    `json:"excludeStateKeys,omitempty"`
 	SeverityKeys       []int    `json:"severityKeys,omitempty"`
 	IssueTypeKeys      []int    `json:"issueTypeKeys,omitempty"`

--- a/entity-service/internal/service/sn_case_service_test.go
+++ b/entity-service/internal/service/sn_case_service_test.go
@@ -17,10 +17,13 @@
 package service
 
 import (
+	"bytes"
 	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -1116,6 +1119,137 @@ func TestSNCaseService_SearchCases_GenericFiltersTranslateToSNPayload(t *testing
 		gotBody.Filters.ProjectTypeNames[1] != "Free Trial" {
 		t.Fatalf("ProjectTypeNames = %v, want [Subscription, Free Trial] passed through unchanged", gotBody.Filters.ProjectTypeNames)
 	}
+}
+
+// TestSNCaseService_SearchCases_StateNotInTranslatesToExcludeStateKeys pins
+// both halves of the state notIn filter's wire form: the key name and the
+// value representation. Both matter because the backing data source drops a
+// filter key it does not recognize instead of rejecting it, so a wrong key --
+// or the right key carrying state names where numeric keys are expected --
+// would silently widen the result set rather than fail. The assertions run
+// against the raw request body, not the decoded struct, since decoding through
+// the same struct tags would agree with any name they happened to carry.
+func TestSNCaseService_SearchCases_StateNotInTranslatesToExcludeStateKeys(t *testing.T) {
+	var rawBody []byte
+	mux := http.NewServeMux()
+	mux.HandleFunc("/cases/search", func(w http.ResponseWriter, r *http.Request) {
+		b, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read request body: %v", err)
+		}
+		rawBody = b
+		_ = json.NewEncoder(w).Encode(map[string]any{"cases": []map[string]any{}, "total": 0, "offset": 0, "limit": 20})
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowCaseService(client, nil)
+
+	req := domain.SearchCasesRequest{
+		Filters: domain.SearchCasesFilters{
+			Filters: []domain.CaseFieldFilter{
+				{Field: "state", Op: "in", Values: []string{"open"}},
+				{Field: "state", Op: "notIn", Values: []string{"awaiting_info", "solution_proposed", "closed"}},
+			},
+		},
+	}
+
+	ctx := contextWithUserIDToken(fakeJWTWithEmail(t, "jane.doe@example.com"))
+	if _, err := svc.SearchCases(ctx, req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var envelope struct {
+		Filters map[string]json.RawMessage `json:"filters"`
+	}
+	if err := json.Unmarshal(rawBody, &envelope); err != nil {
+		t.Fatalf("decode request body: %v; raw: %s", err, rawBody)
+	}
+	got, ok := envelope.Filters["excludeStateKeys"]
+	if !ok {
+		t.Fatalf("filters has no \"excludeStateKeys\" key; keys sent: %v", filterKeys(envelope.Filters))
+	}
+	// awaiting_info=18, solution_proposed=6, closed=3 -- the same numeric keys
+	// the positive stateKeys list is built from.
+	if string(got) != "[18,6,3]" {
+		t.Fatalf("excludeStateKeys = %s, want [18,6,3] (numeric state keys, not names)", got)
+	}
+	// The positive list is unaffected: notIn must never be folded into it.
+	if stateKeys, ok := envelope.Filters["stateKeys"]; !ok || string(stateKeys) != "[1]" {
+		t.Fatalf("stateKeys = %s (present=%v), want [1]", stateKeys, ok)
+	}
+	// The pre-rename key must not appear at all.
+	if _, ok := envelope.Filters["excludeStates"]; ok {
+		t.Fatal("filters carries \"excludeStates\"; the wire key is \"excludeStateKeys\"")
+	}
+}
+
+// TestSNCaseService_SearchCases_StateNotInOmittedWhenUnused guards the
+// inertness of the filter: a request that does not ask for an exclusion must
+// send no exclusion key, so nothing changes for existing callers while the
+// downstream layers do not yet honor it.
+func TestSNCaseService_SearchCases_StateNotInOmittedWhenUnused(t *testing.T) {
+	var rawBody []byte
+	mux := http.NewServeMux()
+	mux.HandleFunc("/cases/search", func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		rawBody = b
+		_ = json.NewEncoder(w).Encode(map[string]any{"cases": []map[string]any{}, "total": 0, "offset": 0, "limit": 20})
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowCaseService(client, nil)
+
+	req := domain.SearchCasesRequest{
+		Filters: domain.SearchCasesFilters{
+			Filters: []domain.CaseFieldFilter{{Field: "state", Op: "in", Values: []string{"open"}}},
+		},
+	}
+	ctx := contextWithUserIDToken(fakeJWTWithEmail(t, "jane.doe@example.com"))
+	if _, err := svc.SearchCases(ctx, req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if bytes.Contains(rawBody, []byte("excludeStateKeys")) {
+		t.Fatalf("excludeStateKeys must be omitted when no notIn filter was given; body: %s", rawBody)
+	}
+}
+
+// TestSNCaseService_SearchCases_StateNotInRejectsUnknownValue guards against
+// an unrecognized state silently vanishing in the domain-to-key conversion,
+// which for an exclusion would widen the result set.
+func TestSNCaseService_SearchCases_StateNotInRejectsUnknownValue(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/cases/search", func(w http.ResponseWriter, r *http.Request) {
+		t.Error("upstream must not be called for an invalid filter value")
+		_ = json.NewEncoder(w).Encode(map[string]any{"cases": []map[string]any{}, "total": 0, "offset": 0, "limit": 20})
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowCaseService(client, nil)
+
+	req := domain.SearchCasesRequest{
+		Filters: domain.SearchCasesFilters{
+			Filters: []domain.CaseFieldFilter{{Field: "state", Op: "notIn", Values: []string{"not_a_state"}}},
+		},
+	}
+	ctx := contextWithUserIDToken(fakeJWTWithEmail(t, "jane.doe@example.com"))
+	_, err := svc.SearchCases(ctx, req)
+	if err == nil {
+		t.Fatal("expected a validation error for an unknown state (notIn) value")
+	}
+	if !strings.Contains(err.Error(), "not_a_state") {
+		t.Fatalf("error = %v, want it to name the offending value", err)
+	}
+}
+
+// filterKeys returns the keys of a decoded filters object, for test failure
+// messages.
+func filterKeys(m map[string]json.RawMessage) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 // TestSNCaseService_SearchCases_AnyOfKeepsSNOrGroupsWireFormat is the guard

--- a/entity-service/internal/service/sn_case_service_test.go
+++ b/entity-service/internal/service/sn_case_service_test.go
@@ -1552,11 +1552,20 @@ func TestSNCaseService_SearchCases_PopulatesUpdatedOn(t *testing.T) {
 	}
 }
 
+// TestSNCaseService_SearchTags_Success pins the upstream wire format: tag search is a POST
+// with the query nested under `filters.searchQuery`, not a GET with a `q` param. The body is
+// asserted as raw JSON on purpose — decoding it through a struct with the same tags would
+// agree with whatever key the payload happens to carry, which is how an earlier wire-format
+// bug got through.
 func TestSNCaseService_SearchTags_Success(t *testing.T) {
-	var gotQuery string
+	var gotMethod string
+	var gotBody map[string]any
 	mux := http.NewServeMux()
 	mux.HandleFunc("/tags/search", func(w http.ResponseWriter, r *http.Request) {
-		gotQuery = r.URL.Query().Get("q")
+		gotMethod = r.Method
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Errorf("decode request body: %v", err)
+		}
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"tags": []map[string]any{
 				{"id": testTagSysid, "label": "micro-gw", "color": "#f97316"},
@@ -1567,12 +1576,27 @@ func TestSNCaseService_SearchTags_Success(t *testing.T) {
 	client := newTestSNClient(t, mux)
 	svc := NewServiceNowCaseService(client, nil)
 
-	tags, err := svc.SearchTags(contextWithUserIDToken("token"), "micro", 0)
+	tags, err := svc.SearchTags(contextWithUserIDToken("token"), domain.SearchTagsRequest{
+		Filters: domain.SearchTagsFilters{SearchQuery: "micro"},
+	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if gotQuery != "micro" {
-		t.Fatalf("q sent = %q, want micro", gotQuery)
+	if gotMethod != http.MethodPost {
+		t.Fatalf("method = %q, want POST", gotMethod)
+	}
+	filters, ok := gotBody["filters"].(map[string]any)
+	if !ok {
+		t.Fatalf("body has no filters object: %#v", gotBody)
+	}
+	if filters["searchQuery"] != "micro" {
+		t.Fatalf("filters.searchQuery = %v, want micro", filters["searchQuery"])
+	}
+	if _, present := gotBody["q"]; present {
+		t.Fatalf("body must not carry the legacy q key: %#v", gotBody)
+	}
+	if _, present := gotBody["limit"]; present {
+		t.Fatalf("limit must be omitted when unset: %#v", gotBody)
 	}
 	if len(tags) != 1 {
 		t.Fatalf("expected 1 tag, got %d", len(tags))
@@ -1589,49 +1613,98 @@ func TestSNCaseService_SearchTags_Success(t *testing.T) {
 }
 
 func TestSNCaseService_SearchTags_ForwardsLimit(t *testing.T) {
-	var gotLimit string
+	var rawBody []byte
 	mux := http.NewServeMux()
 	mux.HandleFunc("/tags/search", func(w http.ResponseWriter, r *http.Request) {
-		gotLimit = r.URL.Query().Get("limit")
+		rawBody, _ = io.ReadAll(r.Body)
 		_ = json.NewEncoder(w).Encode(map[string]any{"tags": []map[string]any{}})
 	})
 
 	client := newTestSNClient(t, mux)
 	svc := NewServiceNowCaseService(client, nil)
 
-	if _, err := svc.SearchTags(contextWithUserIDToken("token"), "micro", 5); err != nil {
+	if _, err := svc.SearchTags(contextWithUserIDToken("token"), domain.SearchTagsRequest{
+		Filters: domain.SearchTagsFilters{SearchQuery: "micro"},
+		Limit:   5,
+	}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if gotLimit != "5" {
-		t.Fatalf("limit sent = %q, want 5", gotLimit)
+	if want := `{"filters":{"searchQuery":"micro"},"limit":5}`; strings.TrimSpace(string(rawBody)) != want {
+		t.Fatalf("raw body = %s, want %s", rawBody, want)
 	}
 }
 
 func TestSNCaseService_SearchTags_EmptyQuery(t *testing.T) {
+	var rawBody []byte
 	mux := http.NewServeMux()
 	mux.HandleFunc("/tags/search", func(w http.ResponseWriter, r *http.Request) {
-		if q := r.URL.Query().Get("q"); q != "" {
-			t.Fatalf("expected no q param, got %q", q)
-		}
+		rawBody, _ = io.ReadAll(r.Body)
 		_ = json.NewEncoder(w).Encode(map[string]any{"tags": []map[string]any{}})
 	})
 
 	client := newTestSNClient(t, mux)
 	svc := NewServiceNowCaseService(client, nil)
 
-	tags, err := svc.SearchTags(contextWithUserIDToken("token"), "", 0)
+	tags, err := svc.SearchTags(contextWithUserIDToken("token"), domain.SearchTagsRequest{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if want := `{"filters":{}}`; strings.TrimSpace(string(rawBody)) != want {
+		t.Fatalf("raw body = %s, want %s", rawBody, want)
 	}
 	if len(tags) != 0 {
 		t.Fatalf("expected 0 tags, got %d", len(tags))
 	}
 }
 
+// TestSNCaseService_SearchTags_NeverSendsCaseID guards the deliberate decision not to expose
+// the case-scoped variant upward: the upstream contract accepts filters.caseId, but nothing
+// above the entity service consumes it, so the entity service must never emit it.
+func TestSNCaseService_SearchTags_NeverSendsCaseID(t *testing.T) {
+	var gotBody map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/tags/search", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		_ = json.NewEncoder(w).Encode(map[string]any{"tags": []map[string]any{}})
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowCaseService(client, nil)
+
+	if _, err := svc.SearchTags(contextWithUserIDToken("token"), domain.SearchTagsRequest{
+		Filters: domain.SearchTagsFilters{SearchQuery: "micro"},
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	filters, _ := gotBody["filters"].(map[string]any)
+	if _, present := filters["caseId"]; present {
+		t.Fatalf("filters must not carry caseId: %#v", filters)
+	}
+}
+
+func TestSNCaseService_SearchTags_QueryTooLong(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/tags/search", func(w http.ResponseWriter, r *http.Request) {
+		t.Error("upstream must not be called for an over-long query")
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowCaseService(client, nil)
+
+	_, err := svc.SearchTags(contextWithUserIDToken("token"), domain.SearchTagsRequest{
+		Filters: domain.SearchTagsFilters{SearchQuery: strings.Repeat("a", 201)},
+	})
+	if _, ok := err.(*apierror.ValidationError); !ok {
+		t.Fatalf("expected *apierror.ValidationError, got %T: %v", err, err)
+	}
+}
+
 func TestCaseService_SearchTags_ServiceUnavailable(t *testing.T) {
 	svc := &caseService{}
 
-	if _, err := svc.SearchTags(contextWithUserIDToken("token"), "micro", 0); err == nil {
+	if _, err := svc.SearchTags(contextWithUserIDToken("token"), domain.SearchTagsRequest{
+		Filters: domain.SearchTagsFilters{SearchQuery: "micro"},
+	}); err == nil {
 		t.Fatalf("expected error")
 	} else if _, ok := err.(*apierror.ServiceUnavailableError); !ok {
 		t.Fatalf("expected *apierror.ServiceUnavailableError, got %T: %v", err, err)

--- a/entity-service/internal/service/sn_case_service_test.go
+++ b/entity-service/internal/service/sn_case_service_test.go
@@ -1552,6 +1552,152 @@ func TestSNCaseService_SearchCases_PopulatesUpdatedOn(t *testing.T) {
 	}
 }
 
+// TestSNCaseService_SearchCases_SetsIncludeExtendedFields proves SearchCases
+// always opts every outbound search request into the account/project-key/
+// fix-ETA fields on search rows -- the backing service only returns them when
+// this flag is explicitly set true, and defaults to leaving them off (the
+// customer-portal's own search calls never set it, so the flag is what keeps
+// this call additive rather than a shared-contract change).
+func TestSNCaseService_SearchCases_SetsIncludeExtendedFields(t *testing.T) {
+	var gotBody snCaseSearchPayload
+	mux := http.NewServeMux()
+	mux.HandleFunc("/cases/search", func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"cases": []map[string]any{}, "total": 0, "offset": 0, "limit": 20})
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowCaseService(client, nil)
+
+	if _, err := svc.SearchCases(contextWithUserIDToken("token"), domain.SearchCasesRequest{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !gotBody.IncludeExtendedFields {
+		t.Fatalf("expected includeExtendedFields to be sent as true on every search request")
+	}
+}
+
+// TestSNCaseService_SearchCases_MapsExtendedFieldsWhenPresent proves that when
+// the mocked SN response includes the account reference, project key, and the
+// three fix-ETA fields on a row, SearchCases maps every one of them through to
+// the returned SearchCaseView.
+func TestSNCaseService_SearchCases_MapsExtendedFieldsWhenPresent(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/cases/search", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"cases": []map[string]any{
+				{
+					"id":               "case-sys-id",
+					"internalId":       "INT-1",
+					"number":           "CS0001",
+					"title":            "t",
+					"description":      "d",
+					"createdOn":        "2026-01-01 00:00:00",
+					"createdBy":        "jane.doe@example.com",
+					"project":          map[string]any{"id": "proj-sys-id", "name": "Proj", "key": "TESTQUERYSUB"},
+					"deployment":       map[string]any{"id": "", "name": ""},
+					"deployedProduct":  map[string]any{"id": "", "name": "", "product": map[string]any{"id": "", "name": ""}},
+					"account":          map[string]any{"id": "acct-sys-id", "name": "Acme Corp", "type": "premium"},
+					"bestCaseFixEta":   "2026-04-15",
+					"mostLikelyFixEta": "2026-04-22",
+					"worstCaseFixEta":  "2026-04-29",
+				},
+			},
+			"total": 1, "offset": 0, "limit": 20,
+		})
+	})
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowCaseService(client, nil)
+	ctx := contextWithUserIDToken(fakeJWTWithEmail(t, "jane.doe@example.com"))
+
+	resp, err := svc.SearchCases(ctx, domain.SearchCasesRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Cases) != 1 {
+		t.Fatalf("expected 1 case, got %d", len(resp.Cases))
+	}
+	got := resp.Cases[0]
+
+	if got.ProjectKey == nil || *got.ProjectKey != "TESTQUERYSUB" {
+		t.Fatalf("ProjectKey = %v, want \"TESTQUERYSUB\"", got.ProjectKey)
+	}
+	if got.AccountDetails == nil {
+		t.Fatalf("expected AccountDetails to be populated")
+	}
+	if got.AccountDetails.Name != "Acme Corp" || got.AccountDetails.Type != "premium" {
+		t.Fatalf("AccountDetails = %+v, want Name=Acme Corp Type=premium", got.AccountDetails)
+	}
+	if got.BestCaseFixEta == nil || *got.BestCaseFixEta != "2026-04-15" {
+		t.Fatalf("BestCaseFixEta = %v, want \"2026-04-15\"", got.BestCaseFixEta)
+	}
+	if got.MostLikelyFixEta == nil || *got.MostLikelyFixEta != "2026-04-22" {
+		t.Fatalf("MostLikelyFixEta = %v, want \"2026-04-22\"", got.MostLikelyFixEta)
+	}
+	if got.WorstCaseFixEta == nil || *got.WorstCaseFixEta != "2026-04-29" {
+		t.Fatalf("WorstCaseFixEta = %v, want \"2026-04-29\"", got.WorstCaseFixEta)
+	}
+}
+
+// TestSNCaseService_SearchCases_ExtendedFieldsAbsentDoNotPanic proves that
+// when a mocked SN response omits the account/project-key/fix-ETA fields
+// entirely (simulating the backing service ignoring includeExtendedFields, or
+// an older response shape), SearchCases does not panic or error -- the new
+// fields come through as nil, matching this file's existing nil-handling
+// convention for every other optional reference.
+func TestSNCaseService_SearchCases_ExtendedFieldsAbsentDoNotPanic(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/cases/search", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"cases": []map[string]any{
+				{
+					"id":              "case-sys-id",
+					"internalId":      "INT-1",
+					"number":          "CS0001",
+					"title":           "t",
+					"description":     "d",
+					"createdOn":       "2026-01-01 00:00:00",
+					"createdBy":       "jane.doe@example.com",
+					"project":         map[string]any{"id": "proj-sys-id", "name": "Proj"},
+					"deployment":      map[string]any{"id": "", "name": ""},
+					"deployedProduct": map[string]any{"id": "", "name": "", "product": map[string]any{"id": "", "name": ""}},
+				},
+			},
+			"total": 1, "offset": 0, "limit": 20,
+		})
+	})
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowCaseService(client, nil)
+	ctx := contextWithUserIDToken(fakeJWTWithEmail(t, "jane.doe@example.com"))
+
+	resp, err := svc.SearchCases(ctx, domain.SearchCasesRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Cases) != 1 {
+		t.Fatalf("expected 1 case, got %d", len(resp.Cases))
+	}
+	got := resp.Cases[0]
+
+	if got.ProjectKey != nil {
+		t.Fatalf("ProjectKey = %v, want nil", got.ProjectKey)
+	}
+	if got.AccountDetails != nil {
+		t.Fatalf("AccountDetails = %v, want nil", got.AccountDetails)
+	}
+	if got.BestCaseFixEta != nil {
+		t.Fatalf("BestCaseFixEta = %v, want nil", got.BestCaseFixEta)
+	}
+	if got.MostLikelyFixEta != nil {
+		t.Fatalf("MostLikelyFixEta = %v, want nil", got.MostLikelyFixEta)
+	}
+	if got.WorstCaseFixEta != nil {
+		t.Fatalf("WorstCaseFixEta = %v, want nil", got.WorstCaseFixEta)
+	}
+}
+
 // TestSNCaseService_SearchTags_Success pins the upstream wire format: tag search is a POST
 // with the query nested under `filters.searchQuery`, not a GET with a `q` param. The body is
 // asserted as raw JSON on purpose — decoding it through a struct with the same tags would

--- a/entity-service/internal/service/sn_case_service_test.go
+++ b/entity-service/internal/service/sn_case_service_test.go
@@ -1121,6 +1121,57 @@ func TestSNCaseService_SearchCases_GenericFiltersTranslateToSNPayload(t *testing
 	}
 }
 
+// TestSNCaseService_SearchCases_ProjectTypeGoesOutAsNamesOnItsOwnKey pins the
+// projectType filter's wire form against the raw request body. The values are
+// readable project-type names and must travel untouched -- no id validation,
+// no id conversion -- under "projectTypes". They must not go out under the
+// retired id-based key: that one is declared as a fixed-width hex id array
+// upstream, so a name sent through it fails request validation outright.
+func TestSNCaseService_SearchCases_ProjectTypeGoesOutAsNamesOnItsOwnKey(t *testing.T) {
+	var rawBody []byte
+	mux := http.NewServeMux()
+	mux.HandleFunc("/cases/search", func(w http.ResponseWriter, r *http.Request) {
+		b, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read request body: %v", err)
+		}
+		rawBody = b
+		_ = json.NewEncoder(w).Encode(map[string]any{"cases": []map[string]any{}, "total": 0, "offset": 0, "limit": 20})
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowCaseService(client, nil)
+
+	req := domain.SearchCasesRequest{
+		Filters: domain.SearchCasesFilters{
+			Filters: []domain.CaseFieldFilter{
+				{Field: "projectType", Op: "in", Values: []string{"Subscription", "Free Trial"}},
+			},
+		},
+	}
+	ctx := contextWithUserIDToken(fakeJWTWithEmail(t, "jane.doe@example.com"))
+	if _, err := svc.SearchCases(ctx, req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var envelope struct {
+		Filters map[string]json.RawMessage `json:"filters"`
+	}
+	if err := json.Unmarshal(rawBody, &envelope); err != nil {
+		t.Fatalf("decode request body: %v; raw: %s", err, rawBody)
+	}
+	got, ok := envelope.Filters["projectTypes"]
+	if !ok {
+		t.Fatalf("filters has no \"projectTypes\" key; keys sent: %v", filterKeys(envelope.Filters))
+	}
+	if string(got) != `["Subscription","Free Trial"]` {
+		t.Fatalf("projectTypes = %s, want the names passed through unchanged", got)
+	}
+	if _, ok := envelope.Filters["projectTypeIds"]; ok {
+		t.Fatal("filters still carries the retired id-based project-type key")
+	}
+}
+
 // TestSNCaseService_SearchCases_StateNotInTranslatesToExcludeStateKeys pins
 // both halves of the state notIn filter's wire form: the key name and the
 // value representation. Both matter because the backing data source drops a

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -4810,8 +4810,12 @@ components:
           security_report_analysis/announcement/engagement. For the ServiceNow
           data source each value is translated to its SN caseTypes equivalent
           (case → default_case).
-        - **state** (in): one of open/work_in_progress/waiting_on_wso2/
-          awaiting_info/reopened/solution_proposed/closed.
+        - **state** (in / notIn): one of open/work_in_progress/
+          waiting_on_wso2/awaiting_info/reopened/solution_proposed/closed. in
+          matches cases in any of the given states; notIn matches cases in
+          none of them. The two are independent and may be combined. notIn is
+          not supported inside an anyOf branch, and not supported by the
+          relational data source.
         - **severity** (in): one of catastrophic/critical/high/medium/low.
           Only applicable when a type filter includes case.
         - **engagementType** (in): one of migration/consultancy/

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -1051,28 +1051,19 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
 
   /tags/search:
-    get:
+    post:
       summary: Search existing case tags, not scoped to any single case.
       description: |
         Returns tags whose label matches the free-text query, for use in FE autocomplete when
-        attaching a tag to a case. An empty/omitted `q` returns all known tags.
-        Only supported for the ServiceNow data source.
+        attaching a tag to a case. An empty/omitted `filters.searchQuery` returns all known tags.
+        Only supported when the backing data source provides tags.
       operationId: searchTags
-      parameters:
-        - name: q
-          in: query
-          required: false
-          schema:
-            type: string
-          description: Free-text label query. Omit or leave empty to return all known tags.
-        - name: limit
-          in: query
-          required: false
-          schema:
-            type: integer
-            default: 20
-            maximum: 100
-          description: Maximum number of tags to return.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SearchTagsRequest'
       responses:
         "200":
           description: Tags matching the query.
@@ -1087,7 +1078,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
         "503":
-          description: Case tags are only supported for the ServiceNow data source.
+          description: Case tags are not supported by the configured data source.
           content:
             application/json:
               schema:
@@ -4632,6 +4623,24 @@ components:
           type: string
           nullable: true
           description: Optional display color for the label; null if the label carries none.
+
+    SearchTagsRequest:
+      type: object
+      properties:
+        filters:
+          type: object
+          properties:
+            searchQuery:
+              type: string
+              description: >
+                Free-text label query, matched partially and case-insensitively.
+                Omit or leave empty to return all known tags.
+        limit:
+          type: integer
+          default: 20
+          minimum: 0
+          maximum: 100
+          description: Maximum number of tags to return. Omit or 0 to use the default.
 
     SearchTagsResponse:
       type: object

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -1089,6 +1089,58 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+    get:
+      summary: Search existing case tags (deprecated query-parameter form).
+      description: |
+        Deprecated: use `POST /tags/search` instead. This alias accepts the old
+        `q`/`limit` query parameters, maps them onto the same request as the POST and
+        returns an identical response. It exists only to bridge one release so callers
+        can be rolled out independently of this service, and is removed after that.
+      operationId: searchTagsByQuery
+      deprecated: true
+      parameters:
+        - name: q
+          in: query
+          required: false
+          schema:
+            type: string
+          description: >
+            Free-text query matched partially and case-insensitively against tag labels.
+            Equivalent to `filters.searchQuery` on the POST. Omit to return all known tags.
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 20
+            minimum: 0
+            maximum: 100
+          description: Maximum number of tags to return. Equivalent to `limit` on the POST.
+      responses:
+        "200":
+          description: Tags matching the query.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchTagsResponse'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "503":
+          description: Case tags are not supported by the configured data source.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
   /cases/{id}/github-issues:
     post:

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -1104,9 +1104,11 @@ paths:
           required: false
           schema:
             type: string
+            maxLength: 200
           description: >
             Free-text query matched partially and case-insensitively against tag labels.
             Equivalent to `filters.searchQuery` on the POST. Omit to return all known tags.
+            A longer value is rejected with a validation error.
         - name: limit
           in: query
           required: false
@@ -4684,9 +4686,11 @@ components:
           properties:
             searchQuery:
               type: string
+              maxLength: 200
               description: >
                 Free-text label query, matched partially and case-insensitively.
-                Omit or leave empty to return all known tags.
+                Omit or leave empty to return all known tags. A longer value is
+                rejected with a validation error.
         limit:
           type: integer
           default: 20

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -5434,6 +5434,12 @@ components:
           description: Case type value (Postgres) or SN caseType label (ServiceNow).
         project:
           $ref: '#/components/schemas/EntityRef'
+        projectKey:
+          type: string
+          nullable: true
+          description: >-
+            The project's short human-readable key (e.g. "TESTQUERYSUB").
+            Populated for the ServiceNow data source only; null otherwise.
         deployment:
           $ref: '#/components/schemas/EntityRef'
         deployedProduct:
@@ -5452,6 +5458,36 @@ components:
           nullable: true
           $ref: '#/components/schemas/EntityRef'
           description: Populated for ServiceNow data source only.
+        account:
+          nullable: true
+          $ref: '#/components/schemas/AccountRef'
+          description: >-
+            The case's account, including support tier (type). Populated for
+            the ServiceNow data source only; null otherwise.
+        bestCaseFixEta:
+          type: string
+          format: date
+          nullable: true
+          description: >-
+            Internal-only best-case fix-commitment date (date-only, YYYY-MM-DD),
+            visible to CSM engineers only. Populated for the ServiceNow data
+            source only; null otherwise.
+        mostLikelyFixEta:
+          type: string
+          format: date
+          nullable: true
+          description: >-
+            Internal-only most-likely fix-commitment date (date-only,
+            YYYY-MM-DD), visible to CSM engineers only. Populated for the
+            ServiceNow data source only; null otherwise.
+        worstCaseFixEta:
+          type: string
+          format: date
+          nullable: true
+          description: >-
+            Internal-only worst-case fix-commitment date (date-only,
+            YYYY-MM-DD), visible to CSM engineers only. Populated for the
+            ServiceNow data source only; null otherwise.
 
     SearchCasesResponse:
       type: object


### PR DESCRIPTION
## Purpose
Fixes for defects found while regression-testing the previous bundle (`#1392`) on a full local stack, plus one consistency change, and three additions pushed onto the same branch from a concurrent session (fix-ETA display and its backend counterpart, "Create change request" from a service request, and editing a submitted time card).

1. **Public case comments were rejected for every user, including the assignee.** The ownership guard compared the identity provider's user id against a platform record id. They are unrelated identifier spaces and can never be equal, so `POST /cases/{id}/comments` returned `403 "Only the assigned engineer can add a public comment on this case."` to the assigned engineer. Live-verified against a real case.
2. **Every dashboard widget using a state exclusion failed.** The dashboard config expresses "all active states" as `state notIn [...]`, but the case-search filter parser accepted only `in` for `state`, so those widgets returned `field "state" does not support op "notIn"`. This was the single largest cause of dashboard widget failures: 12 of 13 searches on one dashboard.
3. **Project-type filtering could not work.** Sending project-type names on the existing `projectTypeIds` key fails validation upstream, because that key's contract constrains values to 32-character ids — turning a wrong-but-quiet empty result into a hard `400`.
4. **Tag search was the only search endpoint on a `GET`** with query parameters, while `/cases/search`, `/tasks/search` and `/deployed-products/search` are all `POST` with a JSON body.
5. **The fix-commitment dates were captured but never shown.** A case carries internal best-case, most-likely and worst-case fix ETAs, engineer-facing only and never shared with the customer. The case detail response already returns them; nothing in the portal rendered them, so an engineer had to look them up outside the portal.
6. **Case search returned less than the portal's own contract already described.** A search row carried no account reference (even though the portal backend's `CaseSearchView` schema has documented `account` for some time), no project key, and none of the three fix ETAs. Any list, dashboard or picker surface wanting a support tier, a project key or a fix date had to fall back to a per-case detail fetch.
7. **Raising a change request from a service request was a manual round trip.** The engineer had to leave the service request, open the change-request create form from the operations area, and re-find that same service request by number in an unscoped picker.
8. **A submitted time card could not be corrected.** Editing was previously ruled out on the belief that a card's own content fields (per-activity minutes, issue complexity) were write-only and never read back, so prefilling an edit form would silently blank them. That belief turned out to be wrong: those fields do round-trip. Until now a typo in a logged card could only be undone by asking an approver to reject it.

## Goals
1. Let the assigned engineer post public comments; keep everyone else out.
2. Support `notIn` on the case `state` filter so exclusions can be stated directly.
3. Send project-type names on a field that actually accepts names.
4. Make tag search consistent with every other search endpoint, without forcing a lockstep deploy.
5. Show the three fix ETAs on the case details tab, read-only, and only when a value exists.
6. Carry the account reference (with support tier), the project key and the three fix ETAs on case-search rows, without changing what any other consumer of that shared search sees.
7. Let an engineer raise a change request straight from a service request, with that service request pre-linked and still editable.
8. Let the engineer who logged a time card fix its content while it is still `submitted`.

## Approach
1. **Ownership guard** — resolve the caller through `GET /users/me` and compare that platform id against the case's assigned-engineer id, instead of the gateway's `userid` claim. This reuses the pattern already established when the dashboard's current-user placeholder had the identical bug. Two deliberate differences, because this is an authorization gate rather than a display value: no fallback to the token claim on error, and an unresolvable caller gets a `500` rather than a misleading `403`. The lookup runs only for a public comment that has already cleared the state gate, so work notes cost nothing.
2. **`state notIn`** — mirrors the existing `tag` in/notIn pair: a new `ExcludeStates` on the parsed filters, marshalled to `excludeStateKeys` through the same state-to-key conversion the positive filter uses. Rejected where it cannot be honoured (inside an `anyOf` branch, and on the relational backend). Excluded values are validated up front, because a *dropped exclusion* widens the result set — the more dangerous direction. Deliberately no `notIn` → `in` fallback: converting an exclusion into an allowlist reintroduces exactly the silent-drop bug being fixed.
3. **`projectTypes`** — project-type names now go out on their own key, passed through verbatim like product names already are. The id-based key is retired; id validation and conversion remain in place for the fields that genuinely are ids.
4. **Tag search → `POST /tags/search`** at all three layers, body `{"filters":{"searchQuery":…},"limit":N}`. The backend forwards the body verbatim, matching how case search already works, so bounds are enforced once in the entity service rather than twice. The `GET` form is retained at both server layers as a **deprecated alias** that builds the same request and delegates to the same code path, so services can be deployed independently for one release instead of simultaneously; both aliases should be deleted after that. The frontend calls only the POST.
5. **Fix ETAs on the case details tab** — three cells in the case meta band, each rendered only when its own value is present, so a case with none of them looks exactly as it does today and a case with one shows one. Values are already date-only `YYYY-MM-DD` strings end to end, formatted for display through the shared date-only formatter rather than the timestamp path, which would otherwise shift a date across a timezone boundary. Read-only: this PR adds no way to set or change a fix ETA from the portal.
6. **Search response widened, additively** — the entity service now sets an explicit opt-in flag on its outbound case-search request and maps three groups onto each returned row: the account reference including support tier, the project's short human-readable key, and the three fix ETAs. Two properties make this safe rather than a shared-contract change. First, the flag is **off by default upstream**, so every other consumer of that shared search endpoint keeps the response it gets today; only this caller opts in. Second, every new field is nullable and tolerates absence, with tests that assert exactly that, so the branch behaves correctly whether or not the corresponding entity-service change is deployed yet. The group-count fan-out deliberately leaves the flag unset: it reads only the total and never touches a row's fields, so it stays as cheap as it is now. The portal backend needs no code change here: `POST /cases/search` is a byte-level passthrough, so widened rows reach the webapp untouched.
7. **"Create change request" from a service request** — a new secondary action, offered only when the case is a service request (the same gate the Related tab already applies to its linked-change-requests widget) and disabled with an explanatory tooltip once that request is closed. It navigates to the existing create form with router state carrying the case id, number, subject and project id. The form previously read one router-state shape (clone); it now narrows on `caseId`, the field only the new shape carries, so the two entry points stay mutually exclusive and the clone path is untouched. The picker starts pre-selected but stays a normal editable control rather than a locked field, so a wrong prefill can be corrected in place, and the section holding it auto-expands so the prefilled value is not hidden behind a collapsed accordion. Project scoping of the picker's search is a **soft preference, not a filter**: the scoped search runs first and falls straight through to the same unscoped, system-wide search the picker has always run when it returns nothing, so a stale or missing project id can only reorder suggestions, never hide a real match. Submission is unchanged: create, then `PATCH { caseId }`, exactly as the manual picker path already does.
8. **Editing a submitted time card** — a content-only `PATCH` with no `state` key, which the contract already treats as mutually exclusive with the approve/reject transition. Prefill is what makes this safe, and it is now safe: the per-activity minutes and issue complexity are confirmed to come back on every card from `POST /time-cards/search`, not just the card just created, so the edit form opens on the card's real current values instead of zeros. The existing log-time dialog doubles as the edit form rather than a second near-identical dialog. The single `cardActions` helper stays the one source of truth for which buttons render, and now splits cleanly: on a `submitted` card the owner gets `edit` only (never approve/reject on their own card), an approver or admin gets `approve`/`reject` only (never edit someone else's card), and a decided card offers nothing. The approver field is read-only in edit mode and never sent. The mapper only accepts a recognised issue-complexity value and otherwise leaves the field unset, so an unknown value shows as no selection rather than a bogus cast. The client-side gate mirrors the server's submitter-only, `submitted`-only rule; it is a UI affordance, not the enforcement, which stays server-side.

## User stories
- As the engineer assigned to a case, I can post a public reply to the customer.
- As a CS engineer, I do not see empty or failing tiles on my dashboard.
- As a CS engineer, tiles scoped to a project type show real numbers.
- As a CS engineer, adding and removing a tag on a case works from the case detail page.
- As a CS engineer, I can see a case's best-case, most-likely and worst-case fix dates on the case details tab, without leaving the portal.
- As a CS engineer working a service request, I can raise a change request from it and have it already linked back to that request.
- As the engineer who logged a time card, I can correct its hours, complexity, billing flag, date or comment while it is still awaiting approval, instead of getting it rejected to redo it.

## Release note
- Fix: public comments can again be posted by the case's assigned engineer.
- Fix: dashboard widgets that exclude a set of case states now work.
- Fix: project-type case filtering now works, by name.
- Change: tag search moves to `POST /tags/search`; the `GET` form is deprecated and removed after one release.
- New: case details shows the internal best-case, most-likely and worst-case fix ETAs when set.
- New: "Create change request…" on a service request, with the request pre-linked on the create form.
- New: the submitter of a time card can edit it while it is still submitted.
- Change: case-search rows now carry the account reference (with support tier), the project key and the fix ETAs.

## Documentation
Both `openapi.yaml` files updated for the tag-search verb change (including the deprecated `GET`), the project-type filter, and `state` supporting `notIn`. The entity service's `openapi.yaml` also documents the three new search-row fields (`projectKey`, `account`, and the three fix ETAs), each explicitly nullable and noted as populated only where the backing data source supplies them. The portal backend's own `CaseSearchView` already documented `account`; documenting `projectKey` and the fix ETAs there is a follow-up, since the webapp does not read them off search rows yet and the endpoint is a verbatim passthrough.

## Training
N/A — no new user-facing workflow for the fixes; the three additions are self-explanatory in place (a menu item, three read-only fields, an Edit button on your own submitted card).

## Certification
N/A — no certification-affecting change.

## Marketing
N/A — internal portal fixes.

## Automation tests
- Unit tests: added at every layer. Wire-format tests assert against the **raw request body** rather than a struct decoded through the same tags, because a decode-based assertion agrees with whatever key it happens to carry — which is how the project-type wire bug reached review in the first place. The ownership-guard tests use ids drawn from deliberately different identifier spaces, and the regression was confirmed to bite: reverting the comparison fails them. The `GET` alias test asserts its outbound body is byte-identical to the equivalent `POST`.
- Search widening: three tests. One asserts the opt-in flag is actually sent on every outbound search, which is the whole reason the change stays additive. One asserts every new field maps through when the upstream row carries it. One asserts the **absent** case: a row without any of them yields nulls rather than a panic or an error, which is what makes the branch deployable ahead of the corresponding entity-service change.
- Fix-ETA display: covers all three present, all three absent (no cells rendered at all), and a partial subset, since per-field conditional rendering is exactly where an "all or nothing" assumption would hide.
- Create change request from a service request: the action is offered on a service request, absent on a plain case, and disabled on a closed one; the create form pre-selects the originating request and shows a banner naming it, still allows it to be changed or cleared, and issues the `PATCH { caseId }` on submit; opening the form directly shows neither banner and no preselection. The picker hook is tested for all three search paths: unscoped, scoped with matches, and scoped-with-no-matches falling back to the system-wide search.
- Time card edit: the action matrix in `cardActions` is tested per state and role, and the dialog's edit mode is tested for prefill and for emitting the edit-shaped submission.
- Integration tests: the four earlier fixes were exercised end to end on a full local stack against the DEV data source (see Test environment).

## Security checks
- Followed secure coding standards: yes.
- Ran FindSecurityBugs plugin and verified report? N/A — Java tool, not applicable to this Go/TypeScript change.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes.
- The fix ETAs are internal, engineer-facing values and are rendered only in the internal portal; nothing here exposes them on a customer-facing surface.
- The time-card edit gate is client-side affordance only. Submitter-only and `submitted`-state-only remain enforced server-side, and the UI does not assume otherwise.

## Samples
N/A — no samples consume these endpoints.

## Related PRs
Stacked on `#1392`, which has since **merged**, so this branch no longer waits on it. A corresponding entity-service contract change (project-type-by-name, state exclusion, tag search POST with matching deprecation shims, and the opt-in flag plus the extra fields on case-search rows) is tracked separately.

## Migrations (if applicable)
No data migration. Deployment ordering only: deploy servers before their callers. The deprecated `GET /tags/search` aliases and the retired project-type id field exist to make that ordering safe and must be removed in a follow-up after one release. The widened search rows need no ordering guarantee of their own: until the corresponding entity-service change is deployed, the opt-in flag is simply ignored and the new fields arrive null, which is the case the tests pin. The state exclusion is the one item here with a hard ordering requirement and no compatibility shim: `excludeStateKeys` only goes on the wire when a `state notIn` filter is actually requested, and the downstream filter record is closed, so if this service ships first those searches fail with a validation error rather than silently returning an unfiltered result set. Deploy the entity service first and that window never opens.

## Test environment
Full local stack against the DEV data source: webapp (Vite) → gateway shim → portal backend → entity service → entity service (Ballerina) → DEV tenant. Real authentication, no stubs in the data path. Go 1.x (`build`, `vet`, `gofmt`, `test` clean on both modules); webapp `tsc` and production build clean, unit tests green with no new failures.

Verified with real responses: public comment as the assignee → `201`, and a non-assignee on an equivalent case → `403`. Dashboards: 14 and 33 widget searches respectively with **zero** failures, where 12 of 13 and 4 of 26 previously failed. Project type by name → 2,292 of a 12,453-case baseline, an unknown name → 0. Tag search → add → delete driven from the real UI, with the record read back empty afterwards. No production write of any kind was made.

For the three later additions, be aware of what is and is not proven here. The time-card round trip **was** checked against a live entity service: the per-activity minutes and the issue complexity come back unchanged on the next search, for a pre-existing card and not only a freshly created one, which is the specific claim the edit prefill depends on. The widened search fields are proven at contract level only, against a mocked upstream in both the present and absent shapes; no live dashboard or case-list run against the widened rows is recorded on this branch, and none is required, because nothing in the webapp reads those fields off a search row yet. The fix-ETA cells and the change-request action are covered by unit tests rather than a recorded live click-through.

## Learning
The project-type fix in `#1392` was made after probing the data source **directly**, a path that never traverses the intermediate service — so "that layer is a pass-through" was asserted rather than checked, and the intermediate contract rejected the new values. A probe only proves things about the layers it actually crosses. Separately, an identity check that compares ids from two different systems is a defect on sight; the durable rule is to resolve the caller through the platform's own user endpoint.

A third one from this branch, in the same spirit: the time-card fields were documented in code as write-only, "accepted on create but never returned on read," and that comment was the stated reason edit could not be built. Nobody had actually looked at a search response for a pre-existing card. They were returned all along. A documented limitation that no longer matches the wire is worse than no documentation, because it is trusted and it closes off work that was possible the whole time. Same failure mode as the pass-through assumption above: an inherited claim about a layer, believed without a request being made.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added editing for submitted time cards, including activity details, billing status, comments, complexity, and dates.
  * Added “Create change request” actions from service requests with prefilled request and project information.
  * Added best-, likely-, and worst-case fix ETA fields to case details.
  * Improved service-request selection with project-scoped search and fallback results.
  * Added structured tag search with filtering and result limits.
* **Bug Fixes**
  * Improved case ownership validation and state exclusion filtering.
  * Preserved legacy tag-search compatibility while transitioning to the new request format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
