### PR TITLE
Add view, case-matrix and side-menu E2E coverage

### DIFF
--- a/apps/customer-portal/webapp/tests/e2e/config/testData.ts
+++ b/apps/customer-portal/webapp/tests/e2e/config/testData.ts
@@ -86,6 +86,11 @@ export interface ProjectFixture {
    * CreateCasePage.tsx). Cannot be derived from `productVersion` by trimming, so
    * it is recorded explicitly. */
   productName: string;
+  /** Whether the project offers the "Security Report" item in the Get Help
+   * dropdown. Gated on the project's SRA write access
+   * (`isSecurityReportVisible` in GetHelpDropdown.tsx) — Cloud Support does not
+   * have it, so specs assert its absence rather than trying to raise one. */
+  hasSecurityReport: boolean;
 }
 
 /**
@@ -106,6 +111,7 @@ export const PROJECTS: Record<ProjectType, ProjectFixture> = {
     autoSelectsDeployment: false,
     productVersion: "WSO2 API Manager 4.5.0",
     productName: "WSO2 API Manager",
+    hasSecurityReport: true,
   },
   [ProjectType.MANAGED_CLOUD_SUBSCRIPTION]: {
     id: "a0873629eba28f90fcf5f5dabad0cda0",
@@ -117,6 +123,7 @@ export const PROJECTS: Record<ProjectType, ProjectFixture> = {
     autoSelectsDeployment: false,
     productVersion: "WSO2 Identity Server 7.1.0",
     productName: "WSO2 Identity Server",
+    hasSecurityReport: true,
   },
   [ProjectType.CLOUD_SUPPORT]: {
     id: "cd9776ed3ba28b503e1e088aa4e45a81",
@@ -129,6 +136,7 @@ export const PROJECTS: Record<ProjectType, ProjectFixture> = {
     autoSelectsDeployment: true,
     productVersion: "WSO2 Developer Platform",
     productName: "WSO2 Developer Platform",
+    hasSecurityReport: false,
   },
 };
 
@@ -241,6 +249,371 @@ export const SERVICE_REQUEST_INPUT: ServiceRequestInput = {
   description: "This is a test Generic Request SR for MS subscription project",
 };
 
+/** Short code for each severity, for building case subjects. The display label
+ * cannot be used directly: S4's is "S4(Query)", which would produce subjects like
+ * "subscription case S4(Query)". */
+export const SEVERITY_CODES: Record<Severity, string> = {
+  [Severity.S0]: "S0",
+  [Severity.S1]: "S1",
+  [Severity.S2]: "S2",
+  [Severity.S3]: "S3",
+  [Severity.S4]: "S4",
+};
+
+/** Severities the case matrix covers, per project. */
+export const CASE_MATRIX_SEVERITIES: Severity[] = [
+  Severity.S1,
+  Severity.S2,
+  Severity.S3,
+  Severity.S4,
+];
+
+/**
+ * Naming for the case matrix: one case per project type per severity.
+ *
+ * Subjects are deterministic — `<titlePrefix> <severity code>` — because that is
+ * what makes the spec idempotent: it searches for the subject and only creates a
+ * case when none is found. Changing a prefix orphans the existing cases and the
+ * next run recreates the whole row, so treat these as fixed.
+ */
+export const CASE_MATRIX: Record<
+  ProjectType,
+  { titlePrefix: string; descriptionPrefix: string }
+> = {
+  [ProjectType.SUBSCRIPTION]: {
+    titlePrefix: "subscription case",
+    descriptionPrefix:
+      "This is a test case for subscription project with severity",
+  },
+  [ProjectType.MANAGED_CLOUD_SUBSCRIPTION]: {
+    titlePrefix: "MS subscription case",
+    descriptionPrefix:
+      "This is a test case for MS subscription project with severity",
+  },
+  [ProjectType.CLOUD_SUPPORT]: {
+    titlePrefix: "Cloud support case",
+    descriptionPrefix:
+      "This is a test case for cloud support project with severity",
+  },
+};
+
+/** A case to open and inspect on its detail page. */
+export interface CaseView {
+  /** Severity the case was raised at, as the header renders it (S1, S2, …). */
+  severity: Severity;
+  /** Case sysid, as it appears in `/support/cases/<id>`. */
+  caseId: string;
+  /** Subject shown in the header. */
+  subject: string;
+  /** Comment on the Activity tab — the case's original description. */
+  comment: string;
+}
+
+/** One project's set of cases for the view-case spec. */
+export interface CaseViewSet {
+  projectType: ProjectType;
+  /** WSO2 Case ID format for this project. The prefix is project-specific and
+   * is NOT the same as `ProjectFixture.projectKey` — Cloud Support's cases read
+   * `AUTOMATIONTESTCUSCLSUB-<n>`, verified live. */
+  wso2CaseIdPattern: RegExp;
+  cases: CaseView[];
+}
+
+/**
+ * Existing cases to open and assert, one per severity per project. Read-only —
+ * these are opened and checked, never modified.
+ *
+ * Sysids, subjects and comments are environment data, all read off the live
+ * pages, so this has to be recaptured for any other tenant.
+ *
+ * Subjects and comments are pinned per case rather than derived from a pattern,
+ * because the naming is not uniform: the Subscription and Cloud Support S4 cases
+ * carry no severity suffix and no "…with severity" in their comment (they came
+ * from `CASE_INPUT`), while every other case — including MCS's S4 — follows the
+ * per-severity naming.
+ */
+export const CASE_VIEWS: CaseViewSet[] = [
+  {
+    projectType: ProjectType.SUBSCRIPTION,
+    wso2CaseIdPattern: /^AUTOMATIONTESTCUSSUB-\d+$/,
+    cases: [
+      {
+        severity: Severity.S1,
+        caseId: "ce1502cf3bee4b103e1e088aa4e45a6d",
+        subject: "subscription case S1",
+        comment:
+          "This is a test case for subscription project with severity S1",
+      },
+      {
+        severity: Severity.S2,
+        caseId: "d225c2473ba64b1091404c6aa5e45af0",
+        subject: "subscription case S2",
+        comment:
+          "This is a test case for subscription project with severity S2",
+      },
+      {
+        severity: Severity.S3,
+        caseId: "12350ecf3bee4b103e1e088aa4e45a9b",
+        subject: "subscription case S3",
+        comment:
+          "This is a test case for subscription project with severity S3",
+      },
+      {
+        severity: Severity.S4,
+        caseId: "62e442073ba64b1091404c6aa5e45a39",
+        subject: "subscription case",
+        comment: "This is a test case for subscription project",
+      },
+    ],
+  },
+  {
+    projectType: ProjectType.MANAGED_CLOUD_SUBSCRIPTION,
+    wso2CaseIdPattern: /^AUTOMATIONTESTCUSMSSUB-\d+$/,
+    cases: [
+      {
+        severity: Severity.S1,
+        caseId: "07962293ebeec310fcf5f5dabad0cdcd",
+        subject: "MS subscription case S1",
+        comment:
+          "This is a test case for MS subscription project with severity S1",
+      },
+      {
+        severity: Severity.S2,
+        caseId: "67a6aedb3bea0f1091404c6aa5e45a8f",
+        subject: "MS subscription case S2",
+        comment:
+          "This is a test case for MS subscription project with severity S2",
+      },
+      {
+        severity: Severity.S3,
+        caseId: "33b6661f3bea0f1091404c6aa5e45a7e",
+        subject: "MS subscription case S3",
+        comment:
+          "This is a test case for MS subscription project with severity S3",
+      },
+      {
+        // Unlike the other two projects, this project's S4 case follows the same
+        // naming as its S1-S3 — it was raised through the case matrix rather than
+        // from CASE_INPUT.
+        severity: Severity.S4,
+        caseId: "c4d62e93ebeec310fcf5f5dabad0cdbb",
+        subject: "MS subscription case S4",
+        comment:
+          "This is a test case for MS subscription project with severity S4",
+      },
+    ],
+  },
+  {
+    projectType: ProjectType.CLOUD_SUPPORT,
+    wso2CaseIdPattern: /^AUTOMATIONTESTCUSCLSUB-\d+$/,
+    cases: [
+      {
+        severity: Severity.S1,
+        caseId: "d4e66e1f3bea0f1091404c6aa5e45ae0",
+        subject: "Cloud support case S1",
+        comment:
+          "This is a test case for cloud support project with severity S1",
+      },
+      {
+        severity: Severity.S2,
+        caseId: "d8f626d3ebeec310fcf5f5dabad0cd98",
+        subject: "Cloud support case S2",
+        comment:
+          "This is a test case for cloud support project with severity S2",
+      },
+      {
+        severity: Severity.S3,
+        caseId: "d407eed33baa4f103e1e088aa4e45a5c",
+        subject: "Cloud support case S3",
+        comment:
+          "This is a test case for cloud support project with severity S3",
+      },
+      {
+        severity: Severity.S4,
+        caseId: "4a054a8f3bee4b103e1e088aa4e45a11",
+        subject: "Cloud support case",
+        comment: "This is a test case for cloud support project",
+      },
+    ],
+  },
+];
+
+/** A security report analysis to open and inspect. */
+export interface SraView {
+  projectType: ProjectType;
+  /** SRA sysid, as it appears in
+   * `/security-center/security-report-analysis/<id>`. */
+  sraId: string;
+  /** Subject shown in the header.
+   *
+   * ⚠️ Pinned literally, and the date in it is the date the SRA was RAISED, not
+   * today's. Security report subjects are generated as
+   * `<deployment> - <product name> - YYYY-MM-DD` at creation time, so for an
+   * existing record that string is fixed. Do not "fix" this by computing today's
+   * date — that would break the test the next day.
+   */
+  subject: string;
+  /** WSO2 Case ID format for this project. */
+  wso2CaseIdPattern: RegExp;
+}
+
+/**
+ * Existing security report analyses to open and assert. Read-only.
+ *
+ * Sysids and subjects are environment data, read off the live pages.
+ */
+export const SRA_VIEWS: SraView[] = [
+  {
+    projectType: ProjectType.SUBSCRIPTION,
+    sraId: "5fc57257eba20710fcf5f5dabad0cd08",
+    subject: "Production - WSO2 API Manager - 2026-08-12",
+    wso2CaseIdPattern: /^AUTOMATIONTESTCUSSUB-\d+$/,
+  },
+  {
+    projectType: ProjectType.MANAGED_CLOUD_SUBSCRIPTION,
+    sraId: "92d57e1b3b6e4f103e1e088aa4e45a9b",
+    subject: "Production - WSO2 Identity Server - 2026-08-12",
+    wso2CaseIdPattern: /^AUTOMATIONTESTCUSMSSUB-\d+$/,
+  },
+];
+
+/** A service request to open and inspect. */
+export interface ServiceRequestView {
+  projectType: ProjectType;
+  /** Service request sysid, as it appears in
+   * `/operations/service-requests/<id>`. */
+  serviceRequestId: string;
+  /** Subject shown in the header. For a service request this is the Request
+   * Details value it was raised with, which is why it reuses
+   * SERVICE_REQUEST_INPUT rather than repeating the string. */
+  subject: string;
+  /** WSO2 Case ID format for this project. */
+  wso2CaseIdPattern: RegExp;
+}
+
+/**
+ * Existing service requests to open and assert. Read-only.
+ *
+ * Sysids are environment data, read off the live pages.
+ */
+export const SERVICE_REQUEST_VIEWS: ServiceRequestView[] = [
+  {
+    projectType: ProjectType.MANAGED_CLOUD_SUBSCRIPTION,
+    serviceRequestId: "7ef3c6d7eb2ac310fcf5f5dabad0cdcc",
+    subject: SERVICE_REQUEST_INPUT.requestDetails,
+    wso2CaseIdPattern: /^AUTOMATIONTESTCUSMSSUB-\d+$/,
+  },
+];
+
+/** Subject of the announcement published to all three automation projects. */
+export const SHARED_ANNOUNCEMENT_SUBJECT =
+  "[SECURITY Announcement] Lack of access control in the keymanager-operations " +
+  "DCR endpoint (WSO2-2025-4483/CVE-2025-9152)";
+
+/** An announcement to open and inspect. */
+export interface AnnouncementView {
+  projectType: ProjectType;
+  /** Announcement sysid, as it appears in `/announcements/<id>`. */
+  announcementId: string;
+  /** Subject shown in the header. */
+  subject: string;
+  /** WSO2 Case ID format for this project. */
+  wso2CaseIdPattern: RegExp;
+}
+
+/**
+ * Existing announcements to open and assert. Read-only.
+ *
+ * The same advisory is published to all three projects, so they share a subject
+ * but each carries its own case number and WSO2 id.
+ */
+export const ANNOUNCEMENT_VIEWS: AnnouncementView[] = [
+  {
+    projectType: ProjectType.SUBSCRIPTION,
+    announcementId: "25fd83573ba28f103e1e088aa4e45a98",
+    subject: SHARED_ANNOUNCEMENT_SUBJECT,
+    wso2CaseIdPattern: /^AUTOMATIONTESTCUSSUB-\d+$/,
+  },
+  {
+    projectType: ProjectType.MANAGED_CLOUD_SUBSCRIPTION,
+    announcementId: "0cfdcb173ba28f103e1e088aa4e45ae8",
+    subject: SHARED_ANNOUNCEMENT_SUBJECT,
+    wso2CaseIdPattern: /^AUTOMATIONTESTCUSMSSUB-\d+$/,
+  },
+  {
+    projectType: ProjectType.CLOUD_SUPPORT,
+    announcementId: "20fd0f173ba28f103e1e088aa4e45ae0",
+    subject: SHARED_ANNOUNCEMENT_SUBJECT,
+    wso2CaseIdPattern: /^AUTOMATIONTESTCUSCLSUB-\d+$/,
+  },
+];
+
+/** Expected side-menu visibility for a project: item label to whether it should
+ * render. */
+export type SideNavVisibility = Record<string, boolean>;
+
+/**
+ * Side-menu expectations per project type.
+ *
+ * Visibility is driven by the project's feature flags rather than its type label
+ * (see SideBar.tsx), so these are recorded per project and verified live rather
+ * than inferred. Only projects listed here are covered; add an entry to extend
+ * the suite.
+ *
+ * Note "Settings" also renders for these projects but is deliberately not
+ * asserted — it is outside the set under test.
+ */
+export const SIDE_NAV_VISIBILITY: Partial<
+  Record<ProjectType, SideNavVisibility>
+> = {
+  [ProjectType.SUBSCRIPTION]: {
+    Dashboard: true,
+    Support: true,
+    // Hidden: the Operations item needs service-request or change-request access,
+    // which this project does not have.
+    Operations: false,
+    Updates: true,
+    "Security Center": true,
+    Engagements: true,
+    "Usage & Metrics": true,
+    "Project Details": true,
+    Announcements: true,
+  },
+  [ProjectType.MANAGED_CLOUD_SUBSCRIPTION]: {
+    Dashboard: true,
+    Support: true,
+    // Visible here, unlike Subscription: this project has service-request access.
+    Operations: true,
+    Updates: true,
+    "Security Center": true,
+    Engagements: true,
+    "Usage & Metrics": true,
+    "Project Details": true,
+    Announcements: true,
+  },
+  [ProjectType.CLOUD_SUPPORT]: {
+    Dashboard: true,
+    Support: true,
+    // The four hidden items each trace to a feature flag this project lacks:
+    // Operations needs SR or CR access, Updates needs updates access, Security
+    // Center needs SRA or component analysis, and Usage & Metrics needs both the
+    // project flag and the portal-wide one.
+    Operations: false,
+    Updates: false,
+    "Security Center": false,
+    Engagements: true,
+    "Usage & Metrics": false,
+    "Project Details": true,
+    Announcements: true,
+  },
+};
+
+/** Formats shared across every project's cases. */
+export const CASE_VIEW_EXPECTATIONS = {
+  /** ServiceNow case number format, e.g. CS0441157. */
+  caseNumberPattern: /^CS\d+$/,
+} as const;
+
 /** Deployment types offered by the Add Deployment modal. Verified live against
  * staging — note there is no plain "Production": the production-like option is
  * "Primary Production". */
