### PR TITLE
[CSM] Fix customer-portal backend-v2 WebSocket authentication and move it to its own port

### DIFF
--- a/apps/customer-portal/backend-v2/.choreo/component.yaml
+++ b/apps/customer-portal/backend-v2/.choreo/component.yaml
@@ -11,11 +11,15 @@ endpoints:
       - Public
     schemaFilePath: openapi.yaml
 
+  # The WebSocket endpoint runs on its own listener and port (WS_PORT), not on
+  # 8080 alongside the REST API — matching apps/customer-portal/backend, which
+  # serves REST on 9090 and WebSocket on 9091. See the wsSrv block in
+  # cmd/server/main.go for why the two cannot share a listener.
   - name: customer-portal-websocket
     displayName: Customer Portal Websocket
     service:
       basePath: /
-      port: 8080
+      port: 8081
     type: WS
     networkVisibilities:
       - Public

--- a/apps/customer-portal/backend-v2/.env.example
+++ b/apps/customer-portal/backend-v2/.env.example
@@ -63,3 +63,9 @@ AUTH_ADMIN_ROLE=
 
 # Server
 PORT=8080
+# The WebSocket endpoint (GET /ws) listens on its own port, separate from the
+# REST API above — a browser cannot send the x-jwt-assertion header on a
+# WebSocket handshake, so that listener runs without the Auth middleware and
+# authenticates the token itself. Must match the customer-portal-websocket
+# endpoint's port in .choreo/component.yaml. Optional — defaults to 8081.
+WS_PORT=8081

--- a/apps/customer-portal/backend-v2/CLAUDE.md
+++ b/apps/customer-portal/backend-v2/CLAUDE.md
@@ -167,7 +167,37 @@ busy-flag/mutex; the client
 can still send another frame at any time, this handler simply won't look at it until the current
 one finishes.
 
-Primary authorization on `GET /ws` is the same JWT middleware chain as every other route.
+**`GET /ws` is the one route that does NOT go through `middleware.Auth`, and it runs on its own
+listener and port (`WS_PORT`, default 8081) rather than 8080.** This mirrors
+`apps/customer-portal/backend`, which serves REST on 9090 and its WebSocket on 9091 — read that
+backend's `ws` upgrade resource in `service.bal` before changing anything here.
+
+The reason is a browser limitation, not a preference: **a browser cannot set custom headers on a
+WebSocket handshake**, so the `x-jwt-assertion` header `middleware.Auth` requires can never arrive.
+The frontend instead smuggles its tokens through the `Sec-WebSocket-Protocol` header as
+
+```
+choreo-oauth2-token, <accessToken>, cs-customer-portal, <userIdToken>
+```
+
+(see `WS_CHOREO_OAUTH2_TOKEN`/`WS_CUSTOMER_PORTAL` in the webapp's `constants/apiConstants.ts` and
+`features/support/api/useChatWebSocket.ts`). Choreo's gateway consumes the leading
+`choreo-oauth2-token, <accessToken>` pair for its own authorization and forwards only the
+remainder, so **the token this backend needs is always the last comma-separated value** — which
+holds whether or not the gateway is in the path, so a direct local connection works identically.
+`handler.userIDTokenFromRequest` implements exactly that, trying the `x-user-id-token` header first
+for non-browser callers, and `HandleWebSocket` validates the result through the shared
+`middleware.TokenValidator` before rebuilding the context (`middleware.WithUserInfo` +
+`entity.WithUserIDToken`) that `Auth` would normally have populated.
+
+`Upgrader.Subprotocols` must keep listing `cs-customer-portal`: the client offers it, and a browser
+aborts the connection if the server selects a subprotocol it never offered. It is not cosmetic.
+
+The second reason the listener is separate: the REST server's `ReadTimeout`/`WriteTimeout` would
+cap the lifetime of an upgraded connection. The handler clears those deadlines after upgrading, but
+a listener without them is safe by construction. `handler.wsIdleTimeout` bounds the connection
+instead, per frame.
+
 `WebSocketHandler`'s `gorilla/websocket.Upgrader.CheckOrigin` is a defense-in-depth hook against
 cross-site WebSocket hijacking that could restrict which browser `Origin`s may open the connection,
 but `main.go` currently passes it `nil` (allow any origin) — there is no env var for this.
@@ -335,6 +365,12 @@ responses are fanned out into eight differently-shaped, purpose-built views rath
 
 Apart from `CORS`, identical to `apps/csm-portal/backend`'s chain — see that backend's CLAUDE.md for
 the rationale of each layer. `middleware.ConfigureLogger()` must be called at startup.
