### PR TITLE
Add deployment E2E coverage

### DIFF
--- a/apps/customer-portal/webapp/tests/e2e/config/testData.ts
+++ b/apps/customer-portal/webapp/tests/e2e/config/testData.ts
@@ -235,6 +235,52 @@ export const SERVICE_REQUEST_INPUT: ServiceRequestInput = {
   description: "This is a test Generic Request SR for MS subscription project",
 };
 
+/** Deployment types offered by the Add Deployment modal. Verified live against
+ * staging — note there is no plain "Production": the production-like option is
+ * "Primary Production". */
+export const DeploymentType = {
+  DEVELOPMENT: "Development",
+  QA: "QA",
+  STAGING: "Staging",
+  STRESS: "Stress",
+  UAT: "UAT",
+  PRIMARY_PRODUCTION: "Primary Production",
+} as const;
+
+export type DeploymentType =
+  (typeof DeploymentType)[keyof typeof DeploymentType];
+
+/** Content submitted by the add-deployment flow. */
+export interface DeploymentInput {
+  /** Name *prefix*. The spec appends a timestamp because the backend rejects a
+   * duplicate name with 409 and there is no delete endpoint, so a fixed name
+   * only ever works on the very first run. */
+  namePrefix: string;
+  /** Name of a deployment that already exists on the project, for exercising the
+   * duplicate-name rejection. Durable as a fixture because deployments have no
+   * delete endpoint, so once created this name cannot disappear. */
+  existingName: string;
+  type: DeploymentType;
+  /** Goes in the field labelled "Description *" — the modal does not call it
+   * "Deployment Description". */
+  description: string;
+}
+
+/**
+ * Deployment to create on the Managed Cloud Subscription project.
+ *
+ * ⚠️ Creates a permanent record on every run — `POST /projects/{id}/deployments`
+ * has no delete counterpart, so these accumulate and cannot be cleaned up. The
+ * timestamped name keeps them identifiable and ordered.
+ */
+export const DEPLOYMENT_INPUT: DeploymentInput = {
+  namePrefix: "Automation Test Deployment",
+  existingName: "Automation Test Deployment",
+  type: DeploymentType.PRIMARY_PRODUCTION,
+  description:
+    "This is a test deployment for Automation Test MS Customer Project",
+};
+
 /** Content submitted by the create-security-report flow.
  *
  * A security report is a case raised at `/support/security-report/create`. The

--- a/apps/customer-portal/webapp/tests/e2e/pages/ProjectDeploymentsPage.ts
+++ b/apps/customer-portal/webapp/tests/e2e/pages/ProjectDeploymentsPage.ts
@@ -154,9 +154,19 @@ export class ProjectDeploymentsPage {
     await this.modalSubmitButton().click();
   }
 
-  /** Any element showing a deployment's name — for asserting it appears in the
-   * list after creation. */
+  /**
+   * The list entry for a deployment, matched on its exact name.
+   *
+   * Exact rather than substring: every deployment this suite creates shares the
+   * `namePrefix`, so a substring match would also hit the entries left by
+   * earlier runs. Deliberately not narrowed with `.first()` either — callers
+   * assert the count, so an ambiguous match fails loudly instead of silently
+   * asserting against whichever entry happens to come first.
+   *
+   * @param name - Full deployment name.
+   * @returns Locator for the matching entry (expected to be unique).
+   */
   deploymentEntry(name: string): Locator {
-    return this.main().getByText(name, { exact: false }).first();
+    return this.main().getByText(name, { exact: true });
   }
 }

