### PR TITLE
[CSM Portal] settings: tile grid for user management directories and dashboard list

### DIFF
--- a/apps/csm-portal/webapp/src/App.tsx
+++ b/apps/csm-portal/webapp/src/App.tsx
@@ -94,6 +94,9 @@ const CreateProblemPage = lazy(
 const CsmAdminLayout = lazy(
   () => import("@features/csm-admin/pages/CsmAdminLayout"),
 );
+const CsmUserManagementLandingPage = lazy(
+  () => import("@features/csm-admin/pages/CsmUserManagementLandingPage"),
+);
 const CsmUsersPage = lazy(
   () => import("@features/csm-users/pages/CsmUsersPage"),
 );
@@ -335,7 +338,8 @@ export default function App(): JSX.Element {
                   {/* Administration — "User management" groups the
                       Users/Roles/Groups/Teams/Permissions directory pages
                       (Users/Roles/Groups/Teams are real, Permissions is still
-                      WIP) under one nested tab; Dashboards is a sibling. */}
+                      WIP) behind a tile-grid landing page; Dashboards is a
+                      sibling tab. */}
                   <Route path="admin" element={<CsmAdminLayout />}>
                     <Route
                       index
@@ -343,9 +347,7 @@ export default function App(): JSX.Element {
                     />
                     <Route
                       path="user-management"
-                      element={
-                        <SectionIndexRedirect sectionId="admin.user-management" />
-                      }
+                      element={<CsmUserManagementLandingPage />}
                     />
                     <Route path="user-management/users" element={<CsmUsersPage />} />
                     <Route path="user-management/roles" element={<CsmRolesPage />} />

--- a/apps/csm-portal/webapp/src/config/csmNavItems.ts
+++ b/apps/csm-portal/webapp/src/config/csmNavItems.ts
@@ -21,10 +21,14 @@ import {
   Clock,
   Cog,
   Headset,
+  KeyRound,
   Megaphone,
   RefreshCw,
   Settings,
   Shield,
+  UserCog,
+  Users,
+  UsersRound,
 } from "@wso2/oxygen-ui-icons-react";
 import type { ComponentType } from "react";
 
@@ -213,21 +217,25 @@ export const CSM_NAV_ITEMS: CsmNavSection[] = [
             id: "admin.user-management.users",
             label: "Users",
             href: "/admin/user-management/users",
+            icon: Users,
           },
           {
             id: "admin.user-management.roles",
             label: "Roles",
             href: "/admin/user-management/roles",
+            icon: UserCog,
           },
           {
             id: "admin.user-management.groups",
             label: "Groups",
             href: "/admin/user-management/groups",
+            icon: UsersRound,
           },
           {
             id: "admin.user-management.teams",
             label: "Teams",
             href: "/admin/user-management/teams",
+            icon: Building2,
           },
           // Routes to a placeholder that already names its backend blocker, so
           // it renders itself rather than the generic WIP page.
@@ -236,6 +244,7 @@ export const CSM_NAV_ITEMS: CsmNavSection[] = [
             label: "Permissions",
             href: "/admin/user-management/permissions",
             rendersOwnWipPage: true,
+            icon: KeyRound,
           },
         ],
       },

