### PR TITLE
[CSM Portal] Allow deleting a submitted time card

### DIFF
--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -196,6 +196,7 @@ func main() {
 	mux.HandleFunc("POST /time-cards/search", timeCardHandler.SearchTimeCards)
 	mux.HandleFunc("POST /time-cards", timeCardHandler.CreateTimeCard)
 	mux.HandleFunc("PATCH /time-cards/{id}", timeCardHandler.UpdateTimeCard)
+	mux.HandleFunc("DELETE /time-cards/{id}", timeCardHandler.DeleteTimeCard)
 	mux.HandleFunc("POST /catalogs/search", catalogHandler.SearchCatalogs)
 	mux.HandleFunc("GET /catalogs/{catalogId}/items/{catalogItemId}/variables", catalogHandler.GetCatalogItemVariables)
 	mux.HandleFunc("POST /products/vulnerabilities/search", productVulnerabilityHandler.SearchProductVulnerabilities)

--- a/apps/csm-portal/backend/internal/entity/customer.go
+++ b/apps/csm-portal/backend/internal/entity/customer.go
@@ -292,6 +292,11 @@ func (c *CustomerEntityClient) UpdateTimeCard(ctx context.Context, id string, bo
 	return c.do(ctx, http.MethodPatch, fmt.Sprintf("/time-cards/%s", url.PathEscape(id)), body)
 }
 
+// DeleteTimeCard calls DELETE /time-cards/{id} on the entity service.
+func (c *CustomerEntityClient) DeleteTimeCard(ctx context.Context, id string) ([]byte, error) {
+	return c.do(ctx, http.MethodDelete, fmt.Sprintf("/time-cards/%s", url.PathEscape(id)), nil)
+}
+
 // CreateCaseAttachment calls POST /attachments on the entity service.
 // Response is returned as raw JSON.
 func (c *CustomerEntityClient) CreateCaseAttachment(ctx context.Context, body []byte) ([]byte, error) {

--- a/apps/csm-portal/backend/internal/handler/helpers_test.go
+++ b/apps/csm-portal/backend/internal/handler/helpers_test.go
@@ -690,6 +690,7 @@ type mockEntityTimeCardClient struct {
 	searchTimeCardsFn func(ctx context.Context, body []byte) ([]byte, error)
 	createTimeCardFn  func(ctx context.Context, body []byte) ([]byte, error)
 	updateTimeCardFn  func(ctx context.Context, id string, body []byte) ([]byte, error)
+	deleteTimeCardFn  func(ctx context.Context, id string) ([]byte, error)
 }
 
 func (m *mockEntityTimeCardClient) SearchTimeCards(ctx context.Context, body []byte) ([]byte, error) {
@@ -711,6 +712,13 @@ func (m *mockEntityTimeCardClient) UpdateTimeCard(ctx context.Context, id string
 		return m.updateTimeCardFn(ctx, id, body)
 	}
 	return []byte(`{"timeCard":{"id":"` + id + `","state":"submitted"}}`), nil
+}
+
+func (m *mockEntityTimeCardClient) DeleteTimeCard(ctx context.Context, id string) ([]byte, error) {
+	if m.deleteTimeCardFn != nil {
+		return m.deleteTimeCardFn(ctx, id)
+	}
+	return []byte(`{"message":"Time card deleted"}`), nil
 }
 
 // ----- mock entity deployment client -----

--- a/apps/csm-portal/backend/internal/handler/time_cards.go
+++ b/apps/csm-portal/backend/internal/handler/time_cards.go
@@ -32,6 +32,7 @@ type entityTimeCardClient interface {
 	SearchTimeCards(ctx context.Context, body []byte) ([]byte, error)
 	CreateTimeCard(ctx context.Context, body []byte) ([]byte, error)
 	UpdateTimeCard(ctx context.Context, id string, body []byte) ([]byte, error)
+	DeleteTimeCard(ctx context.Context, id string) ([]byte, error)
 }
 
 // TimeCardHandler handles HTTP requests for time-card operations.
@@ -146,6 +147,33 @@ func (h *TimeCardHandler) UpdateTimeCard(w http.ResponseWriter, r *http.Request)
 	if err != nil {
 		slog.ErrorContext(r.Context(), "entity UpdateTimeCard failed", "userID", user.UserID, "id", id, "err", err)
 		mapUpstreamError(w, err, "Failed to update time card.")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, result)
+}
+
+// DeleteTimeCard handles DELETE /time-cards/{id}. Carries no body for
+// upstream to reject with a caller-fixable reason, so — unlike UpdateTimeCard
+// above — this uses mapUpstreamErrorGeneric, matching every other
+// non-PATCH-with-a-body handler (see backend CLAUDE.md's Handler conventions).
+func (h *TimeCardHandler) DeleteTimeCard(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	id := r.PathValue("id")
+	if id == "" || !uuidRe.MatchString(id) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	result, err := h.entity.DeleteTimeCard(r.Context(), id)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity DeleteTimeCard failed", "userID", user.UserID, "id", id, "err", err)
+		mapUpstreamErrorGeneric(w, err, "Failed to delete time card.")
 		return
 	}
 

--- a/apps/csm-portal/backend/internal/handler/time_cards_test.go
+++ b/apps/csm-portal/backend/internal/handler/time_cards_test.go
@@ -186,6 +186,10 @@ func TestDeleteTimeCard(t *testing.T) {
 		if capturedID != testTCID {
 			t.Errorf("upstream received id %q, want %q", capturedID, testTCID)
 		}
+		resp := decodeJSON[map[string]any](t, w)
+		if resp["message"] != "Time card deleted" {
+			t.Errorf("message = %v, want %q", resp["message"], "Time card deleted")
+		}
 	})
 
 	t.Run("upstream errors are mapped correctly", func(t *testing.T) {

--- a/apps/csm-portal/backend/internal/handler/time_cards_test.go
+++ b/apps/csm-portal/backend/internal/handler/time_cards_test.go
@@ -147,3 +147,64 @@ func TestUpdateTimeCard(t *testing.T) {
 		}
 	})
 }