--- a/apps/customer-portal/webapp/tests/e2e/pages/ProjectDeploymentsPage.ts
+++ b/apps/customer-portal/webapp/tests/e2e/pages/ProjectDeploymentsPage.ts
@@ -1,0 +1,162 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { type Locator, type Page, expect } from "../fixtures/test";
+import {
+  ADD_DEPLOYMENT,
+  CASE_DETAIL,
+  PROJECT_DETAILS,
+} from "../utils/selectors";
+
+/** How long to allow for the dashboard, the project-details page and the
+ * deployments list to load — each is skeletonised while its queries resolve,
+ * well beyond the 5s default expect timeout. */
+const LOAD_TIMEOUT_MS = 60_000;
+
+/**
+ * Page object for the Deployments tab of the project details page
+ * (`/projects/:projectId/project-details`).
+ */
+export class ProjectDeploymentsPage {
+  constructor(private readonly page: Page) {}
+
+  /** The app's <main> region. Scoping matters here: the modal's confirm button
+   * shares its accessible name with the button that opens it. */
+  private main(): Locator {
+    return this.page.getByTestId(CASE_DETAIL.mainTestId);
+  }
+
+  /**
+   * Navigates from the project dashboard to the Deployments tab via the side
+   * nav, then waits for the deployments list.
+   *
+   * @param projectId - Project whose deployments to open.
+   */
+  async openDeploymentsTab(projectId: string): Promise<void> {
+    await this.page.goto(`/projects/${projectId}/dashboard`);
+
+    const navItem = this.page.getByRole("button", {
+      name: PROJECT_DETAILS.navItem,
+    });
+    await expect(navItem).toBeVisible({ timeout: LOAD_TIMEOUT_MS });
+    await navItem.click();
+    await expect(this.page).toHaveURL(
+      new RegExp(`/projects/${projectId}/${PROJECT_DETAILS.pathSegment}`),
+    );
+
+    await this.deploymentsTab().click();
+    // The Add Deployment button only renders once the deployments query resolves
+    // (and is withheld entirely for a Restricted project), so waiting on it
+    // confirms the tab is ready to act on.
+    await expect(this.addDeploymentButton()).toBeVisible({
+      timeout: LOAD_TIMEOUT_MS,
+    });
+  }
+
+  deploymentsTab(): Locator {
+    return this.page.getByRole("tab", {
+      name: new RegExp(PROJECT_DETAILS.tabs.deployments),
+    });
+  }
+
+  /** The button that opens the modal. Scoped to <main> and excluded from the
+   * dialog, since the modal's confirm control has the same name. */
+  addDeploymentButton(): Locator {
+    return this.main().getByRole("button", {
+      name: ADD_DEPLOYMENT.openButton,
+      exact: true,
+    });
+  }
+
+  modal(): Locator {
+    return this.page.getByRole("dialog");
+  }
+
+  nameInput(): Locator {
+    return this.modal().locator(ADD_DEPLOYMENT.ids.name);
+  }
+
+  typeSelect(): Locator {
+    return this.modal().locator(ADD_DEPLOYMENT.ids.type);
+  }
+
+  descriptionInput(): Locator {
+    return this.modal().locator(ADD_DEPLOYMENT.ids.description);
+  }
+
+  /** The modal's confirm control, scoped to the dialog to keep it distinct from
+   * the button that opened it. */
+  modalSubmitButton(): Locator {
+    return this.modal().getByRole("button", {
+      name: ADD_DEPLOYMENT.submitButton,
+      exact: true,
+    });
+  }
+
+  modalCancelButton(): Locator {
+    return this.modal().getByRole("button", { name: "Cancel", exact: true });
+  }
+
+  /** Picks a deployment type without touching the other fields. */
+  async selectType(type: string): Promise<void> {
+    await this.typeSelect().click();
+    await this.page.getByRole("option", { name: type, exact: true }).click();
+  }
+
+  async cancel(): Promise<void> {
+    await this.modalCancelButton().click();
+    await expect(this.modal()).toBeHidden();
+  }
+
+  /** Opens the Add Deployment modal and waits for it. */
+  async openAddDeploymentModal(): Promise<void> {
+    await this.addDeploymentButton().click();
+    await expect(this.modal()).toBeVisible();
+    await expect(
+      this.page.getByText(ADD_DEPLOYMENT.dialogTitle),
+    ).toBeVisible();
+  }
+
+  /**
+   * Fills the modal.
+   *
+   * @param name - Deployment name.
+   * @param type - Deployment type option label.
+   * @param description - Description text.
+   */
+  async fillDeployment(
+    name: string,
+    type: string,
+    description: string,
+  ): Promise<void> {
+    await this.nameInput().fill(name);
+
+    await this.typeSelect().click();
+    await this.page.getByRole("option", { name: type, exact: true }).click();
+
+    await this.descriptionInput().fill(description);
+  }
+
+  async submit(): Promise<void> {
+    await this.modalSubmitButton().click();
+  }
+
+  /** Any element showing a deployment's name — for asserting it appears in the
+   * list after creation. */
+  deploymentEntry(name: string): Locator {
+    return this.main().getByText(name, { exact: false }).first();
+  }
+}

