### PR TITLE
[Customer Portal][Webapp] Migrate date range filters to Oxygen UI DatePicker with validation and smarter defaults

### DIFF
--- a/apps/customer-portal/webapp/src/features/project-details/components/time-tracking/ProjectTimeTracking.tsx
+++ b/apps/customer-portal/webapp/src/features/project-details/components/time-tracking/ProjectTimeTracking.tsx
@@ -20,6 +20,7 @@ import {
   type JSX,
   type ChangeEvent,
 } from "react";
+import { format } from "date-fns";
 import useSearchProjectCaseTimeCards from "@features/usage-metrics/api/useSearchProjectCaseTimeCards";
 import ServiceHoursStatCards from "@time-tracking/ServiceHoursStatCards";
 import TimeCardsBillableStats from "@time-tracking/TimeCardsBillableStats";
@@ -47,7 +48,17 @@ export default function ProjectTimeTracking({
   const [startDate, setStartDate] = useState("");
   const [endDate, setEndDate] = useState("");
   const [page, setPage] = useState(1);
+  const [hasAppliedDefaultDates, setHasAppliedDefaultDates] = useState(false);
   const pageSize = 10;
+
+  // Default the date range to the project's start date through today once it loads.
+  useEffect(() => {
+    if (hasAppliedDefaultDates || !project?.startDate) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setHasAppliedDefaultDates(true);
+    setStartDate(project.startDate);
+    setEndDate(format(new Date(), "yyyy-MM-dd"));
+  }, [hasAppliedDefaultDates, project?.startDate]);
 
   const {
     data,
@@ -64,10 +75,12 @@ export default function ProjectTimeTracking({
     enabled: !!projectId,
   });
 
-  // Reset pagination when the project changes
+  // Reset pagination and default dates when the project changes
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setPage(1);
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setHasAppliedDefaultDates(false);
   }, [projectId]);
 
   const paginatedTimeCards = data?.caseTimeCards ?? [];

--- a/apps/customer-portal/webapp/src/features/project-details/components/time-tracking/TimeCardsDateFilter.tsx
+++ b/apps/customer-portal/webapp/src/features/project-details/components/time-tracking/TimeCardsDateFilter.tsx
@@ -14,16 +14,26 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import {
-  Box,
-  Typography,
-  TextField,
-  InputAdornment,
-  Button,
-} from "@wso2/oxygen-ui";
+import { Box, Typography, Button } from "@wso2/oxygen-ui";
 import { Calendar, X } from "@wso2/oxygen-ui-icons-react";
+import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
+import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
+import { DatePicker } from "@mui/x-date-pickers/DatePicker";
+import { format } from "date-fns";
 import type { JSX } from "react";
 import type { TimeCardsDateFilterProps } from "@features/project-details/types/projectDetailsComponents";
+
+function parseDateOnly(value: string): Date | null {
+  if (!value) return null;
+  const match = /^(\d{4})-(\d{2})-(\d{2})/.exec(value);
+  if (!match) return null;
+  const date = new Date(Number(match[1]), Number(match[2]) - 1, Number(match[3]));
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function formatDateOnly(date: Date): string {
+  return format(date, "yyyy-MM-dd");
+}
 
 /**
  * TimeCardsDateFilter provides a compact time-range filter for time cards.
@@ -39,66 +49,70 @@ export default function TimeCardsDateFilter({
   onClear,
 }: TimeCardsDateFilterProps): JSX.Element {
   const hasFilters = Boolean(startDate || endDate);
+  const parsedStart = parseDateOnly(startDate);
+  const parsedEnd = parseDateOnly(endDate);
 
   return (
-    <Box
-      sx={{
-        display: "flex",
-        alignItems: "center",
-        gap: 1.5,
-        flexWrap: "wrap",
-      }}
-    >
-      <Calendar size={18} />
-      <Typography variant="body2" sx={{ fontWeight: 600 }}>
-        Time Range:
-      </Typography>
-      <TextField
-        id="time-cards-start-date"
-        type="date"
-        size="small"
-        value={startDate}
-        onChange={(e) => onStartDateChange(e.target.value)}
-        inputProps={{ "aria-label": "Start date" }}
-        sx={{ minWidth: 160 }}
-        InputProps={{
-          startAdornment: (
-            <InputAdornment position="start">
-              <Calendar size={16} />
-            </InputAdornment>
-          ),
+    <LocalizationProvider dateAdapter={AdapterDateFns}>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          gap: 1.5,
+          flexWrap: "wrap",
         }}
-      />
-      <Typography variant="body2" color="text.secondary">
-        to
-      </Typography>
-      <TextField
-        id="time-cards-end-date"
-        type="date"
-        size="small"
-        value={endDate}
-        onChange={(e) => onEndDateChange(e.target.value)}
-        inputProps={{ "aria-label": "End date" }}
-        sx={{ minWidth: 160 }}
-        InputProps={{
-          startAdornment: (
-            <InputAdornment position="start">
-              <Calendar size={16} />
-            </InputAdornment>
-          ),
-        }}
-      />
-      {hasFilters && onClear && (
-        <Button
-          variant="text"
-          size="small"
-          onClick={onClear}
-          startIcon={<X size={16} />}
-          sx={{ color: "text.secondary" }}
-        >
-          Clear
-        </Button>
-      )}
-    </Box>
+      >
+        <Calendar size={18} />
+        <Typography variant="body2" sx={{ fontWeight: 600 }}>
+          Time Range:
+        </Typography>
+        <DatePicker
+          value={parsedStart}
+          maxDate={parsedEnd ?? undefined}
+          onChange={(date) => {
+            onStartDateChange(date instanceof Date && !isNaN(date.getTime()) ? formatDateOnly(date) : "");
+          }}
+          slotProps={{
+            textField: {
+              id: "time-cards-start-date",
+              size: "small",
+              sx: { minWidth: 160 },
+              inputProps: { "aria-label": "Start date" },
+            },
+            field: { clearable: true },
+          }}
+        />
+        <Typography variant="body2" color="text.secondary">
+          to
+        </Typography>
+        <DatePicker
+          value={parsedEnd}
+          minDate={parsedStart ?? undefined}
+          onChange={(date) => {
+            onEndDateChange(date instanceof Date && !isNaN(date.getTime()) ? formatDateOnly(date) : "");
+          }}
+          slotProps={{
+            textField: {
+              id: "time-cards-end-date",
+              size: "small",
+              sx: { minWidth: 160 },
+              inputProps: { "aria-label": "End date" },
+            },
+            field: { clearable: true },
+          }}
+        />
+        {hasFilters && onClear && (
+          <Button
+            variant="text"
+            size="small"
+            onClick={onClear}
+            startIcon={<X size={16} />}
+            sx={{ color: "text.secondary" }}
+          >
+            Clear
+          </Button>
+        )}
+      </Box>
+    </LocalizationProvider>
   );
 }

--- a/apps/customer-portal/webapp/src/features/project-details/components/time-tracking/TimeCardsDateFilter.tsx
+++ b/apps/customer-portal/webapp/src/features/project-details/components/time-tracking/TimeCardsDateFilter.tsx
@@ -14,12 +14,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Box, Typography, Button } from "@wso2/oxygen-ui";
+import { Box, Typography, Button, DatePickers, AdapterDateFns } from "@wso2/oxygen-ui";
 import { Calendar, X } from "@wso2/oxygen-ui-icons-react";
-import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
-import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
-import { DatePicker } from "@mui/x-date-pickers/DatePicker";
 import { format } from "date-fns";
+
+const { LocalizationProvider, DatePicker } = DatePickers;
 import type { JSX } from "react";
 import type { TimeCardsDateFilterProps } from "@features/project-details/types/projectDetailsComponents";
 
@@ -77,7 +76,7 @@ export default function TimeCardsDateFilter({
               id: "time-cards-start-date",
               size: "small",
               sx: { minWidth: 160 },
-              inputProps: { "aria-label": "Start date" },
+              slotProps: { htmlInput: { "aria-label": "Start date" } },
             },
             field: { clearable: true },
           }}
@@ -96,7 +95,7 @@ export default function TimeCardsDateFilter({
               id: "time-cards-end-date",
               size: "small",
               sx: { minWidth: 160 },
-              inputProps: { "aria-label": "End date" },
+              slotProps: { htmlInput: { "aria-label": "End date" } },
             },
             field: { clearable: true },
           }}

--- a/apps/customer-portal/webapp/src/features/project-details/components/time-tracking/TimeCardsDateFilter.tsx
+++ b/apps/customer-portal/webapp/src/features/project-details/components/time-tracking/TimeCardsDateFilter.tsx
@@ -67,6 +67,7 @@ export default function TimeCardsDateFilter({
         </Typography>
         <DatePicker
           value={parsedStart}
+          disableFuture
           maxDate={parsedEnd ?? undefined}
           onChange={(date) => {
             onStartDateChange(date instanceof Date && !isNaN(date.getTime()) ? formatDateOnly(date) : "");
@@ -86,6 +87,7 @@ export default function TimeCardsDateFilter({
         </Typography>
         <DatePicker
           value={parsedEnd}
+          disableFuture
           minDate={parsedStart ?? undefined}
           onChange={(date) => {
             onEndDateChange(date instanceof Date && !isNaN(date.getTime()) ? formatDateOnly(date) : "");

--- a/apps/customer-portal/webapp/src/features/project-details/components/time-tracking/TimeTrackingCard.tsx
+++ b/apps/customer-portal/webapp/src/features/project-details/components/time-tracking/TimeTrackingCard.tsx
@@ -87,7 +87,7 @@ export default function TimeTrackingCard({
           </Typography>
           {createdBy && (
             <Typography variant="caption" color="text.secondary">
-              Reported by {createdBy}
+              Created by {createdBy}
             </Typography>
           )}
         </Box>

--- a/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageMetricsTimeRangeSelector.tsx
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageMetricsTimeRangeSelector.tsx
@@ -17,11 +17,12 @@
 import {
   Box,
   Button,
-  InputAdornment,
-  TextField,
   Typography,
+  DatePickers,
+  AdapterDateFns,
 } from "@wso2/oxygen-ui";
 import { Calendar } from "@wso2/oxygen-ui-icons-react";
+import { format } from "date-fns";
 import type { JSX } from "react";
 import {
   USAGE_METRICS_CUSTOM_RANGE_APPLY,
@@ -42,6 +43,20 @@ import {
 } from "@features/usage-metrics/types/usageMetrics";
 import { UsageTimeRange } from "@features/project-details/types/usage";
 import { getUsagePresetShortLabel } from "@features/usage-metrics/utils/usageMetricsTab";
+
+const { LocalizationProvider, DatePicker } = DatePickers;
+
+function parseDateOnly(value: string): Date | null {
+  if (!value) return null;
+  const match = /^(\d{4})-(\d{2})-(\d{2})/.exec(value);
+  if (!match) return null;
+  const date = new Date(Number(match[1]), Number(match[2]) - 1, Number(match[3]));
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function formatDateOnly(date: Date): string {
+  return format(date, "yyyy-MM-dd");
+}
 
 /**
  * Preset and custom date range controls for Usage & Metrics panels.
@@ -138,45 +153,47 @@ export default function UsageMetricsTimeRangeSelector({
           {timeRange === UsageTimeRange.CUSTOM && (
             <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5, ml: 1 }}>
               <Box sx={{ display: "flex", alignItems: "center", gap: 2, flexWrap: "wrap" }}>
-                <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
-                  <TextField
-                    type="date"
-                    size="small"
-                    value={customStart}
-                    onChange={(e) => onCustomStartChange(e.target.value)}
-                    error={!!customRangeError}
-                    sx={{ minWidth: 160, maxWidth: "100%" }}
-                    InputProps={{
-                      startAdornment: (
-                        <InputAdornment position="start">
-                          <Calendar size={16} />
-                        </InputAdornment>
-                      ),
-                    }}
-                  />
-                  <Typography
-                    variant="body2"
-                    color="text.secondary"
-                    sx={{ mx: 0.5 }}
-                  >
-                    {USAGE_METRICS_CUSTOM_RANGE_TO}
-                  </Typography>
-                  <TextField
-                    type="date"
-                    size="small"
-                    value={customEnd}
-                    onChange={(e) => onCustomEndChange(e.target.value)}
-                    error={!!customRangeError}
-                    sx={{ minWidth: 160, maxWidth: "100%" }}
-                    InputProps={{
-                      startAdornment: (
-                        <InputAdornment position="start">
-                          <Calendar size={16} />
-                        </InputAdornment>
-                      ),
-                    }}
-                  />
-                </Box>
+                <LocalizationProvider dateAdapter={AdapterDateFns}>
+                  <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
+                    <DatePicker
+                      value={parseDateOnly(customStart)}
+                      maxDate={parseDateOnly(customEnd) ?? undefined}
+                      onChange={(date) => {
+                        onCustomStartChange(date instanceof Date && !isNaN(date.getTime()) ? formatDateOnly(date) : "");
+                      }}
+                      slotProps={{
+                        textField: {
+                          size: "small",
+                          error: !!customRangeError,
+                          sx: { minWidth: 160, maxWidth: "100%" },
+                        },
+                        field: { clearable: true },
+                      }}
+                    />
+                    <Typography
+                      variant="body2"
+                      color="text.secondary"
+                      sx={{ mx: 0.5 }}
+                    >
+                      {USAGE_METRICS_CUSTOM_RANGE_TO}
+                    </Typography>
+                    <DatePicker
+                      value={parseDateOnly(customEnd)}
+                      minDate={parseDateOnly(customStart) ?? undefined}
+                      onChange={(date) => {
+                        onCustomEndChange(date instanceof Date && !isNaN(date.getTime()) ? formatDateOnly(date) : "");
+                      }}
+                      slotProps={{
+                        textField: {
+                          size: "small",
+                          error: !!customRangeError,
+                          sx: { minWidth: 160, maxWidth: "100%" },
+                        },
+                        field: { clearable: true },
+                      }}
+                    />
+                  </Box>
+                </LocalizationProvider>
                 <Box sx={{ display: "flex", gap: 1 }}>
                   <Button
                     size="small"

--- a/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageMetricsTimeRangeSelector.tsx
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageMetricsTimeRangeSelector.tsx
@@ -157,6 +157,7 @@ export default function UsageMetricsTimeRangeSelector({
                   <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
                     <DatePicker
                       value={parseDateOnly(customStart)}
+                      disableFuture
                       maxDate={parseDateOnly(customEnd) ?? undefined}
                       onChange={(date) => {
                         onCustomStartChange(date instanceof Date && !isNaN(date.getTime()) ? formatDateOnly(date) : "");
@@ -179,6 +180,7 @@ export default function UsageMetricsTimeRangeSelector({
                     </Typography>
                     <DatePicker
                       value={parseDateOnly(customEnd)}
+                      disableFuture
                       minDate={parseDateOnly(customStart) ?? undefined}
                       onChange={(date) => {
                         onCustomEndChange(date instanceof Date && !isNaN(date.getTime()) ? formatDateOnly(date) : "");

--- a/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageMetricsTimeRangeSelector.tsx
+++ b/apps/customer-portal/webapp/src/features/usage-metrics/components/UsageMetricsTimeRangeSelector.tsx
@@ -167,6 +167,7 @@ export default function UsageMetricsTimeRangeSelector({
                           size: "small",
                           error: !!customRangeError,
                           sx: { minWidth: 160, maxWidth: "100%" },
+                          slotProps: { htmlInput: { "aria-label": "Custom range start date" } },
                         },
                         field: { clearable: true },
                       }}
@@ -190,6 +191,7 @@ export default function UsageMetricsTimeRangeSelector({
                           size: "small",
                           error: !!customRangeError,
                           sx: { minWidth: 160, maxWidth: "100%" },
+                          slotProps: { htmlInput: { "aria-label": "Custom range end date" } },
                         },
                         field: { clearable: true },
                       }}


### PR DESCRIPTION
## Summary
- Replaced native `TextField type="date"` inputs with the Oxygen UI–exported MUI `DatePicker` in the Time Tracking date filter and the Usage & Metrics date range selector.
- Added validation to both pickers: future dates are disabled, and start/end are constrained so the range can't be inverted.
- Time Tracking date range now defaults to the project's start date through today, instead of loading empty (previously it also briefly defaulted to the full subscription period, which allowed future end dates — fixed to use today).

## Test plan
- [ ] Open a project's Time Tracking tab, confirm the date range defaults to project start date → today.
- [ ] Try selecting a future date in either picker — confirm it's disabled.
- [ ] Try setting an end date before the start date (and vice versa) — confirm it's blocked/grayed out.
- [ ] Repeat the future-date and start/end checks on the Usage & Metrics custom range picker.
- [ ] Confirm Clear still resets the Time Tracking filter to empty (no auto re-default).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Replaced date text fields with calendar-based date pickers in time tracking and usage metrics.
  * Prevented selection of future dates and invalid date ranges.
  * Added support for clearing date filters while preserving accessibility and validation.

* **Improvements**
  * Time tracking now defaults its date range from the project start date through today.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->