### PR TITLE
[CSM][Web] Fix case detail page overflowing off-screen on wide comment content

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentBubble.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentBubble.tsx
@@ -332,6 +332,28 @@ export default function CsmCaseCommentBubble({
         <Box
           sx={{
             minWidth: 0,
+            maxWidth: "100%",
+            // Backend HTML can put an explicit pixel width on *any* element — a
+            // Word/Excel paste arrives as `<div style="width:2400px">`, and a
+            // `<pre>`/`<p>` can carry one just as easily — so the per-tag rules
+            // below can never cover every case.
+            //
+            // `contain: inline-size` is what actually stops it: it makes this
+            // box's own width independent of its contents, so an over-wide child
+            // can no longer inflate the *intrinsic* min-content width that
+            // otherwise propagates up the whole chain (bubble → feed → tab →
+            // page root → AppShell.Main) and drags the page off-screen, cutting
+            // off the header actions, the Overview grid's last column, and the
+            // timeline toolbar. `min-width: 0` / `overflow` alone do NOT do this:
+            // they zero a *flex item's* automatic minimum size, not the
+            // min-content contribution travelling up through block ancestors —
+            // verified empirically against this exact layout chain, where the
+            // page still blew out to 3080px with overflow set but no containment.
+            //
+            // `overflowX` then makes that over-wide content reachable by
+            // scrolling inside the comment, rather than being clipped away.
+            contain: "inline-size",
+            overflowX: "auto",
             overflowWrap: "anywhere",
             wordBreak: "break-word",
             "& p": { m: 0 },
@@ -345,11 +367,15 @@ export default function CsmCaseCommentBubble({
               fontSize: "0.85em",
               overflowWrap: "anywhere",
             },
+            // `maxWidth` matters as much as `overflowX` here: a `<pre>` carrying
+            // an explicit `width` would otherwise just *be* that wide, and
+            // `overflow-x` would have nothing to scroll.
             "& pre": {
               bgcolor: "background.default",
               p: 1,
               borderRadius: 1,
               overflowX: "auto",
+              maxWidth: "100%",
               fontFamily: "monospace",
               fontSize: "0.85em",
             },

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentBubble.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentBubble.tsx
@@ -245,6 +245,12 @@ export default function CsmCaseCommentBubble({
             sx={{
               flex: 1,
               minWidth: 0,
+              // A system entry is backend HTML too, so it needs the same width
+              // containment as a regular comment body — see the full note on the
+              // rich-text host below for why `min-width: 0` alone doesn't hold.
+              maxWidth: "100%",
+              contain: "inline-size",
+              overflowX: "auto",
               overflowWrap: "anywhere",
               wordBreak: "break-word",
               "& p": { m: 0 },

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -2153,6 +2153,14 @@ export default function CsmCaseDetailPage(): JSX.Element {
                 sx={{
                   typography: "body2",
                   color: "text.primary",
+                  // Same containment the comment bubble needs — see the long
+                  // note in `CsmCaseCommentBubble`. This description is backend
+                  // HTML too, so it can carry an explicit pixel width that would
+                  // otherwise drag the whole page off-screen.
+                  minWidth: 0,
+                  maxWidth: "100%",
+                  contain: "inline-size",
+                  overflowX: "auto",
                   "& p": { mb: 0.5 },
                   "& p:last-child": { mb: 0 },
                 }}


### PR DESCRIPTION
## Purpose
A case comment whose body carries an explicit pixel width — what a Word/Excel paste through the comment editor's **HTML source** mode produces (e.g. `<div style="width:2400px">`) — pushed the entire case-detail page wider than the viewport. The header actions (Assign to me / Acknowledge / More), the last column of the Overview section, and the activity-timeline toolbar (Filter / Newest first) all got cut off past the right edge, on any case type.

> **Scope note:** this fixes the containment of backend-rendered rich text on the case-detail surface. It deliberately does not touch `AppShell.Main` (vendored in `@wso2/oxygen-ui`) or add a blanket page-level clamp — the over-wide content should be contained where it enters, so wide tables stay scrollable/readable rather than being clipped app-wide.

## Goals
- Page content always fits the available width, regardless of what markup a comment body contains.
- Over-wide content (tables, pasted spreadsheet blocks, code) stays reachable by scrolling **inside** the comment, not clipped away.
- Fix holds for any element, not just the handful of tags currently special-cased.

## Approach
- `src/features/csm-cases/components/CsmCaseCommentBubble.tsx` — added `contain: inline-size` (plus `max-width: 100%` / `overflow-x: auto`) to the rich-text host.

  The existing per-tag rules (`& table`, `& pre`, `& img`) can't cover this, because the width can sit on *any* element. `contain: inline-size` makes the host's own width independent of its contents, so an over-wide child can no longer inflate the intrinsic min-content width that propagates up `bubble → feed → tab → page root → AppShell.Main`.

  Worth recording, since it's the non-obvious part: **`min-width: 0` / `overflow` alone do not fix this.** They zero a *flex item's automatic minimum size*, not the *min-content contribution* travelling up through block ancestors. Measured against this exact layout chain — with `overflow` set but no containment the page still blew out to **3120px**; with containment it sits at the correct **930px**.
- Same host also gained the missing `max-width` on `& pre`, which otherwise simply *is* its explicit width, leaving its own `overflow-x` nothing to scroll.
- `src/features/csm-cases/pages/CsmCaseDetailPage.tsx` — same guard on the read-only Description fallback card (rendered when `comments/search` fails, so the description never reaches the activity feed). It renders backend HTML through its own host and was exposed to the identical problem.

## User stories
As a CS engineer viewing a case, I can read a comment containing a wide pasted table without the page's header actions, Overview column, and timeline toolbar being pushed off-screen.

## Release note
Fixed case detail page content overflowing off-screen when a comment contains wide HTML content such as a pasted table.

## Documentation
N/A — internal CSM portal UI, no external doc surface affected.

## Automation tests
- Unit tests: `csm-cases` suite passing (282 passed). Two failures in `LinkCaseDialog` / `CaseActionBar` are pre-existing on `main` and unrelated — confirmed by re-running them on a clean checkout.
- Verified with the real `CaseActivitiesFeed` / `CsmCaseCommentBubble` components mounted in the actual shell layout shape, with a control run to prove the check detects the bug:

  | | main width | "More" button right edge | contained |
  |---|---|---|---|
  | before | 3120px | 3179px | ❌ |
  | after | 930px | 989px | ✅ |

  (930px = 1000px viewport − 64px sidebar − borders, i.e. correct layout rather than a collapse.)

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (frontend-only change)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
- `pnpm run lint` (no new findings), `pnpm run test`, `tsc -b` all passing locally.
- CSS-only change; no API, payload, or sanitisation behaviour altered.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented oversized comments and case descriptions from expanding the page layout.
  * Added horizontal scrolling for wide content, including preformatted text and backend-provided HTML.
  * Improved display of content with explicit widths within the available screen space.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->