### PR TITLE
[CSM] Add deployment attachment list and upload routes to backend-v2

### DIFF
--- a/apps/customer-portal/backend-v2/CLAUDE.md
+++ b/apps/customer-portal/backend-v2/CLAUDE.md
@@ -6,7 +6,7 @@ responses for the frontend. This is a rewrite of the existing backend at
 `apps/customer-portal/backend`, modeled on `apps/csm-portal/backend`'s conventions — read that
 backend's own CLAUDE.md too if something here is underspecified.
 
-**Status: in progress.** 105 routes are wired up so far, across seven upstream services:
+**Status: in progress.** 107 routes are wired up so far, across seven upstream services:
 entity-service, the WSO2 Updates service, SCIM, the AI chat agent, the product-consumption
 service, the registry (robot-account) service, and the project-contact onboarding service (see
 "The AI chat agent", "The product-consumption service", "The registry service", and "The
@@ -45,6 +45,7 @@ all). Route list: `GET /health`, `GET`/`PATCH /users/me`, `POST /accounts/search
 `GET /metadata`, `POST /search`, `GET /products/vulnerabilities/meta`,
 `GET /cases/{id}/feedback`, `POST /cases/{id}/feedback`, `GET /cases/{id}/attachments`,
 `GET /attachments/{id}`,
+`GET`/`POST /deployments/{deploymentId}/attachments`,
 `PATCH /deployments/{deploymentId}/attachments/{attachmentId}`,
 `PATCH /cases/{caseId}/attachments/{attachmentId}`,
 `POST /deployments/{deploymentId}/products/{productId}/metrics/search`,

--- a/apps/customer-portal/backend-v2/README.md
+++ b/apps/customer-portal/backend-v2/README.md
@@ -331,6 +331,8 @@ backend-v2/
 - `POST /projects/{id}/deployments/search` — search a project's deployments
 - `POST /projects/{id}/deployments` — create a deployment (ServiceNow data source only)
 - `PATCH /projects/{projectId}/deployments/{id}` — update a deployment's name/type/description, or deactivate it
+- `GET /deployments/{deploymentId}/attachments` — list a deployment's attachments (paged via `limit`/`offset`)
+- `POST /deployments/{deploymentId}/attachments` — upload an attachment to a deployment
 - `PATCH /deployments/{deploymentId}/attachments/{attachmentId}` — update a deployment attachment's name/description
 - `POST /deployments/{deploymentId}/products/search` — search a deployment's deployed products
 - `POST /deployments/{deploymentId}/products` — create a deployed product (ServiceNow data source only)

--- a/apps/customer-portal/backend-v2/cmd/server/main.go
+++ b/apps/customer-portal/backend-v2/cmd/server/main.go
@@ -245,6 +245,8 @@ func main() {
 	// ServiceNow data source — see internal/entity/deployments.go.
 	mux.HandleFunc("POST /projects/{id}/deployments", deploymentHandler.CreateDeployment)
 	mux.HandleFunc("PATCH /projects/{projectId}/deployments/{id}", deploymentHandler.PatchDeployment)
+	mux.HandleFunc("GET /deployments/{deploymentId}/attachments", deploymentHandler.SearchDeploymentAttachments)
+	mux.HandleFunc("POST /deployments/{deploymentId}/attachments", deploymentHandler.CreateDeploymentAttachment)
 	mux.HandleFunc("PATCH /deployments/{deploymentId}/attachments/{attachmentId}", deploymentHandler.PatchDeploymentAttachment)
 	mux.HandleFunc("POST /deployments/{id}/instances/search", instanceHandler.SearchDeploymentInstances)
 	mux.HandleFunc("POST /deployments/{id}/instances/metrics/search", instanceHandler.SearchDeploymentInstanceMetrics)

--- a/apps/customer-portal/backend-v2/internal/dto/attachment.go
+++ b/apps/customer-portal/backend-v2/internal/dto/attachment.go
@@ -245,3 +245,66 @@ func MapUpdatedAttachment(r entity.UpdateAttachmentResponse) UpdatedAttachment {
 		UpdatedBy: r.Attachment.UpdatedBy,
 	}
 }
+
+// CreateDeploymentAttachmentRequest mirrors the frontend's
+// PostDeploymentAttachmentRequest field-for-field. Like its case counterpart
+// there is no referenceId field: the deployment is scoped by the
+// {deploymentId} path parameter, never the body.
+type CreateDeploymentAttachmentRequest struct {
+	Name        string  `json:"name"`
+	Type        string  `json:"type"`
+	Content     string  `json:"content"`
+	Description *string `json:"description,omitempty"`
+}
+
+// BuildEntityCreateDeploymentAttachmentRequest translates the portal's request
+// into entity-service's CreateAttachmentRequest, forcing ReferenceID (from the
+// path) and ReferenceType to deployment, and renaming Content->File to match
+// entity-service's own field name.
+func BuildEntityCreateDeploymentAttachmentRequest(deploymentID string, req CreateDeploymentAttachmentRequest) entity.CreateAttachmentRequest {
+	return entity.CreateAttachmentRequest{
+		ReferenceID:   deploymentID,
+		ReferenceType: entity.ReferenceTypeDeployment,
+		Name:          req.Name,
+		Type:          req.Type,
+		File:          req.Content,
+		Description:   req.Description,
+	}
+}
+
+// DeploymentAttachmentsResponse is the portal's response for
+// GET /deployments/{deploymentId}/attachments. TotalRecords (not Total) to
+// match the frontend's shared pagination envelope, same as the case variant.
+type DeploymentAttachmentsResponse struct {
+	Attachments  []AttachmentSummary `json:"attachments"`
+	Offset       int                 `json:"offset"`
+	Limit        int                 `json:"limit"`
+	TotalRecords int                 `json:"totalRecords"`
+}
+
+// MapDeploymentAttachments builds the portal response from entity-service's
+// attachment search.
+func MapDeploymentAttachments(r entity.SearchAttachmentsResponse) DeploymentAttachmentsResponse {
+	items := make([]AttachmentSummary, 0, len(r.Attachments))
+	for _, a := range r.Attachments {
+		items = append(items, AttachmentSummary{
+			ID:            a.ID,
+			ReferenceID:   a.ReferenceID,
+			ReferenceType: string(a.ReferenceType),
+			Name:          a.Name,
+			Type:          a.Type,
+			SizeBytes:     a.SizeBytes,
+			Description:   a.Description,
+			CreatedBy:     a.CreatedBy,
+			CreatedOn:     a.CreatedOn,
+			DownloadURL:   a.DownloadURL,
+			PreviewURL:    a.PreviewURL,
+		})
+	}
+	return DeploymentAttachmentsResponse{
+		Attachments:  items,
+		Offset:       r.Offset,
+		Limit:        r.Limit,
+		TotalRecords: r.Total,
+	}
+}

--- a/apps/customer-portal/backend-v2/internal/handler/deployment_attachments_test.go
+++ b/apps/customer-portal/backend-v2/internal/handler/deployment_attachments_test.go
@@ -1,0 +1,120 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+)
+
+const testDeploymentID = "22222222-2222-2222-2222-222222222222"
+
+// attachFakeEntity records what the handler sent upstream.
+type attachFakeEntity struct {
+	entityDeploymentClient
+	gotSearch entity.SearchAttachmentsRequest
+	gotCreate entity.CreateAttachmentRequest
+}
+
+func (f *attachFakeEntity) SearchAttachments(_ context.Context, req entity.SearchAttachmentsRequest) (entity.SearchAttachmentsResponse, error) {
+	f.gotSearch = req
+	return entity.SearchAttachmentsResponse{Total: 0, Limit: req.Pagination.Limit, Offset: req.Pagination.Offset}, nil
+}
+
+func (f *attachFakeEntity) CreateAttachment(_ context.Context, req entity.CreateAttachmentRequest) (entity.CreateAttachmentResponse, error) {
+	f.gotCreate = req
+	return entity.CreateAttachmentResponse{}, nil
+}
+
+// TestSearchDeploymentAttachments_ScopesToPathDeployment checks the route reaches
+// the handler with deploymentId populated, and that the upstream search is scoped
+// by the path value and forced to referenceType=deployment — the deployment must
+// never come from a query parameter or body.
+func TestSearchDeploymentAttachments_ScopesToPathDeployment(t *testing.T) {
+	fake := &attachFakeEntity{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /deployments/{deploymentId}/attachments", NewDeploymentHandler(fake).SearchDeploymentAttachments)
+
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, authedRequest(http.MethodGet, "/deployments/"+testDeploymentID+"/attachments?limit=25&offset=50", ""))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body: %s)", w.Code, w.Body.String())
+	}
+	if fake.gotSearch.ReferenceID != testDeploymentID {
+		t.Errorf("ReferenceID = %q, want the path deploymentId %q", fake.gotSearch.ReferenceID, testDeploymentID)
+	}
+	if fake.gotSearch.ReferenceType != entity.ReferenceTypeDeployment {
+		t.Errorf("ReferenceType = %q, want %q", fake.gotSearch.ReferenceType, entity.ReferenceTypeDeployment)
+	}
+	if fake.gotSearch.Pagination.Limit != 25 || fake.gotSearch.Pagination.Offset != 50 {
+		t.Errorf("pagination = %+v, want limit 25 offset 50 from the query string", fake.gotSearch.Pagination)
+	}
+}
+
+// TestSearchDeploymentAttachments_RejectsNonUUID guards the path-param check.
+func TestSearchDeploymentAttachments_RejectsNonUUID(t *testing.T) {
+	fake := &attachFakeEntity{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /deployments/{deploymentId}/attachments", NewDeploymentHandler(fake).SearchDeploymentAttachments)
+
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, authedRequest(http.MethodGet, "/deployments/not-a-uuid/attachments", ""))
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+	if fake.gotSearch.ReferenceID != "" {
+		t.Error("upstream was called despite an invalid deploymentId")
+	}
+}
+
+// TestCreateDeploymentAttachment_ForcesReferenceFromPath is the security-relevant
+// case: a client supplying its own referenceId/referenceType in the body must not
+// be able to attach a file to another deployment. The portal request DTO has no
+// such fields, and the reference is always injected from the path.
+func TestCreateDeploymentAttachment_ForcesReferenceFromPath(t *testing.T) {
+	fake := &attachFakeEntity{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /deployments/{deploymentId}/attachments", NewDeploymentHandler(fake).CreateDeploymentAttachment)
+
+	body := `{"name":"runbook.pdf","type":"application/pdf","content":"YmFzZTY0","referenceId":"99999999-9999-9999-9999-999999999999","referenceType":"case"}`
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, authedRequest(http.MethodPost, "/deployments/"+testDeploymentID+"/attachments", body))
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201 (body: %s)", w.Code, w.Body.String())
+	}
+	if fake.gotCreate.ReferenceID != testDeploymentID {
+		t.Errorf("ReferenceID = %q, want the path value %q — a body-supplied reference must never win",
+			fake.gotCreate.ReferenceID, testDeploymentID)
+	}
+	if fake.gotCreate.ReferenceType != entity.ReferenceTypeDeployment {
+		t.Errorf("ReferenceType = %q, want %q", fake.gotCreate.ReferenceType, entity.ReferenceTypeDeployment)
+	}
+	// Content is renamed to File for entity-service's own field name.
+	if fake.gotCreate.File != "YmFzZTY0" {
+		t.Errorf("File = %q, want the request's content value", fake.gotCreate.File)
+	}
+	if fake.gotCreate.Name != "runbook.pdf" {
+		t.Errorf("Name = %q, want runbook.pdf", fake.gotCreate.Name)
+	}
+}

--- a/apps/customer-portal/backend-v2/internal/handler/deployments.go
+++ b/apps/customer-portal/backend-v2/internal/handler/deployments.go
@@ -34,6 +34,8 @@ type entityDeploymentClient interface {
 	CreateDeployment(ctx context.Context, req entity.CreateDeploymentRequest) (entity.CreateDeploymentResponse, error)
 	UpdateDeployment(ctx context.Context, id string, req entity.UpdateDeploymentRequest) (entity.UpdateDeploymentResponse, error)
 	UpdateAttachment(ctx context.Context, id string, req entity.UpdateAttachmentRequest) (entity.UpdateAttachmentResponse, error)
+	SearchAttachments(ctx context.Context, req entity.SearchAttachmentsRequest) (entity.SearchAttachmentsResponse, error)
+	CreateAttachment(ctx context.Context, req entity.CreateAttachmentRequest) (entity.CreateAttachmentResponse, error)
 }
 
 // DeploymentHandler handles HTTP requests for deployment operations.
@@ -215,4 +217,77 @@ func (h *DeploymentHandler) PatchDeploymentAttachment(w http.ResponseWriter, r *
 	}
 
 	writeJSONValue(w, http.StatusOK, dto.MapUpdatedAttachment(result))
+}
+
+// SearchDeploymentAttachments handles GET /deployments/{deploymentId}/attachments.
+//
+// Deployment attachments are stored through entity-service's generic attachment
+// API, keyed by reference — this is the deployment-scoped read of it, the exact
+// counterpart of CaseHandler.SearchCaseAttachments. The reference type is forced
+// to deployment and the reference ID comes from the path, never the query.
+func (h *DeploymentHandler) SearchDeploymentAttachments(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	deploymentID := r.PathValue("deploymentId")
+	if deploymentID == "" || !uuidRe.MatchString(deploymentID) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	limit, offset, ok := parseLimitOffset(w, r)
+	if !ok {
+		return
+	}
+
+	result, err := h.entity.SearchAttachments(r.Context(), entity.SearchAttachmentsRequest{
+		ReferenceID:   deploymentID,
+		ReferenceType: entity.ReferenceTypeDeployment,
+		Pagination:    entity.Pagination{Limit: limit, Offset: offset},
+	})
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity SearchAttachments failed", "userID", user.UserID, "deploymentID", deploymentID, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to retrieve deployment attachments.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusOK, dto.MapDeploymentAttachments(result))
+}
+
+// CreateDeploymentAttachment handles POST /deployments/{deploymentId}/attachments.
+func (h *DeploymentHandler) CreateDeploymentAttachment(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	deploymentID := r.PathValue("deploymentId")
+	if deploymentID == "" || !uuidRe.MatchString(deploymentID) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	body, ok := readJSONBody(w, r)
+	if !ok {
+		return
+	}
+
+	var req dto.CreateDeploymentAttachmentRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.CreateAttachment(r.Context(), dto.BuildEntityCreateDeploymentAttachmentRequest(deploymentID, req))
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity CreateAttachment failed", "userID", user.UserID, "deploymentID", deploymentID, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to create deployment attachment.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusCreated, dto.MapAttachmentCreate(result))
 }

--- a/apps/customer-portal/backend-v2/openapi.yaml
+++ b/apps/customer-portal/backend-v2/openapi.yaml
@@ -3986,6 +3986,121 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
+  /deployments/{deploymentId}/attachments:
+    get:
+      summary: List a deployment's attachments.
+      operationId: getDeploymentsDeploymentIdAttachments
+      parameters:
+        - name: deploymentId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: limit
+          in: query
+          schema:
+            type: integer
+        - name: offset
+          in: query
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeploymentAttachmentsResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: NotFound
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+    post:
+      summary: Upload an attachment to a deployment.
+      operationId: postDeploymentsDeploymentIdAttachments
+      parameters:
+        - name: deploymentId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateDeploymentAttachmentRequest'
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AttachmentCreateResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: NotFound
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: PayloadTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
   /deployments/{deploymentId}/attachments/{attachmentId}:
     patch:
       summary: Update a deployment's attachment.
@@ -6998,6 +7113,40 @@ components:
         description:
           type: string
 
+    DeploymentAttachmentsResponse:
+      type: object
+      properties:
+        attachments:
+          type: array
+          items:
+            $ref: '#/components/schemas/AttachmentSummary'
+        offset:
+          type: integer
+        limit:
+          type: integer
+        totalRecords:
+          type: integer
+    CreateDeploymentAttachmentRequest:
+      type: object
+      description: >-
+        The deployment is taken from the {deploymentId} path parameter; there is
+        deliberately no referenceId/referenceType field, so a client cannot
+        attach a file to a different entity.
+      required:
+        - name
+        - type
+        - content
+      properties:
+        name:
+          type: string
+        type:
+          type: string
+        content:
+          type: string
+          description: Base64-encoded file content.
+        description:
+          type: string
+          nullable: true
     AttachmentCreateResponse:
       type: object
       properties:


### PR DESCRIPTION
Resolves wso2-enterprise/digiops-cs#2792 (epic wso2-enterprise/digiops-cs#2751).

## Summary

**Four frontend hooks call routes backend-v2 never implemented**, so deployment documents can currently be neither listed nor uploaded:

| Hook | Call |
|---|---|
| `useGetDeploymentDocuments` | `GET /deployments/{id}/attachments` |
| `useInfiniteDeploymentDocuments` | `GET /deployments/{id}/attachments?limit&offset` |
| `usePostDeploymentAttachment` | `POST /deployments/{id}/attachments` |

Only `PATCH /deployments/{deploymentId}/attachments/{attachmentId}` existed — an attachment could be renamed, but never created or read.

**No new upstream capability was needed.** entity-service stores attachments through its generic reference-keyed API, `entity.ReferenceTypeDeployment` already exists, and `POST /attachments` + `POST /attachments/search` were already wired. These two routes are just the deployment-scoped URL shape the frontend expects, mirroring `CaseHandler.SearchCaseAttachments`/`CreateCaseAttachment`.

- `SearchDeploymentAttachments` / `CreateDeploymentAttachment` on `DeploymentHandler`
- `dto.MapDeploymentAttachments` returns `totalRecords` (not `total`) to match the frontend's shared pagination envelope
- README, CLAUDE.md route inventory (105 → 107), `openapi.yaml`

## The reference can't be spoofed

`dto.CreateDeploymentAttachmentRequest` deliberately has **no** `referenceId`/`referenceType` field. Both are injected from the `{deploymentId}` path value, so a client cannot attach a file to a different entity — the same rule as the case-attachment path and the project-scoping rule in CLAUDE.md. A test sends a body containing `referenceId` and `referenceType: "case"` and asserts the path value still wins.

## Test plan

Container (no local Go toolchain):

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` — clean
- [x] `go test -race ./...` — all pass, incl. 3 new `*DeploymentAttachment*` tests
- [x] `gosec -fmt=text ./...` — **0 issues**
- [x] `openapi.yaml` parses; both methods and both new schemas present
- [ ] Staging: open a deployment's Documents tab, confirm the list loads, then upload a file

## Note on the spec

The two new paths use inline error responses referencing `ErrorPayload`, matching the rest of this file — my first attempt referenced a `components/responses` section that doesn't exist here, which would have produced an unresolvable spec.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deployment-scoped attachment endpoints for listing and uploading attachments.
  * Added pagination support for attachment listings using optional limit and offset parameters.
  * Added validation to ensure deployment identifiers are valid and attachment uploads use the deployment specified in the URL.
* **Documentation**
  * Updated API documentation and route inventory with the new attachment capabilities.
* **Tests**
  * Added coverage for deployment scoping, identifier validation, pagination, and upload behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->