### PR TITLE
[CSM Portal] Support drag-and-drop file attachments in the comment composer

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentInput.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentInput.test.tsx
@@ -200,6 +200,20 @@ describe("CsmCaseCommentInput — drag-and-drop attachments", () => {
     expect(screen.getByText(/huge\.zip.*too large/i)).toBeInTheDocument();
   });
 
+  it("still prevents the browser's default file handling when the composer is disabled, without attaching anything", () => {
+    render(<CsmCaseCommentInput onSubmit={vi.fn()} disabled />);
+    const composer = screen.getByTestId("csm-comment-composer");
+
+    // fireEvent returns false when preventDefault() was called on a
+    // cancelable event — a real file drag must still be prevented even
+    // though the composer won't act on it, or the browser falls through to
+    // navigating the tab to open the dropped file.
+    const notPrevented = fireEvent.drop(composer, fileDrop([makeFile("a.txt", 100)]));
+
+    expect(notPrevented).toBe(false);
+    expect(screen.getByTestId("attachment-count")).toHaveTextContent("0");
+  });
+
   it("dedupes a file that's already attached", () => {
     render(<CsmCaseCommentInput onSubmit={vi.fn()} />);
     const composer = screen.getByTestId("csm-comment-composer");

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentInput.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentInput.test.tsx
@@ -31,19 +31,26 @@ import CsmCaseCommentInput from "@features/csm-cases/components/CsmCaseCommentIn
 
 // This component isn't under test here; stub it to a plain textarea (same
 // technique EditCaseDetailsDialog.test.tsx uses for the same dependency).
+// Also surfaces `attachments.length` as text so drag-and-drop tests below
+// can assert on it without needing the real editor's own attachment-chip UI.
 vi.mock("@components/rich-text-editor/Editor", () => ({
   default: ({
     value,
     onChange,
+    attachments,
   }: {
     value: string;
     onChange: (v: string) => void;
+    attachments: File[];
   }) => (
-    <textarea
-      aria-label="comment-editor"
-      value={value}
-      onChange={(e) => onChange(e.target.value)}
-    />
+    <div data-testid="editor-stub">
+      <textarea
+        aria-label="comment-editor"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      />
+      <span data-testid="attachment-count">{attachments.length}</span>
+    </div>
   ),
 }));
 
@@ -133,5 +140,82 @@ describe("CsmCaseCommentInput — resume-work quick-fix", () => {
     );
 
     expect(screen.getByRole("button", { name: "Resuming…" })).toBeDisabled();
+  });
+});
+
+/** A File-like drop payload — jsdom's DataTransfer doesn't populate `files`
+ * from a plain object literal the way a real browser drag event would. */
+function fileDrop(files: File[]): { dataTransfer: { types: string[]; files: File[] } } {
+  return { dataTransfer: { types: ["Files"], files } };
+}
+
+function makeFile(name: string, sizeBytes: number, type = "text/plain"): File {
+  return new File([new Uint8Array(sizeBytes)], name, { type });
+}
+
+describe("CsmCaseCommentInput — drag-and-drop attachments", () => {
+  it("shows the drop overlay only while a file is being dragged over the composer", () => {
+    render(<CsmCaseCommentInput onSubmit={vi.fn()} />);
+    const composer = screen.getByTestId("csm-comment-composer");
+
+    expect(screen.queryByText("Drop files to attach")).not.toBeInTheDocument();
+
+    fireEvent.dragEnter(composer, fileDrop([]));
+    expect(screen.getByText("Drop files to attach")).toBeInTheDocument();
+
+    fireEvent.dragLeave(composer, fileDrop([]));
+    expect(screen.queryByText("Drop files to attach")).not.toBeInTheDocument();
+  });
+
+  it("attaches a dropped file without opening the naming modal", () => {
+    render(<CsmCaseCommentInput onSubmit={vi.fn()} />);
+    const composer = screen.getByTestId("csm-comment-composer");
+
+    fireEvent.drop(composer, fileDrop([makeFile("screenshot.png", 1024, "image/png")]));
+
+    expect(screen.getByTestId("attachment-count")).toHaveTextContent("1");
+    expect(screen.queryByText("Attach a file")).not.toBeInTheDocument();
+  });
+
+  it("attaches every file from a multi-file drop", () => {
+    render(<CsmCaseCommentInput onSubmit={vi.fn()} />);
+    const composer = screen.getByTestId("csm-comment-composer");
+
+    fireEvent.drop(
+      composer,
+      fileDrop([makeFile("a.txt", 100), makeFile("b.txt", 200), makeFile("c.txt", 300)]),
+    );
+
+    expect(screen.getByTestId("attachment-count")).toHaveTextContent("3");
+  });
+
+  it("rejects a dropped file over the size limit but keeps the ones that fit", () => {
+    render(<CsmCaseCommentInput onSubmit={vi.fn()} />);
+    const composer = screen.getByTestId("csm-comment-composer");
+
+    const tooBig = makeFile("huge.zip", 11 * 1024 * 1024);
+    fireEvent.drop(composer, fileDrop([makeFile("ok.txt", 100), tooBig]));
+
+    expect(screen.getByTestId("attachment-count")).toHaveTextContent("1");
+    expect(screen.getByText(/huge\.zip.*too large/i)).toBeInTheDocument();
+  });
+
+  it("dedupes a file that's already attached", () => {
+    render(<CsmCaseCommentInput onSubmit={vi.fn()} />);
+    const composer = screen.getByTestId("csm-comment-composer");
+    const file = makeFile("dup.txt", 100);
+
+    fireEvent.drop(composer, fileDrop([file]));
+    fireEvent.drop(composer, fileDrop([file]));
+
+    expect(screen.getByTestId("attachment-count")).toHaveTextContent("1");
+  });
+
+  it("ignores a drag that isn't carrying files (e.g. dragging selected text)", () => {
+    render(<CsmCaseCommentInput onSubmit={vi.fn()} />);
+    const composer = screen.getByTestId("csm-comment-composer");
+
+    fireEvent.dragEnter(composer, { dataTransfer: { types: ["text/plain"], files: [] } });
+    expect(screen.queryByText("Drop files to attach")).not.toBeInTheDocument();
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentInput.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentInput.tsx
@@ -31,6 +31,7 @@ import {
   Maximize2,
   Minimize2,
   Send,
+  Upload,
 } from "@wso2/oxygen-ui-icons-react";
 import {
   useCallback,
@@ -38,6 +39,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type DragEvent,
   type JSX,
 } from "react";
 import Editor from "@components/rich-text-editor/Editor";
@@ -144,6 +146,87 @@ export default function CsmCaseCommentInput({
   const onAttachmentRemove = useCallback((index: number) => {
     setAttachments((prev) => prev.filter((_, i) => i !== index));
   }, []);
+
+  // Dropping files directly onto the composer, as an alternative to the
+  // paperclip button's naming-modal flow (see CsmUploadAttachmentModal) —
+  // faster for the common case of "just attach these," at the cost of
+  // skipping the custom-name step. dragCounter handles dragenter/dragleave
+  // firing on every child element as the pointer crosses them; dragOver
+  // should only go false once the pointer has actually left the composer,
+  // not just moved between its children.
+  const [dragOver, setDragOver] = useState(false);
+  const dragCounter = useRef(0);
+
+  const isFileDrag = useCallback(
+    (e: DragEvent) => Array.from(e.dataTransfer.types).includes("Files"),
+    [],
+  );
+
+  const onDragEnter = useCallback(
+    (e: DragEvent) => {
+      if (disabled || submitting || !isFileDrag(e)) return;
+      e.preventDefault();
+      dragCounter.current += 1;
+      setDragOver(true);
+    },
+    [disabled, submitting, isFileDrag],
+  );
+  const onDragOver = useCallback(
+    (e: DragEvent) => {
+      // Required on dragover too (not just dragenter) — without this the
+      // browser refuses to fire a drop event at all.
+      if (disabled || submitting || !isFileDrag(e)) return;
+      e.preventDefault();
+    },
+    [disabled, submitting, isFileDrag],
+  );
+  const onDragLeave = useCallback((e: DragEvent) => {
+    if (!isFileDrag(e)) return;
+    dragCounter.current = Math.max(0, dragCounter.current - 1);
+    if (dragCounter.current === 0) setDragOver(false);
+  }, [isFileDrag]);
+
+  const addDroppedFiles = useCallback((files: FileList) => {
+    const incoming = Array.from(files);
+    if (incoming.length === 0) return;
+
+    // Same size limit the naming modal enforces. Report the first offender
+    // (matching submit()'s own single-message pattern below) but still
+    // attach whichever dropped files DO pass, rather than rejecting the
+    // whole drop over one oversized file.
+    const tooLarge = incoming.find((f) => f.size > MAX_ATTACHMENT_SIZE_BYTES);
+    const accepted = incoming.filter((f) => f.size <= MAX_ATTACHMENT_SIZE_BYTES);
+
+    if (accepted.length > 0) {
+      setAttachments((prev) => {
+        const next = [...prev];
+        for (const file of accepted) {
+          // Same dedupe rule as the modal-driven path.
+          if (next.some((a) => fileSignature(a.file) === fileSignature(file))) continue;
+          next.push({ file, name: file.name });
+        }
+        return next;
+      });
+    }
+    setError(
+      tooLarge
+        ? `"${tooLarge.name}" is too large. The maximum attachment size is ${formatBytes(
+            MAX_ATTACHMENT_SIZE_BYTES,
+          )}.`
+        : null,
+    );
+  }, []);
+
+  const onDrop = useCallback(
+    (e: DragEvent) => {
+      if (disabled || submitting || !isFileDrag(e)) return;
+      e.preventDefault();
+      dragCounter.current = 0;
+      setDragOver(false);
+      addDroppedFiles(e.dataTransfer.files);
+    },
+    [disabled, submitting, isFileDrag, addDroppedFiles],
+  );
 
   // Incrementing this trigger clears the editor (see Editor's ResetPlugin).
   const resetTriggerRef = useRef(0);
@@ -255,7 +338,13 @@ export default function CsmCaseCommentInput({
 
   return (
     <Box
+      data-testid="csm-comment-composer"
+      onDragEnter={onDragEnter}
+      onDragOver={onDragOver}
+      onDragLeave={onDragLeave}
+      onDrop={onDrop}
       sx={{
+        position: "relative",
         display: "flex",
         flexDirection: "column",
         gap: 1,
@@ -267,6 +356,29 @@ export default function CsmCaseCommentInput({
         ...(internal && { borderLeftWidth: "3px", borderLeftColor: "primary.main" }),
       }}
     >
+      {dragOver && (
+        <Box
+          aria-hidden
+          sx={{
+            position: "absolute",
+            inset: 0,
+            zIndex: 1,
+            pointerEvents: "none",
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: 0.5,
+            borderRadius: 1,
+            border: "2px dashed",
+            borderColor: "primary.main",
+            bgcolor: "action.hover",
+          }}
+        >
+          <Upload size={22} />
+          <Typography variant="body2">Drop files to attach</Typography>
+        </Box>
+      )}
       <Box
         sx={{
           display: "flex",

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentInput.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentInput.tsx
@@ -164,8 +164,14 @@ export default function CsmCaseCommentInput({
 
   const onDragEnter = useCallback(
     (e: DragEvent) => {
-      if (disabled || submitting || !isFileDrag(e)) return;
+      // preventDefault unconditionally for a real file drag, before the
+      // disabled/submitting check below — otherwise a file dropped while
+      // the composer is unavailable falls through to the browser's own
+      // default handling (navigating the tab to open the file), discarding
+      // whatever was on the page.
+      if (!isFileDrag(e)) return;
       e.preventDefault();
+      if (disabled || submitting) return;
       dragCounter.current += 1;
       setDragOver(true);
     },
@@ -175,10 +181,10 @@ export default function CsmCaseCommentInput({
     (e: DragEvent) => {
       // Required on dragover too (not just dragenter) — without this the
       // browser refuses to fire a drop event at all.
-      if (disabled || submitting || !isFileDrag(e)) return;
+      if (!isFileDrag(e)) return;
       e.preventDefault();
     },
-    [disabled, submitting, isFileDrag],
+    [isFileDrag],
   );
   const onDragLeave = useCallback((e: DragEvent) => {
     if (!isFileDrag(e)) return;
@@ -219,10 +225,14 @@ export default function CsmCaseCommentInput({
 
   const onDrop = useCallback(
     (e: DragEvent) => {
-      if (disabled || submitting || !isFileDrag(e)) return;
+      // Same ordering as onDragEnter: prevent the browser's default file
+      // handling before checking whether the composer can actually accept
+      // the drop, and always reset the drag-visual state either way.
+      if (!isFileDrag(e)) return;
       e.preventDefault();
       dragCounter.current = 0;
       setDragOver(false);
+      if (disabled || submitting) return;
       addDroppedFiles(e.dataTransfer.files);
     },
     [disabled, submitting, isFileDrag, addDroppedFiles],


### PR DESCRIPTION
## Purpose
Dragging a file onto the comment composer did nothing; the only way to attach a file was via the paperclip button's picker/naming modal (drag-and-drop existed, but only inside that modal's own dropzone, single file only, and only once the modal was already open).

## Goals
Let a user drop one or more files directly onto the comment composer to attach them, without needing to open the naming modal first.

## Approach
Added drag event handlers (dragenter/dragover/dragleave/drop) to `CsmCaseCommentInput`'s outer container. A files-carrying drag over any part of the composer shows a dashed-border "Drop files to attach" overlay; on drop, each file is validated against the existing `MAX_ATTACHMENT_SIZE_BYTES` limit and deduped the same way the modal-driven path already does, then added directly to the `attachments` array — skipping the naming step (each file keeps its own name, still renameable via the existing remove-and-reattach flow). A drop with one oversized file among several still attaches the ones that fit, with a clear error naming the rejected file. Non-file drags (e.g. dragging selected text) are ignored.

## User stories
As a CSM engineer composing a case comment, I can drag a file from my desktop directly onto the comment box to attach it, instead of having to click the attach button and use the picker every time.

## Release note
CSM Portal: the comment composer now supports drag-and-drop file attachments, in addition to the existing file picker.

## Documentation
N/A — UI affordance addition only, no new concept to document.

## Automation tests
- Unit tests: added 6 new tests (drop overlay show/hide, single-file drop, multi-file drop, oversized-file rejection alongside valid files, dedupe, non-file drag ignored) in `CsmCaseCommentInput.test.tsx`, merged alongside 5 pre-existing tests for an unrelated feature in the same file — all 11 pass. Full `csm-cases` suite (372 tests) passes with no regressions.

## Security checks
- Followed secure coding standards in the WSO2 secure engineering guidelines: yes
- Ran FindSecurityBugs plugin and verified report: N/A (frontend TypeScript, not a JVM component)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets: yes

## Test environment
Tested locally in Chrome (macOS) against the real staging backend.