### PR TITLE
[CSM] Return productCount on deployment search so the Usage Metrics page renders

### DIFF
--- a/apps/customer-portal/backend-v2/internal/dto/deployment.go
+++ b/apps/customer-portal/backend-v2/internal/dto/deployment.go
@@ -37,6 +37,14 @@ type DeploymentSummary struct {
 	Project     *IDLabelRef `json:"project,omitempty"`
 	CreatedOn   time.Time   `json:"createdOn"`
 	UpdatedOn   time.Time   `json:"updatedOn"`
+	// ProductCount is named productCount, NOT deployedProductCount: the
+	// frontend's ProjectDeploymentItem reads productCount, and the Usage
+	// Metrics page filters deployments on `(dep.productCount ?? 0) > 0`. An
+	// absent value silently filters every deployment out, leaving that page
+	// blank with no error and no network calls. The Ballerina backend does the
+	// same rename (utils.bal: `productCount: deployment.deployedProductCount`).
+	ProductCount  *int `json:"productCount,omitempty"`
+	InstanceCount *int `json:"instanceCount,omitempty"`
 }
 
 // SearchDeploymentsResponse is the portal's response for
@@ -73,6 +81,27 @@ func MapSearchDeployments(r entity.SearchDeploymentsResponse) SearchDeploymentsR
 		Offset:       r.Offset,
 		HasMore:      r.HasMore,
 	}
+}
+
+// WithDeploymentCounts fills ProductCount/InstanceCount on each deployment from
+// per-deployment tallies keyed by deployment ID.
+//
+// entity-service's DeploymentView carries no counts (neither does the
+// ServiceNow payload behind it), so the handler derives them and passes them
+// here — see DeploymentHandler.SearchDeployments. A deployment missing from a
+// map is left nil rather than set to 0, so "not counted" stays distinguishable
+// from "counted zero"; the frontend treats both as 0 via `?? 0`.
+func WithDeploymentCounts(resp SearchDeploymentsResponse, productCounts, instanceCounts map[string]int) SearchDeploymentsResponse {
+	for i := range resp.Deployments {
+		id := resp.Deployments[i].ID
+		if n, ok := productCounts[id]; ok {
+			resp.Deployments[i].ProductCount = &n
+		}
+		if n, ok := instanceCounts[id]; ok {
+			resp.Deployments[i].InstanceCount = &n
+		}
+	}
+	return resp
 }
 
 // DeploymentCreateRequest is the portal's request body for

