### PR TITLE
[CSM] Add GET /projects/{id}/stats/usage so the Usage Metrics page fetches data

### DIFF
--- a/apps/customer-portal/backend-v2/CLAUDE.md
+++ b/apps/customer-portal/backend-v2/CLAUDE.md
@@ -6,7 +6,7 @@ responses for the frontend. This is a rewrite of the existing backend at
 `apps/customer-portal/backend`, modeled on `apps/csm-portal/backend`'s conventions — read that
 backend's own CLAUDE.md too if something here is underspecified.
 
-**Status: in progress.** 104 routes are wired up so far, across seven upstream services:
+**Status: in progress.** 105 routes are wired up so far, across seven upstream services:
 entity-service, the WSO2 Updates service, SCIM, the AI chat agent, the product-consumption
 service, the registry (robot-account) service, and the project-contact onboarding service (see
 "The AI chat agent", "The product-consumption service", "The registry service", and "The
@@ -40,7 +40,8 @@ all). Route list: `GET /health`, `GET`/`PATCH /users/me`, `POST /accounts/search
 `GET /projects/{id}/filters`, `GET /projects/{id}/features`, `GET /projects/{id}/stats`,
 `GET /projects/{id}/stats/cases`, `GET /projects/{id}/stats/conversations`,
 `GET /projects/{id}/stats/support`, `GET /projects/{id}/stats/time-cards`,
-`GET /projects/{id}/stats/change-requests`, `POST /projects/{id}/cases/time-cards/search`,
+`GET /projects/{id}/stats/change-requests`, `GET /projects/{id}/stats/usage`,
+`POST /projects/{id}/cases/time-cards/search`,
 `GET /metadata`, `POST /search`, `GET /products/vulnerabilities/meta`,
 `GET /cases/{id}/feedback`, `POST /cases/{id}/feedback`, `GET /cases/{id}/attachments`,
 `GET /attachments/{id}`,

--- a/apps/customer-portal/backend-v2/README.md
+++ b/apps/customer-portal/backend-v2/README.md
@@ -315,6 +315,7 @@ backend-v2/
 - `GET /projects/{id}/stats/support` — get a project's combined support statistics (case + conversation; partial failures are tolerated)
 - `GET /projects/{id}/stats/time-cards` — get a project's time-card statistics, optionally filtered by `startDate`/`endDate`
 - `GET /projects/{id}/stats/change-requests` — get a project's change-request statistics
+- `GET /projects/{id}/stats/usage` — get a project's usage statistics (deployment, deployed-product and instance counts) for the Usage Metrics page
 - `POST /projects/{id}/cases/search` — search a project's cases
 - `GET /cases/{id}` — get case by ID
 - `POST /cases` — create a case
@@ -450,6 +451,8 @@ curl -H "x-jwt-assertion: $JWT" http://localhost:8080/projects/<project-id>/stat
 curl -H "x-jwt-assertion: $JWT" "http://localhost:8080/projects/<project-id>/stats/time-cards?startDate=2026-07-01&endDate=2026-07-31"
 
 curl -H "x-jwt-assertion: $JWT" http://localhost:8080/projects/<project-id>/stats/change-requests
+
+curl -H "x-jwt-assertion: $JWT" http://localhost:8080/projects/<project-id>/stats/usage
 
 curl -X POST http://localhost:8080/projects/<project-id>/cases/search \
   -H "x-jwt-assertion: $JWT" -H "Content-Type: application/json" \

--- a/apps/customer-portal/backend-v2/cmd/server/main.go
+++ b/apps/customer-portal/backend-v2/cmd/server/main.go
@@ -208,6 +208,7 @@ func main() {
 	mux.HandleFunc("GET /projects/{id}/stats/support", projectStatsHandler.GetProjectSupportStats)
 	mux.HandleFunc("GET /projects/{id}/stats/time-cards", projectStatsHandler.GetProjectTimeCardStats)
 	mux.HandleFunc("GET /projects/{id}/stats/change-requests", projectStatsHandler.GetProjectChangeRequestStats)
+	mux.HandleFunc("GET /projects/{id}/stats/usage", projectStatsHandler.GetProjectUsageStats)
 	mux.HandleFunc("POST /projects/{id}/cases/time-cards/search", projectStatsHandler.SearchProjectCaseTimeCards)
 	mux.HandleFunc("POST /projects/{id}/instances/search", instanceHandler.SearchProjectInstances)
 	mux.HandleFunc("POST /projects/{id}/instances/metrics/search", instanceHandler.SearchProjectInstanceMetrics)

--- a/apps/customer-portal/backend-v2/internal/dto/project_stats.go
+++ b/apps/customer-portal/backend-v2/internal/dto/project_stats.go
@@ -411,3 +411,28 @@ func MapProjectChangeRequestStats(r entity.ProjectChangeRequestStatsResponse) Pr
 		ResolvedCount:       mapResolvedCountBreakdown(r.ResolvedCount),
 	}
 }
+
+// UsageStats is the counter trio the Usage Metrics page reads from
+// GET /projects/{id}/stats/usage.
+//
+// entity-service's ProjectStatsResponse carries more than this (hours, SLA
+// status, outstanding counts), but the frontend's own contract for this
+// endpoint is exactly these three fields — see UsageStatsResponse in
+// webapp/src/features/project-details/types/usage.ts — and the Ballerina
+// backend's mapUsageStats returns the same three. Match the frontend's
+// contract, not entity-service's superset; the richer numbers are already
+// exposed through GET /projects/{id}/stats.
+type UsageStats struct {
+	DeploymentCount      int `json:"deploymentCount"`
+	DeployedProductCount int `json:"deployedProductCount"`
+	InstanceCount        int `json:"instanceCount"`
+}
+
+// MapUsageStats trims entity-service's project stats to the Usage Metrics view.
+func MapUsageStats(r entity.ProjectStatsResponse) UsageStats {
+	return UsageStats{
+		DeploymentCount:      r.DeploymentCount,
+		DeployedProductCount: r.DeployedProductCount,
+		InstanceCount:        r.InstanceCount,
+	}
+}

--- a/apps/customer-portal/backend-v2/internal/dto/project_usage_stats_test.go
+++ b/apps/customer-portal/backend-v2/internal/dto/project_usage_stats_test.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dto
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+)
+
+// TestMapUsageStats_CopiesTheThreeCounters checks the mapping the Usage
+// Metrics page depends on. The page fetched nothing at all before this
+// endpoint existed in backend-v2 (it was only ever implemented in the
+// Ballerina backend).
+func TestMapUsageStats_CopiesTheThreeCounters(t *testing.T) {
+	got := MapUsageStats(entity.ProjectStatsResponse{
+		DeploymentCount:      3,
+		DeployedProductCount: 7,
+		InstanceCount:        11,
+	})
+
+	if got.DeploymentCount != 3 {
+		t.Errorf("DeploymentCount = %d, want 3", got.DeploymentCount)
+	}
+	if got.DeployedProductCount != 7 {
+		t.Errorf("DeployedProductCount = %d, want 7", got.DeployedProductCount)
+	}
+	if got.InstanceCount != 11 {
+		t.Errorf("InstanceCount = %d, want 11", got.InstanceCount)
+	}
+}
+
+// TestMapUsageStats_MatchesFrontendContract pins the wire shape to the
+// frontend's UsageStatsResponse type
+// (webapp/src/features/project-details/types/usage.ts): exactly three keys,
+// named as below. entity-service's ProjectStatsResponse is a superset — hours,
+// SLA status and outstanding counts must not leak into this endpoint, which is
+// why it maps through a DTO rather than being passed through.
+func TestMapUsageStats_MatchesFrontendContract(t *testing.T) {
+	raw, err := json.Marshal(MapUsageStats(entity.ProjectStatsResponse{
+		TotalHours:       42,
+		BillableHours:    21,
+		SLAStatus:        "AT_RISK",
+		DeploymentCount:  1,
+		InstanceCount:    2,
+		OutstandingCount: entity.ProjectStatsOutstandingCount{},
+	}))
+	if err != nil {
+		t.Fatalf("marshal returned error: %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("result is not valid JSON: %v", err)
+	}
+
+	want := []string{"deploymentCount", "deployedProductCount", "instanceCount"}
+	if len(got) != len(want) {
+		t.Errorf("got %d keys %v, want exactly %d %v", len(got), got, len(want), want)
+	}
+	for _, k := range want {
+		if _, ok := got[k]; !ok {
+			t.Errorf("missing key %q", k)
+		}
+	}
+	for _, leaked := range []string{"totalHours", "billableHours", "slaStatus", "outstandingCount"} {
+		if _, ok := got[leaked]; ok {
+			t.Errorf("entity-service field %q leaked into the usage-stats response", leaked)
+		}
+	}
+}

--- a/apps/customer-portal/backend-v2/internal/handler/project_stats.go
+++ b/apps/customer-portal/backend-v2/internal/handler/project_stats.go
@@ -320,3 +320,30 @@ func (h *ProjectStatsHandler) SearchProjectCaseTimeCards(w http.ResponseWriter, 
 
 	writeJSONValue(w, http.StatusOK, dto.MapCaseTimeCardSearchResponse(result))
 }
+
+// GetProjectUsageStats handles GET /projects/{id}/stats/usage — the counter
+// trio on the Usage Metrics page. Backed by the same entity-service call as
+// GET /projects/{id}/stats, trimmed to the fields that page reads (see
+// dto.UsageStats).
+func (h *ProjectStatsHandler) GetProjectUsageStats(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	id := r.PathValue("id")
+	if id == "" || !uuidRe.MatchString(id) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	result, err := h.entity.GetProjectStats(r.Context(), id)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity GetProjectStats failed", "userID", user.UserID, "projectID", id, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to retrieve usage statistics.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusOK, dto.MapUsageStats(result))
+}

--- a/apps/customer-portal/backend-v2/openapi.yaml
+++ b/apps/customer-portal/backend-v2/openapi.yaml
@@ -677,6 +677,54 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
+  /projects/{id}/stats/usage:
+    get:
+      summary: Get a project's usage statistics.
+      operationId: getProjectsIdStatsUsage
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UsageStats'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: NotFound
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
   /projects/{id}/stats/change-requests:
     get:
       summary: Get a project's change-request statistics.
@@ -8410,6 +8458,24 @@ components:
     #
     # GET /projects/{id}/filters, /features, /stats, /stats/cases,
     # /stats/conversations, /stats/support, /stats/time-cards, and
+    UsageStats:
+      type: object
+      description: >-
+        Counter trio for the Usage Metrics page. Deliberately narrower than
+        ProjectStats, which is served from the same entity-service call — this
+        endpoint's contract is fixed at what the frontend reads.
+      required:
+        - deploymentCount
+        - deployedProductCount
+        - instanceCount
+      properties:
+        deploymentCount:
+          type: integer
+        deployedProductCount:
+          type: integer
+        instanceCount:
+          type: integer
+
     # /stats/change-requests — see internal/dto/project_stats.go and this
     # backend's CLAUDE.md, "Project metadata and stats — reshaped, not
     # passed through".


### PR DESCRIPTION
Resolves wso2-enterprise/digiops-cs#2789 (epic wso2-enterprise/digiops-cs#2751).

## Summary

The Usage Metrics page renders but **fetches no data** against backend-v2.

The frontend calls `GET /projects/{projectId}/stats/usage` (`webapp/src/features/project-details/api/useGetProjectUsageStats.ts:39`). The Ballerina backend implements it (`service.bal:5713`); backend-v2 never ported it, so the route 404s.

**No new upstream call was needed.** Ballerina's handler calls `entity:getProjectActivityStats`, which resolves to `GET /projects/{id}/stats` on entity-service — the exact path `entity.GetProjectStats` already uses here. The gap was only the DTO, handler and route.

- `dto.UsageStats` + `MapUsageStats` trim `entity.ProjectStatsResponse` to the three counters the page reads
- `ProjectStatsHandler.GetProjectUsageStats` + route registration
- README, CLAUDE.md route inventory (104 → 105) and `openapi.yaml` updated

## Why the response is narrower than `GET /projects/{id}/stats`

Both endpoints are served from the same entity-service call, but this one returns only `deploymentCount`, `deployedProductCount` and `instanceCount`. That is deliberate on two counts: it matches the frontend's own `UsageStatsResponse` type (`webapp/src/features/project-details/types/usage.ts`), and it matches the Ballerina `mapUsageStats`, which returns exactly those three.

Per CLAUDE.md's "match the frontend's contract, not entity-service's superset" rule, `totalHours`, `billableHours`, `slaStatus` and `outstandingCount` are trimmed — they remain available on `GET /projects/{id}/stats`. One of the new tests asserts the serialised response has exactly three keys and fails if any of those fields ever leaks in.

## Test plan

Run in a `golang:1.26-alpine` container (no local Go toolchain):

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` — clean
- [x] `go test -race ./...` — all packages pass, including 2 new `TestMapUsageStats_*` subtests
- [x] `gosec -fmt=text ./...` — **0 issues**
- [x] `openapi.yaml` parses as valid YAML; new path and `UsageStats` schema both present
- [ ] Staging: open Usage Metrics for a project and confirm the counters populate

## Note — a second, unrelated failure on the same page

The Usage Metrics page also calls `GET /projects/{projectId}/timetracking` (`useGetTimeTrackingDetails.ts:51`), which exists in **neither** backend — grepping both for `timetracking` finds nothing. That call has presumably always 404d and is **not** fixed here; it needs a decision (dead code, different service, or unbuilt feature) rather than a port. Tracked separately as wso2-enterprise/digiops-cs#2790, so don't expect this PR alone to make every widget on that page populate.
