### PR TITLE
[CSM] Accept ServiceNow sysids on attachment-by-id routes, matching the Ballerina backend

### DIFF
--- a/apps/customer-portal/backend-v2/internal/handler/attachment_id_test.go
+++ b/apps/customer-portal/backend-v2/internal/handler/attachment_id_test.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import "testing"
+
+// TestIsAttachmentID covers both id shapes an attachment reaches this API as.
+// The sysid case is the one that mattered in staging: an inline comment image is
+// referenced only by "<img src='…/<sysid>.iix'>", so the frontend extracts a bare
+// 32-hex sysid and asks for its content. Requiring a dashed UUID made every
+// inline image fail, while the Ballerina backend accepted both (its path
+// parameter is entity:IdString, an unconstrained string alias).
+func TestIsAttachmentID(t *testing.T) {
+	valid := map[string]string{
+		"dashed uuid from the attachments list": "09dc581d-3bb2-8710-9140-4c6aa5e45afe",
+		"bare sysid from an .iix image src":     "09dc581d3bb2871091404c6aa5e45afe",
+		"uppercase sysid":                       "09DC581D3BB2871091404C6AA5E45AFE",
+		"uppercase uuid":                        "09DC581D-3BB2-8710-9140-4C6AA5E45AFE",
+	}
+	for name, id := range valid {
+		if !isAttachmentID(id) {
+			t.Errorf("%s: isAttachmentID(%q) = false, want true", name, id)
+		}
+	}
+
+	// Still rejected: anything that is neither shape must not reach an upstream
+	// URL path.
+	invalid := map[string]string{
+		"empty":              "",
+		"too short":          "09dc581d",
+		"31 hex":             "09dc581d3bb2871091404c6aa5e45af",
+		"33 hex":             "09dc581d3bb2871091404c6aa5e45afef",
+		"non-hex":            "09dc581d3bb2871091404c6aa5e45azz",
+		"path traversal":     "../../secrets",
+		"slash injection":    "09dc581d3bb2871091404c6aa5e45afe/../other",
+		"query injection":    "09dc581d3bb2871091404c6aa5e45afe?x=1",
+		"uuid missing group": "09dc581d-3bb2-8710-4c6aa5e45afe",
+	}
+	for name, id := range invalid {
+		if isAttachmentID(id) {
+			t.Errorf("%s: isAttachmentID(%q) = true, want false", name, id)
+		}
+	}
+}

--- a/apps/customer-portal/backend-v2/internal/handler/attachments.go
+++ b/apps/customer-portal/backend-v2/internal/handler/attachments.go
@@ -117,7 +117,7 @@ func (h *AttachmentHandler) GetAttachmentContent(w http.ResponseWriter, r *http.
 	}
 
 	id := r.PathValue("id")
