### PR TITLE
[CSM] Fix 401 on every customer-portal backend-v2 WebSocket connection

### DIFF
--- a/apps/customer-portal/backend-v2/CLAUDE.md
+++ b/apps/customer-portal/backend-v2/CLAUDE.md
@@ -186,9 +186,28 @@ choreo-oauth2-token, <accessToken>, cs-customer-portal, <userIdToken>
 remainder, so **the token this backend needs is always the last comma-separated value** — which
 holds whether or not the gateway is in the path, so a direct local connection works identically.
 `handler.userIDTokenFromRequest` implements exactly that, trying the `x-user-id-token` header first
-for non-browser callers, and `HandleWebSocket` validates the result through the shared
-`middleware.TokenValidator` before rebuilding the context (`middleware.WithUserInfo` +
+for non-browser callers.
+
+**The token that arrives is NOT the same token the `Auth` middleware validates, and this trips
+people up.** `middleware.Auth` validates the `x-jwt-assertion` that Choreo's gateway injects. What
+the WebSocket handshake carries is the browser's **Asgardeo-issued ID token** — different issuer
+(`https://api.asgardeo.io/t/<org>/oauth2/token`), different audience (the SPA's client ID plus
+`choreo:deployment:<env>`), different signing key. Passing it to `TokenValidator.Validate` therefore
+fails on issuer/audience/signature every single time, which is exactly how this surfaced: **every
+WebSocket connection returned 401**. `HandleWebSocket` calls
+`middleware.TokenValidator.DecodeUnverified` instead, which decodes the claims without verifying
+signature/issuer/audience, then rebuilds the context (`middleware.WithUserInfo` +
 `entity.WithUserIDToken`) that `Auth` would normally have populated.
+
+That is safe **only** because Choreo's API Manager gateway has already authenticated the caller's
+access token (the leading `choreo-oauth2-token, <accessToken>` subprotocol pair) before forwarding
+the handshake — the same trust boundary described under "Why no Auth middleware". The ID token
+*identifies* an already-authenticated caller; it does not authenticate one. The Ballerina backend
+does the same thing for the same reason (`authorization:getUserInfoFromTokens` calls plain
+`jwt:decode`). **Never use `DecodeUnverified` on a route reachable without the gateway** — it will
+accept a forged, unsigned, or expired token. If that assumption ever changes, the fix is to validate
+the ID token against Asgardeo's own JWKS/issuer/audience via separate config, not to point
+`Validate` at it.
 
 `Upgrader.Subprotocols` must keep listing `cs-customer-portal`: the client offers it, and a browser
 aborts the connection if the server selects a subprotocol it never offered. It is not cosmetic.

--- a/apps/customer-portal/backend-v2/cmd/server/main.go
+++ b/apps/customer-portal/backend-v2/cmd/server/main.go
@@ -369,6 +369,12 @@ func main() {
 		IdleTimeout:       60 * time.Second,
 	}
 
+	// Established before the WebSocket listener binds, so that listener's setup
+	// is cancellable (see lc.Listen below) and a signal arriving mid-bind is
+	// caught rather than killing the process outright.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
 	// GET /ws lives on its own listener and port, mirroring the Ballerina
 	// backend's split (REST on 9090, WebSocket on 9091 — see that service's
 	// .choreo/component.yaml). Two reasons it cannot share the REST server:
@@ -388,7 +394,12 @@ func main() {
 	wsMux.HandleFunc("GET /ws", webSocketHandler.HandleWebSocket)
 
 	wsAddr := ":" + mustPort("WS_PORT", "8081")
-	wsLn, err := net.Listen("tcp", wsAddr)
+	// ctx here covers only the listen operation itself (address resolution and
+	// socket setup) — it does NOT tie the listener's lifetime to the context,
+	// so cancelling ctx will not close wsLn. Shutdown still comes from
+	// wsSrv.Shutdown below.
+	var lc net.ListenConfig
+	wsLn, err := lc.Listen(ctx, "tcp", wsAddr)
 	if err != nil {
 		slog.Error("failed to bind websocket listener", "addr", wsAddr, "err", err)
 		os.Exit(1)
@@ -407,9 +418,6 @@ func main() {
 		// instead, per-frame.
 		ReadHeaderTimeout: 10 * time.Second,
 	}
-
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stop()
 
 	go func() {
 		if err := srv.Serve(ln); err != nil && err != http.ErrServerClosed {

--- a/apps/customer-portal/backend-v2/internal/handler/websocket.go
+++ b/apps/customer-portal/backend-v2/internal/handler/websocket.go
@@ -67,12 +67,17 @@ const wsSubprotocol = "cs-customer-portal"
 // userIDTokenHeader carries the caller's user-ID token on ordinary HTTP
 // requests. A browser cannot set it on a WebSocket handshake — see
 // userIDTokenFromRequest.
-const userIDTokenHeader = "x-user-id-token"
+const userIDTokenHeader = "x-user-id-token" // #nosec G101 -- HTTP header name, not a credential
 
 // wsTokenValidator abstracts middleware.TokenValidator so tests can inject a
 // fake identity without minting real JWTs.
+//
+// DecodeUnverified, not Validate: the token arriving here is the browser's
+// Asgardeo ID token, not the Choreo-injected x-jwt-assertion the validator is
+// configured for, so full validation always rejects it. See that method's doc
+// comment for the trust model that makes this safe.
 type wsTokenValidator interface {
-	Validate(token string) (*middleware.UserInfo, error)
+	DecodeUnverified(token string) (*middleware.UserInfo, error)
 }
 
 // WebSocketHandler proxies real-time chat messages between the browser and
@@ -187,11 +192,16 @@ func (h *WebSocketHandler) HandleWebSocket(w http.ResponseWriter, r *http.Reques
 		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
 		return
 	}
-	user, err := h.auth.Validate(token)
+	// Decode, not validate: this is the browser's Asgardeo ID token, signed by a
+	// different issuer for a different audience than the x-jwt-assertion the
+	// validator is configured for. Choreo's gateway has already authenticated
+	// the caller's access token by this point — see
+	// middleware.TokenValidator.DecodeUnverified.
+	user, err := h.auth.DecodeUnverified(token)
 	if err != nil {
 		// The error is deliberately not logged: some jwt/v5 error paths embed
 		// parts of the offending token.
-		slog.WarnContext(r.Context(), "websocket auth: token validation failed")
+		slog.WarnContext(r.Context(), "websocket auth: could not decode user ID token")
 		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
 		return
 	}

--- a/apps/customer-portal/backend-v2/internal/handler/websocket_test.go
+++ b/apps/customer-portal/backend-v2/internal/handler/websocket_test.go
@@ -102,7 +102,7 @@ type stubValidator struct {
 	called int
 }
 
-func (s *stubValidator) Validate(token string) (*middleware.UserInfo, error) {
+func (s *stubValidator) DecodeUnverified(token string) (*middleware.UserInfo, error) {
 	s.called++
 	if token != s.accept {
 		return nil, errors.New("invalid token")
@@ -148,7 +148,7 @@ func TestHandleWebSocket_RejectsUnauthenticated(t *testing.T) {
 				t.Errorf("status = %d, want %d", w.Code, tc.wantStatus)
 			}
 			if v.called != tc.wantCalls {
-				t.Errorf("Validate called %d times, want %d", v.called, tc.wantCalls)
+				t.Errorf("DecodeUnverified called %d times, want %d", v.called, tc.wantCalls)
 			}
 		})
 	}

--- a/apps/customer-portal/backend-v2/internal/middleware/auth.go
+++ b/apps/customer-portal/backend-v2/internal/middleware/auth.go
@@ -104,6 +104,32 @@ func (v *TokenValidator) Validate(tokenStr string) (*UserInfo, error) {
 	return extractUserInfo(tokenStr, v.cfg, v.keyFunc)
 }
 
+// DecodeUnverified extracts the identity from a JWT **without** verifying its
+// signature, issuer, or audience.
+//
+// It exists for exactly one caller: the WebSocket upgrade path, which receives
+// the browser's Asgardeo-issued **ID token**, not the Choreo-injected
+// x-jwt-assertion that Validate is configured for. Those are two different
+// tokens — different issuer (`https://api.asgardeo.io/t/<org>/oauth2/token`),
+// different audience (the SPA's client ID plus `choreo:deployment:<env>`), and
+// a different signing key — so Validate rejects the ID token every time,
+// which surfaced as a 401 on every WebSocket connection.
+//
+// The trust boundary for that route is Choreo's API Manager gateway, which has
+// already validated the caller's access token (the leading
+// `choreo-oauth2-token, <accessToken>` subprotocol pair) before forwarding the
+// handshake — the same model CLAUDE.md documents under "Why no Auth
+// middleware". The ID token is therefore used to *identify* an
+// already-authenticated caller, not to authenticate one. This mirrors the
+// Ballerina backend's authorization:getUserInfoFromTokens, which likewise only
+// calls jwt:decode.
+//
+// Do NOT use this for any route that is reachable without passing through the
+// gateway: it will accept a forged, unsigned, or expired token.
+func (v *TokenValidator) DecodeUnverified(tokenStr string) (*UserInfo, error) {
+	return extractUserInfo(tokenStr, Config{TokenValidatorEnabled: false}, nil)
+}
+
 // Auth returns an HTTP middleware that validates the x-jwt-assertion header on
 // every request and stores the resulting UserInfo in the request context.
 // When Config.TokenValidatorEnabled is false the token is only decoded without


### PR DESCRIPTION
Follow-up to #1433, which got the handshake as far as the backend but left it returning **401 on every connection**.

## Summary

The token a WebSocket handshake carries is **not** the token `middleware.Auth` validates, and #1433 assumed it was.

| | `x-jwt-assertion` (REST) | ID token (WebSocket) |
|---|---|---|
| Issuer | Choreo gateway | `https://api.asgardeo.io/t/<org>/oauth2/token` |
| Audience | per `AUTH_AUDIENCE` | SPA client ID + `choreo:deployment:<env>` |
| Signing key | per `AUTH_JWKS_ENDPOINT` | Asgardeo's |

`AUTH_ISSUER`/`AUTH_AUDIENCE`/`AUTH_JWKS_ENDPOINT` are configured for the first column, so calling `TokenValidator.Validate` on the second failed issuer/audience/signature checks every time — hence a 401 on every upgrade, confirmed by decoding a real staging token.

This is precisely why the Ballerina backend uses plain `jwt:decode` on this path (`authorization:getUserInfoFromTokens`, `authorization.bal:104-125`) rather than its usual validation.

- **Add `middleware.TokenValidator.DecodeUnverified`** — extracts the claims without verifying signature, issuer, or audience — and call it from `HandleWebSocket` instead of `Validate`.
- **Bind the WebSocket listener through `net.ListenConfig.Listen(ctx, …)`**, with `signal.NotifyContext` hoisted above it. This addresses a review finding on #1433 that **wasn't included when that PR merged** — #1433 merged at its first commit only.
- **Annotate `userIDTokenHeader` with `#nosec G101`** (an HTTP header name, not a credential), matching the identical annotation in `internal/entity/client.go`. **`dev` currently fails the 0-issue gosec gate without this** — same reason: the fix was in the unmerged commit.

## Security note — please read

`DecodeUnverified` accepts a forged, unsigned, or expired JWT. It is safe *only* because Choreo's API Manager gateway has already authenticated the caller's access token (the leading `choreo-oauth2-token, <accessToken>` subprotocol pair) before forwarding the handshake — the trust boundary CLAUDE.md already documents under "Why no Auth middleware". The ID token *identifies* an already-authenticated caller rather than authenticating one, exactly as in the Ballerina backend.

Its doc comment and CLAUDE.md both state that it must never be used on a route reachable without the gateway. **If that assumption doesn't hold in your deployment, this needs to change** — the correct fix would then be validating the ID token against Asgardeo's own JWKS/issuer/audience through separate config, not pointing `Validate` at it. Flagging explicitly rather than burying it, since it's a deliberate weakening relative to every other route.

## Test plan

Run in a `golang:1.26-alpine` container (no local Go toolchain):

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` — clean
- [x] `go test -race ./...` — all packages pass
- [x] `gosec -fmt=text ./...` — **0 issues**
- [ ] Staging: confirm a browser connection now completes the upgrade instead of 401

## Still required for staging to work

`.choreo/component.yaml` points the `customer-portal-websocket` endpoint at **port 8081** (from #1433). If that endpoint hasn't been reconfigured and redeployed in Choreo yet, it's still pointing at a port nothing serves, and this fix alone won't be visible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved WebSocket connection setup so startup can be cancelled cleanly when the service is stopping.
  - Enhanced WebSocket authentication handling for browser connections, supporting smoother authenticated sessions.
  - Updated authentication guidance and safeguards for WebSocket-based communication.
- **Bug Fixes**
  - Improved handling of unauthenticated WebSocket connection attempts and related authentication errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->