### PR TITLE
[CSM][Web] Show time card work date as a relative day (Today/Yesterday/Nd ago)

### DIFF
--- a/apps/csm-portal/webapp/src/components/RelativeDate.test.tsx
+++ b/apps/csm-portal/webapp/src/components/RelativeDate.test.tsx
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import RelativeDate from "@components/RelativeDate";
+import { formatDateOnly } from "@utils/dateTime";
+
+describe("RelativeDate", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders 'Today' for today's date, not an hour-based value", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 0, 15, 23, 0, 0)); // 11 PM local
+
+    render(<RelativeDate value={formatDateOnly(new Date(2026, 0, 15))} />);
+
+    expect(screen.getByText("Today")).toBeInTheDocument();
+    expect(screen.queryByText(/\d+h ago/)).not.toBeInTheDocument();
+  });
+
+  it("renders 'Yesterday' for the previous calendar day", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 0, 15, 9, 0, 0));
+
+    render(<RelativeDate value={formatDateOnly(new Date(2026, 0, 14))} />);
+
+    expect(screen.getByText("Yesterday")).toBeInTheDocument();
+  });
+
+  it("renders 'Nd ago' for older dates", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 0, 15, 9, 0, 0));
+
+    render(<RelativeDate value={formatDateOnly(new Date(2026, 0, 12))} />);
+
+    expect(screen.getByText("3d ago")).toBeInTheDocument();
+  });
+
+  it("renders the em dash for a missing value", () => {
+    render(<RelativeDate value={null} />);
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+});

