### PR TITLE
[CSM][Web] Show a total count on every dashboard widget shape

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardBarChart.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardBarChart.tsx
@@ -78,35 +78,54 @@ export default function DashboardBarChart({
     );
   }
 
+  // Bars already label their own individual values (see the `label` prop
+  // below), but nothing showed the widget's overall total —
+  // `DashboardPieChart` has the same number+"Total" pairing built into its
+  // donut hole; a bar chart has no equivalent spot, so it sits above the
+  // chart instead. Computed once and reused by both the empty and non-empty
+  // returns below, so a zero-total widget still shows "0 Total" rather than
+  // silently omitting it.
+  const totalHeader = (
+    <Box sx={{ display: "flex", alignItems: "baseline", gap: 0.75, mb: 1 }}>
+      <Typography variant="h6">{total.toLocaleString()}</Typography>
+      <Typography variant="caption" color="text.secondary">
+        Total
+      </Typography>
+    </Box>
+  );
+
   if (total === 0) {
     return (
-      <Box
-        sx={{
-          minHeight: CHART_HEIGHT_PX,
-          width: "100%",
-          display: "flex",
-          flexDirection: "column",
-          alignItems: "center",
-          justifyContent: "center",
-          gap: 1.5,
-        }}
-      >
+      <Box sx={{ width: "100%" }}>
+        {totalHeader}
         <Box
           sx={{
-            width: 52,
-            height: 52,
-            borderRadius: "50%",
-            bgcolor: alpha(theme.palette.grey[500], 0.08),
+            minHeight: CHART_HEIGHT_PX,
+            width: "100%",
             display: "flex",
+            flexDirection: "column",
             alignItems: "center",
             justifyContent: "center",
+            gap: 1.5,
           }}
         >
-          <Inbox size={24} color={isDarkMode ? theme.palette.grey[400] : theme.palette.grey[500]} />
+          <Box
+            sx={{
+              width: 52,
+              height: 52,
+              borderRadius: "50%",
+              bgcolor: alpha(theme.palette.grey[500], 0.08),
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+            }}
+          >
+            <Inbox size={24} color={isDarkMode ? theme.palette.grey[400] : theme.palette.grey[500]} />
+          </Box>
+          <Typography variant="body2" sx={{ color: isDarkMode ? theme.palette.grey[400] : theme.palette.text.disabled }}>
+            Nothing to show here right now
+          </Typography>
         </Box>
-        <Typography variant="body2" sx={{ color: isDarkMode ? theme.palette.grey[400] : theme.palette.text.disabled }}>
-          Nothing to show here right now
-        </Typography>
       </Box>
     );
   }
