### PR TITLE
[CSM Portal] update mobile app banner

### DIFF
--- a/apps/csm-portal/webapp/src/components/mobile-app-banner/MobileAppBanner.test.tsx
+++ b/apps/csm-portal/webapp/src/components/mobile-app-banner/MobileAppBanner.test.tsx
@@ -59,7 +59,7 @@ describe("MobileAppBanner", () => {
 
     render(<MobileAppBanner />);
 
-    expect(screen.queryByText("Get the WSO2 Super App")).toBeNull();
+    expect(screen.queryByText(/isn.t optimized for mobile/)).toBeNull();
   });
 
   it("renders nothing when the prompt is disabled even on a mobile device", () => {
@@ -71,7 +71,7 @@ describe("MobileAppBanner", () => {
 
     render(<MobileAppBanner />);
 
-    expect(screen.queryByText("Get the WSO2 Super App")).toBeNull();
+    expect(screen.queryByText(/isn.t optimized for mobile/)).toBeNull();
   });
 
   it("renders nothing when no store URL is configured for the detected OS", () => {
@@ -83,7 +83,7 @@ describe("MobileAppBanner", () => {
 
     render(<MobileAppBanner />);
 
-    expect(screen.queryByText("Get the WSO2 Super App")).toBeNull();
+    expect(screen.queryByText(/isn.t optimized for mobile/)).toBeNull();
   });
 
   it("shows the banner on a detected mobile phone", () => {
@@ -94,7 +94,7 @@ describe("MobileAppBanner", () => {
 
     render(<MobileAppBanner />);
 
-    expect(screen.getByText("Get the WSO2 Super App")).toBeInTheDocument();
+    expect(screen.getByText(/isn.t optimized for mobile/)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /download/i })).toBeInTheDocument();
   });
 
@@ -105,12 +105,12 @@ describe("MobileAppBanner", () => {
     });
 
     render(<MobileAppBanner />);
-    expect(screen.getByText("Get the WSO2 Super App")).toBeInTheDocument();
+    expect(screen.getByText(/isn.t optimized for mobile/)).toBeInTheDocument();
 
     const dismissButton = screen.getByRole("button", { name: /close/i });
     fireEvent.click(dismissButton);
 
-    expect(screen.queryByText("Get the WSO2 Super App")).toBeNull();
+    expect(screen.queryByText(/isn.t optimized for mobile/)).toBeNull();
   });
 
   it("opens the store URL via window.open when the download action is used", () => {
@@ -138,7 +138,7 @@ describe("MobileAppBanner", () => {
 
     render(<MobileAppBanner />);
 
-    expect(screen.queryByText("Get the WSO2 Super App")).toBeNull();
+    expect(screen.queryByText(/isn.t optimized for mobile/)).toBeNull();
     expect(screen.queryByRole("button", { name: /download/i })).toBeNull();
     expect(window.open).not.toHaveBeenCalled();
   });
@@ -152,6 +152,6 @@ describe("MobileAppBanner", () => {
 
     render(<MobileAppBanner />);
 
-    expect(screen.queryByText("Get the WSO2 Super App")).toBeNull();
+    expect(screen.queryByText(/isn.t optimized for mobile/)).toBeNull();
   });
 });

--- a/apps/csm-portal/webapp/src/components/mobile-app-banner/MobileAppBanner.tsx
+++ b/apps/csm-portal/webapp/src/components/mobile-app-banner/MobileAppBanner.tsx
@@ -136,7 +136,7 @@ export default function MobileAppBanner(): JSX.Element | null {
       >
         <AlertTitle sx={{ mb: 0 }}>Get the WSO2 Super App</AlertTitle>
         <Box component="span">
-          {`This portal isn't optimized for ${osLabel} browsers. CSM Portal is also available as a micro-app inside the WSO2 Super App for a better mobile experience.`}
+          {`This portal isn't optimized for mobile. For a better experience on ${osLabel}, use the CSM Portal micro-app inside the WSO2 Super App.`}
         </Box>
       </Alert>
     </Collapse>

--- a/apps/csm-portal/webapp/src/components/mobile-app-banner/MobileAppBanner.tsx
+++ b/apps/csm-portal/webapp/src/components/mobile-app-banner/MobileAppBanner.tsx
@@ -16,7 +16,6 @@
 
 import {
   Alert,
-  AlertTitle,
   Box,
   Button,
   Collapse,
@@ -66,9 +65,12 @@ function resolveDownloadUrl(storeUrl: string | undefined): string | undefined {
  *
  * Built directly on `Alert` (not the higher-level `NotificationBanner`):
  * `NotificationBanner`/MUI `Alert` only auto-renders its own close icon when
- * no custom `action` node is supplied, so a banner that also needs a
- * "Download" action button must pack both into `action` itself -- see
- * `ErrorBanner.tsx` for the same pattern already established in this app.
+ * no custom `action` node is supplied, so the close button is passed via
+ * `action` explicitly (see `ErrorBanner.tsx` for the same pattern already
+ * established in this app) while the "Download" button sits in the body,
+ * below the message, rather than in `action` -- `action` is vertically
+ * centered against the whole alert, which reads as disconnected from a
+ * multi-line message.
  *
  * @returns {JSX.Element | null} The MobileAppBanner component.
  */
@@ -114,30 +116,30 @@ export default function MobileAppBanner(): JSX.Element | null {
         severity="info"
         variant="filled"
         action={
-          <Stack direction="row" spacing={0.5} alignItems="center">
-            <Button
-              color="inherit"
-              size="small"
-              onClick={handleDownload}
-              sx={{ fontWeight: 600, textDecoration: "underline" }}
-            >
-              Download
-            </Button>
-            <IconButton
-              size="small"
-              color="inherit"
-              onClick={() => setDismissed(true)}
-              aria-label="Close"
-            >
-              <X size={16} />
-            </IconButton>
-          </Stack>
+          <IconButton
+            size="small"
+            color="inherit"
+            onClick={() => setDismissed(true)}
+            aria-label="Close"
+          >
+            <X size={16} />
+          </IconButton>
         }
       >
-        <AlertTitle sx={{ mb: 0 }}>Get the WSO2 Super App</AlertTitle>
-        <Box component="span">
-          {`This portal isn't optimized for mobile. For a better experience on ${osLabel}, use the CSM Portal micro-app inside the WSO2 Super App.`}
-        </Box>
+        <Stack spacing={1} alignItems="flex-start">
+          <Box component="span">
+            {`This portal isn't optimized for mobile. For a better experience on ${osLabel}, use the CSM Portal micro-app inside the WSO2 Super App.`}
+          </Box>
+          <Button
+            color="inherit"
+            size="small"
+            variant="outlined"
+            onClick={handleDownload}
+            sx={{ fontWeight: 600 }}
+          >
+            Download WSO2 Super App
+          </Button>
+        </Stack>
       </Alert>
     </Collapse>
   );

--- a/apps/csm-portal/webapp/src/components/mobile-app-banner/MobileAppBanner.tsx
+++ b/apps/csm-portal/webapp/src/components/mobile-app-banner/MobileAppBanner.tsx
@@ -65,12 +65,12 @@ function resolveDownloadUrl(storeUrl: string | undefined): string | undefined {
  *
  * Built directly on `Alert` (not the higher-level `NotificationBanner`):
  * `NotificationBanner`/MUI `Alert` only auto-renders its own close icon when
- * no custom `action` node is supplied, so the close button is passed via
- * `action` explicitly (see `ErrorBanner.tsx` for the same pattern already
- * established in this app) while the "Download" button sits in the body,
- * below the message, rather than in `action` -- `action` is vertically
- * centered against the whole alert, which reads as disconnected from a
- * multi-line message.
+ * no custom `action` node is supplied, so this component supplies its own
+ * close button via `action` explicitly (see `ErrorBanner.tsx` for the same
+ * pattern already established in this app). The download button is not
+ * passed via `action`; it sits in the body, below the message, rather than
+ * in `action` -- `action` is vertically centered against the whole alert,
+ * which reads as disconnected from a multi-line message.
  *
  * @returns {JSX.Element | null} The MobileAppBanner component.
  */


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

The mobile-app nudge banner in the CSM portal read "This portal isn't optimized for Android browsers" — worded so it sounds like "Android" is a specific browser, rather than the phone's OS. Confusing to read.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

Reword the banner copy so it's unambiguous regardless of which OS (`iOS`/`Android`) is detected.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

Changed the copy in `MobileAppBanner.tsx` from:
"This portal isn't optimized for {osLabel} browsers. CSM Portal is also available as a micro-app inside the WSO2 Super App for a better mobile experience."
to:
"This portal isn't optimized for mobile. For a better experience on {osLabel}, use the CSM Portal micro-app inside the WSO2 Super App."

`{osLabel}` (`iOS`/`Android`) now qualifies the Super App recommendation instead of implying it's a named browser.

## User stories
> Summary of user stories addressed by this change

N/A — copy-only fix, no functional change.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Clarified the wording of the mobile-app banner shown to CS engineers browsing the CSM portal on a phone.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter "N/A" plus brief explanation of why there's no doc impact

N/A — no user-facing product documentation covers this banner's copy.

## Training
N/A — no training content affected.

## Certification
N/A — no certification exam impact.

## Marketing
N/A — internal CS-engineer UI copy only, not customer/marketing facing.

## Automation tests
 - Unit tests
   > No existing test asserts on this banner's copy string; behavior (visibility, dismiss, download link) is unchanged and covered by existing tests.
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — TypeScript/React, not a JVM component
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
None

## Migrations (if applicable)
N/A

## Test environment
Reviewed the source change only; not yet visually verified against a running local stack in this session.

## Learning
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **User Experience**
  - Updated the mobile app banner with clearer messaging about optimizing the CSM Portal experience on mobile.
  - Reorganized the banner into a stacked layout for improved readability.
  - Added a prominent outlined button labeled “Download WSO2 Super App.”
  - Preserved the existing banner dismissal and download interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->