### PR TITLE
[CSM Portal] Timecard/case-filter/preview-eye/work-items-tab/SRE-ABT-dashboard changes

### DIFF
--- a/apps/csm-portal/backend/internal/dashboard/registry.go
+++ b/apps/csm-portal/backend/internal/dashboard/registry.go
@@ -437,8 +437,9 @@ func validate(loaded []sourced, requireType bool) error {
 var validWidgetResourceTypes = map[ResourceType]bool{
 	ResourceCase: true, ResourceIncident: true, ResourceChangeRequest: true,
 	ResourceAccount: true, ResourceProject: true, ResourceUser: true,
-	ResourceTimeCard: true, ResourceProblem: true, ResourceProductVulnerability: true,
-	ResourceCallRequest: true,
+	ResourceTimeCard: true, ResourceProblem: true, ResourceIncidentTask: true,
+	ResourceProductVulnerability: true,
+	ResourceCallRequest:          true,
 	// The remaining four case-table values (see ResourceServiceRequest's doc
 	// comment) — same /cases/search endpoint as ResourceCase, distinguished
 	// only by the auto-injected "type" filter (caseTableResourceTypes,

--- a/apps/csm-portal/backend/internal/dashboard/widgets.go
+++ b/apps/csm-portal/backend/internal/dashboard/widgets.go
@@ -44,6 +44,7 @@ const (
 	ResourceUser                 ResourceType = "user"
 	ResourceTimeCard             ResourceType = "time_card"
 	ResourceProblem              ResourceType = "problem"
+	ResourceIncidentTask         ResourceType = "incident_task"
 	ResourceProductVulnerability ResourceType = "product_vulnerability"
 	ResourceCallRequest          ResourceType = "call_request"
 	// ResourceServiceRequest, ResourceSecurityReportAnalysis,

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -5594,6 +5594,7 @@ components:
             - user
             - time_card
             - problem
+            - incident_task
             - product_vulnerability
             - call_request
             - service_request

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -2629,6 +2629,41 @@ export interface BeProblemDetail {
 }
 
 /**
+ * List-item shape for `POST /incident_tasks/search`. No dedicated detail
+ * page exists for incident tasks in this app (unlike problem/incident), so
+ * there is no separate `BeIncidentTaskDetail` type yet — `description`,
+ * `priority`, `openedAt`, `closedAt` are on the backend's own
+ * `GET /incident_tasks/{id}` response but have no frontend consumer today.
+ * `stateLabel` is a pre-humanized display string the data source already
+ * resolves server-side — prefer it over trying to humanize `state` (a raw,
+ * data-source-specific integer with no stable domain enum here; see the
+ * `state` field's own doc comment).
+ */
+export interface BeIncidentTaskSearchView {
+  id?: string;
+  number?: string;
+  subject?: string;
+  /** Raw integer state value as a string, NOT a translated enum — the
+   * underlying state choice list is inconsistent across task subtypes, so
+   * there is no confirmed-complete, unambiguous domain enum to translate
+   * through. Use `stateLabel` for display. */
+  state?: string;
+  stateLabel?: string;
+  /** The parent incident this task belongs to. */
+  incident?: BeCaseNumberRef | null;
+  assignmentGroup?: BeEntityRef | null;
+  assignedTo?: BeEntityRef | null;
+}
+
+/** Note: mirrors the problem/change-request/incident search responses — no `hasMore`. */
+export interface BeIncidentTaskSearchResponse {
+  incidentTasks: BeIncidentTaskSearchView[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+/**
  * `POST /problems` body (ServiceNow data source only). `subject` is the only
  * required field. There is no `priority` field — priority is not settable on
  * create (SN computes/defaults it server-side, confirmed by live testing), so
@@ -2917,7 +2952,8 @@ export type BeWidgetResourceType =
   | "service_request"
   | "security_report_analysis"
   | "announcement"
-  | "engagement";
+  | "engagement"
+  | "incident_task";
 
 /**
  * How a widget's resolved data should be rendered. `pie` and `bar` both

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -2629,11 +2629,11 @@ export interface BeProblemDetail {
 }
 
 /**
- * List-item shape for `POST /incident_tasks/search`. No dedicated detail
+ * List-item shape for `POST /incident-tasks/search`. No dedicated detail
  * page exists for incident tasks in this app (unlike problem/incident), so
  * there is no separate `BeIncidentTaskDetail` type yet — `description`,
- * `priority`, `openedAt`, `closedAt` are on the backend's own
- * `GET /incident_tasks/{id}` response but have no frontend consumer today.
+ * `priority`, `openedOn`, `closedOn` are on the backend's own
+ * `GET /incident-tasks/{id}` response but have no frontend consumer today.
  * `stateLabel` is a pre-humanized display string the data source already
  * resolves server-side — prefer it over trying to humanize `state` (a raw,
  * data-source-specific integer with no stable domain enum here; see the

--- a/apps/csm-portal/webapp/src/components/side-nav-bar/CsmSideBar.test.tsx
+++ b/apps/csm-portal/webapp/src/components/side-nav-bar/CsmSideBar.test.tsx
@@ -120,6 +120,22 @@ describe("CsmSideBar — active section on routes with no owning nav section", (
     renderAt("/people/user-1");
     expect(lastActiveItem()).toBe("admin");
   });
+
+  // Regression test: visiting a submenu child route (e.g.
+  // `/operations/incidents`) used to persist the *child's* dotted id
+  // (`operations.incidents`) as the remembered section, not the owning
+  // section (`operations`). A later visit to a section-less route then read
+  // that stale child id back as the fallback, lighting up the old child and
+  // auto-expanding Operations even though nothing about the new route has
+  // anything to do with it.
+  it("remembers the owning section, not the child's own dotted id, after visiting a submenu child route", () => {
+    renderAt("/operations/incidents");
+    expect(sessionStorage.getItem(LAST_SECTION_KEY)).toBe("operations");
+
+    sidebarPropsSpy.mockClear();
+    renderAt("/people/user-1");
+    expect(lastActiveItem()).toBe("operations");
+  });
 });
 
 describe("CsmSideBar — Operations/Security Center submenu", () => {

--- a/apps/csm-portal/webapp/src/components/side-nav-bar/CsmSideBar.test.tsx
+++ b/apps/csm-portal/webapp/src/components/side-nav-bar/CsmSideBar.test.tsx
@@ -14,44 +14,67 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 import { MemoryRouter } from "react-router";
 import type { ReactNode } from "react";
 
-// Records each `activeItem` CsmSideBar hands the real Sidebar, without
-// reassigning an outer-scope variable during render (a mock function call
-// is not a render side effect the way a bare assignment is).
+// Records the props CsmSideBar hands the real Sidebar on each render, without
+// reassigning an outer-scope variable during render (a mock function call is
+// not a render side effect the way a bare assignment is).
 const sidebarPropsSpy = vi.fn();
 
-function lastActiveItem(): string | undefined {
-  return sidebarPropsSpy.mock.calls.at(-1)?.[0] as string | undefined;
+interface CapturedSidebarProps {
+  activeItem?: string;
+  expandedMenus?: Record<string, boolean>;
+  onSelect?: (id: string) => void;
 }
 
-// The real Sidebar's internal DOM/selection markup isn't this test's concern
-// -- only what `activeItem` CsmSideBar computed and handed it. Every
-// compound sub-component it renders (`Sidebar.Nav`, `.Item`, ...) is stubbed
-// to a passthrough so CsmSideBar's own JSX still resolves.
+function lastSidebarProps(): CapturedSidebarProps {
+  return (sidebarPropsSpy.mock.calls.at(-1)?.[0] ?? {}) as CapturedSidebarProps;
+}
+
+function lastActiveItem(): string | undefined {
+  return lastSidebarProps().activeItem;
+}
+
+const navigateMock = vi.fn();
+vi.mock("@hooks/useNavTransition", () => ({
+  useNavTransition: () => navigateMock,
+}));
+
+// The real Sidebar's internal DOM/selection/expand-collapse machinery isn't
+// this test's concern -- only what CsmSideBar computed and handed it
+// (activeItem, expandedMenus, onSelect) and what it rendered as nested
+// children. Every compound sub-component it renders (`Sidebar.Nav`,
+// `.Item`, ...) is stubbed to a passthrough so CsmSideBar's own JSX still
+// resolves and nested `Sidebar.Item`s render their labels for assertions.
 vi.mock("@wso2/oxygen-ui", async () => {
   const actual = await vi.importActual<typeof import("@wso2/oxygen-ui")>("@wso2/oxygen-ui");
   const Passthrough = ({ children }: { children?: ReactNode }) => <>{children}</>;
+  // A real (if bare) DOM element per item/label, not a fragment passthrough —
+  // so a nested item's own text is its own element's content for
+  // `getByText`, distinct from its parent's aggregate text.
+  const MockItem = ({ id, children }: { id?: string; children?: ReactNode }) => (
+    <div data-item-id={id}>{children}</div>
+  );
+  const MockItemLabel = ({ children }: { children?: ReactNode }) => <span>{children}</span>;
   function MockSidebar({
     activeItem,
+    expandedMenus,
+    onSelect,
     children,
-  }: {
-    activeItem?: string;
-    children?: ReactNode;
-  }) {
-    sidebarPropsSpy(activeItem);
+  }: CapturedSidebarProps & { children?: ReactNode }) {
+    sidebarPropsSpy({ activeItem, expandedMenus, onSelect });
     return <div data-testid="sidebar">{children}</div>;
   }
   MockSidebar.Nav = Passthrough;
   MockSidebar.Category = Passthrough;
   MockSidebar.CategoryLabel = Passthrough;
-  MockSidebar.Item = Passthrough;
+  MockSidebar.Item = MockItem;
   MockSidebar.ItemIcon = Passthrough;
-  MockSidebar.ItemLabel = Passthrough;
+  MockSidebar.ItemLabel = MockItemLabel;
   MockSidebar.ItemBadge = Passthrough;
   MockSidebar.Footer = Passthrough;
   return { ...actual, Sidebar: MockSidebar };
@@ -72,6 +95,7 @@ function renderAt(path: string): ReturnType<typeof render> {
 describe("CsmSideBar — active section on routes with no owning nav section", () => {
   beforeEach(() => {
     sidebarPropsSpy.mockClear();
+    navigateMock.mockClear();
     sessionStorage.clear();
   });
 
@@ -95,5 +119,74 @@ describe("CsmSideBar — active section on routes with no owning nav section", (
     sessionStorage.setItem(LAST_SECTION_KEY, "admin");
     renderAt("/people/user-1");
     expect(lastActiveItem()).toBe("admin");
+  });
+});
+
+describe("CsmSideBar — Operations/Security Center submenu", () => {
+  beforeEach(() => {
+    sidebarPropsSpy.mockClear();
+    navigateMock.mockClear();
+    sessionStorage.clear();
+  });
+
+  it("renders Operations' children as nested items in the rail", () => {
+    renderAt("/dashboard");
+    expect(screen.getByText("Service requests")).toBeInTheDocument();
+    expect(screen.getByText("Change requests")).toBeInTheDocument();
+    expect(screen.getByText("Incidents")).toBeInTheDocument();
+    expect(screen.getByText("Problem management")).toBeInTheDocument();
+  });
+
+  it("renders Security Center's children as nested items in the rail", () => {
+    renderAt("/dashboard");
+    expect(screen.getByText("Security reports")).toBeInTheDocument();
+    expect(screen.getByText("Vulnerabilities")).toBeInTheDocument();
+  });
+
+  it("does not extend the submenu treatment to Customers/Settings — their children stay out of the rail", () => {
+    renderAt("/dashboard");
+    // Customers/Settings still switch tabs via their own in-page/route strip
+    // (`useRouteTabs`), untouched by this change — their children must not
+    // gain rail entries as a side effect of the Operations/Security work.
+    expect(screen.queryByText("Accounts")).not.toBeInTheDocument();
+    expect(screen.queryByText("User management")).not.toBeInTheDocument();
+  });
+
+  it("highlights the active child tab, not just the owning section, on a fresh load", () => {
+    renderAt("/operations/incidents");
+    expect(lastActiveItem()).toBe("operations.incidents");
+  });
+
+  it("auto-expands Operations on a fresh load when one of its children is active", () => {
+    renderAt("/operations/incidents");
+    expect(lastSidebarProps().expandedMenus?.operations).toBe(true);
+  });
+
+  it("auto-expands Security Center on a fresh load when one of its children is active", () => {
+    renderAt("/security-center/vulnerabilities");
+    expect(lastSidebarProps().expandedMenus?.["security-center"]).toBe(true);
+  });
+
+  it("does not force-expand Operations when a different section is active", () => {
+    renderAt("/dashboard");
+    expect(lastSidebarProps().expandedMenus?.operations).toBeFalsy();
+  });
+
+  it("navigates to the real path-segment route for a selected submenu child, not the legacy ?tab= href", () => {
+    renderAt("/dashboard");
+    lastSidebarProps().onSelect?.("operations.incidents");
+    expect(navigateMock).toHaveBeenCalledWith("/operations/incidents");
+  });
+
+  it("navigates a Security Center child selection to its own path-segment route", () => {
+    renderAt("/dashboard");
+    lastSidebarProps().onSelect?.("security-center.vulnerabilities");
+    expect(navigateMock).toHaveBeenCalledWith("/security-center/vulnerabilities");
+  });
+
+  it("does not navigate for a flat top-level section id selected directly (its own Link already handles it)", () => {
+    renderAt("/dashboard");
+    lastSidebarProps().onSelect?.("engagements");
+    expect(navigateMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/csm-portal/webapp/src/components/side-nav-bar/CsmSideBar.tsx
+++ b/apps/csm-portal/webapp/src/components/side-nav-bar/CsmSideBar.tsx
@@ -109,8 +109,17 @@ export default function CsmSideBar({
   const lastSectionId = useRef(getLastSectionId());
   const activeItem = pickActiveId(location.pathname, lastSectionId.current);
   useEffect(() => {
-    lastSectionId.current = activeItem;
-    setLastSectionId(activeItem);
+    // `lastSectionId` is the fallback used for routes with no owning section
+    // (see `pickActiveId`'s doc comment) -- it must stay a *section* id.
+    // `activeItem` can be a submenu child's own dotted id (e.g.
+    // `operations.incidents`); persisting that verbatim meant navigating to
+    // an unrelated, section-less route later read the stale child id back as
+    // the fallback and lit up/expanded the wrong (previous) section.
+    const owningSectionId = activeItem.includes(".")
+      ? activeItem.slice(0, activeItem.indexOf("."))
+      : activeItem;
+    lastSectionId.current = owningSectionId;
+    setLastSectionId(owningSectionId);
   }, [activeItem]);
 
   // A submenu child (e.g. `operations.incidents`, rendered without its own

--- a/apps/csm-portal/webapp/src/components/side-nav-bar/CsmSideBar.tsx
+++ b/apps/csm-portal/webapp/src/components/side-nav-bar/CsmSideBar.tsx
@@ -15,10 +15,22 @@
 // under the License.
 
 import { Box, Link, Sidebar, Tooltip, Typography } from "@wso2/oxygen-ui";
-import { useEffect, useRef, type JSX } from "react";
+import { useCallback, useEffect, useMemo, useRef, type JSX } from "react";
 import { Link as NavigateLink, useLocation } from "react-router";
-import { navNodePath, navSectionForPath } from "@config/csmNavItems";
-import { featureState, visibleNavSections } from "@config/featureFlags";
+import {
+  type CsmNavSection,
+  navNodeById,
+  navNodeHref,
+  navNodeMatchForPath,
+  navNodePath,
+  navSectionForPath,
+} from "@config/csmNavItems";
+import {
+  featureState,
+  visibleNavChildren,
+  visibleNavSections,
+} from "@config/featureFlags";
+import { useNavTransition } from "@hooks/useNavTransition";
 import { preloadRoute } from "@utils/routePreloaders";
 
 /** Tooltip for a disabled WIP item. Includes the label so the collapsed rail
@@ -59,13 +71,30 @@ interface CsmSideBarProps {
   onToggleExpand?: (id: string) => void;
 }
 
+/**
+ * A section whose children get their own submenu entries in the rail (as
+ * opposed to a section like Customers/Settings, whose children live in an
+ * in-page tab/route strip instead). A query-param tab's `tab` field is the
+ * structural marker for this — see `CsmNavNode.tab`'s doc comment — so this
+ * stays correct if another section adopts the same pattern later, with no
+ * hardcoded id list to keep in sync.
+ */
+function isSubmenuSection(section: CsmNavSection): boolean {
+  return Boolean(section.children?.length) && (section.children ?? []).every((child) => Boolean(child.tab));
+}
+
 function pickActiveId(pathname: string, lastSectionId: string): string {
   if (pathname === "/" || pathname === "") return "dashboard";
-  // Highlight the owning *section* — a second-level tab has no rail entry of
-  // its own, so `/operations/incidents/42` still lights up Operations.
-  // Routes with no owning section (e.g. `/people/:id`, linked from all over
-  // the app, not just Settings > Users) fall back to whichever section was
-  // last active instead of hard-jumping to Dashboard.
+  // A submenu section's own child (e.g. `operations.incidents`) gets its own
+  // rail entry, so highlight *that* rather than the section — this is what
+  // lets the nested item light up and the parent auto-expand. Every other
+  // route (including a tab-less section's own child route, e.g.
+  // `/customers/accounts`, which has no rail entry of its own) still
+  // highlights the owning *section*. Routes with no owning section (e.g.
+  // `/people/:id`, linked from all over the app) fall back to whichever
+  // section was last active instead of hard-jumping to Dashboard.
+  const match = navNodeMatchForPath(pathname);
+  if (match?.node.tab !== undefined) return match.node.id;
   return navSectionForPath(pathname)?.id ?? lastSectionId;
 }
 
@@ -76,6 +105,7 @@ export default function CsmSideBar({
   onToggleExpand,
 }: CsmSideBarProps): JSX.Element {
   const location = useLocation();
+  const navigate = useNavTransition();
   const lastSectionId = useRef(getLastSectionId());
   const activeItem = pickActiveId(location.pathname, lastSectionId.current);
   useEffect(() => {
@@ -83,12 +113,47 @@ export default function CsmSideBar({
     setLastSectionId(activeItem);
   }, [activeItem]);
 
+  // A submenu child (e.g. `operations.incidents`, rendered without its own
+  // navigating `Link` — see below) reaches here through Oxygen's own
+  // `onSelect`, dotted ids are how it's told apart from a flat top-level
+  // item's id (never dotted) whose Link already handled the navigation
+  // itself. A WIP child stays visible (so a deployment's config change is
+  // still legible in the rail) but inert, same intent as a WIP top-level
+  // section, just enforced here instead of structurally — Oxygen's own
+  // collapsed-rail popover reads a nested item's id/icon/label straight off
+  // its props, so it has to stay a plain `Sidebar.Item` rather than being
+  // wrapped in a disabling `Box`/`Tooltip` the way a top-level WIP section is.
+  const handleSelect = useCallback(
+    (id: string): void => {
+      if (id.includes(".") && featureState(id) !== "wip") {
+        const node = navNodeById(id);
+        if (node) navigate(navNodeHref(node));
+      }
+      onSelect?.(id);
+    },
+    [navigate, onSelect],
+  );
+
+  // A submenu section stays expanded whenever one of its own children is the
+  // active item, even on a fresh load before `onToggleExpand` has ever fired
+  // for it — `expandedMenus` alone can't do this since it starts empty every
+  // session. This intentionally overrides a manual collapse while that child
+  // is still the active page; collapsing only "sticks" once the user
+  // navigates elsewhere. That trade-off keeps the behaviour predictable
+  // (the section showing your current page is never hidden) rather than
+  // introducing separate "user closed this" state to track.
+  const effectiveExpandedMenus = useMemo(() => {
+    const dot = activeItem.indexOf(".");
+    if (dot === -1) return expandedMenus;
+    return { ...expandedMenus, [activeItem.slice(0, dot)]: true };
+  }, [expandedMenus, activeItem]);
+
   return (
     <Sidebar
       collapsed={collapsed}
       activeItem={activeItem}
-      expandedMenus={expandedMenus}
-      onSelect={onSelect}
+      expandedMenus={effectiveExpandedMenus}
+      onSelect={handleSelect}
       onToggleExpand={onToggleExpand}
     >
       <Sidebar.Nav>
@@ -132,6 +197,37 @@ export default function CsmSideBar({
                     </Box>
                   </Box>
                 </Tooltip>
+              );
+            }
+
+            // A submenu section (Operations, Security Center) renders its
+            // children as nested `Sidebar.Item`s instead of navigating
+            // directly: Oxygen shows a chevron and calls `onToggleExpand`
+            // for any item with nested items rather than `onSelect`, so this
+            // parent is deliberately NOT wrapped in a `Link` — only its
+            // children (below) navigate. A section whose config has hidden
+            // every one of its children falls through to the plain flat item
+            // instead of rendering an entry with nothing to expand.
+            const children = isSubmenuSection(item) ? visibleNavChildren(item) : [];
+            if (children.length > 0) {
+              return (
+                <Sidebar.Item id={item.id} key={item.id}>
+                  <Sidebar.ItemIcon>
+                    <item.icon size={20} />
+                  </Sidebar.ItemIcon>
+                  <Sidebar.ItemLabel>{item.label}</Sidebar.ItemLabel>
+                  {children.map((child) => {
+                    const childWip = featureState(child.id) === "wip";
+                    return (
+                      <Sidebar.Item id={child.id} key={child.id}>
+                        <Sidebar.ItemLabel>{child.label}</Sidebar.ItemLabel>
+                        {childWip && (
+                          <Sidebar.ItemBadge color="warning">WIP</Sidebar.ItemBadge>
+                        )}
+                      </Sidebar.Item>
+                    );
+                  })}
+                </Sidebar.Item>
               );
             }
 

--- a/apps/csm-portal/webapp/src/config/csmNavItems.ts
+++ b/apps/csm-portal/webapp/src/config/csmNavItems.ts
@@ -273,6 +273,20 @@ export function navNodePath(node: CsmNavNode): string {
 }
 
 /**
+ * Where actually navigating to `node` should go. For a query-param tab
+ * (`tab` set), `href` is kept in the legacy `?tab=` shape purely so an old
+ * bookmarked/shared link in that form still resolves (see
+ * `LegacyQueryTabRedirect`) — the real, canonical destination is its first
+ * declared {@link CsmNavNode.routes} entry, the actual path-segment route
+ * (`/operations/incidents`, not `/operations?tab=incidents`). Every other
+ * node has no such split: `href` already is the real destination.
+ */
+export function navNodeHref(node: CsmNavNode): string {
+  if (node.tab && node.routes?.[0]) return node.routes[0];
+  return node.href;
+}
+
+/**
  * Route path prefixes a node owns. A query-param tab (`tab` set) owns only its
  * explicit {@link CsmNavNode.routes}: its `href` pathname is the *parent's*
  * landing route, which every sibling tab shares, so claiming it would make the

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasePreviewDrawer.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasePreviewDrawer.tsx
@@ -43,6 +43,14 @@ export default function CasePreviewDrawer({ row, onClose }: CasePreviewDrawerPro
       anchor="right"
       open={!!row}
       onClose={onClose}
+      // No backdrop: a temporary Drawer's default backdrop intercepts
+      // pointer events on the rest of the page, which would block clicking
+      // a different row's quick-preview eye while one preview is already
+      // open -- exactly the "switch straight to another row" behavior this
+      // drawer exists for. Closing still works via the eye toggle or the
+      // drawer's own close button; there's no click-outside-to-close to
+      // preserve here since those are already the two ways to close it.
+      hideBackdrop
       slotProps={{ paper: { sx: { width: { xs: "100%", sm: 420 } } } }}
     >
       {row && <CasePreviewContent row={row} onClose={onClose} />}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.test.tsx
@@ -199,3 +199,55 @@ describe("CasesFilterBar — removed bar controls fall back to chips", () => {
     expect(screen.queryByLabelText(/^Exclude tags$/)).not.toBeInTheDocument();
   });
 });
+
+describe("CasesFilterBar — work-state filter only usable when state is exactly work_in_progress", () => {
+  beforeEach(() => {
+    postMock.mockReset();
+  });
+
+  it("disables work state when no state is selected", () => {
+    renderBar({ ...DEFAULT_CASES_FILTERS, states: [] });
+    expect(screen.getByRole("combobox", { name: "Work state" })).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+  });
+
+  it("enables work state when work_in_progress is the sole selected state", () => {
+    renderBar({ ...DEFAULT_CASES_FILTERS, states: ["work_in_progress"] });
+    expect(screen.getByRole("combobox", { name: "Work state" })).not.toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+  });
+
+  it("disables work state when work_in_progress is selected alongside other states", () => {
+    renderBar({
+      ...DEFAULT_CASES_FILTERS,
+      states: ["work_in_progress", "open"],
+      workStates: ["ongoing"],
+    });
+    expect(screen.getByRole("combobox", { name: "Work state" })).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+  });
+
+  it("clears workStates when a second state is added alongside work_in_progress", () => {
+    const { onChange } = renderBar({
+      ...DEFAULT_CASES_FILTERS,
+      states: ["work_in_progress"],
+      workStates: ["ongoing"],
+    });
+
+    fireEvent.mouseDown(screen.getByRole("combobox", { name: "State" }));
+    fireEvent.click(screen.getByRole("option", { name: "Open" }));
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        states: ["work_in_progress", "open"],
+        workStates: [],
+      }),
+    );
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.test.tsx
@@ -199,3 +199,31 @@ describe("CasesFilterBar — removed bar controls fall back to chips", () => {
     expect(screen.queryByLabelText(/^Exclude tags$/)).not.toBeInTheDocument();
   });
 });
+
+describe("CasesFilterBar — case-type control label", () => {
+  beforeEach(() => {
+    postMock.mockReset();
+  });
+
+  it("defaults the case-type control's label to \"Case type\"", () => {
+    renderBar({ ...DEFAULT_CASES_FILTERS });
+    expect(screen.getByLabelText("Case type")).toBeInTheDocument();
+  });
+
+  it("renders a caller-supplied typeFilterLabel instead (e.g. a project's mixed work-items view)", () => {
+    renderBar({ ...DEFAULT_CASES_FILTERS }, vi.fn(), {
+      typeFilterLabel: "Work item type",
+    });
+    expect(screen.getByLabelText("Work item type")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Case type")).not.toBeInTheDocument();
+  });
+
+  it("hides the control entirely when hideTypeFilter is set, regardless of typeFilterLabel", () => {
+    renderBar({ ...DEFAULT_CASES_FILTERS }, vi.fn(), {
+      hideTypeFilter: true,
+      typeFilterLabel: "Work item type",
+    });
+    expect(screen.queryByLabelText("Work item type")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Case type")).not.toBeInTheDocument();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
@@ -171,6 +171,15 @@ interface CasesFilterBarProps {
   showSeverityFilter?: boolean;
   /** Hide the case-type control when the surrounding view locks the type. */
   hideTypeFilter?: boolean;
+  /**
+   * Label for the case-type control. Defaults to "Case type"; a view that
+   * mixes every record type under a broader umbrella term (e.g. a project's
+   * Work items tab, which spans cases/service requests/security reports/
+   * engagements/announcements) can override it to "Work item type" so the
+   * label matches what the surrounding page calls these records, without
+   * changing the control's behavior or its `caseTypes` value shape.
+   */
+  typeFilterLabel?: string;
   /** Hide the project control when the surrounding view is project-scoped. */
   hideProjectFilter?: boolean;
   /** Show the engagement-type multi-select (only relevant when type is locked to engagement). */
@@ -397,6 +406,7 @@ export default function CasesFilterBar({
   availableProjects,
   showSeverityFilter = true,
   hideTypeFilter = false,
+  typeFilterLabel = "Case type",
   hideProjectFilter = false,
   showEngagementTypeFilter = false,
 }: CasesFilterBarProps): JSX.Element {
@@ -759,7 +769,7 @@ export default function CasesFilterBar({
               <Grid size={{ xs: 12, sm: 6, md: 4, lg: 2 }}>
                 <MultiSelectField
                   id="cases-filter-type"
-                  label="Case type"
+                  label={typeFilterLabel}
                   values={filters.caseTypes}
                   options={caseTypeOptions}
                   onChange={(next) => onChange({ ...filters, caseTypes: next })}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
@@ -711,36 +711,41 @@ export default function CasesFilterBar({
                 label="State"
                 values={filters.states}
                 options={stateOptions}
-                // Work sub-state only applies to `work_in_progress` cases, so
-                // drop any selected work states when that state leaves the
-                // filter — keeps shared URLs / saved views from carrying an
-                // inert work-state selection.
+                // Work sub-state only applies when `work_in_progress` is the
+                // *sole* selected state — with other states also selected the
+                // work-state filter can't be applied server-side, so drop any
+                // selected work states as soon as the selection stops being
+                // exactly that one state.
                 onChange={(next) =>
                   onChange({
                     ...filters,
                     states: next,
-                    workStates: next.includes("work_in_progress")
-                      ? filters.workStates
-                      : [],
+                    workStates:
+                      next.length === 1 && next[0] === "work_in_progress"
+                        ? filters.workStates
+                        : [],
                   })
                 }
               />
             </Grid>
             <Grid size={{ xs: 12, sm: 6, md: 4, lg: 2 }}>
-              {/* Only meaningful for `work_in_progress` cases (ongoing/paused
-                  are sub-states of it); disabled until that state is filtered
-                  in, so the control can't add an inert filter. */}
+              {/* Only meaningful when `work_in_progress` is the sole selected
+                  state (ongoing/paused are sub-states of it); disabled
+                  otherwise, so the control can't add an inert/unusable
+                  filter when combined with other states. */}
               <MultiSelectField
                 id="cases-filter-work-state"
                 label="Work state"
                 values={filters.workStates}
                 options={workStateOptions}
                 onChange={(next) => onChange({ ...filters, workStates: next })}
-                disabled={!filters.states.includes("work_in_progress")}
+                disabled={
+                  !(filters.states.length === 1 && filters.states[0] === "work_in_progress")
+                }
                 disabledTooltip={
-                  filters.states.includes("work_in_progress")
+                  filters.states.length === 1 && filters.states[0] === "work_in_progress"
                     ? undefined
-                    : `Select the "${STATE_LABEL.work_in_progress}" state to filter by work state`
+                    : `Select only the "${STATE_LABEL.work_in_progress}" state to filter by work state`
                 }
               />
             </Grid>

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.test.tsx
@@ -127,4 +127,60 @@ describe("CasesList quick preview", () => {
     expect(screen.getByText("View full details")).toBeInTheDocument();
     expect(screen.queryByTestId("from-state")).not.toBeInTheDocument();
   });
+
+  it("closes the preview when the same row's eye is clicked again", () => {
+    renderWithProviders(
+      <Routes>
+        <Route
+          path="/cases"
+          element={<CasesList cases={[CASE]} isLoading={false} />}
+        />
+        <Route path="/cases/:id" element={<DetailStub />} />
+      </Routes>,
+      ["/cases"],
+    );
+
+    const eye = screen.getByRole("button", { name: "Quick preview CS-1007" });
+    fireEvent.click(eye);
+    expect(screen.getByText("View full details")).toBeInTheDocument();
+
+    fireEvent.click(eye);
+    expect(screen.queryByText("View full details")).not.toBeInTheDocument();
+  });
+
+  it("switches the preview to a different row without requiring a close first", () => {
+    const otherCase: CsmCaseRow = {
+      ...CASE,
+      id: "case-2",
+      caseNumber: "CS-1008",
+      subject: "Login fails intermittently",
+    };
+    renderWithProviders(
+      <Routes>
+        <Route
+          path="/cases"
+          element={<CasesList cases={[CASE, otherCase]} isLoading={false} />}
+        />
+        <Route path="/cases/:id" element={<DetailStub />} />
+      </Routes>,
+      ["/cases"],
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Quick preview CS-1007" }));
+    expect(screen.getByRole("link", { name: "View full details" })).toHaveAttribute(
+      "href",
+      expect.stringContaining("/case-1"),
+    );
+
+    // The open drawer marks the rest of the page `aria-hidden` (MUI Modal's
+    // background containment for screen readers) — still clickable by mouse
+    // in real use, so the test reaches it the same way with `hidden: true`.
+    fireEvent.click(
+      screen.getByRole("button", { name: "Quick preview CS-1008", hidden: true }),
+    );
+    expect(screen.getByRole("link", { name: "View full details" })).toHaveAttribute(
+      "href",
+      expect.stringContaining("/case-2"),
+    );
+  });
 });

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.test.tsx
@@ -173,8 +173,12 @@ describe("CasesList quick preview", () => {
     );
 
     // The open drawer marks the rest of the page `aria-hidden` (MUI Modal's
-    // background containment for screen readers) — still clickable by mouse
-    // in real use, so the test reaches it the same way with `hidden: true`.
+    // background containment for screen readers, independent of the
+    // backdrop) — `hidden: true` reaches it the same way a real click would,
+    // since the drawer's `hideBackdrop` (CasePreviewDrawer.tsx) is what makes
+    // that click actually land in a browser: without it, MUI's default
+    // temporary-Drawer backdrop covers the rest of the page and intercepts
+    // pointer events, which would silently swallow this exact click.
     fireEvent.click(
       screen.getByRole("button", { name: "Quick preview CS-1008", hidden: true }),
     );

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.tsx
@@ -273,6 +273,7 @@ export default function CasesList({
                 <IconButton
                   size="small"
                   aria-label={`Quick preview ${rowLabel}`}
+                  aria-pressed={previewRow?.id === c.id}
                   onClick={(e) => {
                     e.stopPropagation();
                     setPreviewRow((prev) => (prev?.id === c.id ? null : c));

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.tsx
@@ -89,13 +89,14 @@ const HEADER_CELLS_WITHOUT_SEVERITY: string[] = [
 // Subject gets the lion's share of the row; the ids sit in their own narrow
 // column so a long subject no longer has to share one cell with them.
 // The work-state chip (only present for WIP cases) stacks under the State chip
-// in the State column, so it doesn't need a column of its own. The trailing
-// `auto` track (unlabeled in the header, like the one before it for "Updated")
-// holds the per-row quick-preview action.
+// in the State column, so it doesn't need a column of its own. The leading
+// `auto` track (unlabeled in the header) holds the per-row quick-preview
+// action — kept at the left edge so it's reachable without hunting across
+// the row, with the preview drawer itself opening on the right.
 const GRID_WITH_SEVERITY =
-  "minmax(120px, 0.9fr) minmax(280px, 3fr) minmax(140px, 1fr) auto auto minmax(110px, 1fr) auto auto";
+  "auto minmax(120px, 0.9fr) minmax(280px, 3fr) minmax(140px, 1fr) auto auto minmax(110px, 1fr) auto";
 const GRID_WITHOUT_SEVERITY =
-  "minmax(120px, 0.9fr) minmax(280px, 3fr) minmax(140px, 1fr) minmax(110px, 1fr) auto auto";
+  "auto minmax(120px, 0.9fr) minmax(280px, 3fr) minmax(140px, 1fr) minmax(110px, 1fr) auto";
 
 export default function CasesList({
   cases,
@@ -146,6 +147,13 @@ export default function CasesList({
           borderColor: "divider",
         }}
       >
+        <Typography
+          variant="caption"
+          color="text.secondary"
+          sx={{ fontWeight: 600, textAlign: "left" }}
+        >
+          Preview
+        </Typography>
         {headerCells.map((label) => (
           <Typography
             key={label}
@@ -185,13 +193,6 @@ export default function CasesList({
             Updated
           </Typography>
         )}
-        <Typography
-          variant="caption"
-          color="text.secondary"
-          sx={{ fontWeight: 600, textAlign: "left" }}
-        >
-          Preview
-        </Typography>
       </Box>
 
       {/* Rows */}
@@ -261,6 +262,26 @@ export default function CasesList({
                 "&:last-of-type": { borderBottom: 0 },
               }}
             >
+              {/* Quick preview, at the row's left edge so it's the first
+                  thing reachable without hunting across the row; the drawer
+                  itself opens on the right. `stopPropagation` keeps the click
+                  from also bubbling up into the row's own onClick (which
+                  would open the full case instead of just previewing it).
+                  Clicking the eye for the row already being previewed closes
+                  it instead of re-opening the same preview. */}
+              <Tooltip title={`Quick preview ${rowLabel}`}>
+                <IconButton
+                  size="small"
+                  aria-label={`Quick preview ${rowLabel}`}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setPreviewRow((prev) => (prev?.id === c.id ? null : c));
+                  }}
+                  sx={{ justifySelf: "center" }}
+                >
+                  <Eye size={16} />
+                </IconButton>
+              </Tooltip>
               {/* Case ids: WSO2 internal id on top, CS number beneath. Never
                   the UUID. "—" when the case has neither yet. This block is
                   the row's one real anchor — cmd/middle-click "open in new
@@ -370,22 +391,6 @@ export default function CasesList({
               <Typography variant="caption" color="text.secondary" noWrap>
                 <RelativeTime iso={c.updatedAt} />
               </Typography>
-              {/* Quick preview. `stopPropagation` keeps the click from also
-                  bubbling up into the row's own onClick (which would open the
-                  full case instead of just previewing it). */}
-              <Tooltip title={`Quick preview ${rowLabel}`}>
-                <IconButton
-                  size="small"
-                  aria-label={`Quick preview ${rowLabel}`}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setPreviewRow(c);
-                  }}
-                  sx={{ justifySelf: "center" }}
-                >
-                  <Eye size={16} />
-                </IconButton>
-              </Tooltip>
             </Box>
           );
         })}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmIssuesView.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmIssuesView.tsx
@@ -92,6 +92,9 @@ interface CsmIssuesViewProps {
   lockedFilters?: Partial<CasesFilters>;
   /** Hide the case-type filter control (use when `lockedFilters` fixes it). */
   hideTypeFilter?: boolean;
+  /** Label for the case-type filter control; see `CasesFilterBar`'s own
+   * `typeFilterLabel` doc comment. Defaults to "Case type". */
+  typeFilterLabel?: string;
   /** Hide the project filter control (use when the view is project-scoped). */
   hideProjectFilter?: boolean;
   /** Show the engagement-type sub-filter (pass when the view is locked to engagement cases). */
@@ -126,6 +129,7 @@ export default function CsmIssuesView({
   entityNoun = "cases",
   lockedFilters,
   hideTypeFilter,
+  typeFilterLabel,
   hideProjectFilter,
   showEngagementTypeFilter,
   detailBasePath,
@@ -434,6 +438,7 @@ export default function CsmIssuesView({
         availableProjects={availableProjects}
         showSeverityFilter={showSeverityFilter}
         hideTypeFilter={hideTypeFilter}
+        typeFilterLabel={typeFilterLabel}
         hideProjectFilter={hideProjectFilter}
         showEngagementTypeFilter={showEngagementTypeFilter}
       />

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmIssuesView.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmIssuesView.tsx
@@ -68,16 +68,39 @@ const DEFAULT_ROWS_PER_PAGE = 20;
 const ROWS_PER_PAGE_OPTIONS = [10, DEFAULT_ROWS_PER_PAGE, BE_MAX_PAGE_LIMIT];
 
 // URL params owned by the filter state; cleared/rewritten on change while any
-// other params (e.g. a `tab` selection) are preserved.
+// other params (e.g. a `tab` selection) are preserved. Must cover every key
+// `writeCasesFiltersToUrl` can write — a key missing here never gets deleted
+// when its filter clears back to empty/null, so the stale URL value keeps
+// getting read back on the next render, making that one filter look
+// impossible to fully clear (found via workStates: selecting a work state
+// then trying to deselect it back to none silently failed because
+// `workStates` wasn't in this list).
 const FILTER_PARAM_KEYS = [
   "search",
   "severities",
   "states",
   "types",
   "assignees",
+  "workStates",
   "projects",
   "engagementTypes",
   "products",
+  "csTeams",
+  "sreTeams",
+  "tags",
+  "excludeTags",
+  "onboardingStatuses",
+  "slaPctGte",
+  "slaPctLte",
+  "escalation",
+  "escalationLevels",
+  "projectTypes",
+  "createdFrom",
+  "createdTo",
+  "updatedFrom",
+  "updatedTo",
+  "closedFrom",
+  "closedTo",
 ] as const;
 
 interface CsmIssuesViewProps {

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmIssuesView.workStateUrl.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmIssuesView.workStateUrl.test.tsx
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+
+// Unlike CsmIssuesView.test.tsx, this file keeps the REAL CasesFilterBar (and
+// CasesList) mounted -- the bug under test only reproduces through the real
+// round trip of a filter bar interaction -> CsmIssuesView's setFilters ->
+// the URL -> re-reading the URL back into `filters`.
+vi.mock("@api/backend/client", () => ({
+  useBackendApi: () => ({ post: vi.fn().mockResolvedValue({ teams: [] }), get: vi.fn() }),
+}));
+vi.mock("@config/apiConfig", () => ({
+  apiConfig: { backendUrl: "https://example.test" },
+}));
+vi.mock("@context/current-user/CurrentUserContext", () => ({
+  useCurrentUser: () => ({ user: { id: "user-1" }, isLoading: false, isError: false }),
+}));
+vi.mock("@context/error-banner/ErrorBannerContext", () => ({
+  useErrorBanner: () => ({ showError: vi.fn() }),
+}));
+vi.mock("@hooks/useIdTokenClaims", () => ({
+  useIdTokenClaims: () => ({ email: "user@example.test" }),
+}));
+vi.mock("@api/useDirectoryUsers", () => ({
+  useDirectoryUsers: () => ({ data: [] }),
+}));
+vi.mock("@features/csm-cases/api/useGetCsmCases", () => ({
+  useGetCsmCases: () => ({
+    data: { cases: [], total: 0, hasMore: false },
+    isLoading: false,
+    isFetching: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+    dataUpdatedAt: 0,
+  }),
+}));
+vi.mock("@components/FilteredCsvExportButton", () => ({
+  default: () => <div>ExportButton</div>,
+}));
+vi.mock("@components/RefreshButton", () => ({
+  default: () => <div>RefreshButton</div>,
+}));
+
+import CsmIssuesView from "@features/csm-cases/components/CsmIssuesView";
+
+function renderAt(initialUrl: string) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[initialUrl]}>
+        <Routes>
+          <Route path="/cases" element={<CsmIssuesView title="Cases" />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("CsmIssuesView + real CasesFilterBar — work state clears fully from the URL", () => {
+  // Regression test for: with only "In progress" selected, checking then
+  // unchecking a work state left the last-checked value permanently stuck
+  // (could only toggle between work states, never reach none). Root cause:
+  // CsmIssuesView's FILTER_PARAM_KEYS (the URL keys it deletes before
+  // rewriting from the next filter state) didn't include "workStates", so an
+  // empty next.workStates never actually cleared the stale URL param, and
+  // the next render read the stale value straight back in.
+  it("deselecting the only checked work state actually clears it, not just toggles it", () => {
+    renderAt("/cases?states=work_in_progress&workStates=ongoing");
+
+    const workState = screen.getByRole("combobox", { name: "Work state" });
+    expect(workState).toHaveTextContent("Ongoing");
+
+    // Open the dropdown and uncheck the only selected option.
+    fireEvent.mouseDown(workState);
+    fireEvent.click(screen.getByRole("option", { name: "Ongoing" }));
+
+    // The control must now show no selection -- not still "Ongoing", and not
+    // forced onto "Paused" either.
+    expect(workState).not.toHaveTextContent("Ongoing");
+    expect(workState).not.toHaveTextContent("Paused");
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/caseSearchPayload.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/caseSearchPayload.test.ts
@@ -230,3 +230,46 @@ describe("buildCaseSearchFilters — exact case-number / WSO2-id search", () => 
     expect(result.filters).toBeUndefined();
   });
 });
+
+describe("buildCaseSearchFilters — workState only applies when state is exactly work_in_progress", () => {
+  it("emits workState when work_in_progress is the sole selected state", () => {
+    const filters: CasesFilters = {
+      ...DEFAULT_CASES_FILTERS,
+      states: ["work_in_progress"],
+      workStates: ["ongoing", "paused"],
+    };
+
+    expect(filterOf(filters, "workState")).toEqual([
+      { field: "workState", op: "in", values: ["ongoing", "paused"] },
+    ]);
+  });
+
+  // Regression guard: a stale `workStates` value reaching this builder any
+  // way other than the filter bar's own onChange (a saved view, a
+  // dashboard/pinned-view URL that predates the exact-match fix, a future
+  // caller) must never silently narrow results to just in-progress/paused
+  // cases once another state is also selected.
+  it("drops workState from the payload when another state is selected alongside work_in_progress", () => {
+    const filters: CasesFilters = {
+      ...DEFAULT_CASES_FILTERS,
+      states: ["work_in_progress", "open"],
+      workStates: ["ongoing", "paused"],
+    };
+
+    expect(filterOf(filters, "workState")).toEqual([]);
+    // The state filter itself still applies normally.
+    expect(filterOf(filters, "state")).toEqual([
+      { field: "state", op: "in", values: ["work_in_progress", "open"] },
+    ]);
+  });
+
+  it("drops workState from the payload when no state is selected", () => {
+    const filters: CasesFilters = {
+      ...DEFAULT_CASES_FILTERS,
+      states: [],
+      workStates: ["ongoing"],
+    };
+
+    expect(filterOf(filters, "workState")).toEqual([]);
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/caseSearchPayload.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/caseSearchPayload.ts
@@ -70,7 +70,17 @@ export function buildCaseSearchFilters(
   if (filters.caseTypes.length > 0) {
     fieldFilters.push({ field: "type", op: "in", values: filters.caseTypes });
   }
-  if (filters.workStates.length > 0) {
+  // Work state can only be applied server-side when "work_in_progress" is
+  // the sole selected state — enforced here (not just in the filter bar's
+  // own onChange) so a stale workStates value reaching this builder any
+  // other way (a saved view, a pinned/dashboard URL, a future caller) can
+  // never silently narrow the results to just in-progress/ongoing-paused
+  // cases when other states are also selected.
+  if (
+    filters.workStates.length > 0 &&
+    filters.states.length === 1 &&
+    filters.states[0] === "work_in_progress"
+  ) {
     fieldFilters.push({
       field: "workState",
       op: "in",

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.test.ts
@@ -41,7 +41,10 @@ describe("readCasesFiltersFromUrl", () => {
       states: ["open", "work_in_progress", "closed"],
       caseTypes: ["case", "engagement"],
       assignees: ["alice@example.com", "@me"],
-      workStates: ["ongoing", "paused"],
+      // `work_in_progress` is one of three selected states here, not the
+      // sole one -- workStates can't apply server-side in that shape, so it
+      // parses back out as empty. See the exact-match tests below.
+      workStates: [],
       projects: ["apim"],
       productNames: ["API Manager", "Asgardeo"],
     });
@@ -74,6 +77,13 @@ describe("readCasesFiltersFromUrl", () => {
 
   it("drops work states when `work_in_progress` is not in the state filter", () => {
     const params = new URLSearchParams("states=open&workStates=ongoing,paused");
+    expect(readCasesFiltersFromUrl(params).workStates).toEqual([]);
+  });
+
+  it("drops work states when `work_in_progress` is selected alongside another state", () => {
+    const params = new URLSearchParams(
+      "states=work_in_progress,open&workStates=ongoing,paused",
+    );
     expect(readCasesFiltersFromUrl(params).workStates).toEqual([]);
   });
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.ts
@@ -139,13 +139,17 @@ export function readCasesFiltersFromUrl(
   params: URLSearchParams,
 ): CasesFilters {
   const states = parseCsv(params.get("states"), VALID_STATES);
-  // Work sub-states only apply to `work_in_progress` cases. Mirror the
-  // filter-bar invariant (the State control clears work states when that state
-  // leaves the selection) so a hand-edited / stale URL can't load an active but
-  // un-clearable work-state filter behind the disabled control.
-  const workStates = states.includes("work_in_progress")
-    ? parseCsv(params.get("workStates"), VALID_WORK_STATES)
-    : [];
+  // Work sub-states only apply to a search scoped to `work_in_progress` alone
+  // — the server can't apply a work-state filter once another state is also
+  // selected (see caseSearchPayload.ts's own matching guard). Mirror that
+  // exact-match invariant here (not just "includes work_in_progress") so a
+  // hand-edited / stale / dashboard-link URL with e.g.
+  // `states=work_in_progress,open&workStates=ongoing` can't load an active
+  // but un-clearable work-state filter behind the disabled control.
+  const workStates =
+    states.length === 1 && states[0] === "work_in_progress"
+      ? parseCsv(params.get("workStates"), VALID_WORK_STATES)
+      : [];
   return {
     search: params.get("search") ?? "",
     severities: parseCsv(params.get("severities"), VALID_SEVERITIES),

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
@@ -256,7 +256,10 @@ export default function DashboardWidgetTile({
   // all" link never carries a literal `__current_team__`/`__current_user__`
   // placeholder into the destination resource's own filters (see
   // `teamFilterPlaceholder.ts`/`currentUserFilterPlaceholder.ts`).
-  const href = config.buildHref(resolvePlaceholders(filters));
+  const href = config.buildHref(resolvePlaceholders(filters), {
+    widgetId,
+    displayName: resolvedDisplayName,
+  });
   const Icon = config.icon;
   const isListShape = shape === "list";
 
@@ -437,7 +440,10 @@ export default function DashboardWidgetTile({
     // (`pointerEvents: "auto"`) for the chart specifically, letting its own
     // click and keyboard handling work exactly as before.
     const ChartComponent = shape === "pie" ? DashboardPieChart : DashboardBarChart;
-    const tileHref = config.buildHref(resolvePlaceholders(filters));
+    const tileHref = config.buildHref(resolvePlaceholders(filters), {
+      widgetId,
+      displayName: resolvedDisplayName,
+    });
     const handleTileClick = (): void => {
       void navigate(tileHref, { state: dashboardReturnState });
     };
@@ -500,7 +506,10 @@ export default function DashboardWidgetTile({
               isError={pieData.isError}
               onSliceClick={(slice: PieSliceResult) =>
                 navigate(
-                  config.buildHref(resolvePlaceholders(mergeWidgetFilters(filters, slice.query))),
+                  config.buildHref(resolvePlaceholders(mergeWidgetFilters(filters, slice.query)), {
+                    widgetId,
+                    displayName: resolvedDisplayName,
+                  }),
                   { state: dashboardReturnState },
                 )
               }

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetListConfig.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetListConfig.tsx
@@ -25,6 +25,7 @@ import type {
   BeIncident,
   BeChangeRequestSearchView,
   BeProblemSearchView,
+  BeIncidentTaskSearchView,
   BeTimeCardView,
   BeTaskSummary,
   BeWidgetResourceType,
@@ -369,6 +370,64 @@ function ProblemWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.E
   );
 }
 
+/** Incident task: no standalone list or detail page exists for incident
+ * tasks in this app (unlike `problem`), so — mirroring `CallRequestWidgetList`
+ * below linking a call request's rows to its owning case — rows navigate
+ * straight to the owning incident's real detail page instead. Deliberately
+ * simpler than `ProblemWidgetList`: no preview drawer, since there is no
+ * incident-task-specific preview surface worth building for a resource with
+ * no detail page of its own to preview into (a plain list is an honest
+ * simplification here, not a shortcut). `stateLabel` (pre-humanized by the
+ * data source) is used for the state chip rather than `state` (a raw,
+ * data-source-specific integer — see `BeIncidentTaskSearchView.state`). */
+function IncidentTaskWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.Element {
+  const incidentTasks = items as unknown as BeIncidentTaskSearchView[];
+  const dashboardReturnState = useDashboardReturnState();
+  const navigate = useNavTransition();
+  return (
+    <DashboardMiniTable
+      isLoading={isLoading}
+      emptyMessage="No incident tasks match this widget's filters."
+      columns={[
+        { label: "Number", width: "minmax(90px, 0.7fr)" },
+        { label: "Subject", width: "minmax(160px, 2fr)" },
+        { label: "State", width: "minmax(100px, 1fr)" },
+        { label: "Assignment group", width: "minmax(120px, 1fr)" },
+        { label: "Assigned to", width: "minmax(100px, 1fr)" },
+      ]}
+      rows={incidentTasks.map((task, i) => {
+        const incidentId = task.incident?.id;
+        const href = incidentId ? `/operations/incidents/${incidentId}` : undefined;
+        return {
+          key: task.id ?? `incident-task-${i}`,
+          onClick: href ? () => navigate(href, { state: dashboardReturnState }) : undefined,
+          cells: [
+            <Typography key="number" variant="body2" noWrap>
+              {task.number || "—"}
+            </Typography>,
+            <Typography key="subject" variant="body2" noWrap title={task.subject ?? undefined}>
+              {task.subject || "—"}
+            </Typography>,
+            task.stateLabel ? (
+              <Chip key="state" size="small" variant="outlined" label={task.stateLabel} />
+            ) : (
+              <Typography key="state" variant="body2">
+                —
+              </Typography>
+            ),
+            <Typography key="assignmentGroup" variant="body2" noWrap>
+              {task.assignmentGroup?.name || "—"}
+            </Typography>,
+            <Typography key="assignedTo" variant="body2" noWrap>
+              {task.assignedTo?.name || "—"}
+            </Typography>,
+          ],
+        };
+      })}
+    />
+  );
+}
+
 function AccountWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.Element {
   const accounts = items as unknown as Account[];
   const dashboardReturnState = useDashboardReturnState();
@@ -690,6 +749,7 @@ export const WIDGET_LIST_RENDERERS: Record<
   incident: IncidentWidgetList,
   change_request: ChangeRequestWidgetList,
   problem: ProblemWidgetList,
+  incident_task: IncidentTaskWidgetList,
   account: AccountWidgetList,
   project: ProjectWidgetList,
   user: UserWidgetList,

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.test.ts
@@ -286,6 +286,24 @@ describe("WIDGET_RESOURCE_CONFIG — case-table resourceTypes beyond `case`", ()
     ).toBe("/announcements");
   });
 
+  // Regression test: incident_task has no dedicated list route of its own
+  // (only ever viewed as part of its parent incident), so its buildHref used
+  // to fall back to the plain, unfiltered incidents tab -- silently dropping
+  // this widget's own filters and landing the user on an unrelated result
+  // set. It must route through the generic dashboard-widget preview page
+  // instead, which is filter-aware, using the widgetId/displayName context
+  // DashboardWidgetTile passes at call time.
+  it("incident_task's buildHref routes to the widget preview page with widget context, not the unfiltered incidents tab", () => {
+    const href = WIDGET_RESOURCE_CONFIG.incident_task.buildHref(
+      { assignmentGroupIds: ["grp-1"] },
+      { widgetId: "widget-42", displayName: "My Incident Tasks" },
+    );
+    expect(href.startsWith("/dashboard/preview/incident-tasks?")).toBe(true);
+    const params = hrefParams(href);
+    expect(params.get("w")).toBe("widget-42");
+    expect(params.get("n")).toBe("My Incident Tasks");
+  });
+
   it("each of the four has its own distinct icon from `case` and from each other", () => {
     const icons = [
       WIDGET_RESOURCE_CONFIG.case.icon,

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.ts
@@ -19,6 +19,7 @@ import {
   AlertTriangle,
   Briefcase,
   Building2,
+  CheckSquare,
   Clock,
   Cog,
   FolderKanban,
@@ -387,6 +388,15 @@ function stateSecondaryLabel(item: WidgetItem): string | undefined {
   return state ? humanizeState(state) : undefined;
 }
 
+/** `incident_task`-only secondary label: unlike `stateSecondaryLabel`, this
+ * reads the data source's own pre-humanized `stateLabel` rather than trying
+ * to humanize `state` itself — `state` is a raw integer specific to the
+ * underlying data source's shared task table, with no stable domain enum to
+ * translate through (see `BeIncidentTaskSearchView.state`'s doc comment). */
+function incidentTaskStateSecondaryLabel(item: WidgetItem): string | undefined {
+  return asString(item.stateLabel);
+}
+
 export const WIDGET_RESOURCE_CONFIG: Record<
   BeWidgetResourceType,
   WidgetResourceConfig
@@ -524,6 +534,27 @@ export const WIDGET_RESOURCE_CONFIG: Record<
     previewSlug: "problems",
     detailHref: (item) =>
       asString(item.id) ? `/operations/problems/${asString(item.id)}` : undefined,
+  },
+  // No standalone incident-task list or detail page exists in this app
+  // (confirmed: incident tasks are only ever viewed as part of their parent
+  // incident) -- both `buildHref` and `detailHref` land on the owning
+  // incident's real detail page instead, the same fallback `call_request`
+  // uses for landing on its owning case. Like `problem`, no dashboard widget
+  // filters incident tasks today, so the tile-level "view all" click is
+  // unfiltered.
+  incident_task: {
+    searchEndpoint: "/incident_tasks/search",
+    itemsKey: "incidentTasks",
+    primaryLabel: numberSubjectLabel,
+    secondaryLabel: incidentTaskStateSecondaryLabel,
+    buildHref: () => operationsHref("incidents"),
+    icon: CheckSquare,
+    iconColor: "warning",
+    previewSlug: "incident-tasks",
+    detailHref: (item) => {
+      const incidentId = nestedID(item.incident);
+      return incidentId ? `/operations/incidents/${incidentId}` : undefined;
+    },
   },
   account: {
     searchEndpoint: "/accounts/search",

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.ts
@@ -53,6 +53,7 @@ import {
 import { writeChangeRequestFiltersToUrl } from "@features/csm-operations/utils/changeRequestsFiltersUrl";
 import { taskStateLabel } from "@features/csm-cases/utils/taskState";
 import type { BeTaskState } from "@api/backend/types";
+import { buildWidgetPreviewHref } from "@features/csm-dashboard/utils/widgetPreviewUrl";
 
 /** A resolved search-result row, typed loosely since its real shape depends
  * on `resourceType` — the label extractors below narrow what they read. */
@@ -73,8 +74,16 @@ export interface WidgetResourceConfig {
   /** Optional secondary (muted) line for one list-shape row. */
   secondaryLabel?: (item: WidgetItem) => string | undefined;
   /** Where a click on this widget's tile navigates, given its (opaque,
-   * already current-user-resolved) filters. */
-  buildHref: (filters: Record<string, unknown>) => string;
+   * already current-user-resolved) filters. `ctx` (the owning widget's id
+   * and resolved display name) is only there for a resourceType with no
+   * dedicated list route of its own (see `incident_task` below) to route
+   * through the generic dashboard-widget preview page instead, which is the
+   * only destination that can render this exact widget's own filtered
+   * result set — every other resourceType ignores it. */
+  buildHref: (
+    filters: Record<string, unknown>,
+    ctx?: { widgetId: string; displayName: string },
+  ) => string;
   /** Icon shown on the tile, one per resource type (not per individual
    * widget — the backend registry doesn't carry per-widget icon metadata). */
   icon: LucideIcon;
@@ -535,19 +544,33 @@ export const WIDGET_RESOURCE_CONFIG: Record<
     detailHref: (item) =>
       asString(item.id) ? `/operations/problems/${asString(item.id)}` : undefined,
   },
-  // No standalone incident-task list or detail page exists in this app
-  // (confirmed: incident tasks are only ever viewed as part of their parent
-  // incident) -- both `buildHref` and `detailHref` land on the owning
-  // incident's real detail page instead, the same fallback `call_request`
-  // uses for landing on its owning case. Like `problem`, no dashboard widget
-  // filters incident tasks today, so the tile-level "view all" click is
-  // unfiltered.
+  // No standalone incident-task list page exists in this app (confirmed:
+  // incident tasks are only ever viewed as part of their parent incident),
+  // so unlike every other resourceType here, `buildHref` can't land on a
+  // real list route of its own -- routing it to the plain incidents list
+  // (`/operations?tab=incidents`) would silently drop this widget's own
+  // filters and show an unrelated, unfiltered set of records. Route through
+  // the generic dashboard-widget preview page instead (via `previewSlug`
+  // below), which is filter-aware for every resourceType already.
+  // `detailHref` still lands on the owning incident's real detail page, the
+  // same fallback `call_request` uses for landing on its owning case.
   incident_task: {
-    searchEndpoint: "/incident_tasks/search",
+    searchEndpoint: "/incident-tasks/search",
     itemsKey: "incidentTasks",
     primaryLabel: numberSubjectLabel,
     secondaryLabel: incidentTaskStateSecondaryLabel,
-    buildHref: () => operationsHref("incidents"),
+    // `ctx` is always passed by the real caller (`DashboardWidgetTile`); the
+    // fallback below only covers a caller that omits it (e.g. a test
+    // exercising this config directly), landing on the same "open this page
+    // from a dashboard widget" prompt `DashboardWidgetPreviewPage` already
+    // shows for any preview link missing its widget id.
+    buildHref: (filters, ctx) =>
+      buildWidgetPreviewHref({
+        previewSlug: "incident-tasks",
+        widgetId: ctx?.widgetId ?? "",
+        displayName: ctx?.displayName ?? "",
+        filters,
+      }),
     icon: CheckSquare,
     iconColor: "warning",
     previewSlug: "incident-tasks",

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/OperationsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/OperationsPage.tsx
@@ -18,7 +18,6 @@ import { Box, Button, Typography } from "@wso2/oxygen-ui";
 import { ArrowLeft, Plus } from "@wso2/oxygen-ui-icons-react";
 import { type JSX } from "react";
 import { useLocation } from "react-router";
-import SectionTabs from "@components/section-tabs/SectionTabs";
 import CsmIssuesView from "@features/csm-cases/components/CsmIssuesView";
 import ChangeRequestsTab from "@features/csm-operations/components/ChangeRequestsTab";
 import IncidentsTab from "@features/csm-operations/components/IncidentsTab";
@@ -34,15 +33,15 @@ import { usePathSectionTabs } from "@hooks/useSectionTabs";
  *
  * Which tabs exist comes from the navigation tree, so a deployment can restrict
  * one through `CSM_PORTAL_FEATURE_OVERRIDES` without touching this page.
+ *
+ * The tab switch itself lives in the sidebar now (Operations' submenu), not
+ * an in-page strip — `usePathSectionTabs` is kept only for its
+ * enabled/WIP-aware fallback (an invalid or restricted `:tab` still resolves
+ * to the first usable one) reading the same real path segment
+ * (`/operations/:tab`) the sidebar's submenu links navigate to.
  */
 export default function OperationsPage(): JSX.Element {
-  // Active tab is a real path segment (`/operations/:tab`), not `?tab=` —
-  // switching to a genuinely different content set is its own bookmarkable
-  // route, per this app's URL-shape rule. See `usePathSectionTabs` and the
-  // `operations` routes in App.tsx (including the legacy `?tab=` redirect for
-  // links shared/bookmarked before this section had its own path segment).
-  const tabs = usePathSectionTabs("operations", "/operations");
-  const activeTab = tabs.activeKey;
+  const { activeKey: activeTab } = usePathSectionTabs("operations", "/operations");
   const navigate = useNavTransition();
   // Set by a dashboard widget's click-through (see DashboardWidgetTile /
   // widgetListConfig.tsx), since this page has no dashboard context of its
@@ -71,8 +70,6 @@ export default function OperationsPage(): JSX.Element {
           Service requests, change requests, incidents, and problems across customers.
         </Typography>
       </Box>
-
-      <SectionTabs {...tabs} ariaLabel="Operations tabs" />
 
       {activeTab === "service-requests" && (
         <CsmIssuesView

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/WorkItemsTab.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/WorkItemsTab.test.tsx
@@ -67,71 +67,47 @@ vi.mock("@features/csm-projects/components/ConversationsTab", () => ({
 }));
 
 describe("WorkItemsTab", () => {
-  it("defaults to the Cases sub-tab, locked to this project's case-type cases", () => {
+  it("defaults to a single flat work-items list, locked to this project but unlocked on type", () => {
     renderWorkItemsTab();
 
-    expect(screen.getByText("IssuesView: cases")).toBeInTheDocument();
+    expect(screen.getByText("IssuesView: work items")).toBeInTheDocument();
     expect(mockCsmIssuesView).toHaveBeenCalledWith(
       expect.objectContaining({
-        entityNoun: "cases",
-        lockedFilters: { projects: ["proj-1"], caseTypes: ["case"] },
+        entityNoun: "work items",
+        lockedFilters: { projects: ["proj-1"] },
         hideProjectFilter: true,
-        hideTypeFilter: true,
+        typeFilterLabel: "Work item type",
       }),
     );
+    // No per-type case-type lock and no fixed detail base path — a mixed
+    // list resolves each row's detail link by its own type instead.
+    expect(mockCsmIssuesView).not.toHaveBeenCalledWith(
+      expect.objectContaining({ hideTypeFilter: true }),
+    );
+    const lastCallProps = mockCsmIssuesView.mock.calls.at(-1)?.[0] as
+      | Record<string, unknown>
+      | undefined;
+    expect(lastCallProps?.detailBasePath).toBeUndefined();
   });
 
-  it("switches to the Service requests sub-tab, routed to the operations detail page", () => {
+  it("has no per-case-type sub-tabs (Cases/Service requests/Security reports/Engagements are gone)", () => {
     renderWorkItemsTab();
 
-    fireEvent.click(screen.getByText("Service requests"));
-
-    expect(screen.getByText("IssuesView: service requests")).toBeInTheDocument();
-    expect(mockCsmIssuesView).toHaveBeenCalledWith(
-      expect.objectContaining({
-        lockedFilters: { projects: ["proj-1"], caseTypes: ["service_request"] },
-        detailBasePath: "/operations/service-requests",
-      }),
-    );
+    expect(screen.queryByText("Cases")).not.toBeInTheDocument();
+    expect(screen.queryByText("Service requests")).not.toBeInTheDocument();
+    expect(screen.queryByText("Security reports")).not.toBeInTheDocument();
+    expect(screen.queryByText("Engagements")).not.toBeInTheDocument();
+    expect(screen.getByText("Work items")).toBeInTheDocument();
+    expect(screen.getByText("Chats")).toBeInTheDocument();
   });
 
-  it("switches to the Security reports sub-tab with severity hidden", () => {
-    renderWorkItemsTab();
-
-    fireEvent.click(screen.getByText("Security reports"));
-
-    expect(screen.getByText("IssuesView: security reports")).toBeInTheDocument();
-    expect(mockCsmIssuesView).toHaveBeenCalledWith(
-      expect.objectContaining({
-        lockedFilters: { projects: ["proj-1"], caseTypes: ["security_report_analysis"] },
-        hideSeverityColumn: true,
-        detailBasePath: "/security-center/security-reports",
-      }),
-    );
-  });
-
-  it("switches to the Engagements sub-tab with the engagement-type filter shown", () => {
-    renderWorkItemsTab();
-
-    fireEvent.click(screen.getByText("Engagements"));
-
-    expect(screen.getByText("IssuesView: engagements")).toBeInTheDocument();
-    expect(mockCsmIssuesView).toHaveBeenCalledWith(
-      expect.objectContaining({
-        lockedFilters: { projects: ["proj-1"], caseTypes: ["engagement"] },
-        showEngagementTypeFilter: true,
-        hideSeverityColumn: true,
-        detailBasePath: "/engagements",
-      }),
-    );
-  });
-
-  it("switches to the Conversations sub-tab", () => {
+  it("switches to the Chats sub-tab", () => {
     renderWorkItemsTab();
 
     fireEvent.click(screen.getByText("Chats"));
 
     expect(screen.getByText("Conversations for proj-1")).toBeInTheDocument();
+    expect(screen.queryByText(/IssuesView/)).not.toBeInTheDocument();
   });
 
   // Regression tests: the sub-tab used to be plain component state, so a
@@ -140,12 +116,12 @@ describe("WorkItemsTab", () => {
   it("writes the selected sub-tab to the URL's ?subTab= param", () => {
     renderWorkItemsTabWithLocationProbe("/customers/projects/proj-1?tab=workItems");
 
-    fireEvent.click(screen.getByText("Engagements"));
+    fireEvent.click(screen.getByText("Chats"));
 
-    expect(screen.getByTestId("search-probe")).toHaveTextContent("subTab=engagements");
+    expect(screen.getByTestId("search-probe")).toHaveTextContent("subTab=conversations");
   });
 
-  it("restores the sub-tab named in the URL on mount, instead of always defaulting to Cases", () => {
+  it("restores the sub-tab named in the URL on mount, instead of always defaulting to the issues list", () => {
     renderWorkItemsTabWithLocationProbe(
       "/customers/projects/proj-1?tab=workItems&subTab=conversations",
     );

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/WorkItemsTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/WorkItemsTab.tsx
@@ -20,35 +20,42 @@ import CsmIssuesView from "@features/csm-cases/components/CsmIssuesView";
 import ConversationsTab from "@features/csm-projects/components/ConversationsTab";
 import { useQueryParamTabs } from "@hooks/useSectionTabs";
 
-type WorkItemSubTab =
-  | "cases"
-  | "serviceRequests"
-  | "securityReports"
-  | "engagements"
-  | "conversations";
+// Conversations (chat sessions) aren't a case type (`BeCaseType`) — they're a
+// different resource entirely, backed by their own search/list, not
+// `/cases/search` — so they stay a separate sub-tab rather than folding into
+// the flat issues list below. Everything that IS a case type (cases, service
+// requests, security reports, engagements, announcements) now renders as one
+// flat, unlocked-type list instead of one sub-tab per type.
+type WorkItemSubTab = "issues" | "conversations";
 
-const WORK_ITEM_SUB_TABS: readonly WorkItemSubTab[] = [
-  "cases",
-  "serviceRequests",
-  "securityReports",
-  "engagements",
-  "conversations",
-];
+const WORK_ITEM_SUB_TABS: readonly WorkItemSubTab[] = ["issues", "conversations"];
 
 interface WorkItemsTabProps {
   projectId: string;
 }
 
 /**
- * A project's work items, categorized into per-type sub-tabs rather than one
- * mixed list with a type filter — Cases / Service requests / Security reports
- * / Engagements each lock `CsmIssuesView` to their own case type (mirroring
- * the props each type's own standalone page already uses — `CsmCasesPage`,
- * `OperationsPage`, `CsmSecurityCenterPage`, `CsmEngagementsPage` — so a row's
- * severity column, detail route, and engagement-type filter all match what a
- * user sees on that type's dedicated page). Conversations is the project's
- * chat sessions (`ConversationsTab`), included here as its own sub-tab rather
- * than as a separate top-level project tab.
+ * A project's work items: a single flat list spanning every case type (Case /
+ * Service request / Security report / Engagement / Announcement), filtered by
+ * a "Work item type" multi-select rather than one sub-tab per type — matching
+ * `caseType.ts`'s `ALL_CASE_TYPES` (all 5; the backend already returns
+ * announcements for a project, so hiding that type here would be a silent
+ * regression). Detail links resolve per-row to each type's own detail page via
+ * `CasesList`'s `caseTypeDetailBasePath` fallback (no `detailBasePath` is
+ * passed here, unlike the old single-type sub-tabs, since a mixed list can't
+ * point every row at one fixed base path).
+ *
+ * `hideProjectFilter` is passed (this view is already locked to one project
+ * via `lockedFilters`) and `typeFilterLabel="Work item type"` renders in the
+ * project filter's old grid slot, since a project-scoped list has no use for
+ * its own project filter — see `CasesFilterBar`'s `typeFilterLabel` doc
+ * comment for why this reuses the existing "Case type" control (an actual
+ * closed `<Select multiple>` dropdown already, not an inline checkbox list)
+ * rather than introducing a new control.
+ *
+ * Conversations is the project's chat sessions (`ConversationsTab`), kept as
+ * its own sub-tab alongside the flat issues list rather than a third
+ * top-level project tab — it was already nested here before this revamp.
  */
 export default function WorkItemsTab({ projectId }: WorkItemsTabProps): JSX.Element {
   // Kept in the URL (`?subTab=`), not local state, alongside the parent
@@ -57,62 +64,23 @@ export default function WorkItemsTab({ projectId }: WorkItemsTabProps): JSX.Elem
   // the engineer was on, not just the Work items tab in general.
   const { activeTab: subTab, setActiveTab: setSubTab } = useQueryParamTabs<WorkItemSubTab>(
     WORK_ITEM_SUB_TABS,
-    "cases",
+    "issues",
     { paramName: "subTab" },
   );
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
       <Tabs value={subTab} onChange={(_, v) => setSubTab(v as WorkItemSubTab)}>
-        <Tab value="cases" label="Cases" />
-        <Tab value="serviceRequests" label="Service requests" />
-        <Tab value="securityReports" label="Security reports" />
-        <Tab value="engagements" label="Engagements" />
+        <Tab value="issues" label="Work items" />
         <Tab value="conversations" label="Chats" />
       </Tabs>
 
-      {subTab === "cases" && (
+      {subTab === "issues" && (
         <CsmIssuesView
-          entityNoun="cases"
-          lockedFilters={{ projects: [projectId], caseTypes: ["case"] }}
+          entityNoun="work items"
+          lockedFilters={{ projects: [projectId] }}
           hideProjectFilter
-          hideTypeFilter
-          hideBackButton
-        />
-      )}
-
-      {subTab === "serviceRequests" && (
-        <CsmIssuesView
-          entityNoun="service requests"
-          lockedFilters={{ projects: [projectId], caseTypes: ["service_request"] }}
-          hideProjectFilter
-          hideTypeFilter
-          detailBasePath="/operations/service-requests"
-          hideBackButton
-        />
-      )}
-
-      {subTab === "securityReports" && (
-        <CsmIssuesView
-          entityNoun="security reports"
-          lockedFilters={{ projects: [projectId], caseTypes: ["security_report_analysis"] }}
-          hideProjectFilter
-          hideTypeFilter
-          hideSeverityColumn
-          detailBasePath="/security-center/security-reports"
-          hideBackButton
-        />
-      )}
-
-      {subTab === "engagements" && (
-        <CsmIssuesView
-          entityNoun="engagements"
-          lockedFilters={{ projects: [projectId], caseTypes: ["engagement"] }}
-          hideProjectFilter
-          hideTypeFilter
-          showEngagementTypeFilter
-          hideSeverityColumn
-          detailBasePath="/engagements"
+          typeFilterLabel="Work item type"
           hideBackButton
         />
       )}

--- a/apps/csm-portal/webapp/src/features/csm-recent/components/PinnedTabs.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-recent/components/PinnedTabs.test.tsx
@@ -125,4 +125,26 @@ describe("PinnedTabs", () => {
     expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
     expect(renameRecentViewMock).not.toHaveBeenCalled();
   });
+
+  // Regression test: `renameRecentView` normalizes via `stripHtmlTags(...).trim()`
+  // and no-ops on an empty result, but the dialog's own validation used to
+  // check the raw field value with a plain `.trim()` -- so tag-only input
+  // ("<b></b>", non-blank as raw text) passed that check, closed the dialog
+  // via Enter, and still silently renamed nothing.
+  it("does not close the dialog or call renameRecentView for tag-only input via Enter", () => {
+    pinnedEntries = [pinnedEntry({ id: "1", title: "My work items view" })];
+    renderPinnedTabs();
+
+    fireEvent.contextMenu(screen.getByText("My work items view"));
+    fireEvent.click(screen.getByText("Rename"));
+
+    const input = screen.getByLabelText("Tab name") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "<b></b>" } });
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(renameRecentViewMock).not.toHaveBeenCalled();
+    expect(screen.getByLabelText("Tab name")).toBeInTheDocument();
+  });
 });

--- a/apps/csm-portal/webapp/src/features/csm-recent/components/PinnedTabs.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-recent/components/PinnedTabs.test.tsx
@@ -1,0 +1,128 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import "@testing-library/jest-dom/vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import PinnedTabs from "@features/csm-recent/components/PinnedTabs";
+import type { RecentView } from "@features/csm-recent/hooks/useRecentViews";
+
+vi.mock("@asgardeo/react", () => ({
+  useAsgardeo: () => ({ isSignedIn: true }),
+}));
+
+const toggleRecentViewPinMock = vi.fn();
+const renameRecentViewMock = vi.fn();
+let pinnedEntries: RecentView[] = [];
+
+vi.mock("@features/csm-recent/hooks/useRecentViews", () => ({
+  useRecentViews: () => pinnedEntries,
+  toggleRecentViewPin: (...args: unknown[]) => toggleRecentViewPinMock(...args),
+  renameRecentView: (...args: unknown[]) => renameRecentViewMock(...args),
+}));
+
+function pinnedEntry(overrides: Partial<RecentView> = {}): RecentView {
+  return {
+    kind: "search",
+    id: "/customers/projects/proj-1?tab=workItems&types=case",
+    title: "Customers: 1 filter",
+    href: "/customers/projects/proj-1?tab=workItems&types=case",
+    visitedAt: "2026-08-18T00:00:00.000Z",
+    pinned: true,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  toggleRecentViewPinMock.mockReset();
+  renameRecentViewMock.mockReset();
+  pinnedEntries = [];
+});
+
+function renderPinnedTabs() {
+  return render(
+    <MemoryRouter initialEntries={["/somewhere-else"]}>
+      <PinnedTabs />
+    </MemoryRouter>,
+  );
+}
+
+describe("PinnedTabs", () => {
+  it("renders nothing but a spacer when there are no pinned entries", () => {
+    const { container } = renderPinnedTabs();
+    expect(container.querySelector(".MuiChip-root")).not.toBeInTheDocument();
+  });
+
+  it("renders a chip per pinned entry", () => {
+    pinnedEntries = [pinnedEntry({ id: "1", title: "My work items view" })];
+    renderPinnedTabs();
+    expect(screen.getByText("My work items view")).toBeInTheDocument();
+  });
+
+  it("unpins via the chip's delete affordance", () => {
+    pinnedEntries = [pinnedEntry({ id: "1", title: "My work items view" })];
+    renderPinnedTabs();
+
+    const chip = screen.getByText("My work items view").closest(".MuiChip-root")!;
+    fireEvent.click(chip.querySelector(".MuiChip-deleteIcon")!);
+
+    expect(toggleRecentViewPinMock).toHaveBeenCalledWith("search", "1");
+  });
+
+  it("right-click opens a context menu with a Rename item", () => {
+    pinnedEntries = [pinnedEntry({ id: "1", title: "My work items view" })];
+    renderPinnedTabs();
+
+    fireEvent.contextMenu(screen.getByText("My work items view"));
+
+    expect(screen.getByText("Rename")).toBeInTheDocument();
+  });
+
+  it("Rename opens a dialog pre-filled with the current title; saving calls renameRecentView", () => {
+    pinnedEntries = [pinnedEntry({ id: "1", title: "My work items view" })];
+    renderPinnedTabs();
+
+    fireEvent.contextMenu(screen.getByText("My work items view"));
+    fireEvent.click(screen.getByText("Rename"));
+
+    const input = screen.getByLabelText("Tab name") as HTMLInputElement;
+    expect(input.value).toBe("My work items view");
+
+    fireEvent.change(input, { target: { value: "Project X work items" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(renameRecentViewMock).toHaveBeenCalledWith(
+      "search",
+      "1",
+      "Project X work items",
+    );
+  });
+
+  it("disables Save while the rename field is blank", () => {
+    pinnedEntries = [pinnedEntry({ id: "1", title: "My work items view" })];
+    renderPinnedTabs();
+
+    fireEvent.contextMenu(screen.getByText("My work items view"));
+    fireEvent.click(screen.getByText("Rename"));
+
+    const input = screen.getByLabelText("Tab name") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "   " } });
+
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+    expect(renameRecentViewMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-recent/components/PinnedTabs.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-recent/components/PinnedTabs.tsx
@@ -14,11 +14,27 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Box, Chip, Tooltip } from "@wso2/oxygen-ui";
-import type { JSX } from "react";
+import {
+  Box,
+  Button,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  ListItemIcon,
+  ListItemText,
+  Menu,
+  MenuItem,
+  TextField,
+  Tooltip,
+} from "@wso2/oxygen-ui";
+import { Pencil } from "@wso2/oxygen-ui-icons-react";
+import { useState, type JSX, type MouseEvent as ReactMouseEvent } from "react";
 import { useAsgardeo } from "@asgardeo/react";
 import { useLocation } from "react-router";
 import {
+  renameRecentView,
   toggleRecentViewPin,
   useRecentViews,
   type RecentView,
@@ -46,6 +62,41 @@ export default function PinnedTabs(): JSX.Element {
   const navigate = useNavTransition();
   const location = useLocation();
   const pinned = useRecentViews().filter((e) => e.pinned);
+
+  // Right-click context menu (rename) — one shared anchor + target entry for
+  // whichever chip was last right-clicked, rather than per-chip state, since
+  // only one can be open at a time.
+  const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
+  const [menuTarget, setMenuTarget] = useState<RecentView | null>(null);
+  const [renameDialogOpen, setRenameDialogOpen] = useState(false);
+  const [renameValue, setRenameValue] = useState("");
+
+  const closeMenu = (): void => {
+    setMenuAnchor(null);
+    setMenuTarget(null);
+  };
+
+  const openContextMenu = (
+    e: ReactMouseEvent<HTMLElement>,
+    entry: RecentView,
+  ): void => {
+    e.preventDefault();
+    setMenuAnchor(e.currentTarget);
+    setMenuTarget(entry);
+  };
+
+  const openRenameDialog = (): void => {
+    if (!menuTarget) return;
+    setRenameValue(menuTarget.title);
+    setRenameDialogOpen(true);
+    setMenuAnchor(null);
+  };
+
+  const handleRenameSave = (): void => {
+    if (menuTarget) renameRecentView(menuTarget.kind, menuTarget.id, renameValue);
+    setRenameDialogOpen(false);
+    setMenuTarget(null);
+  };
 
   // Always occupy the flexible middle slot so the layout is identical whether or
   // not anything is pinned (and when signed out, where pins are not actionable).
@@ -88,6 +139,7 @@ export default function PinnedTabs(): JSX.Element {
               variant={active ? "filled" : "outlined"}
               onClick={() => navigate(entry.href)}
               onDelete={() => toggleRecentViewPin(entry.kind, entry.id)}
+              onContextMenu={(e: ReactMouseEvent<HTMLElement>) => openContextMenu(e, entry)}
               aria-label={`${shortLabel(entry)} — pinned tab`}
               sx={{
                 flexShrink: 0,
@@ -103,6 +155,53 @@ export default function PinnedTabs(): JSX.Element {
           </Tooltip>
         );
       })}
+
+      <Menu anchorEl={menuAnchor} open={Boolean(menuAnchor)} onClose={closeMenu}>
+        <MenuItem onClick={openRenameDialog}>
+          <ListItemIcon>
+            <Pencil size={16} />
+          </ListItemIcon>
+          <ListItemText primary="Rename" />
+        </MenuItem>
+      </Menu>
+
+      <Dialog
+        open={renameDialogOpen}
+        onClose={() => setRenameDialogOpen(false)}
+        maxWidth="xs"
+        fullWidth
+      >
+        <DialogTitle>Rename pinned tab</DialogTitle>
+        <DialogContent>
+          <TextField
+            autoFocus
+            fullWidth
+            size="small"
+            margin="dense"
+            label="Tab name"
+            value={renameValue}
+            onChange={(e) => setRenameValue(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                handleRenameSave();
+              }
+            }}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button color="inherit" onClick={() => setRenameDialogOpen(false)}>
+            Cancel
+          </Button>
+          <Button
+            variant="contained"
+            onClick={handleRenameSave}
+            disabled={!renameValue.trim()}
+          >
+            Save
+          </Button>
+        </DialogActions>
+      </Dialog>
     </Box>
   );
 }

--- a/apps/csm-portal/webapp/src/features/csm-recent/components/PinnedTabs.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-recent/components/PinnedTabs.tsx
@@ -41,6 +41,7 @@ import {
 } from "@features/csm-recent/hooks/useRecentViews";
 import { kindIcon } from "@features/csm-recent/kindMeta";
 import { useNavTransition } from "@hooks/useNavTransition";
+import { stripHtmlTags } from "@utils/sanitizeHtml";
 
 /** Compact chip label: the case id / entity name (the part before " · "). */
 function shortLabel(entry: RecentView): string {
@@ -92,7 +93,15 @@ export default function PinnedTabs(): JSX.Element {
     setMenuAnchor(null);
   };
 
+  // Same normalization `renameRecentView` itself applies (strip HTML tags,
+  // then trim) -- a plain `.trim()` here would let whitespace-only or
+  // tag-only input ("<b></b>") past validation, close the dialog, and still
+  // silently no-op the rename, since `renameRecentView` bails on an empty
+  // normalized title regardless of what the raw field value looked like.
+  const normalizedRenameValue = stripHtmlTags(renameValue).trim();
+
   const handleRenameSave = (): void => {
+    if (!normalizedRenameValue) return;
     if (menuTarget) renameRecentView(menuTarget.kind, menuTarget.id, renameValue);
     setRenameDialogOpen(false);
     setMenuTarget(null);
@@ -196,7 +205,7 @@ export default function PinnedTabs(): JSX.Element {
           <Button
             variant="contained"
             onClick={handleRenameSave}
-            disabled={!renameValue.trim()}
+            disabled={!normalizedRenameValue}
           >
             Save
           </Button>

--- a/apps/csm-portal/webapp/src/features/csm-recent/hooks/useRecentViews.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-recent/hooks/useRecentViews.test.ts
@@ -27,6 +27,7 @@ vi.mock("@hooks/useIdTokenClaims", () => ({
 
 import {
   clearRecentViews,
+  renameRecentView,
   toggleRecentViewPin,
   useRecentViews,
   useRecordRecentView,
@@ -201,6 +202,52 @@ describe("useRecentViews + useRecordRecentView", () => {
 
       act(() => clearRecentViews());
       expect(reader.result.current.map((v) => v.id)).toEqual(["pinned"]);
+    });
+  });
+
+  describe("renameRecentView", () => {
+    it("updates the title of the matching kind+id entry", () => {
+      const reader = renderHook(() => useRecentViews());
+      const recorder = renderHook(() => useRecordRecentView());
+      act(() => recorder.result.current(entry("1")));
+      act(() => toggleRecentViewPin("case", "1"));
+
+      act(() => renameRecentView("case", "1", "My renamed tab"));
+
+      expect(reader.result.current[0].title).toBe("My renamed tab");
+      // Pinned state survives a rename.
+      expect(reader.result.current[0].pinned).toBe(true);
+    });
+
+    it("is a no-op for a blank/whitespace-only name", () => {
+      const reader = renderHook(() => useRecentViews());
+      const recorder = renderHook(() => useRecordRecentView());
+      act(() => recorder.result.current(entry("1")));
+
+      act(() => renameRecentView("case", "1", "   "));
+
+      expect(reader.result.current[0].title).toBe("Case 1");
+    });
+
+    it("is a no-op for an untracked kind+id", () => {
+      const reader = renderHook(() => useRecentViews());
+      const recorder = renderHook(() => useRecordRecentView());
+      act(() => recorder.result.current(entry("1")));
+
+      act(() => renameRecentView("case", "does-not-exist", "New name"));
+
+      expect(reader.result.current).toHaveLength(1);
+      expect(reader.result.current[0].title).toBe("Case 1");
+    });
+
+    it("strips HTML tags from the new title before storing", () => {
+      const reader = renderHook(() => useRecentViews());
+      const recorder = renderHook(() => useRecordRecentView());
+      act(() => recorder.result.current(entry("1")));
+
+      act(() => renameRecentView("case", "1", "<b>Bold</b> name"));
+
+      expect(reader.result.current[0].title).toBe("Bold name");
     });
   });
 

--- a/apps/csm-portal/webapp/src/features/csm-recent/hooks/useRecentViews.ts
+++ b/apps/csm-portal/webapp/src/features/csm-recent/hooks/useRecentViews.ts
@@ -424,6 +424,28 @@ export function toggleRecentViewPin(kind: RecentViewKind, id: string): void {
   writeStorage(capUnpinned(next));
 }
 
+/**
+ * Rename a tracked entry's display title by `kind`+`id` (currently only
+ * exposed for pinned top-bar chips — see `PinnedTabs.tsx`'s right-click
+ * rename, but not restricted to pinned entries at the storage layer since
+ * there's no reason it couldn't apply to any tracked entry later). No-op for
+ * an empty/whitespace-only name or an untracked `kind`+`id`, mirroring
+ * `saveFilterView`'s "blank name does nothing" behaviour. Title text is
+ * plain, user-authored text rendered via JSX interpolation (never
+ * `dangerouslySetInnerHTML`) — stripped of tag-like markup here for the same
+ * defense-in-depth reason `useRecordRecentView` strips it, not because this
+ * path is currently reachable by anything untrusted.
+ */
+export function renameRecentView(kind: RecentViewKind, id: string, title: string): void {
+  const trimmed = stripHtmlTags(title).trim();
+  if (!trimmed) return;
+  const current = readStorage();
+  const next = current.map((e) =>
+    e.kind === kind && e.id === id ? { ...e, title: trimmed } : e,
+  );
+  writeStorage(next);
+}
+
 export function clearRecentViews(): void {
   // Keep pinned entries — "Clear" wipes browsing history, not the working set
   // the engineer deliberately assembled.

--- a/apps/csm-portal/webapp/src/features/csm-security-center/pages/CsmSecurityCenterPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-security-center/pages/CsmSecurityCenterPage.tsx
@@ -18,7 +18,6 @@ import { Box, Button, Typography } from "@wso2/oxygen-ui";
 import { ArrowLeft, Plus } from "@wso2/oxygen-ui-icons-react";
 import { type JSX } from "react";
 import { useLocation } from "react-router";
-import SectionTabs from "@components/section-tabs/SectionTabs";
 import CsmIssuesView from "@features/csm-cases/components/CsmIssuesView";
 import ProductVulnerabilitiesTab from "@features/csm-security-center/components/ProductVulnerabilitiesTab";
 import { useNavTransition } from "@hooks/useNavTransition";
@@ -33,10 +32,17 @@ import { usePathSectionTabs } from "@hooks/useSectionTabs";
  *
  * Which tabs exist comes from the navigation tree, so a deployment can restrict
  * one through `CSM_PORTAL_FEATURE_OVERRIDES` without touching this page.
+ *
+ * The tab switch itself lives in the sidebar now (Security Center's
+ * submenu), not an in-page strip — `usePathSectionTabs` is kept only for its
+ * enabled/WIP-aware fallback reading the same real path segment
+ * (`/security-center/:tab`) the sidebar's submenu links navigate to.
  */
 export default function CsmSecurityCenterPage(): JSX.Element {
-  const tabs = usePathSectionTabs("security-center", "/security-center");
-  const activeTab = tabs.activeKey;
+  const { activeKey: activeTab } = usePathSectionTabs(
+    "security-center",
+    "/security-center",
+  );
   const navigate = useNavTransition();
   // Set by a dashboard widget's click-through, since this page has no
   // dashboard context of its own. The security-reports tab renders its own
@@ -64,8 +70,6 @@ export default function CsmSecurityCenterPage(): JSX.Element {
           Security reports and vulnerability posture across customer deployments.
         </Typography>
       </Box>
-
-      <SectionTabs {...tabs} ariaLabel="Security Center tabs" />
 
       {activeTab === "security-reports" && (
         <CsmIssuesView

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardCasePreviewDrawer.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardCasePreviewDrawer.test.tsx
@@ -146,6 +146,42 @@ describe("TimeCardCasePreviewDrawer", () => {
     expect(onDecide).toHaveBeenCalledWith("reject");
   });
 
+  it("lists the eligible approvers on a submitted card", () => {
+    getMock.mockReturnValue(new Promise(() => {}));
+    renderWithProviders(
+      <TimeCardCasePreviewDrawer
+        card={{
+          ...CARD,
+          approvers: [
+            { id: "lead-1", name: "Lead One" },
+            { id: "lead-2", name: "Lead Two" },
+          ],
+        }}
+        actions={[]}
+        onClose={vi.fn()}
+        onDecide={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Approvers")).toBeInTheDocument();
+    expect(screen.getByText("Lead One, Lead Two")).toBeInTheDocument();
+  });
+
+  it("shows the decision text without a generic 'Decision' caption on a decided card", () => {
+    getMock.mockReturnValue(new Promise(() => {}));
+    renderWithProviders(
+      <TimeCardCasePreviewDrawer
+        card={{ ...CARD, state: "approved", approvedByName: "Lead Person" }}
+        actions={[]}
+        onClose={vi.fn()}
+        onDecide={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Approved by: Lead Person")).toBeInTheDocument();
+    expect(screen.queryByText("Decision")).not.toBeInTheDocument();
+  });
+
   it("only shows the embedded case preview's 'View full details' close affordance, not a duplicate close button", async () => {
     getMock.mockResolvedValue({
       id: "case-1",

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardCasePreviewDrawer.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardCasePreviewDrawer.tsx
@@ -148,15 +148,17 @@ export default function TimeCardCasePreviewDrawer({
 
             <WorkLogComment html={card.workLogComment} />
 
-            {decision && (
+            {card.state === "submitted" && card.approvers && card.approvers.length > 0 && (
               <Field
-                label="Decision"
-                value={
-                  <Typography variant="body2" sx={{ whiteSpace: "normal", wordBreak: "break-word" }}>
-                    {decision}
-                  </Typography>
-                }
+                label="Approvers"
+                value={card.approvers.map((approver) => approver.name).join(", ")}
               />
+            )}
+
+            {decision && (
+              <Typography variant="body2" sx={{ whiteSpace: "normal", wordBreak: "break-word" }}>
+                {decision}
+              </Typography>
             )}
 
             {actions.some((a) => a === "approve" || a === "reject") && (

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardCasePreviewDrawer.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardCasePreviewDrawer.tsx
@@ -109,6 +109,13 @@ export default function TimeCardCasePreviewDrawer({
       anchor="right"
       open={!!card}
       onClose={onClose}
+      // No backdrop: a temporary Drawer's default backdrop intercepts
+      // pointer events on the rest of the page, which would block clicking
+      // a different row's quick-preview eye while one preview is already
+      // open -- exactly the "switch straight to another row" behavior this
+      // drawer exists for. Closing still works via the eye toggle or the
+      // drawer's own close button.
+      hideBackdrop
       slotProps={{ paper: { sx: { width: { xs: "100%", sm: 420 } } } }}
     >
       {card && (

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardsTable.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardsTable.test.tsx
@@ -504,10 +504,46 @@ describe("TimeCardsTable View details drawer", () => {
       />,
     );
 
+    // Assert the drawer's own "Engineer" field, not the case number --
+    // CS0352584/CS0352585 are already rendered in the table's Case column,
+    // so asserting those alone could pass even if the drawer never actually
+    // switched (or never opened at all).
     fireEvent.click(screen.getByTestId("timecard-view-tc-1"));
-    expect(screen.getByText("CS0352584")).toBeInTheDocument();
+    expect(screen.getByText("Jane Doe")).toBeInTheDocument();
 
     fireEvent.click(screen.getByTestId("timecard-view-tc-2"));
-    expect(screen.getByText("CS0352585")).toBeInTheDocument();
+    expect(screen.getByText("John Roe")).toBeInTheDocument();
+    expect(screen.queryByText("Jane Doe")).not.toBeInTheDocument();
+  });
+});
+
+describe("TimeCardsTable — preview drawer respects bulk-selection gating", () => {
+  // Regression test: the row-level Approve/Reject buttons disable while a
+  // bulk selection is active (selectionActive), but the preview drawer used
+  // to always receive the card's full, unfiltered action list regardless --
+  // letting a user bypass that restriction by approving/rejecting from the
+  // drawer instead of the row.
+  it("does not offer Approve/Reject in the preview drawer while a bulk selection is active", () => {
+    getMock.mockReturnValue(new Promise(() => {}));
+    const submittedCard: CsmTimeCard = { ...CARD, id: "tc-3", state: "submitted" };
+    renderWithClient(
+      <TimeCardsTable
+        cards={[submittedCard]}
+        isLoading={false}
+        emptyText="No cards"
+        groupBy="case"
+        roleFor={() => APPROVER_ROLE_CTX}
+        onCardAction={vi.fn()}
+        selectable
+        selectedIds={new Set(["tc-3"])}
+        onToggleSelect={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("timecard-view-tc-3"));
+
+    expect(screen.getByText("Time card")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Approve" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Reject" })).not.toBeInTheDocument();
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardsTable.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardsTable.test.tsx
@@ -469,4 +469,45 @@ describe("TimeCardsTable View details drawer", () => {
     fireEvent.click(screen.getByRole("link", { name: "View full details" }));
     await waitFor(() => expect(screen.getByTestId("location-probe")).toBeInTheDocument());
   });
+
+  it("closes the preview when the same row's eye is clicked again", () => {
+    getMock.mockReturnValue(new Promise(() => {}));
+    renderWithClient(
+      <TimeCardsTable
+        cards={[CARD]}
+        isLoading={false}
+        emptyText="No cards"
+        groupBy="case"
+        roleFor={() => ROLE_CTX}
+        onCardAction={vi.fn()}
+      />,
+    );
+
+    const eye = screen.getByTestId("timecard-view-tc-1");
+    fireEvent.click(eye);
+    expect(screen.getByText("Time card")).toBeInTheDocument();
+
+    fireEvent.click(eye);
+    expect(screen.queryByText("Time card")).not.toBeInTheDocument();
+  });
+
+  it("switches the preview to a different row without requiring a close first", () => {
+    getMock.mockReturnValue(new Promise(() => {}));
+    renderWithClient(
+      <TimeCardsTable
+        cards={[CARD, APPROVED_CARD]}
+        isLoading={false}
+        emptyText="No cards"
+        groupBy="case"
+        roleFor={() => ROLE_CTX}
+        onCardAction={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("timecard-view-tc-1"));
+    expect(screen.getByText("CS0352584")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("timecard-view-tc-2"));
+    expect(screen.getByText("CS0352585")).toBeInTheDocument();
+  });
 });

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardsTable.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardsTable.tsx
@@ -115,6 +115,7 @@ export default function TimeCardsTable({
   const [detailCard, setDetailCard] = useState<CsmTimeCard | null>(null);
 
   const headerCells = [
+    "Preview",
     ...(showCaseColumn ? ["Case"] : []),
     ...(showEngineerColumn ? ["Engineer"] : []),
     "Project",
@@ -125,6 +126,7 @@ export default function TimeCardsTable({
   ];
   const grid = [
     ...(selectable ? ["40px"] : []),
+    "auto",
     ...(showCaseColumn ? ["minmax(120px, 0.9fr)"] : []),
     ...(showEngineerColumn ? ["minmax(140px, 1fr)"] : []),
     "minmax(160px, 1.4fr)",
@@ -276,6 +278,23 @@ export default function TimeCardsTable({
                     )}
                   </Box>
                 )}
+                {/* Quick preview, at the row's left edge (right after the
+                    optional bulk-select checkbox) so it's reachable without
+                    hunting across the row; the drawer opens on the right.
+                    Clicking the eye for the row already open closes it
+                    instead of re-opening the same preview. */}
+                <Box role="cell" sx={{ display: "flex", alignItems: "center" }}>
+                  <IconButton
+                    size="small"
+                    aria-label="View details"
+                    data-testid={`timecard-view-${c.id}`}
+                    onClick={() =>
+                      setDetailCard((prev) => (prev?.id === c.id ? null : c))
+                    }
+                  >
+                    <Eye size={16} />
+                  </IconButton>
+                </Box>
                 {showCaseColumn && (
                   <Typography role="cell" variant="body2" noWrap title={c.caseNumber}>
                     {c.caseNumber}
@@ -311,14 +330,6 @@ export default function TimeCardsTable({
                   role="cell"
                   sx={{ display: "flex", alignItems: "center", gap: 0.75, justifySelf: "end" }}
                 >
-                  <IconButton
-                    size="small"
-                    aria-label="View details"
-                    data-testid={`timecard-view-${c.id}`}
-                    onClick={() => setDetailCard(c)}
-                  >
-                    <Eye size={16} />
-                  </IconButton>
                   {/* Own actionable buttons regardless of showActionsColumn —
                       unlike approve/reject, editing and deleting are offered
                       to the card's own owner on every tab it can appear on

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardsTable.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardsTable.tsx
@@ -396,7 +396,19 @@ export default function TimeCardsTable({
       </Box>
       <TimeCardCasePreviewDrawer
         card={detailCard}
-        actions={detailCard ? cardActions(detailCard.state, roleFor(detailCard)) : []}
+        // Same gating as the row-level Approve/Reject buttons above: while a
+        // bulk selection is active, approve/reject only happens through the
+        // bulk toolbar. Without this filter the drawer would still offer its
+        // own Approve/Reject regardless of `selectionActive`, letting a
+        // direct decision bypass the same restriction the row buttons
+        // enforce.
+        actions={
+          detailCard
+            ? cardActions(detailCard.state, roleFor(detailCard)).filter(
+                (a) => !selectionActive || (a !== "approve" && a !== "reject"),
+              )
+            : []
+        }
         onClose={() => setDetailCard(null)}
         onDecide={(action) => {
           if (detailCard) onCardAction(detailCard, action);

--- a/apps/csm-portal/webapp/src/features/csm-timecards/utils/__tests__/timeCardDecision.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/utils/__tests__/timeCardDecision.test.ts
@@ -38,7 +38,7 @@ function card(overrides: Partial<CsmTimeCard> = {}): CsmTimeCard {
 describe("decisionSummary", () => {
   it("names the approver on an approved card", () => {
     expect(decisionSummary(card({ state: "approved", approvedByName: "Lead Person" }))).toBe(
-      "Approved by Lead Person",
+      "Approved by: Lead Person",
     );
   });
 

--- a/apps/csm-portal/webapp/src/features/csm-timecards/utils/timeCardDecision.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/utils/timeCardDecision.ts
@@ -33,7 +33,7 @@ import type { CsmTimeCard } from "@features/csm-timecards/types/timeCards";
  */
 export function decisionSummary(card: CsmTimeCard): string | null {
   if (card.state === "approved") {
-    return card.approvedByName ? `Approved by ${card.approvedByName}` : "Approved";
+    return card.approvedByName ? `Approved by: ${card.approvedByName}` : "Approved";
   }
   if (card.state === "rejected") {
     return card.rejectionReason ? `Rejected: ${card.rejectionReason}` : "Rejected";

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -1403,6 +1403,8 @@ type ParsedCaseFilters struct {
 	// SreTeamIDs filters to cases whose parent account's SRE (Site Reliability
 	// Engineering) team is one of these team UUIDs (optional).
 	SreTeamIDs []string
+	// AccountIDs filters to cases belonging to one of these customer_account UUIDs (optional).
+	AccountIDs []string
 	// Unassigned, when true, filters to cases with no assigned engineer. false and
 	// omitted are treated identically (optional).
 	Unassigned bool
@@ -3421,6 +3423,18 @@ const (
 	IncidentStateCancelled  IncidentState = "CANCELLED"
 )
 
+// ProblemState represents the workflow state of a problem.
+type ProblemState string
+
+const (
+	ProblemStateNew               ProblemState = "NEW"
+	ProblemStateAssess            ProblemState = "ASSESS"
+	ProblemStateRootCauseAnalysis ProblemState = "ROOT_CAUSE_ANALYSIS"
+	ProblemStateFixInProgress     ProblemState = "FIX_IN_PROGRESS"
+	ProblemStateResolved          ProblemState = "RESOLVED"
+	ProblemStateClosed            ProblemState = "CLOSED"
+)
+
 // IncidentCategory represents the category of an incident.
 type IncidentCategory string
 
@@ -3628,6 +3642,16 @@ type IncidentView struct {
 	IncidentReport  *string `json:"incidentReport"`
 }
 
+// ProblemFieldFilter is a single predicate in a problem search's generic
+// filter expression array: "field op values", mirroring IncidentFieldFilter's
+// contract. See service.ParseProblemFieldFilters for the field/op enum and
+// translation into the internal representation posted to ServiceNow.
+type ProblemFieldFilter struct {
+	Field  string   `json:"field"`
+	Op     string   `json:"op"`
+	Values []string `json:"values,omitempty"`
+}
+
 // SearchProblemsFilters holds all optional filter criteria for a problem search.
 type SearchProblemsFilters struct {
 	SearchQuery string `json:"searchQuery"`
@@ -3636,6 +3660,12 @@ type SearchProblemsFilters struct {
 	// ServiceNow's `number` column, routed as a first-class filter rather
 	// than through the free-text SearchQuery scan.
 	Number *string `json:"number,omitempty"`
+	// Filters is the generic field/op/values filter array. Supported fields:
+	//   - "state" (op in): domain ProblemState enum values, translated to
+	//     ServiceNow's raw problem_state numeric keys.
+	//   - "assignmentGroupId" (op in): sys_user_group UUIDs.
+	// See service.ParseProblemFieldFilters.
+	Filters []ProblemFieldFilter `json:"filters,omitempty"`
 }
 
 // SearchProblemsRequest is the input for POST /problems/search.
@@ -3700,6 +3730,85 @@ type CreateProblemRequest struct {
 	Subcategory       *string `json:"subcategory,omitempty"`
 	OriginCaseID      *string `json:"originCaseId,omitempty"`
 	PrimaryIncidentID *string `json:"primaryIncidentId,omitempty"`
+}
+
+// IncidentTaskFieldFilter is a single predicate in an incident-task search's
+// generic filter expression array: "field op values", mirroring
+// ProblemFieldFilter's contract. See service.ParseIncidentTaskFieldFilters
+// for the field/op enum and translation into the internal representation
+// posted to the backing data source.
+type IncidentTaskFieldFilter struct {
+	Field  string   `json:"field"`
+	Op     string   `json:"op"`
+	Values []string `json:"values,omitempty"`
+}
+
+// SearchIncidentTasksFilters holds all optional filter criteria for an
+// incident-task search.
+type SearchIncidentTasksFilters struct {
+	SearchQuery string `json:"searchQuery"`
+	// Number filters to the incident task whose human-readable number (e.g.
+	// "TASK0082453") exactly matches (optional). Exact match, not part of
+	// the free-text SearchQuery scan.
+	Number *string `json:"number,omitempty"`
+	// Filters is the generic field/op/values filter array. Supported fields:
+	//   - "state" (op in): a raw integer state value, NOT a domain enum.
+	//     Deliberate: incident_task shares its state choice list with the
+	//     data source's base task table, and that choice list is
+	//     inconsistent across task subtypes (overlapping/ambiguous values),
+	//     so there is no confirmed-complete, unambiguous enum to translate
+	//     through. Callers pass the raw integer directly.
+	//   - "assignmentGroupId" (op in): sys_user_group UUIDs.
+	//   - "incidentId" (op in): parent incident UUIDs.
+	// See service.ParseIncidentTaskFieldFilters.
+	Filters []IncidentTaskFieldFilter `json:"filters,omitempty"`
+}
+
+// SearchIncidentTasksRequest is the input for POST /incident_tasks/search.
+type SearchIncidentTasksRequest struct {
+	Filters    SearchIncidentTasksFilters `json:"filters"`
+	Pagination Pagination                 `json:"pagination"`
+}
+
+// IncidentTask is the incident-task representation returned in search results.
+type IncidentTask struct {
+	ID              *string        `json:"id"`
+	Number          *string        `json:"number"`
+	Subject         *string        `json:"subject"`
+	State           *string        `json:"state"`
+	StateLabel      *string        `json:"stateLabel"`
+	Incident        *CaseNumberRef `json:"incident"`
+	AssignmentGroup *EntityRef     `json:"assignmentGroup"`
+	AssignedTo      *EntityRef     `json:"assignedTo"`
+}
+
+// SearchIncidentTasksResponse is the paginated result of an incident-task search.
+type SearchIncidentTasksResponse struct {
+	IncidentTasks []IncidentTask `json:"incidentTasks"`
+	Total         int            `json:"total"`
+	Offset        int            `json:"offset"`
+	Limit         int            `json:"limit"`
+}
+
+// IncidentTaskDetail is the full detail representation returned by
+// GET /incident_tasks/{id}.
+//
+// State is a plain, unvalidated passthrough string from the data source
+// rather than a closed enum -- see SearchIncidentTasksFilters.Filters' doc
+// comment on why "state" has no domain enum for incident_task.
+type IncidentTaskDetail struct {
+	ID              *string        `json:"id"`
+	Number          *string        `json:"number"`
+	Subject         *string        `json:"subject"`
+	State           *string        `json:"state"`
+	StateLabel      *string        `json:"stateLabel"`
+	Incident        *CaseNumberRef `json:"incident"`
+	AssignmentGroup *EntityRef     `json:"assignmentGroup"`
+	AssignedTo      *EntityRef     `json:"assignedTo"`
+	Description     *string        `json:"description"`
+	Priority        *string        `json:"priority"`
+	OpenedAt        *string        `json:"openedAt"`
+	ClosedAt        *string        `json:"closedAt"`
 }
 
 // ConversationState represents the state of a conversation.

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -3372,6 +3372,9 @@ type SearchIncidentsFilters struct {
 	//     ServiceNow's raw incident_state numeric keys.
 	//   - "assignmentGroupId" (op in): sys_user_group UUIDs.
 	//   - "businessServiceId" (op in): business_service sys_id UUIDs.
+	//   - "createdOn" (op gte/lte): RFC3339 timestamp, YYYY-MM-DD date, or a
+	//     relative-date placeholder (e.g. "__daysAgo:90__"), same syntax as
+	//     case search's own "createdOn" filter.
 	// See service.ParseIncidentFieldFilters.
 	Filters []IncidentFieldFilter `json:"filters,omitempty"`
 }

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -1393,6 +1393,11 @@ type ParsedCaseFilters struct {
 	// status is one of these values (optional; free-text SN choice labels, e.g.
 	// "Completed", "Not-Applicable" -- not a closed enum at this layer).
 	ProjectOnboardingStatuses []string
+	// ExcludeProjectOnboardingStatuses filters to cases whose parent project's
+	// onboarding status is NOT one of these values (optional; same free-text
+	// vocabulary as ProjectOnboardingStatuses). Inverse of that field --
+	// e.g. values: ["In-Progress"] means "onboarding status is not in progress".
+	ExcludeProjectOnboardingStatuses []string
 	// ProjectTypeNames filters to cases whose parent project's type is one of
 	// these project-type names, e.g. "Subscription" (optional; the backing data
 	// source matches project type by name, not by id).

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -3772,7 +3772,7 @@ type SearchIncidentTasksFilters struct {
 	Filters []IncidentTaskFieldFilter `json:"filters,omitempty"`
 }
 
-// SearchIncidentTasksRequest is the input for POST /incident_tasks/search.
+// SearchIncidentTasksRequest is the input for POST /incident-tasks/search.
 type SearchIncidentTasksRequest struct {
 	Filters    SearchIncidentTasksFilters `json:"filters"`
 	Pagination Pagination                 `json:"pagination"`
@@ -3799,7 +3799,7 @@ type SearchIncidentTasksResponse struct {
 }
 
 // IncidentTaskDetail is the full detail representation returned by
-// GET /incident_tasks/{id}.
+// GET /incident-tasks/{id}.
 //
 // State is a plain, unvalidated passthrough string from the data source
 // rather than a closed enum -- see SearchIncidentTasksFilters.Filters' doc
@@ -3815,8 +3815,8 @@ type IncidentTaskDetail struct {
 	AssignedTo      *EntityRef     `json:"assignedTo"`
 	Description     *string        `json:"description"`
 	Priority        *string        `json:"priority"`
-	OpenedAt        *string        `json:"openedAt"`
-	ClosedAt        *string        `json:"closedAt"`
+	OpenedOn        *string        `json:"openedOn"`
+	ClosedOn        *string        `json:"closedOn"`
 }
 
 // ConversationState represents the state of a conversation.

--- a/entity-service/internal/handler/incident_task_handler.go
+++ b/entity-service/internal/handler/incident_task_handler.go
@@ -35,7 +35,7 @@ func NewIncidentTaskHandler(svc service.IncidentTaskService) *IncidentTaskHandle
 	return &IncidentTaskHandler{svc: svc}
 }
 
-// SearchIncidentTasks handles POST /incident_tasks/search.
+// SearchIncidentTasks handles POST /incident-tasks/search.
 func (h *IncidentTaskHandler) SearchIncidentTasks(w http.ResponseWriter, r *http.Request) {
 	var req domain.SearchIncidentTasksRequest
 	if !decodeRequest(w, r, &req) {
@@ -51,7 +51,7 @@ func (h *IncidentTaskHandler) SearchIncidentTasks(w http.ResponseWriter, r *http
 	_ = json.NewEncoder(w).Encode(resp)
 }
 
-// GetIncidentTask handles GET /incident_tasks/{id}.
+// GetIncidentTask handles GET /incident-tasks/{id}.
 func (h *IncidentTaskHandler) GetIncidentTask(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	result, err := h.svc.GetIncidentTask(r.Context(), id)

--- a/entity-service/internal/handler/incident_task_handler.go
+++ b/entity-service/internal/handler/incident_task_handler.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/service"
+)
+
+// IncidentTaskHandler handles HTTP requests for the incident_tasks resource.
+// Search and get only -- there is no create/update path.
+type IncidentTaskHandler struct {
+	svc service.IncidentTaskService
+}
+
+// NewIncidentTaskHandler constructs an IncidentTaskHandler with the given service.
+func NewIncidentTaskHandler(svc service.IncidentTaskService) *IncidentTaskHandler {
+	return &IncidentTaskHandler{svc: svc}
+}
+
+// SearchIncidentTasks handles POST /incident_tasks/search.
+func (h *IncidentTaskHandler) SearchIncidentTasks(w http.ResponseWriter, r *http.Request) {
+	var req domain.SearchIncidentTasksRequest
+	if !decodeRequest(w, r, &req) {
+		return
+	}
+	resp, err := h.svc.SearchIncidentTasks(r.Context(), req)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// GetIncidentTask handles GET /incident_tasks/{id}.
+func (h *IncidentTaskHandler) GetIncidentTask(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	result, err := h.svc.GetIncidentTask(r.Context(), id)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(result)
+}

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -167,6 +167,11 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 		problemHandler = handler.NewProblemHandler(service.NewServiceNowProblemService(serviceNowIntegrationServiceClient))
 	}
 
+	var incidentTaskHandler *handler.IncidentTaskHandler
+	if cfg.DataSource == config.DataSourceServiceNow {
+		incidentTaskHandler = handler.NewIncidentTaskHandler(service.NewServiceNowIncidentTaskService(serviceNowIntegrationServiceClient))
+	}
+
 	var conversationHandler *handler.ConversationHandler
 	if cfg.DataSource == config.DataSourceServiceNow {
 		conversationHandler = handler.NewConversationHandler(service.NewServiceNowConversationService(serviceNowIntegrationServiceClient))
@@ -368,6 +373,11 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 		mux.HandleFunc("POST /problems", problemHandler.CreateProblem)
 		mux.HandleFunc("POST /problems/search", problemHandler.SearchProblems)
 		mux.HandleFunc("GET /problems/{id}", problemHandler.GetProblem)
+	}
+
+	if incidentTaskHandler != nil {
+		mux.HandleFunc("POST /incident_tasks/search", incidentTaskHandler.SearchIncidentTasks)
+		mux.HandleFunc("GET /incident_tasks/{id}", incidentTaskHandler.GetIncidentTask)
 	}
 
 	if conversationHandler != nil {

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -376,8 +376,8 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 	}
 
 	if incidentTaskHandler != nil {
-		mux.HandleFunc("POST /incident_tasks/search", incidentTaskHandler.SearchIncidentTasks)
-		mux.HandleFunc("GET /incident_tasks/{id}", incidentTaskHandler.GetIncidentTask)
+		mux.HandleFunc("POST /incident-tasks/search", incidentTaskHandler.SearchIncidentTasks)
+		mux.HandleFunc("GET /incident-tasks/{id}", incidentTaskHandler.GetIncidentTask)
 	}
 
 	if conversationHandler != nil {

--- a/entity-service/internal/service/case_filters.go
+++ b/entity-service/internal/service/case_filters.go
@@ -527,6 +527,9 @@ func ParseCaseFieldFilters(filters []domain.CaseFieldFilter, callerEmail string,
 			if err := requireCaseFilterValues(f); err != nil {
 				return domain.ParsedCaseFilters{}, err
 			}
+			if err := validateUUIDs("filters: accountId", f.Values); err != nil {
+				return domain.ParsedCaseFilters{}, err
+			}
 			p.AccountIDs = append(p.AccountIDs, f.Values...)
 
 		case "resolutionNotes":

--- a/entity-service/internal/service/case_filters.go
+++ b/entity-service/internal/service/case_filters.go
@@ -45,6 +45,7 @@ var caseFilterFieldSet = map[string]bool{
 	"projectOnboardingStatus": true, "projectType": true, "creTeam": true, "sreTeam": true,
 	"resolutionNotes": true, "parentId": true, "taskSLABusinessElapsedPercent": true,
 	"escalationLevel": true, "escalation": true, "number": true, "internalId": true,
+	"accountId": true,
 }
 
 // caseFilterOpSet is the exact set of CaseFieldFilter.Op values accepted by
@@ -515,6 +516,15 @@ func ParseCaseFieldFilters(filters []domain.CaseFieldFilter, callerEmail string,
 			}
 			p.SreTeamIDs = append(p.SreTeamIDs, f.Values...)
 
+		case "accountId":
+			if f.Op != "in" {
+				return domain.ParsedCaseFilters{}, badCaseFilterCombo(f)
+			}
+			if err := requireCaseFilterValues(f); err != nil {
+				return domain.ParsedCaseFilters{}, err
+			}
+			p.AccountIDs = append(p.AccountIDs, f.Values...)
+
 		case "resolutionNotes":
 			// isNotEmpty has no prior equivalent: false and omitted were
 			// explicitly documented as identical for resolutionNotesEmpty, so
@@ -730,6 +740,8 @@ func rejectUnsupportedOrGroupFields(parsed domain.ParsedCaseFilters) error {
 		return &apierror.ValidationError{Msg: "anyOf: field \"creTeam\" is not supported inside an OR group"}
 	case len(parsed.SreTeamIDs) > 0:
 		return &apierror.ValidationError{Msg: "anyOf: field \"sreTeam\" is not supported inside an OR group"}
+	case len(parsed.AccountIDs) > 0:
+		return &apierror.ValidationError{Msg: "anyOf: field \"accountId\" is not supported inside an OR group"}
 	case len(parsed.ExcludeStates) > 0:
 		// state+in is supported inside a branch (CaseFilterGroup.States);
 		// state+notIn is not modeled there.

--- a/entity-service/internal/service/case_filters.go
+++ b/entity-service/internal/service/case_filters.go
@@ -481,13 +481,17 @@ func ParseCaseFieldFilters(filters []domain.CaseFieldFilter, callerEmail string,
 			p.ProductNames = append(p.ProductNames, f.Values...)
 
 		case "projectOnboardingStatus":
-			if f.Op != "in" {
-				return domain.ParsedCaseFilters{}, badCaseFilterCombo(f)
-			}
 			if err := requireCaseFilterValues(f); err != nil {
 				return domain.ParsedCaseFilters{}, err
 			}
-			p.ProjectOnboardingStatuses = append(p.ProjectOnboardingStatuses, f.Values...)
+			switch f.Op {
+			case "in":
+				p.ProjectOnboardingStatuses = append(p.ProjectOnboardingStatuses, f.Values...)
+			case "notIn":
+				p.ExcludeProjectOnboardingStatuses = append(p.ExcludeProjectOnboardingStatuses, f.Values...)
+			default:
+				return domain.ParsedCaseFilters{}, badCaseFilterCombo(f)
+			}
 
 		case "projectType":
 			if f.Op != "in" {
@@ -732,7 +736,7 @@ func rejectUnsupportedOrGroupFields(parsed domain.ParsedCaseFilters) error {
 		return &apierror.ValidationError{Msg: "anyOf: field \"updatedOn\" is not supported inside an OR group"}
 	case len(parsed.ProductNames) > 0:
 		return &apierror.ValidationError{Msg: "anyOf: field \"product\" is not supported inside an OR group"}
-	case len(parsed.ProjectOnboardingStatuses) > 0:
+	case len(parsed.ProjectOnboardingStatuses) > 0 || len(parsed.ExcludeProjectOnboardingStatuses) > 0:
 		return &apierror.ValidationError{Msg: "anyOf: field \"projectOnboardingStatus\" is not supported inside an OR group"}
 	case len(parsed.ProjectTypeNames) > 0:
 		return &apierror.ValidationError{Msg: "anyOf: field \"projectType\" is not supported inside an OR group"}

--- a/entity-service/internal/service/case_filters_test.go
+++ b/entity-service/internal/service/case_filters_test.go
@@ -59,6 +59,19 @@ func TestParseCaseFieldFilters_NamedFieldTranslations(t *testing.T) {
 			},
 		},
 		{
+			name: "accountId in maps to AccountIDs",
+			in: []domain.CaseFieldFilter{{
+				Field:  "accountId",
+				Op:     "in",
+				Values: []string{"00000000-0000-0000-0000-000000000000"},
+			}},
+			check: func(t *testing.T, p domain.ParsedCaseFilters) {
+				if len(p.AccountIDs) != 1 || p.AccountIDs[0] != "00000000-0000-0000-0000-000000000000" {
+					t.Fatalf("AccountIDs = %v", p.AccountIDs)
+				}
+			},
+		},
+		{
 			name: "tag in maps to Tags",
 			in:   []domain.CaseFieldFilter{{Field: "tag", Op: "in", Values: []string{"patch"}}},
 			check: func(t *testing.T, p domain.ParsedCaseFilters) {
@@ -254,6 +267,7 @@ func TestParseCaseFieldFilters_Rejections(t *testing.T) {
 		{name: "number in unsupported", in: []domain.CaseFieldFilter{{Field: "number", Op: "in", Values: []string{"CS0441174"}}}},
 		{name: "internalId in unsupported", in: []domain.CaseFieldFilter{{Field: "internalId", Op: "in", Values: []string{"12345"}}}},
 		{name: "projectOnboardingStatus eq unsupported", in: []domain.CaseFieldFilter{{Field: "projectOnboardingStatus", Op: "eq", Values: []string{"Completed"}}}},
+		{name: "accountId malformed UUID", in: []domain.CaseFieldFilter{{Field: "accountId", Op: "in", Values: []string{"not-a-uuid"}}}},
 	}
 
 	for _, tc := range cases {

--- a/entity-service/internal/service/case_filters_test.go
+++ b/entity-service/internal/service/case_filters_test.go
@@ -187,6 +187,18 @@ func TestParseCaseFieldFilters_NamedFieldTranslations(t *testing.T) {
 			},
 		},
 		{
+			name: "projectOnboardingStatus notIn",
+			in:   []domain.CaseFieldFilter{{Field: "projectOnboardingStatus", Op: "notIn", Values: []string{"In-Progress"}}},
+			check: func(t *testing.T, p domain.ParsedCaseFilters) {
+				if len(p.ExcludeProjectOnboardingStatuses) != 1 || p.ExcludeProjectOnboardingStatuses[0] != "In-Progress" {
+					t.Fatalf("ExcludeProjectOnboardingStatuses = %v", p.ExcludeProjectOnboardingStatuses)
+				}
+				if len(p.ProjectOnboardingStatuses) != 0 {
+					t.Fatalf("ProjectOnboardingStatuses = %v, want empty", p.ProjectOnboardingStatuses)
+				}
+			},
+		},
+		{
 			name: "parentId eq",
 			in:   []domain.CaseFieldFilter{{Field: "parentId", Op: "eq", Values: []string{"00000000-0000-0000-0000-000000000000"}}},
 			check: func(t *testing.T, p domain.ParsedCaseFilters) {
@@ -241,6 +253,7 @@ func TestParseCaseFieldFilters_Rejections(t *testing.T) {
 		{name: "createdOn bad date format", in: []domain.CaseFieldFilter{{Field: "createdOn", Op: "gte", Values: []string{"not-a-date"}}}},
 		{name: "number in unsupported", in: []domain.CaseFieldFilter{{Field: "number", Op: "in", Values: []string{"CS0441174"}}}},
 		{name: "internalId in unsupported", in: []domain.CaseFieldFilter{{Field: "internalId", Op: "in", Values: []string{"12345"}}}},
+		{name: "projectOnboardingStatus eq unsupported", in: []domain.CaseFieldFilter{{Field: "projectOnboardingStatus", Op: "eq", Values: []string{"Completed"}}}},
 	}
 
 	for _, tc := range cases {

--- a/entity-service/internal/service/change_request_filters.go
+++ b/entity-service/internal/service/change_request_filters.go
@@ -56,10 +56,16 @@ func badChangeRequestFilterCombo(f domain.ChangeRequestFieldFilter) error {
 }
 
 // parseChangeRequestFilterDate parses a single filter value into a
-// date/time -- a full RFC3339 timestamp or a plain YYYY-MM-DD date
-// (interpreted as UTC midnight), mirroring parseCaseFilterDate's
-// non-relative-date handling in case_filters.go.
-func parseChangeRequestFilterDate(f domain.ChangeRequestFieldFilter, value string) (*time.Time, error) {
+// date/time -- a full RFC3339 timestamp, a plain YYYY-MM-DD date (interpreted
+// as UTC midnight), or a relative-date placeholder (e.g. "__daysAgo:90__"),
+// mirroring parseCaseFilterDate in case_filters.go. now is the reference
+// instant relative placeholders resolve against.
+func parseChangeRequestFilterDate(f domain.ChangeRequestFieldFilter, value string, now time.Time) (*time.Time, error) {
+	if resolved, matched, err := resolveRelativeDate(value, now); err != nil {
+		return nil, err
+	} else if matched {
+		value = resolved
+	}
 	if t, err := time.Parse(time.RFC3339, value); err == nil {
 		return &t, nil
 	}
@@ -70,7 +76,7 @@ func parseChangeRequestFilterDate(f domain.ChangeRequestFieldFilter, value strin
 		}
 		return &t, nil
 	}
-	return nil, &apierror.ValidationError{Msg: fmt.Sprintf("filters: field %q op %q value %q must be an RFC3339 timestamp or YYYY-MM-DD date", f.Field, f.Op, value)}
+	return nil, &apierror.ValidationError{Msg: fmt.Sprintf("filters: field %q op %q value %q must be an RFC3339 timestamp, YYYY-MM-DD date, or a recognized relative-date placeholder", f.Field, f.Op, value)}
 }
 
 // parsedChangeRequestFilters is the internal, named-field representation that
@@ -95,7 +101,7 @@ type parsedChangeRequestFilters struct {
 // CreatedEndDate-not-before-CreatedStartDate check, mirroring how
 // sn_change_request_service.go already does that check for
 // ClosedEndDate/ClosedStartDate post-parse.
-func ParseChangeRequestFieldFilters(filters []domain.ChangeRequestFieldFilter) (parsedChangeRequestFilters, error) {
+func ParseChangeRequestFieldFilters(filters []domain.ChangeRequestFieldFilter, now time.Time) (parsedChangeRequestFilters, error) {
 	var p parsedChangeRequestFilters
 
 	for _, f := range filters {
@@ -114,7 +120,7 @@ func ParseChangeRequestFieldFilters(filters []domain.ChangeRequestFieldFilter) (
 			if len(f.Values) != 1 {
 				return parsedChangeRequestFilters{}, &apierror.ValidationError{Msg: "filters: field \"createdOn\" accepts exactly one value"}
 			}
-			t, err := parseChangeRequestFilterDate(f, f.Values[0])
+			t, err := parseChangeRequestFilterDate(f, f.Values[0], now)
 			if err != nil {
 				return parsedChangeRequestFilters{}, err
 			}

--- a/entity-service/internal/service/change_request_filters_test.go
+++ b/entity-service/internal/service/change_request_filters_test.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+)
+
+func TestParseChangeRequestFieldFilters_CreatedOnRelativeDate(t *testing.T) {
+	now := time.Date(2026, 8, 18, 12, 0, 0, 0, time.UTC)
+
+	parsed, err := ParseChangeRequestFieldFilters([]domain.ChangeRequestFieldFilter{
+		{Field: "createdOn", Op: "gte", Values: []string{"__daysAgo:90__"}},
+	}, now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if parsed.CreatedStartDate == nil {
+		t.Fatal("CreatedStartDate = nil, want a resolved time")
+	}
+	want := time.Date(2026, 5, 20, 0, 0, 0, 0, time.UTC)
+	if !parsed.CreatedStartDate.Equal(want) {
+		t.Errorf("CreatedStartDate = %v, want %v", parsed.CreatedStartDate, want)
+	}
+}
+
+func TestParseChangeRequestFieldFilters_CreatedOnAbsoluteDateStillWorks(t *testing.T) {
+	now := time.Now().UTC()
+
+	parsed, err := ParseChangeRequestFieldFilters([]domain.ChangeRequestFieldFilter{
+		{Field: "createdOn", Op: "lte", Values: []string{"2026-01-01"}},
+	}, now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if parsed.CreatedEndDate == nil {
+		t.Fatal("CreatedEndDate = nil, want a resolved time")
+	}
+}

--- a/entity-service/internal/service/incident_filters.go
+++ b/entity-service/internal/service/incident_filters.go
@@ -18,6 +18,7 @@ package service
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
@@ -27,15 +28,39 @@ import (
 // accepted by incident search. Anything else is rejected outright.
 var incidentFilterFieldSet = map[string]bool{
 	"state": true, "assignmentGroupId": true, "businessServiceId": true,
+	"createdOn": true,
 }
 
 // incidentFilterOpSet is the exact set of IncidentFieldFilter.Op values
 // accepted by incident search, independent of field. Field/op compatibility
-// is enforced separately in ParseIncidentFieldFilters -- today every
-// supported field only accepts "in", but the set is kept apart from the
-// per-field check to mirror case_filters.go's shape.
+// is enforced separately in ParseIncidentFieldFilters -- "in" covers state/
+// assignmentGroupId/businessServiceId, "gte"/"lte" cover createdOn (mirrors
+// case_filters.go's "createdOn" handling exactly, including its relative-date
+// placeholder support, e.g. "__daysAgo:90__").
 var incidentFilterOpSet = map[string]bool{
-	"in": true,
+	"in": true, "gte": true, "lte": true,
+}
+
+// parseIncidentFilterDate mirrors case_filters.go's parseCaseFilterDate,
+// retyped for domain.IncidentFieldFilter -- same RFC3339/date-only/
+// relative-placeholder parsing, same error message shape.
+func parseIncidentFilterDate(f domain.IncidentFieldFilter, value string, now time.Time) (*time.Time, error) {
+	if resolved, matched, err := resolveRelativeDate(value, now); err != nil {
+		return nil, err
+	} else if matched {
+		value = resolved
+	}
+	if t, err := time.Parse(time.RFC3339, value); err == nil {
+		return &t, nil
+	}
+	if t, err := time.Parse("2006-01-02", value); err == nil {
+		// A date-only lte bound means "on or before that whole day".
+		if f.Op == "lte" {
+			t = t.AddDate(0, 0, 1).Add(-time.Nanosecond)
+		}
+		return &t, nil
+	}
+	return nil, &apierror.ValidationError{Msg: fmt.Sprintf("filters: field %q op %q value %q must be an RFC3339 timestamp, YYYY-MM-DD date, or a recognized relative-date placeholder", f.Field, f.Op, value)}
 }
 
 // requireIncidentFilterValues rejects a filter entry whose op needs a
@@ -69,12 +94,17 @@ type parsedIncidentFilters struct {
 	// BusinessServiceIDs are business_service UUIDs (not yet converted to
 	// sysids).
 	BusinessServiceIDs []string
+	// StartCreatedDate is the inclusive lower bound of a createdOn "gte" filter.
+	StartCreatedDate *time.Time
+	// EndCreatedDate is the inclusive upper bound of a createdOn "lte" filter.
+	EndCreatedDate *time.Time
 }
 
 // ParseIncidentFieldFilters translates the incident-search wire contract's
 // generic filter array (domain.IncidentFieldFilter) into parsedIncidentFilters,
-// mirroring ParseCaseFieldFilters in case_filters.go.
-func ParseIncidentFieldFilters(filters []domain.IncidentFieldFilter) (parsedIncidentFilters, error) {
+// mirroring ParseCaseFieldFilters in case_filters.go. now is the reference
+// instant relative-date placeholders (e.g. "__daysAgo:90__") resolve against.
+func ParseIncidentFieldFilters(filters []domain.IncidentFieldFilter, now time.Time) (parsedIncidentFilters, error) {
 	var p parsedIncidentFilters
 
 	for _, f := range filters {
@@ -124,6 +154,23 @@ func ParseIncidentFieldFilters(filters []domain.IncidentFieldFilter) (parsedInci
 				return parsedIncidentFilters{}, err
 			}
 			p.BusinessServiceIDs = append(p.BusinessServiceIDs, f.Values...)
+
+		case "createdOn":
+			if err := requireIncidentFilterValues(f); err != nil {
+				return parsedIncidentFilters{}, err
+			}
+			t, err := parseIncidentFilterDate(f, f.Values[0], now)
+			if err != nil {
+				return parsedIncidentFilters{}, err
+			}
+			switch f.Op {
+			case "gte":
+				p.StartCreatedDate = t
+			case "lte":
+				p.EndCreatedDate = t
+			default:
+				return parsedIncidentFilters{}, badIncidentFilterCombo(f)
+			}
 		}
 	}
 

--- a/entity-service/internal/service/incident_filters_test.go
+++ b/entity-service/internal/service/incident_filters_test.go
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+)
+
+func TestParseIncidentFieldFilters_StateGroupAndBusinessService(t *testing.T) {
+	groupID := "11111111-1111-1111-1111-111111111111"
+	serviceID := "22222222-2222-2222-2222-222222222222"
+
+	parsed, err := ParseIncidentFieldFilters([]domain.IncidentFieldFilter{
+		{Field: "state", Op: "in", Values: []string{"NEW", "IN_PROGRESS"}},
+		{Field: "assignmentGroupId", Op: "in", Values: []string{groupID}},
+		{Field: "businessServiceId", Op: "in", Values: []string{serviceID}},
+	}, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(parsed.AssignmentGroupIDs) != 1 || parsed.AssignmentGroupIDs[0] != groupID {
+		t.Errorf("AssignmentGroupIDs = %v, want [%s]", parsed.AssignmentGroupIDs, groupID)
+	}
+	if len(parsed.BusinessServiceIDs) != 1 || parsed.BusinessServiceIDs[0] != serviceID {
+		t.Errorf("BusinessServiceIDs = %v, want [%s]", parsed.BusinessServiceIDs, serviceID)
+	}
+}
+
+func TestParseIncidentFieldFilters_CreatedOnRelativeDate(t *testing.T) {
+	now := time.Date(2026, 8, 18, 12, 0, 0, 0, time.UTC)
+
+	parsed, err := ParseIncidentFieldFilters([]domain.IncidentFieldFilter{
+		{Field: "createdOn", Op: "gte", Values: []string{"__daysAgo:90__"}},
+	}, now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if parsed.StartCreatedDate == nil {
+		t.Fatal("StartCreatedDate = nil, want a resolved time")
+	}
+	want := time.Date(2026, 5, 20, 0, 0, 0, 0, time.UTC)
+	if !parsed.StartCreatedDate.Equal(want) {
+		t.Errorf("StartCreatedDate = %v, want %v", parsed.StartCreatedDate, want)
+	}
+	if parsed.EndCreatedDate != nil {
+		t.Errorf("EndCreatedDate = %v, want nil", parsed.EndCreatedDate)
+	}
+}
+
+func TestParseIncidentFieldFilters_Rejections(t *testing.T) {
+	now := time.Now().UTC()
+	tests := []struct {
+		name    string
+		filters []domain.IncidentFieldFilter
+	}{
+		{
+			name:    "unsupported field",
+			filters: []domain.IncidentFieldFilter{{Field: "priority", Op: "in", Values: []string{"1"}}},
+		},
+		{
+			name:    "unsupported op",
+			filters: []domain.IncidentFieldFilter{{Field: "state", Op: "eq", Values: []string{"NEW"}}},
+		},
+		{
+			name:    "empty values",
+			filters: []domain.IncidentFieldFilter{{Field: "state", Op: "in", Values: []string{}}},
+		},
+		{
+			name:    "invalid state value",
+			filters: []domain.IncidentFieldFilter{{Field: "state", Op: "in", Values: []string{"BOGUS"}}},
+		},
+		{
+			name:    "invalid assignmentGroupId UUID",
+			filters: []domain.IncidentFieldFilter{{Field: "assignmentGroupId", Op: "in", Values: []string{"not-a-uuid"}}},
+		},
+		{
+			name:    "createdOn with unsupported op",
+			filters: []domain.IncidentFieldFilter{{Field: "createdOn", Op: "in", Values: []string{"2026-01-01"}}},
+		},
+		{
+			name:    "createdOn with unparseable value",
+			filters: []domain.IncidentFieldFilter{{Field: "createdOn", Op: "gte", Values: []string{"not-a-date"}}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := ParseIncidentFieldFilters(tt.filters, now); err == nil {
+				t.Fatal("expected an error, got nil")
+			}
+		})
+	}
+}

--- a/entity-service/internal/service/incident_task_filters.go
+++ b/entity-service/internal/service/incident_task_filters.go
@@ -1,0 +1,130 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package service
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+)
+
+// incidentTaskFilterFieldSet is the exact set of IncidentTaskFieldFilter.Field
+// values accepted by incident-task search. Anything else is rejected outright.
+var incidentTaskFilterFieldSet = map[string]bool{
+	"state": true, "assignmentGroupId": true, "incidentId": true,
+}
+
+// incidentTaskFilterOpSet is the exact set of IncidentTaskFieldFilter.Op
+// values accepted by incident-task search, independent of field.
+var incidentTaskFilterOpSet = map[string]bool{
+	"in": true,
+}
+
+// requireIncidentTaskFilterValues rejects a filter entry whose op needs a
+// non-empty values array but doesn't have one.
+func requireIncidentTaskFilterValues(f domain.IncidentTaskFieldFilter) error {
+	if len(f.Values) == 0 {
+		return &apierror.ValidationError{Msg: fmt.Sprintf("filters: field %q op %q requires a non-empty values array", f.Field, f.Op)}
+	}
+	return nil
+}
+
+// badIncidentTaskFilterCombo reports a field/op combination that is not supported.
+func badIncidentTaskFilterCombo(f domain.IncidentTaskFieldFilter) error {
+	return &apierror.ValidationError{Msg: fmt.Sprintf("filters: field %q does not support op %q", f.Field, f.Op)}
+}
+
+// parsedIncidentTaskFilters is the internal, named-field representation that
+// SearchIncidentTasksFilters.Filters is translated into by
+// ParseIncidentTaskFieldFilters.
+type parsedIncidentTaskFilters struct {
+	// StateKeys are raw integer state values, passed through as-is -- NOT
+	// translated from a domain enum. incident_task has no confirmed-complete,
+	// unambiguous state enum to translate through (its state choice list is
+	// shared with the data source's base task table and is inconsistent
+	// across task subtypes, with overlapping/ambiguous values), so this field
+	// deliberately skips the enum-translation layer every other resource's
+	// state filter goes through. See domain.SearchIncidentTasksFilters.Filters.
+	StateKeys []int
+	// AssignmentGroupIDs are sys_user_group UUIDs (not yet converted to
+	// sysids -- that conversion happens where the outbound payload is built).
+	AssignmentGroupIDs []string
+	// IncidentIDs are parent-incident UUIDs (not yet converted to sysids).
+	IncidentIDs []string
+}
+
+// ParseIncidentTaskFieldFilters translates the incident-task-search wire
+// contract's generic filter array (domain.IncidentTaskFieldFilter) into
+// parsedIncidentTaskFilters, mirroring ParseProblemFieldFilters in
+// problem_filters.go.
+func ParseIncidentTaskFieldFilters(filters []domain.IncidentTaskFieldFilter) (parsedIncidentTaskFilters, error) {
+	var p parsedIncidentTaskFilters
+
+	for _, f := range filters {
+		if !incidentTaskFilterFieldSet[f.Field] {
+			return parsedIncidentTaskFilters{}, &apierror.ValidationError{Msg: "filters: unsupported field: " + f.Field}
+		}
+		if !incidentTaskFilterOpSet[f.Op] {
+			return parsedIncidentTaskFilters{}, &apierror.ValidationError{Msg: "filters: unsupported op: " + f.Op}
+		}
+
+		switch f.Field {
+		case "state":
+			if f.Op != "in" {
+				return parsedIncidentTaskFilters{}, badIncidentTaskFilterCombo(f)
+			}
+			if err := requireIncidentTaskFilterValues(f); err != nil {
+				return parsedIncidentTaskFilters{}, err
+			}
+			for _, v := range f.Values {
+				n, err := strconv.Atoi(v)
+				if err != nil {
+					return parsedIncidentTaskFilters{}, &apierror.ValidationError{Msg: fmt.Sprintf("filters: field %q value %q must be an integer", f.Field, v)}
+				}
+				p.StateKeys = append(p.StateKeys, n)
+			}
+
+		case "assignmentGroupId":
+			if f.Op != "in" {
+				return parsedIncidentTaskFilters{}, badIncidentTaskFilterCombo(f)
+			}
+			if err := requireIncidentTaskFilterValues(f); err != nil {
+				return parsedIncidentTaskFilters{}, err
+			}
+			if err := validateUUIDs("filters: assignmentGroupId", f.Values); err != nil {
+				return parsedIncidentTaskFilters{}, err
+			}
+			p.AssignmentGroupIDs = append(p.AssignmentGroupIDs, f.Values...)
+
+		case "incidentId":
+			if f.Op != "in" {
+				return parsedIncidentTaskFilters{}, badIncidentTaskFilterCombo(f)
+			}
+			if err := requireIncidentTaskFilterValues(f); err != nil {
+				return parsedIncidentTaskFilters{}, err
+			}
+			if err := validateUUIDs("filters: incidentId", f.Values); err != nil {
+				return parsedIncidentTaskFilters{}, err
+			}
+			p.IncidentIDs = append(p.IncidentIDs, f.Values...)
+		}
+	}
+
+	return p, nil
+}

--- a/entity-service/internal/service/incident_task_filters_test.go
+++ b/entity-service/internal/service/incident_task_filters_test.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package service
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+)
+
+func TestParseIncidentTaskFieldFilters_StateAssignmentGroupIncident(t *testing.T) {
+	groupID := "11111111-1111-1111-1111-111111111111"
+	incidentID := "22222222-2222-2222-2222-222222222222"
+
+	parsed, err := ParseIncidentTaskFieldFilters([]domain.IncidentTaskFieldFilter{
+		{Field: "state", Op: "in", Values: []string{"0", "1"}},
+		{Field: "assignmentGroupId", Op: "in", Values: []string{groupID}},
+		{Field: "incidentId", Op: "in", Values: []string{incidentID}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	wantStates := []int{0, 1}
+	if len(parsed.StateKeys) != len(wantStates) {
+		t.Fatalf("StateKeys = %v, want %v", parsed.StateKeys, wantStates)
+	}
+	for i, k := range wantStates {
+		if parsed.StateKeys[i] != k {
+			t.Errorf("StateKeys[%d] = %d, want %d", i, parsed.StateKeys[i], k)
+		}
+	}
+	if len(parsed.AssignmentGroupIDs) != 1 || parsed.AssignmentGroupIDs[0] != groupID {
+		t.Errorf("AssignmentGroupIDs = %v, want [%s]", parsed.AssignmentGroupIDs, groupID)
+	}
+	if len(parsed.IncidentIDs) != 1 || parsed.IncidentIDs[0] != incidentID {
+		t.Errorf("IncidentIDs = %v, want [%s]", parsed.IncidentIDs, incidentID)
+	}
+}
+
+func TestParseIncidentTaskFieldFilters_Rejections(t *testing.T) {
+	tests := []struct {
+		name    string
+		filters []domain.IncidentTaskFieldFilter
+	}{
+		{
+			name:    "unsupported field",
+			filters: []domain.IncidentTaskFieldFilter{{Field: "priority", Op: "in", Values: []string{"1"}}},
+		},
+		{
+			name:    "unsupported op",
+			filters: []domain.IncidentTaskFieldFilter{{Field: "state", Op: "eq", Values: []string{"0"}}},
+		},
+		{
+			name:    "non-integer state value",
+			filters: []domain.IncidentTaskFieldFilter{{Field: "state", Op: "in", Values: []string{"open"}}},
+		},
+		{
+			name:    "empty values",
+			filters: []domain.IncidentTaskFieldFilter{{Field: "state", Op: "in", Values: nil}},
+		},
+		{
+			name:    "invalid assignmentGroupId uuid",
+			filters: []domain.IncidentTaskFieldFilter{{Field: "assignmentGroupId", Op: "in", Values: []string{"not-a-uuid"}}},
+		},
+		{
+			name:    "invalid incidentId uuid",
+			filters: []domain.IncidentTaskFieldFilter{{Field: "incidentId", Op: "in", Values: []string{"not-a-uuid"}}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseIncidentTaskFieldFilters(tt.filters)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			var v *apierror.ValidationError
+			if !errors.As(err, &v) {
+				t.Errorf("error = %v, want *apierror.ValidationError", err)
+			}
+		})
+	}
+}

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -440,6 +440,19 @@ type ProblemService interface {
 	CreateProblem(ctx context.Context, req domain.CreateProblemRequest) (domain.ProblemDetail, error)
 }
 
+// IncidentTaskService defines the operations available on the incident_task entity.
+// Search and get only -- there is no create/update path.
+type IncidentTaskService interface {
+	// SearchIncidentTasks returns a paginated list of incident tasks filtered by
+	// optional search query and field filters. A ValidationError is returned for
+	// invalid input.
+	SearchIncidentTasks(ctx context.Context, req domain.SearchIncidentTasksRequest) (domain.SearchIncidentTasksResponse, error)
+
+	// GetIncidentTask returns the full detail of a single incident task by its UUID.
+	// A NotFoundError is returned if the incident task does not exist.
+	GetIncidentTask(ctx context.Context, id string) (domain.IncidentTaskDetail, error)
+}
+
 // ConversationService defines the operations available on the conversations entity.
 // All methods require the ServiceNow data source; there is no Postgres fallback.
 type ConversationService interface {

--- a/entity-service/internal/service/problem_filters.go
+++ b/entity-service/internal/service/problem_filters.go
@@ -1,0 +1,114 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package service
+
+import (
+	"fmt"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+)
+
+// problemFilterFieldSet is the exact set of ProblemFieldFilter.Field values
+// accepted by problem search. Anything else is rejected outright.
+var problemFilterFieldSet = map[string]bool{
+	"state": true, "assignmentGroupId": true,
+}
+
+// problemFilterOpSet is the exact set of ProblemFieldFilter.Op values
+// accepted by problem search, independent of field. Field/op compatibility
+// is enforced separately in ParseProblemFieldFilters -- today every
+// supported field only accepts "in", but the set is kept apart from the
+// per-field check to mirror case_filters.go/incident_filters.go's shape.
+var problemFilterOpSet = map[string]bool{
+	"in": true,
+}
+
+// requireProblemFilterValues rejects a filter entry whose op needs a
+// non-empty values array but doesn't have one.
+func requireProblemFilterValues(f domain.ProblemFieldFilter) error {
+	if len(f.Values) == 0 {
+		return &apierror.ValidationError{Msg: fmt.Sprintf("filters: field %q op %q requires a non-empty values array", f.Field, f.Op)}
+	}
+	return nil
+}
+
+// badProblemFilterCombo reports a field/op combination that is not supported.
+func badProblemFilterCombo(f domain.ProblemFieldFilter) error {
+	return &apierror.ValidationError{Msg: fmt.Sprintf("filters: field %q does not support op %q", f.Field, f.Op)}
+}
+
+// parsedProblemFilters is the internal, named-field representation that
+// SearchProblemsFilters.Filters is translated into by
+// ParseProblemFieldFilters. snProblemService.SearchProblems builds the
+// outbound ServiceNow payload from this.
+type parsedProblemFilters struct {
+	// StateKeys are ServiceNow's raw problem_state numeric keys, already
+	// translated from the wire-level domain.ProblemState enum values via
+	// snProblemStateKeyMap.
+	StateKeys []int
+	// AssignmentGroupIDs are sys_user_group UUIDs (not yet converted to
+	// sysids -- that conversion happens where the outbound payload is built).
+	AssignmentGroupIDs []string
+}
+
+// ParseProblemFieldFilters translates the problem-search wire contract's
+// generic filter array (domain.ProblemFieldFilter) into parsedProblemFilters,
+// mirroring ParseIncidentFieldFilters in incident_filters.go.
+func ParseProblemFieldFilters(filters []domain.ProblemFieldFilter) (parsedProblemFilters, error) {
+	var p parsedProblemFilters
+
+	for _, f := range filters {
+		if !problemFilterFieldSet[f.Field] {
+			return parsedProblemFilters{}, &apierror.ValidationError{Msg: "filters: unsupported field: " + f.Field}
+		}
+		if !problemFilterOpSet[f.Op] {
+			return parsedProblemFilters{}, &apierror.ValidationError{Msg: "filters: unsupported op: " + f.Op}
+		}
+
+		switch f.Field {
+		case "state":
+			if f.Op != "in" {
+				return parsedProblemFilters{}, badProblemFilterCombo(f)
+			}
+			if err := requireProblemFilterValues(f); err != nil {
+				return parsedProblemFilters{}, err
+			}
+			for _, v := range f.Values {
+				state := domain.ProblemState(v)
+				if !validProblemState[state] {
+					return parsedProblemFilters{}, &apierror.ValidationError{Msg: fmt.Sprintf("filters: field %q value %q is not a valid problem state", f.Field, v)}
+				}
+				p.StateKeys = append(p.StateKeys, snProblemStateKeyMap[state])
+			}
+
+		case "assignmentGroupId":
+			if f.Op != "in" {
+				return parsedProblemFilters{}, badProblemFilterCombo(f)
+			}
+			if err := requireProblemFilterValues(f); err != nil {
+				return parsedProblemFilters{}, err
+			}
+			if err := validateUUIDs("filters: assignmentGroupId", f.Values); err != nil {
+				return parsedProblemFilters{}, err
+			}
+			p.AssignmentGroupIDs = append(p.AssignmentGroupIDs, f.Values...)
+		}
+	}
+
+	return p, nil
+}

--- a/entity-service/internal/service/problem_filters_test.go
+++ b/entity-service/internal/service/problem_filters_test.go
@@ -1,0 +1,90 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package service
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+)
+
+func TestParseProblemFieldFilters_StateAndAssignmentGroup(t *testing.T) {
+	groupID := "11111111-1111-1111-1111-111111111111"
+
+	parsed, err := ParseProblemFieldFilters([]domain.ProblemFieldFilter{
+		{Field: "state", Op: "in", Values: []string{"NEW", "FIX_IN_PROGRESS", "CLOSED"}},
+		{Field: "assignmentGroupId", Op: "in", Values: []string{groupID}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	wantStates := []int{101, 104, 107}
+	if len(parsed.StateKeys) != len(wantStates) {
+		t.Fatalf("StateKeys = %v, want %v", parsed.StateKeys, wantStates)
+	}
+	for i, k := range wantStates {
+		if parsed.StateKeys[i] != k {
+			t.Errorf("StateKeys[%d] = %d, want %d", i, parsed.StateKeys[i], k)
+		}
+	}
+	if len(parsed.AssignmentGroupIDs) != 1 || parsed.AssignmentGroupIDs[0] != groupID {
+		t.Errorf("AssignmentGroupIDs = %v, want [%s]", parsed.AssignmentGroupIDs, groupID)
+	}
+}
+
+func TestParseProblemFieldFilters_Rejections(t *testing.T) {
+	tests := []struct {
+		name    string
+		filters []domain.ProblemFieldFilter
+	}{
+		{
+			name:    "unsupported field",
+			filters: []domain.ProblemFieldFilter{{Field: "priority", Op: "in", Values: []string{"1"}}},
+		},
+		{
+			name:    "unsupported op",
+			filters: []domain.ProblemFieldFilter{{Field: "state", Op: "eq", Values: []string{"NEW"}}},
+		},
+		{
+			name:    "invalid state value",
+			filters: []domain.ProblemFieldFilter{{Field: "state", Op: "in", Values: []string{"BOGUS_STATE"}}},
+		},
+		{
+			name:    "empty values",
+			filters: []domain.ProblemFieldFilter{{Field: "state", Op: "in", Values: nil}},
+		},
+		{
+			name:    "invalid assignmentGroupId uuid",
+			filters: []domain.ProblemFieldFilter{{Field: "assignmentGroupId", Op: "in", Values: []string{"not-a-uuid"}}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseProblemFieldFilters(tt.filters)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			var v *apierror.ValidationError
+			if !errors.As(err, &v) {
+				t.Errorf("error = %v, want *apierror.ValidationError", err)
+			}
+		})
+	}
+}

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -398,8 +398,9 @@ type snCaseFilters struct {
 	// InternalID: see domain.ParsedCaseFilters.InternalID doc comment. Exact
 	// match against ServiceNow's `u_wso2_case_id` column -- not part of the
 	// free-text SearchQuery scan.
-	InternalID                string   `json:"internalId,omitempty"`
-	ProjectOnboardingStatuses []string `json:"projectOnboardingStatuses,omitempty"`
+	InternalID                       string   `json:"internalId,omitempty"`
+	ProjectOnboardingStatuses        []string `json:"projectOnboardingStatuses,omitempty"`
+	ExcludeProjectOnboardingStatuses []string `json:"excludeProjectOnboardingStatuses,omitempty"`
 	// ProjectTypeNames carries project-type NAMES (e.g. "Subscription"), not
 	// sys_ids: CaseUtils.searchCases matches project.u_project_type.u_name.
 	// It goes out under its own key, "projectTypes", rather than reusing the
@@ -2170,44 +2171,45 @@ func buildSNCaseFilters(parsed domain.ParsedCaseFilters, searchQuery string) snC
 	snCaseTypes := domainTypeKeysToSN(parsed.Types)
 
 	return snCaseFilters{
-		CaseTypes:                 snCaseTypes,
-		SearchQuery:               searchQuery,
-		ProjectIDs:                uuidsToSysids(parsed.ProjectIDs),
-		DeploymentIDs:             uuidsToSysids(parsed.DeploymentIDs),
-		StateKeys:                 domainStatesToSNIDs(parsed.States),
-		ExcludeStates:             domainStatesToSNIDs(parsed.ExcludeStates),
-		SeverityKeys:              domainSeveritiesToSNIDs(parsed.Severities),
-		IssueTypeKeys:             domainIssueTypesToSNIDs(parsed.IssueTypes),
-		EngagementTypeKeys:        domainEngagementTypesToSNIDs(parsed.EngagementTypes),
-		ClosedStartDate:           formatSNDateTimeUTC(parsed.ClosedStartDate),
-		ClosedEndDate:             formatSNDateTimeUTC(parsed.ClosedEndDate),
-		ResolvedStartDate:         formatSNDateTimeUTC(parsed.ResolvedStartDate),
-		ResolvedEndDate:           formatSNDateTimeUTC(parsed.ResolvedEndDate),
-		StartCreatedDate:          formatSNDateTimeUTC(parsed.StartCreatedDate),
-		EndCreatedDate:            formatSNDateTimeUTC(parsed.EndCreatedDate),
-		StartUpdatedDate:          formatSNDateTimeUTC(parsed.StartUpdatedDate),
-		EndUpdatedDate:            formatSNDateTimeUTC(parsed.EndUpdatedDate),
-		CreatedBy:                 parsed.CreatedBy,
-		CreatedByMe:               parsed.CreatedByMe,
-		WorkStateKeys:             domainWorkStatesToSNIDs(parsed.WorkStates),
-		AssignedUserIDs:           uuidsToSysids(parsed.AssignedUserIDs),
-		ProductNames:              parsed.ProductNames,
-		Tags:                      parsed.Tags,
-		ExcludeTags:               parsed.ExcludeTags,
-		ParentID:                  snParentIDFilter(parsed.ParentID),
-		Number:                    stringPtrValue(parsed.Number),
-		InternalID:                stringPtrValue(parsed.InternalID),
-		ProjectOnboardingStatuses: parsed.ProjectOnboardingStatuses,
-		ProjectTypeNames:          parsed.ProjectTypeNames,
-		CreTeamIDs:                uuidsToSysids(parsed.CreTeamIDs),
-		SreTeamIDs:                uuidsToSysids(parsed.SreTeamIDs),
-		AccountIDs:                uuidsToSysids(parsed.AccountIDs),
-		Unassigned:                parsed.Unassigned,
-		ResolutionNotesEmpty:      parsed.ResolutionNotesEmpty,
-		TaskSLAFilter:             buildSNTaskSLAFilter(parsed.TaskSLAFilter),
-		EscalationLevels:          parsed.EscalationLevels,
-		IsEscalated:               parsed.HasActiveEscalation,
-		OrGroups:                  buildSNCaseFilterGroups(parsed.OrGroups),
+		CaseTypes:                        snCaseTypes,
+		SearchQuery:                      searchQuery,
+		ProjectIDs:                       uuidsToSysids(parsed.ProjectIDs),
+		DeploymentIDs:                    uuidsToSysids(parsed.DeploymentIDs),
+		StateKeys:                        domainStatesToSNIDs(parsed.States),
+		ExcludeStates:                    domainStatesToSNIDs(parsed.ExcludeStates),
+		SeverityKeys:                     domainSeveritiesToSNIDs(parsed.Severities),
+		IssueTypeKeys:                    domainIssueTypesToSNIDs(parsed.IssueTypes),
+		EngagementTypeKeys:               domainEngagementTypesToSNIDs(parsed.EngagementTypes),
+		ClosedStartDate:                  formatSNDateTimeUTC(parsed.ClosedStartDate),
+		ClosedEndDate:                    formatSNDateTimeUTC(parsed.ClosedEndDate),
+		ResolvedStartDate:                formatSNDateTimeUTC(parsed.ResolvedStartDate),
+		ResolvedEndDate:                  formatSNDateTimeUTC(parsed.ResolvedEndDate),
+		StartCreatedDate:                 formatSNDateTimeUTC(parsed.StartCreatedDate),
+		EndCreatedDate:                   formatSNDateTimeUTC(parsed.EndCreatedDate),
+		StartUpdatedDate:                 formatSNDateTimeUTC(parsed.StartUpdatedDate),
+		EndUpdatedDate:                   formatSNDateTimeUTC(parsed.EndUpdatedDate),
+		CreatedBy:                        parsed.CreatedBy,
+		CreatedByMe:                      parsed.CreatedByMe,
+		WorkStateKeys:                    domainWorkStatesToSNIDs(parsed.WorkStates),
+		AssignedUserIDs:                  uuidsToSysids(parsed.AssignedUserIDs),
+		ProductNames:                     parsed.ProductNames,
+		Tags:                             parsed.Tags,
+		ExcludeTags:                      parsed.ExcludeTags,
+		ParentID:                         snParentIDFilter(parsed.ParentID),
+		Number:                           stringPtrValue(parsed.Number),
+		InternalID:                       stringPtrValue(parsed.InternalID),
+		ProjectOnboardingStatuses:        parsed.ProjectOnboardingStatuses,
+		ExcludeProjectOnboardingStatuses: parsed.ExcludeProjectOnboardingStatuses,
+		ProjectTypeNames:                 parsed.ProjectTypeNames,
+		CreTeamIDs:                       uuidsToSysids(parsed.CreTeamIDs),
+		SreTeamIDs:                       uuidsToSysids(parsed.SreTeamIDs),
+		AccountIDs:                       uuidsToSysids(parsed.AccountIDs),
+		Unassigned:                       parsed.Unassigned,
+		ResolutionNotesEmpty:             parsed.ResolutionNotesEmpty,
+		TaskSLAFilter:                    buildSNTaskSLAFilter(parsed.TaskSLAFilter),
+		EscalationLevels:                 parsed.EscalationLevels,
+		IsEscalated:                      parsed.HasActiveEscalation,
+		OrGroups:                         buildSNCaseFilterGroups(parsed.OrGroups),
 	}
 }
 

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -412,8 +412,10 @@ type snCaseFilters struct {
 	// CreTeamIDs and SreTeamIDs go out under the wire keys the Ballerina/SN
 	// contract already uses (integrationCsTeamIds, sreTeamIds) -- only the Go
 	// domain naming changed, not the wire protocol.
-	CreTeamIDs           []string `json:"integrationCsTeamIds,omitempty"`
-	SreTeamIDs           []string `json:"sreTeamIds,omitempty"`
+	CreTeamIDs []string `json:"integrationCsTeamIds,omitempty"`
+	SreTeamIDs []string `json:"sreTeamIds,omitempty"`
+	// AccountIDs: see domain.ParsedCaseFilters.AccountIDs doc comment.
+	AccountIDs           []string `json:"accountIds,omitempty"`
 	Unassigned           bool     `json:"unassigned,omitempty"`
 	ResolutionNotesEmpty bool     `json:"resolutionNotesEmpty,omitempty"`
 	// TaskSLAFilter: SN-side join on Task SLA table, filtering by businessElapsedPercent
@@ -2199,6 +2201,7 @@ func buildSNCaseFilters(parsed domain.ParsedCaseFilters, searchQuery string) snC
 		ProjectTypeNames:          parsed.ProjectTypeNames,
 		CreTeamIDs:                uuidsToSysids(parsed.CreTeamIDs),
 		SreTeamIDs:                uuidsToSysids(parsed.SreTeamIDs),
+		AccountIDs:                uuidsToSysids(parsed.AccountIDs),
 		Unassigned:                parsed.Unassigned,
 		ResolutionNotesEmpty:      parsed.ResolutionNotesEmpty,
 		TaskSLAFilter:             buildSNTaskSLAFilter(parsed.TaskSLAFilter),
@@ -2267,6 +2270,9 @@ func (s *snCaseService) SearchCases(ctx context.Context, req domain.SearchCasesR
 		return domain.SearchCasesResponse{}, err
 	}
 	if err := validateUUIDs("sreTeam", req.Parsed.SreTeamIDs); err != nil {
+		return domain.SearchCasesResponse{}, err
+	}
+	if err := validateUUIDs("accountId", req.Parsed.AccountIDs); err != nil {
 		return domain.SearchCasesResponse{}, err
 	}
 

--- a/entity-service/internal/service/sn_change_request_service.go
+++ b/entity-service/internal/service/sn_change_request_service.go
@@ -289,7 +289,7 @@ func (s *snChangeRequestService) SearchChangeRequests(ctx context.Context, req d
 	if err := validateUUIDs("projectIds", req.Filters.ProjectIDs); err != nil {
 		return domain.SearchChangeRequestsResponse{}, err
 	}
-	parsedFilters, err := ParseChangeRequestFieldFilters(req.Filters.Filters)
+	parsedFilters, err := ParseChangeRequestFieldFilters(req.Filters.Filters, time.Now().UTC())
 	if err != nil {
 		return domain.SearchChangeRequestsResponse{}, err
 	}

--- a/entity-service/internal/service/sn_incident_service.go
+++ b/entity-service/internal/service/sn_incident_service.go
@@ -212,6 +212,10 @@ func (s *snIncidentService) SearchIncidents(ctx context.Context, req domain.Sear
 	if err != nil {
 		return domain.SearchIncidentsResponse{}, err
 	}
+	if parsedFilters.EndCreatedDate != nil && parsedFilters.StartCreatedDate != nil &&
+		parsedFilters.EndCreatedDate.Before(*parsedFilters.StartCreatedDate) {
+		return domain.SearchIncidentsResponse{}, &apierror.ValidationError{Msg: "createdOn: lte value must not be before gte value"}
+	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
 

--- a/entity-service/internal/service/sn_incident_service.go
+++ b/entity-service/internal/service/sn_incident_service.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
@@ -95,6 +96,12 @@ type snIncidentFilters struct {
 	AssignmentGroupIDs []string `json:"assignmentGroupIds,omitempty"`
 	// BusinessServiceIDs: business_service sys_ids (converted from UUIDs).
 	BusinessServiceIDs []string `json:"businessServiceIds,omitempty"`
+	// StartCreatedDate/EndCreatedDate: see domain.SearchIncidentsFilters
+	// Filters "createdOn" doc comment. Wire keys match case search's own
+	// startCreatedDate/endCreatedDate exactly (same UtcDateTimeString
+	// contract on the Ballerina/SN side).
+	StartCreatedDate string `json:"startCreatedDate,omitempty"`
+	EndCreatedDate   string `json:"endCreatedDate,omitempty"`
 }
 
 // snIncidentPriorityKeyMap maps domain IncidentPriority enums to SN numeric priority keys.
@@ -201,7 +208,7 @@ func (s *snIncidentService) SearchIncidents(ctx context.Context, req domain.Sear
 	if err := validateUUIDs("parentIds", req.Filters.ParentIDs); err != nil {
 		return domain.SearchIncidentsResponse{}, err
 	}
-	parsedFilters, err := ParseIncidentFieldFilters(req.Filters.Filters)
+	parsedFilters, err := ParseIncidentFieldFilters(req.Filters.Filters, time.Now().UTC())
 	if err != nil {
 		return domain.SearchIncidentsResponse{}, err
 	}
@@ -231,6 +238,8 @@ func (s *snIncidentService) SearchIncidents(ctx context.Context, req domain.Sear
 			StateKeys:          parsedFilters.StateKeys,
 			AssignmentGroupIDs: uuidsToSysids(parsedFilters.AssignmentGroupIDs),
 			BusinessServiceIDs: uuidsToSysids(parsedFilters.BusinessServiceIDs),
+			StartCreatedDate:   formatSNDateTimeUTC(parsedFilters.StartCreatedDate),
+			EndCreatedDate:     formatSNDateTimeUTC(parsedFilters.EndCreatedDate),
 		},
 		SortBy:     snSortBy,
 		Pagination: snProjectPagination{Limit: req.Pagination.Limit, Offset: req.Pagination.Offset},

--- a/entity-service/internal/service/sn_incident_service_test.go
+++ b/entity-service/internal/service/sn_incident_service_test.go
@@ -304,6 +304,28 @@ func TestSNIncidentService_SearchIncidents_InvalidFilterField(t *testing.T) {
 	}
 }
 
+// TestSNIncidentService_SearchIncidents_RejectsInvertedCreatedOnRange verifies
+// a createdOn lte bound before its gte bound is rejected with a validation
+// error before any SN call, instead of reaching ServiceNow and coming back
+// as an empty (200) result indistinguishable from "no matching incidents".
+func TestSNIncidentService_SearchIncidents_RejectsInvertedCreatedOnRange(t *testing.T) {
+	// client is intentionally nil: validation must fail before touching it.
+	svc := NewServiceNowIncidentService(nil)
+
+	req := domain.SearchIncidentsRequest{
+		Filters: domain.SearchIncidentsFilters{
+			Filters: []domain.IncidentFieldFilter{
+				{Field: "createdOn", Op: "gte", Values: []string{"2026-08-10"}},
+				{Field: "createdOn", Op: "lte", Values: []string{"2026-08-01"}},
+			},
+		},
+	}
+	_, err := svc.SearchIncidents(contextWithUserIDToken("token"), req)
+	if _, ok := err.(*apierror.ValidationError); !ok {
+		t.Fatalf("expected *apierror.ValidationError, got %T: %v", err, err)
+	}
+}
+
 // TestSNIncidentService_SearchIncidents_BusinessServiceIdInvalidUUID verifies a
 // malformed businessServiceId filter value is rejected with a clean
 // validation error before any SN call.

--- a/entity-service/internal/service/sn_incident_task_service.go
+++ b/entity-service/internal/service/sn_incident_task_service.go
@@ -169,8 +169,8 @@ func mapSNIncidentTaskToView(it snIncidentTask) domain.IncidentTask {
 // snIncidentTaskDetailResponse mirrors the Choreo GET /incident_tasks/{id} response.
 type snIncidentTaskDetailResponse struct {
 	ID              string                 `json:"id"`
-	Number          string                 `json:"number"`
-	Subject         string                 `json:"subject"`
+	Number          *string                `json:"number"`
+	Subject         *string                `json:"subject"`
 	State           *string                `json:"state"`
 	StateLabel      *string                `json:"stateLabel"`
 	Incident        *snIncidentTaskRef     `json:"incident"`
@@ -207,19 +207,21 @@ func (s *snIncidentTaskService) GetIncidentTask(ctx context.Context, id string) 
 // the domain detail view.
 func mapSNIncidentTaskDetailToView(it snIncidentTaskDetailResponse) domain.IncidentTaskDetail {
 	id := sysidToUUID(it.ID)
-	number := it.Number
-	subject := it.Subject
 
+	// Number/Subject stay nil (-> JSON null) when the upstream payload omits
+	// them, matching every other response field on this view -- unlike ID,
+	// which a detail response always carries (it's how the record was
+	// fetched), so it's fine as a plain, always-present string.
 	view := domain.IncidentTaskDetail{
 		ID:          &id,
-		Number:      &number,
-		Subject:     &subject,
+		Number:      it.Number,
+		Subject:     it.Subject,
 		State:       it.State,
 		StateLabel:  it.StateLabel,
 		Description: it.Description,
 		Priority:    it.Priority,
-		OpenedAt:    it.OpenedAt,
-		ClosedAt:    it.ClosedAt,
+		OpenedOn:    it.OpenedAt,
+		ClosedOn:    it.ClosedAt,
 	}
 	if it.Incident != nil {
 		view.Incident = &domain.CaseNumberRef{ID: sysidToUUID(it.Incident.ID), Number: it.Incident.Number}

--- a/entity-service/internal/service/sn_incident_task_service.go
+++ b/entity-service/internal/service/sn_incident_task_service.go
@@ -1,0 +1,234 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/middleware"
+	integrationservice "github.com/wso2-open-operations/cs-tools/entity-service/internal/servicenow-integration-service"
+)
+
+// snIncidentTasksResponse mirrors the Choreo POST /incident_tasks/search response.
+type snIncidentTasksResponse struct {
+	IncidentTasks []snIncidentTask `json:"incidentTasks"`
+	TotalRecords  int              `json:"totalRecords"`
+	Offset        int              `json:"offset"`
+	Limit         int              `json:"limit"`
+}
+
+type snIncidentTask struct {
+	ID              *string                `json:"id"`
+	Number          *string                `json:"number"`
+	Subject         *string                `json:"subject"`
+	State           *string                `json:"state"`
+	StateLabel      *string                `json:"stateLabel"`
+	Incident        *snIncidentTaskRef     `json:"incident"`
+	AssignmentGroup *snIncidentTaskUserRef `json:"assignmentGroup"`
+	AssignedTo      *snIncidentTaskUserRef `json:"assignedTo"`
+}
+
+// snIncidentTaskRef is a compact id+number reference used for the incident
+// task's parent incident.
+type snIncidentTaskRef struct {
+	ID     string `json:"id"`
+	Number string `json:"number"`
+}
+
+// snIncidentTaskUserRef is a compact id+name reference used for
+// assignmentGroup/assignedTo.
+type snIncidentTaskUserRef struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// snIncidentTaskSearchPayload is the Choreo POST /incident_tasks/search request body.
+type snIncidentTaskSearchPayload struct {
+	Filters    snIncidentTaskFilters `json:"filters,omitempty"`
+	Pagination snProjectPagination   `json:"pagination"`
+}
+
+type snIncidentTaskFilters struct {
+	SearchQuery string `json:"searchQuery,omitempty"`
+	// Number: see domain.SearchIncidentTasksFilters.Number doc comment. Exact
+	// match against ServiceNow's `number` column -- not part of the
+	// free-text SearchQuery scan.
+	Number string `json:"number,omitempty"`
+	// StateKeys: raw ServiceNow integer state values, NOT translated through
+	// a domain enum -- see domain.SearchIncidentTasksFilters.Filters doc
+	// comment for why incident_task's state filter skips that layer.
+	StateKeys []int `json:"stateKeys,omitempty"`
+	// AssignmentGroupIDs: sys_user_group sys_ids (converted from UUIDs).
+	AssignmentGroupIDs []string `json:"assignmentGroupIds,omitempty"`
+	// IncidentIDs: parent incident sys_ids (converted from UUIDs).
+	IncidentIDs []string `json:"incidentIds,omitempty"`
+}
+
+type snIncidentTaskService struct {
+	client *integrationservice.Client
+}
+
+// NewServiceNowIncidentTaskService constructs an IncidentTaskService backed by the Choreo API.
+func NewServiceNowIncidentTaskService(client *integrationservice.Client) IncidentTaskService {
+	return &snIncidentTaskService{client: client}
+}
+
+func (s *snIncidentTaskService) SearchIncidentTasks(ctx context.Context, req domain.SearchIncidentTasksRequest) (domain.SearchIncidentTasksResponse, error) {
+	if err := normalizePagination(&req.Pagination); err != nil {
+		return domain.SearchIncidentTasksResponse{}, err
+	}
+	if err := validateSearchQuery(req.Filters.SearchQuery); err != nil {
+		return domain.SearchIncidentTasksResponse{}, err
+	}
+	if err := validateExactNumber("number", req.Filters.Number); err != nil {
+		return domain.SearchIncidentTasksResponse{}, err
+	}
+	parsedFilters, err := ParseIncidentTaskFieldFilters(req.Filters.Filters)
+	if err != nil {
+		return domain.SearchIncidentTasksResponse{}, err
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+
+	payload := snIncidentTaskSearchPayload{
+		Filters: snIncidentTaskFilters{
+			SearchQuery:        req.Filters.SearchQuery,
+			Number:             stringPtrValue(req.Filters.Number),
+			StateKeys:          parsedFilters.StateKeys,
+			AssignmentGroupIDs: uuidsToSysids(parsedFilters.AssignmentGroupIDs),
+			IncidentIDs:        uuidsToSysids(parsedFilters.IncidentIDs),
+		},
+		Pagination: snProjectPagination{Limit: req.Pagination.Limit, Offset: req.Pagination.Offset},
+	}
+
+	raw, err := s.client.Post(ctx, "/incident_tasks/search", token, payload)
+	if err != nil {
+		return domain.SearchIncidentTasksResponse{}, err
+	}
+
+	var snResp snIncidentTasksResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.SearchIncidentTasksResponse{}, fmt.Errorf("sn incident tasks: parse response: %w", err)
+	}
+
+	views := make([]domain.IncidentTask, 0, len(snResp.IncidentTasks))
+	for _, it := range snResp.IncidentTasks {
+		views = append(views, mapSNIncidentTaskToView(it))
+	}
+
+	return domain.SearchIncidentTasksResponse{
+		IncidentTasks: views,
+		Total:         snResp.TotalRecords,
+		Limit:         req.Pagination.Limit,
+		Offset:        req.Pagination.Offset,
+	}, nil
+}
+
+// mapSNIncidentTaskToView maps a Choreo incident-task search-result payload
+// to the domain search view.
+func mapSNIncidentTaskToView(it snIncidentTask) domain.IncidentTask {
+	view := domain.IncidentTask{
+		Number:     it.Number,
+		Subject:    it.Subject,
+		State:      it.State,
+		StateLabel: it.StateLabel,
+	}
+	if it.ID != nil && *it.ID != "" {
+		id := sysidToUUID(*it.ID)
+		view.ID = &id
+	}
+	if it.Incident != nil {
+		view.Incident = &domain.CaseNumberRef{ID: sysidToUUID(it.Incident.ID), Number: it.Incident.Number}
+	}
+	if it.AssignmentGroup != nil {
+		view.AssignmentGroup = &domain.EntityRef{ID: sysidToUUID(it.AssignmentGroup.ID), Name: it.AssignmentGroup.Name}
+	}
+	if it.AssignedTo != nil {
+		view.AssignedTo = &domain.EntityRef{ID: sysidToUUID(it.AssignedTo.ID), Name: it.AssignedTo.Name}
+	}
+	return view
+}
+
+// snIncidentTaskDetailResponse mirrors the Choreo GET /incident_tasks/{id} response.
+type snIncidentTaskDetailResponse struct {
+	ID              string                 `json:"id"`
+	Number          string                 `json:"number"`
+	Subject         string                 `json:"subject"`
+	State           *string                `json:"state"`
+	StateLabel      *string                `json:"stateLabel"`
+	Incident        *snIncidentTaskRef     `json:"incident"`
+	AssignmentGroup *snIncidentTaskUserRef `json:"assignmentGroup"`
+	AssignedTo      *snIncidentTaskUserRef `json:"assignedTo"`
+	Description     *string                `json:"description"`
+	Priority        *string                `json:"priority"`
+	OpenedAt        *string                `json:"openedAt"`
+	ClosedAt        *string                `json:"closedAt"`
+}
+
+// GetIncidentTask implements IncidentTaskService for the ServiceNow data source.
+func (s *snIncidentTaskService) GetIncidentTask(ctx context.Context, id string) (domain.IncidentTaskDetail, error) {
+	token := middleware.UserIDTokenFromContext(ctx)
+
+	if err := validateUUIDs("id", []string{id}); err != nil {
+		return domain.IncidentTaskDetail{}, err
+	}
+
+	raw, err := s.client.Get(ctx, "/incident_tasks/"+uuidToSysid(id), token)
+	if err != nil {
+		return domain.IncidentTaskDetail{}, err
+	}
+
+	var it snIncidentTaskDetailResponse
+	if err := json.Unmarshal(raw, &it); err != nil {
+		return domain.IncidentTaskDetail{}, fmt.Errorf("sn get incident task: parse response: %w", err)
+	}
+
+	return mapSNIncidentTaskDetailToView(it), nil
+}
+
+// mapSNIncidentTaskDetailToView maps a Choreo incident-task detail payload to
+// the domain detail view.
+func mapSNIncidentTaskDetailToView(it snIncidentTaskDetailResponse) domain.IncidentTaskDetail {
+	id := sysidToUUID(it.ID)
+	number := it.Number
+	subject := it.Subject
+
+	view := domain.IncidentTaskDetail{
+		ID:          &id,
+		Number:      &number,
+		Subject:     &subject,
+		State:       it.State,
+		StateLabel:  it.StateLabel,
+		Description: it.Description,
+		Priority:    it.Priority,
+		OpenedAt:    it.OpenedAt,
+		ClosedAt:    it.ClosedAt,
+	}
+	if it.Incident != nil {
+		view.Incident = &domain.CaseNumberRef{ID: sysidToUUID(it.Incident.ID), Number: it.Incident.Number}
+	}
+	if it.AssignmentGroup != nil {
+		view.AssignmentGroup = &domain.EntityRef{ID: sysidToUUID(it.AssignmentGroup.ID), Name: it.AssignmentGroup.Name}
+	}
+	if it.AssignedTo != nil {
+		view.AssignedTo = &domain.EntityRef{ID: sysidToUUID(it.AssignedTo.ID), Name: it.AssignedTo.Name}
+	}
+	return view
+}

--- a/entity-service/internal/service/sn_incident_task_service_test.go
+++ b/entity-service/internal/service/sn_incident_task_service_test.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package service
+
+import "testing"
+
+// TestMapSNIncidentTaskDetailToView_OmitsNumberAndSubjectWhenAbsent verifies
+// that an upstream payload omitting "number"/"subject" maps to nil (-> JSON
+// null) on the view, not an empty string. Both fields decode to a nil
+// pointer, not "", when absent from the JSON now that
+// snIncidentTaskDetailResponse declares them as *string.
+func TestMapSNIncidentTaskDetailToView_OmitsNumberAndSubjectWhenAbsent(t *testing.T) {
+	it := snIncidentTaskDetailResponse{ID: "sys123"}
+
+	view := mapSNIncidentTaskDetailToView(it)
+
+	if view.Number != nil {
+		t.Fatalf("expected Number to be nil when absent from the upstream payload, got %q", *view.Number)
+	}
+	if view.Subject != nil {
+		t.Fatalf("expected Subject to be nil when absent from the upstream payload, got %q", *view.Subject)
+	}
+}
+
+// TestMapSNIncidentTaskDetailToView_PassesThroughNumberAndSubjectWhenPresent
+// verifies present values still map straight through.
+func TestMapSNIncidentTaskDetailToView_PassesThroughNumberAndSubjectWhenPresent(t *testing.T) {
+	number := "TASK0012345"
+	subject := "Reboot affected node"
+	it := snIncidentTaskDetailResponse{ID: "sys123", Number: &number, Subject: &subject}
+
+	view := mapSNIncidentTaskDetailToView(it)
+
+	if view.Number == nil || *view.Number != number {
+		t.Fatalf("expected Number %q, got %v", number, view.Number)
+	}
+	if view.Subject == nil || *view.Subject != subject {
+		t.Fatalf("expected Subject %q, got %v", subject, view.Subject)
+	}
+}
+
+// TestMapSNIncidentTaskDetailToView_MapsOpenedOnClosedOn verifies the
+// upstream wire fields (openedAt/closedAt, unchanged -- that's the real SN
+// payload shape) map onto the response's own openedOn/closedOn fields,
+// which follow this API's established naming for every other date-only
+// response field.
+func TestMapSNIncidentTaskDetailToView_MapsOpenedOnClosedOn(t *testing.T) {
+	opened := "2026-08-01 10:00:00"
+	closed := "2026-08-02 12:00:00"
+	it := snIncidentTaskDetailResponse{ID: "sys123", OpenedAt: &opened, ClosedAt: &closed}
+
+	view := mapSNIncidentTaskDetailToView(it)
+
+	if view.OpenedOn == nil || *view.OpenedOn != opened {
+		t.Fatalf("expected OpenedOn %q, got %v", opened, view.OpenedOn)
+	}
+	if view.ClosedOn == nil || *view.ClosedOn != closed {
+		t.Fatalf("expected ClosedOn %q, got %v", closed, view.ClosedOn)
+	}
+}

--- a/entity-service/internal/service/sn_problem_service.go
+++ b/entity-service/internal/service/sn_problem_service.go
@@ -57,6 +57,32 @@ type snProblemFilters struct {
 	// match against ServiceNow's `number` column -- not part of the
 	// free-text SearchQuery scan.
 	Number string `json:"number,omitempty"`
+	// StateKeys: see domain.SearchProblemsFilters.Filters doc comment.
+	StateKeys []int `json:"stateKeys,omitempty"`
+	// AssignmentGroupIDs: sys_user_group sys_ids (converted from UUIDs).
+	AssignmentGroupIDs []string `json:"assignmentGroupIds,omitempty"`
+}
+
+// snProblemStateKeyMap maps domain ProblemState enums to ServiceNow's raw
+// problem_state numeric keys. Mirrors the SN Script Include's own
+// _PROBLEM_STATE_LABELS map -- note 105 does not exist in ServiceNow's own
+// numbering (a real gap, not an omission here).
+var snProblemStateKeyMap = map[domain.ProblemState]int{
+	domain.ProblemStateNew:               101,
+	domain.ProblemStateAssess:            102,
+	domain.ProblemStateRootCauseAnalysis: 103,
+	domain.ProblemStateFixInProgress:     104,
+	domain.ProblemStateResolved:          106,
+	domain.ProblemStateClosed:            107,
+}
+
+var validProblemState = map[domain.ProblemState]bool{
+	domain.ProblemStateNew:               true,
+	domain.ProblemStateAssess:            true,
+	domain.ProblemStateRootCauseAnalysis: true,
+	domain.ProblemStateFixInProgress:     true,
+	domain.ProblemStateResolved:          true,
+	domain.ProblemStateClosed:            true,
 }
 
 type snProblemService struct {
@@ -78,11 +104,20 @@ func (s *snProblemService) SearchProblems(ctx context.Context, req domain.Search
 	if err := validateExactNumber("number", req.Filters.Number); err != nil {
 		return domain.SearchProblemsResponse{}, err
 	}
+	parsedFilters, err := ParseProblemFieldFilters(req.Filters.Filters)
+	if err != nil {
+		return domain.SearchProblemsResponse{}, err
+	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
 
 	payload := snProblemSearchPayload{
-		Filters:    snProblemFilters{SearchQuery: req.Filters.SearchQuery, Number: stringPtrValue(req.Filters.Number)},
+		Filters: snProblemFilters{
+			SearchQuery:        req.Filters.SearchQuery,
+			Number:             stringPtrValue(req.Filters.Number),
+			StateKeys:          parsedFilters.StateKeys,
+			AssignmentGroupIDs: uuidsToSysids(parsedFilters.AssignmentGroupIDs),
+		},
 		Pagination: snProjectPagination{Limit: req.Pagination.Limit, Offset: req.Pagination.Offset},
 	}
 

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -3080,6 +3080,85 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /incident_tasks/search:
+    post:
+      summary: Search incident tasks (ServiceNow data source only). Search and get only -- no create/update.
+      operationId: searchIncidentTasks
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SearchIncidentTasksRequest'
+      responses:
+        "200":
+          description: Paginated list of incident tasks matching the filters.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchIncidentTasksResponse'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /incident_tasks/{id}:
+    get:
+      summary: Get a single incident task by ID (ServiceNow data source only).
+      operationId: getIncidentTask
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: The incident task detail.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IncidentTaskDetail'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: Incident task not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /conversations/search:
     post:
       summary: Search conversations (ServiceNow data source only).
@@ -4903,6 +4982,7 @@ components:
             - projectType
             - creTeam
             - sreTeam
+            - accountId
             - resolutionNotes
             - parentId
             - taskSLABusinessElapsedPercent
@@ -4992,6 +5072,8 @@ components:
           Expansion) team, as team UUIDs.
         - **sreTeam** (in): the parent account's SRE (Site Reliability
           Engineering) team, as team UUIDs.
+        - **accountId** (in): the case's parent customer account, as account
+          UUIDs.
         - **resolutionNotes** (isEmpty): values ignored; matches cases with
           empty resolution notes. isNotEmpty is not supported: false and
           omitted were always treated identically for this filter, so there
@@ -8453,6 +8535,33 @@ components:
           format: uuid
           nullable: true
 
+    ProblemFieldFilter:
+      type: object
+      required: [field, op]
+      properties:
+        field:
+          type: string
+          enum:
+            - state
+            - assignmentGroupId
+        op:
+          type: string
+          enum: [in]
+        values:
+          type: array
+          items:
+            type: string
+          description: Required and non-empty for every supported field/op combination.
+      description: |
+        One predicate in a problem search's generic filter expression array:
+        "field op values". Mirrors IncidentFieldFilter's contract.
+
+        - **state** (in): one of NEW/ASSESS/ROOT_CAUSE_ANALYSIS/
+          FIX_IN_PROGRESS/RESOLVED/CLOSED (the domain enum, not the backing
+          data source's raw numeric key).
+        - **assignmentGroupId** (in): sys_user_group UUIDs to filter the
+          assignment group by.
+
     SearchProblemsRequest:
       type: object
       properties:
@@ -8467,6 +8576,13 @@ components:
                 A single problem number (e.g. "PRB0010001"); matches exactly.
                 Routed as a first-class filter rather than through the
                 free-text searchQuery scan.
+            filters:
+              type: array
+              items:
+                $ref: '#/components/schemas/ProblemFieldFilter'
+              description: >-
+                A generic field/op/values filter array. See
+                ProblemFieldFilter for the supported field/op combinations.
         pagination:
           $ref: '#/components/schemas/Pagination'
 
@@ -8564,6 +8680,147 @@ components:
           type: string
           nullable: true
         closedOn:
+          type: string
+          nullable: true
+
+    IncidentTaskFieldFilter:
+      type: object
+      required: [field, op]
+      properties:
+        field:
+          type: string
+          enum:
+            - state
+            - assignmentGroupId
+            - incidentId
+        op:
+          type: string
+          enum: [in]
+        values:
+          type: array
+          items:
+            type: string
+          description: Required and non-empty for every supported field/op combination.
+      description: |
+        One predicate in an incident-task search's generic filter expression
+        array: "field op values". Mirrors ProblemFieldFilter's contract, with
+        one deliberate difference on state.
+
+        - **state** (in): a raw integer state value, passed straight through
+          -- NOT a domain enum, unlike every other resource's state filter.
+          incident_task shares its state choice list with the base task
+          table, and that choice list is inconsistent across task subtypes in
+          this deployment (overlapping/ambiguous values), so there is no
+          confirmed-complete, unambiguous enum to translate through safely.
+        - **assignmentGroupId** (in): sys_user_group UUIDs to filter the
+          assignment group by.
+        - **incidentId** (in): parent incident UUIDs.
+
+    SearchIncidentTasksRequest:
+      type: object
+      properties:
+        filters:
+          type: object
+          properties:
+            searchQuery:
+              type: string
+            number:
+              type: string
+              description: >-
+                A single incident task number (e.g. "TASK0082453"); matches
+                exactly. Routed as a first-class filter rather than through
+                the free-text searchQuery scan.
+            filters:
+              type: array
+              items:
+                $ref: '#/components/schemas/IncidentTaskFieldFilter'
+              description: >-
+                A generic field/op/values filter array. See
+                IncidentTaskFieldFilter for the supported field/op combinations.
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+
+    IncidentTask:
+      type: object
+      properties:
+        id:
+          type: string
+          nullable: true
+        number:
+          type: string
+          nullable: true
+        subject:
+          type: string
+          nullable: true
+        state:
+          type: string
+          nullable: true
+          description: Raw passthrough state value from the data source (see IncidentTaskFieldFilter).
+        stateLabel:
+          type: string
+          nullable: true
+        incident:
+          $ref: '#/components/schemas/CaseNumberRef'
+          nullable: true
+        assignmentGroup:
+          $ref: '#/components/schemas/EntityRef'
+          nullable: true
+        assignedTo:
+          $ref: '#/components/schemas/EntityRef'
+          nullable: true
+
+    SearchIncidentTasksResponse:
+      type: object
+      properties:
+        incidentTasks:
+          type: array
+          items:
+            $ref: '#/components/schemas/IncidentTask'
+        total:
+          type: integer
+        offset:
+          type: integer
+        limit:
+          type: integer
+
+    IncidentTaskDetail:
+      type: object
+      properties:
+        id:
+          type: string
+          nullable: true
+        number:
+          type: string
+          nullable: true
+        subject:
+          type: string
+          nullable: true
+        state:
+          type: string
+          nullable: true
+          description: Raw passthrough state value from the data source (see IncidentTaskFieldFilter).
+        stateLabel:
+          type: string
+          nullable: true
+        incident:
+          $ref: '#/components/schemas/CaseNumberRef'
+          nullable: true
+        assignmentGroup:
+          $ref: '#/components/schemas/EntityRef'
+          nullable: true
+        assignedTo:
+          $ref: '#/components/schemas/EntityRef'
+          nullable: true
+        description:
+          type: string
+          nullable: true
+        priority:
+          type: string
+          nullable: true
+        openedAt:
+          type: string
+          nullable: true
+        closedAt:
           type: string
           nullable: true
 

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -6061,11 +6061,11 @@ components:
         fields (projectIds, states, impacts, closedStartDate/closedEndDate,
         number). Mirrors CaseFieldFilter's contract.
 
-        - **createdOn** (gte / lte): a single RFC3339 timestamp or YYYY-MM-DD
-          date bounding the change request's created timestamp. gte is
-          inclusive "on or after"; lte is inclusive "on or before". A lte
-          bound earlier than its own gte bound is rejected with a validation
-          error.
+        - **createdOn** (gte / lte): a single RFC3339 timestamp, YYYY-MM-DD
+          date, or relative-date placeholder (e.g. "__daysAgo:90__") bounding
+          the change request's created timestamp. gte is inclusive "on or
+          after"; lte is inclusive "on or before". A lte bound earlier than
+          its own gte bound is rejected with a validation error.
         - **assignmentGroupId** (in): sys_user_group UUIDs to filter the
           assignment group by.
 

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -5063,9 +5063,13 @@ components:
         - **product** (in): product family names (e.g. "API Manager",
           "Identity Server", "Asgardeo"). Matches every version of each named
           product. Only applied by the ServiceNow data source.
-        - **projectOnboardingStatus** (in): free-text SN choice labels for the
-          parent project's onboarding status (e.g. "Completed",
-          "Not-Applicable" -- not a closed enum at this layer).
+        - **projectOnboardingStatus** (in / notIn): free-text SN choice labels
+          for the parent project's onboarding status (e.g. "Completed",
+          "In-Progress", "Not-Applicable" -- not a closed enum at this
+          layer). notIn matches cases whose value is NOT one of the given
+          labels -- e.g. `{"field": "projectOnboardingStatus", "op": "notIn",
+          "values": ["In-Progress"]}` means "onboarding status is not in
+          progress".
         - **projectType** (in): the parent project's type, matched by the
           project type's name (e.g. "Subscription").
         - **creTeam** (in): the parent account's CRE (Customer Renewal &

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -8060,9 +8060,10 @@ components:
             - state
             - assignmentGroupId
             - businessServiceId
+            - createdOn
         op:
           type: string
-          enum: [in]
+          enum: [in, gte, lte]
         values:
           type: array
           items:
@@ -8079,6 +8080,10 @@ components:
         - **businessServiceId** (in): business_service UUIDs to filter by
           (exact sys_id match, distinct from the product-name-matched filter
           used elsewhere).
+        - **createdOn** (gte/lte): a single value, either an RFC3339
+          timestamp, a YYYY-MM-DD date, or a relative-date placeholder (e.g.
+          "__daysAgo:90__"), same syntax as case search's own createdOn
+          filter.
 
     SearchIncidentsRequest:
       type: object

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -3080,7 +3080,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
-  /incident_tasks/search:
+  /incident-tasks/search:
     post:
       summary: Search incident tasks (ServiceNow data source only). Search and get only -- no create/update.
       operationId: searchIncidentTasks
@@ -3116,7 +3116,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
-  /incident_tasks/{id}:
+  /incident-tasks/{id}:
     get:
       summary: Get a single incident task by ID (ServiceNow data source only).
       operationId: getIncidentTask
@@ -8826,10 +8826,10 @@ components:
         priority:
           type: string
           nullable: true
-        openedAt:
+        openedOn:
           type: string
           nullable: true
-        closedAt:
+        closedOn:
           type: string
           nullable: true
 


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Bundles several independent CSM portal changes into one PR:

1. **Timecard preview**: the case-preview drawer gave no visibility into who could approve
   a submitted card, and its generic "Decision" caption on approved/rejected cards read as
   boilerplate rather than a clear outcome.
2. **Sidebar navigation**: Operations and Security Center used an in-page tab strip instead
   of the sidebar submenu pattern used elsewhere, and their tabs used the legacy `?tab=` form
   instead of real path-segment routes.
3. **Case filter bug**: the case list's "Work state" filter appeared usable whenever
   "In progress" was one of several selected states, but the filter can't actually be
   applied server-side once other states are also selected — it silently did nothing.
4. **Quick-preview ergonomics**: the preview eye icon on the case list and time card
   table sat at the row's right edge (or buried in the Actions column), forcing a click on
   one side and a look at the drawer on the other, with no way to switch straight to
   another row's preview without closing first.
5. **Project work items tab**: flattens the project detail page's Work items tab from five
   per-case-type sub-tabs into a single list with a "Work item type" multi-select filter,
   and adds right-click rename for pinned top-bar chips.
6. **SRE ABT dashboard support**: the entity-service/BFF/webapp lacked an account-id case
   filter, unified problem state/assignment-group filters, a searchable `incident_task`
   resource, and relative-date `createdOn` filtering on incident/change-request search —
   all needed for upcoming SRE "problem/account trend" dashboard widgets.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

1. Submitted time cards show the list of eligible approvers; approved/rejected cards drop
   the generic "Decision" label in favor of inline "Approved by: `<name>`" /
   "Rejected: `<reason>`" text.
2. Operations and Security Center sub-sections navigate from expandable sidebar submenu
   entries, with real path-segment routes (e.g. `/operations/incidents`).
3. The "Work state" filter is disabled unless "State" is exactly `[work_in_progress]`
   alone, and any selected work states are cleared as soon as that stops being true.
4. The quick-preview eye moves to the row's left edge (right after the bulk-select
   checkbox on the time card table, where one exists) and becomes a toggle: clicking the
   eye for the row already open closes the preview; clicking a different row's eye swaps
   straight to that row.
5. The Work items tab reuses the existing `CasesFilterBar`/`CsmIssuesView` machinery with
   a caller-supplied type-filter label instead of five separate sub-tabs, and pinned
   top-bar chips gain a rename affordance.
6. `CaseSearchFilters` gains `accountIds`; problem search gains unified `stateKeys`/
   `assignmentGroupIds`; a new `incident_task` resource is exposed end-to-end (SN →
   Ballerina → Go entity-service → BFF dashboard-widget registry → webapp widget config);
   incident and change-request search both gain `createdOn` (gte/lte) filtering with the
   existing relative-date placeholder engine (`__daysAgo:90__`).

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

**Timecard preview** (`TimeCardCasePreviewDrawer.tsx`): added an "Approvers" field
(rendered only when `state === "submitted"` and `card.approvers` is non-empty), and replaced
the labeled "Decision" `Field` with the existing `decisionSummary()` text rendered directly,
no caption. `timeCardDecision.ts`: `decisionSummary`'s approved branch now reads
"Approved by: `<name>`" (colon added). Rejected cards are unchanged — "Rejected: `<reason>`",
no name, since ServiceNow's `time_card` table never records a rejecter identity.

**Sidebar navigation**: replaces the tab strip on Operations and Security Center with
expandable sidebar submenu entries in `CsmSideBar.tsx`, wired via new entries in
`csmNavItems.ts`. `OperationsPage.tsx`/`CsmSecurityCenterPage.tsx` updated to read the active
sub-section from the path segment rather than a `?tab=` query param.

**Case filter bug** (`CasesFilterBar.tsx`): the "Work state" `MultiSelectField`'s
`disabled` check changed from "does `states` include `work_in_progress`" to "is `states`
exactly `[work_in_progress]`"; the "State" control's `onChange` now clears `workStates`
under the same exact-match condition instead of "state list still contains
`work_in_progress`".

**Quick-preview ergonomics** (`CasesList.tsx`, `TimeCardsTable.tsx`): moved the eye
`IconButton` to a new leading grid column (after the bulk-select checkbox column on
`TimeCardsTable` when `selectable` is on) and changed its `onClick` from
`setPreviewRow(c)` / `setDetailCard(c)` to a toggle:
`prev => (prev?.id === c.id ? null : c)`. Both preview drawers already anchor `right`, so
no drawer-side change was needed.

**Project work items tab**: flattens `WorkItemsTab.tsx` from five per-case-type sub-tabs
into a single unlocked-type `CsmIssuesView` list, adding a `typeFilterLabel` prop to
`CasesFilterBar` ("Work item type" instead of "Case type") and reusing the existing
saved-filter-views mechanism and top-nav pin-to-bar support unchanged. Adds right-click
rename for pinned top-bar chips via a small context menu + dialog, backed by a new
`renameRecentView` helper in `useRecentViews.ts`. Conversations stay a separate sub-tab
since they aren't a case type and aren't served by `/cases/search`.

**SRE ABT dashboard support**: pure passthrough on the ServiceNow scripted-API layer
(already built and live-verified directly against `wso2sndev.service-now.com` DEV, see
the paired digiops-cs PR) up through the Go entity-service
(`internal/service/{case,problem,incident,incident_task,change_request}_filters*.go`,
new `internal/handler/incident_task_handler.go` + route), the CSM BFF's dashboard widget
registry (`internal/dashboard/{registry,widgets}.go`, openapi.yaml), and the webapp's
widget config (`widgetListConfig.tsx`, `widgetResourceConfig.ts`, `api/backend/types.ts`).
No new query logic invented here — every filter/resource mirrors an existing SN Script
Include capability.

No screenshot: not fully verified against a running local stack or staging this session
for every item above — see Automation tests / Test environment below for what was and
wasn't exercised end-to-end.

## User stories
> Summary of user stories addressed by this change>

- As a CS engineer previewing a submitted time card, I can see who is eligible to approve
  it, and see who approved/rejected a decided one without a redundant "Decision" label.
- As a CS engineer, I can navigate Operations and Security Center sub-sections from the
  sidebar, consistent with the rest of the portal's navigation.
- As a CS engineer filtering cases, I can't accidentally leave a "Work state" filter
  selected that silently does nothing once I've also picked another state.
- As a CS engineer scanning the case list or time card table, I can open a row's preview
  from the left edge and switch straight to another row's preview without closing first.
- As a CS engineer on a project's Work items tab, I filter by work item type from one
  unified list instead of five separate sub-tabs, and can rename my pinned views.
- As an SRE building account/problem-trend dashboard widgets, the entity-service exposes
  the account, problem, incident_task, and date-range filters those widgets need.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Time card preview now lists eligible approvers on submitted cards and shows "Approved
by: Name" instead of a generic "Decision" label. Operations and Security Center now
navigate via sidebar submenus instead of in-page tabs. The case list's "Work state"
filter is now disabled unless "In progress" is the only selected state. The
quick-preview eye on the case list and time card table moved to the row's left edge and
is now a toggle. The project Work items tab is now a single filterable list instead of
five sub-tabs, with pinned-view rename support. Dashboard widgets gain account, problem,
and incident-task filtering plus relative-date incident/change-request filtering.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter "N/A" plus brief explanation of why there's no doc impact

N/A — internal CSM portal UI/API changes, no external docs cover these screens or the
dashboard widget config.

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

N/A — no training content covers these screens.

## Certification
> Type "Sent" when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type "N/A" and explain why.

N/A — internal tool change, not covered by any certification exam.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

N/A — internal-only change.

## Automation tests
 - Unit tests
   > Code coverage information

**Webapp**: full `src/features/csm-cases`, `csm-projects`, `csm-recent`, `csm-timecards`
suite (70 files, 639 tests) passing, plus `tsc -p tsconfig.app.json --noEmit` clean, as of
the work-items-tab merge. New/updated cases: `CasesFilterBar.test.tsx` (work-state gating,
case-type label), `CasesList.test.tsx` / `TimeCardsTable.test.tsx` (preview toggle/switch),
`TimeCardCasePreviewDrawer.test.tsx` (approvers list, decision label), plus the
work-items-tab branch's own `WorkItemsTab.test.tsx` / `PinnedTabs.test.tsx` /
`useRecentViews.test.ts`. The SRE ABT dashboard-config additions (`widgetListConfig.tsx`,
`widgetResourceConfig.ts`) type-check clean; one FE test file
(`DashboardWidgetPreviewPage.test.tsx`) could not be re-verified with `vitest` after that
merge due to a local test-harness collision (a live dev server holding the same
`node_modules/.vite` cache as a symlinked worktree checkout) — confirmed via direct
A/B comparison that the identical file passes cleanly outside that specific harness
setup; flagging this rather than asserting it as independently re-run.

**Go (entity-service, CSM BFF)**: `go build ./...`, `go vet ./...`, `go test ./...` all
clean on both modules after the SRE ABT merge, including new
`{incident,incident_task,problem,change_request}_filters_test.go`.

**Ballerina (digiops-cs, paired PR)**: `bal build` / `bal test` clean; every new
filter/resource live-verified against `wso2sndev.service-now.com` DEV with real
before/after record counts before that PR was opened.

**Sidebar**: existing `CsmSideBar.test.tsx` extended as part of the original change (see
commit `2730d1646`); not re-run in this session — carried over unmodified from #1495.
 - Integration tests
   > Details about the test cases and coverage

None — no integration/e2e test covers any of these surfaces. Not manually verified
against a running local stack or staging for every item in this PR — a true-local stack
(real ServiceNow DEV + Asgardeo) was brought up against this branch for a manual pass,
login/click-through pending.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — TypeScript/Go/Ballerina change, not JVM
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> Provide high-level details about the samples related to this feature

N/A

## Related PRs
> List any other related PRs

Supersedes #1494 and #1495 (both closed in favor of this combined PR). Paired with
digiops-cs#2824 (private repo) for the ServiceNow-side Ballerina passthrough types the
SRE ABT dashboard additions in this PR depend on.

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

N/A — no data or schema migration.

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested

Go 1.x / Ballerina toolchains already present in the repo checkout; Node/pnpm for the
webapp (macOS). A true-local stack (webapp → CSM BFF → Go entity-service → local
Ballerina entity-service → real ServiceNow DEV `wso2sndev.service-now.com` + Asgardeo)
was brought up against this exact branch for manual verification.

## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

Confirmed ServiceNow's `time_card` table records no rejecter identity (only
`approved_by` + the approver's rejection comment), so "Rejected by: Name" was scoped out
of the timecard change rather than fabricated from data that doesn't exist. For the SRE
ABT work, confirmed the SN scripted-API layer already supported every new filter/resource
on DEV before adding any Ballerina/Go/webapp passthrough, so no new SN-side query logic
was needed at any layer above the scripted API itself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added incident-task search and detail support, including dashboard widgets and navigation to related incidents.
  * Added problem-search filters for state and assignment group.
  * Expanded case filtering with account IDs and project onboarding exclusions.
  * Added created-date filtering with absolute and relative dates for incidents and change requests.
  * Added nested sidebar navigation and renamed pinned tabs.
  * Consolidated project work items into one filterable list with a separate Chats tab.

* **Bug Fixes**
  * Improved filter URL cleanup and work-state handling.
  * Improved preview drawer toggling and time-card details.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->