+
+**This chain covers the REST listener (`PORT`, 8080) only.** The WebSocket listener (`WS_PORT`,
+8081) runs a shorter chain — `SecurityHeaders → CorrelationID → Logger → Mux` — with **no `Auth`
+and no `CORS`**: `Auth` is impossible there (a browser cannot send `x-jwt-assertion` on a WebSocket
+handshake, so `WebSocketHandler` authenticates the token itself), and `CORS` is irrelevant since a
+WebSocket handshake is not subject to preflight. See "The AI chat agent" above.
 
 **`CORS` must be outermost, wrapping everything including `Auth`.** A CORS preflight is a bare
 `OPTIONS` request with no JWT at all; if `Auth` ran before `CORS`, it would reject every preflight
@@ -666,5 +702,8 @@ struct actually carries it), and a stray extra check on `PATCH` would just be de
   staged.
 - **No sensitive data in logs** — do not log request bodies, JWT payloads, or PII such as email/name. The opaque `userID` claim (`UserInfo.UserID`) is not PII and may be logged for correlation/support purposes, as every handler does today.
 - **JWT is the only inbound auth mechanism** — every non-health endpoint must go through
-  `middleware.Auth`.
+  `middleware.Auth`, with exactly one exception: `GET /ws`, which cannot receive the
+  `x-jwt-assertion` header at all and so validates its own token through the same
+  `middleware.TokenValidator` instead (see "The AI chat agent"). It is still JWT-authenticated —
+  do not add a second exception without the same browser-level justification.
 - **Run gosec on every change** — `gosec -fmt=text ./...` must report 0 issues before opening a PR.

--- a/apps/customer-portal/backend-v2/README.md
+++ b/apps/customer-portal/backend-v2/README.md
@@ -178,7 +178,8 @@ A separate service (not entity-service, not SCIM) — see
 
 | Variable | Description |
 |---|---|
-| `PORT` | Server listen port — a plain number, not an address (default `8080`) |
+| `PORT` | REST server listen port — a plain number, not an address (default `8080`) |
+| `WS_PORT` | WebSocket (`GET /ws`) listen port — a separate listener from `PORT`, must match the `customer-portal-websocket` endpoint in `.choreo/component.yaml` (default `8081`) |
 
 ## Project Structure
 
@@ -373,7 +374,7 @@ backend-v2/
 - `GET /conversations/{id}/messages` — get a conversation's messages (backed by generic comment search)
 - `POST /projects/{projectId}/conversations/{conversationId}/messages` — send a follow-up message on an existing conversation
 - `GET /projects/{id}/conversations/{conversationId}/summary` — get a conversation's summary via the AI chat agent
