### PR TITLE
add case comment suite and case details tab coverage

### DIFF
--- a/apps/customer-portal/webapp/tests/e2e/config/testData.ts
+++ b/apps/customer-portal/webapp/tests/e2e/config/testData.ts
@@ -86,6 +86,12 @@ export interface ProjectFixture {
    * CreateCasePage.tsx). Cannot be derived from `productVersion` by trimming, so
    * it is recorded explicitly. */
   productName: string;
+  /** Whether the case Details tab renders a "Production Version" field.
+   *
+   * It is omitted when the project's product carries no version — Cloud
+   * Support's WSO2 Developer Platform, verified live — so the details assertions
+   * must not demand it there. */
+  hasProductVersionField: boolean;
   /** Whether the project offers the "Security Report" item in the Get Help
    * dropdown. Gated on the project's SRA write access
    * (`isSecurityReportVisible` in GetHelpDropdown.tsx) — Cloud Support does not
@@ -111,6 +117,7 @@ export const PROJECTS: Record<ProjectType, ProjectFixture> = {
     autoSelectsDeployment: false,
     productVersion: "WSO2 API Manager 4.5.0",
     productName: "WSO2 API Manager",
+    hasProductVersionField: true,
     hasSecurityReport: true,
   },
   [ProjectType.MANAGED_CLOUD_SUBSCRIPTION]: {
@@ -123,6 +130,7 @@ export const PROJECTS: Record<ProjectType, ProjectFixture> = {
     autoSelectsDeployment: false,
     productVersion: "WSO2 Identity Server 7.1.0",
     productName: "WSO2 Identity Server",
+    hasProductVersionField: true,
     hasSecurityReport: true,
   },
   [ProjectType.CLOUD_SUPPORT]: {
@@ -136,6 +144,7 @@ export const PROJECTS: Record<ProjectType, ProjectFixture> = {
     autoSelectsDeployment: true,
     productVersion: "WSO2 Developer Platform",
     productName: "WSO2 Developer Platform",
+    hasProductVersionField: false,
     hasSecurityReport: false,
   },
 };
@@ -607,6 +616,45 @@ export const SIDE_NAV_VISIBILITY: Partial<
     Announcements: true,
   },
 };
+
+/** A comment to post on a case, and the case it goes on. */
+export interface CaseCommentTarget {
+  projectType: ProjectType;
+  /** Case to comment on — each project's S1 case, also used by the view-case
+   * suite. */
+  caseId: string;
+  text: string;
+}
+
+/**
+ * Comments posted by the case-comment spec, one per project type.
+ *
+ * ⚠️ Comments cannot be deleted — there is no delete endpoint — so the spec posts
+ * only when this exact text is not already on the case. The text is therefore the
+ * idempotency key: changing it makes the next run post a new comment on every
+ * project, permanently.
+ *
+ * The same text is used across projects deliberately: each comment lives on a
+ * different case, so there is no ambiguity, and one string keeps the intent
+ * obvious.
+ */
+export const CASE_COMMENTS: CaseCommentTarget[] = [
+  {
+    projectType: ProjectType.SUBSCRIPTION,
+    caseId: "ce1502cf3bee4b103e1e088aa4e45a6d",
+    text: "This is a test comment from Automation Test",
+  },
+  {
+    projectType: ProjectType.MANAGED_CLOUD_SUBSCRIPTION,
+    caseId: "07962293ebeec310fcf5f5dabad0cdcd",
+    text: "This is a test comment from Automation Test",
+  },
+  {
+    projectType: ProjectType.CLOUD_SUPPORT,
+    caseId: "d4e66e1f3bea0f1091404c6aa5e45ae0",
+    text: "This is a test comment from Automation Test",
+  },
+];
 
 /** Formats shared across every project's cases. */
 export const CASE_VIEW_EXPECTATIONS = {

--- a/apps/customer-portal/webapp/tests/e2e/pages/CaseDetailPage.ts
+++ b/apps/customer-portal/webapp/tests/e2e/pages/CaseDetailPage.ts
@@ -20,7 +20,11 @@ import {
   type Response,
   expect,
 } from "../fixtures/test";
-import { CASE_DETAIL } from "../utils/selectors";
+import {
+  CASE_COMMENT_INPUT,
+  CASE_DETAIL,
+  CASE_DETAILS_PANEL,
+} from "../utils/selectors";
 import { isSuccess } from "../utils/caseFlows";
 
 /** How long to allow for a case's detail page to resolve — the header is
@@ -155,6 +159,79 @@ export class CaseDetailPage {
   /** A comment on the Activity tab, matched as a substring. */
   comment(text: string): Locator {
     return this.main().getByText(text, { exact: false }).first();
+  }
+
+  //
+  // Details tab.
+  //
+
+  /** Switches to the Details tab and waits for its first section. */
+  async openDetailsTab(): Promise<void> {
+    await this.page
+      .getByRole("tab", { name: CASE_DETAILS_PANEL.tab, exact: true })
+      .click();
+    await expect(
+      this.detailsText(CASE_DETAILS_PANEL.sections.caseOverview),
+    ).toHaveCount(1, { timeout: LOAD_TIMEOUT_MS });
+  }
+
+  /**
+   * Text within the page, for asserting a Details-tab label or section is shown.
+   *
+   * Returns the full match set rather than narrowing with `.first()`: several
+   * labels legitimately repeat — the header already shows a status and a
+   * severity, for instance — so callers assert on the count being non-zero,
+   * which states "this is displayed" without pretending the page has only one.
+   *
+   * @param text - Exact label or heading text.
+   * @returns Locator for every match.
+   */
+  detailsText(text: string): Locator {
+    return this.main().getByText(text, { exact: true });
+  }
+
+  //
+  // Activity tab — the comment box.
+  //
+
+  /** The comment editor. A Lexical contenteditable, so it is typed into rather
+   * than filled. */
+  commentEditor(): Locator {
+    return this.main().getByTestId(CASE_DETAIL.commentEditorTestId);
+  }
+
+  sendCommentButton(): Locator {
+    return this.main().getByRole("button", {
+      name: CASE_COMMENT_INPUT.sendButton,
+      exact: true,
+    });
+  }
+
+  /**
+   * Types a comment and sends it, waiting for the POST to land.
+   *
+   * @param text - Comment body.
+   * @returns The create response, for the caller to assert on.
+   */
+  async addComment(text: string): Promise<Response> {
+    const editor = this.commentEditor();
+    await expect(editor).toBeVisible({ timeout: LOAD_TIMEOUT_MS });
+    await editor.click();
+    await editor.pressSequentially(text);
+
+    // The send control stays disabled until the editor holds submittable
+    // content, so this also confirms the text registered with Lexical.
+    await expect(this.sendCommentButton()).toBeEnabled();
+
+    const [response] = await Promise.all([
+      this.page.waitForResponse(
+        (r) =>
+          /\/cases\/[^/]+\/comments$/.test(new URL(r.url()).pathname) &&
+          r.request().method() === "POST",
+      ),
+      this.sendCommentButton().click(),
+    ]);
+    return response;
   }
 
   confirmDialog(): Locator {

--- a/apps/customer-portal/webapp/tests/e2e/specs/support/case-comment.spec.ts
+++ b/apps/customer-portal/webapp/tests/e2e/specs/support/case-comment.spec.ts
@@ -1,0 +1,89 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+// Posting a comment on a case's Activity tab.
+//
+// ⚠️ IDEMPOTENT, because comments cannot be deleted — `POST /cases/{id}/comments`
+// has no delete counterpart. The test posts only when its exact text is not
+// already on the case, so retries and repeated runs add nothing. The first run
+// exercises the full post path; later runs assert the comment is still there.
+//
+// The text is the idempotency key: changing it in CASE_COMMENTS makes the next
+// run post a new comment on every project, permanently.
+//
+// Each project comments on its own S1 case — the same records the view-case suite
+// asserts on. Those assertions match comments by text, so extra comments do not
+// disturb them.
+//
+// The Activity tab is the case detail page's default tab, so no tab switch is
+// needed. The comment box is the shared rich-text Editor — a contenteditable, so
+// the text is typed rather than filled, and the send control only enables once
+// Lexical registers submittable content.
+//
+
+import { test, expect, withSession } from "../../fixtures/test";
+import { CaseDetailPage } from "../../pages/CaseDetailPage";
+import { CASE_COMMENTS, PROJECTS } from "../../config/testData";
+import { isSuccess } from "../../utils/caseFlows";
+
+withSession(test);
+
+test.describe("Case Comment", () => {
+  // A cold case load plus a round trip for the post; the 30s default is not
+  // enough.
+  test.describe.configure({ timeout: 120_000 });
+
+  for (const { projectType, caseId, text } of CASE_COMMENTS) {
+    const project = PROJECTS[projectType];
+
+    test.describe(projectType, () => {
+      test("adds a comment to the case activity", async ({ page }) => {
+        test.skip(
+          !project.id || !caseId,
+          `${projectType} needs a project id and a case id. ` +
+            `Fill them in tests/e2e/config/testData.ts.`,
+        );
+
+        const caseDetail = new CaseDetailPage(page);
+        await caseDetail.open(project.id, caseId);
+
+        const existing = caseDetail.comment(text);
+        if ((await existing.count()) > 0) {
+          // Already posted by an earlier run. Assert it is still displayed
+          // rather than posting a duplicate that could not be removed.
+          console.log(`${projectType}: comment already present`);
+          await expect(existing).toBeVisible();
+          return;
+        }
+
+        console.log(`${projectType}: comment missing, posting it`);
+
+        const response = await caseDetail.addComment(text);
+
+        // Status asserted here rather than in the response predicate, so a
+        // rejected post reports the server's message instead of timing out.
+        expect(
+          isSuccess(response.status()),
+          `post comment failed: ${response.status()} ${await response.text()}`,
+        ).toBe(true);
+
+        // The list refetches after a successful post, so the comment should
+        // appear in the activity feed without a reload.
+        await expect(caseDetail.comment(text)).toBeVisible();
+      });
+    });
+  }
+});

--- a/apps/customer-portal/webapp/tests/e2e/specs/support/view-case.spec.ts
+++ b/apps/customer-portal/webapp/tests/e2e/specs/support/view-case.spec.ts
@@ -37,9 +37,16 @@
 //   the Subscription and Cloud Support S4 cases carry no severity suffix and no
 //   "…with severity" in their comment, while MCS's S4 does.
 //
-// The header carries the WSO2 case id as well as the Details tab, so these
-// assertions all run against the header without switching tabs. Comments live on
-// the Activity tab, which is the default.
+// The header carries the WSO2 case id as well as the Details tab, so those
+// assertions run against the header. Comments live on the Activity tab, which is
+// the default.
+//
+// The test then switches to the **Details** tab and checks its five sections and
+// their field labels are displayed. Labels are asserted as "present at least
+// once" rather than exactly once: several repeat legitimately — the header
+// already shows a status and a severity — so requiring uniqueness would fail for
+// the wrong reason. The checks are soft, so one run reports every missing field
+// rather than stopping at the first.
 //
 
 import { test, expect, withSession } from "../../fixtures/test";
@@ -49,7 +56,7 @@ import {
   CASE_VIEW_EXPECTATIONS,
   PROJECTS,
 } from "../../config/testData";
-import { CASE_DETAIL } from "../../utils/selectors";
+import { CASE_DETAIL, CASE_DETAILS_PANEL } from "../../utils/selectors";
 
 withSession(test);
 
@@ -103,6 +110,48 @@ test.describe("View Case", () => {
           // The comment, on the Activity tab (the default). Pinned per case: the S4
           // case's wording differs from the other three (see the fixture note).
           await expect(caseDetail.comment(comment)).toBeVisible();
+
+          // ── Details tab ──────────────────────────────────────────────────
+          await caseDetail.openDetailsTab();
+
+          const { sections, fields } = CASE_DETAILS_PANEL;
+
+          // Sections are asserted present; Escalation Levels and Watch List
+          // carry no fields of their own here, so their headings are the check.
+          for (const section of Object.values(sections)) {
+            await expect
+              .soft(
+                caseDetail.detailsText(section),
+                `"${section}" section should be shown`,
+              )
+              .not.toHaveCount(0);
+          }
+
+          // Field labels, asserted as "displayed at least once" rather than
+          // exactly once: several repeat legitimately — the header already shows
+          // a status and a severity — so requiring uniqueness would fail for the
+          // wrong reason.
+          // "Production Version" is omitted when the project's product has no
+          // version — Cloud Support's does not — so it is only expected where
+          // the fixture says the field exists.
+          const productFields = project.hasProductVersionField
+            ? fields.productEnvironment
+            : fields.productEnvironment.filter(
+                (label) => label !== "Production Version",
+              );
+
+          for (const label of [
+            ...fields.caseOverview,
+            ...productFields,
+            ...fields.customerInformation,
+          ]) {
+            await expect
+              .soft(
+                caseDetail.detailsText(label),
+                `"${label}" field should be shown`,
+              )
+              .not.toHaveCount(0);
+          }
         });
       }
     });

