### PR TITLE
acp-closure-service: add EXCLUDED_PROJECT_IDS for deliberate project exclusion

### DIFF
--- a/integrations/acp-closure-service/.env.example
+++ b/integrations/acp-closure-service/.env.example
@@ -24,3 +24,11 @@ DRY_RUN=true
 # Safe to combine with DRY_RUN=false for an end-to-end test against a single
 # dedicated project without touching anything else.
 TEST_PROJECT_ID=
+
+# Optional, comma-separated project IDs. Any project ID listed here is
+# skipped entirely by the sweep — never fetched, never evaluated. For
+# deliberate, verified business exclusions only, NOT a workaround for data
+# bugs (see CLAUDE.md's "EXCLUDED_PROJECT_IDS" section for the full
+# reasoning). Expected to be empty almost all the time in production; fine
+# to hold real entries in dev/staging.
+EXCLUDED_PROJECT_IDS=

--- a/integrations/acp-closure-service/CLAUDE.md
+++ b/integrations/acp-closure-service/CLAUDE.md
@@ -95,6 +95,49 @@ loop's `offset := 0` line. This is what backs safe testing against a single
 dedicated project without risk of touching every open project in an
 environment.
 
+## EXCLUDED_PROJECT_IDS — deliberate exclusion, not a bug workaround
+
+`Run`'s `excludedProjectIDs` parameter (backed by the `EXCLUDED_PROJECT_IDS`
+env var, comma-separated, parsed by `main.go`'s `parseExcludedProjectIDs`) is
+a set of project IDs the sweep skips entirely — not fetched in detail, not
+evaluated, not counted as a failure, just logged and counted in
+`Result.ProjectsExcluded`. This applies uniformly to both the broad sweep and
+the `TEST_PROJECT_ID`-scoped path: if the scoped `projectID` is itself
+excluded, `GetProject` is never called at all.
+
+This came out of a real production incident (a project returning `500` on
+both `GET` and `PATCH` — a genuine data problem on the entity-service side,
+confirmed by the fact that even a bare read failed, not just the write) and
+a design discussion with Sajith Ekanayake about how to handle it. The
+resulting agreement, worth preserving verbatim since it's easy to
+misapply this mechanism otherwise:
+
+- **This is for deliberate, verified business exclusions only** — a project
+  someone has actually decided should never go through ACP, for a real
+  business reason. It is explicitly **not** a workaround for data bugs like
+  the incident that prompted it. A project excluded here produces zero log
+  signal about whatever might actually be wrong with it — the opposite of
+  what you want when something is broken and needs fixing.
+- **Expected to be empty almost all the time in production.** It's fine —
+  expected, even — for this to hold real entries in dev/staging (e.g.
+  keeping a known-broken test project out of the way while iterating).
+- The real incident that prompted this discussion was **not** resolved by
+  adding the project to this list — it needed (and still needs, as of this
+  writing) an actual data-level fix from whoever owns `entity-service`. See
+  the "known discrepancies" pattern elsewhere in this file for the general
+  practice of escalating rather than silently working around upstream
+  problems.
+- **Visibility was the sticking point in the design discussion**: the
+  concern was "if we skip a project entirely, how do we know something's
+  still wrong with it, or that it's since been fixed?" The answer landed on:
+  every excluded project ID is logged (`"project excluded from evaluation"`)
+  each time the sweep would otherwise have touched it, and the full
+  configured list is logged once at startup (`"excludedProjectIDs"` on the
+  `"acp-closure-service starting"` line) — so the exclusion itself stays
+  visible in the logs even though the project's own data never gets
+  evaluated. This does *not* answer "is the underlying issue still there" —
+  that still requires someone to actually go check, same as before.
+
 ## Notice audience matrix and content (redesigned per Chamara's direct request)
 
 Confirmed audience rule, unchanged: 90/60/30-day windows are internal-only;

