### PR TITLE
Add E2E coverage for case and service request creation

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -14,13 +14,37 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# ⚠️ NOT RUNNABLE IN CI YET — session provisioning is unsolved.
+#
+# The specs authenticate by replaying a captured browser session from
+# apps/customer-portal/webapp/tests/e2e/storageState/session.json. That file
+# holds real tokens and is git-ignored, so it does not exist on a runner. Without
+# it withSession() skips every test and the job exits 0 — a green tick that means
+# "nothing ran", not "E2E passed". The guard step below turns that into an
+# explicit failure instead.
+#
+# Before enabling this on push/PR, three things need settling:
+#   1. Session provisioning — inject a bundle from a secret, or drive a real
+#      login. Access tokens expire in well under an hour, so a stored secret goes
+#      stale between runs.
+#   2. Target environment — .env.e2e points at staging with E2E_NO_WEBSERVER=1,
+#      so the build/preview steps below are currently inert: the tests never hit
+#      localhost:3000. (They could not anyway — public/config.js is git-ignored,
+#      so a preview build boots without runtime config.) Either drop those steps
+#      or capture a localhost session and override E2E_BASE_URL here.
+#   3. Test data — the creation specs write to a REAL backend and there is no
+#      delete endpoint, so every run leaves permanent cases and service requests.
+#      Only the "Create Case — validation" suite is side-effect free.
+#
+# Kept as workflow_dispatch-only until the above is resolved.
+
 name: END TO END TESTS
 
 on:
   #push:
     #branches:
       #- customer-portal-milestone-1
-  workflow_dispatch: 
+  workflow_dispatch:
 
 jobs:
   e2e:
@@ -46,6 +70,18 @@ jobs:
           node-version: 20
           cache: pnpm
           cache-dependency-path: apps/customer-portal/webapp/pnpm-lock.yaml
+
+      # Fail fast rather than reporting a green "all skipped" run. withSession()
+      # skips every spec when the bundle is absent, which Playwright counts as
+      # success — so without this check the job passes having tested nothing.
+      - name: Verify E2E session bundle is present
+        run: |
+          if [ ! -f tests/e2e/storageState/session.json ]; then
+            echo "::error::No tests/e2e/storageState/session.json on the runner."
+            echo "::error::Every spec would skip and this job would pass without testing anything."
+            echo "::error::See the header of .github/workflows/e2e-tests.yml — CI session provisioning is not solved yet."
+            exit 1
+          fi
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,10 @@ handoffs/
 
 # Local working docs (PR reply/decision drafts, etc.) — never committed/pushed
 local-docs/
+
+# Local Claude Code config — kept out of version control.
+# Note other CLAUDE.md files in this repo (csm-portal, entity-service,
+# integrations/*) are deliberately tracked, so these are ignored by path rather
+# than by a blanket CLAUDE.md pattern.
+.claude/agents/e2e-test-writer.md
+apps/customer-portal/CLAUDE.md

--- a/apps/customer-portal/webapp/.env.e2e
+++ b/apps/customer-portal/webapp/.env.e2e
@@ -1,0 +1,30 @@
+# Playwright E2E configuration — read by playwright.config.ts.
+#
+# Committed defaults for the whole team. Precedence, highest first:
+#   1. real environment / CLI  (E2E_BASE_URL=… pnpm run test:e2e)
+#   2. .env.e2e.local          (your personal overrides, git-ignored)
+#   3. this file
+#
+# NO SECRETS HERE — this file is committed. Login is by replaying a captured
+# browser session (tests/e2e/storageState/session.json, git-ignored), so no
+# credentials or tokens are ever needed as env vars.
+
+# Environment the specs run against.
+#
+# This MUST match the `origin` of the captured session bundle: the storage
+# replay is scoped to that origin, so a mismatched run restores nothing and the
+# app boots signed-out. withSession() detects this and skips with a message
+# naming both origins.
+#
+# Set to http://localhost:3000 if you recapture session.json against the local
+# dev server (and drop E2E_NO_WEBSERVER so Playwright boots it for you).
+E2E_BASE_URL=http://localhost:3000
+
+# Don't boot the local vite dev server — required whenever E2E_BASE_URL points
+# at an already-running deployment.
+#
+# To have Playwright start `pnpm run dev` itself, override with an explicitly
+# EMPTY value (`E2E_NO_WEBSERVER=`) rather than omitting the key: a key absent
+# from .env.e2e.local still picks up the value below, while an empty value reads
+# as falsy.
+E2E_NO_WEBSERVER=1

