### PR TITLE
[CSM] Rebuild the base64 data URI for attachment uploads

### DIFF
--- a/apps/customer-portal/backend-v2/internal/dto/attachment.go
+++ b/apps/customer-portal/backend-v2/internal/dto/attachment.go
@@ -17,6 +17,7 @@
 package dto
 
 import (
+	"strings"
 	"time"
 
 	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
@@ -35,6 +36,33 @@ type CreateCaseAttachmentRequest struct {
 	Description *string `json:"description,omitempty"`
 }
 
+// attachmentFileDataURI builds the base64 data URI entity-service requires for an
+// attachment upload.
+//
+// The frontend deliberately strips the "data:<mime>;base64," prefix before
+// sending: UploadAttachmentModal.tsx reads the file with readAsDataURL then
+// slices off everything up to the first comma, passing the MIME type separately
+// as `type`. entity-service validates the opposite — `file` must start with
+// "data:" and contain ";base64," — so forwarding the raw content fails with
+// "file must be a base64 data URI (e.g. data:image/png;base64,...)".
+//
+// Reconciling that mismatch is the DTO layer's job: the frontend contract stays
+// frozen and entity-service gets the shape it demands. A value that already looks
+// like a data URI passes through untouched, so a caller sending the full URI
+// keeps working.
+func attachmentFileDataURI(mimeType, content string) string {
+	if content == "" {
+		return ""
+	}
+	if strings.HasPrefix(content, "data:") && strings.Contains(content, ";base64,") {
+		return content
+	}
+	if mimeType == "" {
+		mimeType = "application/octet-stream"
+	}
+	return "data:" + mimeType + ";base64," + content
+}
+
 // BuildEntityCreateCaseAttachmentRequest translates the portal's request
 // into entity-service's CreateAttachmentRequest, forcing ReferenceID (from
 // the {id} path parameter) and ReferenceType to case, and renaming
@@ -45,7 +73,7 @@ func BuildEntityCreateCaseAttachmentRequest(caseID string, req CreateCaseAttachm
 		ReferenceType: entity.ReferenceTypeCase,
 		Name:          req.Name,
 		Type:          req.Type,
-		File:          req.Content,
+		File:          attachmentFileDataURI(req.Type, req.Content),
 		Description:   req.Description,
 	}
 }
@@ -267,7 +295,7 @@ func BuildEntityCreateDeploymentAttachmentRequest(deploymentID string, req Creat
 		ReferenceType: entity.ReferenceTypeDeployment,
 		Name:          req.Name,
 		Type:          req.Type,
-		File:          req.Content,
+		File:          attachmentFileDataURI(req.Type, req.Content),
 		Description:   req.Description,
 	}
 }

--- a/apps/customer-portal/backend-v2/internal/dto/attachment_data_uri_test.go
+++ b/apps/customer-portal/backend-v2/internal/dto/attachment_data_uri_test.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dto
+
+import "testing"
+
+// TestAttachmentUpload_RebuildsDataURI is the regression guard for a 400 seen in
+// staging: `file must be a base64 data URI (e.g. data:image/png;base64,...)`.
+//
+// The frontend strips the "data:<mime>;base64," prefix before sending and passes
+// the MIME type separately, while entity-service requires the prefix. Both upload
+// paths must reconstruct it.
+func TestAttachmentUpload_RebuildsDataURI(t *testing.T) {
+	const content = "JVBERi0xLjQK"
+	const mime = "application/pdf"
+	want := "data:" + mime + ";base64," + content
+
+	caseReq := BuildEntityCreateCaseAttachmentRequest("case-1", CreateCaseAttachmentRequest{
+		Name: "runbook.pdf", Type: mime, Content: content,
+	})
+	if caseReq.File != want {
+		t.Errorf("case upload File = %q, want %q", caseReq.File, want)
+	}
+
+	depReq := BuildEntityCreateDeploymentAttachmentRequest("dep-1", CreateDeploymentAttachmentRequest{
+		Name: "runbook.pdf", Type: mime, Content: content,
+	})
+	if depReq.File != want {
+		t.Errorf("deployment upload File = %q, want %q", depReq.File, want)
+	}
+}
+
+// TestAttachmentUpload_PassesThroughAnExistingDataURI keeps a caller that already
+// sends the full URI working — the value must not be double-prefixed.
+func TestAttachmentUpload_PassesThroughAnExistingDataURI(t *testing.T) {
+	full := "data:image/png;base64,iVBORw0KGgo="
+	got := BuildEntityCreateDeploymentAttachmentRequest("dep-1", CreateDeploymentAttachmentRequest{
+		Name: "shot.png", Type: "image/png", Content: full,
+	})
+	if got.File != full {
+		t.Errorf("File = %q, want it passed through unchanged", got.File)
+	}
+}
+
+// TestAttachmentUpload_FallsBackWhenTypeMissing covers a client omitting `type`:
+// entity-service still needs a syntactically valid data URI, so a generic MIME
+// type is used rather than emitting "data:;base64,..." which would fail its check.
+func TestAttachmentUpload_FallsBackWhenTypeMissing(t *testing.T) {
+	got := BuildEntityCreateCaseAttachmentRequest("case-1", CreateCaseAttachmentRequest{
+		Name: "blob.bin", Type: "", Content: "AAAA",
+	})
+	if got.File != "data:application/octet-stream;base64,AAAA" {
+		t.Errorf("File = %q, want the octet-stream fallback", got.File)
+	}
+}
+
+// TestAttachmentUpload_EmptyContentStaysEmpty leaves validation to entity-service,
+// which returns "file is required" — this must not become "data:...;base64,".
+func TestAttachmentUpload_EmptyContentStaysEmpty(t *testing.T) {
+	got := BuildEntityCreateDeploymentAttachmentRequest("dep-1", CreateDeploymentAttachmentRequest{
+		Name: "empty", Type: "text/plain", Content: "",
+	})
+	if got.File != "" {
+		t.Errorf("File = %q, want empty so entity-service reports 'file is required'", got.File)
+	}
+}

