### PR TITLE
acp-closure-service: real notice content (subject/body templates, structured recipients)

### DIFF
--- a/integrations/acp-closure-service/CLAUDE.md
+++ b/integrations/acp-closure-service/CLAUDE.md
@@ -221,6 +221,19 @@ wrong answer:
   `internal/sweep/types.go`'s `project.Account` has always expected the
   nested `{id, name}` shape; only the doc comment needed correcting once the
   broader `SearchProjects` gap closed.
+- **Project key field name.** `csm-integration-service`'s own `openapi.yaml`
+  documents this field as `projectKey` on the `Project` schema. The real,
+  live `GetProject` response actually names it `key` (confirmed directly by
+  the user via Postman against the dedicated test project — the response
+  had `"key": "APPSUB"`, no `projectKey` field at all). `internal/sweep/
+  types.go`'s `project.ProjectKey` was tagged `json:"projectKey"` for a
+  while as a result — silently, always empty on every real response, since
+  the tag never matched anything on the wire. Caught only because the
+  notice-content redesign started actually reading and logging the value;
+  before that, nothing exercised it. Now tagged `json:"key"`, confirmed
+  against the real response. If this ever gets "corrected" back to
+  `projectKey` by an openapi.yaml update, verify live behavior again before
+  copying it — don't just trust the spec.
 
 ## Open dependencies
 

--- a/integrations/acp-closure-service/CLAUDE.md
+++ b/integrations/acp-closure-service/CLAUDE.md
@@ -262,7 +262,10 @@ wrong answer:
 - TDD throughout: red before green, one seam at a time. Seams under test:
   `closure.Decide`, `recipients.ResolveCustomerContact` /
   `AccountManagerEmail`, `suspensionstate.LastNoticeWindow` /
-  `WithSubscriptionEndDateState`, `sweep.processProject`, `sweep.Run`.
+  `WithSubscriptionEndDateState`, `sweep.processProject`, `sweep.Run`, and
+  the pure subject/body builders (`internalNoticeSubject`,
+  `customerNoticeSubject`, `internalNoticeBody`, `customerNoticeBody` in
+  `sweep.go`) tested directly rather than only through `processProject`.
   `main.go` and the two logging/no-op implementations
   (`notify.LoggingNotifier`, `sweep.DryRunProjectUpdater`) are deliberately
   untested, matching this repo's convention that wiring-only code and

--- a/integrations/acp-closure-service/CLAUDE.md
+++ b/integrations/acp-closure-service/CLAUDE.md
@@ -76,8 +76,9 @@ decision logic cheaply testable without mocks.
 have exactly two side-effecting dependencies — `projectUpdater` (writes) and
 `notifier` (sends) — expressed as small interfaces. `main.go` decides which
 concrete implementation to inject based on `DRY_RUN`:
-`sweep.DryRunProjectUpdater` (logs, never calls `UpdateProject`) vs. the real
-`*entity.Client`. Reads (`SearchProjects`, `GetAccount`,
+`sweep.DryRunProjectUpdater` (silently no-ops, never calls `UpdateProject`
+— see the notice-content-redesign section below for why it deliberately
+doesn't log) vs. the real `*entity.Client`. Reads (`SearchProjects`, `GetAccount`,
 `SearchProjectContacts`, `SearchAccountContacts`) are never dry-run-gated —
 fetching and deciding has no write effect to protect against.
 
@@ -98,41 +99,76 @@ environment.
 
 Confirmed audience rule, unchanged: 90/60/30-day windows are internal-only;
 15/7/0-day windows are both internal and customer (`needsCustomerAudience`
-in `sweep.go`). What changed is notice *shape*, not audience — this is a
-deliberate redesign (superseding the original `Kind`
-internal/customer/am_nudge model), decided directly with Chamara and
-recorded here so the reasoning isn't lost:
+in `sweep.go`). Notice *shape* went through two redesigns superseding the
+original `Kind` internal/customer/am_nudge model — the second one, current
+as of this writing, is a materially different design from the first (a
+single consolidated `Notice` per window), because it turned out the
+internal and customer copies have genuinely different subject/body content,
+not just different recipients. Recorded here in detail so the reasoning
+isn't lost or re-litigated:
 
-- **One consolidated day-count reminder `Notice` per firing window**, not
-  separate `Kind`-tagged sends. `Recipients` (`AccountOwner`,
-  `RenewalManager`, `TechnicalOwner`, always populated; `Customer`, only for
-  a resolved 15/7/0 window) replaces the old single `Recipient` string
-  entirely. There is no more `Kind` field — audience is implied by which
-  `Recipients` fields are populated and by `Subject`'s wording, not stated
-  explicitly, per Chamara's request that the log stop saying
-  "internal"/"external".
-- **`Subject`** (`reminderSubject` in `sweep.go`) is `"{N} Days Reminder of
-  Project for {ProjectName} of {AccountName}"`, `[ACP] `-prefixed only for
-  the internal-only 90/60/30 windows. Confirmed against two real examples
-  from Chamara — do not change the template without re-confirming; in
-  particular, `ProjectName` itself often already contains the word
-  "Subscription" (e.g. `"TICKETNETWORK - Subscription"`), which is why a
-  literal subject can visually resemble "...Subscription of TicketNetwork"
-  without "Subscription of" being separate template wording.
+- **Internal and customer notices are always two separate `Send` calls**
+  for a customer-audience window (15/7/0) — never one `Notice` bundling
+  both. The internal notice fires unconditionally for every window
+  (90/60/30/15/7/0); a second notice (customer, or the no-business-contact
+  nudge) fires only for 15/7/0.
+- **`Subject`** has no single template — four distinct ones
+  (`internalNoticeSubject`/`customerNoticeSubject` in `sweep.go`), confirmed
+  against multiple real examples from Chamara:
+  - Internal, day-count (90/60/30/15/7): `"[ACP] {N} Days Reminder of
+    Project for {ProjectName} of {AccountName}"`. The `[ACP] ` prefix marks
+    "this is the internal-audience copy" and applies to **every** window,
+    including 15/7 — not just 90/60/30. (An earlier version of this logic
+    had that backwards; confirmed wrong directly against real examples
+    where a 15-day internal subject still carried `[ACP]`.)
+  - Internal, day-0: `"[ACP] Project Suspension Notice of {ProjectName} of
+    {AccountName}"` — no "days remaining" left to report once suspended.
+  - Customer, 15/7: `"Upcoming Project Suspension Notice - {ProjectName}"`
+    — never `[ACP]`-prefixed, never names the account.
+  - Customer, day-0: `"Project Suspension Notice - {ProjectName}"` — past
+    tense, no "Upcoming".
+  - No-business-contact (see below): `"[Urgent] [ACP] No Business Contacts
+    Specified for Project {ProjectName}"`.
+  `ProjectName` itself often already contains the word "Subscription"
+  (e.g. `"TICKETNETWORK - Subscription"`), which is why a literal internal
+  subject can visually resemble "...Subscription of TicketNetwork" without
+  "Subscription of" being separate template wording.
+- **Every notice has a real `Body` now** — not just the no-business-contact
+  one. Internal bodies (`internalNoticeBody`) open with a greeting that
+  **always names the Account Manager** (`"Dear {AccountManagerName}"`),
+  regardless of which of the three internal recipients is actually reading
+  their own copy — confirmed explicitly, not personalized per recipient —
+  and list `Project Name`/`Project Key`/`Account Owner`/`Start Date`/`End
+  Date` in `2006-01-02` date format. Customer bodies (`customerNoticeBody`)
+  have **no greeting at all** and use `01/02/2006` (US-style) dates embedded
+  in prose instead. Day-0 bodies (both internal and customer) use distinct
+  past-tense/"already suspended" wording instead of the day-count
+  reminder's future-tense "needs renewal" wording — see the four body
+  template constants in `sweep.go` for the exact confirmed text.
 - **The no-business-contact case** (three-tier customer-contact fallback
   lands on `NeedsAMNudge`: no business contact, no primary contact) sends a
-  **second, separate** `Notice` alongside the day-count reminder — not
-  instead of it, and with no suppression logic collapsing the two. This
-  notice has a fixed `Subject` (`"[Urgent] [ACP] No Business Contacts
-  Specified for Project {ProjectName}"`), a `Recipients.AccountOwner`-only
-  audience, and a fixed `Body` template (`noBusinessContactBody`) confirmed
-  verbatim from a real existing notice. Sending both is a deliberate
-  simplification the user confirmed rather than inventing a new suppression
-  rule for this shape — revisit if it proves too noisy in practice. (The
-  previous design's `shouldSuppressInternalNotice`, which collapsed a
-  same-recipient internal+nudge pair into one send, no longer applies: there
-  is no separate "internal" notice to suppress anymore, just the one
-  reminder plus this second notice.)
+  **second, separate** `Notice` alongside the internal notice — not instead
+  of it, and with no suppression logic collapsing the two. Recipients are
+  **all three** internal recipients (Account Owner, Renewal Manager,
+  Technical Owner) — confirmed explicitly; an earlier version sent this to
+  the Account Owner alone. Sending both notices (internal + nudge) is a
+  deliberate simplification the user confirmed rather than inventing a
+  suppression rule for this shape — revisit if it proves too noisy in
+  practice. (The original design's `shouldSuppressInternalNotice`, which
+  collapsed a same-recipient internal+nudge pair into one send, no longer
+  applies — there's no shared-recipient collision to worry about now that
+  internal and nudge always target the same three internal recipients by
+  design.)
+- **`DryRunProjectUpdater` intentionally logs nothing** (`dryrun.go`) — per
+  explicit user direction, the only log line that should exist for a dry
+  run is `notify.LoggingNotifier`'s `"notice"` line (the actual email
+  content: subject, body, recipients). A separate `"dry-run: would update
+  project"` line describing the raw PATCH body used to exist here and was
+  removed deliberately — it's noise once every window produces a real
+  notice log, and stays noise once real email sending (Sajith's team, still
+  pending) replaces `LoggingNotifier` as the thing this component
+  ultimately integrates with. Don't re-add logging to this type without
+  confirming that direction has changed.
 
 ## suspensionProcessState's real shape
 
@@ -214,7 +250,7 @@ wrong answer:
   `closure.Decide`, `recipients.ResolveCustomerContact` /
   `AccountManagerEmail`, `suspensionstate.LastNoticeWindow` /
   `WithSubscriptionEndDateState`, `sweep.processProject`, `sweep.Run`.
-  `main.go` and the two logging-only implementations
+  `main.go` and the two logging/no-op implementations
   (`notify.LoggingNotifier`, `sweep.DryRunProjectUpdater`) are deliberately
   untested, matching this repo's convention that wiring-only code and
   behaviorless placeholders don't need dedicated tests.

--- a/integrations/acp-closure-service/CLAUDE.md
+++ b/integrations/acp-closure-service/CLAUDE.md
@@ -46,6 +46,8 @@ session, ever, so that code path would be permanently dead here.
   extracts an email from an already-fetched `PersonRef`, treating "no AM
   assigned" and "AM assigned but no email" both as legitimate absence
   (`""`), not errors — many real accounts have incomplete role assignments.
+  `Contact` (`{Name, Email}`) is the resolved-recipient shape shared with
+  `notify.Recipients`.
 - `internal/suspensionstate` — translates between
   `suspensionProcessState`'s real wire shape (see below) and
   `closure.NoticeWindow`. `WithSubscriptionEndDateState` only ever touches
@@ -63,10 +65,10 @@ session, ever, so that code path would be permanently dead here.
   and acts on a single project.
 
 Each pure package has an I/O counterpart living in `sweep` (e.g.
-`resolveAccountManagerEmail` does the `GetAccount` call and DTO parsing,
-then hands parsed data to `recipients.AccountManagerEmail`). Keep new
-decision logic in the pure packages and I/O in `sweep` — this split is what
-makes the decision logic cheaply testable without mocks.
+`resolveAccountContacts` does the `GetAccount` call and DTO parsing, then
+hands parsed data to `recipients.AccountManagerEmail`). Keep new decision
+logic in the pure packages and I/O in `sweep` — this split is what makes the
+decision logic cheaply testable without mocks.
 
 ## Dry-run is an injection choice, not a branch
 
@@ -92,22 +94,45 @@ loop's `offset := 0` line. This is what backs safe testing against a single
 dedicated project without risk of touching every open project in an
 environment.
 
-## Notice audience matrix and the AM-notice suppression
+## Notice audience matrix and content (redesigned per Chamara's direct request)
 
-Confirmed audience rule: 90/60/30-day windows are internal-only (Account
-Manager); 15/7/0-day windows are both internal and customer
-(`needsCustomerAudience` in `sweep.go`). The internal (Account Manager)
-notice is sent for **every** firing window unconditionally — except when the
-three-tier customer-contact fallback lands on `NeedsAMNudge` (no business
-contact, no primary contact) *and* the nudge email would reach the exact
-same recipient as the internal notice. In that case only the AM-nudge fires
-— the same Account Manager doesn't get two separate emails about the same
-window in the same run (`shouldSuppressInternalNotice`). Two empty
-recipients are deliberately **not** treated as a match — an unresolved AM
-email isn't a real duplicate-email risk, and suppressing would only hide
-debug visibility for no benefit. This was confirmed correct against real
-broad-sweep data (multiple real `am_nudge`/internal pairs collapsed to one
-notice; the empty-recipient exception correctly did not collapse).
+Confirmed audience rule, unchanged: 90/60/30-day windows are internal-only;
+15/7/0-day windows are both internal and customer (`needsCustomerAudience`
+in `sweep.go`). What changed is notice *shape*, not audience — this is a
+deliberate redesign (superseding the original `Kind`
+internal/customer/am_nudge model), decided directly with Chamara and
+recorded here so the reasoning isn't lost:
+
+- **One consolidated day-count reminder `Notice` per firing window**, not
+  separate `Kind`-tagged sends. `Recipients` (`AccountOwner`,
+  `RenewalManager`, `TechnicalOwner`, always populated; `Customer`, only for
+  a resolved 15/7/0 window) replaces the old single `Recipient` string
+  entirely. There is no more `Kind` field — audience is implied by which
+  `Recipients` fields are populated and by `Subject`'s wording, not stated
+  explicitly, per Chamara's request that the log stop saying
+  "internal"/"external".
+- **`Subject`** (`reminderSubject` in `sweep.go`) is `"{N} Days Reminder of
+  Project for {ProjectName} of {AccountName}"`, `[ACP] `-prefixed only for
+  the internal-only 90/60/30 windows. Confirmed against two real examples
+  from Chamara — do not change the template without re-confirming; in
+  particular, `ProjectName` itself often already contains the word
+  "Subscription" (e.g. `"TICKETNETWORK - Subscription"`), which is why a
+  literal subject can visually resemble "...Subscription of TicketNetwork"
+  without "Subscription of" being separate template wording.
+- **The no-business-contact case** (three-tier customer-contact fallback
+  lands on `NeedsAMNudge`: no business contact, no primary contact) sends a
+  **second, separate** `Notice` alongside the day-count reminder — not
+  instead of it, and with no suppression logic collapsing the two. This
+  notice has a fixed `Subject` (`"[Urgent] [ACP] No Business Contacts
+  Specified for Project {ProjectName}"`), a `Recipients.AccountOwner`-only
+  audience, and a fixed `Body` template (`noBusinessContactBody`) confirmed
+  verbatim from a real existing notice. Sending both is a deliberate
+  simplification the user confirmed rather than inventing a new suppression
+  rule for this shape — revisit if it proves too noisy in practice. (The
+  previous design's `shouldSuppressInternalNotice`, which collapsed a
+  same-recipient internal+nudge pair into one send, no longer applies: there
+  is no separate "internal" notice to suppress anymore, just the one
+  reminder plus this second notice.)
 
 ## suspensionProcessState's real shape
 

