### PR TITLE
[CSM][Web] Allow resolving call requests (reject/cancel/notes) on a closed case

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CallRequestsTable.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CallRequestsTable.test.tsx
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { CallRequestsTable } from "@features/csm-cases/components/CallRequestsTable";
+import type { BeCallRequestView } from "@api/backend/types";
+
+function callRequest(overrides: Partial<BeCallRequestView> = {}): BeCallRequestView {
+  return {
+    id: "cr-1",
+    number: "CSTASK0000001",
+    reason: "Discuss upgrade",
+    state: { id: "pending_on_wso2", label: "Pending on WSO2" },
+    createdOn: "2026-08-01 10:00:00",
+    updatedOn: "2026-08-01 10:00:00",
+    ...overrides,
+  };
+}
+
+describe("CallRequestsTable — closed-case gating", () => {
+  it("keeps Reject enabled on a `pending_on_wso2` request even when the case is closed", () => {
+    render(
+      <CallRequestsTable
+        requests={[callRequest()]}
+        onAction={vi.fn()}
+        scheduleBlockReason="Calls can only be requested while the case is work in progress, awaiting info, waiting on WSO2, solution proposed, or reopened."
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Reject" })).toBeEnabled();
+  });
+
+  it("disables Schedule when scheduleBlockReason is set", () => {
+    render(
+      <CallRequestsTable
+        requests={[callRequest()]}
+        onAction={vi.fn()}
+        scheduleBlockReason="Calls can only be requested while the case is work in progress."
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Schedule" })).toBeDisabled();
+  });
+
+  it("keeps Cancel enabled on a `scheduled` request when scheduleBlockReason is set", () => {
+    render(
+      <CallRequestsTable
+        requests={[callRequest({ state: { id: "scheduled", label: "Scheduled" } })]}
+        onAction={vi.fn()}
+        scheduleBlockReason="blocked"
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Reschedule" })).toBeDisabled();
+  });
+
+  it("keeps Send call notes enabled on a `notes_pending` request when scheduleBlockReason is set", () => {
+    render(
+      <CallRequestsTable
+        requests={[callRequest({ state: { id: "notes_pending", label: "Notes Pending" } })]}
+        onAction={vi.fn()}
+        scheduleBlockReason="blocked"
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Send call notes" })).toBeEnabled();
+  });
+
+  it("enables every action (including Schedule) when there is no block reason", () => {
+    render(
+      <CallRequestsTable requests={[callRequest()]} onAction={vi.fn()} />,
+    );
+
+    expect(screen.getByRole("button", { name: "Schedule" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Reject" })).toBeEnabled();
+  });
+
+  it("calls onAction with the clicked action and the row's call request", () => {
+    const onAction = vi.fn();
+    const cr = callRequest();
+    render(<CallRequestsTable requests={[cr]} onAction={onAction} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Reject" }));
+    expect(onAction).toHaveBeenCalledWith("reject", cr);
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CallRequestsTable.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CallRequestsTable.tsx
@@ -81,9 +81,20 @@ const GRID =
 export interface CallRequestsTableProps {
   requests: BeCallRequestView[];
   onAction: (action: CallRequestAgentAction, cr: BeCallRequestView) => void;
-  /** True when the parent case is closed — existing call requests stay visible
-   * but can no longer be updated (scheduled, rejected, etc.). */
-  isClosed?: boolean;
+  /**
+   * Non-null when the case's current state doesn't accept a schedule/create
+   * (see `callRequestCaseStateBlockReason` — this always includes a closed
+   * case, since `closed` is never one of the 5 allowed states). Disables only
+   * the `schedule`/`reschedule` actions, with this as the tooltip reason.
+   *
+   * Reject/Cancel/Send call notes are NOT gated by this: nothing in our own
+   * stack (the Go BFF and entity-service are both pass-throughs to
+   * ServiceNow's PATCH) restricts them by case state, so they stay available
+   * even on a closed case — the only way to resolve a call request that
+   * outlived its case, rather than leaving it stuck showing as active
+   * indefinitely.
+   */
+  scheduleBlockReason?: string | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -93,7 +104,7 @@ export interface CallRequestsTableProps {
 export function CallRequestsTable({
   requests,
   onAction,
-  isClosed,
+  scheduleBlockReason,
 }: CallRequestsTableProps): JSX.Element {
   const [detailTarget, setDetailTarget] = useState<BeCallRequestView | null>(null);
 
@@ -258,25 +269,26 @@ export function CallRequestsTable({
                   >
                     <Eye size={16} />
                   </IconButton>
-                  {actions.map((action, i) => (
-                    <Tooltip
-                      key={action}
-                      title={isClosed ? "This case is closed — it's read-only." : ""}
-                    >
-                      <span>
-                        <Button
-                          size="small"
-                          variant={i === 0 && action !== "cancel" ? "contained" : "outlined"}
-                          color={action === "reject" || action === "cancel" ? "error" : "primary"}
-                          onClick={() => onAction(action, cr)}
-                          disabled={isClosed}
-                          sx={{ textTransform: "none" }}
-                        >
-                          {ACTION_LABEL[action]}
-                        </Button>
-                      </span>
-                    </Tooltip>
-                  ))}
+                  {actions.map((action, i) => {
+                    const isScheduleAction = action === "schedule" || action === "reschedule";
+                    const blocked = isScheduleAction && !!scheduleBlockReason;
+                    return (
+                      <Tooltip key={action} title={blocked ? scheduleBlockReason : ""}>
+                        <span>
+                          <Button
+                            size="small"
+                            variant={i === 0 && action !== "cancel" ? "contained" : "outlined"}
+                            color={action === "reject" || action === "cancel" ? "error" : "primary"}
+                            onClick={() => onAction(action, cr)}
+                            disabled={blocked}
+                            sx={{ textTransform: "none" }}
+                          >
+                            {ACTION_LABEL[action]}
+                          </Button>
+                        </span>
+                      </Tooltip>
+                    );
+                  })}
                 </Box>
                 {cr.assignee && (
                   <Typography

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CallRequestsWidget.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CallRequestsWidget.tsx
@@ -77,9 +77,6 @@ interface CallRequestsWidgetProps {
    * widget (e.g. just clicking back onto the tab) would reopen the dialog. */
   autoOpenCreate?: boolean;
   onAutoOpenCreateHandled?: () => void;
-  /** True when the parent case is closed — call requests stay visible but
-   * become read-only: no new requests, no updates to existing ones. */
-  isClosed?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -92,7 +89,6 @@ export function CallRequestsWidget({
   caseState,
   autoOpenCreate,
   onAutoOpenCreateHandled,
-  isClosed,
 }: CallRequestsWidgetProps): JSX.Element {
   // State filter — empty string means "all". Filtering happens server-side
   // via `filters.states` on the search request.
@@ -111,13 +107,13 @@ export function CallRequestsWidget({
 
   useEffect(() => {
     if (autoOpenCreate) {
-      if (!isClosed && !stateBlockReason) {
+      if (!stateBlockReason) {
         // eslint-disable-next-line react-hooks/set-state-in-effect -- syncs the dialog open to an external one-shot trigger from the case action bar
         setCreateOpen(true);
       }
       onAutoOpenCreateHandled?.();
     }
-  }, [autoOpenCreate, isClosed, stateBlockReason, onAutoOpenCreateHandled]);
+  }, [autoOpenCreate, stateBlockReason, onAutoOpenCreateHandled]);
 
   // Dialog targets — only one dialog is ever open at a time, driven by which
   // action was clicked on a row.
@@ -310,20 +306,14 @@ export function CallRequestsWidget({
                 ))}
               </Select>
             </FormControl>
-            <Tooltip
-              title={
-                isClosed
-                  ? "This case is closed — it's read-only."
-                  : (stateBlockReason ?? "")
-              }
-            >
+            <Tooltip title={stateBlockReason ?? ""}>
               <span>
                 <Button
                   size="small"
                   variant="contained"
                   startIcon={<Plus size={14} />}
                   onClick={() => setCreateOpen(true)}
-                  disabled={isClosed || !!stateBlockReason}
+                  disabled={!!stateBlockReason}
                   sx={{ textTransform: "none" }}
                 >
                   Create call request
@@ -381,7 +371,7 @@ export function CallRequestsWidget({
           <CallRequestsTable
             requests={requests}
             onAction={handleAction}
-            isClosed={isClosed}
+            scheduleBlockReason={stateBlockReason}
           />
         )}
       </Card>

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -2342,7 +2342,6 @@ export default function CsmCaseDetailPage(): JSX.Element {
             caseId={caseId}
             severity={c.severity}
             caseState={c.state}
-            isClosed={isClosed}
           />
         </Box>
       )}


### PR DESCRIPTION
## Purpose
A closed case's Call Requests tab treated every action as read-only, on the assumption that "case closed" meant "nothing here can change." That's only true for two of the five agent actions. Reject, Cancel, and Send call notes have no case-state restriction anywhere in the stack — the Go BFF (`PatchCallRequest`) and the entity-service (`updateCallRequest`) are both pure pass-throughs to ServiceNow's own PATCH, with no business logic of their own. The blanket UI gate was the *only* thing stopping an agent from resolving a call request whose case closed before the call itself got scheduled or rejected — leaving it stuck showing as active indefinitely, with no way to clear it from the portal.

> **Scope note:** Schedule/Reschedule/Create call request stay disabled on a closed case. Those genuinely are backend-restricted — `CALL_REQUEST_ALLOWED_CASE_STATES` documents mirroring ServiceNow's own `CallRequestUtils.scheduleCall` gate, and `closed` isn't one of its 5 allowed states. Enabling those in the UI would just replace a disabled button with a submit-then-fail round trip. Unblocking them for real needs a ServiceNow-side change, which is out of scope for this repo.

## Goals
- An agent can Reject / Cancel / Send call notes on a call request whose case has already closed.
- Schedule / Reschedule / Create stay blocked where the restriction is real (ServiceNow's own state gate), with the actual reason shown instead of a generic "read-only" message.
- No behavior change for a case that's still open.

## Approach
- `CallRequestsTable.tsx`: replaced the `isClosed` prop (which disabled every row action) with `scheduleBlockReason` — non-null exactly when the case's state doesn't accept a schedule (this already covers `closed`, since it's never one of the 5 allowed states). Only `schedule`/`reschedule` actions are disabled on it now; the reason string is the tooltip.
- `CallRequestsWidget.tsx`: dropped `isClosed` entirely. It was redundant with `stateBlockReason` (`callRequestCaseStateBlockReason(caseState)`) everywhere it was used — the Create button's disabled/tooltip logic and the auto-open-create effect now read `stateBlockReason` directly, which also fixes the Create button showing a generic "This case is closed" message instead of the more specific, already-correct reason.
- `CsmCaseDetailPage.tsx`: stopped passing the now-removed `isClosed` prop (it was `c.state === "closed"`, duplicating what `caseState` already carries).

## User stories
As a CS engineer, I can reject, cancel, or send notes on a call request even after its parent case has closed, so it stops sitting in the queue as if it were still active.

## Release note
Fixed: Call requests on a closed case can now be rejected, canceled, or concluded with notes. Scheduling/creating a new call request still requires an open case.

## Documentation
N/A — internal CSM portal UI, no external doc surface affected.

## Automation tests
- Unit tests: 6 new in `CallRequestsTable.test.tsx` — Reject/Cancel/Send call notes stay enabled with a block reason set (across the three states that offer each), Schedule is disabled when a reason is present, everything is enabled with no reason, and `onAction` fires with the right action/row.
- Verified the two new tests that matter most (Schedule-disabled, Cancel-stays-enabled) actually catch the regression: run against the pre-change component, both fail.
- Verified live against a real closed staging case with several call requests stuck in an active-looking state: with the old code, Reject was genuinely disabled; with this change, enabled — confirmed via a local-only Playwright script (not part of the committed suite), removed after verification. No mutating action (Reject/Cancel/etc.) was actually submitted against real data — only button enabled/disabled state was checked.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (frontend-only change)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
- `tsc -b`, `pnpm run lint` (no new findings beyond one pre-existing, unrelated warning), `pnpm run test` all passing locally.
- No API contract change — every mutation this enables was already accepted end-to-end by the Go BFF and entity-service before this PR; only the frontend's own UI gate changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scheduling and rescheduling actions are disabled only when a scheduling restriction applies.
  * Restriction details are shown in action tooltips.
  * Reject, cancel, and send-notes actions remain available regardless of case status.

* **Bug Fixes**
  * Call request creation and automatic opening now follow the applicable case-state restrictions more accurately.

* **Tests**
  * Added coverage for action availability and rejection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->