### PR TITLE
[CSM Portal] accept team UUID in users/search teamIds filter

### DIFF
--- a/apps/csm-portal/backend/internal/directory/directory.go
+++ b/apps/csm-portal/backend/internal/directory/directory.go
@@ -30,7 +30,8 @@ import (
 //
 //   - teams sorted for stable paging, with each team's backing group id already
 //     converted to this platform's UUID form (Team.GroupID -> Result.GroupID),
-//   - key -> team and group-name -> team lookups as maps,
+//   - key -> team, group-name -> team, and resolved-group-UUID -> team lookups
+//     as maps,
 //   - the group-name list a membership query needs,
 //   - the role catalogue with its display names, and the role membership set.
 //
@@ -44,6 +45,7 @@ type Directory struct {
 	teamResults []TeamResult
 	byKey       map[string]Team
 	byGroupName map[string]Team
+	byGroupID   map[string]Team
 	groupNames  []string
 
 	roleResults []RoleResult
@@ -54,7 +56,10 @@ type Directory struct {
 //
 // A duplicate team key or duplicate display name is an error: both would be
 // silently swallowed by the lookup maps, and a shadowed row is always a typo.
-// Callers are expected to treat any error here as fatal at startup -- a
+// A duplicate resolved group-id UUID is the same class of mistake -- two rows
+// configured with the same backing GroupID would shadow each other in
+// byGroupID exactly as a duplicate key would in byKey -- so it fails startup
+// too. Callers are expected to treat any error here as fatal at startup -- a
 // half-resolved directory would mis-route dashboards rather than fail visibly.
 func New(teams []Team, roles []string) (*Directory, error) {
 	d := &Directory{
@@ -62,6 +67,7 @@ func New(teams []Team, roles []string) (*Directory, error) {
 		teamResults: make([]TeamResult, 0, len(teams)),
 		byKey:       make(map[string]Team, len(teams)),
 		byGroupName: make(map[string]Team, len(teams)),
+		byGroupID:   make(map[string]Team, len(teams)),
 		groupNames:  make([]string, 0, len(teams)),
 		roleResults: make([]RoleResult, 0, len(roles)),
 		roleSet:     make(map[string]bool, len(roles)),
@@ -81,6 +87,10 @@ func New(teams []Team, roles []string) (*Directory, error) {
 		result := TeamResult{ID: t.Key, Name: t.Name, Family: string(t.Family)}
 		if t.GroupID != "" {
 			result.GroupID = sourceIDToUUID(t.GroupID)
+			if _, dup := d.byGroupID[result.GroupID]; dup {
+				return nil, fmt.Errorf("team registry: groupId %q (team %q) is configured more than once", t.GroupID, t.Key)
+			}
+			d.byGroupID[result.GroupID] = t
 		}
 		d.teamResults = append(d.teamResults, result)
 	}
@@ -118,6 +128,20 @@ func (d *Directory) TeamByKey(key string) (Team, bool) {
 // exactly matches name. ok is false if no configured team matches.
 func (d *Directory) TeamByGroupName(name string) (Team, bool) {
 	t, ok := d.byGroupName[name]
+	return t, ok
+}
+
+// TeamByUUID looks a team up by this platform's canonical UUID form of its
+// backing group id -- the same form Team.GroupID is converted to for
+// TeamResult.GroupID and for accounts.creTeam.id/sreTeam.id elsewhere. ok is
+// false if uuid does not match any configured team's resolved group id,
+// including for a team that has no GroupID configured at all: such a team
+// has no UUID to be looked up by.
+//
+// uuid is lowercased before lookup, matching sourceIDToUUID's canonical
+// lowercase form, so a caller-supplied uppercase UUID still resolves.
+func (d *Directory) TeamByUUID(uuid string) (Team, bool) {
+	t, ok := d.byGroupID[strings.ToLower(uuid)]
 	return t, ok
 }
 

--- a/apps/csm-portal/backend/internal/directory/directory_test.go
+++ b/apps/csm-portal/backend/internal/directory/directory_test.go
@@ -181,6 +181,13 @@ func TestNew_RejectsDuplicates(t *testing.T) {
 	if _, err := New(dupName, DefaultRoles); err == nil {
 		t.Error("duplicate display name was accepted")
 	}
+	// Two teams configured with the same backing GroupID would shadow each
+	// other in byGroupID exactly as a duplicate key would in byKey.
+	dupGroupID, _ := ParseTeamRegistry(
+		"alpha|Alpha Team||aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,beta|Beta Team||aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	if _, err := New(dupGroupID, DefaultRoles); err == nil {
+		t.Error("duplicate groupId was accepted")
+	}
 }
 
 // An unconfigured registry is legal: the deployment still has to start.
@@ -318,6 +325,36 @@ func TestSearchTeams_PageDoesNotAliasTheSnapshot(t *testing.T) {
 
 	if again := dir.SearchTeams(SearchRequest{}); again.Teams[0].Name == "mutated" {
 		t.Fatal("mutating a returned page changed the startup snapshot")
+	}
+}
+
+// TeamByUUID is the reverse of the id -> UUID conversion done at startup: a
+// caller holding the platform UUID form of a team's backing group id (the
+// same form TeamResult.GroupID and accounts.creTeam.id/sreTeam.id expose)
+// must be able to resolve the team from it.
+func TestTeamByUUID_ResolvesTheConfiguredTeam(t *testing.T) {
+	dir := mustDirectory(t, registryFixture, "")
+
+	// alpha's fixture GroupID "aaaa...aaaa" (32 hex chars) resolves to this
+	// UUID -- see TestStartupResolution_BuildsTheExpectedIndex.
+	team, ok := dir.TeamByUUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+	if !ok {
+		t.Fatal("TeamByUUID missed the configured alpha team")
+	}
+	if team.Key != "alpha" {
+		t.Fatalf("TeamByUUID resolved %+v, want the alpha row", team)
+	}
+
+	// A well-formed UUID that matches no configured team's group id.
+	if _, ok := dir.TeamByUUID("ffffffff-ffff-ffff-ffff-ffffffffffff"); ok {
+		t.Error("TeamByUUID matched a UUID no team is configured with")
+	}
+
+	// beta and gamma have no GroupID configured at all, so they have no UUID
+	// to be looked up by -- confirm neither is reachable through some
+	// unintended fallback.
+	if _, ok := dir.TeamByUUID(""); ok {
+		t.Error("TeamByUUID matched the empty string against an unconfigured group id")
 	}
 }
 

--- a/apps/csm-portal/backend/internal/handler/user_teams.go
+++ b/apps/csm-portal/backend/internal/handler/user_teams.go
@@ -20,6 +20,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
+
+	"github.com/wso2-open-operations/cs-tools/apps/csm-portal/backend/internal/directory"
 )
 
 // teamIDFilterLimit caps the teamIds filter. Each key expands to one group name
@@ -31,6 +34,12 @@ const teamIDFilterLimit = 50
 // roleIDFilterLimit caps the roleIds filter, matching what the entity service
 // enforced while it owned the role allow-list.
 const roleIDFilterLimit = 20
+
+// teamUUIDPattern matches this platform's canonical UUID text (lowercase or
+// uppercase hex, 8-4-4-4-12 hyphenated). A teamIds entry in this shape is
+// resolved against a team's backing group id rather than its registry key --
+// the same UUID form accounts.creTeam.id/sreTeam.id already expose elsewhere.
+var teamUUIDPattern = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
 
 // userTeamRef is a team the user is a member of, as GET /users/{id} exposes it.
 // ID is the registry team key, which is stable across environments -- unlike
@@ -109,9 +118,12 @@ func (h *UsersHandler) withUserTeams(raw []byte) ([]byte, error) {
 //   - roleIds is validated against the configured allow-list, which lives here
 //     now. An unknown role is a caller mistake, and letting it through would
 //     return a confidently empty page instead of an error.
-//   - teamIds is replaced by the group names those teams resolve to. The
-//     entity service filters membership by group name; only this layer knows
-//     which name a team key means.
+//   - teamIds is replaced by the group names those teams resolve to. Each
+//     entry may be either a registry teamKey or the platform UUID form of the
+//     team's backing group id (the same shape accounts.creTeam.id/sreTeam.id
+//     expose) -- both resolve to the same team. The entity service filters
+//     membership by group name; only this layer knows which name either id
+//     shape means.
 //
 // Every other field passes through untouched, and a body with no filters object
 // is returned byte-for-byte as it arrived. The returned error is caller-facing:
@@ -173,7 +185,15 @@ func (h *UsersHandler) resolveUserSearchFilters(body []byte) ([]byte, error) {
 			}
 		}
 		for _, key := range teamIDs {
-			team, ok := h.dir.TeamByKey(key)
+			var team directory.Team
+			var ok bool
+			if teamUUIDPattern.MatchString(key) {
+				// The platform UUID form of a team's backing group id -- the
+				// same shape accounts.creTeam.id/sreTeam.id already expose.
+				team, ok = h.dir.TeamByUUID(key)
+			} else {
+				team, ok = h.dir.TeamByKey(key)
+			}
 			if !ok {
 				return nil, fmt.Errorf("teamIds contains unknown team: %s", key)
 			}

--- a/apps/csm-portal/backend/internal/handler/user_teams_test.go
+++ b/apps/csm-portal/backend/internal/handler/user_teams_test.go
@@ -95,6 +95,50 @@ func TestSearchUsers_UnfilteredBodyIsForwardedVerbatim(t *testing.T) {
 	}
 }
 
+// TestSearchUsers_TeamFilterAcceptsUUIDForm: a teamIds entry may also be the
+// platform UUID form of a team's backing group id -- the same shape
+// accounts.creTeam.id/sreTeam.id already expose -- and must resolve to the
+// same group name a teamKey would.
+func TestSearchUsers_TeamFilterAcceptsUUIDForm(t *testing.T) {
+	// abt-1's fixture GroupID "aaaa...aaaa" (32 hex chars, see testTeamRegistry
+	// in helpers_test.go) resolves to this UUID.
+	captured, w := capturedSearch(t, `{"filters":{"teamIds":["aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"]}}`)
+	assertStatus(t, w, http.StatusOK)
+
+	var got struct {
+		Filters struct {
+			GroupNames []string `json:"groupNames"`
+		} `json:"filters"`
+	}
+	if err := json.Unmarshal([]byte(captured), &got); err != nil {
+		t.Fatalf("forwarded body is not JSON: %v (%s)", err, captured)
+	}
+	if len(got.Filters.GroupNames) != 1 || got.Filters.GroupNames[0] != "ABT One" {
+		t.Errorf("groupNames = %v, want [\"ABT One\"] resolved from the UUID form", got.Filters.GroupNames)
+	}
+}
+
+// A UUID-shaped teamIds entry that matches no configured team's group id is
+// still the same caller-facing "unknown team" error as an unknown teamKey.
+func TestSearchUsers_UnknownTeamUUIDIsRejectedWithoutCallingUpstream(t *testing.T) {
+	called := false
+	h := NewUsersHandler(&mockSCIMClient{}, &mockEntityUserClient{
+		searchUsersFn: func(_ context.Context, _ []byte) ([]byte, error) {
+			called = true
+			return []byte(`{}`), nil
+		},
+	}, testDirectory(t))
+	w := httptest.NewRecorder()
+	h.SearchUsers(w, withUser(httptest.NewRequest(http.MethodPost, "/users/search",
+		strings.NewReader(`{"filters":{"teamIds":["ffffffff-ffff-ffff-ffff-ffffffffffff"]}}`))))
+
+	assertStatus(t, w, http.StatusBadRequest)
+	assertErrorMessage(t, w, "teamIds contains unknown team: ffffffff-ffff-ffff-ffff-ffffffffffff")
+	if called {
+		t.Error("the entity service was called with an unresolvable team UUID")
+	}
+}
+
 // An unknown team key is a client error, not a silent empty page. It has to be
 // caught here now: the entity service has nothing to check it against.
 func TestSearchUsers_UnknownTeamKeyIsRejectedWithoutCallingUpstream(t *testing.T) {


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

The CSM Go backend's `POST /users/search` `filters.teamIds` currently only accepts a team's registry `teamKey` (e.g. `"atlas"`). Callers that hold a team's platform UUID form instead (the same shape `accounts.creTeam.id`/`sreTeam.id` already expose elsewhere in this backend) have no way to filter by team without a separate lookup back to a `teamKey`.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

Widen `filters.teamIds` so each entry may be either the existing registry `teamKey` string or the platform UUID form of a team's backing group id. Both forms resolve to the same team and the same downstream `groupNames` filter; an unresolvable value in either shape still produces the same caller-facing `"teamIds contains unknown team: <value>"` error.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

- Added a `byGroupID map[string]Team` index to `internal/directory.Directory`, built in `New()` alongside the existing `byKey`/`byGroupName` indexes: for each team with a configured `GroupID`, the backing data source's compact id is converted to this platform's canonical UUID form (`sourceIDToUUID`, already used for `TeamResult.GroupID`) and indexed. A duplicate resolved UUID across two teams is a fatal startup error, consistent with the existing duplicate-key/duplicate-name checks.
- Added `Directory.TeamByUUID(uuid string) (Team, bool)`, mirroring `TeamByKey`.
- In `internal/handler/user_teams.go`'s `resolveUserSearchFilters`, each `teamIds` entry is now checked against a UUID shape (`8-4-4-4-12` hyphenated hex) before resolution: UUID-shaped entries resolve via `TeamByUUID`, everything else resolves via the existing `TeamByKey` path unchanged.
- No API contract change beyond widening what a `teamIds` string element may contain; the response shape and the "unknown team" error format are unchanged.

## User stories
> Summary of user stories addressed by this change

A caller of `POST /users/search` that already holds a team's UUID form (e.g. from `accounts.creTeam.id`) can filter users by team without a separate `teamKey` lookup.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

`POST /users/search`'s `filters.teamIds` now also accepts a team's platform UUID form, in addition to its registry `teamKey`.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

N/A -- internal backend API filter widening with no published external API doc.

## Training
N/A -- no training content covers this internal filter.

## Certification
N/A -- no certification exam covers this internal filter.

## Marketing
N/A -- internal backend change, not user-facing.

## Automation tests
 - Unit tests
   > Extended `internal/directory` tests with `TeamByUUID` hit/miss cases and a duplicate-`GroupID` rejection case. Extended `internal/handler/user_teams_test.go` with a `teamIds` UUID-form resolution case, an unknown-UUID rejection case, and confirmed the existing teamKey-only regression case still passes unchanged. `go test ./...` passes.
 - Integration tests
   > None added; this is a pure in-memory resolution change covered by the unit tests above.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A -- this is a Go backend, not Java; `go vet ./...` ran clean instead.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A -- no samples affected.

## Related PRs
None.

## Migrations (if applicable)
N/A -- no data or schema migration.

## Test environment
Local: Go module `apps/csm-portal/backend`, `go build ./...`, `go vet ./...`, `go test ./...`.

## Learning
N/A -- straightforward extension of the existing `byKey`/`byGroupName` lookup pattern already in `internal/directory`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Team filters in user search now accept configured team group UUIDs in addition to team keys.
  * UUID-based team filters resolve to the associated team.

* **Bug Fixes**
  * Unknown or invalid team UUIDs are rejected with a clear bad-request response.
  * Empty or duplicate group identifiers are handled safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->