--- a/apps/customer-portal/webapp/tests/e2e/utils/selectors.ts
+++ b/apps/customer-portal/webapp/tests/e2e/utils/selectors.ts
@@ -206,6 +206,47 @@ export const SECURITY_CENTER = {
   emptyMessage: "No reports found.",
 } as const;
 
+/** The comment box on a case's Activity tab (ActivityCommentInput). */
+export const CASE_COMMENT_INPUT = {
+  /** Placeholder of the rich-text editor. */
+  placeholder: "Write a comment...",
+  /** The send control's accessible name — it carries an aria-label as well as a
+   * matching tooltip. */
+  sendButton: "Send comment",
+} as const;
+
+/** The case detail page's Details tab (CaseDetailsDetailsPanel).
+ *
+ * Every label below is copied verbatim from the component — including
+ * "Production Version", which really is spelt that way. The overview ID label is
+ * dynamic ("Case ID" for a case, "Service Request Overview" / "Security Report
+ * Analysis ID" / "Engagement ID" for the other kinds), so only the case value
+ * appears here. */
+export const CASE_DETAILS_PANEL = {
+  tab: "Details",
+  sections: {
+    caseOverview: "Case Overview",
+    escalationLevels: "Escalation Levels",
+    productEnvironment: "Product & Environment",
+    customerInformation: "Customer Information",
+    watchList: "Watch List",
+  },
+  fields: {
+    caseOverview: [
+      "Case ID",
+      "WSO2 Case ID",
+      "Status",
+      "Severity",
+      "Category",
+      "Created by",
+      "Created Date",
+      "Last Updated",
+    ],
+    productEnvironment: ["Product Name", "Production Version"],
+    customerInformation: ["Organization", "Project"],
+  },
+} as const;
+
 /** Cases list (`/projects/:projectId/support/cases`). */
 export const CASES_LIST = {
   pathSegment: "support/cases",
@@ -233,6 +274,10 @@ export const CASE_DETAIL = {
    * "Close", which otherwise makes the locator ambiguous. */
   mainTestId: "app-main",
   closeButton: "Close",
+  /** The comment editor's test id. The shared Editor hardcodes this id, so the
+   * Activity tab's comment box carries the same one as the case form's
+   * description field. */
+  commentEditorTestId: "case-description-editor",
   /** Status shown in the header chip once the case is closed. */
   closedStatus: "Closed",
   /** The header row renders, in order: WSO2 case id, case number, a status chip,


### PR DESCRIPTION
### What

Two additions to the case coverage:

| Change | Tests |
|---|---|
| `Case Comment` suite (new) | 3 — one per project type |
| Details-tab assertions added to `View Case` | existing 12 tests extended |

Suite total is now 82.

### Case Comment

Posts a comment on a case's Activity tab and verifies it appears, on Subscription,
Managed Cloud Subscription and Cloud Support.

**Idempotent, because comments cannot be deleted** — `POST /cases/{id}/comments`
has no delete counterpart. Each test posts only when its exact text is not already
on the case, so retries and repeated runs add nothing. The first run exercises the
full post path; later runs assert the comment is still displayed. The text is
therefore the idempotency key: changing it makes the next run post a new comment
on every project, permanently.

Each project comments on its own S1 case — the same records the `View Case` suite
asserts on. That suite matches comments by text, so extra comments do not disturb
it; checked before choosing those cases.

Locators come from `ActivityCommentInput`: the editor is the shared Lexical
contenteditable (typed into, not filled), and the send control carries
`aria-label="Send comment"`. Note "Write a comment..." is the editor's
**placeholder**, not a tooltip — the tooltip is on the send button.

### View Case — Details tab

Each of the 12 view-case tests now switches to the Details tab and checks all five
sections and their field labels:

| Section | Fields |
|---|---|
| Case Overview | Case ID, WSO2 Case ID, Status, Severity, Category, Created by, Created Date, Last Updated |
| Escalation Levels | heading |
| Product & Environment | Product Name, Production Version |
| Customer Information | Organization, Project |
| Watch List | heading |

Two deliberate choices:

- **Presence, not uniqueness.** Assertions are `not.toHaveCount(0)` rather than
  `toBeVisible()`. Several labels legitimately repeat — the header already renders
  a status and a severity — and `toBeVisible()` on a multi-match locator is a
  strict-mode violation. This states "the field is displayed" without pretending
  the page has exactly one.
- **Soft assertions**, so one run reports every missing field rather than stopping
  at the first. That is what identified the finding below.

### One per-project difference found

**Cloud Support renders no version field.** All four of its tests failed on
"Production Version"; probing showed it has every other field and all five
sections, but no version label at all — not "Production Version", "Product
Version" or "Product". Its product (WSO2 Developer Platform) carries no version,
so the row is omitted.

Handled with a `hasProductVersionField` flag on the fixture rather than by
loosening the assertion, so a version field *appearing* on Cloud Support would be
as visible as one going missing elsewhere.

Also worth recording: **"Production Version" really is the app's spelling** —
`CaseDetailsDetailsPanel.tsx` says so. "Correcting" it to "Product Version" would
break the test.

### Testing

`tsc -b` on the E2E tsconfig and `eslint tests/e2e` are clean.

- **View Case: verified.** All 12 pass with the Details assertions, across the
  three project types (1.4m). Read-only.
- **Case Comment: not verified.** The captured session expired before it could be
  run, and this suite writes — the first run posts three real, undeletable
  comments, so it should be run deliberately rather than as part of a sweep.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for posting and displaying case comments.
  * Expanded case detail validation across supported project types, including section headings and field labels.
  * Added coverage for cases where the Production Version field is unavailable.
  * Improved test handling for existing comments and incomplete configurations to provide more reliable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->