### PR TITLE
[Customer Portal] Enhance project time tracking: billable/non-billable stats, compact date filter, and reporter info

### DIFF
--- a/apps/customer-portal/backend/modules/entity/types.bal
+++ b/apps/customer-portal/backend/modules/entity/types.bal
@@ -1985,6 +1985,12 @@ public type CaseTimeCardSummary record {|
         string name;
         # Last updated date and time
         string updatedOn;
+        # Created date and time
+        string? createdOn?;
+        # User who created the case
+        string? createdBy?;
+        # User who last updated the case
+        string? updatedBy?;
         # Associated project information
         ReferenceTableItem? project;
         json...;

--- a/apps/customer-portal/backend/modules/types/types.bal
+++ b/apps/customer-portal/backend/modules/types/types.bal
@@ -1441,6 +1441,12 @@ public type CaseTimeCard record {|
         string name;
         # Last updated date and time
         string updatedOn;
+        # Created date and time
+        string? createdOn?;
+        # User who created the case
+        string? createdBy?;
+        # User who last updated the case
+        string? updatedBy?;
         # Associated project information
         ReferenceItem? project;
         json...;

--- a/apps/customer-portal/backend/openapi.yaml
+++ b/apps/customer-portal/backend/openapi.yaml
@@ -2424,6 +2424,10 @@ paths:
       responses:
         "200":
           description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CaseTimeCardsSearchResponse'
         "400":
           description: BadRequest
           content:
@@ -4175,6 +4179,101 @@ components:
             $ref: '#/components/schemas/Email'
       additionalProperties: false
       description: Request payload for updating a case.
+    CaseTimeCardBillingInfo:
+      required:
+      - count
+      - totalTime
+      type: object
+      properties:
+        totalTime:
+          type: number
+          description: Total time
+          format: double
+        count:
+          type: integer
+          description: Count of time cards
+          format: int64
+      description: Billing summary for time cards (billable or non-billable).
+    CaseTimeCard:
+      required:
+      - case
+      - totalCount
+      - totalTime
+      type: object
+      properties:
+        case:
+          required:
+          - id
+          - name
+          - number
+          - updatedOn
+          type: object
+          properties:
+            id:
+              $ref: '#/components/schemas/IdString'
+            number:
+              type: string
+              description: Case number
+            name:
+              type: string
+              description: Case name/summary
+            updatedOn:
+              type: string
+              description: Last updated date and time
+            createdOn:
+              type: string
+              description: Created date and time
+              nullable: true
+            createdBy:
+              type: string
+              description: User who created the case
+              nullable: true
+            updatedBy:
+              type: string
+              description: User who last updated the case
+              nullable: true
+            project:
+              $ref: '#/components/schemas/ReferenceItem'
+              nullable: true
+          description: Case information
+        totalTime:
+          type: number
+          description: Total time logged for this case
+          format: double
+        totalCount:
+          type: integer
+          description: Total count of time cards
+          format: int64
+        billable:
+          $ref: '#/components/schemas/CaseTimeCardBillingInfo'
+        nonBillable:
+          $ref: '#/components/schemas/CaseTimeCardBillingInfo'
+      description: Time card grouped by case.
+    CaseTimeCardsSearchResponse:
+      required:
+      - caseTimeCards
+      - totalRecords
+      type: object
+      properties:
+        caseTimeCards:
+          type: array
+          description: List of case time card summaries
+          items:
+            $ref: '#/components/schemas/CaseTimeCard'
+        totalRecords:
+          type: integer
+          description: Total records count
+          format: int64
+        offset:
+          minimum: 0
+          type: integer
+          description: Offset for pagination
+          format: int64
+        limit:
+          type: integer
+          description: Limit for pagination
+          format: int64
+      description: Cases time cards search response.
     CasesTrend:
       required:
       - period

--- a/apps/customer-portal/backend/utils.bal
+++ b/apps/customer-portal/backend/utils.bal
@@ -1178,6 +1178,9 @@ public isolated function mapTimeCardSearchResponseGroupedByCases(entity:CaseTime
                 number: caseTimeCard.case.number,
                 name: caseTimeCard.case.name,
                 updatedOn: caseTimeCard.case.updatedOn,
+                createdOn: caseTimeCard.case?.createdOn,
+                createdBy: caseTimeCard.case?.createdBy,
+                updatedBy: caseTimeCard.case?.updatedBy,
                 project: project != () ? {id: project.id, label: project.name} : ()
             },
             totalTime: caseTimeCard.totalTime,

--- a/apps/customer-portal/webapp/src/features/project-details/components/time-tracking/ProjectTimeTracking.tsx
+++ b/apps/customer-portal/webapp/src/features/project-details/components/time-tracking/ProjectTimeTracking.tsx
@@ -104,7 +104,7 @@ export default function ProjectTimeTracking({
         isError={isProjectError}
       />
 
-      <Box sx={{ mb: 3 }}>
+      <Box sx={{ mb: 2 }}>
         <TimeCardsDateFilter
           startDate={startDate}
           endDate={endDate}

--- a/apps/customer-portal/webapp/src/features/project-details/components/time-tracking/ProjectTimeTracking.tsx
+++ b/apps/customer-portal/webapp/src/features/project-details/components/time-tracking/ProjectTimeTracking.tsx
@@ -22,6 +22,7 @@ import {
 } from "react";
 import useSearchProjectCaseTimeCards from "@features/usage-metrics/api/useSearchProjectCaseTimeCards";
 import ServiceHoursStatCards from "@time-tracking/ServiceHoursStatCards";
+import TimeCardsBillableStats from "@time-tracking/TimeCardsBillableStats";
 import TimeCardsDateFilter from "@time-tracking/TimeCardsDateFilter";
 import TimeTrackingCard from "@time-tracking/TimeTrackingCard";
 import TimeTrackingCardSkeleton from "@time-tracking/TimeTrackingCardSkeleton";
@@ -113,6 +114,12 @@ export default function ProjectTimeTracking({
           hasFilters={hasDateFilters}
         />
       </Box>
+
+      <TimeCardsBillableStats
+        projectId={projectId}
+        startDate={startDate}
+        endDate={endDate}
+      />
 
       <Box sx={{ mb: 2, display: "flex", alignItems: "center", justifyContent: "space-between" }}>
         <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>

--- a/apps/customer-portal/webapp/src/features/project-details/components/time-tracking/ServiceHoursStatCards.tsx
+++ b/apps/customer-portal/webapp/src/features/project-details/components/time-tracking/ServiceHoursStatCards.tsx
@@ -71,11 +71,11 @@ export default function ServiceHoursStatCards({
           md: hideOnboardingCard ? "1fr" : "1fr 1fr",
         },
         gap: 2,
-        mb: 3,
+        mb: 2,
       }}
     >
       {/* Query Hours Card */}
-      <Card sx={{ p: 2.5 }}>
+      <Card sx={{ p: 2 }}>
         <CardContent sx={{ p: 0, "&:last-child": { pb: 0 } }}>
           <Box
             sx={{
@@ -123,7 +123,7 @@ export default function ServiceHoursStatCards({
 
       {/* Onboarding Hours Card */}
       {!hideOnboardingCard && (
-        <Card sx={{ p: 2.5 }}>
+        <Card sx={{ p: 2 }}>
         <CardContent sx={{ p: 0, "&:last-child": { pb: 0 } }}>
           <Box
             sx={{

--- a/apps/customer-portal/webapp/src/features/project-details/components/time-tracking/TimeCardsBillableStats.tsx
+++ b/apps/customer-portal/webapp/src/features/project-details/components/time-tracking/TimeCardsBillableStats.tsx
@@ -47,10 +47,10 @@ export default function TimeCardsBillableStats({
         display: "grid",
         gridTemplateColumns: { xs: "1fr", md: "1fr 1fr" },
         gap: 2,
-        mb: 3,
+        mb: 2,
       }}
     >
-      <Card sx={{ p: 2.5 }}>
+      <Card sx={{ p: 2 }}>
         <CardContent sx={{ p: 0, "&:last-child": { pb: 0 } }}>
           <Box
             sx={{
@@ -82,7 +82,7 @@ export default function TimeCardsBillableStats({
         </CardContent>
       </Card>
 
-      <Card sx={{ p: 2.5 }}>
+      <Card sx={{ p: 2 }}>
         <CardContent sx={{ p: 0, "&:last-child": { pb: 0 } }}>
           <Box
             sx={{

--- a/apps/customer-portal/webapp/src/features/project-details/components/time-tracking/TimeCardsBillableStats.tsx
+++ b/apps/customer-portal/webapp/src/features/project-details/components/time-tracking/TimeCardsBillableStats.tsx
@@ -1,0 +1,118 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Box, Card, CardContent, Typography, Skeleton } from "@wso2/oxygen-ui";
+import { Clock } from "@wso2/oxygen-ui-icons-react";
+import type { JSX } from "react";
+
+import useGetTimeCardsStats from "@features/usage-metrics/api/useGetTimeCardsStats";
+import { formatServiceHoursDecimalCompact } from "@features/project-details/utils/projectDetails";
+import ErrorIndicator from "@components/error-indicator/ErrorIndicator";
+import type { TimeCardsBillableStatsProps } from "@features/project-details/types/projectDetailsComponents";
+
+/**
+ * TimeCardsBillableStats displays billable and non-billable hours for the currently
+ * applied time card date range.
+ *
+ * @param {TimeCardsBillableStatsProps} props - Project ID and applied date range.
+ * @returns {JSX.Element} The rendered TimeCardsBillableStats component.
+ */
+export default function TimeCardsBillableStats({
+  projectId,
+  startDate,
+  endDate,
+}: TimeCardsBillableStatsProps): JSX.Element {
+  const {
+    data,
+    isLoading,
+    isError,
+  } = useGetTimeCardsStats({ projectId, startDate, endDate });
+
+  return (
+    <Box
+      sx={{
+        display: "grid",
+        gridTemplateColumns: { xs: "1fr", md: "1fr 1fr" },
+        gap: 2,
+        mb: 3,
+      }}
+    >
+      <Card sx={{ p: 2.5 }}>
+        <CardContent sx={{ p: 0, "&:last-child": { pb: 0 } }}>
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              mb: 1,
+            }}
+          >
+            <Typography variant="body2" color="text.secondary">
+              Billable Hours
+            </Typography>
+            <Box
+              component="span"
+              sx={{ color: "info.main", display: "inline-flex" }}
+            >
+              <Clock size={16} />
+            </Box>
+          </Box>
+          {isLoading ? (
+            <Skeleton variant="text" width="60%" height={32} />
+          ) : isError ? (
+            <ErrorIndicator entityName="billable hours" />
+          ) : (
+            <Typography variant="h5">
+              {formatServiceHoursDecimalCompact(data?.billableHours)}
+            </Typography>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card sx={{ p: 2.5 }}>
+        <CardContent sx={{ p: 0, "&:last-child": { pb: 0 } }}>
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              mb: 1,
+            }}
+          >
+            <Typography variant="body2" color="text.secondary">
+              Non-Billable Hours
+            </Typography>
+            <Box
+              component="span"
+              sx={{ color: "success.main", display: "inline-flex" }}
+            >
+              <Clock size={16} />
+            </Box>
+          </Box>
+          {isLoading ? (
+            <Skeleton variant="text" width="60%" height={32} />
+          ) : isError ? (
+            <ErrorIndicator entityName="non-billable hours" />
+          ) : (
+            <Typography variant="h5">
+              {formatServiceHoursDecimalCompact(data?.nonBillableHours)}
+            </Typography>
+          )}
+        </CardContent>
+      </Card>
+    </Box>
+  );
+}

--- a/apps/customer-portal/webapp/src/features/project-details/components/time-tracking/TimeCardsDateFilter.tsx
+++ b/apps/customer-portal/webapp/src/features/project-details/components/time-tracking/TimeCardsDateFilter.tsx
@@ -59,6 +59,7 @@ export default function TimeCardsDateFilter({
         size="small"
         value={startDate}
         onChange={(e) => onStartDateChange(e.target.value)}
+        inputProps={{ "aria-label": "Start date" }}
         sx={{ minWidth: 160 }}
         InputProps={{
           startAdornment: (
@@ -77,6 +78,7 @@ export default function TimeCardsDateFilter({
         size="small"
         value={endDate}
         onChange={(e) => onEndDateChange(e.target.value)}
+        inputProps={{ "aria-label": "End date" }}
         sx={{ minWidth: 160 }}
         InputProps={{
           startAdornment: (

--- a/apps/customer-portal/webapp/src/features/project-details/components/time-tracking/TimeCardsDateFilter.tsx
+++ b/apps/customer-portal/webapp/src/features/project-details/components/time-tracking/TimeCardsDateFilter.tsx
@@ -15,131 +15,73 @@
 // under the License.
 
 import {
-  Card,
   Box,
   Typography,
   TextField,
   InputAdornment,
-  Button,
 } from "@wso2/oxygen-ui";
-import { Calendar, X } from "@wso2/oxygen-ui-icons-react";
-import { type JSX } from "react";
+import { Calendar } from "@wso2/oxygen-ui-icons-react";
+import type { JSX } from "react";
 import type { TimeCardsDateFilterProps } from "@features/project-details/types/projectDetailsComponents";
 
 /**
- * TimeCardsDateFilter provides date range filters for time cards.
+ * TimeCardsDateFilter provides a compact time-range filter for time cards.
  *
- * @param {TimeCardsDateFilterProps} props - Date values, change handlers, and optional clear handler.
- * @returns {JSX.Element} The rendered filter card.
+ * @param {TimeCardsDateFilterProps} props - Date values and change handlers.
+ * @returns {JSX.Element} The rendered filter row.
  */
 export default function TimeCardsDateFilter({
   startDate,
   endDate,
   onStartDateChange,
   onEndDateChange,
-  onClear,
-  hasFilters,
 }: TimeCardsDateFilterProps): JSX.Element {
   return (
-    <Card
+    <Box
       sx={{
-        p: 3,
         display: "flex",
-        flexDirection: "column",
-        gap: 3,
+        alignItems: "center",
+        gap: 1.5,
+        flexWrap: "wrap",
       }}
     >
-      <Box
-        sx={{
-          display: "flex",
-          alignItems: "center",
-          gap: 2,
-          flexWrap: "wrap",
+      <Calendar size={18} />
+      <Typography variant="body2" sx={{ fontWeight: 600 }}>
+        Time Range:
+      </Typography>
+      <TextField
+        id="time-cards-start-date"
+        type="date"
+        size="small"
+        value={startDate}
+        onChange={(e) => onStartDateChange(e.target.value)}
+        sx={{ minWidth: 160 }}
+        InputProps={{
+          startAdornment: (
+            <InputAdornment position="start">
+              <Calendar size={16} />
+            </InputAdornment>
+          ),
         }}
-      >
-        <Typography
-          variant="body2"
-          component="label"
-          sx={{
-            fontWeight: 500,
-            color: "text.secondary",
-            whiteSpace: "nowrap",
-          }}
-        >
-          Filter by Date Range:
-        </Typography>
-        <Box sx={{ display: "flex", alignItems: "center", gap: 2, flexWrap: "wrap" }}>
-          <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-            <Typography
-              component="label"
-              htmlFor="time-cards-start-date"
-              variant="body2"
-              sx={{
-                fontWeight: 500,
-                color: "text.secondary",
-                whiteSpace: "nowrap",
-              }}
-            >
-              From:
-            </Typography>
-            <TextField
-              id="time-cards-start-date"
-              type="date"
-              size="small"
-              value={startDate}
-              onChange={(e) => onStartDateChange(e.target.value)}
-              sx={{ minWidth: 200 }}
-              InputProps={{
-                startAdornment: (
-                  <InputAdornment position="start">
-                    <Calendar size={16} />
-                  </InputAdornment>
-                ),
-              }}
-            />
-          </Box>
-          <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-            <Typography
-              component="label"
-              htmlFor="time-cards-end-date"
-              variant="body2"
-              sx={{
-                fontWeight: 500,
-                color: "text.secondary",
-                whiteSpace: "nowrap",
-              }}
-            >
-              To:
-            </Typography>
-            <TextField
-              id="time-cards-end-date"
-              type="date"
-              size="small"
-              value={endDate}
-              onChange={(e) => onEndDateChange(e.target.value)}
-              sx={{ minWidth: 200 }}
-              InputProps={{
-                startAdornment: (
-                  <InputAdornment position="start">
-                    <Calendar size={16} />
-                  </InputAdornment>
-                ),
-              }}
-            />
-          </Box>
-          {hasFilters && onClear && (
-            <Button
-              variant="text"
-              size="small"
-              onClick={onClear}
-              startIcon={<X size={16} />}
-              sx={{ color: "text.secondary" }}
-            >
-              Clear
-            </Button>
-          )}
-        </Box>
-      </Box>
-    </Card>
+      />
+      <Typography variant="body2" color="text.secondary">
+        to
+      </Typography>
+      <TextField
+        id="time-cards-end-date"
+        type="date"
+        size="small"
+        value={endDate}
+        onChange={(e) => onEndDateChange(e.target.value)}
+        sx={{ minWidth: 160 }}
+        InputProps={{
+          startAdornment: (
+            <InputAdornment position="start">
+              <Calendar size={16} />
+            </InputAdornment>
+          ),
+        }}
+      />
+    </Box>
   );
 }

--- a/apps/customer-portal/webapp/src/features/project-details/components/time-tracking/TimeCardsDateFilter.tsx
+++ b/apps/customer-portal/webapp/src/features/project-details/components/time-tracking/TimeCardsDateFilter.tsx
@@ -19,8 +19,9 @@ import {
   Typography,
   TextField,
   InputAdornment,
+  Button,
 } from "@wso2/oxygen-ui";
-import { Calendar } from "@wso2/oxygen-ui-icons-react";
+import { Calendar, X } from "@wso2/oxygen-ui-icons-react";
 import type { JSX } from "react";
 import type { TimeCardsDateFilterProps } from "@features/project-details/types/projectDetailsComponents";
 
@@ -35,7 +36,10 @@ export default function TimeCardsDateFilter({
   endDate,
   onStartDateChange,
   onEndDateChange,
+  onClear,
 }: TimeCardsDateFilterProps): JSX.Element {
+  const hasFilters = Boolean(startDate || endDate);
+
   return (
     <Box
       sx={{
@@ -82,6 +86,17 @@ export default function TimeCardsDateFilter({
           ),
         }}
       />
+      {hasFilters && onClear && (
+        <Button
+          variant="text"
+          size="small"
+          onClick={onClear}
+          startIcon={<X size={16} />}
+          sx={{ color: "text.secondary" }}
+        >
+          Clear
+        </Button>
+      )}
     </Box>
   );
 }

--- a/apps/customer-portal/webapp/src/features/project-details/components/time-tracking/TimeTrackingCard.tsx
+++ b/apps/customer-portal/webapp/src/features/project-details/components/time-tracking/TimeTrackingCard.tsx
@@ -33,6 +33,7 @@ export default function TimeTrackingCard({
 
   const caseNumber = caseData?.number?.trim() || "--";
   const caseName = caseData?.name?.trim() || "--";
+  const createdBy = caseData?.createdBy?.trim();
 
   const totalTimeDisplay = formatMinutesAsHrMin(totalTime);
 
@@ -66,6 +67,11 @@ export default function TimeTrackingCard({
           <Typography variant="body2" color="text.primary" sx={{ mb: 0.5 }}>
             {caseName}
           </Typography>
+          {createdBy && (
+            <Typography variant="caption" color="text.secondary">
+              Reported by {createdBy}
+            </Typography>
+          )}
         </Box>
         <Box sx={{ textAlign: "right", flexShrink: 0 }}>
           <Typography

--- a/apps/customer-portal/webapp/src/features/project-details/types/projectDetailsComponents.ts
+++ b/apps/customer-portal/webapp/src/features/project-details/types/projectDetailsComponents.ts
@@ -297,3 +297,9 @@ export type TimeCardsDateFilterProps = {
   onClear?: () => void;
   hasFilters?: boolean;
 };
+
+export type TimeCardsBillableStatsProps = {
+  projectId: string;
+  startDate?: string;
+  endDate?: string;
+};

--- a/apps/customer-portal/webapp/src/features/usage-metrics/api/__tests__/useGetTimeCardsStats.test.tsx
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/api/__tests__/useGetTimeCardsStats.test.tsx
@@ -102,9 +102,10 @@ describe("useGetTimeCardsStats", () => {
     expect(data?.billableHours).toBe(6.67);
     expect(data?.nonBillableHours).toBe(0);
 
-    const requestedUrl = String(authFetchMock.mock.calls[0][0]);
-    expect(requestedUrl).toContain("startDate=2025-01-01");
-    expect(requestedUrl).toContain("endDate=2025-12-31");
+    const requestedUrl = new URL(String(authFetchMock.mock.calls[0][0]));
+    expect(requestedUrl.searchParams.size).toBe(2);
+    expect(requestedUrl.searchParams.get("startDate")).toBe("2025-01-01");
+    expect(requestedUrl.searchParams.get("endDate")).toBe("2025-12-31");
   });
 
   it("should request stats without any query params when no dates are provided", async () => {
@@ -128,9 +129,10 @@ describe("useGetTimeCardsStats", () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    const requestedUrl = String(authFetchMock.mock.calls[0][0]);
-    expect(requestedUrl).toContain("startDate=2025-01-01");
-    expect(requestedUrl).not.toContain("endDate=");
+    const requestedUrl = new URL(String(authFetchMock.mock.calls[0][0]));
+    expect(requestedUrl.searchParams.size).toBe(1);
+    expect(requestedUrl.searchParams.get("startDate")).toBe("2025-01-01");
+    expect(requestedUrl.searchParams.has("endDate")).toBe(false);
   });
 
   it("should include only endDate when startDate is not provided", async () => {
@@ -142,8 +144,9 @@ describe("useGetTimeCardsStats", () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    const requestedUrl = String(authFetchMock.mock.calls[0][0]);
-    expect(requestedUrl).toContain("endDate=2025-12-31");
-    expect(requestedUrl).not.toContain("startDate=");
+    const requestedUrl = new URL(String(authFetchMock.mock.calls[0][0]));
+    expect(requestedUrl.searchParams.size).toBe(1);
+    expect(requestedUrl.searchParams.get("endDate")).toBe("2025-12-31");
+    expect(requestedUrl.searchParams.has("startDate")).toBe(false);
   });
 });

--- a/apps/customer-portal/webapp/src/features/usage-metrics/api/__tests__/useGetTimeCardsStats.test.tsx
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/api/__tests__/useGetTimeCardsStats.test.tsx
@@ -37,23 +37,24 @@ vi.mock("@hooks/useLogger", () => ({
   }),
 }));
 
+const authFetchMock = vi.fn(async (input: RequestInfo | URL) => {
+  const url = String(input);
+  if (url.includes("/stats/time-cards")) {
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({
+        totalHours: 400,
+        billableHours: 400,
+        nonBillableHours: 0,
+      }),
+    };
+  }
+  throw new Error(`Unexpected request: ${url}`);
+});
+
 vi.mock("@/hooks/useAuthApiClient", () => ({
-  useAuthApiClient: () =>
-    vi.fn(async (input: RequestInfo | URL) => {
-      const url = String(input);
-      if (url.includes("/stats/time-cards")) {
-        return {
-          ok: true,
-          status: 200,
-          json: async () => ({
-            totalHours: 400,
-            billableHours: 400,
-            nonBillableHours: 0,
-          }),
-        };
-      }
-      throw new Error(`Unexpected request: ${url}`);
-    }),
+  useAuthApiClient: () => authFetchMock,
 }));
 
 const createWrapper = () => {
@@ -100,5 +101,49 @@ describe("useGetTimeCardsStats", () => {
     expect(data?.totalHours).toBe(6.67);
     expect(data?.billableHours).toBe(6.67);
     expect(data?.nonBillableHours).toBe(0);
+
+    const requestedUrl = String(authFetchMock.mock.calls[0][0]);
+    expect(requestedUrl).toContain("startDate=2025-01-01");
+    expect(requestedUrl).toContain("endDate=2025-12-31");
+  });
+
+  it("should request stats without any query params when no dates are provided", async () => {
+    const { result } = renderHook(
+      () => useGetTimeCardsStats({ projectId: "project-1" }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const requestedUrl = String(authFetchMock.mock.calls[0][0]);
+    expect(requestedUrl).toBe("https://api.test/projects/project-1/stats/time-cards");
+  });
+
+  it("should include only startDate when endDate is not provided", async () => {
+    const { result } = renderHook(
+      () =>
+        useGetTimeCardsStats({ projectId: "project-1", startDate: "2025-01-01" }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const requestedUrl = String(authFetchMock.mock.calls[0][0]);
+    expect(requestedUrl).toContain("startDate=2025-01-01");
+    expect(requestedUrl).not.toContain("endDate=");
+  });
+
+  it("should include only endDate when startDate is not provided", async () => {
+    const { result } = renderHook(
+      () =>
+        useGetTimeCardsStats({ projectId: "project-1", endDate: "2025-12-31" }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const requestedUrl = String(authFetchMock.mock.calls[0][0]);
+    expect(requestedUrl).toContain("endDate=2025-12-31");
+    expect(requestedUrl).not.toContain("startDate=");
   });
 });

--- a/apps/customer-portal/webapp/src/features/usage-metrics/api/useGetTimeCardsStats.ts
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/api/useGetTimeCardsStats.ts
@@ -56,10 +56,11 @@ export default function useGetTimeCardsStats({
         }
 
         const params = new URLSearchParams({
-          startDate,
-          endDate,
+          ...(startDate && { startDate }),
+          ...(endDate && { endDate }),
         });
-        const requestUrl = `${baseUrl}/projects/${projectId}/stats/time-cards?${params.toString()}`;
+        const queryString = params.toString();
+        const requestUrl = `${baseUrl}/projects/${projectId}/stats/time-cards${queryString ? `?${queryString}` : ""}`;
 
         const response = await authFetch(requestUrl, {
           method: "GET",
@@ -96,8 +97,7 @@ export default function useGetTimeCardsStats({
         throw error;
       }
     },
-    enabled:
-      !!projectId && !!startDate && !!endDate && isSignedIn && !isAuthLoading,
+    enabled: !!projectId && isSignedIn && !isAuthLoading,
     staleTime: 0,
   });
 }

--- a/apps/customer-portal/webapp/src/features/usage-metrics/types/timeTracking.ts
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/types/timeTracking.ts
@@ -86,7 +86,10 @@ export type CaseTimeCardCaseRef = {
   number: string;
   name: string;
   updatedOn: string;
-  project: { id: string; label: string };
+  createdOn?: string | null;
+  createdBy?: string | null;
+  updatedBy?: string | null;
+  project: { id: string; label: string } | null;
 };
 
 // Billable / non-billable breakdown in a CaseTimeCard.

--- a/apps/customer-portal/webapp/src/features/usage-metrics/types/usageMetrics.ts
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/types/usageMetrics.ts
@@ -169,8 +169,8 @@ export type UseSearchProjectTimeCardsParams = {
 
 export type UseGetTimeCardsStatsParams = {
   projectId: string;
-  startDate: string;
-  endDate: string;
+  startDate?: string;
+  endDate?: string;
 };
 
 export type UsageEnvironmentPanelAccent = {


### PR DESCRIPTION
## Summary
- Add Billable Hours / Non-Billable Hours stat cards to the Time Tracking tab, powered by the existing `/projects/{projectId}/stats/time-cards` endpoint, scoped to the applied date range (or all time when no filter is set).
- Simplify the "Filter by Date Range" section into a compact single-row "Time Range" filter with From/To inputs and a Clear button to reset back to the all-time view.
- Tighten spacing/padding across the Query Hours, Onboarding Hours, and new stat cards to reduce excess vertical whitespace.
- Surface who reported each case's time card ("Reported by ...") on the time card list, fixing a backend mapping gap where `createdBy`/`createdOn`/`updatedBy` were declared on the response type but silently dropped by the mapper.

## Test plan
- [ ] Open a project's Time Tracking tab and confirm Query Hours, Onboarding Hours, and new Billable/Non-Billable Hours cards render correctly
- [ ] Apply a custom date range and confirm billable/non-billable stats update accordingly
- [ ] Click Clear and confirm the filter resets and stats revert to all-time totals
- [ ] Confirm each time card shows "Reported by {name}" when `createdBy` is present, and hides it gracefully when absent
- [ ] `bal build` passes for the backend changes
- [ ] `tsc --noEmit` passes for the frontend changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added billable and non-billable hour summaries to project time tracking.
  - Added case reporter details when available.
  - Enhanced time-card search results with billing totals, case details, pagination, and record counts.

- **Improvements**
  - Redesigned the time-range filter with a compact, responsive layout.
  - Date filters can now be used independently or omitted.
  - Refined spacing and presentation across time-tracking cards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->