+
+func TestDeleteTimeCard(t *testing.T) {
+	t.Run("rejects unauthenticated requests", func(t *testing.T) {
+		h := NewTimeCardHandler(&mockEntityTimeCardClient{})
+		r := httptest.NewRequest(http.MethodDelete, "/time-cards/"+testTCID, nil)
+		r.SetPathValue("id", testTCID)
+		w := httptest.NewRecorder()
+		h.DeleteTimeCard(w, r)
+		assertStatus(t, w, http.StatusUnauthorized)
+	})
+
+	t.Run("rejects malformed UUID", func(t *testing.T) {
+		h := NewTimeCardHandler(&mockEntityTimeCardClient{})
+		r := withUser(httptest.NewRequest(http.MethodDelete, "/time-cards/not-a-uuid", nil))
+		r.SetPathValue("id", "not-a-uuid")
+		w := httptest.NewRecorder()
+		h.DeleteTimeCard(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+	})
+
+	t.Run("forwards id and returns 200", func(t *testing.T) {
+		var capturedID string
+		client := &mockEntityTimeCardClient{
+			deleteTimeCardFn: func(_ context.Context, id string) ([]byte, error) {
+				capturedID = id
+				return []byte(`{"message":"Time card deleted"}`), nil
+			},
+		}
+		h := NewTimeCardHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodDelete, "/time-cards/"+testTCID, nil))
+		r.SetPathValue("id", testTCID)
+		w := httptest.NewRecorder()
+		h.DeleteTimeCard(w, r)
+
+		assertStatus(t, w, http.StatusOK)
+		assertContentType(t, w, "application/json")
+		if capturedID != testTCID {
+			t.Errorf("upstream received id %q, want %q", capturedID, testTCID)
+		}
+	})
+
+	t.Run("upstream errors are mapped correctly", func(t *testing.T) {
+		for _, tc := range upstreamErrorsGeneric("Failed to delete time card.") {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				client := &mockEntityTimeCardClient{
+					deleteTimeCardFn: func(_ context.Context, _ string) ([]byte, error) {
+						return nil, tc.err
+					},
+				}
+				h := NewTimeCardHandler(client)
+				r := withUser(httptest.NewRequest(http.MethodDelete, "/time-cards/"+testTCID, nil))
+				r.SetPathValue("id", testTCID)
+				w := httptest.NewRecorder()
+				h.DeleteTimeCard(w, r)
+				assertStatus(t, w, tc.wantCode)
+				assertErrorMessage(t, w, tc.wantMsg)
+			})
+		}
+	})
+}

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -4176,6 +4176,61 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
+    delete:
+      summary: >
+        Delete a time card (ServiceNow data source only). Only validates that
+        id is a well-formed UUID; the entity service (and, underneath it,
+        ServiceNow) enforces that the caller is the card's own submitter and
+        that it's still in the submitted state, the same trust model the
+        PATCH operation above uses.
+      operationId: deleteTimeCard
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          description: UUID of the time card.
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Time card deleted successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeleteTimeCardResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: Time card not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
 
   /incidents/search:
     post:
