### PR TITLE
[CSM Portal] Surface SLA status on the case Overview band

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseMetaBand.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseMetaBand.test.tsx
@@ -28,7 +28,7 @@ vi.mock("@api/backend/client", () => ({
 }));
 
 import CaseMetaBand from "@features/csm-cases/components/CaseMetaBand";
-import type { CsmCaseDetail } from "@features/csm-cases/types/csmCases";
+import type { CaseSla, CsmCaseDetail } from "@features/csm-cases/types/csmCases";
 
 /** A complete, minimal case-detail fixture; tests override the fix-ETA fields. */
 const BASE_CASE: CsmCaseDetail = {
@@ -77,7 +77,10 @@ const BASE_CASE: CsmCaseDetail = {
   isWatching: false,
 };
 
-function renderBand(overrides: Partial<CsmCaseDetail>): ReturnType<typeof render> {
+function renderBand(
+  overrides: Partial<CsmCaseDetail>,
+  options?: { collapsed?: boolean; slas?: CaseSla[] },
+): ReturnType<typeof render> {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
@@ -86,13 +89,28 @@ function renderBand(overrides: Partial<CsmCaseDetail>): ReturnType<typeof render
       <MemoryRouter>
         <CaseMetaBand
           detail={{ ...BASE_CASE, ...overrides }}
-          collapsed={false}
+          collapsed={options?.collapsed ?? false}
           onToggleCollapsed={() => {}}
+          slas={options?.slas}
         />
       </MemoryRouter>
     </QueryClientProvider>,
   );
 }
+
+const IN_PROGRESS_SLA: CaseSla = {
+  id: "sla-1",
+  definition: "S1 - Response",
+  target: "1 Business Hour",
+  stage: "in_progress",
+  stageLabel: "In progress",
+  hasBreached: false,
+  businessTimeLeftLabel: "30 minutes",
+  businessElapsedLabel: "30 minutes",
+  businessElapsedPercent: 50,
+  startTime: "2026-07-01T10:00:00Z",
+  stopTime: null,
+};
 
 describe("CaseMetaBand — fix ETA cells", () => {
   it("renders all three fix ETA cells when all three values are set", () => {
@@ -133,5 +151,25 @@ describe("CaseMetaBand — fix ETA cells", () => {
     expect(screen.getByText("Aug 1, 2026")).toBeInTheDocument();
     expect(screen.queryByText("Most likely fix ETA")).not.toBeInTheDocument();
     expect(screen.queryByText("Worst case fix ETA")).not.toBeInTheDocument();
+  });
+});
+
+describe("CaseMetaBand — SLA strip", () => {
+  it("shows an active SLA's summary line", () => {
+    renderBand({}, { slas: [IN_PROGRESS_SLA] });
+    expect(screen.getByText("S1 - Response")).toBeInTheDocument();
+    expect(screen.getByText("50%")).toBeInTheDocument();
+  });
+
+  it("renders nothing extra when there are no SLAs", () => {
+    renderBand({}, { slas: [] });
+    expect(screen.queryByText("S1 - Response")).not.toBeInTheDocument();
+  });
+
+  it("stays visible even while the band is collapsed", () => {
+    renderBand({}, { collapsed: true, slas: [IN_PROGRESS_SLA] });
+    expect(screen.getByText("S1 - Response")).toBeInTheDocument();
+    // The rest of the Overview body is hidden while collapsed.
+    expect(screen.queryByText("Account")).not.toBeInTheDocument();
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseMetaBand.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseMetaBand.tsx
@@ -19,10 +19,11 @@ import { ChevronDown, ChevronUp } from "@wso2/oxygen-ui-icons-react";
 import { useState, type JSX, type ReactNode } from "react";
 import { Link as RouterLink } from "react-router";
 import { tierLabel, tierColor } from "@features/csm-cases/utils/caseTier";
-import type { CsmCaseDetail } from "@features/csm-cases/types/csmCases";
+import type { CaseSla, CsmCaseDetail } from "@features/csm-cases/types/csmCases";
 import { parentRecordPath } from "@features/csm-cases/utils/parentRecordRoute";
 import SemanticChip from "@components/SemanticChip";
 import UserRefLink from "@components/UserRefLink";
+import CaseSlaStrip from "@features/csm-cases/components/CaseSlaStrip";
 import DeploymentDetailsDialog from "@features/csm-projects/components/DeploymentDetailsDialog";
 import type { BeDeploymentType } from "@api/backend/types";
 import { announcementStateRole } from "@features/csm-announcements/utils/announcementState";
@@ -33,6 +34,9 @@ interface CaseMetaBandProps {
   detail: CsmCaseDetail;
   collapsed: boolean;
   onToggleCollapsed: () => void;
+  /** The case's SLA records, for the compact strip below the header —
+   * undefined for case types with no SLA tab (e.g. announcements). */
+  slas?: CaseSla[];
 }
 
 function Cell({
@@ -182,6 +186,7 @@ export default function CaseMetaBand({
   detail: c,
   collapsed,
   onToggleCollapsed,
+  slas,
 }: CaseMetaBandProps): JSX.Element {
   const product = c.productContext;
   const tier = c.customerContext.tier;
@@ -257,6 +262,11 @@ export default function CaseMetaBand({
         )}
         {collapsed ? <ChevronDown size={18} /> : <ChevronUp size={18} />}
       </Box>
+
+      {/* Shown regardless of `collapsed` — SLA breach risk is high-attention
+       * and shouldn't disappear along with the rest of the Overview body. */}
+      <CaseSlaStrip slas={slas} />
+
       {!collapsed && (
         <Box
           sx={[

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseSlaStrip.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseSlaStrip.test.tsx
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import CaseSlaStrip from "@features/csm-cases/components/CaseSlaStrip";
+import type { CaseSla } from "@features/csm-cases/types/csmCases";
+
+function sla(overrides: Partial<CaseSla>): CaseSla {
+  return {
+    id: "sla-1",
+    definition: "S1 - Response",
+    target: "1 Business Hour",
+    stage: "in_progress",
+    stageLabel: "In progress",
+    hasBreached: false,
+    businessTimeLeftLabel: "30 minutes",
+    businessElapsedLabel: "30 minutes",
+    businessElapsedPercent: 50,
+    startTime: "2026-07-01T10:00:00Z",
+    stopTime: null,
+    ...overrides,
+  };
+}
+
+describe("CaseSlaStrip", () => {
+  it("renders nothing when there are no SLAs", () => {
+    const { container } = render(<CaseSlaStrip slas={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when slas is undefined", () => {
+    const { container } = render(<CaseSlaStrip slas={undefined} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when every SLA is completed or cancelled", () => {
+    const { container } = render(
+      <CaseSlaStrip
+        slas={[
+          sla({ id: "a", stage: "completed", stageLabel: "Completed" }),
+          sla({ id: "b", stage: "cancelled", stageLabel: "Cancelled" }),
+        ]}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows an in-progress SLA with its definition, stage, time left, and percent", () => {
+    render(<CaseSlaStrip slas={[sla({})]} />);
+    expect(screen.getByText("S1 - Response")).toBeInTheDocument();
+    expect(screen.getByText("In progress")).toBeInTheDocument();
+    expect(screen.getByText("30 minutes left")).toBeInTheDocument();
+    expect(screen.getByText("50%")).toBeInTheDocument();
+  });
+
+  it("filters out completed/cancelled SLAs but keeps in-progress and breached ones", () => {
+    render(
+      <CaseSlaStrip
+        slas={[
+          sla({ id: "a", definition: "Query - Resolution", stage: "completed" }),
+          sla({
+            id: "b",
+            definition: "S1 - Response",
+            stage: "breached",
+            stageLabel: "Breached",
+            hasBreached: true,
+            businessElapsedPercent: 109,
+            businessTimeLeftLabel: "0 seconds",
+          }),
+        ]}
+      />,
+    );
+    expect(screen.queryByText("Query - Resolution")).not.toBeInTheDocument();
+    expect(screen.getByText("S1 - Response")).toBeInTheDocument();
+    expect(screen.getByText("Breached")).toBeInTheDocument();
+    expect(screen.getByText("109%")).toBeInTheDocument();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseSlaStrip.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseSlaStrip.tsx
@@ -1,0 +1,92 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { alpha, Box, Typography } from "@wso2/oxygen-ui";
+import type { JSX } from "react";
+import { slaProgressColor } from "@features/csm-cases/utils/caseSlaMapping";
+import type { CaseSla } from "@features/csm-cases/types/csmCases";
+
+interface CaseSlaStripProps {
+  slas: CaseSla[] | undefined;
+}
+
+/**
+ * Compact, always-visible SLA summary shown on the case Overview band — one
+ * line per SLA that still needs attention, with the same colour-fill
+ * treatment as the full SLA tab (see {@link CaseSlaTable}), so a breach reads
+ * pre-attentively without opening that tab. `Completed`/`Cancelled` SLAs are
+ * dropped here on purpose: those no longer need attention, and the full
+ * history stays available on the SLA tab.
+ */
+export default function CaseSlaStrip({ slas }: CaseSlaStripProps): JSX.Element | null {
+  const active = (slas ?? []).filter(
+    (s) => s.stage !== "completed" && s.stage !== "cancelled",
+  );
+  if (active.length === 0) return null;
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 0.5,
+        px: 2,
+        py: 1,
+        borderTop: 1,
+        borderColor: "divider",
+      }}
+    >
+      {active.map((sla) => {
+        const elapsedPct = Math.min(Math.max(sla.businessElapsedPercent, 0), 100);
+        return (
+          <Box
+            key={sla.id}
+            aria-label={`${sla.definition} ${Math.round(elapsedPct)}% elapsed`}
+            sx={(theme) => ({
+              display: "flex",
+              alignItems: "center",
+              gap: 1,
+              px: 1,
+              py: 0.5,
+              borderRadius: 1,
+              background: `linear-gradient(to right, ${alpha(
+                theme.palette[slaProgressColor(sla)].main,
+                0.14,
+              )} ${elapsedPct}%, transparent ${elapsedPct}%)`,
+            })}
+          >
+            <Typography variant="body2" noWrap sx={{ flexShrink: 0 }}>
+              {sla.definition}
+            </Typography>
+            <Typography variant="body2" color="text.secondary" noWrap>
+              {sla.stageLabel}
+            </Typography>
+            <Typography variant="body2" color="text.secondary" noWrap>
+              {sla.businessTimeLeftLabel ? `${sla.businessTimeLeftLabel} left` : null}
+            </Typography>
+            <Typography
+              variant="body2"
+              sx={{ ml: "auto", fontWeight: 600, flexShrink: 0 }}
+              color={`${slaProgressColor(sla)}.main`}
+            >
+              {`${Math.round(sla.businessElapsedPercent)}%`}
+            </Typography>
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseSlaTable.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseSlaTable.tsx
@@ -35,6 +35,7 @@ import type { JSX } from "react";
 import { formatAbsoluteForUser } from "@utils/dateTime";
 import { formatRelativeTime } from "@features/csm-dashboard/utils/abtDashboard";
 import { useGetCsmCaseSlas } from "@features/csm-cases/api/useGetCsmCaseSlas";
+import { slaProgressColor } from "@features/csm-cases/utils/caseSlaMapping";
 import type { CaseSla } from "@features/csm-cases/types/csmCases";
 
 /** The known, closed set of SLA stages that map to a curated chip color. */
@@ -72,13 +73,6 @@ function stageColor(sla: CaseSla): "info" | "warning" | "success" | "default" | 
   return sla.hasBreached
     ? "error"
     : (SLA_STAGE_COLOR[sla.stage as KnownSlaStage] ?? "default");
-}
-
-/** Progress bar color for a row: redder as more of the SLA target is consumed. */
-function slaProgressColor(sla: CaseSla): "error" | "warning" | "success" {
-  if (sla.hasBreached || sla.businessElapsedPercent >= 100) return "error";
-  if (sla.businessElapsedPercent >= 75) return "warning";
-  return "success";
 }
 
 interface CaseSlaTableProps {

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -1885,6 +1885,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
         detail={c}
         collapsed={metaCollapsed}
         onToggleCollapsed={() => setMetaCollapsed((v) => !v)}
+        slas={slaList?.slas}
       />
 
       {feedback && (

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/caseSlaMapping.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/caseSlaMapping.ts
@@ -65,6 +65,15 @@ export function normalizeStage(raw: string | null): { stage: SlaStage; label: st
   return { stage: normalized, label: trimmed };
 }
 
+/** Progress-fill color for an SLA: redder as more of the target is consumed.
+ * Shared by {@link CaseSlaTable} and {@link CaseSlaStrip} so both the full
+ * table and the compact Overview summary agree on the same thresholds. */
+export function slaProgressColor(sla: CaseSla): "error" | "warning" | "success" {
+  if (sla.hasBreached || sla.businessElapsedPercent >= 100) return "error";
+  if (sla.businessElapsedPercent >= 75) return "warning";
+  return "success";
+}
+
 /** Maps one wire-shape SLA record onto the row model {@link CaseSlaTable} renders. */
 export function toCaseSla(view: TaskSlaView): CaseSla {
   const { stage, label } = normalizeStage(view.stage);


### PR DESCRIPTION
## Purpose
SLA status is one of the highest-attention attributes on a case, but it's currently invisible until an engineer deliberately clicks into the SLAs tab. The Overview section (Account, Tier, Project, Deployment, Product, Created By, Assignee) shows no SLA signal at all.

## Goals
- Surface a compact, at-a-glance SLA summary directly on the case Overview band, reusing the same colour-fill treatment as the full SLA tab.
- Keep the SLAs tab as the full detail view — this only promotes a summary into Overview, nothing is removed.

## Approach
- Extracted `slaProgressColor` out of `CaseSlaTable` into `caseSlaMapping.ts` so both the full table and the new compact strip share the same red/orange/green thresholds instead of duplicating them.
- New `CaseSlaStrip` component: one line per SLA that's still `in_progress` or `breached` (definition, stage, business time left, elapsed %), each row using the same hard-stop `linear-gradient` fill as the SLA tab's rows. Completed/cancelled SLAs are dropped — they no longer need attention, and the full history stays on the SLA tab. Renders nothing when there's nothing active, so it stays out of the way on healthy cases.
- `CaseMetaBand` renders the strip right under its header, **regardless of the band's collapsed state** — SLA breach risk shouldn't disappear along with the rest of the Overview body when an engineer collapses it.
- `CsmCaseDetailPage` passes its already-fetched SLA list (previously only used for the SLA tab's count badge) straight through — no extra fetch.

## User stories
- As an engineer viewing a case, I can see any in-progress or breached SLA's stage, time left, and elapsed % without opening the SLAs tab.
- As an engineer, a case with no active SLA shows no extra clutter.
- As an engineer, collapsing the Overview band still leaves the SLA status visible.

## Release note
The case detail page's Overview section now shows a compact SLA status strip (definition, stage, time left, elapsed %) for any in-progress or breached SLA, with the same colour-fill indicator as the SLAs tab.

## Documentation
No API changes — this is a frontend-only reuse of already-fetched data.

## Automation tests
- New `CaseSlaStrip.test.tsx` (5 tests): empty/undefined SLAs render nothing, completed/cancelled-only renders nothing, an active SLA's summary line renders, filtering keeps in-progress/breached while dropping completed.
- Extended `CaseMetaBand.test.tsx` with 3 tests covering the new `slas` prop, including that the strip stays visible while the band is collapsed.
- Full `csm-cases` suite (42 files / 381 tests) passes; `tsc -b --noEmit` and `eslint` clean on all touched files.

## Security checks
No new endpoints, no new data exposure — reuses an existing query's already-authorized response.

## Test environment
Verified via `tsc`/`eslint`/`vitest` locally. Visual verification against a real case with an active/breached SLA pending.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an SLA summary to the case overview, showing active SLAs, stages, remaining time, and elapsed progress.
  - SLA information remains visible even when case metadata is collapsed.
  - Added visual status indicators for healthy, at-risk, and breached SLAs.

- **Bug Fixes**
  - Completed and cancelled SLAs are excluded from active SLA summaries.
  - Progress indicators are capped to prevent visual overflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->