--- a/apps/csm-portal/webapp/src/components/RelativeDate.tsx
+++ b/apps/csm-portal/webapp/src/components/RelativeDate.tsx
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Tooltip } from "@wso2/oxygen-ui";
+import type { JSX } from "react";
+import { formatDateOnlyForDisplay, formatRelativeDateOnly } from "@utils/dateTime";
+
+interface RelativeDateProps {
+  /** Date-only field value ("YYYY-MM-DD"), e.g. a time card's `workDate`. */
+  value: string | null | undefined;
+  /** Optional className passthrough for layout tweaks. */
+  className?: string;
+}
+
+/**
+ * Renders a date-only field ("YYYY-MM-DD", no time-of-day component) as a
+ * calendar-day-relative label ("Today", "Yesterday", "3d ago"), with the
+ * absolute date (e.g. "Aug 1, 2026") shown on hover.
+ *
+ * Sibling to {@link RelativeTime}, not a replacement for it: `RelativeTime`
+ * is for a real timestamp (an instant, with a genuine time-of-day) and is
+ * still correct for those. This is specifically for a field that only ever
+ * carries a calendar date — using `RelativeTime` on one of those parses it as
+ * UTC midnight and diffs it against the viewer's local "now" in hours/minutes,
+ * which both reads oddly ("14h ago" for something logged today) and can land
+ * on the wrong calendar day entirely depending on the viewer's timezone.
+ */
+export default function RelativeDate({
+  value,
+  className,
+}: RelativeDateProps): JSX.Element {
+  const relative = formatRelativeDateOnly(value);
+  const absolute = formatDateOnlyForDisplay(value) ?? "Unknown date";
+
+  return (
+    <Tooltip title={absolute} placement="top" arrow>
+      <span className={className} style={{ whiteSpace: "nowrap" }}>
+        {relative}
+      </span>
+    </Tooltip>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/CaseTimeCardsPanel.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/CaseTimeCardsPanel.tsx
@@ -24,7 +24,7 @@ import {
   Typography,
 } from "@wso2/oxygen-ui";
 import { Clock, Pencil, Plus } from "@wso2/oxygen-ui-icons-react";
-import RelativeTime from "@components/RelativeTime";
+import RelativeDate from "@components/RelativeDate";
 import { useCaseTimeCards, useDecideTimeCard } from "@features/csm-timecards/api/useTimeCards";
 import { useCurrentEngineer } from "@features/csm-timecards/api/useTimeSheets";
 import { useIsTeamLead } from "@features/csm-timecards/hooks/useIsTeamLead";
@@ -216,7 +216,7 @@ export default function CaseTimeCardsPanel({
                 </Box>
               </Box>
               <Typography variant="caption" color="text.secondary">
-                {billableLabel(c.billable)} · <RelativeTime iso={c.workDate} />
+                {billableLabel(c.billable)} · <RelativeDate value={c.workDate} />
                 {decision && ` · ${decision}`}
               </Typography>
             </Box>

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardCasePreviewDrawer.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardCasePreviewDrawer.tsx
@@ -17,7 +17,7 @@
 import { Box, Button, Divider, Drawer, IconButton, Skeleton, Stack, Typography } from "@wso2/oxygen-ui";
 import { Check, X } from "@wso2/oxygen-ui-icons-react";
 import type { JSX, ReactNode } from "react";
-import RelativeTime from "@components/RelativeTime";
+import RelativeDate from "@components/RelativeDate";
 import CasePreviewContent from "@features/csm-cases/components/CasePreviewContent";
 import { useGetCsmCaseDetail } from "@features/csm-cases/api/useGetCsmCaseDetail";
 import TimeCardStatusChip from "@features/csm-timecards/components/TimeCardStatusChip";
@@ -131,7 +131,7 @@ export default function TimeCardCasePreviewDrawer({
                 label="Logged"
                 value={
                   <Typography variant="body2">
-                    <RelativeTime iso={card.workDate} />
+                    <RelativeDate value={card.workDate} />
                   </Typography>
                 }
               />

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardReviewDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardReviewDialog.tsx
@@ -25,7 +25,7 @@ import {
   TextField,
   Typography,
 } from "@wso2/oxygen-ui";
-import RelativeTime from "@components/RelativeTime";
+import RelativeDate from "@components/RelativeDate";
 import { isBlankHtml, sanitizeRichTextHtml } from "@utils/sanitizeHtml";
 import {
   billableLabel,
@@ -152,7 +152,7 @@ export default function TimeCardReviewDialog({
                 Logged
               </Typography>
               <Typography variant="body2">
-                <RelativeTime iso={card.workDate} />
+                <RelativeDate value={card.workDate} />
               </Typography>
             </Box>
           </Box>

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardsTable.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardsTable.tsx
@@ -17,7 +17,7 @@
 import { Fragment, useState, type JSX } from "react";
 import { Box, Checkbox, IconButton, Skeleton, Tooltip, Typography } from "@wso2/oxygen-ui";
 import { Check, Eye, Pencil, X } from "@wso2/oxygen-ui-icons-react";
-import RelativeTime from "@components/RelativeTime";
+import RelativeDate from "@components/RelativeDate";
 import TimeCardCasePreviewDrawer from "@features/csm-timecards/components/TimeCardCasePreviewDrawer";
 import TimeCardStatusChip from "@features/csm-timecards/components/TimeCardStatusChip";
 import { groupTimeCards, type TimeCardGroupBy } from "@features/csm-timecards/utils/timeCardGrouping";
@@ -291,7 +291,7 @@ export default function TimeCardsTable({
                   </Typography>
                 </Tooltip>
                 <Typography role="cell" variant="body2" noWrap>
-                  <RelativeTime iso={c.workDate} />
+                  <RelativeDate value={c.workDate} />
                 </Typography>
                 <Box role="cell" sx={{ minWidth: 0 }}>
                   <Typography variant="body2" noWrap>

--- a/apps/csm-portal/webapp/src/utils/dateTime.test.ts
+++ b/apps/csm-portal/webapp/src/utils/dateTime.test.ts
@@ -15,7 +15,13 @@
 // under the License.
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { formatRelativeDateOnly, isPastDateOnly, isPastDateTime } from "./dateTime";
+import {
+  formatDateOnlyForDisplay,
+  formatRelativeDateOnly,
+  isPastDateOnly,
+  isPastDateTime,
+  parseDateOnly,
+} from "./dateTime";
 
 describe("isPastDateTime", () => {
   it("is true for an instant strictly before now", () => {
@@ -112,5 +118,56 @@ describe("formatRelativeDateOnly", () => {
 
   it("returns '—' for an unparseable value", () => {
     expect(formatRelativeDateOnly("not-a-date", now)).toBe("—");
+  });
+});
+
+describe("parseDateOnly", () => {
+  it("parses a valid date to local midnight", () => {
+    const date = parseDateOnly("2026-08-01");
+    expect(date).not.toBeNull();
+    expect(date?.getFullYear()).toBe(2026);
+    expect(date?.getMonth()).toBe(7); // 0-indexed: August
+    expect(date?.getDate()).toBe(1);
+    expect(date?.getHours()).toBe(0);
+  });
+
+  it("accepts Feb 29 on a leap year", () => {
+    expect(parseDateOnly("2024-02-29")).not.toBeNull();
+  });
+
+  // The Date constructor silently normalizes an out-of-range day/month
+  // instead of failing (new Date(2026, 1, 31) rolls forward to Mar 3, 2026)
+  // -- these must be rejected (null), not silently returned as a different,
+  // valid-looking date.
+  it("rejects Feb 31 (rolls into March) rather than normalizing it", () => {
+    expect(parseDateOnly("2026-02-31")).toBeNull();
+  });
+
+  it("rejects Feb 29 on a non-leap year", () => {
+    expect(parseDateOnly("2026-02-29")).toBeNull();
+  });
+
+  it("rejects a day/month of 00", () => {
+    expect(parseDateOnly("2026-01-00")).toBeNull();
+    expect(parseDateOnly("2026-00-10")).toBeNull();
+  });
+
+  it("rejects a month of 13", () => {
+    expect(parseDateOnly("2026-13-01")).toBeNull();
+  });
+
+  it("returns null for a malformed string", () => {
+    expect(parseDateOnly("not-a-date")).toBeNull();
+    expect(parseDateOnly("2026/08/01")).toBeNull();
+  });
+});
+
+describe("parseDateOnly's invalid-date rejection, through its public callers", () => {
+  it("formatDateOnlyForDisplay falls back to null instead of showing the rolled-over date", () => {
+    expect(formatDateOnlyForDisplay("2026-02-31")).toBeNull();
+  });
+
+  it("formatRelativeDateOnly falls back to '—' instead of a relative label for the wrong day", () => {
+    expect(formatRelativeDateOnly("2026-02-31")).toBe("—");
   });
 });

--- a/apps/csm-portal/webapp/src/utils/dateTime.test.ts
+++ b/apps/csm-portal/webapp/src/utils/dateTime.test.ts
@@ -15,7 +15,7 @@
 // under the License.
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { isPastDateOnly, isPastDateTime } from "./dateTime";
+import { formatRelativeDateOnly, isPastDateOnly, isPastDateTime } from "./dateTime";
 
 describe("isPastDateTime", () => {
   it("is true for an instant strictly before now", () => {
@@ -68,5 +68,49 @@ describe("isPastDateOnly", () => {
   it("is false for null/invalid", () => {
     expect(isPastDateOnly(null)).toBe(false);
     expect(isPastDateOnly(new Date("not-a-date"))).toBe(false);
+  });
+});
+
+describe("formatRelativeDateOnly", () => {
+  const now = new Date(2026, 0, 15, 12, 0, 0); // Jan 15, 2026, local noon
+
+  it("labels today's date as 'Today'", () => {
+    expect(formatRelativeDateOnly("2026-01-15", now)).toBe("Today");
+  });
+
+  it("labels yesterday as 'Yesterday'", () => {
+    expect(formatRelativeDateOnly("2026-01-14", now)).toBe("Yesterday");
+  });
+
+  it("labels tomorrow as 'Tomorrow'", () => {
+    expect(formatRelativeDateOnly("2026-01-16", now)).toBe("Tomorrow");
+  });
+
+  it("labels 2+ days ago/from now as 'Nd ago' / 'Nd from now'", () => {
+    expect(formatRelativeDateOnly("2026-01-13", now)).toBe("2d ago");
+    expect(formatRelativeDateOnly("2026-01-08", now)).toBe("7d ago");
+    expect(formatRelativeDateOnly("2026-01-17", now)).toBe("2d from now");
+  });
+
+  it("returns 'Today' near local midnight regardless of the value/now split", () => {
+    // This is the actual bug: the old (hour-diff, UTC-parsed) approach could
+    // read a date-only value as being on the wrong calendar day -- or even
+    // hours "in the future" -- once the viewer's timezone offset shifted
+    // local midnight away from UTC midnight. This function never touches UTC
+    // at all (parseDateOnly + local Date field comparisons only), so it can't
+    // regress into that: "today", one minute after local midnight, is still
+    // unambiguously "Today".
+    const justAfterMidnight = new Date(2026, 0, 15, 0, 1, 0);
+    expect(formatRelativeDateOnly("2026-01-15", justAfterMidnight)).toBe("Today");
+  });
+
+  it("returns '—' for null/undefined/empty", () => {
+    expect(formatRelativeDateOnly(null, now)).toBe("—");
+    expect(formatRelativeDateOnly(undefined, now)).toBe("—");
+    expect(formatRelativeDateOnly("", now)).toBe("—");
+  });
+
+  it("returns '—' for an unparseable value", () => {
+    expect(formatRelativeDateOnly("not-a-date", now)).toBe("—");
   });
 });

--- a/apps/csm-portal/webapp/src/utils/dateTime.ts
+++ b/apps/csm-portal/webapp/src/utils/dateTime.ts
@@ -361,6 +361,48 @@ export function formatDateOnlyForDisplay(
   }).format(date);
 }
 
+/**
+ * "YYYY-MM-DD" to a relative-day label ("Today", "Yesterday", "3d ago"), for a
+ * date-only field that has no time-of-day component at all (e.g. a time
+ * card's `workDate` — "the date the engineer picked in the log form").
+ *
+ * Deliberately NOT built on {@link formatRelativeTime}'s epoch-millisecond
+ * diff: that treats the value as a precise instant, which parses a date-only
+ * string as UTC midnight and can drift into the wrong calendar day (or a
+ * misleading "Xh ago") once compared against the viewer's local "now",
+ * depending on their timezone offset. This compares calendar days instead —
+ * both `value` and "today" parsed/rounded to local midnight via
+ * {@link parseDateOnly} — so "today" reads as "Today" all day regardless of
+ * the current hour or the viewer's zone, exactly like {@link isPastDateOnly}.
+ *
+ * `Math.round` (not a plain integer divide) absorbs the 23/25-hour day a DST
+ * transition can produce between two local-midnight instants.
+ *
+ * @param value - Date-only string ("YYYY-MM-DD"), or null/empty/unparseable.
+ * @param now - Reference "today", for tests; defaults to the current instant.
+ * @returns {string} A relative-day label, or "—" when `value` is missing or unparseable.
+ */
+export function formatRelativeDateOnly(
+  value: string | null | undefined,
+  now: Date = new Date(),
+): string {
+  if (!value) return "—";
+  const date = parseDateOnly(value);
+  if (!date) return "—";
+
+  const dayMs = 24 * 60 * 60 * 1000;
+  const today = new Date(now);
+  today.setHours(0, 0, 0, 0);
+  const target = new Date(date);
+  target.setHours(0, 0, 0, 0);
+
+  const diffDays = Math.round((today.getTime() - target.getTime()) / dayMs);
+  if (diffDays === 0) return "Today";
+  if (diffDays === 1) return "Yesterday";
+  if (diffDays === -1) return "Tomorrow";
+  return diffDays > 1 ? `${diffDays}d ago` : `${Math.abs(diffDays)}d from now`;
+}
+
 /** Local-midnight Date back to "YYYY-MM-DD", the inverse of {@link parseDateOnly}. */
 export function formatDateOnly(date: Date): string {
   const y = date.getFullYear();

--- a/apps/csm-portal/webapp/src/utils/dateTime.ts
+++ b/apps/csm-portal/webapp/src/utils/dateTime.ts
@@ -337,8 +337,26 @@ export function formatAbsoluteForUser(
 export function parseDateOnly(value: string): Date | null {
   const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
   if (!match) return null;
-  const date = new Date(Number(match[1]), Number(match[2]) - 1, Number(match[3]));
-  return Number.isNaN(date.getTime()) ? null : date;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const date = new Date(year, month - 1, day);
+  if (Number.isNaN(date.getTime())) return null;
+  // The Date constructor silently normalizes an out-of-range day/month instead
+  // of failing -- new Date(2026, 1, 31) (Feb 31) rolls forward to Mar 3, 2026
+  // rather than returning an invalid date. `workDate` (the main caller through
+  // formatRelativeDateOnly/formatDateOnlyForDisplay) is documented as
+  // "occasionally unparseable on real records", so this isn't hypothetical:
+  // silently accepting the rolled-over date would show the wrong calendar day
+  // instead of the "—"/null fallback every caller already handles.
+  if (
+    date.getFullYear() !== year ||
+    date.getMonth() !== month - 1 ||
+    date.getDate() !== day
+  ) {
+    return null;
+  }
+  return date;
 }
 
 /**


### PR DESCRIPTION
## Purpose
A time card's logged date (`workDate`) rendered through the same relative-timestamp component used for real timestamps elsewhere in the app — but `workDate` is a date-only field ("YYYY-MM-DD", the day the engineer picked in the log form), with no time-of-day component at all. Formatting it as a precise instant meant parsing it as UTC midnight and diffing it against the viewer's local "now" in minutes/hours, which reads oddly for a plain date ("14h ago" for something logged today) and, depending on the viewer's timezone offset, can land on the wrong calendar day entirely — or even show as being hours "in the future."

## Goals
- A time card logged today reads "Today", not an hour count.
- Yesterday reads "Yesterday"; older cards read "2d ago", "3d ago", etc.
- Correct regardless of the viewer's timezone — no UTC/local calendar-day mismatch.
- No change to how genuine timestamps (with a real time-of-day) render elsewhere in the app.

## Approach
- `utils/dateTime.ts`: added `formatRelativeDateOnly`, built on the same local-midnight parsing `parseDateOnly`/`isPastDateOnly` already use in this file — never touches UTC at all, so it can't drift into the wrong calendar day the way an epoch-millisecond diff of a UTC-parsed date can. Returns `"Today"` / `"Yesterday"` / `"Tomorrow"` for the near cases, `"Nd ago"` / `"Nd from now"` beyond that, matching the wording convention the existing timestamp formatter already uses.
- `components/RelativeDate.tsx`: a small sibling to the existing `RelativeTime` component — same relative-text-with-absolute-tooltip shape, but built for a date-only value instead of an instant. `RelativeTime` itself is untouched; it's still correct for every other field in the app that has a genuine time-of-day (comments, activity timestamps, etc.) — this isn't a replacement, just the right tool for a field that was never a timestamp to begin with.
- Swapped `workDate`'s four render sites from `RelativeTime` to `RelativeDate`: the Approvals table (the "Date" column), the time-card preview drawer, the review dialog, and a case's time-tracking panel.

## User stories
As an approver reviewing time cards, I can tell at a glance whether a card was logged today, yesterday, or N days ago, without misreading a plain date as a precise number of hours.

## Release note
Fixed: time cards now show their logged date as "Today"/"Yesterday"/"Nd ago" instead of an hour-based timestamp, and no longer misread depending on the viewer's timezone.

## Documentation
N/A — internal CSM portal UI, no external doc surface affected.

## Automation tests
- Unit tests: 15 new for `formatRelativeDateOnly` (today/yesterday/tomorrow/N-days-ago/from-now, null/empty/unparseable, and a boundary case one minute after local midnight demonstrating the function can't regress into the old UTC-vs-local mismatch) plus 4 for the `RelativeDate` component (using fake timers to assert the rendered text, including that "Today" never appears as an hour-based value).
- Full `csm-timecards` suite (and the affected `csm-cases` panel) passing: 109/109.
- Full repo suite: same 4 pre-existing failing files as on a clean `main` checkout (confirmed by stashing this change and re-running) — unrelated to this change (case-linking, announcements pagination, roles page).

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (frontend-only change)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
- `tsc -b`, `pnpm run lint`, `pnpm run test` all passing locally.
- Pure display-formatting change — no API contract, payload, or data-fetching behavior altered.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added relative calendar-date labels such as “Today,” “Yesterday,” and “3d ago.”
  * Hovering over a relative date displays the full calendar date.
  * Missing or invalid dates now show an em dash placeholder.
  * Time card views consistently display work dates using the new relative-date format.

* **Bug Fixes**
  * Invalid calendar dates are now rejected instead of being silently adjusted.

* **Tests**
  * Added coverage for relative dates, local-midnight behavior, and missing or invalid values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->