### PR TITLE
[CSM] Attribute Novera AI replies to the assistant instead of the customer

### DIFF
--- a/apps/customer-portal/backend-v2/internal/entity/types.go
+++ b/apps/customer-portal/backend-v2/internal/entity/types.go
@@ -1072,7 +1072,23 @@ type CreateCommentRequest struct {
 	ReferenceType ReferenceType `json:"referenceType"`
 	Type          CommentType   `json:"type"`
 	Content       string        `json:"content"`
+	// CreatedBy overrides the comment's author, which entity-service otherwise
+	// derives from the caller's own token. Only ever set by this backend itself
+	// (to CreatedByAgent, for an AI reply) — never populated from a client
+	// request body, or a customer could post as the assistant.
+	CreatedBy string `json:"createdBy,omitempty"`
 }
+
+// CreatedByAgent is the CreateCommentRequest.CreatedBy value that attributes a
+// comment to the Novera AI assistant instead of the customer whose token
+// relayed it. Mirrors the Ballerina backend's entity:CHAT_SENT_AGENT.
+//
+// Note the asymmetry between what is written and what is read back: the write
+// value is "agent", but ServiceNow resolves it to the Novera user, so reads
+// return createdBy "novera" — which is what the webapp matches on to render
+// the assistant's bubble (see ConversationDetailsPage's isBot check). Don't
+// "fix" this constant to "novera"; that is the read form, not the write form.
+const CreatedByAgent = "agent"
 
 // CommentUserRef holds user details embedded in a comment response.
 type CommentUserRef struct {

--- a/apps/customer-portal/backend-v2/internal/handler/ai_chat.go
+++ b/apps/customer-portal/backend-v2/internal/handler/ai_chat.go
@@ -193,17 +193,6 @@ func (h *AIChatHandler) GetConversationMessages(w http.ResponseWriter, r *http.R
 	writeJSONValue(w, http.StatusOK, dto.MapSearchComments(result))
 }
 
-// agentReplyCreatedBy documents a known limitation of this endpoint:
-// entity-service's CreateCommentRequest has no createdBy override (comments
-// are always attributed to the caller's own identity via their auth token),
-// so there is no way to tag the AI's own reply with a distinct "agent"
-// identity. Both the user's message and the AI's reply are therefore saved
-// here under the calling user's identity — there is no way to distinguish
-// them by author alone.
-// TODO(entity-service): revisit once/if CreateCommentRequest gains a
-// createdBy override.
-const agentReplyCreatedByCaveat = "AI reply comment attributed to caller (see agentReplyCreatedBy doc comment) — entity-service has no createdBy override"
-
 // createEntityStateResolved is entity-service's ConversationState value used
 // to auto-resolve a conversation when the AI agent reports the issue solved.
 const createEntityStateResolved = "RESOLVED"
@@ -289,13 +278,14 @@ func (h *AIChatHandler) CreateConversation(w http.ResponseWriter, r *http.Reques
 		}
 	}
 