@@ -4905,6 +4960,12 @@ components:
           type: string
         timeCard:
           $ref: '#/components/schemas/TimeCardView'
+
+    DeleteTimeCardResponse:
+      type: object
+      properties:
+        message:
+          type: string
 
     UpdateCaseRequest:
       type: object

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -2858,6 +2858,10 @@ export interface BeTimeCardMutationResponse {
   timeCard: BeTimeCardView;
 }
 
+export interface BeDeleteTimeCardResponse {
+  message: string;
+}
+
 // ---------------------------------------------------------------------------
 // Users
 // ---------------------------------------------------------------------------

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -2859,7 +2859,7 @@ export interface BeTimeCardMutationResponse {
 }
 
 export interface BeDeleteTimeCardResponse {
-  message: string;
+  message?: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeCards.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeCards.ts
@@ -18,9 +18,10 @@
 // Card-level React Query hooks (a case's cards, create, decide), backed by
 // the real csm-portal-backend endpoints:
 //
-//   POST  /time-cards/search   list for a case (server-side caseId filter)
-//   POST  /time-cards          create (already `submitted` — no draft step)
-//   PATCH /time-cards/{id}     accept/reject { state, leadComment }
+//   POST   /time-cards/search   list for a case (server-side caseId filter)
+//   POST   /time-cards          create (already `submitted` — no draft step)
+//   PATCH  /time-cards/{id}     accept/reject { state, leadComment }
+//   DELETE /time-cards/{id}     delete an own, still-submitted card
 //
 
 import {
@@ -34,6 +35,7 @@ import { ApiQueryKeys } from "@constants/apiConstants";
 import { useBackendApi } from "@api/backend/client";
 import type {
   BeCreateTimeCardPayload,
+  BeDeleteTimeCardResponse,
   BeTimeCardMutationResponse,
   BeUpdateTimeCardPayload,
 } from "@api/backend/types";
@@ -169,6 +171,27 @@ export function useUpdateTimeCard(): UseMutationResult<
         payload,
       );
       return mapTimeCard(res.timeCard);
+    },
+    onSuccess: () => invalidateTimecards(queryClient),
+  });
+}
+
+/**
+ * Delete an already-submitted card the signed-in engineer owns — the fix for
+ * a submitted-by-accident or otherwise wrong entry, which previously had no
+ * way to be removed. Same trust model as {@link useUpdateTimeCard}: the
+ * backend only validates the ID's shape, ServiceNow enforces submitter-only
+ * + `submitted`-state-only. `cardActions` only ever offers this to the
+ * card's own owner while `submitted`, matching that same rule client-side.
+ */
+export function useDeleteTimeCard(): UseMutationResult<void, Error, string> {
+  const api = useBackendApi();
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, string>({
+    mutationFn: async (cardId): Promise<void> => {
+      await api.del<BeDeleteTimeCardResponse>(
+        `/time-cards/${encodeURIComponent(cardId)}`,
+      );
     },
     onSuccess: () => invalidateTimecards(queryClient),
   });

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/CaseTimeCardsPanel.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/CaseTimeCardsPanel.tsx
@@ -19,13 +19,22 @@ import {
   Box,
   Button,
   Card,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
   Divider,
+  IconButton,
   Skeleton,
   Typography,
 } from "@wso2/oxygen-ui";
-import { Clock, Pencil, Plus } from "@wso2/oxygen-ui-icons-react";
+import { Clock, Pencil, Plus, Trash2 } from "@wso2/oxygen-ui-icons-react";
 import RelativeDate from "@components/RelativeDate";
-import { useCaseTimeCards, useDecideTimeCard } from "@features/csm-timecards/api/useTimeCards";
+import {
+  useCaseTimeCards,
+  useDecideTimeCard,
+  useDeleteTimeCard,
+} from "@features/csm-timecards/api/useTimeCards";
 import { useCurrentEngineer } from "@features/csm-timecards/api/useTimeSheets";
 import { useIsTeamLead } from "@features/csm-timecards/hooks/useIsTeamLead";
 import { billableLabel } from "@features/csm-timecards/constants/timeCardConstants";
@@ -64,8 +73,10 @@ export default function CaseTimeCardsPanel({
   const isTeamLead = useIsTeamLead();
   const me = useCurrentEngineer();
   const decide = useDecideTimeCard();
+  const deleteTimeCard = useDeleteTimeCard();
   const { showError } = useErrorBanner();
   const [reviewCard, setReviewCard] = useState<CsmTimeCard | null>(null);
+  const [pendingDelete, setPendingDelete] = useState<CsmTimeCard | null>(null);
 
   const cards = useMemo(() => data?.cards ?? [], [data]);
   const total = useMemo(
@@ -184,14 +195,24 @@ export default function CaseTimeCardsPanel({
                    its content, matching the backend's own submitter-only +
                    submitted-state-only enforcement (see cardActions). */}
                   {c.state === "submitted" && !!me.id && c.userId === me.id && (
-                    <Button
-                      size="small"
-                      variant="outlined"
-                      startIcon={<Pencil size={14} />}
-                      onClick={() => onEditTimeCard(c)}
-                    >
-                      Edit
-                    </Button>
+                    <>
+                      <Button
+                        size="small"
+                        variant="outlined"
+                        startIcon={<Pencil size={14} />}
+                        onClick={() => onEditTimeCard(c)}
+                      >
+                        Edit
+                      </Button>
+                      <IconButton
+                        size="small"
+                        color="error"
+                        aria-label="Delete time card"
+                        onClick={() => setPendingDelete(c)}
+                      >
+                        <Trash2 size={14} />
+                      </IconButton>
+                    </>
                   )}
                   {/* Never shown on your own card: the backend 403s a
                    self-decide regardless of approver status, so a card you
@@ -248,6 +269,54 @@ export default function CaseTimeCardsPanel({
           }
         />
       )}
+
+      <Dialog
+        open={!!pendingDelete}
+        onClose={() => {
+          if (!deleteTimeCard.isPending) setPendingDelete(null);
+        }}
+        maxWidth="xs"
+        fullWidth
+      >
+        <DialogTitle>Delete time card?</DialogTitle>
+        <DialogContent>
+          <Typography variant="body2">
+            Permanently delete this {pendingDelete?.totalMinutes} min entry? This can&apos;t be
+            undone.
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            color="inherit"
+            onClick={() => setPendingDelete(null)}
+            disabled={deleteTimeCard.isPending}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="contained"
+            color="error"
+            disabled={deleteTimeCard.isPending}
+            onClick={() => {
+              if (!pendingDelete) return;
+              const target = pendingDelete;
+              deleteTimeCard.mutate(target.id, {
+                onSuccess: () => setPendingDelete(null),
+                onError: (err) => {
+                  setPendingDelete(null);
+                  const msg =
+                    err instanceof BackendApiError && err.status < 500 && err.message
+                      ? err.message
+                      : "Could not delete this time card.";
+                  showError(msg, err);
+                },
+              });
+            }}
+          >
+            {deleteTimeCard.isPending ? "Deleting…" : "Delete"}
+          </Button>
+        </DialogActions>
+      </Dialog>
     </Card>
   );
 }

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardCasePreviewDrawer.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardCasePreviewDrawer.tsx
@@ -159,7 +159,7 @@ export default function TimeCardCasePreviewDrawer({
               />
             )}
 
-            {actions.some((a) => a !== "edit") && (
+            {actions.some((a) => a === "approve" || a === "reject") && (
               <Box sx={{ display: "flex", gap: 1 }}>
                 {actions.includes("reject") && (
                   <Button

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardsTable.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardsTable.tsx
@@ -16,7 +16,7 @@
 
 import { Fragment, useState, type JSX } from "react";
 import { Box, Checkbox, IconButton, Skeleton, Tooltip, Typography } from "@wso2/oxygen-ui";
-import { Check, Eye, Pencil, X } from "@wso2/oxygen-ui-icons-react";
+import { Check, Eye, Pencil, Trash2, X } from "@wso2/oxygen-ui-icons-react";
 import RelativeDate from "@components/RelativeDate";
 import TimeCardCasePreviewDrawer from "@features/csm-timecards/components/TimeCardCasePreviewDrawer";
 import TimeCardStatusChip from "@features/csm-timecards/components/TimeCardStatusChip";
@@ -73,11 +73,12 @@ interface TimeCardsTableProps {
   onToggleSelectAll?: (selectableCards: CsmTimeCard[]) => void;
 }
 
-// "edit" isn't in here — unlike approve/reject, it renders as its own icon
-// button (matching the Eye view icon) shown unconditionally when a card is
-// editable, not as an icon button gated by showActionsColumn (see below).
+// "edit"/"delete" aren't in here — unlike approve/reject, they each render as
+// their own icon button (matching the Eye view icon) shown unconditionally
+// when a card is eligible, not as an icon button gated by showActionsColumn
+// (see below).
 const ACTION_BUTTONS: Record<
-  Exclude<TimecardAction, "edit">,
+  Exclude<TimecardAction, "edit" | "delete">,
   { label: string; color: "primary" | "error"; icon: JSX.Element }
 > = {
   approve: { label: "Approve", color: "primary", icon: <Check size={16} /> },
@@ -318,10 +319,10 @@ export default function TimeCardsTable({
                   >
                     <Eye size={16} />
                   </IconButton>
-                  {/* Own actionable button regardless of showActionsColumn —
-                      unlike approve/reject, editing is offered to the card's
-                      own owner on every tab it can appear on (My time
-                      sheets, All), not just the Approvals queue. */}
+                  {/* Own actionable buttons regardless of showActionsColumn —
+                      unlike approve/reject, editing and deleting are offered
+                      to the card's own owner on every tab it can appear on
+                      (My time sheets, All), not just the Approvals queue. */}
                   {actions.includes("edit") && (
                     <IconButton
                       size="small"
@@ -332,9 +333,23 @@ export default function TimeCardsTable({
                       <Pencil size={16} />
                     </IconButton>
                   )}
+                  {actions.includes("delete") && (
+                    <IconButton
+                      size="small"
+                      color="error"
+                      aria-label="Delete time card"
+                      data-testid={`timecard-delete-${c.id}`}
+                      onClick={() => onCardAction(c, "delete")}
+                    >
+                      <Trash2 size={16} />
+                    </IconButton>
+                  )}
                   {showActionsColumn &&
                     actions
-                      .filter((a): a is Exclude<TimecardAction, "edit"> => a !== "edit")
+                      .filter(
+                        (a): a is Exclude<TimecardAction, "edit" | "delete"> =>
+                          a !== "edit" && a !== "delete",
+                      )
                       .map((a) => {
                         const b = ACTION_BUTTONS[a];
                         return (

--- a/apps/csm-portal/webapp/src/features/csm-timecards/pages/CsmTimeCardsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/pages/CsmTimeCardsPage.tsx
@@ -19,6 +19,10 @@ import {
   AdapterDateFns,
   Box,
   DatePickers,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
   Divider,
   MenuItem,
   Paper,
@@ -63,7 +67,7 @@ import {
   useMyTimeCards,
   type TimeCardPagination,
 } from "@features/csm-timecards/api/useTimeSheets";
-import { useUpdateTimeCard } from "@features/csm-timecards/api/useTimeCards";
+import { useDeleteTimeCard, useUpdateTimeCard } from "@features/csm-timecards/api/useTimeCards";
 import AsyncProjectMultiSelect from "@features/csm-cases/components/AsyncProjectMultiSelect";
 import { BackendApiError } from "@api/backend/client";
 import { BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
@@ -185,6 +189,10 @@ export default function CsmTimeCardsPage(): JSX.Element {
   // projectName all come from the card being edited (see the render below).
   const [editingCard, setEditingCard] = useState<CsmTimeCard | null>(null);
   const updateTimeCard = useUpdateTimeCard();
+  // The card pending a delete confirmation, if any — mirrors
+  // CsmCaseDetailPage's own attachment-delete `pendingDelete` pattern.
+  const [pendingDelete, setPendingDelete] = useState<CsmTimeCard | null>(null);
+  const deleteTimeCard = useDeleteTimeCard();
 
   // Bulk-approve selection — Approvals tab only. Holds card ids rather than
   // whole cards so a background refetch (refresh button, or the queue
@@ -323,6 +331,7 @@ export default function CsmTimeCardsPage(): JSX.Element {
   const handleCardAction = (card: CsmTimeCard, action: TimecardAction): void => {
     if (action === "approve" || action === "reject") setReview({ card, action });
     else if (action === "edit") setEditingCard(card);
+    else if (action === "delete") setPendingDelete(card);
   };
 
   const toggleSelectCard = (card: CsmTimeCard): void => {
@@ -848,6 +857,57 @@ export default function CsmTimeCardsPage(): JSX.Element {
           }}
         />
       )}
+
+      <Dialog
+        open={!!pendingDelete}
+        onClose={() => {
+          if (!deleteTimeCard.isPending) setPendingDelete(null);
+        }}
+        maxWidth="xs"
+        fullWidth
+      >
+        <DialogTitle>Delete time card?</DialogTitle>
+        <DialogContent>
+          <Typography variant="body2">
+            Permanently delete this {pendingDelete?.totalMinutes} min entry on{" "}
+            <strong>{pendingDelete?.caseNumber}</strong>? This can&apos;t be undone.
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            color="inherit"
+            onClick={() => setPendingDelete(null)}
+            disabled={deleteTimeCard.isPending}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="contained"
+            color="error"
+            disabled={deleteTimeCard.isPending}
+            onClick={() => {
+              if (!pendingDelete) return;
+              const target = pendingDelete;
+              deleteTimeCard.mutate(target.id, {
+                onSuccess: () => {
+                  setPendingDelete(null);
+                  showSuccess("Time card deleted.");
+                },
+                onError: (err) => {
+                  setPendingDelete(null);
+                  const msg =
+                    err instanceof BackendApiError && err.status < 500 && err.message
+                      ? err.message
+                      : "Could not delete this time card.";
+                  showError(msg, err);
+                },
+              });
+            }}
+          >
+            {deleteTimeCard.isPending ? "Deleting…" : "Delete"}
+          </Button>
+        </DialogActions>
+      </Dialog>
 
       {review && (
         <TimeCardReviewDialog

--- a/apps/csm-portal/webapp/src/features/csm-timecards/utils/__tests__/timeSheetState.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/utils/__tests__/timeSheetState.test.ts
@@ -23,8 +23,8 @@ const ADMIN = { isOwner: false, isApprover: false, isAdmin: true };
 const NONE = { isOwner: false, isApprover: false, isAdmin: false };
 
 describe("cardActions", () => {
-  it("owner can edit their own submitted card", () => {
-    expect(cardActions("submitted", OWNER)).toEqual(["edit"]);
+  it("owner can edit or delete their own submitted card", () => {
+    expect(cardActions("submitted", OWNER)).toEqual(["edit", "delete"]);
   });
   it("approver approves/rejects a submitted card that isn't their own", () => {
     expect(cardActions("submitted", APPROVER)).toEqual(["approve", "reject"]);

--- a/apps/csm-portal/webapp/src/features/csm-timecards/utils/timeSheetState.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/utils/timeSheetState.ts
@@ -18,13 +18,15 @@ import type { TimeCardState } from "@features/csm-timecards/types/timeCards";
 
 /**
  * Actions that can be taken on a card. The backend supports a state-transition
- * PATCH (`approved` / `rejected`) and a content-only PATCH — `edit` — while a
- * card is still `submitted` and the caller is its own submitter (matching
- * ServiceNow's own edit-in-place behavior). There's no submit (cards are
+ * PATCH (`approved` / `rejected`), a content-only PATCH — `edit` — and now a
+ * DELETE, all while a card is still `submitted` and the caller is its own
+ * submitter (matching ServiceNow's own edit-in-place behavior — see
+ * DeleteTimeCard's own doc comment in the backend for why deletion follows
+ * the exact same trust model as editing). There's no submit (cards are
  * created already submitted), no recall, and no process. There's also no
  * bulk/sheet-level endpoint, so there are no sheet actions.
  */
-export type TimecardAction = "approve" | "reject" | "edit";
+export type TimecardAction = "approve" | "reject" | "edit" | "delete";
 
 /** The capabilities of the current user relative to a card. */
 export interface TimecardRoleCtx {
@@ -39,16 +41,16 @@ export interface TimecardRoleCtx {
 /**
  * Allowed actions on a single card given its state and the user's role.
  * Single source of truth for which buttons render. On a `submitted` card,
- * the owner can only edit it (never approve/reject their own — the backend
- * 403s a self-decide regardless of approver status) and an approver/admin
- * can only decide it (never edit someone else's card). Once decided
- * (approved/rejected), nobody has any action.
+ * the owner can edit or delete it (never approve/reject their own — the
+ * backend 403s a self-decide regardless of approver status) and an
+ * approver/admin can only decide it (never edit or delete someone else's
+ * card). Once decided (approved/rejected), nobody has any action.
  */
 export function cardActions(
   state: TimeCardState,
   role: TimecardRoleCtx,
 ): TimecardAction[] {
   if (state !== "submitted") return [];
-  if (role.isOwner) return ["edit"];
+  if (role.isOwner) return ["edit", "delete"];
   return role.isApprover || role.isAdmin ? ["approve", "reject"] : [];
 }

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -2604,6 +2604,16 @@ type TimeCardMutationResponse struct {
 	TimeCard *TimeCardView `json:"timeCard,omitempty"`
 }
 
+// DeleteTimeCardRequest is the input for DELETE /time-cards/{id}.
+type DeleteTimeCardRequest struct {
+	ID string `json:"-"`
+}
+
+// DeleteTimeCardResponse is the output for DELETE /time-cards/{id}.
+type DeleteTimeCardResponse struct {
+	Message string `json:"message"`
+}
+
 // ChangeRequest is the full change request detail returned by GET /change-requests/{id}.
 // It extends SearchChangeRequestView with additional fields.
 type ChangeRequest struct {

--- a/entity-service/internal/handler/time_card_handler.go
+++ b/entity-service/internal/handler/time_card_handler.go
@@ -86,3 +86,19 @@ func (h *TimeCardHandler) UpdateTimeCard(w http.ResponseWriter, r *http.Request)
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(resp)
 }
+
+// DeleteTimeCard handles DELETE /time-cards/{id}.
+func (h *TimeCardHandler) DeleteTimeCard(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if id == "" {
+		apierror.WriteJSON(w, http.StatusBadRequest, "time card ID is required")
+		return
+	}
+	resp, err := h.svc.DeleteTimeCard(r.Context(), domain.DeleteTimeCardRequest{ID: id})
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -309,6 +309,7 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 		mux.HandleFunc("POST /time-cards/search", timeCardHandler.SearchTimeCards)
 		mux.HandleFunc("POST /time-cards", timeCardHandler.CreateTimeCard)
 		mux.HandleFunc("PATCH /time-cards/{id}", timeCardHandler.UpdateTimeCard)
+		mux.HandleFunc("DELETE /time-cards/{id}", timeCardHandler.DeleteTimeCard)
 	}
 
 	if catalogHandler != nil {

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -306,6 +306,13 @@ type TimeCardService interface {
 	// UpdateTimeCard edits an editable (submitted) time card, or transitions its
 	// state (approve/reject) when req.State is set. SN enforces authorization.
 	UpdateTimeCard(ctx context.Context, req domain.UpdateTimeCardRequest) (domain.TimeCardMutationResponse, error)
+	// DeleteTimeCard permanently deletes a time card. Matches UpdateTimeCard's
+	// trust model exactly: this only validates the ID's shape and forwards the
+	// caller's token to SN, which enforces that only the submitter may delete
+	// their own card, and only while it's still in the submitted state — see
+	// UpdateTimeCard's own doc comment for why that authorization isn't (and,
+	// consistent with every other write here, shouldn't be) duplicated in Go.
+	DeleteTimeCard(ctx context.Context, req domain.DeleteTimeCardRequest) (domain.DeleteTimeCardResponse, error)
 }
 
 // ConfigurationItemService defines the operations available on the configuration items entity.

--- a/entity-service/internal/service/sn_time_card_service.go
+++ b/entity-service/internal/service/sn_time_card_service.go
@@ -497,3 +497,26 @@ func (s *snTimeCardService) UpdateTimeCard(ctx context.Context, req domain.Updat
 	}
 	return parseTimeCardMutation(raw, "update")
 }
+
+// DeleteTimeCard forwards a delete straight to SN with the caller's own
+// token, the same trust model UpdateTimeCard uses — no fetch-then-check
+// here; SN's own ACL is what actually enforces submitter-only +
+// submitted-state-only, exactly as it already does for edits.
+func (s *snTimeCardService) DeleteTimeCard(ctx context.Context, req domain.DeleteTimeCardRequest) (domain.DeleteTimeCardResponse, error) {
+	token := middleware.UserIDTokenFromContext(ctx)
+	if err := validateUUIDs("id", []string{req.ID}); err != nil {
+		return domain.DeleteTimeCardResponse{}, err
+	}
+
+	raw, err := s.client.Delete(ctx, fmt.Sprintf("/time-cards/%s", uuidToSysid(req.ID)), token)
+	if err != nil {
+		return domain.DeleteTimeCardResponse{}, err
+	}
+	var snResp struct {
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.DeleteTimeCardResponse{}, fmt.Errorf("sn time cards: parse delete response: %w", err)
+	}
+	return domain.DeleteTimeCardResponse{Message: snResp.Message}, nil
+}

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -2326,6 +2326,53 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+    delete:
+      summary: Delete a time card (ServiceNow data source only).
+      description: >
+        Only validates that id is a well-formed UUID; ServiceNow enforces
+        that the caller is the card's own submitter and that it's still in
+        the submitted state, the same trust model the PATCH operation above
+        uses.
+      operationId: deleteTimeCard
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Time card UUID.
+      responses:
+        "200":
+          description: Time card deleted successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeleteTimeCardResponse'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: Time card not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
   /slas/{id}:
     get:
@@ -6707,6 +6754,12 @@ components:
           type: string
         timeCard:
           $ref: '#/components/schemas/TimeCardView'
+
+    DeleteTimeCardResponse:
+      type: object
+      properties:
+        message:
+          type: string
 
     VulnerabilityPriority:
       type: string


### PR DESCRIPTION
## Purpose
Engineers submit a time card with no way to remove it afterward — a wrong entry (wrong case, wrong date, submitted by mistake) sits there permanently. This adds a delete action for a time card's own submitter, while it's still in the `submitted` state.

## Goals
- Let an engineer delete their own time card, but only while it hasn't yet been approved/rejected.
- Reuse the existing attachment-delete pattern end to end rather than inventing a new one.

## Approach
- **entity-service**: `DeleteTimeCard` forwards the caller's token to the downstream ServiceNow integration's DELETE endpoint, validating only that the id is a well-formed UUID — the same trust model `UpdateTimeCard` already uses. The downstream layer's own ACL/business-rule enforcement is what actually restricts this to submitter-only + submitted-state-only; no ownership/state check is duplicated in Go.
- **backend (BFF)**: thin pass-through `DeleteTimeCard` handler/route, using `mapUpstreamErrorGeneric` (consistent with every non-PATCH time-card handler).
- **webapp**: `cardActions()` now includes `"delete"` for a card's own owner while `submitted`; a new `useDeleteTimeCard()` mutation hook; a delete button + confirm dialog on both the main time-cards table (`CsmTimeCardsPage`) and the case-detail "Time tracking" panel (`CaseTimeCardsPanel`), matching the existing attachment-delete confirm-dialog shape.

## User stories
- As an engineer, I can delete a time card I submitted by mistake, as long as it hasn't been reviewed yet.
- As an engineer, I can no longer delete a card once it's been approved or rejected, or one that isn't mine.

## Release note
Time cards can now be deleted by their submitter while still in the "submitted" state, from both the Time Cards page and a case's Time tracking panel.

## Documentation
OpenAPI specs updated for both `entity-service` and the `csm-portal` backend (`DELETE /time-cards/{id}`).

## Automation tests
- entity-service: `go build`, `go vet`, `go test ./...` all pass (no existing time-card test coverage at this layer to extend — matches current state).
- backend: added `TestDeleteTimeCard` (unauthenticated, malformed id, forwards id + 200, upstream error mapping) — full `go test ./...` passes.
- webapp: updated `timeSheetState.test.ts` for the new gating; full `csm-timecards` suite (85 tests) passes; `tsc -b --noEmit` and `eslint` clean on all touched files.

## Security checks
- `gosec -fmt=text ./...` on the backend: only 2 pre-existing, `nolint`-annotated findings in unrelated code (`dashboard/registry.go`), nothing new.
- `govulncheck ./...` on entity-service: no vulnerabilities found.
- Authorization is enforced downstream (submitter-only + submitted-state-only), matching the existing edit flow's trust model.

## Test environment
Local build/vet/test/lint only. This also depends on a downstream integration-layer change to support the DELETE verb for time cards, which is tracked and in progress separately — end-to-end verification against a live environment is pending that.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability for users to delete their submitted time cards.
  * Added delete actions, confirmation dialogs, success messages, and error handling across time-card views.
  * Added authenticated API support with UUID validation and documented responses.

* **Bug Fixes**
  * Action controls now appear only when applicable approval or rejection actions are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->