-- `GET /ws?sessionId={projectId}` — WebSocket: real-time AI chat proxy for an existing conversation (starting a brand-new conversation over this connection isn't supported — use `POST /projects/{id}/conversations` first, see CLAUDE.md)
+- `GET /ws?sessionId={projectId}` — WebSocket: real-time AI chat proxy for an existing conversation (starting a brand-new conversation over this connection isn't supported — use `POST /projects/{id}/conversations` first, see CLAUDE.md). **Served on `WS_PORT` (8081), not `PORT`, and authenticated via the `Sec-WebSocket-Protocol` header rather than `x-jwt-assertion` — see CLAUDE.md for why.**
 - `POST /projects/{projectId}/deployments/{deploymentId}/license` — provision (or resume provisioning) and return a deployment's license via the product-consumption service
 - `POST /deployment-usages` — import a deployment-usage zip file (raw binary body, `Content-Type: application/zip`) via the product-consumption service
 - `GET /updates/product-update-levels` — list product update levels
@@ -597,8 +598,12 @@ curl -X POST http://localhost:8080/projects/<project-id>/conversations/<conversa
 curl -H "x-jwt-assertion: $JWT" http://localhost:8080/projects/<project-id>/conversations/<conversation-id>/summary
 
 # WebSocket (real-time chat proxy) — resumes an existing conversation only, see CLAUDE.md.
-# Using websocat (https://github.com/vi/websocat) as an example client:
-websocat "ws://localhost:8080/ws?sessionId=<project-id>" -H "x-jwt-assertion: $JWT"
+# NOTE: this runs on WS_PORT (8081), not 8080, and does NOT use x-jwt-assertion —
+# a browser can't set headers on a WebSocket handshake, so the token travels as the
+# last Sec-WebSocket-Protocol value. websocat sends that via --protocol:
+websocat "ws://localhost:8081/ws?sessionId=<project-id>" --protocol "cs-customer-portal,$JWT"
+# A non-browser client may instead send the header directly:
+websocat "ws://localhost:8081/ws?sessionId=<project-id>" -H "x-user-id-token: $JWT"
 # then send: {"message":"still seeing the error","conversationId":"<conversation-id>"}
 
 curl -X POST http://localhost:8080/projects/<project-id>/deployments/<deployment-id>/license \

--- a/apps/customer-portal/backend-v2/asyncapi.yaml
+++ b/apps/customer-portal/backend-v2/asyncapi.yaml
@@ -33,9 +33,18 @@ info:
 
 servers:
   local:
-    url: localhost:8080
+    url: localhost:8081
     protocol: ws
-    description: Local server — WebSocket is served on the same port as the REST API (GET /ws), not a separate port.
+    description: >
+      Local server. The WebSocket runs on its own listener and port (WS_PORT,
+      default 8081), separate from the REST API's PORT (8080) — mirroring
+      apps/customer-portal/backend, which serves REST on 9090 and WebSocket on
+      9091. Authentication does NOT use the x-jwt-assertion header: a browser
+      cannot set custom headers on a WebSocket handshake, so the caller's
+      user-ID token is sent as the last Sec-WebSocket-Protocol value, after the
+      "cs-customer-portal" subprotocol name. Choreo's gateway consumes the
+      leading "choreo-oauth2-token, <accessToken>" pair and forwards the rest.
+      See CLAUDE.md's "The AI chat agent" section.
 
 channels:
   /ws:

--- a/apps/customer-portal/backend-v2/cmd/server/main.go
+++ b/apps/customer-portal/backend-v2/cmd/server/main.go
@@ -153,6 +153,17 @@ func main() {
 	// grants admin privileges for registry-token and contact management.
 	adminRole := mustEnv("AUTH_ADMIN_ROLE")
 
+	authCfg := middleware.Config{
+		JWKSEndpoint:          mustEnv("AUTH_JWKS_ENDPOINT"),
+		Issuer:                mustEnv("AUTH_ISSUER"),
+		Audiences:             splitComma(mustEnv("AUTH_AUDIENCE")),
+		ClockSkew:             5 * time.Second,
+		TokenValidatorEnabled: os.Getenv("AUTH_TOKEN_VALIDATOR_ENABLED") != "false",
+	}
+	// One validator, shared by the REST middleware chain and the WebSocket
+	// listener, so the JWKS is fetched and refreshed once per process.
+	tokenValidator := middleware.NewTokenValidator(authCfg)
+
 	userHandler := handler.NewUserHandler(entityClient, scimClient)
 	projectHandler := handler.NewProjectHandler(entityClient)
 	projectStatsHandler := handler.NewProjectStatsHandler(entityClient)
@@ -170,20 +181,12 @@ func main() {
 	catalogHandler := handler.NewCatalogHandler(entityClient)
 	timeCardHandler := handler.NewTimeCardHandler(entityClient)
 	aiChatHandler := handler.NewAIChatHandler(aiChatAgentClient, entityClient)
-	webSocketHandler := handler.NewWebSocketHandler(aiChatAgentWsClient, entityClient, nil)
+	webSocketHandler := handler.NewWebSocketHandler(aiChatAgentWsClient, entityClient, tokenValidator, nil)
 	productConsumptionHandler := handler.NewProductConsumptionHandler(productConsumptionClient, entityClient)
 	globalHandler := handler.NewGlobalHandler(entityClient)
 	instanceHandler := handler.NewInstanceHandler(entityClient)
 	registryHandler := handler.NewRegistryHandler(entityClient, registryClient, adminRole)
 	contactHandler := handler.NewContactHandler(entityClient, userManagementClient)
-
-	authCfg := middleware.Config{
-		JWKSEndpoint:          mustEnv("AUTH_JWKS_ENDPOINT"),
-		Issuer:                mustEnv("AUTH_ISSUER"),
-		Audiences:             splitComma(mustEnv("AUTH_AUDIENCE")),
-		ClockSkew:             5 * time.Second,
-		TokenValidatorEnabled: os.Getenv("AUTH_TOKEN_VALIDATOR_ENABLED") != "false",
-	}
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /health", func(w http.ResponseWriter, r *http.Request) {
@@ -329,7 +332,6 @@ func main() {
 	mux.HandleFunc("GET /conversations/{id}/messages", aiChatHandler.GetConversationMessages)
 	mux.HandleFunc("POST /projects/{projectId}/conversations/{conversationId}/messages", aiChatHandler.SendConversationMessage)
 	mux.HandleFunc("GET /projects/{id}/conversations/{conversationId}/summary", aiChatHandler.GetConversationSummary)
-	mux.HandleFunc("GET /ws", webSocketHandler.HandleWebSocket)
 
 	// The product-consumption service is a separate service (not
 	// entity-service) — see internal/productconsumption's package doc comment.
@@ -355,7 +357,7 @@ func main() {
 		Handler: middleware.CORS(nil)(
 			middleware.SecurityHeaders(
 				middleware.CorrelationID(
-					middleware.Auth(authCfg)(
+					middleware.AuthWithValidator(tokenValidator)(
 						middleware.Logger(mux),
 					),
 				),
@@ -365,6 +367,45 @@ func main() {
 		ReadTimeout:       30 * time.Second,
 		WriteTimeout:      30 * time.Second,
 		IdleTimeout:       60 * time.Second,
+	}
+
+	// GET /ws lives on its own listener and port, mirroring the Ballerina
+	// backend's split (REST on 9090, WebSocket on 9091 — see that service's
+	// .choreo/component.yaml). Two reasons it cannot share the REST server:
+	//
+	//  1. middleware.Auth demands an x-jwt-assertion header, which a browser
+	//     cannot set on a WebSocket handshake. This chain therefore omits Auth;
+	//     WebSocketHandler authenticates the token itself (see
+	//     handler.userIDTokenFromRequest).
+	//  2. The REST server's Read/WriteTimeout would cap the lifetime of an
+	//     upgraded connection. The handler clears those deadlines after the
+	//     upgrade, but only a listener without them is safe by construction.
+	//
+	// Each Choreo endpoint maps to one port, so this also gives the
+	// customer-portal-websocket endpoint a port of its own — see
+	// .choreo/component.yaml.
+	wsMux := http.NewServeMux()
+	wsMux.HandleFunc("GET /ws", webSocketHandler.HandleWebSocket)
+
+	wsAddr := ":" + mustPort("WS_PORT", "8081")
+	wsLn, err := net.Listen("tcp", wsAddr)
+	if err != nil {
+		slog.Error("failed to bind websocket listener", "addr", wsAddr, "err", err)
+		os.Exit(1)
+	}
+	slog.Info("Customer Portal Backend (v2) websocket listener started", "addr", wsAddr)
+
+	wsSrv := &http.Server{
+		Handler: middleware.SecurityHeaders(
+			middleware.CorrelationID(
+				middleware.Logger(wsMux),
+			),
+		),
+		// ReadHeaderTimeout bounds the handshake itself. Read/Write/Idle
+		// timeouts are deliberately unset: they would terminate a healthy but
+		// idle chat session. handler.wsIdleTimeout bounds the connection
+		// instead, per-frame.
+		ReadHeaderTimeout: 10 * time.Second,
 	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
@@ -377,11 +418,25 @@ func main() {
 		}
 	}()
 
+	go func() {
+		if err := wsSrv.Serve(wsLn); err != nil && err != http.ErrServerClosed {
+			slog.Error("websocket server exited", "err", err)
+			os.Exit(1)
+		}
+	}()
+
 	<-ctx.Done()
 	stop()
 
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
+	// Shut the WebSocket listener down first so it stops accepting new
+	// upgrades while the REST server drains. Shutdown does not close
+	// already-hijacked connections; those end when their peer disconnects or
+	// handler.wsIdleTimeout expires.
+	if err := wsSrv.Shutdown(shutdownCtx); err != nil {
+		slog.Error("websocket graceful shutdown failed", "err", err)
+	}
 	if err := srv.Shutdown(shutdownCtx); err != nil {
 		slog.Error("graceful shutdown failed", "err", err)
 		os.Exit(1)

--- a/apps/customer-portal/backend-v2/internal/handler/websocket.go
+++ b/apps/customer-portal/backend-v2/internal/handler/websocket.go
@@ -58,6 +58,23 @@ type entityCommentCreator interface {
 // auto-resolve a conversation when the AI agent reports the issue solved.
 const wsAutoResolveState = "RESOLVED"
 
+// wsSubprotocol is the WebSocket subprotocol this endpoint negotiates. The
+// frontend offers it (see WS_CUSTOMER_PORTAL in the webapp's apiConstants.ts)
+// and the upgrade echoes it back, matching the Ballerina backend's
+// `@websocket:ServiceConfig { subProtocols: ["cs-customer-portal"] }`.
+const wsSubprotocol = "cs-customer-portal"
+
+// userIDTokenHeader carries the caller's user-ID token on ordinary HTTP
+// requests. A browser cannot set it on a WebSocket handshake — see
+// userIDTokenFromRequest.
+const userIDTokenHeader = "x-user-id-token"
+
+// wsTokenValidator abstracts middleware.TokenValidator so tests can inject a
+// fake identity without minting real JWTs.
+type wsTokenValidator interface {
+	Validate(token string) (*middleware.UserInfo, error)
+}
+
 // WebSocketHandler proxies real-time chat messages between the browser and
 // the upstream AI chat agent for an existing conversation.
 //
@@ -73,15 +90,18 @@ const wsAutoResolveState = "RESOLVED"
 type WebSocketHandler struct {
 	ai      wsStreamer
 	entity  entityCommentCreator
+	auth    wsTokenValidator
 	upgrade websocket.Upgrader
 }
 
 // NewWebSocketHandler creates a WebSocketHandler backed by the given AI chat
-// agent WebSocket client and entity client. allowedOrigins restricts which
-// browser Origins may open this connection (defense in depth against
-// cross-site WebSocket hijacking) — pass nil/empty to allow any origin,
-// e.g. for local development.
-func NewWebSocketHandler(ai wsStreamer, entityClient entityCommentCreator, allowedOrigins []string) *WebSocketHandler {
+// agent WebSocket client and entity client. auth validates the caller's token
+// (see userIDTokenFromRequest for why this route authenticates itself instead
+// of going through middleware.Auth). allowedOrigins restricts which browser
+// Origins may open this connection (defense in depth against cross-site
+// WebSocket hijacking) — pass nil/empty to allow any origin, e.g. for local
+// development.
+func NewWebSocketHandler(ai wsStreamer, entityClient entityCommentCreator, auth wsTokenValidator, allowedOrigins []string) *WebSocketHandler {
 	allowed := make(map[string]bool, len(allowedOrigins))
 	for _, o := range allowedOrigins {
 		allowed[o] = true
@@ -89,18 +109,57 @@ func NewWebSocketHandler(ai wsStreamer, entityClient entityCommentCreator, allow
 	return &WebSocketHandler{
 		ai:     ai,
 		entity: entityClient,
+		auth:   auth,
 		upgrade: websocket.Upgrader{
-			// Primary authorization is still the same JWT middleware chain as
-			// every other route (see cmd/server/main.go); this Origin check is
-			// defense in depth against cross-site WebSocket hijacking. A
-			// non-browser caller (e.g. a server-to-server client) sends no
-			// Origin header at all and is allowed through either way.
+			// Negotiating the subprotocol the frontend offers is required, not
+			// cosmetic: the handshake carries the caller's token as a
+			// subprotocol value (see userIDTokenFromRequest), and a browser
+			// aborts the connection if the server selects a protocol it never
+			// offered. Selecting this one echoes back a value the client sent.
+			Subprotocols: []string{wsSubprotocol},
+			// Authorization is the token check in HandleWebSocket; this Origin
+			// check is defense in depth against cross-site WebSocket
+			// hijacking. A non-browser caller (e.g. a server-to-server client)
+			// sends no Origin header at all and is allowed through either way.
 			CheckOrigin: func(r *http.Request) bool {
 				origin := r.Header.Get("Origin")
 				return origin == "" || len(allowed) == 0 || allowed[origin]
 			},
 		},
 	}
+}
+
+// userIDTokenFromRequest recovers the caller's user-ID token from a WebSocket
+// upgrade request.
+//
+// A browser cannot set custom headers on a WebSocket handshake, so the
+// frontend smuggles its tokens through Sec-WebSocket-Protocol as
+//
+//	"choreo-oauth2-token, <accessToken>, cs-customer-portal, <userIdToken>"
+//
+// (see the webapp's useChatWebSocket.ts). Choreo's gateway consumes the
+// leading "choreo-oauth2-token, <accessToken>" pair for its own authorization
+// and forwards only the remainder, so the token this backend needs is always
+// the last comma-separated value — which holds whether or not the gateway is
+// in the path, so a direct local connection works the same way.
+//
+// The x-user-id-token header is tried first, for non-browser callers and for
+// any deployment where the gateway injects it. This mirrors the Ballerina
+// backend's ws upgrade resource in apps/customer-portal/backend/service.bal.
+func userIDTokenFromRequest(r *http.Request) string {
+	if h := strings.TrimSpace(r.Header.Get(userIDTokenHeader)); h != "" {
+		return h
+	}
+	// Values (not Get) because a client may split the offer across repeated
+	// headers; both forms are equivalent on the wire.
+	raw := strings.Join(r.Header.Values("Sec-WebSocket-Protocol"), ",")
+	parts := strings.Split(raw, ",")
+	last := strings.TrimSpace(parts[len(parts)-1])
+	// A handshake offering only the subprotocol name carries no token.
+	if last == wsSubprotocol {
+		return ""
+	}
+	return last
 }
 
 // wsEvent is the JSON envelope used for events this handler sends directly
@@ -118,8 +177,21 @@ type wsEvent struct {
 // project ID — the AI agent's own per-conversation session key is derived
 // below as "{projectId}:{conversationId}".
 func (h *WebSocketHandler) HandleWebSocket(w http.ResponseWriter, r *http.Request) {
-	user := middleware.UserInfoFromContext(r.Context())
-	if user == nil {
+	// This route runs on its own listener, without middleware.Auth — the
+	// x-jwt-assertion header that middleware depends on cannot be set by a
+	// browser opening a WebSocket, so the token arrives as a subprotocol value
+	// instead. See userIDTokenFromRequest.
+	token := userIDTokenFromRequest(r)
+	if token == "" {
+		slog.WarnContext(r.Context(), "websocket auth: no token on upgrade request")
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+	user, err := h.auth.Validate(token)
+	if err != nil {
+		// The error is deliberately not logged: some jwt/v5 error paths embed
+		// parts of the offending token.
+		slog.WarnContext(r.Context(), "websocket auth: token validation failed")
 		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
 		return
 	}
@@ -129,6 +201,12 @@ func (h *WebSocketHandler) HandleWebSocket(w http.ResponseWriter, r *http.Reques
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
+
+	// Rebuild the context the Auth middleware would normally have populated,
+	// so downstream entity-service calls authenticate as this caller.
+	ctx := middleware.WithUserInfo(r.Context(), user)
+	ctx = entity.WithUserIDToken(ctx, token)
+	r = r.WithContext(ctx)
 
 	conn, err := h.upgrade.Upgrade(w, r, nil)
 	if err != nil {

--- a/apps/customer-portal/backend-v2/internal/handler/websocket_test.go
+++ b/apps/customer-portal/backend-v2/internal/handler/websocket_test.go
@@ -1,0 +1,172 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/middleware"
+)
+
+// TestUserIDTokenFromRequest covers the Sec-WebSocket-Protocol token smuggling
+// the frontend relies on, because a browser cannot set a custom header on a
+// WebSocket handshake. The "via Choreo" case is the one that actually runs in
+// a deployed environment — the gateway strips the leading
+// "choreo-oauth2-token, <accessToken>" pair before the request reaches here.
+func TestUserIDTokenFromRequest(t *testing.T) {
+	tests := map[string]struct {
+		header    string
+		protocols string
+		want      string
+	}{
+		"header wins when present": {
+			header:    "header-token",
+			protocols: "cs-customer-portal, protocol-token",
+			want:      "header-token",
+		},
+		"via Choreo — gateway already stripped the oauth2 pair": {
+			protocols: "cs-customer-portal, user-id-token",
+			want:      "user-id-token",
+		},
+		"direct connection — full offer from the browser": {
+			protocols: "choreo-oauth2-token, access-token, cs-customer-portal, user-id-token",
+			want:      "user-id-token",
+		},
+		"no padding around the separator": {
+			protocols: "cs-customer-portal,user-id-token",
+			want:      "user-id-token",
+		},
+		"subprotocol alone carries no token": {
+			protocols: "cs-customer-portal",
+			want:      "",
+		},
+		"nothing at all": {
+			want: "",
+		},
+		"blank header falls through to the subprotocol": {
+			header:    "   ",
+			protocols: "cs-customer-portal, user-id-token",
+			want:      "user-id-token",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodGet, "/ws?sessionId=x", nil)
+			if tc.header != "" {
+				r.Header.Set(userIDTokenHeader, tc.header)
+			}
+			if tc.protocols != "" {
+				r.Header.Set("Sec-WebSocket-Protocol", tc.protocols)
+			}
+			if got := userIDTokenFromRequest(r); got != tc.want {
+				t.Errorf("userIDTokenFromRequest() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestUserIDTokenFromRequest_RepeatedHeaders proves a client that splits its
+// offer across repeated headers is read the same as a single comma-separated
+// one — the two forms are equivalent on the wire.
+func TestUserIDTokenFromRequest_RepeatedHeaders(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/ws?sessionId=x", nil)
+	r.Header.Add("Sec-WebSocket-Protocol", "cs-customer-portal")
+	r.Header.Add("Sec-WebSocket-Protocol", "user-id-token")
+
+	if got := userIDTokenFromRequest(r); got != "user-id-token" {
+		t.Errorf("userIDTokenFromRequest() = %q, want %q", got, "user-id-token")
+	}
+}
+
+// stubValidator is a wsTokenValidator that accepts exactly one token.
+type stubValidator struct {
+	accept string
+	called int
+}
+
+func (s *stubValidator) Validate(token string) (*middleware.UserInfo, error) {
+	s.called++
+	if token != s.accept {
+		return nil, errors.New("invalid token")
+	}
+	return &middleware.UserInfo{UserID: "user-1", Email: "u@example.com"}, nil
+}
+
+// TestHandleWebSocket_RejectsUnauthenticated asserts the upgrade never happens
+// without a valid token — the handler must answer with a normal HTTP error
+// rather than completing the handshake, since it runs on a listener that has
+// no Auth middleware in front of it.
+func TestHandleWebSocket_RejectsUnauthenticated(t *testing.T) {
+	tests := map[string]struct {
+		protocols  string
+		wantStatus int
+		wantCalls  int
+	}{
+		"no token at all": {
+			wantStatus: http.StatusUnauthorized,
+			wantCalls:  0,
+		},
+		"token present but not valid": {
+			protocols:  "cs-customer-portal, wrong-token",
+			wantStatus: http.StatusUnauthorized,
+			wantCalls:  1,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			v := &stubValidator{accept: "good-token"}
+			h := NewWebSocketHandler(nil, nil, v, nil)
+
+			r := httptest.NewRequest(http.MethodGet, "/ws?sessionId=11111111-1111-1111-1111-111111111111", nil)
+			if tc.protocols != "" {
+				r.Header.Set("Sec-WebSocket-Protocol", tc.protocols)
+			}
+			w := httptest.NewRecorder()
+
+			h.HandleWebSocket(w, r)
+
+			if w.Code != tc.wantStatus {
+				t.Errorf("status = %d, want %d", w.Code, tc.wantStatus)
+			}
+			if v.called != tc.wantCalls {
+				t.Errorf("Validate called %d times, want %d", v.called, tc.wantCalls)
+			}
+		})
+	}
+}
+
+// TestHandleWebSocket_ValidatesSessionIDAfterAuth pins the ordering: an
+// authenticated caller with a malformed sessionId gets 400, not 401.
+func TestHandleWebSocket_ValidatesSessionIDAfterAuth(t *testing.T) {
+	v := &stubValidator{accept: "good-token"}
+	h := NewWebSocketHandler(nil, nil, v, nil)
+
+	r := httptest.NewRequest(http.MethodGet, "/ws?sessionId=not-a-uuid", nil)
+	r.Header.Set("Sec-WebSocket-Protocol", "cs-customer-portal, good-token")
+	w := httptest.NewRecorder()
+
+	h.HandleWebSocket(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}

--- a/apps/customer-portal/backend-v2/internal/middleware/auth.go
+++ b/apps/customer-portal/backend-v2/internal/middleware/auth.go
@@ -72,11 +72,21 @@ type jwtClaims struct {
 	jwt.RegisteredClaims
 }
 
-// Auth returns an HTTP middleware that validates the x-jwt-assertion header on
-// every request and stores the resulting UserInfo in the request context.
-// When Config.TokenValidatorEnabled is false the token is only decoded without
+// TokenValidator validates the customer portal's JWTs and extracts the identity
+// they carry. It owns the JWKS client, so build one at startup and share it
+// rather than constructing several: both the Auth middleware (which reads the
+// x-jwt-assertion header) and the WebSocket listener (which cannot use a
+// header at all — see handler.WebSocketHandler) validate through the same
+// instance, so the JWKS is fetched and refreshed once per process.
+type TokenValidator struct {
+	cfg     Config
+	keyFunc jwt.Keyfunc
+}
+
+// NewTokenValidator builds a TokenValidator from cfg. When
+// Config.TokenValidatorEnabled is false the token is only decoded without
 // signature verification — safe for local development only.
-func Auth(cfg Config) func(http.Handler) http.Handler {
+func NewTokenValidator(cfg Config) *TokenValidator {
 	var keyFunc jwt.Keyfunc
 	if cfg.TokenValidatorEnabled {
 		jwks, err := keyfunc.NewDefault([]string{cfg.JWKSEndpoint})
@@ -86,7 +96,26 @@ func Auth(cfg Config) func(http.Handler) http.Handler {
 		}
 		keyFunc = jwks.Keyfunc
 	}
+	return &TokenValidator{cfg: cfg, keyFunc: keyFunc}
+}
 
+// Validate parses and validates a raw JWT, returning the identity it carries.
+func (v *TokenValidator) Validate(tokenStr string) (*UserInfo, error) {
+	return extractUserInfo(tokenStr, v.cfg, v.keyFunc)
+}
+
+// Auth returns an HTTP middleware that validates the x-jwt-assertion header on
+// every request and stores the resulting UserInfo in the request context.
+// When Config.TokenValidatorEnabled is false the token is only decoded without
+// signature verification — safe for local development only.
+func Auth(cfg Config) func(http.Handler) http.Handler {
+	return AuthWithValidator(NewTokenValidator(cfg))
+}
+
+// AuthWithValidator is Auth over an already-built TokenValidator, so a process
+// that also authenticates elsewhere (the WebSocket listener) shares one JWKS
+// client instead of opening a second.
+func AuthWithValidator(v *TokenValidator) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			addSecurityHeaders(w)
@@ -103,7 +132,7 @@ func Auth(cfg Config) func(http.Handler) http.Handler {
 				return
 			}
 
-			info, err := extractUserInfo(tokenStr, cfg, keyFunc)
+			info, err := v.Validate(tokenStr)
 			if err != nil {
 				slog.ErrorContext(r.Context(), "auth: token validation failed", "err", summarizeAuthErr(err))
 				writeAuthError(w, "You are not authorized to perform this action. Please try again.")


### PR DESCRIPTION
## Summary

`GET /ws` could never authenticate. **A browser cannot set custom headers on a WebSocket handshake**, so the `x-jwt-assertion` header `middleware.Auth` requires never arrives on that route — which is what the Azure Staging `403 BACKEND_RESPONSE` (`Duration=3`) on `/ws?sessionId=…` comes down to.

The frontend already handles this the way the Ballerina backend expects, sending its tokens as subprotocol values:

```
Sec-WebSocket-Protocol: choreo-oauth2-token, <accessToken>, cs-customer-portal, <userIdToken>
```

(`webapp/src/constants/apiConstants.ts`, `features/support/api/useChatWebSocket.ts`). Choreo's gateway consumes the leading `choreo-oauth2-token, <accessToken>` pair for its own authorization and forwards the rest, so the token this backend needs is the last comma-separated value. `apps/customer-portal/backend/service.bal`'s `ws` upgrade resource reads exactly that. backend-v2 implemented none of it — there were zero references to `Subprotocols`, `Sec-WebSocket-Protocol`, or `choreo-oauth2-token` anywhere in the service.

This follows the Ballerina implementation, including its listener split:

- **Negotiate the `cs-customer-portal` subprotocol** on the upgrader. Not cosmetic — a browser aborts the connection if the server selects a protocol it never offered.
- **`handler.userIDTokenFromRequest`** reads the token from `x-user-id-token` first (non-browser callers, or a deployment where the gateway injects it), falling back to the last `Sec-WebSocket-Protocol` value. Taking the *last* value works whether or not the gateway is in the path, so a direct local connection behaves the same way.
- **`GET /ws` moves to its own listener on `WS_PORT` (8081)**, mirroring the Ballerina backend's REST-on-9090 / WebSocket-on-9091 split. Two reasons it can't share the REST server: `middleware.Auth` is impossible there (above), and the REST server's `Read`/`WriteTimeout` would cap the lifetime of an upgraded connection. Chain is `SecurityHeaders → CorrelationID → Logger`, with no `Auth` and no `CORS` (a WS handshake isn't subject to preflight). `handler.wsIdleTimeout` bounds the connection per frame instead.
- **One `middleware.TokenValidator` shared** by the REST chain and the WebSocket listener, so the JWKS is fetched and refreshed once per process rather than twice. `middleware.Auth(cfg)` is kept and now delegates to `AuthWithValidator`.
- `HandleWebSocket` rebuilds the context `Auth` would have populated (`middleware.WithUserInfo` + `entity.WithUserIDToken`) so downstream entity-service calls still authenticate as the caller.
- The WebSocket listener binds through `net.ListenConfig.Listen(ctx, …)`, with `signal.NotifyContext` hoisted above it so the lifecycle context exists at bind time. Note this context covers only the listen operation — it does not tie the listener's lifetime to `ctx`; shutdown is unchanged.

`GET /ws` remains JWT-authenticated — the token just arrives by a different route. CLAUDE.md's "every non-health endpoint must go through `middleware.Auth`" rule is updated to record this as the single, browser-forced exception.

## ⚠️ Deployment step — code alone does not fix staging

`.choreo/component.yaml` now points the `customer-portal-websocket` endpoint at **port 8081**. The Choreo endpoint must be reconfigured and redeployed to match, or it will point at a port nothing serves.

## Test plan

Run in a `golang:1.26-alpine` container (no local Go toolchain on the authoring machine):

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` — clean
- [x] `go test -race ./...` — all packages pass
- [x] `gosec -fmt=text ./...` — **0 issues**
- [ ] Local end-to-end: `websocat "ws://localhost:8081/ws?sessionId=<project-id>" --protocol "cs-customer-portal,$JWT"`
- [ ] Staging: Choreo WS endpoint repointed to 8081, then confirm the 403 is gone from the browser client

New `internal/handler/websocket_test.go` covers token extraction (including the via-Choreo stripped form, the full browser offer, repeated headers, and the no-token cases), 401 when no valid token is present, and that `sessionId` validation happens after auth.

## Reviewer notes

- **The gateway-stripping behaviour is taken from the Ballerina code comment, not from observing the gateway directly.** `userIDTokenFromRequest` takes the last subprotocol value, which is correct under either behaviour — but if the gateway forwards no subprotocol at all, the token won't arrive and the result is a 401 rather than a connection. Worth confirming against staging.
- `userIDTokenHeader` carries a `#nosec G101` annotation: G101 fires on `Token` in the identifier, but it's an HTTP header name. This matches the existing annotation on the identical string in `internal/entity/client.go`.
- `asyncapi.yaml`'s server port/description update is included here since it documents this endpoint.
- The REST listener at `cmd/server/main.go:346` still uses a bare `net.Listen`. Left alone as pre-existing code outside this change's scope — happy to make the two consistent in a follow-up if preferred.
