### PR TITLE
[CSM][Web] Fix pnpm-workspace.yaml missing packages field

### DIFF
--- a/apps/csm-portal/webapp/pnpm-workspace.yaml
+++ b/apps/csm-portal/webapp/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+packages:
+  - "."
+
 allowBuilds:
   core-js: true
   esbuild: true


### PR DESCRIPTION
## Purpose
`pnpm` (9.15.9+) hard-requires a `packages` field once `pnpm-workspace.yaml` exists at all — even to run `pnpm --version` — but this repo's `webapp/pnpm-workspace.yaml` (used only for its `allowBuilds` config) never had one, silently breaking every `pnpm` command in this package for anyone on a recent pnpm version.

## Approach
Add `packages: ["."]` — this is a single, non-workspace package, so this only satisfies the required field without changing dependency resolution.

## Release note
N/A — internal tooling fix, no user-facing change.

## Documentation
N/A.

## Automation tests
`pnpm --version` failed with `packages field missing or empty` before this fix; `pnpm install`, `pnpm run lint`, `pnpm run test`, `pnpm run build` all run successfully after.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (config-only change, no source code)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
- `pnpm install`, `pnpm run lint`, `pnpm run test`, `pnpm run build` all passing locally.