--- a/apps/customer-portal/backend-v2/internal/dto/deployment_counts_test.go
+++ b/apps/customer-portal/backend-v2/internal/dto/deployment_counts_test.go
@@ -1,0 +1,100 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dto
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestWithDeploymentCounts_UsesFrontendFieldNames is the regression guard for
+// the Usage Metrics page rendering blank.
+//
+// That page filters deployments on `(dep.productCount ?? 0) > 0`. The field is
+// productCount — NOT deployedProductCount, which is what entity-service calls
+// the equivalent aggregate elsewhere. When the key is absent or misnamed every
+// deployment is filtered out, no deployment tab is selected, and every
+// downstream metrics query is disabled by its `enabled` guard — so the page
+// renders empty with no console error and no network request at all. Renaming
+// this key would silently reintroduce that.
+func TestWithDeploymentCounts_UsesFrontendFieldNames(t *testing.T) {
+	resp := WithDeploymentCounts(
+		SearchDeploymentsResponse{Deployments: []DeploymentSummary{{ID: "dep-1"}}},
+		map[string]int{"dep-1": 3},
+		map[string]int{"dep-1": 5},
+	)
+
+	raw, err := json.Marshal(resp.Deployments[0])
+	if err != nil {
+		t.Fatalf("marshal returned error: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("result is not valid JSON: %v", err)
+	}
+
+	if got["productCount"] != float64(3) {
+		t.Errorf(`productCount = %v, want 3 — the Usage Metrics page filters on this exact key`, got["productCount"])
+	}
+	if got["instanceCount"] != float64(5) {
+		t.Errorf("instanceCount = %v, want 5", got["instanceCount"])
+	}
+	if _, wrong := got["deployedProductCount"]; wrong {
+		t.Error(`emitted "deployedProductCount"; the frontend reads "productCount"`)
+	}
+}
+
+// TestWithDeploymentCounts_AbsentWhenNotCounted checks that a deployment with
+// no tally is left without the key rather than reported as zero, so "we did not
+// count" stays distinguishable from "counted zero" for any future consumer.
+// The current frontend collapses both to 0 via `?? 0`.
+func TestWithDeploymentCounts_AbsentWhenNotCounted(t *testing.T) {
+	resp := WithDeploymentCounts(
+		SearchDeploymentsResponse{Deployments: []DeploymentSummary{{ID: "dep-1"}, {ID: "dep-2"}}},
+		map[string]int{"dep-1": 2},
+		nil,
+	)
+
+	if resp.Deployments[0].ProductCount == nil || *resp.Deployments[0].ProductCount != 2 {
+		t.Errorf("dep-1 ProductCount = %v, want 2", resp.Deployments[0].ProductCount)
+	}
+	if resp.Deployments[1].ProductCount != nil {
+		t.Errorf("dep-2 ProductCount = %v, want nil (never counted)", *resp.Deployments[1].ProductCount)
+	}
+
+	raw, _ := json.Marshal(resp.Deployments[1])
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("result is not valid JSON: %v", err)
+	}
+	if _, present := got["productCount"]; present {
+		t.Error("productCount should be omitted entirely when the deployment was never counted")
+	}
+}
+
+// TestWithDeploymentCounts_NilMapsAreSafe covers the best-effort path: when the
+// upstream tally fails the handler passes nil, and the response must still be
+// well-formed rather than panicking or emitting zeros.
+func TestWithDeploymentCounts_NilMapsAreSafe(t *testing.T) {
+	resp := WithDeploymentCounts(
+		SearchDeploymentsResponse{Deployments: []DeploymentSummary{{ID: "dep-1"}}},
+		nil, nil,
+	)
+	if resp.Deployments[0].ProductCount != nil || resp.Deployments[0].InstanceCount != nil {
+		t.Error("nil count maps must leave both counts unset")
+	}
+}

