### PR TITLE
add project details E2E coverage

### DIFF
--- a/apps/customer-portal/webapp/tests/e2e/config/testData.ts
+++ b/apps/customer-portal/webapp/tests/e2e/config/testData.ts
@@ -57,6 +57,9 @@ export interface ProjectFixture {
   id: string;
   /** Project name exactly as displayed in the portal. */
   name: string;
+  /** Short project key, shown as a chip beside the name on the Overview tab.
+   * Empty when not yet captured for this environment. */
+  projectKey: string;
   /** The project's type label, for specs that assert type-driven behaviour. */
   type: ProjectType;
   /** Deployment option label, exactly as rendered in the Deployment dropdown.
@@ -96,6 +99,7 @@ export const PROJECTS: Record<ProjectType, ProjectFixture> = {
   [ProjectType.SUBSCRIPTION]: {
     id: "641058e63b5a87103e1e088aa4e45a13",
     name: "Automation Test Customer Project - Subscription",
+    projectKey: "",
     type: ProjectType.SUBSCRIPTION,
     deployment: "Production",
     deploymentId: "8f8a33693bee8b503e1e088aa4e45ab4",
@@ -106,6 +110,7 @@ export const PROJECTS: Record<ProjectType, ProjectFixture> = {
   [ProjectType.MANAGED_CLOUD_SUBSCRIPTION]: {
     id: "a0873629eba28f90fcf5f5dabad0cda0",
     name: "Automation Test MS Customer Project - Managed Cloud Subscription",
+    projectKey: "AUTOMATIONTESTCUSMSSUB",
     type: ProjectType.MANAGED_CLOUD_SUBSCRIPTION,
     deployment: "Production",
     deploymentId: "f40cf7e53b2a4b9091404c6aa5e45a00",
@@ -116,6 +121,7 @@ export const PROJECTS: Record<ProjectType, ProjectFixture> = {
   [ProjectType.CLOUD_SUPPORT]: {
     id: "cd9776ed3ba28b503e1e088aa4e45a81",
     name: "Automation Test Cloud Customer Project - Cloud Support",
+    projectKey: "",
     type: ProjectType.CLOUD_SUPPORT,
     // Deployment is hidden and auto-locked to primary production for this type.
     deployment: "",

--- a/apps/customer-portal/webapp/tests/e2e/pages/ProjectOverviewPage.ts
+++ b/apps/customer-portal/webapp/tests/e2e/pages/ProjectOverviewPage.ts
@@ -1,0 +1,165 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { type Locator, type Page, expect } from "../fixtures/test";
+import {
+  CASE_DETAIL,
+  PROJECT_DETAILS,
+  PROJECT_OVERVIEW,
+} from "../utils/selectors";
+
+/** How long to allow for the dashboard and the overview cards to load — each is
+ * skeletonised while its queries resolve, well beyond the 5s default. */
+const LOAD_TIMEOUT_MS = 60_000;
+
+/**
+ * Page object for the Overview tab of the project details page
+ * (`/projects/:projectId/project-details`).
+ *
+ * The cards render each field as a label `<Typography>` followed by a sibling
+ * value `<Typography>`, with no ids or test ids, so a field's value is reached
+ * by scoping to the smallest container holding its label. `fieldValue()` does
+ * that; everything else here addresses labels and section headings directly.
+ */
+export class ProjectOverviewPage {
+  constructor(private readonly page: Page) {}
+
+  private main(): Locator {
+    return this.page.getByTestId(CASE_DETAIL.mainTestId);
+  }
+
+  /**
+   * Navigates from the project dashboard to the Overview tab via the side nav.
+   *
+   * Overview is the default tab, but it is selected explicitly so the test does
+   * not depend on that default.
+   *
+   * @param projectId - Project whose overview to open.
+   */
+  async openOverviewTab(projectId: string): Promise<void> {
+    await this.page.goto(`/projects/${projectId}/dashboard`);
+
+    const navItem = this.page.getByRole("button", {
+      name: PROJECT_DETAILS.navItem,
+    });
+    await expect(navItem).toBeVisible({ timeout: LOAD_TIMEOUT_MS });
+    await navItem.click();
+    await expect(this.page).toHaveURL(
+      new RegExp(`/projects/${projectId}/${PROJECT_DETAILS.pathSegment}`),
+    );
+
+    await this.overviewTab().click();
+    // The Project Information heading renders before its data does, so wait on a
+    // field label instead — by then the card has resolved.
+    await expect(
+      this.label(
+        PROJECT_OVERVIEW.sections.projectInformation,
+        PROJECT_OVERVIEW.labels.createdDate,
+        PROJECT_OVERVIEW.labels.projectName,
+      ),
+    ).toBeVisible({ timeout: LOAD_TIMEOUT_MS });
+  }
+
+  overviewTab(): Locator {
+    return this.page.getByRole("tab", {
+      name: new RegExp(PROJECT_DETAILS.tabs.overview),
+    });
+  }
+
+  /** A section heading, e.g. "Project Information". */
+  sectionHeading(name: string): Locator {
+    return this.main().getByRole("heading", { name, exact: true });
+  }
+
+  /**
+   * The card containing a given section heading.
+   *
+   * Labels repeat across sections — "Remaining" appears both under Subscription
+   * Period and in Service Hours Allocations — so a page-wide text match is
+   * ambiguous. Every field assertion is scoped through here instead.
+   *
+   * Two details this depends on, both established by probing the live page:
+   *
+   * - The `has:` locators must be page-level, not `main`-scoped. Playwright
+   *   resolves them relative to each candidate element, so a `main`-scoped
+   *   locator would look for <main> *inside* the card and match nothing.
+   * - Filtering on the heading alone is not enough: the innermost div holding it
+   *   is the header wrapper, which contains none of the fields. Requiring an
+   *   `anchorLabel` from the section's body narrows it to a div holding both, so
+   *   `.last()` lands on the card rather than on a header or an ancestor.
+   *
+   * @param headingName - The section's heading text.
+   * @param anchorLabel - A label known to sit in that section's body.
+   * @returns Locator for that section's card.
+   */
+  section(headingName: string, anchorLabel: string): Locator {
+    return this.main()
+      .locator("div")
+      .filter({
+        has: this.page.getByRole("heading", { name: headingName, exact: true }),
+      })
+      .filter({ has: this.page.getByText(anchorLabel, { exact: true }) })
+      .last();
+  }
+
+  /**
+   * A field label within a section.
+   *
+   * @param sectionHeading - Heading of the section to search inside.
+   * @param anchorLabel - A label known to sit in that section's body.
+   * @param name - Exact label text.
+   * @returns Locator for the label.
+   */
+  label(sectionHeading: string, anchorLabel: string, name: string): Locator {
+    return this.section(sectionHeading, anchorLabel).getByText(name, {
+      exact: true,
+    });
+  }
+
+  /** The name shown under "Project Name". */
+  projectName(name: string): Locator {
+    return this.main().getByText(name, { exact: true });
+  }
+
+  /** The project key chip beside the name. */
+  projectKeyChip(key: string): Locator {
+    return this.main().getByText(key, { exact: true });
+  }
+
+  /**
+   * Placeholders (`"--"`) within a section — rendered where the API returned no
+   * value. Asserting a section has none is how a spec distinguishes "the card
+   * rendered" from "the card rendered with data".
+   *
+   * Section-scoped rather than page-wide because whether a field is populated is
+   * per-field project data: on the current fixture Support Tier and Go Live Date
+   * are legitimately empty, so a page-wide count of zero would fail on a data
+   * condition rather than on a defect.
+   *
+   * @param sectionHeading - Heading of the section to search inside.
+   * @param anchorLabel - A label known to sit in that section's body.
+   * @returns Locator for the placeholders in that section.
+   */
+  emptyValuePlaceholders(
+    sectionHeading: string,
+    anchorLabel: string,
+  ): Locator {
+    return this.section(sectionHeading, anchorLabel).getByText(
+      PROJECT_OVERVIEW.emptyValue,
+      { exact: true },
+    );
+  }
+}

--- a/apps/customer-portal/webapp/tests/e2e/specs/project-details/project-overview.spec.ts
+++ b/apps/customer-portal/webapp/tests/e2e/specs/project-details/project-overview.spec.ts
@@ -1,0 +1,138 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//
+// The Overview tab of the project details page, reached through the side nav as
+// a user would.
+//
+// ✅ READ-ONLY — nothing here creates or modifies a record, so it is safe to run
+// repeatedly.
+//
+// The project name and key are asserted exactly, since they identify the
+// project. Everything else is asserted as *present and populated* rather than by
+// value: created date, support tier, go-live date, subscription dates and query
+// hours are all environment data that legitimately changes, so pinning them
+// would make this a test of staging's contents rather than of the page.
+//
+// Service Hours Allocations is feature-gated (`showServiceHoursAllocationsCard`
+// follows the project's time-logs access), which is why this targets Managed
+// Cloud Subscription.
+//
+
+import { test, expect, withSession } from "../../fixtures/test";
+import { ProjectOverviewPage } from "../../pages/ProjectOverviewPage";
+import { PROJECTS, ProjectType } from "../../config/testData";
+import { PROJECT_OVERVIEW } from "../../utils/selectors";
+
+withSession(test);
+
+test.describe("Project Details — overview", () => {
+  // Loads the dashboard, navigates the side nav and waits on several cards;
+  // the 30s default is not enough for a cold navigation.
+  test.describe.configure({ timeout: 120_000 });
+
+  const project = PROJECTS[ProjectType.MANAGED_CLOUD_SUBSCRIPTION];
+  const { labels, sections } = PROJECT_OVERVIEW;
+
+  test(`${ProjectType.MANAGED_CLOUD_SUBSCRIPTION} — shows project, contact and service hours details`, async ({
+    page,
+  }) => {
+    test.skip(
+      !project.id || !project.projectKey,
+      `${ProjectType.MANAGED_CLOUD_SUBSCRIPTION} fixture needs id and projectKey. ` +
+        `Fill them in tests/e2e/config/testData.ts.`,
+    );
+
+    const overview = new ProjectOverviewPage(page);
+    await overview.openOverviewTab(project.id);
+
+    // ── Project Information ────────────────────────────────────────────────
+    await expect(
+      overview.sectionHeading(sections.projectInformation),
+    ).toBeVisible();
+
+    // The one thing worth pinning by value: it identifies the project, so a
+    // fixture pointed at the wrong one fails here rather than passing silently.
+    await expect(overview.projectName(project.name)).toBeVisible();
+    await expect(overview.projectKeyChip(project.projectKey)).toBeVisible();
+
+    // Labels are scoped to their section: several repeat across the page —
+    // "Remaining" appears both here and in Service Hours Allocations — so a
+    // page-wide match is ambiguous.
+    for (const label of [
+      labels.projectName,
+      labels.createdDate,
+      labels.supportTier,
+      labels.goLiveDate,
+      // Subscription Period sits within the Project Information card.
+      labels.subscriptionPeriod,
+      labels.start,
+      labels.end,
+      labels.remaining,
+    ]) {
+      await expect(
+        overview.label(sections.projectInformation, labels.createdDate, label),
+        `${label} label`,
+      ).toBeVisible();
+    }
+
+    // ── Contact Information ────────────────────────────────────────────────
+    await expect(
+      overview.sectionHeading(sections.contactInformation),
+    ).toBeVisible();
+    await expect(
+      overview.label(
+        sections.contactInformation,
+        labels.accountManager,
+        labels.accountManager,
+      ),
+    ).toBeVisible();
+
+    // ── Service Hours Allocations ──────────────────────────────────────────
+    await expect(
+      overview.sectionHeading(sections.serviceHoursAllocations),
+    ).toBeVisible();
+    await expect(
+      overview.label(
+        sections.serviceHoursAllocations,
+        labels.queryHours,
+        labels.queryHours,
+      ),
+    ).toBeVisible();
+
+    // The cards fall back to "--" when the API returns nothing, so the absence
+    // of that placeholder is what distinguishes "displayed correctly" from
+    // "rendered but empty".
+    //
+    // Checked only for these two sections. Project Information is deliberately
+    // excluded: on this project Support Tier and Go Live Date are genuinely
+    // empty (verified live), which is project data rather than a UI fault —
+    // asserting it placeholder-free would fail for the wrong reason, and would
+    // start failing the moment either value was filled in.
+    await expect(
+      overview.emptyValuePlaceholders(
+        sections.contactInformation,
+        labels.accountManager,
+      ),
+    ).toHaveCount(0);
+    await expect(
+      overview.emptyValuePlaceholders(
+        sections.serviceHoursAllocations,
+        labels.queryHours,
+      ),
+    ).toHaveCount(0);
+  });
+});

--- a/apps/customer-portal/webapp/tests/e2e/utils/selectors.ts
+++ b/apps/customer-portal/webapp/tests/e2e/utils/selectors.ts
@@ -76,6 +76,34 @@ export const PROJECT_DETAILS = {
   },
 } as const;
 
