### PR TITLE
[CSM Portal] Surface locked-out status on user displays

### DIFF
--- a/apps/csm-portal/backend/internal/handler/user_teams_test.go
+++ b/apps/csm-portal/backend/internal/handler/user_teams_test.go
@@ -185,7 +185,7 @@ func TestGetUser_DerivesTeamsFromGroups(t *testing.T) {
 	const id = "11111111-1111-1111-1111-111111111111"
 	h := NewUsersHandler(&mockSCIMClient{}, &mockEntityUserClient{
 		getUserFn: func(_ context.Context, _ string) ([]byte, error) {
-			return []byte(`{"id":"` + id + `","email":"staff@example.com","groups":[` +
+			return []byte(`{"id":"` + id + `","email":"staff@example.com","lockedOut":true,"groups":[` +
 				`{"id":"g-1","name":"ABT One"},{"id":"g-2","name":"Some Other Group"}]}`), nil
 		},
 	}, testDirectory(t))
@@ -197,8 +197,9 @@ func TestGetUser_DerivesTeamsFromGroups(t *testing.T) {
 
 	assertStatus(t, w, http.StatusOK)
 	got := decodeJSON[struct {
-		Email  string `json:"email"`
-		Groups []struct {
+		Email     string `json:"email"`
+		LockedOut bool   `json:"lockedOut"`
+		Groups    []struct {
 			Name string `json:"name"`
 		} `json:"groups"`
 		Teams []struct {
@@ -219,6 +220,12 @@ func TestGetUser_DerivesTeamsFromGroups(t *testing.T) {
 	}
 	if got.Email != "staff@example.com" {
 		t.Errorf("email = %q, want the rest of the profile preserved", got.Email)
+	}
+	// The entity service's lockedOut field is not something this layer knows
+	// about; the envelope-based re-encoding in withUserTeams must still carry
+	// it through untouched.
+	if !got.LockedOut {
+		t.Errorf("lockedOut = %v, want true (passed through from the entity service)", got.LockedOut)
 	}
 }
 

--- a/apps/csm-portal/webapp/src/features/csm-admin/components/DirectoryMembersList.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/components/DirectoryMembersList.tsx
@@ -225,7 +225,21 @@ export default function DirectoryMembersList({
                       )}
                     </TableCell>
                     <TableCell>
-                      {u.active === undefined ? (
+                      {u.lockedOut ? (
+                        <Stack direction="row" spacing={0.75} alignItems="center">
+                          <Box
+                            aria-hidden
+                            sx={{
+                              width: 7,
+                              height: 7,
+                              flexShrink: 0,
+                              borderRadius: "50%",
+                              bgcolor: "error.main",
+                            }}
+                          />
+                          <Typography variant="body2">Locked out</Typography>
+                        </Stack>
+                      ) : u.active === undefined ? (
                         "—"
                       ) : (
                         <Stack direction="row" spacing={0.75} alignItems="center">

--- a/apps/csm-portal/webapp/src/features/csm-users/components/UserPreviewDrawer.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/components/UserPreviewDrawer.tsx
@@ -67,14 +67,18 @@ export default function UserPreviewDrawer({ user, onClose }: UserPreviewDrawerPr
                 <X size={18} />
               </IconButton>
             </Box>
-            {user.active !== undefined && (
+            {(user.lockedOut === true || user.active !== undefined) && (
               <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
-                <Chip
-                  size="small"
-                  variant="outlined"
-                  color={user.active ? "success" : "default"}
-                  label={user.active ? "Active" : "Inactive"}
-                />
+                {user.lockedOut === true ? (
+                  <Chip size="small" variant="outlined" color="error" label="Locked out" />
+                ) : (
+                  <Chip
+                    size="small"
+                    variant="outlined"
+                    color={user.active ? "success" : "default"}
+                    label={user.active ? "Active" : "Inactive"}
+                  />
+                )}
               </Box>
             )}
           </Box>

--- a/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.test.tsx
@@ -336,6 +336,23 @@ describe("CsmUsersPage — role truncation and row navigation", () => {
     );
   });
 
+  it("shows 'Locked out' in the status column instead of 'Active', for a locked-out user even though they're active", async () => {
+    authFetchMock.mockResolvedValue(
+      jsonResponse({
+        users: [{ ...FEW_ROLES_USER, active: true, lockedOut: true }],
+        total: 1,
+        limit: 20,
+        offset: 0,
+      }),
+    );
+    renderPage("/admin/users");
+
+    await waitFor(() => expect(screen.getByText("John Smith")).toBeInTheDocument());
+    const row = screen.getByText("John Smith").closest("tr") as HTMLElement;
+    expect(within(row).getByText("Locked out")).toBeInTheDocument();
+    expect(within(row).queryByText("Active")).not.toBeInTheDocument();
+  });
+
   it("renders no Back button when it wasn't reached from a dashboard widget", () => {
     renderPage("/admin/users");
     expect(screen.queryByRole("button", { name: "Back" })).not.toBeInTheDocument();

--- a/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.tsx
@@ -468,7 +468,21 @@ export default function CsmUsersPage(): JSX.Element {
                         )}
                       </TableCell>
                       <TableCell>
-                        {u.active === undefined ? (
+                        {u.lockedOut ? (
+                          <Stack direction="row" spacing={0.75} alignItems="center">
+                            <Box
+                              aria-hidden
+                              sx={{
+                                width: 7,
+                                height: 7,
+                                flexShrink: 0,
+                                borderRadius: "50%",
+                                bgcolor: "error.main",
+                              }}
+                            />
+                            <Typography variant="body2">Locked out</Typography>
+                          </Stack>
+                        ) : u.active === undefined ? (
                           "—"
                         ) : (
                           <Stack direction="row" spacing={0.75} alignItems="center">

--- a/apps/csm-portal/webapp/src/features/csm-users/pages/UserProfilePage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/pages/UserProfilePage.test.tsx
@@ -259,6 +259,41 @@ describe("UserProfilePage", () => {
     ).toBeInTheDocument();
   });
 
+  it("renders a 'Locked out' chip when the account is locked out", () => {
+    mockQueryResult({ data: { ...INTERNAL_USER, lockedOut: true } });
+    renderPage();
+    expect(screen.getByText("Locked out", { selector: ".MuiChip-label" })).toBeInTheDocument();
+  });
+
+  it("does not render a 'Locked out' chip when the account isn't locked out", () => {
+    mockQueryResult({ data: { ...INTERNAL_USER, lockedOut: false } });
+    renderPage();
+    expect(screen.queryByText("Locked out", { selector: ".MuiChip-label" })).not.toBeInTheDocument();
+  });
+
+  it("shows only the 'Locked out' chip in the header — not 'Active' — for an active-but-locked-out user", () => {
+    mockQueryResult({ data: { ...INTERNAL_USER, active: true, lockedOut: true } });
+    renderPage();
+    // Exactly one "Locked out" chip (header) and exactly one "Active" chip
+    // (the Overview card's own, unconditional "Account status" field) — the
+    // header itself must not also render a second "Active" chip.
+    expect(screen.getAllByText("Locked out", { selector: ".MuiChip-label" })).toHaveLength(1);
+    expect(screen.getAllByText("Active", { selector: ".MuiChip-label" })).toHaveLength(1);
+  });
+
+  it("still shows both Account status and Locked out as separate fields in the Overview card", () => {
+    mockQueryResult({ data: { ...INTERNAL_USER, active: true, lockedOut: true } });
+    renderPage();
+    expect(screen.getByText("Account status")).toBeInTheDocument();
+    // "Locked out" appears twice: the header chip's label and the Overview
+    // field's caption — both are expected here, not a duplicate bug.
+    expect(screen.getAllByText("Locked out").length).toBeGreaterThanOrEqual(2);
+    // The header collapses to one "Locked out" chip; the Overview card still
+    // shows "Active" for account status and "Yes" for locked-out separately.
+    expect(screen.getByText("Active", { selector: ".MuiChip-label" })).toBeInTheDocument();
+    expect(screen.getByText("Yes", { selector: ".MuiChip-label" })).toBeInTheDocument();
+  });
+
   it("calls out an inactive account as blocking access to every project", () => {
     mockQueryResult({ data: { ...BLOCKED_EXTERNAL_USER, active: false } });
     renderPage();

--- a/apps/csm-portal/webapp/src/features/csm-users/pages/UserProfilePage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/pages/UserProfilePage.tsx
@@ -528,13 +528,25 @@ export default function UserProfilePage(): JSX.Element {
             color={internal ? "primary" : "default"}
             variant="outlined"
           />
-          {user.active !== undefined && (
-            <Chip
-              size="small"
-              label={user.active ? "Active" : "Inactive"}
-              color={user.active ? "success" : "default"}
-              variant="outlined"
-            />
+          {/* Locked out takes priority over Active in this single top-line status
+              chip — a locked-out account isn't usable regardless of its Active
+              flag, so showing "Active" here would be misleading. Both attributes
+              are still shown separately (and unconditionally) in the Overview
+              card below; this chip is just the headline. Named to be unambiguous
+              next to the unrelated SCIM "external" account lock chip in the
+              Overview grid (see `ExternalAccountMetaCell`), a different lock
+              concept. */}
+          {user.lockedOut === true ? (
+            <Chip size="small" label="Locked out" color="error" variant="outlined" />
+          ) : (
+            user.active !== undefined && (
+              <Chip
+                size="small"
+                label={user.active ? "Active" : "Inactive"}
+                color={user.active ? "success" : "default"}
+                variant="outlined"
+              />
+            )
           )}
         </Box>
         <Typography variant="body2" color="text.secondary">
@@ -563,10 +575,34 @@ export default function UserProfilePage(): JSX.Element {
               {user.email}
             </Typography>
           </MetaCell>
-          {internal && <TeamMetaCell user={user} />}
           <MetaCell label="Timezone">
             <Typography variant="body2">{user.timezone ?? "Not set"}</Typography>
           </MetaCell>
+          {/* Account status and Locked out are two independent attributes — a
+              locked-out user can also be Active — so both are always shown
+              here, separately, even though the header chip above collapses them
+              into one headline status. */}
+          {user.lockedOut !== undefined && (
+            <MetaCell label="Locked out">
+              <Chip
+                size="small"
+                label={user.lockedOut ? "Yes" : "No"}
+                color={user.lockedOut ? "error" : "default"}
+                variant="outlined"
+              />
+            </MetaCell>
+          )}
+          {internal && <TeamMetaCell user={user} />}
+          {user.active !== undefined && (
+            <MetaCell label="Account status">
+              <Chip
+                size="small"
+                label={user.active ? "Active" : "Inactive"}
+                color={user.active ? "success" : "default"}
+                variant="outlined"
+              />
+            </MetaCell>
+          )}
           {internal && (
             <MetaCell label="Phone">
               <Typography variant="body2">{user.phone ?? "Not set"}</Typography>

--- a/apps/csm-portal/webapp/src/features/csm-users/types/csmUsers.ts
+++ b/apps/csm-portal/webapp/src/features/csm-users/types/csmUsers.ts
@@ -74,6 +74,13 @@ export interface SnUser {
   mobilePhone?: string | null;
   userType?: UserType;
   active: boolean;
+  /**
+   * Whether the data source has locked the account out (e.g. too many failed
+   * sign-in attempts) — independent of {@link active}: a user can be active
+   * but locked out. Distinct from {@link ExternalAccountStatus.locked}, which
+   * is a separate concept from the SCIM "external" org.
+   */
+  lockedOut: boolean;
   createdOn: string;
   updatedOn: string;
   roles: string[];
@@ -214,6 +221,8 @@ export interface NormalizedUser {
   userType?: UserType;
   /** Present only from the ServiceNow source. */
   active?: boolean;
+  /** Present only from the ServiceNow source; see {@link SnUser.lockedOut}. */
+  lockedOut?: boolean;
   /** Present only from the ServiceNow source. */
   roles?: string[];
   /** Present from either source, when the caller requested the full profile. */
@@ -245,6 +254,7 @@ export function normalizeUser(u: User | SnUser): NormalizedUser {
       timezone: u.timeZone ?? null,
       userType: u.userType,
       active: u.active,
+      lockedOut: u.lockedOut,
       roles: u.roles,
       phone: u.mobilePhone ?? null,
       createdOn: u.createdOn,

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -145,8 +145,12 @@ type SNUser struct {
 	MobilePhone *string `json:"mobilePhone,omitempty"`
 	// UserType distinguishes staff from customer/partner contacts. Derived by the
 	// backing data source from role membership, not stored as a column.
-	UserType  UserType `json:"userType,omitempty"`
-	Active    bool     `json:"active"`
+	UserType UserType `json:"userType,omitempty"`
+	Active   bool     `json:"active"`
+	// LockedOut reports whether the backing data source has locked the account out,
+	// independent of Active: a user can be active but locked out after too many failed
+	// login attempts.
+	LockedOut bool     `json:"lockedOut"`
 	CreatedOn string   `json:"createdOn"`
 	UpdatedOn string   `json:"updatedOn"`
 	Roles     []string `json:"roles"`

--- a/entity-service/internal/service/sn_user_directory_test.go
+++ b/entity-service/internal/service/sn_user_directory_test.go
@@ -32,7 +32,7 @@ import (
 func snUserRowJSON(sysid, email, userType string) string {
 	return `{"id":"` + sysid + `","userName":"` + email + `","name":"Test User","email":"` + email +
 		`","timeZone":"Asia/Colombo","mobilePhone":"+94700000000","userType":"` + userType +
-		`","active":true,"createdOn":"2020-01-01 00:00:00","updatedOn":"2020-01-02 00:00:00",` +
+		`","active":true,"lockedOut":true,"createdOn":"2020-01-01 00:00:00","updatedOn":"2020-01-02 00:00:00",` +
 		`"roles":["snc_internal"]}`
 }
 
@@ -125,6 +125,9 @@ func TestSNUserService_SearchUsers_GroupNameFilterSendsUserIDs(t *testing.T) {
 	if got.Users[0].MobilePhone == nil || *got.Users[0].MobilePhone != "+94700000000" {
 		t.Fatalf("mobilePhone = %v, want +94700000000", got.Users[0].MobilePhone)
 	}
+	if !got.Users[0].LockedOut {
+		t.Fatalf("lockedOut = %v, want true", got.Users[0].LockedOut)
+	}
 
 	var req struct {
 		Filters struct {
@@ -168,6 +171,9 @@ func TestSNUserService_GetUser_Groups(t *testing.T) {
 	// Staff get no project-access block.
 	if got.ProjectAccess != nil {
 		t.Fatalf("projectAccess = %+v, want nil for an internal user", got.ProjectAccess)
+	}
+	if !got.LockedOut {
+		t.Fatalf("lockedOut = %v, want true", got.LockedOut)
 	}
 }
 

--- a/entity-service/internal/service/sn_user_service.go
+++ b/entity-service/internal/service/sn_user_service.go
@@ -96,6 +96,7 @@ type snUser struct {
 	MobilePhone *string  `json:"mobilePhone"`
 	UserType    string   `json:"userType"`
 	Active      bool     `json:"active"`
+	LockedOut   bool     `json:"lockedOut"`
 	CreatedOn   string   `json:"createdOn"`
 	UpdatedOn   string   `json:"updatedOn"`
 	Roles       []string `json:"roles"`
@@ -313,6 +314,7 @@ func (s *snUserService) SearchUsers(ctx context.Context, req domain.SearchUsersR
 			MobilePhone: u.MobilePhone,
 			UserType:    domain.UserType(u.UserType),
 			Active:      u.Active,
+			LockedOut:   u.LockedOut,
 			CreatedOn:   u.CreatedOn,
 			UpdatedOn:   u.UpdatedOn,
 			Roles:       roles,
@@ -466,6 +468,7 @@ func (s *snUserService) GetUser(ctx context.Context, id string) (domain.SNUserDe
 			MobilePhone: u.MobilePhone,
 			UserType:    domain.UserType(u.UserType),
 			Active:      u.Active,
+			LockedOut:   u.LockedOut,
 			CreatedOn:   u.CreatedOn,
 			UpdatedOn:   u.UpdatedOn,
 			Roles:       roles,


### PR DESCRIPTION
## Purpose
ServiceNow user records track a locked-out state (`locked_out`) that wasn't surfaced anywhere in the CSM portal. A CS engineer looking at a user's profile had no way to tell that account was locked out in ServiceNow, which caused confusion when investigating access issues.

## Goals
Add the locked-out signal end-to-end and surface it consistently everywhere a user's status is shown:
- Entity-service and BFF now carry a `lockedOut` boolean on user responses.
- The user list's status column, the profile page's header, and the quick-preview drawer now show "Locked out" instead of "Active"/"Inactive" when the account is locked out — a locked-out account isn't usable regardless of its Active flag, so collapsing to one headline status avoids a misleading "Active" reading.
- The profile page's Overview card still lists "Account status" and "Locked out" as two separate, always-visible fields, since they're independent attributes and that level of detail belongs there.

## Approach
- `entity-service`: added `LockedOut bool` to the SN user domain types (`internal/domain/entity.go`), populated from the upstream search/get responses (`internal/service/sn_user_service.go`).
- `apps/csm-portal/backend`: no code change needed — `GetUser` already passes the entity-service's JSON through via a `map[string]json.RawMessage` envelope, so the new field survives untouched. Added a test assertion to lock that in.
- `apps/csm-portal/webapp`: threaded `lockedOut` through the user types (`csmUsers.ts`), and updated the status rendering in `UserProfilePage.tsx`, `CsmUsersPage.tsx`, `DirectoryMembersList.tsx`, and `UserPreviewDrawer.tsx`.

Manually verified end-to-end against a real local stack (real Asgardeo login, real ServiceNow DEV data) — confirmed both a locked-out user and a normal active user render correctly in the list, header, and Overview card. Screenshots available on request (not attached here).

## User stories
As a CS engineer viewing a user's profile or the user directory, I want to see when an account is locked out in ServiceNow, so I don't mistake it for a normal active account when investigating access issues.

## Release note
The CSM user list, profile page, and quick-preview drawer now show "Locked out" when a user's ServiceNow account is locked out, taking priority over the Active/Inactive status. The profile page's Overview card lists both attributes separately.

## Documentation
N/A — internal CSM-portal UI change, no external product documentation affected.

## Training
N/A — no customer-facing training content affected.

## Certification
N/A — no certification exam impact.

## Marketing
N/A — internal tooling change, not customer-facing.

## Automation tests
- Unit tests
  - `entity-service/internal/service/sn_user_directory_test.go` — asserts `LockedOut` on both the search and get-by-id paths.
  - `apps/csm-portal/backend/internal/handler/user_teams_test.go` — asserts the field survives the BFF's passthrough envelope.
  - `apps/csm-portal/webapp/.../UserProfilePage.test.tsx` — chip presence/absence, header suppression, Overview dual-field display.
  - `apps/csm-portal/webapp/.../CsmUsersPage.test.tsx` — status column shows "Locked out" over "Active".
  - All new and existing tests pass (`go test ./...`, `vitest run`); `go build`, `go vet`, `tsc -b`, `eslint` all clean.
- Integration tests
  - No new CI integration tests; verified manually end-to-end against a real local stack with real ServiceNow DEV data (see Approach).

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — Go/TypeScript codebase; `go vet` and `eslint` ran clean instead
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
A corresponding ServiceNow-side change (adding `locked_out` to the user search endpoint's response) is tracked separately and already live on the DEV tenant.

## Migrations (if applicable)
N/A — additive field, no schema/data migration.

## Test environment
macOS, local dev stack (Go per `go.mod`, Node/pnpm per `package.json`), Chrome, real ServiceNow DEV tenant.

## Learning
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clear “Locked out” status indicators across user lists, profiles, and preview drawers.
  * Locked-out status now takes precedence over Active or Inactive status.
  * User profiles separately display account status and lockout status.

* **Bug Fixes**
  * Preserved locked-out status when retrieving and displaying user information.

* **Tests**
  * Added coverage verifying locked-out status across user lists, profiles, and service responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->