--- a/apps/customer-portal/webapp/tests/e2e/pages/ProjectDeploymentsPage.ts
+++ b/apps/customer-portal/webapp/tests/e2e/pages/ProjectDeploymentsPage.ts
@@ -43,6 +43,14 @@ export class ProjectDeploymentsPage {
    * Navigates from the project dashboard to the Deployments tab via the side
    * nav, then waits for the deployments list.
    *
+   * Readiness is signalled by the Add Deployment button, which is permission
+   * gated — `ProjectDeployments` withholds it entirely for a Restricted project.
+   * That is fine for every fixture this suite has (none is Restricted) but means
+   * this method cannot be pointed at a Restricted project as-is: it would time
+   * out waiting for a button that is deliberately absent. A Restricted fixture
+   * would need a readiness signal independent of the button — the deployments
+   * list or its empty state.
+   *
    * @param projectId - Project whose deployments to open.
    */
   async openDeploymentsTab(projectId: string): Promise<void> {
@@ -125,8 +133,13 @@ export class ProjectDeploymentsPage {
   async openAddDeploymentModal(): Promise<void> {
     await this.addDeploymentButton().click();
     await expect(this.modal()).toBeVisible();
+    // Scoped to the dialog so nothing elsewhere on the page can satisfy it.
+    // Substring, not exact: the title is a bare text node inside DialogTitle
+    // alongside the description Typography, so the element's full text is
+    // "Add New Deployment" + "Create a new deployment environment…" and no
+    // element's text equals the title on its own.
     await expect(
-      this.page.getByText(ADD_DEPLOYMENT.dialogTitle),
+      this.modal().getByText(ADD_DEPLOYMENT.dialogTitle),
     ).toBeVisible();
   }
 

--- a/apps/customer-portal/webapp/tests/e2e/specs/project-details/add-deployment-validation.spec.ts
+++ b/apps/customer-portal/webapp/tests/e2e/specs/project-details/add-deployment-validation.spec.ts
@@ -1,0 +1,161 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//
+// Edge cases and field gating on the Add Deployment modal.
+//
+// ✅ NOTHING HERE CREATES A DEPLOYMENT. The required-field cases never submit —
+// AddDeploymentModal gates its confirm button on
+// `name && deploymentTypeKey && description`, so an incomplete form cannot be
+// sent at all. The duplicate-name case does submit, but the backend rejects it
+// with 409, and the cancel case closes the modal without submitting.
+//
+// That matters more here than elsewhere: deployments have NO delete endpoint, so
+// anything this suite created would be permanent and unremovable.
+//
+
+import { test, expect, withSession } from "../../fixtures/test";
+import { ProjectDeploymentsPage } from "../../pages/ProjectDeploymentsPage";
+import {
+  DEPLOYMENT_INPUT,
+  PROJECTS,
+  ProjectType,
+} from "../../config/testData";
+import { skipWhenUnconfigured } from "../../utils/caseFlows";
+
+withSession(test);
+
+test.describe("Deployment — validation", () => {
+  // Each test loads the dashboard, navigates the side nav and switches tab;
+  // the 30s default is not enough.
+  test.describe.configure({ timeout: 180_000 });
+
+  const project = PROJECTS[ProjectType.MANAGED_CLOUD_SUBSCRIPTION];
+
+  /** Path of the create endpoint, distinct from the /deployments/search POST
+   * that also fires on this page. */
+  const createPath = `/projects/${project.id}/deployments`;
+
+  test("keeps submit disabled until every required field is filled", async ({
+    page,
+  }) => {
+    skipWhenUnconfigured(project);
+    const deployments = new ProjectDeploymentsPage(page);
+    await deployments.openDeploymentsTab(project.id);
+    await deployments.openAddDeploymentModal();
+
+    // isValid requires all three; check each step rather than only the endpoint,
+    // so a rule that stopped covering one field would still fail here.
+    await expect(deployments.modalSubmitButton()).toBeDisabled();
+
+    await deployments.nameInput().fill(DEPLOYMENT_INPUT.namePrefix);
+    await expect(deployments.modalSubmitButton()).toBeDisabled();
+
+    await deployments.selectType(DEPLOYMENT_INPUT.type);
+    await expect(deployments.modalSubmitButton()).toBeDisabled();
+
+    await deployments.descriptionInput().fill(DEPLOYMENT_INPUT.description);
+    await expect(deployments.modalSubmitButton()).toBeEnabled();
+  });
+
+  test("keeps submit disabled when only the description is missing", async ({
+    page,
+  }) => {
+    skipWhenUnconfigured(project);
+    const deployments = new ProjectDeploymentsPage(page);
+    await deployments.openDeploymentsTab(project.id);
+    await deployments.openAddDeploymentModal();
+
+    await deployments.nameInput().fill(DEPLOYMENT_INPUT.namePrefix);
+    await deployments.selectType(DEPLOYMENT_INPUT.type);
+
+    await expect(deployments.modalSubmitButton()).toBeDisabled();
+  });
+
+  test("keeps submit disabled for a whitespace-only name", async ({ page }) => {
+    skipWhenUnconfigured(project);
+    const deployments = new ProjectDeploymentsPage(page);
+    await deployments.openDeploymentsTab(project.id);
+    await deployments.openAddDeploymentModal();
+
+    // isValid trims before comparing, so spaces must not count as a name.
+    await deployments.nameInput().fill("   ");
+    await deployments.selectType(DEPLOYMENT_INPUT.type);
+    await deployments.descriptionInput().fill(DEPLOYMENT_INPUT.description);
+
+    await expect(deployments.modalSubmitButton()).toBeDisabled();
+  });
+
+  test("rejects a duplicate deployment name", async ({ page }) => {
+    skipWhenUnconfigured(project);
+    const deployments = new ProjectDeploymentsPage(page);
+    await deployments.openDeploymentsTab(project.id);
+    await deployments.openAddDeploymentModal();
+
+    await deployments.fillDeployment(
+      DEPLOYMENT_INPUT.existingName,
+      DEPLOYMENT_INPUT.type,
+      DEPLOYMENT_INPUT.description,
+    );
+
+    const [response] = await Promise.all([
+      page.waitForResponse(
+        (r) =>
+          new URL(r.url()).pathname.endsWith(createPath) &&
+          r.request().method() === "POST",
+      ),
+      deployments.submit(),
+    ]);
+
+    // The backend enforces name uniqueness per project. Nothing is created, so
+    // this case is safe to re-run.
+    expect(response.status()).toBe(409);
+    expect(await response.text()).toContain("already exists");
+
+    // The modal stays open on failure. Note the UI surfaces no visible error
+    // here — from the user's side the button simply does nothing — which is
+    // worth treating as a product defect rather than expected behaviour.
+    await expect(deployments.modal()).toBeVisible();
+  });
+
+  test("cancelling closes the modal without creating a deployment", async ({
+    page,
+  }) => {
+    skipWhenUnconfigured(project);
+    const deployments = new ProjectDeploymentsPage(page);
+    await deployments.openDeploymentsTab(project.id);
+    await deployments.openAddDeploymentModal();
+
+    let createAttempts = 0;
+    page.on("request", (r) => {
+      if (
+        new URL(r.url()).pathname.endsWith(createPath) &&
+        r.method() === "POST"
+      ) {
+        createAttempts += 1;
+      }
+    });
+
+    await deployments.fillDeployment(
+      `${DEPLOYMENT_INPUT.namePrefix} cancelled`,
+      DEPLOYMENT_INPUT.type,
+      DEPLOYMENT_INPUT.description,
+    );
+    await deployments.cancel();
+
+    expect(createAttempts, "cancel must not send a create request").toBe(0);
+  });
+});

--- a/apps/customer-portal/webapp/tests/e2e/specs/project-details/add-deployment.spec.ts
+++ b/apps/customer-portal/webapp/tests/e2e/specs/project-details/add-deployment.spec.ts
@@ -58,10 +58,13 @@ test.describe("Deployment", () => {
 
     // Unique per run, so the 409-on-duplicate rule cannot fail the test. Uses a
     // sortable compact timestamp to keep the accumulated records readable.
+    // Milliseconds are kept: at whole-second resolution two runs starting in the
+    // same second — a retry, or a colleague running against the same staging
+    // project — would collide and hit the very 409 this is here to avoid.
     const deploymentName = `${DEPLOYMENT_INPUT.namePrefix} ${new Date()
       .toISOString()
-      .slice(0, 19)
-      .replace(/[:T]/g, "-")}`;
+      .slice(0, 23)
+      .replace(/[:T.]/g, "-")}`;
 
     await deployments.openDeploymentsTab(project.id);
     await deployments.openAddDeploymentModal();
@@ -101,9 +104,12 @@ test.describe("Deployment", () => {
     };
     expect(created.id, "backend returned no deployment id").toBeTruthy();
 
-    // The modal closes and the new deployment shows up in the list.
+    // The modal closes and the new deployment shows up in the list — exactly
+    // once, since the name is unique to this run.
     await expect(deployments.modal()).toBeHidden();
-    await expect(deployments.deploymentEntry(deploymentName)).toBeVisible();
+    const entry = deployments.deploymentEntry(deploymentName);
+    await expect(entry).toHaveCount(1);
+    await expect(entry).toBeVisible();
 
     console.log(
       `Created deployment (${ProjectType.MANAGED_CLOUD_SUBSCRIPTION}): ` +

--- a/apps/customer-portal/webapp/tests/e2e/specs/project-details/add-deployment.spec.ts
+++ b/apps/customer-portal/webapp/tests/e2e/specs/project-details/add-deployment.spec.ts
@@ -1,0 +1,113 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//
+// Adds a deployment from the Deployments tab of the project details page,
+// reached through the side nav as a user would.
+//
+// ⚠️ Writes to a REAL backend via POST /projects/{id}/deployments and leaves a
+// permanent deployment on every run — there is no delete endpoint.
+//
+// The name carries a timestamp because the backend rejects a duplicate with
+// `409 {"message":"A deployment with the same name already exists for the
+// project."}` (confirmed live). A fixed name therefore only ever works on the
+// first run; every later one failed, and — because the response wait originally
+// required a 2xx — failed as an unexplained 180s timeout rather than as a 409.
+//
+// Scoped to Managed Cloud Subscription: the Add Deployment button is withheld
+// for a Restricted project, and deployment access is a per-project feature flag.
+//
+
+import { test, expect, withSession } from "../../fixtures/test";
+import { ProjectDeploymentsPage } from "../../pages/ProjectDeploymentsPage";
+import {
+  DEPLOYMENT_INPUT,
+  PROJECTS,
+  ProjectType,
+} from "../../config/testData";
+import { isSuccess, skipWhenUnconfigured } from "../../utils/caseFlows";
+
+withSession(test);
+
+test.describe("Deployment", () => {
+  // Spans a dashboard load, a side-nav navigation, a tab switch and a
+  // filters-backed dropdown; the 30s default is not enough.
+  test.describe.configure({ timeout: 180_000 });
+
+  const project = PROJECTS[ProjectType.MANAGED_CLOUD_SUBSCRIPTION];
+
+  test(`${ProjectType.MANAGED_CLOUD_SUBSCRIPTION} — adds a deployment`, async ({
+    page,
+  }) => {
+    skipWhenUnconfigured(project);
+
+    const deployments = new ProjectDeploymentsPage(page);
+
+    // Unique per run, so the 409-on-duplicate rule cannot fail the test. Uses a
+    // sortable compact timestamp to keep the accumulated records readable.
+    const deploymentName = `${DEPLOYMENT_INPUT.namePrefix} ${new Date()
+      .toISOString()
+      .slice(0, 19)
+      .replace(/[:T]/g, "-")}`;
+
+    await deployments.openDeploymentsTab(project.id);
+    await deployments.openAddDeploymentModal();
+    await deployments.fillDeployment(
+      deploymentName,
+      DEPLOYMENT_INPUT.type,
+      DEPLOYMENT_INPUT.description,
+    );
+
+    await expect(deployments.modalSubmitButton()).toBeEnabled();
+
+    // Wait for the create POST regardless of status, then assert it succeeded.
+    // Requiring 2xx in the predicate instead would mean a rejected create never
+    // matches, leaving the test to time out with no clue as to why — so the
+    // status check belongs in an assertion that can report the body.
+    //
+    // The path must match exactly: POST /projects/{id}/deployments/search fires
+    // on this page too, and a substring match would happily capture it.
+    const [createResponse] = await Promise.all([
+      page.waitForResponse(
+        (r) =>
+          new URL(r.url()).pathname.endsWith(
+            `/projects/${project.id}/deployments`,
+          ) && r.request().method() === "POST",
+      ),
+      deployments.submit(),
+    ]);
+
+    expect(
+      isSuccess(createResponse.status()),
+      `create deployment failed: ${createResponse.status()} ${await createResponse.text()}`,
+    ).toBe(true);
+
+    const created = (await createResponse.json()) as {
+      id?: string;
+      name?: string;
+    };
+    expect(created.id, "backend returned no deployment id").toBeTruthy();
+
+    // The modal closes and the new deployment shows up in the list.
+    await expect(deployments.modal()).toBeHidden();
+    await expect(deployments.deploymentEntry(deploymentName)).toBeVisible();
+
+    console.log(
+      `Created deployment (${ProjectType.MANAGED_CLOUD_SUBSCRIPTION}): ` +
+        `${created.name ?? deploymentName} (${created.id})`,
+    );
+  });
+});

--- a/apps/customer-portal/webapp/tests/e2e/utils/selectors.ts
+++ b/apps/customer-portal/webapp/tests/e2e/utils/selectors.ts
@@ -64,6 +64,35 @@ export const CREATE_CASE = {
   },
 } as const;
 
+/** Project details page (`/projects/:projectId/project-details`), reached from
+ * the side nav. Its tabs are Overview, Deployments and Time Tracking. */
+export const PROJECT_DETAILS = {
+  navItem: "Project Details",
+  pathSegment: "project-details",
+  tabs: {
+    overview: "Overview",
+    deployments: "Deployments",
+    timeTracking: "Time Tracking",
+  },
+} as const;
+
+/** Add Deployment modal, opened from the Deployments tab.
+ *
+ * Unusually for this app the fields have real ids and associated labels, so no
+ * structural locators are needed here. */
+export const ADD_DEPLOYMENT = {
+  openButton: "Add Deployment",
+  dialogTitle: "Add New Deployment",
+  /** The modal's confirm control carries the same name as the button that opens
+   * it, so it must be scoped to the dialog. */
+  submitButton: "Add Deployment",
+  ids: {
+    name: "#deployment-name",
+    type: "#deployment-type",
+    description: "#deployment-description",
+  },
+} as const;
+
 /** Get Help dropdown menu items (the arrow half of the split button). */
 export const GET_HELP_MENU = {
   trigger: "More help options",


### PR DESCRIPTION
### What

Adds E2E coverage for creating a deployment from the Deployments tab of the
project details page, reached through the side nav as a user would. **6 tests.**

| Suite | Tests | Creates records? |
|---|---|---|
| `Deployment` | 1 | Yes — one deployment |
| `Deployment — validation` | 5 | **No** (one submits, backend rejects it) |

Scoped to Managed Cloud Subscription: the Add Deployment button is withheld for a
Restricted project, and deployment access is a per-project feature flag.

### Files

| File | Purpose |
|---|---|
| `specs/project-details/add-deployment.spec.ts` | Happy path |
| `specs/project-details/add-deployment-validation.spec.ts` | Field gating and rejection cases |
| `pages/ProjectDeploymentsPage.ts` | Side-nav navigation, tab switch, modal |
| `config/testData.ts` | `DeploymentType`, `DEPLOYMENT_INPUT` |
| `utils/selectors.ts` | `PROJECT_DETAILS`, `ADD_DEPLOYMENT` |

### Two things the flow required getting right

**Names must be unique.** The backend rejects a duplicate with
`409 {"message":"A deployment with the same name already exists for the
project."}`, and there is **no delete endpoint** for deployments — so a fixed
name works exactly once. The spec appends a sortable timestamp
(`Automation Test Deployment 2026-08-11-15-40-11`), which also keeps the
accumulated records identifiable.

**The create POST must be matched exactly.** `POST
/projects/{id}/deployments/search` also fires on this page, so a substring URL
match can capture the wrong response. The predicate uses `pathname.endsWith`.

Relatedly, the status check sits in an **assertion** rather than in the response
predicate. Requiring 2xx to match means a rejected create never resolves, and the
test dies on an unexplained 180s timeout instead of reporting the server's
message — which is exactly how the duplicate-name failure first presented. Worth
copying to the case, service-request and security-report specs, which still bake
`isSuccess` into their predicates.

### Validation coverage

`AddDeploymentModal` gates its confirm button on
`name && deploymentTypeKey && description`, so an incomplete form cannot be
submitted at all — those cases assert **button state**, not error text.

| Test | Submits? |
|---|---|
| keeps submit disabled until every required field is filled | No |
| keeps submit disabled when only the description is missing | No |
| keeps submit disabled for a whitespace-only name | No |
| rejects a duplicate deployment name → 409 | Yes, rejected |
| cancelling closes the modal without creating a deployment | No |

The whitespace case exists because `isValid` trims before comparing. The cancel
case counts create requests with a `page.on("request")` listener and asserts
zero, rather than inferring it from the modal closing.

### Notes on the UI

- The modal has real ids and associated labels (`#deployment-name`,
  `#deployment-type`, `#deployment-description`), so no structural locators were
  needed here.
- Its confirm button shares an accessible name with the button that opens it, so
  the opener is scoped to `<main>` and the confirm to the dialog.
- The type options are `Development, QA, Staging, Stress, UAT, Primary
  Production` — there is no plain "Production".

### One product observation

**A failed create shows the user nothing.** On 409 the modal stays open with no
visible error and `role="alert"` empty — from the user's side the button simply
does nothing. Asserted as current behaviour, but it looks like a defect worth
fixing separately.

### Testing

`tsc -b` on the E2E tsconfig and `eslint tests/e2e` are clean.

- **Happy path: verified.** Passes on consecutive runs (10.1s, 8.0s) — the repeat
  being the case the duplicate-name fix addresses.
- **Validation suite: not verified.** The captured session expired mid-run and
  all five redirected to sign-in. Nothing in the output points at a defect in the
  specs, but they have not been seen green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for creating deployments from the project Deployments tab.
  * Added validation coverage for required fields, whitespace-only names, duplicate names, and cancellation.
  * Added checks confirming successful creation, deployment identifiers, and list visibility.
  * Added coverage for deployment type selection, descriptions, modal interactions, and project navigation readiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->