### PR TITLE
Add call requests  related e2e and the dashboard menu items

### DIFF
--- a/apps/customer-portal/webapp/tests/e2e/config/testData.ts
+++ b/apps/customer-portal/webapp/tests/e2e/config/testData.ts
@@ -342,6 +342,87 @@ export interface CaseViewSet {
  * per-severity naming.
  */
 /**
+ * The case a call is requested against, and what to request.
+ *
+ * The reason is fixed rather than stamped per run, which is what lets the spec
+ * recognise its own earlier request and not file another: a call request cannot
+ * be removed — the delete action cancels it and leaves the record — so an
+ * unguarded create would add one on every run.
+ *
+ * `durationLabel` is the default duration as the card renders it; the spec
+ * leaves the duration select untouched.
+ */
+export const CALL_REQUEST_INPUT = {
+  projectType: ProjectType.SUBSCRIPTION,
+  caseId: "3f18677f3ba6c35091404c6aa5e45ae0",
+  reason: "This is a test call request from Automation Test",
+  durationLabel: "30 minutes",
+  /** Time of day to request, on tomorrow's date. Late enough in the morning to
+   * clear the earliest-allowed time the modal computes from the case severity,
+   * which is a floor measured from now. */
+  preferredTimeOfDay: "10:00",
+  /** What a reschedule moves the request to: the day after tomorrow, at the
+   * same time of day, for an hour.
+   *
+   * The two duration strings differ because the modal and the card disagree on
+   * how to say it — the Meeting Duration option reads "1 hour", while the card
+   * always renders the raw minutes. */
+  rescheduledDurationOption: "1 hour",
+  rescheduledDurationLabel: "60 minutes",
+  /**
+   * The cancellation test's own request, kept separate from the one above.
+   *
+   * Cancelling is terminal — it disables both Reschedule and Cancel — so a test
+   * that cancelled the shared request would leave the reschedule test with a
+   * dead button. Two records, two purposes, same split as the attachment suite's
+   * kept and transient cases.
+   *
+   * The reason deliberately shares no wording with the request above: cards are
+   * matched by reason as a substring, so one reason containing the other would
+   * make each test find the wrong card.
+   *
+   * Reusing the same reason every run is safe here even though a cancelled
+   * request cannot be cancelled twice — the tab searches only the non-cancelled
+   * states, so a spent record drops off the list instead of lingering.
+   */
+  /**
+   * Cases whose status sits outside CALL_SCHEDULABLE_CASE_STATUSES, where the
+   * Calls tab is withheld altogether rather than merely empty.
+   *
+   * Read-only fixtures — the suite never changes their status, since doing so
+   * would be what makes them stop testing the rule.
+   */
+  callsUnavailableCaseIds: [
+    "b686e2933baa4f103e1e088aa4e45a9b",
+    "12350ecf3bee4b103e1e088aa4e45a9b",
+  ],
+  cancel: {
+    reason: "Automation Test call request awaiting cancellation",
+    cancellationReason: "Cancelled by the automated test run",
+  },
+} as const;
+
+/**
+ * Whether each project's dashboard carries the Outstanding Operations donut.
+ *
+ * The chart is gated on `showOutstandingOpsChart` (`hasSR || hasCR`) — service
+ * request or change request access — not on the project type label. It happens
+ * to line up with Managed Cloud Subscription on this tenant, but it is the
+ * access that decides, so this is recorded per project rather than inferred
+ * from the type.
+ *
+ * Mirrors the Operations row of SIDE_NAV_VISIBILITY, which the same access
+ * governs. The two are kept separate because a chart and a nav item could
+ * legitimately diverge; if they ever do, that is a finding rather than a bug in
+ * the test.
+ */
+export const DASHBOARD_OPERATIONS_VISIBILITY: Record<ProjectType, boolean> = {
+  [ProjectType.SUBSCRIPTION]: false,
+  [ProjectType.MANAGED_CLOUD_SUBSCRIPTION]: true,
+  [ProjectType.CLOUD_SUPPORT]: false,
+};
+
+/**
  * Project types whose cases lists are covered by the list-cases suite.
  *
  * Every project type reaches the lists the same way — Support Center →

--- a/apps/customer-portal/webapp/tests/e2e/config/testData.ts
+++ b/apps/customer-portal/webapp/tests/e2e/config/testData.ts
@@ -370,6 +370,17 @@ export const CALL_REQUEST_INPUT = {
   rescheduledDurationOption: "1 hour",
   rescheduledDurationLabel: "60 minutes",
   /**
+   * Cases whose status sits outside CALL_SCHEDULABLE_CASE_STATUSES, where the
+   * Calls tab is withheld altogether rather than merely empty.
+   *
+   * Read-only fixtures — the suite never changes their status, since doing so
+   * would be what makes them stop testing the rule.
+   */
+  callsUnavailableCaseIds: [
+    "b686e2933baa4f103e1e088aa4e45a9b",
+    "12350ecf3bee4b103e1e088aa4e45a9b",
+  ],
+  /**
    * The cancellation test's own request, kept separate from the one above.
    *
    * Cancelling is terminal — it disables both Reschedule and Cancel — so a test
@@ -381,21 +392,11 @@ export const CALL_REQUEST_INPUT = {
    * matched by reason as a substring, so one reason containing the other would
    * make each test find the wrong card.
    *
-   * Reusing the same reason every run is safe here even though a cancelled
-   * request cannot be cancelled twice — the tab searches only the non-cancelled
-   * states, so a spent record drops off the list instead of lingering.
+   * `reason` is a *prefix*: the spec stamps it per run. A cancelled request
+   * drops off the tab — it is filtered out of its own list — but one left
+   * pending by a run that failed mid-flow does not, and two cards sharing a
+   * reason would have the spec acting on whichever it happened to resolve to.
    */
-  /**
-   * Cases whose status sits outside CALL_SCHEDULABLE_CASE_STATUSES, where the
-   * Calls tab is withheld altogether rather than merely empty.
-   *
-   * Read-only fixtures — the suite never changes their status, since doing so
-   * would be what makes them stop testing the rule.
-   */
-  callsUnavailableCaseIds: [
-    "b686e2933baa4f103e1e088aa4e45a9b",
-    "12350ecf3bee4b103e1e088aa4e45a9b",
-  ],
   cancel: {
     reason: "Automation Test call request awaiting cancellation",
     cancellationReason: "Cancelled by the automated test run",

--- a/apps/customer-portal/webapp/tests/e2e/pages/CaseCallsPage.ts
+++ b/apps/customer-portal/webapp/tests/e2e/pages/CaseCallsPage.ts
@@ -1,0 +1,431 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  type Locator,
+  type Page,
+  type Response,
+  expect,
+} from "../fixtures/test";
+import { CASE_CALLS, CASE_DETAIL } from "../utils/selectors";
+
+/** How long to allow for the tab and its queries to resolve. */
+const LOAD_TIMEOUT_MS = 60_000;
+
+/**
+ * Page object for a case's Calls tab and its Request Call modal.
+ */
+export class CaseCallsPage {
+  constructor(private readonly page: Page) {}
+
+  private main(): Locator {
+    return this.page.getByTestId(CASE_DETAIL.mainTestId);
+  }
+
+  /**
+   * The Calls tab itself, whether or not it is rendered.
+   *
+   * The tab is withheld unless the case's status is one that allows scheduling
+   * (CALL_SCHEDULABLE_CASE_STATUSES), so callers assert on its count to check
+   * availability rather than assuming it is there.
+   */
+  tab(): Locator {
+    return this.page.getByRole("tab", { name: CASE_CALLS.tab });
+  }
+
+  /**
+   * The case's other tabs, which are present whatever the status.
+   *
+   * Exists so that "the Calls tab is absent" can be told apart from "the tab
+   * strip has not rendered yet" — without that, the absence assertion would
+   * pass on a page that never finished loading.
+   */
+  alwaysPresentTabs(): Locator {
+    return this.page
+      .getByRole("tab")
+      .filter({ hasText: CASE_CALLS.alwaysPresentTab });
+  }
+
+  /**
+   * Switches to the Calls tab and waits for the list to resolve.
+   *
+   * The Request Call button renders while the requests are still loading, so it
+   * is not on its own a signal that the list is real — a caller counting cards
+   * straight afterwards would read zero. The button is rendered either above the
+   * list or inside the empty state, so its presence marks the point where the
+   * panel has settled into one of those two states.
+   */
+  async openTab(): Promise<void> {
+    const tab = this.page.getByRole("tab", { name: CASE_CALLS.tab });
+    await expect(tab).toBeVisible({ timeout: LOAD_TIMEOUT_MS });
+    await tab.click();
+    await expect(this.requestCallButton().first()).toBeVisible({
+      timeout: LOAD_TIMEOUT_MS,
+    });
+  }
+
+  /**
+   * The Request Call button.
+   *
+   * Returns every match: the panel renders it above the list, or inside the
+   * empty state when there are none, and callers act on the first.
+   */
+  requestCallButton(): Locator {
+    return this.main().getByRole("button", {
+      name: CASE_CALLS.requestButton,
+      exact: true,
+    });
+  }
+
+  modal(): Locator {
+    return this.page.getByRole("dialog");
+  }
+
+  /**
+   * Opens the Request Call modal.
+   *
+   * Fails with a pointed message when the account has no time zone on its
+   * profile: CallsPanel then opens a "Time Zone Not Set" dialog instead, and the
+   * request modal never appears. That is account setup rather than a bug in the
+   * flow under test, so it is worth naming.
+   */
+  async openRequestModal(): Promise<void> {
+    await this.requestCallButton().first().click();
+
+    const modal = this.modal();
+    await expect(modal).toBeVisible({ timeout: LOAD_TIMEOUT_MS });
+    await expect(
+      modal.getByText(CASE_CALLS.timeZoneDialogTitle),
+      "the signed-in account has no time zone set on its profile, so the " +
+        "Request Call modal cannot open — set one in profile settings",
+    ).toHaveCount(0);
+    await expect(modal.getByText(CASE_CALLS.modal.description)).toBeVisible();
+  }
+
+  /** The preferred time input, which takes a "YYYY-MM-DDTHH:mm" value. */
+  preferredTimeInput(): Locator {
+    return this.modal().locator(`#${CASE_CALLS.modal.preferredTimeInputId}`);
+  }
+
+  /**
+   * A preferred time input by position, for the rows the Add button appends.
+   *
+   * @param index - Zero-based row.
+   */
+  preferredTimeInputAt(index: number): Locator {
+    return this.modal().locator(`#preferred-time-${index}`);
+  }
+
+  /**
+   * All preferred time inputs currently on the form.
+   *
+   * Narrowed to `input`: MUI gives each field's label the id `<id>-label`, so a
+   * bare prefix match counts every row twice.
+   */
+  preferredTimeInputs(): Locator {
+    return this.modal().locator('input[id^="preferred-time-"]');
+  }
+
+  /** Appends another preferred time row. */
+  addPreferredTimeButton(): Locator {
+    return this.modal()
+      .getByRole("button", { name: CASE_CALLS.modal.addTimeButton, exact: true })
+      .first();
+  }
+
+  /**
+   * The remove control on a preferred time row.
+   *
+   * @param position - 1-based row, matching the control's accessible name.
+   */
+  removePreferredTimeButton(position: number): Locator {
+    return this.modal().getByRole("button", {
+      name: CASE_CALLS.modal.removeTimeButton(position),
+      exact: true,
+    });
+  }
+
+  /**
+   * Opens the duration select and reads the options it offers.
+   *
+   * Closes it again with Escape, so the caller is left with the form as it was
+   * rather than an open listbox covering the buttons it wants to assert on.
+   *
+   * @returns The option labels, in order.
+   */
+  async durationOptionLabels(): Promise<string[]> {
+    await this.durationSelect().click();
+    const labels = await this.page.getByRole("option").allInnerTexts();
+    await this.page.keyboard.press("Escape");
+    return labels.map((label) => label.trim());
+  }
+
+  reasonInput(): Locator {
+    return this.modal().getByLabel(CASE_CALLS.modal.reasonLabel, {
+      exact: true,
+    });
+  }
+
+  /**
+   * Fills the request form.
+   *
+   * The modal seeds the preferred time with the earliest allowed value on open,
+   * so this overwrites it rather than typing into an empty field. The duration
+   * is left at its default.
+   *
+   * @param preferredTimeLocal - Value for the datetime-local input.
+   * @param reason - Reason for the call.
+   */
+  async fillRequest(preferredTimeLocal: string, reason: string): Promise<void> {
+    await this.preferredTimeInput().fill(preferredTimeLocal);
+    await this.reasonInput().fill(reason);
+  }
+
+  /** The modal's submit button, scoped to the dialog — the button that opened
+   * the modal carries the same label and is still in the DOM behind it. */
+  submitButton(): Locator {
+    return this.modal().getByRole("button", {
+      name: CASE_CALLS.modal.submitButton,
+      exact: true,
+    });
+  }
+
+  /**
+   * Submits the request and waits for the create POST to land.
+   *
+   * Waits for the response whatever its status, then leaves the caller to assert
+   * on it: requiring 2xx in the predicate would mean a rejected create never
+   * matches and the test times out with no clue as to why.
+   *
+   * @returns The create response.
+   */
+  async submit(): Promise<Response> {
+    const [response] = await Promise.all([
+      this.page.waitForResponse(
+        (r) =>
+          /\/cases\/[^/]+\/call-requests$/.test(new URL(r.url()).pathname) &&
+          r.request().method() === "POST",
+        { timeout: LOAD_TIMEOUT_MS },
+      ),
+      this.submitButton().click(),
+    ]);
+    return response;
+  }
+
+  /**
+   * The card for a request, found by its reason.
+   *
+   * Reasons come back from the backend with a "[Customer] " prefix on some
+   * tenants, so this matches on the reason as a substring rather than exactly.
+   *
+   * A cancelled request leaves the list entirely rather than staying on with a
+   * spent state — the panel searches only the non-cancelled states — so this
+   * needs no narrowing to avoid picking up a dead record.
+   *
+   * @param reason - Reason the request was filed with.
+   * @returns Locator for the card.
+   */
+  card(reason: string): Locator {
+    return this.main()
+      .locator("div")
+      .filter({ has: this.page.getByText(CASE_CALLS.card.title, { exact: true }) })
+      .filter({ hasText: reason })
+      .last();
+  }
+
+  /** Whether a request with this reason is already on the tab. */
+  async hasRequest(reason: string): Promise<boolean> {
+    return (await this.main().getByText(reason, { exact: false }).count()) > 0;
+  }
+
+  /** A card's Reschedule button, which reopens the modal in edit mode. */
+  rescheduleButton(reason: string): Locator {
+    return this.card(reason).getByRole("button", {
+      name: CASE_CALLS.card.rescheduleButton,
+      exact: true,
+    });
+  }
+
+  /**
+   * Opens the Edit Call Request modal from a card.
+   *
+   * Asserts the title, which is what tells edit mode apart from create — both
+   * are the same component and the same dialog role, so without this a failure
+   * to enter edit mode would only surface later as a confusing missing-field
+   * error.
+   *
+   * @param reason - Reason of the request to reschedule.
+   */
+  async openEditModal(reason: string): Promise<void> {
+    const reschedule = this.rescheduleButton(reason);
+    await expect(
+      reschedule,
+      "Reschedule is disabled once a request reaches a terminal state",
+    ).toBeEnabled({ timeout: LOAD_TIMEOUT_MS });
+    await reschedule.click();
+
+    const modal = this.modal();
+    await expect(modal).toBeVisible({ timeout: LOAD_TIMEOUT_MS });
+    await expect(modal.getByText(CASE_CALLS.editModal.title)).toBeVisible();
+    await expect(
+      modal.getByText(CASE_CALLS.editModal.description),
+    ).toBeVisible();
+  }
+
+  /**
+   * The Meeting Duration select.
+   *
+   * The modal's only combobox — the preferred time is a native datetime input —
+   * so it needs no further narrowing. MUI does not tie the label to the control
+   * with `for`, which rules out `getByLabel`.
+   */
+  durationSelect(): Locator {
+    return this.modal().getByRole("combobox");
+  }
+
+  /**
+   * Picks a meeting duration.
+   *
+   * The option list renders in a portal at the document root rather than inside
+   * the dialog, so it is looked up page-wide.
+   *
+   * @param option - Exact option label, e.g. "1 hour".
+   */
+  async selectDuration(option: string): Promise<void> {
+    await this.durationSelect().click();
+    await this.page.getByRole("option", { name: option, exact: true }).click();
+  }
+
+  /**
+   * The modal's Cancel button, which dismisses it without saving.
+   *
+   * Named for what it does to the dialog, not to the call — a card's Cancel
+   * button cancels the request itself, which is a different action entirely.
+   */
+  modalCancelButton(): Locator {
+    return this.modal().getByRole("button", {
+      name: CASE_CALLS.modal.cancelButton,
+      exact: true,
+    });
+  }
+
+  /**
+   * Dismisses the modal without saving and waits for it to close.
+   */
+  async dismissModal(): Promise<void> {
+    await this.modalCancelButton().click();
+    await expect(this.modal()).toBeHidden({ timeout: LOAD_TIMEOUT_MS });
+  }
+
+  /** The edit modal's submit button, scoped to the dialog. */
+  updateButton(): Locator {
+    return this.modal().getByRole("button", {
+      name: CASE_CALLS.editModal.submitButton,
+      exact: true,
+    });
+  }
+
+  /**
+   * A card's Cancel button.
+   *
+   * @param reason - Reason of the request.
+   */
+  cancelButton(reason: string): Locator {
+    return this.card(reason).getByRole("button", {
+      name: CASE_CALLS.card.cancelButton,
+      exact: true,
+    });
+  }
+
+  /**
+   * Opens the cancellation dialog from a card.
+   *
+   * @param reason - Reason of the request to cancel.
+   */
+  async openCancelModal(reason: string): Promise<void> {
+    const cancel = this.cancelButton(reason);
+    await expect(
+      cancel,
+      "Cancel is disabled once a request reaches a terminal state",
+    ).toBeEnabled({ timeout: LOAD_TIMEOUT_MS });
+    await cancel.click();
+
+    const modal = this.modal();
+    await expect(modal).toBeVisible({ timeout: LOAD_TIMEOUT_MS });
+    await expect(modal).toContainText(CASE_CALLS.cancelModal.title);
+  }
+
+  /** The cancellation dialog's own Reason field, which is required. */
+  cancellationReasonInput(): Locator {
+    return this.modal().locator(`#${CASE_CALLS.cancelModal.reasonInputId}`);
+  }
+
+  /**
+   * Confirms the cancellation and waits for the PATCH to land.
+   *
+   * Cancelling goes through the same endpoint as a reschedule — it is a state
+   * change, not a delete — so the request body is what tells the two apart.
+   *
+   * @param cancellationReason - Why the call is being cancelled.
+   * @returns The cancellation response.
+   */
+  async confirmCancel(cancellationReason: string): Promise<Response> {
+    await this.cancellationReasonInput().fill(cancellationReason);
+
+    const confirm = this.modal().getByRole("button", {
+      name: CASE_CALLS.cancelModal.confirmButton,
+      exact: true,
+    });
+    await expect(
+      confirm,
+      "Confirm stays disabled until a cancellation reason is given",
+    ).toBeEnabled();
+
+    const [response] = await Promise.all([
+      this.page.waitForResponse(
+        (r) =>
+          /\/cases\/[^/]+\/call-requests\/[^/]+$/.test(
+            new URL(r.url()).pathname,
+          ) && r.request().method() === "PATCH",
+        { timeout: LOAD_TIMEOUT_MS },
+      ),
+      confirm.click(),
+    ]);
+    return response;
+  }
+
+  /**
+   * Submits the edit and waits for the update PATCH to land.
+   *
+   * Waits whatever the status, for the same reason as `submit()`: a rejected
+   * update that never matched the predicate would time out unexplained.
+   *
+   * @returns The update response.
+   */
+  async update(): Promise<Response> {
+    const [response] = await Promise.all([
+      this.page.waitForResponse(
+        (r) =>
+          /\/cases\/[^/]+\/call-requests\/[^/]+$/.test(
+            new URL(r.url()).pathname,
+          ) && r.request().method() === "PATCH",
+        { timeout: LOAD_TIMEOUT_MS },
+      ),
+      this.updateButton().click(),
+    ]);
+    return response;
+  }
+}

--- a/apps/customer-portal/webapp/tests/e2e/pages/CaseCallsPage.ts
+++ b/apps/customer-portal/webapp/tests/e2e/pages/CaseCallsPage.ts
@@ -164,11 +164,21 @@ export class CaseCallsPage {
    * Closes it again with Escape, so the caller is left with the form as it was
    * rather than an open listbox covering the buttons it wants to assert on.
    *
+   * Waits for the first option before reading them. `allInnerTexts` resolves
+   * immediately against whatever matches at that moment — it does not retry like
+   * an assertion — so reading straight after the click can return an empty list
+   * while the portal is still mounting, and the caller would compare that empty
+   * list against the expected options.
+   *
    * @returns The option labels, in order.
    */
   async durationOptionLabels(): Promise<string[]> {
     await this.durationSelect().click();
-    const labels = await this.page.getByRole("option").allInnerTexts();
+
+    const options = this.page.getByRole("option");
+    await expect(options.first()).toBeVisible({ timeout: LOAD_TIMEOUT_MS });
+    const labels = await options.allInnerTexts();
+
     await this.page.keyboard.press("Escape");
     return labels.map((label) => label.trim());
   }

--- a/apps/customer-portal/webapp/tests/e2e/pages/DashboardPage.ts
+++ b/apps/customer-portal/webapp/tests/e2e/pages/DashboardPage.ts
@@ -1,0 +1,371 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { type Locator, type Page, expect } from "../fixtures/test";
+import { CASES_LIST, CASE_DETAIL, DASHBOARD } from "../utils/selectors";
+import { SideNavPage } from "./SideNavPage";
+
+/** How long to allow for the shell and the dashboard's own queries to resolve. */
+const LOAD_TIMEOUT_MS = 60_000;
+
+/** Escapes a label for use inside a RegExp. The card labels carry "." and
+ * parentheses, which would otherwise be metacharacters. */
+function escapeForRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Page object for a project's dashboard.
+ */
+export class DashboardPage {
+  constructor(private readonly page: Page) {}
+
+  private main(): Locator {
+    return this.page.getByTestId(CASE_DETAIL.mainTestId);
+  }
+
+  /**
+   * Opens the dashboard through the side nav, as a user would.
+   *
+   * @param projectId - Project whose dashboard to open.
+   */
+  async openViaSideNav(projectId: string): Promise<void> {
+    const sideNav = new SideNavPage(this.page);
+    await sideNav.open(projectId);
+    await sideNav.clickItem(
+      DASHBOARD.navItem,
+      new RegExp(`/projects/${projectId}/${DASHBOARD.pathSegment}$`),
+    );
+
+    // The cards are skeletons until the stats queries resolve, so the first
+    // card's label marks the point where the grid is real.
+    await expect(this.statCard(DASHBOARD.statCards[0].label)).toBeVisible({
+      timeout: LOAD_TIMEOUT_MS,
+    });
+  }
+
+  /**
+   * A stat card, located by its label.
+   *
+   * Matched on the label text rather than by role: only three of the four cards
+   * are buttons — Avg. Response Time is non-clickable — so a role-based locator
+   * could not address them uniformly.
+   *
+   * @param label - The card's label.
+   * @returns Locator for the label element.
+   */
+  statCard(label: string): Locator {
+    return this.main().getByText(label, { exact: true });
+  }
+
+  /**
+   * The clickable form of a stat card, for the three that open a list.
+   *
+   * @param label - The card's label.
+   * @returns Locator for the card button.
+   */
+  statCardButton(label: string): Locator {
+    return this.main().getByRole("button", {
+      name: new RegExp(escapeForRegExp(label)),
+    });
+  }
+
+  /**
+   * A section heading below the stat cards.
+   *
+   * Returns every match rather than narrowing to one: "Outstanding Support
+   * Cases" titles both the severity donut and the cases table under it, so
+   * callers assert the count is non-zero instead of asserting visibility on what
+   * is legitimately two elements.
+   *
+   * @param title - The section's heading.
+   * @returns Locator for the matching headings.
+   */
+  section(title: string): Locator {
+    return this.main().getByRole("heading", { name: title, exact: true });
+  }
+
+  /**
+   * An entry in one of the donut legends — severity, or operations.
+   *
+   * Located by text rather than by role: the entries carry no button role, and
+   * the legend row itself is what handles the click.
+   *
+   * @param label - The legend entry, e.g. "S1 - Critical".
+   * @returns Locator for the entry.
+   */
+  legendEntry(label: string): Locator {
+    return this.main().getByText(label, { exact: true });
+  }
+
+  /**
+   * A donut chart, located by its own heading.
+   *
+   * Narrowed by *both* the heading and the presence of a slice: "Outstanding
+   * Support Cases" also titles the cases table below, which has no chart.
+   * `.last()` then takes the innermost such container — the chart card rather
+   * than a wrapper around the whole page.
+   *
+   * @param heading - The chart card's heading.
+   * @returns Locator for the chart card.
+   */
+  chartByHeading(heading: string): Locator {
+    return this.main()
+      .locator("div")
+      .filter({
+        has: this.page.getByRole("heading", { name: heading, exact: true }),
+      })
+      .filter({ has: this.page.locator(DASHBOARD.severityChartSlice) })
+      .last();
+  }
+
+  /**
+   * A donut's slices, in legend order.
+   *
+   * Only series with a non-zero count are drawn: Recharts' `minAngle` applies to
+   * non-zero values, so a zero-count series has no slice at all. Callers compare
+   * the count against what they expect rather than assuming one per legend row.
+   *
+   * @param heading - The chart card's heading.
+   */
+  chartSlices(heading: string): Locator {
+    return this.chartByHeading(heading).locator(DASHBOARD.severityChartSlice);
+  }
+
+  /**
+   * Clicks a donut slice.
+   *
+   * Dispatches the event rather than clicking at a point. A slice is an arc, so
+   * the centre of its bounding box falls in the donut's hole — a normal click
+   * lands on nothing, and `force` clicks that same empty centre. Verified live:
+   * forcing a click on the first slice left the dashboard where it was.
+   *
+   * @param heading - The chart card's heading.
+   * @param index - Zero-based slice, in legend order.
+   */
+  async clickChartSlice(heading: string, index: number): Promise<void> {
+    await this.chartSlices(heading).nth(index).dispatchEvent("click");
+  }
+
+  /** The Outstanding Support Cases donut's slices. */
+  severityChartSlices(): Locator {
+    return this.chartSlices(DASHBOARD.sections.outstandingCases);
+  }
+
+  /**
+   * Clicks a slice of the Outstanding Support Cases donut.
+   *
+   * @param index - Zero-based slice, in legend order.
+   */
+  async clickSeverityChartSlice(index: number): Promise<void> {
+    await this.clickChartSlice(DASHBOARD.sections.outstandingCases, index);
+  }
+
+  /**
+   * Data rows of the Outstanding Support Cases table.
+   *
+   * Filtered on the case id so the header row is excluded — it is a `role="row"`
+   * too, and taking `nth(1)` to skip it would silently start clicking the wrong
+   * thing if a column were ever added above.
+   */
+  casesTableRows(): Locator {
+    return this.main()
+      .getByRole("row")
+      .filter({ hasText: DASHBOARD.casesTable.rowIdPattern });
+  }
+
+  /**
+   * A view tab of the Outstanding Support Cases table — My Cases or All Cases.
+   *
+   * @param label - The tab's label.
+   * @returns Locator for the tab.
+   */
+  casesTableViewTab(label: string): Locator {
+    return this.main().getByRole("tab", { name: label, exact: true });
+  }
+
+  /**
+   * The email addresses named in the table's Created by column, one per row.
+   *
+   * Parsed out of each row's text: the column has no test id, and reading the
+   * cells positionally would break the moment a column is added.
+   *
+   * @returns One address per row that names one.
+   */
+  async casesTableCreators(): Promise<string[]> {
+    const rows = await this.casesTableRows().allInnerTexts();
+    return rows
+      .map((row) => /([\w.+-]+@[\w.-]+)/.exec(row)?.[1])
+      .filter((creator): creator is string => !!creator);
+  }
+
+  /**
+   * The Rows per page control at the foot of the cases table.
+   *
+   * MUI's TablePagination points the select's `aria-labelledby` at the "Rows per
+   * page:" text, so the accessible name carries it — but the trigger's role
+   * changed from `button` to `combobox` across MUI versions, so this accepts
+   * either rather than pinning one.
+   */
+  rowsPerPageSelect(): Locator {
+    const label = DASHBOARD.casesTable.pagination.rowsPerPageLabel;
+    const asCombobox = this.main().getByRole("combobox", {
+      name: new RegExp(escapeForRegExp(label)),
+    });
+    const asButton = this.main().getByRole("button", {
+      name: new RegExp(escapeForRegExp(label)),
+    });
+    return asCombobox.or(asButton).first();
+  }
+
+  /**
+   * Changes the cases table's page size.
+   *
+   * The option list renders in a portal at the document root rather than inside
+   * the table, so it is looked up page-wide.
+   *
+   * @param rows - Page size to choose.
+   */
+  async selectRowsPerPage(rows: number): Promise<void> {
+    await this.rowsPerPageSelect().click();
+    await this.page
+      .getByRole("option", { name: String(rows), exact: true })
+      .click();
+  }
+
+  /**
+   * Item rows on a dashboard item page — Action Required and its siblings.
+   *
+   * Those pages render the same ListCard as the cases list, so a row is a
+   * clickable element carrying "Created by".
+   */
+  itemRows(): Locator {
+    return this.main()
+      .getByRole("button")
+      .filter({ hasText: CASES_LIST.createdByPrefix });
+  }
+
+  /**
+   * The copy a dashboard item page shows when it has nothing to list.
+   *
+   * Each mode has its own wording, and it is the *page's* EmptyState rather than
+   * ListItems' — sections with no items are filtered out before they render, so
+   * the list component's own empty copy never appears here.
+   *
+   * @param message - The mode's empty message.
+   * @returns Locator for it.
+   */
+  emptyItemsMessage(message: string): Locator {
+    return this.main().getByText(message, { exact: true });
+  }
+
+  /** Opens the cases table's filter panel. */
+  casesTableFiltersButton(): Locator {
+    return this.main().getByRole("button", {
+      name: DASHBOARD.casesTable.filtersButton,
+      exact: true,
+    });
+  }
+
+  /**
+   * The same control as the Filters button once a filter is applied, where it
+   * clears rather than toggles the panel.
+   *
+   * @param activeCount - How many filters are active, which the label carries.
+   * @returns Locator for the clear control.
+   */
+  clearFiltersButton(activeCount: number): Locator {
+    return this.main().getByRole("button", {
+      name: DASHBOARD.casesTable.clearFiltersButton(activeCount),
+      exact: true,
+    });
+  }
+
+  /** The Severity filter Select, addressed by the element id the field sets. */
+  severityFilterSelect(): Locator {
+    return this.main().locator(
+      `#${DASHBOARD.casesTable.filters.severity.selectId}`,
+    );
+  }
+
+  /**
+   * Chooses a severity in the cases table's filter panel.
+   *
+   * The Select is multi-select, so its menu stays open after a click — Escape
+   * closes it, which both commits the choice and clears the overlay that would
+   * otherwise intercept clicks on the table beneath.
+   *
+   * The option list renders in a portal at the document root, so it is looked up
+   * page-wide rather than inside the panel.
+   *
+   * @param label - Option label, e.g. "S4(Query)".
+   */
+  async selectSeverityFilter(label: string): Promise<void> {
+    await this.severityFilterSelect().click();
+    await this.page.getByRole("option", { name: label, exact: true }).click();
+    await this.page.keyboard.press("Escape");
+  }
+
+  /** The cases table's next-page control. Disabled on the last page. */
+  nextPageButton(): Locator {
+    return this.main().getByRole("button", {
+      name: DASHBOARD.casesTable.pagination.nextPageButton,
+      exact: true,
+    });
+  }
+
+  /** The cases table's previous-page control. Disabled on the first page. */
+  previousPageButton(): Locator {
+    return this.main().getByRole("button", {
+      name: DASHBOARD.casesTable.pagination.previousPageButton,
+      exact: true,
+    });
+  }
+
+  /** The "1–5 of 36" range text MUI renders beside the page controls. */
+  displayedRows(): Locator {
+    return this.main().getByText(
+      DASHBOARD.casesTable.pagination.displayedRowsPattern,
+    );
+  }
+
+  /**
+   * The first row number the table is currently showing, from the range text.
+   *
+   * @returns The "from" of "from–to of count", or null when it is not rendered.
+   */
+  async displayedFromRow(): Promise<number | null> {
+    const text = await this.displayedRows().innerText();
+    const match = DASHBOARD.casesTable.pagination.displayedRowsPattern.exec(
+      text,
+    );
+    return match ? Number(match[1]) : null;
+  }
+
+  /**
+   * Every stat card label on the page, for counting them.
+   *
+   * A union of the expected labels rather than a structural selector: the grid's
+   * cards carry no test id, and each label appears exactly once on the page
+   * (verified live), so this counts cards without depending on the DOM shape.
+   */
+  statCardLabels(): Locator {
+    const pattern = DASHBOARD.statCards
+      .map((card) => escapeForRegExp(card.label))
+      .join("|");
+    return this.main().getByText(new RegExp(`^(${pattern})$`));
+  }
+}

--- a/apps/customer-portal/webapp/tests/e2e/specs/dashboard/dashboard.spec.ts
+++ b/apps/customer-portal/webapp/tests/e2e/specs/dashboard/dashboard.spec.ts
@@ -1,0 +1,732 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//
+// The project dashboard, reached the way a user reaches it: the side nav's
+// Dashboard item. Run against every project type.
+//
+// Read-only — nothing here creates or changes a record.
+//
+// The four stat cards come from DASHBOARD_STATS and are not feature-gated, so
+// every project type gets the same four. Three of them open a list; Avg.
+// Response Time is named in the grid's `nonClickableKeys` and is a plain card,
+// which the test asserts rather than leaves to chance — a card that quietly
+// became clickable would navigate somewhere on a stray click.
+//
+
+import { test, expect, withSession } from "../../fixtures/test";
+import { CaseDetailPage } from "../../pages/CaseDetailPage";
+import { DashboardPage } from "../../pages/DashboardPage";
+import {
+  DASHBOARD_OPERATIONS_VISIBILITY,
+  PROJECTS,
+  ProjectType,
+} from "../../config/testData";
+import { DASHBOARD } from "../../utils/selectors";
+import { expectSuccess } from "../../utils/caseFlows";
+import {
+  caseSearchWithPagination,
+  caseSearchWithSeverity,
+  caseSearchWithoutSeverity,
+  myCasesSearchResponse,
+} from "../../utils/listSearch";
+
+withSession(test);
+
+test.describe("Dashboard", () => {
+  // A shell load, a nav navigation and the dashboard's own stats queries — well
+  // past the 30s default.
+  test.describe.configure({ timeout: 180_000 });
+
+  for (const projectType of Object.values(ProjectType)) {
+    const project = PROJECTS[projectType];
+
+    // Named in the test title rather than only asserted, so a run's output says
+    // which projects are expected to carry the Operations chart without anyone
+    // having to open the config.
+    const operationsExpectation = DASHBOARD_OPERATIONS_VISIBILITY[projectType]
+      ? "present"
+      : "withheld";
+
+    test.describe(projectType, () => {
+      test("shows the four overview cards", async ({ page }) => {
+        test.skip(
+          !project.id,
+          `${projectType} needs a project id. ` +
+            `Fill it in tests/e2e/config/testData.ts.`,
+        );
+
+        const dashboard = new DashboardPage(page);
+        await dashboard.openViaSideNav(project.id);
+
+        // Soft, so one missing card does not hide the state of the other three.
+        for (const card of DASHBOARD.statCards) {
+          await expect.soft(dashboard.statCard(card.label)).toBeVisible();
+        }
+
+        // Exactly four — a fifth card appearing is as much a change as one going
+        // missing, and the loop above would not notice it.
+        await expect(dashboard.statCardLabels()).toHaveCount(
+          DASHBOARD.statCards.length,
+        );
+
+        // Which cards open a list and which do not is part of the contract.
+        for (const card of DASHBOARD.statCards) {
+          await expect
+            .soft(
+              dashboard.statCardButton(card.label),
+              card.clickable
+                ? `${card.label} should be clickable`
+                : `${card.label} should not be clickable`,
+            )
+            .toHaveCount(card.clickable ? 1 : 0);
+        }
+
+        console.log(
+          `Dashboard (${projectType}): ${DASHBOARD.statCards.length} cards`,
+        );
+      });
+
+      test(`shows the outstanding cases and engagements sections with operations ${operationsExpectation}`, async ({
+        page,
+      }) => {
+        test.skip(!project.id, `${projectType} needs a project id.`);
+
+        const dashboard = new DashboardPage(page);
+        await dashboard.openViaSideNav(project.id);
+
+        // Asserted as "at least one" rather than by visibility: the Outstanding
+        // Support Cases title is used twice — by the severity donut and by the
+        // cases table below it — and a single-element locator would be a
+        // strict-mode violation.
+        await expect
+          .soft(dashboard.section(DASHBOARD.sections.outstandingCases))
+          .not.toHaveCount(0);
+
+        // Engagements is feature-gated, so this asserts the flag is on for the
+        // fixture projects as much as it asserts the section renders. A project
+        // without engagements would legitimately have no such section — see
+        // SIDE_NAV_VISIBILITY, which records the same flag per project.
+        await expect
+          .soft(dashboard.section(DASHBOARD.sections.outstandingEngagements))
+          .not.toHaveCount(0);
+
+        // Outstanding Operations is the one section that differs by project: it
+        // needs service-request or change-request access, which not every
+        // project has. Asserting its absence is safe here because the two
+        // assertions above have already established the dashboard rendered.
+        const operations = dashboard.section(
+          DASHBOARD.sections.outstandingOperations,
+        );
+        if (DASHBOARD_OPERATIONS_VISIBILITY[projectType]) {
+          await expect
+            .soft(
+              operations,
+              `${projectType} has SR/CR access, so Outstanding Operations ` +
+                `should render`,
+            )
+            .not.toHaveCount(0);
+        } else {
+          await expect
+            .soft(
+              operations,
+              `${projectType} has no SR/CR access, so Outstanding Operations ` +
+                `should be withheld`,
+            )
+            .toHaveCount(0);
+        }
+
+        console.log(
+          `Dashboard (${projectType}): outstanding cases and engagements ` +
+            `present, operations ` +
+            `${DASHBOARD_OPERATIONS_VISIBILITY[projectType] ? "present" : "withheld"}`,
+        );
+      });
+
+
+      test("opens a case from the Outstanding Support Cases table", async ({
+        page,
+      }) => {
+        test.skip(!project.id, `${projectType} needs a project id.`);
+
+        const dashboard = new DashboardPage(page);
+        await dashboard.openViaSideNav(project.id);
+
+        // The subtitle, not the title: the title is shared with the severity
+        // donut above, so it would not tell the two cards apart.
+        await expect(
+          dashboard.section(DASHBOARD.sections.outstandingCases).first(),
+        ).toBeVisible();
+        await expect(
+          page.getByText(DASHBOARD.casesTable.subtitle, { exact: true }),
+        ).toBeVisible();
+
+        const firstRow = dashboard.casesTableRows().first();
+        await expect(
+          firstRow,
+          "the table should list at least one outstanding case to open",
+        ).toBeVisible();
+
+        // Read the case number off the row before clicking, so the detail page
+        // can be checked against the row that was actually clicked rather than
+        // against a case id from config.
+        const rowText = await firstRow.innerText();
+        const caseNumber = DASHBOARD.casesTable.rowCaseNumberPattern.exec(
+          rowText,
+        )?.[1];
+        expect(caseNumber, "row should carry a case number").toBeTruthy();
+
+        await firstRow.click();
+
+        // A case sysid is a 32-character hex string; anchoring rules out landing
+        // on the list route instead of a case.
+        await expect(page).toHaveURL(
+          new RegExp(
+            `/projects/${project.id}/support/cases/[0-9a-f]{32}$`,
+          ),
+        );
+
+        // The case that was clicked, not merely some case: the detail page shows
+        // the number bare, where the row prefixes it with "ID: ".
+        const caseDetail = new CaseDetailPage(page);
+        await expect(caseDetail.caseNumber()).toHaveText(caseNumber as string);
+
+        console.log(
+          `Dashboard (${projectType}): opened ${caseNumber} from the cases table`,
+        );
+      });
+
+
+      test("loads my cases in the Outstanding Support Cases table", async ({
+        page,
+      }) => {
+        test.skip(!project.id, `${projectType} needs a project id.`);
+
+        const dashboard = new DashboardPage(page);
+        await dashboard.openViaSideNav(project.id);
+
+        await expect(
+          page.getByText(DASHBOARD.casesTable.subtitle, { exact: true }),
+        ).toBeVisible();
+
+        const myCases = dashboard.casesTableViewTab(
+          DASHBOARD.casesTable.viewTabs.myCases,
+        );
+        const allCases = dashboard.casesTableViewTab(
+          DASHBOARD.casesTable.viewTabs.allCases,
+        );
+
+        // All Cases is where the table starts, so the switch below is a real
+        // change of state rather than a no-op.
+        await expect(allCases).toHaveAttribute("aria-selected", "true");
+        await expect(myCases).toHaveAttribute("aria-selected", "false");
+
+        // Armed before the click: the table refetches as soon as the tab
+        // changes, and a listener registered afterwards can miss the response.
+        const searchResponse = myCasesSearchResponse(page);
+        await myCases.click();
+
+        // Matching this response at all is the proof that the table re-queried
+        // with createdByMe — the predicate is what selected it.
+        await expectSuccess(await searchResponse, "my cases search");
+
+        await expect(myCases).toHaveAttribute("aria-selected", "true");
+
+        // Still on the dashboard: this switch filters the table in place, unlike
+        // Support Center's "View my cases", which opens a separate list page.
+        await expect(page).toHaveURL(
+          new RegExp(`/projects/${project.id}/${DASHBOARD.pathSegment}$`),
+        );
+
+        // Every remaining row is the signed-in user's. Asserted as "one distinct
+        // creator" rather than against a hardcoded address, so it holds for
+        // whichever account the captured session belongs to.
+        await expect(dashboard.casesTableRows().first()).toBeVisible();
+        const creators = await dashboard.casesTableCreators();
+        expect(creators.length, "no row named a creator").toBeGreaterThan(0);
+        expect(
+          new Set(creators).size,
+          `creators listed: ${creators.join(", ")}`,
+        ).toBe(1);
+
+        console.log(
+          `Dashboard (${projectType}): my cases table shows ${creators.length} ` +
+            `rows, all by ${creators[0]}`,
+        );
+      });
+
+
+      test("changes the cases table page size to 10", async ({ page }) => {
+        test.skip(!project.id, `${projectType} needs a project id.`);
+
+        const dashboard = new DashboardPage(page);
+        await dashboard.openViaSideNav(project.id);
+
+        await expect(
+          page.getByText(DASHBOARD.casesTable.subtitle, { exact: true }),
+        ).toBeVisible();
+
+        const pagination = DASHBOARD.casesTable.pagination;
+
+        // The table starts at 5, so switching to 10 is a real change.
+        const select = dashboard.rowsPerPageSelect();
+        await expect(select).toContainText(String(pagination.defaultRowsPerPage));
+
+        // Wait for the rows before counting them. The pagination control renders
+        // while the first search is still in flight, so an immediate count reads
+        // 0 — which would satisfy both bounds below and make this test pass
+        // without ever comparing two loaded pages.
+        await expect(dashboard.casesTableRows().first()).toBeVisible();
+
+        const rowsBefore = await dashboard.casesTableRows().count();
+        expect(
+          rowsBefore,
+          `the default page size is ${pagination.defaultRowsPerPage}, so the ` +
+            `table should show no more than that`,
+        ).toBeLessThanOrEqual(pagination.defaultRowsPerPage);
+        expect(rowsBefore, "the table should have loaded rows").toBeGreaterThan(
+          0,
+        );
+
+        // Armed before the change: the page size travels as `pagination.limit`,
+        // so this both waits for the refetch and proves the new size reached the
+        // backend rather than only the control.
+        const searchResponse = caseSearchWithPagination(page, { limit: 10 });
+        await dashboard.selectRowsPerPage(10);
+        await expectSuccess(await searchResponse, "cases search at 10 per page");
+
+        await expect(select).toContainText("10");
+
+        // A larger page cannot show fewer rows, and must not exceed the size
+        // asked for. Bounds rather than an exact count, because how many rows
+        // exist is environment data.
+        const rowsAfter = await dashboard.casesTableRows().count();
+        expect(rowsAfter).toBeLessThanOrEqual(10);
+        expect(rowsAfter).toBeGreaterThanOrEqual(rowsBefore);
+
+        console.log(
+          `Dashboard (${projectType}): page size 5 → 10, rows ${rowsBefore} → ${rowsAfter}`,
+        );
+      });
+
+
+      test("pages the cases table forward and back", async ({ page }) => {
+        test.skip(!project.id, `${projectType} needs a project id.`);
+
+        const dashboard = new DashboardPage(page);
+        await dashboard.openViaSideNav(project.id);
+
+        await expect(
+          page.getByText(DASHBOARD.casesTable.subtitle, { exact: true }),
+        ).toBeVisible();
+
+        const pageSize = DASHBOARD.casesTable.pagination.defaultRowsPerPage;
+
+        // Wait for the first page to load before reading the controls: the
+        // pagination renders while the search is still in flight, when next is
+        // disabled simply because the count is not known yet.
+        await expect(dashboard.casesTableRows().first()).toBeVisible();
+        await expect(dashboard.displayedRows()).toBeVisible();
+        expect(await dashboard.displayedFromRow()).toBe(1);
+
+        // Previous is always dead on the first page, whatever the count.
+        await expect(dashboard.previousPageButton()).toBeDisabled();
+
+        const next = dashboard.nextPageButton();
+        await expect(next).toBeVisible();
+
+        // "if active" — a project whose outstanding cases fit on one page has
+        // nothing to page through, and that is a pass rather than a skip: the
+        // control is correctly disabled.
+        if (!(await next.isEnabled())) {
+          console.log(
+            `Dashboard (${projectType}): outstanding cases fit on one page, ` +
+              `next is disabled`,
+          );
+          return;
+        }
+
+        // Forward. The offset is what asks the backend for the second page, so
+        // matching it proves the click did more than move the highlight.
+        const forward = caseSearchWithPagination(page, { offset: pageSize });
+        await next.click();
+        await expectSuccess(await forward, "cases search for page 2");
+
+        expect(await dashboard.displayedFromRow()).toBe(pageSize + 1);
+        await expect(dashboard.previousPageButton()).toBeEnabled();
+
+        // And back, which must return to offset 0 and the original range.
+        const backward = caseSearchWithPagination(page, { offset: 0 });
+        await dashboard.previousPageButton().click();
+        await expectSuccess(await backward, "cases search for page 1");
+
+        expect(await dashboard.displayedFromRow()).toBe(1);
+        await expect(dashboard.previousPageButton()).toBeDisabled();
+
+        console.log(
+          `Dashboard (${projectType}): paged forward to row ${pageSize + 1} and back to 1`,
+        );
+      });
+
+
+      test("filters the cases table by severity and clears it", async ({
+        page,
+      }) => {
+        test.skip(!project.id, `${projectType} needs a project id.`);
+
+        const dashboard = new DashboardPage(page);
+        await dashboard.openViaSideNav(project.id);
+
+        await expect(
+          page.getByText(DASHBOARD.casesTable.subtitle, { exact: true }),
+        ).toBeVisible();
+
+        // Wait for the unfiltered table first, so the filtered result below is a
+        // change from a known state rather than from a still-loading one.
+        await expect(dashboard.casesTableRows().first()).toBeVisible();
+
+        const severity = DASHBOARD.casesTable.filters.severity;
+
+        // The panel is collapsed on load and its contents are unmounted, so the
+        // Select does not exist until this is clicked.
+        await expect(dashboard.severityFilterSelect()).toHaveCount(0);
+        await dashboard.casesTableFiltersButton().click();
+        await expect(dashboard.severityFilterSelect()).toBeVisible();
+        await expect(
+          page.getByText(severity.label, { exact: true }).first(),
+        ).toBeVisible();
+
+        // Armed before the choice: the id on the wire is what shows the filter
+        // was applied, rather than merely ticked in the menu.
+        const searchResponse = caseSearchWithSeverity(page, severity.option.id);
+        await dashboard.selectSeverityFilter(severity.option.label);
+        await expectSuccess(
+          await searchResponse,
+          `cases search filtered to ${severity.option.label}`,
+        );
+
+        // The control reports the choice back.
+        await expect(dashboard.severityFilterSelect()).toContainText(
+          severity.option.label,
+        );
+
+        // Every row left is at that severity. Not asserted to be non-empty: a
+        // project with no outstanding S4 cases legitimately shows none, and the
+        // request assertion above is what proves the filter ran.
+        const rows = await dashboard.casesTableRows().allInnerTexts();
+        for (const [index, row] of rows.entries()) {
+          expect(
+            row,
+            `row ${index + 1} should be ${severity.option.label}`,
+          ).toContain(severity.option.label);
+        }
+
+        // The Filters button turns into the clear control once a filter is on,
+        // counting what is active.
+        const clearFilters = dashboard.clearFiltersButton(1);
+        await expect(clearFilters).toBeVisible();
+        await expect(dashboard.casesTableFiltersButton()).toHaveCount(0);
+
+        // Clearing drops the severity from the request. Armed before the click,
+        // because the page's own first load matches this predicate too.
+        const clearedResponse = caseSearchWithoutSeverity(page);
+        await clearFilters.click();
+        await expectSuccess(await clearedResponse, "cases search after clearing");
+
+        // The control goes back to offering the panel, and the Select no longer
+        // holds the choice.
+        await expect(dashboard.casesTableFiltersButton()).toBeVisible();
+        await expect(dashboard.severityFilterSelect()).not.toContainText(
+          severity.option.label,
+        );
+
+        console.log(
+          `Dashboard (${projectType}): filtered to ${severity.option.label} ` +
+            `(${rows.length} rows), then cleared`,
+        );
+      });
+
+
+      for (const target of DASHBOARD.statCardTargets) {
+        test(`opens the ${target.title} list from the ${target.label} card`, async ({
+          page,
+        }) => {
+          test.skip(!project.id, `${projectType} needs a project id.`);
+
+          const dashboard = new DashboardPage(page);
+          await dashboard.openViaSideNav(project.id);
+
+          await dashboard.statCardButton(target.label).click();
+
+          // Nested under the dashboard route, so the path keeps that segment.
+          await expect(page).toHaveURL(
+            new RegExp(`/projects/${project.id}/${target.pathSegment}$`),
+          );
+
+          const main = page.getByTestId("app-main");
+          await expect(
+            main.getByRole("heading", { name: target.title, exact: true }),
+          ).toBeVisible();
+          await expect(
+            main.getByText(target.description, { exact: true }),
+          ).toBeVisible();
+
+          // Wait for the list area to settle into one of its two real states — a
+          // row, or this mode's empty copy. Without this the test would pass
+          // against a page still showing skeletons, which is what "see the list
+          // initialise" has to rule out.
+          await expect(
+            dashboard
+              .itemRows()
+              .first()
+              .or(dashboard.emptyItemsMessage(target.emptyMessage)),
+          ).toBeVisible();
+
+          // How many items each list holds is environment data, so an empty one
+          // is a legitimate result — what matters is that the list rendered.
+          const rows = await dashboard.itemRows().count();
+
+          console.log(
+            `Dashboard (${projectType}): ${target.title} listed ${rows} items`,
+          );
+        });
+      }
+
+      test(`the ${DASHBOARD.nonClickableStatCard} card does not drill down`, async ({
+        page,
+      }) => {
+        test.skip(!project.id, `${projectType} needs a project id.`);
+
+        const dashboard = new DashboardPage(page);
+        await dashboard.openViaSideNav(project.id);
+
+        const label = DASHBOARD.nonClickableStatCard;
+        const card = dashboard.statCard(label);
+        await expect(card).toBeVisible();
+
+        // Not a button, unlike the other three: it is named in the grid's
+        // `nonClickableKeys`, so it reports a value and nothing more.
+        await expect(dashboard.statCardButton(label)).toHaveCount(0);
+
+        // Clicking it anyway must leave the dashboard where it is. This is the
+        // behavioural half of the assertion above — a card could lose its button
+        // role and still navigate through some other handler.
+        await card.click();
+        await expect(page).toHaveURL(
+          new RegExp(`/projects/${project.id}/${DASHBOARD.pathSegment}$`),
+        );
+
+        // And the dashboard is still the dashboard, not a half-navigated shell.
+        await expect(
+          dashboard.statCard(DASHBOARD.statCards[0].label),
+        ).toBeVisible();
+
+        console.log(
+          `Dashboard (${projectType}): ${label} is not clickable, as intended`,
+        );
+      });
+
+
+      test("drills down from every slice of the Outstanding Support Cases donut", async ({
+        page,
+      }) => {
+        test.skip(!project.id, `${projectType} needs a project id.`);
+
+        const dashboard = new DashboardPage(page);
+        await dashboard.openViaSideNav(project.id);
+
+        // Wait for the donut itself, not just its heading: the chart renders on
+        // its own query, well after the stat cards, so counting slices as soon
+        // as the heading appears reads zero.
+        await expect(dashboard.severityChartSlices().first()).toBeVisible();
+
+        // One slice per legend entry, including any severity with a count of
+        // zero — the chart's `minAngle` keeps those on screen and clickable.
+        const sliceCount = await dashboard.severityChartSlices().count();
+        expect(
+          sliceCount,
+          "the donut should have one slice per severity in the legend",
+        ).toBe(DASHBOARD.severityLegend.length);
+
+        for (const [index, entry] of DASHBOARD.severityLegend.entries()) {
+          // Back to the dashboard between slices: each drill-down navigates
+          // away, and returning through the nav re-renders the chart.
+          if (index > 0) {
+            await dashboard.openViaSideNav(project.id);
+            await expect(dashboard.severityChartSlices().first()).toBeVisible();
+          }
+
+          await dashboard.clickSeverityChartSlice(index);
+
+          // Slices are drawn in legend order, so slice n must open the same list
+          // as legend entry n — which is what ties the chart to its key.
+          await expect(page).toHaveURL(
+            new RegExp(
+              `/projects/${project.id}/support/cases\\?severityId=${entry.severityId}$`,
+            ),
+          );
+
+          const main = page.getByTestId("app-main");
+          await expect(
+            main.getByRole("heading", { name: entry.title, exact: true }),
+          ).toBeVisible();
+          await expect(
+            main.getByText(entry.description, { exact: true }),
+          ).toBeVisible();
+        }
+
+        console.log(
+          `Dashboard (${projectType}): all ${sliceCount} donut slices drilled ` +
+            `down to their severity lists`,
+        );
+      });
+
+      for (const entry of DASHBOARD.severityLegend) {
+        test(`the ${entry.label} legend entry opens its list`, async ({
+          page,
+        }) => {
+          test.skip(!project.id, `${projectType} needs a project id.`);
+
+          const dashboard = new DashboardPage(page);
+          await dashboard.openViaSideNav(project.id);
+
+          await dashboard.legendEntry(entry.label).click();
+
+          // The severity id is what filters the list; the heading below merely
+          // reports it, and all four entries land on the same route.
+          await expect(page).toHaveURL(
+            new RegExp(
+              `/projects/${project.id}/support/cases\\?severityId=${entry.severityId}$`,
+            ),
+          );
+
+          // Both come from the id rather than from the data, so they hold even
+          // for a severity this project has no outstanding cases at — which is
+          // why this asserts the heading rather than the rows.
+          const main = page.getByTestId("app-main");
+          await expect(
+            main.getByRole("heading", { name: entry.title, exact: true }),
+          ).toBeVisible();
+          await expect(
+            main.getByText(entry.description, { exact: true }),
+          ).toBeVisible();
+
+          console.log(
+            `Dashboard (${projectType}): ${entry.label} → ${entry.title}`,
+          );
+        });
+      }
+
+      // Only where the Operations chart renders at all — a project without SR or
+      // CR access has no such legend to click.
+      if (DASHBOARD_OPERATIONS_VISIBILITY[projectType]) {
+
+        test("drills down from every slice of the Outstanding Operations donut", async ({
+          page,
+        }) => {
+          test.skip(!project.id, `${projectType} needs a project id.`);
+
+          const dashboard = new DashboardPage(page);
+          await dashboard.openViaSideNav(project.id);
+
+          const heading = DASHBOARD.sections.outstandingOperations;
+          await expect(
+            dashboard.section(heading).first(),
+            `${projectType} should carry the Outstanding Operations chart`,
+          ).toBeVisible();
+
+          // Wait for the donut itself: the charts render on their own queries,
+          // well after the stat cards, so counting slices any earlier reads zero.
+          await expect(dashboard.chartSlices(heading).first()).toBeVisible();
+
+          // One slice per legend row here, because both series carry work on this
+          // project. A series with a count of zero would have no slice at all —
+          // Recharts' minAngle only applies to non-zero values — so this asserts
+          // the data as much as the chart.
+          const sliceCount = await dashboard.chartSlices(heading).count();
+          expect(
+            sliceCount,
+            "the operations donut should have one slice per legend row",
+          ).toBe(DASHBOARD.operationsLegend.length);
+
+          for (const [index, entry] of DASHBOARD.operationsLegend.entries()) {
+            // Back to the dashboard between slices: each drill-down navigates
+            // away, and returning through the nav re-renders the chart.
+            if (index > 0) {
+              await dashboard.openViaSideNav(project.id);
+              await expect(dashboard.chartSlices(heading).first()).toBeVisible();
+            }
+
+            await dashboard.clickChartSlice(heading, index);
+
+            await expect(page).toHaveURL(
+              new RegExp(`/projects/${project.id}/${entry.pathSegment}$`),
+            );
+
+            // As with the legend, the path is the one the Operations hub uses for
+            // the whole list — the "Outstanding" title is what shows the chart
+            // handed over its `outstandingOnly` state, which travels outside the
+            // URL.
+            const main = page.getByTestId("app-main");
+            await expect(
+              main.getByRole("heading", { name: entry.title, exact: true }),
+            ).toBeVisible();
+            await expect(
+              main.getByText(entry.description, { exact: true }),
+            ).toBeVisible();
+          }
+
+          console.log(
+            `Dashboard (${projectType}): all ${sliceCount} operations donut ` +
+              `slices drilled down to their lists`,
+          );
+        });
+
+        for (const entry of DASHBOARD.operationsLegend) {
+          test(`the ${entry.label} legend entry opens its list`, async ({
+            page,
+          }) => {
+            test.skip(!project.id, `${projectType} needs a project id.`);
+
+            const dashboard = new DashboardPage(page);
+            await dashboard.openViaSideNav(project.id);
+
+            await dashboard.legendEntry(entry.label).click();
+
+            await expect(page).toHaveURL(
+              new RegExp(`/projects/${project.id}/${entry.pathSegment}$`),
+            );
+
+            // The path is the same one the Operations hub uses for the whole
+            // list; the "Outstanding" title is what shows the chart handed over
+            // its `outstandingOnly` state, which travels outside the URL.
+            const main = page.getByTestId("app-main");
+            await expect(
+              main.getByRole("heading", { name: entry.title, exact: true }),
+            ).toBeVisible();
+            await expect(
+              main.getByText(entry.description, { exact: true }),
+            ).toBeVisible();
+
+            console.log(
+              `Dashboard (${projectType}): ${entry.label} → ${entry.title}`,
+            );
+          });
+        }
+      }
+    });
+  }
+});

--- a/apps/customer-portal/webapp/tests/e2e/specs/dashboard/dashboard.spec.ts
+++ b/apps/customer-portal/webapp/tests/e2e/specs/dashboard/dashboard.spec.ts
@@ -255,16 +255,24 @@ test.describe("Dashboard", () => {
         // creator" rather than against a hardcoded address, so it holds for
         // whichever account the captured session belongs to.
         await expect(dashboard.casesTableRows().first()).toBeVisible();
+
+        // Counted, not named: the creators are real email addresses, and a test
+        // report is no place to put them. The distinct count is what carries the
+        // assertion — more than one means the filter let another user's cases
+        // through.
         const creators = await dashboard.casesTableCreators();
+        const distinctCreators = new Set(creators).size;
+
         expect(creators.length, "no row named a creator").toBeGreaterThan(0);
         expect(
-          new Set(creators).size,
-          `creators listed: ${creators.join(", ")}`,
+          distinctCreators,
+          "every row should name the same creator — more than one means the " +
+            "createdByMe filter did not hold",
         ).toBe(1);
 
         console.log(
           `Dashboard (${projectType}): my cases table shows ${creators.length} ` +
-            `rows, all by ${creators[0]}`,
+            `rows from ${distinctCreators} creator`,
         );
       });
 
@@ -553,15 +561,30 @@ test.describe("Dashboard", () => {
         // as the heading appears reads zero.
         await expect(dashboard.severityChartSlices().first()).toBeVisible();
 
-        // One slice per legend entry, including any severity with a count of
-        // zero — the chart's `minAngle` keeps those on screen and clickable.
+        // How many slices the donut draws depends on the data — a severity with
+        // no outstanding cases may or may not get a sector — so the count is
+        // bounded rather than pinned, and no slice is assumed to be a particular
+        // severity by its position.
         const sliceCount = await dashboard.severityChartSlices().count();
+        expect(sliceCount, "the donut should have slices").toBeGreaterThan(0);
         expect(
           sliceCount,
-          "the donut should have one slice per severity in the legend",
-        ).toBe(DASHBOARD.severityLegend.length);
+          "the donut should not draw more slices than the legend has entries",
+        ).toBeLessThanOrEqual(DASHBOARD.severityLegend.length);
 
-        for (const [index, entry] of DASHBOARD.severityLegend.entries()) {
+        // Which severity each slice belongs to is read back from where it lands,
+        // not assumed from its index: if the chart ever skips a zero-count
+        // severity, index n stops meaning legend entry n, and a test that
+        // assumed otherwise would assert the wrong list against the wrong slice.
+        const bySeverityId = new Map<
+          string,
+          { severityId: string; title: string; description: string }
+        >(
+          DASHBOARD.severityLegend.map((entry) => [entry.severityId, entry]),
+        );
+        const visited: string[] = [];
+
+        for (let index = 0; index < sliceCount; index += 1) {
           // Back to the dashboard between slices: each drill-down navigates
           // away, and returning through the nav re-renders the chart.
           if (index > 0) {
@@ -571,22 +594,40 @@ test.describe("Dashboard", () => {
 
           await dashboard.clickSeverityChartSlice(index);
 
-          // Slices are drawn in legend order, so slice n must open the same list
-          // as legend entry n — which is what ties the chart to its key.
+          // Every slice must open a severity-filtered cases list.
           await expect(page).toHaveURL(
             new RegExp(
-              `/projects/${project.id}/support/cases\\?severityId=${entry.severityId}$`,
+              `/projects/${project.id}/support/cases\\?severityId=\\d+$`,
             ),
           );
 
+          const severityId = new URL(page.url()).searchParams.get("severityId");
+          const entry = severityId
+            ? bySeverityId.get(severityId)
+            : undefined;
+          expect(
+            entry,
+            `slice ${index + 1} opened severityId ${severityId}, which is not ` +
+              `one of the severities in the legend`,
+          ).toBeDefined();
+          visited.push(severityId as string);
+
           const main = page.getByTestId("app-main");
+          const expected = entry as { title: string; description: string };
           await expect(
-            main.getByRole("heading", { name: entry.title, exact: true }),
+            main.getByRole("heading", { name: expected.title, exact: true }),
           ).toBeVisible();
           await expect(
-            main.getByText(entry.description, { exact: true }),
+            main.getByText(expected.description, { exact: true }),
           ).toBeVisible();
         }
+
+        // Each slice is its own severity — two slices landing on the same list
+        // would mean the chart is mis-wired even though every click "worked".
+        expect(
+          new Set(visited).size,
+          `slices opened ${new Set(visited).size} distinct severities out of ${sliceCount}`,
+        ).toBe(sliceCount);
 
         console.log(
           `Dashboard (${projectType}): all ${sliceCount} donut slices drilled ` +
@@ -652,10 +693,12 @@ test.describe("Dashboard", () => {
           // well after the stat cards, so counting slices any earlier reads zero.
           await expect(dashboard.chartSlices(heading).first()).toBeVisible();
 
-          // One slice per legend row here, because both series carry work on this
-          // project. A series with a count of zero would have no slice at all —
-          // Recharts' minAngle only applies to non-zero values — so this asserts
-          // the data as much as the chart.
+          // Both series carry work on this project, so there is a slice for each
+          // legend row and index n means legend entry n. Pinned rather than
+          // bounded — unlike the severity donut, which has to allow for a
+          // severity with no cases — because if either series ever emptied, this
+          // count failing is the signal to revisit the mapping below rather than
+          // something to absorb silently.
           const sliceCount = await dashboard.chartSlices(heading).count();
           expect(
             sliceCount,

--- a/apps/customer-portal/webapp/tests/e2e/specs/support/request-call.spec.ts
+++ b/apps/customer-portal/webapp/tests/e2e/specs/support/request-call.spec.ts
@@ -260,23 +260,35 @@ test.describe("Request Call", () => {
       // terminal, and taking the shared request out would leave the reschedule
       // test with a disabled button. Unguarded on purpose — a cancelled request
       // cannot be cancelled twice, so each run needs a live one of its own.
+      //
+      // The reason is stamped per run because cards are matched on it as a
+      // substring. A run that dies between creating and cancelling leaves a
+      // pending request behind; with a fixed reason the next run would have two
+      // cards matching, act on whichever `.last()` resolved to, and then fail its
+      // closing absence check on the other one — permanently, until someone
+      // cleaned up by hand. Milliseconds are kept so two runs starting in the
+      // same second cannot collide either.
+      const cancelReason =
+        `${CALL_REQUEST_INPUT.cancel.reason} ` +
+        `${new Date().toISOString().slice(0, 23).replace(/[:T.]/g, "-")}`;
+
       const preferredTime = daysFromNowAt(
         1,
         CALL_REQUEST_INPUT.preferredTimeOfDay,
       );
       await calls.openRequestModal();
-      await calls.fillRequest(preferredTime, CALL_REQUEST_INPUT.cancel.reason);
+      await calls.fillRequest(preferredTime, cancelReason);
       await expect(calls.preferredTimeInput()).toHaveValue(preferredTime);
 
       const created = await calls.submit();
       await expectSuccess(created, "create call request to cancel");
       await expect(calls.modal()).toBeHidden();
 
-      const live = calls.card(CALL_REQUEST_INPUT.cancel.reason);
+      const live = calls.card(cancelReason);
       await expect(live).toBeVisible();
       await expect(live).toContainText(CASE_CALLS.card.pendingState);
 
-      await calls.openCancelModal(CALL_REQUEST_INPUT.cancel.reason);
+      await calls.openCancelModal(cancelReason);
       const cancelled = await calls.confirmCancel(
         CALL_REQUEST_INPUT.cancel.cancellationReason,
       );
@@ -301,11 +313,11 @@ test.describe("Request Call", () => {
       // request is filtered out of its own tab. Its disappearance is therefore
       // what proves the cancellation took, and it is also why these records do
       // not pile up on the tab run after run.
-      await expect(calls.card(CALL_REQUEST_INPUT.cancel.reason)).toHaveCount(0);
+      await expect(calls.card(cancelReason)).toHaveCount(0);
 
       console.log(
         `Call request (${CALL_REQUEST_INPUT.projectType}): created for ` +
-          `${preferredTime} and cancelled`,
+          `${preferredTime} and cancelled (${cancelReason})`,
       );
     });
   });

--- a/apps/customer-portal/webapp/tests/e2e/specs/support/request-call.spec.ts
+++ b/apps/customer-portal/webapp/tests/e2e/specs/support/request-call.spec.ts
@@ -1,0 +1,574 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//
+// Requesting a call from a case's Calls tab.
+//
+// ⚠️ Writes to a REAL backend via POST /cases/{id}/call-requests. A call request
+// cannot be removed — the delete action cancels it and the record stays — so the
+// spec files one only when its own earlier request is not already on the tab,
+// keyed on the fixed reason text. Every later run asserts the existing card
+// instead of stacking another.
+//
+// That guard is also why the preferred time is only checked against tomorrow on
+// the run that actually created the request: on later runs the card carries
+// whichever date that first run picked.
+//
+// The second describe below covers field gating across all three dialogs and
+// writes NOTHING — every scenario stops at a disabled control or dismisses the
+// dialog, and each test counts the writes that left the browser to prove it.
+//
+
+import { test, expect, withSession, type Page } from "../../fixtures/test";
+import { CALL_REQUEST_INPUT, PROJECTS } from "../../config/testData";
+import { CASE_CALLS } from "../../utils/selectors";
+import { expectSuccess } from "../../utils/caseFlows";
+import { CaseCallsPage } from "../../pages/CaseCallsPage";
+import { CaseDetailPage } from "../../pages/CaseDetailPage";
+import {
+  daysFromNowAt,
+  ensureCallRequest,
+  openCallsTab,
+} from "../../utils/callFlows";
+
+withSession(test);
+
+/**
+ * Counts the call-request writes a test causes, so "nothing was submitted" can
+ * be asserted rather than assumed.
+ *
+ * @param page - Test page.
+ * @returns A reader for the count so far.
+ */
+function countCallRequestWrites(page: Page): () => number {
+  let writes = 0;
+  page.on("request", (request) => {
+    const path = new URL(request.url()).pathname;
+    const method = request.method();
+
+    // Only the two write endpoints. Reading the list is *also* a POST — to
+    // `/call-requests/search` — so matching "POST to anything under
+    // call-requests" counts every refetch as a write, which is exactly the
+    // mistake that made this counter report 3 instead of 0.
+    const isCreate = method === "POST" && /\/call-requests$/.test(path);
+    const isUpdate =
+      method === "PATCH" && /\/call-requests\/[^/]+$/.test(path);
+
+    if (isCreate || isUpdate) writes += 1;
+  });
+  return () => writes;
+}
+
+test.describe("Request Call", () => {
+  // A cold case load, a tab switch, the call-requests query and a modal whose
+  // fields depend on the user's profile — well past the 30s default.
+  test.describe.configure({ timeout: 180_000 });
+
+  const project = PROJECTS[CALL_REQUEST_INPUT.projectType];
+
+  test.describe(CALL_REQUEST_INPUT.projectType, () => {
+    test("requests a call from the case's Calls tab", async ({ page }) => {
+      test.skip(
+        !project.id || !CALL_REQUEST_INPUT.caseId,
+        `${CALL_REQUEST_INPUT.projectType} needs a project id and a case id. ` +
+          `Fill them in tests/e2e/config/testData.ts.`,
+      );
+
+      const calls = await openCallsTab(page);
+      const alreadyRequested = await ensureCallRequest(calls);
+
+      // The card, whichever run created it.
+      const card = calls.card(CALL_REQUEST_INPUT.reason);
+      await expect(card).toBeVisible();
+      await expect(card).toContainText(CALL_REQUEST_INPUT.reason);
+      await expect(card).toContainText(CASE_CALLS.card.durationLabel);
+      await expect(card).toContainText(CASE_CALLS.card.preferredTimesLabel);
+
+      // The default duration only holds on the run that filed the request. The
+      // reschedule test below moves an existing one to an hour, and the record
+      // persists between runs — so a later run finds 60 minutes here, which is
+      // correct rather than a regression.
+      await expect(card).toContainText(
+        alreadyRequested
+          ? CASE_CALLS.card.durationPattern
+          : CALL_REQUEST_INPUT.durationLabel,
+      );
+
+      // A newly filed request opens pending on WSO2. Soft, because a request
+      // left by an earlier run may since have been actioned by a real engineer,
+      // which is not a failure of this flow.
+      await expect
+        .soft(card, "a new call request should be pending on WSO2")
+        .toContainText(CASE_CALLS.card.pendingState);
+
+      // The requested time is rendered in the user's profile time zone, so the
+      // exact string is not reconstructable here — what matters is that a time
+      // came back at all rather than the placeholder.
+      await expect(card).not.toContainText(
+        `${CASE_CALLS.card.preferredTimesLabel} ${CASE_CALLS.card.emptyValue}`,
+      );
+
+      console.log(
+        `Call request (${CALL_REQUEST_INPUT.projectType}): ` +
+          `${alreadyRequested ? "existing" : "created"}`,
+      );
+    });
+
+    test("reschedules the call request", async ({ page }) => {
+      test.skip(
+        !project.id || !CALL_REQUEST_INPUT.caseId,
+        `${CALL_REQUEST_INPUT.projectType} needs a project id and a case id.`,
+      );
+
+      const calls = await openCallsTab(page);
+      await ensureCallRequest(calls);
+
+      await calls.openEditModal(CALL_REQUEST_INPUT.reason);
+
+      const rescheduledTime = daysFromNowAt(
+        2,
+        CALL_REQUEST_INPUT.preferredTimeOfDay,
+      );
+      await calls.preferredTimeInput().fill(rescheduledTime);
+      await expect(calls.preferredTimeInput()).toHaveValue(rescheduledTime);
+
+      await calls.selectDuration(CALL_REQUEST_INPUT.rescheduledDurationOption);
+
+      const response = await calls.update();
+      await expectSuccess(response, "update call request");
+
+      // The duration on the wire, which is free of the time zone problem that
+      // stops the rendered times from being checked exactly. The modal calls it
+      // "1 hour"; the payload is minutes.
+      const payload = JSON.parse(
+        response.request().postData() ?? "{}",
+      ) as { durationInMinutes?: number; utcTimes?: string[] };
+      expect(payload.durationInMinutes).toBe(60);
+      expect(
+        payload.utcTimes?.length,
+        "the update should carry the rescheduled time",
+      ).toBeGreaterThan(0);
+
+      await expect(calls.modal()).toBeHidden();
+
+      // The card picks the change up, which is what makes this a reschedule
+      // rather than an accepted request that never reached the list.
+      const card = calls.card(CALL_REQUEST_INPUT.reason);
+      await expect(card).toBeVisible();
+      await expect(card).toContainText(
+        CALL_REQUEST_INPUT.rescheduledDurationLabel,
+      );
+      await expect(card).not.toContainText(
+        `${CASE_CALLS.card.preferredTimesLabel} ${CASE_CALLS.card.emptyValue}`,
+      );
+
+      console.log(
+        `Call request (${CALL_REQUEST_INPUT.projectType}): rescheduled to ` +
+          `${rescheduledTime} for ${CALL_REQUEST_INPUT.rescheduledDurationLabel}`,
+      );
+    });
+
+    test("discards a reschedule when the modal is cancelled", async ({
+      page,
+    }) => {
+      test.skip(
+        !project.id || !CALL_REQUEST_INPUT.caseId,
+        `${CALL_REQUEST_INPUT.projectType} needs a project id and a case id.`,
+      );
+
+      // Counted from before the modal opens: dismissing must not send anything,
+      // and an assertion on the card alone could not tell "nothing was saved"
+      // apart from "saved the same values back".
+      let updateRequests = 0;
+      page.on("request", (request) => {
+        if (
+          request.method() === "PATCH" &&
+          /\/cases\/[^/]+\/call-requests\/[^/]+$/.test(
+            new URL(request.url()).pathname,
+          )
+        ) {
+          updateRequests += 1;
+        }
+      });
+
+      const calls = await openCallsTab(page);
+      await ensureCallRequest(calls);
+
+      // Snapshot the card, so the comparison afterwards covers every field
+      // rather than the couple this test thought to name.
+      const card = calls.card(CALL_REQUEST_INPUT.reason);
+      await expect(card).toBeVisible();
+      const before = await card.innerText();
+
+      await calls.openEditModal(CALL_REQUEST_INPUT.reason);
+
+      // Edit the form before dismissing. Without a pending change, the dialog
+      // closing proves nothing: there would be nothing for it to discard.
+      const discardedTime = daysFromNowAt(
+        3,
+        CALL_REQUEST_INPUT.preferredTimeOfDay,
+      );
+      await calls.preferredTimeInput().fill(discardedTime);
+      await expect(calls.preferredTimeInput()).toHaveValue(discardedTime);
+
+      await calls.dismissModal();
+
+      expect(
+        updateRequests,
+        "cancelling the modal should not send an update",
+      ).toBe(0);
+
+      // The card is exactly as it was — the edit went nowhere. Compared through
+      // innerText on both sides: toHaveText normalises whitespace differently
+      // from innerText, so identical content fails against a snapshot taken
+      // this way.
+      await expect
+        .poll(async () => (await card.innerText()).trim(), {
+          message: "the card should be unchanged after dismissing the modal",
+          timeout: 10_000,
+        })
+        .toBe(before.trim());
+
+      console.log(
+        `Call request (${CALL_REQUEST_INPUT.projectType}): reschedule to ` +
+          `${discardedTime} discarded`,
+      );
+    });
+
+    test("cancels a call request", async ({ page }) => {
+      test.skip(
+        !project.id || !CALL_REQUEST_INPUT.caseId,
+        `${CALL_REQUEST_INPUT.projectType} needs a project id and a case id.`,
+      );
+
+      const calls = await openCallsTab(page);
+
+      // Files its own request rather than reusing the one above: cancelling is
+      // terminal, and taking the shared request out would leave the reschedule
+      // test with a disabled button. Unguarded on purpose — a cancelled request
+      // cannot be cancelled twice, so each run needs a live one of its own.
+      const preferredTime = daysFromNowAt(
+        1,
+        CALL_REQUEST_INPUT.preferredTimeOfDay,
+      );
+      await calls.openRequestModal();
+      await calls.fillRequest(preferredTime, CALL_REQUEST_INPUT.cancel.reason);
+      await expect(calls.preferredTimeInput()).toHaveValue(preferredTime);
+
+      const created = await calls.submit();
+      await expectSuccess(created, "create call request to cancel");
+      await expect(calls.modal()).toBeHidden();
+
+      const live = calls.card(CALL_REQUEST_INPUT.cancel.reason);
+      await expect(live).toBeVisible();
+      await expect(live).toContainText(CASE_CALLS.card.pendingState);
+
+      await calls.openCancelModal(CALL_REQUEST_INPUT.cancel.reason);
+      const cancelled = await calls.confirmCancel(
+        CALL_REQUEST_INPUT.cancel.cancellationReason,
+      );
+      await expectSuccess(cancelled, "cancel call request");
+
+      // Cancelling reuses the update endpoint, so the body is the only thing
+      // that distinguishes it from a reschedule: state 6 is the cancelled state
+      // (CALL_REQUEST_STATE_CANCELLED).
+      const payload = JSON.parse(cancelled.request().postData() ?? "{}") as {
+        stateKey?: number;
+        cancellationReason?: string;
+      };
+      expect(payload.stateKey).toBe(6);
+      expect(payload.cancellationReason).toBe(
+        CALL_REQUEST_INPUT.cancel.cancellationReason,
+      );
+
+      await expect(calls.modal()).toBeHidden();
+
+      // The request leaves the list rather than staying on with a cancelled
+      // state: the panel searches only the non-cancelled states, so a cancelled
+      // request is filtered out of its own tab. Its disappearance is therefore
+      // what proves the cancellation took, and it is also why these records do
+      // not pile up on the tab run after run.
+      await expect(calls.card(CALL_REQUEST_INPUT.cancel.reason)).toHaveCount(0);
+
+      console.log(
+        `Call request (${CALL_REQUEST_INPUT.projectType}): created for ` +
+          `${preferredTime} and cancelled`,
+      );
+    });
+  });
+});
+
+test.describe("Request Call — validation", () => {
+  // A cold case load, a tab switch and the call-requests query, before any
+  // dialog is even opened — well past the 30s default.
+  test.describe.configure({ timeout: 180_000 });
+
+  const project = PROJECTS[CALL_REQUEST_INPUT.projectType];
+
+  test.describe(CALL_REQUEST_INPUT.projectType, () => {
+    test.beforeEach(() => {
+      test.skip(
+        !project.id || !CALL_REQUEST_INPUT.caseId,
+        `${CALL_REQUEST_INPUT.projectType} needs a project id and a case id. ` +
+          `Fill them in tests/e2e/config/testData.ts.`,
+      );
+    });
+
+    test("keeps submit disabled until a reason is given", async ({ page }) => {
+      const writes = countCallRequestWrites(page);
+      const calls = await openCallsTab(page);
+      await calls.openRequestModal();
+
+      // The preferred time is seeded on open, so the reason is the only thing
+      // still missing — which makes this a clean test of that one rule.
+      await expect(calls.preferredTimeInput()).not.toHaveValue("");
+      await expect(calls.submitButton()).toBeDisabled();
+
+      await calls.reasonInput().fill(CALL_REQUEST_INPUT.reason);
+      await expect(calls.submitButton()).toBeEnabled();
+
+      // Whitespace is not a reason: handleSubmit trims before checking.
+      await calls.reasonInput().fill("   ");
+      await expect(calls.submitButton()).toBeDisabled();
+
+      await calls.dismissModal();
+      expect(writes(), "validation must not submit anything").toBe(0);
+    });
+
+    test("keeps submit disabled when a preferred time is cleared", async ({
+      page,
+    }) => {
+      const writes = countCallRequestWrites(page);
+      const calls = await openCallsTab(page);
+      await calls.openRequestModal();
+
+      await calls.reasonInput().fill(CALL_REQUEST_INPUT.reason);
+      await expect(calls.submitButton()).toBeEnabled();
+
+      await calls.preferredTimeInput().fill("");
+      await expect(calls.submitButton()).toBeDisabled();
+
+      await calls.dismissModal();
+      expect(writes(), "validation must not submit anything").toBe(0);
+    });
+
+    test("refuses a preferred time earlier than the allowed floor", async ({
+      page,
+    }) => {
+      const writes = countCallRequestWrites(page);
+      const calls = await openCallsTab(page);
+      await calls.openRequestModal();
+
+      // The floor is computed from the case severity's allocation time, so it
+      // is read off the input rather than recomputed here — the test asserts the
+      // rule is enforced, not what the tenant's allocation happens to be.
+      const input = calls.preferredTimeInput();
+      const floor = await input.getAttribute("min");
+      expect(floor, "the input should carry a min").toBeTruthy();
+
+      // A date well in the past, which the change handler snaps back up.
+      await input.fill(daysFromNowAt(-7, CALL_REQUEST_INPUT.preferredTimeOfDay));
+      await expect(input).toHaveValue(floor as string);
+
+      await calls.dismissModal();
+      expect(writes(), "validation must not submit anything").toBe(0);
+    });
+
+    test("offers up to three preferred times and keeps the first", async ({
+      page,
+    }) => {
+      const writes = countCallRequestWrites(page);
+      const calls = await openCallsTab(page);
+      await calls.openRequestModal();
+
+      await expect(calls.preferredTimeInputs()).toHaveCount(1);
+
+      // The first row can never be removed — a request must keep at least one
+      // preferred time.
+      await expect(calls.removePreferredTimeButton(1)).toBeDisabled();
+
+      for (let count = 2; count <= CASE_CALLS.modal.maxPreferredTimes; count++) {
+        await calls.addPreferredTimeButton().click();
+        await expect(calls.preferredTimeInputs()).toHaveCount(count);
+      }
+
+      // At the maximum the control is withheld rather than silently ignoring
+      // the click.
+      await expect(calls.addPreferredTimeButton()).toBeDisabled();
+
+      // Added rows are seeded with the floor, so the form stays submittable.
+      await expect(
+        calls.preferredTimeInputAt(CASE_CALLS.modal.maxPreferredTimes - 1),
+      ).not.toHaveValue("");
+
+      // And they can be taken back off.
+      await calls
+        .removePreferredTimeButton(CASE_CALLS.modal.maxPreferredTimes)
+        .click();
+      await expect(calls.preferredTimeInputs()).toHaveCount(
+        CASE_CALLS.modal.maxPreferredTimes - 1,
+      );
+      await expect(calls.addPreferredTimeButton()).toBeEnabled();
+
+      await calls.dismissModal();
+      expect(writes(), "validation must not submit anything").toBe(0);
+    });
+
+    test("offers exactly the four meeting durations", async ({ page }) => {
+      const writes = countCallRequestWrites(page);
+      const calls = await openCallsTab(page);
+      await calls.openRequestModal();
+
+      expect(await calls.durationOptionLabels()).toEqual([
+        ...CASE_CALLS.modal.durationOptions,
+      ]);
+
+      await calls.dismissModal();
+      expect(writes(), "validation must not submit anything").toBe(0);
+    });
+
+    test("does not offer the reason field when rescheduling", async ({
+      page,
+    }) => {
+      const writes = countCallRequestWrites(page);
+      const calls = await openCallsTab(page);
+      const created = await ensureCallRequest(calls);
+
+      await calls.openEditModal(CALL_REQUEST_INPUT.reason);
+
+      // A reschedule may change times and duration only; the reason the call was
+      // asked for is fixed once filed.
+      await expect(calls.reasonInput()).toHaveCount(0);
+      await expect(calls.durationSelect()).toBeVisible();
+
+      await calls.dismissModal();
+
+      // One write is allowed here, and only if the shared request had to be
+      // filed first — the dialog itself must send nothing.
+      expect(writes()).toBe(created ? 0 : 1);
+    });
+
+    test("keeps update disabled when a preferred time is cleared", async ({
+      page,
+    }) => {
+      const writes = countCallRequestWrites(page);
+      const calls = await openCallsTab(page);
+      const created = await ensureCallRequest(calls);
+
+      await calls.openEditModal(CALL_REQUEST_INPUT.reason);
+      await expect(calls.updateButton()).toBeEnabled();
+
+      await calls.preferredTimeInput().fill("");
+      await expect(calls.updateButton()).toBeDisabled();
+
+      await calls.dismissModal();
+      expect(writes()).toBe(created ? 0 : 1);
+    });
+
+    test("keeps confirm disabled until a cancellation reason is given", async ({
+      page,
+    }) => {
+      const writes = countCallRequestWrites(page);
+      const calls = await openCallsTab(page);
+      const created = await ensureCallRequest(calls);
+
+      await calls.openCancelModal(CALL_REQUEST_INPUT.reason);
+
+      const confirm = calls
+        .modal()
+        .getByRole("button", {
+          name: CASE_CALLS.cancelModal.confirmButton,
+          exact: true,
+        });
+      await expect(confirm).toBeDisabled();
+
+      await calls
+        .cancellationReasonInput()
+        .fill(CALL_REQUEST_INPUT.cancel.cancellationReason);
+      await expect(confirm).toBeEnabled();
+
+      // Whitespace does not count as a reason either.
+      await calls.cancellationReasonInput().fill("   ");
+      await expect(confirm).toBeDisabled();
+
+      // Go Back leaves the request alone — the point of this test is that the
+      // shared request survives it.
+      await calls
+        .modal()
+        .getByRole("button", {
+          name: CASE_CALLS.cancelModal.goBackButton,
+          exact: true,
+        })
+        .click();
+      await expect(calls.modal()).toBeHidden();
+
+      await expect(calls.card(CALL_REQUEST_INPUT.reason)).toBeVisible();
+      expect(writes()).toBe(created ? 0 : 1);
+    });
+  });
+});
+
+test.describe("Calls tab availability", () => {
+  // A cold case load per test, twice over — well past the 30s default.
+  test.describe.configure({ timeout: 180_000 });
+
+  const project = PROJECTS[CALL_REQUEST_INPUT.projectType];
+
+  // Scheduling is offered only while a case is in one of
+  // CALL_SCHEDULABLE_CASE_STATUSES. Outside those the Calls tab is not rendered
+  // at all — it is withheld rather than shown empty — so there is nowhere to
+  // request a call from.
+  for (const [index, caseId] of CALL_REQUEST_INPUT.callsUnavailableCaseIds.entries()) {
+    test(`withholds the Calls tab on a non-schedulable case (${index + 1})`, async ({
+      page,
+    }) => {
+      test.skip(
+        !project.id || !caseId,
+        `${CALL_REQUEST_INPUT.projectType} needs a project id and a case id. ` +
+          `Fill them in tests/e2e/config/testData.ts.`,
+      );
+
+      const caseDetail = new CaseDetailPage(page);
+      await caseDetail.open(project.id, caseId);
+
+      const calls = new CaseCallsPage(page);
+
+      // The tab strip has to be on screen first: without this, "no Calls tab"
+      // would also be true of a page that never finished loading, and the test
+      // would pass for the wrong reason.
+      await expect(calls.alwaysPresentTabs().first()).toBeVisible();
+
+      await expect(
+        calls.tab(),
+        "this case is not in a call-schedulable status, so it should have no " +
+          "Calls tab",
+      ).toHaveCount(0);
+
+      // And the reason it is absent, so a tab that disappeared for some
+      // unrelated cause could not pass itself off as this rule working.
+      for (const status of CASE_CALLS.schedulableStatuses) {
+        await expect
+          .soft(
+            caseDetail.stateLabel(status),
+            `a case with no Calls tab should not be "${status}"`,
+          )
+          .toHaveCount(0);
+      }
+
+      console.log(`Calls tab withheld on ${caseId}`);
+    });
+  }
+});

--- a/apps/customer-portal/webapp/tests/e2e/utils/callFlows.ts
+++ b/apps/customer-portal/webapp/tests/e2e/utils/callFlows.ts
@@ -1,0 +1,106 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//
+// Call-request flows shared by the happy-path suite and the validation suite.
+// Both need a case's Calls tab open, and both need a request to exist before
+// they can exercise anything that acts on one.
+//
+
+import { expect, type Page } from "../fixtures/test";
+import { CaseCallsPage } from "../pages/CaseCallsPage";
+import { CaseDetailPage } from "../pages/CaseDetailPage";
+import { CALL_REQUEST_INPUT, PROJECTS } from "../config/testData";
+import { expectSuccess } from "./caseFlows";
+
+/**
+ * A future date at a given time, formatted for a `datetime-local` input.
+ *
+ * Built from local date parts rather than an ISO string, because `toISOString`
+ * is UTC and would shift the date by a day either side of midnight for anyone
+ * not on UTC.
+ *
+ * @param days - How many days ahead: 1 for tomorrow, 2 for the day after.
+ * @param timeOfDay - "HH:mm" to request.
+ * @returns A "YYYY-MM-DDTHH:mm" value.
+ */
+export function daysFromNowAt(days: number, timeOfDay: string): string {
+  const date = new Date();
+  date.setDate(date.getDate() + days);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}T${timeOfDay}`;
+}
+
+/**
+ * Opens the configured case's Calls tab.
+ *
+ * @param page - Test page.
+ * @returns The tab's page object.
+ */
+export async function openCallsTab(page: Page): Promise<CaseCallsPage> {
+  const project = PROJECTS[CALL_REQUEST_INPUT.projectType];
+  const caseDetail = new CaseDetailPage(page);
+  await caseDetail.open(project.id, CALL_REQUEST_INPUT.caseId);
+  const calls = new CaseCallsPage(page);
+  await calls.openTab();
+  return calls;
+}
+
+/**
+ * Makes sure a call request with the configured reason exists, filing one only
+ * when it does not.
+ *
+ * ⚠️ May create a permanent record — a call request cannot be removed, only
+ * cancelled. The guard on the reason is what stops it stacking one per run.
+ *
+ * Shared rather than owned by one spec so that every test needing a request to
+ * act on can get one itself, instead of depending on another test having run
+ * first — which holds in a whole-file run but not when a test runs alone.
+ *
+ * @param calls - The case's open Calls tab.
+ * @returns Whether a request was already there.
+ */
+export async function ensureCallRequest(
+  calls: CaseCallsPage,
+): Promise<boolean> {
+  if (await calls.hasRequest(CALL_REQUEST_INPUT.reason)) {
+    console.log(
+      `${CALL_REQUEST_INPUT.projectType}: a call request with this reason ` +
+        `already exists, asserting it rather than filing another`,
+    );
+    return true;
+  }
+
+  const preferredTime = daysFromNowAt(1, CALL_REQUEST_INPUT.preferredTimeOfDay);
+  await calls.openRequestModal();
+  await calls.fillRequest(preferredTime, CALL_REQUEST_INPUT.reason);
+
+  // The modal seeds the field with the earliest allowed time on open, so this
+  // confirms the value was actually replaced with tomorrow's — and that the
+  // input did not reject it against its own `min`.
+  await expect(calls.preferredTimeInput()).toHaveValue(preferredTime);
+  await expect(calls.submitButton()).toBeEnabled();
+
+  const response = await calls.submit();
+  await expectSuccess(response, "create call request");
+
+  // The modal closes itself on success, so it staying open would mean the
+  // request was accepted but the UI never moved on.
+  await expect(calls.modal()).toBeHidden();
+  return false;
+}

--- a/apps/customer-portal/webapp/tests/e2e/utils/listSearch.ts
+++ b/apps/customer-portal/webapp/tests/e2e/utils/listSearch.ts
@@ -58,16 +58,65 @@ function isCaseSearch(response: Response): boolean {
 /** Parses a request body, or returns undefined when it is absent/unparseable. */
 function searchFilters(
   postData: string | null,
-): { createdByMe?: boolean; statusIds?: number[] } | undefined {
+):
+  | { createdByMe?: boolean; statusIds?: number[]; severityIds?: number[] }
+  | undefined {
   if (!postData) return undefined;
   try {
     const body = JSON.parse(postData) as {
-      filters?: { createdByMe?: boolean; statusIds?: number[] };
+      filters?: {
+        createdByMe?: boolean;
+        statusIds?: number[];
+        severityIds?: number[];
+      };
     };
     return body.filters ?? {};
   } catch {
     return undefined;
   }
+}
+
+/**
+ * Starts waiting for a case search asking for a specific page of results.
+ *
+ * Call this **before** operating the pagination control, then await it after.
+ *
+ * Page size and position travel as `pagination.limit` and `pagination.offset`,
+ * so matching on them ties the wait to the change under test rather than to any
+ * other refetch the table happens to make. Only the fields given are matched.
+ *
+ * @param page - Test page.
+ * @param match - The `limit` and/or `offset` the request must carry.
+ * @returns Promise for the matching search response.
+ */
+export function caseSearchWithPagination(
+  page: Page,
+  match: { limit?: number; offset?: number },
+): Promise<Response> {
+  return page.waitForResponse(
+    (response) => {
+      if (!isCaseSearch(response)) return false;
+      const postData = response.request().postData();
+      if (!postData) return false;
+      try {
+        const body = JSON.parse(postData) as {
+          pagination?: { limit?: number; offset?: number };
+        };
+        const pagination = body.pagination;
+        if (!pagination) return false;
+        if (match.limit !== undefined && pagination.limit !== match.limit) {
+          return false;
+        }
+        if (match.offset !== undefined && pagination.offset !== match.offset) {
+          return false;
+        }
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    { timeout: SEARCH_TIMEOUT_MS },
+  );
 }
 
 /**
@@ -151,6 +200,57 @@ export function caseSearchResponse(
         return false;
       }
       return searchQueryOf(request.postData()) === searchText;
+    },
+    { timeout: SEARCH_TIMEOUT_MS },
+  );
+}
+
+/**
+ * Starts waiting for a case search filtered to a specific severity.
+ *
+ * Call this **before** choosing the severity, then await it after.
+ *
+ * The chosen severity travels as a numeric id inside `filters.severityIds`, so
+ * matching it is what proves the filter reached the backend rather than only
+ * highlighting an option in the menu.
+ *
+ * @param page - Test page.
+ * @param severityId - Severity id the request must carry.
+ * @returns Promise for the matching search response.
+ */
+export function caseSearchWithSeverity(
+  page: Page,
+  severityId: number,
+): Promise<Response> {
+  return page.waitForResponse(
+    (response) => {
+      if (!isCaseSearch(response)) return false;
+      const severityIds = searchFilters(
+        response.request().postData(),
+      )?.severityIds;
+      return !!severityIds && severityIds.includes(severityId);
+    },
+    { timeout: SEARCH_TIMEOUT_MS },
+  );
+}
+
+/**
+ * Starts waiting for a case search carrying no severity filter.
+ *
+ * Call this **before** clearing the filter, then await it after — the initial
+ * unfiltered load matches this predicate too, so arming it beforehand is what
+ * ties the wait to the clearing rather than to the page load.
+ *
+ * @param page - Test page.
+ * @returns Promise for the matching search response.
+ */
+export function caseSearchWithoutSeverity(page: Page): Promise<Response> {
+  return page.waitForResponse(
+    (response) => {
+      if (!isCaseSearch(response)) return false;
+      const filters = searchFilters(response.request().postData());
+      if (!filters) return false;
+      return filters.severityIds === undefined;
     },
     { timeout: SEARCH_TIMEOUT_MS },
   );

--- a/apps/customer-portal/webapp/tests/e2e/utils/selectors.ts
+++ b/apps/customer-portal/webapp/tests/e2e/utils/selectors.ts
@@ -286,6 +286,324 @@ export const CASE_ATTACHMENTS = {
   },
 } as const;
 
+/** Project dashboard (`/projects/:projectId/dashboard`), the side nav's first
+ * item and the landing page for a project. */
+export const DASHBOARD = {
+  navItem: "Dashboard",
+  pathSegment: "dashboard",
+  /**
+   * The four stat cards across the top (DASHBOARD_STATS), in render order.
+   *
+   * `clickable` records which ones open a list: Avg. Response Time is named in
+   * the grid's `nonClickableKeys`, so it is a plain card while the other three
+   * are buttons. Unlike the Support Center cards, none of these carry their
+   * value in the accessible name, so they cannot be counted as "buttons
+   * starting with a digit".
+   */
+  statCards: [
+    { label: "Action Required", clickable: true },
+    { label: "Outstanding", clickable: true },
+    { label: "Closed (Last 30d)", clickable: true },
+    { label: "Avg. Response Time (Last 30d)", clickable: false },
+  ],
+  /**
+   * Where each clickable stat card leads (DashboardPage's `onStatClick`).
+   *
+   * The item pages are nested *under* the dashboard route, so their paths carry
+   * the `dashboard/` segment — `navigate("action-required")` from the dashboard
+   * resolves against the route tree, not the bare project path.
+   *
+   * Card label and destination title differ on every one of these: the card
+   * reads "Closed (Last 30d)" while the page it opens is titled "Closed items
+   * (last 30d)", so both are recorded.
+   *
+   * Avg. Response Time is absent on purpose — it is in the grid's
+   * `nonClickableKeys` and opens nothing.
+   */
+  statCardTargets: [
+    {
+      label: "Action Required",
+      pathSegment: "dashboard/action-required",
+      title: "Action Required Items",
+      description: "Items awaiting your response",
+      emptyMessage: "No action required items.",
+    },
+    {
+      label: "Outstanding",
+      pathSegment: "dashboard/outstanding-interactions",
+      title: "Outstanding Items",
+      description: "View all currently active and unresolved items",
+      emptyMessage: "No outstanding items.",
+    },
+    {
+      label: "Closed (Last 30d)",
+      pathSegment: "dashboard/closed-last-30d",
+      title: "Closed items (last 30d)",
+      description:
+        "Successfully closed and resolved items during the last 30 days",
+      emptyMessage: "No closed items in the last 30 days.",
+    },
+  ],
+  /** The one card that opens nothing. */
+  nonClickableStatCard: "Avg. Response Time (Last 30d)",
+  /** Sections below the stat cards. */
+  sections: {
+    /** Used twice on the page — the severity donut and the cases table beneath
+     * it carry the same title (CASES_TABLE_HEADER_TITLE) — so specs assert it is
+     * present rather than matching a single element.
+     *
+     * The table is also withheld on mid-size touch viewports, where the layout
+     * is too cramped for it; a desktop browser gets both. */
+    outstandingCases: "Outstanding Support Cases",
+    /** Gated on `permissions.hasEngagements`, the same flag as the Engagements
+     * nav item — which SIDE_NAV_VISIBILITY records as on for all three fixture
+     * projects. */
+    outstandingEngagements: "Outstanding Engagements",
+    /** Gated on `showOutstandingOpsChart` (`hasSR || hasCR`) — the same access
+     * that governs the Operations nav item, so it is present for some projects
+     * and withheld for others. Expected visibility per project lives in
+     * DASHBOARD_OPERATIONS_VISIBILITY. */
+    outstandingOperations: "Outstanding Operations",
+  },
+  /**
+   * The Outstanding Support Cases table at the foot of the dashboard.
+   *
+   * Shares its title with the severity donut above it, so the subtitle is what
+   * identifies this card specifically.
+   *
+   * Each row is a `role="row"` carrying the case's number as "ID: CS…" — not as
+   * a bare "CS…", which is how the case detail page renders it. Clicking a row
+   * opens that case.
+   */
+  casesTable: {
+    subtitle: "Track and manage all active support tickets",
+    /**
+     * The table's own My Cases / All Cases switch (DASHBOARD_CASES_VIEW_TABS).
+     *
+     * These are tabs, not links: choosing one re-queries the table in place with
+     * `createdByMe` set, leaving the dashboard URL untouched — unlike Support
+     * Center's "View my cases", which navigates to a filtered list page. So the
+     * request body and the rows are the only evidence the switch took.
+     *
+     * TabBar renders each as `role="tab"` with `aria-selected`.
+     */
+    viewTabs: {
+      myCases: "My Cases",
+      allCases: "All Cases",
+    },
+    /** Prefix the Created by column puts before each row's creator. */
+    createdByPrefix: "Created by",
+    /** Opens the filter panel. Becomes "Clear Filters (n)" once a filter is
+     * applied, so this label only matches while none is. */
+    filtersButton: "Filters",
+    /** The same button once a filter is applied — it clears rather than toggles
+     * (`formatCasesTableClearFiltersLabel`). The count makes the label change
+     * with the number of active filters. */
+    clearFiltersButton: (activeCount: number) =>
+      `Clear Filters (${activeCount})`,
+    /**
+     * Filters in the panel. Each Select takes its element id from the field's
+     * `filterKey` and its label from `deriveFilterLabels`, so the severity
+     * control is `#severityIds` labelled "Severity".
+     */
+    filters: {
+      severity: {
+        label: "Severity",
+        selectId: "severityIds",
+        /** The severity option to choose, and the id it sends. Option labels are
+         * display names (`mapCasesTableFilterOptionLabel`), not the API's own
+         * labels — "Low (P4)" is shown as "S4(Query)" — while the request
+         * carries the numeric id. */
+        option: { label: "S4(Query)", id: 13 },
+      },
+    },
+    /** MUI TablePagination at the foot of the card. The table starts at 5 rows
+     * (`useState(5)` in CasesTable) and offers 5, 10, 25 and 50. */
+    pagination: {
+      rowsPerPageLabel: "Rows per page:",
+      defaultRowsPerPage: 5,
+      options: [5, 10, 25, 50],
+      /** MUI's default `getItemAriaLabel` strings. */
+      nextPageButton: "Go to next page",
+      previousPageButton: "Go to previous page",
+      /** MUI's `labelDisplayedRows`: "1–5 of 36". The separator is an en dash,
+       * but a hyphen is accepted too so a locale or MUI change does not break
+       * the match. */
+      displayedRowsPattern: /(\d+)[–-](\d+) of (\d+)/,
+    },
+    /** Marks a data row; the header row has no case id. */
+    rowIdPattern: /ID: CS\d+/,
+    /** Captures the case number out of a row's text. */
+    rowCaseNumberPattern: /ID: (CS\d+)/,
+  },
+  /**
+   * The legend of the Outstanding Operations donut. Each entry opens the
+   * matching operations list, narrowed to outstanding.
+   *
+   * Only rendered where the Operations chart is — see
+   * DASHBOARD_OPERATIONS_VISIBILITY.
+   *
+   * `outstandingOnly` travels in router state rather than the URL, so the path
+   * alone cannot tell this apart from the unfiltered list. The "Outstanding …"
+   * title is what proves the state was handed over, which is why it is asserted
+   * as well as the path.
+   */
+  operationsLegend: [
+    {
+      label: "Service Requests (SR)",
+      pathSegment: "operations/service-requests",
+      title: "Outstanding Service Requests",
+      description: "Manage and track outstanding service requests",
+    },
+    {
+      label: "Change Requests (CR)",
+      pathSegment: "operations/change-requests",
+      title: "Outstanding Change Requests",
+      description: "Manage and track outstanding change requests",
+    },
+  ],
+  /**
+   * The donut itself, whose slices are clickable in the same order as the
+   * legend below it.
+   *
+   * Recharts renders each slice as an SVG `path.recharts-sector` with no
+   * accessible name, so they can only be addressed structurally and by
+   * position. There is one per legend entry — including severities with a count
+   * of zero, which still render because the chart sets `minAngle`.
+   */
+  severityChartSlice: "path.recharts-sector",
+  /**
+   * The severity legend of the Outstanding Support Cases donut. Each entry
+   * opens the cases list filtered to that severity.
+   *
+   * `severityId` is the numeric id the URL carries
+   * (SEVERITY_LEGEND_KEY_TO_ID); `title` and `description` are what the
+   * destination renders, both derived from that id rather than from the data,
+   * so they hold even for a severity with no outstanding cases.
+   *
+   * Entries are plain text, not buttons — the whole legend row is the click
+   * target.
+   *
+   * S0 - Catastrophic is deliberately absent: it renders only where
+   * `acceptedSeverityValues` includes P0, which is a per-project policy rather
+   * than something every project shows.
+   */
+  severityLegend: [
+    {
+      label: "S1 - Critical",
+      severityId: "10",
+      title: "Outstanding S1 Cases",
+      description: "Manage and track S1 outstanding support cases",
+    },
+    {
+      label: "S2 - High",
+      severityId: "11",
+      title: "Outstanding S2 Cases",
+      description: "Manage and track S2 outstanding support cases",
+    },
+    {
+      label: "S3 - Medium",
+      severityId: "12",
+      title: "Outstanding S3 Cases",
+      description: "Manage and track S3 outstanding support cases",
+    },
+    {
+      label: "S4 (Query) - Low",
+      severityId: "13",
+      title: "Outstanding S4 Cases",
+      description: "Manage and track S4 outstanding support cases",
+    },
+  ],
+} as const;
+
+/** Calls tab of a case detail page, and its Request Call modal. */
+export const CASE_CALLS = {
+  /** Tab label carries a live count ("Calls (0)"), so it is matched on the
+   * prefix — same as the Attachments tab. */
+  tab: /^Calls/,
+  /** A tab every case carries whatever its status — the marker that the tab
+   * strip has rendered, so an absent Calls tab means withheld rather than not
+   * yet drawn. */
+  alwaysPresentTab: "Activity",
+  /** Statuses that allow call scheduling (CALL_SCHEDULABLE_CASE_STATUSES). A
+   * case outside these — a new one, or a closed one — has no Calls tab at all. */
+  schedulableStatuses: [
+    "Work In Progress",
+    "Awaiting Info",
+    "Waiting on WSO2",
+    "Solution Proposed",
+    "Reopened",
+  ],
+  requestButton: "Request Call",
+  modal: {
+    title: "Request Call",
+    description: "Schedule a call with our support team.",
+    /** `<input type="datetime-local">`, so it takes a "YYYY-MM-DDTHH:mm" value.
+     * Addressed by id: the label carries a required marker and MUI does not tie
+     * it to the input with `for`. */
+    preferredTimeInputId: "preferred-time-0",
+    durationLabel: "Meeting Duration *",
+    reasonLabel: "Reason *",
+    /** Same wording as the button that opened the modal, so any locator for it
+     * must be scoped to the dialog. */
+    submitButton: "Request Call",
+    cancelButton: "Cancel",
+    /** Adds another preferred time. Disabled at the maximum. */
+    addTimeButton: "Add preferred time",
+    /** Removes one, by 1-based position. The first row's is always disabled —
+     * a request must keep at least one preferred time. */
+    removeTimeButton: (position: number) => `Remove preferred time ${position}`,
+    /** MAX_PREFERRED_TIMES in RequestCallModal. */
+    maxPreferredTimes: 3,
+    /** Every duration on offer, in the order the select lists them. */
+    durationOptions: ["15 minutes", "30 minutes", "45 minutes", "1 hour"],
+  },
+  /** A call request as CallRequestCard renders it. */
+  card: {
+    title: "Call Request",
+    preferredTimesLabel: "Preferred Times",
+    durationLabel: "Duration",
+    /** The card always renders raw minutes, whatever the modal called the
+     * option ("1 hour" is shown as "60 minutes"). */
+    durationPattern: /\d+ minutes/,
+    reasonLabel: "Reason / Notes",
+    /** Rendered in place of a value the request does not carry. */
+    emptyValue: "--",
+    /** State a newly created request opens in. */
+    pendingState: "Pending on WSO2",
+    /** Opens the same modal in edit mode. Disabled once the request reaches a
+     * terminal state, so a request an engineer has closed cannot be edited. */
+    rescheduleButton: "Reschedule",
+    /** Opens the cancellation dialog. Disabled on a terminal request, which is
+     * what makes cancelling a one-way move. */
+    cancelButton: "Cancel",
+  },
+  /** Confirmation dialog behind a card's Cancel button. Its own Reason is
+   * required and is separate from the reason the call was requested for. */
+  cancelModal: {
+    title: "Confirm Action",
+    reasonInputId: "cancel-call-reason",
+    confirmButton: "Confirm",
+    goBackButton: "Go Back",
+  },
+  /** The same modal in edit mode, reached from a card's Reschedule button.
+   *
+   * It offers only the preferred times and the duration — the Reason field is
+   * not rendered when editing (`{!isEdit && …}` in RequestCallModal), so a
+   * reschedule cannot change why the call was asked for. */
+  editModal: {
+    title: "Edit Call Request",
+    description:
+      "Update preferred times and meeting duration for this call request.",
+    submitButton: "Update Call Request",
+  },
+  /** Shown *instead of* the request modal when the profile has no time zone
+   * (CallsPanel.handleOpenModal returns early). A prerequisite of the account,
+   * not something a spec can set up, so specs name it in their failure message
+   * rather than trying to work around it. */
+  timeZoneDialogTitle: "Time Zone Not Set",
+} as const;
+
 /** Support Center landing page (`/projects/:projectId/support`), reached from
  * the side nav. Its Outstanding Cases card is the only entry point to the
  * filtered "my cases" list — the URL is otherwise undiscoverable in the UI. */

--- a/apps/customer-portal/webapp/tests/e2e/utils/selectors.ts
+++ b/apps/customer-portal/webapp/tests/e2e/utils/selectors.ts
@@ -467,9 +467,14 @@ export const DASHBOARD = {
    * legend below it.
    *
    * Recharts renders each slice as an SVG `path.recharts-sector` with no
-   * accessible name, so they can only be addressed structurally and by
-   * position. There is one per legend entry — including severities with a count
-   * of zero, which still render because the chart sets `minAngle`.
+   * accessible name, so they can only be addressed structurally and by position.
+   *
+   * How many are drawn depends on the data, and whether a series with a count of
+   * zero gets a sector is not something these specs establish — so a slice's
+   * index must not be taken to mean the legend entry at the same index. Specs
+   * read the severity back from the list a slice opens instead. Every fixture
+   * project currently has cases at all four severities, so the question has not
+   * arisen in practice.
    */
   severityChartSlice: "path.recharts-sector",
   /**


### PR DESCRIPTION
Adds two Playwright suites — call requests on a case, and the project dashboard —
for 65 tests in total. Both are driven from config and parameterised over project
type where the feature is not project-specific.

### Request Call (14 tests)

The call lifecycle on a case's Calls tab, plus field gating across all three of
its dialogs.

- **Happy path (4)** — request a call for tomorrow; reschedule it to the day
  after for an hour; dismiss the Edit modal and confirm the change is discarded;
  cancel a request outright.
- **Validation (8)** — submit gated on a reason and on a preferred time, a time
  before the allowed floor snapping back up, up to three preferred times with the
  first not removable, exactly four durations, no Reason field when rescheduling,
  and Confirm gated on a cancellation reason.
- **Tab availability (2)** — the Calls tab is withheld entirely on a case whose
  status is outside `CALL_SCHEDULABLE_CASE_STATUSES`.

⚠️ Creates permanent records: `POST /cases/{id}/call-requests` has no delete —
cancelling leaves the record behind. The suite files a request only when its own
earlier one is not already on the tab, keyed on a fixed reason, so repeated runs
do not stack them. The cancellation test keeps a *separate* request for the same
reason the attachment suite keeps a separate case: cancelling is terminal and
would leave the reschedule test with a dead button.

The validation half writes **nothing**, and proves it — each test counts the
`POST`/`PATCH` calls that left the browser and asserts zero.

### Dashboard (51 tests)

The project dashboard reached through the side nav, read-only throughout.

- **Stat cards** — all four present, exactly four, and which ones are clickable;
  each of the three clickable cards opens its list; Avg. Response Time opens
  nothing, asserted both by role and by clicking it anyway.
- **Sections** — Outstanding Support Cases and Outstanding Engagements on every
  project; Outstanding Operations only where SR/CR access exists, with expected
  visibility declared per project and its absence asserted where it should not
  render.
- **Severity donut** — all four legend entries and all four pie slices drill down
  to their severity list, each checked against its own entry.
- **Operations donut** (MCS only) — both legend entries and both pie slices drill
  down to the outstanding SR and CR lists.
- **Cases table** — open a case from a row, switch to My Cases, change page size
  to 10, page forward and back, filter by severity and clear it.

### Notes on what the assertions check

Several of these flows change nothing in the URL, so the tests assert the request
on the wire as well as what renders:

- My Cases in the cases table re-queries in place — matched on
  `filters.createdByMe`, with the dashboard URL asserted **unchanged**.
- Page size and paging are matched on `pagination.limit` / `pagination.offset`.
- The severity filter is matched on `filters.severityIds`, and clearing on its
  absence.
- Reschedule and cancel share one endpoint, so `stateKey` and
  `durationInMinutes` in the PATCH body are what tell them apart.
- The operations lists carry `outstandingOnly` in router state, not the URL, so
  the "Outstanding …" heading is the only evidence the chart passed it.

Pie slices are clicked by dispatching the event, not by clicking a point: a slice
is an arc, so its bounding-box centre falls in the donut's hole and both a normal
and a forced click land on nothing (verified live).

### Verification

All 65 pass — Request Call 14, Dashboard 51 (6.2m). `tsc --noEmit` and `eslint`
clean on every touched file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added comprehensive end-to-end coverage for dashboard cards, charts, filters, pagination, case navigation, and project-specific visibility.
  - Added end-to-end coverage for scheduling, rescheduling, and cancelling case calls, including validation, duration selection, preferred times, modal behavior, and request status.
  - Added shared test utilities and selectors to improve reliability when validating dashboard and case-call workflows.
  - Expanded search testing for severity filters, pagination, and empty severity results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->