### PR TITLE
[CSM Portal] timecard preview: approvers list + Approved by/Rejected by labels

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardCasePreviewDrawer.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardCasePreviewDrawer.test.tsx
@@ -146,6 +146,42 @@ describe("TimeCardCasePreviewDrawer", () => {
     expect(onDecide).toHaveBeenCalledWith("reject");
   });
 
+  it("lists the eligible approvers on a submitted card", () => {
+    getMock.mockReturnValue(new Promise(() => {}));
+    renderWithProviders(
+      <TimeCardCasePreviewDrawer
+        card={{
+          ...CARD,
+          approvers: [
+            { id: "lead-1", name: "Lead One" },
+            { id: "lead-2", name: "Lead Two" },
+          ],
+        }}
+        actions={[]}
+        onClose={vi.fn()}
+        onDecide={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Approvers")).toBeInTheDocument();
+    expect(screen.getByText("Lead One, Lead Two")).toBeInTheDocument();
+  });
+
+  it("shows the decision text without a generic 'Decision' caption on a decided card", () => {
+    getMock.mockReturnValue(new Promise(() => {}));
+    renderWithProviders(
+      <TimeCardCasePreviewDrawer
+        card={{ ...CARD, state: "approved", approvedByName: "Lead Person" }}
+        actions={[]}
+        onClose={vi.fn()}
+        onDecide={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Approved by: Lead Person")).toBeInTheDocument();
+    expect(screen.queryByText("Decision")).not.toBeInTheDocument();
+  });
+
   it("only shows the embedded case preview's 'View full details' close affordance, not a duplicate close button", async () => {
     getMock.mockResolvedValue({
       id: "case-1",

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardCasePreviewDrawer.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardCasePreviewDrawer.tsx
@@ -148,15 +148,17 @@ export default function TimeCardCasePreviewDrawer({
 
             <WorkLogComment html={card.workLogComment} />
 
-            {decision && (
+            {card.state === "submitted" && card.approvers && card.approvers.length > 0 && (
               <Field
-                label="Decision"
-                value={
-                  <Typography variant="body2" sx={{ whiteSpace: "normal", wordBreak: "break-word" }}>
-                    {decision}
-                  </Typography>
-                }
+                label="Approvers"
+                value={card.approvers.map((approver) => approver.name).join(", ")}
               />
+            )}
+
+            {decision && (
+              <Typography variant="body2" sx={{ whiteSpace: "normal", wordBreak: "break-word" }}>
+                {decision}
+              </Typography>
             )}
 
             {actions.some((a) => a === "approve" || a === "reject") && (

--- a/apps/csm-portal/webapp/src/features/csm-timecards/utils/__tests__/timeCardDecision.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/utils/__tests__/timeCardDecision.test.ts
@@ -38,7 +38,7 @@ function card(overrides: Partial<CsmTimeCard> = {}): CsmTimeCard {
 describe("decisionSummary", () => {
   it("names the approver on an approved card", () => {
     expect(decisionSummary(card({ state: "approved", approvedByName: "Lead Person" }))).toBe(
-      "Approved by Lead Person",
+      "Approved by: Lead Person",
     );
   });
 

--- a/apps/csm-portal/webapp/src/features/csm-timecards/utils/timeCardDecision.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/utils/timeCardDecision.ts
@@ -33,7 +33,7 @@ import type { CsmTimeCard } from "@features/csm-timecards/types/timeCards";
  */
 export function decisionSummary(card: CsmTimeCard): string | null {
   if (card.state === "approved") {
-    return card.approvedByName ? `Approved by ${card.approvedByName}` : "Approved";
+    return card.approvedByName ? `Approved by: ${card.approvedByName}` : "Approved";
   }
   if (card.state === "rejected") {
     return card.rejectionReason ? `Rejected: ${card.rejectionReason}` : "Rejected";


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

The time card case-preview drawer gave no visibility into who could approve
a submitted card, and its generic "Decision" caption on approved/rejected
cards read as boilerplate rather than a clear outcome.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

- Submitted cards show the list of eligible approvers.
- Approved/rejected cards drop the generic "Decision" label in favor of
  inline "Approved by: `<name>`" / "Rejected: `<reason>`" text.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

`TimeCardCasePreviewDrawer.tsx`: added an "Approvers" field (rendered only
when `state === "submitted"` and `card.approvers` is non-empty), and
replaced the labeled "Decision" `Field` with the existing
`decisionSummary()` text rendered directly, no caption. `timeCardDecision.ts`:
`decisionSummary`'s approved branch now reads "Approved by: `<name>`"
(colon added). Rejected cards are unchanged — "Rejected: `<reason>`", no
name, since ServiceNow's `time_card` table never records a rejecter
identity (only the approver's comment). No screenshot: not verified against
a running local stack or staging this session (see Automation tests below).

## User stories
> Summary of user stories addressed by this change>

As a CS engineer previewing a submitted time card, I can see who is
eligible to approve it. As a CS engineer previewing a decided time card, I
can see who approved it (or why it was rejected) without a redundant
"Decision" label.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Time card preview now lists eligible approvers on submitted cards and shows
"Approved by: Name" instead of a generic "Decision" label.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter "N/A" plus brief explanation of why there's no doc impact

N/A — internal CSM portal UI copy change, no external docs cover this screen.

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

N/A — no training content covers this screen.

## Certification
> Type "Sent" when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type "N/A" and explain why.

N/A — internal tool UI change, not covered by any certification exam.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

N/A — internal-only UI change.

## Automation tests
 - Unit tests
   > Code coverage information

Updated `timeCardDecision.test.ts` for the new "Approved by: `<name>`"
format, and added two new cases to `TimeCardCasePreviewDrawer.test.tsx`
(approver list rendering, decision text without the "Decision" caption).
Ran `vitest run src/features/csm-timecards` directly (11 files, 87/87
passed) and `tsc -p tsconfig.app.json --noEmit` (no errors in touched
files).
 - Integration tests
   > Details about the test cases and coverage

None — no integration/e2e test covers this drawer. Not manually verified
against a running local stack or staging this session.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — TypeScript/React change, not JVM
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> Provide high-level details about the samples related to this feature

N/A

## Related PRs
> List any other related PRs

N/A

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

N/A — no data or schema migration.

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested

Not run against a live environment this session; verified via unit tests
and typecheck only (macOS, Node/pnpm toolchain already present in the repo
checkout).

## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

Confirmed ServiceNow's `time_card` table records no rejecter identity (only
`approved_by` + the approver's rejection comment), so "Rejected by: Name"
was scoped out rather than fabricated from data that doesn't exist.
