### PR TITLE
[Customer Portal][Webapp] Show billable/non-billable time breakdown on case time cards

### DIFF
--- a/apps/customer-portal/webapp/src/features/project-details/components/time-tracking/TimeTrackingCard.tsx
+++ b/apps/customer-portal/webapp/src/features/project-details/components/time-tracking/TimeTrackingCard.tsx
@@ -29,13 +29,17 @@ import type { TimeTrackingCardProps } from "@features/project-details/types/proj
 export default function TimeTrackingCard({
   card,
 }: TimeTrackingCardProps): JSX.Element {
-  const { case: caseData, totalTime } = card;
+  const { case: caseData, totalTime, billable, nonBillable } = card;
 
   const caseNumber = caseData?.number?.trim() || "--";
   const caseName = caseData?.name?.trim() || "--";
   const createdBy = caseData?.createdBy?.trim();
 
   const totalTimeDisplay = formatMinutesAsHrMin(totalTime);
+
+  const hasBillable = (billable?.count ?? 0) > 0;
+  const hasNonBillable = (nonBillable?.count ?? 0) > 0;
+  const hasBothTypes = hasBillable && hasNonBillable;
 
   return (
     <Card sx={{ p: "20px", display: "flex", flexDirection: "column", gap: 2 }}>
@@ -63,6 +67,14 @@ export default function TimeTrackingCard({
               variant="outlined"
               sx={getPlainChipSx()}
             />
+            {!hasBothTypes && (hasBillable || hasNonBillable) && (
+              <Chip
+                label={hasBillable ? "Billable" : "Non-Billable"}
+                size="small"
+                variant="outlined"
+                sx={getPlainChipSx()}
+              />
+            )}
           </Box>
           <Typography variant="body2" color="text.primary" sx={{ mb: 0.5 }}>
             {caseName}
@@ -74,12 +86,33 @@ export default function TimeTrackingCard({
           )}
         </Box>
         <Box sx={{ textAlign: "right", flexShrink: 0 }}>
-          <Typography
-            variant="h5"
-            sx={{ fontWeight: 400, fontSize: "1.5rem", color: "text.primary" }}
-          >
-            {totalTimeDisplay === "Not Available" ? "--" : totalTimeDisplay}
-          </Typography>
+          {hasBothTypes ? (
+            <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5 }}>
+              <Box sx={{ display: "flex", alignItems: "center", gap: 1, justifyContent: "flex-end" }}>
+                <Typography variant="caption" color="text.secondary">
+                  Billable
+                </Typography>
+                <Typography variant="body1" sx={{ color: "text.primary" }}>
+                  {formatMinutesAsHrMin(billable.totalTime)}
+                </Typography>
+              </Box>
+              <Box sx={{ display: "flex", alignItems: "center", gap: 1, justifyContent: "flex-end" }}>
+                <Typography variant="caption" color="text.secondary">
+                  Non-Billable
+                </Typography>
+                <Typography variant="body1" sx={{ color: "text.primary" }}>
+                  {formatMinutesAsHrMin(nonBillable.totalTime)}
+                </Typography>
+              </Box>
+            </Box>
+          ) : (
+            <Typography
+              variant="h5"
+              sx={{ fontWeight: 400, fontSize: "1.5rem", color: "text.primary" }}
+            >
+              {totalTimeDisplay === "Not Available" ? "--" : totalTimeDisplay}
+            </Typography>
+          )}
         </Box>
       </Box>
     </Card>

--- a/apps/customer-portal/webapp/src/features/project-details/components/time-tracking/TimeTrackingCard.tsx
+++ b/apps/customer-portal/webapp/src/features/project-details/components/time-tracking/TimeTrackingCard.tsx
@@ -14,10 +14,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Card, Box, Typography, Chip } from "@wso2/oxygen-ui";
+import { Card, Box, Typography, Chip, useTheme } from "@wso2/oxygen-ui";
 import { type JSX } from "react";
 import { formatMinutesAsHrMin } from "@features/project-details/utils/projectDetails";
-import { getPlainChipSx } from "@features/support/utils/support";
+import {
+  getPlainChipSx,
+  getSupportOverviewChipSx,
+} from "@features/support/utils/support";
 import type { TimeTrackingCardProps } from "@features/project-details/types/projectDetailsComponents";
 
 /**
@@ -29,6 +32,7 @@ import type { TimeTrackingCardProps } from "@features/project-details/types/proj
 export default function TimeTrackingCard({
   card,
 }: TimeTrackingCardProps): JSX.Element {
+  const theme = useTheme();
   const { case: caseData, totalTime, billable, nonBillable } = card;
 
   const caseNumber = caseData?.number?.trim() || "--";
@@ -71,8 +75,10 @@ export default function TimeTrackingCard({
               <Chip
                 label={hasBillable ? "Billable" : "Non-Billable"}
                 size="small"
-                variant="outlined"
-                sx={getPlainChipSx()}
+                sx={getSupportOverviewChipSx(
+                  hasBillable ? "warning.main" : "success.main",
+                  theme,
+                )}
               />
             )}
           </Box>
@@ -89,7 +95,7 @@ export default function TimeTrackingCard({
           {hasBothTypes ? (
             <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5 }}>
               <Box sx={{ display: "flex", alignItems: "center", gap: 1, justifyContent: "flex-end" }}>
-                <Typography variant="caption" color="text.secondary">
+                <Typography variant="caption" sx={{ color: "warning.main" }}>
                   Billable
                 </Typography>
                 <Typography variant="body1" sx={{ color: "text.primary" }}>
@@ -97,7 +103,7 @@ export default function TimeTrackingCard({
                 </Typography>
               </Box>
               <Box sx={{ display: "flex", alignItems: "center", gap: 1, justifyContent: "flex-end" }}>
-                <Typography variant="caption" color="text.secondary">
+                <Typography variant="caption" sx={{ color: "success.main" }}>
                   Non-Billable
                 </Typography>
                 <Typography variant="body1" sx={{ color: "text.primary" }}>


### PR DESCRIPTION
## Summary
- Add a colored "Billable" (amber) or "Non-Billable" (green) chip next to the case number when a time card has only one type of time logged
- When a case has both billable and non-billable time, replace the single total-time figure with a labeled breakdown of each

## Test plan
- [ ] View Project Time Tracking with cases that are billable-only, non-billable-only, and both, and confirm the chip/breakdown renders correctly for each case
- [ ] Confirm cases with zero time entries still render without errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the time tracking card to clearly distinguish billable and non-billable time.
  * Displays separate durations when both time types are available.
  * Shows a status indicator when entries contain only billable or only non-billable time.
  * Uses `--` for unavailable duration values to make incomplete data clear.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->