### PR TITLE
[CSM Portal] preserve in-progress work through token-expiry recovery

### DIFF
--- a/apps/csm-portal/webapp/src/AppWithConfig.tsx
+++ b/apps/csm-portal/webapp/src/AppWithConfig.tsx
@@ -49,6 +49,26 @@ function shouldRetryQuery(failureCount: number, error: Error): boolean {
   return statusCode === 502 || statusCode === 503;
 }
 
+// `signInSilently()` (from `@asgardeo/react`) recovers an expired access
+// token by loading the IdP's authorize URL, with prompt=none, inside a
+// hidden, invisible iframe. Because this app's own SPA is served at the
+// same redirect_uri as the top-level app, that hidden iframe's document is
+// a full second load of THIS SAME bundle — `AsgardeoProvider` needs to
+// mount and initialize there to complete the SDK's internal handshake
+// (it detects the silent-sign-in state in the URL and short-circuits), but
+// nothing below it should. Without this guard, the router/`AuthGuard`/page
+// tree fully mounts inside that hidden iframe too, and `AuthGuard`'s own
+// (correct, needed) recovery logic then notices "not signed in yet" INSIDE
+// that iframe and starts its own silent sign-in — recursively nesting
+// another hidden iframe inside this one. Observed live: a single token
+// expiry cascaded into 7 nested iframe loads and dropped an in-flight POST
+// (a case comment was never created) somewhere in that churn. This app is
+// never legitimately embedded by anything else, so `window.self !==
+// window.top` unambiguously means "I am the SDK's own hidden recovery
+// iframe," not a real embedding scenario to support.
+const isInsideHiddenAuthIframe =
+  typeof window !== "undefined" && window.self !== window.top;
+
 const queryClient: QueryClient = new QueryClient({
   defaultOptions: {
     queries: {
@@ -84,22 +104,24 @@ export default function AppWithConfig(): JSX.Element {
         },
       }}
     >
-      <BrowserRouter>
-        <LoggerProvider config={loggerConfig}>
-          <ThemePreferenceProvider>
-            <QueryClientProvider client={queryClient}>
-              <AppErrorBoundary>
-                <App />
-              </AppErrorBoundary>
-              {ReactQueryDevtools && (
-                <Suspense fallback={null}>
-                  <ReactQueryDevtools initialIsOpen={false} />
-                </Suspense>
-              )}
-            </QueryClientProvider>
-          </ThemePreferenceProvider>
-        </LoggerProvider>
-      </BrowserRouter>
+      {isInsideHiddenAuthIframe ? null : (
+        <BrowserRouter>
+          <LoggerProvider config={loggerConfig}>
+            <ThemePreferenceProvider>
+              <QueryClientProvider client={queryClient}>
+                <AppErrorBoundary>
+                  <App />
+                </AppErrorBoundary>
+                {ReactQueryDevtools && (
+                  <Suspense fallback={null}>
+                    <ReactQueryDevtools initialIsOpen={false} />
+                  </Suspense>
+                )}
+              </QueryClientProvider>
+            </ThemePreferenceProvider>
+          </LoggerProvider>
+        </BrowserRouter>
+      )}
     </AsgardeoProvider>
   );
 }

--- a/apps/csm-portal/webapp/src/hooks/silentSignIn.test.ts
+++ b/apps/csm-portal/webapp/src/hooks/silentSignIn.test.ts
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { describe, expect, it, vi } from "vitest";
+import { trySilentSignInOnce } from "@hooks/silentSignIn";
+
+describe("trySilentSignInOnce", () => {
+  it("shares one in-flight attempt across two independent callers, as if from AuthGuard and useAuthApiClient at once", async () => {
+    let resolveSignIn: (value: boolean) => void;
+    const signInSilently = vi.fn(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolveSignIn = resolve;
+        }),
+    );
+
+    // Two independent callers (mirroring AuthGuard's route-mount check and
+    // useAuthApiClient's fetch-401 recovery both noticing the same expired
+    // token around the same moment) each start their own attempt.
+    const first = trySilentSignInOnce(signInSilently);
+    const second = trySilentSignInOnce(signInSilently);
+
+    expect(signInSilently).toHaveBeenCalledTimes(1);
+
+    resolveSignIn!(true);
+    await expect(first).resolves.toBe(true);
+    await expect(second).resolves.toBe(true);
+  });
+
+  it("starts a fresh attempt once the previous one has settled", async () => {
+    const signInSilently = vi.fn().mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+
+    await expect(trySilentSignInOnce(signInSilently)).resolves.toBe(false);
+    await expect(trySilentSignInOnce(signInSilently)).resolves.toBe(true);
+
+    expect(signInSilently).toHaveBeenCalledTimes(2);
+  });
+
+  it("resolves false and reports a sanitized message when the attempt rejects", async () => {
+    const signInSilently = vi.fn().mockRejectedValue(new Error("iframe blocked"));
+    const onError = vi.fn();
+
+    await expect(trySilentSignInOnce(signInSilently, onError)).resolves.toBe(false);
+
+    expect(onError).toHaveBeenCalledWith("iframe blocked");
+  });
+});