--- a/integrations/acp-closure-service/cmd/acp-closure/main.go
+++ b/integrations/acp-closure-service/cmd/acp-closure/main.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -48,9 +49,10 @@ func main() {
 
 	dryRun := envBool("DRY_RUN", true)
 	testProjectID := os.Getenv("TEST_PROJECT_ID")
+	excludedProjectIDs := parseExcludedProjectIDs(os.Getenv("EXCLUDED_PROJECT_IDS"))
 	runID := newRunID()
 
-	slog.Info("acp-closure-service starting", "runID", runID, "dryRun", dryRun, "testProjectID", testProjectID)
+	slog.Info("acp-closure-service starting", "runID", runID, "dryRun", dryRun, "testProjectID", testProjectID, "excludedProjectIDs", sortedKeys(excludedProjectIDs))
 
 	entityClient := entity.NewClient(entity.Config{
 		BaseURL:      mustEnv("CSM_INTEGRATION_BASE_URL"),
@@ -69,7 +71,7 @@ func main() {
 
 	ctx := entity.WithCorrelationID(context.Background(), runID)
 
-	result, err := sweep.Run(ctx, entityClient, updater, notifier, time.Now(), testProjectID)
+	result, err := sweep.Run(ctx, entityClient, updater, notifier, time.Now(), testProjectID, excludedProjectIDs)
 	if err != nil {
 		slog.Error("acp-closure-service sweep failed", "runID", runID, "err", err)
 		os.Exit(1)
@@ -79,6 +81,7 @@ func main() {
 		"runID", runID,
 		"dryRun", dryRun,
 		"projectsEvaluated", result.ProjectsEvaluated,
+		"projectsExcluded", result.ProjectsExcluded,
 		"failureCount", len(result.Failures),
 	)
 	for _, f := range result.Failures {
@@ -123,6 +126,41 @@ func envBool(key string, def bool) bool {
 		return def
 	}
 	return parsed
+}
+
+// parseExcludedProjectIDs parses EXCLUDED_PROJECT_IDS: a comma-separated
+// list of project IDs the sweep should skip entirely, never fetching or
+// evaluating them (backs sweep.Run's excludedProjectIDs parameter). Per
+// explicit design direction (PR #1440 discussion, Sajith Ekanayake): this
+// is meant for deliberate, verified business exclusions — expected to be
+// empty in production almost all the time, populated more often in
+// dev/staging to keep a known-broken project out of the way. Not a
+// substitute for fixing genuine data issues; a project put here produces
+// zero signal about whatever might actually be wrong with it. Each entry
+// is trimmed of surrounding whitespace; empty entries (from a stray comma,
+// or an entirely empty/unset value) are dropped rather than matching "".
+func parseExcludedProjectIDs(v string) map[string]bool {
+	ids := map[string]bool{}
+	for raw := range strings.SplitSeq(v, ",") {
+		id := strings.TrimSpace(raw)
+		if id == "" {
+			continue
+		}
+		ids[id] = true
+	}
+	return ids
+}
+
+// sortedKeys returns m's keys in sorted order, for stable, readable log
+// output — map iteration order is randomized in Go, which would make the
+// same EXCLUDED_PROJECT_IDS configuration log differently across runs.
+func sortedKeys(m map[string]bool) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 // loadDotEnv reads a .env file and sets any unset environment variables from

--- a/integrations/acp-closure-service/cmd/acp-closure/main_test.go
+++ b/integrations/acp-closure-service/cmd/acp-closure/main_test.go
@@ -16,7 +16,49 @@
 
 package main
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
+
+// TestParseExcludedProjectIDs covers EXCLUDED_PROJECT_IDS parsing: a
+// comma-separated list of project IDs, trimmed of surrounding whitespace,
+// with empty entries dropped. An unset/empty value parses to an empty set
+// rather than a set containing "" — an empty string is never a real
+// project ID that should match anything.
+func TestParseExcludedProjectIDs(t *testing.T) {
+	tests := []struct {
+		name string
+		v    string
+		want map[string]bool
+	}{
+		{name: "empty value", v: "", want: map[string]bool{}},
+		{name: "single ID", v: "abc-123", want: map[string]bool{"abc-123": true}},
+		{
+			name: "multiple IDs",
+			v:    "abc-123,def-456,ghi-789",
+			want: map[string]bool{"abc-123": true, "def-456": true, "ghi-789": true},
+		},
+		{
+			name: "whitespace around IDs is trimmed",
+			v:    " abc-123 , def-456 ,ghi-789 ",
+			want: map[string]bool{"abc-123": true, "def-456": true, "ghi-789": true},
+		},
+		{
+			name: "empty entries from stray commas are dropped",
+			v:    "abc-123,,def-456,",
+			want: map[string]bool{"abc-123": true, "def-456": true},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseExcludedProjectIDs(tt.v)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseExcludedProjectIDs(%q) = %v, want %v", tt.v, got, tt.want)
+			}
+		})
+	}
+}
 
 // TestExitCode verifies the process reports failure to its caller (a
 // scheduled Choreo task) whenever any project failed during the sweep, and

--- a/integrations/acp-closure-service/internal/sweep/run.go
+++ b/integrations/acp-closure-service/internal/sweep/run.go
@@ -46,10 +46,28 @@ const pageSize = 50
 // fatal, the same as a page-fetch failure in the broad-sweep mode — there is
 // nothing else to fall back to when the one requested project can't be
 // fetched.
-func Run(ctx context.Context, reader sweepReader, updater projectUpdater, ntf notifier, now time.Time, projectID string) (Result, error) {
+//
+// excludedProjectIDs backs EXCLUDED_PROJECT_IDS: any project whose ID is a
+// key in this set (with value true) is skipped entirely — not fetched in
+// detail, not evaluated, not counted toward failures, just logged and
+// counted in Result.ProjectsExcluded. This applies uniformly to both the
+// broad sweep and the TEST_PROJECT_ID-scoped path: if projectID itself is
+// excluded, GetProject is never called at all. Per explicit design
+// direction (PR #1440 discussion, Sajith Ekanayake): this exists for
+// deliberate business-driven exclusions, not as a workaround for data
+// bugs — a project excluded here produces zero log signal about whatever
+// might be wrong with it, which is the opposite of what you want for an
+// actual bug. nil is equivalent to an empty set (nothing excluded).
+func Run(ctx context.Context, reader sweepReader, updater projectUpdater, ntf notifier, now time.Time, projectID string, excludedProjectIDs map[string]bool) (Result, error) {
 	var result Result
 
 	if projectID != "" {
+		if excludedProjectIDs[projectID] {
+			slog.InfoContext(ctx, "project excluded from evaluation", "projectID", projectID)
+			result.ProjectsExcluded++
+			return result, nil
+		}
+
 		raw, err := reader.GetProject(ctx, projectID)
 		if err != nil {
 			return result, fmt.Errorf("sweep: get project %s: %w", projectID, err)
@@ -92,6 +110,12 @@ func Run(ctx context.Context, reader sweepReader, updater projectUpdater, ntf no
 		}
 
 		for _, proj := range page.Projects {
+			if excludedProjectIDs[proj.ID] {
+				slog.InfoContext(ctx, "project excluded from evaluation", "projectID", proj.ID)
+				result.ProjectsExcluded++
+				continue
+			}
+
 			result.ProjectsEvaluated++
 			if err := processProject(ctx, reader, updater, ntf, now, proj); err != nil {
 				slog.ErrorContext(ctx, "processProject failed", "projectID", proj.ID, "err", err)
@@ -107,9 +131,9 @@ func Run(ctx context.Context, reader sweepReader, updater projectUpdater, ntf no
 			break
 		}
 
-		if page.Total > 0 && result.ProjectsEvaluated >= page.Total {
+		if page.Total > 0 && result.ProjectsEvaluated+result.ProjectsExcluded >= page.Total {
 			slog.WarnContext(ctx, "sweep: pagination hit the Total bound while hasMore was still true",
-				"total", page.Total, "projectsEvaluated", result.ProjectsEvaluated)
+				"total", page.Total, "projectsEvaluated", result.ProjectsEvaluated, "projectsExcluded", result.ProjectsExcluded)
 			break
 		}
 

--- a/integrations/acp-closure-service/internal/sweep/run.go
+++ b/integrations/acp-closure-service/internal/sweep/run.go
@@ -62,9 +62,7 @@ func Run(ctx context.Context, reader sweepReader, updater projectUpdater, ntf no
 	var result Result
 
 	if projectID != "" {
-		if excludedProjectIDs[projectID] {
-			slog.InfoContext(ctx, "project excluded from evaluation", "projectID", projectID)
-			result.ProjectsExcluded++
+		if skipExcluded(ctx, projectID, excludedProjectIDs, &result) {
 			return result, nil
 		}
 
@@ -110,9 +108,7 @@ func Run(ctx context.Context, reader sweepReader, updater projectUpdater, ntf no
 		}
 
 		for _, proj := range page.Projects {
-			if excludedProjectIDs[proj.ID] {
-				slog.InfoContext(ctx, "project excluded from evaluation", "projectID", proj.ID)
-				result.ProjectsExcluded++
+			if skipExcluded(ctx, proj.ID, excludedProjectIDs, &result) {
 				continue
 			}
 
@@ -141,4 +137,17 @@ func Run(ctx context.Context, reader sweepReader, updater projectUpdater, ntf no
 	}
 
 	return result, nil
+}
+
+// skipExcluded reports whether id is in excludedProjectIDs, logging and
+// counting the skip in result if so. Shared by both of Run's paths (the
+// TEST_PROJECT_ID-scoped early check and the broad-sweep loop) so the
+// log line and counter update have exactly one definition.
+func skipExcluded(ctx context.Context, id string, excludedProjectIDs map[string]bool, result *Result) bool {
+	if !excludedProjectIDs[id] {
+		return false
+	}
+	slog.InfoContext(ctx, "project excluded from evaluation", "projectID", id)
+	result.ProjectsExcluded++
+	return true
 }

--- a/integrations/acp-closure-service/internal/sweep/run_test.go
+++ b/integrations/acp-closure-service/internal/sweep/run_test.go
@@ -289,12 +289,23 @@ func TestRun_ScopedProjectFetchFailureIsFatal(t *testing.T) {
 // processProject call at all — while the other projects in the same page
 // are unaffected.
 func TestRun_SkipsExcludedProjectsInBroadSweep(t *testing.T) {
+	now := time.Date(2026, 7, 28, 0, 0, 0, 0, time.UTC)
+	firingEndDate := now.AddDate(0, 0, 89).Format(time.RFC3339) // fires the 90-day window
+
 	reader := &mockEntityReader{
 		searchProjectsFn: func(ctx context.Context, body []byte) ([]byte, error) {
+			// p2 (the excluded one) is given a firing end date and an
+			// invalid suspensionProcessState — if processProject ever
+			// actually ran on it, that would produce a real, visible
+			// failure. Its endDate being null instead would make
+			// processProject a silent no-op either way, so the
+			// zero-failures assertion below couldn't distinguish
+			// "never evaluated" from "evaluated but harmless" (PR #1482
+			// review, CodeRabbit).
 			return []byte(`{
 				"projects": [
 					{"id": "p1", "endDate": null},
-					{"id": "p2", "endDate": null},
+					{"id": "p2", "endDate": "` + firingEndDate + `", "suspensionProcessState": "not-an-object"},
 					{"id": "p3", "endDate": null}
 				],
 				"total": 3, "limit": 50, "offset": 0, "hasMore": false
@@ -305,7 +316,7 @@ func TestRun_SkipsExcludedProjectsInBroadSweep(t *testing.T) {
 	ntf := &mockNotifier{}
 	excluded := map[string]bool{"p2": true}
 
-	result, err := Run(context.Background(), reader, updater, ntf, time.Now(), "", excluded)
+	result, err := Run(context.Background(), reader, updater, ntf, now, "", excluded)
 	if err != nil {
 		t.Fatalf("Run() error = %v, want nil", err)
 	}

--- a/integrations/acp-closure-service/internal/sweep/run_test.go
+++ b/integrations/acp-closure-service/internal/sweep/run_test.go
@@ -39,7 +39,7 @@ func TestRun_SinglePageEvaluatesAllProjects(t *testing.T) {
 	updater := &mockProjectUpdater{}
 	ntf := &mockNotifier{}
 
-	result, err := Run(context.Background(), reader, updater, ntf, time.Now(), "")
+	result, err := Run(context.Background(), reader, updater, ntf, time.Now(), "", nil)
 	if err != nil {
 		t.Fatalf("Run() error = %v, want nil", err)
 	}
@@ -81,7 +81,7 @@ func TestRun_MultiPagePaginatesUntilHasMoreFalse(t *testing.T) {
 	updater := &mockProjectUpdater{}
 	ntf := &mockNotifier{}
 
-	result, err := Run(context.Background(), reader, updater, ntf, time.Now(), "")
+	result, err := Run(context.Background(), reader, updater, ntf, time.Now(), "", nil)
 	if err != nil {
 		t.Fatalf("Run() error = %v, want nil", err)
 	}
@@ -115,7 +115,7 @@ func TestRun_StopsWhenPageReturnsZeroProjects(t *testing.T) {
 	updater := &mockProjectUpdater{}
 	ntf := &mockNotifier{}
 
-	result, err := Run(context.Background(), reader, updater, ntf, time.Now(), "")
+	result, err := Run(context.Background(), reader, updater, ntf, time.Now(), "", nil)
 	if err != nil {
 		t.Fatalf("Run() error = %v, want nil", err)
 	}
@@ -157,7 +157,7 @@ func TestRun_BoundsIterationsByTotalWhenHasMoreNeverFalse(t *testing.T) {
 	updater := &mockProjectUpdater{}
 	ntf := &mockNotifier{}
 
-	result, err := Run(context.Background(), reader, updater, ntf, time.Now(), "")
+	result, err := Run(context.Background(), reader, updater, ntf, time.Now(), "", nil)
 	if err != nil {
 		t.Fatalf("Run() error = %v, want nil", err)
 	}
@@ -193,7 +193,7 @@ func TestRun_OneProjectFailureDoesNotBlockTheRest(t *testing.T) {
 	updater := &mockProjectUpdater{}
 	ntf := &mockNotifier{}
 
-	result, err := Run(context.Background(), reader, updater, ntf, now, "")
+	result, err := Run(context.Background(), reader, updater, ntf, now, "", nil)
 	if err != nil {
 		t.Fatalf("Run() error = %v, want nil", err)
 	}
@@ -220,7 +220,7 @@ func TestRun_PageFetchFailureIsFatal(t *testing.T) {
 	updater := &mockProjectUpdater{}
 	ntf := &mockNotifier{}
 
-	_, err := Run(context.Background(), reader, updater, ntf, time.Now(), "")
+	_, err := Run(context.Background(), reader, updater, ntf, time.Now(), "", nil)
 	if err == nil {
 		t.Fatal("Run() error = nil, want non-nil")
 	}
@@ -248,7 +248,7 @@ func TestRun_ScopedToProjectIDFetchesOnlyThatProject(t *testing.T) {
 	updater := &mockProjectUpdater{}
 	ntf := &mockNotifier{}
 
-	result, err := Run(context.Background(), reader, updater, ntf, time.Now(), testProjectID)
+	result, err := Run(context.Background(), reader, updater, ntf, time.Now(), testProjectID, nil)
 	if err != nil {
 		t.Fatalf("Run() error = %v, want nil", err)
 	}
@@ -277,8 +277,75 @@ func TestRun_ScopedProjectFetchFailureIsFatal(t *testing.T) {
 	updater := &mockProjectUpdater{}
 	ntf := &mockNotifier{}
 
-	_, err := Run(context.Background(), reader, updater, ntf, time.Now(), "e3e87599-1bc7-6650-182c-0dc5604bcb68")
+	_, err := Run(context.Background(), reader, updater, ntf, time.Now(), "e3e87599-1bc7-6650-182c-0dc5604bcb68", nil)
 	if err == nil {
 		t.Fatal("Run() error = nil, want non-nil")
+	}
+}
+
+// TestRun_SkipsExcludedProjectsInBroadSweep verifies EXCLUDED_PROJECT_IDS:
+// a project whose ID is in excludedProjectIDs is skipped entirely in the
+// broad sweep — not evaluated, not counted in ProjectsEvaluated, no
+// processProject call at all — while the other projects in the same page
+// are unaffected.
+func TestRun_SkipsExcludedProjectsInBroadSweep(t *testing.T) {
+	reader := &mockEntityReader{
+		searchProjectsFn: func(ctx context.Context, body []byte) ([]byte, error) {
+			return []byte(`{
+				"projects": [
+					{"id": "p1", "endDate": null},
+					{"id": "p2", "endDate": null},
+					{"id": "p3", "endDate": null}
+				],
+				"total": 3, "limit": 50, "offset": 0, "hasMore": false
+			}`), nil
+		},
+	}
+	updater := &mockProjectUpdater{}
+	ntf := &mockNotifier{}
+	excluded := map[string]bool{"p2": true}
+
+	result, err := Run(context.Background(), reader, updater, ntf, time.Now(), "", excluded)
+	if err != nil {
+		t.Fatalf("Run() error = %v, want nil", err)
+	}
+	if result.ProjectsEvaluated != 2 {
+		t.Errorf("ProjectsEvaluated = %d, want 2 (p2 excluded)", result.ProjectsEvaluated)
+	}
+	if result.ProjectsExcluded != 1 {
+		t.Errorf("ProjectsExcluded = %d, want 1", result.ProjectsExcluded)
+	}
+	if len(result.Failures) != 0 {
+		t.Errorf("Failures = %d, want 0", len(result.Failures))
+	}
+}
+
+// TestRun_ScopedToProjectIDSkipsExcludedProjectWithoutFetching verifies the
+// TEST_PROJECT_ID + EXCLUDED_PROJECT_IDS interaction: if the scoped
+// projectID is itself excluded, Run must not call GetProject at all — per
+// Sajith Ekanayake's explicit requirement, excluded projects must not even
+// have their details fetched, not just be skipped after fetching.
+func TestRun_ScopedToProjectIDSkipsExcludedProjectWithoutFetching(t *testing.T) {
+	const excludedID = "e3e87599-1bc7-6650-182c-0dc5604bcb68"
+
+	reader := &mockEntityReader{
+		getProjectFn: func(ctx context.Context, id string) ([]byte, error) {
+			t.Fatal("GetProject should not be called for an excluded projectID")
+			return nil, nil
+		},
+	}
+	updater := &mockProjectUpdater{}
+	ntf := &mockNotifier{}
+	excluded := map[string]bool{excludedID: true}
+
+	result, err := Run(context.Background(), reader, updater, ntf, time.Now(), excludedID, excluded)
+	if err != nil {
+		t.Fatalf("Run() error = %v, want nil", err)
+	}
+	if result.ProjectsEvaluated != 0 {
+		t.Errorf("ProjectsEvaluated = %d, want 0", result.ProjectsEvaluated)
+	}
+	if result.ProjectsExcluded != 1 {
+		t.Errorf("ProjectsExcluded = %d, want 1", result.ProjectsExcluded)
 	}
 }

--- a/integrations/acp-closure-service/internal/sweep/types.go
+++ b/integrations/acp-closure-service/internal/sweep/types.go
@@ -173,12 +173,14 @@ type searchProjectsRequest struct {
 	SortOrder     string     `json:"sortOrder"`
 }
 
-// Result summarizes one full Run: how many projects were evaluated, and any
-// per-project failures encountered along the way. A non-empty Failures list
-// is a "soft" outcome — Run's own error return is reserved for a fatal
-// page-fetch failure that prevented the sweep from completing at all.
+// Result summarizes one full Run: how many projects were evaluated, how
+// many were skipped via EXCLUDED_PROJECT_IDS, and any per-project failures
+// encountered along the way. A non-empty Failures list is a "soft"
+// outcome — Run's own error return is reserved for a fatal page-fetch
+// failure that prevented the sweep from completing at all.
 type Result struct {
 	ProjectsEvaluated int
+	ProjectsExcluded  int
 	Failures          []ProjectFailure
 }
 


### PR DESCRIPTION
Adds a new env var, `EXCLUDED_PROJECT_IDS` (comma-separated project IDs),
letting the sweep skip specific projects entirely — never fetched, never
evaluated. Applies uniformly to both the broad sweep and the
`TEST_PROJECT_ID`-scoped path: if the scoped project itself is excluded,
`GetProject` is never called at all.

## Background

Prompted by a real production incident: a project returned `500` on both
`GET` and `PATCH` — a genuine `entity-service`-side data problem, not
something fixable in this component. Discussed the right response with
Sajith Ekanayake, landing on this design:

- **Deliberate, verified business exclusions only** — not a workaround for
  data bugs. A project excluded here produces zero log signal about
  whatever might actually be wrong with it, which is the opposite of what
  you want for a real bug. The incident that prompted this was **not**
  resolved by excluding the project — it still needs an actual data-level
  fix upstream.
- **Expected to be empty almost all the time in production.** Fine to hold
  real entries in dev/staging (e.g. keeping a known-broken test project
  out of the way while iterating).
- **Visibility was the main design concern**: every excluded project is
  logged as it's skipped, and the full configured list is logged once at
  startup, so the exclusion itself stays visible in the logs even though
  the project's data is never evaluated.

Full reasoning recorded in `CLAUDE.md`'s new "EXCLUDED_PROJECT_IDS —
deliberate exclusion, not a bug workaround" section.

## Verification

- Full test suite (`gofmt`, `go vet`, `go test -race`, `make build`) green.
- New tests: `TestRun_SkipsExcludedProjectsInBroadSweep`,
  `TestRun_ScopedToProjectIDSkipsExcludedProjectWithoutFetching`,
  `TestParseExcludedProjectIDs`.
- A Standards+Spec code review was run against this diff before opening
  the PR; the one finding (duplicated check/log/count logic between the
  two skip-check sites) was applied — extracted into a shared
  `skipExcluded()` helper, no behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional project exclusions using comma-separated project IDs.
  * Excluded projects are skipped during both broad and project-specific sweeps.
  * Completion results now report the number of excluded projects.
  * Exclusions are normalized, deduplicated, and logged consistently.

* **Documentation**
  * Added guidance covering exclusion behavior, reporting, and intended use.

* **Tests**
  * Added coverage for parsing exclusions and skipping excluded projects without fetching or evaluating them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->