@@ -115,17 +134,7 @@ export default function DashboardBarChart({
 
   return (
     <Box sx={{ width: "100%" }}>
-      {/* Bars already label their own individual values (see the `label`
-          prop below), but nothing showed the widget's overall total —
-          `DashboardPieChart` has the same number+"Total" pairing built into
-          its donut hole; a bar chart has no equivalent spot, so it sits
-          above the chart instead. */}
-      <Box sx={{ display: "flex", alignItems: "baseline", gap: 0.75, mb: 1 }}>
-        <Typography variant="h6">{total.toLocaleString()}</Typography>
-        <Typography variant="caption" color="text.secondary">
-          Total
-        </Typography>
-      </Box>
+      {totalHeader}
       <Box sx={{ width: "100%", height: CHART_HEIGHT_PX, "& .recharts-bar-rectangle": { cursor: "pointer" } }}>
         <BarChart
           data={chartData}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardBarChart.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardBarChart.tsx
@@ -78,26 +78,13 @@ export default function DashboardBarChart({
     );
   }
 
-  // Bars already label their own individual values (see the `label` prop
-  // below), but nothing showed the widget's overall total —
-  // `DashboardPieChart` has the same number+"Total" pairing built into its
-  // donut hole; a bar chart has no equivalent spot, so it sits above the
-  // chart instead. Computed once and reused by both the empty and non-empty
-  // returns below, so a zero-total widget still shows "0 Total" rather than
-  // silently omitting it.
-  const totalHeader = (
-    <Box sx={{ display: "flex", alignItems: "baseline", gap: 0.75, mb: 1 }}>
-      <Typography variant="h6">{total.toLocaleString()}</Typography>
-      <Typography variant="caption" color="text.secondary">
-        Total
-      </Typography>
-    </Box>
-  );
-
+  // The widget's overall total renders next to its title in
+  // `DashboardWidgetTile`'s own header row, not here — bars already label
+  // their own individual values (see the `label` prop below), so there's
+  // nothing else this chart needs to show for it.
   if (total === 0) {
     return (
       <Box sx={{ width: "100%" }}>
-        {totalHeader}
         <Box
           sx={{
             minHeight: CHART_HEIGHT_PX,
@@ -134,7 +121,6 @@ export default function DashboardBarChart({
 
   return (
     <Box sx={{ width: "100%" }}>
-      {totalHeader}
       <Box sx={{ width: "100%", height: CHART_HEIGHT_PX, "& .recharts-bar-rectangle": { cursor: "pointer" } }}>
         <BarChart
           data={chartData}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardBarChart.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardBarChart.tsx
@@ -114,63 +114,76 @@ export default function DashboardBarChart({
   const chartData = slices.map((slice) => ({ name: slice.label, value: slice.value }));
 
   return (
-    <Box sx={{ width: "100%", height: CHART_HEIGHT_PX, "& .recharts-bar-rectangle": { cursor: "pointer" } }}>
-      <BarChart
-        data={chartData}
-        xAxisDataKey="name"
-        // height is a fixed constant (the parent Box's own height, CHART_HEIGHT_PX),
-        // not a percentage -- passing it directly avoids the same first-render
-        // ResizeObserver race as DashboardPieChart's width/height (see that
-        // component's comment). width genuinely must stay "100%": this tile's
-        // rendered width varies with its grid column count, so it still depends
-        // on a ResizeObserver measurement, which is the expected/correct
-        // behavior for a responsive dimension -- only the height half of the
-        // warning is avoidable here.
-        height={CHART_HEIGHT_PX}
-        width="100%"
-        legend={{ show: false }}
-        yAxis={{ show: false }}
-        grid={{ show: false }}
-        // Library default top margin (12px) is too tight once each bar has
-        // its own always-visible value label sitting above it.
-        margin={{ top: 24, right: 8, bottom: 8, left: 0 }}
-        // cursor: false drops the library's default full-height highlight
-        // box behind the hovered bar — the bar's own hover color/border is
-        // enough of a highlight on its own.
-        tooltip={{ show: true, wrapperStyle: { zIndex: 1000 }, cursor: false }}
-      >
-        <Bar
-          dataKey="value"
-          radius={[4, 4, 0, 0]}
-          isAnimationActive={false}
-          label={{
-            position: "top",
-            fill: isDarkMode ? theme.palette.common.white : theme.palette.text.primary,
-            fontSize: 13,
-            fontWeight: 600,
-          }}
-          onMouseEnter={(_data: unknown, i: number) => setActiveIndex(i)}
-          onMouseLeave={() => setActiveIndex(undefined)}
-          // Stops the click from also bubbling up to the tile-level
-          // click-through `DashboardWidgetTile` attaches to the whole card
-          // for shape "pie"/"bar" — see `DashboardPieChart`'s wedge onClick
-          // for the same fix and full rationale.
-          onClick={(_data: unknown, i: number, event?: SyntheticEvent) => {
-            event?.stopPropagation();
-            const slice = slices[i];
-            if (slice) onSliceClick(slice);
-          }}
+    <Box sx={{ width: "100%" }}>
+      {/* Bars already label their own individual values (see the `label`
+          prop below), but nothing showed the widget's overall total —
+          `DashboardPieChart` has the same number+"Total" pairing built into
+          its donut hole; a bar chart has no equivalent spot, so it sits
+          above the chart instead. */}
+      <Box sx={{ display: "flex", alignItems: "baseline", gap: 0.75, mb: 1 }}>
+        <Typography variant="h6">{total.toLocaleString()}</Typography>
+        <Typography variant="caption" color="text.secondary">
+          Total
+        </Typography>
+      </Box>
+      <Box sx={{ width: "100%", height: CHART_HEIGHT_PX, "& .recharts-bar-rectangle": { cursor: "pointer" } }}>
+        <BarChart
+          data={chartData}
+          xAxisDataKey="name"
+          // height is a fixed constant (the parent Box's own height, CHART_HEIGHT_PX),
+          // not a percentage -- passing it directly avoids the same first-render
+          // ResizeObserver race as DashboardPieChart's width/height (see that
+          // component's comment). width genuinely must stay "100%": this tile's
+          // rendered width varies with its grid column count, so it still depends
+          // on a ResizeObserver measurement, which is the expected/correct
+          // behavior for a responsive dimension -- only the height half of the
+          // warning is avoidable here.
+          height={CHART_HEIGHT_PX}
+          width="100%"
+          legend={{ show: false }}
+          yAxis={{ show: false }}
+          grid={{ show: false }}
+          // Library default top margin (12px) is too tight once each bar has
+          // its own always-visible value label sitting above it.
+          margin={{ top: 24, right: 8, bottom: 8, left: 0 }}
+          // cursor: false drops the library's default full-height highlight
+          // box behind the hovered bar — the bar's own hover color/border is
+          // enough of a highlight on its own.
+          tooltip={{ show: true, wrapperStyle: { zIndex: 1000 }, cursor: false }}
         >
-          {slices.map((slice, i) => (
-            <Cell
-              key={slice.label}
-              fill={colorFor(slice, i)}
-              stroke={activeIndex === i ? colorFor(slice, i) : "none"}
-              strokeWidth={activeIndex === i ? 2 : 0}
-            />
-          ))}
-        </Bar>
-      </BarChart>
+          <Bar
+            dataKey="value"
+            radius={[4, 4, 0, 0]}
+            isAnimationActive={false}
+            label={{
+              position: "top",
+              fill: isDarkMode ? theme.palette.common.white : theme.palette.text.primary,
+              fontSize: 13,
+              fontWeight: 600,
+            }}
+            onMouseEnter={(_data: unknown, i: number) => setActiveIndex(i)}
+            onMouseLeave={() => setActiveIndex(undefined)}
+            // Stops the click from also bubbling up to the tile-level
+            // click-through `DashboardWidgetTile` attaches to the whole card
+            // for shape "pie"/"bar" — see `DashboardPieChart`'s wedge onClick
+            // for the same fix and full rationale.
+            onClick={(_data: unknown, i: number, event?: SyntheticEvent) => {
+              event?.stopPropagation();
+              const slice = slices[i];
+              if (slice) onSliceClick(slice);
+            }}
+          >
+            {slices.map((slice, i) => (
+              <Cell
+                key={slice.label}
+                fill={colorFor(slice, i)}
+                stroke={activeIndex === i ? colorFor(slice, i) : "none"}
+                strokeWidth={activeIndex === i ? 2 : 0}
+              />
+            ))}
+          </Bar>
+        </BarChart>
+      </Box>
     </Box>
   );
 }

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.test.tsx
@@ -1041,6 +1041,24 @@ describe("DashboardWidgetTile", () => {
     expect(params.get("states")).toBe("open");
   });
 
+  it("shape bar: still shows '0 Total' above the empty state when the widget has no slices configured yet", async () => {
+    renderWithClient(
+      <DashboardWidgetTile
+        widgetId="cases-by-severity"
+        displayName="Cases by severity"
+        resourceType="case"
+        shape="bar"
+        filters={{}}
+      />,
+    );
+
+    expect(screen.getByText("Cases by severity")).toBeInTheDocument();
+    expect(screen.getByText("Nothing to show here right now")).toBeInTheDocument();
+    expect(screen.getByText("0")).toBeInTheDocument();
+    expect(screen.getByText("Total")).toBeInTheDocument();
+    expect(postMock).not.toHaveBeenCalled();
+  });
+
   it("shape pie: renders an empty state (no slices, zero total) rather than crashing when a widget has no slices configured yet", async () => {
     renderWithClient(
       <DashboardWidgetTile

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.test.tsx
@@ -236,6 +236,32 @@ describe("DashboardWidgetTile", () => {
     });
   });
 
+  it("shape list: shows the widget's own total count, not just the capped row count shown below it", async () => {
+    postMock.mockResolvedValue({
+      total: 42,
+      cases: [
+        { id: "11111111-1111-1111-1111-111111111111", number: "CS-1", subject: "Disk full", state: "open" },
+      ],
+      limit: 5,
+      offset: 0,
+      hasMore: false,
+    });
+
+    renderWithClient(
+      <DashboardWidgetTile
+        widgetId="my_critical_open"
+        displayName="My Critical & High Cases"
+        resourceType="case"
+        shape="list"
+        filters={{}}
+        listLimit={5}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByText("CS-1")).toBeInTheDocument());
+    expect(screen.getByText("42")).toBeInTheDocument();
+  });
+
   it("shows a 'View more' link through to the full tab only when more records exist than shown", async () => {
     postMock.mockResolvedValue({
       total: 1,
@@ -561,6 +587,41 @@ describe("DashboardWidgetTile", () => {
     const params = new URLSearchParams(probeText.split("?")[1]);
     expect(params.get("severities")).toBe("S1");
     expect(params.get("states")).toBe("open");
+  });
+
+  it("shape bar: shows the widget's overall total (sum of every slice) above the chart", async () => {
+    postMock.mockImplementation(
+      (_path: string, body: { filters: { filters: { field: string; values?: string[] }[] } }) => {
+        const severity = body.filters.filters.find((f) => f.field === "severity")?.values;
+        if (severity?.includes("critical")) return Promise.resolve({ total: 1 });
+        if (severity?.includes("high")) return Promise.resolve({ total: 3 });
+        return Promise.resolve({ total: 0 });
+      },
+    );
+
+    renderWithClient(
+      <DashboardWidgetTile
+        widgetId="cases_by_severity"
+        displayName="Open Cases by Severity"
+        resourceType="case"
+        shape="bar"
+        filters={{}}
+        slices={[
+          {
+            label: "S1 · Critical",
+            query: { filters: [{ field: "severity", op: "in", values: ["critical"] }] },
+          },
+          {
+            label: "S2 · High",
+            query: { filters: [{ field: "severity", op: "in", values: ["high"] }] },
+          },
+        ]}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByText("bar:S1 · Critical:1")).toBeInTheDocument());
+    expect(screen.getByText("4")).toBeInTheDocument();
+    expect(screen.getByText("Total")).toBeInTheDocument();
   });
 
   it("shape pie: issues one search per slice (own filters merged under the widget's base filters) and renders values + percentages", async () => {

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.test.tsx
@@ -589,7 +589,7 @@ describe("DashboardWidgetTile", () => {
     expect(params.get("states")).toBe("open");
   });
 
-  it("shape bar: shows the widget's overall total (sum of every slice) above the chart", async () => {
+  it("shape bar: shows the widget's overall total (sum of every slice) next to its title", async () => {
     postMock.mockImplementation(
       (_path: string, body: { filters: { filters: { field: string; values?: string[] }[] } }) => {
         const severity = body.filters.filters.find((f) => f.field === "severity")?.values;
@@ -621,7 +621,6 @@ describe("DashboardWidgetTile", () => {
 
     await waitFor(() => expect(screen.getByText("bar:S1 · Critical:1")).toBeInTheDocument());
     expect(screen.getByText("4")).toBeInTheDocument();
-    expect(screen.getByText("Total")).toBeInTheDocument();
   });
 
   it("shape pie: issues one search per slice (own filters merged under the widget's base filters) and renders values + percentages", async () => {
@@ -1041,7 +1040,7 @@ describe("DashboardWidgetTile", () => {
     expect(params.get("states")).toBe("open");
   });
 
-  it("shape bar: still shows '0 Total' above the empty state when the widget has no slices configured yet", async () => {
+  it("shape bar: still shows a '0' total next to the title when the widget has no slices configured yet", async () => {
     renderWithClient(
       <DashboardWidgetTile
         widgetId="cases-by-severity"
@@ -1055,7 +1054,6 @@ describe("DashboardWidgetTile", () => {
     expect(screen.getByText("Cases by severity")).toBeInTheDocument();
     expect(screen.getByText("Nothing to show here right now")).toBeInTheDocument();
     expect(screen.getByText("0")).toBeInTheDocument();
-    expect(screen.getByText("Total")).toBeInTheDocument();
     expect(postMock).not.toHaveBeenCalled();
   });
 

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
@@ -202,7 +202,13 @@ export default function DashboardWidgetTile({
     </Tooltip>
   );
 
-  const header = (
+  // Shared title row: icon + name, with an optional total-count badge sitting
+  // immediately after the name (ServiceNow-style "Title 42" rather than a
+  // number floated off to the card's far edge or stacked in its own line).
+  // `undefined` renders no badge — shape "pie" keeps its total in the donut
+  // hole instead, and list/bar themselves pass `undefined` while their own
+  // total is still loading or errored.
+  const renderHeader = (total?: number): JSX.Element => (
     <Box sx={{ display: "flex", alignItems: "flex-start", gap: 1.25 }}>
       <Box
         sx={{
@@ -219,9 +225,19 @@ export default function DashboardWidgetTile({
       >
         <Icon size={16} />
       </Box>
-      <Typography variant="caption" color="text.secondary" sx={{ mt: 0.5 }}>
-        {resolvedDisplayName}
-      </Typography>
+      <Box sx={{ display: "flex", alignItems: "center", gap: 0.75, mt: 0.5, minWidth: 0 }}>
+        <Typography variant="caption" color="text.secondary">
+          {resolvedDisplayName}
+        </Typography>
+        {total !== undefined && (
+          <Chip
+            label={total.toLocaleString()}
+            size="small"
+            color="default"
+            sx={{ flexShrink: 0, fontWeight: 600 }}
+          />
+        )}
+      </Box>
     </Box>
   );
 
@@ -230,21 +246,11 @@ export default function DashboardWidgetTile({
     const total = data?.total ?? 0;
     return (
       <Card variant="outlined" sx={{ position: "relative", p: 1.75, height: "100%" }}>
-        <Box sx={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 1 }}>
-          {header}
-          {/* The rows below are capped at `listLimit` (see `useWidgetData`'s
-              DEFAULT_LIST_LIMIT) — this is the only place the widget's own
-              full count is visible, since "View more" only appears once
-              `total` exceeds that cap. */}
-          {!isLoading && !isError && (
-            <Chip
-              label={total.toLocaleString()}
-              size="small"
-              color="default"
-              sx={{ flexShrink: 0, fontWeight: 600 }}
-            />
-          )}
-        </Box>
+        {/* The rows below are capped at `listLimit` (see `useWidgetData`'s
+            DEFAULT_LIST_LIMIT) — this badge next to the title is the only
+            place the widget's own full count is visible, since "View more"
+            only appears once `total` exceeds that cap. */}
+        {renderHeader(!isLoading && !isError ? total : undefined)}
         {isLoading ? (
           <Skeleton variant="rounded" height={28 * (listLimit ?? 4) + 40} sx={{ mt: 1 }} />
         ) : isError ? (
@@ -351,7 +357,11 @@ export default function DashboardWidgetTile({
               chart below it — so the chart's top edge (and, at the size this
               chart renders at, its tooltip) never sits flush against/behind
               the title row above it. */}
-          <Box sx={{ pb: resolvedDescription ? 1 : 2.5 }}>{header}</Box>
+          <Box sx={{ pb: resolvedDescription ? 1 : 2.5 }}>
+            {renderHeader(
+              shape === "bar" && !pieData.isLoading && !pieData.isError ? pieData.total : undefined,
+            )}
+          </Box>
           {resolvedDescription && (
             <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
               {resolvedDescription}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Box, Button, Card, IconButton, Skeleton, Tooltip, Typography, alpha, useTheme } from "@wso2/oxygen-ui";
+import { Box, Button, Card, Chip, IconButton, Skeleton, Tooltip, Typography, alpha, useTheme } from "@wso2/oxygen-ui";
 import { ArrowRight, Info } from "@wso2/oxygen-ui-icons-react";
 import type { JSX, KeyboardEvent, ReactNode } from "react";
 import { Link as RouterLink, useNavigate } from "react-router";
@@ -227,9 +227,24 @@ export default function DashboardWidgetTile({
 
   if (isListShape) {
     const ListRenderer = WIDGET_LIST_RENDERERS[resourceType];
+    const total = data?.total ?? 0;
     return (
       <Card variant="outlined" sx={{ position: "relative", p: 1.75, height: "100%" }}>
-        {header}
+        <Box sx={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 1 }}>
+          {header}
+          {/* The rows below are capped at `listLimit` (see `useWidgetData`'s
+              DEFAULT_LIST_LIMIT) — this is the only place the widget's own
+              full count is visible, since "View more" only appears once
+              `total` exceeds that cap. */}
+          {!isLoading && !isError && (
+            <Chip
+              label={total.toLocaleString()}
+              size="small"
+              color="default"
+              sx={{ flexShrink: 0, fontWeight: 600 }}
+            />
+          )}
+        </Box>
         {isLoading ? (
           <Skeleton variant="rounded" height={28 * (listLimit ?? 4) + 40} sx={{ mt: 1 }} />
         ) : isError ? (


### PR DESCRIPTION
## Purpose
Dashboard widgets didn't show a total count for the items they represent — users had to manually count or scroll to know how many cases/incidents/etc. a widget covered.

## Goals
- Every dashboard widget shape should visibly show a total count.

## Approach
- Audited all four widget shapes in `DashboardWidgetTile.tsx`: `count` (the big number itself is the total) and `pie` (already shows a center-of-donut total, see `DashboardPieChart.tsx`) were already fine. `list` and `bar` were the actual gap:
  - `shape: "list"` rows are capped at `listLimit` (default 4) with no indication of the real total — the "View more" link only appears once `total` exceeds the cap, and even then doesn't say by how much.
  - `shape: "bar"` labels each individual bar's value but never showed the sum across all of them.
- Added a small total-count `Chip` next to a list widget's header (`DashboardWidgetTile.tsx`), and a number+"Total" pairing above a bar widget's chart (`DashboardBarChart.tsx`), matching the pairing `DashboardPieChart.tsx` already uses in its donut hole.

## User stories
As a CS engineer viewing my dashboard, every widget — regardless of whether it renders as a number, a list, a pie, or a bar chart — shows me the total count of items it represents at a glance.

## Release note
Fix: dashboard list and bar-chart widgets now show a total count, matching the count and pie widgets that already had one.

## Documentation
N/A — internal CSM portal UI, no external doc surface affected.

## Automation tests
- Unit tests: extended `DashboardWidgetTile.test.tsx` with a shape:"list" total-count assertion and a shape:"bar" total-display assertion — all passing (31/31, up from 29).
- Verified against staging: not yet — only verified locally via `tsc -b`, `eslint`, and `vitest`; haven't run this against a live/staging environment in a browser.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (frontend-only change)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
- `apps/csm-portal/webapp`: `tsc -b`, `eslint .`, and `vitest run` all passing locally (2 pre-existing unrelated eslint issues confirmed present on `main` too).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard list widgets now display the total item count beside the widget heading.
  * Bar charts now show the overall total above the chart.
  * Total values reflect all available data, including items beyond displayed row limits.
  * Empty bar widgets display a total of zero without unnecessary data loading.

* **Bug Fixes**
  * Total counts are hidden while widget data is loading or unavailable.
  * Bar charts and empty states now use the available widget width with consistent sizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->