### PR TITLE
Update auto-label-assign rules for backend-v2 and notification service

### DIFF
--- a/.github/workflows/auto-label-assign.yml
+++ b/.github/workflows/auto-label-assign.yml
@@ -51,11 +51,13 @@ jobs:
               { label: 'App/CSM Portal',      test: f => f.startsWith('apps/csm-portal/') },
               { label: 'App/Customer Portal', test: f => f.startsWith('apps/customer-portal/') },
               { label: 'Area/Backend',        test: f => /^apps\/[^/]+\/backend\//.test(f) },
+              { label: 'Area/Backend',        test: f => /^apps\/[^/]+\/backend-v2\//.test(f) },
               { label: 'Area/Frontend',       test: f => /^apps\/[^/]+\/webapp\//.test(f) },
               { label: 'Platform/Microapp',   test: f => /^apps\/[^/]+\/microapp\//.test(f) },
               { label: 'Platform/Web',        test: f => /^apps\/[^/]+\/webapp\//.test(f) },
               { label: 'Entity Service',      test: f => f.startsWith('entity-service/') },
-              { label: 'Op/CSM Integration Service',      test: f => f.startsWith('integrations/csm-integration-service/') },
+              { label: 'Int/CSM Integration Service',      test: f => f.startsWith('integrations/csm-integration-service/') },
+              { label: 'Int/CSM Notification Service',      test: f => f.startsWith('integrations/csm-notification-service/') },
             ];
 
             const labelsToApply = fileRules


### PR DESCRIPTION
## Summary
- Add an `Area/Backend` label rule for `apps/*/backend-v2/`
- Rename the CSM integration service label from `Op/CSM Integration Service` to `Int/CSM Integration Service`
- Add an `Int/CSM Notification Service` label rule for `integrations/csm-notification-service/`

## Test plan
- [ ] Confirm labels are applied correctly to a PR touching `apps/*/backend-v2/`
- [ ] Confirm labels are applied correctly to a PR touching `integrations/csm-notification-service/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automatic labeling for backend-related changes.
  * Renamed the CSM integration label for consistency.
  * Added automatic labeling for CSM notification-service changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->