--- a/apps/customer-portal/webapp/.gitignore
+++ b/apps/customer-portal/webapp/.gitignore
@@ -39,3 +39,5 @@ config.js
 /playwright/.cache/
 # Captured auth sessions hold real tokens — never commit them.
 tests/e2e/storageState/*.json
+# Session-capture instructions — kept local.
+tests/e2e/auth/README.md

--- a/apps/customer-portal/webapp/playwright.config.ts
+++ b/apps/customer-portal/webapp/playwright.config.ts
@@ -15,6 +15,26 @@
 // under the License.
 
 import { defineConfig, devices } from "@playwright/test";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// This package is ESM ("type": "module"), so __dirname does not exist — derive
+// the config's own directory so the env files resolve regardless of cwd.
+const CONFIG_DIR = path.dirname(fileURLToPath(import.meta.url));
+
+// Load E2E env files (see .env.e2e for the documented variables). Uses node's
+// built-in loader rather than a dotenv dependency, and it never overwrites a
+// variable already present in the environment — so precedence is:
+//   real env / CLI  >  .env.e2e.local (personal, git-ignored)  >  .env.e2e
+// Load order matters: the first file to define a key wins, so the personal
+// override file is read first.
+for (const file of [".env.e2e.local", ".env.e2e"]) {
+  const envPath = path.join(CONFIG_DIR, file);
+  if (fs.existsSync(envPath)) {
+    process.loadEnvFile(envPath);
+  }
+}
 
 // Base URL of the locally-served app (vite dev server, see vite.config.ts).
 // Override with E2E_BASE_URL to point at a deployed environment, and set

--- a/apps/customer-portal/webapp/tests/e2e/README.md
+++ b/apps/customer-portal/webapp/tests/e2e/README.md
@@ -28,8 +28,11 @@ is configured against (`public/config.js`), so anything a spec creates is a
 
 ## Run
 
+Configuration lives in **`.env.e2e`** (at the webapp root, committed), so no env
+vars need to be typed on the command line:
+
 ```bash
-pnpm run test:e2e                          # all specs (boots dev server)
+pnpm run test:e2e                          # all specs
 node_modules/.bin/playwright test --ui     # author/debug interactively
 node_modules/.bin/playwright show-report   # open the last HTML report
 ```
@@ -37,20 +40,52 @@ node_modules/.bin/playwright show-report   # open the last HTML report
 > Note: `pnpm exec playwright …` fails in this repo ("packages field missing");
 > call the binary directly via `node_modules/.bin/playwright …`.
 
-Environment switches (see `playwright.config.ts`):
+### Configuration
+
+`playwright.config.ts` loads the env files itself (via node's built-in
+`process.loadEnvFile`, no dotenv dependency). Precedence, highest first:
+
+1. **real environment / CLI** — `E2E_BASE_URL=… pnpm run test:e2e`
+2. **`.env.e2e.local`** — your personal overrides, git-ignored (`.env.*.local`)
+3. **`.env.e2e`** — committed team defaults
 
 | Var | Effect |
 |---|---|
-| `E2E_BASE_URL` | Target a deployed environment instead of `http://localhost:3000` |
-| `E2E_NO_WEBSERVER=1` | Don't boot the dev server (use with `E2E_BASE_URL`) |
+| `E2E_BASE_URL` | Environment under test. Default in `.env.e2e` is staging; falls back to `http://localhost:3000` if unset everywhere |
+| `E2E_NO_WEBSERVER=1` | Don't boot the local dev server — required when `E2E_BASE_URL` points at a running deployment |
 | `CI` | `forbidOnly`, and never reuse an already-running dev server |
+
+No secrets belong in these files. Login is by replaying
+`storageState/session.json` (git-ignored), not by credentials in env vars.
+
+### Base URL must match the captured session
+
+**The captured bundle decides which environment you can run against** — it only
+restores into the origin it was captured from (see `fixtures/test.ts`).
+`.env.e2e` ships pointing at staging because that is where the current
+`session.json` was captured.
+
+To run against the local dev server instead: recapture `session.json` while
+signed in at `http://localhost:3000`, then create `.env.e2e.local` with
+
+```bash
+E2E_BASE_URL=http://localhost:3000
+# Must be set empty, not omitted: keys absent from .env.e2e.local still come
+# from .env.e2e, and an empty value reads as falsy so Playwright boots
+# `pnpm run dev` itself.
+E2E_NO_WEBSERVER=
+```
+
+`withSession()` skips (rather than fails) any test whose session bundle is
+missing or captured against a different origin than the run targets, and the
+skip message names the mismatch.
 
 ## Layout
 
 | Path | Purpose |
 |---|---|
 | `auth/README.md` | How to capture a session bundle (localStorage + sessionStorage) |
-| `fixtures/test.ts` | `withRole(test, role)` replays a session, skipping each test that uses it when the bundle is absent (it skips from `beforeEach`, so tests are reported individually as skipped rather than the file being skipped as a unit); `openContextAs(browser, role)` opens a second authenticated context |
+| `fixtures/test.ts` | `withSession(test)` replays `storageState/session.json`, skipping each test that uses it when the bundle is absent or captured against a different origin (it skips from `beforeEach`, so tests are reported individually as skipped rather than the file being skipped as a unit); `openContextAs(browser, name)` opens a second authenticated context |
 | `pages/` | Page objects — one per screen, no assertions inside |
 | `specs/` | The specs, grouped in subfolders by feature area |
 | `utils/` | Shared selectors / data-tagging helpers |
@@ -58,17 +93,18 @@ Environment switches (see `playwright.config.ts`):
 
 ## Roles
 
-`PortalRole` in `fixtures/test.ts` is `"admin" | "lead" | "portal" | "security"`,
-matching the portal's user types. Capabilities are split across two sources, so
-a test account needs both set correctly:
+One session (`session.json`) is captured today, so specs run as whatever that
+account is. For role-gated coverage, capture additional bundles as
+`storageState/<name>.json` and pass the name to `withSession(test, name)` or
+`openContextAs(browser, name)`.
 
-- **admin** — both the ServiceNow user role `sn_customerservice.customer_admin`
-  (read from `GET /users/me`), which gates Settings user management and
-  registry service tokens, **and** an Admin membership on the project under
-  test.
-- **lead / portal / security** — project **membership** flags (`isLead`,
-  `isPortalUser`, `isSecurityContact`) on the project under test, read from the
-  project contacts list.
+Each bundle should be captured from an account holding one role on the project
+under test, so a spec can assert what that role can and cannot do:
+
+- **admin** — manages users and registry service tokens in Settings.
+- **lead** — a portal user who can also escalate a case past EL3.
+- **portal** — the baseline: signs in, creates and manages cases.
+- **security** — receives security advisories and raises security reports.
 
 Project-level feature visibility (Operations, Security Center, Updates,
 Engagements, Usage & Metrics …) is independent of all of these — it comes from

--- a/apps/customer-portal/webapp/tests/e2e/config/testData.ts
+++ b/apps/customer-portal/webapp/tests/e2e/config/testData.ts
@@ -1,0 +1,291 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//
+// MASTER TEST DATA for the E2E suite — VALUES ONLY.
+//
+// Every spec sources its environment-specific data from here, not just
+// case creation. This file holds no locators, no helpers, and no page logic:
+// selectors live in `../utils/selectors.ts`, actions in `../pages/`.
+//
+// Pointing the suite at a different tenant means editing this file and nothing
+// else. Values below were captured against **staging**
+// (https://support-stg.wso2.com), which is what `.env.e2e` targets.
+//
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Project fixtures
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Project types this suite exercises.
+ *
+ * The portal derives feature visibility from `GET /projects/{id}/features`
+ * rather than from these labels, but the type still drives a few rules —
+ * deployment filtering, case/SR product category, and which severities are on
+ * offer — so each type needs its own dedicated project. */
+export const ProjectType = {
+  SUBSCRIPTION: "Subscription",
+  MANAGED_CLOUD_SUBSCRIPTION: "Managed Cloud Subscription",
+  CLOUD_SUPPORT: "Cloud Support",
+} as const;
+
+export type ProjectType = (typeof ProjectType)[keyof typeof ProjectType];
+
+/** A project the suite runs against, plus the option labels its forms offer.
+ *
+ * `deployment` and `productVersion` are per-project rather than shared: those
+ * dropdowns are populated from the project's own deployments, so the labels
+ * differ between projects even for the same project type. */
+export interface ProjectFixture {
+  /** Project id as it appears in the URL (`/projects/<id>/...`).
+   *
+   * An empty string means "not yet captured for this environment" — specs must
+   * skip rather than run against the wrong project. */
+  id: string;
+  /** Project name exactly as displayed in the portal. */
+  name: string;
+  /** The project's type label, for specs that assert type-driven behaviour. */
+  type: ProjectType;
+  /** Deployment option label, exactly as rendered in the Deployment dropdown.
+   * Empty when `autoSelectsDeployment` is true — there is nothing to pick. */
+  deployment: string;
+  /** Sysid of the deployment above. The case form selects by label, so this is
+   * only needed by specs that assert against the API payload or filter by
+   * deployment in a URL. */
+  deploymentId: string;
+  /** True when the case form hides the Deployment field and locks it to the
+   * project's primary production deployment. Cloud Support and Cloud Evaluation
+   * Support behave this way (`shouldRestrictToPrimaryProductionDeployments` →
+   * `hideDeploymentField` in CreateCasePage.tsx), so specs must not try to pick
+   * a deployment for them. */
+  autoSelectsDeployment: boolean;
+  /** Product option label, exactly as rendered. The field itself is labelled
+   * "Product Version" on most types but "Product" on Cloud Support. */
+  productVersion: string;
+}
+
+/**
+ * The dedicated automation projects, one per project type.
+ *
+ * `deployment` and `productVersion` still need capturing for every entry — take
+ * them from each project's own case form, since the options come from that
+ * project's deployments. Specs that need them must skip while they are empty.
+ */
+export const PROJECTS: Record<ProjectType, ProjectFixture> = {
+  [ProjectType.SUBSCRIPTION]: {
+    id: "641058e63b5a87103e1e088aa4e45a13",
+    name: "Automation Test Customer Project - Subscription",
+    type: ProjectType.SUBSCRIPTION,
+    deployment: "Production",
+    deploymentId: "8f8a33693bee8b503e1e088aa4e45ab4",
+    autoSelectsDeployment: false,
+    productVersion: "WSO2 API Manager 4.5.0",
+  },
+  [ProjectType.MANAGED_CLOUD_SUBSCRIPTION]: {
+    id: "a0873629eba28f90fcf5f5dabad0cda0",
+    name: "Automation Test MS Customer Project - Managed Cloud Subscription",
+    type: ProjectType.MANAGED_CLOUD_SUBSCRIPTION,
+    deployment: "Production",
+    deploymentId: "f40cf7e53b2a4b9091404c6aa5e45a00",
+    autoSelectsDeployment: false,
+    productVersion: "WSO2 Identity Server 7.1.0",
+  },
+  [ProjectType.CLOUD_SUPPORT]: {
+    id: "cd9776ed3ba28b503e1e088aa4e45a81",
+    name: "Automation Test Cloud Customer Project - Cloud Support",
+    type: ProjectType.CLOUD_SUPPORT,
+    // Deployment is hidden and auto-locked to primary production for this type.
+    deployment: "",
+    deploymentId: "",
+    autoSelectsDeployment: true,
+    productVersion: "WSO2 Developer Platform",
+  },
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Form option vocabularies
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Case severity levels as rendered in the Severity Level dropdown. S4 carries
+ * no space before the parenthesis — it is exactly "S4(Query)" (see
+ * `CaseSeverityLevel` in src/features/support/constants/supportConstants.ts).
+ *
+ * Which of these appear depends on the project's `acceptedSeverityValues`:
+ * S0 shows only when the project accepts P0, and severity locks to S4 when P4
+ * is the only accepted value — so the available set differs by project. */
+export const Severity = {
+  S0: "S0",
+  S1: "S1",
+  S2: "S2",
+  S3: "S3",
+  S4: "S4(Query)",
+} as const;
+
+export type Severity = (typeof Severity)[keyof typeof Severity];
+
+/** Issue Type options offered on the case form. */
+export const IssueType = {
+  TOTAL_OUTAGE: "Total Outage",
+  QUESTION: "Question",
+  PERFORMANCE_DEGRADATION: "Performance Degradation",
+  PARTIAL_OUTAGE: "Partial Outage",
+  ERROR: "Error",
+  SECURITY_OR_COMPLIANCE: "Security or Compliance",
+} as const;
+
+export type IssueType = (typeof IssueType)[keyof typeof IssueType];
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Per-flow input data
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Case content submitted by the create-case flow. */
+export interface CaseInput {
+  /** Goes in the field labelled "Title" — "Case Details" is the section
+   * heading above it, not the input. */
+  title: string;
+  description: string;
+  issueType: IssueType;
+  severity: Severity;
+}
+
+/**
+ * Case content per project type. Kept per-type so each project's cases are
+ * distinguishable, and because the available severities differ by project.
+ *
+ * ⚠️ `POST /cases` has no delete counterpart, so every run leaves a permanent
+ * record. Keep `description` self-describing so those records stay identifiable
+ * in the target environment.
+ */
+export const CASE_INPUT: Record<ProjectType, CaseInput> = {
+  [ProjectType.SUBSCRIPTION]: {
+    title: "subscription case",
+    description: "This is a test case for subscription project",
+    issueType: IssueType.QUESTION,
+    severity: Severity.S4,
+  },
+  [ProjectType.MANAGED_CLOUD_SUBSCRIPTION]: {
+    title: "MS subscription case",
+    description: "This is a test case for MS subscription project",
+    issueType: IssueType.QUESTION,
+    severity: Severity.S4,
+  },
+  [ProjectType.CLOUD_SUPPORT]: {
+    title: "Cloud support case",
+    description: "This is a test case for cloud support project",
+    issueType: IssueType.QUESTION,
+    severity: Severity.S4,
+  },
+};
+
+/** Content submitted by the create-service-request flow.
+ *
+ * The Request Details fields are **dynamic**: they are rendered from the
+ * selected catalog item's ServiceNow variables (`variable.questionText` in
+ * VariableFormFields.tsx), so their labels come from the catalog rather than
+ * from the frontend. `requestDetailsLabel` and `descriptionLabel` therefore
+ * record what those fields are actually called on the target environment. */
+export interface ServiceRequestInput {
+  /** Catalog accordion to expand, e.g. "Generic Requests". */
+  catalog: string;
+  /** Radio item to select inside that catalog. Note this is NOT always the same
+   * wording as the catalog it lives under. */
+  catalogItem: string;
+  requestDetails: string;
+  description: string;
+}
+
+/**
+ * Service request content for the Managed Cloud Subscription project.
+ *
+ * The catalog and item names come from ServiceNow, not the frontend, so they
+ * are environment data. Verified live: the "Generic Requests" catalog holds a
+ * single item named "General Requests" — the wording genuinely differs.
+ *
+ * ⚠️ Creates a permanent record on every run, like case creation.
+ */
+export const SERVICE_REQUEST_INPUT: ServiceRequestInput = {
+  catalog: "Generic Requests",
+  catalogItem: "General Requests",
+  requestDetails: "This is test Generic Request SR for MS sub",
+  description: "This is a test Generic Request SR for MS subscription project",
+};
+
+/**
+ * "Request Product Logs" service request, under the Information Request
+ * catalog.
+ *
+ * This catalog item has several variables rather than the single free-text
+ * field the Generic Requests item has, including two date/time inputs. The
+ * dates are expressed as offsets so each run submits a valid, recent window
+ * rather than a hardcoded date that drifts into the past.
+ *
+ * ⚠️ Creates a permanent record on every run.
+ */
+export interface ProductLogsRequestInput {
+  catalog: string;
+  catalogItem: string;
+  /** Value for "Types of product log required". */
+  logType: string;
+  /** Start Time, as whole days before today. */
+  startDaysAgo: number;
+  /** End Time, as whole days before today. */
+  endDaysAgo: number;
+  purpose: string;
+  description: string;
+}
+
+export const PRODUCT_LOGS_REQUEST_INPUT: ProductLogsRequestInput = {
+  catalog: "Information Request",
+  catalogItem: "Request Product Logs",
+  logType: "Carbon",
+  startDaysAgo: 3,
+  endDaysAgo: 1,
+  purpose: "This is a test Inofrmation Request SR for MS subscription project",
+  description:
+    "This is a test Inofrmation Request Description SR for MS subscription project",
+};
+
+/**
+ * Additional severity coverage, Subscription project only.
+ *
+ * `CASE_INPUT` already covers S4 for every type; these exercise the rest of the
+ * range on one project. Which severities a project actually offers comes from
+ * its `acceptedSeverityValues`, so this list is deliberately scoped to the
+ * Subscription fixture rather than applied to all types.
+ *
+ * ⚠️ Each entry creates its own permanent case on every run.
+ */
+export const SUBSCRIPTION_SEVERITY_CASES: CaseInput[] = [
+  {
+    title: "subscription case S1",
+    description: "This is a test case for subscription project with severity S1",
+    issueType: IssueType.QUESTION,
+    severity: Severity.S1,
+  },
+  {
+    title: "subscription case S2",
+    description: "This is a test case for subscription project with severity S2",
+    issueType: IssueType.QUESTION,
+    severity: Severity.S2,
+  },
+  {
+    title: "subscription case S3",
+    description: "This is a test case for subscription project with severity S3",
+    issueType: IssueType.QUESTION,
+    severity: Severity.S3,
+  },
+];

--- a/apps/customer-portal/webapp/tests/e2e/fixtures/test.ts
+++ b/apps/customer-portal/webapp/tests/e2e/fixtures/test.ts
@@ -32,9 +32,10 @@ import {
 import fs from "node:fs";
 import path from "node:path";
 
-/** Portal user types, each backed by its own captured session bundle.
- * See tests/e2e/auth/README.md for what each account must be granted. */
-export type PortalRole = "admin" | "lead" | "portal" | "security";
+/** The default captured session, used for login unless a spec asks for another.
+ * Additional identities (for multi-account specs) are captured alongside it as
+ * `storageState/<name>.json`; see tests/e2e/auth/README.md. */
+export const DEFAULT_SESSION = "session";
 
 /** A captured session: the origin's localStorage + sessionStorage snapshots.
  * `cookies` (optional) carries the IdP-domain cookies so the SDK's silent
@@ -50,24 +51,29 @@ interface SessionBundle {
   cookies?: Parameters<BrowserContext["addCookies"]>[0];
 }
 
-/** Absolute path to a role's captured session bundle. */
-export function sessionPath(role: PortalRole): string {
-  return path.join(process.cwd(), "tests", "e2e", "storageState", `${role}.json`);
+/** Absolute path to a captured session bundle. */
+export function sessionPath(name: string = DEFAULT_SESSION): string {
+  return path.join(process.cwd(), "tests", "e2e", "storageState", `${name}.json`);
 }
 
-export function hasSession(role: PortalRole): boolean {
-  return fs.existsSync(sessionPath(role));
+export function hasSession(name: string = DEFAULT_SESSION): boolean {
+  return fs.existsSync(sessionPath(name));
 }
 
-function readBundle(role: PortalRole): SessionBundle {
-  return JSON.parse(fs.readFileSync(sessionPath(role), "utf8")) as SessionBundle;
+function readBundle(name: string): SessionBundle {
+  return JSON.parse(fs.readFileSync(sessionPath(name), "utf8")) as SessionBundle;
+}
+
+/** Origin a captured bundle belongs to, or undefined if it has none/is absent. */
+export function sessionOrigin(name: string = DEFAULT_SESSION): string | undefined {
+  return hasSession(name) ? readBundle(name).origin : undefined;
 }
 
 async function applySession(
   context: BrowserContext,
-  role: PortalRole,
+  name: string,
 ): Promise<void> {
-  const bundle = readBundle(role);
+  const bundle = readBundle(name);
   if (!bundle.origin) {
     // Without an origin we cannot tell the portal's documents apart from the
     // IdP's, and the init script below would have to either skip everything or
@@ -75,13 +81,13 @@ async function applySession(
     // silently booting signed-out. The capture snippet in auth/README.md always
     // records `origin`; a bundle missing it predates that and must be recaptured.
     throw new Error(
-      `Session bundle for '${role}' has no "origin". Recapture it — see tests/e2e/auth/README.md.`,
+      `Session bundle '${name}.json' has no "origin". Recapture it — see tests/e2e/auth/README.md.`,
     );
   }
   if (bundle.cookies?.length) {
     // Best-effort: lets the SDK's hidden-iframe silent refresh reach the IdP
     // with an existing session when the access token expires during a long run.
-    // A malformed cookies array must not abort the role's beforeEach — degrade
+    // A malformed cookies array must not abort the beforeEach — degrade
     // gracefully, same as the storage replay below.
     try {
       await context.addCookies(bundle.cookies);
@@ -114,39 +120,55 @@ async function applySession(
 }
 
 /**
- * Opens a second, independent browser context authenticated as `role` — for
- * specs that need two identities in the same test (e.g. an admin edits another
- * user's roles). Caller must close the returned context. Requires that role's
- * session to have been captured.
+ * Opens a second, independent authenticated browser context — for specs that
+ * need two identities in the same test (e.g. an admin edits another user's
+ * roles). Pass the name of another captured bundle. Caller must close the
+ * returned context.
  */
 export async function openContextAs(
   browser: Browser,
-  role: PortalRole,
+  name: string,
 ): Promise<BrowserContext> {
   const context = await browser.newContext();
-  await applySession(context, role);
+  await applySession(context, name);
   return context;
 }
 
 /**
- * Configure a test file to run authenticated as `role`. Replays the captured
- * localStorage + sessionStorage before each page loads (so the Asgardeo SDK
- * finds its session and boots signed-in). Skips the whole file when the bundle
- * is absent, with a message pointing at the capture steps.
+ * Configure a test file to run authenticated. Replays the captured
+ * localStorage + sessionStorage from `storageState/session.json` before each
+ * page loads, so the Asgardeo SDK finds its session and boots signed-in.
+ * Defaults to the shared `session` bundle; pass a name to use another identity.
+ *
+ * It skips from `beforeEach`, so each test that uses it is reported
+ * individually as skipped (rather than the file being skipped as a unit) when
+ * the bundle is missing, or when the run targets an origin the bundle was not
+ * captured against — in that case the storage replay is scoped out and the app
+ * would silently boot signed-out, which reads as a mass assertion failure
+ * instead of a setup problem.
  *
  * Usage at the top of a spec:
- *   withRole(test, "admin");
+ *   withSession(test);
  */
-export function withRole(t: typeof base, role: PortalRole): void {
-  t.beforeEach(async ({ context }) => {
+export function withSession(t: typeof base, name: string = DEFAULT_SESSION): void {
+  t.beforeEach(async ({ context, baseURL }) => {
     t.skip(
-      !hasSession(role),
-      `No captured session for '${role}'. See tests/e2e/auth/README.md to create ` +
-        `tests/e2e/storageState/${role}.json.`,
+      !hasSession(name),
+      `No captured session '${name}'. See tests/e2e/auth/README.md to create ` +
+        `tests/e2e/storageState/${name}.json.`,
     );
-    await applySession(context, role);
+    const captured = sessionOrigin(name);
+    const target = baseURL ? new URL(baseURL).origin : undefined;
+    t.skip(
+      !!captured && !!target && captured !== target,
+      `Session '${name}' was captured against ${captured} but this run targets ` +
+        `${target}. Re-run with E2E_BASE_URL=${captured} E2E_NO_WEBSERVER=1, or ` +
+        `recapture against ${target}.`,
+    );
+    await applySession(context, name);
   });
 }
 
 export const test = base;
 export { expect };
+export type { Page } from "@playwright/test";

--- a/apps/customer-portal/webapp/tests/e2e/fixtures/test.ts
+++ b/apps/customer-portal/webapp/tests/e2e/fixtures/test.ts
@@ -169,6 +169,13 @@ export function withSession(t: typeof base, name: string = DEFAULT_SESSION): voi
   });
 }
 
+//
+// Everything under tests/e2e imports `test`, `expect` and the Playwright types
+// from this module rather than from "@playwright/test" directly. Today `test` is
+// just `base`, so the two are equivalent — but the moment withSession becomes a
+// proper `base.extend()` fixture, a direct import would silently bypass it and
+// run without the session replay. Re-exporting here keeps that refactor safe.
+//
 export const test = base;
 export { expect };
-export type { Page } from "@playwright/test";
+export type { Locator, Page, Response } from "@playwright/test";

--- a/apps/customer-portal/webapp/tests/e2e/pages/CaseCreatePage.ts
+++ b/apps/customer-portal/webapp/tests/e2e/pages/CaseCreatePage.ts
@@ -1,0 +1,149 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { type Locator, type Page, expect } from "@playwright/test";
+import { CREATE_CASE, GET_HELP_BUTTON } from "../utils/selectors";
+
+/**
+ * Page object for the case-creation form at
+ * `/projects/:projectId/support/chat/create-case` (`CreateCasePage.tsx`).
+ *
+ * Locator strategy: the form's field labels are plain sibling `<Typography>`
+ * nodes, not `<label for>`, so `getByLabel` does not work here. Title, Issue
+ * Type and Severity have stable element ids; the description is a Lexical
+ * contenteditable carrying a `data-testid`; Deployment and Product Version have
+ * neither, so they are located by the placeholder text their `renderValue`
+ * emits.
+ */
+export class CaseCreatePage {
+  constructor(private readonly page: Page) {}
+
+  /**
+   * Opens the project dashboard and starts case creation via the header's
+   * "Get Help" button, then waits for the form to render.
+   *
+   * @param projectId - Project to create the case under (see PROJECTS in
+   * ../config/testData.ts).
+   */
+  async openViaGetHelp(projectId: string): Promise<void> {
+    await this.page.goto(`/projects/${projectId}/dashboard`);
+    await this.page
+      .getByRole("button", { name: GET_HELP_BUTTON, exact: true })
+      .click();
+    // "Get Help" branches on the project's Novera AI flag (see handleIssue in
+    // GetHelpDropdown.tsx): with the agent enabled it opens the describe-issue
+    // chat page instead of this form. Asserting the URL makes that divergence a
+    // clear failure rather than a confusing missing-field error.
+    await expect(this.page).toHaveURL(
+      new RegExp(`/projects/${projectId}/support/chat/create-case`),
+    );
+    await expect(
+      this.page.getByRole("heading", { name: CREATE_CASE.heading }),
+    ).toBeVisible();
+  }
+
+  /** The MUI Select for Deployment, matched on its placeholder text. */
+  deploymentSelect(): Locator {
+    return this.page
+      .getByRole("combobox")
+      .filter({ hasText: CREATE_CASE.placeholders.deployment });
+  }
+
+  /** The MUI Select for Product Version. Stays disabled, reading "Select
+   * deployment first", until a deployment is chosen. */
+  productVersionSelect(): Locator {
+    return this.page
+      .getByRole("combobox")
+      .filter({ hasText: CREATE_CASE.placeholders.productVersion });
+  }
+
+  titleInput(): Locator {
+    return this.page.locator(CREATE_CASE.ids.title);
+  }
+
+  descriptionEditor(): Locator {
+    return this.page.getByTestId(CREATE_CASE.testIds.description);
+  }
+
+  issueTypeSelect(): Locator {
+    return this.page.locator(CREATE_CASE.ids.issueType);
+  }
+
+  severitySelect(): Locator {
+    return this.page.locator(CREATE_CASE.ids.severity);
+  }
+
+  submitButton(): Locator {
+    return this.page.getByRole("button", { name: CREATE_CASE.submitButton });
+  }
+
+  /**
+   * Opens a MUI Select and picks an option by its exact visible text.
+   *
+   * @param select - The Select control to open.
+   * @param option - Exact option label to choose.
+   */
+  private async chooseOption(select: Locator, option: string): Promise<void> {
+    await select.click();
+    await this.page.getByRole("option", { name: option, exact: true }).click();
+  }
+
+  async selectDeployment(name: string): Promise<void> {
+    await this.chooseOption(this.deploymentSelect(), name);
+  }
+
+  /**
+   * Selects a product version. Waits for the control to become enabled first —
+   * the options are fetched per-deployment, so it is disabled immediately after
+   * a deployment is chosen.
+   *
+   * @param name - Exact product version label.
+   */
+  async selectProductVersion(name: string): Promise<void> {
+    const select = this.productVersionSelect();
+    await expect(select).toBeEnabled();
+    await this.chooseOption(select, name);
+  }
+
+  async fillTitle(title: string): Promise<void> {
+    await this.titleInput().fill(title);
+  }
+
+  /**
+   * Types into the Lexical description editor. It is a contenteditable, so
+   * `fill()` does not apply — the text is typed so Lexical's own key handling
+   * builds the editor state the form reads.
+   *
+   * @param text - Description body.
+   */
+  async fillDescription(text: string): Promise<void> {
+    const editor = this.descriptionEditor();
+    await editor.click();
+    await editor.pressSequentially(text);
+  }
+
+  async selectIssueType(name: string): Promise<void> {
+    await this.chooseOption(this.issueTypeSelect(), name);
+  }
+
+  async selectSeverity(name: string): Promise<void> {
+    await this.chooseOption(this.severitySelect(), name);
+  }
+
+  async submit(): Promise<void> {
+    await this.submitButton().click();
+  }
+}

--- a/apps/customer-portal/webapp/tests/e2e/pages/CaseCreatePage.ts
+++ b/apps/customer-portal/webapp/tests/e2e/pages/CaseCreatePage.ts
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { type Locator, type Page, expect } from "@playwright/test";
+import { type Locator, type Page, expect } from "../fixtures/test";
 import { CASE_DETAIL, CREATE_CASE, GET_HELP_BUTTON } from "../utils/selectors";
 
 /** How long to allow for the create-case form to render. Well above the 5s

--- a/apps/customer-portal/webapp/tests/e2e/pages/CaseCreatePage.ts
+++ b/apps/customer-portal/webapp/tests/e2e/pages/CaseCreatePage.ts
@@ -15,7 +15,12 @@
 // under the License.
 
 import { type Locator, type Page, expect } from "@playwright/test";
-import { CREATE_CASE, GET_HELP_BUTTON } from "../utils/selectors";
+import { CASE_DETAIL, CREATE_CASE, GET_HELP_BUTTON } from "../utils/selectors";
+
+/** How long to allow for the create-case form to render. Well above the 5s
+ * default expect timeout: the page waits on project details, features and
+ * filters before the form appears. */
+const FORM_LOAD_TIMEOUT_MS = 60_000;
 
 /**
  * Page object for the case-creation form at
@@ -52,7 +57,61 @@ export class CaseCreatePage {
     );
     await expect(
       this.page.getByRole("heading", { name: CREATE_CASE.heading }),
-    ).toBeVisible();
+    ).toBeVisible({ timeout: FORM_LOAD_TIMEOUT_MS });
+
+    // The heading renders before the Basic Information selects do — those are
+    // Skeletons until deployments/products resolve. The Product select is the
+    // reliable readiness signal because it is present for every project type
+    // (Cloud Support hides Deployment but still shows Product), so waiting on
+    // it lets callers assert on field state without racing the load.
+    await expect(this.productVersionSelect()).toBeVisible({
+      timeout: FORM_LOAD_TIMEOUT_MS,
+    });
+  }
+
+  /** The app's <main> region, for scoping text assertions away from the
+   * surrounding chrome. */
+  private main(): Locator {
+    return this.page.getByTestId(CASE_DETAIL.mainTestId);
+  }
+
+  /** Error banner shown by `showError` for failed submit validation. */
+  errorAlert(): Locator {
+    return this.page.getByRole("alert");
+  }
+
+  /** The `<n>/160` character counter under the Title field. */
+  titleCounter(): Locator {
+    return this.main().getByText(CREATE_CASE.titleCounter);
+  }
+
+  /** Field-level error shown when the title exceeds 160 characters. */
+  titleLengthError(): Locator {
+    return this.main().getByText(CREATE_CASE.titleTooLongError);
+  }
+
+  /** Clicks submit without waiting for a create response — for cases that are
+   * expected to be rejected before any request is made. */
+  async attemptSubmit(): Promise<void> {
+    await this.submitButton().click();
+  }
+
+  /**
+   * Fills only the Basic Information fields, leaving the case details empty.
+   * Validation tests build on this and then supply just the field under test.
+   *
+   * @param deployment - Deployment label, or empty when the project
+   * auto-selects it (Cloud Support).
+   * @param productVersion - Product option label.
+   */
+  async fillBasicInformation(
+    deployment: string,
+    productVersion: string,
+  ): Promise<void> {
+    if (deployment) {
+      await this.selectDeployment(deployment);
+    }
+    await this.selectProductVersion(productVersion);
   }
 
   /** The MUI Select for Deployment, matched on its placeholder text. */
@@ -97,6 +156,12 @@ export class CaseCreatePage {
    * @param option - Exact option label to choose.
    */
   private async chooseOption(select: Locator, option: string): Promise<void> {
+    // Each of these Selects is replaced by a Skeleton while its options are
+    // being fetched (see BasicInformationSection / CaseDetailsSection), so the
+    // control genuinely does not exist yet on a cold load — waiting for it to
+    // be present and interactive is required, not belt-and-braces.
+    await expect(select).toBeVisible({ timeout: FORM_LOAD_TIMEOUT_MS });
+    await expect(select).toBeEnabled({ timeout: FORM_LOAD_TIMEOUT_MS });
     await select.click();
     await this.page.getByRole("option", { name: option, exact: true }).click();
   }
@@ -113,9 +178,10 @@ export class CaseCreatePage {
    * @param name - Exact product version label.
    */
   async selectProductVersion(name: string): Promise<void> {
-    const select = this.productVersionSelect();
-    await expect(select).toBeEnabled();
-    await this.chooseOption(select, name);
+    // chooseOption already waits for the control to be present and enabled, on
+    // the long form-load budget — which is what this needs, since the options
+    // are refetched after a deployment is picked.
+    await this.chooseOption(this.productVersionSelect(), name);
   }
 
   async fillTitle(title: string): Promise<void> {

--- a/apps/customer-portal/webapp/tests/e2e/pages/CaseDetailPage.ts
+++ b/apps/customer-portal/webapp/tests/e2e/pages/CaseDetailPage.ts
@@ -16,6 +16,7 @@
 
 import { type Locator, type Page, expect } from "@playwright/test";
 import { CASE_DETAIL } from "../utils/selectors";
+import { isSuccess } from "../utils/caseFlows";
 
 /**
  * Page object for the case detail page
@@ -87,7 +88,7 @@ export class CaseDetailPage {
         (r) =>
           r.url().includes("/cases/") &&
           r.request().method() === "PATCH" &&
-          r.status() < 400,
+          isSuccess(r.status()),
       ),
       this.confirmButton().click(),
     ]);

--- a/apps/customer-portal/webapp/tests/e2e/pages/CaseDetailPage.ts
+++ b/apps/customer-portal/webapp/tests/e2e/pages/CaseDetailPage.ts
@@ -14,7 +14,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { type Locator, type Page, expect } from "@playwright/test";
+import {
+  type Locator,
+  type Page,
+  type Response,
+  expect,
+} from "../fixtures/test";
 import { CASE_DETAIL } from "../utils/selectors";
 import { isSuccess } from "../utils/caseFlows";
 
@@ -73,7 +78,7 @@ export class CaseDetailPage {
    *
    * @returns The successful PATCH response for the caller to assert on.
    */
-  async closeCase(): Promise<import("@playwright/test").Response> {
+  async closeCase(): Promise<Response> {
     await expect(this.closeButton()).toBeEnabled();
     await this.closeButton().click();
 

--- a/apps/customer-portal/webapp/tests/e2e/pages/CaseDetailPage.ts
+++ b/apps/customer-portal/webapp/tests/e2e/pages/CaseDetailPage.ts
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { type Locator, type Page, expect } from "@playwright/test";
+import { CASE_DETAIL } from "../utils/selectors";
+
+/**
+ * Page object for the case detail page
+ * (`/projects/:projectId/support/cases/:caseId`).
+ *
+ * Only the state-change actions are modelled here so far. Which buttons the
+ * action row renders depends on the case's current status — see
+ * `getAvailableCaseActions` in src/features/support/utils/support.ts.
+ */
+export class CaseDetailPage {
+  constructor(private readonly page: Page) {}
+
+  /** The app's <main> region. Everything on this page is scoped to it so the
+   * surrounding chrome — notably a promo banner with its own "Close" dismiss
+   * control — cannot make a locator ambiguous. */
+  private main(): Locator {
+    return this.page.getByTestId(CASE_DETAIL.mainTestId);
+  }
+
+  /** The "Close" action button. Present while the case is open; once closed the
+   * action row swaps it for "Open Related Case". */
+  closeButton(): Locator {
+    return this.main().getByRole("button", {
+      name: CASE_DETAIL.closeButton,
+      exact: true,
+    });
+  }
+
+  confirmDialog(): Locator {
+    return this.page.getByRole("dialog");
+  }
+
+  confirmButton(): Locator {
+    return this.confirmDialog().getByRole("button", {
+      name: CASE_DETAIL.confirmDialog.confirmButton,
+      exact: true,
+    });
+  }
+
+  /** Any element rendering the closed-status text — the header chip. */
+  closedStatusChip(): Locator {
+    return this.main()
+      .getByText(CASE_DETAIL.closedStatus, { exact: true })
+      .first();
+  }
+
+  /**
+   * Clicks "Close" and confirms the dialog, then waits for the PATCH to
+   * succeed.
+   *
+   * The button stays disabled until the case-states metadata resolves (the
+   * action needs a state key to patch with), so this waits for it to be
+   * enabled rather than clicking into a no-op.
+   *
+   * @returns The successful PATCH response for the caller to assert on.
+   */
+  async closeCase(): Promise<import("@playwright/test").Response> {
+    await expect(this.closeButton()).toBeEnabled();
+    await this.closeButton().click();
+
+    // Closing is confirmation-gated; the dialog must appear before confirming.
+    await expect(this.confirmDialog()).toBeVisible();
+    await expect(
+      this.page.getByText(CASE_DETAIL.confirmDialog.title),
+    ).toBeVisible();
+
+    const [response] = await Promise.all([
+      this.page.waitForResponse(
+        (r) =>
+          r.url().includes("/cases/") &&
+          r.request().method() === "PATCH" &&
+          r.status() < 400,
+      ),
+      this.confirmButton().click(),
+    ]);
+    return response;
+  }
+}

--- a/apps/customer-portal/webapp/tests/e2e/pages/ServiceRequestCreatePage.ts
+++ b/apps/customer-portal/webapp/tests/e2e/pages/ServiceRequestCreatePage.ts
@@ -23,6 +23,11 @@ import {
   GET_HELP_MENU,
 } from "../utils/selectors";
 
+/** How long to allow for the project dashboard's header to finish loading.
+ * Well above the 5s default expect timeout, because the header is skeletonised
+ * until the projects list resolves. */
+const DASHBOARD_LOAD_TIMEOUT_MS = 60_000;
+
 /**
  * Page object for the create-service-request form at
  * `/projects/:projectId/support/service-requests/create`
@@ -56,11 +61,14 @@ export class ServiceRequestCreatePage {
    */
   async openViaGetHelpMenu(projectId: string): Promise<void> {
     await this.page.goto(`/projects/${projectId}/dashboard`);
-    // The header renders skeletons until the projects list resolves; waiting on
-    // the primary button confirms the real split button is mounted.
+    // The header renders skeletons until the projects list resolves, which on a
+    // cold dashboard load can exceed the 5s default expect timeout — observed
+    // failing here when this spec ran last in a full-suite run. The wait is for
+    // the real split button to replace the skeleton, so it needs the longer
+    // budget rather than the default.
     await expect(
       this.page.getByRole("button", { name: GET_HELP_BUTTON, exact: true }),
-    ).toBeVisible();
+    ).toBeVisible({ timeout: DASHBOARD_LOAD_TIMEOUT_MS });
 
     await this.page
       .getByRole("button", { name: GET_HELP_MENU.trigger })

--- a/apps/customer-portal/webapp/tests/e2e/pages/ServiceRequestCreatePage.ts
+++ b/apps/customer-portal/webapp/tests/e2e/pages/ServiceRequestCreatePage.ts
@@ -1,0 +1,205 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { type Locator, type Page, expect } from "@playwright/test";
+import {
+  CASE_DETAIL,
+  CREATE_CASE,
+  CREATE_SERVICE_REQUEST,
+  GET_HELP_BUTTON,
+  GET_HELP_MENU,
+} from "../utils/selectors";
+
+/**
+ * Page object for the create-service-request form at
+ * `/projects/:projectId/support/service-requests/create`
+ * (`CreateServiceRequestPage.tsx`).
+ *
+ * Deployment and Product reuse the same placeholder-matched MUI Selects as the
+ * case form. The Request Details fields are different in kind: they are built
+ * from the chosen catalog item's ServiceNow variables, so their ids are
+ * React-generated (`_r_16_`) and change between renders, and their labels are
+ * sibling `<span>`s rather than `<label for>`. They are therefore addressed
+ * structurally — see `requestDetailsInput()`.
+ */
+export class ServiceRequestCreatePage {
+  constructor(private readonly page: Page) {}
+
+  /** The app's <main> region — scoping everything to it keeps the surrounding
+   * chrome (global search, promo banner) out of the locators. */
+  private main(): Locator {
+    return this.page.getByTestId(CASE_DETAIL.mainTestId);
+  }
+
+  /**
+   * Opens the project dashboard and starts a service request from the "Get
+   * Help" split button's dropdown, then waits for the form.
+   *
+   * The Service Request item only appears when the project has service-request
+   * read access (`isServiceRequestVisible` in GetHelpDropdown.tsx), so a
+   * project without it fails here rather than somewhere more obscure.
+   *
+   * @param projectId - Project to raise the request under.
+   */
+  async openViaGetHelpMenu(projectId: string): Promise<void> {
+    await this.page.goto(`/projects/${projectId}/dashboard`);
+    // The header renders skeletons until the projects list resolves; waiting on
+    // the primary button confirms the real split button is mounted.
+    await expect(
+      this.page.getByRole("button", { name: GET_HELP_BUTTON, exact: true }),
+    ).toBeVisible();
+
+    await this.page
+      .getByRole("button", { name: GET_HELP_MENU.trigger })
+      .click();
+    const menu = this.page.getByRole("menu");
+    await expect(menu).toBeVisible();
+    await menu
+      .getByRole("menuitem")
+      .filter({ hasText: GET_HELP_MENU.items.serviceRequest })
+      .click();
+
+    await expect(this.page).toHaveURL(
+      new RegExp(`/projects/${projectId}/support/service-requests/create`),
+    );
+    await expect(this.deploymentSelect()).toBeVisible();
+  }
+
+  deploymentSelect(): Locator {
+    return this.page
+      .getByRole("combobox")
+      .filter({ hasText: CREATE_CASE.placeholders.deployment });
+  }
+
+  productVersionSelect(): Locator {
+    return this.page
+      .getByRole("combobox")
+      .filter({ hasText: CREATE_CASE.placeholders.productVersion });
+  }
+
+  /** Accordion header for a request-type catalog, e.g. "Generic Requests". */
+  catalogAccordion(name: string): Locator {
+    return this.main().getByRole("button").filter({ hasText: name });
+  }
+
+  /** A catalog item's radio. Rendered as role="radio" by CatalogSelector. */
+  catalogItemRadio(name: string): Locator {
+    return this.main().getByRole("radio", { name });
+  }
+
+  /**
+   * The single-line Request Details input.
+   *
+   * The catalog item's variables carry no stable id, test id, or associated
+   * label, so this selects on the one structural fact that holds: within
+   * <main> it is the only control that is both exposed as a textbox and
+   * enabled. Verified live — of the elements in <main>:
+   *   - the Project field is a textbox but disabled;
+   *   - the description editor is a contenteditable div, not an input;
+   *   - the Deployment/Product Selects render enabled `MuiSelect-nativeInput`
+   *     inputs, but they are aria-hidden so carry no textbox role.
+   * Matching on `input:enabled` alone picks up those hidden Select inputs (5
+   * matches), which is why the role is part of the locator rather than a
+   * bare CSS selector.
+   *
+   * `fillRequestDetails` asserts the count is exactly one, so a catalog item
+   * with extra variables fails loudly instead of typing into the wrong box.
+   */
+  requestDetailsInput(): Locator {
+    return this.main().getByRole("textbox").and(this.page.locator(":enabled"));
+  }
+
+  /** Lexical rich-text description editor — a contenteditable, not an input. */
+  descriptionEditor(): Locator {
+    return this.main().getByTestId(CREATE_SERVICE_REQUEST.testIds.description);
+  }
+
+  submitButton(): Locator {
+    return this.page.getByRole("button", {
+      name: CREATE_SERVICE_REQUEST.submitButton,
+    });
+  }
+
+  async selectDeployment(name: string): Promise<void> {
+    await this.deploymentSelect().click();
+    await this.page.getByRole("option", { name, exact: true }).click();
+  }
+
+  /**
+   * Selects a product. Waits for the control to become enabled first — options
+   * are fetched per-deployment, so it is disabled immediately after one is
+   * chosen.
+   *
+   * @param name - Exact product option label.
+   */
+  async selectProductVersion(name: string): Promise<void> {
+    const select = this.productVersionSelect();
+    await expect(select).toBeEnabled();
+    await select.click();
+    await this.page.getByRole("option", { name, exact: true }).click();
+  }
+
+  /**
+   * Expands a catalog and picks one of its items.
+   *
+   * @param catalog - Catalog accordion name.
+   * @param item - Radio item name within it.
+   */
+  async selectRequestType(catalog: string, item: string): Promise<void> {
+    await expect(
+      this.main().getByText(CREATE_SERVICE_REQUEST.requestTypeHeading).first(),
+    ).toBeVisible();
+    await this.catalogAccordion(catalog).click();
+
+    const radio = this.catalogItemRadio(item);
+    await radio.click();
+    await expect(radio).toHaveAttribute("aria-checked", "true");
+
+    // Selecting an item loads its variables, which is what renders the section
+    // the next steps type into.
+    await expect(
+      this.main()
+        .getByRole("heading", { name: CREATE_SERVICE_REQUEST.detailsHeading })
+        .first(),
+    ).toBeVisible();
+  }
+
+  async fillRequestDetails(text: string): Promise<void> {
+    const input = this.requestDetailsInput();
+    await expect(
+      input,
+      "expected exactly one enabled text input in the Request Details section",
+    ).toHaveCount(1);
+    await input.fill(text);
+  }
+
+  /**
+   * Types into the Lexical description editor. It is a contenteditable, so
+   * `fill()` does not apply — the text is typed so Lexical's key handling
+   * builds the editor state the form reads.
+   *
+   * @param text - Description body.
+   */
+  async fillDescription(text: string): Promise<void> {
+    const editor = this.descriptionEditor();
+    await editor.click();
+    await editor.pressSequentially(text);
+  }
+
+  async submit(): Promise<void> {
+    await this.submitButton().click();
+  }
+}

--- a/apps/customer-portal/webapp/tests/e2e/pages/ServiceRequestCreatePage.ts
+++ b/apps/customer-portal/webapp/tests/e2e/pages/ServiceRequestCreatePage.ts
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { type Locator, type Page, expect } from "@playwright/test";
+import { type Locator, type Page, expect } from "../fixtures/test";
 import {
   CASE_DETAIL,
   CREATE_CASE,

--- a/apps/customer-portal/webapp/tests/e2e/specs/operations/create-service-request.spec.ts
+++ b/apps/customer-portal/webapp/tests/e2e/specs/operations/create-service-request.spec.ts
@@ -1,0 +1,107 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//
+// Raises a service request from the "Get Help" split button's dropdown.
+//
+// Scoped to the Managed Cloud Subscription project: the Service Request menu
+// item only appears when the project has service-request access
+// (`isServiceRequestVisible` in GetHelpDropdown.tsx), which is a per-project
+// feature flag rather than something every type has.
+//
+// ⚠️ Writes to a REAL backend and leaves a permanent service request on every
+// run — there is no delete counterpart. The configured description is
+// deliberately self-describing so the records stay identifiable.
+//
+
+import { test, expect, withSession } from "../../fixtures/test";
+import { ServiceRequestCreatePage } from "../../pages/ServiceRequestCreatePage";
+import {
+  PROJECTS,
+  ProjectType,
+  SERVICE_REQUEST_INPUT,
+} from "../../config/testData";
+import { skipWhenUnconfigured } from "../../utils/caseFlows";
+import { CREATE_SERVICE_REQUEST } from "../../utils/selectors";
+
+withSession(test);
+
+test.describe("Service Request", () => {
+  // Spans a dashboard load, a menu navigation, two backend-populated dropdowns,
+  // a catalog fetch and a variables fetch; the 30s default is not enough.
+  test.describe.configure({ timeout: 180_000 });
+
+  const project = PROJECTS[ProjectType.MANAGED_CLOUD_SUBSCRIPTION];
+
+  test(`${ProjectType.MANAGED_CLOUD_SUBSCRIPTION} — creates a generic request`, async ({
+    page,
+  }) => {
+    skipWhenUnconfigured(project);
+
+    const serviceRequest = new ServiceRequestCreatePage(page);
+
+    await serviceRequest.openViaGetHelpMenu(project.id);
+
+    await serviceRequest.selectDeployment(project.deployment);
+    await serviceRequest.selectProductVersion(project.productVersion);
+    await serviceRequest.selectRequestType(
+      SERVICE_REQUEST_INPUT.catalog,
+      SERVICE_REQUEST_INPUT.catalogItem,
+    );
+    await serviceRequest.fillRequestDetails(SERVICE_REQUEST_INPUT.requestDetails);
+    await serviceRequest.fillDescription(SERVICE_REQUEST_INPUT.description);
+
+    await expect(serviceRequest.submitButton()).toBeEnabled();
+
+    // Capture the created request from the response so the assertions below
+    // prove the backend accepted it, not just that the UI moved on.
+    //
+    // Note the endpoint is POST /cases, not /service-requests: a service
+    // request is a case carrying `requestType: "service_request"` (see
+    // usePostCase.ts). Only the detail URL it redirects to is SR-specific.
+    const [createResponse] = await Promise.all([
+      page.waitForResponse(
+        (r) =>
+          r.url().includes("/cases") &&
+          r.request().method() === "POST" &&
+          r.status() < 400,
+      ),
+      serviceRequest.submit(),
+    ]);
+
+    const created = (await createResponse.json()) as {
+      id?: string;
+      number?: string;
+    };
+    expect(created.id, "backend returned no service request id").toBeTruthy();
+
+    // On success the page routes to the new request's detail page and shows a
+    // banner naming it.
+    await expect(page).toHaveURL(
+      new RegExp(
+        `/projects/${project.id}/.*${CREATE_SERVICE_REQUEST.detailPathSegment}/${created.id}`,
+      ),
+    );
+    await expect(
+      page.getByText(CREATE_SERVICE_REQUEST.successMessage),
+    ).toBeVisible();
+
+    console.log(
+      `Created service request (${ProjectType.MANAGED_CLOUD_SUBSCRIPTION}): ` +
+        `${created.number ?? created.id}`,
+    );
+  });
+});

--- a/apps/customer-portal/webapp/tests/e2e/specs/operations/create-service-request.spec.ts
+++ b/apps/customer-portal/webapp/tests/e2e/specs/operations/create-service-request.spec.ts
@@ -34,7 +34,7 @@ import {
   ProjectType,
   SERVICE_REQUEST_INPUT,
 } from "../../config/testData";
-import { skipWhenUnconfigured } from "../../utils/caseFlows";
+import { isSuccess, skipWhenUnconfigured } from "../../utils/caseFlows";
 import { CREATE_SERVICE_REQUEST } from "../../utils/selectors";
 
 withSession(test);
@@ -77,7 +77,7 @@ test.describe("Service Request", () => {
         (r) =>
           r.url().includes("/cases") &&
           r.request().method() === "POST" &&
-          r.status() < 400,
+          isSuccess(r.status()),
       ),
       serviceRequest.submit(),
     ]);

--- a/apps/customer-portal/webapp/tests/e2e/specs/support/close-case.spec.ts
+++ b/apps/customer-portal/webapp/tests/e2e/specs/support/close-case.spec.ts
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//
+// Closes a support case from its detail page.
+//
+// The case is created by the test rather than picked from the project's
+// existing cases: closing is destructive and irreversible from the portal, so
+// the test must only ever act on a record it owns. Creation lands on
+// `/projects/:projectId/support/cases/:caseId`, which is where the Close action
+// lives.
+//
+// Scoped to the Subscription project. Closing is not project-type specific, but
+// exercising it on one project keeps the number of permanent records these
+// specs leave behind to a minimum.
+//
+// "Close" is the present-tense rendering of the `Closed` action that
+// `getAvailableCaseActions` offers for an open case, and it is
+// confirmation-gated — see CaseStateConfirmDialog.
+//
+
+import { test, expect, withSession } from "../../fixtures/test";
+import { CaseDetailPage } from "../../pages/CaseDetailPage";
+import { CASE_INPUT, PROJECTS, ProjectType } from "../../config/testData";
+import {
+  createCaseViaGetHelp,
+  skipWhenUnconfigured,
+} from "../../utils/caseFlows";
+import { CASE_DETAIL } from "../../utils/selectors";
+
+withSession(test);
+
+test.describe("Close Case", () => {
+  // Creates a case first, so this needs the create flow's budget on top of its
+  // own.
+  test.describe.configure({ timeout: 180_000 });
+
+  const project = PROJECTS[ProjectType.SUBSCRIPTION];
+  const caseInput = CASE_INPUT[ProjectType.SUBSCRIPTION];
+
+  test(`${ProjectType.SUBSCRIPTION} — closes a newly created case`, async ({
+    page,
+  }) => {
+    skipWhenUnconfigured(project);
+
+    const created = await createCaseViaGetHelp(page, project, caseInput);
+    console.log(
+      `Created case to close (${ProjectType.SUBSCRIPTION}): ` +
+        `${created.number ?? created.id}`,
+    );
+
+    // Creation must have landed on the case detail page — that is where the
+    // Close action lives, and the rest of this test depends on it.
+    await expect(page).toHaveURL(new RegExp(CASE_DETAIL.pathSegment));
+
+    const caseDetail = new CaseDetailPage(page);
+    await caseDetail.closeCase();
+
+    // The action row rebuilds from the new status: an open case offers "Close",
+    // a closed one does not (it offers "Open Related Case" instead), so the
+    // button disappearing is the UI's own confirmation that the state changed.
+    await expect(caseDetail.closeButton()).toBeHidden();
+    await expect(caseDetail.closedStatusChip()).toBeVisible();
+
+    console.log(`Closed case: ${created.number ?? created.id}`);
+  });
+});

--- a/apps/customer-portal/webapp/tests/e2e/specs/support/create-case-validation.spec.ts
+++ b/apps/customer-portal/webapp/tests/e2e/specs/support/create-case-validation.spec.ts
@@ -1,0 +1,182 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//
+// Edge cases and field gating on the create-case form, across all three project
+// types.
+//
+// ✅ Unlike the happy-path suite, NOTHING HERE CREATES A RECORD. Every scenario
+// is either read-only or is rejected by `handleSubmit` before a request is made
+// (see CreateCasePage.tsx — it returns early on an empty title, an over-long
+// title, and an empty description). That makes this suite safe to run
+// repeatedly, which the creation suite is not.
+//
+// Each test asserts the form stayed put afterwards, so a validation rule that
+// silently stopped working would surface as an unexpected navigation rather
+// than as a passing test plus a stray case in staging.
+//
+
+import { test, expect, withSession } from "../../fixtures/test";
+import { CaseCreatePage } from "../../pages/CaseCreatePage";
+import { CASE_INPUT, PROJECTS, ProjectType } from "../../config/testData";
+import { skipWhenUnconfigured } from "../../utils/caseFlows";
+import { CREATE_CASE } from "../../utils/selectors";
+
+withSession(test);
+
+test.describe("Create Case — validation", () => {
+  // Each test loads the form, which waits on project details, features and
+  // filters; the 30s default is not enough for a cold navigation.
+  test.describe.configure({ timeout: 120_000 });
+
+  for (const projectType of Object.values(ProjectType)) {
+    const project = PROJECTS[projectType];
+    const caseInput = CASE_INPUT[projectType];
+
+    test.describe(projectType, () => {
+      test("rejects submit when the title is empty", async ({ page }) => {
+        skipWhenUnconfigured(project);
+        const form = new CaseCreatePage(page);
+        await form.openViaGetHelp(project.id);
+        await form.fillBasicInformation(project.deployment, project.productVersion);
+        await form.fillDescription(caseInput.description);
+        await form.selectIssueType(caseInput.issueType);
+        await form.selectSeverity(caseInput.severity);
+
+        await form.attemptSubmit();
+
+        await expect(form.errorAlert()).toContainText(
+          CREATE_CASE.validationErrors.missingTitle,
+        );
+        // Still on the form: no case was created.
+        await expect(page).toHaveURL(/create-case/);
+      });
+
+      test("rejects submit when the description is empty", async ({ page }) => {
+        skipWhenUnconfigured(project);
+        const form = new CaseCreatePage(page);
+        await form.openViaGetHelp(project.id);
+        await form.fillBasicInformation(project.deployment, project.productVersion);
+        await form.fillTitle(caseInput.title);
+        await form.selectIssueType(caseInput.issueType);
+        await form.selectSeverity(caseInput.severity);
+
+        await form.attemptSubmit();
+
+        await expect(form.errorAlert()).toContainText(
+          CREATE_CASE.validationErrors.missingDescription,
+        );
+        await expect(page).toHaveURL(/create-case/);
+      });
+
+      test("rejects a title longer than 160 characters", async ({ page }) => {
+        skipWhenUnconfigured(project);
+        const form = new CaseCreatePage(page);
+        await form.openViaGetHelp(project.id);
+        await form.fillBasicInformation(project.deployment, project.productVersion);
+
+        const overLimit = "x".repeat(CREATE_CASE.titleMaxLength + 1);
+        await form.fillTitle(overLimit);
+        await form.fillDescription(caseInput.description);
+        await form.selectIssueType(caseInput.issueType);
+        await form.selectSeverity(caseInput.severity);
+
+        // The field flags it, and handleSubmit refuses to send — note it does so
+        // silently, with no error banner, which is why the URL is the assertion
+        // that the submit was actually blocked.
+        await expect(form.titleLengthError()).toBeVisible();
+        await expect(form.titleCounter()).toHaveText(
+          `${CREATE_CASE.titleMaxLength + 1}/${CREATE_CASE.titleMaxLength}`,
+        );
+
+        await form.attemptSubmit();
+        await expect(page).toHaveURL(/create-case/);
+      });
+
+      test("accepts a title of exactly 160 characters", async ({ page }) => {
+        skipWhenUnconfigured(project);
+        const form = new CaseCreatePage(page);
+        await form.openViaGetHelp(project.id);
+        await form.fillTitle("x".repeat(CREATE_CASE.titleMaxLength));
+
+        // Boundary: 160 is allowed, 161 is not. Deliberately not submitted —
+        // that would create a record; the field-level state is the assertion.
+        await expect(form.titleLengthError()).toBeHidden();
+        await expect(form.titleCounter()).toHaveText(
+          `${CREATE_CASE.titleMaxLength}/${CREATE_CASE.titleMaxLength}`,
+        );
+      });
+
+      test("offers the severity this project is configured for", async ({
+        page,
+      }) => {
+        skipWhenUnconfigured(project);
+        const form = new CaseCreatePage(page);
+        await form.openViaGetHelp(project.id);
+        await form.fillBasicInformation(project.deployment, project.productVersion);
+
+        // Severity options come from the project's acceptedSeverityValues, so
+        // the set differs per project. Asserting the configured one is present
+        // is the check that holds for every type.
+        await form.severitySelect().click();
+        await expect(
+          page.getByRole("option", { name: caseInput.severity, exact: true }),
+        ).toBeVisible();
+      });
+
+      if (project.autoSelectsDeployment) {
+        test("hides the deployment field and still allows submit", async ({
+          page,
+        }) => {
+          skipWhenUnconfigured(project);
+          const form = new CaseCreatePage(page);
+          await form.openViaGetHelp(project.id);
+
+          // Cloud Support locks the deployment to primary production, so the
+          // field is absent and the submit button is not gated on choosing one.
+          await expect(form.deploymentSelect()).toBeHidden();
+          await expect(form.submitButton()).toBeEnabled();
+        });
+      } else {
+        test("gates product selection on choosing a deployment", async ({
+          page,
+        }) => {
+          skipWhenUnconfigured(project);
+          const form = new CaseCreatePage(page);
+          await form.openViaGetHelp(project.id);
+
+          // Product options are fetched per deployment, so the field reads
+          // "Select deployment first" and stays disabled until one is picked.
+          await expect(form.productVersionSelect()).toBeDisabled();
+          await form.selectDeployment(project.deployment);
+          await expect(form.productVersionSelect()).toBeEnabled();
+        });
+
+        test("keeps submit disabled until a deployment is chosen", async ({
+          page,
+        }) => {
+          skipWhenUnconfigured(project);
+          const form = new CaseCreatePage(page);
+          await form.openViaGetHelp(project.id);
+
+          await expect(form.submitButton()).toBeDisabled();
+          await form.selectDeployment(project.deployment);
+          await expect(form.submitButton()).toBeEnabled();
+        });
+      }
+    });
+  }
+});

--- a/apps/customer-portal/webapp/tests/e2e/specs/support/create-case.spec.ts
+++ b/apps/customer-portal/webapp/tests/e2e/specs/support/create-case.spec.ts
@@ -1,0 +1,89 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//
+// Creates a support case through the header's "Get Help" button: once per
+// project type, plus the remaining severity levels on the Subscription project.
+// The project, deployment, product version and case content all come from
+// ../config/testData.ts — a type whose fixture is not fully filled in skips
+// with a message naming the missing fields, rather than failing.
+//
+// ⚠️ These tests write to a REAL backend. `POST /cases` has no delete
+// counterpart, so every test leaves a permanent case on the target environment
+// (staging by default). The configured descriptions are deliberately
+// self-describing so the records stay identifiable.
+//
+// The "Get Help" primary button reaches this form directly only when the
+// project's Novera AI agent is disabled; with it enabled the same button opens
+// the describe-issue chat page instead (see handleIssue in
+// GetHelpDropdown.tsx). The page object asserts the resulting URL so that
+// divergence surfaces clearly instead of as a missing-field error.
+//
+
+import { test, withSession } from "../../fixtures/test";
+import {
+  CASE_INPUT,
+  PROJECTS,
+  ProjectType,
+  SUBSCRIPTION_SEVERITY_CASES,
+} from "../../config/testData";
+import {
+  createCaseViaGetHelp,
+  skipWhenUnconfigured,
+} from "../../utils/caseFlows";
+
+withSession(test);
+
+test.describe("Create Case", () => {
+  // Each case spans a project-dashboard load, a route change, and four
+  // backend-populated dropdowns against a shared staging environment; the
+  // 30s default is not enough for the cold first navigation. Set on the suite
+  // so every case added here inherits it.
+  test.describe.configure({ timeout: 120_000 });
+
+  for (const projectType of Object.values(ProjectType)) {
+    const project = PROJECTS[projectType];
+    const caseInput = CASE_INPUT[projectType];
+
+    test(`${projectType} — via Get Help`, async ({ page }) => {
+      skipWhenUnconfigured(project);
+      const created = await createCaseViaGetHelp(page, project, caseInput);
+      // Surfaced in the run output so the permanent record this test created is
+      // traceable without digging through the HTML report.
+      console.log(
+        `Created case (${projectType}): ${created.number ?? created.id}`,
+      );
+    });
+  }
+
+  // Severity coverage beyond the S4 default, on the Subscription project only.
+  // Which levels a project offers depends on its `acceptedSeverityValues`, so
+  // this deliberately targets one project rather than every type.
+  const subscription = PROJECTS[ProjectType.SUBSCRIPTION];
+
+  for (const caseInput of SUBSCRIPTION_SEVERITY_CASES) {
+    test(`${ProjectType.SUBSCRIPTION} — severity ${caseInput.severity}`, async ({
+      page,
+    }) => {
+      skipWhenUnconfigured(subscription);
+      const created = await createCaseViaGetHelp(page, subscription, caseInput);
+      console.log(
+        `Created case (${ProjectType.SUBSCRIPTION}, ${caseInput.severity}): ` +
+          `${created.number ?? created.id}`,
+      );
+    });
+  }
+});

--- a/apps/customer-portal/webapp/tests/e2e/utils/caseFlows.ts
+++ b/apps/customer-portal/webapp/tests/e2e/utils/caseFlows.ts
@@ -1,0 +1,125 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//
+// Multi-step case flows shared by more than one spec. These sit above the page
+// objects: they drive a whole user journey and assert it succeeded, so a spec
+// that merely needs a case to exist can call one instead of restating every
+// step.
+//
+
+import { expect, test, type Page } from "@playwright/test";
+import { CaseCreatePage } from "../pages/CaseCreatePage";
+import type { CaseInput, ProjectFixture } from "../config/testData";
+import { CREATE_CASE } from "./selectors";
+
+/** A case as identified by the API response that created it. */
+export interface CreatedCase {
+  id?: string;
+  number?: string;
+}
+
+/** Fixture fields a create-case run cannot proceed without. `deployment` is
+ * required only when the form actually offers the field — types that
+ * auto-select it legitimately leave it empty. */
+export function missingFields(project: ProjectFixture): string[] {
+  const required: (keyof ProjectFixture)[] = ["id", "productVersion"];
+  if (!project.autoSelectsDeployment) required.push("deployment");
+  return required.filter((field) => !project[field]);
+}
+
+/**
+ * Skips the current test when the project's fixture is incomplete. Without
+ * this a run would navigate to /projects//dashboard, or try to pick an option
+ * labelled "", and fail with a confusing element-not-found error rather than
+ * naming the missing configuration.
+ *
+ * @param project - Fixture to validate.
+ */
+export function skipWhenUnconfigured(project: ProjectFixture): void {
+  const missing = missingFields(project);
+  test.skip(
+    missing.length > 0,
+    `${project.type} fixture is missing ${missing.join(", ")}. ` +
+      `Fill it in tests/e2e/config/testData.ts.`,
+  );
+}
+
+/**
+ * Runs the whole create-case flow from the "Get Help" button and asserts the
+ * case was really created.
+ *
+ * ⚠️ Creates a permanent record — `POST /cases` has no delete counterpart.
+ *
+ * @param page - Test page.
+ * @param project - Project to create the case under.
+ * @param caseInput - Case content to submit.
+ * @returns The created case's id and number, straight from the API response.
+ */
+export async function createCaseViaGetHelp(
+  page: Page,
+  project: ProjectFixture,
+  caseInput: CaseInput,
+): Promise<CreatedCase> {
+  const createCase = new CaseCreatePage(page);
+
+  await createCase.openViaGetHelp(project.id);
+
+  if (project.autoSelectsDeployment) {
+    // The form must hide Deployment entirely for this project type and lock it
+    // to primary production; asserting it stays hidden is the point, since a
+    // regression here would silently widen deployment choice.
+    await expect(createCase.deploymentSelect()).toBeHidden();
+  } else {
+    await createCase.selectDeployment(project.deployment);
+  }
+  await createCase.selectProductVersion(project.productVersion);
+  await createCase.fillTitle(caseInput.title);
+  await createCase.fillDescription(caseInput.description);
+  await createCase.selectIssueType(caseInput.issueType);
+  await createCase.selectSeverity(caseInput.severity);
+
+  await expect(createCase.submitButton()).toBeEnabled();
+
+  // Capture the created case's id from the response so the assertions below
+  // prove the backend accepted the case, not just that the UI moved on.
+  const [createResponse] = await Promise.all([
+    page.waitForResponse(
+      (r) =>
+        r.url().includes("/cases") &&
+        r.request().method() === "POST" &&
+        r.status() < 400,
+    ),
+    createCase.submit(),
+  ]);
+
+  const created = (await createResponse.json()) as CreatedCase;
+  expect(created.id, "backend returned no case id").toBeTruthy();
+
+  // On success CreateCasePage shows a banner and routes to the new case's
+  // detail page (`/projects/:projectId/support/cases/:caseId`).
+  await expect(page.getByText(CREATE_CASE.successMessage)).toBeVisible();
+  await expect(page).toHaveURL(
+    new RegExp(`/projects/${project.id}/support/cases/${created.id}`),
+  );
+
+  // The detail page must render the case we just submitted.
+  await expect(
+    page.getByText(caseInput.title, { exact: false }).first(),
+  ).toBeVisible();
+
+  return created;
+}

--- a/apps/customer-portal/webapp/tests/e2e/utils/caseFlows.ts
+++ b/apps/customer-portal/webapp/tests/e2e/utils/caseFlows.ts
@@ -32,6 +32,19 @@ export interface CreatedCase {
   number?: string;
 }
 
+/**
+ * Whether a response status means the mutation actually succeeded.
+ *
+ * Deliberately 2xx-only rather than `< 400`: a 3xx is not a completed write, and
+ * matching one would hand the caller a redirect to parse as JSON.
+ *
+ * @param status - HTTP status code.
+ * @returns True for 200-299.
+ */
+export function isSuccess(status: number): boolean {
+  return status >= 200 && status < 300;
+}
+
 /** Fixture fields a create-case run cannot proceed without. `deployment` is
  * required only when the form actually offers the field — types that
  * auto-select it legitimately leave it empty. */
@@ -101,7 +114,7 @@ export async function createCaseViaGetHelp(
       (r) =>
         r.url().includes("/cases") &&
         r.request().method() === "POST" &&
-        r.status() < 400,
+        isSuccess(r.status()),
     ),
     createCase.submit(),
   ]);

--- a/apps/customer-portal/webapp/tests/e2e/utils/caseFlows.ts
+++ b/apps/customer-portal/webapp/tests/e2e/utils/caseFlows.ts
@@ -21,7 +21,7 @@
 // step.
 //
 
-import { expect, test, type Page } from "@playwright/test";
+import { expect, test, type Page } from "../fixtures/test";
 import { CaseCreatePage } from "../pages/CaseCreatePage";
 import type { CaseInput, ProjectFixture } from "../config/testData";
 import { CREATE_CASE } from "./selectors";

--- a/apps/customer-portal/webapp/tests/e2e/utils/selectors.ts
+++ b/apps/customer-portal/webapp/tests/e2e/utils/selectors.ts
@@ -1,0 +1,108 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//
+// How the UI is addressed: accessible names, element ids, and test ids.
+// Environment-specific data (project ids, form values) lives in
+// `../config/testData.ts`.
+//
+
+/** Accessible name of the header control that starts the issue/case flow.
+ * Rendered by GetHelpDropdown as a split button: this is the primary half
+ * (aria-label="Get Help"), which goes straight to the flow. The other half
+ * ("More help options") opens the Issue / Service Request / Security Report
+ * menu. */
+export const GET_HELP_BUTTON = "Get Help";
+
+/** Case-creation form. Its field labels are sibling <Typography> nodes rather
+ * than real <label for>, so `getByLabel` does not work here — the MUI Selects
+ * are located by the placeholder text their `renderValue` emits, and the
+ * inputs by their stable ids. */
+export const CREATE_CASE = {
+  heading: "Complete Case Details",
+  submitButton: "Create Support Case",
+  successMessage: "Case created successfully",
+  placeholders: {
+    deployment: "Select Deployment...",
+    /** Reads "Select deployment first" until a deployment is chosen, and
+     * "Select Product..." on Cloud Support projects. */
+    productVersion: /Select Product Version|Select Product|Select deployment first/,
+  },
+  ids: {
+    title: "#title",
+    issueType: "#issue-type-select",
+    severity: "#severity-level-select",
+  },
+  testIds: {
+    /** Lexical rich-text editor — a contenteditable, not an <input>. */
+    description: "case-description-editor",
+  },
+} as const;
+
+/** Get Help dropdown menu items (the arrow half of the split button). */
+export const GET_HELP_MENU = {
+  trigger: "More help options",
+  items: {
+    issue: "Issue",
+    serviceRequest: "Service Request",
+    securityReport: "Security Report",
+  },
+} as const;
+
+/** Create-service-request form
+ * (`/projects/:projectId/support/service-requests/create`).
+ *
+ * Deployment and Product reuse the same controls as the case form. The Request
+ * Details fields below are rendered from the selected catalog item's ServiceNow
+ * variables (VariableFormFields.tsx), so they have no stable ids and no
+ * `<label for>` — see ServiceRequestCreatePage for how they are addressed. */
+export const CREATE_SERVICE_REQUEST = {
+  heading: "New Service Request",
+  requestTypeHeading: "Select Request Type",
+  detailsHeading: "Request Details",
+  submitButton: "Create Service Request",
+  successMessage: /Service request .*created successfully/,
+  /** URL segment a created service request's detail page carries. */
+  detailPathSegment: "service-requests",
+  testIds: {
+    /** The shared rich-text Editor hardcodes this id, so the description field
+     * carries the same test id here as on the case form. */
+    description: "case-description-editor",
+  },
+} as const;
+
+/** Case detail page (`/projects/:projectId/support/cases/:caseId`).
+ *
+ * The state-change buttons come from `getAvailableCaseActions(status)`: an open
+ * case offers the "Closed" action, rendered in present tense as "Close" by
+ * `toPresentTenseActionLabel`. Clicking it opens a confirmation dialog rather
+ * than closing outright. */
+export const CASE_DETAIL = {
+  /** URL segment every case detail page carries. */
+  pathSegment: "support/cases",
+  /** The app's <main> region (AppShellLayout). Actions must be scoped to it:
+   * the promo banner outside it renders its own dismiss control also named
+   * "Close", which otherwise makes the locator ambiguous. */
+  mainTestId: "app-main",
+  closeButton: "Close",
+  /** Status shown in the header chip once the case is closed. */
+  closedStatus: "Closed",
+  confirmDialog: {
+    title: "Confirm State Change",
+    confirmButton: "Confirm",
+    cancelButton: "Cancel",
+  },
+} as const;

--- a/apps/customer-portal/webapp/tests/e2e/utils/selectors.ts
+++ b/apps/customer-portal/webapp/tests/e2e/utils/selectors.ts
@@ -35,6 +35,16 @@ export const CREATE_CASE = {
   heading: "Complete Case Details",
   submitButton: "Create Support Case",
   successMessage: "Case created successfully",
+  /** Maximum title length enforced by CreateCasePage's handleSubmit and shown
+   * by the Title field's counter. */
+  titleMaxLength: 160,
+  titleCounter: /^\d+\/160$/,
+  titleTooLongError: "Title must be 160 characters or fewer.",
+  /** Banner messages from `showError` when submit validation rejects. */
+  validationErrors: {
+    missingTitle: "Please enter a case title.",
+    missingDescription: "Please enter a description.",
+  },
   placeholders: {
     deployment: "Select Deployment...",
     /** Reads "Select deployment first" until a deployment is chosen, and


### PR DESCRIPTION
### What

Adds Playwright end-to-end coverage for the two main customer-facing creation
flows, on top of the scaffolding merged earlier. **8 tests across 3 suites**,
all verified green against staging.

| Suite | Tests | Covers |
|---|---|---|
| `Create Case` | 6 | One per project type (Subscription, Managed Cloud Subscription, Cloud Support), plus S1/S2/S3 severities on Subscription |
| `Close Case` | 1 | Creates a case, then closes it via the confirmation dialog |
| `Service Request` | 1 | Raises a Generic Request from the Get Help dropdown |

### Structure

Test data is fully separated from test logic:

- `tests/e2e/config/testData.ts` — **master config, values only.** Project
  fixtures per type (id, deployment, product), severity and issue-type
  vocabularies, and per-flow input. Repointing the suite at another tenant means
  editing this file and nothing else.
- `tests/e2e/pages/` — page objects (locators + actions, no behavioural
  assertions)
- `tests/e2e/utils/selectors.ts` — how the UI is addressed
- `tests/e2e/utils/caseFlows.ts` — multi-step flows shared across specs
- `tests/e2e/specs/` — the specs

The Create Case suite is data-driven: it loops over the configured project types,
and a type whose fixture is incomplete **skips with a message naming the missing
fields** rather than failing obscurely.

### Configuration

Run config moved into `.env.e2e` (committed, no secrets), loaded by
`playwright.config.ts` via node's built-in `process.loadEnvFile` — no dotenv
dependency. Precedence: real env / CLI > `.env.e2e.local` (git-ignored) >
`.env.e2e`. So `pnpm run test:e2e` works with no env vars on the command line.

### Behaviour worth knowing about

Several things the UI does that the tests had to be built around, each verified
live rather than assumed:

- **Cloud Support hides the Deployment field entirely** and locks it to primary
  production. The spec asserts it stays hidden — a regression that widened
  deployment choice would now fail.
- **Service requests POST to `/cases`**, not `/service-requests`; an SR is a case
  carrying `requestType: "service_request"`.
- **The "Generic Requests" catalog contains an item named "General Requests"** —
  the wording genuinely differs, recorded in config.
- The case description is a **Lexical contenteditable**, so it is typed rather
  than filled.
- Catalog-item variables have no stable ids or `<label for>`, so the Request
  Details input is located by role ∩ enabled; a `toHaveCount(1)` guard makes an
  ambiguous match fail loudly.

### ⚠️ These tests write to a real backend

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added end-to-end coverage for creating support cases and service requests across supported project types.
  - Added coverage for closing cases, confirmation dialogs, status updates, and success navigation.
  - Expanded validation for form fields, project-specific options, and backend responses.
  - Improved reusable test setup with captured sessions and centralized test data.
  - Added a CI check to prevent false-success results when test sessions are unavailable.

- **Documentation**
  - Updated E2E setup guidance, environment configuration, session requirements, and local testing instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->