### PR TITLE
[CSM Portal] Redirect dashless UUID ids to the dashed form on detail routes

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.test.tsx
@@ -396,6 +396,53 @@ function renderPage(): ReturnType<typeof render> {
   );
 }
 
+const DASHED_ID = "56f49f0a-eb1e-c310-fcf5-f5dabad0cdab";
+const DASHLESS_ID = "56f49f0aeb1ec310fcf5f5dabad0cdab";
+
+function renderPageAtCaseId(initialEntry: string): ReturnType<typeof render> {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <LocationProbe />
+        <Routes>
+          <Route path="/cases/:caseId" element={<CsmCaseDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("CsmCaseDetailPage — dashless id normalization", () => {
+  it("fetches the case detail with the dashed id and redirects the URL when the route carries a dashless id", () => {
+    useGetCsmCaseDetailMock.mockClear();
+    navigateMock.mockClear();
+
+    renderPageAtCaseId(`/cases/${DASHLESS_ID}`);
+
+    // The underlying data-fetch hook must be called with the corrected,
+    // dashed id, not the raw dashless one straight off the URL.
+    expect(useGetCsmCaseDetailMock).toHaveBeenCalledWith(DASHED_ID);
+
+    expect(navigateMock).toHaveBeenCalledWith(
+      { pathname: `/cases/${DASHED_ID}`, search: "", hash: "" },
+      { replace: true },
+    );
+  });
+
+  it("does not redirect or alter an already-dashed id", () => {
+    useGetCsmCaseDetailMock.mockClear();
+    navigateMock.mockClear();
+
+    renderPageAtCaseId(`/cases/${DASHED_ID}`);
+
+    expect(useGetCsmCaseDetailMock).toHaveBeenCalledWith(DASHED_ID);
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+});
+
 describe("CsmCaseDetailPage — time-card edit dialog reset on case change", () => {
   it("stops showing the previous case's edit dialog once the route moves to a new case", () => {
     renderPage();

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.test.tsx
@@ -14,10 +14,18 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import type { JSX } from "react";
-import { MemoryRouter, Route, Routes, useLocation, useNavigate } from "react-router";
+import {
+  MemoryRouter,
+  Route,
+  Routes,
+  useLocation,
+  useNavigate,
+  type NavigateOptions,
+  type To,
+} from "react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import "@testing-library/jest-dom/vitest";
 import type { CsmCaseDetail } from "@features/csm-cases/types/csmCases";
@@ -399,6 +407,21 @@ function renderPage(): ReturnType<typeof render> {
 const DASHED_ID = "56f49f0a-eb1e-c310-fcf5-f5dabad0cdab";
 const DASHLESS_ID = "56f49f0aeb1ec310fcf5f5dabad0cdab";
 
+// `useNavTransition` is mocked module-wide (above) so the rest of this
+// file's tests can assert on navigate-call arguments without a real router
+// transition. For the dashless-id tests specifically we want to prove the
+// router's own location actually changes, not just that the mock was
+// invoked — so this bridges the mock to the real `useNavigate` from this
+// render tree, and `LocationProbe` (already used elsewhere in this file)
+// verifies the resulting location.
+function NavigateBridge(): null {
+  const navigate = useNavigate();
+  navigateMock.mockImplementation((to: To, options?: NavigateOptions) =>
+    navigate(to, options),
+  );
+  return null;
+}
+
 function renderPageAtCaseId(initialEntry: string): ReturnType<typeof render> {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
@@ -406,6 +429,7 @@ function renderPageAtCaseId(initialEntry: string): ReturnType<typeof render> {
   return render(
     <QueryClientProvider client={queryClient}>
       <MemoryRouter initialEntries={[initialEntry]}>
+        <NavigateBridge />
         <LocationProbe />
         <Routes>
           <Route path="/cases/:caseId" element={<CsmCaseDetailPage />} />
@@ -416,7 +440,7 @@ function renderPageAtCaseId(initialEntry: string): ReturnType<typeof render> {
 }
 
 describe("CsmCaseDetailPage — dashless id normalization", () => {
-  it("fetches the case detail with the dashed id and redirects the URL when the route carries a dashless id", () => {
+  it("fetches the case detail with the dashed id and redirects the URL when the route carries a dashless id", async () => {
     useGetCsmCaseDetailMock.mockClear();
     navigateMock.mockClear();
 
@@ -426,9 +450,12 @@ describe("CsmCaseDetailPage — dashless id normalization", () => {
     // dashed id, not the raw dashless one straight off the URL.
     expect(useGetCsmCaseDetailMock).toHaveBeenCalledWith(DASHED_ID);
 
-    expect(navigateMock).toHaveBeenCalledWith(
-      { pathname: `/cases/${DASHED_ID}`, search: "", hash: "" },
-      { replace: true },
+    // Exercise the real router replacement: the address bar must actually
+    // land on the dashed path, not just the mock being called with it.
+    await waitFor(() =>
+      expect(screen.getByTestId("location-probe")).toHaveTextContent(
+        `/cases/${DASHED_ID}`,
+      ),
     );
   });
 
@@ -440,6 +467,9 @@ describe("CsmCaseDetailPage — dashless id normalization", () => {
 
     expect(useGetCsmCaseDetailMock).toHaveBeenCalledWith(DASHED_ID);
     expect(navigateMock).not.toHaveBeenCalled();
+    expect(screen.getByTestId("location-probe")).toHaveTextContent(
+      `/cases/${DASHED_ID}`,
+    );
   });
 });
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -47,7 +47,7 @@ import {
   X,
 } from "@wso2/oxygen-ui-icons-react";
 import { useCallback, useEffect, useMemo, useState, type JSX } from "react";
-import { useLocation, useParams } from "react-router";
+import { useLocation } from "react-router";
 import { useGetCsmCaseDetail } from "@features/csm-cases/api/useGetCsmCaseDetail";
 import {
   usePatchCsmCase,
@@ -167,6 +167,7 @@ import type {
 } from "@features/csm-cases/types/csmCases";
 import type { CaseState } from "@features/csm-dashboard/types/abtDashboard";
 import { useNavTransition } from "@hooks/useNavTransition";
+import { useNormalizedIdParam } from "@hooks/useNormalizedIdParam";
 
 function MetaCell({
   label,
@@ -309,7 +310,7 @@ const TAB_DEFS: Array<{
 ];
 
 export default function CsmCaseDetailPage(): JSX.Element {
-  const { caseId } = useParams<{ caseId: string }>();
+  const caseId = useNormalizedIdParam("caseId");
   const navigate = useNavTransition();
   const location = useLocation();
   const isEngagementRoute = location.pathname.startsWith("/engagements/");

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.tsx
@@ -46,7 +46,7 @@ import {
   useMemo,
   useState,
 } from "react";
-import { useLocation, useParams } from "react-router";
+import { useLocation } from "react-router";
 import { formatBackendTimestampForDisplay } from "@utils/dateTime";
 import { isBlankHtml, sanitizeRichTextHtml } from "@utils/sanitizeHtml";
 import { BackendApiError } from "@api/backend/client";
@@ -80,6 +80,7 @@ import {
 } from "@features/csm-cases/api/useCsmCaseAttachments";
 import type { BeEntityRef } from "@api/backend/types";
 import { useNavTransition } from "@hooks/useNavTransition";
+import { useNormalizedIdParam } from "@hooks/useNormalizedIdParam";
 
 const OPERATIONS_CR_PATH = "/operations?tab=change_requests";
 
@@ -182,7 +183,7 @@ const TAB_DEFS: Array<{
  * rollback / test / communication plans.
  */
 export default function CsmChangeRequestDetailPage(): JSX.Element {
-  const { id } = useParams<{ id: string }>();
+  const id = useNormalizedIdParam("id");
   const navigate = useNavTransition();
   // Prefer the list URL the row link captured (if any) so "back" returns to
   // the exact view the engineer came from, falling back to the bare tab path

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmIncidentDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmIncidentDetailPage.tsx
@@ -34,7 +34,7 @@ import {
   useMemo,
   useState,
 } from "react";
-import { useLocation, useParams } from "react-router";
+import { useLocation } from "react-router";
 import { formatBackendTimestampForDisplay } from "@utils/dateTime";
 import { BackendApiError } from "@api/backend/client";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
@@ -75,6 +75,7 @@ import type {
   BeUpdateIncidentPayload,
 } from "@api/backend/types";
 import { useNavTransition } from "@hooks/useNavTransition";
+import { useNormalizedIdParam } from "@hooks/useNormalizedIdParam";
 
 const OPERATIONS_INCIDENTS_PATH = "/operations?tab=incidents";
 
@@ -170,7 +171,7 @@ const TAB_DEFS: Array<{ id: IncidentTabId; label: string; icon: JSX.Element }> =
  * for the related, already-handled `additionalComments`/`workNotes` quirk).
  */
 export default function CsmIncidentDetailPage(): JSX.Element {
-  const { id } = useParams<{ id: string }>();
+  const id = useNormalizedIdParam("id");
   const navigate = useNavTransition();
   // Prefer the list URL the row link captured (if any) so "back" returns to
   // the exact view the engineer came from, falling back to the bare tab path

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/ProblemDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/ProblemDetailPage.tsx
@@ -17,12 +17,13 @@
 import { Box, Button, Card, Chip, Skeleton, Typography } from "@wso2/oxygen-ui";
 import { ArrowLeft, Link as LinkIcon } from "@wso2/oxygen-ui-icons-react";
 import { type JSX, type ReactNode, useEffect } from "react";
-import { useLocation, useParams } from "react-router";
+import { useLocation } from "react-router";
 import { formatBackendTimestampForDisplay } from "@utils/dateTime";
 import { useGetProblem } from "@features/csm-operations/api/useGetProblem";
 import { problemStateColor, problemStateLabel } from "@features/csm-operations/utils/problems";
 import type { BeEntityRef, BeProblemRef } from "@api/backend/types";
 import { useNavTransition } from "@hooks/useNavTransition";
+import { useNormalizedIdParam } from "@hooks/useNormalizedIdParam";
 import { useRecordRecentView } from "@features/csm-recent/hooks/useRecentViews";
 
 const OPERATIONS_PROBLEMS_PATH = "/operations?tab=problems";
@@ -95,7 +96,7 @@ function ProblemRefItem({
  * endpoint for them (unlike change requests/incidents).
  */
 export default function ProblemDetailPage(): JSX.Element {
-  const { id } = useParams<{ id: string }>();
+  const id = useNormalizedIdParam("id");
   const navigate = useNavTransition();
   // Prefer the list URL the row link captured (if any) so "back" returns to
   // the exact view the engineer came from, falling back to the bare tab path

--- a/apps/csm-portal/webapp/src/features/csm-security-center/pages/ProductVulnerabilityDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-security-center/pages/ProductVulnerabilityDetailPage.tsx
@@ -24,9 +24,10 @@ import {
 } from "@wso2/oxygen-ui";
 import { ArrowLeft } from "@wso2/oxygen-ui-icons-react";
 import { type JSX, type ReactNode } from "react";
-import { useLocation, useParams } from "react-router";
+import { useLocation } from "react-router";
 import { useGetProductVulnerability } from "@features/csm-security-center/api/useGetProductVulnerability";
 import { useNavTransition } from "@hooks/useNavTransition";
+import { useNormalizedIdParam } from "@hooks/useNormalizedIdParam";
 import {
   vulnerabilityPriorityColor,
 } from "@features/csm-security-center/utils/vulnerabilities";
@@ -76,7 +77,7 @@ function TextSection({ title, text }: { title: string; text?: string | null }): 
  * long-form text sections for use case, justification, and resolution.
  */
 export default function ProductVulnerabilityDetailPage(): JSX.Element {
-  const { id } = useParams<{ id: string }>();
+  const id = useNormalizedIdParam("id");
   const navigate = useNavTransition();
   // Prefer the list URL the row link captured (if any) so "back" returns to
   // the exact view the engineer came from, falling back to the bare tab path

--- a/apps/csm-portal/webapp/src/hooks/useNormalizedIdParam.test.tsx
+++ b/apps/csm-portal/webapp/src/hooks/useNormalizedIdParam.test.tsx
@@ -14,80 +14,114 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { renderHook, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { ReactNode } from "react";
-import { MemoryRouter, Route, Routes } from "react-router";
-
-const navigateMock = vi.fn();
-vi.mock("@hooks/useNavTransition", () => ({
-  useNavTransition: () => navigateMock,
-}));
-
-// Imported after the mock above so the module picks it up.
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { JSX } from "react";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router";
+import "@testing-library/jest-dom/vitest";
 import { useNormalizedIdParam } from "@hooks/useNormalizedIdParam";
 
 const DASHED_ID = "56f49f0a-eb1e-c310-fcf5-f5dabad0cdab";
 const DASHLESS_ID = "56f49f0aeb1ec310fcf5f5dabad0cdab";
 
-function wrapperAt(initialEntry: string) {
-  return function Wrapper({ children }: { children: ReactNode }) {
-    return (
-      <MemoryRouter initialEntries={[initialEntry]}>
-        <Routes>
-          <Route path="/cases/:caseId" element={children} />
-        </Routes>
-      </MemoryRouter>
-    );
-  };
+// Renders the real react-router stack (no mock on the navigation hook) so
+// these tests prove an actual `replace` navigation happened, not just that
+// some navigate function was called with the expected arguments.
+function LocationProbe(): JSX.Element {
+  const location = useLocation();
+  return (
+    <div data-testid="location-probe">
+      {location.pathname}
+      {location.search}
+      {location.hash}
+    </div>
+  );
+}
+
+function Probe({ paramName }: { paramName: string }): JSX.Element {
+  const id = useNormalizedIdParam(paramName);
+  return <div data-testid="hook-result">{id}</div>;
+}
+
+function renderAt(
+  initialEntry: { pathname: string; search?: string; hash?: string; state?: unknown },
+): ReturnType<typeof render> {
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <LocationProbe />
+      <Routes>
+        <Route path="/cases/:caseId" element={<Probe paramName="caseId" />} />
+      </Routes>
+    </MemoryRouter>,
+  );
 }
 
 describe("useNormalizedIdParam", () => {
-  beforeEach(() => {
-    navigateMock.mockClear();
-  });
-
   it("returns the dashed id and redirects when the route param is a dashless 32-hex id", async () => {
-    const { result } = renderHook(() => useNormalizedIdParam("caseId"), {
-      wrapper: wrapperAt(`/cases/${DASHLESS_ID}`),
-    });
+    renderAt({ pathname: `/cases/${DASHLESS_ID}` });
 
-    expect(result.current).toBe(DASHED_ID);
+    expect(screen.getByTestId("hook-result")).toHaveTextContent(DASHED_ID);
 
     await waitFor(() =>
-      expect(navigateMock).toHaveBeenCalledWith(
-        { pathname: `/cases/${DASHED_ID}`, search: "", hash: "" },
-        { replace: true },
+      expect(screen.getByTestId("location-probe")).toHaveTextContent(
+        `/cases/${DASHED_ID}`,
       ),
     );
   });
 
   it("preserves the query string and hash on the redirect", async () => {
-    const { result } = renderHook(() => useNormalizedIdParam("caseId"), {
-      wrapper: wrapperAt(`/cases/${DASHLESS_ID}?tab=comments#section-2`),
+    renderAt({
+      pathname: `/cases/${DASHLESS_ID}`,
+      search: "?tab=comments",
+      hash: "#section-2",
     });
 
-    expect(result.current).toBe(DASHED_ID);
+    expect(screen.getByTestId("hook-result")).toHaveTextContent(DASHED_ID);
 
     await waitFor(() =>
-      expect(navigateMock).toHaveBeenCalledWith(
-        {
-          pathname: `/cases/${DASHED_ID}`,
-          search: "?tab=comments",
-          hash: "#section-2",
-        },
-        { replace: true },
+      expect(screen.getByTestId("location-probe")).toHaveTextContent(
+        `/cases/${DASHED_ID}?tab=comments#section-2`,
+      ),
+    );
+  });
+
+  it("preserves router state on the redirect", async () => {
+    const state = { from: "/cases", parentState: { from: "/dashboard" } };
+
+    render(
+      <MemoryRouter
+        initialEntries={[{ pathname: `/cases/${DASHLESS_ID}`, state }]}
+      >
+        <Routes>
+          <Route
+            path="/cases/:caseId"
+            element={
+              <>
+                <Probe paramName="caseId" />
+                <StateProbe />
+              </>
+            }
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId("hook-result")).toHaveTextContent(DASHED_ID);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("state-probe")).toHaveTextContent(
+        JSON.stringify(state),
       ),
     );
   });
 
   it("returns an already-dashed id unchanged and does not navigate", () => {
-    const { result } = renderHook(() => useNormalizedIdParam("caseId"), {
-      wrapper: wrapperAt(`/cases/${DASHED_ID}`),
-    });
+    renderAt({ pathname: `/cases/${DASHED_ID}` });
 
-    expect(result.current).toBe(DASHED_ID);
-    expect(navigateMock).not.toHaveBeenCalled();
+    expect(screen.getByTestId("hook-result")).toHaveTextContent(DASHED_ID);
+    expect(screen.getByTestId("location-probe")).toHaveTextContent(
+      `/cases/${DASHED_ID}`,
+    );
   });
 
   it.each([
@@ -97,12 +131,19 @@ describe("useNormalizedIdParam", () => {
   ])(
     "returns a malformed id unchanged and does not navigate or crash — %s",
     (_desc, malformedId) => {
-      const { result } = renderHook(() => useNormalizedIdParam("caseId"), {
-        wrapper: wrapperAt(`/cases/${malformedId}`),
-      });
+      renderAt({ pathname: `/cases/${malformedId}` });
 
-      expect(result.current).toBe(malformedId);
-      expect(navigateMock).not.toHaveBeenCalled();
+      expect(screen.getByTestId("hook-result")).toHaveTextContent(malformedId);
+      expect(screen.getByTestId("location-probe")).toHaveTextContent(
+        `/cases/${malformedId}`,
+      );
     },
   );
 });
+
+function StateProbe(): JSX.Element {
+  const location = useLocation();
+  return (
+    <div data-testid="state-probe">{JSON.stringify(location.state)}</div>
+  );
+}

--- a/apps/csm-portal/webapp/src/hooks/useNormalizedIdParam.test.tsx
+++ b/apps/csm-portal/webapp/src/hooks/useNormalizedIdParam.test.tsx
@@ -1,0 +1,108 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+import { MemoryRouter, Route, Routes } from "react-router";
+
+const navigateMock = vi.fn();
+vi.mock("@hooks/useNavTransition", () => ({
+  useNavTransition: () => navigateMock,
+}));
+
+// Imported after the mock above so the module picks it up.
+import { useNormalizedIdParam } from "@hooks/useNormalizedIdParam";
+
+const DASHED_ID = "56f49f0a-eb1e-c310-fcf5-f5dabad0cdab";
+const DASHLESS_ID = "56f49f0aeb1ec310fcf5f5dabad0cdab";
+
+function wrapperAt(initialEntry: string) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <Routes>
+          <Route path="/cases/:caseId" element={children} />
+        </Routes>
+      </MemoryRouter>
+    );
+  };
+}
+
+describe("useNormalizedIdParam", () => {
+  beforeEach(() => {
+    navigateMock.mockClear();
+  });
+
+  it("returns the dashed id and redirects when the route param is a dashless 32-hex id", async () => {
+    const { result } = renderHook(() => useNormalizedIdParam("caseId"), {
+      wrapper: wrapperAt(`/cases/${DASHLESS_ID}`),
+    });
+
+    expect(result.current).toBe(DASHED_ID);
+
+    await waitFor(() =>
+      expect(navigateMock).toHaveBeenCalledWith(
+        { pathname: `/cases/${DASHED_ID}`, search: "", hash: "" },
+        { replace: true },
+      ),
+    );
+  });
+
+  it("preserves the query string and hash on the redirect", async () => {
+    const { result } = renderHook(() => useNormalizedIdParam("caseId"), {
+      wrapper: wrapperAt(`/cases/${DASHLESS_ID}?tab=comments#section-2`),
+    });
+
+    expect(result.current).toBe(DASHED_ID);
+
+    await waitFor(() =>
+      expect(navigateMock).toHaveBeenCalledWith(
+        {
+          pathname: `/cases/${DASHED_ID}`,
+          search: "?tab=comments",
+          hash: "#section-2",
+        },
+        { replace: true },
+      ),
+    );
+  });
+
+  it("returns an already-dashed id unchanged and does not navigate", () => {
+    const { result } = renderHook(() => useNormalizedIdParam("caseId"), {
+      wrapper: wrapperAt(`/cases/${DASHED_ID}`),
+    });
+
+    expect(result.current).toBe(DASHED_ID);
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["too short (31 hex chars)", DASHLESS_ID.slice(0, 31)],
+    ["too long (33 hex chars)", `${DASHLESS_ID}a`],
+    ["non-hex characters", `${DASHLESS_ID.slice(0, 30)}gz`],
+  ])(
+    "returns a malformed id unchanged and does not navigate or crash — %s",
+    (_desc, malformedId) => {
+      const { result } = renderHook(() => useNormalizedIdParam("caseId"), {
+        wrapper: wrapperAt(`/cases/${malformedId}`),
+      });
+
+      expect(result.current).toBe(malformedId);
+      expect(navigateMock).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/apps/csm-portal/webapp/src/hooks/useNormalizedIdParam.ts
+++ b/apps/csm-portal/webapp/src/hooks/useNormalizedIdParam.ts
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useEffect } from "react";
+import { useLocation, useParams } from "react-router";
+import { useNavTransition } from "@hooks/useNavTransition";
+
+// Backend ids are 36-char UUIDs (8-4-4-4-12, dashes at positions 8/13/18/23,
+// e.g. 56f49f0a-eb1e-c310-fcf5-f5dabad0cdab). Some inbound links carry the
+// same 32 hex characters with the dashes stripped — this matches that exact
+// shape only, nothing shorter/longer or non-hex.
+const DASHLESS_ID_PATTERN = /^[0-9a-f]{32}$/i;
+
+function toDashedId(dashless: string): string {
+  return [
+    dashless.slice(0, 8),
+    dashless.slice(8, 12),
+    dashless.slice(12, 16),
+    dashless.slice(16, 20),
+    dashless.slice(20, 32),
+  ].join("-");
+}
+
+/**
+ * Reads a route param that is expected to hold a backend UUID id, and
+ * transparently repairs a dashless variant of it (32 hex chars, no
+ * separators): the dashed id is returned immediately so the caller's first
+ * render/fetch already uses the corrected value, while a `replace` navigation
+ * to the dashed URL runs as a side effect so the address bar catches up.
+ *
+ * An already-dashed id, or anything that isn't exactly 32 hex chars, is
+ * returned unchanged with no navigation — malformed ids are not validated or
+ * rejected here, that stays whatever it does today (404/error state).
+ */
+export function useNormalizedIdParam(paramName: string): string | undefined {
+  const params = useParams();
+  const rawValue = params[paramName];
+  const navigate = useNavTransition();
+  const location = useLocation();
+
+  const isDashless = !!rawValue && DASHLESS_ID_PATTERN.test(rawValue);
+  const normalizedValue = isDashless && rawValue ? toDashedId(rawValue) : rawValue;
+
+  useEffect(() => {
+    if (!isDashless || !rawValue) return;
+    const dashed = toDashedId(rawValue);
+    const newPathname = location.pathname.replace(rawValue, dashed);
+    navigate(
+      { pathname: newPathname, search: location.search, hash: location.hash },
+      { replace: true },
+    );
+  }, [isDashless, rawValue, location.pathname, location.search, location.hash, navigate]);
+
+  return normalizedValue;
+}

--- a/apps/csm-portal/webapp/src/hooks/useNormalizedIdParam.ts
+++ b/apps/csm-portal/webapp/src/hooks/useNormalizedIdParam.ts
@@ -60,9 +60,17 @@ export function useNormalizedIdParam(paramName: string): string | undefined {
     const newPathname = location.pathname.replace(rawValue, dashed);
     navigate(
       { pathname: newPathname, search: location.search, hash: location.hash },
-      { replace: true },
+      { replace: true, state: location.state },
     );
-  }, [isDashless, rawValue, location.pathname, location.search, location.hash, navigate]);
+  }, [
+    isDashless,
+    rawValue,
+    location.pathname,
+    location.search,
+    location.hash,
+    location.state,
+    navigate,
+  ]);
 
   return normalizedValue;
 }


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Opening a CSM portal detail URL with the id's dashes stripped (e.g.
`/cases/56f49f0aeb1ec310fcf5f5dabad0cdab` instead of
`/cases/56f49f0a-eb1e-c310-fcf5-f5dabad0cdab`) hit the API with the wrong id shape instead
of loading the record. No tracked issue; reported directly.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

When a detail route's id param is a dashless 32-hex-char UUID, insert the dashes and
redirect (replace, not push) to the corrected URL — across every work-item type that has a
detail page keyed by such an id: cases, service requests, engagements, security reports
(SRA), incidents, change requests, problems, and product vulnerabilities.

## Approach
> Describe how you are implementing the solutions.

A shared hook, `useNormalizedIdParam(paramName)` (`src/hooks/useNormalizedIdParam.ts`),
reads the given route param, and if it matches exactly 32 hex chars with no separators,
returns the dashed (8-4-4-4-12) form immediately (so the caller's own data fetch never
fires with the bad id) and issues a `replace` navigation to the corrected path, preserving
query string and hash. An already-dashed id, or anything else, passes through unchanged
with no navigation — malformed ids keep whatever behavior they hit today.

Wired into the 5 pages that own all 8 id-bearing detail routes:
`CsmCaseDetailPage` (cases, service requests, engagements, security reports),
`CsmIncidentDetailPage`, `CsmChangeRequestDetailPage`, `ProblemDetailPage`,
`ProductVulnerabilityDetailPage` — each replacing its raw `useParams()` read of the id
field with a call to the new hook.

No UI-visible change beyond the redirect itself; no screenshot/GIF applicable.

## User stories
> Summary of user stories addressed by this change

As a CS engineer who receives or types a case/incident/SR/CR/engagement/SRA/vulnerability
link with the id's dashes accidentally stripped, I land on the correct record instead of a
broken load.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Fix: opening a work-item detail link (case, service request, engagement, security report,
incident, change request, problem, or product vulnerability) whose id is missing its dashes
now redirects to the correctly formatted URL and loads the record, instead of failing.

## Documentation
> Link(s) to product documentation

N/A — internal URL-normalization behavior, no user-facing documentation surface.

## Training
N/A — no training content affected.

## Certification
N/A — no certification exam impact.

## Marketing
N/A — not a marketing-facing feature.

## Automation tests
 - Unit tests
   > 6 new tests on `useNormalizedIdParam` (dashless→dashed conversion + redirect,
   query/hash preservation, already-dashed passthrough, 3 malformed-id cases: too short,
   too long, non-hex).
 - Integration tests
   > 2 new tests on `CsmCaseDetailPage` confirming the underlying data fetch is made with
   the corrected dashed id (not the raw dashless one) when mounted at a dashless URL, and
   that an already-dashed id triggers no redirect.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — TypeScript/React frontend, not a Java component this tool covers
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
None.

## Migrations (if applicable)
N/A — no schema, config, or data migration.

## Test environment
Verified locally: `npx tsc -b` clean; `npx eslint` on all touched files 0 errors (1
pre-existing unrelated warning, confirmed present on `main` too); `npx vitest run` — all
new/changed tests passing, whole-app run shows the same 8 pre-existing failures (in 4
files this PR doesn't touch) as `main`, confirmed by re-running those files directly
against `main`.

## Learning
N/A — straightforward client-side URL normalization, no external research required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Detail pages now recognize dashless IDs and automatically convert them to the standard dashed format.
  * Existing dashed IDs and malformed values remain unchanged.
  * URL query strings, hash fragments, and navigation state are preserved during normalization.
* **Tests**
  * Added coverage for ID normalization, redirects, unchanged values, and malformed inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->