### PR TITLE
[CSM] Forward the client's WebSocket payload verbatim so the AI agent receives accountId

### DIFF
--- a/apps/customer-portal/backend-v2/internal/handler/websocket.go
+++ b/apps/customer-portal/backend-v2/internal/handler/websocket.go
@@ -167,6 +167,42 @@ func userIDTokenFromRequest(r *http.Request) string {
 	return last
 }
 
+// buildUpstreamPayload prepares a client chat message for the AI agent: the
+// payload is forwarded **as the client sent it**, with conversationId replaced
+// by the server-resolved value.
+//
+// Forwarding verbatim is required, not lazy. The agent reads several fields
+// straight off this object and rejects the message outright if they're missing
+// — most importantly accountId ("accountId is required"), which it uses to
+// create the session, enforce the per-account token budget, and attribute
+// analytics. An earlier version of this function forwarded only
+// message/conversationId/envProducts, which made every chat message fail.
+//
+// This mirrors the Ballerina backend's ws onMessage
+// (apps/customer-portal/backend/service.bal), which likewise sets
+// parsed["conversationId"] and forwards the rest unchanged.
+//
+// Trust note: accountId is therefore client-supplied and is NOT verified here
+// against the caller's access to that account — a caller could name another
+// account and have its budget/analytics charged. That is a deliberate parity
+// decision with the Ballerina backend rather than an oversight. The agent
+// itself only cross-checks a claimed accountId against the session's own for
+// token_increase_request, and not on the first user_message. If this needs
+// hardening, resolve the account server-side instead via
+// entity.GetProject(projectID).Account.ID (see entity.ProjectAccountRef) —
+// don't reintroduce a field whitelist, which is what broke it before.
+//
+// conversationID always wins over any value in parsed: the caller has already
+// validated it as a UUID, and it keys the agent session this message belongs to.
+func buildUpstreamPayload(parsed map[string]any, conversationID string) ([]byte, error) {
+	upstream := make(map[string]any, len(parsed)+1)
+	for k, v := range parsed {
+		upstream[k] = v
+	}
+	upstream["conversationId"] = conversationID
+	return json.Marshal(upstream)
+}
+
 // wsEvent is the JSON envelope used for events this handler sends directly
 // to the browser (ping/pong, errors) — matches the upstream AI chat agent's
 // own event shape so the frontend handles both uniformly.
@@ -279,17 +315,7 @@ func (h *WebSocketHandler) handleMessage(ctx context.Context, conn *websocket.Co
 	}
 
 	userMessage, _ := parsed["message"].(string)