--- a/apps/csm-portal/webapp/src/features/csm-admin/dashboards/pages/CsmDashboardBuilderListPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/dashboards/pages/CsmDashboardBuilderListPage.test.tsx
@@ -65,8 +65,7 @@ describe("CsmDashboardBuilderListPage", () => {
     await waitFor(() => expect(screen.getByText("Engineer overview")).toBeInTheDocument());
     expect(screen.getByText("Team performance")).toBeInTheDocument();
 
-    const editButtons = screen.getAllByRole("button", { name: "Edit" });
-    fireEvent.click(editButtons[0]);
+    fireEvent.click(screen.getByText("Engineer overview"));
 
     await waitFor(() =>
       expect(screen.getByTestId("location-probe")).toHaveTextContent("/admin/dashboards/agents_pilot"),

--- a/apps/csm-portal/webapp/src/features/csm-admin/dashboards/pages/CsmDashboardBuilderListPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/dashboards/pages/CsmDashboardBuilderListPage.tsx
@@ -18,6 +18,7 @@ import {
   Box,
   Button,
   Card,
+  CardActionArea,
   Chip,
   IconButton,
   Skeleton,
@@ -115,41 +116,42 @@ export default function CsmDashboardBuilderListPage(): JSX.Element {
           No dashboards are registered in this deployment yet.
         </Typography>
       ) : (
-        <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+        <Box
+          sx={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fill, minmax(320px, 1fr))",
+            gap: 2,
+          }}
+        >
           {(dashboards ?? []).map((d) => (
-            <Card
-              key={d.id}
-              variant="outlined"
-              sx={{
-                p: 2,
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "space-between",
-                gap: 2,
-              }}
-            >
-              <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, minWidth: 0 }}>
-                <LayoutGrid size={18} />
-                <Box sx={{ minWidth: 0 }}>
-                  <Typography variant="body1" sx={{ fontWeight: 600 }} noWrap>
+            <Card key={d.id} variant="outlined">
+              <CardActionArea
+                onClick={() => navigate(`/admin/dashboards/${d.id}`)}
+                sx={{
+                  p: 3,
+                  display: "flex",
+                  flexDirection: "column",
+                  alignItems: "flex-start",
+                  gap: 1.5,
+                  minHeight: 120,
+                }}
+              >
+                <LayoutGrid size={24} />
+                <Box sx={{ minWidth: 0, width: "100%" }}>
+                  <Typography variant="subtitle1" sx={{ fontWeight: 600 }} noWrap>
                     {d.displayName}
                   </Typography>
-                  <Typography variant="caption" color="text.secondary">
+                  <Typography variant="caption" color="text.secondary" noWrap>
                     {d.id}
                   </Typography>
                 </Box>
-                {d.isDefault && <Chip size="small" label="Default" />}
-                {d.isTeamBased && <Chip size="small" label="Team-based" variant="outlined" />}
-                {d.type && <Chip size="small" label={d.type.toUpperCase()} variant="outlined" />}
-                {draftIds.has(d.id) && <LocalDraftDriftChip dashboardId={d.id} />}
-              </Box>
-              <Button
-                variant="outlined"
-                size="small"
-                onClick={() => navigate(`/admin/dashboards/${d.id}`)}
-              >
-                Edit
-              </Button>
+                <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5 }}>
+                  {d.isDefault && <Chip size="small" label="Default" />}
+                  {d.isTeamBased && <Chip size="small" label="Team-based" variant="outlined" />}
+                  {d.type && <Chip size="small" label={d.type.toUpperCase()} variant="outlined" />}
+                  {draftIds.has(d.id) && <LocalDraftDriftChip dashboardId={d.id} />}
+                </Box>
+              </CardActionArea>
             </Card>
           ))}
         </Box>
