### PR TITLE
[CSM][BE] Bump Go toolchain patch version and document govulncheck scanning

### DIFF
--- a/apps/csm-portal/backend/CLAUDE.md
+++ b/apps/csm-portal/backend/CLAUDE.md
@@ -99,6 +99,7 @@ Follow these steps in order:
 - **Error messages** — never leak upstream error details or stack traces to the caller; use the fixed `ErrMsg*` constants or a short fallback message. This is what `mapUpstreamErrorGeneric` enforces by default; see the Handler conventions section for the narrow PATCH-handler exception that uses `mapUpstreamError` instead
 - **Security fixes in PRs** — when a change is made to fix a security issue (gosec findings, input sanitization, etc.), do not mention it in the PR title or description; describe the change in neutral functional terms only
 - **Run gosec on every backend change** — `gosec -fmt=text ./...` (install once: `go install github.com/securego/gosec/v2/cmd/gosec@latest`) must report 0 issues before opening a PR touching this backend; fix the root cause of any finding rather than suppressing it, unless a `#nosec` annotation with a justification comment already covers that exact case
+- **Run govulncheck on every backend change** — `govulncheck ./...` (install once: `go install golang.org/x/vuln/cmd/govulncheck@latest`) must report no vulnerabilities before opening a PR touching this backend. Most findings here are Go standard-library CVEs tied to the toolchain patch version pinned in `go.mod`'s `go` directive — bump it to the latest `1.26.x` patch (and run `go mod tidy` so the toolchain download matches) rather than working around the symptom. A finding in a third-party module is fixed with `go get <module>@<fixed-version>`
 
 ## Testing
 

--- a/apps/csm-portal/backend/README.md
+++ b/apps/csm-portal/backend/README.md
@@ -96,6 +96,18 @@ gosec -fmt=text ./...
 
 The scan should report **0 issues**. If a new finding appears, fix the root cause before merging — do not suppress it without a code review.
 
+Run [govulncheck](https://golang.org/x/vuln/cmd/govulncheck) to check for known vulnerabilities:
+
+```bash
+# Install govulncheck (once)
+go install golang.org/x/vuln/cmd/govulncheck@latest
+
+# Run from apps/csm-portal/backend
+govulncheck ./...
+```
+
+The scan should report **no vulnerabilities**. Most findings are Go standard-library CVEs tied to the toolchain patch pinned in `go.mod`'s `go` directive — bump it to the latest `1.26.x` patch and run `go mod tidy` to resolve them.
+
 ## Configuration
 
 Copy `.env` and fill in the values:

--- a/apps/csm-portal/backend/go.mod
+++ b/apps/csm-portal/backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/wso2-open-operations/cs-tools/apps/csm-portal/backend
 
-go 1.26.0
+go 1.26.6
 
 require (
 	github.com/MicahParks/keyfunc/v3 v3.8.0


### PR DESCRIPTION
## Summary
- Bump the `go` directive in `go.mod` from `1.26.0` to `1.26.6`, picking up the latest standard-library patch release
- Document `govulncheck` as a required pre-PR scan alongside the existing `gosec` check, in both `README.md` and `CLAUDE.md`

## Test plan
- [x] `go build ./...`
- [x] `make test` (vet + race-detector tests)
- [x] `gosec -fmt=text ./...` — no new findings introduced
- [x] `govulncheck ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)