-	// Forward only the fields the upstream contract defines — never the raw
-	// client-supplied map verbatim, which could otherwise let a client smuggle
-	// extra keys (e.g. its own "accountId"/"sessionId") the agent might trust.
-	upstreamPayload := map[string]any{
-		"message":        userMessage,
-		"conversationId": conversationID,
-	}
-	if envProducts, ok := parsed["envProducts"]; ok {
-		upstreamPayload["envProducts"] = envProducts
-	}
-	enriched, err := json.Marshal(upstreamPayload)
+	enriched, err := buildUpstreamPayload(parsed, conversationID)
 	if err != nil {
 		_ = writeWSJSON(conn, wsEvent{Type: "error", Message: "Failed to process message."})
 		return

--- a/apps/customer-portal/backend-v2/internal/handler/websocket.go
+++ b/apps/customer-portal/backend-v2/internal/handler/websocket.go
@@ -49,9 +49,12 @@ const wsIdleTimeout = 5 * time.Minute
 
 // entityCommentCreator is the subset of the entity client needed to persist
 // conversation messages as comments and auto-resolve a conversation.
+// GetProject resolves the project's owning account (and doubles as the
+// caller's access-control gate for that project) — see HandleWebSocket.
 type entityCommentCreator interface {
 	CreateComment(ctx context.Context, req entity.CreateCommentRequest) (entity.CreateCommentResponse, error)
 	UpdateConversation(ctx context.Context, id string, req entity.UpdateConversationRequest) (entity.UpdateConversationResponse, error)
+	GetProject(ctx context.Context, id string) (entity.ProjectDetailsView, error)
 }
 
 // wsAutoResolveState is entity-service's ConversationState value used to
@@ -182,24 +185,28 @@ func userIDTokenFromRequest(r *http.Request) string {
 // (apps/customer-portal/backend/service.bal), which likewise sets
 // parsed["conversationId"] and forwards the rest unchanged.
 //
-// Trust note: accountId is therefore client-supplied and is NOT verified here
-// against the caller's access to that account — a caller could name another
-// account and have its budget/analytics charged. That is a deliberate parity
-// decision with the Ballerina backend rather than an oversight. The agent
-// itself only cross-checks a claimed accountId against the session's own for
-// token_increase_request, and not on the first user_message. If this needs
-// hardening, resolve the account server-side instead via
-// entity.GetProject(projectID).Account.ID (see entity.ProjectAccountRef) —
-// don't reintroduce a field whitelist, which is what broke it before.
+// Two fields are NOT taken from the client, and both are overwritten here even
+// when the client supplied its own value:
 //
-// conversationID always wins over any value in parsed: the caller has already
-// validated it as a UUID, and it keys the agent session this message belongs to.
-func buildUpstreamPayload(parsed map[string]any, conversationID string) ([]byte, error) {
-	upstream := make(map[string]any, len(parsed)+1)
+//   - conversationID — already validated as a UUID by the caller, and it keys
+//     the agent session this message belongs to.
+//   - accountID — resolved server-side from the project the connection is
+//     scoped to (see HandleWebSocket). The agent charges its per-account token
+//     budget and attributes analytics to this value, so trusting the client
+//     would let a caller bill another account. The Ballerina backend does
+//     forward the client's accountId, but that is a weakness to not reproduce,
+//     not a contract to match.
+//
+// Everything else — message, type, envProducts, and any field the frontend adds
+// later — passes through untouched. Do not reintroduce a field whitelist here:
+// that is what dropped accountId and broke every message before.
+func buildUpstreamPayload(parsed map[string]any, conversationID, accountID string) ([]byte, error) {
+	upstream := make(map[string]any, len(parsed)+2)
 	for k, v := range parsed {
 		upstream[k] = v
 	}
 	upstream["conversationId"] = conversationID
+	upstream["accountId"] = accountID
 	return json.Marshal(upstream)
 }
 
@@ -254,6 +261,34 @@ func (h *WebSocketHandler) HandleWebSocket(w http.ResponseWriter, r *http.Reques
 	ctx = entity.WithUserIDToken(ctx, token)
 	r = r.WithContext(ctx)
 
+	// Resolve the account this connection may act on, server-side, before the
+	// upgrade. Two jobs in one call:
+	//
+	//  1. Access control — entity-service rejects a project this caller can't
+	//     see, so an unauthorized sessionId never reaches an upgraded socket.
+	//     Same gate ProductConsumptionHandler uses for its own project scoping.
+	//  2. Supplies accountId for every message on this connection, so the agent
+	//     bills the per-account token budget to an account the caller actually
+	//     belongs to rather than to whichever one it claimed.
+	//
+	// Resolved once here, not per message: projectID is fixed for the lifetime
+	// of the connection. Failing before the upgrade also means the caller gets a
+	// real HTTP status instead of an immediate WebSocket close.
+	project, err := h.entity.GetProject(ctx, projectID)
+	if err != nil {
+		slog.ErrorContext(ctx, "websocket: failed to resolve project account",
+			"userID", user.UserID, "projectID", projectID, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to open the chat connection.")
+		return
+	}
+	// Fall back to the project ID when entity-service reports no account, which
+	// is what the frontend does too (`projectDetails?.account?.id || projectId`).
+	// The agent rejects an empty accountId outright.
+	accountID := project.Account.ID
+	if accountID == "" {
+		accountID = projectID
+	}
+
 	conn, err := h.upgrade.Upgrade(w, r, nil)
 	if err != nil {
 		slog.ErrorContext(r.Context(), "websocket upgrade failed", "userID", user.UserID, "err", summarizeErr(err))
@@ -283,11 +318,11 @@ func (h *WebSocketHandler) HandleWebSocket(w http.ResponseWriter, r *http.Reques
 			}
 			return
 		}
-		h.handleMessage(r.Context(), conn, user, projectID, data)
+		h.handleMessage(r.Context(), conn, user, projectID, accountID, data)
 	}
 }
 
-func (h *WebSocketHandler) handleMessage(ctx context.Context, conn *websocket.Conn, user *middleware.UserInfo, projectID string, data []byte) {
+func (h *WebSocketHandler) handleMessage(ctx context.Context, conn *websocket.Conn, user *middleware.UserInfo, projectID, accountID string, data []byte) {
 	trimmed := strings.TrimSpace(strings.ToLower(string(data)))
 	var parsed map[string]any
 	_ = json.Unmarshal(data, &parsed)
@@ -315,7 +350,7 @@ func (h *WebSocketHandler) handleMessage(ctx context.Context, conn *websocket.Co
 	}
 
 	userMessage, _ := parsed["message"].(string)
-	enriched, err := buildUpstreamPayload(parsed, conversationID)
+	enriched, err := buildUpstreamPayload(parsed, conversationID, accountID)
 	if err != nil {
 		_ = writeWSJSON(conn, wsEvent{Type: "error", Message: "Failed to process message."})
 		return

--- a/apps/customer-portal/backend-v2/internal/handler/websocket_test.go
+++ b/apps/customer-portal/backend-v2/internal/handler/websocket_test.go
@@ -17,12 +17,15 @@
 package handler
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/apierror"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
 	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/middleware"
 )
 
@@ -104,16 +107,16 @@ func TestUserIDTokenFromRequest_RepeatedHeaders(t *testing.T) {
 // "accountId is required".
 func TestBuildUpstreamPayload(t *testing.T) {
 	const serverConvID = "11111111-1111-1111-1111-111111111111"
+	const serverAccountID = "22222222-2222-2222-2222-222222222222"
 
-	t.Run("preserves accountId, type and envProducts", func(t *testing.T) {
+	t.Run("forwards type, message and envProducts untouched", func(t *testing.T) {
 		parsed := map[string]any{
 			"type":        "user_message",
-			"accountId":   "9460f8a9-1bfa-a694-a002-c9d3604bcbbb",
 			"message":     "hi",
 			"envProducts": map[string]any{"dep-1": []any{"apim"}},
 		}
 
-		raw, err := buildUpstreamPayload(parsed, serverConvID)
+		raw, err := buildUpstreamPayload(parsed, serverConvID, serverAccountID)
 		if err != nil {
 			t.Fatalf("buildUpstreamPayload returned error: %v", err)
 		}
@@ -121,9 +124,6 @@ func TestBuildUpstreamPayload(t *testing.T) {
 		var got map[string]any
 		if err := json.Unmarshal(raw, &got); err != nil {
 			t.Fatalf("result is not valid JSON: %v", err)
-		}
-		if got["accountId"] != "9460f8a9-1bfa-a694-a002-c9d3604bcbbb" {
-			t.Errorf("accountId = %v, want it forwarded unchanged", got["accountId"])
 		}
 		if got["type"] != "user_message" {
 			t.Errorf("type = %v, want user_message", got["type"])
@@ -134,13 +134,39 @@ func TestBuildUpstreamPayload(t *testing.T) {
 		if _, ok := got["envProducts"]; !ok {
 			t.Error("envProducts was dropped")
 		}
+		// accountId must be present even though the client sent none — the
+		// agent rejects the message outright without it.
+		if got["accountId"] != serverAccountID {
+			t.Errorf("accountId = %v, want the server-resolved %v", got["accountId"], serverAccountID)
+		}
+	})
+
+	// The security-relevant case: a caller naming someone else's account must
+	// not have that account's token budget or analytics charged.
+	t.Run("server accountId overrides a client-supplied one", func(t *testing.T) {
+		raw, err := buildUpstreamPayload(map[string]any{
+			"accountId": "someone-elses-account",
+			"message":   "hi",
+		}, serverConvID, serverAccountID)
+		if err != nil {
+			t.Fatalf("buildUpstreamPayload returned error: %v", err)
+		}
+
+		var got map[string]any
+		if err := json.Unmarshal(raw, &got); err != nil {
+			t.Fatalf("result is not valid JSON: %v", err)
+		}
+		if got["accountId"] != serverAccountID {
+			t.Errorf("accountId = %v, want the server-resolved %v — a client value must never win",
+				got["accountId"], serverAccountID)
+		}
 	})
 
 	t.Run("server conversationId overrides the client's", func(t *testing.T) {
 		raw, err := buildUpstreamPayload(map[string]any{
 			"conversationId": "whatever-the-client-said",
 			"message":        "hi",
-		}, serverConvID)
+		}, serverConvID, serverAccountID)
 		if err != nil {
 			t.Fatalf("buildUpstreamPayload returned error: %v", err)
 		}
@@ -157,7 +183,7 @@ func TestBuildUpstreamPayload(t *testing.T) {
 	t.Run("does not mutate the caller's map", func(t *testing.T) {
 		parsed := map[string]any{"conversationId": "client-value", "message": "hi"}
 
-		if _, err := buildUpstreamPayload(parsed, serverConvID); err != nil {
+		if _, err := buildUpstreamPayload(parsed, serverConvID, serverAccountID); err != nil {
 			t.Fatalf("buildUpstreamPayload returned error: %v", err)
 		}
 		if parsed["conversationId"] != "client-value" {
@@ -166,7 +192,7 @@ func TestBuildUpstreamPayload(t *testing.T) {
 	})
 
 	t.Run("nil input does not panic", func(t *testing.T) {
-		raw, err := buildUpstreamPayload(nil, serverConvID)
+		raw, err := buildUpstreamPayload(nil, serverConvID, serverAccountID)
 		if err != nil {
 			t.Fatalf("buildUpstreamPayload returned error: %v", err)
 		}
@@ -236,6 +262,52 @@ func TestHandleWebSocket_RejectsUnauthenticated(t *testing.T) {
 				t.Errorf("DecodeUnverified called %d times, want %d", v.called, tc.wantCalls)
 			}
 		})
+	}
+}
+
+// stubEntity is an entityCommentCreator whose GetProject result is scripted.
+type stubEntity struct {
+	project entity.ProjectDetailsView
+	err     error
+	calls   int
+}
+
+func (s *stubEntity) GetProject(_ context.Context, _ string) (entity.ProjectDetailsView, error) {
+	s.calls++
+	return s.project, s.err
+}
+
+func (s *stubEntity) CreateComment(_ context.Context, _ entity.CreateCommentRequest) (entity.CreateCommentResponse, error) {
+	return entity.CreateCommentResponse{}, nil
+}
+
+func (s *stubEntity) UpdateConversation(_ context.Context, _ string, _ entity.UpdateConversationRequest) (entity.UpdateConversationResponse, error) {
+	return entity.UpdateConversationResponse{}, nil
+}
+
+// TestHandleWebSocket_ProjectAccessGatesTheUpgrade asserts the account lookup
+// doubles as an authorization gate: a project the caller can't see must be
+// rejected with an HTTP status *before* any upgrade happens, not closed after.
+func TestHandleWebSocket_ProjectAccessGatesTheUpgrade(t *testing.T) {
+	v := &stubValidator{accept: "good-token"}
+	e := &stubEntity{err: apierror.NewUpstreamError(http.StatusForbidden, nil)}
+	h := NewWebSocketHandler(nil, e, v, nil)
+
+	r := httptest.NewRequest(http.MethodGet, "/ws?sessionId=11111111-1111-1111-1111-111111111111", nil)
+	r.Header.Set("Sec-WebSocket-Protocol", "cs-customer-portal, good-token")
+	w := httptest.NewRecorder()
+
+	h.HandleWebSocket(w, r)
+
+	if e.calls != 1 {
+		t.Errorf("GetProject called %d times, want 1", e.calls)
+	}
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusForbidden)
+	}
+	// A completed upgrade would have written 101 and hijacked the connection.
+	if w.Code == http.StatusSwitchingProtocols {
+		t.Error("connection was upgraded despite the project being inaccessible")
 	}
 }
 

--- a/apps/customer-portal/backend-v2/internal/handler/websocket_test.go
+++ b/apps/customer-portal/backend-v2/internal/handler/websocket_test.go
@@ -17,6 +17,7 @@
 package handler
 
 import (
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -94,6 +95,90 @@ func TestUserIDTokenFromRequest_RepeatedHeaders(t *testing.T) {
 	if got := userIDTokenFromRequest(r); got != "user-id-token" {
 		t.Errorf("userIDTokenFromRequest() = %q, want %q", got, "user-id-token")
 	}
+}
+
+// TestBuildUpstreamPayload guards the fields the AI agent reads straight off
+// the message. accountId in particular is required by the agent — it uses it
+// for the session, the per-account token budget, and analytics — and an
+// earlier field whitelist dropped it, which made every chat message fail with
+// "accountId is required".
+func TestBuildUpstreamPayload(t *testing.T) {
+	const serverConvID = "11111111-1111-1111-1111-111111111111"
+
+	t.Run("preserves accountId, type and envProducts", func(t *testing.T) {
+		parsed := map[string]any{
+			"type":        "user_message",
+			"accountId":   "9460f8a9-1bfa-a694-a002-c9d3604bcbbb",
+			"message":     "hi",
+			"envProducts": map[string]any{"dep-1": []any{"apim"}},
+		}
+
+		raw, err := buildUpstreamPayload(parsed, serverConvID)
+		if err != nil {
+			t.Fatalf("buildUpstreamPayload returned error: %v", err)
+		}
+
+		var got map[string]any
+		if err := json.Unmarshal(raw, &got); err != nil {
+			t.Fatalf("result is not valid JSON: %v", err)
+		}
+		if got["accountId"] != "9460f8a9-1bfa-a694-a002-c9d3604bcbbb" {
+			t.Errorf("accountId = %v, want it forwarded unchanged", got["accountId"])
+		}
+		if got["type"] != "user_message" {
+			t.Errorf("type = %v, want user_message", got["type"])
+		}
+		if got["message"] != "hi" {
+			t.Errorf("message = %v, want hi", got["message"])
+		}
+		if _, ok := got["envProducts"]; !ok {
+			t.Error("envProducts was dropped")
+		}
+	})
+
+	t.Run("server conversationId overrides the client's", func(t *testing.T) {
+		raw, err := buildUpstreamPayload(map[string]any{
+			"conversationId": "whatever-the-client-said",
+			"message":        "hi",
+		}, serverConvID)
+		if err != nil {
+			t.Fatalf("buildUpstreamPayload returned error: %v", err)
+		}
+
+		var got map[string]any
+		if err := json.Unmarshal(raw, &got); err != nil {
+			t.Fatalf("result is not valid JSON: %v", err)
+		}
+		if got["conversationId"] != serverConvID {
+			t.Errorf("conversationId = %v, want the server-resolved %v", got["conversationId"], serverConvID)
+		}
+	})
+
+	t.Run("does not mutate the caller's map", func(t *testing.T) {
+		parsed := map[string]any{"conversationId": "client-value", "message": "hi"}
+
+		if _, err := buildUpstreamPayload(parsed, serverConvID); err != nil {
+			t.Fatalf("buildUpstreamPayload returned error: %v", err)
+		}
+		if parsed["conversationId"] != "client-value" {
+			t.Errorf("input map was mutated: conversationId = %v", parsed["conversationId"])
+		}
+	})
+
+	t.Run("nil input does not panic", func(t *testing.T) {
+		raw, err := buildUpstreamPayload(nil, serverConvID)
+		if err != nil {
+			t.Fatalf("buildUpstreamPayload returned error: %v", err)
+		}
+
+		var got map[string]any
+		if err := json.Unmarshal(raw, &got); err != nil {
+			t.Fatalf("result is not valid JSON: %v", err)
+		}
+		if got["conversationId"] != serverConvID {
+			t.Errorf("conversationId = %v, want %v", got["conversationId"], serverConvID)
+		}
+	})
 }
 
 // stubValidator is a wsTokenValidator that accepts exactly one token.


### PR DESCRIPTION
Re-raise of a commit that was left behind when #1436 merged (it merged with its first commit only). Cherry-picked cleanly onto the current `dev-app-csm-portal` tip.

## Summary

With auth fixed by #1436, the first real chat message fails:

```
→ {"type":"user_message","accountId":"…","conversationId":"…","envProducts":{},"message":"hi"}
← {"type":"error","message":"accountId is required"}
← {"type":"error","message":"Failed to process message."}
```

`handleMessage` rebuilt the upstream payload from a three-field whitelist — `message`, `conversationId`, `envProducts` — and so **dropped `accountId`**, which the AI agent reads straight off the message body. From the agent's own source (`claude_chatbot/routes.py`, `user_message` branch):

```python
account_id = (data.get("accountId") or "").strip()
if not account_id:
    await ws.send_json({"type": "error", "message": "accountId is required"})
```

It then uses that value for `sessions.create()`, `check_account_budget()` (per-account token budget), and per-account analytics — so it is the real account identity, not a project ID.

This is a latent bug rather than a regression: the WebSocket could never authenticate before #1433/#1436, so this code had never actually run against the agent.

**The Ballerina backend forwards the whole payload** (`apps/customer-portal/backend/service.bal`, ws `onMessage`) — `parsed["conversationId"] = conversationId` and everything else passes through unchanged. This matches that.

- Extract `buildUpstreamPayload`, which copies the client's payload and overrides only `conversationId` with the server-validated value.
- Tests: `accountId`/`type`/`envProducts` passthrough, the `conversationId` override, that the caller's map isn't mutated, and nil-safety.

## ⚠️ This reverses a deliberate security decision — please review

The whitelist it replaces carried an explicit comment against forwarding "the raw client-supplied map verbatim, which could otherwise let a client smuggle extra keys (e.g. its own `accountId`/`sessionId`) the agent might trust."

So `accountId` is now **client-supplied and not verified** against the caller's access to that account — a caller could name another account and have its token budget and analytics charged. There is no upstream backstop either: the agent only cross-checks a claimed `accountId` against the session's own for `token_increase_request`, never on the first `user_message`.

This was a deliberate call for parity with the Ballerina backend (which is what production runs today) rather than an oversight, and it's documented on the helper along with the hardening path: resolve the account server-side via `entity.GetProject(projectID).Account.ID` (`entity.ProjectAccountRef.ID`) once per connection. Happy to switch to that instead if you'd prefer it — flagging it here rather than leaving it to be discovered.

For reference, `accountId` must satisfy the agent's own guardrail (`^[a-zA-Z0-9._-]+$`, ≤128 chars — `guardrails.py:97`), so a malformed value is rejected upstream rather than here.

## Test plan

Validated in a `golang:1.26-alpine` container on the pre-cherry-pick base (no local Go toolchain):

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` — clean
- [x] `go test -race ./...` — all packages pass, including the 4 new subtests
- [x] `gosec -fmt=text ./...` — 0 issues
- [ ] **Re-run against this branch's rebased base** — the cherry-pick applied cleanly with no conflicts, but the validation above ran before the rebase onto `508e6a558`
- [ ] Staging: send the message above and confirm the agent streams a reply instead of `accountId is required`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * WebSocket messages now preserve all client-provided fields when forwarded.
  * The server consistently applies the resolved conversation identifier.
  * Incoming message data remains unchanged during processing.
  * Empty or missing message data is handled safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->