--- a/apps/customer-portal/backend-v2/internal/handler/deployment_attachments_test.go
+++ b/apps/customer-portal/backend-v2/internal/handler/deployment_attachments_test.go
@@ -110,9 +110,10 @@ func TestCreateDeploymentAttachment_ForcesReferenceFromPath(t *testing.T) {
 	if fake.gotCreate.ReferenceType != entity.ReferenceTypeDeployment {
 		t.Errorf("ReferenceType = %q, want %q", fake.gotCreate.ReferenceType, entity.ReferenceTypeDeployment)
 	}
-	// Content is renamed to File for entity-service's own field name.
-	if fake.gotCreate.File != "YmFzZTY0" {
-		t.Errorf("File = %q, want the request's content value", fake.gotCreate.File)
+	// Content becomes File, rebuilt into the base64 data URI entity-service
+	// requires (the frontend strips that prefix; see dto.attachmentFileDataURI).
+	if fake.gotCreate.File != "data:application/pdf;base64,YmFzZTY0" {
+		t.Errorf("File = %q, want the content rebuilt as a data URI", fake.gotCreate.File)
 	}
 	if fake.gotCreate.Name != "runbook.pdf" {
 		t.Errorf("Name = %q, want runbook.pdf", fake.gotCreate.Name)


### PR DESCRIPTION
Fixes a 400 hit in Azure-Staging while testing #1479:

```
POST /deployments/{id}/attachments
400 {"message":"file must be a base64 data URI (e.g. data:image/png;base64,...)"}
```

## Cause — a contract mismatch neither side was wrong about

| Side | Behaviour |
|---|---|
| **Frontend** | `UploadAttachmentModal.tsx:181-183` reads the file with `readAsDataURL`, then **slices off** everything up to the first comma — so it sends bare base64, with the MIME type separately as `type` |
| **entity-service** | `sn_case_service.go:1688` requires `file` to start with `data:` **and** contain `;base64,` |

backend-v2 forwarded `req.Content` untouched, so the upload could never succeed. Reconciling this is exactly the DTO layer's job — the frontend contract stays frozen and entity-service gets the shape it demands.

## The case path had the same bug

`BuildEntityCreateCaseAttachmentRequest` did the identical `File: req.Content`, so **`POST /cases/{id}/attachments` was equally broken** — it had simply never been exercised against entity-service. Adding the deployment route is what surfaced it. Both are fixed here.

`attachmentFileDataURI`:
- rebuilds `data:<type>;base64,<content>`
- **passes an existing data URI through untouched**, so a caller sending the full value isn't double-prefixed
- falls back to `application/octet-stream` when `type` is absent, since `data:;base64,…` would fail entity-service's check
- leaves empty content empty, so entity-service still reports its own `file is required`

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` — clean
- [x] `go test -race ./...` — all pass, incl. 4 new `TestAttachmentUpload_*`
- [x] `gosec -fmt=text ./...` — **0 issues**
- [ ] Staging: upload a file to a deployment's Documents tab → 201, appears in the list
- [ ] Staging: upload to a **case** as well — that path is fixed here too and is worth confirming didn't regress

One test correction included: `TestCreateDeploymentAttachment_ForcesReferenceFromPath` asserted `File` equalled the raw content, which encoded the broken behaviour. It now expects the data URI.

## Note

backend-v2 only — no entity-service change, so this deploys independently.