+/** Overview tab of the project details page.
+ *
+ * Every entry below is a rendered label rather than a value: the values are
+ * environment data (dates, tiers, hours) that change, so specs assert the
+ * fields are present and populated rather than pinning them. */
+export const PROJECT_OVERVIEW = {
+  sections: {
+    projectInformation: "Project Information",
+    contactInformation: "Contact Information",
+    serviceHoursAllocations: "Service Hours Allocations",
+  },
+  labels: {
+    projectName: "Project Name",
+    createdDate: "Created Date",
+    supportTier: "Support Tier",
+    goLiveDate: "Go Live Date",
+    subscriptionPeriod: "Subscription Period",
+    start: "Start",
+    end: "End",
+    remaining: "Remaining",
+    accountManager: "Account Manager",
+    queryHours: "Query Hours",
+  },
+  /** Rendered in place of a value the API did not return — see the `"--"`
+   * fallbacks in ProjectInformationCard. */
+  emptyValue: "--",
+} as const;
+
 /** Add Deployment modal, opened from the Deployments tab.
  *
  * Unusually for this app the fields have real ids and associated labels, so no


### PR DESCRIPTION
### What

Adds E2E coverage for the project details page 

| Suite | Tests | Creates records? |
|---|---|---|
| `Project Details — overview` | 1 | **No** — read-only |

### Testing

`tsc -b` on the E2E tsconfig and `eslint tests/e2e` are clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for viewing project overview details.
  * Added deployment creation coverage, including successful creation and list verification.
  * Added validation coverage for required fields, whitespace-only names, duplicate deployments, and cancellation.
* **Test Improvements**
  * Added reusable page interactions and selectors for project details, overview, and deployment workflows.
  * Expanded test data support for project keys and deployment types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->