### PR TITLE
feat(support): put Novera answer feedback behind a config flag

### DIFF
--- a/apps/customer-portal/webapp/public/config.js.example
+++ b/apps/customer-portal/webapp/public/config.js.example
@@ -131,6 +131,14 @@ window.config = {
   //   false – feature hidden. Keep false until the backend handler is ready.
   CUSTOMER_PORTAL_NOVERA_TOKEN_REQUEST_ENABLED: false,
 
+  // ── Novera answer feedback ──────────────────────────────────────────────────
+  //
+  // CUSTOMER_PORTAL_NOVERA_FEEDBACK_ENABLED  (optional — default: false)
+  //   true  – shows thumbs up/down on each Novera answer, with reason tags once
+  //           a rating is given (sent over the chat WebSocket).
+  //   false – feature hidden. Ratings already stored are unaffected.
+  CUSTOMER_PORTAL_NOVERA_FEEDBACK_ENABLED: false,
+
   // ── Top banners ─────────────────────────────────────────────────────────────
   //
   // CUSTOMER_PORTAL_TOP_BANNERS  (optional — default: [])

--- a/apps/customer-portal/webapp/src/config/portalConfig.ts
+++ b/apps/customer-portal/webapp/src/config/portalConfig.ts
@@ -36,6 +36,8 @@ export interface CustomerPortalWindowConfig {
   CUSTOMER_PORTAL_FLOATING_NOVERA_ENABLED?: boolean;
   /** Enables the Novera chat "request a token limit increase" flow. */
   CUSTOMER_PORTAL_NOVERA_TOKEN_REQUEST_ENABLED?: boolean;
+  /** Enables 👍/👎 answer feedback, with its reason tags, on Novera answers. */
+  CUSTOMER_PORTAL_NOVERA_FEEDBACK_ENABLED?: boolean;
   CUSTOMER_PORTAL_TOP_BANNERS?: Array<{
     enabled: boolean;
     html: string;

--- a/apps/customer-portal/webapp/src/features/support/pages/ConversationDetailsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/ConversationDetailsPage.tsx
@@ -336,6 +336,11 @@ export default function ConversationDetailsPage(): JSX.Element {
   const [inputValue, setInputValueState] = useState("");
   const [resetTrigger, setResetTrigger] = useState(0);
   const [isSending, setIsSending] = useState(false);
+  // Feature-flagged (config.js): 👍/👎 on Novera answers. Passing the handlers
+  // as undefined is what hides the row — ChatMessageBubble only renders it when
+  // it has somewhere to send a rating — so no separate prop is needed.
+  const feedbackEnabled =
+    window.config?.CUSTOMER_PORTAL_NOVERA_FEEDBACK_ENABLED ?? false;
   // Mirrors isSending for the socket's onClose handler. The hook installs
   // ws.onclose during connect(), so that closure captures the options object
   // from whichever render connected — reading isSending directly there would
@@ -984,8 +989,8 @@ export default function ConversationDetailsPage(): JSX.Element {
                       <ChatMessageBubble
                         key={m.id}
                         message={m}
-                        onThumbsUp={isConnected ? handleThumbsUp : undefined}
-                        onThumbsDown={isConnected ? handleThumbsDown : undefined}
+                        onThumbsUp={feedbackEnabled && isConnected ? handleThumbsUp : undefined}
+                        onThumbsDown={feedbackEnabled && isConnected ? handleThumbsDown : undefined}
                         onFeedbackTag={isConnected ? handleFeedbackTag : undefined}
                       />
                     ),

--- a/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
@@ -890,6 +890,12 @@ export default function NoveraChatPage(): JSX.Element {
   // WebSocket. Kept off until the backend handler is ready.
   const tokenRequestEnabled =
     window.config?.CUSTOMER_PORTAL_NOVERA_TOKEN_REQUEST_ENABLED ?? false;
+
+  // Feature-flagged (config.js): 👍/👎 on Novera answers. Passing the handlers
+  // as undefined is what hides the row — ChatMessageBubble only renders it when
+  // it has somewhere to send a rating — so no separate prop is needed.
+  const feedbackEnabled =
+    window.config?.CUSTOMER_PORTAL_NOVERA_FEEDBACK_ENABLED ?? false;
   const [isTokenModalOpen, setIsTokenModalOpen] = useState(false);
 
   const handleTokenIncreaseSubmit = useCallback(
@@ -972,8 +978,8 @@ export default function NoveraChatPage(): JSX.Element {
               messages={messages}
               messagesEndRef={messagesEndRef}
               onCreateCase={handleCreateCase}
-              onThumbsUp={isConnected ? handleThumbsUp : undefined}
-              onThumbsDown={isConnected ? handleThumbsDown : undefined}
+              onThumbsUp={feedbackEnabled && isConnected ? handleThumbsUp : undefined}
+              onThumbsDown={feedbackEnabled && isConnected ? handleThumbsDown : undefined}
             onFeedbackTag={isConnected ? handleFeedbackTag : undefined}
               onSolutionWorked={handleSolutionWorked}
               onRequestTokenIncrease={


### PR DESCRIPTION
## Why

Thumbs up/down on Novera answers shipped **unconditionally** — there was no way to turn it off in an environment without a redeploy. The token-limit-increase flow sitting right next to it has had `CUSTOMER_PORTAL_NOVERA_TOKEN_REQUEST_ENABLED` since it landed; feedback should match.

## Change

Adds `CUSTOMER_PORTAL_NOVERA_FEEDBACK_ENABLED`, **defaulting to `false`**, following the existing flag exactly:

| | |
|---|---|
| Declared | `src/config/portalConfig.ts` |
| Documented | `public/config.js.example` |
| Read | `window.config?.… ?? false` at render, on both rating pages |

```tsx
onThumbsUp={feedbackEnabled && isConnected ? handleThumbsUp : undefined}
onThumbsDown={feedbackEnabled && isConnected ? handleThumbsDown : undefined}
```

Gating by passing the handlers as `undefined` is deliberate: `ChatMessageBubble` already renders the row only when it has somewhere to send a rating (`showFeedbackRow` requires a handler), so nothing else needs to know the feature is off and there's no second code path to keep in step.

Turning it off **hides the control only** — ratings already stored are untouched and reappear if it's turned back on.

## Note on the default

`false` matches the neighbouring flag's convention, which means **feedback disappears on deploy until the flag is set**. If you'd rather it stay visible where it's already live, say so and I'll flip the default to `true` — it's a one-word change, but the direction should be your call rather than mine.

## Verification

- `npx tsc --noEmit` clean
- `npx eslint` clean on all three changed files
- `npx vitest run src/features/support` → 49 failed / 394 passed, exactly the pre-existing baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional thumbs-up/down feedback for Novera answers.
  * Users can select reason tags after rating an answer.
  * Feedback is submitted when a chat connection is available.
  * The feature is disabled by default and can be enabled through portal configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->