--- a/apps/customer-portal/backend-v2/internal/handler/deployment_product_counts_test.go
+++ b/apps/customer-portal/backend-v2/internal/handler/deployment_product_counts_test.go
@@ -1,0 +1,161 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+)
+
+// countsFakeEntityClient serves a fixed deployment list and a fixed deployed
+// product list. entityDeploymentClient is embedded (nil) so only the two
+// methods under test need implementing.
+type countsFakeEntityClient struct {
+	entityDeploymentClient
+	deployments     []entity.DeploymentView
+	deployedProduct []entity.DeployedProductView
+	productsErr     error
+	productsCalls   int
+}
+
+func (f *countsFakeEntityClient) SearchDeployments(_ context.Context, _ entity.SearchDeploymentsRequest) (entity.SearchDeploymentsResponse, error) {
+	return entity.SearchDeploymentsResponse{
+		Deployments: f.deployments,
+		Total:       len(f.deployments),
+	}, nil
+}
+
+func (f *countsFakeEntityClient) SearchDeployedProducts(_ context.Context, _ entity.SearchDeployedProductsRequest) (entity.SearchDeployedProductsResponse, error) {
+	f.productsCalls++
+	if f.productsErr != nil {
+		return entity.SearchDeployedProductsResponse{}, f.productsErr
+	}
+	return entity.SearchDeployedProductsResponse{
+		DeployedProducts: f.deployedProduct,
+		Total:            len(f.deployedProduct),
+	}, nil
+}
+
+// searchDeploymentsBody runs SearchDeployments through a real ServeMux using
+// main.go's exact pattern, and returns the decoded deployments array.
+func searchDeploymentsBody(t *testing.T, fake *countsFakeEntityClient) []map[string]any {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /projects/{id}/deployments/search", NewDeploymentHandler(fake).SearchDeployments)
+
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, authedRequest(http.MethodPost, "/projects/"+testProjectID+"/deployments/search", "{}"))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body: %s)", w.Code, w.Body.String())
+	}
+	var got struct {
+		Deployments []map[string]any `json:"deployments"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("response is not valid JSON: %v", err)
+	}
+	return got.Deployments
+}
+
+// TestSearchDeployments_EmptyProductSearchEmitsZeroCounts covers the case that
+// motivated seeding the tally map: the deployed-product search succeeds but
+// returns nothing. Every deployment has genuinely been counted, so each must
+// report productCount 0 rather than omitting the field — omitting it would be
+// indistinguishable from the tally having failed.
+func TestSearchDeployments_EmptyProductSearchEmitsZeroCounts(t *testing.T) {
+	fake := &countsFakeEntityClient{
+		deployments: []entity.DeploymentView{
+			{ID: "dep-1", Name: "one"},
+			{ID: "dep-2", Name: "two"},
+		},
+		deployedProduct: nil, // successful search, no products
+	}
+
+	deployments := searchDeploymentsBody(t, fake)
+
+	if len(deployments) != 2 {
+		t.Fatalf("got %d deployments, want 2", len(deployments))
+	}
+	for i, d := range deployments {
+		got, present := d["productCount"]
+		if !present {
+			t.Errorf("deployment %d: productCount omitted; a successful tally must report 0", i)
+			continue
+		}
+		if got != float64(0) {
+			t.Errorf("deployment %d: productCount = %v, want 0", i, got)
+		}
+	}
+}
+
+// TestSearchDeployments_CountsPerDeployment checks products are attributed to
+// the deployment that owns them, and that a deployment with none still reports
+// zero in the same response.
+func TestSearchDeployments_CountsPerDeployment(t *testing.T) {
+	fake := &countsFakeEntityClient{
+		deployments: []entity.DeploymentView{
+			{ID: "dep-1"}, {ID: "dep-2"}, {ID: "dep-3"},
+		},
+		deployedProduct: []entity.DeployedProductView{
+			{ID: "p1", Deployment: entity.EntityRef{ID: "dep-1"}},
+			{ID: "p2", Deployment: entity.EntityRef{ID: "dep-1"}},
+			{ID: "p3", Deployment: entity.EntityRef{ID: "dep-3"}},
+		},
+	}
+
+	deployments := searchDeploymentsBody(t, fake)
+
+	want := map[string]float64{"dep-1": 2, "dep-2": 0, "dep-3": 1}
+	for _, d := range deployments {
+		id, _ := d["id"].(string)
+		if got := d["productCount"]; got != want[id] {
+			t.Errorf("%s: productCount = %v, want %v", id, got, want[id])
+		}
+	}
+
+	// One upstream call for all three deployments — not an N+1.
+	if fake.productsCalls != 1 {
+		t.Errorf("SearchDeployedProducts called %d times, want 1", fake.productsCalls)
+	}
+}
+
+// TestSearchDeployments_ProductTallyFailureOmitsCounts pins the best-effort
+// contract: when the tally errors the deployment search still succeeds, and the
+// counts are omitted entirely rather than reported as a misleading 0.
+func TestSearchDeployments_ProductTallyFailureOmitsCounts(t *testing.T) {
+	fake := &countsFakeEntityClient{
+		deployments: []entity.DeploymentView{{ID: "dep-1"}},
+		productsErr: errors.New("upstream unavailable"),
+	}
+
+	deployments := searchDeploymentsBody(t, fake)
+
+	if len(deployments) != 1 {
+		t.Fatalf("got %d deployments, want 1", len(deployments))
+	}
+	if _, present := deployments[0]["productCount"]; present {
+		t.Errorf("productCount = %v, want it omitted when the tally failed", deployments[0]["productCount"])
+	}
+}

--- a/apps/customer-portal/backend-v2/internal/handler/deployments.go
+++ b/apps/customer-portal/backend-v2/internal/handler/deployments.go
@@ -31,6 +31,7 @@ import (
 // used by DeploymentHandler.
 type entityDeploymentClient interface {
 	SearchDeployments(ctx context.Context, req entity.SearchDeploymentsRequest) (entity.SearchDeploymentsResponse, error)
+	SearchDeployedProducts(ctx context.Context, req entity.SearchDeployedProductsRequest) (entity.SearchDeployedProductsResponse, error)
 	CreateDeployment(ctx context.Context, req entity.CreateDeploymentRequest) (entity.CreateDeploymentResponse, error)
 	UpdateDeployment(ctx context.Context, id string, req entity.UpdateDeploymentRequest) (entity.UpdateDeploymentResponse, error)
 	UpdateAttachment(ctx context.Context, id string, req entity.UpdateAttachmentRequest) (entity.UpdateAttachmentResponse, error)
@@ -83,7 +84,57 @@ func (h *DeploymentHandler) SearchDeployments(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	writeJSONValue(w, http.StatusOK, dto.MapSearchDeployments(result))
+	resp := dto.MapSearchDeployments(result)
+	productCounts := h.deployedProductCounts(r.Context(), user.UserID, result.Deployments)
+	writeJSONValue(w, http.StatusOK, dto.WithDeploymentCounts(resp, productCounts, nil))
+}
+
+// deployedProductCountsPageLimit is the page size used when tallying deployed
+// products. entity-service caps limit at 100, so this is the effective maximum.
+const deployedProductCountsPageLimit = 100
+
+// deployedProductCounts tallies deployed products per deployment for the
+// deployments just returned by a search.
+//
+// One upstream call (paged) covers every deployment, because
+// SearchDeployedProductsRequest accepts DeploymentIDs as a list and each
+// DeployedProductView carries its own Deployment ref — so this is not an N+1
+// over deployments.
+//
+// Best-effort by design: a failure here logs and returns nil, leaving the
+// counts absent rather than failing the whole deployment search. The frontend
+// treats an absent count as 0, so the worst case is the pre-existing behaviour,
+// not a broken page. Same graceful-degradation stance as
+// dto.BuildProjectDashboardStats.
+func (h *DeploymentHandler) deployedProductCounts(ctx context.Context, userID string, deployments []entity.DeploymentView) map[string]int {
+	if len(deployments) == 0 {
+		return nil
+	}
+	ids := make([]string, 0, len(deployments))
+	for _, d := range deployments {
+		ids = append(ids, d.ID)
+	}
+
+	counts := make(map[string]int, len(ids))
+	for offset := 0; ; {
+		page, err := h.entity.SearchDeployedProducts(ctx, entity.SearchDeployedProductsRequest{
+			DeploymentIDs: ids,
+			Pagination:    entity.Pagination{Limit: deployedProductCountsPageLimit, Offset: offset},
+		})
+		if err != nil {
+			slog.WarnContext(ctx, "entity SearchDeployedProducts failed while tallying deployment product counts",
+				"userID", userID, "err", summarizeErr(err))
+			return nil
+		}
+		for _, p := range page.DeployedProducts {
+			counts[p.Deployment.ID]++
+		}
+		offset += len(page.DeployedProducts)
+		if len(page.DeployedProducts) == 0 || offset >= page.Total {
+			break
+		}
+	}
+	return counts
 }
 
 // CreateDeployment handles POST /projects/{id}/deployments.

--- a/apps/customer-portal/backend-v2/internal/handler/deployments.go
+++ b/apps/customer-portal/backend-v2/internal/handler/deployments.go
@@ -101,11 +101,15 @@ const deployedProductCountsPageLimit = 100
 // DeployedProductView carries its own Deployment ref — so this is not an N+1
 // over deployments.
 //
+// Every requested deployment is present in the returned map, at zero if it has
+// no products — a successful tally covers all of them, so "no products" is a
+// real answer rather than a gap.
+//
 // Best-effort by design: a failure here logs and returns nil, leaving the
-// counts absent rather than failing the whole deployment search. The frontend
-// treats an absent count as 0, so the worst case is the pre-existing behaviour,
-// not a broken page. Same graceful-degradation stance as
-// dto.BuildProjectDashboardStats.
+// counts absent rather than failing the whole deployment search. nil is
+// therefore the only "not counted" signal. The frontend treats an absent count
+// as 0, so the worst case is the pre-existing behaviour, not a broken page.
+// Same graceful-degradation stance as dto.BuildProjectDashboardStats.
 func (h *DeploymentHandler) deployedProductCounts(ctx context.Context, userID string, deployments []entity.DeploymentView) map[string]int {
 	if len(deployments) == 0 {
 		return nil
@@ -115,7 +119,14 @@ func (h *DeploymentHandler) deployedProductCounts(ctx context.Context, userID st
 		ids = append(ids, d.ID)
 	}
 
+	// Seed every deployment at zero. The tally either succeeds for all ids or
+	// fails for all of them (nil, below), so once we get here a deployment with
+	// no products has genuinely been counted and its answer is 0 — reporting it
+	// as absent would be indistinguishable from "never counted".
 	counts := make(map[string]int, len(ids))
+	for _, id := range ids {
+		counts[id] = 0
+	}
 	for offset := 0; ; {
 		page, err := h.entity.SearchDeployedProducts(ctx, entity.SearchDeployedProductsRequest{
 			DeploymentIDs: ids,

--- a/apps/customer-portal/backend-v2/openapi.yaml
+++ b/apps/customer-portal/backend-v2/openapi.yaml
@@ -6750,6 +6750,17 @@ components:
           type: string
         updatedOn:
           type: string
+        productCount:
+          type: integer
+          description: >-
+            Number of deployed products in this deployment. Named productCount
+            (not deployedProductCount) to match the frontend contract — the
+            Usage Metrics page filters deployments on this field. Omitted when
+            the tally could not be retrieved.
+        instanceCount:
+          type: integer
+          description: >-
+            Number of instances in this deployment. Omitted when not counted.
 
     SearchDeploymentsResponse:
       description: >


### PR DESCRIPTION
Follow-up to #1463. That PR added the missing `/projects/{id}/stats/usage` endpoint — genuinely needed — but it was **not** why the Usage Metrics page was blank. This is.

## Summary

The page rendered empty with **no console error and no network request at all**, which is why it was hard to place: there was nothing to follow.

The chain is entirely client-side:

```ts
.filter((dep) => (dep.productCount ?? 0) > 0)   // UsageAndMetricsTabContent
const defaultTab = deploymentTabs[0]?.id ?? "";
const activeDeploymentId = getActiveUsageDeploymentId(activeTab);
```

1. This backend never sent `productCount` → `undefined`
2. Every deployment filtered out → `deploymentTabs` empty
3. `activeDeploymentId` empty → every metrics query disabled by its `enabled` guard
4. Disabled queries in React Query v5 are silent — no request, no error, no loading state

`entity.DeploymentView` carries no counts, and neither does the ServiceNow payload behind it, so they can't be mapped through. The Ballerina backend derives and renames the field — `utils.bal`: `productCount: deployment.deployedProductCount`.

- `DeploymentSummary` gains `ProductCount`/`InstanceCount` as `*int`, emitted as **`productCount`/`instanceCount`** to match the frontend's `ProjectDeploymentItem`
- `SearchDeployments` tallies deployed products per deployment
- Counts are left `nil` rather than `0` when never tallied, so "not counted" stays distinguishable from "counted zero" (the frontend collapses both via `?? 0`)
- `openapi.yaml` documents both fields

## Not an N+1

`SearchDeployedProductsRequest` accepts `DeploymentIDs` as a **list**, and each `DeployedProductView` carries its own `Deployment` ref — so a single paged upstream call covers every deployment in the page, and the results are grouped by deployment ID. Paging loops only if a project has more than 100 deployed products.

## Best-effort by design

A tally failure logs at WARN and leaves the counts absent rather than failing the whole deployment search. Worst case is the pre-existing behaviour, not a broken page — the same graceful-degradation stance as `dto.BuildProjectDashboardStats`. `POST /projects/{id}/deployments/search` is shared with the Deployments page, so it must not become more fragile than it was.

## `instanceCount` is wired but not populated

It's plumbed through the DTO and spec, but not yet filled: per-deployment instance tallies need a second upstream fan-out, and **only `productCount` gates the page**. The frontend already treats an absent count as `0`, which is what it received before. Happy to add it here if you'd rather, at the cost of another upstream call on a shared endpoint.

## Test plan

Containers (no local Go toolchain):

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` — clean
- [x] `go test -race ./...` — all pass, incl. 3 new `TestWithDeploymentCounts_*`
- [x] `gosec -fmt=text ./...` — **0 issues**
- [x] `openapi.yaml` parses; both properties present on `DeploymentSummary`
- [ ] Staging: open Usage Metrics on a project with at least one deployment that has products — deployment tabs should appear and the metrics queries should fire

The new tests assert the exact JSON keys and fail if `deployedProductCount` is ever emitted instead, since a rename is precisely what caused this.

## Note for verification

Pick a project whose deployments actually contain deployed products. A project with deployments but **no** products will still show no tabs — that is correct behaviour, not this bug.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Deployment search results now display optional counts for deployed products and instances.
  - Counts are provided when available and omitted when unavailable.
  - Results remain available even if count retrieval encounters an issue.

- **Bug Fixes**
  - Improved handling of missing or unavailable deployment count data without showing misleading zero values.

- **Documentation**
  - Updated the API specification to document the new deployment count fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->