-	// See agentReplyCreatedBy doc comment: attributed to the caller, not a
-	// distinct "agent" identity — entity-service has no createdBy override.
+	// Attributed to the assistant, not the customer whose token relayed it —
+	// see entity.CreatedByAgent.
 	if _, err := h.entity.CreateComment(r.Context(), entity.CreateCommentRequest{
 		ReferenceID:   conversationID,
 		ReferenceType: entity.ReferenceTypeConversation,
 		Type:          entity.CommentTypeComment,
 		Content:       chatResp.Message,
+		CreatedBy:     entity.CreatedByAgent,
 	}); err != nil {
 		slog.ErrorContext(r.Context(), "entity CreateComment failed for chat response", "userID", user.UserID, "conversationID", conversationID, "err", summarizeErr(err))
 		mapUpstreamError(w, err, "Failed to save chat response as comment.")
@@ -370,13 +360,14 @@ func (h *AIChatHandler) SendConversationMessage(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	// See agentReplyCreatedBy doc comment: attributed to the caller, not a
-	// distinct "agent" identity — entity-service has no createdBy override.
+	// Attributed to the assistant, not the customer whose token relayed it —
+	// see entity.CreatedByAgent.
 	if _, err := h.entity.CreateComment(r.Context(), entity.CreateCommentRequest{
 		ReferenceID:   conversationID,
 		ReferenceType: entity.ReferenceTypeConversation,
 		Type:          entity.CommentTypeComment,
 		Content:       chatResp.Message,
+		CreatedBy:     entity.CreatedByAgent,
 	}); err != nil {
 		slog.ErrorContext(r.Context(), "entity CreateComment failed for chat response", "userID", user.UserID, "conversationID", conversationID, "err", summarizeErr(err))
 		mapUpstreamError(w, err, "Failed to save chat response as comment.")

--- a/apps/customer-portal/backend-v2/internal/handler/websocket.go
+++ b/apps/customer-portal/backend-v2/internal/handler/websocket.go
@@ -92,9 +92,9 @@ type wsTokenValidator interface {
 // must first create one via
 // POST /projects/{id}/conversations (see handler.AIChatHandler.CreateConversation).
 // The AI agent's own reply IS persisted as a comment here (see
-// handleMessage), but — like AIChatHandler.SendConversationMessage — it is
-// attributed to the caller's own identity, not a distinct "agent" identity,
-// since entity-service's CreateCommentRequest has no createdBy override.
+// handleMessage), attributed to the assistant rather than to the customer
+// whose token relayed it, via entity.CreatedByAgent — the same as
+// AIChatHandler.SendConversationMessage.
 type WebSocketHandler struct {
 	ai      wsStreamer
 	entity  entityCommentCreator
@@ -381,13 +381,14 @@ func (h *WebSocketHandler) handleMessage(ctx context.Context, conn *websocket.Co
 		_ = json.Unmarshal(raw, &agentMessageText)
 	}
 	if agentMessageText != "" {
-		// See WebSocketHandler's doc comment: attributed to the caller, not a
-		// distinct "agent" identity — entity-service has no createdBy override.
+		// Attributed to the assistant, not the customer whose token relayed it
+		// — see entity.CreatedByAgent.
 		if _, err := h.entity.CreateComment(ctx, entity.CreateCommentRequest{
 			ReferenceID:   conversationID,
 			ReferenceType: entity.ReferenceTypeConversation,
 			Type:          entity.CommentTypeComment,
 			Content:       agentMessageText,
+			CreatedBy:     entity.CreatedByAgent,
 		}); err != nil {
 			slog.ErrorContext(ctx, "entity CreateComment failed for chat response", "userID", user.UserID, "conversationID", conversationID, "err", summarizeErr(err))
 		}

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -2008,6 +2008,15 @@ type CreateCommentRequest struct {
 	ReferenceType ReferenceType `json:"referenceType"`
 	Type          CommentType   `json:"type"`
 	Content       string        `json:"content"`
+	// CreatedBy optionally overrides the comment's author, which ServiceNow
+	// otherwise derives from the caller's own x-user-id-token. Its only current
+	// use is letting an AI-assistant reply be attributed to the assistant
+	// rather than to the customer whose token relayed it — pass "agent" for
+	// that, matching the digiops-cs entity-service contract
+	// (CommentCreatePayload.createdBy) the Ballerina customer-portal backend
+	// already uses. Omitted from the upstream payload when empty, so ordinary
+	// callers keep the caller-attributed default.
+	CreatedBy string `json:"createdBy,omitempty"`
 }
 
 // CreateCommentResponse is the response for POST /comments.

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -915,6 +915,11 @@ type snCreateCommentPayload struct {
 	ReferenceType string `json:"referenceType"`
 	Type          string `json:"type"`
 	Content       string `json:"content"`
+	// CreatedBy is omitted unless a caller explicitly overrides the author —
+	// ServiceNow then falls back to resolving it from the caller's token, which
+	// is what the case-comment path here relies on. See
+	// domain.CreateCommentRequest.CreatedBy.
+	CreatedBy string `json:"createdBy,omitempty"`
 }
 
 type snCreateCommentResponse struct {

--- a/entity-service/internal/service/sn_comment_service.go
+++ b/entity-service/internal/service/sn_comment_service.go
@@ -153,6 +153,7 @@ func (s *snCommentSearchService) CreateComment(ctx context.Context, req domain.C
 		ReferenceType: string(req.ReferenceType),
 		Type:          snType,
 		Content:       req.Content,
+		CreatedBy:     req.CreatedBy,
 	}
 
 	raw, err := s.client.Post(ctx, "/comments", token, payload)


### PR DESCRIPTION
Resolves wso2-enterprise/digiops-cs#2755 (epic wso2-enterprise/digiops-cs#2751).

## Summary

In a conversation transcript, **both the customer's message and the AI's reply render as the customer**. Under the Ballerina backend the reply rendered as "Novera" with the bot avatar, so this is a regression against the service backend-v2 replaces.

Both messages are persisted as comments, and `cs-tools/entity-service`'s `CreateCommentRequest` had **no `createdBy` field at all** — the author is always derived from the caller's token. The webapp picks the assistant bubble with:

```ts
const isBot = msg.type?.toLowerCase() === "bot" || msg.createdBy?.toLowerCase() === "novera";
```

backend-v2 could satisfy neither signal. The Ballerina backend sets `createdBy: entity:CHAT_SENT_AGENT`, and `digiops-cs/entity-service` supports it (`CommentCreatePayload.createdBy?`); `cs-tools/entity-service` did not.

- **entity-service** — optional `CreatedBy` on `domain.CreateCommentRequest` and on the ServiceNow `snCreateCommentPayload`, forwarded only when non-empty. That payload is shared with the case-comment path in `sn_case_service.go`, which is unaffected: it never sets the field, so `omitempty` keeps it off the wire and ServiceNow keeps resolving the author from the caller's token.
- **backend-v2** — `CreatedBy` on `entity.CreateCommentRequest` plus an `entity.CreatedByAgent` constant, set on the **three AI-reply writes only**: `websocket.go`'s `handleMessage`, and both `AIChatHandler` reply paths. User-message writes are untouched.
- Removed the now-obsolete `agentReplyCreatedByCaveat` constant and the doc comments describing the limitation.
- **No frontend change** — it already handles the signal.

## Two things worth a reviewer's attention

**It writes `"agent"`, not `"novera"` — this is deliberate.** `digiops-cs/entity-service` passes `createdBy` straight through, and ServiceNow resolves `"agent"` to the Novera user, which is why *reads* come back as `"novera"`. Write and read forms differ. The constant's doc comment says so, to stop it being "corrected" to `"novera"` later.

**It is not client-settable.** `POST /comments` builds its upstream request through `dto.BuildEntityCreateCommentRequest`, which never copies `createdBy` from the request body — so a customer cannot post as the assistant.

## Test plan

Both services, in containers (no local Go toolchain):

- [x] `go build ./...` — backend-v2, entity-service
- [x] `go vet ./...` — both
- [x] `gofmt -l .` — clean, both
- [x] `go test -race ./...` — all packages pass, both
- [x] `gosec -fmt=text ./...` — **0 issues**, both
- [ ] Staging: close/accept a case-solution conversation and confirm the reply renders as "Novera" with the bot avatar, and the customer's own message still renders as the customer

## Note on the ServiceNow behaviour

That ServiceNow resolves `"agent"` to the Novera user is inferred from two things: existing transcripts written by the Ballerina backend show `createdBy` reading back as `"novera"`, and `digiops-cs/entity-service`'s `CommentCreatePayload` declares `string createdBy?` with no mapping of its own. I could not exercise the ServiceNow API directly. If staging shows the author as literally "agent", the mapping lives somewhere else and this needs revisiting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * AI-generated comments are now correctly attributed to the assistant instead of the authenticated customer.
  * Comment attribution is consistently preserved for initial chats, follow-up messages, and WebSocket responses.
  * Comment creation now supports an optional author override while retaining the default caller attribution when unspecified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->