### PR TITLE
[CSM Portal] fix page clipping, dark-mode comment readability, and severity defaulting to S3

### DIFF
--- a/apps/csm-portal/webapp/src/api/backend/mappers.test.ts
+++ b/apps/csm-portal/webapp/src/api/backend/mappers.test.ts
@@ -20,36 +20,39 @@ import {
   beStateFromUi,
   commentTypeFromInternal,
   priorityFromSeverity,
-  severityFromPriority,
+  severityFromBe,
   uiCommentFromBe,
   uiStateFromBe,
 } from "./mappers";
 
-describe("severityFromPriority", () => {
+describe("severityFromBe", () => {
   it("maps legacy English names onto the S0-S4 scale", () => {
-    expect(severityFromPriority("catastrophic")).toBe("S0");
-    expect(severityFromPriority("critical")).toBe("S1");
-    expect(severityFromPriority("high")).toBe("S2");
-    expect(severityFromPriority("medium")).toBe("S3");
-    expect(severityFromPriority("low")).toBe("S4");
+    expect(severityFromBe("catastrophic")).toBe("S0");
+    expect(severityFromBe("critical")).toBe("S1");
+    expect(severityFromBe("high")).toBe("S2");
+    expect(severityFromBe("medium")).toBe("S3");
+    expect(severityFromBe("low")).toBe("S4");
   });
 
   it("maps the backend display-string format 'Label (Px)' onto S0-S4", () => {
-    expect(severityFromPriority("Catastrophic (P0)")).toBe("S0");
-    expect(severityFromPriority("Critical (P1)")).toBe("S1");
-    expect(severityFromPriority("High (P2)")).toBe("S2");
-    expect(severityFromPriority("Medium (P3)")).toBe("S3");
-    expect(severityFromPriority("Low (P4)")).toBe("S4");
+    expect(severityFromBe("Catastrophic (P0)")).toBe("S0");
+    expect(severityFromBe("Critical (P1)")).toBe("S1");
+    expect(severityFromBe("High (P2)")).toBe("S2");
+    expect(severityFromBe("Medium (P3)")).toBe("S3");
+    expect(severityFromBe("Low (P4)")).toBe("S4");
   });
 
-  it("falls back to S3 for an unknown/undefined priority", () => {
-    expect(severityFromPriority(undefined)).toBe("S3");
-    expect(severityFromPriority("unknown_value")).toBe("S3");
+  it("maps a falsy/unrecognized severity to the distinct 'unset' state, never to S3", () => {
+    // A case with no severity value is NOT the same fact as "the severity
+    // really is Medium" — it must never collapse into a real severity.
+    expect(severityFromBe(undefined)).toBe("unset");
+    expect(severityFromBe("")).toBe("unset");
+    expect(severityFromBe("unknown_value")).toBe("unset");
   });
 });
 
 describe("priorityFromSeverity", () => {
-  it("is the inverse of severityFromPriority for the known set", () => {
+  it("is the inverse of severityFromBe for the known set", () => {
     expect(priorityFromSeverity("S0")).toBe("catastrophic");
     expect(priorityFromSeverity("S1")).toBe("critical");
     expect(priorityFromSeverity("S2")).toBe("high");

--- a/apps/csm-portal/webapp/src/api/backend/mappers.ts
+++ b/apps/csm-portal/webapp/src/api/backend/mappers.ts
@@ -37,6 +37,7 @@ import type { UserReference } from "@/types/userReference";
 import type {
   CaseState,
   Severity,
+  SeverityOrUnset,
 } from "@features/csm-dashboard/types/abtDashboard";
 
 // ---------------------------------------------------------------------------
@@ -44,20 +45,25 @@ import type {
 // ---------------------------------------------------------------------------
 
 /**
- * Best-effort mapping from the backend's five-step priority taxonomy onto the
- * UI's S0-S4 severity scale. Until the BE adds explicit severity, priority
- * doubles as the source.
+ * Best-effort mapping from the backend's severity string onto the UI's
+ * S0-S4 severity scale — plus the explicit `"unset"` state.
+ *
+ * A falsy value (the backend sends `""` for a case with no severity — it
+ * never defaults one to Medium/S3) and an unrecognized string both map to
+ * `"unset"`, never to `"S3"`: "we don't know the severity" and "the severity
+ * really is Medium" are different facts and must never render/filter
+ * identically. See `SeverityChip` for the distinct "Unset" badge.
  */
-export function severityFromPriority(priority: string | undefined): Severity {
-  if (!priority) return "S3";
-  const s = priority.toLowerCase();
+export function severityFromBe(severity: string | undefined): SeverityOrUnset {
+  if (!severity) return "unset";
+  const s = severity.toLowerCase();
   // Match both P-notation ("Low (P4)", "P4") and legacy English names.
   if (s.includes("p0") || s === "catastrophic") return "S0";
   if (s.includes("p1") || s === "critical") return "S1";
   if (s.includes("p2") || s === "high") return "S2";
   if (s.includes("p3") || s === "medium") return "S3";
   if (s.includes("p4") || s === "low") return "S4";
-  return "S3";
+  return "unset";
 }
 
 export function priorityFromSeverity(severity: Severity): BeCaseSeverity {

--- a/apps/csm-portal/webapp/src/components/SeverityChip.test.tsx
+++ b/apps/csm-portal/webapp/src/components/SeverityChip.test.tsx
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import "@testing-library/jest-dom/vitest";
+
+import SeverityChip from "@components/SeverityChip";
+
+describe("SeverityChip", () => {
+  it("renders a real severity as a bold, solid badge", () => {
+    render(<SeverityChip severity="S3" />);
+    const chip = screen.getByText("S3");
+    expect(chip).toBeInTheDocument();
+    // Filled variant (MuiChip-filled), not outlined.
+    expect(chip.closest(".MuiChip-root")).toHaveClass("MuiChip-filled");
+  });
+
+  it("renders 'unset' as a distinct outlined 'Unset' badge, never as S3", () => {
+    render(<SeverityChip severity="unset" />);
+    expect(screen.getByText("Unset")).toBeInTheDocument();
+    expect(screen.queryByText("S3")).not.toBeInTheDocument();
+    const chip = screen.getByText("Unset").closest(".MuiChip-root");
+    // Outlined, not filled — visually distinct from every real severity chip
+    // (including S4, which also uses the "default" grey role but filled).
+    expect(chip).toHaveClass("MuiChip-outlined");
+    expect(chip).not.toHaveClass("MuiChip-filled");
+  });
+});

--- a/apps/csm-portal/webapp/src/components/SeverityChip.tsx
+++ b/apps/csm-portal/webapp/src/components/SeverityChip.tsx
@@ -15,7 +15,7 @@
 // under the License.
 
 import type { JSX } from "react";
-import type { Severity } from "@features/csm-dashboard/types/abtDashboard";
+import type { SeverityOrUnset } from "@features/csm-dashboard/types/abtDashboard";
 import {
   SEVERITY_COLOR,
   SEVERITY_LABEL,
@@ -23,7 +23,7 @@ import {
 import SemanticChip from "@components/SemanticChip";
 
 interface SeverityChipProps {
-  severity: Severity;
+  severity: SeverityOrUnset;
   /** Append the descriptive label, e.g. "S1 — Critical" (used on the case header). */
   withLabel?: boolean;
   size?: "small" | "medium";
@@ -36,6 +36,11 @@ interface SeverityChipProps {
  * the highest-priority scan signal in the portal, so it renders as a bold,
  * solid {@link SemanticChip} (which guarantees WCAG AA) — visually out-ranking
  * the quieter outlined state chip.
+ *
+ * `"unset"` (the source has no severity value) renders as a distinct
+ * outlined, non-bold "Unset" badge — deliberately unlike any of the solid
+ * S0-S4 badges (in particular S4's grey "default" role) so it can never be
+ * mistaken for a real severity.
  */
 export default function SeverityChip({
   severity,
@@ -43,6 +48,17 @@ export default function SeverityChip({
   size = "small",
   clickable = false,
 }: SeverityChipProps): JSX.Element {
+  if (severity === "unset") {
+    return (
+      <SemanticChip
+        role="default"
+        label="Unset"
+        variant="outlined"
+        size={size}
+        clickable={clickable}
+      />
+    );
+  }
   return (
     <SemanticChip
       role={SEVERITY_COLOR[severity]}

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCaseDetail.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCaseDetail.ts
@@ -19,7 +19,7 @@ import { useIdTokenClaims } from "@hooks/useIdTokenClaims";
 import { ApiQueryKeys } from "@constants/apiConstants";
 import { useBackendApi } from "@api/backend/client";
 import {
-  severityFromPriority,
+  severityFromBe,
   uiStateFromBe,
   userReferenceFromBe,
 } from "@api/backend/mappers";
@@ -79,7 +79,7 @@ function detailFromBeCase(
     projectId: c.project?.id ?? "",
     projectName: c.project?.name ?? "—",
     product,
-    severity: severityFromPriority(c.severity),
+    severity: severityFromBe(c.severity),
     state: uiStateFromBe(c.state),
     workState: c.workState ?? null,
     nextStates: (c.nextStates ?? []).map(uiStateFromBe),

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useQuickCaseSearch.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useQuickCaseSearch.ts
@@ -17,7 +17,7 @@
 import { useQuery, type UseQueryResult } from "@tanstack/react-query";
 import { ApiQueryKeys } from "@constants/apiConstants";
 import { useBackendApi } from "@api/backend/client";
-import { severityFromPriority, uiStateFromBe } from "@api/backend/mappers";
+import { severityFromBe, uiStateFromBe } from "@api/backend/mappers";
 import type {
   BeCaseFieldFilter,
   BeCaseSearchFilters,
@@ -28,7 +28,7 @@ import type {
 import type {
   CaseState,
   CaseWorkState,
-  Severity,
+  SeverityOrUnset,
 } from "@features/csm-dashboard/types/abtDashboard";
 import { ALL_CASE_TYPES } from "@features/csm-cases/utils/caseType";
 
@@ -83,7 +83,7 @@ export interface QuickCaseHit {
   caseNumber?: string;
   wso2CaseId?: string;
   subject: string;
-  severity: Severity;
+  severity: SeverityOrUnset;
   state: CaseState;
   workState?: CaseWorkState | null;
   caseType?: BeCaseType;
@@ -147,7 +147,7 @@ export function useQuickCaseSearch(
         caseNumber: c.number,
         wso2CaseId: c.internalId,
         subject: c.subject ?? "(no subject)",
-        severity: severityFromPriority(c.severity),
+        severity: severityFromBe(c.severity),
         state: uiStateFromBe(c.state),
         workState: c.workState,
         caseType: c.type,

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useSearchChildCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useSearchChildCases.ts
@@ -17,9 +17,12 @@
 import { useQuery, type UseQueryResult } from "@tanstack/react-query";
 import { ApiQueryKeys } from "@constants/apiConstants";
 import { useBackendApi } from "@api/backend/client";
-import { severityFromPriority, uiStateFromBe } from "@api/backend/mappers";
+import { severityFromBe, uiStateFromBe } from "@api/backend/mappers";
 import type { BeCaseSearchPayload, BeCaseSearchResponse } from "@api/backend/types";
-import type { CaseState, Severity } from "@features/csm-dashboard/types/abtDashboard";
+import type {
+  CaseState,
+  SeverityOrUnset,
+} from "@features/csm-dashboard/types/abtDashboard";
 
 const CHILD_CASES_LIMIT = 20;
 
@@ -27,7 +30,7 @@ export interface ChildCaseRow {
   id: string;
   caseNumber?: string;
   subject: string;
-  severity: Severity;
+  severity: SeverityOrUnset;
   state: CaseState;
   assigneeName?: string;
 }
@@ -68,7 +71,7 @@ export function useSearchChildCases(
           id: c.id,
           caseNumber: c.number,
           subject: c.subject ?? "(no subject)",
-          severity: severityFromPriority(c.severity),
+          severity: severityFromBe(c.severity),
           state: uiStateFromBe(c.state),
           assigneeName: c.assignedEngineer?.name ?? undefined,
         })),

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CallRequestsWidget.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CallRequestsWidget.tsx
@@ -31,7 +31,10 @@ import {
 import { Phone, Plus, RefreshCw } from "@wso2/oxygen-ui-icons-react";
 import { useEffect, useState, type JSX } from "react";
 import type { BeCallRequestView, BeCallRequestStateKey } from "@api/backend/types";
-import type { CaseState, Severity } from "@features/csm-dashboard/types/abtDashboard";
+import type {
+  CaseState,
+  SeverityOrUnset,
+} from "@features/csm-dashboard/types/abtDashboard";
 import {
   useGetCsmCaseCallRequests,
   usePostCsmCaseCallRequest,
@@ -58,8 +61,8 @@ import RefreshButton from "@components/RefreshButton";
 
 interface CallRequestsWidgetProps {
   caseId: string;
-  /** Case severity (S0-S4) — passed to the create dialog to enforce the lead-time rule. */
-  severity?: Severity;
+  /** Case severity — passed to the create dialog to enforce the lead-time rule. */
+  severity?: SeverityOrUnset;
   /**
    * Case's current state — the data source only accepts a call request while
    * the case is in one of a fixed set of states. Gates both the "Create call

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
@@ -48,7 +48,10 @@ import type {
   CaseLifecycleAction,
   CsmCaseDetail,
 } from "@features/csm-cases/types/csmCases";
-import type { CaseState, Severity } from "@features/csm-dashboard/types/abtDashboard";
+import type {
+  CaseState,
+  SeverityOrUnset,
+} from "@features/csm-dashboard/types/abtDashboard";
 import { stateLabel } from "@features/csm-dashboard/utils/abtDashboard";
 import UserRefLink from "@components/UserRefLink";
 
@@ -424,8 +427,12 @@ interface CaseActionBarProps {
  * it mirrors which cases the out-of-band acknowledgement notifications are
  * raised for, so the button appears on exactly the cases an engineer could
  * already have acknowledged from a notification, and on no others.
+ * `caseDetail.severity` may be `"unset"` (case has no severity value) —
+ * typed `SeverityOrUnset` so `.has()` accepts it directly; it is never a
+ * member of this set, so an unset-severity case is correctly never
+ * acknowledgeable.
  */
-const ACKNOWLEDGEABLE_SEVERITIES = new Set<Severity>(["S0", "S1", "S2", "S3"]);
+const ACKNOWLEDGEABLE_SEVERITIES = new Set<SeverityOrUnset>(["S0", "S1", "S2", "S3"]);
 
 /**
  * Whether the acknowledge action applies to this case: nobody has claimed it

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/ChangeSeverityDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/ChangeSeverityDialog.tsx
@@ -27,13 +27,22 @@ import {
   Typography,
 } from "@wso2/oxygen-ui";
 import { useState, type JSX } from "react";
-import type { Severity } from "@features/csm-dashboard/types/abtDashboard";
+import type {
+  Severity,
+  SeverityOrUnset,
+} from "@features/csm-dashboard/types/abtDashboard";
 import { SEVERITY_LABEL } from "@features/csm-dashboard/utils/abtDashboard";
 
 const SEVERITIES: Severity[] = ["S0", "S1", "S2", "S3", "S4"];
 
 interface ChangeSeverityDialogProps {
-  currentSeverity: Severity;
+  /**
+   * May be `"unset"` when the case has no severity value at all — the radio
+   * group then starts with nothing selected (none of `SEVERITIES` match),
+   * which correctly forces the engineer to pick a real value before "Change
+   * severity" enables.
+   */
+  currentSeverity: SeverityOrUnset;
   /** True when the case's project is a Managed Cloud subscription — S0 is
    * reserved for those, same rule as case creation (see CsmCaseCreatePage.tsx). */
   isManagedCloud: boolean;
@@ -59,7 +68,7 @@ export default function ChangeSeverityDialog({
   onClose,
   onChange,
 }: ChangeSeverityDialogProps): JSX.Element {
-  const [selected, setSelected] = useState<Severity>(currentSeverity);
+  const [selected, setSelected] = useState<SeverityOrUnset>(currentSeverity);
 
   const changed = selected !== currentSeverity;
 
@@ -70,7 +79,9 @@ export default function ChangeSeverityDialog({
         <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
           Current severity:{" "}
           <Typography component="span" variant="body2" sx={{ fontWeight: 600, color: "text.primary" }}>
-            {currentSeverity} · {SEVERITY_LABEL[currentSeverity]}
+            {currentSeverity === "unset"
+              ? "Not set"
+              : `${currentSeverity} · ${SEVERITY_LABEL[currentSeverity]}`}
           </Typography>
         </Typography>
 
@@ -104,9 +115,13 @@ export default function ChangeSeverityDialog({
         </Button>
         <Button
           variant="contained"
-          disabled={!changed || isChanging}
+          disabled={!changed || isChanging || selected === "unset"}
           loading={isChanging}
-          onClick={() => onChange(selected)}
+          onClick={() => {
+            // Guard is redundant with `disabled` above (the radio group never
+            // offers "unset" as an option) but keeps this call type-safe.
+            if (selected !== "unset") onChange(selected);
+          }}
         >
           Change severity
         </Button>

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CreateCallRequestDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CreateCallRequestDialog.tsx
@@ -28,7 +28,10 @@ import {
 } from "@wso2/oxygen-ui";
 import { Plus } from "@wso2/oxygen-ui-icons-react";
 import { useState, type JSX } from "react";
-import type { CaseState, Severity } from "@features/csm-dashboard/types/abtDashboard";
+import type {
+  CaseState,
+  SeverityOrUnset,
+} from "@features/csm-dashboard/types/abtDashboard";
 import { callRequestCaseStateBlockReason } from "@features/csm-cases/utils/callRequestState";
 import {
   formatDateTimeLocal,
@@ -71,12 +74,15 @@ const MAX_TIME_SLOTS = 3;
  *     catastrophic=14, critical=10, high=11, medium=12, low=13
  *   SN priority id -> offset (SN CallRequestUtils._PRIORITY_TIME_OFFSETS):
  *     14=15, 10=30, 11=60, 12=90, 13=120; null/unknown -> 300
- * Caveat: the mapper collapses null-priority cases to S3, so a genuinely
- * null-priority case is enforced at 90 min here vs 300 min at the backend
- * (lenient: it may still 400, but never falsely blocks a valid time).
  * If these backend maps change, this table must change with them.
+ * A genuinely unset-severity case (`severity === "unset"`) is enforced at
+ * `DEFAULT_LEAD_TIME_MINUTES` below, matching the backend's null/unknown
+ * fallback exactly — see the `severity` prop's doc comment.
  */
-const LEAD_TIME_MINUTES_BY_SEVERITY: Record<Severity, number> = {
+const LEAD_TIME_MINUTES_BY_SEVERITY: Record<
+  Exclude<SeverityOrUnset, "unset">,
+  number
+> = {
   S0: 15,
   S1: 30,
   S2: 60,
@@ -167,8 +173,13 @@ export interface CreateDialogProps {
   open: boolean;
   submitting: boolean;
   error: string | null;
-  /** Case severity (S0-S4) — drives the minimum lead time for each proposed slot. */
-  severity?: Severity;
+  /**
+   * Case severity — drives the minimum lead time for each proposed slot.
+   * `"unset"` (no severity value at all) is treated like `undefined`: the
+   * most conservative `DEFAULT_LEAD_TIME_MINUTES`, matching the backend's
+   * own null/unknown fallback.
+   */
+  severity?: SeverityOrUnset;
   /**
    * Case's current state — the data source only accepts a call request while
    * the case is in one of a fixed set of states (see
@@ -214,9 +225,10 @@ export function CreateCallRequestDialog({
 
   // Times are entered in the user's timezone and stored/submitted as UTC.
   const timeZone = resolveDisplayTimeZone();
-  const leadMinutes = severity
-    ? LEAD_TIME_MINUTES_BY_SEVERITY[severity]
-    : DEFAULT_LEAD_TIME_MINUTES;
+  const leadMinutes =
+    severity && severity !== "unset"
+      ? LEAD_TIME_MINUTES_BY_SEVERITY[severity]
+      : DEFAULT_LEAD_TIME_MINUTES;
   const minAllowedMs = earliestAllowedMs(leadMinutes);
   const minLocal = utcMsToZonedInputValue(minAllowedMs, timeZone);
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -913,7 +913,11 @@ export default function CsmCaseDetailPage(): JSX.Element {
             relatedCaseNumber: data.caseNumber,
             deploymentId: data.productContext.deploymentId,
             deployedProductId: data.productContext.deployedProductId,
-            severity: data.severity,
+            // The related case's severity only prefills the new-case form
+            // when it's a real S0-S4 value — an "unset" source severity
+            // leaves the (required) field blank so the engineer must pick
+            // one, same as any other case with no severity to carry over.
+            severity: data.severity === "unset" ? undefined : data.severity,
             issueType: data.issueType,
             subject: `Related Case : ${data.subject}`,
           };

--- a/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
@@ -18,6 +18,7 @@ import type {
   CaseState,
   CaseWorkState,
   Severity,
+  SeverityOrUnset,
   SlaClockType,
 } from "@features/csm-dashboard/types/abtDashboard";
 import type {
@@ -56,7 +57,12 @@ export interface CsmCaseRow {
   projectName: string;
   /** Affected WSO2 product (e.g. "WSO2 Identity Server"). Used for list filtering. */
   product: string;
-  severity: Severity;
+  /**
+   * `"unset"` when the source has no severity value at all (empty/missing) —
+   * a distinct fact from "the severity really is S3/Medium", never collapsed
+   * into a real severity. See `severityFromBe` in `api/backend/mappers.ts`.
+   */
+  severity: SeverityOrUnset;
   state: CaseState;
   /**
    * Case type (BE `typeKey` / search `caseType`). Optional: a legacy row may

--- a/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
@@ -58,8 +58,9 @@ export interface CsmCaseRow {
   /** Affected WSO2 product (e.g. "WSO2 Identity Server"). Used for list filtering. */
   product: string;
   /**
-   * `"unset"` when the source has no severity value at all (empty/missing) —
-   * a distinct fact from "the severity really is S3/Medium", never collapsed
+   * `"unset"` when the source has no severity value at all (empty/missing),
+   * or the value doesn't match anything `severityFromBe` recognizes — a
+   * distinct fact from "the severity really is S3/Medium", never collapsed
    * into a real severity. See `severityFromBe` in `api/backend/mappers.ts`.
    */
   severity: SeverityOrUnset;

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/caseSearchPayload.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/caseSearchPayload.ts
@@ -18,7 +18,7 @@ import type { BackendApi } from "@api/backend/client";
 import {
   beStateFromUi,
   priorityFromSeverity,
-  severityFromPriority,
+  severityFromBe,
   uiStateFromBe,
 } from "@api/backend/mappers";
 import { ASSIGNEE_ME_TOKEN } from "@features/csm-cases/utils/assignee";
@@ -254,7 +254,7 @@ export function mapCaseSearchViewToRow(
     projectId,
     projectName: c.project?.name ?? "-",
     product: c.deployedProduct?.name ?? c.product?.name ?? "-",
-    severity: severityFromPriority(c.severity),
+    severity: severityFromBe(c.severity),
     state: uiStateFromBe(c.state),
     caseType: c.type,
     workState: c.workState ?? null,

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useGetMyAssignedOpenCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useGetMyAssignedOpenCases.ts
@@ -21,7 +21,7 @@ import {
 } from "@tanstack/react-query";
 import { ApiQueryKeys } from "@constants/apiConstants";
 import { useBackendApi } from "@api/backend/client";
-import { severityFromPriority, uiStateFromBe } from "@api/backend/mappers";
+import { severityFromBe, uiStateFromBe } from "@api/backend/mappers";
 import { useCurrentUser } from "@context/current-user/CurrentUserContext";
 import { useIdTokenClaims } from "@hooks/useIdTokenClaims";
 import type {
@@ -139,7 +139,7 @@ export function useGetMyAssignedOpenCases(
           projectId: c.project?.id ?? "",
           projectName: c.project?.name ?? "-",
           product: c.deployedProduct?.name ?? "-",
-          severity: severityFromPriority(c.severity),
+          severity: severityFromBe(c.severity),
           state: uiStateFromBe(c.state),
           caseType: c.type,
           workState: c.workState ?? null,

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/types/abtDashboard.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/types/abtDashboard.ts
@@ -16,6 +16,15 @@
 
 export type Severity = "S0" | "S1" | "S2" | "S3" | "S4";
 
+/**
+ * Severity plus the "no value" state: a case whose source has no severity set
+ * (empty/missing, never sent to us as `"medium"`) is a distinct fact from
+ * "the severity really is S3/Medium" and must never render/filter as one.
+ * Not one of the S0-S4 filter options by design — see `severityFromBe` in
+ * `api/backend/mappers.ts`.
+ */
+export type SeverityOrUnset = Severity | "unset";
+
 export type CaseState =
   | "open"
   | "work_in_progress"

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/types/abtDashboard.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/types/abtDashboard.ts
@@ -18,10 +18,10 @@ export type Severity = "S0" | "S1" | "S2" | "S3" | "S4";
 
 /**
  * Severity plus the "no value" state: a case whose source has no severity set
- * (empty/missing, never sent to us as `"medium"`) is a distinct fact from
- * "the severity really is S3/Medium" and must never render/filter as one.
- * Not one of the S0-S4 filter options by design — see `severityFromBe` in
- * `api/backend/mappers.ts`.
+ * (empty/missing, or a value `severityFromBe` doesn't recognize — never sent
+ * to us as `"medium"`) is a distinct fact from "the severity really is
+ * S3/Medium" and must never render/filter as one. Not one of the S0-S4 filter
+ * options by design — see `severityFromBe` in `api/backend/mappers.ts`.
  */
 export type SeverityOrUnset = Severity | "unset";
 

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/LogTimeCardDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/LogTimeCardDialog.tsx
@@ -51,7 +51,7 @@ import {
   type NormalizedUser,
 } from "@features/csm-users/types/csmUsers";
 import TimeCardStatusChip from "@features/csm-timecards/components/TimeCardStatusChip";
-import type { Severity } from "@features/csm-dashboard/types/abtDashboard";
+import type { SeverityOrUnset } from "@features/csm-dashboard/types/abtDashboard";
 import {
   ACTIVITY_BUCKETS,
   DEFAULT_BILLABLE,
@@ -94,8 +94,10 @@ interface LogTimeCardDialogProps {
    * severity to hand in; the switch stays enabled there rather than being
    * force-disabled on a guess, and the backend's own business rule still
    * enforces the real non-billable-severities constraint server-side either
-   * way (see NON_BILLABLE_SEVERITIES's doc comment). */
-  caseSeverity?: Severity;
+   * way (see NON_BILLABLE_SEVERITIES's doc comment). Also `"unset"` when the
+   * case has no severity value at all — treated the same as "no severity to
+   * hand in" below (switch stays enabled, backend still enforces server-side). */
+  caseSeverity?: SeverityOrUnset;
   projectId: string;
   projectName: string;
   /** True while the create/edit mutation is in flight. */
@@ -202,7 +204,9 @@ export default function LogTimeCardDialog({
   const isEditMode = !!editingCard;
 
   const isAlwaysNonBillable =
-    !!caseSeverity && NON_BILLABLE_SEVERITIES.includes(caseSeverity);
+    !!caseSeverity &&
+    caseSeverity !== "unset" &&
+    NON_BILLABLE_SEVERITIES.includes(caseSeverity);
 
   const [date, setDate] = useState(editingCard?.workDate ?? localTodayIso());
   const [issueComplexity, setIssueComplexity] = useState<IssueComplexity>(

--- a/apps/csm-portal/webapp/src/layouts/AppLayout.tsx
+++ b/apps/csm-portal/webapp/src/layouts/AppLayout.tsx
@@ -15,13 +15,7 @@
 // under the License.
 
 import { notificationBannerConfig } from "@config/notificationBannerConfig";
-import {
-  AppShell,
-  Box,
-  useAppShell,
-  LinearProgress,
-  Typography,
-} from "@wso2/oxygen-ui";
+import { Box, useAppShell, LinearProgress, Typography } from "@wso2/oxygen-ui";
 import {
   type JSX,
   type ReactNode,
@@ -43,6 +37,7 @@ import TopBanner from "@components/top-banner/TopBanner";
 import Header from "@components/header/Header";
 import CsmSideBar from "@components/side-nav-bar/CsmSideBar";
 import RouteSuspenseFallback from "@components/route-fallback/RouteSuspenseFallback";
+import AppShellLayout from "@layouts/AppShellLayout";
 
 const SIDEBAR_COLLAPSED_KEY = "csm.sidebar.collapsed";
 
@@ -135,95 +130,91 @@ export default function AppLayout({ children }: AppLayoutProps): JSX.Element {
         <MobileAppBanner />
         <GlobalNotificationBanner visible={notificationBannerConfig.visible} />
         <HtmlAnnouncementBanner />
-        <AppShell sx={{ flex: 1, minHeight: 0, height: "auto" }}>
-          <AppShell.Navbar>
+        <AppShellLayout
+          header={
             <Header
               onToggleSidebar={shellActions.toggleSidebar}
               collapsed={shellState.sidebarCollapsed}
               hideProjectControls={!isSignedIn || !hasInitialized}
             />
-          </AppShell.Navbar>
-
-          {hasInitialized && isSignedIn && !isErrorPageDisplayed && (
-            <AppShell.Sidebar>
+          }
+          sidebar={
+            hasInitialized && isSignedIn && !isErrorPageDisplayed ? (
               <CsmSideBar
                 collapsed={shellState.sidebarCollapsed}
                 expandedMenus={shellState.expandedMenus}
                 onSelect={shellActions.setActiveMenuItem}
                 onToggleExpand={shellActions.toggleMenu}
               />
-            </AppShell.Sidebar>
-          )}
-
-          <AppShell.Main>
+            ) : undefined
+          }
+        >
+          <Box
+            sx={{
+              display: "flex",
+              flexDirection: "column",
+              height: "100%",
+              width: "100%",
+              flex: 1,
+              minHeight: 0,
+              overflow: "hidden",
+              position: "relative",
+            }}
+          >
+            {isVisible && (
+              <LinearProgress
+                color="inherit"
+                sx={{
+                  color: "primary.main",
+                  position: "absolute",
+                  top: 0,
+                  left: 0,
+                  right: 0,
+                  zIndex: 1300,
+                  height: 3,
+                }}
+              />
+            )}
             <Box
+              ref={mainContentRef}
               sx={{
-                display: "flex",
-                flexDirection: "column",
-                height: "100%",
-                width: "100%",
                 flex: 1,
                 minHeight: 0,
-                overflow: "hidden",
-                position: "relative",
+                minWidth: 0,
+                display: "flex",
+                flexDirection: "column",
+                overflow: "auto",
+                ...(isAuthLoading ? { p: 0 } : { p: 3 }),
               }}
             >
-              {isVisible && (
-                <LinearProgress
-                  color="inherit"
+              {!hasInitialized ? (
+                <Box
                   sx={{
-                    color: "primary.main",
-                    position: "absolute",
-                    top: 0,
-                    left: 0,
-                    right: 0,
-                    zIndex: 1300,
-                    height: 3,
+                    flex: 1,
+                    minHeight: 0,
+                    display: "flex",
+                    flexDirection: "column",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    gap: 2,
                   }}
-                />
+                >
+                  <LinearProgress
+                    color="inherit"
+                    sx={{ color: "primary.main", width: "80%", maxWidth: 400, height: 4 }}
+                  />
+                  <Typography variant="body2" color="text.secondary">
+                    {loadingMessage}
+                  </Typography>
+                </Box>
+              ) : (
+                <Suspense fallback={<RouteSuspenseFallback />}>
+                  {children || <Outlet />}
+                </Suspense>
               )}
-              <Box
-                ref={mainContentRef}
-                sx={{
-                  flex: 1,
-                  minHeight: 0,
-                  minWidth: 0,
-                  display: "flex",
-                  flexDirection: "column",
-                  overflowY: "auto",
-                  overflowX: "hidden",
-                  ...(isAuthLoading ? { p: 0 } : { p: 3 }),
-                }}
-              >
-                {!hasInitialized ? (
-                  <Box
-                    sx={{
-                      flex: 1,
-                      minHeight: 0,
-                      display: "flex",
-                      flexDirection: "column",
-                      alignItems: "center",
-                      justifyContent: "center",
-                      gap: 2,
-                    }}
-                  >
-                    <LinearProgress
-                      color="inherit"
-                      sx={{ color: "primary.main", width: "80%", maxWidth: 400, height: 4 }}
-                    />
-                    <Typography variant="body2" color="text.secondary">
-                      {loadingMessage}
-                    </Typography>
-                  </Box>
-                ) : (
-                  <Suspense fallback={<RouteSuspenseFallback />}>
-                    {children || <Outlet />}
-                  </Suspense>
-                )}
-              </Box>
             </Box>
-          </AppShell.Main>
-        </AppShell>
+          </Box>
+        </AppShellLayout>
       </Box>
     </IdleTimeoutProvider>
   );

--- a/apps/csm-portal/webapp/src/layouts/AppShellLayout.tsx
+++ b/apps/csm-portal/webapp/src/layouts/AppShellLayout.tsx
@@ -1,0 +1,112 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Box } from "@wso2/oxygen-ui";
+import type { JSX, ReactNode } from "react";
+
+export interface AppShellLayoutProps {
+  header: ReactNode;
+  sidebar?: ReactNode;
+  children: ReactNode;
+}
+
+/**
+ * Application shell with a flex layout that constrains main content to the
+ * viewport width remaining after the sidebar (Oxygen AppShell omits
+ * minWidth: 0 on the main column, which prevents inner content from sizing
+ * to the screen and silently clips it on any viewport narrower than the
+ * content's intrinsic width). Ported from the customer portal's
+ * `AppShellLayout` (`apps/customer-portal/webapp/src/layouts/AppShellLayout.tsx`),
+ * trimmed to what CSM actually uses today: no footer slot and no
+ * overlay/mobile-drawer sidebar mode (CSM's sidebar only ever renders
+ * inline, collapsed/expanded via `CsmSideBar`'s own `collapsed` prop).
+ *
+ * @param {AppShellLayoutProps} props - Shell regions and page content.
+ * @returns {JSX.Element} The app shell layout.
+ */
+export default function AppShellLayout({
+  header,
+  sidebar,
+  children,
+}: AppShellLayoutProps): JSX.Element {
+  return (
+    <Box
+      data-testid="app-shell"
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        flex: 1,
+        minHeight: 0,
+        minWidth: 0,
+        width: "100%",
+        maxWidth: "100%",
+        overflow: "hidden",
+      }}
+    >
+      <Box
+        component="header"
+        data-testid="app-navbar"
+        sx={{
+          flexShrink: 0,
+          width: "100%",
+          maxWidth: "100%",
+          minWidth: 0,
+        }}
+      >
+        {header}
+      </Box>
+
+      <Box
+        sx={{
+          display: "flex",
+          flex: 1,
+          minHeight: 0,
+          minWidth: 0,
+          width: "100%",
+          maxWidth: "100%",
+          overflow: "hidden",
+          position: "relative",
+        }}
+      >
+        {sidebar ? (
+          <Box
+            component="aside"
+            data-testid="app-sidebar"
+            sx={{ flexShrink: 0, minWidth: 0 }}
+          >
+            {sidebar}
+          </Box>
+        ) : null}
+
+        <Box
+          component="main"
+          data-testid="app-main"
+          sx={{
+            display: "flex",
+            flexDirection: "column",
+            flex: "1 1 0",
+            minWidth: 0,
+            width: 0,
+            maxWidth: "100%",
+            overflow: "hidden",
+          }}
+        >
+          {children}
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/utils/sanitizeHtml.test.ts
+++ b/apps/csm-portal/webapp/src/utils/sanitizeHtml.test.ts
@@ -130,6 +130,16 @@ describe("stripLightModeInlineStyles", () => {
     expect(out).toContain("padding: 0.01em 16px");
   });
 
+  it("removes a mid-gray background whose contrast against light text is below WCAG AA", () => {
+    // #808080 (luminance ~0.216) contrasts with white text at ~3.95:1, below
+    // the 4.5:1 AA minimum for normal text — a fixed 0.55 luminance cutoff
+    // missed this; the contrast-derived threshold must catch it.
+    const out = stripLightModeInlineStyles(
+      '<div style="background-color: #808080;">x</div>',
+    );
+    expect(out).not.toContain("background-color");
+  });
+
   it("still removes near-white backgrounds (no regression)", () => {
     const hex = stripLightModeInlineStyles('<div style="background-color: #f4f4f4;">x</div>');
     expect(hex).not.toContain("background-color");

--- a/apps/csm-portal/webapp/src/utils/sanitizeHtml.test.ts
+++ b/apps/csm-portal/webapp/src/utils/sanitizeHtml.test.ts
@@ -121,4 +121,27 @@ describe("stripLightModeInlineStyles", () => {
     const cyan = stripLightModeInlineStyles('<span style="color: #2fffff;">x</span>');
     expect(cyan).toContain("color: #2fffff");
   });
+
+  it("removes a light pastel background (e.g. a ServiceNow call-note highlight)", () => {
+    const out = stripLightModeInlineStyles(
+      '<div style="background-color: #bce4e8; padding: 0.01em 16px;">x</div>',
+    );
+    expect(out).not.toContain("background-color");
+    expect(out).toContain("padding: 0.01em 16px");
+  });
+
+  it("still removes near-white backgrounds (no regression)", () => {
+    const hex = stripLightModeInlineStyles('<div style="background-color: #f4f4f4;">x</div>');
+    expect(hex).not.toContain("background-color");
+    const rgb = stripLightModeInlineStyles('<div style="background: rgb(250, 250, 250);">x</div>');
+    expect(rgb).not.toContain("rgb(250");
+  });
+
+  it("leaves a dark/saturated background alone", () => {
+    const out = stripLightModeInlineStyles(
+      '<div style="background-color: #1a1a1a; color: red;">x</div>',
+    );
+    expect(out).toContain("background-color: #1a1a1a");
+    expect(out).toContain("color: red");
+  });
 });

--- a/apps/csm-portal/webapp/src/utils/sanitizeHtml.ts
+++ b/apps/csm-portal/webapp/src/utils/sanitizeHtml.ts
@@ -58,13 +58,17 @@ export function sanitizeDescriptionHtml(html: string): string {
 }
 
 /**
- * Strips pure-white inline background declarations from style attributes so
- * dark-mode containers no longer render white boxes on a dark background.
- * Everything else (code-block backgrounds, borders, shadows, text colors) is
- * intentionally left untouched so light-mode and structural styling stay intact.
+ * Strips light/pastel inline background declarations from style attributes so
+ * dark-mode containers don't end up with washed-out, low-contrast backgrounds
+ * (default dark-mode text is light, so any sufficiently light background —
+ * not just near-white — reads poorly against it; a ServiceNow call note with
+ * e.g. a light pastel teal background is a real example that a pure-white-only
+ * check misses). Everything else (code-block backgrounds, borders, shadows,
+ * text colors) is intentionally left untouched so light-mode and structural
+ * styling stay intact.
  *
  * @param html - Raw HTML string.
- * @returns HTML with pure-white background declarations removed.
+ * @returns HTML with light background declarations removed.
  */
 export function stripLightModeInlineStyles(html: string): string {
   return html.replace(
@@ -74,13 +78,7 @@ export function stripLightModeInlineStyles(html: string): string {
       const filtered = declarations.filter((decl) => {
         const normalized = decl.toLowerCase().replace(/\s+/g, " ").trim();
         if (!normalized) return false;
-        if (
-          /^background(-color)?\s*:\s*(#fff(fff)?|white|#f4f4f4|#f5f5f5|#f0f0f0|#f9f9f9|#f8f8f8|#fafafa|#e9e9e9)\s*$/.test(
-            normalized,
-          )
-        )
-          return false;
-        if (/^background(-color)?\s*:/.test(normalized) && isNearWhiteRgb(normalized))
+        if (/^background(-color)?\s*:/.test(normalized) && isLightBackground(normalized))
           return false;
         if (/^color\s*:/.test(normalized) && isDarkColor(normalized))
           return false;
@@ -93,13 +91,72 @@ export function stripLightModeInlineStyles(html: string): string {
   );
 }
 
-function isNearWhiteRgb(bgDecl: string): boolean {
+// Small set of named CSS colors that show up in ServiceNow-authored HTML
+// backgrounds; not a full CSS color table, just enough to mirror the parsing
+// coverage (hex3/hex6/rgb/named) already used for the dark-text-color check.
+const NAMED_BACKGROUND_COLORS: Record<string, [number, number, number]> = {
+  white: [255, 255, 255],
+  black: [0, 0, 0],
+  whitesmoke: [245, 245, 245],
+  silver: [192, 192, 192],
+  gainsboro: [220, 220, 220],
+};
+
+/**
+ * WCAG relative luminance (0 = black, 1 = white) of an sRGB color, used to
+ * catch any background light enough to wash out light dark-mode text —
+ * not just backgrounds near pure white.
+ */
+function relativeLuminance(r: number, g: number, b: number): number {
+  const [rl, gl, bl] = [r, g, b].map((c) => {
+    const cs = c / 255;
+    return cs <= 0.03928 ? cs / 12.92 : ((cs + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * rl + 0.7152 * gl + 0.0722 * bl;
+}
+
+// Above this, a background reads as "light" against light dark-mode text.
+// Pure/near-white (~1.0) and #bce4e8-style pastels (~0.72) both clear it;
+// genuinely dark or saturated backgrounds (that already contrast fine with
+// light text) stay well under it.
+const LIGHT_BACKGROUND_LUMINANCE_THRESHOLD = 0.55;
+
+function isLightBackground(bgDecl: string): boolean {
+  const rgb = parseBackgroundColorRgb(bgDecl);
+  if (!rgb) return false;
+  return relativeLuminance(...rgb) > LIGHT_BACKGROUND_LUMINANCE_THRESHOLD;
+}
+
+function parseBackgroundColorRgb(bgDecl: string): [number, number, number] | null {
   const rgbMatch = bgDecl.match(
     /^background(?:-color)?\s*:\s*rgb\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)\s*$/,
   );
-  if (!rgbMatch) return false;
-  const [, r, g, b] = rgbMatch.map(Number);
-  return r > 230 && g > 230 && b > 230;
+  if (rgbMatch) {
+    const [, r, g, b] = rgbMatch.map(Number);
+    return [r, g, b];
+  }
+  const hex6Match = bgDecl.match(/^background(?:-color)?\s*:\s*#([0-9a-f]{6})\s*$/);
+  if (hex6Match) {
+    const hex = hex6Match[1];
+    return [
+      parseInt(hex.slice(0, 2), 16),
+      parseInt(hex.slice(2, 4), 16),
+      parseInt(hex.slice(4, 6), 16),
+    ];
+  }
+  const hex3Match = bgDecl.match(/^background(?:-color)?\s*:\s*#([0-9a-f]{3})\s*$/);
+  if (hex3Match) {
+    return hex3Match[1].split("").map((c) => parseInt(c + c, 16)) as [
+      number,
+      number,
+      number,
+    ];
+  }
+  const namedMatch = bgDecl.match(/^background(?:-color)?\s*:\s*([a-z]+)\s*$/);
+  if (namedMatch && namedMatch[1] in NAMED_BACKGROUND_COLORS) {
+    return NAMED_BACKGROUND_COLORS[namedMatch[1]];
+  }
+  return null;
 }
 
 function isDarkColor(colorDecl: string): boolean {

--- a/apps/csm-portal/webapp/src/utils/sanitizeHtml.ts
+++ b/apps/csm-portal/webapp/src/utils/sanitizeHtml.ts
@@ -115,11 +115,20 @@ function relativeLuminance(r: number, g: number, b: number): number {
   return 0.2126 * rl + 0.7152 * gl + 0.0722 * bl;
 }
 
-// Above this, a background reads as "light" against light dark-mode text.
-// Pure/near-white (~1.0) and #bce4e8-style pastels (~0.72) both clear it;
-// genuinely dark or saturated backgrounds (that already contrast fine with
-// light text) stay well under it.
-const LIGHT_BACKGROUND_LUMINANCE_THRESHOLD = 0.55;
+// WCAG AA minimum contrast ratio for normal-size text.
+const MIN_CONTRAST_RATIO = 4.5;
+// Dark-mode default text renders effectively white; used only to derive the
+// background threshold below, not to special-case any particular text color.
+const DARK_MODE_TEXT_LUMINANCE = 1;
+
+// A background is stripped once its own contrast against dark-mode text would
+// drop below MIN_CONTRAST_RATIO — i.e. WCAG contrast = (L_text + 0.05) /
+// (L_bg + 0.05) solved for the L_bg at which that ratio equals the minimum.
+// Deriving it this way (rather than an eyeballed constant) means a background
+// like #808080 (luminance ~0.22, ~3.95:1 against white — below AA) is caught:
+// a fixed 0.55 threshold missed it.
+const LIGHT_BACKGROUND_LUMINANCE_THRESHOLD =
+  (DARK_MODE_TEXT_LUMINANCE + 0.05) / MIN_CONTRAST_RATIO - 0.05;
 
 function isLightBackground(bgDecl: string): boolean {
   const rgb = parseBackgroundColorRgb(bgDecl);


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Three UX/correctness issues reported on the CSM portal's case-detail page and case views:

1. Page content (comment bubbles, the case Overview info grid) silently clips at the right edge on any browser window narrower than roughly 1780px — most laptop screens. Root cause: `@wso2/oxygen-ui`'s `AppShell` component never sets `minWidth: 0` on the `<main>` flex item it renders, so `<main>` locks to its content's intrinsic width instead of shrinking to the viewport, and the surrounding flex row's `overflow: hidden` then clips the excess instead of scrolling or wrapping. This affects the whole page, not just comments.
2. A ServiceNow-authored comment (e.g. a call-note callout box) with a light/pastel inline background is unreadable in dark mode, because the dark-mode style-stripping only neutralized near-white backgrounds, not light backgrounds generally.
3. A case with no severity value (empty/unrecognized from the backend) was silently displayed and filtered as if it were severity S3 (Medium) — a false signal, since "severity unknown" and "severity is genuinely Medium" are different facts that were rendered identically. Reported separately from the two issues above.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

1. Stop relying on oxygen-ui's `AppShell` for the page shell; use a hand-built `AppShellLayout` that explicitly cascades `minWidth: 0` through every flex ancestor down to `<main>`, so content sizes to the actual viewport instead of clipping.
2. Broaden the dark-mode inline-style stripping so any sufficiently light background (measured via WCAG relative luminance, not just near-white) gets neutralized before a comment renders in dark mode.
3. Stop the severity mapper from defaulting falsy/unrecognized severity to `"S3"`. Represent "unset" as its own distinct value, rendered as a visually distinct "Unset" badge, and keep it excluded from all S1-S4 severity filters so it can never be mistaken for a real severity again.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

`apps/csm-portal/webapp/src/layouts/AppShellLayout.tsx` (new) ports the same pattern the customer portal already ships in production for the identical bug (`apps/customer-portal/webapp/src/layouts/AppShellLayout.tsx`), trimmed to what CSM's `AppLayout` actually needs (no footer slot, no overlay/mobile-drawer sidebar — CSM's sidebar only ever renders inline). `AppLayout.tsx` swaps its `<AppShell>`/`<AppShell.Navbar>`/`<AppShell.Sidebar>`/`<AppShell.Main>` usage for the new component; all surrounding behavior (banners, loading state, scroll-reset-on-route-change, `useAppShell()` state) is unchanged.

`utils/sanitizeHtml.ts`'s `stripLightModeInlineStyles` (dark-mode only, called from `CsmCaseCommentBubble.tsx`) replaces its near-white-only RGB threshold with a WCAG relative-luminance calculation, catching light/pastel backgrounds generally while leaving dark/saturated backgrounds (code blocks, etc.) untouched.

For the severity issue: `src/api/backend/mappers.ts`'s severity mapper (renamed `severityFromPriority` → `severityFromBe`, since it consumes the backend's `severity` field, not a "priority" field) now returns a new `"unset"` value instead of `"S3"` for falsy/unrecognized input. A new `SeverityOrUnset = Severity | "unset"` type is applied only to display-facing fields (case-list rows, case detail, quick-search hits, child-case rows); severity filter option arrays and the severity-change dialog's radio options stay `Severity`-only, which keeps "unset" out of the filter UI by construction rather than needing separate exclusion logic. `SeverityChip` renders `"unset"` as an outlined, non-bold "Unset" badge, visually distinct from every real severity's filled/bold chip. Investigation confirmed the backend (Go entity-service) already returns an empty value for unmapped severity and never defaults it to Medium — the defaulting was purely a frontend display bug.

## User stories
> Summary of user stories addressed by this change

As a CS engineer, I can see the full case-detail page (Overview fields, comment content) without content being cut off on my laptop screen, I can read ServiceNow-authored comments with light-colored callout boxes in dark mode, and I can tell at a glance whether a case genuinely has no severity set versus being a real S3 case.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Fixed CSM portal page content being clipped on narrower browser windows, fixed low-contrast comment backgrounds in dark mode, and fixed cases with no severity set incorrectly displaying as S3.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter "N/A" plus brief explanation of why there's no doc impact

N/A — internal layout/rendering/display fix, no user-facing documentation to update.

## Training
N/A — not training content.

## Certification
N/A — no certification exam impact.

## Marketing
N/A — internal bug fix, not a marketed feature.

## Automation tests
 - Unit tests
   > Code coverage information

Added/updated `sanitizeHtml.test.ts` (16 tests passing, including 3 new cases: pastel background stripped, near-white regression check, dark background left untouched). Added/updated `mappers.test.ts` and new `SeverityChip.test.tsx` for the severity fix (61/61 passing across the 7 directly-affected test files: mapper, chip, severity-change dialog, log-time-card dialog, case-detail page, case search payload, filters URL).
 - Integration tests
   > Details about the test cases and coverage

None added; layout and severity changes verified via typecheck + full existing suite (`tsc -b --force` exit 0, `eslint .` unchanged from baseline, `vitest run` 133/141 with the same 8 pre-existing unrelated failures confirmed present on `main`).

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A for TS — ran `eslint`, clean on touched files
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
A companion fix for the same dark-mode background-contrast issue in the customer portal is being opened separately (different app, kept as its own PR).

## Migrations (if applicable)
N/A

## Test environment
Verified with `pnpm run build` and `pnpm run test` (Vitest) locally against Node/pnpm versions pinned in this repo. Full local-stack browser verification (real viewport resize + dark-mode screenshot, and a live unset-severity case vs. a real S3 case) is recommended as a follow-up before merge.

## Learning
Root-caused the clipping bug by reading `@wso2/oxygen-ui`'s compiled source directly (a shallow-merge bug in its `Layout.Content`'s `sx` prop handling drops `minWidth`/`overflow` defaults) and comparing against the customer portal's existing fix for the same issue. For the severity bug, confirmed the defaulting lived entirely in the frontend mapper by reading the Go entity-service's case-severity path first — it already exposes `severity` (not `priority`) and never defaults unmapped input to Medium.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for cases with missing or unrecognized severity, displayed as “Unset.”
  - Prevented unset severities from being treated as S3 or selected accidentally.
  - Improved related-case, call-request, and time-entry behavior when severity is unset.
  - Added a refreshed application shell with improved content sizing, scrolling, and loading layout.

- **Bug Fixes**
  - Improved inline background sanitization to remove low-contrast light colors while preserving appropriate dark or saturated colors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->