@@ -297,20 +670,29 @@ export const DEPLOYMENT_INPUT: DeploymentInput = {
  * anything typed (see the auto-fill effect in CreateCasePage.tsx). */
 export interface SecurityReportInput {
   description: string;
-  /** Attachment path, relative to the tests/e2e directory. Kept in-repo rather
-   * than pointing at a developer's Downloads folder so the spec is portable to
-   * other machines and to CI. */
-  attachmentPath: string;
 }
 
+/** Attachment used by every security report. Path is relative to the tests/e2e
+ * directory, and the file is kept in-repo rather than pointing at a developer's
+ * Downloads folder so the specs are portable to other machines and to CI. */
+export const SECURITY_REPORT_ATTACHMENT = "fixtures/files/sraattachment.csv";
+
 /**
- * Security report content for the Managed Cloud Subscription project.
+ * Security report content per project type.
  *
- * ⚠️ Creates a permanent record on every run.
+ * ⚠️ Creates a permanent record on every run, for every project type covered.
+ * Descriptions name their project so the records stay identifiable.
  */
-export const SECURITY_REPORT_INPUT: SecurityReportInput = {
-  description: "This is a test Security Report SR for MS subscription project",
-  attachmentPath: "fixtures/files/sraattachment.csv",
+export const SECURITY_REPORT_INPUT: Record<ProjectType, SecurityReportInput> = {
+  [ProjectType.SUBSCRIPTION]: {
+    description: "This is a test security report for subscription project",
+  },
+  [ProjectType.MANAGED_CLOUD_SUBSCRIPTION]: {
+    description: "This is a test security report for MS subscription project",
+  },
+  [ProjectType.CLOUD_SUPPORT]: {
+    description: "This is a test security report for cloud support project",
+  },
 };
 
 /**

--- a/apps/customer-portal/webapp/tests/e2e/pages/CaseDetailPage.ts
+++ b/apps/customer-portal/webapp/tests/e2e/pages/CaseDetailPage.ts
@@ -23,6 +23,10 @@ import {
 import { CASE_DETAIL } from "../utils/selectors";
 import { isSuccess } from "../utils/caseFlows";
 
+/** How long to allow for a case's detail page to resolve — the header is
+ * skeletonised while the case loads, well beyond the 5s default. */
+const LOAD_TIMEOUT_MS = 60_000;
+
 /**
  * Page object for the case detail page
  * (`/projects/:projectId/support/cases/:caseId`).
@@ -48,6 +52,109 @@ export class CaseDetailPage {
       name: CASE_DETAIL.closeButton,
       exact: true,
     });
+  }
+
+  /**
+   * Opens a case's detail page directly.
+   *
+   * @param projectId - Project the case belongs to.
+   * @param caseId - Case sysid.
+   */
+  async open(projectId: string, caseId: string): Promise<void> {
+    await this.page.goto(
+      `/projects/${projectId}/${CASE_DETAIL.pathSegment}/${caseId}`,
+    );
+    // The header renders once the case resolves; the case number is the first
+    // field guaranteed to be present for every case.
+    await expect(this.caseNumber()).toBeVisible({ timeout: LOAD_TIMEOUT_MS });
+  }
+
+  /**
+   * Opens a security report analysis. It reuses the same header as a case, so
+   * the field locators below apply unchanged.
+   *
+   * @param projectId - Project the SRA belongs to.
+   * @param sraId - SRA sysid.
+   */
+  async openSecurityReportAnalysis(
+    projectId: string,
+    sraId: string,
+  ): Promise<void> {
+    await this.page.goto(
+      `/projects/${projectId}/${CASE_DETAIL.sraPathSegment}/${sraId}`,
+    );
+    await expect(this.caseNumber()).toBeVisible({ timeout: LOAD_TIMEOUT_MS });
+  }
+
+  /**
+   * Opens a service request. It reuses the same header as a case, so the field
+   * locators below apply unchanged — bar severity, which service requests do not
+   * carry.
+   *
+   * @param projectId - Project the request belongs to.
+   * @param serviceRequestId - Service request sysid.
+   */
+  async openServiceRequest(
+    projectId: string,
+    serviceRequestId: string,
+  ): Promise<void> {
+    await this.page.goto(
+      `/projects/${projectId}/${CASE_DETAIL.serviceRequestPathSegment}/${serviceRequestId}`,
+    );
+    await expect(this.caseNumber()).toBeVisible({ timeout: LOAD_TIMEOUT_MS });
+  }
+
+  /**
+   * Opens an announcement. Like SRAs and service requests it reuses the case
+   * detail header, so the field locators below apply unchanged.
+   *
+   * @param projectId - Project the announcement belongs to.
+   * @param announcementId - Announcement sysid.
+   */
+  async openAnnouncement(
+    projectId: string,
+    announcementId: string,
+  ): Promise<void> {
+    await this.page.goto(
+      `/projects/${projectId}/${CASE_DETAIL.announcementPathSegment}/${announcementId}`,
+    );
+    await expect(this.caseNumber()).toBeVisible({ timeout: LOAD_TIMEOUT_MS });
+  }
+
+  //
+  // Header fields. None carry ids, test ids or labels, so rather than guessing
+  // at positions in the header row these match on the *shape* of their content —
+  // which is both stable against markup changes and self-documenting.
+  //
+
+  /** The ServiceNow case number, e.g. CS0441157. */
+  caseNumber(): Locator {
+    return this.main().getByText(/^CS\d+$/);
+  }
+
+  /** The WSO2 case id, e.g. AUTOMATIONTESTCUSSUB-42. */
+  wso2CaseId(pattern: RegExp): Locator {
+    return this.main().getByText(pattern);
+  }
+
+  /** The severity chip, e.g. "S1" or "S4(Query)". */
+  severityChip(severity: string): Locator {
+    return this.main().getByText(severity, { exact: true });
+  }
+
+  /** The case state shown beside the number, e.g. "Open". */
+  stateLabel(state: string): Locator {
+    return this.main().getByText(state, { exact: true });
+  }
+
+  /** The case subject — the header's `variant="h6"` heading. */
+  subject(): Locator {
+    return this.main().getByRole("heading").first();
+  }
+
+  /** A comment on the Activity tab, matched as a substring. */
+  comment(text: string): Locator {
+    return this.main().getByText(text, { exact: false }).first();
   }
 
   confirmDialog(): Locator {

--- a/apps/customer-portal/webapp/tests/e2e/pages/CasesListPage.ts
+++ b/apps/customer-portal/webapp/tests/e2e/pages/CasesListPage.ts
@@ -16,13 +16,11 @@
 
 import { type Locator, type Page, expect } from "../fixtures/test";
 import { CASES_LIST, CASE_DETAIL } from "../utils/selectors";
+import { isSuccess } from "../utils/caseFlows";
+import { caseSearchResponse } from "../utils/listSearch";
 
 /** How long to allow for the list and its search results to resolve. */
 const LOAD_TIMEOUT_MS = 60_000;
-
-/** The list debounces its search by 300ms before refetching (see AllCasesPage),
- * so results lag the keystrokes. */
-const SEARCH_DEBOUNCE_MS = 300;
 
 /**
  * Page object for a project's cases list
@@ -63,12 +61,19 @@ export class CasesListPage {
    * @returns True when a row with that subject is present.
    */
   async hasCaseWithSubject(subject: string): Promise<boolean> {
+    // Wait for the search request carrying THIS subject — see listSearch for why
+    // `networkidle` is not a safe signal here.
+    const searchResponse = caseSearchResponse(this.page, subject);
+
     await this.searchInput().fill(subject);
-    // Wait out the debounce, then let the request settle. `networkidle` is the
-    // signal here rather than a fixed sleep, so a slow backend does not produce
-    // a false negative — which would make the caller create a duplicate.
-    await this.page.waitForTimeout(SEARCH_DEBOUNCE_MS);
-    await this.page.waitForLoadState("networkidle");
+    const response = await searchResponse;
+
+    // A failed search returns no rows, which is indistinguishable from "no such
+    // case" — so assert it succeeded rather than silently treating it as absent.
+    expect(
+      isSuccess(response.status()),
+      `case search failed: ${response.status()} ${await response.text()}`,
+    ).toBe(true);
 
     const match = this.main().getByText(subject, { exact: true });
     return (await match.count()) > 0;

--- a/apps/customer-portal/webapp/tests/e2e/pages/CasesListPage.ts
+++ b/apps/customer-portal/webapp/tests/e2e/pages/CasesListPage.ts
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { type Locator, type Page, expect } from "../fixtures/test";
+import { CASES_LIST, CASE_DETAIL } from "../utils/selectors";
+
+/** How long to allow for the list and its search results to resolve. */
+const LOAD_TIMEOUT_MS = 60_000;
+
+/** The list debounces its search by 300ms before refetching (see AllCasesPage),
+ * so results lag the keystrokes. */
+const SEARCH_DEBOUNCE_MS = 300;
+
+/**
+ * Page object for a project's cases list
+ * (`/projects/:projectId/support/cases`).
+ */
+export class CasesListPage {
+  constructor(private readonly page: Page) {}
+
+  private main(): Locator {
+    return this.page.getByTestId(CASE_DETAIL.mainTestId);
+  }
+
+  searchInput(): Locator {
+    return this.page.getByPlaceholder(CASES_LIST.searchPlaceholder);
+  }
+
+  /**
+   * Opens the list and waits for the search box.
+   *
+   * @param projectId - Project whose cases to list.
+   */
+  async open(projectId: string): Promise<void> {
+    await this.page.goto(
+      `/projects/${projectId}/${CASES_LIST.pathSegment}`,
+    );
+    await expect(this.searchInput()).toBeVisible({ timeout: LOAD_TIMEOUT_MS });
+  }
+
+  /**
+   * Searches the list and reports whether a case with this exact subject is
+   * listed.
+   *
+   * The search matches id, title or description, so it can return near misses —
+   * "subscription case S1" also matches "subscription case S10". The exact-text
+   * check is what makes this a reliable existence test rather than a fuzzy one.
+   *
+   * @param subject - Exact case subject to look for.
+   * @returns True when a row with that subject is present.
+   */
+  async hasCaseWithSubject(subject: string): Promise<boolean> {
+    await this.searchInput().fill(subject);
+    // Wait out the debounce, then let the request settle. `networkidle` is the
+    // signal here rather than a fixed sleep, so a slow backend does not produce
+    // a false negative — which would make the caller create a duplicate.
+    await this.page.waitForTimeout(SEARCH_DEBOUNCE_MS);
+    await this.page.waitForLoadState("networkidle");
+
+    const match = this.main().getByText(subject, { exact: true });
+    return (await match.count()) > 0;
+  }
+}

--- a/apps/customer-portal/webapp/tests/e2e/pages/SecurityCenterPage.ts
+++ b/apps/customer-portal/webapp/tests/e2e/pages/SecurityCenterPage.ts
@@ -1,0 +1,89 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { type Locator, type Page, expect } from "../fixtures/test";
+import { CASE_DETAIL, SECURITY_CENTER } from "../utils/selectors";
+import { isSuccess } from "../utils/caseFlows";
+import { caseSearchResponse } from "../utils/listSearch";
+
+/** How long to allow for the list and its search results to resolve. */
+const LOAD_TIMEOUT_MS = 60_000;
+
+/**
+ * Page object for the Security Center's Security Report Analysis list
+ * (`/projects/:projectId/security-center`).
+ *
+ * Exists so the create-report spec can check whether its report already exists
+ * before raising another: reports are cases, and cases have no delete endpoint,
+ * so an unguarded create accumulates permanent records on every run.
+ */
+export class SecurityCenterPage {
+  constructor(private readonly page: Page) {}
+
+  private main(): Locator {
+    return this.page.getByTestId(CASE_DETAIL.mainTestId);
+  }
+
+  searchInput(): Locator {
+    return this.page.getByPlaceholder(SECURITY_CENTER.searchPlaceholder);
+  }
+
+  /**
+   * Opens the Security Center and waits for the report list's search box.
+   *
+   * @param projectId - Project whose reports to list.
+   */
+  async open(projectId: string): Promise<void> {
+    await this.page.goto(
+      `/projects/${projectId}/${SECURITY_CENTER.pathSegment}`,
+    );
+    await expect(this.searchInput()).toBeVisible({ timeout: LOAD_TIMEOUT_MS });
+  }
+
+  /**
+   * Searches the report list and reports whether anything matched.
+   *
+   * The list's search covers case number, title and description, so passing a
+   * report's **description** finds it regardless of its generated title — which
+   * carries the creation date and so differs day to day.
+   *
+   * Waits for the search response produced by this very term, so a result is
+   * never read mid-flight.
+   *
+   * @param searchText - Text to search for, typically the report's description.
+   * @returns True when the search returns at least one report.
+   */
+  async hasReportMatching(searchText: string): Promise<boolean> {
+    // The report list is backed by the same /cases/search endpoint as the cases
+    // list, so it uses the same term-matched wait. `networkidle` would be unsafe
+    // here for the same reason: a premature read reports "no report" and the
+    // caller raises a duplicate that cannot be deleted.
+    const searchResponse = caseSearchResponse(this.page, searchText);
+    await this.searchInput().fill(searchText);
+    const response = await searchResponse;
+
+    expect(
+      isSuccess(response.status()),
+      `report search failed: ${response.status()} ${await response.text()}`,
+    ).toBe(true);
+
+    // A result row always carries a case number. Checking for one is a positive
+    // signal, rather than inferring a hit from the empty message being absent —
+    // which would also be true mid-load.
+    const rows = this.main().getByText(/^CS\d+$/);
+    return (await rows.count()) > 0;
+  }
+}

--- a/apps/customer-portal/webapp/tests/e2e/pages/SecurityReportCreatePage.ts
+++ b/apps/customer-portal/webapp/tests/e2e/pages/SecurityReportCreatePage.ts
@@ -69,22 +69,42 @@ export class SecurityReportCreatePage {
       this.page.getByRole("button", { name: GET_HELP_BUTTON, exact: true }),
     ).toBeVisible({ timeout: LOAD_TIMEOUT_MS });
 
-    await this.page.getByRole("button", { name: GET_HELP_MENU.trigger }).click();
-    const menu = this.page.getByRole("menu");
-    await expect(menu).toBeVisible();
-    await menu
-      .getByRole("menuitem")
-      .filter({ hasText: GET_HELP_MENU.items.securityReport })
-      .click();
+    await this.openGetHelpMenu();
+    await this.securityReportMenuItem().click();
 
     await expect(this.page).toHaveURL(
       new RegExp(`/projects/${projectId}/support/security-report/create`),
     );
-    // The Product select is the readiness signal — it is present for every
-    // project type and only renders once deployments/products resolve.
+    // The Product select is the readiness signal: verified present on all three
+    // project types, whereas Deployment is absent on Cloud Support, whose
+    // deployment is locked to primary production.
     await expect(this.productVersionSelect()).toBeVisible({
       timeout: LOAD_TIMEOUT_MS,
     });
+  }
+
+  /**
+   * Opens the Get Help dropdown from the split button's arrow half.
+   *
+   * The menu gets the long timeout rather than the 5s default: the header
+   * renders skeletons until the projects list resolves, so on a cold dashboard
+   * the click can land before the real menu is mounted.
+   */
+  async openGetHelpMenu(): Promise<void> {
+    await this.page.getByRole("button", { name: GET_HELP_MENU.trigger }).click();
+    await expect(this.getHelpMenu()).toBeVisible({ timeout: LOAD_TIMEOUT_MS });
+  }
+
+  getHelpMenu(): Locator {
+    return this.page.getByRole("menu");
+  }
+
+  /** The "Security Report" item. Present only when the project has SRA write
+   * access, so its absence is itself an assertable fact. */
+  securityReportMenuItem(): Locator {
+    return this.getHelpMenu()
+      .getByRole("menuitem")
+      .filter({ hasText: GET_HELP_MENU.items.securityReport });
   }
 
   deploymentSelect(): Locator {
@@ -195,20 +215,27 @@ export class SecurityReportCreatePage {
    * rather than hardcoded so it is always today's, matching how CreateCasePage
    * generates it.
    *
-   * @param deployment - Deployment label the report is filed against.
+   * @param deployment - Deployment label the report is filed against, or null
+   * when the project auto-selects it (Cloud Support): the generator uses whichever
+   * primary production deployment it picked, whose label the fixtures do not
+   * record, so that segment is matched loosely.
    * @param productName - Product name *without* its version, as the generator
    * uses (`ProjectFixture.productName`, not `productVersion`).
    * @returns A regex the Title field's value should satisfy.
    */
-  static expectedTitlePattern(deployment: string, productName: string): RegExp {
+  static expectedTitlePattern(
+    deployment: string | null,
+    productName: string,
+  ): RegExp {
     const today = new Date();
     const date = [
       today.getFullYear(),
       String(today.getMonth() + 1).padStart(2, "0"),
       String(today.getDate()).padStart(2, "0"),
     ].join("-");
+    const deploymentSegment = deployment ? escapeForRegExp(deployment) : ".+";
     return new RegExp(
-      `^${escapeForRegExp(deployment)} - ${escapeForRegExp(productName)} - ${date}$`,
+      `^${deploymentSegment} - ${escapeForRegExp(productName)} - ${date}$`,
     );
   }
 

--- a/apps/customer-portal/webapp/tests/e2e/pages/SideNavPage.ts
+++ b/apps/customer-portal/webapp/tests/e2e/pages/SideNavPage.ts
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { type Locator, type Page, expect } from "../fixtures/test";
+import { GET_HELP_BUTTON, SIDE_NAV } from "../utils/selectors";
+
+/** How long to allow for the shell to finish loading. The header and sidebar are
+ * skeletonised until the projects list resolves, well beyond the 5s default. */
+const LOAD_TIMEOUT_MS = 60_000;
+
+/**
+ * Page object for the side navigation.
+ *
+ * Which items render is driven by the project's feature flags, so this exists to
+ * assert presence and absence rather than to navigate.
+ */
+export class SideNavPage {
+  constructor(private readonly page: Page) {}
+
+  /**
+   * Opens a project and waits for the shell to finish rendering.
+   *
+   * Waits on the header's Get Help button rather than a nav item: every nav item
+   * is exactly what is under test here, so gating readiness on one would make
+   * the test unable to distinguish "not rendered yet" from "not rendered at all".
+   *
+   * @param projectId - Project whose navigation to inspect.
+   */
+  async open(projectId: string): Promise<void> {
+    await this.page.goto(`/projects/${projectId}/dashboard`);
+    await expect(
+      this.page.getByRole("button", { name: GET_HELP_BUTTON, exact: true }),
+    ).toBeVisible({ timeout: LOAD_TIMEOUT_MS });
+    // The sidebar mounts with the shell, but its items arrive with the project's
+    // features; Dashboard is present for every project, so it marks the point
+    // where the item list is real rather than still empty.
+    await expect(this.item(SIDE_NAV.items.dashboard)).toBeVisible({
+      timeout: LOAD_TIMEOUT_MS,
+    });
+  }
+
+  /**
+   * The sidebar landmark.
+   *
+   * The page exposes two `complementary` regions, so this picks the one holding
+   * the Dashboard item rather than relying on document order.
+   */
+  sidebar(): Locator {
+    return this.page.getByRole("complementary").filter({
+      has: this.page.getByRole("button", {
+        name: SIDE_NAV.items.dashboard,
+        exact: true,
+      }),
+    });
+  }
+
+  /**
+   * A navigation item, scoped to the sidebar so header controls with similar
+   * names cannot satisfy it.
+   *
+   * @param name - Exact item label.
+   * @returns Locator for the item.
+   */
+  item(name: string): Locator {
+    return this.sidebar().getByRole("button", { name, exact: true });
+  }
+}

--- a/apps/customer-portal/webapp/tests/e2e/specs/announcements/view-announcement.spec.ts
+++ b/apps/customer-portal/webapp/tests/e2e/specs/announcements/view-announcement.spec.ts
@@ -1,0 +1,98 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+// Opens existing announcements and checks the header shows what it should.
+//
+// ✅ READ-ONLY. Announcements are opened by URL and asserted; nothing is created
+// or modified, so this is safe to run repeatedly.
+//
+// An announcement reuses the case detail header — verified live: the header row
+// reads `<wso2 case id> | <case number> <state>`, followed by the subject — so
+// the same locators apply. It carries no severity chip.
+//
+// What is and is not pinned:
+//
+// - **Subject** is pinned. The same advisory is published to all three projects,
+//   so they share it while each keeps its own number and id.
+// - **WSO2 case id** and **case number** are asserted by format, since the values
+//   differ per project. The id prefix is per project.
+// - **State** must be one of the real case states, so a blank or placeholder
+//   fails.
+//
+
+import { test, expect, withSession } from "../../fixtures/test";
+import { CaseDetailPage } from "../../pages/CaseDetailPage";
+import {
+  ANNOUNCEMENT_VIEWS,
+  CASE_VIEW_EXPECTATIONS,
+  PROJECTS,
+} from "../../config/testData";
+import { CASE_DETAIL } from "../../utils/selectors";
+
+withSession(test);
+
+test.describe("View Announcement", () => {
+  // Each announcement is a cold page load with several queries behind the
+  // header, and this page resolves more slowly than the case pages do — the
+  // 30s default is not enough.
+  test.describe.configure({ timeout: 120_000 });
+
+  for (const {
+    projectType,
+    announcementId,
+    subject,
+    wso2CaseIdPattern,
+  } of ANNOUNCEMENT_VIEWS) {
+    const project = PROJECTS[projectType];
+
+    test.describe(projectType, () => {
+      test("shows details for an announcement", async ({ page }) => {
+        test.skip(
+          !project.id || !announcementId,
+          `${projectType} needs a project id and an announcement id. ` +
+            `Fill them in tests/e2e/config/testData.ts.`,
+        );
+
+        const announcement = new CaseDetailPage(page);
+        await announcement.openAnnouncement(project.id, announcementId);
+
+        // Case number — format only; the value differs per project.
+        await expect(announcement.caseNumber()).toBeVisible();
+        await expect(announcement.caseNumber()).toHaveText(
+          CASE_VIEW_EXPECTATIONS.caseNumberPattern,
+        );
+
+        // WSO2 case id — project-specific prefix plus an integer.
+        await expect(
+          announcement.wso2CaseId(wso2CaseIdPattern),
+        ).toBeVisible();
+
+        // State — must be one of the real states rather than blank or a dash.
+        const states = CASE_DETAIL.header.states;
+        const visibleStates = await Promise.all(
+          states.map((state) => announcement.stateLabel(state).count()),
+        );
+        expect(
+          visibleStates.reduce((total, n) => total + n, 0),
+          `expected one of ${states.join(", ")} to be shown as the state`,
+        ).toBeGreaterThan(0);
+
+        // Subject — the advisory title, shared across the three projects.
+        await expect(announcement.subject()).toHaveText(subject);
+      });
+    });
+  }
+});

--- a/apps/customer-portal/webapp/tests/e2e/specs/navigation/side-menu.spec.ts
+++ b/apps/customer-portal/webapp/tests/e2e/specs/navigation/side-menu.spec.ts
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+// Side-menu visibility per project.
+//
+// ✅ READ-ONLY. Nothing is created or modified, so this is safe to run
+// repeatedly.
+//
+// Which items render is driven by the project's **feature flags**, not its type
+// label — SideBar.tsx removes Operations without service-request or
+// change-request access, Engagements without engagements access, Updates without
+// updates access, Security Center without SRA or component analysis, and Usage &
+// Metrics unless both the project flag and the portal-wide flag are on. That is
+// why expectations live per project in SIDE_NAV_VISIBILITY, verified live, rather
+// than being derived from the type.
+//
+// Both presence and absence are asserted. A hidden item is as much a requirement
+// as a visible one: Operations appearing on a project without operations access
+// would be a real regression.
+//
+// The checks are soft (`expect.soft`) so a single run reports every mismatch
+// rather than stopping at the first — with nine items, knowing the full picture
+// matters more than failing fast. One page load per project keeps it quick.
+//
+
+import { test, expect, withSession } from "../../fixtures/test";
+import { SideNavPage } from "../../pages/SideNavPage";
+import {
+  PROJECTS,
+  ProjectType,
+  SIDE_NAV_VISIBILITY,
+} from "../../config/testData";
+
+withSession(test);
+
+test.describe("Side Menu", () => {
+  // A cold shell load, whose sidebar waits on the project's features.
+  test.describe.configure({ timeout: 120_000 });
+
+  for (const projectType of Object.values(ProjectType)) {
+    const expected = SIDE_NAV_VISIBILITY[projectType];
+    if (!expected) continue;
+
+    const project = PROJECTS[projectType];
+
+    test.describe(projectType, () => {
+      test("shows the expected navigation items", async ({ page }) => {
+        test.skip(
+          !project.id,
+          `${projectType} needs a project id. Fill it in tests/e2e/config/testData.ts.`,
+        );
+
+        const nav = new SideNavPage(page);
+        await nav.open(project.id);
+
+        for (const [item, shouldBeVisible] of Object.entries(expected)) {
+          const locator = nav.item(item);
+          if (shouldBeVisible) {
+            await expect
+              .soft(locator, `"${item}" should be visible`)
+              .toBeVisible();
+          } else {
+            // toHaveCount(0) rather than toBeHidden(): a hidden item is not
+            // rendered at all here, and toHaveCount states that directly.
+            await expect
+              .soft(locator, `"${item}" should not be rendered`)
+              .toHaveCount(0);
+          }
+        }
+      });
+    });
+  }
+});

--- a/apps/customer-portal/webapp/tests/e2e/specs/operations/view-service-request.spec.ts
+++ b/apps/customer-portal/webapp/tests/e2e/specs/operations/view-service-request.spec.ts
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+// Opens existing service requests and checks the header shows what it should.
+//
+// ✅ READ-ONLY. Requests are opened by URL and asserted; nothing is created or
+// modified, so this is safe to run repeatedly.
+//
+// A service request reuses the case detail header, so the same locators apply —
+// but it carries no severity chip, since the service request form has no severity
+// field.
+//
+// What is and is not pinned:
+//
+// - **Subject** is pinned, and is the Request Details value the request was
+//   raised with — so it comes from SERVICE_REQUEST_INPUT rather than a duplicated
+//   string. If the create spec's input changes, this fixture follows it.
+// - **WSO2 case id** and **case number** are asserted by format, since the values
+//   differ per record. The id prefix is per project.
+// - **State** must be one of the real case states, so a blank or placeholder
+//   fails.
+//
+// Only Managed Cloud Subscription has an entry: it is the one project whose
+// service request coverage exists so far.
+//
+
+import { test, expect, withSession } from "../../fixtures/test";
+import { CaseDetailPage } from "../../pages/CaseDetailPage";
+import {
+  CASE_VIEW_EXPECTATIONS,
+  PROJECTS,
+  SERVICE_REQUEST_VIEWS,
+} from "../../config/testData";
+import { CASE_DETAIL } from "../../utils/selectors";
+
+withSession(test);
+
+test.describe("View Service Request", () => {
+  // Each request is a cold page load with several queries behind the header; the
+  // 30s default is not enough.
+  test.describe.configure({ timeout: 120_000 });
+
+  for (const {
+    projectType,
+    serviceRequestId,
+    subject,
+    wso2CaseIdPattern,
+  } of SERVICE_REQUEST_VIEWS) {
+    const project = PROJECTS[projectType];
+
+    test.describe(projectType, () => {
+      test("shows details for a service request", async ({ page }) => {
+        test.skip(
+          !project.id || !serviceRequestId,
+          `${projectType} needs a project id and a service request id. ` +
+            `Fill them in tests/e2e/config/testData.ts.`,
+        );
+
+        const serviceRequest = new CaseDetailPage(page);
+        await serviceRequest.openServiceRequest(project.id, serviceRequestId);
+
+        // Case number — format only; the value differs per record.
+        await expect(serviceRequest.caseNumber()).toBeVisible();
+        await expect(serviceRequest.caseNumber()).toHaveText(
+          CASE_VIEW_EXPECTATIONS.caseNumberPattern,
+        );
+
+        // WSO2 case id — project-specific prefix plus an integer.
+        await expect(
+          serviceRequest.wso2CaseId(wso2CaseIdPattern),
+        ).toBeVisible();
+
+        // State — must be one of the real states rather than blank or a dash.
+        const states = CASE_DETAIL.header.states;
+        const visibleStates = await Promise.all(
+          states.map((state) => serviceRequest.stateLabel(state).count()),
+        );
+        expect(
+          visibleStates.reduce((total, n) => total + n, 0),
+          `expected one of ${states.join(", ")} to be shown as the state`,
+        ).toBeGreaterThan(0);
+
+        // Subject — the Request Details value the request was raised with.
+        await expect(serviceRequest.subject()).toHaveText(subject);
+      });
+    });
+  }
+});

--- a/apps/customer-portal/webapp/tests/e2e/specs/security/create-security-report-validation.spec.ts
+++ b/apps/customer-portal/webapp/tests/e2e/specs/security/create-security-report-validation.spec.ts
@@ -58,7 +58,7 @@ test.describe("Security Report — validation", () => {
   test.describe.configure({ timeout: 180_000 });
 
   const project = PROJECTS[ProjectType.MANAGED_CLOUD_SUBSCRIPTION];
-  const input = SECURITY_REPORT_INPUT;
+  const input = SECURITY_REPORT_INPUT[ProjectType.MANAGED_CLOUD_SUBSCRIPTION];
 
   /** Opens the form ready for a validation assertion. */
   async function openForm(page: Page): Promise<SecurityReportCreatePage> {

--- a/apps/customer-portal/webapp/tests/e2e/specs/security/create-security-report.spec.ts
+++ b/apps/customer-portal/webapp/tests/e2e/specs/security/create-security-report.spec.ts
@@ -15,12 +15,7 @@
 // under the License.
 
 //
-// Raises a security report from the "Get Help" split button's dropdown.
-//
-// Scoped to the Managed Cloud Subscription project: the Security Report menu
-// item only appears when the project has SRA write access
-// (`isSecurityReportVisible` in GetHelpDropdown.tsx), which is a per-project
-// feature flag rather than something every type has.
+// Raises a security report from the "Get Help" dropdown, on each project type.
 //
 // A security report is a case raised at /support/security-report/create. The
 // same CreateCasePage backs it, with `isSecurityReport` derived from the path —
@@ -28,9 +23,23 @@
 // Title is generated from the deployment, product and today's date rather than
 // entered.
 //
-// ⚠️ Writes to a REAL backend and leaves a permanent record on every run —
-// there is no delete counterpart. The configured description is deliberately
-// self-describing so the records stay identifiable.
+// Coverage differs by project type, verified live:
+//
+// - Subscription and Managed Cloud Subscription offer the option and raise a
+//   report. Both show a Deployment select, with Product gated on it ("Select
+//   deployment first").
+// - Cloud Support does NOT offer it — the Get Help dropdown has no Security
+//   Report item, because the option is gated on the project's SRA write access.
+//   Its test asserts that absence, which passes today and would fail if the
+//   option appeared. A skip would silently pass either way.
+//
+// The `hasSecurityReport` flag on each fixture decides which branch a project
+// takes, so the expectation is declared in config rather than discovered at
+// runtime.
+//
+// ⚠️ Writes to a REAL backend and leaves a permanent record per project type on
+// every run — there is no delete counterpart. The configured descriptions name
+// their project so the records stay identifiable.
 //
 
 import { test, expect, withSession } from "../../fixtures/test";
@@ -38,6 +47,7 @@ import { SecurityReportCreatePage } from "../../pages/SecurityReportCreatePage";
 import {
   PROJECTS,
   ProjectType,
+  SECURITY_REPORT_ATTACHMENT,
   SECURITY_REPORT_INPUT,
 } from "../../config/testData";
 import { isSuccess, skipWhenUnconfigured } from "../../utils/caseFlows";
@@ -45,72 +55,105 @@ import { isSuccess, skipWhenUnconfigured } from "../../utils/caseFlows";
 withSession(test);
 
 test.describe("Security Report", () => {
-  // Spans a dashboard load, a menu navigation, two backend-populated dropdowns
-  // and a file upload; the 30s default is not enough.
+  // Spans a dashboard load, a menu navigation, backend-populated dropdowns and a
+  // file upload; the 30s default is not enough.
   test.describe.configure({ timeout: 180_000 });
 
-  const project = PROJECTS[ProjectType.MANAGED_CLOUD_SUBSCRIPTION];
+  for (const projectType of Object.values(ProjectType)) {
+    const project = PROJECTS[projectType];
+    const input = SECURITY_REPORT_INPUT[projectType];
 
-  test(`${ProjectType.MANAGED_CLOUD_SUBSCRIPTION} — creates a security report`, async ({
-    page,
-  }) => {
-    skipWhenUnconfigured(project);
+    test.describe(projectType, () => {
+      if (!project.hasSecurityReport) {
+        // Security reports are gated on the project's SRA write access, which
+        // this project does not have. Asserting the option is absent is the
+        // correct expectation here — and it still fails if the option ever
+        // appears, which a skip would not.
+        test("does not offer security reports", async ({ page }) => {
+          skipWhenUnconfigured(project);
 
-    const form = new SecurityReportCreatePage(page);
+          const form = new SecurityReportCreatePage(page);
+          await page.goto(`/projects/${project.id}/dashboard`);
+          await expect(
+            page.getByRole("button", { name: "Get Help", exact: true }),
+          ).toBeVisible({ timeout: 60_000 });
 
-    await form.openViaGetHelpMenu(project.id);
+          await form.openGetHelpMenu();
+          await expect(form.securityReportMenuItem()).toHaveCount(0);
+        });
+        return;
+      }
 
-    // Issue Type and Severity belong to the ordinary case form only. Asserting
-    // they are absent is the check that this route really is in security-report
-    // mode, rather than the case form at a different URL.
-    await expect(form.issueTypeSelect()).toBeHidden();
-    await expect(form.severitySelect()).toBeHidden();
+      test("creates a security report", async ({ page }) => {
+        skipWhenUnconfigured(project);
 
-    await form.selectDeployment(project.deployment);
-    await form.selectProductVersion(project.productVersion);
+        const form = new SecurityReportCreatePage(page);
+        await form.openViaGetHelpMenu(project.id);
 
-    // The title is not typed: choosing a deployment and product generates it as
-    // "<deployment> - <product name> - YYYY-MM-DD", overwriting anything
-    // entered. Asserting it here means the report is submitted with a title we
-    // have actually verified rather than an unchecked one.
-    await expect(form.titleInput()).toHaveValue(
-      SecurityReportCreatePage.expectedTitlePattern(
-        project.deployment,
-        project.productName,
-      ),
-    );
+        // Issue Type and Severity belong to the ordinary case form only.
+        // Asserting they are absent is the check that this route really is in
+        // security-report mode, rather than the case form at another URL.
+        await expect(form.issueTypeSelect()).toBeHidden();
+        await expect(form.severitySelect()).toBeHidden();
 
-    await form.fillDescription(SECURITY_REPORT_INPUT.description);
-    await form.attachSecurityReport(SECURITY_REPORT_INPUT.attachmentPath);
+        if (project.autoSelectsDeployment) {
+          // Locked to primary production, so the field is not rendered at all.
+          await expect(form.deploymentSelect()).toBeHidden();
+        } else {
+          await form.selectDeployment(project.deployment);
+        }
+        await form.selectProductVersion(project.productVersion);
 
-    await expect(form.submitButton()).toBeEnabled();
+        // The title is not typed: choosing a deployment and product generates it
+        // as "<deployment> - <product name> - YYYY-MM-DD", overwriting anything
+        // entered. Asserting it means the report is submitted with a title we
+        // have actually verified rather than an unchecked one.
+        await expect(form.titleInput()).toHaveValue(
+          SecurityReportCreatePage.expectedTitlePattern(
+            project.autoSelectsDeployment ? null : project.deployment,
+            project.productName,
+          ),
+        );
 
-    // Capture the created report from the response so the assertions below
-    // prove the backend accepted it, not just that the UI moved on. Security
-    // reports post to /cases like every other case type.
-    const [createResponse] = await Promise.all([
-      page.waitForResponse(
-        (r) =>
-          r.url().includes("/cases") &&
-          r.request().method() === "POST" &&
-          isSuccess(r.status()),
-      ),
-      form.submit(),
-    ]);
+        await form.fillDescription(input.description);
+        await form.attachSecurityReport(SECURITY_REPORT_ATTACHMENT);
 
-    const created = (await createResponse.json()) as {
-      id?: string;
-      number?: string;
-    };
-    expect(created.id, "backend returned no case id").toBeTruthy();
+        await expect(form.submitButton()).toBeEnabled();
 
-    await expect(page).toHaveURL(
-      new RegExp(`/projects/${project.id}/.*/${created.id}`),
-    );
+        // Capture the created report from the response so the assertions below
+        // prove the backend accepted it, not just that the UI moved on. Security
+        // reports post to /cases like every other case type.
+        const [createResponse] = await Promise.all([
+          page.waitForResponse(
+            (r) =>
+              new URL(r.url()).pathname.endsWith("/cases") &&
+              r.request().method() === "POST",
+          ),
+          form.submit(),
+        ]);
 
-    console.log(
-      `Created security report (${ProjectType.MANAGED_CLOUD_SUBSCRIPTION}): ` +
-        `${created.number ?? created.id}`,
-    );
-  });
+        // Status asserted here rather than in the predicate, so a rejected
+        // create reports the server's message instead of timing out.
+        expect(
+          isSuccess(createResponse.status()),
+          `create security report failed: ${createResponse.status()} ${await createResponse.text()}`,
+        ).toBe(true);
+
+        const created = (await createResponse.json()) as {
+          id?: string;
+          number?: string;
+        };
+        expect(created.id, "backend returned no case id").toBeTruthy();
+
+        await expect(page).toHaveURL(
+          new RegExp(`/projects/${project.id}/.*/${created.id}`),
+        );
+
+        console.log(
+          `Created security report (${projectType}): ` +
+            `${created.number ?? created.id}`,
+        );
+      });
+    });
+  }
 });

--- a/apps/customer-portal/webapp/tests/e2e/specs/security/create-security-report.spec.ts
+++ b/apps/customer-portal/webapp/tests/e2e/specs/security/create-security-report.spec.ts
@@ -37,13 +37,19 @@
 // takes, so the expectation is declared in config rather than discovered at
 // runtime.
 //
-// ⚠️ Writes to a REAL backend and leaves a permanent record per project type on
-// every run — there is no delete counterpart. The configured descriptions name
-// their project so the records stay identifiable.
+// ⚠️ IDEMPOTENT, because reports are cases and cases cannot be deleted. Each test
+// searches the project's report list for its configured description and raises a
+// report only when none is found — so retries and repeated runs add nothing. The
+// descriptions are the idempotency key: they are stable per project, whereas the
+// generated title carries the creation date and would only dedupe within a day.
+//
+// Changing a description in SECURITY_REPORT_INPUT therefore orphans the existing
+// report and causes the next run to create a replacement, permanently.
 //
 
 import { test, expect, withSession } from "../../fixtures/test";
 import { SecurityReportCreatePage } from "../../pages/SecurityReportCreatePage";
+import { SecurityCenterPage } from "../../pages/SecurityCenterPage";
 import {
   PROJECTS,
   ProjectType,
@@ -84,8 +90,22 @@ test.describe("Security Report", () => {
         return;
       }
 
-      test("creates a security report", async ({ page }) => {
+      test("has a security report", async ({ page }) => {
         skipWhenUnconfigured(project);
+
+        // Reports are cases, and cases have no delete endpoint — so raising one
+        // unconditionally would leave a permanent, customer-visible record on
+        // every run, retry and scheduled execution. Look first: the description
+        // is stable per project (unlike the generated title, which carries the
+        // creation date), and the list search covers descriptions.
+        const securityCenter = new SecurityCenterPage(page);
+        await securityCenter.open(project.id);
+        if (await securityCenter.hasReportMatching(input.description)) {
+          console.log(`${projectType}: security report already exists`);
+          return;
+        }
+
+        console.log(`${projectType}: no security report found, creating one`);
 
         const form = new SecurityReportCreatePage(page);
         await form.openViaGetHelpMenu(project.id);

--- a/apps/customer-portal/webapp/tests/e2e/specs/security/view-security-report.spec.ts
+++ b/apps/customer-portal/webapp/tests/e2e/specs/security/view-security-report.spec.ts
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+// Opens existing security report analyses and checks the header shows what it
+// should.
+//
+// ✅ READ-ONLY. SRAs are opened by URL and asserted; nothing is created or
+// modified, so this is safe to run repeatedly.
+//
+// A security report analysis reuses the case detail header, so the same locators
+// apply — but it carries no severity chip, since security reports hide severity
+// on the way in.
+//
+// What is and is not pinned:
+//
+// - **Subject** is pinned literally. Security report subjects are generated at
+//   creation as `<deployment> - <product name> - YYYY-MM-DD`, so for an existing
+//   record the string is fixed. The date in it is the SRA's *creation* date, not
+//   today's — computing it would break the test the next day.
+// - **WSO2 case id** and **case number** are asserted by format, since the values
+//   differ per record. The id prefix is per project.
+// - **State** must be one of the real case states, so a blank or placeholder
+//   fails.
+//
+// Cloud Support has no entry: that project does not offer security reports at all
+// (see the create spec), so it has none to view.
+//
+
+import { test, expect, withSession } from "../../fixtures/test";
+import { CaseDetailPage } from "../../pages/CaseDetailPage";
+import {
+  CASE_VIEW_EXPECTATIONS,
+  PROJECTS,
+  SRA_VIEWS,
+} from "../../config/testData";
+import { CASE_DETAIL } from "../../utils/selectors";
+
+withSession(test);
+
+test.describe("View Security Report", () => {
+  // Each SRA is a cold page load with several queries behind the header; the 30s
+  // default is not enough.
+  test.describe.configure({ timeout: 120_000 });
+
+  for (const { projectType, sraId, subject, wso2CaseIdPattern } of SRA_VIEWS) {
+    const project = PROJECTS[projectType];
+
+    test.describe(projectType, () => {
+      test("shows details for a security report analysis", async ({ page }) => {
+        test.skip(
+          !project.id || !sraId,
+          `${projectType} needs a project id and an SRA id. ` +
+            `Fill them in tests/e2e/config/testData.ts.`,
+        );
+
+        const sra = new CaseDetailPage(page);
+        await sra.openSecurityReportAnalysis(project.id, sraId);
+
+        // Case number — format only; the value differs per record.
+        await expect(sra.caseNumber()).toBeVisible();
+        await expect(sra.caseNumber()).toHaveText(
+          CASE_VIEW_EXPECTATIONS.caseNumberPattern,
+        );
+
+        // WSO2 case id — project-specific prefix plus an integer.
+        await expect(sra.wso2CaseId(wso2CaseIdPattern)).toBeVisible();
+
+        // State — must be one of the real states rather than blank or a dash.
+        const states = CASE_DETAIL.header.states;
+        const visibleStates = await Promise.all(
+          states.map((state) => sra.stateLabel(state).count()),
+        );
+        expect(
+          visibleStates.reduce((total, n) => total + n, 0),
+          `expected one of ${states.join(", ")} to be shown as the state`,
+        ).toBeGreaterThan(0);
+
+        // Subject — the generated title, pinned as-is.
+        await expect(sra.subject()).toHaveText(subject);
+      });
+    });
+  }
+});

--- a/apps/customer-portal/webapp/tests/e2e/specs/support/case-matrix.spec.ts
+++ b/apps/customer-portal/webapp/tests/e2e/specs/support/case-matrix.spec.ts
@@ -28,8 +28,21 @@
 // - The subject IS the key. Renaming a prefix in CASE_MATRIX orphans the
 //   existing cases, and the next run recreates that whole row — permanently.
 // - A false negative on the existence check creates a duplicate that cannot be
-//   removed, so `hasCaseWithSubject` waits for the search to settle rather than
-//   sampling the list mid-flight.
+//   removed, so `hasCaseWithSubject` waits for the search response produced by
+//   its own query rather than sampling the list mid-flight.
+//
+// ⚠️ DO NOT RUN THIS SUITE CONCURRENTLY AGAINST ONE ENVIRONMENT. The lookup and
+// the create are separate steps, so two overlapping runs can both find nothing
+// and both create — leaving a duplicate that cannot be deleted. Within a single
+// run this cannot happen (playwright.config.ts pins `workers: 1` and
+// `fullyParallel: false`), but nothing stops a second run, on another machine or
+// in CI, from racing this one.
+//
+// This is deliberately a documented constraint rather than a coded guard:
+// `POST /cases` offers no idempotency key and no uniqueness on subject, so the
+// server cannot dedupe; and a lock file would only serialize runs on the same
+// machine, giving false assurance against exactly the cross-machine case that
+// matters. Fixing it properly needs a server-side unique-create.
 //
 // Severity availability is per project: it comes from `acceptedSeverityValues`,
 // so a project that does not offer a severity skips that combination rather than

--- a/apps/customer-portal/webapp/tests/e2e/specs/support/case-matrix.spec.ts
+++ b/apps/customer-portal/webapp/tests/e2e/specs/support/case-matrix.spec.ts
@@ -1,0 +1,149 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//
+// Ensures one case exists per project type per severity — S1 to S4 across
+// Subscription, Managed Cloud Subscription and Cloud Support.
+//
+// ⚠️ IDEMPOTENT BY DESIGN, which matters because cases cannot be deleted. Each
+// test searches the project's case list for its deterministic subject
+// (`<prefix> <severity code>`, from CASE_MATRIX) and creates a case only when
+// none is found. A second run therefore creates nothing.
+//
+// Two consequences worth understanding before changing anything here:
+//
+// - The subject IS the key. Renaming a prefix in CASE_MATRIX orphans the
+//   existing cases, and the next run recreates that whole row — permanently.
+// - A false negative on the existence check creates a duplicate that cannot be
+//   removed, so `hasCaseWithSubject` waits for the search to settle rather than
+//   sampling the list mid-flight.
+//
+// Severity availability is per project: it comes from `acceptedSeverityValues`,
+// so a project that does not offer a severity skips that combination rather than
+// failing.
+//
+
+import { test, expect, withSession } from "../../fixtures/test";
+import { CasesListPage } from "../../pages/CasesListPage";
+import { CaseCreatePage } from "../../pages/CaseCreatePage";
+import {
+  CASE_MATRIX,
+  CASE_MATRIX_SEVERITIES,
+  IssueType,
+  PROJECTS,
+  ProjectType,
+  SEVERITY_CODES,
+} from "../../config/testData";
+import { skipWhenUnconfigured } from "../../utils/caseFlows";
+import { CREATE_CASE } from "../../utils/selectors";
+
+withSession(test);
+
+test.describe("Case Matrix", () => {
+  // Each test may load a list, search it, then run the whole create-case flow;
+  // the 30s default is nowhere near enough.
+  test.describe.configure({ timeout: 180_000 });
+
+  for (const projectType of Object.values(ProjectType)) {
+    const project = PROJECTS[projectType];
+    const naming = CASE_MATRIX[projectType];
+
+    test.describe(projectType, () => {
+      for (const severity of CASE_MATRIX_SEVERITIES) {
+        const code = SEVERITY_CODES[severity];
+        const subject = `${naming.titlePrefix} ${code}`;
+
+        test(`has a ${code} case`, async ({ page }) => {
+          skipWhenUnconfigured(project);
+
+          const list = new CasesListPage(page);
+          await list.open(project.id);
+
+          if (await list.hasCaseWithSubject(subject)) {
+            // Nothing to do — this is the steady state after the first run.
+            console.log(`${projectType} ${code}: exists ("${subject}")`);
+            return;
+          }
+
+          console.log(`${projectType} ${code}: missing, creating "${subject}"`);
+
+          const form = new CaseCreatePage(page);
+          await form.openViaGetHelp(project.id);
+
+          if (project.autoSelectsDeployment) {
+            await expect(form.deploymentSelect()).toBeHidden();
+          } else {
+            await form.selectDeployment(project.deployment);
+          }
+          await form.selectProductVersion(project.productVersion);
+
+          // Skip rather than fail when the project does not offer this severity:
+          // the available set is project data, not a defect.
+          await form.severitySelect().click();
+          const option = page.getByRole("option", {
+            name: severity,
+            exact: true,
+          });
+          const offered = (await option.count()) > 0;
+          if (!offered) {
+            await page.keyboard.press("Escape");
+          }
+          test.skip(
+            !offered,
+            `${projectType} does not offer ${severity} — its acceptedSeverityValues exclude it.`,
+          );
+          await option.click();
+
+          await form.fillTitle(subject);
+          await form.fillDescription(`${naming.descriptionPrefix} ${code}`);
+          await form.selectIssueType(IssueType.QUESTION);
+
+          await expect(form.submitButton()).toBeEnabled();
+
+          const [response] = await Promise.all([
+            page.waitForResponse(
+              (r) =>
+                new URL(r.url()).pathname.endsWith("/cases") &&
+                r.request().method() === "POST",
+            ),
+            form.submit(),
+          ]);
+
+          // Status asserted here rather than in the predicate, so a rejected
+          // create reports the server's message instead of timing out.
+          expect(
+            response.status() >= 200 && response.status() < 300,
+            `create case failed: ${response.status()} ${await response.text()}`,
+          ).toBe(true);
+
+          const created = (await response.json()) as {
+            id?: string;
+            number?: string;
+          };
+          expect(created.id, "backend returned no case id").toBeTruthy();
+
+          await expect(
+            page.getByText(CREATE_CASE.successMessage),
+          ).toBeVisible();
+
+          console.log(
+            `${projectType} ${code}: created ${created.number ?? created.id}`,
+          );
+        });
+      }
+    });
+  }
+});

--- a/apps/customer-portal/webapp/tests/e2e/specs/support/view-case.spec.ts
+++ b/apps/customer-portal/webapp/tests/e2e/specs/support/view-case.spec.ts
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//
+// Opens existing cases — one per severity, across all three project types — and
+// checks each detail page shows what it should.
+//
+// ✅ READ-ONLY. Cases are opened by URL and asserted; nothing is created,
+// commented on or closed, so this is safe to run repeatedly.
+//
+// What is and is not pinned:
+//
+// - **Severity** is pinned per case, since that is the axis these fixtures exist
+//   to cover.
+// - **WSO2 case id** and **case number** are asserted by format, not by value —
+//   the values differ per case and pinning them would make this a test of
+//   staging's contents. The id prefix is per project and is not the project key:
+//   Subscription cases read `AUTOMATIONTESTCUSSUB-<n>`, Cloud Support's
+//   `AUTOMATIONTESTCUSCLSUB-<n>` and MCS's `AUTOMATIONTESTCUSMSSUB-<n>`.
+// - **State** is asserted to be one of the real case states, so a placeholder or
+//   a blank would fail.
+// - **Subject** and **comment** are pinned per case, every value read off the
+//   live pages. Per-case rather than shared because the naming is not uniform:
+//   the Subscription and Cloud Support S4 cases carry no severity suffix and no
+//   "…with severity" in their comment, while MCS's S4 does.
+//
+// The header carries the WSO2 case id as well as the Details tab, so these
+// assertions all run against the header without switching tabs. Comments live on
+// the Activity tab, which is the default.
+//
+
+import { test, expect, withSession } from "../../fixtures/test";
+import { CaseDetailPage } from "../../pages/CaseDetailPage";
+import {
+  CASE_VIEWS,
+  CASE_VIEW_EXPECTATIONS,
+  PROJECTS,
+} from "../../config/testData";
+import { CASE_DETAIL } from "../../utils/selectors";
+
+withSession(test);
+
+test.describe("View Case", () => {
+  // Each case is a cold page load with several queries behind the header; the
+  // 30s default is not enough.
+  test.describe.configure({ timeout: 120_000 });
+
+  for (const { projectType, wso2CaseIdPattern, cases } of CASE_VIEWS) {
+    const project = PROJECTS[projectType];
+
+    test.describe(projectType, () => {
+      for (const { severity, caseId, subject, comment } of cases) {
+        test(`shows details for a ${severity} case`, async ({ page }) => {
+          test.skip(
+            !project.id || !caseId,
+            `${projectType} fixture needs a project id and a case id for ${severity}. ` +
+              `Fill them in tests/e2e/config/testData.ts.`,
+          );
+
+          const caseDetail = new CaseDetailPage(page);
+          await caseDetail.open(project.id, caseId);
+
+          // Case number — format only; the value differs per case.
+          await expect(caseDetail.caseNumber()).toBeVisible();
+          await expect(caseDetail.caseNumber()).toHaveText(
+            CASE_VIEW_EXPECTATIONS.caseNumberPattern,
+          );
+
+          // WSO2 case id — project-specific prefix plus an integer.
+          await expect(
+            caseDetail.wso2CaseId(wso2CaseIdPattern),
+          ).toBeVisible();
+
+          // Severity — the reason these four fixtures exist, so pinned exactly.
+          await expect(caseDetail.severityChip(severity)).toBeVisible();
+
+          // State — must be one of the real states rather than blank or a dash.
+          const states = CASE_DETAIL.header.states;
+          const visibleStates = await Promise.all(
+            states.map((state) => caseDetail.stateLabel(state).count()),
+          );
+          expect(
+            visibleStates.reduce((total, n) => total + n, 0),
+            `expected one of ${states.join(", ")} to be shown as the case state`,
+          ).toBeGreaterThan(0);
+
+          // Subject — pinned per case.
+          await expect(caseDetail.subject()).toHaveText(subject);
+
+          // The comment, on the Activity tab (the default). Pinned per case: the S4
+          // case's wording differs from the other three (see the fixture note).
+          await expect(caseDetail.comment(comment)).toBeVisible();
+        });
+      }
+    });
+  }
+});

--- a/apps/customer-portal/webapp/tests/e2e/utils/listSearch.ts
+++ b/apps/customer-portal/webapp/tests/e2e/utils/listSearch.ts
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//
+// Waiting on a list's search results.
+//
+// Every searchable list in the portal — the cases list and the Security Report
+// Analysis list included — is backed by the same `POST /projects/{id}/cases/search`
+// endpoint, so one helper serves them all.
+//
+
+import { type Page, type Response } from "../fixtures/test";
+
+/** How long to allow for a debounced search to fire and return. */
+const SEARCH_TIMEOUT_MS = 60_000;
+
+/**
+ * Reads the search term out of a `/cases/search` request body.
+ *
+ * @param postData - Raw request body, or null when there is none.
+ * @returns The search term, or undefined if absent or unparseable.
+ */
+function searchQueryOf(postData: string | null): string | undefined {
+  if (!postData) return undefined;
+  try {
+    // The term travels inside `filters`, alongside caseTypes — verified against a
+    // live request. It is NOT at the root of the body.
+    const body = JSON.parse(postData) as {
+      filters?: { searchQuery?: string };
+    };
+    return body.filters?.searchQuery;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Starts waiting for the search response produced by a specific term.
+ *
+ * Call this **before** typing, then await the returned promise afterwards.
+ *
+ * Matching the request's own term is what makes this reliable. Waiting for
+ * `networkidle` instead is too weak: it can resolve before the debounced request
+ * has even been issued, leaving a caller to read stale rows and conclude a record
+ * does not exist — which, for the specs that create on absence, means a permanent
+ * duplicate that cannot be deleted.
+ *
+ * @param page - Test page.
+ * @param searchText - The term about to be typed into the list's search box.
+ * @returns Promise for the matching search response.
+ */
+export function caseSearchResponse(
+  page: Page,
+  searchText: string,
+): Promise<Response> {
+  return page.waitForResponse(
+    (response) => {
+      const request = response.request();
+      if (request.method() !== "POST") return false;
+      if (!new URL(response.url()).pathname.endsWith("/cases/search")) {
+        return false;
+      }
+      return searchQueryOf(request.postData()) === searchText;
+    },
+    { timeout: SEARCH_TIMEOUT_MS },
+  );
+}

--- a/apps/customer-portal/webapp/tests/e2e/utils/selectors.ts
+++ b/apps/customer-portal/webapp/tests/e2e/utils/selectors.ts
@@ -64,6 +64,23 @@ export const CREATE_CASE = {
   },
 } as const;
 
+/** Side navigation. Items are buttons inside the sidebar landmark; which ones
+ * render depends on the project's feature flags (see SideBar.tsx). */
+export const SIDE_NAV = {
+  items: {
+    dashboard: "Dashboard",
+    support: "Support",
+    operations: "Operations",
+    updates: "Updates",
+    securityCenter: "Security Center",
+    engagements: "Engagements",
+    usageMetrics: "Usage & Metrics",
+    projectDetails: "Project Details",
+    announcements: "Announcements",
+    settings: "Settings",
+  },
+} as const;
+
 /** Project details page (`/projects/:projectId/project-details`), reached from
  * the side nav. Its tabs are Overview, Deployments and Time Tracking. */
 export const PROJECT_DETAILS = {
@@ -178,6 +195,13 @@ export const CREATE_SECURITY_REPORT = {
   },
 } as const;
 
+/** Cases list (`/projects/:projectId/support/cases`). */
+export const CASES_LIST = {
+  pathSegment: "support/cases",
+  /** Default placeholder of ListSearchPanel's input. */
+  searchPlaceholder: /Search cases/,
+} as const;
+
 /** Case detail page (`/projects/:projectId/support/cases/:caseId`).
  *
  * The state-change buttons come from `getAvailableCaseActions(status)`: an open
@@ -187,6 +211,12 @@ export const CREATE_SECURITY_REPORT = {
 export const CASE_DETAIL = {
   /** URL segment every case detail page carries. */
   pathSegment: "support/cases",
+  /** URL segment for a security report analysis, which reuses the same header. */
+  sraPathSegment: "security-center/security-report-analysis",
+  /** URL segment for a service request, which reuses the same header too. */
+  serviceRequestPathSegment: "operations/service-requests",
+  /** URL segment for an announcement — also the same header. */
+  announcementPathSegment: "announcements",
   /** The app's <main> region (AppShellLayout). Actions must be scoped to it:
    * the promo banner outside it renders its own dismiss control also named
    * "Close", which otherwise makes the locator ambiguous. */
@@ -194,6 +224,25 @@ export const CASE_DETAIL = {
   closeButton: "Close",
   /** Status shown in the header chip once the case is closed. */
   closedStatus: "Closed",
+  /** The header row renders, in order: WSO2 case id, case number, a status chip,
+   * a severity chip, then the subject. None carry ids or test ids, so they are
+   * addressed positionally within the header — see CaseDetailPage. */
+  header: {
+    /** Case states the header may show, for asserting the value is a real one
+     * rather than a placeholder. Mirrors CaseStatus in supportConstants.ts. */
+    states: [
+      "Open",
+      "Work In Progress",
+      "Awaiting Info",
+      "Waiting On WSO2",
+      "Solution Proposed",
+      "Reopened",
+      "Closed",
+    ],
+  },
+  /** Label on the Details tab. The header shows the same value, so the view spec
+   * asserts it there rather than switching tabs. */
+  wso2CaseIdLabel: "WSO2 Case ID",
   confirmDialog: {
     title: "Confirm State Change",
     confirmButton: "Confirm",

--- a/apps/customer-portal/webapp/tests/e2e/utils/selectors.ts
+++ b/apps/customer-portal/webapp/tests/e2e/utils/selectors.ts
@@ -195,6 +195,17 @@ export const CREATE_SECURITY_REPORT = {
   },
 } as const;
 
+/** Security Center (`/projects/:projectId/security-center`), whose default tab is
+ * the Security Report Analysis list. */
+export const SECURITY_CENTER = {
+  pathSegment: "security-center",
+  /** The list search covers case number, title AND description — which is what
+   * lets a report be found by its stable description rather than by its
+   * date-stamped generated title. */
+  searchPlaceholder: /Search reports/,
+  emptyMessage: "No reports found.",
+} as const;
+
 /** Cases list (`/projects/:projectId/support/cases`). */
 export const CASES_LIST = {
   pathSegment: "support/cases",


### PR DESCRIPTION
### What

Adds read-mostly E2E coverage across the portal: four "view" suites, an
idempotent case matrix, and side-menu visibility. **33 new tests**, plus the
Security Report suite extended from 1 project to 3. Suite total is now 83 across
17 files.

| Suite | Tests | Creates records? |
|---|---|---|
| `Case Matrix` | 12 | *Yes* |
| `View Case` | 12 | **No** |
| `View Announcement` | 3 | **No** |
| `Side Menu` | 3 | **No** |
| `View Security Report` | 2 | **No** |
| `View Service Request` | 1 | **No** |
| `Security Report` (was 1) | 3 | 2 create, 1 asserts absence |

All grouped by project type, so `-g "View Case › Cloud Support"` targets one
project.

### Case Matrix — idempotent by design

Ensures one case exists per project type per severity (S1-S4, 12 combinations).
Each test searches the project's case list for a deterministic subject
(`<prefix> <severity code>`) and creates a case **only when none is found**, so a
second run creates nothing. That matters because cases cannot be deleted.

Two consequences are documented in the spec: the subject *is* the key, so renaming
a prefix orphans the existing cases and recreates the row permanently; and a false
negative on the existence check makes an unremovable duplicate, so the search
waits out the 300ms debounce and for `networkidle` rather than sampling
mid-flight. It also matches subjects exactly, since the list search covers
id/title/description and would otherwise let `…S1` match `…S10`.

Severity availability is per project (`acceptedSeverityValues`), so a project that
does not offer a severity skips that combination rather than failing.

### The view suites

Case, security report analysis, service request and announcement detail pages all
turn out to **reuse the case detail header**, so `CaseDetailPage` gained one
`open…` method per route and every existing field locator applied unchanged.

What is pinned and what is not:

- **Severity** (cases) and **subject** are pinned per record.
- **Case number** and **WSO2 case id** are asserted by *format*, since values
  differ per record. The id prefix is per project and is **not** the project key —
  `AUTOMATIONTESTCUSSUB-`, `AUTOMATIONTESTCUSMSSUB-`, `AUTOMATIONTESTCUSCLSUB-`.
- **State** must be one of the real case states, so a blank or a `--` fails.

Every value was read off the live pages rather than assumed. Three findings that
would otherwise have produced wrong tests:

1. The S4 cases on Subscription and Cloud Support carry no severity suffix and no
   "…with severity" in their comment, while MCS's S4 does — so subjects and
   comments are pinned per case, not derived from a pattern.
2. Security report subjects are generated at creation as
   `<deployment> - <product> - YYYY-MM-DD`. For an existing record the date is
   fixed, so it is pinned literally with a warning **not** to compute today's
   date.
3. Service requests and announcements carry no severity chip at all.

### Security Report across project types

Extended to all three, grouped. Subscription turned out to have SRA write access
too, so it raises a real report. **Cloud Support does not offer the option** —
its test asserts the Get Help menu item is absent, which passes today and fails
if the option ever appears. A skip would pass either way. The choice is driven by
a `hasSecurityReport` flag on the fixture, so the expectation is declared in
config rather than discovered at runtime.

### Side Menu

Visibility is driven by **feature flags, not the project type label** (SideBar.tsx
filters items out), so expectations live per project in `SIDE_NAV_VISIBILITY` and
were verified live. Both presence and absence are asserted — Operations appearing
on a project without operations access would be a real regression.

| Item | Subscription | MCS | Cloud Support |
|---|---|---|---|
| Dashboard / Support / Engagements / Project Details / Announcements | ✅ | ✅ | ✅ |
| Operations | ✗ | ✅ | ✗ |
| Updates | ✅ | ✅ | ✗ |
| Security Center | ✅ | ✅ | ✗ |
| Usage & Metrics | ✅ | ✅ | ✗ |

Hidden items use `toHaveCount(0)` rather than `toBeHidden()`, because the items are
filtered out of the DOM entirely. Checks are soft, so one run reports all nine
items rather than stopping at the first mismatch.

### Testing

`tsc -b` on the E2E tsconfig and `eslint tests/e2e` are clean. Every suite in
this PR has been run green against staging:

- View Case 12/12, View Announcement 3/3, Side Menu 3/3, View Security Report
  2/2, View Service Request 1/1, Security Report 3/3.
- Case Matrix: run in part. The Subscription rows correctly reported `exists`
  without creating anything, and the MCS/Cloud Support rows created their missing
  cases — the sequential `CS04413xx` numbers those runs produced are what the view
  fixtures now point at.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added end-to-end coverage for viewing cases, security reports, service requests, and announcements.
  * Added coverage for project side-navigation visibility and case creation across supported severity levels.
  * Expanded security report validation across supported project types, including access restrictions and attachment handling.
* **Bug Fixes**
  * Improved page-load waiting and navigation reliability for slower environments.
  * Improved security report title validation when deployment details are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->