### PR TITLE
[CSM Portal] Fix product search duplicates and version search failures

### DIFF
--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -578,10 +578,14 @@ type Product struct {
 }
 
 // SearchProductsRequest is the input for a product search operation.
-// SearchQuery is matched case-insensitively against name.
+// SearchQuery is matched case-insensitively against name. Class optionally
+// restricts results to a single product class; the set of accepted values
+// and the default applied when it is empty both depend on the active data
+// source — see the Postgres- and ServiceNow-backed search implementations.
 type SearchProductsRequest struct {
 	Pagination  Pagination `json:"pagination"`
 	SearchQuery string     `json:"searchQuery"`
+	Class       string     `json:"class"`
 }
 
 // SearchProductsResponse is the paginated result of a product search.

--- a/entity-service/internal/repository/product_repo.go
+++ b/entity-service/internal/repository/product_repo.go
@@ -58,6 +58,12 @@ func (r *productRepo) SearchProducts(ctx context.Context, req domain.SearchProdu
 		argIdx++
 	}
 
+	if req.Class != "" {
+		where += fmt.Sprintf(" AND class = $%d::product_class_enum", argIdx)
+		filterArgs = append(filterArgs, req.Class)
+		argIdx++
+	}
+
 	countQuery := "SELECT COUNT(*) FROM products " + where
 
 	dataQuery := fmt.Sprintf(

--- a/entity-service/internal/service/product_service.go
+++ b/entity-service/internal/service/product_service.go
@@ -20,9 +20,19 @@ package service
 import (
 	"context"
 
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/repository"
 )
+
+// validProductClass enumerates the class values the products table accepts.
+// Unlike the ServiceNow-backed search, an empty Class here means "no
+// filter" — the products table already stores one row per distinct
+// product, so there is no version-duplication problem to default around.
+var validProductClass = map[domain.ProductClass]bool{
+	domain.ProductClassSoftware: true,
+	domain.ProductClassService:  true,
+}
 
 type productService struct {
 	repo repository.ProductRepository
@@ -40,6 +50,9 @@ func (s *productService) SearchProducts(ctx context.Context, req domain.SearchPr
 	}
 	if err := validateSearchQuery(req.SearchQuery); err != nil {
 		return domain.SearchProductsResponse{}, err
+	}
+	if req.Class != "" && !validProductClass[domain.ProductClass(req.Class)] {
+		return domain.SearchProductsResponse{}, &apierror.ValidationError{Msg: "invalid class"}
 	}
 
 	products, total, err := s.repo.SearchProducts(ctx, req)

--- a/entity-service/internal/service/product_service_test.go
+++ b/entity-service/internal/service/product_service_test.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+)
+
+// fakeProductRepo captures the request it was called with so tests can
+// assert on what the service layer forwards to the repository, without a
+// live Postgres connection.
+type fakeProductRepo struct {
+	gotReq domain.SearchProductsRequest
+}
+
+func (f *fakeProductRepo) SearchProducts(_ context.Context, req domain.SearchProductsRequest) ([]domain.Product, int, error) {
+	f.gotReq = req
+	return []domain.Product{}, 0, nil
+}
+
+// TestProductService_SearchProducts_EmptyClassIsUnfiltered guards against
+// reintroducing the ServiceNow-only "product_model" default on the
+// Postgres-backed path: the products table already stores one row per
+// distinct product, so an empty Class must reach the repository unchanged
+// (empty), not be defaulted to any value.
+func TestProductService_SearchProducts_EmptyClassIsUnfiltered(t *testing.T) {
+	repo := &fakeProductRepo{}
+	svc := NewProductService(repo)
+
+	_, err := svc.SearchProducts(context.Background(), domain.SearchProductsRequest{
+		Pagination: domain.Pagination{Limit: 20, Offset: 0},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if repo.gotReq.Class != "" {
+		t.Fatalf("expected empty class to reach repo unfiltered, got %q", repo.gotReq.Class)
+	}
+}
+
+// TestProductService_SearchProducts_ExplicitClassForwarded verifies an
+// explicit, valid class value reaches the repository unchanged so it can be
+// applied as a SQL predicate.
+func TestProductService_SearchProducts_ExplicitClassForwarded(t *testing.T) {
+	for _, class := range []string{"software", "service"} {
+		t.Run(class, func(t *testing.T) {
+			repo := &fakeProductRepo{}
+			svc := NewProductService(repo)
+
+			_, err := svc.SearchProducts(context.Background(), domain.SearchProductsRequest{
+				Pagination: domain.Pagination{Limit: 20, Offset: 0},
+				Class:      class,
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if repo.gotReq.Class != class {
+				t.Fatalf("expected class %q forwarded to repo, got %q", class, repo.gotReq.Class)
+			}
+		})
+	}
+}
+
+// TestProductService_SearchProducts_RejectsUnknownClass ensures an invalid
+// class value never reaches the repository (and so can never be
+// interpolated into the SQL predicate).
+func TestProductService_SearchProducts_RejectsUnknownClass(t *testing.T) {
+	repo := &fakeProductRepo{}
+	svc := NewProductService(repo)
+
+	_, err := svc.SearchProducts(context.Background(), domain.SearchProductsRequest{
+		Pagination: domain.Pagination{Limit: 20, Offset: 0},
+		Class:      "product_model", // valid for the SN path, not for Postgres
+	})
+	if err == nil {
+		t.Fatal("expected validation error for unknown class, got nil")
+	}
+}

--- a/entity-service/internal/service/sn_product_service.go
+++ b/entity-service/internal/service/sn_product_service.go
@@ -21,10 +21,27 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/middleware"
 	integrationservice "github.com/wso2-open-operations/cs-tools/entity-service/internal/servicenow-integration-service"
 )
+
+// defaultSNProductClass is applied when the caller sends no class filter.
+// The Choreo product search endpoint's underlying catalog stores one row per
+// distinct product under this class, and one row per product *version*
+// under snProductClassSoftwareModel/snProductClassServiceModel. Defaulting
+// to the product-level class keeps unfiltered searches from returning
+// several rows for the same product name (one per version).
+const defaultSNProductClass = "product_model"
+
+// validSNProductClass enumerates every class value the Choreo product search
+// endpoint accepts.
+var validSNProductClass = map[string]bool{
+	"product_model":  true,
+	"software_model": true,
+	"service_model":  true,
+}
 
 // snProductsResponse mirrors the Choreo POST /products/search response.
 type snProductsResponse struct {
@@ -48,6 +65,7 @@ type snProductSearchPayload struct {
 
 type snProductFilters struct {
 	SearchQuery string `json:"searchQuery,omitempty"`
+	Class       string `json:"class,omitempty"`
 }
 
 type snProductService struct {
@@ -67,10 +85,17 @@ func (s *snProductService) SearchProducts(ctx context.Context, req domain.Search
 		return domain.SearchSNProductsResponse{}, err
 	}
 
+	class := req.Class
+	if class == "" {
+		class = defaultSNProductClass
+	} else if !validSNProductClass[class] {
+		return domain.SearchSNProductsResponse{}, &apierror.ValidationError{Msg: "invalid class"}
+	}
+
 	token := middleware.UserIDTokenFromContext(ctx)
 
 	payload := snProductSearchPayload{
-		Filters:    snProductFilters{SearchQuery: req.SearchQuery},
+		Filters:    snProductFilters{SearchQuery: req.SearchQuery, Class: class},
 		Pagination: snProjectPagination{Limit: req.Pagination.Limit, Offset: req.Pagination.Offset},
 	}
 

--- a/entity-service/internal/service/sn_product_service_test.go
+++ b/entity-service/internal/service/sn_product_service_test.go
@@ -1,0 +1,118 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package service
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+)
+
+// TestSNProductService_SearchProducts_DefaultsClassToProductModel guards
+// against regressing to the pre-fix behavior where an unfiltered product
+// search returned one row per product *version* (e.g. 20 rows all named
+// "Identity Server") instead of one row per distinct product. When the
+// caller sends no class, the request forwarded to the Choreo product search
+// endpoint must carry class=product_model.
+func TestSNProductService_SearchProducts_DefaultsClassToProductModel(t *testing.T) {
+	var gotFilters snProductFilters
+	mux := http.NewServeMux()
+	mux.HandleFunc("/products/search", func(w http.ResponseWriter, r *http.Request) {
+		var payload snProductSearchPayload
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		gotFilters = payload.Filters
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"products":     []map[string]any{},
+			"totalRecords": 0, "offset": 0, "limit": 20,
+		})
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowProductService(client)
+
+	_, err := svc.SearchProducts(contextWithUserIDToken("token"), domain.SearchProductsRequest{
+		Pagination: domain.Pagination{Limit: 20, Offset: 0},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotFilters.Class != "product_model" {
+		t.Fatalf("expected class %q forwarded to SN, got %q", "product_model", gotFilters.Class)
+	}
+}
+
+// TestSNProductService_SearchProducts_ForwardsExplicitClassUnchanged verifies
+// that when the caller explicitly requests version-level rows (class=
+// software_model or service_model), the entity service does not override
+// that choice with the product_model default.
+func TestSNProductService_SearchProducts_ForwardsExplicitClassUnchanged(t *testing.T) {
+	for _, class := range []string{"software_model", "service_model", "product_model"} {
+		t.Run(class, func(t *testing.T) {
+			var gotFilters snProductFilters
+			mux := http.NewServeMux()
+			mux.HandleFunc("/products/search", func(w http.ResponseWriter, r *http.Request) {
+				var payload snProductSearchPayload
+				if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+					t.Fatalf("decode request body: %v", err)
+				}
+				gotFilters = payload.Filters
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"products":     []map[string]any{},
+					"totalRecords": 0, "offset": 0, "limit": 20,
+				})
+			})
+
+			client := newTestSNClient(t, mux)
+			svc := NewServiceNowProductService(client)
+
+			_, err := svc.SearchProducts(contextWithUserIDToken("token"), domain.SearchProductsRequest{
+				Pagination: domain.Pagination{Limit: 20, Offset: 0},
+				Class:      class,
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if gotFilters.Class != class {
+				t.Fatalf("expected class %q forwarded unchanged, got %q", class, gotFilters.Class)
+			}
+		})
+	}
+}
+
+// TestSNProductService_SearchProducts_RejectsUnknownClass ensures a caller
+// cannot forward an arbitrary string to the Choreo product search endpoint.
+func TestSNProductService_SearchProducts_RejectsUnknownClass(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/products/search", func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("SN endpoint should not be called for an invalid class")
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowProductService(client)
+
+	_, err := svc.SearchProducts(contextWithUserIDToken("token"), domain.SearchProductsRequest{
+		Pagination: domain.Pagination{Limit: 20, Offset: 0},
+		Class:      "bogus_model",
+	})
+	if err == nil {
+		t.Fatal("expected validation error for unknown class, got nil")
+	}
+}

--- a/entity-service/internal/service/sn_product_version_service.go
+++ b/entity-service/internal/service/sn_product_version_service.go
@@ -44,13 +44,13 @@ type snProductVersion struct {
 }
 
 // snProductVersionSearchPayload is the Choreo POST /products/{id}/versions/search request body.
+// The Choreo API's ProductVersionSearchPayload is a closed record with only a
+// "pagination" field -- no "filters" field exists on it. Do not add one back:
+// a struct-valued field survives `omitempty` (encoding/json never treats a
+// non-pointer struct as empty) and Ballerina rejects any unrecognized field on
+// a closed record at bind time, so a "filters" key here 400s every call.
 type snProductVersionSearchPayload struct {
-	Filters    snProductVersionFilters `json:"filters,omitempty"`
-	Pagination snProjectPagination     `json:"pagination"`
-}
-
-type snProductVersionFilters struct {
-	SearchQuery string `json:"searchQuery,omitempty"`
+	Pagination snProjectPagination `json:"pagination"`
 }
 
 type snProductVersionService struct {
@@ -76,7 +76,6 @@ func (s *snProductVersionService) SearchProductVersions(ctx context.Context, req
 	path := fmt.Sprintf("/products/%s/versions/search", productSysid)
 
 	payload := snProductVersionSearchPayload{
-		Filters:    snProductVersionFilters{SearchQuery: req.SearchQuery},
 		Pagination: snProjectPagination{Limit: req.Pagination.Limit, Offset: req.Pagination.Offset},
 	}
 

--- a/entity-service/internal/service/sn_product_version_service_test.go
+++ b/entity-service/internal/service/sn_product_version_service_test.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package service
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+)
+
+// TestSNProductVersionService_SearchProductVersions_PayloadHasNoFiltersKey
+// guards against reintroducing a "filters" key on the outbound payload to the
+// Choreo POST /products/{id}/versions/search endpoint. The Choreo API's
+// ProductVersionSearchPayload is a closed Ballerina record with only a
+// "pagination" field: any "filters" key, including an empty "filters": {},
+// makes the downstream call fail at bind time with every single call 400ing.
+// Go's `omitempty` never suppresses a non-pointer struct field, so this must
+// be verified against the actual serialized JSON, not just the Go struct
+// definition.
+func TestSNProductVersionService_SearchProductVersions_PayloadHasNoFiltersKey(t *testing.T) {
+	cases := []struct {
+		name        string
+		searchQuery string
+	}{
+		{name: "empty search query", searchQuery: ""},
+		{name: "populated search query", searchQuery: "3.2.0"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotBody map[string]any
+			mux := http.NewServeMux()
+			mux.HandleFunc("/products/", func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost {
+					t.Fatalf("expected POST, got %s", r.Method)
+				}
+				if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+					t.Fatalf("decode request body: %v", err)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"versions": [], "totalRecords": 0, "offset": 0, "limit": 20}`))
+			})
+
+			client := newTestSNClient(t, mux)
+			svc := NewServiceNowProductVersionService(client)
+
+			req := domain.SearchProductVersionsRequest{
+				ProductID:   "11111111-2222-3333-4444-555555555555",
+				SearchQuery: tc.searchQuery,
+				Pagination:  domain.Pagination{Limit: 20, Offset: 0},
+			}
+			if _, err := svc.SearchProductVersions(contextWithUserIDToken("token"), req); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if _, hasFilters := gotBody["filters"]; hasFilters {
+				t.Fatalf("expected no \"filters\" key in outbound payload, got %+v", gotBody["filters"])
+			}
+			if _, hasPagination := gotBody["pagination"]; !hasPagination {
+				t.Fatalf("expected \"pagination\" key in outbound payload, got %+v", gotBody)
+			}
+		})
+	}
+}

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -3926,6 +3926,7 @@ components:
           description: Case-insensitive match against product name.
         class:
           type: string
+          enum: [software, service, product_model, software_model, service_model]
           description: >
             Optional filter restricting results to a single product class.
             Accepted values and default behavior depend on the active data

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -3924,6 +3924,18 @@ components:
         searchQuery:
           type: string
           description: Case-insensitive match against product name.
+        class:
+          type: string
+          description: >
+            Optional filter restricting results to a single product class.
+            Accepted values and default behavior depend on the active data
+            source. On the data source where products are stored one row per
+            distinct product, an empty value returns every class unfiltered.
+            On the data source where the same catalog also exposes one row
+            per product version, an empty value defaults to "product_model"
+            (one row per distinct product); "software_model" or
+            "service_model" can be requested explicitly to get version-level
+            rows instead.
 
     Product:
       type: object


### PR DESCRIPTION
## Purpose
Two related product-search defects, both surfaced while verifying a fix end to end:

1. `POST /products/search` returns one row per underlying catalog record, which on the ServiceNow data source includes both top-level products and their individual version records sharing the same product name — so a caller searching for a product by name sees many duplicate-looking rows instead of the distinct products it actually has.
2. `POST /products/{id}/versions/search` fails on every single call — the request this service sends to the downstream ServiceNow integration includes a `filters` object that integration's payload type has no field for at all, so every call is rejected before it ever reaches ServiceNow. This blocks the second half of the deployed-product creation flow (pick a product, then pick a version) for every product, regardless of (1).

## Goals
- Let a caller ask for only the distinct, top-level products a search should normally return, without losing the ability to query the full underlying catalog when that's genuinely what's needed.
- Stop sending a request field the downstream integration doesn't accept, so version lookups succeed instead of failing outright.

## Approach
1. Added an optional `class` filter to `SearchProductsRequest`, forwarded to the ServiceNow integration on the ServiceNow data source only, defaulting to the top-level product class when the caller sends nothing. The Postgres data source already stores one row per product, so `class` there is accepted as an optional filter with no default. The downstream integration and its ServiceNow-side query already supported this filter; the gap was purely that this service never forwarded it.
2. Removed a request field (`filters`) this service was always sending to the version-search integration call, even when empty — Go's `omitempty` doesn't suppress a populated-but-zero-valued struct, so the field was sent on every call regardless. The downstream integration's payload type doesn't declare a `filters` field at all, so every call was rejected at the point where it validates the incoming request shape. Nothing in this codebase ever populated the field this was meant to carry, so removing it is a pure bug fix with no lost capability.

## User stories
As a CS engineer filtering cases by product, or adding a deployed product to a project deployment, I see one entry per distinct product instead of many duplicate-looking rows for the same product name, and picking a product's version actually returns results instead of failing.

## Release note
`POST /products/search` now returns distinct products by default on the ServiceNow data source, with an optional `class` filter for explicit requests. `POST /products/{id}/versions/search` no longer fails on every call.

## Documentation
N/A — internal API behavior change, documented in this service's own `openapi.yaml`.

## Training
N/A — internal API implementation detail, no training-content impact.

## Certification
N/A — internal API implementation detail, not exam-relevant.

## Marketing
N/A — internal API behavior change, no customer-facing feature to promote.

## Automation tests
- Unit tests: added coverage for both data-source paths of the product-class change (ServiceNow path defaults/forwards/rejects invalid classes; Postgres path leaves an empty class unfiltered), and for the version-search fix (asserts the outbound request to the integration service never includes a `filters` key, regardless of what the caller sends).
- Integration tests: manually verified both fixes against a live ServiceNow DEV instance through the full local stack (integration service + this entity-service + the CSM portal BFF/webapp) — confirmed the previously duplicate-heavy product search collapses to one row per product with no change for callers that don't send `class`, and confirmed version search returns real results instead of failing, for multiple different products.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A for Go — `go vet`/`govulncheck` ran clean instead
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
None

## Migrations (if applicable)
N/A — no schema or data migration involved.

## Samples
N/A — no public sample code affected.

## Test environment
Go 1.26 (this repo's pinned toolchain), local ServiceNow DEV integration stack

## Learning
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional product class filter to product searches.
  - Supported classes include software, service, and product/model variants.
  - Added validation with clear rejection of unsupported class values.
  - Search behavior now applies appropriate defaults based on the data source.

- **Bug Fixes**
  - Product-version searches no longer send unsupported filter data, improving compatibility with downstream services.

- **Documentation**
  - Updated API documentation to describe class filtering, allowed values, defaults, and result behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->