### PR TITLE
[CSM Portal] Scope time-card approver search to the approver role

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/LogTimeCardDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/LogTimeCardDialog.tsx
@@ -46,10 +46,7 @@ import { useDebouncedValue } from "@hooks/useDebouncedValue";
 import { useIdTokenClaims } from "@hooks/useIdTokenClaims";
 import { initialsOf, resolveUserInfo } from "@utils/userClaims";
 import { useSearchUsers } from "@features/csm-users/api/useSearchUsers";
-import {
-  INTERNAL_USER_ROLES,
-  type NormalizedUser,
-} from "@features/csm-users/types/csmUsers";
+import type { NormalizedUser } from "@features/csm-users/types/csmUsers";
 import TimeCardStatusChip from "@features/csm-timecards/components/TimeCardStatusChip";
 import type { SeverityOrUnset } from "@features/csm-dashboard/types/abtDashboard";
 import {
@@ -58,6 +55,7 @@ import {
   DEFAULT_ISSUE_COMPLEXITY,
   ISSUE_COMPLEXITY_OPTIONS,
   NON_BILLABLE_SEVERITIES,
+  TIMECARD_APPROVER_GROUP,
   WORK_LOG_MAX,
 } from "@features/csm-timecards/constants/timeCardConstants";
 import type {
@@ -251,10 +249,11 @@ export default function LogTimeCardDialog({
   const { data } = useSearchUsers({
     filters: {
       ...(search.length > 0 && { searchQuery: search }),
-      // Approvers must be real internal accounts — the backend requires a
-      // real UUID in `approverIds`, so there is no offline/mock fallback
-      // (a fabricated id would always be rejected on submit).
-      roleIds: INTERNAL_USER_ROLES,
+      // Approvers must hold the timecard_approver role — listing every
+      // internal WSO2 account here (the old INTERNAL_USER_ROLES filter)
+      // let a submitter pick literally anyone at the company, including
+      // people with no CS/team-lead involvement at all (digiops-cs#2821).
+      roleIds: [TIMECARD_APPROVER_GROUP],
       active: true,
     },
     pagination: { limit: 6, offset: 0 },


### PR DESCRIPTION
## Purpose
The Log Time dialog's "Approver (team lead)" search let a submitter pick literally anyone at WSO2 as their approver — including people with no CS involvement at all — because it filtered by `INTERNAL_USER_ROLES` (any internal/agent/admin account), not by anything approver-specific.

## Goals
Only accounts that actually hold the timecard-approver role should show up as approver candidates.

## Approach
Swapped the search filter from `roleIds: INTERNAL_USER_ROLES` to `roleIds: [TIMECARD_APPROVER_GROUP]` in `LogTimeCardDialog.tsx` — the same role key `useTimecardRole.ts` already uses elsewhere to identify eligible approvers, so this reuses an existing, correct concept rather than inventing a new one.

## User stories
- As an engineer logging time, the approver search only shows people who can actually approve time cards, not every WSO2 employee.

## Release note
The time-card "Approver (team lead)" search now only returns accounts with the approver role, instead of any internal WSO2 account.

## Documentation
No API contract change — this only narrows an existing `roleIds` search filter value on the client.

## Automation tests
Full `csm-timecards` suite (11 files / 86 tests) passes; `tsc -b --noEmit` clean on the touched file.

## Security checks
No new data exposure — this narrows, rather than widens, what the search returns.

## Test environment
Verified via `tsc`/`vitest` locally. Live verification (searching for a non-approver by name and confirming they no longer appear) pending.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Timecard approver searches now show only users with the designated timecard approver role, improving accuracy and reducing irrelevant results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->