-	if id == "" || !uuidRe.MatchString(id) {
+	if id == "" || !isAttachmentID(id) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -144,7 +144,7 @@ func (h *AttachmentHandler) DeleteAttachment(w http.ResponseWriter, r *http.Requ
 	}
 
 	id := r.PathValue("id")
-	if id == "" || !uuidRe.MatchString(id) {
+	if id == "" || !isAttachmentID(id) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
@@ -169,7 +169,7 @@ func (h *AttachmentHandler) GetAttachment(w http.ResponseWriter, r *http.Request
 	}
 
 	id := r.PathValue("id")
-	if id == "" || !uuidRe.MatchString(id) {
+	if id == "" || !isAttachmentID(id) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}

--- a/apps/customer-portal/backend-v2/internal/handler/response.go
+++ b/apps/customer-portal/backend-v2/internal/handler/response.go
@@ -40,6 +40,27 @@ const maxZipUploadBytes = 25 << 20 // 25 MiB
 // uuidRe validates path parameters that are expected to be UUIDs.
 var uuidRe = regexp.MustCompile(`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
 
+// sysidRe matches a bare ServiceNow sysid: 32 hex characters, no dashes.
+var sysidRe = regexp.MustCompile(`(?i)^[0-9a-f]{32}$`)
+
+// isAttachmentID reports whether id is a usable attachment identifier — either a
+// dashed UUID or a bare ServiceNow sysid.
+//
+// Attachment ids reach this API in both forms. The attachments list returns
+// dashed UUIDs (entity-service applies sysidToUUID), but an inline comment image
+// is referenced only by its `<img src="…/<sysid>.iix">`, and the frontend
+// extracts that 32-hex sysid directly (see the .iix regex in
+// features/support/utils/support.ts) before asking for its content. Rejecting
+// the sysid form makes every inline comment image fail.
+//
+// The Ballerina backend accepts both because its path parameter is typed
+// `entity:IdString`, a plain string alias with no format constraint. This keeps
+// the same contract while still refusing anything that is neither shape, so the
+// value remains safe to place in an upstream URL path.
+func isAttachmentID(id string) bool {
+	return uuidRe.MatchString(id) || sysidRe.MatchString(id)
+}
+
 // Error message constants matching the customer-portal error vocabulary.
 const (
 	ErrMsgUnauthorized = "You are not authorized to perform this action. Please try again."


### PR DESCRIPTION
Fixes inline comment images failing in Azure-Staging: `GET /attachments/09dc581d3bb2871091404c6aa5e45afe/content` — note the id is a **bare 32-hex sysid**, not a dashed UUID.

## Cause

Two id vocabularies legitimately coexist, and this backend only accepted one:

| Path | Id form | backend-v2 (before) |
|---|---|---|
| Attachments list → download | dashed UUID (entity-service applies `sysidToUUID`) | ✅ accepted |
| **Inline comment image** | **bare sysid**, scraped from `<img src="…/<sysid>.iix">` | ❌ rejected by `uuidRe` |

The frontend has no other handle on an inline image — `features/support/utils/support.ts` matches `/([a-f0-9]{32})\.iix/` out of the `src` and asks for that id's content. So every inline image 400'd before reaching entity-service.

**The Ballerina backend accepts both** because its path parameter is typed `entity:IdString`, which is `public type IdString string` — an unconstrained string alias. This restores that contract.

## Traced from the working implementation

Worth recording, because it redirected the fix twice:

- I first assumed the **activities** payload was missing inline-attachment fields. It isn't — Ballerina's `Activity` record (`types.bal:1831`) has exactly the fields Go's `dto.CaseActivity` already has: `fileName?`, `contentType?`, `sizeBytes?`, `downloadUrl?`, `commentType?`, `changes?`. **Nothing to add there.**
- Inline images were never delivered as structured fields on the case path at all. They live in the comment HTML, and resolution is client-side. The only backend requirement is an attachment-content route that accepts a sysid.

So this is the whole fix; #1483's comment-level fields remain correct for the conversation view and are unrelated.

## Still validated, not loosened

`isAttachmentID` accepts a dashed UUID **or** a bare 32-hex sysid, and rejects everything else — the id is interpolated into an upstream URL path, so this is not relaxed to a free string. Tests cover path traversal, slash and query injection, 31/33-hex, non-hex and malformed UUIDs.

Applied to `GET /attachments/{id}`, `GET /attachments/{id}/content` and `DELETE /attachments/{id}`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` — clean
- [x] `go test -race ./...` — all pass, incl. `TestIsAttachmentID` (4 valid, 9 rejected shapes)
- [x] `gosec -fmt=text ./...` — **0 issues**
- [ ] Staging: open a case comment containing a pasted image — the image should render rather than the request 400ing
- [ ] Staging: confirm the normal attachment download (dashed UUID from the list) still works

backend-v2 only — no entity-service change, deploys independently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attachment ID validation to support both dashed UUIDs and 32-character hexadecimal IDs.
  * Rejected malformed, unsafe, and injection-style attachment IDs more reliably.
  * Preserved existing unauthorized and bad-request responses for invalid attachment requests.

* **Tests**
  * Added coverage for valid attachment ID formats and invalid or potentially harmful inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->