### PR TITLE
[CSM Portal] Convert Operations/Security Center to sidebar submenus

### DIFF
--- a/apps/csm-portal/webapp/src/components/side-nav-bar/CsmSideBar.test.tsx
+++ b/apps/csm-portal/webapp/src/components/side-nav-bar/CsmSideBar.test.tsx
@@ -14,44 +14,67 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 import { MemoryRouter } from "react-router";
 import type { ReactNode } from "react";
 
-// Records each `activeItem` CsmSideBar hands the real Sidebar, without
-// reassigning an outer-scope variable during render (a mock function call
-// is not a render side effect the way a bare assignment is).
+// Records the props CsmSideBar hands the real Sidebar on each render, without
+// reassigning an outer-scope variable during render (a mock function call is
+// not a render side effect the way a bare assignment is).
 const sidebarPropsSpy = vi.fn();
 
-function lastActiveItem(): string | undefined {
-  return sidebarPropsSpy.mock.calls.at(-1)?.[0] as string | undefined;
+interface CapturedSidebarProps {
+  activeItem?: string;
+  expandedMenus?: Record<string, boolean>;
+  onSelect?: (id: string) => void;
 }
 
-// The real Sidebar's internal DOM/selection markup isn't this test's concern
-// -- only what `activeItem` CsmSideBar computed and handed it. Every
-// compound sub-component it renders (`Sidebar.Nav`, `.Item`, ...) is stubbed
-// to a passthrough so CsmSideBar's own JSX still resolves.
+function lastSidebarProps(): CapturedSidebarProps {
+  return (sidebarPropsSpy.mock.calls.at(-1)?.[0] ?? {}) as CapturedSidebarProps;
+}
+
+function lastActiveItem(): string | undefined {
+  return lastSidebarProps().activeItem;
+}
+
+const navigateMock = vi.fn();
+vi.mock("@hooks/useNavTransition", () => ({
+  useNavTransition: () => navigateMock,
+}));
+
+// The real Sidebar's internal DOM/selection/expand-collapse machinery isn't
+// this test's concern -- only what CsmSideBar computed and handed it
+// (activeItem, expandedMenus, onSelect) and what it rendered as nested
+// children. Every compound sub-component it renders (`Sidebar.Nav`,
+// `.Item`, ...) is stubbed to a passthrough so CsmSideBar's own JSX still
+// resolves and nested `Sidebar.Item`s render their labels for assertions.
 vi.mock("@wso2/oxygen-ui", async () => {
   const actual = await vi.importActual<typeof import("@wso2/oxygen-ui")>("@wso2/oxygen-ui");
   const Passthrough = ({ children }: { children?: ReactNode }) => <>{children}</>;
+  // A real (if bare) DOM element per item/label, not a fragment passthrough —
+  // so a nested item's own text is its own element's content for
+  // `getByText`, distinct from its parent's aggregate text.
+  const MockItem = ({ id, children }: { id?: string; children?: ReactNode }) => (
+    <div data-item-id={id}>{children}</div>
+  );
+  const MockItemLabel = ({ children }: { children?: ReactNode }) => <span>{children}</span>;
   function MockSidebar({
     activeItem,
+    expandedMenus,
+    onSelect,
     children,
-  }: {
-    activeItem?: string;
-    children?: ReactNode;
-  }) {
-    sidebarPropsSpy(activeItem);
+  }: CapturedSidebarProps & { children?: ReactNode }) {
+    sidebarPropsSpy({ activeItem, expandedMenus, onSelect });
     return <div data-testid="sidebar">{children}</div>;
   }
   MockSidebar.Nav = Passthrough;
   MockSidebar.Category = Passthrough;
   MockSidebar.CategoryLabel = Passthrough;
-  MockSidebar.Item = Passthrough;
+  MockSidebar.Item = MockItem;
   MockSidebar.ItemIcon = Passthrough;
-  MockSidebar.ItemLabel = Passthrough;
+  MockSidebar.ItemLabel = MockItemLabel;
   MockSidebar.ItemBadge = Passthrough;
   MockSidebar.Footer = Passthrough;
   return { ...actual, Sidebar: MockSidebar };
@@ -72,6 +95,7 @@ function renderAt(path: string): ReturnType<typeof render> {
 describe("CsmSideBar — active section on routes with no owning nav section", () => {
   beforeEach(() => {
     sidebarPropsSpy.mockClear();
+    navigateMock.mockClear();
     sessionStorage.clear();
   });
 
@@ -95,5 +119,74 @@ describe("CsmSideBar — active section on routes with no owning nav section", (
     sessionStorage.setItem(LAST_SECTION_KEY, "admin");
     renderAt("/people/user-1");
     expect(lastActiveItem()).toBe("admin");
+  });
+});
+
+describe("CsmSideBar — Operations/Security Center submenu", () => {
+  beforeEach(() => {
+    sidebarPropsSpy.mockClear();
+    navigateMock.mockClear();
+    sessionStorage.clear();
+  });
+
+  it("renders Operations' children as nested items in the rail", () => {
+    renderAt("/dashboard");
+    expect(screen.getByText("Service requests")).toBeInTheDocument();
+    expect(screen.getByText("Change requests")).toBeInTheDocument();
+    expect(screen.getByText("Incidents")).toBeInTheDocument();
+    expect(screen.getByText("Problem management")).toBeInTheDocument();
+  });
+
+  it("renders Security Center's children as nested items in the rail", () => {
+    renderAt("/dashboard");
+    expect(screen.getByText("Security reports")).toBeInTheDocument();
+    expect(screen.getByText("Vulnerabilities")).toBeInTheDocument();
+  });
+
+  it("does not extend the submenu treatment to Customers/Settings — their children stay out of the rail", () => {
+    renderAt("/dashboard");
+    // Customers/Settings still switch tabs via their own in-page/route strip
+    // (`useRouteTabs`), untouched by this change — their children must not
+    // gain rail entries as a side effect of the Operations/Security work.
+    expect(screen.queryByText("Accounts")).not.toBeInTheDocument();
+    expect(screen.queryByText("User management")).not.toBeInTheDocument();
+  });
+
+  it("highlights the active child tab, not just the owning section, on a fresh load", () => {
+    renderAt("/operations/incidents");
+    expect(lastActiveItem()).toBe("operations.incidents");
+  });
+
+  it("auto-expands Operations on a fresh load when one of its children is active", () => {
+    renderAt("/operations/incidents");
+    expect(lastSidebarProps().expandedMenus?.operations).toBe(true);
+  });
+
+  it("auto-expands Security Center on a fresh load when one of its children is active", () => {
+    renderAt("/security-center/vulnerabilities");
+    expect(lastSidebarProps().expandedMenus?.["security-center"]).toBe(true);
+  });
+
+  it("does not force-expand Operations when a different section is active", () => {
+    renderAt("/dashboard");
+    expect(lastSidebarProps().expandedMenus?.operations).toBeFalsy();
+  });
+
+  it("navigates to the real path-segment route for a selected submenu child, not the legacy ?tab= href", () => {
+    renderAt("/dashboard");
+    lastSidebarProps().onSelect?.("operations.incidents");
+    expect(navigateMock).toHaveBeenCalledWith("/operations/incidents");
+  });
+
+  it("navigates a Security Center child selection to its own path-segment route", () => {
+    renderAt("/dashboard");
+    lastSidebarProps().onSelect?.("security-center.vulnerabilities");
+    expect(navigateMock).toHaveBeenCalledWith("/security-center/vulnerabilities");
+  });
+
+  it("does not navigate for a flat top-level section id selected directly (its own Link already handles it)", () => {
+    renderAt("/dashboard");
+    lastSidebarProps().onSelect?.("engagements");
+    expect(navigateMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/csm-portal/webapp/src/components/side-nav-bar/CsmSideBar.tsx
+++ b/apps/csm-portal/webapp/src/components/side-nav-bar/CsmSideBar.tsx
@@ -15,10 +15,22 @@
 // under the License.
 
 import { Box, Link, Sidebar, Tooltip, Typography } from "@wso2/oxygen-ui";
-import { useEffect, useRef, type JSX } from "react";
+import { useCallback, useEffect, useMemo, useRef, type JSX } from "react";
 import { Link as NavigateLink, useLocation } from "react-router";
-import { navNodePath, navSectionForPath } from "@config/csmNavItems";
-import { featureState, visibleNavSections } from "@config/featureFlags";
+import {
+  type CsmNavSection,
+  navNodeById,
+  navNodeHref,
+  navNodeMatchForPath,
+  navNodePath,
+  navSectionForPath,
+} from "@config/csmNavItems";
+import {
+  featureState,
+  visibleNavChildren,
+  visibleNavSections,
+} from "@config/featureFlags";
+import { useNavTransition } from "@hooks/useNavTransition";
 import { preloadRoute } from "@utils/routePreloaders";
 
 /** Tooltip for a disabled WIP item. Includes the label so the collapsed rail
@@ -59,13 +71,30 @@ interface CsmSideBarProps {
   onToggleExpand?: (id: string) => void;
 }
 
+/**
+ * A section whose children get their own submenu entries in the rail (as
+ * opposed to a section like Customers/Settings, whose children live in an
+ * in-page tab/route strip instead). A query-param tab's `tab` field is the
+ * structural marker for this — see `CsmNavNode.tab`'s doc comment — so this
+ * stays correct if another section adopts the same pattern later, with no
+ * hardcoded id list to keep in sync.
+ */
+function isSubmenuSection(section: CsmNavSection): boolean {
+  return Boolean(section.children?.length) && (section.children ?? []).every((child) => Boolean(child.tab));
+}
+
 function pickActiveId(pathname: string, lastSectionId: string): string {
   if (pathname === "/" || pathname === "") return "dashboard";
-  // Highlight the owning *section* — a second-level tab has no rail entry of
-  // its own, so `/operations/incidents/42` still lights up Operations.
-  // Routes with no owning section (e.g. `/people/:id`, linked from all over
-  // the app, not just Settings > Users) fall back to whichever section was
-  // last active instead of hard-jumping to Dashboard.
+  // A submenu section's own child (e.g. `operations.incidents`) gets its own
+  // rail entry, so highlight *that* rather than the section — this is what
+  // lets the nested item light up and the parent auto-expand. Every other
+  // route (including a tab-less section's own child route, e.g.
+  // `/customers/accounts`, which has no rail entry of its own) still
+  // highlights the owning *section*. Routes with no owning section (e.g.
+  // `/people/:id`, linked from all over the app) fall back to whichever
+  // section was last active instead of hard-jumping to Dashboard.
+  const match = navNodeMatchForPath(pathname);
+  if (match?.node.tab !== undefined) return match.node.id;
   return navSectionForPath(pathname)?.id ?? lastSectionId;
 }
 
@@ -76,6 +105,7 @@ export default function CsmSideBar({
   onToggleExpand,
 }: CsmSideBarProps): JSX.Element {
   const location = useLocation();
+  const navigate = useNavTransition();
   const lastSectionId = useRef(getLastSectionId());
   const activeItem = pickActiveId(location.pathname, lastSectionId.current);
   useEffect(() => {
@@ -83,12 +113,47 @@ export default function CsmSideBar({
     setLastSectionId(activeItem);
   }, [activeItem]);
 
+  // A submenu child (e.g. `operations.incidents`, rendered without its own
+  // navigating `Link` — see below) reaches here through Oxygen's own
+  // `onSelect`, dotted ids are how it's told apart from a flat top-level
+  // item's id (never dotted) whose Link already handled the navigation
+  // itself. A WIP child stays visible (so a deployment's config change is
+  // still legible in the rail) but inert, same intent as a WIP top-level
+  // section, just enforced here instead of structurally — Oxygen's own
+  // collapsed-rail popover reads a nested item's id/icon/label straight off
+  // its props, so it has to stay a plain `Sidebar.Item` rather than being
+  // wrapped in a disabling `Box`/`Tooltip` the way a top-level WIP section is.
+  const handleSelect = useCallback(
+    (id: string): void => {
+      if (id.includes(".") && featureState(id) !== "wip") {
+        const node = navNodeById(id);
+        if (node) navigate(navNodeHref(node));
+      }
+      onSelect?.(id);
+    },
+    [navigate, onSelect],
+  );
+
+  // A submenu section stays expanded whenever one of its own children is the
+  // active item, even on a fresh load before `onToggleExpand` has ever fired
+  // for it — `expandedMenus` alone can't do this since it starts empty every
+  // session. This intentionally overrides a manual collapse while that child
+  // is still the active page; collapsing only "sticks" once the user
+  // navigates elsewhere. That trade-off keeps the behaviour predictable
+  // (the section showing your current page is never hidden) rather than
+  // introducing separate "user closed this" state to track.
+  const effectiveExpandedMenus = useMemo(() => {
+    const dot = activeItem.indexOf(".");
+    if (dot === -1) return expandedMenus;
+    return { ...expandedMenus, [activeItem.slice(0, dot)]: true };
+  }, [expandedMenus, activeItem]);
+
   return (
     <Sidebar
       collapsed={collapsed}
       activeItem={activeItem}
-      expandedMenus={expandedMenus}
-      onSelect={onSelect}
+      expandedMenus={effectiveExpandedMenus}
+      onSelect={handleSelect}
       onToggleExpand={onToggleExpand}
     >
       <Sidebar.Nav>
@@ -132,6 +197,37 @@ export default function CsmSideBar({
                     </Box>
                   </Box>
                 </Tooltip>
+              );
+            }
+
+            // A submenu section (Operations, Security Center) renders its
+            // children as nested `Sidebar.Item`s instead of navigating
+            // directly: Oxygen shows a chevron and calls `onToggleExpand`
+            // for any item with nested items rather than `onSelect`, so this
+            // parent is deliberately NOT wrapped in a `Link` — only its
+            // children (below) navigate. A section whose config has hidden
+            // every one of its children falls through to the plain flat item
+            // instead of rendering an entry with nothing to expand.
+            const children = isSubmenuSection(item) ? visibleNavChildren(item) : [];
+            if (children.length > 0) {
+              return (
+                <Sidebar.Item id={item.id} key={item.id}>
+                  <Sidebar.ItemIcon>
+                    <item.icon size={20} />
+                  </Sidebar.ItemIcon>
+                  <Sidebar.ItemLabel>{item.label}</Sidebar.ItemLabel>
+                  {children.map((child) => {
+                    const childWip = featureState(child.id) === "wip";
+                    return (
+                      <Sidebar.Item id={child.id} key={child.id}>
+                        <Sidebar.ItemLabel>{child.label}</Sidebar.ItemLabel>
+                        {childWip && (
+                          <Sidebar.ItemBadge color="warning">WIP</Sidebar.ItemBadge>
+                        )}
+                      </Sidebar.Item>
+                    );
+                  })}
+                </Sidebar.Item>
               );
             }
 

--- a/apps/csm-portal/webapp/src/config/csmNavItems.ts
+++ b/apps/csm-portal/webapp/src/config/csmNavItems.ts
@@ -273,6 +273,20 @@ export function navNodePath(node: CsmNavNode): string {
 }
 
 /**
+ * Where actually navigating to `node` should go. For a query-param tab
+ * (`tab` set), `href` is kept in the legacy `?tab=` shape purely so an old
+ * bookmarked/shared link in that form still resolves (see
+ * `LegacyQueryTabRedirect`) — the real, canonical destination is its first
+ * declared {@link CsmNavNode.routes} entry, the actual path-segment route
+ * (`/operations/incidents`, not `/operations?tab=incidents`). Every other
+ * node has no such split: `href` already is the real destination.
+ */
+export function navNodeHref(node: CsmNavNode): string {
+  if (node.tab && node.routes?.[0]) return node.routes[0];
+  return node.href;
+}
+
+/**
  * Route path prefixes a node owns. A query-param tab (`tab` set) owns only its
  * explicit {@link CsmNavNode.routes}: its `href` pathname is the *parent's*
  * landing route, which every sibling tab shares, so claiming it would make the

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/OperationsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/OperationsPage.tsx
@@ -18,7 +18,6 @@ import { Box, Button, Typography } from "@wso2/oxygen-ui";
 import { ArrowLeft, Plus } from "@wso2/oxygen-ui-icons-react";
 import { type JSX } from "react";
 import { useLocation } from "react-router";
-import SectionTabs from "@components/section-tabs/SectionTabs";
 import CsmIssuesView from "@features/csm-cases/components/CsmIssuesView";
 import ChangeRequestsTab from "@features/csm-operations/components/ChangeRequestsTab";
 import IncidentsTab from "@features/csm-operations/components/IncidentsTab";
@@ -34,15 +33,15 @@ import { usePathSectionTabs } from "@hooks/useSectionTabs";
  *
  * Which tabs exist comes from the navigation tree, so a deployment can restrict
  * one through `CSM_PORTAL_FEATURE_OVERRIDES` without touching this page.
+ *
+ * The tab switch itself lives in the sidebar now (Operations' submenu), not
+ * an in-page strip — `usePathSectionTabs` is kept only for its
+ * enabled/WIP-aware fallback (an invalid or restricted `:tab` still resolves
+ * to the first usable one) reading the same real path segment
+ * (`/operations/:tab`) the sidebar's submenu links navigate to.
  */
 export default function OperationsPage(): JSX.Element {
-  // Active tab is a real path segment (`/operations/:tab`), not `?tab=` —
-  // switching to a genuinely different content set is its own bookmarkable
-  // route, per this app's URL-shape rule. See `usePathSectionTabs` and the
-  // `operations` routes in App.tsx (including the legacy `?tab=` redirect for
-  // links shared/bookmarked before this section had its own path segment).
-  const tabs = usePathSectionTabs("operations", "/operations");
-  const activeTab = tabs.activeKey;
+  const { activeKey: activeTab } = usePathSectionTabs("operations", "/operations");
   const navigate = useNavTransition();
   // Set by a dashboard widget's click-through (see DashboardWidgetTile /
   // widgetListConfig.tsx), since this page has no dashboard context of its
@@ -71,8 +70,6 @@ export default function OperationsPage(): JSX.Element {
           Service requests, change requests, incidents, and problems across customers.
         </Typography>
       </Box>
-
-      <SectionTabs {...tabs} ariaLabel="Operations tabs" />
 
       {activeTab === "service-requests" && (
         <CsmIssuesView

--- a/apps/csm-portal/webapp/src/features/csm-security-center/pages/CsmSecurityCenterPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-security-center/pages/CsmSecurityCenterPage.tsx
@@ -18,7 +18,6 @@ import { Box, Button, Typography } from "@wso2/oxygen-ui";
 import { ArrowLeft, Plus } from "@wso2/oxygen-ui-icons-react";
 import { type JSX } from "react";
 import { useLocation } from "react-router";
-import SectionTabs from "@components/section-tabs/SectionTabs";
 import CsmIssuesView from "@features/csm-cases/components/CsmIssuesView";
 import ProductVulnerabilitiesTab from "@features/csm-security-center/components/ProductVulnerabilitiesTab";
 import { useNavTransition } from "@hooks/useNavTransition";
@@ -33,10 +32,17 @@ import { usePathSectionTabs } from "@hooks/useSectionTabs";
  *
  * Which tabs exist comes from the navigation tree, so a deployment can restrict
  * one through `CSM_PORTAL_FEATURE_OVERRIDES` without touching this page.
+ *
+ * The tab switch itself lives in the sidebar now (Security Center's
+ * submenu), not an in-page strip — `usePathSectionTabs` is kept only for its
+ * enabled/WIP-aware fallback reading the same real path segment
+ * (`/security-center/:tab`) the sidebar's submenu links navigate to.
  */
 export default function CsmSecurityCenterPage(): JSX.Element {
-  const tabs = usePathSectionTabs("security-center", "/security-center");
-  const activeTab = tabs.activeKey;
+  const { activeKey: activeTab } = usePathSectionTabs(
+    "security-center",
+    "/security-center",
+  );
   const navigate = useNavTransition();
   // Set by a dashboard widget's click-through, since this page has no
   // dashboard context of its own. The security-reports tab renders its own
@@ -64,8 +70,6 @@ export default function CsmSecurityCenterPage(): JSX.Element {
           Security reports and vulnerability posture across customer deployments.
         </Typography>
       </Box>
-
-      <SectionTabs {...tabs} ariaLabel="Security Center tabs" />
 
       {activeTab === "security-reports" && (
         <CsmIssuesView


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Operations and Security Center currently appear as top-level sidebar navigation items, with their sub-sections (Service requests, Change requests, Incidents, Problem management for Operations; Security reports, Vulnerabilities for Security Center) selected via an in-page tab strip. Feedback from user testing was that these sub-sections should be reachable directly from the sidebar instead.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

Turn Operations and Security Center into expandable sidebar sections whose sub-sections render as nested submenu items, and remove the in-page tab strip for those two sections so the sidebar becomes the sole way to navigate between them.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

- `CsmSideBar.tsx`: any top-level nav section whose children all carry a `tab` (currently just Operations and Security Center, detected structurally rather than by a hardcoded id list) now renders as an expandable parent with nested `Sidebar.Item` children, using the sidebar's existing expand/collapse state plumbing. Active-child resolution highlights the correct nested item and auto-expands its parent on a fresh page load. Flat top-level sections (Customers, Settings, Home, etc.) are unaffected.
- `OperationsPage.tsx` / `CsmSecurityCenterPage.tsx`: removed the in-page tab-strip UI; the page now resolves which sub-section to render purely from the route, matching what the sidebar submenu links to.
- `csmNavItems.ts`: added a small helper to resolve a nav node's real navigation target; no data changes.

## User stories
> Summary of user stories addressed by this change

As a CS engineer, I can expand Operations or Security Center in the sidebar and jump directly to a sub-section (e.g. Incidents, Vulnerabilities) without an extra in-page tab click.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Operations and Security Center sub-sections are now reachable directly from the sidebar as expandable submenu items, replacing the previous in-page tab strip.

## Documentation
N/A — internal navigation/IA change, no externally documented behavior affected.

## Training
N/A — internal CS-engineer portal navigation change, not covered by external training content.

## Certification
N/A — no impact on certification exam content.

## Marketing
N/A — internal navigation change, not a marketable feature.

## Automation tests
 - Unit tests
   10 new tests added to `CsmSideBar.test.tsx` (13 total for this file) covering: nested children render for both sections; other sections (Customers, Settings) unaffected; active-child highlighting on fresh load; auto-expand on fresh load; no navigation regression for flat top-level items. Full suite: `npx vitest run` — 170 files / 1557 tests passed.
 - Integration tests
   Manually verified end-to-end against real ServiceNow DEV data (local full-stack topology: local Ballerina → Go entity-service → BFF → webapp, real Asgardeo auth) — Operations and Security Center expand/collapse, submenu navigation, and active-state highlighting confirmed working in the running app.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — TypeScript/React change, no Go/Java code touched; `npx eslint .` and `npx tsc -b` ran clean instead
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no new sample code introduced.

## Related PRs
None.

## Migrations (if applicable)
N/A — no data or schema migration.

## Test environment
Local full-stack topology against real ServiceNow DEV (`wso2sndev`) and real Asgardeo auth; Node/pnpm per the webapp's `package.json` engines; Chrome (latest) for manual verification.

## Learning
N/A — straightforward use of the existing sidebar component's built-in nested-item support; no new libraries or patterns introduced.