--- a/integrations/acp-closure-service/CLAUDE.md
+++ b/integrations/acp-closure-service/CLAUDE.md
@@ -116,7 +116,7 @@ isn't lost or re-litigated:
   (`internalNoticeSubject`/`customerNoticeSubject` in `sweep.go`), confirmed
   against multiple real examples from Chamara:
   - Internal, day-count (90/60/30/15/7): `"[ACP] {N} Days Reminder of
-    Project for {ProjectName} of {AccountName}"`. The `[ACP] ` prefix marks
+    Project for {ProjectName} of {AccountName}"`. The `[ACP]` prefix marks
     "this is the internal-audience copy" and applies to **every** window,
     including 15/7 — not just 90/60/30. (An earlier version of this logic
     had that backwards; confirmed wrong directly against real examples

--- a/integrations/acp-closure-service/cmd/acp-closure/main.go
+++ b/integrations/acp-closure-service/cmd/acp-closure/main.go
@@ -62,7 +62,7 @@ func main() {
 
 	var updater projectUpdater = entityClient
 	if dryRun {
-		updater = &sweep.DryRunProjectUpdater{Logger: slog.Default()}
+		updater = &sweep.DryRunProjectUpdater{}
 	}
 
 	notifier := &notify.LoggingNotifier{Logger: slog.Default()}

--- a/integrations/acp-closure-service/internal/closure/decide.go
+++ b/integrations/acp-closure-service/internal/closure/decide.go
@@ -36,6 +36,15 @@ const (
 	NoticeWindow0  NoticeWindow = 0
 )
 
+// IsTerminal reports whether w is the terminal day-0/suspension window, as
+// opposed to a day-count reminder window (90/60/30/15/7). The single
+// canonical definition of this check — callers that need to branch on it
+// (e.g. sweep.go's subject/body builders) should call this rather than
+// independently comparing against NoticeWindow0.
+func (w NoticeWindow) IsTerminal() bool {
+	return w == NoticeWindow0
+}
+
 // noticeWindows is the notify cascade, ordered widest (earliest) to
 // narrowest (latest). NoticeWindow0 is deliberately excluded: its notify
 // gating and its suspend signal are handled separately in Decide, since

--- a/integrations/acp-closure-service/internal/closure/decide_test.go
+++ b/integrations/acp-closure-service/internal/closure/decide_test.go
@@ -21,6 +21,30 @@ import (
 	"time"
 )
 
+// TestNoticeWindow_IsTerminal covers the single canonical "is this the
+// terminal/day-0 window" predicate — added so callers needing this check
+// (e.g. sweep.go's subject/body builders) share one definition instead of
+// each independently comparing against NoticeWindow0 (PR #1440 review,
+// Sajith Ekanayake: that re-derivation had already gone wrong once).
+func TestNoticeWindow_IsTerminal(t *testing.T) {
+	tests := []struct {
+		window NoticeWindow
+		want   bool
+	}{
+		{NoticeWindow90, false},
+		{NoticeWindow60, false},
+		{NoticeWindow30, false},
+		{NoticeWindow15, false},
+		{NoticeWindow7, false},
+		{NoticeWindow0, true},
+	}
+	for _, tt := range tests {
+		if got := tt.window.IsTerminal(); got != tt.want {
+			t.Errorf("NoticeWindow(%d).IsTerminal() = %v, want %v", tt.window, got, tt.want)
+		}
+	}
+}
+
 func TestDecide_FiresCorrectWindowWhenNoPriorNotice(t *testing.T) {
 	now := time.Date(2026, 7, 24, 0, 0, 0, 0, time.UTC)
 

--- a/integrations/acp-closure-service/internal/notify/notify.go
+++ b/integrations/acp-closure-service/internal/notify/notify.go
@@ -63,9 +63,9 @@ type Notice struct {
 	// no-business-contact notice's fixed "[Urgent] [ACP] No Business
 	// Contacts Specified for Project {ProjectName}".
 	Subject string
-	// Body is only populated for the no-business-contact notice today — no
-	// body template exists yet for the day-count reminders, so it's left
-	// empty there rather than inventing one.
+	// Body is the notice's full email body — populated for every notice
+	// type today (day-count reminder, day-0 suspension, customer notice,
+	// no-business-contact urgent notice all have their own template).
 	Body       string
 	Recipients Recipients
 	// ResolvedVia records which tier of the three-tier customer-contact

--- a/integrations/acp-closure-service/internal/notify/notify.go
+++ b/integrations/acp-closure-service/internal/notify/notify.go
@@ -57,11 +57,16 @@ type Notice struct {
 	StartDate   time.Time
 	EndDate     time.Time
 	Window      closure.NoticeWindow
-	// Subject is the notice's title line — either the day-count reminder
-	// ("{N} Days Reminder of Project for {ProjectName} of {AccountName}",
-	// [ACP]-prefixed only for the internal-only 90/60/30 windows) or the
-	// no-business-contact notice's fixed "[Urgent] [ACP] No Business
-	// Contacts Specified for Project {ProjectName}".
+	// Subject is the notice's title line — one of five templates depending
+	// on notice type and window (see sweep.go's internalNoticeSubject/
+	// customerNoticeSubject for the exact wording): the internal day-count
+	// reminder (90/60/30/15/7, [ACP]-prefixed — every internal window, not
+	// just 90/60/30), the internal day-0 suspension notice (also
+	// [ACP]-prefixed, distinct wording since there's no "days remaining"
+	// left to report), the customer day-count/day-0 notices (never
+	// [ACP]-prefixed), or the no-business-contact notice's fixed
+	// "[Urgent] [ACP] No Business Contacts Specified for Project
+	// {ProjectName}".
 	Subject string
 	// Body is the notice's full email body — populated for every notice
 	// type today (day-count reminder, day-0 suspension, customer notice,

--- a/integrations/acp-closure-service/internal/notify/notify.go
+++ b/integrations/acp-closure-service/internal/notify/notify.go
@@ -69,10 +69,13 @@ type Notice struct {
 	Body       string
 	Recipients Recipients
 	// ResolvedVia records which tier of the three-tier customer-contact
-	// fallback produced Recipients.Customer (see
-	// recipients.ResolveCustomerContact). Left at its zero value ("") when
-	// not applicable — a 90/60/30 notice, or the no-business-contact notice
-	// itself, neither of which carry a resolved customer contact.
+	// fallback was attempted (see recipients.ResolveCustomerContact). Left
+	// at its zero value ("") only when the fallback was never attempted at
+	// all — an internal-only 90/60/30 notice. It IS set on the
+	// no-business-contact notice too, to recipients.ResolvedViaNone — the
+	// fallback was attempted there, it just found nothing; that's a
+	// different, more specific fact than "never attempted," worth keeping
+	// distinct in the log.
 	ResolvedVia recipients.ResolvedVia
 }
 
@@ -92,12 +95,15 @@ func (n *LoggingNotifier) Send(ctx context.Context, notice Notice) error {
 		"startDate", notice.StartDate,
 		"endDate", notice.EndDate,
 		"accountOwner", notice.Recipients.AccountOwner.Email,
+		"accountOwnerName", notice.Recipients.AccountOwner.Name,
 		"renewalManager", notice.Recipients.RenewalManager.Email,
+		"renewalManagerName", notice.Recipients.RenewalManager.Name,
 		"technicalOwner", notice.Recipients.TechnicalOwner.Email,
+		"technicalOwnerName", notice.Recipients.TechnicalOwner.Name,
 		"resolvedVia", notice.ResolvedVia,
 	}
 	if notice.Recipients.Customer != nil {
-		attrs = append(attrs, "customer", notice.Recipients.Customer.Email)
+		attrs = append(attrs, "customer", notice.Recipients.Customer.Email, "customerName", notice.Recipients.Customer.Name)
 	}
 	if notice.Body != "" {
 		attrs = append(attrs, "body", notice.Body)

--- a/integrations/acp-closure-service/internal/notify/notify.go
+++ b/integrations/acp-closure-service/internal/notify/notify.go
@@ -24,40 +24,55 @@ package notify
 import (
 	"context"
 	"log/slog"
+	"time"
 
 	"github.com/wso2-open-operations/cs-tools/integrations/acp-closure-service/internal/closure"
 	"github.com/wso2-open-operations/cs-tools/integrations/acp-closure-service/internal/recipients"
 )
 
-// Kind distinguishes the purpose of a Notice, since the same window can
-// produce different recipients and content depending on audience.
-type Kind string
-
-const (
-	// KindCustomer is the customer-facing closure notice for a given window.
-	KindCustomer Kind = "customer"
-	// KindInternal is the Account Manager notice sent for every firing window.
-	KindInternal Kind = "internal"
-	// KindAMNudge is a distinct "please configure a business contact" email,
-	// sent to the Account Manager instead of (not in addition to) a customer
-	// notice when recipients.Resolution.NeedsAMNudge is true.
-	KindAMNudge Kind = "am_nudge"
-)
+// Recipients is the structured set of people one Notice should reach.
+// AccountOwner (the Account Manager), RenewalManager, and TechnicalOwner are
+// always populated for a day-count reminder — an individual Contact's Email
+// may legitimately be "" per recipients.AccountManagerEmail's existing
+// convention (role assigned but no email on file, or no role assigned at
+// all), which is not an error state. Customer is nil except on a resolved
+// 15/7/0-window notice; it is also nil (not a zero-value Contact) on the
+// separate no-business-contact notice, which names only an Account Owner.
+type Recipients struct {
+	AccountOwner   recipients.Contact
+	RenewalManager recipients.Contact
+	TechnicalOwner recipients.Contact
+	Customer       *recipients.Contact
+}
 
 // Notice is everything a Notifier needs to send (or, today, log) one ACP
-// notification.
+// notification. There is no more Kind field distinguishing
+// internal/customer/am_nudge audiences — that distinction is now implied by
+// Subject's wording and which Recipients fields are populated, per Chamara's
+// request that the log stop saying "internal"/"external" explicitly.
 type Notice struct {
-	Kind      Kind
-	Window    closure.NoticeWindow
-	ProjectID string
-	Recipient string
+	ProjectID   string
+	ProjectName string
+	ProjectKey  string
+	StartDate   time.Time
+	EndDate     time.Time
+	Window      closure.NoticeWindow
+	// Subject is the notice's title line — either the day-count reminder
+	// ("{N} Days Reminder of Project for {ProjectName} of {AccountName}",
+	// [ACP]-prefixed only for the internal-only 90/60/30 windows) or the
+	// no-business-contact notice's fixed "[Urgent] [ACP] No Business
+	// Contacts Specified for Project {ProjectName}".
+	Subject string
+	// Body is only populated for the no-business-contact notice today — no
+	// body template exists yet for the day-count reminders, so it's left
+	// empty there rather than inventing one.
+	Body       string
+	Recipients Recipients
 	// ResolvedVia records which tier of the three-tier customer-contact
-	// fallback produced Recipient (see recipients.ResolveCustomerContact).
-	// Only meaningful for KindCustomer/KindAMNudge — left at its zero value
-	// ("") for KindInternal, which never goes through that fallback chain at
-	// all. Deliberately distinct from recipients.ResolvedViaNone ("none"),
-	// which means "every tier was tried and none resolved" — a different,
-	// more specific fact than "this notice doesn't use tiers."
+	// fallback produced Recipients.Customer (see
+	// recipients.ResolveCustomerContact). Left at its zero value ("") when
+	// not applicable — a 90/60/30 notice, or the no-business-contact notice
+	// itself, neither of which carry a resolved customer contact.
 	ResolvedVia recipients.ResolvedVia
 }
 
@@ -68,13 +83,27 @@ type LoggingNotifier struct {
 
 // Send logs the notice and always succeeds.
 func (n *LoggingNotifier) Send(ctx context.Context, notice Notice) error {
-	n.Logger.InfoContext(ctx, "notice",
-		"kind", notice.Kind,
+	attrs := []any{
+		"subject", notice.Subject,
 		"window", notice.Window,
 		"projectID", notice.ProjectID,
-		"recipient", notice.Recipient,
+		"projectName", notice.ProjectName,
+		"projectKey", notice.ProjectKey,
+		"startDate", notice.StartDate,
+		"endDate", notice.EndDate,
+		"accountOwner", notice.Recipients.AccountOwner.Email,
+		"renewalManager", notice.Recipients.RenewalManager.Email,
+		"technicalOwner", notice.Recipients.TechnicalOwner.Email,
 		"resolvedVia", notice.ResolvedVia,
-	)
+	}
+	if notice.Recipients.Customer != nil {
+		attrs = append(attrs, "customer", notice.Recipients.Customer.Email)
+	}
+	if notice.Body != "" {
+		attrs = append(attrs, "body", notice.Body)
+	}
+
+	n.Logger.InfoContext(ctx, "notice", attrs...)
 	return nil
 }
 

--- a/integrations/acp-closure-service/internal/notify/notify_test.go
+++ b/integrations/acp-closure-service/internal/notify/notify_test.go
@@ -105,8 +105,10 @@ func TestLoggingNotifier_Send_LogsProjectAndSubjectFields(t *testing.T) {
 
 // TestLoggingNotifier_Send_LogsRecipientsIncludingCustomerWhenPresent covers
 // the structured Recipients attribute: Account Owner/Renewal Manager/
-// Technical Owner are always logged, and Customer is logged too when
-// present (a resolved 15/7/0-window customer contact).
+// Technical Owner's names AND emails are always logged (names matter here —
+// Renewal Manager and Technical Owner never appear by name anywhere else in
+// the log, unlike Account Owner which also shows up in Body), and Customer
+// is logged too when present (a resolved 15/7/0-window customer contact).
 func TestLoggingNotifier_Send_LogsRecipientsIncludingCustomerWhenPresent(t *testing.T) {
 	h := &capturingHandler{}
 	n := &LoggingNotifier{Logger: slog.New(h)}
@@ -130,11 +132,15 @@ func TestLoggingNotifier_Send_LogsRecipientsIncludingCustomerWhenPresent(t *test
 	}
 
 	wantAttrs := map[string]string{
-		"accountOwner":   "jordan.perera@wso2.example",
-		"renewalManager": "sam.jayasuriya@wso2.example",
-		"technicalOwner": "alex.fernando@wso2.example",
-		"customer":       "bob@customer.example",
-		"resolvedVia":    string(recipients.ResolvedViaBusinessContact),
+		"accountOwner":       "jordan.perera@wso2.example",
+		"accountOwnerName":   "Jordan Perera",
+		"renewalManager":     "sam.jayasuriya@wso2.example",
+		"renewalManagerName": "Sam Jayasuriya",
+		"technicalOwner":     "alex.fernando@wso2.example",
+		"technicalOwnerName": "Alex Fernando",
+		"customer":           "bob@customer.example",
+		"customerName":       "Bob",
+		"resolvedVia":        string(recipients.ResolvedViaBusinessContact),
 	}
 	for key, want := range wantAttrs {
 		got, found := attrValue(t, h.records[0], key)
@@ -172,6 +178,9 @@ func TestLoggingNotifier_Send_OmitsCustomerAttributeWhenNil(t *testing.T) {
 
 	if _, found := attrValue(t, h.records[0], "customer"); found {
 		t.Error("customer attribute present in log record, want absent when Recipients.Customer is nil")
+	}
+	if _, found := attrValue(t, h.records[0], "customerName"); found {
+		t.Error("customerName attribute present in log record, want absent when Recipients.Customer is nil")
 	}
 }
 

--- a/integrations/acp-closure-service/internal/notify/notify_test.go
+++ b/integrations/acp-closure-service/internal/notify/notify_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"log/slog"
 	"testing"
+	"time"
 
 	"github.com/wso2-open-operations/cs-tools/integrations/acp-closure-service/internal/recipients"
 )
@@ -56,20 +57,69 @@ func attrValue(t *testing.T, r slog.Record, key string) (string, bool) {
 	return val, found
 }
 
-// TestLoggingNotifier_Send_LogsResolvedViaForCustomerNotice verifies a
-// customer notice's log line carries which fallback tier resolved the
-// recipient — the exact signal needed to observe, from real run logs, how
-// often each tier of the three-tier fallback actually fires (e.g. to gather
-// evidence toward confirming the still-unconfirmed business-contact role
-// string).
-func TestLoggingNotifier_Send_LogsResolvedViaForCustomerNotice(t *testing.T) {
+// TestLoggingNotifier_Send_LogsProjectAndSubjectFields verifies the core
+// project-identity and subject-line attributes land in the log record — the
+// fields Chamara asked to have visible directly in the logs (project id,
+// project name, start date, end date), plus the new Subject that replaces
+// the old internal/customer/am_nudge Kind label entirely.
+func TestLoggingNotifier_Send_LogsProjectAndSubjectFields(t *testing.T) {
+	h := &capturingHandler{}
+	n := &LoggingNotifier{Logger: slog.New(h)}
+
+	startDate := time.Date(2025, 7, 29, 0, 0, 0, 0, time.UTC)
+	endDate := time.Date(2026, 10, 27, 0, 0, 0, 0, time.UTC)
+
+	err := n.Send(context.Background(), Notice{
+		ProjectID:   "p1",
+		ProjectName: "TICKETNETWORK - Subscription",
+		ProjectKey:  "TICKETNET",
+		StartDate:   startDate,
+		EndDate:     endDate,
+		Window:      90,
+		Subject:     "[ACP] 90 Days Reminder of Project for TICKETNETWORK - Subscription of TicketNetwork",
+	})
+	if err != nil {
+		t.Fatalf("Send() error = %v, want nil", err)
+	}
+	if len(h.records) != 1 {
+		t.Fatalf("records = %d, want 1", len(h.records))
+	}
+
+	wantAttrs := map[string]string{
+		"projectID":   "p1",
+		"projectName": "TICKETNETWORK - Subscription",
+		"projectKey":  "TICKETNET",
+		"subject":     "[ACP] 90 Days Reminder of Project for TICKETNETWORK - Subscription of TicketNetwork",
+	}
+	for key, want := range wantAttrs {
+		got, found := attrValue(t, h.records[0], key)
+		if !found {
+			t.Errorf("attribute %q not present in log record", key)
+			continue
+		}
+		if got != want {
+			t.Errorf("%s = %q, want %q", key, got, want)
+		}
+	}
+}
+
+// TestLoggingNotifier_Send_LogsRecipientsIncludingCustomerWhenPresent covers
+// the structured Recipients attribute: Account Owner/Renewal Manager/
+// Technical Owner are always logged, and Customer is logged too when
+// present (a resolved 15/7/0-window customer contact).
+func TestLoggingNotifier_Send_LogsRecipientsIncludingCustomerWhenPresent(t *testing.T) {
 	h := &capturingHandler{}
 	n := &LoggingNotifier{Logger: slog.New(h)}
 
 	err := n.Send(context.Background(), Notice{
-		Kind:        KindCustomer,
-		ProjectID:   "p1",
-		Recipient:   "bob@customer.example",
+		ProjectID: "p1",
+		Window:    7,
+		Recipients: Recipients{
+			AccountOwner:   recipients.Contact{Name: "Jordan Perera", Email: "jordan.perera@wso2.example"},
+			RenewalManager: recipients.Contact{Name: "Sam Jayasuriya", Email: "sam.jayasuriya@wso2.example"},
+			TechnicalOwner: recipients.Contact{Name: "Alex Fernando", Email: "alex.fernando@wso2.example"},
+			Customer:       &recipients.Contact{Name: "Bob", Email: "bob@customer.example"},
+		},
 		ResolvedVia: recipients.ResolvedViaBusinessContact,
 	})
 	if err != nil {
@@ -79,29 +129,39 @@ func TestLoggingNotifier_Send_LogsResolvedViaForCustomerNotice(t *testing.T) {
 		t.Fatalf("records = %d, want 1", len(h.records))
 	}
 
-	got, found := attrValue(t, h.records[0], "resolvedVia")
-	if !found {
-		t.Fatal("resolvedVia attribute not present in log record")
+	wantAttrs := map[string]string{
+		"accountOwner":   "jordan.perera@wso2.example",
+		"renewalManager": "sam.jayasuriya@wso2.example",
+		"technicalOwner": "alex.fernando@wso2.example",
+		"customer":       "bob@customer.example",
+		"resolvedVia":    string(recipients.ResolvedViaBusinessContact),
 	}
-	if got != string(recipients.ResolvedViaBusinessContact) {
-		t.Errorf("resolvedVia = %q, want %q", got, recipients.ResolvedViaBusinessContact)
+	for key, want := range wantAttrs {
+		got, found := attrValue(t, h.records[0], key)
+		if !found {
+			t.Errorf("attribute %q not present in log record", key)
+			continue
+		}
+		if got != want {
+			t.Errorf("%s = %q, want %q", key, got, want)
+		}
 	}
 }
 
-// TestLoggingNotifier_Send_LogsEmptyResolvedViaForInternalNotice covers the
-// internal (Account Manager) notice, which never goes through
-// recipients.ResolveCustomerContact's fallback chain at all — its
-// resolvedVia should log as empty, distinguishable from
-// recipients.ResolvedViaNone ("none"), which specifically means "all
-// fallback tiers were tried and none resolved."
-func TestLoggingNotifier_Send_LogsEmptyResolvedViaForInternalNotice(t *testing.T) {
+// TestLoggingNotifier_Send_OmitsCustomerAttributeWhenNil covers the
+// internal-only (90/60/30) case: Recipients.Customer is nil, and the log
+// must not carry a misleading empty "customer" attribute implying a
+// customer was in scope for this notice at all.
+func TestLoggingNotifier_Send_OmitsCustomerAttributeWhenNil(t *testing.T) {
 	h := &capturingHandler{}
 	n := &LoggingNotifier{Logger: slog.New(h)}
 
 	err := n.Send(context.Background(), Notice{
-		Kind:      KindInternal,
 		ProjectID: "p1",
-		Recipient: "am@wso2.example",
+		Window:    90,
+		Recipients: Recipients{
+			AccountOwner: recipients.Contact{Name: "Jordan Perera", Email: "jordan.perera@wso2.example"},
+		},
 	})
 	if err != nil {
 		t.Fatalf("Send() error = %v, want nil", err)
@@ -110,11 +170,36 @@ func TestLoggingNotifier_Send_LogsEmptyResolvedViaForInternalNotice(t *testing.T
 		t.Fatalf("records = %d, want 1", len(h.records))
 	}
 
-	got, found := attrValue(t, h.records[0], "resolvedVia")
-	if !found {
-		t.Fatal("resolvedVia attribute not present in log record")
+	if _, found := attrValue(t, h.records[0], "customer"); found {
+		t.Error("customer attribute present in log record, want absent when Recipients.Customer is nil")
 	}
-	if got != "" {
-		t.Errorf("resolvedVia = %q, want \"\" (not %q)", got, recipients.ResolvedViaNone)
+}
+
+// TestLoggingNotifier_Send_LogsBodyWhenPresent covers the no-business-contact
+// notice's Body field, the one notice type that carries one today.
+func TestLoggingNotifier_Send_LogsBodyWhenPresent(t *testing.T) {
+	h := &capturingHandler{}
+	n := &LoggingNotifier{Logger: slog.New(h)}
+
+	const body = "Internal - Customer Project without Business Contacts\n\nUrgent reminder..."
+
+	err := n.Send(context.Background(), Notice{
+		ProjectID: "p1",
+		Subject:   "[Urgent] [ACP] No Business Contacts Specified for Project HFC Subscription - Subscription",
+		Body:      body,
+	})
+	if err != nil {
+		t.Fatalf("Send() error = %v, want nil", err)
+	}
+	if len(h.records) != 1 {
+		t.Fatalf("records = %d, want 1", len(h.records))
+	}
+
+	got, found := attrValue(t, h.records[0], "body")
+	if !found {
+		t.Fatal("body attribute not present in log record")
+	}
+	if got != body {
+		t.Errorf("body = %q, want %q", got, body)
 	}
 }

--- a/integrations/acp-closure-service/internal/sweep/dryrun.go
+++ b/integrations/acp-closure-service/internal/sweep/dryrun.go
@@ -16,23 +16,24 @@
 
 package sweep
 
-import (
-	"context"
-	"log/slog"
-)
+import "context"
 
 // DryRunProjectUpdater satisfies projectUpdater without ever calling
-// entity-service — it only logs what would have been written. This is the
+// entity-service — it silently no-ops instead of writing. This is the
 // entire mechanism behind DRY_RUN: main.go injects this instead of the real
 // *entity.Client when dry-run is active, and processProject/Run are
 // completely unaware of the distinction — they just call whichever
 // projectUpdater they were given.
-type DryRunProjectUpdater struct {
-	Logger *slog.Logger
-}
+//
+// Deliberately does not log the write it would have made: per user
+// direction, the only log output that matters for a dry run is the
+// notify.LoggingNotifier "notice" line (the actual email content) — a
+// separate "would update project" line describing the raw PATCH body is
+// noise once every window produces a real notice log, and stays noise once
+// real email sending replaces LoggingNotifier.
+type DryRunProjectUpdater struct{}
 
-// UpdateProject logs the write that would have happened and always succeeds.
+// UpdateProject always succeeds without doing anything.
 func (u *DryRunProjectUpdater) UpdateProject(ctx context.Context, id string, body []byte) ([]byte, error) {
-	u.Logger.InfoContext(ctx, "dry-run: would update project", "projectID", id, "body", string(body))
 	return []byte(`{}`), nil
 }

--- a/integrations/acp-closure-service/internal/sweep/sweep.go
+++ b/integrations/acp-closure-service/internal/sweep/sweep.go
@@ -83,16 +83,113 @@ func needsCustomerAudience(window closure.NoticeWindow) bool {
 	}
 }
 
-// reminderSubject builds the day-count reminder's title line: "{N} Days
-// Reminder of Project for {ProjectName} of {AccountName}", [ACP]-prefixed
-// only for the internal-only 90/60/30 windows (confirmed against two real
-// examples from Chamara — do not change this wording without re-confirming).
-func reminderSubject(window closure.NoticeWindow, projectName, accountName string) string {
-	s := fmt.Sprintf("%d Days Reminder of Project for %s of %s", int(window), projectName, accountName)
-	if !needsCustomerAudience(window) {
-		s = "[ACP] " + s
+// internalNoticeSubject builds the always-sent internal (Account Owner/
+// Renewal Manager/Technical Owner) notice's title line. Every internal copy
+// is [ACP]-prefixed regardless of window — that prefix marks "this is the
+// internal-audience copy," not "this is a 90/60/30 window" (confirmed
+// against real examples from Chamara spanning 90 through 0; an earlier
+// version of this function had the rule backwards). Day-0 gets distinct
+// "suspension notice" wording instead of "N Days Reminder" — there's no
+// "days remaining" left to report once a project is actually suspended.
+func internalNoticeSubject(window closure.NoticeWindow, projectName, accountName string) string {
+	if window == closure.NoticeWindow0 {
+		return fmt.Sprintf("[ACP] Project Suspension Notice of %s of %s", projectName, accountName)
 	}
-	return s
+	return fmt.Sprintf("[ACP] %d Days Reminder of Project for %s of %s", int(window), projectName, accountName)
+}
+
+// customerNoticeSubject builds the customer-facing notice's title line
+// (15/7/0 only) — never [ACP]-prefixed, never names the account, and uses
+// future tense ("Upcoming") before day-0 versus past tense once actually
+// suspended.
+func customerNoticeSubject(window closure.NoticeWindow, projectName string) string {
+	if window == closure.NoticeWindow0 {
+		return fmt.Sprintf("Project Suspension Notice - %s", projectName)
+	}
+	return fmt.Sprintf("Upcoming Project Suspension Notice - %s", projectName)
+}
+
+// internalReminderBodyTemplate is the day-count (90/60/30/15/7) internal
+// notice body, confirmed verbatim from real examples Chamara shared. The
+// greeting always names the Account Manager (%[1]s), regardless of which of
+// the three internal recipients is actually reading their copy — not
+// personalized per recipient. Dates are formatted 2006-01-02.
+const internalReminderBodyTemplate = `Dear %[1]s
+
+The following project has a non renewed contract. Please find the details below.
+
+Project Name: %[2]s
+
+Project Key: %[3]s
+
+Account Owner: %[1]s
+
+Start Date: %[4]s
+
+End Date: %[5]s
+
+Since projects needs contract renewal, kindly take the remedial actions to avoid any disruptions of subscription support. We appreciate your understanding and your prompt attention to this matter.
+
+Best Regards,
+WSO2 Team`
+
+// internalSuspensionBodyTemplate is the day-0 internal notice body — past
+// tense ("has been suspended"), asking for reinstatement rather than
+// renewal.
+const internalSuspensionBodyTemplate = `Dear %[1]s
+
+The following project has been suspended due to non renewed contract. Kindly request that you take the appropriate action to reinitiate the suspended support account.
+
+Project Name: %[2]s
+
+Project Key: %[3]s
+
+Account Owner: %[1]s
+
+Start Date: %[4]s
+
+End Date: %[5]s
+
+Since the project is suspended, kindly take the remedial actions to reinstate the subscription support. We appreciate your prompt attention to this matter.
+
+Best Regards,
+WSO2 Team`
+
+func internalNoticeBody(window closure.NoticeWindow, proj project, accountOwnerName string) string {
+	template := internalReminderBodyTemplate
+	if window == closure.NoticeWindow0 {
+		template = internalSuspensionBodyTemplate
+	}
+	return fmt.Sprintf(template, accountOwnerName, proj.Name, proj.ProjectKey, formatDate(proj.StartDate), formatDate(proj.EndDate))
+}
+
+// customerUpcomingSuspensionBodyTemplate is the 15/7-day customer-facing
+// body — future tense, no greeting (customer-facing notices never open with
+// "Dear X", confirmed explicitly). Dates are formatted 01/02/2006 (US
+// style), distinct from the internal bodies' 2006-01-02 — matches Chamara's
+// real examples exactly.
+const customerUpcomingSuspensionBodyTemplate = `We regret to inform you that the project %[1]s will be suspended on %[2]s due to non-renewal of the contracts upon the end of the previous subscription period.
+
+Please ensure to take necessary actions on or before %[2]s to avoid service disruption. If you have any questions or need assistance, please contact your Account Manager or the WSO2 Customer Success Team.
+
+Best Regards,
+WSO2 Team`
+
+// customerAlreadySuspendedBodyTemplate is the day-0 customer-facing body —
+// past tense, once the project has actually been suspended.
+const customerAlreadySuspendedBodyTemplate = `We trust this message finds you well. This project %[1]s was suspended %[2]s due to non-renewal of the contracts upon the end of the previous subscription period.
+
+To avoid future suspensions, please ensure that all necessary actions are completed in a timely manner. If you have any questions or need assistance, please contact your Account Manager or the WSO2 Customer Success Team.
+
+Best Regards,
+WSO2 Team`
+
+func customerNoticeBody(window closure.NoticeWindow, proj project) string {
+	template := customerUpcomingSuspensionBodyTemplate
+	if window == closure.NoticeWindow0 {
+		template = customerAlreadySuspendedBodyTemplate
+	}
+	return fmt.Sprintf(template, proj.Name, formatDateUS(proj.EndDate))
 }
 
 // noBusinessContactBodyTemplate is the fixed body for the urgent
@@ -125,6 +222,16 @@ func formatDate(t *time.Time) string {
 	return t.Format("2006-01-02")
 }
 
+// formatDateUS formats a date 01/02/2006 (US style), for the customer-facing
+// prose bodies specifically — distinct from formatDate's 2006-01-02, used
+// everywhere else (internal bodies' "Start Date:"/"End Date:" fields).
+func formatDateUS(t *time.Time) string {
+	if t == nil {
+		return ""
+	}
+	return t.Format("01/02/2006")
+}
+
 func timeValue(t *time.Time) time.Time {
 	if t == nil {
 		return time.Time{}
@@ -139,37 +246,46 @@ func accountName(proj project) string {
 	return proj.Account.Name
 }
 
-// notifyForWindow sends the single day-count reminder notice due for every
-// firing window (Account Owner/Renewal Manager/Technical Owner always
-// populated in Recipients; Customer only for a resolved 15/7/0 window) and,
-// only when a 15/7/0 window's customer-contact resolution comes up empty,
-// an additional, separate no-business-contact urgent notice to the Account
-// Owner. Sending both in that case — rather than suppressing the reminder
-// or merging them — is a deliberate simplification, not an oversight;
-// revisit if it proves too noisy in practice.
+// notifyForWindow sends the always-fired internal notice (Account Owner/
+// Renewal Manager/Technical Owner) for every firing window, and, only for
+// the customer-audience windows (15/7/0), a second, separate notice with
+// entirely different subject/body: either the customer notice (Customer
+// populated, Account Owner/Renewal Manager/Technical Owner copied alongside
+// as context) when the three-tier contact fallback resolves, or the
+// no-business-contact urgent notice (to all three internal recipients) when
+// it doesn't. Internal and customer notices are always two separate Send
+// calls, never merged into one — their content genuinely differs, not just
+// their recipient list.
 func notifyForWindow(ctx context.Context, reader entityReader, ntf notifier, proj project, window closure.NoticeWindow) error {
 	contacts, err := resolveAccountContacts(ctx, reader, proj.accountID())
 	if err != nil {
 		return fmt.Errorf("resolve account contacts: %w", err)
 	}
 
-	reminder := notify.Notice{
+	internalRecipients := notify.Recipients{
+		AccountOwner:   contacts.AccountOwner,
+		RenewalManager: contacts.RenewalManager,
+		TechnicalOwner: contacts.TechnicalOwner,
+	}
+
+	internalNotice := notify.Notice{
 		ProjectID:   proj.ID,
 		ProjectName: proj.Name,
 		ProjectKey:  proj.ProjectKey,
 		StartDate:   timeValue(proj.StartDate),
 		EndDate:     timeValue(proj.EndDate),
 		Window:      window,
-		Subject:     reminderSubject(window, proj.Name, accountName(proj)),
-		Recipients: notify.Recipients{
-			AccountOwner:   contacts.AccountOwner,
-			RenewalManager: contacts.RenewalManager,
-			TechnicalOwner: contacts.TechnicalOwner,
-		},
+		Subject:     internalNoticeSubject(window, proj.Name, accountName(proj)),
+		Body:        internalNoticeBody(window, proj, contacts.AccountOwner.Name),
+		Recipients:  internalRecipients,
 	}
 
 	if !needsCustomerAudience(window) {
-		return ntf.Send(ctx, reminder)
+		return ntf.Send(ctx, internalNotice)
+	}
+
+	if err := ntf.Send(ctx, internalNotice); err != nil {
+		return fmt.Errorf("send internal notice: %w", err)
 	}
 
 	projectContacts, accountContactsList, err := fetchContacts(ctx, reader, proj)
@@ -179,13 +295,23 @@ func notifyForWindow(ctx context.Context, reader entityReader, ntf notifier, pro
 	resolution := recipients.ResolveCustomerContact(projectContacts, accountContactsList)
 
 	if !resolution.NeedsAMNudge {
-		reminder.Recipients.Customer = resolution.CustomerContact
-		reminder.ResolvedVia = resolution.ResolvedVia
-		return ntf.Send(ctx, reminder)
-	}
-
-	if err := ntf.Send(ctx, reminder); err != nil {
-		return fmt.Errorf("send day-count reminder: %w", err)
+		return ntf.Send(ctx, notify.Notice{
+			ProjectID:   proj.ID,
+			ProjectName: proj.Name,
+			ProjectKey:  proj.ProjectKey,
+			StartDate:   timeValue(proj.StartDate),
+			EndDate:     timeValue(proj.EndDate),
+			Window:      window,
+			Subject:     customerNoticeSubject(window, proj.Name),
+			Body:        customerNoticeBody(window, proj),
+			Recipients: notify.Recipients{
+				AccountOwner:   contacts.AccountOwner,
+				RenewalManager: contacts.RenewalManager,
+				TechnicalOwner: contacts.TechnicalOwner,
+				Customer:       resolution.CustomerContact,
+			},
+			ResolvedVia: resolution.ResolvedVia,
+		})
 	}
 
 	return ntf.Send(ctx, notify.Notice{
@@ -197,9 +323,7 @@ func notifyForWindow(ctx context.Context, reader entityReader, ntf notifier, pro
 		Window:      window,
 		Subject:     fmt.Sprintf("[Urgent] [ACP] No Business Contacts Specified for Project %s", proj.Name),
 		Body:        noBusinessContactBody(proj, contacts.AccountOwner.Name),
-		Recipients: notify.Recipients{
-			AccountOwner: contacts.AccountOwner,
-		},
+		Recipients:  internalRecipients,
 		ResolvedVia: resolution.ResolvedVia,
 	})
 }

--- a/integrations/acp-closure-service/internal/sweep/sweep.go
+++ b/integrations/acp-closure-service/internal/sweep/sweep.go
@@ -25,6 +25,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/wso2-open-operations/cs-tools/integrations/acp-closure-service/internal/closure"
@@ -83,6 +84,19 @@ func needsCustomerAudience(window closure.NoticeWindow) bool {
 	}
 }
 
+// projectOfAccount builds the "{ProjectName} of {AccountName}" clause
+// shared by both internal subject variants, omitting the " of {AccountName}"
+// half entirely when there's no linked account — a project with
+// proj.Account == nil previously produced a dangling "...of " with a
+// trailing space and nothing after it in a real outbound email subject (PR
+// #1440 review, Sajith Ekanayake).
+func projectOfAccount(projectName, accountName string) string {
+	if accountName == "" {
+		return projectName
+	}
+	return fmt.Sprintf("%s of %s", projectName, accountName)
+}
+
 // internalNoticeSubject builds the always-sent internal (Account Owner/
 // Renewal Manager/Technical Owner) notice's title line. Every internal copy
 // is [ACP]-prefixed regardless of window — that prefix marks "this is the
@@ -92,10 +106,11 @@ func needsCustomerAudience(window closure.NoticeWindow) bool {
 // "suspension notice" wording instead of "N Days Reminder" — there's no
 // "days remaining" left to report once a project is actually suspended.
 func internalNoticeSubject(window closure.NoticeWindow, projectName, accountName string) string {
-	if window == closure.NoticeWindow0 {
-		return fmt.Sprintf("[ACP] Project Suspension Notice of %s of %s", projectName, accountName)
+	target := projectOfAccount(projectName, accountName)
+	if window.IsTerminal() {
+		return fmt.Sprintf("[ACP] Project Suspension Notice of %s", target)
 	}
-	return fmt.Sprintf("[ACP] %d Days Reminder of Project for %s of %s", int(window), projectName, accountName)
+	return fmt.Sprintf("[ACP] %d Days Reminder of Project for %s", int(window), target)
 }
 
 // customerNoticeSubject builds the customer-facing notice's title line
@@ -103,7 +118,7 @@ func internalNoticeSubject(window closure.NoticeWindow, projectName, accountName
 // future tense ("Upcoming") before day-0 versus past tense once actually
 // suspended.
 func customerNoticeSubject(window closure.NoticeWindow, projectName string) string {
-	if window == closure.NoticeWindow0 {
+	if window.IsTerminal() {
 		return fmt.Sprintf("Project Suspension Notice - %s", projectName)
 	}
 	return fmt.Sprintf("Upcoming Project Suspension Notice - %s", projectName)
@@ -157,7 +172,7 @@ WSO2 Team`
 
 func internalNoticeBody(window closure.NoticeWindow, proj project, accountOwnerName string) string {
 	template := internalReminderBodyTemplate
-	if window == closure.NoticeWindow0 {
+	if window.IsTerminal() {
 		template = internalSuspensionBodyTemplate
 	}
 	return fmt.Sprintf(template, accountOwnerName, proj.Name, proj.ProjectKey, formatDate(proj.StartDate), formatDate(proj.EndDate))
@@ -186,7 +201,7 @@ WSO2 Team`
 
 func customerNoticeBody(window closure.NoticeWindow, proj project) string {
 	template := customerUpcomingSuspensionBodyTemplate
-	if window == closure.NoticeWindow0 {
+	if window.IsTerminal() {
 		template = customerAlreadySuspendedBodyTemplate
 	}
 	return fmt.Sprintf(template, proj.Name, formatDateUS(proj.EndDate))
@@ -256,6 +271,19 @@ func accountName(proj project) string {
 // it doesn't. Internal and customer notices are always two separate Send
 // calls, never merged into one — their content genuinely differs, not just
 // their recipient list.
+//
+// For a customer-audience window, contact resolution (fetchContacts +
+// ResolveCustomerContact) happens BEFORE the internal notice sends, not
+// after — deliberately. A transient fetchContacts failure must leave zero
+// notices sent, not an internal notice sent with no corresponding
+// suspensionProcessState record: the caller (processProject) skips
+// recordNoticeSent on any error here, so a partial send in that order would
+// make the window look "not yet notified" on the next sweep and resend the
+// same internal notice for real (PR #1440 review, Sajith Ekanayake). This
+// does mean ntf.Send(internalNotice) has two call sites below rather than
+// one — that's the tradeoff for keeping "skip contact-fetch entirely for
+// internal-only windows" (needsCustomerAudience) and "never send before
+// contacts resolve" both true at once; both sites wrap the error identically.
 func notifyForWindow(ctx context.Context, reader entityReader, ntf notifier, proj project, window closure.NoticeWindow) error {
 	contacts, err := resolveAccountContacts(ctx, reader, proj.accountID())
 	if err != nil {
@@ -274,11 +302,10 @@ func notifyForWindow(ctx context.Context, reader entityReader, ntf notifier, pro
 	internalNotice.Recipients = internalRecipients
 
 	if !needsCustomerAudience(window) {
-		return ntf.Send(ctx, internalNotice)
-	}
-
-	if err := ntf.Send(ctx, internalNotice); err != nil {
-		return fmt.Errorf("send internal notice: %w", err)
+		if err := ntf.Send(ctx, internalNotice); err != nil {
+			return fmt.Errorf("send internal notice: %w", err)
+		}
+		return nil
 	}
 
 	projectContacts, accountContactsList, err := fetchContacts(ctx, reader, proj)
@@ -286,6 +313,10 @@ func notifyForWindow(ctx context.Context, reader entityReader, ntf notifier, pro
 		return err
 	}
 	resolution := recipients.ResolveCustomerContact(projectContacts, accountContactsList)
+
+	if err := ntf.Send(ctx, internalNotice); err != nil {
+		return fmt.Errorf("send internal notice: %w", err)
+	}
 
 	if !resolution.NeedsAMNudge {
 		customerNotice := baseNotice(proj, window)
@@ -438,10 +469,22 @@ func recordNoticeSent(ctx context.Context, updater projectUpdater, proj project,
 // suspended project, Postman, project
 // acac149b-eba1-4714-fcf5-f5dabad0cdb1) — an equality check against
 // "Suspended" alone would miss that real case and re-suspend indefinitely.
+//
+// Logs unconditionally (real or dry-run — matching Run's own always-on
+// slog.ErrorContext/WarnContext calls, never gated on DRY_RUN) right before
+// attempting the write. This is the only signal a dry run gives for the
+// retry scenario where a prior run already recorded the notice
+// (ShouldNotify=false) but suspend itself failed or was interrupted: that
+// path never calls notifyForWindow at all, and DryRunProjectUpdater no
+// longer logs anything (PR #1440 review, Sajith Ekanayake) — without this,
+// such a project would produce zero dry-run output despite being about to
+// suspend for real.
 func suspend(ctx context.Context, updater projectUpdater, proj project) error {
 	if proj.EndDateClosureState != nil && *proj.EndDateClosureState != "Open" {
 		return nil
 	}
+
+	slog.InfoContext(ctx, "suspending project", "projectID", proj.ID)
 
 	body, err := json.Marshal(map[string]string{"endDateClosureState": "Suspended"})
 	if err != nil {

--- a/integrations/acp-closure-service/internal/sweep/sweep.go
+++ b/integrations/acp-closure-service/internal/sweep/sweep.go
@@ -25,7 +25,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log/slog"
 	"time"
 
 	"github.com/wso2-open-operations/cs-tools/integrations/acp-closure-service/internal/closure"
@@ -470,21 +469,19 @@ func recordNoticeSent(ctx context.Context, updater projectUpdater, proj project,
 // acac149b-eba1-4714-fcf5-f5dabad0cdb1) — an equality check against
 // "Suspended" alone would miss that real case and re-suspend indefinitely.
 //
-// Logs unconditionally (real or dry-run — matching Run's own always-on
-// slog.ErrorContext/WarnContext calls, never gated on DRY_RUN) right before
-// attempting the write. This is the only signal a dry run gives for the
-// retry scenario where a prior run already recorded the notice
-// (ShouldNotify=false) but suspend itself failed or was interrupted: that
-// path never calls notifyForWindow at all, and DryRunProjectUpdater no
-// longer logs anything (PR #1440 review, Sajith Ekanayake) — without this,
-// such a project would produce zero dry-run output despite being about to
-// suspend for real.
+// Deliberately logs nothing, matching DryRunProjectUpdater's own silence —
+// per explicit user direction, the log should show notice/email content
+// only, nothing else, full stop. Known, accepted tradeoff (raised in PR
+// #1440 review, Sajith Ekanayake): the retry scenario where a prior run
+// already recorded the notice (ShouldNotify=false) but suspend itself
+// failed or was interrupted produces zero dry-run output for that project,
+// since notifyForWindow is never called on that path either. Confirmed
+// acceptable — do not add logging back here without re-confirming that
+// decision has changed.
 func suspend(ctx context.Context, updater projectUpdater, proj project) error {
 	if proj.EndDateClosureState != nil && *proj.EndDateClosureState != "Open" {
 		return nil
 	}
-
-	slog.InfoContext(ctx, "suspending project", "projectID", proj.ID)
 
 	body, err := json.Marshal(map[string]string{"endDateClosureState": "Suspended"})
 	if err != nil {

--- a/integrations/acp-closure-service/internal/sweep/sweep.go
+++ b/integrations/acp-closure-service/internal/sweep/sweep.go
@@ -83,101 +83,173 @@ func needsCustomerAudience(window closure.NoticeWindow) bool {
 	}
 }
 
-// notifyForWindow sends the internal (Account Manager) notice — due for
-// every firing window — and, only when the audience matrix calls for it,
-// the customer-facing notice (or the distinct AM-nudge email when no
-// customer contact resolves). If the AM-nudge would reach the exact same
-// recipient as the internal notice, the internal notice is suppressed
-// entirely — the Account Manager gets only the nudge, not both, for the
-// same window in the same run (see shouldSuppressInternalNotice).
+// reminderSubject builds the day-count reminder's title line: "{N} Days
+// Reminder of Project for {ProjectName} of {AccountName}", [ACP]-prefixed
+// only for the internal-only 90/60/30 windows (confirmed against two real
+// examples from Chamara — do not change this wording without re-confirming).
+func reminderSubject(window closure.NoticeWindow, projectName, accountName string) string {
+	s := fmt.Sprintf("%d Days Reminder of Project for %s of %s", int(window), projectName, accountName)
+	if !needsCustomerAudience(window) {
+		s = "[ACP] " + s
+	}
+	return s
+}
+
+// noBusinessContactBodyTemplate is the fixed body for the urgent
+// no-business-contact notice, confirmed verbatim from a real existing
+// notice Chamara shared. Dates are formatted 2006-01-02; Account Owner is
+// the resolved Account Manager's *name*, not email.
+const noBusinessContactBodyTemplate = `Internal - Customer Project without Business Contacts
+
+Urgent reminder regarding the project %[1]s.
+
+Please note that no Business Contacts was found for the project %[1]s. Immediate action is required to address this issue, as without a business contact, the customers will not receive essential notifications regarding their project suspension status. Additionally, this will lead to failures in further automated actions related to project suspension.
+
+Please refer this document to Update Business Contact
+
+Project Name: %[1]s
+Project Key: %[2]s
+Account Owner: %[3]s
+Start Date: %[4]s
+End Date: %[5]s`
+
+func noBusinessContactBody(proj project, accountOwnerName string) string {
+	return fmt.Sprintf(noBusinessContactBodyTemplate,
+		proj.Name, proj.ProjectKey, accountOwnerName, formatDate(proj.StartDate), formatDate(proj.EndDate))
+}
+
+func formatDate(t *time.Time) string {
+	if t == nil {
+		return ""
+	}
+	return t.Format("2006-01-02")
+}
+
+func timeValue(t *time.Time) time.Time {
+	if t == nil {
+		return time.Time{}
+	}
+	return *t
+}
+
+func accountName(proj project) string {
+	if proj.Account == nil {
+		return ""
+	}
+	return proj.Account.Name
+}
+
+// notifyForWindow sends the single day-count reminder notice due for every
+// firing window (Account Owner/Renewal Manager/Technical Owner always
+// populated in Recipients; Customer only for a resolved 15/7/0 window) and,
+// only when a 15/7/0 window's customer-contact resolution comes up empty,
+// an additional, separate no-business-contact urgent notice to the Account
+// Owner. Sending both in that case — rather than suppressing the reminder
+// or merging them — is a deliberate simplification, not an oversight;
+// revisit if it proves too noisy in practice.
 func notifyForWindow(ctx context.Context, reader entityReader, ntf notifier, proj project, window closure.NoticeWindow) error {
-	amEmail, err := resolveAccountManagerEmail(ctx, reader, proj.accountID())
+	contacts, err := resolveAccountContacts(ctx, reader, proj.accountID())
 	if err != nil {
-		return fmt.Errorf("resolve AM email: %w", err)
+		return fmt.Errorf("resolve account contacts: %w", err)
 	}
 
-	internalNotice := notify.Notice{
-		Kind:      notify.KindInternal,
-		Window:    window,
-		ProjectID: proj.ID,
-		Recipient: amEmail,
+	reminder := notify.Notice{
+		ProjectID:   proj.ID,
+		ProjectName: proj.Name,
+		ProjectKey:  proj.ProjectKey,
+		StartDate:   timeValue(proj.StartDate),
+		EndDate:     timeValue(proj.EndDate),
+		Window:      window,
+		Subject:     reminderSubject(window, proj.Name, accountName(proj)),
+		Recipients: notify.Recipients{
+			AccountOwner:   contacts.AccountOwner,
+			RenewalManager: contacts.RenewalManager,
+			TechnicalOwner: contacts.TechnicalOwner,
+		},
 	}
 
 	if !needsCustomerAudience(window) {
-		return ntf.Send(ctx, internalNotice)
+		return ntf.Send(ctx, reminder)
 	}
 
-	projectContacts, accountContacts, err := fetchContacts(ctx, reader, proj)
+	projectContacts, accountContactsList, err := fetchContacts(ctx, reader, proj)
 	if err != nil {
 		return err
 	}
-	resolution := recipients.ResolveCustomerContact(projectContacts, accountContacts)
+	resolution := recipients.ResolveCustomerContact(projectContacts, accountContactsList)
 
-	if resolution.NeedsAMNudge {
-		nudgeNotice := notify.Notice{
-			Kind:        notify.KindAMNudge,
-			Window:      window,
-			ProjectID:   proj.ID,
-			Recipient:   amEmail,
-			ResolvedVia: resolution.ResolvedVia,
-		}
-		if !shouldSuppressInternalNotice(internalNotice.Recipient, nudgeNotice.Recipient) {
-			if err := ntf.Send(ctx, internalNotice); err != nil {
-				return fmt.Errorf("send internal notice: %w", err)
-			}
-		}
-		return ntf.Send(ctx, nudgeNotice)
+	if !resolution.NeedsAMNudge {
+		reminder.Recipients.Customer = resolution.CustomerContact
+		reminder.ResolvedVia = resolution.ResolvedVia
+		return ntf.Send(ctx, reminder)
 	}
 
-	if err := ntf.Send(ctx, internalNotice); err != nil {
-		return fmt.Errorf("send internal notice: %w", err)
+	if err := ntf.Send(ctx, reminder); err != nil {
+		return fmt.Errorf("send day-count reminder: %w", err)
 	}
 
 	return ntf.Send(ctx, notify.Notice{
-		Kind:        notify.KindCustomer,
-		Window:      window,
 		ProjectID:   proj.ID,
-		Recipient:   resolution.CustomerContact.Email,
+		ProjectName: proj.Name,
+		ProjectKey:  proj.ProjectKey,
+		StartDate:   timeValue(proj.StartDate),
+		EndDate:     timeValue(proj.EndDate),
+		Window:      window,
+		Subject:     fmt.Sprintf("[Urgent] [ACP] No Business Contacts Specified for Project %s", proj.Name),
+		Body:        noBusinessContactBody(proj, contacts.AccountOwner.Name),
+		Recipients: notify.Recipients{
+			AccountOwner: contacts.AccountOwner,
+		},
 		ResolvedVia: resolution.ResolvedVia,
 	})
 }
 
-// shouldSuppressInternalNotice reports whether the internal (Account
-// Manager) notice should be skipped in favor of sending only the AM-nudge
-// notice — true exactly when both would reach the identical, non-empty
-// recipient. Two empty recipients are deliberately NOT treated as a match:
-// there is no real person being double-emailed in that case, only two log
-// lines about an unresolved account, and suppressing would just hide useful
-// debug visibility for no benefit.
-func shouldSuppressInternalNotice(internalRecipient, nudgeRecipient string) bool {
-	return internalRecipient != "" && internalRecipient == nudgeRecipient
+// accountContacts is the three account-level people a day-count reminder's
+// Recipients draws from.
+type accountContacts struct {
+	AccountOwner   recipients.Contact
+	RenewalManager recipients.Contact
+	TechnicalOwner recipients.Contact
 }
 
-// resolveAccountManagerEmail fetches the account and extracts its Account
-// Manager's email. Returns "" (not an error) if the project has no linked
-// account, the account has no Account Manager assigned, or the assigned
-// Account Manager has no recorded email — all legitimate, unremarkable
-// states. Only a genuine fetch/parse failure is returned as an error.
-func resolveAccountManagerEmail(ctx context.Context, reader entityReader, accountID string) (string, error) {
+// resolveAccountContacts fetches the account and extracts its Account
+// Manager (Account Owner), Renewal Account Manager, and Technical Owner as
+// Contacts. Each Contact's Email may legitimately be "" — no person
+// assigned to that role, or one assigned with no email on file — mirroring
+// recipients.AccountManagerEmail's existing treatment of that as a
+// non-error state, now applied to all three roles. Returns the zero
+// accountContacts (not an error) if the project has no linked account.
+func resolveAccountContacts(ctx context.Context, reader entityReader, accountID string) (accountContacts, error) {
 	if accountID == "" {
-		return "", nil
+		return accountContacts{}, nil
 	}
 
 	raw, err := reader.GetAccount(ctx, accountID)
 	if err != nil {
-		return "", fmt.Errorf("get account: %w", err)
+		return accountContacts{}, fmt.Errorf("get account: %w", err)
 	}
 
 	var acc accountDTO
 	if err := json.Unmarshal(raw, &acc); err != nil {
-		return "", fmt.Errorf("parse account: %w", err)
+		return accountContacts{}, fmt.Errorf("parse account: %w", err)
 	}
 
-	var am *recipients.PersonRef
-	if acc.AccountManager != nil {
-		am = &recipients.PersonRef{ID: acc.AccountManager.ID, Name: acc.AccountManager.Name, Email: acc.AccountManager.Email}
+	return accountContacts{
+		AccountOwner:   contactFromPersonRef(acc.AccountManager),
+		RenewalManager: contactFromPersonRef(acc.RenewalAccountManager),
+		TechnicalOwner: contactFromPersonRef(acc.TechnicalOwner),
+	}, nil
+}
+
+// contactFromPersonRef converts a possibly-nil personRefDTO into a
+// recipients.Contact, reusing recipients.AccountManagerEmail's nil/no-email
+// handling (role-agnostic despite the name) rather than duplicating it.
+func contactFromPersonRef(p *personRefDTO) recipients.Contact {
+	if p == nil {
+		return recipients.Contact{}
 	}
-	return recipients.AccountManagerEmail(am), nil
+	ref := recipients.PersonRef{ID: p.ID, Name: p.Name, Email: p.Email}
+	return recipients.Contact{Name: p.Name, Email: recipients.AccountManagerEmail(&ref)}
 }
 
 func fetchContacts(ctx context.Context, reader entityReader, proj project) ([]recipients.ProjectContact, []recipients.AccountContact, error) {

--- a/integrations/acp-closure-service/internal/sweep/sweep.go
+++ b/integrations/acp-closure-service/internal/sweep/sweep.go
@@ -268,17 +268,10 @@ func notifyForWindow(ctx context.Context, reader entityReader, ntf notifier, pro
 		TechnicalOwner: contacts.TechnicalOwner,
 	}
 
-	internalNotice := notify.Notice{
-		ProjectID:   proj.ID,
-		ProjectName: proj.Name,
-		ProjectKey:  proj.ProjectKey,
-		StartDate:   timeValue(proj.StartDate),
-		EndDate:     timeValue(proj.EndDate),
-		Window:      window,
-		Subject:     internalNoticeSubject(window, proj.Name, accountName(proj)),
-		Body:        internalNoticeBody(window, proj, contacts.AccountOwner.Name),
-		Recipients:  internalRecipients,
-	}
+	internalNotice := baseNotice(proj, window)
+	internalNotice.Subject = internalNoticeSubject(window, proj.Name, accountName(proj))
+	internalNotice.Body = internalNoticeBody(window, proj, contacts.AccountOwner.Name)
+	internalNotice.Recipients = internalRecipients
 
 	if !needsCustomerAudience(window) {
 		return ntf.Send(ctx, internalNotice)
@@ -295,37 +288,35 @@ func notifyForWindow(ctx context.Context, reader entityReader, ntf notifier, pro
 	resolution := recipients.ResolveCustomerContact(projectContacts, accountContactsList)
 
 	if !resolution.NeedsAMNudge {
-		return ntf.Send(ctx, notify.Notice{
-			ProjectID:   proj.ID,
-			ProjectName: proj.Name,
-			ProjectKey:  proj.ProjectKey,
-			StartDate:   timeValue(proj.StartDate),
-			EndDate:     timeValue(proj.EndDate),
-			Window:      window,
-			Subject:     customerNoticeSubject(window, proj.Name),
-			Body:        customerNoticeBody(window, proj),
-			Recipients: notify.Recipients{
-				AccountOwner:   contacts.AccountOwner,
-				RenewalManager: contacts.RenewalManager,
-				TechnicalOwner: contacts.TechnicalOwner,
-				Customer:       resolution.CustomerContact,
-			},
-			ResolvedVia: resolution.ResolvedVia,
-		})
+		customerNotice := baseNotice(proj, window)
+		customerNotice.Subject = customerNoticeSubject(window, proj.Name)
+		customerNotice.Body = customerNoticeBody(window, proj)
+		customerNotice.Recipients = internalRecipients
+		customerNotice.Recipients.Customer = resolution.CustomerContact
+		customerNotice.ResolvedVia = resolution.ResolvedVia
+		return ntf.Send(ctx, customerNotice)
 	}
 
-	return ntf.Send(ctx, notify.Notice{
+	nudgeNotice := baseNotice(proj, window)
+	nudgeNotice.Subject = fmt.Sprintf("[Urgent] [ACP] No Business Contacts Specified for Project %s", proj.Name)
+	nudgeNotice.Body = noBusinessContactBody(proj, contacts.AccountOwner.Name)
+	nudgeNotice.Recipients = internalRecipients
+	nudgeNotice.ResolvedVia = resolution.ResolvedVia
+	return ntf.Send(ctx, nudgeNotice)
+}
+
+// baseNotice builds the project-identity fields shared by every Notice sent
+// for a project/window — Subject, Body, Recipients, and ResolvedVia are left
+// at their zero value for the caller to fill in per notice type.
+func baseNotice(proj project, window closure.NoticeWindow) notify.Notice {
+	return notify.Notice{
 		ProjectID:   proj.ID,
 		ProjectName: proj.Name,
 		ProjectKey:  proj.ProjectKey,
 		StartDate:   timeValue(proj.StartDate),
 		EndDate:     timeValue(proj.EndDate),
 		Window:      window,
-		Subject:     fmt.Sprintf("[Urgent] [ACP] No Business Contacts Specified for Project %s", proj.Name),
-		Body:        noBusinessContactBody(proj, contacts.AccountOwner.Name),
-		Recipients:  internalRecipients,
-		ResolvedVia: resolution.ResolvedVia,
-	})
+	}
 }
 
 // accountContacts is the three account-level people a day-count reminder's

--- a/integrations/acp-closure-service/internal/sweep/sweep_test.go
+++ b/integrations/acp-closure-service/internal/sweep/sweep_test.go
@@ -171,7 +171,10 @@ func TestProcessProject_CustomerAudienceWindowNotifiesBusinessContact(t *testing
 	if internal.Recipients.Customer != nil {
 		t.Errorf("internal notice Recipients.Customer = %v, want nil", internal.Recipients.Customer)
 	}
-	const wantInternalSubject = "[ACP] 7 Days Reminder of Project for Acme - Subscription of "
+	// The fixture project has an account with no Name set, so the subject
+	// correctly omits the " of {AccountName}" clause entirely (regression
+	// coverage for the dangling "of " bug lives in TestInternalNoticeSubject).
+	const wantInternalSubject = "[ACP] 7 Days Reminder of Project for Acme - Subscription"
 	if internal.Subject != wantInternalSubject {
 		t.Errorf("internal Subject = %q, want %q", internal.Subject, wantInternalSubject)
 	}
@@ -309,6 +312,39 @@ func TestProcessProject_CustomerAudienceWindowSkipsAccountContactLookupWhenNoAcc
 	}
 	if ntf.sent[0].Recipients.Customer != nil {
 		t.Errorf("reminder Recipients.Customer = %v, want nil (no account linked)", ntf.sent[0].Recipients.Customer)
+	}
+}
+
+// TestProcessProject_CustomerAudienceWindowFetchContactsFailureSendsNothing
+// is a regression test for PR #1440 (Sajith Ekanayake): a transient
+// fetchContacts failure must not leave the internal notice already sent
+// with no corresponding suspensionProcessState record — that combination
+// causes a duplicate internal-notice resend on the next sweep, since the
+// window still looks "not yet notified". Contact resolution must happen
+// before any notice sends for a customer-audience window, exactly as it
+// did before this diff, so a fetch failure here sends zero notices.
+func TestProcessProject_CustomerAudienceWindowFetchContactsFailureSendsNothing(t *testing.T) {
+	reader := &mockEntityReader{
+		searchProjectContactsFn: func(ctx context.Context, projectID string, body []byte) ([]byte, error) {
+			return nil, errors.New("transient network error")
+		},
+	}
+	updater := &mockProjectUpdater{}
+	ntf := &mockNotifier{}
+
+	now := time.Date(2026, 7, 28, 0, 0, 0, 0, time.UTC)
+	endDate := now.AddDate(0, 0, 6) // fires the 7-day window (customer-audience)
+	proj := project{ID: "p1", Account: &projectAccountRef{ID: "a1"}, EndDate: &endDate}
+
+	err := processProject(context.Background(), reader, updater, ntf, now, proj)
+	if err == nil {
+		t.Fatal("processProject() error = nil, want non-nil")
+	}
+	if len(ntf.sent) != 0 {
+		t.Errorf("ntf.sent = %d, want 0 (internal notice must not send before contacts are resolved)", len(ntf.sent))
+	}
+	if len(updater.calls) != 0 {
+		t.Errorf("updater.calls = %d, want 0", len(updater.calls))
 	}
 }
 
@@ -711,6 +747,24 @@ func TestInternalNoticeSubject(t *testing.T) {
 			projectName: "Kotak Insurance - Subscription",
 			accountName: "Kotak Life Insurance company Ltd",
 			want:        "[ACP] Project Suspension Notice of Kotak Insurance - Subscription of Kotak Life Insurance company Ltd",
+		},
+		{
+			// Regression test, PR #1440 review (Sajith Ekanayake): a
+			// project with no linked account previously produced a
+			// dangling "...of " with a trailing space and nothing after
+			// it, in a real outbound email subject.
+			name:        "no linked account: omits the dangling \" of \" clause entirely",
+			window:      90,
+			projectName: "Solo Project - Subscription",
+			accountName: "",
+			want:        "[ACP] 90 Days Reminder of Project for Solo Project - Subscription",
+		},
+		{
+			name:        "no linked account, day-0: omits the dangling \" of \" clause entirely",
+			window:      0,
+			projectName: "Solo Project - Subscription",
+			accountName: "",
+			want:        "[ACP] Project Suspension Notice of Solo Project - Subscription",
 		},
 	}
 

--- a/integrations/acp-closure-service/internal/sweep/sweep_test.go
+++ b/integrations/acp-closure-service/internal/sweep/sweep_test.go
@@ -140,8 +140,10 @@ func TestProcessProject_RecordsIgnoredWhenNotifierDoesNotDeliver(t *testing.T) {
 
 // TestProcessProject_CustomerAudienceWindowNotifiesBusinessContact covers a
 // 7-day window: both internal and customer per the confirmed audience
-// matrix. A project contact with the business-contact role should populate
-// Recipients.Customer on the single day-count reminder notice.
+// matrix. A project contact with the business-contact role should produce
+// TWO separate notices — internal (Customer nil) and customer-facing
+// (Customer populated) — since their subject/body genuinely differ, not one
+// notice bundling both.
 func TestProcessProject_CustomerAudienceWindowNotifiesBusinessContact(t *testing.T) {
 	reader := &mockEntityReader{
 		searchProjectContactsFn: func(ctx context.Context, projectID string, body []byte) ([]byte, error) {
@@ -153,25 +155,42 @@ func TestProcessProject_CustomerAudienceWindowNotifiesBusinessContact(t *testing
 
 	now := time.Date(2026, 7, 28, 0, 0, 0, 0, time.UTC)
 	endDate := now.AddDate(0, 0, 6) // fires the 7-day window
-	proj := project{ID: "p1", Account: &projectAccountRef{ID: "a1"}, EndDate: &endDate}
+	proj := project{ID: "p1", Name: "Acme - Subscription", Account: &projectAccountRef{ID: "a1"}, EndDate: &endDate}
 
 	err := processProject(context.Background(), reader, updater, ntf, now, proj)
 	if err != nil {
 		t.Fatalf("processProject() error = %v, want nil", err)
 	}
 
-	if len(ntf.sent) != 1 {
-		t.Fatalf("ntf.sent = %d, want 1 (one consolidated reminder)", len(ntf.sent))
+	if len(ntf.sent) != 2 {
+		t.Fatalf("ntf.sent = %d, want 2 (internal + customer)", len(ntf.sent))
 	}
-	notice := ntf.sent[0]
-	if notice.Recipients.Customer == nil {
-		t.Fatal("Recipients.Customer = nil, want populated")
+
+	internal, customer := ntf.sent[0], ntf.sent[1]
+
+	if internal.Recipients.Customer != nil {
+		t.Errorf("internal notice Recipients.Customer = %v, want nil", internal.Recipients.Customer)
 	}
-	if notice.Recipients.Customer.Email != "bob@customer.example" {
-		t.Errorf("Recipients.Customer.Email = %q, want %q", notice.Recipients.Customer.Email, "bob@customer.example")
+	const wantInternalSubject = "[ACP] 7 Days Reminder of Project for Acme - Subscription of "
+	if internal.Subject != wantInternalSubject {
+		t.Errorf("internal Subject = %q, want %q", internal.Subject, wantInternalSubject)
 	}
-	if notice.ResolvedVia != recipients.ResolvedViaBusinessContact {
-		t.Errorf("ResolvedVia = %q, want %q", notice.ResolvedVia, recipients.ResolvedViaBusinessContact)
+
+	if customer.Recipients.Customer == nil {
+		t.Fatal("customer notice Recipients.Customer = nil, want populated")
+	}
+	if customer.Recipients.Customer.Email != "bob@customer.example" {
+		t.Errorf("customer Recipients.Customer.Email = %q, want %q", customer.Recipients.Customer.Email, "bob@customer.example")
+	}
+	const wantCustomerSubject = "Upcoming Project Suspension Notice - Acme - Subscription"
+	if customer.Subject != wantCustomerSubject {
+		t.Errorf("customer Subject = %q, want %q", customer.Subject, wantCustomerSubject)
+	}
+	if customer.ResolvedVia != recipients.ResolvedViaBusinessContact {
+		t.Errorf("ResolvedVia = %q, want %q", customer.ResolvedVia, recipients.ResolvedViaBusinessContact)
+	}
+	if strings.Contains(customer.Body, "Dear ") {
+		t.Errorf("customer notice Body has a greeting, want none:\n%s", customer.Body)
 	}
 
 	if len(updater.calls) != 1 {
@@ -181,13 +200,18 @@ func TestProcessProject_CustomerAudienceWindowNotifiesBusinessContact(t *testing
 
 // TestProcessProject_CustomerAudienceWindowSendsNoBusinessContactNoticeWhenNoContactFound
 // covers the three-tier fallback's last resort: no business contact, no
-// primary contact. Both the day-count reminder (Customer nil — nothing
-// resolved) and a separate no-business-contact urgent notice (to the
-// Account Owner only) must be sent.
+// primary contact. Both the internal notice (Customer nil — nothing
+// resolved) and a separate no-business-contact urgent notice — sent to all
+// three internal recipients (Account Owner, Renewal Manager, Technical
+// Owner), not the Account Owner alone — must be sent.
 func TestProcessProject_CustomerAudienceWindowSendsNoBusinessContactNoticeWhenNoContactFound(t *testing.T) {
 	reader := &mockEntityReader{
 		getAccountFn: func(ctx context.Context, id string) ([]byte, error) {
-			return []byte(`{"accountManager": {"id": "am-1", "name": "Jordan Perera", "email": "jordan.perera@wso2.example"}}`), nil
+			return []byte(`{
+				"accountManager": {"id": "am-1", "name": "Jordan Perera", "email": "jordan.perera@wso2.example"},
+				"renewalAccountManager": {"id": "ram-1", "name": "Sam Jayasuriya", "email": "sam.jayasuriya@wso2.example"},
+				"technicalOwner": {"id": "tech-1", "name": "Alex Fernando", "email": "alex.fernando@wso2.example"}
+			}`), nil
 		},
 	}
 	updater := &mockProjectUpdater{}
@@ -211,16 +235,16 @@ func TestProcessProject_CustomerAudienceWindowSendsNoBusinessContactNoticeWhenNo
 	}
 
 	if len(ntf.sent) != 2 {
-		t.Fatalf("ntf.sent = %d, want 2 (reminder + no-business-contact)", len(ntf.sent))
+		t.Fatalf("ntf.sent = %d, want 2 (internal + no-business-contact)", len(ntf.sent))
 	}
 
-	reminder, nudge := ntf.sent[0], ntf.sent[1]
+	internal, nudge := ntf.sent[0], ntf.sent[1]
 
-	if reminder.Recipients.Customer != nil {
-		t.Errorf("reminder Recipients.Customer = %v, want nil", reminder.Recipients.Customer)
+	if internal.Recipients.Customer != nil {
+		t.Errorf("internal Recipients.Customer = %v, want nil", internal.Recipients.Customer)
 	}
-	if reminder.Recipients.AccountOwner.Email != "jordan.perera@wso2.example" {
-		t.Errorf("reminder Recipients.AccountOwner.Email = %q, want %q", reminder.Recipients.AccountOwner.Email, "jordan.perera@wso2.example")
+	if internal.Recipients.AccountOwner.Email != "jordan.perera@wso2.example" {
+		t.Errorf("internal Recipients.AccountOwner.Email = %q, want %q", internal.Recipients.AccountOwner.Email, "jordan.perera@wso2.example")
 	}
 
 	const wantSubject = "[Urgent] [ACP] No Business Contacts Specified for Project HFC Subscription - Subscription"
@@ -229,6 +253,12 @@ func TestProcessProject_CustomerAudienceWindowSendsNoBusinessContactNoticeWhenNo
 	}
 	if nudge.Recipients.AccountOwner.Email != "jordan.perera@wso2.example" {
 		t.Errorf("nudge Recipients.AccountOwner.Email = %q, want %q", nudge.Recipients.AccountOwner.Email, "jordan.perera@wso2.example")
+	}
+	if nudge.Recipients.RenewalManager.Email != "sam.jayasuriya@wso2.example" {
+		t.Errorf("nudge Recipients.RenewalManager.Email = %q, want %q", nudge.Recipients.RenewalManager.Email, "sam.jayasuriya@wso2.example")
+	}
+	if nudge.Recipients.TechnicalOwner.Email != "alex.fernando@wso2.example" {
+		t.Errorf("nudge Recipients.TechnicalOwner.Email = %q, want %q", nudge.Recipients.TechnicalOwner.Email, "alex.fernando@wso2.example")
 	}
 	if nudge.Recipients.Customer != nil {
 		t.Errorf("nudge Recipients.Customer = %v, want nil", nudge.Recipients.Customer)
@@ -330,8 +360,11 @@ func TestProcessProject_Day0SuccessfulNotifyThenSuspend(t *testing.T) {
 		t.Fatalf("processProject() error = %v, want nil", err)
 	}
 
-	if len(ntf.sent) != 1 {
-		t.Fatalf("ntf.sent = %d, want 1 (one consolidated reminder, with Customer resolved)", len(ntf.sent))
+	if len(ntf.sent) != 2 {
+		t.Fatalf("ntf.sent = %d, want 2 (internal + customer, Customer resolved)", len(ntf.sent))
+	}
+	if !strings.Contains(ntf.sent[0].Subject, "Project Suspension Notice") {
+		t.Errorf("internal Subject = %q, want day-0 suspension wording", ntf.sent[0].Subject)
 	}
 
 	if len(updater.calls) != 2 {
@@ -623,11 +656,13 @@ func TestProcessProject_ReminderHasEmptyAccountOwnerEmailWhenNoAccountManager(t 
 	}
 }
 
-// TestReminderSubject covers the subject-line template directly, confirmed
-// against two real examples from Chamara: the [ACP] prefix applies only to
-// the internal-only 90/60/30 windows, and ProjectName/AccountName sit in a
-// fixed "for {ProjectName} of {AccountName}" shape.
-func TestReminderSubject(t *testing.T) {
+// TestInternalNoticeSubject covers the always-[ACP]-prefixed internal
+// subject template directly, confirmed against real examples from Chamara:
+// every window (90 through 0) gets the prefix — it marks "internal
+// audience," not "90/60/30 window" specifically (an earlier version of this
+// logic had that backwards). Day-0 uses distinct "Project Suspension
+// Notice" wording; every other window uses "N Days Reminder".
+func TestInternalNoticeSubject(t *testing.T) {
 	tests := []struct {
 		name        string
 		window      closure.NoticeWindow
@@ -636,54 +671,177 @@ func TestReminderSubject(t *testing.T) {
 		want        string
 	}{
 		{
-			name:        "90-day window is [ACP]-prefixed",
+			name:        "90-day window",
 			window:      90,
 			projectName: "TICKETNETWORK - Subscription",
 			accountName: "TicketNetwork",
 			want:        "[ACP] 90 Days Reminder of Project for TICKETNETWORK - Subscription of TicketNetwork",
 		},
 		{
-			name:        "60-day window is [ACP]-prefixed",
+			name:        "60-day window",
 			window:      60,
 			projectName: "P",
 			accountName: "A",
 			want:        "[ACP] 60 Days Reminder of Project for P of A",
 		},
 		{
-			name:        "30-day window is [ACP]-prefixed",
+			name:        "30-day window",
 			window:      30,
 			projectName: "P",
 			accountName: "A",
 			want:        "[ACP] 30 Days Reminder of Project for P of A",
 		},
 		{
-			name:        "15-day window has no prefix",
+			name:        "15-day window is still [ACP]-prefixed",
 			window:      15,
-			projectName: "P",
-			accountName: "A",
-			want:        "15 Days Reminder of Project for P of A",
+			projectName: "SSC ICT - Subscription",
+			accountName: "SSC-ICT",
+			want:        "[ACP] 15 Days Reminder of Project for SSC ICT - Subscription of SSC-ICT",
 		},
 		{
-			name:        "7-day window has no prefix",
+			name:        "7-day window is still [ACP]-prefixed",
 			window:      7,
-			projectName: "P",
-			accountName: "A",
-			want:        "7 Days Reminder of Project for P of A",
+			projectName: "APIM & Integration - Subscription",
+			accountName: "Department of Science & Technology (DOST)",
+			want:        "[ACP] 7 Days Reminder of Project for APIM & Integration - Subscription of Department of Science & Technology (DOST)",
 		},
 		{
-			name:        "0-day window has no prefix",
+			name:        "day-0 uses suspension wording, not days-remaining",
 			window:      0,
-			projectName: "P",
-			accountName: "A",
-			want:        "0 Days Reminder of Project for P of A",
+			projectName: "Kotak Insurance - Subscription",
+			accountName: "Kotak Life Insurance company Ltd",
+			want:        "[ACP] Project Suspension Notice of Kotak Insurance - Subscription of Kotak Life Insurance company Ltd",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := reminderSubject(tt.window, tt.projectName, tt.accountName); got != tt.want {
-				t.Errorf("reminderSubject(%v, %q, %q) = %q, want %q", tt.window, tt.projectName, tt.accountName, got, tt.want)
+			if got := internalNoticeSubject(tt.window, tt.projectName, tt.accountName); got != tt.want {
+				t.Errorf("internalNoticeSubject(%v, %q, %q) = %q, want %q", tt.window, tt.projectName, tt.accountName, got, tt.want)
 			}
 		})
 	}
+}
+
+// TestCustomerNoticeSubject covers the customer-facing subject template,
+// confirmed against real examples: never [ACP]-prefixed, never names the
+// account, future ("Upcoming") tense before day-0 and past tense at day-0.
+func TestCustomerNoticeSubject(t *testing.T) {
+	tests := []struct {
+		name        string
+		window      closure.NoticeWindow
+		projectName string
+		want        string
+	}{
+		{
+			name:        "15-day window",
+			window:      15,
+			projectName: "SSC ICT - Subscription",
+			want:        "Upcoming Project Suspension Notice - SSC ICT - Subscription",
+		},
+		{
+			name:        "7-day window",
+			window:      7,
+			projectName: "SSC ICT - Subscription",
+			want:        "Upcoming Project Suspension Notice - SSC ICT - Subscription",
+		},
+		{
+			name:        "day-0 uses past tense, no \"Upcoming\"",
+			window:      0,
+			projectName: "Kotak Insurance - Subscription",
+			want:        "Project Suspension Notice - Kotak Insurance - Subscription",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := customerNoticeSubject(tt.window, tt.projectName); got != tt.want {
+				t.Errorf("customerNoticeSubject(%v, %q) = %q, want %q", tt.window, tt.projectName, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestInternalNoticeBody covers the internal body templates directly,
+// confirmed verbatim against real examples: the greeting always names the
+// Account Manager (not whichever recipient happens to read their own copy),
+// and day-0 uses distinct "already suspended" wording asking for
+// reinstatement rather than renewal.
+func TestInternalNoticeBody(t *testing.T) {
+	startDate := time.Date(2024, 11, 10, 0, 0, 0, 0, time.UTC)
+	endDate := time.Date(2026, 11, 9, 0, 0, 0, 0, time.UTC)
+	proj := project{
+		Name:       "TICKETNETWORK - Subscription",
+		ProjectKey: "TICKETNETWORKPROD",
+		StartDate:  &startDate,
+		EndDate:    &endDate,
+	}
+
+	t.Run("day-count window", func(t *testing.T) {
+		got := internalNoticeBody(90, proj, "Lochana De Alwis")
+		wantContains := []string{
+			"Dear Lochana De Alwis",
+			"non renewed contract",
+			"Project Name: TICKETNETWORK - Subscription",
+			"Project Key: TICKETNETWORKPROD",
+			"Account Owner: Lochana De Alwis",
+			"Start Date: 2024-11-10",
+			"End Date: 2026-11-09",
+			"Best Regards,\nWSO2 Team",
+		}
+		for _, want := range wantContains {
+			if !strings.Contains(got, want) {
+				t.Errorf("body missing %q, got:\n%s", want, got)
+			}
+		}
+	})
+
+	t.Run("day-0 window uses suspension wording", func(t *testing.T) {
+		got := internalNoticeBody(0, proj, "Rajat Mehta")
+		wantContains := []string{
+			"Dear Rajat Mehta",
+			"has been suspended",
+			"reinitiate the suspended support account",
+			"Account Owner: Rajat Mehta",
+		}
+		for _, want := range wantContains {
+			if !strings.Contains(got, want) {
+				t.Errorf("body missing %q, got:\n%s", want, got)
+			}
+		}
+		if strings.Contains(got, "non renewed contract. Please find") {
+			t.Errorf("day-0 body contains day-count wording, got:\n%s", got)
+		}
+	})
+}
+
+// TestCustomerNoticeBody covers the customer body templates directly:
+// future tense with US-formatted (01/02/2006) dates before day-0, past
+// tense at day-0, and no greeting in either case.
+func TestCustomerNoticeBody(t *testing.T) {
+	endDate := time.Date(2026, 8, 24, 0, 0, 0, 0, time.UTC)
+	proj := project{Name: "SSC ICT - Subscription", EndDate: &endDate}
+
+	t.Run("day-count window uses future tense and US date format", func(t *testing.T) {
+		got := customerNoticeBody(15, proj)
+		if strings.Contains(got, "Dear ") {
+			t.Errorf("body has a greeting, want none:\n%s", got)
+		}
+		wantContains := []string{
+			"will be suspended on 08/24/2026",
+			"on or before 08/24/2026",
+		}
+		for _, want := range wantContains {
+			if !strings.Contains(got, want) {
+				t.Errorf("body missing %q, got:\n%s", want, got)
+			}
+		}
+	})
+
+	t.Run("day-0 window uses past tense", func(t *testing.T) {
+		got := customerNoticeBody(0, proj)
+		if !strings.Contains(got, "was suspended 08/24/2026") {
+			t.Errorf("body missing past-tense suspension wording, got:\n%s", got)
+		}
+	})
 }

--- a/integrations/acp-closure-service/internal/sweep/sweep_test.go
+++ b/integrations/acp-closure-service/internal/sweep/sweep_test.go
@@ -20,9 +20,11 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/wso2-open-operations/cs-tools/integrations/acp-closure-service/internal/closure"
 	"github.com/wso2-open-operations/cs-tools/integrations/acp-closure-service/internal/notify"
 	"github.com/wso2-open-operations/cs-tools/integrations/acp-closure-service/internal/recipients"
 )
@@ -48,8 +50,9 @@ func TestProcessProject_NoEndDateIsNoOp(t *testing.T) {
 
 // TestProcessProject_InternalOnlyWindowSkipsCustomerContactLookup covers a
 // 90-day window: internal-only per the confirmed audience matrix. Only one
-// notify.Send should occur (internal), and no contact-search calls should
-// happen at all, since the customer side isn't consulted for this window.
+// notify.Send should occur, Recipients.Customer must stay nil, and no
+// contact-search calls should happen at all, since the customer side isn't
+// consulted for this window.
 func TestProcessProject_InternalOnlyWindowSkipsCustomerContactLookup(t *testing.T) {
 	reader := &mockEntityReader{
 		searchProjectContactsFn: func(ctx context.Context, projectID string, body []byte) ([]byte, error) {
@@ -76,8 +79,8 @@ func TestProcessProject_InternalOnlyWindowSkipsCustomerContactLookup(t *testing.
 	if len(ntf.sent) != 1 {
 		t.Fatalf("ntf.sent = %d, want 1", len(ntf.sent))
 	}
-	if ntf.sent[0].Kind != notify.KindInternal {
-		t.Errorf("notice.Kind = %v, want %v", ntf.sent[0].Kind, notify.KindInternal)
+	if ntf.sent[0].Recipients.Customer != nil {
+		t.Errorf("Recipients.Customer = %v, want nil for an internal-only window", ntf.sent[0].Recipients.Customer)
 	}
 
 	if len(updater.calls) != 1 {
@@ -137,8 +140,8 @@ func TestProcessProject_RecordsIgnoredWhenNotifierDoesNotDeliver(t *testing.T) {
 
 // TestProcessProject_CustomerAudienceWindowNotifiesBusinessContact covers a
 // 7-day window: both internal and customer per the confirmed audience
-// matrix. A project contact with the business-contact role should receive
-// the customer notice, alongside the internal notice.
+// matrix. A project contact with the business-contact role should populate
+// Recipients.Customer on the single day-count reminder notice.
 func TestProcessProject_CustomerAudienceWindowNotifiesBusinessContact(t *testing.T) {
 	reader := &mockEntityReader{
 		searchProjectContactsFn: func(ctx context.Context, projectID string, body []byte) ([]byte, error) {
@@ -157,29 +160,18 @@ func TestProcessProject_CustomerAudienceWindowNotifiesBusinessContact(t *testing
 		t.Fatalf("processProject() error = %v, want nil", err)
 	}
 
-	if len(ntf.sent) != 2 {
-		t.Fatalf("ntf.sent = %d, want 2", len(ntf.sent))
+	if len(ntf.sent) != 1 {
+		t.Fatalf("ntf.sent = %d, want 1 (one consolidated reminder)", len(ntf.sent))
 	}
-	var sawInternal, sawCustomer bool
-	for _, n := range ntf.sent {
-		switch n.Kind {
-		case notify.KindInternal:
-			sawInternal = true
-		case notify.KindCustomer:
-			sawCustomer = true
-			if n.Recipient != "bob@customer.example" {
-				t.Errorf("customer notice recipient = %q, want %q", n.Recipient, "bob@customer.example")
-			}
-			if n.ResolvedVia != recipients.ResolvedViaBusinessContact {
-				t.Errorf("customer notice ResolvedVia = %q, want %q", n.ResolvedVia, recipients.ResolvedViaBusinessContact)
-			}
-		}
+	notice := ntf.sent[0]
+	if notice.Recipients.Customer == nil {
+		t.Fatal("Recipients.Customer = nil, want populated")
 	}
-	if !sawInternal {
-		t.Error("expected an internal notice, got none")
+	if notice.Recipients.Customer.Email != "bob@customer.example" {
+		t.Errorf("Recipients.Customer.Email = %q, want %q", notice.Recipients.Customer.Email, "bob@customer.example")
 	}
-	if !sawCustomer {
-		t.Error("expected a customer notice, got none")
+	if notice.ResolvedVia != recipients.ResolvedViaBusinessContact {
+		t.Errorf("ResolvedVia = %q, want %q", notice.ResolvedVia, recipients.ResolvedViaBusinessContact)
 	}
 
 	if len(updater.calls) != 1 {
@@ -187,18 +179,31 @@ func TestProcessProject_CustomerAudienceWindowNotifiesBusinessContact(t *testing
 	}
 }
 
-// TestProcessProject_CustomerAudienceWindowNudgesAMWhenNoContactFound covers
-// the three-tier fallback's last resort: no business contact, no primary
-// contact. The customer notice is replaced entirely by an AM-nudge email —
-// not sent in addition to a (nonexistent) customer notice.
-func TestProcessProject_CustomerAudienceWindowNudgesAMWhenNoContactFound(t *testing.T) {
-	reader := &mockEntityReader{}
+// TestProcessProject_CustomerAudienceWindowSendsNoBusinessContactNoticeWhenNoContactFound
+// covers the three-tier fallback's last resort: no business contact, no
+// primary contact. Both the day-count reminder (Customer nil — nothing
+// resolved) and a separate no-business-contact urgent notice (to the
+// Account Owner only) must be sent.
+func TestProcessProject_CustomerAudienceWindowSendsNoBusinessContactNoticeWhenNoContactFound(t *testing.T) {
+	reader := &mockEntityReader{
+		getAccountFn: func(ctx context.Context, id string) ([]byte, error) {
+			return []byte(`{"accountManager": {"id": "am-1", "name": "Jordan Perera", "email": "jordan.perera@wso2.example"}}`), nil
+		},
+	}
 	updater := &mockProjectUpdater{}
 	ntf := &mockNotifier{}
 
 	now := time.Date(2026, 7, 28, 0, 0, 0, 0, time.UTC)
 	endDate := now.AddDate(0, 0, 6) // fires the 7-day window
-	proj := project{ID: "p1", Account: &projectAccountRef{ID: "a1"}, EndDate: &endDate}
+	startDate := now.AddDate(-1, 0, 0)
+	proj := project{
+		ID:         "p1",
+		Name:       "HFC Subscription - Subscription",
+		ProjectKey: "HFCSUBS",
+		Account:    &projectAccountRef{ID: "a1"},
+		StartDate:  &startDate,
+		EndDate:    &endDate,
+	}
 
 	err := processProject(context.Background(), reader, updater, ntf, now, proj)
 	if err != nil {
@@ -206,33 +211,40 @@ func TestProcessProject_CustomerAudienceWindowNudgesAMWhenNoContactFound(t *test
 	}
 
 	if len(ntf.sent) != 2 {
-		t.Fatalf("ntf.sent = %d, want 2", len(ntf.sent))
+		t.Fatalf("ntf.sent = %d, want 2 (reminder + no-business-contact)", len(ntf.sent))
 	}
-	var sawInternal, sawNudge, sawCustomer bool
-	for _, n := range ntf.sent {
-		switch n.Kind {
-		case notify.KindInternal:
-			sawInternal = true
-			if n.ResolvedVia != "" {
-				t.Errorf("internal notice ResolvedVia = %q, want \"\" (internal never goes through the fallback chain)", n.ResolvedVia)
-			}
-		case notify.KindAMNudge:
-			sawNudge = true
-			if n.ResolvedVia != recipients.ResolvedViaNone {
-				t.Errorf("AM-nudge notice ResolvedVia = %q, want %q", n.ResolvedVia, recipients.ResolvedViaNone)
-			}
-		case notify.KindCustomer:
-			sawCustomer = true
+
+	reminder, nudge := ntf.sent[0], ntf.sent[1]
+
+	if reminder.Recipients.Customer != nil {
+		t.Errorf("reminder Recipients.Customer = %v, want nil", reminder.Recipients.Customer)
+	}
+	if reminder.Recipients.AccountOwner.Email != "jordan.perera@wso2.example" {
+		t.Errorf("reminder Recipients.AccountOwner.Email = %q, want %q", reminder.Recipients.AccountOwner.Email, "jordan.perera@wso2.example")
+	}
+
+	const wantSubject = "[Urgent] [ACP] No Business Contacts Specified for Project HFC Subscription - Subscription"
+	if nudge.Subject != wantSubject {
+		t.Errorf("nudge Subject = %q, want %q", nudge.Subject, wantSubject)
+	}
+	if nudge.Recipients.AccountOwner.Email != "jordan.perera@wso2.example" {
+		t.Errorf("nudge Recipients.AccountOwner.Email = %q, want %q", nudge.Recipients.AccountOwner.Email, "jordan.perera@wso2.example")
+	}
+	if nudge.Recipients.Customer != nil {
+		t.Errorf("nudge Recipients.Customer = %v, want nil", nudge.Recipients.Customer)
+	}
+	if nudge.Body == "" {
+		t.Error("nudge Body is empty, want the no-business-contact template populated")
+	}
+	wantBodyContains := []string{
+		"Project Name: HFC Subscription - Subscription",
+		"Project Key: HFCSUBS",
+		"Account Owner: Jordan Perera",
+	}
+	for _, want := range wantBodyContains {
+		if !strings.Contains(nudge.Body, want) {
+			t.Errorf("nudge Body missing %q, got:\n%s", want, nudge.Body)
 		}
-	}
-	if !sawInternal {
-		t.Error("expected an internal notice, got none")
-	}
-	if !sawNudge {
-		t.Error("expected an AM-nudge notice, got none")
-	}
-	if sawCustomer {
-		t.Error("expected no customer notice when no contact resolved, got one")
 	}
 }
 
@@ -240,8 +252,9 @@ func TestProcessProject_CustomerAudienceWindowNudgesAMWhenNoContactFound(t *test
 // verifies that a project with no linked account never calls
 // SearchAccountContacts. Calling it anyway with an empty account ID would hit
 // SearchAccountContacts(ctx, "", ...), which fetchContacts must not do when
-// there's no account to search — it should fall through to the AM nudge
-// exactly as it does when a real account search simply returns no contacts.
+// there's no account to search — it should fall through to the
+// no-business-contact notice exactly as it does when a real account search
+// simply returns no contacts.
 func TestProcessProject_CustomerAudienceWindowSkipsAccountContactLookupWhenNoAccount(t *testing.T) {
 	reader := &mockEntityReader{
 		searchAccountContactsFn: func(ctx context.Context, accountID string, body []byte) ([]byte, error) {
@@ -262,27 +275,10 @@ func TestProcessProject_CustomerAudienceWindowSkipsAccountContactLookupWhenNoAcc
 	}
 
 	if len(ntf.sent) != 2 {
-		t.Fatalf("ntf.sent = %d, want 2", len(ntf.sent))
+		t.Fatalf("ntf.sent = %d, want 2 (reminder + no-business-contact)", len(ntf.sent))
 	}
-	var sawInternal, sawNudge, sawCustomer bool
-	for _, n := range ntf.sent {
-		switch n.Kind {
-		case notify.KindInternal:
-			sawInternal = true
-		case notify.KindAMNudge:
-			sawNudge = true
-		case notify.KindCustomer:
-			sawCustomer = true
-		}
-	}
-	if !sawInternal {
-		t.Error("expected an internal notice, got none")
-	}
-	if !sawNudge {
-		t.Error("expected an AM-nudge notice, got none")
-	}
-	if sawCustomer {
-		t.Error("expected no customer notice when no account is linked, got one")
+	if ntf.sent[0].Recipients.Customer != nil {
+		t.Errorf("reminder Recipients.Customer = %v, want nil (no account linked)", ntf.sent[0].Recipients.Customer)
 	}
 }
 
@@ -334,8 +330,8 @@ func TestProcessProject_Day0SuccessfulNotifyThenSuspend(t *testing.T) {
 		t.Fatalf("processProject() error = %v, want nil", err)
 	}
 
-	if len(ntf.sent) != 2 {
-		t.Fatalf("ntf.sent = %d, want 2 (internal + customer)", len(ntf.sent))
+	if len(ntf.sent) != 1 {
+		t.Fatalf("ntf.sent = %d, want 1 (one consolidated reminder, with Customer resolved)", len(ntf.sent))
 	}
 
 	if len(updater.calls) != 2 {
@@ -529,13 +525,13 @@ func TestProcessProject_NothingDueIsNoOp(t *testing.T) {
 	}
 }
 
-// TestProcessProject_InternalNoticeUsesRealAccountManagerEmail is a
-// regression test using the real GetAccount response shape confirmed via
-// direct Postman testing against the dedicated test account (trimmed to the
-// field this component reads): a populated accountManager with a real email.
-// The internal notice's Recipient must be that email, and GetAccount must be
+// TestProcessProject_ReminderUsesRealAccountContacts is a regression test
+// using the real GetAccount response shape confirmed via direct Postman
+// testing against the dedicated test account: a populated accountManager,
+// technicalOwner, and renewalAccountManager, all with real emails. The
+// reminder notice's Recipients must carry all three, and GetAccount must be
 // called with the project's account ID.
-func TestProcessProject_InternalNoticeUsesRealAccountManagerEmail(t *testing.T) {
+func TestProcessProject_ReminderUsesRealAccountContacts(t *testing.T) {
 	const realGetAccountResponse = `{
 		"id": "f213fdd1-1b4b-a650-a002-c9d3604bcbac",
 		"name": "ACP Test Partner Account",
@@ -585,17 +581,24 @@ func TestProcessProject_InternalNoticeUsesRealAccountManagerEmail(t *testing.T) 
 	if len(ntf.sent) != 1 {
 		t.Fatalf("ntf.sent = %d, want 1", len(ntf.sent))
 	}
-	if got := ntf.sent[0].Recipient; got != "jordan.perera@wso2.example" {
-		t.Errorf("internal notice Recipient = %q, want %q", got, "jordan.perera@wso2.example")
+	got := ntf.sent[0].Recipients
+	if got.AccountOwner.Email != "jordan.perera@wso2.example" {
+		t.Errorf("AccountOwner.Email = %q, want %q", got.AccountOwner.Email, "jordan.perera@wso2.example")
+	}
+	if got.RenewalManager.Email != "sam.jayasuriya@wso2.example" {
+		t.Errorf("RenewalManager.Email = %q, want %q", got.RenewalManager.Email, "sam.jayasuriya@wso2.example")
+	}
+	if got.TechnicalOwner.Email != "alex.fernando@wso2.example" {
+		t.Errorf("TechnicalOwner.Email = %q, want %q", got.TechnicalOwner.Email, "alex.fernando@wso2.example")
 	}
 }
 
-// TestProcessProject_InternalNoticeHasEmptyRecipientWhenNoAccountManager
+// TestProcessProject_ReminderHasEmptyAccountOwnerEmailWhenNoAccountManager
 // covers the legitimate-absence case: an account with no accountManager
 // assigned at all (nested key entirely missing, not just empty). The
-// internal notice must still be sent, with an empty Recipient — this is not
-// an error, per recipients.AccountManagerEmail's contract.
-func TestProcessProject_InternalNoticeHasEmptyRecipientWhenNoAccountManager(t *testing.T) {
+// reminder notice must still be sent, with an empty AccountOwner.Email —
+// this is not an error, per recipients.AccountManagerEmail's contract.
+func TestProcessProject_ReminderHasEmptyAccountOwnerEmailWhenNoAccountManager(t *testing.T) {
 	reader := &mockEntityReader{
 		getAccountFn: func(ctx context.Context, id string) ([]byte, error) {
 			return []byte(`{"id": "a1", "name": "Some Account"}`), nil
@@ -615,84 +618,72 @@ func TestProcessProject_InternalNoticeHasEmptyRecipientWhenNoAccountManager(t *t
 	if len(ntf.sent) != 1 {
 		t.Fatalf("ntf.sent = %d, want 1", len(ntf.sent))
 	}
-	if got := ntf.sent[0].Recipient; got != "" {
-		t.Errorf("internal notice Recipient = %q, want \"\" (no account manager assigned)", got)
+	if got := ntf.sent[0].Recipients.AccountOwner.Email; got != "" {
+		t.Errorf("AccountOwner.Email = %q, want \"\" (no account manager assigned)", got)
 	}
 }
 
-// TestShouldSuppressInternalNotice covers the pure suppression predicate
-// directly. The "recipients differ" case isn't reachable through the wired
-// system today (the AM-nudge recipient is always sourced from the same
-// amEmail as the internal notice — there is no independent source for it),
-// but the predicate must still handle it correctly should that ever change.
-func TestShouldSuppressInternalNotice(t *testing.T) {
+// TestReminderSubject covers the subject-line template directly, confirmed
+// against two real examples from Chamara: the [ACP] prefix applies only to
+// the internal-only 90/60/30 windows, and ProjectName/AccountName sit in a
+// fixed "for {ProjectName} of {AccountName}" shape.
+func TestReminderSubject(t *testing.T) {
 	tests := []struct {
-		name              string
-		internalRecipient string
-		nudgeRecipient    string
-		want              bool
+		name        string
+		window      closure.NoticeWindow
+		projectName string
+		accountName string
+		want        string
 	}{
 		{
-			name:              "same non-empty recipient: suppress",
-			internalRecipient: "am@wso2.example",
-			nudgeRecipient:    "am@wso2.example",
-			want:              true,
+			name:        "90-day window is [ACP]-prefixed",
+			window:      90,
+			projectName: "TICKETNETWORK - Subscription",
+			accountName: "TicketNetwork",
+			want:        "[ACP] 90 Days Reminder of Project for TICKETNETWORK - Subscription of TicketNetwork",
 		},
 		{
-			name:              "different recipients: do not suppress",
-			internalRecipient: "am@wso2.example",
-			nudgeRecipient:    "other@wso2.example",
-			want:              false,
+			name:        "60-day window is [ACP]-prefixed",
+			window:      60,
+			projectName: "P",
+			accountName: "A",
+			want:        "[ACP] 60 Days Reminder of Project for P of A",
 		},
 		{
-			name:              "both empty: do not suppress (not a real duplicate, and suppressing would hide debug visibility)",
-			internalRecipient: "",
-			nudgeRecipient:    "",
-			want:              false,
+			name:        "30-day window is [ACP]-prefixed",
+			window:      30,
+			projectName: "P",
+			accountName: "A",
+			want:        "[ACP] 30 Days Reminder of Project for P of A",
+		},
+		{
+			name:        "15-day window has no prefix",
+			window:      15,
+			projectName: "P",
+			accountName: "A",
+			want:        "15 Days Reminder of Project for P of A",
+		},
+		{
+			name:        "7-day window has no prefix",
+			window:      7,
+			projectName: "P",
+			accountName: "A",
+			want:        "7 Days Reminder of Project for P of A",
+		},
+		{
+			name:        "0-day window has no prefix",
+			window:      0,
+			projectName: "P",
+			accountName: "A",
+			want:        "0 Days Reminder of Project for P of A",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := shouldSuppressInternalNotice(tt.internalRecipient, tt.nudgeRecipient); got != tt.want {
-				t.Errorf("shouldSuppressInternalNotice(%q, %q) = %v, want %v",
-					tt.internalRecipient, tt.nudgeRecipient, got, tt.want)
+			if got := reminderSubject(tt.window, tt.projectName, tt.accountName); got != tt.want {
+				t.Errorf("reminderSubject(%v, %q, %q) = %q, want %q", tt.window, tt.projectName, tt.accountName, got, tt.want)
 			}
 		})
-	}
-}
-
-// TestProcessProject_SuppressesInternalNoticeWhenNudgeGoesToSameRealRecipient
-// covers the real, reachable scenario: a customer-audience window, a
-// resolved (non-empty) real Account Manager email, and no business/primary
-// contact found. The Account Manager must receive exactly one notice
-// (am_nudge) — not both that and a separate internal notice about the same
-// window in the same run.
-func TestProcessProject_SuppressesInternalNoticeWhenNudgeGoesToSameRealRecipient(t *testing.T) {
-	reader := &mockEntityReader{
-		getAccountFn: func(ctx context.Context, id string) ([]byte, error) {
-			return []byte(`{"accountManager": {"id": "am-1", "name": "Jordan Perera", "email": "jordan.perera@wso2.example"}}`), nil
-		},
-	}
-	updater := &mockProjectUpdater{}
-	ntf := &mockNotifier{}
-
-	now := time.Date(2026, 7, 28, 0, 0, 0, 0, time.UTC)
-	endDate := now.AddDate(0, 0, 6) // fires the 7-day (customer-audience) window
-	proj := project{ID: "p1", Account: &projectAccountRef{ID: "a1"}, EndDate: &endDate}
-
-	err := processProject(context.Background(), reader, updater, ntf, now, proj)
-	if err != nil {
-		t.Fatalf("processProject() error = %v, want nil", err)
-	}
-
-	if len(ntf.sent) != 1 {
-		t.Fatalf("ntf.sent = %d, want 1 (only am_nudge; internal suppressed)", len(ntf.sent))
-	}
-	if ntf.sent[0].Kind != notify.KindAMNudge {
-		t.Errorf("Kind = %v, want %v", ntf.sent[0].Kind, notify.KindAMNudge)
-	}
-	if ntf.sent[0].Recipient != "jordan.perera@wso2.example" {
-		t.Errorf("Recipient = %q, want %q", ntf.sent[0].Recipient, "jordan.perera@wso2.example")
 	}
 }

--- a/integrations/acp-closure-service/internal/sweep/types.go
+++ b/integrations/acp-closure-service/internal/sweep/types.go
@@ -36,9 +36,16 @@ import (
 // never read Account directly, so callers don't need to duplicate the nil
 // check.
 type project struct {
-	ID      string             `json:"id"`
-	Account *projectAccountRef `json:"account"`
-	EndDate *time.Time         `json:"endDate"`
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	// ProjectKey is the short project identifier (e.g. "TICKETNET") used in
+	// the no-business-contact notice body, alongside Name.
+	ProjectKey string             `json:"projectKey"`
+	Account    *projectAccountRef `json:"account"`
+	// StartDate is nil only when genuinely absent on the wire — mirrors
+	// EndDate's existing nullable-pointer convention.
+	StartDate *time.Time `json:"startDate"`
+	EndDate   *time.Time `json:"endDate"`
 	// ClosureState is the derived roll-up over EndDateClosureState,
 	// InvoiceDueDateClosureState, and ComplianceViolationClosureState — not
 	// settable directly, and not what suspend()'s idempotency guard checks
@@ -56,11 +63,12 @@ type project struct {
 }
 
 // projectAccountRef is the nested account reference on both GetProject's and
-// SearchProjects's response shapes. Only id is used; the upstream shape
-// carries more (name, activationDate, tier, region, ...) that this
-// component doesn't need.
+// SearchProjects's response shapes. id and name are used (name for the
+// notice subject line); the upstream shape carries more (activationDate,
+// tier, region, ...) that this component doesn't need.
 type projectAccountRef struct {
-	ID string `json:"id"`
+	ID   string `json:"id"`
+	Name string `json:"name"`
 }
 
 // accountID returns the project's account ID, or "" if the project
@@ -112,8 +120,14 @@ type personRefDTO struct {
 }
 
 // accountDTO is the subset of GetAccount's response this component reads.
+// TechnicalOwner and RenewalAccountManager are confirmed present on the real
+// response (verified directly against the live API) alongside
+// AccountManager; all three now feed the notice-content redesign's
+// Recipients (see sweep.go's resolveAccountContacts).
 type accountDTO struct {
-	AccountManager *personRefDTO `json:"accountManager"`
+	AccountManager        *personRefDTO `json:"accountManager"`
+	TechnicalOwner        *personRefDTO `json:"technicalOwner"`
+	RenewalAccountManager *personRefDTO `json:"renewalAccountManager"`
 }
 
 // entityReader is the minimal read surface processProject needs. Satisfied

--- a/integrations/acp-closure-service/internal/sweep/types.go
+++ b/integrations/acp-closure-service/internal/sweep/types.go
@@ -38,9 +38,14 @@ import (
 type project struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
-	// ProjectKey is the short project identifier (e.g. "TICKETNET") used in
-	// the no-business-contact notice body, alongside Name.
-	ProjectKey string             `json:"projectKey"`
+	// ProjectKey is the short project identifier (e.g. "APPSUB") used in
+	// notice bodies, alongside Name. Tagged "key", not "projectKey" —
+	// csm-integration-service's own openapi.yaml documents this field as
+	// "projectKey", but the live response actually names it "key"
+	// (confirmed directly via Postman against the dedicated test project;
+	// "projectKey" silently produced an always-empty ProjectKey until this
+	// was caught). Trust the wire over the spec if they disagree again.
+	ProjectKey string             `json:"key"`
 	Account    *projectAccountRef `json:"account"`
 	// StartDate is nil only when genuinely absent on the wire — mirrors
 	// EndDate's existing nullable-pointer convention.

--- a/integrations/acp-closure-service/internal/sweep/types_test.go
+++ b/integrations/acp-closure-service/internal/sweep/types_test.go
@@ -19,6 +19,7 @@ package sweep
 import (
 	"encoding/json"
 	"testing"
+	"time"
 )
 
 // TestProject_ParsesNestedAccountFromRealGetProjectResponse is a regression
@@ -71,5 +72,72 @@ func TestProject_AccountIDIsEmptyWhenAccountIsAbsent(t *testing.T) {
 
 	if got := proj.accountID(); got != "" {
 		t.Errorf("accountID() = %q, want \"\"", got)
+	}
+}
+
+// TestProject_ParsesNameProjectKeyStartDateAndAccountName covers the fields
+// added for the notice-content redesign: name, projectKey, and startDate are
+// documented on csm-integration-service's Project schema (openapi.yaml) but
+// were previously unread by this component; the same is true of the nested
+// account's own name, alongside its id.
+func TestProject_ParsesNameProjectKeyStartDateAndAccountName(t *testing.T) {
+	const realGetProjectResponse = `{
+		"id": "e3e87599-1bc7-6650-182c-0dc5604bcb68",
+		"name": "TICKETNETWORK - Subscription",
+		"projectKey": "TICKETNET",
+		"startDate": "2025-07-29T00:00:00Z",
+		"endDate": "2026-10-27T00:00:00Z",
+		"account": {
+			"id": "f213fdd1-1b4b-a650-a002-c9d3604bcbac",
+			"name": "TicketNetwork"
+		}
+	}`
+
+	var proj project
+	if err := json.Unmarshal([]byte(realGetProjectResponse), &proj); err != nil {
+		t.Fatalf("unmarshal real GetProject response: %v", err)
+	}
+
+	if proj.Name != "TICKETNETWORK - Subscription" {
+		t.Errorf("Name = %q, want %q", proj.Name, "TICKETNETWORK - Subscription")
+	}
+	if proj.ProjectKey != "TICKETNET" {
+		t.Errorf("ProjectKey = %q, want %q", proj.ProjectKey, "TICKETNET")
+	}
+	if proj.StartDate == nil || !proj.StartDate.Equal(time.Date(2025, 7, 29, 0, 0, 0, 0, time.UTC)) {
+		t.Errorf("StartDate = %v, want 2025-07-29T00:00:00Z", proj.StartDate)
+	}
+	if proj.Account == nil || proj.Account.Name != "TicketNetwork" {
+		t.Errorf("Account.Name = %v, want %q", proj.Account, "TicketNetwork")
+	}
+}
+
+// TestAccountDTO_ParsesTechnicalOwnerAndRenewalAccountManager covers the two
+// account fields that were previously fetched over the wire and silently
+// dropped (accountDTO had no field for them): confirmed present on the real
+// entity-service response for the dedicated test account, alongside
+// accountManager.
+func TestAccountDTO_ParsesTechnicalOwnerAndRenewalAccountManager(t *testing.T) {
+	const realGetAccountResponse = `{
+		"id": "f213fdd1-1b4b-a650-a002-c9d3604bcbac",
+		"name": "ACP Test Partner Account",
+		"technicalOwner": {"id": "tech-1", "name": "Alex Fernando", "email": "alex.fernando@wso2.example"},
+		"accountManager": {"id": "am-1", "name": "Jordan Perera", "email": "jordan.perera@wso2.example"},
+		"renewalAccountManager": {"id": "ram-1", "name": "Sam Jayasuriya", "email": "sam.jayasuriya@wso2.example"}
+	}`
+
+	var acc accountDTO
+	if err := json.Unmarshal([]byte(realGetAccountResponse), &acc); err != nil {
+		t.Fatalf("unmarshal real GetAccount response: %v", err)
+	}
+
+	if acc.TechnicalOwner == nil || acc.TechnicalOwner.Name != "Alex Fernando" {
+		t.Errorf("TechnicalOwner = %v, want Name %q", acc.TechnicalOwner, "Alex Fernando")
+	}
+	if acc.RenewalAccountManager == nil || acc.RenewalAccountManager.Name != "Sam Jayasuriya" {
+		t.Errorf("RenewalAccountManager = %v, want Name %q", acc.RenewalAccountManager, "Sam Jayasuriya")
+	}
+	if acc.AccountManager == nil || acc.AccountManager.Name != "Jordan Perera" {
+		t.Errorf("AccountManager = %v, want Name %q", acc.AccountManager, "Jordan Perera")
 	}
 }

--- a/integrations/acp-closure-service/internal/sweep/types_test.go
+++ b/integrations/acp-closure-service/internal/sweep/types_test.go
@@ -76,20 +76,43 @@ func TestProject_AccountIDIsEmptyWhenAccountIsAbsent(t *testing.T) {
 }
 
 // TestProject_ParsesNameProjectKeyStartDateAndAccountName covers the fields
-// added for the notice-content redesign: name, projectKey, and startDate are
+// added for the notice-content redesign: name, key, and startDate are
 // documented on csm-integration-service's Project schema (openapi.yaml) but
 // were previously unread by this component; the same is true of the nested
-// account's own name, alongside its id.
+// account's own name, alongside its id. Uses the literal real GetProject
+// response for the dedicated test project (Postman, confirmed directly by
+// the user) rather than a synthetic fixture — this is what caught a real
+// discrepancy: openapi.yaml documents this field as "projectKey", but the
+// live response actually names it "key". Trust the wire, not the spec.
 func TestProject_ParsesNameProjectKeyStartDateAndAccountName(t *testing.T) {
 	const realGetProjectResponse = `{
 		"id": "e3e87599-1bc7-6650-182c-0dc5604bcb68",
-		"name": "TICKETNETWORK - Subscription",
-		"projectKey": "TICKETNET",
-		"startDate": "2025-07-29T00:00:00Z",
-		"endDate": "2026-10-27T00:00:00Z",
 		"account": {
 			"id": "f213fdd1-1b4b-a650-a002-c9d3604bcbac",
-			"name": "TicketNetwork"
+			"name": "ACP Test Partner Account",
+			"activationDate": null,
+			"tier": "",
+			"region": null,
+			"agentEnabled": false,
+			"kbReferencesEnabled": false
+		},
+		"sfId": "a0dE200000CZ9ZNIA1",
+		"name": "ACP Partner Project - Subscription",
+		"key": "APPSUB",
+		"subscriptionType": "subscription",
+		"startDate": "2025-07-01T00:00:00Z",
+		"endDate": "2026-07-29T00:00:00Z",
+		"createdOn": "2025-07-29T05:59:07Z",
+		"updatedOn": "2025-07-29T05:59:07Z",
+		"closureState": "Suspended",
+		"endDateClosureState": "Suspended",
+		"invoiceDueDateClosureState": "Open",
+		"complianceViolationClosureState": "Open",
+		"complianceViolationDate": null,
+		"suspensionProcessState": {
+			"based_on_compliance": {"event_type": "open"},
+			"based_on_due_invoices": {"event_type": "7_days_notice", "actionSendEmailNotification": "SUCCESSFUL", "actionServicePortalAnnouncement": "SUCCESSFUL"},
+			"based_on_subscription_end_date": {"actionSendEmailNotification": "IGNORED", "event_type": "suspend"}
 		}
 	}`
 
@@ -98,17 +121,17 @@ func TestProject_ParsesNameProjectKeyStartDateAndAccountName(t *testing.T) {
 		t.Fatalf("unmarshal real GetProject response: %v", err)
 	}
 
-	if proj.Name != "TICKETNETWORK - Subscription" {
-		t.Errorf("Name = %q, want %q", proj.Name, "TICKETNETWORK - Subscription")
+	if proj.Name != "ACP Partner Project - Subscription" {
+		t.Errorf("Name = %q, want %q", proj.Name, "ACP Partner Project - Subscription")
 	}
-	if proj.ProjectKey != "TICKETNET" {
-		t.Errorf("ProjectKey = %q, want %q", proj.ProjectKey, "TICKETNET")
+	if proj.ProjectKey != "APPSUB" {
+		t.Errorf("ProjectKey = %q, want %q", proj.ProjectKey, "APPSUB")
 	}
-	if proj.StartDate == nil || !proj.StartDate.Equal(time.Date(2025, 7, 29, 0, 0, 0, 0, time.UTC)) {
-		t.Errorf("StartDate = %v, want 2025-07-29T00:00:00Z", proj.StartDate)
+	if proj.StartDate == nil || !proj.StartDate.Equal(time.Date(2025, 7, 1, 0, 0, 0, 0, time.UTC)) {
+		t.Errorf("StartDate = %v, want 2025-07-01T00:00:00Z", proj.StartDate)
 	}
-	if proj.Account == nil || proj.Account.Name != "TicketNetwork" {
-		t.Errorf("Account.Name = %v, want %q", proj.Account, "TicketNetwork")
+	if proj.Account == nil || proj.Account.Name != "ACP Test Partner Account" {
+		t.Errorf("Account.Name = %v, want %q", proj.Account, "ACP Test Partner Account")
 	}
 }
 

--- a/integrations/acp-closure-service/internal/sweep/types_test.go
+++ b/integrations/acp-closure-service/internal/sweep/types_test.go
@@ -135,6 +135,65 @@ func TestProject_ParsesNameProjectKeyStartDateAndAccountName(t *testing.T) {
 	}
 }
 
+// TestProject_ParsesNameKeyAndStartDateFromRealSearchProjectsResponse is a
+// regression test addressing a real review concern (PR #1440, Sajith
+// Ekanayake): Name/ProjectKey/StartDate were only regression-tested against
+// a GetProject-shaped fixture, but the unattended production sweep
+// (TEST_PROJECT_ID unset) reads projects from /projects/search instead — a
+// different, historically leaner response shape (CLAUDE.md documents
+// account itself being absent from this endpoint for a period). Confirmed
+// via a real /projects/search response (Postman) that name/key/startDate
+// ARE present on this shape too, not just GetProject's — this is the
+// literal response used as the fixture below.
+func TestProject_ParsesNameKeyAndStartDateFromRealSearchProjectsResponse(t *testing.T) {
+	const realSearchProjectsResponse = `{
+		"projects": [
+			{
+				"id": "266f6292-1b46-f510-264c-997a234bcba9",
+				"name": "DemoCloud - Cloud Support",
+				"key": "DEMOCLOUDCLOUDSUB",
+				"subscriptionType": "cloud_support",
+				"startDate": "2025-02-18T00:00:00Z",
+				"endDate": null,
+				"createdOn": "2023-10-25T06:54:50Z",
+				"account": {
+					"id": "cf3fee52-1b46-f510-264c-997a234bcbe5",
+					"name": "DemoCloud"
+				},
+				"closureState": "Open",
+				"endDateClosureState": "Open",
+				"invoiceDueDateClosureState": "Open",
+				"complianceViolationClosureState": null,
+				"complianceViolationDate": null,
+				"suspensionProcessState": {
+					"based_on_subscription_end_date": {"event_type": "open"},
+					"based_on_due_invoices": {"event_type": "open"},
+					"based_on_compliance": {"event_type": "open"}
+				}
+			}
+		]
+	}`
+
+	var resp searchProjectsResponse
+	if err := json.Unmarshal([]byte(realSearchProjectsResponse), &resp); err != nil {
+		t.Fatalf("unmarshal real SearchProjects response: %v", err)
+	}
+	if len(resp.Projects) != 1 {
+		t.Fatalf("Projects = %d, want 1", len(resp.Projects))
+	}
+
+	proj := resp.Projects[0]
+	if proj.Name != "DemoCloud - Cloud Support" {
+		t.Errorf("Name = %q, want %q", proj.Name, "DemoCloud - Cloud Support")
+	}
+	if proj.ProjectKey != "DEMOCLOUDCLOUDSUB" {
+		t.Errorf("ProjectKey = %q, want %q", proj.ProjectKey, "DEMOCLOUDCLOUDSUB")
+	}
+	if proj.StartDate == nil || !proj.StartDate.Equal(time.Date(2025, 2, 18, 0, 0, 0, 0, time.UTC)) {
+		t.Errorf("StartDate = %v, want 2025-02-18T00:00:00Z", proj.StartDate)
+	}
+}
+
 // TestAccountDTO_ParsesTechnicalOwnerAndRenewalAccountManager covers the two
 // account fields that were previously fetched over the wire and silently
 // dropped (accountDTO had no field for them): confirmed present on the real


### PR DESCRIPTION
Closes wso2-enterprise/digiops-cs#2748

Follow-up to #1330, covering everything on this branch since that PR
merged. Reworks ACP Phase 1 notice content from development-shaped
logging (a `Kind` label + a single `Recipient` string) into real,
Chamara-approved subject-line and email-body templates for every window —
so wiring in real email sending later is a drop-in change, not a
redesign.

## What changed

- **Real subject/body templates** for every notice type: internal
  day-count reminder (90/60/30/15/7), internal day-0 suspension notice,
  customer day-count notice (15/7), customer day-0 notice, and the
  no-business-contact urgent notice — confirmed against real examples,
  wording verified character-for-character.
- **Structured `Recipients`** (Account Owner, Renewal Manager, Technical
  Owner, Customer) replacing the single `Recipient` string — closes a gap
  where Renewal Manager/Technical Owner were fetched from entity-service
  but silently dropped by `accountDTO` having no field for them.
- **Internal and customer notices sent separately** per window, not
  bundled into one — their content genuinely differs, not just their
  recipient list. The `[ACP]` prefix now correctly applies to every
  internal-audience copy (90 through 0), not just 90/60/30.
- **No-business-contact notice now reaches all three internal
  recipients** (Account Owner + Renewal Manager + Technical Owner), not
  Account Owner alone.
- **Dropped the raw "would update project" write-confirmation log
  line** — only real notice/email-style log lines are emitted now, so
  dry-run output reads as actual email content end to end.
- **Fix:** the project key field is `key` on the live `GetProject`
  response, not `projectKey` as `csm-integration-service`'s own
  `openapi.yaml` documents — was silently always empty before this fix,
  caught via a real Postman response.

## Verification

- Full test suite (`go vet` + `-race`) green throughout, TDD one seam at
  a time, matching this component's existing conventions.
- A Standards+Spec two-axis code review was run against this diff before
  opening the PR; findings (a duplicated `Notice`-construction block, a
  stale doc comment, missing recipient names in the log) were applied.
- Confirmed against real staging data via the Choreo POC component,
  including a real (non-dry-run) write against the dedicated test
  project — subject, body, and recipients all matched the confirmed
  templates exactly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added distinct internal, customer, and no-business-contact notifications for closure reminders.
  * Notifications now include project details, dates, tailored subjects, message content, and appropriate recipients.
  * Internal notices include account owner, renewal manager, and technical owner contacts.
  * Customer notices are sent when contacts are available; otherwise, an internal alert is issued.
  * Added clear day-of-closure messaging and suspension status logging.

* **Bug Fixes**
  * Improved handling of project, account, key, date, and contact information.
  * Dry-run updates now complete without misleading update logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->