@@ -160,46 +162,49 @@ export default function CsmDashboardBuilderListPage(): JSX.Element {
           <Typography variant="subtitle2">
             Local drafts not yet deployed
           </Typography>
-          {orphanDrafts.map((d) => (
-            <Card
-              key={d.id}
-              variant="outlined"
-              sx={{
-                p: 2,
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "space-between",
-                gap: 2,
-              }}
-            >
-              <Box sx={{ minWidth: 0 }}>
-                <Typography variant="body1" sx={{ fontWeight: 600 }} noWrap>
-                  {d.displayName || "Untitled dashboard"}
-                </Typography>
-                <Typography variant="caption" color="text.secondary">
-                  Saved locally {new Date(d.updatedAt).toLocaleString()}
-                </Typography>
-              </Box>
-              <Box sx={{ display: "flex", gap: 1 }}>
-                <Button
-                  variant="outlined"
-                  size="small"
-                  onClick={() => navigate(`/admin/dashboards/${d.id}`)}
-                >
-                  Continue editing
-                </Button>
+          <Box
+            sx={{
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fill, minmax(320px, 1fr))",
+              gap: 2,
+            }}
+          >
+            {orphanDrafts.map((d) => (
+              <Card key={d.id} variant="outlined" sx={{ position: "relative" }}>
                 <Tooltip title="Discard this local draft">
                   <IconButton
                     size="small"
                     aria-label={`Discard draft ${d.displayName || d.id}`}
                     onClick={() => handleDiscardDraft(d.id)}
+                    sx={{ position: "absolute", top: 4, right: 4, zIndex: 1 }}
                   >
                     <Trash2 size={16} />
                   </IconButton>
                 </Tooltip>
-              </Box>
-            </Card>
-          ))}
+                <CardActionArea
+                  onClick={() => navigate(`/admin/dashboards/${d.id}`)}
+                  sx={{
+                    p: 3,
+                    display: "flex",
+                    flexDirection: "column",
+                    alignItems: "flex-start",
+                    gap: 1.5,
+                    minHeight: 120,
+                  }}
+                >
+                  <LayoutGrid size={24} />
+                  <Box sx={{ minWidth: 0, width: "100%", pr: 3 }}>
+                    <Typography variant="subtitle1" sx={{ fontWeight: 600 }} noWrap>
+                      {d.displayName || "Untitled dashboard"}
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      Saved locally {new Date(d.updatedAt).toLocaleString()}
+                    </Typography>
+                  </Box>
+                </CardActionArea>
+              </Card>
+            ))}
+          </Box>
         </Box>
       )}
     </Box>

--- a/apps/csm-portal/webapp/src/features/csm-admin/pages/CsmAdminLayout.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/pages/CsmAdminLayout.test.tsx
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import "@testing-library/jest-dom/vitest";
 import { vi } from "vitest";
@@ -44,6 +44,7 @@ function renderLayout(initialEntry: string) {
     <MemoryRouter initialEntries={[initialEntry]}>
       <Routes>
         <Route path="/admin" element={<CsmAdminLayout />}>
+          <Route path="user-management" element={<div>User management tiles</div>} />
           <Route path="user-management/users" element={<div>Users content</div>} />
           <Route path="user-management/roles" element={<div>Roles content</div>} />
           <Route path="user-management/groups" element={<div>Groups content</div>} />
@@ -59,13 +60,11 @@ function renderLayout(initialEntry: string) {
 describe("CsmAdminLayout — top-level tabs", () => {
   it("shows only User management and Dashboards at the top level, for an admin user", () => {
     mockRoles = ["admin"];
-    // Dashboards active, so the nested User management strip is absent —
-    // isolates the top-level strip's own two tabs from its sub-tabs.
     renderLayout("/admin/dashboards");
     expect(screen.getByRole("tab", { name: "User management" })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "Dashboards" })).toBeInTheDocument();
-    // The five directory pages are only reachable as User management's nested
-    // sub-tabs, never as top-level tabs.
+    // The five directory pages are only reachable as tiles on the User
+    // management landing page, never as top-level tabs.
     expect(screen.queryByRole("tab", { name: "Users" })).not.toBeInTheDocument();
   });
 
@@ -77,52 +76,34 @@ describe("CsmAdminLayout — top-level tabs", () => {
   });
 });
 
