### PR TITLE
[CSM] Decode missing case-detail fields (closedBy, engagement dates, SLA response time)

### DIFF
--- a/apps/customer-portal/backend-v2/internal/dto/case.go
+++ b/apps/customer-portal/backend-v2/internal/dto/case.go
@@ -361,7 +361,16 @@ type CaseDetails struct {
 	ResolutionNotes       *string                      `json:"resolutionNotes,omitempty"`
 	WatchList             []CaseWatchListUser          `json:"watchList,omitempty"`
 	FixEta                *time.Time                   `json:"fixEta,omitempty"`
-	Tags                  []CaseTag                    `json:"tags,omitempty"`
+	// Exposed because the frontend's CaseDetails type declares them
+	// (features/support/types/cases.ts). AcknowledgedBy and
+	// EngagementPaymentType are decoded upstream but deliberately NOT exposed:
+	// no frontend consumer, so per CLAUDE.md they stay trimmed until one exists.
+	SLAResponseTime     *string   `json:"slaResponseTime,omitempty"`
+	ClosedBy            *Ref      `json:"closedBy,omitempty"`
+	HasAutoClosed       *bool     `json:"hasAutoClosed,omitempty"`
+	EngagementStartDate *string   `json:"engagementStartDate,omitempty"`
+	EngagementEndDate   *string   `json:"engagementEndDate,omitempty"`
+	Tags                []CaseTag `json:"tags,omitempty"`
 }
 
 // MapCaseDetails builds the portal response from entity-service's CaseView.
@@ -450,6 +459,11 @@ func MapCaseDetails(c entity.CaseView) CaseDetails {
 		ResolutionNotes:       c.ResolutionNotes,
 		WatchList:             watchList,
 		FixEta:                c.FixEta,
+		SLAResponseTime:       c.SLAResponseTime,
+		ClosedBy:              mapRef(c.ClosedBy),
+		HasAutoClosed:         c.HasAutoClosed,
+		EngagementStartDate:   c.EngagementStartDate,
+		EngagementEndDate:     c.EngagementEndDate,
 		Tags:                  tags,
 	}
 }

