### PR TITLE
feat(customer-portal): send the signed-in user with a token request

### DIFF
--- a/apps/customer-portal/backend/service.bal
+++ b/apps/customer-portal/backend/service.bal
@@ -6934,6 +6934,18 @@ isolated service class WsProxyService {
                 if self.userEmail.length() > 0 {
                     parsed["requestedBy"] = self.userEmail;
                 } else {
+                    // No authenticated email to stamp. The page also sends one now,
+                    // but it is not kept: this becomes the actor on a durable audit
+                    // row, and a value the browser chose would let a caller write
+                    // someone else's name into it. Better an honest "Unknown".
+                    //
+                    // Logged because it should not happen — userInfo.email is set
+                    // for every authenticated session — and an empty one is the
+                    // difference between a named requester and an anonymous row.
+                    if parsed.hasKey("requestedBy") {
+                        log:printWarn(string `Dropping client-supplied requestedBy for ${inboundType}: `
+                                + string `no authenticated email on this session (project ${self.projectId})`);
+                    }
                     _ = parsed.removeIfHasKey("requestedBy");
                 }
                 sideChannelPayload = parsed.toJsonString();

--- a/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
@@ -902,11 +902,19 @@ export default function NoveraChatPage(): JSX.Element {
         type: "token_increase_request",
         accountId,
         accountName: projectDetails?.account?.name || undefined,
+        requestedBy: currentUserEmail || undefined,
         reason,
         limitType: "session",
       });
     },
-    [projectId, accountId, projectDetails?.account?.name, connect, sendUserMessage],
+    [
+      projectId,
+      accountId,
+      projectDetails?.account?.name,
+      currentUserEmail,
+      connect,
+      sendUserMessage,
+    ],
   );
 
   const handleSendMessage = useCallback(async (): Promise<boolean> => {

--- a/apps/customer-portal/webapp/src/features/support/types/conversations.ts
+++ b/apps/customer-portal/webapp/src/features/support/types/conversations.ts
@@ -261,6 +261,12 @@ export type ChatWebSocketPayload =
        * addresses the account by sys_id. Display only — the id stays the key.
        */
       accountName?: string;
+      /**
+       * The signed-in user, for the admin notification and the audit trail. The
+       * portal proxy overwrites this from the authenticated session whenever it
+       * can, so treat it as a fallback rather than the source of truth.
+       */
+      requestedBy?: string;
       reason: string;
       limitType: "session" | "monthly";
     }


### PR DESCRIPTION
## Consistency

A token request already carries `accountName` from the page. The requester came only from the proxy — inconsistent, and it meant the page was holding the answer while the message left without it.

`currentUserEmail` is **already derived on this page** (line 108, used for message attribution), so this is just sending what's there:

```ts
accountName: projectDetails?.account?.name || undefined,
requestedBy: currentUserEmail || undefined,
```

## What this does and does not change

The proxy **still overwrites** `requestedBy` from the authenticated session whenever it has one, so the trustworthy value keeps winning. What the page sends only matters where the proxy has nothing.

And there, it is still **dropped rather than forwarded**. This value becomes the `actor` on a durable audit row, and one the browser chose would let a caller write someone else's name into it. `Unknown` is the honest answer; a plausible-looking wrong name is worse than no name.

So to be straight about it: **this alone will not turn today's `Unknown` into a name.** If the proxy is deployed and still has no email, the page's value is discarded by design.

## The part that should actually help

That path is now logged:

```
Dropping client-supplied requestedBy for token_increase_request:
no authenticated email on this session (project <id>)
```

`userInfo.email` is set for every authenticated session, so an empty one should not happen — and it is the difference between a named requester and an anonymous audit row. Silence there is what has made the current `Unknown` impossible to explain from the outside. After this, the log says which case you are in:

- **warning present** → the session genuinely has no email; that is the bug to chase, in `authorization:UserInfoPayload`
- **warning absent** → the proxy is not running this code, i.e. a deploy issue

## Verification

- `bal build` clean on Swan Lake 13.1 (`Dependencies.toml` churn reverted)
- `npx tsc --noEmit` clean; `npx eslint` clean on both changed webapp files
- `npx vitest run src/features/support` → 49 failed / 394 passed, exactly the pre-existing baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)