-describe("CsmAdminLayout — nested User management tabs", () => {
-  it("shows User management's five sub-tabs when it is the active top-level tab", () => {
+describe("CsmAdminLayout — back link to the User management tile grid", () => {
+  it("shows no back link on the landing route itself", () => {
     mockRoles = ["admin"];
-    renderLayout("/admin/user-management/users");
-    expect(screen.getByRole("tab", { name: "User management" })).toHaveAttribute(
-      "aria-selected",
-      "true",
-    );
-    for (const label of ["Users", "Roles", "Groups", "Teams", "Permissions"]) {
-      expect(screen.getByRole("tab", { name: label })).toBeInTheDocument();
-    }
+    renderLayout("/admin/user-management");
+    expect(screen.getByText("User management tiles")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /back to user management/i }),
+    ).not.toBeInTheDocument();
   });
 
-  it("marks the sub-tab matching the current route as active", () => {
+  it("shows a back link on each directory page reached via a tile, and it returns to the landing route", () => {
     mockRoles = ["admin"];
     renderLayout("/admin/user-management/roles");
-    expect(screen.getByRole("tab", { name: "Roles" })).toHaveAttribute(
-      "aria-selected",
-      "true",
-    );
     expect(screen.getByText("Roles content")).toBeInTheDocument();
+    const back = screen.getByRole("button", { name: /back to user management/i });
+
+    fireEvent.click(back);
+
+    expect(screen.getByText("User management tiles")).toBeInTheDocument();
+    expect(screen.queryByText("Roles content")).not.toBeInTheDocument();
   });
 
-  it("deep-links directly to a sub-page with both levels active and the right outlet rendered", () => {
-    mockRoles = ["admin"];
-    renderLayout("/admin/user-management/groups");
-    expect(screen.getByRole("tab", { name: "User management" })).toHaveAttribute(
-      "aria-selected",
-      "true",
-    );
-    expect(screen.getByRole("tab", { name: "Groups" })).toHaveAttribute(
-      "aria-selected",
-      "true",
-    );
-    expect(screen.getByText("Groups content")).toBeInTheDocument();
-  });
-
-  it("does not render the nested strip when Dashboards is the active top-level tab", () => {
+  it("does not show the back link when Dashboards is the active top-level tab", () => {
     mockRoles = ["admin"];
     renderLayout("/admin/dashboards");
-    expect(screen.getByRole("tab", { name: "Dashboards" })).toHaveAttribute(
-      "aria-selected",
-      "true",
-    );
-    expect(screen.queryByRole("tab", { name: "Users" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("tab", { name: "Roles" })).not.toBeInTheDocument();
     expect(screen.getByText("Dashboards content")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /back to user management/i }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-admin/pages/CsmAdminLayout.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/pages/CsmAdminLayout.test.tsx
@@ -18,7 +18,12 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import "@testing-library/jest-dom/vitest";
 import { vi } from "vitest";
-import { MemoryRouter, Route, Routes } from "react-router";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router";
+
+function LocationProbe() {
+  const location = useLocation();
+  return <div data-testid="location-probe">{location.pathname}</div>;
+}
 
 let mockRoles: string[] | undefined = ["admin"];
 
@@ -44,7 +49,15 @@ function renderLayout(initialEntry: string) {
     <MemoryRouter initialEntries={[initialEntry]}>
       <Routes>
         <Route path="/admin" element={<CsmAdminLayout />}>
-          <Route path="user-management" element={<div>User management tiles</div>} />
+          <Route
+            path="user-management"
+            element={
+              <>
+                <div>User management tiles</div>
+                <LocationProbe />
+              </>
+            }
+          />
           <Route path="user-management/users" element={<div>Users content</div>} />
           <Route path="user-management/roles" element={<div>Roles content</div>} />
           <Route path="user-management/groups" element={<div>Groups content</div>} />
@@ -94,6 +107,7 @@ describe("CsmAdminLayout — back link to the User management tile grid", () => 
 
     fireEvent.click(back);
 
+    expect(screen.getByTestId("location-probe")).toHaveTextContent("/admin/user-management");
     expect(screen.getByText("User management tiles")).toBeInTheDocument();
     expect(screen.queryByText("Roles content")).not.toBeInTheDocument();
   });

--- a/apps/csm-portal/webapp/src/features/csm-admin/pages/CsmAdminLayout.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/pages/CsmAdminLayout.tsx
@@ -14,37 +14,35 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Box, Typography } from "@wso2/oxygen-ui";
+import { Box, Button, Typography } from "@wso2/oxygen-ui";
+import { ArrowLeft } from "@wso2/oxygen-ui-icons-react";
 import { type JSX, Suspense, useMemo } from "react";
-import { Outlet } from "react-router";
+import { Outlet, useLocation, useNavigate } from "react-router";
 import RouteSuspenseFallback from "@components/route-fallback/RouteSuspenseFallback";
 import SectionTabs from "@components/section-tabs/SectionTabs";
 import { useRouteTabs } from "@hooks/useSectionTabs";
 import { useCurrentUser } from "@context/current-user/CurrentUserContext";
 import { hasDashboardBuilderAccess } from "@features/csm-admin/dashboards/utils/dashboardBuilderAccess";
 
-/** The nav-node id of the "User management" tab — the only one with its own nested strip. */
-const USER_MANAGEMENT_ID = "admin.user-management";
+/** The tile-grid landing route itself — everything deeper under it gets the back link below. */
+const USER_MANAGEMENT_INDEX_PATH = "/admin/user-management";
 
 /**
- * Settings shell. Two tab levels, both driven by the navigation tree: a
- * top-level strip for [User management, Dashboards], and — only while User
- * management is the active top-level tab — a second, visually subordinate
- * strip underneath it for its own Users / Roles / Groups / Teams / Permissions
- * tabs. Which of those a deployment offers (and which are chipped as work in
- * progress) is decided by `CSM_PORTAL_FEATURE_OVERRIDES` rather than hardcoded
- * here.
+ * Settings shell. A single top-level tab strip, driven by the navigation
+ * tree, for [User management, Dashboards]. User management no longer has its
+ * own nested tab strip underneath it — its Users/Roles/Groups/Teams/
+ * Permissions directories are chosen from a tile grid instead
+ * (`CsmUserManagementLandingPage`, rendered at the `user-management` index
+ * route). Since a directory page reached via a tile has no tab strip to
+ * click back through, this shell adds an explicit "Back to User management"
+ * link above the `<Outlet>` whenever the current route is one level or more
+ * below that index route.
  *
- * The second strip is not a bespoke nesting mechanism: `useRouteTabs` already
- * resolves a section id's children generically, so getting User management's
- * own tabs is just calling it again with `admin.user-management` instead of
- * `admin`.
- *
- * One exception: the "Dashboards" tab is additionally filtered by the
- * signed-in user's own admin role (frontend-only — see
- * `dashboardBuilderAccess.ts` for why this tab specifically needs it, unlike
- * every sibling tab here). This never removes a tab `CSM_PORTAL_FEATURE_OVERRIDES`
- * itself hid/marked WIP — it only ever narrows what a non-admin sees further.
+ * The "Dashboards" tab is additionally filtered by the signed-in user's own
+ * admin role (frontend-only — see `dashboardBuilderAccess.ts` for why this
+ * tab specifically needs it, unlike its sibling). This never removes a tab
+ * `CSM_PORTAL_FEATURE_OVERRIDES` itself hid/marked WIP — it only ever narrows
+ * what a non-admin sees further.
  */
 export default function CsmAdminLayout(): JSX.Element {
   const { user } = useCurrentUser();
@@ -62,28 +60,27 @@ export default function CsmAdminLayout(): JSX.Element {
     return { ...allTabs, tabs: visible, activeKey };
   }, [allTabs, isAdmin]);
 
-  // Always resolved (rules of hooks) — only rendered once User management is
-  // the active top-level tab. Cheap: it's the same route/location read the
-  // top-level hook call already does, just matched against a different node's
-  // children.
-  const userManagementTabs = useRouteTabs(USER_MANAGEMENT_ID);
-  const activeTopNode = tabs.tabs.find((tab) => tab.key === tabs.activeKey)?.node;
-  const showUserManagementTabs = activeTopNode?.id === USER_MANAGEMENT_ID;
+  const { pathname } = useLocation();
+  const navigate = useNavigate();
+  const showBackToUserManagement = pathname.startsWith(`${USER_MANAGEMENT_INDEX_PATH}/`);
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
       <Typography variant="h5">Settings</Typography>
 
-      <Box sx={{ display: "flex", flexDirection: "column" }}>
-        <SectionTabs {...tabs} ariaLabel="Settings tabs" scrollable />
-        {showUserManagementTabs && (
-          <SectionTabs
-            {...userManagementTabs}
-            ariaLabel="User management tabs"
-            variant="secondary"
-          />
-        )}
-      </Box>
+      <SectionTabs {...tabs} ariaLabel="Settings tabs" scrollable />
+
+      {showBackToUserManagement && (
+        <Button
+          variant="text"
+          size="small"
+          startIcon={<ArrowLeft size={16} />}
+          onClick={() => navigate(USER_MANAGEMENT_INDEX_PATH)}
+          sx={{ alignSelf: "flex-start" }}
+        >
+          Back to User management
+        </Button>
+      )}
 
       <Suspense fallback={<RouteSuspenseFallback />}>
         <Outlet />

--- a/apps/csm-portal/webapp/src/features/csm-admin/pages/CsmUserManagementLandingPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/pages/CsmUserManagementLandingPage.tsx
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Box, Card, CardActionArea, Chip, Typography } from "@wso2/oxygen-ui";
+import { LayoutGrid } from "@wso2/oxygen-ui-icons-react";
+import type { JSX } from "react";
+import { useNavigate } from "react-router";
+import { useRouteTabs } from "@hooks/useSectionTabs";
+
+/**
+ * Landing page for Settings → User management: a tile per directory
+ * (Users/Roles/Groups/Teams/Permissions) instead of the tab strip these used
+ * to share. Reuses `useRouteTabs("admin.user-management")` — the same
+ * nav-tree-driven, `CSM_PORTAL_FEATURE_OVERRIDES`-filtered list the old
+ * secondary tab strip rendered — so which tiles appear (and which show as
+ * "WIP") is still decided in one place, not duplicated here.
+ */
+export default function CsmUserManagementLandingPage(): JSX.Element {
+  const navigate = useNavigate();
+  const { tabs } = useRouteTabs("admin.user-management");
+
+  return (
+    <Box
+      sx={{
+        display: "grid",
+        gridTemplateColumns: "repeat(auto-fill, minmax(200px, 1fr))",
+        gap: 2,
+      }}
+    >
+      {tabs.map((tab) => {
+        const Icon = tab.node.icon ?? LayoutGrid;
+        const isWip = tab.state === "wip";
+        return (
+          <Card key={tab.key} variant="outlined">
+            <CardActionArea
+              disabled={isWip}
+              onClick={() => navigate(tab.key)}
+              sx={{
+                p: 3,
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "flex-start",
+                gap: 1.5,
+                minHeight: 120,
+              }}
+            >
+              <Icon size={24} />
+              <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+                  {tab.label}
+                </Typography>
+                {isWip && (
+                  <Chip
+                    size="small"
+                    label="WIP"
+                    color="warning"
+                    variant="outlined"
+                    sx={{ height: 18, fontSize: 10 }}
+                  />
+                )}
+              </Box>
+            </CardActionArea>
+          </Card>
+        );
+      })}
+    </Box>
+  );
+}


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

We are adding a tile-based landing pattern to two spots in Settings that previously relied on tab strips: User management's Users/Roles/Groups/Teams/Permissions directories, and the Dashboard builder's dashboard list. Tabs work poorly once a section has several distinct destinations with no natural default — a tile grid makes each destination a clearly labeled, equally-weighted choice.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

- Settings → User management now lands on a tile grid (Users/Roles/Groups/Teams/Permissions) instead of auto-redirecting into the first tab.
- Settings → Dashboards' dashboard list (deployed dashboards + local drafts) renders as a wider tile grid instead of stacked row cards.
- Since tiles replace the old tab strip, each User management directory page now has an explicit "Back to User management" link back to the tile grid.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

- `CsmUserManagementLandingPage.tsx` (new): reuses the existing `useRouteTabs("admin.user-management")` hook — the same nav-tree-driven, `CSM_PORTAL_FEATURE_OVERRIDES`-filtered list the old secondary tab strip rendered — so tile visibility/WIP state stays decided in one place. Wired in as the `user-management` index route in `App.tsx`, replacing the old `SectionIndexRedirect`.
- `CsmAdminLayout.tsx`: dropped the secondary Users/Roles/Groups/Teams/Permissions tab strip (top-level Settings tabs for User management/Dashboards are unchanged); added a route-driven "Back to User management" link shown on any route one level or more below `/admin/user-management`.
- `csmNavItems.ts`: added an icon to each `admin.user-management` child node, used by the new tile grid.
- `CsmDashboardBuilderListPage.tsx`: converted both the deployed-dashboards list and the local-drafts list from vertical row `Card`s to a `CardActionArea`-based tile grid (wider min column than the user-management tiles, to fit the extra chips). The draft-discard action stays a separate icon button overlaid on its tile, since it's a distinct destructive action rather than navigation.
- Updated `CsmAdminLayout.test.tsx` (nested-tab tests → back-link tests) and `CsmDashboardBuilderListPage.test.tsx` (one test asserted on the removed "Edit" button; now clicks the tile itself) to match.

## User stories
> Summary of user stories addressed by this change

As a CS engineer/admin, I can see all of Settings → User management's directories (and all dashboards under the builder) at a glance as tiles, pick the one I need, and get back to that grid without hunting for a tab.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Settings → User management and the dashboard builder's dashboard list now use a tile grid instead of tabs/rows for navigating to a directory or dashboard.

## Documentation
N/A — internal admin UI navigation change, no externally documented behavior affected.

## Training
N/A — not training content.

## Certification
N/A — no certification exam impact.

## Marketing
N/A — internal admin UI change, not user-facing product marketing.

## Automation tests
 - Unit tests
   > Updated `CsmAdminLayout.test.tsx` (top-level tabs unaffected; nested-tab assertions replaced with back-link coverage: hidden on the landing route, shown and functional on each directory page, hidden on Dashboards) and `CsmDashboardBuilderListPage.test.tsx` (tile click replaces the old "Edit" button click). All pass (`pnpm vitest run`), plus the existing `adminRoutes.redirects.test.tsx` suite.
 - Integration tests
   > None added — no backend/contract change; this is presentation-only.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — TypeScript/React code, not Java; ran `tsc -b` and `eslint` clean on all changed files instead.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no sample code included.

## Related PRs
None.

## Migrations (if applicable)
N/A — no data or schema migration; frontend-only navigation change.

## Test environment
Verified against the local full-stack topology (local Ballerina entity-service → real ServiceNow DEV tenant, real Asgardeo login), webapp on Vite dev server, macOS/Chrome.

## Learning
N/A — straightforward reuse of this codebase's existing nav-tree/tab-strip data hook (`useRouteTabs`) and MUI `CardActionArea`, no new research involved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a tile-based User Management landing page for navigating directory areas.
  * Added icons for Users, Roles, Groups, Teams, and Permissions.
  * Added “Back to User management” navigation on directory pages.
  * Marked work-in-progress areas and disabled navigation where applicable.
  * Improved dashboard and draft layouts with responsive, clickable cards.

* **Bug Fixes**
  * Dashboard names now provide direct navigation to dashboard pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->