--- a/apps/customer-portal/backend-v2/internal/dto/case_detail_fields_test.go
+++ b/apps/customer-portal/backend-v2/internal/dto/case_detail_fields_test.go
@@ -1,0 +1,113 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dto
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+)
+
+// TestMapCaseDetails_ExposesFieldsTheFrontendDeclares covers the five fields
+// added because the frontend's CaseDetails type declares them
+// (features/support/types/cases.ts) while this backend never sent them —
+// entity-service was discarding them from the upstream case response.
+func TestMapCaseDetails_ExposesFieldsTheFrontendDeclares(t *testing.T) {
+	sla := "4 hours"
+	start, end := "2026-01-01", "2026-06-30"
+	auto := true
+
+	raw, err := json.Marshal(MapCaseDetails(entity.CaseView{
+		SLAResponseTime:     &sla,
+		ClosedBy:            &entity.EntityRef{ID: "user-1", Name: "Closer"},
+		HasAutoClosed:       &auto,
+		EngagementStartDate: &start,
+		EngagementEndDate:   &end,
+	}))
+	if err != nil {
+		t.Fatalf("marshal returned error: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("result is not valid JSON: %v", err)
+	}
+
+	if got["slaResponseTime"] != sla {
+		t.Errorf("slaResponseTime = %v, want %q", got["slaResponseTime"], sla)
+	}
+	if got["engagementStartDate"] != start || got["engagementEndDate"] != end {
+		t.Errorf("engagement dates = %v/%v, want %q/%q",
+			got["engagementStartDate"], got["engagementEndDate"], start, end)
+	}
+	if got["hasAutoClosed"] != true {
+		t.Errorf("hasAutoClosed = %v, want true", got["hasAutoClosed"])
+	}
+	cb, ok := got["closedBy"].(map[string]any)
+	if !ok {
+		t.Fatalf("closedBy = %v, want an object", got["closedBy"])
+	}
+	if cb["id"] != "user-1" {
+		t.Errorf("closedBy.id = %v, want user-1", cb["id"])
+	}
+}
+
+// TestMapCaseDetails_TrimsFieldsWithNoConsumer pins the deliberate boundary:
+// acknowledgedBy and engagementPaymentType are decoded upstream for parity with
+// the Ballerina entity-service, but must NOT reach the customer-facing response
+// while no frontend consumer exists — per CLAUDE.md's "restrict, don't mirror"
+// rule. The fix-ETA quartet is trimmed for the stronger reason that it is
+// CSM-internal.
+func TestMapCaseDetails_TrimsFieldsWithNoConsumer(t *testing.T) {
+	raw, err := json.Marshal(MapCaseDetails(entity.CaseView{
+		AcknowledgedBy:        &entity.EntityRef{ID: "user-2", Name: "Acker"},
+		EngagementPaymentType: strPtr("Prepaid"),
+	}))
+	if err != nil {
+		t.Fatalf("marshal returned error: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("result is not valid JSON: %v", err)
+	}
+
+	for _, k := range []string{"acknowledgedBy", "engagementPaymentType", "bestCaseFixEta", "mostLikelyFixEta", "worstCaseFixEta"} {
+		if _, present := got[k]; present {
+			t.Errorf("%q leaked into the customer-facing case response", k)
+		}
+	}
+}
+
+// TestMapCaseDetails_OmitsAbsentFields checks a case response carrying none of
+// these values omits the keys rather than emitting nulls or zero values.
+func TestMapCaseDetails_OmitsAbsentFields(t *testing.T) {
+	raw, err := json.Marshal(MapCaseDetails(entity.CaseView{}))
+	if err != nil {
+		t.Fatalf("marshal returned error: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("result is not valid JSON: %v", err)
+	}
+	for _, k := range []string{"slaResponseTime", "closedBy", "hasAutoClosed", "engagementStartDate", "engagementEndDate"} {
+		if _, present := got[k]; present {
+			t.Errorf("%q present with no upstream value; want omitted", k)
+		}
+	}
+}
+
+func strPtr(s string) *string { return &s }

--- a/apps/customer-portal/backend-v2/internal/entity/types.go
+++ b/apps/customer-portal/backend-v2/internal/entity/types.go
@@ -738,7 +738,16 @@ type CaseView struct {
 	// CaseView), and the customer portal must not surface internal WSO2 support
 	// workflow state to end customers.
 	FixEta *time.Time `json:"fixEta"`
-	Tags   []Tag      `json:"tags"`
+	// Supplied by entity-service; previously not decoded here at all.
+	// Nullable throughout — nil means the upstream gave no value.
+	SLAResponseTime       *string    `json:"slaResponseTime"`
+	ClosedBy              *EntityRef `json:"closedBy"`
+	HasAutoClosed         *bool      `json:"hasAutoClosed"`
+	EngagementStartDate   *string    `json:"engagementStartDate"`
+	EngagementEndDate     *string    `json:"engagementEndDate"`
+	AcknowledgedBy        *EntityRef `json:"acknowledgedBy"`
+	EngagementPaymentType *string    `json:"engagementPaymentType"`
+	Tags                  []Tag      `json:"tags"`
 }
 
 // --- deployments ---

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -1515,6 +1515,16 @@ type CaseView struct {
 	// Choreo GET /cases/{id} contract returns them. This field is always nil until
 	// a Ballerina endpoint surfaces the case's tags.
 	Tags []Tag `json:"tags"`
+	// Fields the upstream case response supplies that consumers read directly.
+	// Nullable throughout: nil means the source gave no value, not zero.
+	// Names mirror the Ballerina entity-service CaseResponse record.
+	SLAResponseTime       *string    `json:"slaResponseTime"`
+	ClosedBy              *EntityRef `json:"closedBy"`
+	HasAutoClosed         *bool      `json:"hasAutoClosed"`
+	EngagementStartDate   *string    `json:"engagementStartDate"`
+	EngagementEndDate     *string    `json:"engagementEndDate"`
+	AcknowledgedBy        *EntityRef `json:"acknowledgedBy"`
+	EngagementPaymentType *string    `json:"engagementPaymentType"`
 }
 
 // Tag is a free-text label attached to a case via ServiceNow's generic

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -117,6 +117,16 @@ type snCase struct {
 	// include a "worstCaseFixEta" key today, so this always unmarshals to nil. Ask:
 	// add a "worstCaseFixEta" (glide_date) field to the case response.
 	WorstCaseFixEta *string `json:"worstCaseFixEta"`
+	// Fields the Ballerina entity-service declares on CaseResponse that were
+	// not declared here, so encoding/json discarded them. All nullable: an
+	// absent key stays nil rather than becoming a zero value.
+	SLAResponseTime       *string          `json:"slaResponseTime"`
+	ClosedBy              *snCaseEntityRef `json:"closedBy"`
+	HasAutoClosed         *bool            `json:"hasAutoClosed"`
+	EngagementStartDate   *string          `json:"engagementStartDate"`
+	EngagementEndDate     *string          `json:"engagementEndDate"`
+	AcknowledgedBy        *snCaseEntityRef `json:"acknowledgedBy"`
+	EngagementPaymentType *snCaseLabel     `json:"engagementPaymentType"`
 }
 
 // snWatchListUser mirrors the watch-list user shape ServiceNow/Ballerina returns on both
@@ -903,6 +913,23 @@ func (s *snCaseService) GetCaseByID(ctx context.Context, id string) (domain.Case
 	}
 	if c.WorstCaseFixEta != nil && *c.WorstCaseFixEta != "" {
 		cv.WorstCaseFixEta = c.WorstCaseFixEta
+	}
+
+	// Pass-through of the fields declared alongside the fix-ETA group above.
+	// Refs get sysidToUUID applied like every other inbound ID; the date fields
+	// are already date-only strings on both sides, so no reformatting.
+	cv.SLAResponseTime = c.SLAResponseTime
+	cv.HasAutoClosed = c.HasAutoClosed
+	cv.EngagementStartDate = c.EngagementStartDate
+	cv.EngagementEndDate = c.EngagementEndDate
+	if c.ClosedBy != nil {
+		cv.ClosedBy = &domain.EntityRef{ID: sysidToUUID(c.ClosedBy.ID), Name: c.ClosedBy.Name}
+	}
+	if c.AcknowledgedBy != nil {
+		cv.AcknowledgedBy = &domain.EntityRef{ID: sysidToUUID(c.AcknowledgedBy.ID), Name: c.AcknowledgedBy.Name}
+	}
+	if c.EngagementPaymentType != nil && c.EngagementPaymentType.Label != "" {
+		cv.EngagementPaymentType = &c.EngagementPaymentType.Label
 	}
 	// Tags are not populated: not yet available in the backing service, see the
 	// CaseView.Tags doc comment. cv.Tags is left nil.

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -6737,6 +6737,25 @@ components:
           description: >-
             Internal-only worst-case fix-commitment date (date-only, YYYY-MM-DD), visible to
             CSM engineers only. Populated for ServiceNow cases; null otherwise.
+        slaResponseTime:
+          type: string
+          nullable: true
+        closedBy:
+          $ref: '#/components/schemas/EntityRef'
+        hasAutoClosed:
+          type: boolean
+          nullable: true
+        engagementStartDate:
+          type: string
+          nullable: true
+        engagementEndDate:
+          type: string
+          nullable: true
+        acknowledgedBy:
+          $ref: '#/components/schemas/EntityRef'
+        engagementPaymentType:
+          type: string
+          nullable: true
 
     CaseSearchView:
       type: object


### PR DESCRIPTION
Resolves wso2-enterprise/digiops-cs#2808 (epic wso2-enterprise/digiops-cs#2751).

## Summary

Same class as the deployment-count bug in #1475: the Ballerina entity-service declares these on `CaseResponse`, the Go `snCase` struct didn't, so `encoding/json` discarded whatever ServiceNow sent. The frontend's `CaseDetails` type declares five of them.

**entity-service** — declare and map, with `sysidToUUID()` on the refs like every other inbound ID:
`slaResponseTime`, `closedBy`, `hasAutoClosed`, `engagementStartDate`, `engagementEndDate`, `acknowledgedBy`, `engagementPaymentType`

**backend-v2** — decode all seven, expose the five the frontend declares (`features/support/types/cases.ts:272,290,291,296,298`).

## The exposure boundary is deliberate

| Field | Exposed? | Why |
|---|---|---|
| the five above | **yes** | frontend's `CaseDetails` declares them |
| `acknowledgedBy`, `engagementPaymentType` | **no** | decoded for parity, no frontend consumer — CLAUDE.md's "restrict, don't mirror" keeps them trimmed |
| fix-ETA quartet | **no** | CSM-internal; must never reach a customer |

A test asserts the trimmed fields don't leak, so widening exposure has to be deliberate rather than accidental. All fields are nullable end to end and **omitted rather than nulled** when absent — a case with no engagement dates shouldn't grow keys.

## Caveat worth reviewing

**Ballerina declaring a field proves it's *expected*, not that ServiceNow populates it.** The existing fix-ETA fields sit in `snCase` with comments saying ServiceNow doesn't send them today and they always unmarshal to `nil` — precedent for exactly this.

For `deployedProductCount` (#1475) we had hard proof: the working page. Here the evidence is circumstantial — the frontend reads these and works against the Ballerina backend. Declaring them is safe either way (absent stays `nil`, and the frontend handles missing keys), but don't expect all five to light up until verified against a real staging case response.

## Test plan

- [x] `go build ./...` — entity-service, backend-v2
- [x] `go vet ./...` — both
- [x] `gofmt -l .` — clean, both
- [x] `go test -race ./...` — all pass, incl. 3 new `TestMapCaseDetails_*`
- [x] `gosec -fmt=text ./...` — **0 issues**, both
- [x] `entity-service/openapi.yaml` parses with the new `CaseView` properties
- [ ] Staging: a closed case for `closedBy`/`hasAutoClosed`; an engagement case for the date fields

## Deployment order

**entity-service first, then backend-v2.** Unlike the `createdBy` change, deploying backend-v2 alone is harmless here — the fields just stay absent, as today.

