### PR TITLE
[Customer Portal v2] Fix 500 on case attachments from createdBy type mismatch

### DIFF
--- a/apps/customer-portal/backend-v2/internal/dto/attachment.go
+++ b/apps/customer-portal/backend-v2/internal/dto/attachment.go
@@ -17,6 +17,7 @@
 package dto
 
 import (
+	"strings"
 	"time"
 
 	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
@@ -104,7 +105,7 @@ func MapSearchAttachments(r entity.SearchAttachmentsResponse) SearchAttachmentsR
 			Type:          a.Type,
 			SizeBytes:     a.SizeBytes,
 			Description:   a.Description,
-			CreatedBy:     a.CreatedBy,
+			CreatedBy:     attachmentCreatedByName(a.CreatedBy),
 			CreatedOn:     a.CreatedOn,
 			DownloadURL:   a.DownloadURL,
 			PreviewURL:    a.PreviewURL,
@@ -133,6 +134,19 @@ type CaseAttachmentsResponse struct {
 
 // MapCaseAttachments builds the portal response from entity-service's
 // SearchAttachmentsResponse for GET /cases/{id}/attachments.
+// attachmentCreatedByName flattens entity-service's createdBy user object to the
+// single display string the portal contract exposes (the frontend's
+// AuditMetadata types createdBy as `string | null` and renders it directly, e.g.
+// "Uploaded by {createdBy}"). Prefers the resolved name and falls back to the
+// email, since Name is omitempty upstream and absent when the data source could
+// not resolve the uploader to a user record.
+func attachmentCreatedByName(u entity.UserRef) string {
+	if n := strings.TrimSpace(u.Name); n != "" {
+		return n
+	}
+	return strings.TrimSpace(u.Email)
+}
+
 func MapCaseAttachments(r entity.SearchAttachmentsResponse) CaseAttachmentsResponse {
 	items := make([]AttachmentSummary, 0, len(r.Attachments))
 	for _, a := range r.Attachments {
@@ -144,7 +158,7 @@ func MapCaseAttachments(r entity.SearchAttachmentsResponse) CaseAttachmentsRespo
 			Type:          a.Type,
 			SizeBytes:     a.SizeBytes,
 			Description:   a.Description,
-			CreatedBy:     a.CreatedBy,
+			CreatedBy:     attachmentCreatedByName(a.CreatedBy),
 			CreatedOn:     a.CreatedOn,
 			DownloadURL:   a.DownloadURL,
 			PreviewURL:    a.PreviewURL,
@@ -295,7 +309,7 @@ func MapDeploymentAttachments(r entity.SearchAttachmentsResponse) DeploymentAtta
 			Type:          a.Type,
 			SizeBytes:     a.SizeBytes,
 			Description:   a.Description,
-			CreatedBy:     a.CreatedBy,
+			CreatedBy:     attachmentCreatedByName(a.CreatedBy),
 			CreatedOn:     a.CreatedOn,
 			DownloadURL:   a.DownloadURL,
 			PreviewURL:    a.PreviewURL,

--- a/apps/customer-portal/backend-v2/internal/dto/attachment_created_by_test.go
+++ b/apps/customer-portal/backend-v2/internal/dto/attachment_created_by_test.go
@@ -1,0 +1,159 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dto
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+)
+
+// entityAttachmentSearchPayload is a verbatim-shaped POST /attachments/search
+// response from entity-service, including the fields backend-v2 does not mirror
+// (createdByUser, hasMore) so the lenient-decode assumption is exercised too.
+const entityAttachmentSearchPayload = `{
+  "attachments": [
+    {
+      "id": "470cac1d-3bfa-8710-3e1e-088aa4e45a89",
+      "referenceId": "2b51f79d-3be6-8790-9140-4c6aa5e45a07",
+      "referenceType": "case",
+      "name": "diagnostics.zip",
+      "type": "application/zip",
+      "sizeBytes": 20481,
+      "description": null,
+      "createdBy": {
+        "id": "a1b2c3d4",
+        "name": "Jane Doe",
+        "userId": "u-99",
+        "email": "jane@example.com"
+      },
+      "createdByUser": {"id": "a1b2c3d4", "email": "jane@example.com", "name": "Jane Doe"},
+      "createdOn": "2026-08-18T06:45:59Z",
+      "downloadUrl": "https://example.invalid/d/470cac1d",
+      "previewUrl": null
+    },
+    {
+      "id": "72de20d9-eb7e-8710-fcf5-f5dabad0cd22",
+      "referenceId": "2b51f79d-3be6-8790-9140-4c6aa5e45a07",
+      "referenceType": "case",
+      "name": "thread-dump.txt",
+      "type": "text/plain",
+      "sizeBytes": 774,
+      "description": "second upload",
+      "createdBy": {"email": "ops@example.com"},
+      "createdByUser": null,
+      "createdOn": "2026-08-18T06:51:32Z",
+      "downloadUrl": null,
+      "previewUrl": null
+    }
+  ],
+  "total": 2,
+  "limit": 10,
+  "offset": 0,
+  "hasMore": false
+}`
+
+// TestAttachmentSearch_DecodesObjectCreatedBy is the regression guard for the
+// 500 on GET /cases/{id}/attachments.
+//
+// entity-service emits createdBy as a domain.UserRef *object* on the search item
+// (unlike AttachmentDetail.createdBy, which genuinely is a string). backend-v2
+// declared it `string`, so json.Unmarshal failed with "cannot unmarshal object
+// into Go value of type string", aborting the entire decode — entity-service
+// logged 200 while the portal showed "Failed to retrieve case attachments."
+func TestAttachmentSearch_DecodesObjectCreatedBy(t *testing.T) {
+	var resp entity.SearchAttachmentsResponse
+	if err := json.Unmarshal([]byte(entityAttachmentSearchPayload), &resp); err != nil {
+		t.Fatalf("decoding entity-service's real payload failed: %v", err)
+	}
+	if len(resp.Attachments) != 2 {
+		t.Fatalf("decoded %d attachments, want 2", len(resp.Attachments))
+	}
+	if got := resp.Attachments[0].CreatedBy.Name; got != "Jane Doe" {
+		t.Errorf("CreatedBy.Name = %q, want %q", got, "Jane Doe")
+	}
+	if got := resp.Attachments[0].CreatedBy.Email; got != "jane@example.com" {
+		t.Errorf("CreatedBy.Email = %q, want %q", got, "jane@example.com")
+	}
+}
+
+// TestMapCaseAttachments_FlattensCreatedByToDisplayString checks the portal
+// contract stays a plain string — the frontend's AuditMetadata types createdBy
+// as `string | null` and renders it directly ("Uploaded by {createdBy}"), so the
+// upstream object must not leak through.
+func TestMapCaseAttachments_FlattensCreatedByToDisplayString(t *testing.T) {
+	var resp entity.SearchAttachmentsResponse
+	if err := json.Unmarshal([]byte(entityAttachmentSearchPayload), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	mapped := MapCaseAttachments(resp)
+
+	if len(mapped.Attachments) != 2 {
+		t.Fatalf("mapped %d attachments, want 2", len(mapped.Attachments))
+	}
+	// Resolved uploader: prefer the name.
+	if got := mapped.Attachments[0].CreatedBy; got != "Jane Doe" {
+		t.Errorf("createdBy = %q, want %q", got, "Jane Doe")
+	}
+	// Unresolved uploader (no name upstream): fall back to the email rather
+	// than rendering an empty author.
+	if got := mapped.Attachments[1].CreatedBy; got != "ops@example.com" {
+		t.Errorf("createdBy = %q, want the email fallback %q", got, "ops@example.com")
+	}
+
+	// createdBy must serialise as a JSON string, never an object.
+	b, err := json.Marshal(mapped.Attachments[0])
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var probe map[string]json.RawMessage
+	if err := json.Unmarshal(b, &probe); err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	var asString string
+	if err := json.Unmarshal(probe["createdBy"], &asString); err != nil {
+		t.Errorf("createdBy is not a JSON string (%s); the frontend renders it directly", probe["createdBy"])
+	}
+}
+
+// TestMapCaseAttachments_EmitsTotalRecords keeps the pagination key the
+// attachments hook depends on — it destructures totalRecords with no
+// array-length fallback.
+func TestMapCaseAttachments_EmitsTotalRecords(t *testing.T) {
+	var resp entity.SearchAttachmentsResponse
+	if err := json.Unmarshal([]byte(entityAttachmentSearchPayload), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	b, err := json.Marshal(MapCaseAttachments(resp))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var probe struct {
+		TotalRecords *int `json:"totalRecords"`
+		Total        *int `json:"total"`
+	}
+	if err := json.Unmarshal(b, &probe); err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if probe.TotalRecords == nil || *probe.TotalRecords != 2 {
+		t.Errorf("totalRecords = %v, want 2", probe.TotalRecords)
+	}
+	if probe.Total != nil {
+		t.Errorf("legacy \"total\" key still emitted: %v", *probe.Total)
+	}
+}

--- a/apps/customer-portal/backend-v2/internal/entity/types.go
+++ b/apps/customer-portal/backend-v2/internal/entity/types.go
@@ -992,10 +992,21 @@ type Attachment struct {
 	Type          string        `json:"type"`
 	SizeBytes     int           `json:"sizeBytes"`
 	Description   *string       `json:"description"`
-	CreatedBy     string        `json:"createdBy"`
-	CreatedOn     time.Time     `json:"createdOn"`
-	DownloadURL   *string       `json:"downloadUrl"`
-	PreviewURL    *string       `json:"previewUrl"`
+	// CreatedBy is an object, not a string: entity-service emits
+	// domain.UserRef ({id, name, userId, email}) here, unlike
+	// AttachmentDetail.CreatedBy which genuinely is a plain string. Declaring
+	// it as a string made json.Unmarshal fail with "cannot unmarshal object
+	// into Go value of type string", which aborted the whole decode and turned
+	// every GET /cases/{id}/attachments into a 500 even though entity-service
+	// had returned 200 with a valid list.
+	//
+	// entity-service also sends a sibling createdByUser (*domain.UserReference);
+	// it is deliberately not mirrored here because no portal consumer reads it
+	// and responses decode leniently, so the extra field is simply ignored.
+	CreatedBy   UserRef   `json:"createdBy"`
+	CreatedOn   time.Time `json:"createdOn"`
+	DownloadURL *string   `json:"downloadUrl"`
+	PreviewURL  *string   `json:"previewUrl"`
 }
 
 // SearchAttachmentsResponse is entity-service's response for POST /attachments/search.


### PR DESCRIPTION
## Purpose

`GET /cases/{id}/attachments` returned **500** while entity-service logged **200** for the same request — surfacing in the portal as *"Failed to retrieve case attachments."*

entity-service emits `createdBy` as a `domain.UserRef` **object** on the attachment search item:

```json
"createdBy": { "id": "...", "name": "Jane Doe", "userId": "...", "email": "..." }
```

backend-v2's mirror declared it a plain `string`, so `json.Unmarshal` failed with `cannot unmarshal object into Go value of type string` and aborted the decode of the **entire** response. A valid, populated 200 became a 500.

The failure was *inside* backend-v2 after a successful upstream call, which is why every gateway and entity-service log line for the request read `200` — the giveaway that this was a mapping defect, not a fetch failure.

## Scope

**Only the search item is affected.** `AttachmentDetail.createdBy` (`GET /attachments/{id}`) genuinely is a string on both sides and is deliberately left alone — the two structs disagree upstream, so a blanket change would have broken the detail route.

## The portal contract is unchanged

`createdBy` stays a plain string: the frontend types it as `string | null` on `AuditMetadata` and renders it directly (`Uploaded by {createdBy}`). `attachmentCreatedByName` flattens the object, preferring the resolved name and falling back to the email — `name` is `omitempty` upstream and absent when the data source could not resolve the uploader to a user record. This matches how comments already flatten their own user object to a display string.

entity-service also sends a sibling `createdByUser` (`*domain.UserReference`) and `hasMore`, neither mirrored here: responses decode with plain `json.Unmarshal`, so unmirrored fields are ignored rather than fatal, and no portal consumer reads either. Noted in a comment at the struct rather than adding unused types.

## Correction to #1487

#1487 claimed its `total` → `totalRecords` rename fixed the `Attachments (0)` count. **That was wrong.** `GET /cases/{id}/attachments` returns `CaseAttachmentsResponse`, which already emitted `totalRecords`; the legacy `total` was on the *generic* `POST /attachments/search` envelope, which the case-detail tab does not call.

**This 500 is what made the tab read `Attachments (0)`** — no data arrives at all. #1487's rename remains valid drift cleanup (CLAUDE.md had flagged those three envelopes), just not the fix for this symptom.

## Testing

- `go build`, `go vet`, `gofmt -l`, `go test -race ./...` — all pass
- `gosec -fmt=text ./...` — **0 issues** (103 files)
- Tests decode a **verbatim-shaped** entity-service payload including the unmirrored `createdByUser`/`hasMore`, so the lenient-decode assumption is exercised rather than assumed, and assert `createdBy` serialises as a JSON **string**, not an object. Both uploader cases are covered: resolved (name) and unresolved (email fallback).

### UI verification

Open a case with attachments: the tab loads instead of erroring, shows the real count, and each row shows the uploader's name (or email when unresolved).

## Deployment

**backend-v2 only** — no entity-service change. Independent of #1487; either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed attachment lists failing to load when uploader details are returned as an object.
  * Attachment uploader information now displays the person’s name, with email used as a fallback.
  * Standardized attachment search responses to return `totalRecords`.
  * Added optional preview links for attachments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->