### PR TITLE
fix(customer-portal): identify who asked for a token increase

### DIFF
--- a/apps/customer-portal/backend/service.bal
+++ b/apps/customer-portal/backend/service.bal
@@ -6919,8 +6919,27 @@ isolated service class WsProxyService {
                 log:printError(string `Discarding ${inboundType}: no conversation id available`);
                 return;
             }
+            // Stamp the requester from the authenticated session rather than
+            // trusting the browser to say who it is: a token increase lands in
+            // the durable audit trail as the actor.
+            //
+            // Rewritten unconditionally. When there is no authenticated email to
+            // stamp, any requestedBy the page supplied is *removed* rather than
+            // forwarded — otherwise that one path would let a caller name
+            // themselves in the audit trail. So the field is either this
+            // session's user or absent, never client-supplied; the backend falls
+            // back to the account when it is absent.
+            string sideChannelPayload = data;
+            if parsed is map<json> {
+                if self.userEmail.length() > 0 {
+                    parsed["requestedBy"] = self.userEmail;
+                } else {
+                    _ = parsed.removeIfHasKey("requestedBy");
+                }
+                sideChannelPayload = parsed.toJsonString();
+            }
             error? sideChannelErr = ai_chat_agent:sendSideChannelMessage(
-                    string `${self.projectId}:${sideChannelConvId}`, data, caller);
+                    string `${self.projectId}:${sideChannelConvId}`, sideChannelPayload, caller);
             if sideChannelErr is error {
                 log:printError(string `Failed to forward ${inboundType} upstream`, sideChannelErr);
             }

--- a/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
@@ -901,11 +901,12 @@ export default function NoveraChatPage(): JSX.Element {
       await sendUserMessage({
         type: "token_increase_request",
         accountId,
+        accountName: projectDetails?.account?.name || undefined,
         reason,
         limitType: "session",
       });
     },
-    [projectId, accountId, connect, sendUserMessage],
+    [projectId, accountId, projectDetails?.account?.name, connect, sendUserMessage],
   );
 
   const handleSendMessage = useCallback(async (): Promise<boolean> => {

--- a/apps/customer-portal/webapp/src/features/support/types/conversations.ts
+++ b/apps/customer-portal/webapp/src/features/support/types/conversations.ts
@@ -256,6 +256,11 @@ export type ChatWebSocketPayload =
   | {
       type: "token_increase_request";
       accountId: string;
+      /**
+       * Readable customer name for the admin notification, which otherwise
+       * addresses the account by sys_id. Display only — the id stays the key.
+       */
+      accountName?: string;
       reason: string;
       limitType: "session" | "monthly";
     }


### PR DESCRIPTION
## Why

A token-budget request tells the admin almost nothing about who is asking. The notification email addresses the customer by sys_id, and the audit trail records the account as its own actor:

```
token_request.created   <account sys_id>   <the same sys_id>
```

Two causes, one on each side of this repo.

## 1. The page sent no account name

`token_increase_request` carried only `accountId`, so the backend had no name to render — even though it accepts one and the template has a slot for it. The page already loads `projectDetails`, so it now sends `accountName` the same way answer feedback does. No new request.

## 2. Nobody sent the requester at all

The proxy now stamps it from the **authenticated session**:

```ballerina
if parsed is map<json> {
    if self.userEmail.length() > 0 {
        parsed["requestedBy"] = self.userEmail;
    } else {
        _ = parsed.removeIfHasKey("requestedBy");
    }
    sideChannelPayload = parsed.toJsonString();
}
```

`self.userEmail` is set at construction from the same `userInfo` the comment writer already trusts, so this is server-side identity rather than the browser asserting who it is.

The rewrite is **unconditional**. An earlier revision only stamped the field when an email was present and otherwise forwarded the original payload untouched — which would have let a caller with no authenticated email name themselves in the audit trail. Now the field is either this session's user or absent, never client-supplied; the backend falls back to the account when it is absent.

Not rejecting the message outright when the email is missing, because this same branch carries **answer feedback**, which has nothing to do with `requestedBy` — refusing it would break ratings for an unrelated reason.

## Verification

- `bal build` clean on Swan Lake 13.1 (`Dependencies.toml` churn reverted, so the diff is only the fix)
- `npx tsc --noEmit` clean; `npx eslint` clean on both changed webapp files
- `npx vitest run src/features/support` → 49 failed / 394 passed, exactly the pre-existing baseline

## Ordering

Needs digiops-cs **#2735** to store and display it; until then the fields are accepted and ignored, so this is safe to merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)