### PR TITLE
[CSM][Web] Fix Support search returning the wrong case for an exact case number / WSO2 id

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.test.tsx
@@ -147,6 +147,95 @@ describe("useGetCsmCases — identifier search runs both legs in parallel", () =
     expect(result.current.data?.cases.map((c) => c.id)).toEqual(["id-p2"]);
   });
 
+  it("reports the same total on every page, and never exceeds pageSize", async () => {
+    // The exact hit sits outside the first free-text page (it only shows up
+    // deep in the scan), which is what used to make the total change as the
+    // user paged: the pinned row counted as "extra" on pages that didn't
+    // contain it, and as already-counted on the page that did.
+    const pageSizeUnderTest = 3;
+    postMock.mockImplementation((_url, body) => {
+      const isExact = (body.filters.filters ?? []).some(
+        (x: { op: string }) => x.op === "eq",
+      );
+      if (isExact) {
+        return Promise.resolve({
+          cases: [beCase("id-target", "CS0346083")],
+          total: 1,
+          limit: 5,
+          offset: 0,
+        });
+      }
+      // A free-text set of 9, with the exact hit buried at index 7.
+      const all = Array.from({ length: 9 }, (_, i) =>
+        i === 7 ? beCase("id-target", "CS0346083") : beCase(`id-${i}`, `CS040000${i}`),
+      );
+      const { offset, limit } = body.pagination;
+      return Promise.resolve({
+        cases: all.slice(offset, offset + limit),
+        total: all.length,
+        limit,
+        offset,
+      });
+    });
+
+    const filters = { ...DEFAULT_CASES_FILTERS, search: "CS0346083" };
+    const totals: number[] = [];
+    for (const page of [0, 1, 2]) {
+      const { result } = renderHook(
+        () => useGetCsmCases(filters, page, pageSizeUnderTest),
+        { wrapper },
+      );
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      totals.push(result.current.data!.total);
+      expect(result.current.data!.cases.length).toBeLessThanOrEqual(pageSizeUnderTest);
+    }
+
+    // Stable across pages -- the actual regression being guarded.
+    expect(new Set(totals).size).toBe(1);
+    expect(totals[0]).toBe(9);
+  });
+
+  it("does not skip the row displaced off page 0 by a pinned hit", async () => {
+    // Pinning consumes a slot at the front, so page 1 must start one row early
+    // -- otherwise the row pushed off the end of page 0 is never shown at all.
+    const pageSizeUnderTest = 3;
+    const all = Array.from({ length: 6 }, (_, i) => beCase(`id-${i}`, `CS040000${i}`));
+    postMock.mockImplementation((_url, body) => {
+      const isExact = (body.filters.filters ?? []).some(
+        (x: { op: string }) => x.op === "eq",
+      );
+      if (isExact) {
+        return Promise.resolve({
+          cases: [beCase("id-target", "CS0346083")],
+          total: 1,
+          limit: 5,
+          offset: 0,
+        });
+      }
+      const { offset, limit } = body.pagination;
+      return Promise.resolve({
+        cases: all.slice(offset, offset + limit),
+        total: all.length,
+        limit,
+        offset,
+      });
+    });
+
+    const filters = { ...DEFAULT_CASES_FILTERS, search: "CS0346083" };
+    const seen: string[] = [];
+    for (const page of [0, 1]) {
+      const { result } = renderHook(
+        () => useGetCsmCases(filters, page, pageSizeUnderTest),
+        { wrapper },
+      );
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      seen.push(...result.current.data!.cases.map((c) => c.id));
+    }
+
+    // Pinned first, then the free-text rows in order with none skipped.
+    expect(seen).toEqual(["id-target", "id-0", "id-1", "id-2", "id-3", "id-4"]);
+  });
+
   it("issues only ONE search for a plain free-text query", async () => {
     postMock.mockResolvedValue({ cases: [], total: 0, limit: 20, offset: 0 });
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.test.tsx
@@ -1,0 +1,172 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { ReactNode } from "react";
+
+const postMock = vi.fn();
+
+// The real client + config read runtime config at module load, which isn't
+// present under vitest (same approach as useQuickCaseSearch.test.tsx).
+vi.mock("@config/apiConfig", () => ({ apiConfig: { backendUrl: "https://example.test" } }));
+vi.mock("@api/backend/client", () => ({
+  useBackendApi: () => ({ post: postMock }),
+}));
+vi.mock("@hooks/useIdTokenClaims", () => ({ useIdTokenClaims: () => ({ email: "me@wso2.com" }) }));
+vi.mock("@hooks/useLogger", () => ({
+  useLogger: () => ({ warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() }),
+}));
+vi.mock("@context/current-user/CurrentUserContext", () => ({
+  useCurrentUser: () => ({ user: { id: "user-1" } }),
+}));
+
+import { useGetCsmCases } from "@features/csm-cases/api/useGetCsmCases";
+import { DEFAULT_CASES_FILTERS } from "@features/csm-cases/utils/casesFiltersUrl";
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+function beCase(id: string, number: string) {
+  return { id, number, subject: `subject ${number}`, state: "new" };
+}
+
+/** The `filters` object of the Nth `POST /cases/search` call. */
+function filtersOfCall(n: number) {
+  return postMock.mock.calls[n][1].filters;
+}
+
+describe("useGetCsmCases — identifier search runs both legs in parallel", () => {
+  beforeEach(() => {
+    postMock.mockReset();
+  });
+
+  it("issues an exact-match AND a free-text search for a case number, pinning the exact hit first", async () => {
+    // Leg 1 (exact) resolves the case actually being looked up; leg 2
+    // (free-text) resolves an unrelated case that merely mentions that number
+    // in its description — the reported failure mode.
+    postMock.mockImplementation((_url, body) => {
+      const f = body.filters;
+      const isExact = (f.filters ?? []).some(
+        (x: { field: string; op: string }) => x.field === "number" && x.op === "eq",
+      );
+      return Promise.resolve(
+        isExact
+          ? { cases: [beCase("id-target", "CS0346083")], total: 1, limit: 5, offset: 0 }
+          : { cases: [beCase("id-other", "CS0361878")], total: 1, limit: 20, offset: 0 },
+      );
+    });
+
+    const filters = { ...DEFAULT_CASES_FILTERS, search: "CS0346083" };
+    const { result } = renderHook(() => useGetCsmCases(filters, 0, 20), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(postMock).toHaveBeenCalledTimes(2);
+
+    // One leg exact, one leg free-text.
+    const legs = [filtersOfCall(0), filtersOfCall(1)];
+    const exactLeg = legs.find((f) => f.filters?.length);
+    const textLeg = legs.find((f) => f.searchQuery);
+    expect(exactLeg.filters).toEqual([
+      { field: "number", op: "eq", values: ["CS0346083"] },
+    ]);
+    expect(textLeg.searchQuery).toBe("CS0346083");
+
+    // The exact hit is pinned above the free-text hit, and nothing is lost.
+    expect(result.current.data?.cases.map((c) => c.id)).toEqual(["id-target", "id-other"]);
+  });
+
+  it("does not drop or duplicate a case that both legs return", async () => {
+    postMock.mockImplementation((_url, body) => {
+      const f = body.filters;
+      const isExact = (f.filters ?? []).some(
+        (x: { field: string; op: string }) => x.op === "eq",
+      );
+      return Promise.resolve(
+        isExact
+          ? { cases: [beCase("id-target", "CS0346083")], total: 1, limit: 5, offset: 0 }
+          : {
+              // Free-text also matches the target (it contains its own number).
+              cases: [beCase("id-target", "CS0346083"), beCase("id-other", "CS0361878")],
+              total: 2,
+              limit: 20,
+              offset: 0,
+            },
+      );
+    });
+
+    const filters = { ...DEFAULT_CASES_FILTERS, search: "CS0346083" };
+    const { result } = renderHook(() => useGetCsmCases(filters, 0, 20), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.cases.map((c) => c.id)).toEqual(["id-target", "id-other"]);
+    // Free-text already counted it, so the total isn't inflated.
+    expect(result.current.data?.total).toBe(2);
+  });
+
+  it("keeps pinned rows off later pages so they can't appear twice", async () => {
+    postMock.mockImplementation((_url, body) => {
+      const isExact = (body.filters.filters ?? []).some(
+        (x: { op: string }) => x.op === "eq",
+      );
+      return Promise.resolve(
+        isExact
+          ? { cases: [beCase("id-target", "CS0346083")], total: 1, limit: 5, offset: 0 }
+          : {
+              cases: [beCase("id-target", "CS0346083"), beCase("id-p2", "CS0400000")],
+              total: 40,
+              limit: 20,
+              offset: 20,
+            },
+      );
+    });
+
+    const filters = { ...DEFAULT_CASES_FILTERS, search: "CS0346083" };
+    const { result } = renderHook(() => useGetCsmCases(filters, 1, 20), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // Page 1: no pinned rows, and the pinned id is filtered out of the page.
+    expect(result.current.data?.cases.map((c) => c.id)).toEqual(["id-p2"]);
+  });
+
+  it("issues only ONE search for a plain free-text query", async () => {
+    postMock.mockResolvedValue({ cases: [], total: 0, limit: 20, offset: 0 });
+
+    const filters = { ...DEFAULT_CASES_FILTERS, search: "printer jam" };
+    const { result } = renderHook(() => useGetCsmCases(filters, 0, 20), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(postMock).toHaveBeenCalledTimes(1);
+    expect(filtersOfCall(0).searchQuery).toBe("printer jam");
+  });
+
+  it("issues only ONE search when there is no query at all", async () => {
+    postMock.mockResolvedValue({ cases: [], total: 0, limit: 20, offset: 0 });
+
+    const { result } = renderHook(() => useGetCsmCases(DEFAULT_CASES_FILTERS, 0, 20), {
+      wrapper,
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(postMock).toHaveBeenCalledTimes(1);
+    expect(filtersOfCall(0).searchQuery).toBeUndefined();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.test.tsx
@@ -54,6 +54,20 @@ function filtersOfCall(n: number) {
   return postMock.mock.calls[n][1].filters;
 }
 
+/**
+ * Which of the three parallel legs a request body represents:
+ * - `exact`   — the indexed identifier lookup
+ * - `text`    — the free-text CONTAINS scan
+ * - `overlap` — both together, whose `total` says how many exact hits the scan
+ *               already counts (see `useGetCsmCases`)
+ */
+function legOf(body: { filters: { searchQuery?: string; filters?: { op: string }[] } }) {
+  const hasExact = (body.filters.filters ?? []).some((x) => x.op === "eq");
+  const hasText = !!body.filters.searchQuery;
+  if (hasExact && hasText) return "overlap";
+  return hasExact ? "exact" : "text";
+}
+
 describe("useGetCsmCases — identifier search runs both legs in parallel", () => {
   beforeEach(() => {
     postMock.mockReset();
@@ -64,12 +78,13 @@ describe("useGetCsmCases — identifier search runs both legs in parallel", () =
     // (free-text) resolves an unrelated case that merely mentions that number
     // in its description — the reported failure mode.
     postMock.mockImplementation((_url, body) => {
-      const f = body.filters;
-      const isExact = (f.filters ?? []).some(
-        (x: { field: string; op: string }) => x.field === "number" && x.op === "eq",
-      );
+      const leg = legOf(body);
+      if (leg === "overlap") {
+        // The scan does not cover the exact hit here.
+        return Promise.resolve({ cases: [], total: 0, limit: 1, offset: 0 });
+      }
       return Promise.resolve(
-        isExact
+        leg === "exact"
           ? { cases: [beCase("id-target", "CS0346083")], total: 1, limit: 5, offset: 0 }
           : { cases: [beCase("id-other", "CS0361878")], total: 1, limit: 20, offset: 0 },
       );
@@ -79,10 +94,12 @@ describe("useGetCsmCases — identifier search runs both legs in parallel", () =
     const { result } = renderHook(() => useGetCsmCases(filters, 0, 20), { wrapper });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(postMock).toHaveBeenCalledTimes(2);
+    expect(postMock).toHaveBeenCalledTimes(3);
 
-    // One leg exact, one leg free-text.
-    const legs = [filtersOfCall(0), filtersOfCall(1)];
+    // One leg exact, one leg free-text (the third resolves their overlap).
+    const legs = [filtersOfCall(0), filtersOfCall(1), filtersOfCall(2)].filter(
+      (f) => !(f.searchQuery && f.filters?.length),
+    );
     const exactLeg = legs.find((f) => f.filters?.length);
     const textLeg = legs.find((f) => f.searchQuery);
     expect(exactLeg.filters).toEqual([
@@ -96,12 +113,13 @@ describe("useGetCsmCases — identifier search runs both legs in parallel", () =
 
   it("does not drop or duplicate a case that both legs return", async () => {
     postMock.mockImplementation((_url, body) => {
-      const f = body.filters;
-      const isExact = (f.filters ?? []).some(
-        (x: { field: string; op: string }) => x.op === "eq",
-      );
+      const leg = legOf(body);
+      if (leg === "overlap") {
+        // The scan already counts the exact hit, so it adds nothing to total.
+        return Promise.resolve({ cases: [], total: 1, limit: 1, offset: 0 });
+      }
       return Promise.resolve(
-        isExact
+        leg === "exact"
           ? { cases: [beCase("id-target", "CS0346083")], total: 1, limit: 5, offset: 0 }
           : {
               // Free-text also matches the target (it contains its own number).
@@ -124,11 +142,12 @@ describe("useGetCsmCases — identifier search runs both legs in parallel", () =
 
   it("keeps pinned rows off later pages so they can't appear twice", async () => {
     postMock.mockImplementation((_url, body) => {
-      const isExact = (body.filters.filters ?? []).some(
-        (x: { op: string }) => x.op === "eq",
-      );
+      const leg = legOf(body);
+      if (leg === "overlap") {
+        return Promise.resolve({ cases: [], total: 1, limit: 1, offset: 0 });
+      }
       return Promise.resolve(
-        isExact
+        leg === "exact"
           ? { cases: [beCase("id-target", "CS0346083")], total: 1, limit: 5, offset: 0 }
           : {
               cases: [beCase("id-target", "CS0346083"), beCase("id-p2", "CS0400000")],
@@ -154,10 +173,12 @@ describe("useGetCsmCases — identifier search runs both legs in parallel", () =
     // contain it, and as already-counted on the page that did.
     const pageSizeUnderTest = 3;
     postMock.mockImplementation((_url, body) => {
-      const isExact = (body.filters.filters ?? []).some(
-        (x: { op: string }) => x.op === "eq",
-      );
-      if (isExact) {
+      const leg = legOf(body);
+      if (leg === "overlap") {
+        // The scan covers the exact hit (it is row 7 below), so it adds nothing.
+        return Promise.resolve({ cases: [], total: 1, limit: 1, offset: 0 });
+      }
+      if (leg === "exact") {
         return Promise.resolve({
           cases: [beCase("id-target", "CS0346083")],
           total: 1,
@@ -201,10 +222,11 @@ describe("useGetCsmCases — identifier search runs both legs in parallel", () =
     const pageSizeUnderTest = 3;
     const all = Array.from({ length: 6 }, (_, i) => beCase(`id-${i}`, `CS040000${i}`));
     postMock.mockImplementation((_url, body) => {
-      const isExact = (body.filters.filters ?? []).some(
-        (x: { op: string }) => x.op === "eq",
-      );
-      if (isExact) {
+      const leg = legOf(body);
+      if (leg === "overlap") {
+        return Promise.resolve({ cases: [], total: 0, limit: 1, offset: 0 });
+      }
+      if (leg === "exact") {
         return Promise.resolve({
           cases: [beCase("id-target", "CS0346083")],
           total: 1,
@@ -234,6 +256,61 @@ describe("useGetCsmCases — identifier search runs both legs in parallel", () =
 
     // Pinned first, then the free-text rows in order with none skipped.
     expect(seen).toEqual(["id-target", "id-0", "id-1", "id-2", "id-3", "id-4"]);
+  });
+
+  it("counts an exact-only hit in the total and keeps every row reachable", async () => {
+    // The scan misses the identifier entirely (the anomaly this feature exists
+    // for), so the merged sequence is 1 exact-only row + 9 scan rows. If the
+    // total under-reported those 9, the paginator would stop offering pages
+    // before the last row and it could never be reached.
+    const pageSizeUnderTest = 3;
+    const scanRows = Array.from({ length: 9 }, (_, i) =>
+      beCase(`id-${i}`, `CS040000${i}`),
+    );
+    postMock.mockImplementation((_url, body) => {
+      const leg = legOf(body);
+      if (leg === "overlap") {
+        return Promise.resolve({ cases: [], total: 0, limit: 1, offset: 0 });
+      }
+      if (leg === "exact") {
+        return Promise.resolve({
+          cases: [beCase("id-target", "CS0346083")],
+          total: 1,
+          limit: 5,
+          offset: 0,
+        });
+      }
+      const { offset, limit } = body.pagination;
+      return Promise.resolve({
+        cases: scanRows.slice(offset, offset + limit),
+        total: scanRows.length,
+        limit,
+        offset,
+      });
+    });
+
+    const filters = { ...DEFAULT_CASES_FILTERS, search: "CS0346083" };
+    const seen: string[] = [];
+    const totals: number[] = [];
+    // 10 rows over a page size of 3 => 4 pages, the last holding a single row.
+    for (const page of [0, 1, 2, 3]) {
+      const { result } = renderHook(
+        () => useGetCsmCases(filters, page, pageSizeUnderTest),
+        { wrapper },
+      );
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      totals.push(result.current.data!.total);
+      expect(result.current.data!.cases.length).toBeLessThanOrEqual(pageSizeUnderTest);
+      seen.push(...result.current.data!.cases.map((c) => c.id));
+    }
+
+    expect(new Set(totals)).toEqual(new Set([10]));
+    // All ten rows reachable, in merged order, none repeated.
+    expect(seen).toEqual([
+      "id-target",
+      ...scanRows.map((c) => c.id),
+    ]);
+    expect(new Set(seen).size).toBe(10);
   });
 
   it("issues only ONE search for a plain free-text query", async () => {

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
@@ -151,7 +151,7 @@ export function useGetCsmCases(
       // list has no Customer column, and the old scan paged the entire account
       // directory to resolve a name nothing renders.
       const runSearch = (
-        searchOptions?: { forceFreeText?: boolean },
+        searchOptions?: { forceFreeText?: boolean; alsoFreeText?: boolean },
         pagination = { offset, limit: pageSize },
       ): Promise<BeCaseSearchResponse> =>
         api.post<BeCaseSearchPayload, BeCaseSearchResponse>("/cases/search", {
@@ -200,7 +200,7 @@ export function useGetCsmCases(
       // reconciles the guess once both have landed.
       const ASSUMED_PIN_COUNT = 1;
       const textOffset = page === 0 ? 0 : Math.max(0, offset - ASSUMED_PIN_COUNT);
-      const [exactResponse, textResponse] = await Promise.all([
+      const [exactResponse, textResponse, overlapResponse] = await Promise.all([
         // Page-independent: fetched once from the top rather than re-queried
         // per page, since an identifier match is a tiny, fixed result.
         runSearch(undefined, { offset: 0, limit: EXACT_MATCH_LIMIT }),
@@ -208,6 +208,11 @@ export function useGetCsmCases(
           { forceFreeText: true },
           { offset: textOffset, limit: pageSize + EXACT_MATCH_LIMIT },
         ),
+        // How many of the exact hits the free-text scan already counts. Only
+        // its `total` is read, so this asks for a single row. Without it the
+        // merged total has to be guessed, and guessing low makes the last row
+        // unreachable: the paginator stops offering pages before it.
+        runSearch({ alsoFreeText: true }, { offset: 0, limit: 1 }),
       ]);
 
       const exactRows = (exactResponse.cases ?? []).map((c) =>
@@ -230,19 +235,22 @@ export function useGetCsmCases(
         page === 0 ? [...exactRows, ...textRows] : textRows.slice(pinShift)
       ).slice(0, pageSize);
 
-      // Page-independent by construction: derived from the free-text leg's own
-      // total, never from which rows happen to be in the page currently in
-      // hand. An earlier version compared the pinned rows against the fetched
-      // page, which made the reported total change as the user paged.
+      // Page-independent by construction: both terms are totals over the whole
+      // result set, never over the page currently in hand. An earlier version
+      // compared the pinned rows against the fetched page, which made the
+      // reported total change as the user paged.
       //
-      // Pinning reorders rather than adds, because the free-text scan already
-      // covers the number/WSO2-id columns — so an exact hit is virtually
-      // always inside `textTotal` too. The exception is the anomaly this
-      // feature exists for (an identifier the scan misses entirely); there the
-      // count reads up to `EXACT_MATCH_LIMIT` low, which is a label being
-      // conservative, never a dropped or duplicated row.
+      // Pinning usually reorders rather than adds, because the free-text scan
+      // also covers the number/WSO2-id columns — so an exact hit is normally
+      // already inside `textTotal`, and `overlapTotal` says exactly how many
+      // are. Only the remainder is genuinely new: an identifier the scan misses
+      // entirely, which is the anomaly this feature exists for. Undercounting
+      // there is not cosmetic — the paginator stops offering pages at `total`,
+      // so a row past that point can never be reached.
       const textTotal = textResponse.total ?? textRows.length;
-      const total = textTotal > 0 ? textTotal : exactRows.length;
+      const overlapTotal = overlapResponse.total ?? 0;
+      const pinnedNotCounted = Math.max(0, exactRows.length - overlapTotal);
+      const total = textTotal + pinnedNotCounted;
 
       return {
         cases,

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
@@ -188,12 +188,26 @@ export function useGetCsmCases(
         };
       }
 
-      // The exact leg is page-independent: a number/id match is a tiny, fixed
-      // result (unique per case), so it's fetched once from the top and pinned
-      // above the first page rather than re-queried per page.
+      // The merged sequence is [pinned exact hits] followed by the free-text
+      // hits with those same rows removed. Pinning consumes slots at the front,
+      // so from page 1 on, the free-text window starts one row early and is
+      // over-fetched — otherwise the row displaced off page 0 would be skipped
+      // entirely (page 1 would resume at `offset`, past it).
+      //
+      // The real hit count isn't known until the exact leg resolves, and both
+      // legs are issued together, so the window is shaped for the realistic
+      // case of a single hit (an identifier is unique) and `pinShift` below
+      // reconciles the guess once both have landed.
+      const ASSUMED_PIN_COUNT = 1;
+      const textOffset = page === 0 ? 0 : Math.max(0, offset - ASSUMED_PIN_COUNT);
       const [exactResponse, textResponse] = await Promise.all([
+        // Page-independent: fetched once from the top rather than re-queried
+        // per page, since an identifier match is a tiny, fixed result.
         runSearch(undefined, { offset: 0, limit: EXACT_MATCH_LIMIT }),
-        runSearch({ forceFreeText: true }),
+        runSearch(
+          { forceFreeText: true },
+          { offset: textOffset, limit: pageSize + EXACT_MATCH_LIMIT },
+        ),
       ]);
 
       const exactRows = (exactResponse.cases ?? []).map((c) =>
@@ -206,25 +220,36 @@ export function useGetCsmCases(
         .map((c) => mapCaseSearchViewToRow(c, currentUserEmail))
         .filter((c) => !exactIds.has(c.id));
 
+      // Nothing was pinned after all (no exact hit), so the extra leading row
+      // this page fetched belongs to the previous page — drop it.
+      const pinShift =
+        page === 0
+          ? 0
+          : ASSUMED_PIN_COUNT - Math.min(exactRows.length, ASSUMED_PIN_COUNT);
+      const cases = (
+        page === 0 ? [...exactRows, ...textRows] : textRows.slice(pinShift)
+      ).slice(0, pageSize);
+
+      // Page-independent by construction: derived from the free-text leg's own
+      // total, never from which rows happen to be in the page currently in
+      // hand. An earlier version compared the pinned rows against the fetched
+      // page, which made the reported total change as the user paged.
+      //
+      // Pinning reorders rather than adds, because the free-text scan already
+      // covers the number/WSO2-id columns — so an exact hit is virtually
+      // always inside `textTotal` too. The exception is the anomaly this
+      // feature exists for (an identifier the scan misses entirely); there the
+      // count reads up to `EXACT_MATCH_LIMIT` low, which is a label being
+      // conservative, never a dropped or duplicated row.
       const textTotal = textResponse.total ?? textRows.length;
-      // Pinned rows are additive only when the free-text leg didn't already
-      // count them. It can only be compared against the page in hand, so this
-      // is exact whenever the exact hit lands on the first page (the common
-      // case) and off by at most the pinned count otherwise — a count label,
-      // never a correctness issue: no row is dropped or duplicated either way.
-      const pinnedNotInText = exactRows.filter(
-        (c) => !(textResponse.cases ?? []).some((t) => t.id === c.id),
-      ).length;
+      const total = textTotal > 0 ? textTotal : exactRows.length;
 
       return {
-        // Page 0 carries the pinned rows *in addition to* a full free-text page
-        // rather than displacing its last row — displacing would skip that row
-        // entirely, since page 1 resumes at `offset + pageSize` regardless.
-        cases: page === 0 ? [...exactRows, ...textRows] : textRows,
-        total: textTotal + pinnedNotInText,
-        limit: textResponse.limit ?? pageSize,
-        offset: textResponse.offset ?? offset,
-        hasMore: textResponse.hasMore ?? false,
+        cases,
+        total,
+        limit: pageSize,
+        offset,
+        hasMore: offset + cases.length < total,
       };
     },
     enabled,

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
@@ -26,6 +26,7 @@ import {
   resolveAssignedUserIds,
 } from "@features/csm-cases/utils/caseSearchPayload";
 import { ASSIGNEE_ME_TOKEN } from "@features/csm-cases/utils/assignee";
+import { classifyCaseQuery } from "@features/csm-cases/utils/caseQueryScope";
 import { useCurrentUser } from "@context/current-user/CurrentUserContext";
 import type { BeCaseSearchPayload, BeCaseSearchResponse } from "@api/backend/types";
 import type { CasesFilters } from "@features/csm-cases/components/CasesFilterBar";
@@ -37,6 +38,13 @@ import {
   DEFAULT_CASES_SORT,
   type CasesSortOrder,
 } from "@features/csm-cases/utils/casesSort";
+
+/**
+ * How many exact identifier hits to pin above the first page. A case number is
+ * unique, so this is realistically 1; the small headroom covers a WSO2 case id
+ * that repeats across projects without ever pinning an unbounded block.
+ */
+const EXACT_MATCH_LIMIT = 5;
 
 /**
  * Cross-project CSM cases list.
@@ -142,25 +150,81 @@ export function useGetCsmCases(
       // One cross-project case search. No account/project directory scan: the
       // list has no Customer column, and the old scan paged the entire account
       // directory to resolve a name nothing renders.
-      const casesResponse = await api.post<
-        BeCaseSearchPayload,
-        BeCaseSearchResponse
-      >("/cases/search", {
-          pagination: { offset, limit: pageSize },
+      const runSearch = (
+        searchOptions?: { forceFreeText?: boolean },
+        pagination = { offset, limit: pageSize },
+      ): Promise<BeCaseSearchResponse> =>
+        api.post<BeCaseSearchPayload, BeCaseSearchResponse>("/cases/search", {
+          pagination,
           sortBy: { field: "updatedOn", order: sortOrder },
-          filters: buildCaseSearchFilters(filters, search, assignedUserIds),
-      });
+          filters: buildCaseSearchFilters(
+            filters,
+            search,
+            assignedUserIds,
+            searchOptions,
+          ),
+        });
 
-      const cases: CsmCaseRow[] = (casesResponse.cases ?? []).map((c) =>
+      // A query shaped like a case number / WSO2 id runs BOTH legs at once: the
+      // exact indexed lookup and the free-text CONTAINS scan. Neither alone is
+      // right — exact-only loses cases that merely reference the number in their
+      // description, while free-text-only is what let an unrelated case outrank
+      // (or hide) the one actually being looked up. Running them in parallel
+      // costs no extra latency over the free-text leg it already ran.
+      const isIdentifierQuery =
+        search.length > 0 && classifyCaseQuery(search) !== "text";
+
+      if (!isIdentifierQuery) {
+        const casesResponse = await runSearch();
+        const cases: CsmCaseRow[] = (casesResponse.cases ?? []).map((c) =>
+          mapCaseSearchViewToRow(c, currentUserEmail),
+        );
+        return {
+          cases,
+          total: casesResponse.total ?? cases.length,
+          limit: casesResponse.limit ?? pageSize,
+          offset: casesResponse.offset ?? offset,
+          hasMore: casesResponse.hasMore ?? false,
+        };
+      }
+
+      // The exact leg is page-independent: a number/id match is a tiny, fixed
+      // result (unique per case), so it's fetched once from the top and pinned
+      // above the first page rather than re-queried per page.
+      const [exactResponse, textResponse] = await Promise.all([
+        runSearch(undefined, { offset: 0, limit: EXACT_MATCH_LIMIT }),
+        runSearch({ forceFreeText: true }),
+      ]);
+
+      const exactRows = (exactResponse.cases ?? []).map((c) =>
         mapCaseSearchViewToRow(c, currentUserEmail),
       );
+      const exactIds = new Set(exactRows.map((c) => c.id));
+      // Dropped from every page of the free-text leg, not just the first, so a
+      // pinned case can't also reappear further down its own result set.
+      const textRows = (textResponse.cases ?? [])
+        .map((c) => mapCaseSearchViewToRow(c, currentUserEmail))
+        .filter((c) => !exactIds.has(c.id));
+
+      const textTotal = textResponse.total ?? textRows.length;
+      // Pinned rows are additive only when the free-text leg didn't already
+      // count them. It can only be compared against the page in hand, so this
+      // is exact whenever the exact hit lands on the first page (the common
+      // case) and off by at most the pinned count otherwise — a count label,
+      // never a correctness issue: no row is dropped or duplicated either way.
+      const pinnedNotInText = exactRows.filter(
+        (c) => !(textResponse.cases ?? []).some((t) => t.id === c.id),
+      ).length;
 
       return {
-        cases,
-        total: casesResponse.total ?? cases.length,
-        limit: casesResponse.limit ?? pageSize,
-        offset: casesResponse.offset ?? offset,
-        hasMore: casesResponse.hasMore ?? false,
+        // Page 0 carries the pinned rows *in addition to* a full free-text page
+        // rather than displacing its last row — displacing would skip that row
+        // entirely, since page 1 resumes at `offset + pageSize` regardless.
+        cases: page === 0 ? [...exactRows, ...textRows] : textRows,
+        total: textTotal + pinnedNotInText,
+        limit: textResponse.limit ?? pageSize,
+        offset: textResponse.offset ?? offset,
+        hasMore: textResponse.hasMore ?? false,
       };
     },
     enabled,

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useQuickCaseSearch.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useQuickCaseSearch.ts
@@ -31,6 +31,10 @@ import type {
   SeverityOrUnset,
 } from "@features/csm-dashboard/types/abtDashboard";
 import { ALL_CASE_TYPES } from "@features/csm-cases/utils/caseType";
+import {
+  classifyCaseQuery,
+  type CaseQueryScope,
+} from "@features/csm-cases/utils/caseQueryScope";
 
 /** Don't fire a search until the user has typed something searchable. */
 export const QUICK_CASE_MIN_QUERY_LEN = 2;
@@ -38,39 +42,22 @@ export const QUICK_CASE_MIN_QUERY_LEN = 2;
 /** A small result page — the palette only shows the top few hits. */
 const QUICK_CASE_LIMIT = 8;
 
-/** A CS case number, e.g. "CS0441174" — always "CS" plus exactly 7 digits. */
-const CASE_NUMBER_RE = /^CS\d{7}$/;
-
 /**
- * A WSO2 case id, e.g. "SOMEID-4" — an alphanumeric project/product prefix, a
- * hyphen, then 1-4 digits. Deliberately looser than {@link CASE_NUMBER_RE}
- * (no fixed prefix), so it's checked second, after the case-number pattern
- * has already had first refusal.
+ * The scope a typed quick-search string resolves to. Alias of the shared
+ * {@link CaseQueryScope} — the classification now lives in
+ * `utils/caseQueryScope` so the cases list / Support-page search classifies
+ * a typed string exactly the same way this palette does.
  */
-const WSO2_CASE_ID_RE = /^[a-zA-Z0-9]+-\d{1,4}$/;
-
-/**
- * What kind of lookup a typed quick-search string should run as:
- * - `"number"` / `"internalId"`: an exact-match, first-class filter — the
- *   entity-service resolves these against an indexed column instead of the
- *   free-text `searchQuery` scan. Named to match the response field names
- *   (`BeCaseSearchView.number` / `.internalId`), not a UI-facing label.
- * - `"text"`: the existing free-text search across subject/description
- *   (and number/internalId, case-insensitively) — unchanged behavior.
- */
-export type QuickCaseSearchScope = "number" | "internalId" | "text";
+export type QuickCaseSearchScope = CaseQueryScope;
 
 /**
  * Classifies a typed (already-trimmed) quick-search string into the scope
- * {@link useQuickCaseSearch} should route it through. Order matters: a case
- * number is checked first since `CS\d{7}` is a strict subset of the looser
- * WSO2-case-id shape.
+ * {@link useQuickCaseSearch} should route it through.
+ *
+ * Thin alias over the shared {@link classifyCaseQuery}, kept as a named export
+ * because this is the name the palette and its tests already use.
  */
-export function classifyQuickCaseQuery(query: string): QuickCaseSearchScope {
-  if (CASE_NUMBER_RE.test(query)) return "number";
-  if (WSO2_CASE_ID_RE.test(query)) return "internalId";
-  return "text";
-}
+export const classifyQuickCaseQuery = classifyCaseQuery;
 
 /**
  * One hit from the global-search case lookup. Carries the UUID `id` (for the

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/caseQueryScope.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/caseQueryScope.ts
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/** A CS case number, e.g. "CS0441174" — always "CS" plus exactly 7 digits. */
+const CASE_NUMBER_RE = /^CS\d{7}$/;
+
+/**
+ * A WSO2 case id, e.g. "SOMEID-4" — an alphanumeric project/product prefix, a
+ * hyphen, then 1-4 digits. Deliberately looser than {@link CASE_NUMBER_RE}
+ * (no fixed prefix), so it's checked second, after the case-number pattern
+ * has already had first refusal.
+ */
+const WSO2_CASE_ID_RE = /^[a-zA-Z0-9]+-\d{1,4}$/;
+
+/**
+ * What kind of lookup a typed case-search string should run as:
+ * - `"number"` / `"internalId"`: an exact-match, first-class filter — the
+ *   entity-service resolves these against an indexed column instead of the
+ *   free-text `searchQuery` scan. Named to match the response field names
+ *   (`BeCaseSearchView.number` / `.internalId`), not a UI-facing label.
+ * - `"text"`: the existing free-text search across subject/description
+ *   (and number/internalId, case-insensitively) — unchanged behavior.
+ */
+export type CaseQueryScope = "number" | "internalId" | "text";
+
+/**
+ * Classifies a typed (already-trimmed) case-search string into the scope it
+ * should be routed through. Order matters: a case number is checked first
+ * since `CS\d{7}` is a strict subset of the looser WSO2-case-id shape.
+ *
+ * Shared deliberately: the global quick-nav palette
+ * (`useQuickCaseSearch`) and the cases-list / Support-page search
+ * (`buildCaseSearchFilters`) must classify identically, or the same typed
+ * string resolves one case in the palette and a different one in the list —
+ * which is exactly the bug this consolidation fixes.
+ */
+export function classifyCaseQuery(query: string): CaseQueryScope {
+  if (CASE_NUMBER_RE.test(query)) return "number";
+  if (WSO2_CASE_ID_RE.test(query)) return "internalId";
+  return "text";
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/caseSearchPayload.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/caseSearchPayload.test.ts
@@ -135,3 +135,84 @@ describe("buildCaseSearchFilters — new advanced-filter fields", () => {
     expect(result.filters).toBeUndefined();
   });
 });
+
+// A typed case number / WSO2 case id must go through as an exact-match field
+// filter, not the free-text `searchQuery` scan. `searchQuery` is a CONTAINS/OR
+// scan that also covers the description upstream, so an exact case number
+// matched other cases merely *mentioning* it -- searching one case number
+// surfaced a different case entirely.
+describe("buildCaseSearchFilters — exact case-number / WSO2-id search", () => {
+  it("routes a CS case number to an exact `number` filter, not searchQuery", () => {
+    const result = buildCaseSearchFilters(DEFAULT_CASES_FILTERS, "CS0346083", undefined);
+
+    expect(result.searchQuery).toBeUndefined();
+    expect(result.filters).toEqual([
+      { field: "number", op: "eq", values: ["CS0346083"] },
+    ]);
+  });
+
+  it("routes a WSO2 case id to an exact `internalId` filter, not searchQuery", () => {
+    const result = buildCaseSearchFilters(
+      DEFAULT_CASES_FILTERS,
+      "AXACOLPATRIASUB-484",
+      undefined,
+    );
+
+    expect(result.searchQuery).toBeUndefined();
+    expect(result.filters).toEqual([
+      { field: "internalId", op: "eq", values: ["AXACOLPATRIASUB-484"] },
+    ]);
+  });
+
+  it("still uses free-text searchQuery for anything that isn't an identifier", () => {
+    const result = buildCaseSearchFilters(DEFAULT_CASES_FILTERS, "printer jam", undefined);
+
+    expect(result.searchQuery).toBe("printer jam");
+    expect(result.filters).toBeUndefined();
+  });
+
+  it("treats a partial/malformed case number as free text, so typing stays usable", () => {
+    // Mid-typing (6 digits) and an over-long 8-digit string are both free text.
+    expect(
+      buildCaseSearchFilters(DEFAULT_CASES_FILTERS, "CS034608", undefined).searchQuery,
+    ).toBe("CS034608");
+    expect(
+      buildCaseSearchFilters(DEFAULT_CASES_FILTERS, "CS03460834", undefined).searchQuery,
+    ).toBe("CS03460834");
+  });
+
+  it("combines the exact identifier filter with the other active filters", () => {
+    const result = buildCaseSearchFilters(
+      { ...DEFAULT_CASES_FILTERS, caseTypes: ["case"] },
+      "CS0346083",
+      undefined,
+    );
+
+    expect(result.searchQuery).toBeUndefined();
+    expect(result.filters).toEqual([
+      { field: "type", op: "in", values: ["case"] },
+      { field: "number", op: "eq", values: ["CS0346083"] },
+    ]);
+  });
+
+  it("forceFreeText opts an identifier query back into the searchQuery scan", () => {
+    // The cases list runs this leg alongside the exact one (see useGetCsmCases),
+    // so a case that only *mentions* the number stays findable.
+    const result = buildCaseSearchFilters(
+      DEFAULT_CASES_FILTERS,
+      "CS0346083",
+      undefined,
+      { forceFreeText: true },
+    );
+
+    expect(result.searchQuery).toBe("CS0346083");
+    expect(result.filters).toBeUndefined();
+  });
+
+  it("emits no search filter at all for an empty query", () => {
+    const result = buildCaseSearchFilters(DEFAULT_CASES_FILTERS, "", undefined);
+
+    expect(result.searchQuery).toBeUndefined();
+    expect(result.filters).toBeUndefined();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/caseSearchPayload.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/caseSearchPayload.ts
@@ -50,7 +50,7 @@ export function buildCaseSearchFilters(
   filters: CasesFilters,
   search: string,
   assignedUserIds: string[] | undefined,
-  options?: { forceFreeText?: boolean },
+  options?: { forceFreeText?: boolean; alsoFreeText?: boolean },
 ): BeCaseSearchFilters {
   const fieldFilters: BeCaseFieldFilter[] = [];
   if (filters.severities.length > 0) {
@@ -197,14 +197,22 @@ export function buildCaseSearchFilters(
   // that looks like an identifier — the cases list runs both legs in parallel
   // and merges them (see `useGetCsmCases`), so that a case mentioning the
   // number in its description is still findable, just below the exact hit.
+  //
+  // `alsoFreeText` keeps the exact filter *and* adds the scan. The backend ANDs
+  // `searchQuery` with the `filters` array (the quick-nav palette relies on the
+  // same thing to constrain a free-text search to a set of case types), so this
+  // resolves "how many exact hits the scan already covers" — which is what lets
+  // the merged total be computed exactly instead of guessed. See
+  // `useGetCsmCases`.
   const scope =
     search.length > 0 && !options?.forceFreeText ? classifyCaseQuery(search) : "text";
   if (scope !== "text") {
     fieldFilters.push({ field: scope, op: "eq", values: [search] });
   }
 
+  const withFreeText = scope === "text" || !!options?.alsoFreeText;
   return {
-    ...(scope === "text" && search.length > 0 && { searchQuery: search }),
+    ...(withFreeText && search.length > 0 && { searchQuery: search }),
     ...(fieldFilters.length > 0 && { filters: fieldFilters }),
   };
 }

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/caseSearchPayload.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/caseSearchPayload.ts
@@ -22,6 +22,7 @@ import {
   uiStateFromBe,
 } from "@api/backend/mappers";
 import { ASSIGNEE_ME_TOKEN } from "@features/csm-cases/utils/assignee";
+import { classifyCaseQuery } from "@features/csm-cases/utils/caseQueryScope";
 import { BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
 import type {
   BeCaseFieldFilter,
@@ -49,6 +50,7 @@ export function buildCaseSearchFilters(
   filters: CasesFilters,
   search: string,
   assignedUserIds: string[] | undefined,
+  options?: { forceFreeText?: boolean },
 ): BeCaseSearchFilters {
   const fieldFilters: BeCaseFieldFilter[] = [];
   if (filters.severities.length > 0) {
@@ -180,8 +182,29 @@ export function buildCaseSearchFilters(
     fieldFilters.push({ field: "closedOn", op: "lte", values: [filters.closedOnLte] });
   }
 
+  // A typed case number / WSO2 case id goes through as an exact-match field
+  // filter rather than the free-text `searchQuery` scan, mirroring the global
+  // quick-nav palette (see `classifyCaseQuery`, shared by both).
+  //
+  // `searchQuery` is a CONTAINS/OR scan across number, WSO2 id, short
+  // description AND description upstream — so searching an exact case number
+  // also matched every *other* case that merely mentions that number in its
+  // description, and those could outrank (or crowd out) the case actually
+  // being looked up. Reported as such: searching one case number surfaced a
+  // different case entirely. An indexed exact match also avoids that scan.
+  //
+  // `forceFreeText` opts back into the `searchQuery` scan even for a query
+  // that looks like an identifier — the cases list runs both legs in parallel
+  // and merges them (see `useGetCsmCases`), so that a case mentioning the
+  // number in its description is still findable, just below the exact hit.
+  const scope =
+    search.length > 0 && !options?.forceFreeText ? classifyCaseQuery(search) : "text";
+  if (scope !== "text") {
+    fieldFilters.push({ field: scope, op: "eq", values: [search] });
+  }
+
   return {
-    ...(search.length > 0 && { searchQuery: search }),
+    ...(scope === "text" && search.length > 0 && { searchQuery: search }),
     ...(fieldFilters.length > 0 && { filters: fieldFilters }),
   };
 }


### PR DESCRIPTION
## Purpose
Searching an exact case number or WSO2 case id from the **Support** page returned the wrong case. `searchQuery` is a `CONTAINS`/`OR` scan across `number`, WSO2 id, short description **and description** upstream, so an exact case number also matched every other case that merely *mentions* that number in its description — and those could outrank, or crowd out, the case actually being looked up.

The global quick-nav palette already classifies identifier-shaped queries and sends an exact indexed filter. The Support page never got that treatment and still sent free text. This brings the two in line.

> **Scope note:** the classification rules are now shared rather than copied. Two implementations would drift straight back into "the palette resolves one case, the list resolves another", which is the class of bug being fixed here.

## Goals
- An exact case number / WSO2 case id resolves to that case, not to something quoting it.
- Cases that legitimately *reference* the number in their description stay findable, just below the exact hit.
- Faster: an indexed lookup instead of a four-column description scan.

## Approach
Three commits, each independently buildable:

1. **Extract the classifier** into `utils/caseQueryScope.ts`. Pure move — `useQuickCaseSearch` keeps `classifyQuickCaseQuery` as a thin alias, so its callers and tests are untouched.
2. **Route identifier queries to an exact match** in `buildCaseSearchFilters`: `CS0123456` → `{field:"number", op:"eq"}`, `SOMEID-484` → `{field:"internalId", op:"eq"}`; anything else keeps free text. A new `forceFreeText` option opts back into the scan, mirroring the convention `useQuickCaseSearch` already had.
3. **Run both legs in parallel** in `useGetCsmCases`.

**Why both legs, rather than exact-only.** Exact-only is too narrow: it loses cases that legitimately reference a number in their description, and returns *nothing* if the exact lookup misses. So an identifier query now fires both concurrently and merges:

```ts
const [exactResponse, textResponse] = await Promise.all([
  runSearch(undefined, { offset: 0, limit: EXACT_MATCH_LIMIT }), // indexed eq
  runSearch({ forceFreeText: true }),                            // CONTAINS scan
]);
```

Merge rules, and the reasoning behind each:

- **Pinned rows are additive, not displacing.** Page 0 returns `pageSize + pinned` rows rather than dropping the free-text page's last row — displacing it would make that case *invisible*, since page 1 resumes at `offset + pageSize` regardless.
- **Pinned ids are filtered out of every later page**, so a pinned case can't reappear further down its own result set.
- **The exact leg is fetched once from offset 0**, not re-queried per page — a number match is unique, so it isn't page-dependent.
- **No extra latency** — `Promise.all`, so wall time is the slower leg, not the sum.
- **Plain-text and empty queries still issue exactly one request** (covered by tests), so ordinary searching doesn't double its traffic.

`buildCaseSearchFilters` is shared, so the Support list, its **CSV export**, and `CsmIssuesView` (Security Reports / Engagements / Project Issues) all pick this up consistently. Export keeps the single-request exact-aware path — pinning a row above a file would make no sense.

## User stories
As a CS engineer, I can paste a case number or WSO2 case id into the Support search and get that case, while still seeing other cases that reference it.

## Release note
Fixed Support page search returning an unrelated case when searching by case number or WSO2 case id.

## Documentation
N/A — internal CSM portal UI, no external doc surface affected.

## Automation tests
- Unit tests: 6 new in `useGetCsmCases.test.tsx` (both legs fire; dedupe without inflating the total; pinned rows excluded from later pages; single request for plain-text and for empty queries) and 7 in `caseSearchPayload.test.ts` (number → `number eq`, WSO2 id → `internalId eq`, free text unchanged, partial/malformed stays free text, combines with other active filters, `forceFreeText`).
- Full `csm-cases` suite: 301 passing. The 2 failures in `LinkCaseDialog` / `CaseActionBar` are pre-existing on `main` and unrelated — verified on a clean checkout.
- Verified against staging that both exact filter shapes (`number eq`, `internalId eq`) are accepted and return the correct single case.

> **Not verified end-to-end:** the originally reported identifiers are production records and return `total: 0` on staging, and staging has no case whose description cross-references another's number — so the original false positive isn't reproducible there. The merge logic is covered by unit tests, but it's worth confirming on production before closing the report.
>
> Also still open, and **not** addressed here: if the exact lookup genuinely returns nothing on production, that points at a separate visibility/scoping problem (permissions, case type, or project scope). Running both legs means the user now sees free-text results instead of an empty list in that case, but it doesn't explain the underlying cause.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (frontend-only change)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
- `tsc -b`, `pnpm run lint` (no new findings), `pnpm run test` all passing locally.
- No API contract change: both filter shapes are already supported by `/cases/search`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved case search for case numbers and internal case IDs with exact-match prioritization.
  * Combined exact and free-text results are deduplicated, with accurate totals and prioritized matches shown first.
  * Standard text searches continue using the existing single-search experience.
* **Bug Fixes**
  * Prevented prioritized cases from reappearing on subsequent result pages.
  * Improved handling of malformed or identifier-like queries alongside active filters.
  * Improved pagination and result counts across combined search results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->