--- a/apps/csm-portal/webapp/src/hooks/silentSignIn.ts
+++ b/apps/csm-portal/webapp/src/hooks/silentSignIn.ts
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Module-scope, shared by every caller across the app (AuthGuard's route-mount
+// check and useAuthApiClient's fetch-401 recovery both call this). The Asgardeo
+// SDK's `signInSilently()` opens its own hidden iframe per invocation with no
+// coordination of its own — if two independent callers each notice the same
+// expired token and call it separately, the app ends up running two
+// unsynchronized hidden-iframe re-auth cycles at once, which can starve or
+// drop whichever in-flight request (e.g. a POST creating a comment) is
+// racing against them. Single-flighting at this shared module scope, rather
+// than per-caller, ensures the whole app ever has at most one silent
+// re-auth attempt in flight, and every caller awaits the SAME outcome.
+let inFlight: Promise<boolean> | null = null;
+
+/**
+ * Run `signInSilently` at most once concurrently across the whole app.
+ * Every caller while an attempt is in flight awaits that same attempt instead
+ * of starting a new one. `onError` (optional) is invoked with a short message
+ * — never the raw error object — if the attempt rejects.
+ */
+export function trySilentSignInOnce(
+  signInSilently: () => Promise<unknown>,
+  onError?: (message: string) => void,
+): Promise<boolean> {
+  if (!inFlight) {
+    inFlight = Promise.resolve(signInSilently())
+      .then((result) => Boolean(result))
+      .catch((error) => {
+        const message = error instanceof Error ? error.message : "unknown error";
+        onError?.(message);
+        return false;
+      })
+      .finally(() => {
+        inFlight = null;
+      });
+  }
+  return inFlight;
+}

--- a/apps/csm-portal/webapp/src/hooks/useAuthApiClient.test.ts
+++ b/apps/csm-portal/webapp/src/hooks/useAuthApiClient.test.ts
@@ -15,7 +15,14 @@
 // under the License.
 
 import { renderHook } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Matches useAuthApiClient.ts's SILENT_RECOVERY_POLL_INTERVAL_MS / _BUDGET_MS
+// (not exported — the chain polls on a short interval after kicking off
+// silent sign-in instead of trusting only its own return value; see that
+// file's comment for why). Tests use fake timers and advance past these.
+const POLL_INTERVAL_MS = 700;
+const POLL_BUDGET_MS = 8_000;
 
 const ASGARDEO_UNAUTHENTICATED_CODE = "SPA-AUTH_CLIENT-VM-IV02";
 
@@ -63,6 +70,7 @@ describe("useAuthApiClient", () => {
   const fetchMock = vi.fn();
 
   beforeEach(() => {
+    vi.useFakeTimers();
     vi.stubGlobal("fetch", fetchMock);
     fetchMock.mockReset();
     getAccessTokenMock.mockReset().mockResolvedValue("access-token");
@@ -72,6 +80,10 @@ describe("useAuthApiClient", () => {
     debugMock.mockReset();
     errorMock.mockReset();
     sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("returns the response untouched on a plain success", async () => {
@@ -139,7 +151,7 @@ describe("useAuthApiClient", () => {
     expect(signInMock).not.toHaveBeenCalled();
   });
 
-  it("on a thrown token-expiry error that survives the bare retry, tries silent sign-in then retries again", async () => {
+  it("on a thrown token-expiry error that survives the bare retry, tries silent sign-in then recovers via the first poll", async () => {
     getAccessTokenMock
       .mockRejectedValueOnce(TOKEN_EXPIRED_ERROR)
       .mockRejectedValueOnce(TOKEN_EXPIRED_ERROR)
@@ -147,21 +159,28 @@ describe("useAuthApiClient", () => {
     fetchMock.mockResolvedValue(jsonResponse(200, { ok: true }));
 
     const { result } = renderHook(() => useAuthApiClient());
-    const response = await result.current("https://example.test/api/thing");
+    const responsePromise = result.current("https://example.test/api/thing");
+    // Silent sign-in's own return value isn't trusted as the sole recovery
+    // signal (see useAuthApiClient.ts) — the chain polls the original
+    // request on an interval instead; advance past the first one.
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+    const response = await responsePromise;
 
     expect(response.status).toBe(200);
     expect(signInSilentlyMock).toHaveBeenCalledTimes(1);
     expect(signInMock).not.toHaveBeenCalled();
   });
 
-  it("on a resolved 401 that survives the bare retry, tries silent sign-in then retries again", async () => {
+  it("on a resolved 401 that survives the bare retry, tries silent sign-in then recovers via the first poll", async () => {
     fetchMock
       .mockResolvedValueOnce(jsonResponse(401))
       .mockResolvedValueOnce(jsonResponse(401))
       .mockResolvedValue(jsonResponse(200, { ok: true }));
 
     const { result } = renderHook(() => useAuthApiClient());
-    const response = await result.current("https://example.test/api/thing");
+    const responsePromise = result.current("https://example.test/api/thing");
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+    const response = await responsePromise;
 
     expect(response.status).toBe(200);
     expect(fetchMock).toHaveBeenCalledTimes(3);
@@ -169,7 +188,7 @@ describe("useAuthApiClient", () => {
     expect(signInMock).not.toHaveBeenCalled();
   });
 
-  it("forces a full sign-in redirect when a resolved 401 survives retry, silent sign-in, and the retry after it", async () => {
+  it("forces a full sign-in redirect once the poll budget is exhausted, when a resolved 401 survives every poll despite silent sign-in reporting success", async () => {
     fetchMock.mockResolvedValue(jsonResponse(401));
 
     const { result } = renderHook(() => useAuthApiClient());
@@ -177,20 +196,24 @@ describe("useAuthApiClient", () => {
     // triggered, so only assert on the calls it makes rather than awaiting it.
     void result.current("https://example.test/api/thing");
 
+    await vi.advanceTimersByTimeAsync(POLL_BUDGET_MS + POLL_INTERVAL_MS);
     await vi.waitFor(() => {
       expect(signInSilentlyMock).toHaveBeenCalledTimes(1);
       expect(signInMock).toHaveBeenCalledTimes(1);
     });
-    expect(fetchMock).toHaveBeenCalledTimes(3);
     expect(sessionStorage.getItem("csm.auth.lastForcedSignInAt")).not.toBeNull();
   });
 
-  it("forces a full sign-in redirect when a thrown token-expiry error survives every recovery attempt", async () => {
+  it("forces a full sign-in redirect when silent sign-in itself reports failure, without waiting out the full poll budget", async () => {
     getAccessTokenMock.mockRejectedValue(TOKEN_EXPIRED_ERROR);
+    signInSilentlyMock.mockResolvedValue(false);
 
     const { result } = renderHook(() => useAuthApiClient());
     void result.current("https://example.test/api/thing");
 
+    // Silent sign-in reporting failure ends polling after the next interval,
+    // not the full budget.
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
     await vi.waitFor(() => {
       expect(signInSilentlyMock).toHaveBeenCalledTimes(1);
       expect(signInMock).toHaveBeenCalledTimes(1);
@@ -200,9 +223,12 @@ describe("useAuthApiClient", () => {
   it("loop guard: does not redirect again, and instead lets the 401 propagate as a normal failure, when a forced sign-in happened moments ago", async () => {
     sessionStorage.setItem("csm.auth.lastForcedSignInAt", String(Date.now()));
     fetchMock.mockResolvedValue(jsonResponse(401));
+    signInSilentlyMock.mockResolvedValue(false);
 
     const { result } = renderHook(() => useAuthApiClient());
-    const response = await result.current("https://example.test/api/thing");
+    const responsePromise = result.current("https://example.test/api/thing");
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+    const response = await responsePromise;
 
     expect(response.status).toBe(401);
     expect(signInMock).not.toHaveBeenCalled();
@@ -243,10 +269,12 @@ describe("useAuthApiClient", () => {
       String(Date.now() - 60_000),
     );
     fetchMock.mockResolvedValue(jsonResponse(401));
+    signInSilentlyMock.mockResolvedValue(false);
 
     const { result } = renderHook(() => useAuthApiClient());
     void result.current("https://example.test/api/thing");
 
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
     await vi.waitFor(() => {
       expect(signInMock).toHaveBeenCalledTimes(1);
     });

--- a/apps/csm-portal/webapp/src/hooks/useAuthApiClient.ts
+++ b/apps/csm-portal/webapp/src/hooks/useAuthApiClient.ts
@@ -22,6 +22,7 @@ import {
   AUTH_NOT_READY_ERROR_MESSAGE,
 } from "@constants/apiConstants";
 import { useLogger } from "@hooks/useLogger";
+import { trySilentSignInOnce } from "@hooks/silentSignIn";
 import { CORRELATION_ID_HEADER, newCorrelationId } from "@utils/correlationId";
 
 // Shared across every caller's hook instance. Each useAuthApiClient() call
@@ -29,12 +30,6 @@ import { CORRELATION_ID_HEADER, newCorrelationId } from "@utils/correlationId";
 // only ONE full sign-in redirect is triggered even when many concurrent calls
 // fail authentication at once.
 let signInInFlight = false;
-
-// Shared across every caller's hook instance for the same reason as
-// `signInInFlight`: many concurrent requests can discover a dead refresh
-// token at once, and they should all await the SAME hidden-iframe silent
-// sign-in attempt rather than each opening their own.
-let silentSignInInFlight: Promise<boolean> | null = null;
 
 // Only the Asgardeo "unauthenticated" code means the token was expired/missing
 // when the call ran (e.g. the refresh token itself has expired, so the SDK's
@@ -104,6 +99,20 @@ function markForcedSignIn(): void {
     // Best-effort only; if we can't record it, the guard simply can't help
     // this time — the redirect below still proceeds.
   }
+}
+
+// How long (and how often) to keep retrying the original request after
+// kicking off silent sign-in, instead of trusting only its own return
+// value — see the call site's comment for why. 700ms/8s matches the
+// observed real-world timing: a genuine token refresh becomes usable via
+// `getAccessToken()` within a few seconds, well inside this budget, while a
+// truly dead session still exhausts it before falling through to the
+// redirect below.
+const SILENT_RECOVERY_POLL_INTERVAL_MS = 700;
+const SILENT_RECOVERY_POLL_BUDGET_MS = 8_000;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 // One attempt's outcome, classified so the retry chain below can treat "the
@@ -243,20 +252,14 @@ export function useAuthApiClient() {
   // dialog), try a silent, hidden-iframe re-authentication. If the user's IdP
   // session (SSO cookie) is still alive, this mints a fresh token without any
   // visible navigation; only a genuinely dead IdP session falls through to
-  // `redirectToSignIn`. Single-flighted for the same reason as sign-in above.
+  // `redirectToSignIn`. Single-flighted via the shared `trySilentSignInOnce`
+  // (not a locally-scoped guard) so this and AuthGuard's own route-mount
+  // silent-reauth check never run two independent, uncoordinated hidden-iframe
+  // attempts at once — see that module's comment for why that mattered.
   const trySilentSignIn = useCallback((): Promise<boolean> => {
-    if (!silentSignInInFlight) {
-      silentSignInInFlight = Promise.resolve(signInSilently())
-        .then((result) => Boolean(result))
-        .catch((error) => {
-          logger.debug("[auth] silent sign-in failed", error);
-          return false;
-        })
-        .finally(() => {
-          silentSignInInFlight = null;
-        });
-    }
-    return silentSignInInFlight;
+    return trySilentSignInOnce(signInSilently, (message) =>
+      logger.debug("[auth] silent sign-in failed", message),
+    );
   }, [signInSilently, logger]);
 
   const attemptFetch = useCallback(
@@ -340,7 +343,7 @@ export function useAuthApiClient() {
 
   return useCallback(
     async (input: RequestInfo | URL, options?: RequestInit): Promise<Response> => {
-      // Attempt 1 of 3. Only a recoverable outcome (thrown token-expiry, or a
+      // First attempt. Only a recoverable outcome (thrown token-expiry, or a
       // resolved genuine HTTP 401) continues the chain below; a success, a
       // non-401 error response, or a non-auth thrown error return/throw here.
       const first = await runAttempt(attemptFetch, input, options);
@@ -354,22 +357,45 @@ export function useAuthApiClient() {
       if (!retry.recoverable) return retry.response;
       let last = retry;
 
-      // Still unauthenticated (or still a genuine 401) after the retry.
-      // Try a silent re-auth first: if the IdP session is still alive this
-      // mints a fresh token with no visible navigation, so in-progress work
-      // survives.
-      if (await trySilentSignIn()) {
-        const afterSilentSignIn = await runAttempt(attemptFetch, input, options);
-        if (!afterSilentSignIn.recoverable) return afterSilentSignIn.response;
-        last = afterSilentSignIn;
-        // Silent sign-in reported success but the token still won't
-        // authenticate (e.g. a race with a session that expired a moment
-        // later, or a genuine 401 that re-auth can't fix at all) — fall
-        // through to the hard redirect below.
+      // Still unauthenticated (or still a genuine 401) after the retry. Try a
+      // silent re-auth: if the IdP session is still alive this mints a fresh
+      // token with no visible navigation. Its own returned promise is not
+      // trustworthy as the sole success signal, though — observed live
+      // against a real IdP, it can take upward of 10 seconds to settle, and
+      // can resolve false even though the underlying token was already
+      // refreshed successfully several seconds earlier (its own
+      // postMessage-based completion signal isn't reliably tied to the
+      // actual token refresh completing). Blocking solely on `await
+      // trySilentSignIn()` before ever retrying meant a real recovery could
+      // sit unused for 10+ seconds while every other in-flight call in the
+      // app had already picked up the fresh token, exclusively because this
+      // one specific promise hadn't settled yet.
+      //
+      // So: kick off silent sign-in, then poll the original request on a
+      // short interval instead of waiting on its return value — whichever
+      // recovers first (an early poll picking up the refreshed token, or
+      // silent sign-in itself reporting success) wins. Stop polling once
+      // silent sign-in has definitively reported failure and the poll
+      // budget is exhausted; a session that's still failing at that point is
+      // presumed genuinely dead and falls through to the hard redirect below.
+      let silentSignInSettled = false;
+      let silentSignInSucceeded = false;
+      void trySilentSignIn().then((ok) => {
+        silentSignInSettled = true;
+        silentSignInSucceeded = ok;
+      });
+
+      const pollDeadline = Date.now() + SILENT_RECOVERY_POLL_BUDGET_MS;
+      while (Date.now() < pollDeadline) {
+        await sleep(SILENT_RECOVERY_POLL_INTERVAL_MS);
+        const polled = await runAttempt(attemptFetch, input, options);
+        if (!polled.recoverable) return polled.response;
+        last = polled;
+        if (silentSignInSettled && !silentSignInSucceeded) break;
       }
 
-      // Attempt 3 of 3 exhausted with no recovery. Before bouncing the whole
-      // tab to a full sign-in redirect, guard against redirect-looping
+      // The poll budget is exhausted with no recovery. Before bouncing the
+      // whole tab to a full sign-in redirect, guard against redirect-looping
       // forever against an account whose 401 isn't actually fixable by
       // re-authenticating (a valid token, but e.g. a backend/upstream-data
       // problem on that account) — if we already forced a sign-in very

--- a/apps/csm-portal/webapp/src/layouts/AuthGuard.test.tsx
+++ b/apps/csm-portal/webapp/src/layouts/AuthGuard.test.tsx
@@ -1,0 +1,217 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import "@testing-library/jest-dom/vitest";
+import { act, render, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// `ProtectedRoute`'s real implementation polls `isSignedIn` on ~1s interval
+// and only calls `onSignIn` once it decides the user isn't authenticated —
+// that's exactly the race under test here (see AuthGuard.tsx), but it's not
+// something worth re-implementing under jsdom. Stub it down to "call
+// onSignIn immediately with a fake defaultSignIn, so the assertions below
+// are about AuthGuard's own onSignIn handler, not ProtectedRoute internals.
+// It also renders a marker so tests can assert whether ProtectedRoute (and
+// therefore its loader-swap behaviour) is even in the tree for a given render.
+const defaultSignInMock = vi.fn();
+const protectedRouteRenderCount = vi.fn();
+vi.mock("@asgardeo/react-router", () => ({
+  ProtectedRoute: ({
+    onSignIn,
+    children,
+  }: {
+    onSignIn?: (
+      defaultSignIn: (options?: Record<string, unknown>) => void,
+      signInOptions?: Record<string, unknown>,
+    ) => void;
+    children?: React.ReactNode;
+  }) => {
+    protectedRouteRenderCount();
+    onSignIn?.(defaultSignInMock, { some: "option" });
+    return children ?? null;
+  },
+}));
+
+const signInSilentlyMock = vi.fn();
+const signInMock = vi.fn();
+// Mutable so individual tests can flip `isSignedIn` across rerenders to
+// simulate a token expiring mid-session, after an initial successful sign-in.
+const asgardeoState = { isSignedIn: false };
+vi.mock("@asgardeo/react", () => ({
+  useAsgardeo: () => ({
+    isSignedIn: asgardeoState.isSignedIn,
+    signIn: signInMock,
+    signInSilently: signInSilentlyMock,
+  }),
+}));
+
+vi.mock("@layouts/AppLayout", () => ({
+  default: () => null,
+}));
+
+vi.mock("@context/current-user/CurrentUserContext", () => ({
+  CurrentUserProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+const loggerDebugMock = vi.fn();
+vi.mock("@hooks/useLogger", () => ({
+  useLogger: () => ({ debug: loggerDebugMock, error: vi.fn(), warn: vi.fn(), info: vi.fn() }),
+}));
+
+const { default: AuthGuard } = await import("./AuthGuard");
+
+function renderAuthGuard() {
+  return render(
+    <MemoryRouter initialEntries={["/some/protected/path"]}>
+      <AuthGuard />
+    </MemoryRouter>,
+  );
+}
+
+describe("AuthGuard onSignIn (before any successful sign-in)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionStorage.clear();
+    asgardeoState.isSignedIn = false;
+  });
+
+  it("attempts a silent re-auth first and does not force a full sign-in redirect when it succeeds", async () => {
+    signInSilentlyMock.mockResolvedValue(true);
+
+    await act(async () => {
+      renderAuthGuard();
+    });
+
+    await waitFor(() => expect(signInSilentlyMock).toHaveBeenCalledTimes(1));
+    expect(defaultSignInMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the full sign-in redirect when silent re-auth resolves falsy", async () => {
+    signInSilentlyMock.mockResolvedValue(false);
+
+    await act(async () => {
+      renderAuthGuard();
+    });
+
+    await waitFor(() =>
+      expect(defaultSignInMock).toHaveBeenCalledWith({ some: "option" }),
+    );
+  });
+
+  it("falls back to the full sign-in redirect when silent re-auth rejects", async () => {
+    signInSilentlyMock.mockRejectedValue(new Error("iframe blocked"));
+
+    await act(async () => {
+      renderAuthGuard();
+    });
+
+    await waitFor(() =>
+      expect(defaultSignInMock).toHaveBeenCalledWith({ some: "option" }),
+    );
+    expect(loggerDebugMock).toHaveBeenCalledWith(
+      "[auth] silent sign-in failed",
+      "iframe blocked",
+    );
+  });
+});
+
+describe("AuthGuard after an initial successful sign-in (transient token-clock expiry)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionStorage.clear();
+    asgardeoState.isSignedIn = false;
+  });
+
+  it("stops rendering ProtectedRoute (and therefore its loader-swap) once signed in, and never re-enters it for a later transient clock expiry", async () => {
+    asgardeoState.isSignedIn = true;
+    let rerender!: ReturnType<typeof renderAuthGuard>["rerender"];
+
+    await act(async () => {
+      ({ rerender } = renderAuthGuard());
+    });
+    // Re-render to let the render-time `setHasSignedInOnce(true)` commit.
+    await act(async () => {
+      rerender(
+        <MemoryRouter initialEntries={["/some/protected/path"]}>
+          <AuthGuard />
+        </MemoryRouter>,
+      );
+    });
+    expect(protectedRouteRenderCount).not.toHaveBeenCalled();
+
+    // Token's local clock expires — a transient drop, not a real sign-out.
+    // AuthGuard must NOT proactively react to this itself (no background
+    // signInSilently() poll here — see AuthGuard.tsx's comment on why an
+    // earlier version's poller raced useAuthApiClient's own call-level
+    // recovery and left an in-flight mutation stuck). Recovery for this case
+    // is useAuthApiClient's job alone, exercised on the next real API call,
+    // not AuthGuard's.
+    asgardeoState.isSignedIn = false;
+    await act(async () => {
+      rerender(
+        <MemoryRouter initialEntries={["/some/protected/path"]}>
+          <AuthGuard />
+        </MemoryRouter>,
+      );
+    });
+
+    expect(protectedRouteRenderCount).not.toHaveBeenCalled();
+    expect(signInSilentlyMock).not.toHaveBeenCalled();
+    expect(signInMock).not.toHaveBeenCalled();
+    expect(defaultSignInMock).not.toHaveBeenCalled();
+  });
+
+  it("resets the latch on an explicit sign-out (app:signing-out), falling back to ProtectedRoute instead of continuing to render stale protected content", async () => {
+    asgardeoState.isSignedIn = true;
+    let rerender!: ReturnType<typeof renderAuthGuard>["rerender"];
+
+    await act(async () => {
+      ({ rerender } = renderAuthGuard());
+    });
+    await act(async () => {
+      rerender(
+        <MemoryRouter initialEntries={["/some/protected/path"]}>
+          <AuthGuard />
+        </MemoryRouter>,
+      );
+    });
+    expect(protectedRouteRenderCount).not.toHaveBeenCalled();
+
+    // The user clicks "Sign out" — this app's existing signal fires
+    // immediately before the SDK's signOut() call (see UserProfile.tsx /
+    // IdleTimeoutProvider.tsx), before isSignedIn has necessarily flipped.
+    await act(async () => {
+      window.dispatchEvent(new CustomEvent("app:signing-out"));
+    });
+
+    // isSignedIn drops (the SDK's own state update, ahead of its redirect
+    // actually navigating away).
+    asgardeoState.isSignedIn = false;
+    await act(async () => {
+      rerender(
+        <MemoryRouter initialEntries={["/some/protected/path"]}>
+          <AuthGuard />
+        </MemoryRouter>,
+      );
+    });
+
+    // Falls back to ProtectedRoute's neutral loader — not stale protected
+    // content — for the brief window before the browser actually navigates
+    // away to the IdP's sign-out endpoint.
+    expect(protectedRouteRenderCount).toHaveBeenCalled();
+  });
+});

--- a/apps/csm-portal/webapp/src/layouts/AuthGuard.tsx
+++ b/apps/csm-portal/webapp/src/layouts/AuthGuard.tsx
@@ -14,13 +14,15 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { type JSX, useEffect } from "react";
+import { type JSX, useEffect, useState } from "react";
 import { useAsgardeo } from "@asgardeo/react";
 import { ProtectedRoute } from "@asgardeo/react-router";
 import { useLocation, useNavigate } from "react-router";
 import AppLayout from "@layouts/AppLayout";
 import { POST_LOGIN_REDIRECT_KEY } from "@layouts/postLoginRedirect";
 import { CurrentUserProvider } from "@context/current-user/CurrentUserContext";
+import { useLogger } from "@hooks/useLogger";
+import { trySilentSignInOnce } from "@hooks/silentSignIn";
 
 /**
  * AuthGuard renders AppLayout (header/footer) so loading state is visible
@@ -38,9 +40,47 @@ import { CurrentUserProvider } from "@context/current-user/CurrentUserContext";
  * @returns {JSX.Element} AppLayout or redirect to home.
  */
 export default function AuthGuard(): JSX.Element {
-  const { isSignedIn } = useAsgardeo();
+  const { isSignedIn, signInSilently } = useAsgardeo();
   const location = useLocation();
   const navigate = useNavigate();
+  const logger = useLogger();
+
+  // Latches true the first time `isSignedIn` is observed true, and never
+  // resets — see the render branch below for why. Set directly in the render
+  // body (React's documented "adjusting state during rendering" pattern, not
+  // an effect) so the very same render that first sees `isSignedIn` also
+  // switches branches, instead of committing one extra render through
+  // `ProtectedRoute` first.
+  const [hasSignedInOnce, setHasSignedInOnce] = useState(false);
+  // One-way latch, separate from `hasSignedInOnce`: once an explicit
+  // sign-out starts, the "bypass ProtectedRoute" branch below must stop
+  // unconditionally, and stay stopped, regardless of what `isSignedIn` does
+  // afterward. `app:signing-out` (this app's existing signal, dispatched by
+  // every manual "Sign out" action in `UserProfile.tsx`/
+  // `IdleTimeoutProvider.tsx`) fires *before* the SDK's `signOut()` call —
+  // i.e. before `isSignedIn` has necessarily flipped to `false` yet. A
+  // reset tied to `isSignedIn` directly would race the render-time
+  // `hasSignedInOnce` latch below (still seeing `isSignedIn === true` on
+  // the very next render) and get immediately re-latched back to `true` in
+  // the same update; `isSigningOut` sidesteps that race entirely by not
+  // depending on `isSignedIn` at all once it's set.
+  const [isSigningOut, setIsSigningOut] = useState(false);
+  if (isSignedIn && !hasSignedInOnce && !isSigningOut) {
+    setHasSignedInOnce(true);
+  }
+
+  // Without this, an explicit sign-out was indistinguishable from a
+  // transient token-clock expiry once `hasSignedInOnce` had latched true —
+  // both just flip `isSignedIn` to `false` eventually — and this component
+  // would keep `CurrentUserProvider`/`AppLayout` mounted with the
+  // just-signed-out user's data during the brief window before the SDK's
+  // `signOut()` redirect actually navigates away, instead of falling back
+  // to `ProtectedRoute`'s neutral loader.
+  useEffect(() => {
+    const handleSigningOut = (): void => setIsSigningOut(true);
+    window.addEventListener("app:signing-out", handleSigningOut);
+    return () => window.removeEventListener("app:signing-out", handleSigningOut);
+  }, []);
 
   // After login, restore the saved deep link so it survives the Asgardeo SDK
   // reloading the page to `afterSignInUrl` ("/") after the callback (which would
@@ -62,6 +102,39 @@ export default function AuthGuard(): JSX.Element {
     }
   }, [isSignedIn, navigate, location.pathname, location.search, location.hash]);
 
+  // Once a session has been established at least once, never again let
+  // `ProtectedRoute` hide the app behind its `loader` for a transient
+  // client-side token-clock expiry. `ProtectedRoute` swaps to `loader`
+  // (unmounting `children`) for as long as `isSignedIn` is false, however
+  // briefly and however recoverable — that is a full React-level unmount of
+  // everything under it, indistinguishable in effect from a page reload even
+  // though the browser itself never navigates. Live reproduction confirmed
+  // this destroys in-progress work (an open case-comment composer and its
+  // draft) within the same instant the token's local clock expires, well
+  // before any silent-reauth attempt could even begin — a plain in-memory
+  // marker on `window` survived the whole cycle while the React tree's own
+  // state did not.
+  //
+  // No background effect proactively re-runs `signInSilently()` here for
+  // this case (an earlier version of this fix added one, driven by
+  // `isSignedIn` transitions) — it raced `useAuthApiClient.ts`'s own
+  // call-level recovery: the shared single-flight guard only dedupes
+  // *concurrent* attempts, so a background poller and a real failing
+  // request could still each trigger their own attempt back-to-back, and
+  // that duplicate cycle was observed to leave an in-flight mutation's own
+  // promise chain stuck (a case comment created successfully server-side,
+  // but the composer's "Sending…" state never cleared). `useAuthApiClient`
+  // already recovers correctly on any actual 401 from real use — once
+  // signed in, that is the ONLY recovery trigger this app needs; a token
+  // expiring while the user does nothing at all needs no proactive fix.
+  if (hasSignedInOnce && !isSigningOut) {
+    return (
+      <CurrentUserProvider>
+        <AppLayout />
+      </CurrentUserProvider>
+    );
+  }
+
   return (
     <ProtectedRoute
       loader={<AppLayout />}
@@ -71,7 +144,13 @@ export default function AuthGuard(): JSX.Element {
         if (intended !== "/") {
           sessionStorage.setItem(POST_LOGIN_REDIRECT_KEY, intended);
         }
-        defaultSignIn(signInOptions);
+        trySilentSignInOnce(signInSilently, (message) =>
+          logger.debug("[auth] silent sign-in failed", message),
+        ).then((result) => {
+          if (!result) {
+            defaultSignIn(signInOptions);
+          }
+        });
       }}
     >
       <CurrentUserProvider>


### PR DESCRIPTION
## Purpose
Expiring the access token mid-session could silently destroy in-progress work (an open case-comment draft, a dialog, scroll position) or leave the UI stuck indefinitely on a pending action — with no error, no visible redirect, just data loss or a hang. Root cause turned out to be two separate, compounding problems, both found via source review + extensive live reproduction against a real staging backend and real Asgardeo login (see commit messages for the detailed trail):

1. `AuthGuard.tsx`'s `ProtectedRoute` hid the entire app behind its loading screen — a full React-level unmount of everything under it — for as long as the SDK's client-side token-expiry clock said "not signed in," however briefly and however recoverable. That's indistinguishable in effect from a page reload even though the browser itself never navigates, which is why it was easy to miss.
2. Even after fixing (1), a comment could still hang forever on "Sending…": the SDK's own `signInSilently()` method doesn't reliably signal success in a timely way — its returned promise can take upward of 10 seconds to settle and can resolve `false` even though the underlying token was already refreshed successfully several seconds earlier. Code that trusted that promise as the sole recovery signal could end up falling through to a full sign-in redirect whose promise never resolves by design, hanging the caller forever.

No public issue to link.

## Goals
Recover from an expired access token — via a silent, hidden-iframe re-authentication whenever the IdP session is still alive — without ever unmounting the app or hanging the UI, for any operation anywhere in the app (not scoped to any one feature: `useAuthApiClient` is the single shared fetch wrapper used by every `useGetX`/`usePostX`/`usePatchX` hook across the codebase).

## Approach
- `AuthGuard.tsx`: once a session has been established at least once, never again render `ProtectedRoute`'s `loader` for a transient client-side clock expiry — render the protected children directly. `ProtectedRoute`'s own loader/`onSignIn` still owns the pre-first-sign-in case, where there's no user content yet to protect from an unmount.
- `useAuthApiClient.ts`: stop trusting `signInSilently()`'s own return value as the sole recovery signal. Kick it off, then poll the original request on a short interval (700ms, up to an 8s budget) instead of blocking on its promise — whichever recovers first (an early poll picking up the refreshed token, or silent sign-in itself reporting success) wins. Only fall through to the full sign-in redirect once silent sign-in has definitively reported failure *and* the poll budget is exhausted.
- `AppWithConfig.tsx`: don't mount the app's router/page tree inside the SDK's own hidden silent-auth iframe (only `AsgardeoProvider` needs to run there to complete the SDK's handshake) — otherwise the router mounts recursively inside every nested iframe the SDK creates.
- `silentSignIn.ts` (new): single-flight `signInSilently()` across the whole app, shared by every caller, so two independent code paths noticing the same expired token never each start their own uncoordinated hidden-iframe attempt.

No architecture change (no new redirect page, no change to the OAuth flow shape) — this is retry/render-branch logic within the existing hooks and guard.

## User stories
As a CS engineer with an open case-comment draft (or any other in-progress action), my work should survive a routine background token refresh instead of being silently lost or leaving the UI stuck.

## Release note
Fix: the portal no longer loses in-progress work or hangs indefinitely on a routine access-token expiry — recovery now happens invisibly in the background wherever possible.

## Documentation
N/A — internal auth-recovery behavior change with no user-facing surface, config, or API change to document.

## Training
N/A — no training-content impact; internal auth timing fix only.

## Certification
N/A — no exam-relevant feature or behavior change.

## Marketing
N/A — internal bug fix/hardening, not a marketing-facing feature.

## Automation tests
- Unit tests
  `AuthGuard.test.tsx` (4 cases): pre-first-sign-in silent-reauth-then-redirect behavior, and that `ProtectedRoute` is never re-entered (nor does any background poll fire) once a session has been established. `silentSignIn.test.ts` (3 cases): single-flighting across concurrent callers. `useAuthApiClient.test.ts` (12 cases, using fake timers): the full retry chain including the new poll-based recovery and its budget/interval behavior. Full suite: `pnpm run test` — 170 files / 1524 tests passed.
- Integration tests
  N/A — no integration/e2e harness exercises the real Asgardeo IdP session lifecycle in this repo; covered by the unit tests above plus extensive manual live reproduction (poisoned session storage against a real staging backend + real IdP login, verified via Chrome DevTools Protocol network/DOM inspection, including a DOM-node-identity probe confirming no React-level unmount and a `window.fetch` monkey-patch confirming the actual backend request completes).

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — TypeScript/React code, not a JVM target FindSecurityBugs analyzes; ran `eslint` clean instead.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no sample code affected.

## Related PRs
N/A

## Migrations (if applicable)
N/A — no data/schema/config migration involved.

## Test environment
Node/pnpm toolchain per this repo's `apps/csm-portal/webapp/package.json`; ran `pnpm run test` and `pnpm exec eslint` on all touched files locally (macOS, Node via the repo's pinned toolchain). Live-verified against `apps/csm-portal/webapp` in local-gateway mode pointed at the real staging backend (`stg-be`), with a real Asgardeo login, using Chrome's DevTools Protocol to poison the SDK's stored session and observe the recovery cycle end-to-end.

## Learning
Traced `ProtectedRoute` (`@asgardeo/react-router`), `AuthAPI.signIn`/`AsgardeoSPAClient` (`@asgardeo/javascript`, `@asgardeo/browser`), and `isSignedIn`'s client-side clock check through `node_modules` source. The two root causes only became visible through live reproduction, not static reading: a DOM-node-identity probe (stamping an attribute on the page root and polling through the recovery window) proved a React-level unmount was happening with zero browser navigation, and temporary `console.error` instrumentation around `getAccessToken()`/`signInSilently()` (removed before this PR) proved the SDK's own promise resolves minutes-scale slower and less reliably than the actual token refresh it's supposed to signal.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved silent sign-in handling for smoother authentication recovery.
  * Added polling-based recovery before redirecting users to sign in again.
  * Added safeguards for authentication checks in hidden sign-in frames.

* **Bug Fixes**
  * Reduced duplicate sign-in attempts during simultaneous authentication failures.
  * Improved handling and logging of failed authentication attempts.
  * Preserved the application experience during temporary token expiry.
  * Ensured explicit sign-out returns the application to the standard sign-in flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->