### PR TITLE
[Customer Portal v2] Port the WebSocket side-channel and Converted-state handling

### DIFF
--- a/apps/customer-portal/backend-v2/internal/aichatagent/ws.go
+++ b/apps/customer-portal/backend-v2/internal/aichatagent/ws.go
@@ -37,7 +37,19 @@ const (
 	eventPayloadKey = "payload"
 	eventFinal      = "final"
 	eventError      = "error"
+
+	// eventFeedbackAck/eventTokenRequestAck terminate a side-channel exchange.
+	// The agent answers a rating or a token-increase request with one of these
+	// and never sends a "final" — see SendSideChannel.
+	eventFeedbackAck     = "feedback_ack"
+	eventTokenRequestAck = "token_request_ack"
 )
+
+// sideChannelTimeout bounds how long SendSideChannel waits for an
+// acknowledgement. The upstream answers these in well under a second, so this
+// is far shorter than idleTimeout — a side-channel exchange must never park an
+// upstream connection for the length of a chat turn.
+const sideChannelTimeout = 30 * time.Second
 
 // maxMessageBytes bounds the size of a single frame read from the upstream
 // AI chat agent — mirrors internal/handler/websocket.go's wsMaxMessageBytes
@@ -185,4 +197,74 @@ func (c *WSClient) StreamChat(ctx context.Context, sessionID, payload string, ca
 		time.Now().Add(2*time.Second))
 
 	return finalPayload, nil
+}
+
+// SendSideChannel forwards a side-channel message — an answer rating, or a
+// request to raise a token limit — to the upstream agent and pipes events back
+// to caller until it acknowledges.
+//
+// Deliberately separate from StreamChat, because these are not chat turns: the
+// agent answers them with a "*_ack" and never sends a "final". Routing them
+// through StreamChat left it reading for an event that could not arrive until
+// the read deadline expired, and because the browser-facing read loop is
+// strictly sequential (it does not read the next frame until the current one is
+// handled) the whole connection stalled for that long — the customer's next
+// message was not even read off the socket, so the chat looked dead while the
+// socket was fine. Mirrors apps/customer-portal/backend's
+// ai_chat_agent:sendSideChannelMessage.
+//
+// A read timeout or a mid-exchange failure is reported as a nil error: the write
+// succeeded, so the rating may well have been stored, and telling the customer
+// their rating failed would be worse than saying nothing. Only a failure to
+// open or write to the upstream connection returns an error.
+func (c *WSClient) SendSideChannel(ctx context.Context, sessionID, payload string, caller BrowserConn) error {
+	conn, err := c.dial(ctx, sessionID)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	conn.SetReadLimit(maxMessageBytes)
+
+	if err := conn.WriteMessage(websocket.TextMessage, []byte(payload)); err != nil {
+		return fmt.Errorf("aichatagent: write side-channel message: %w", err)
+	}
+
+	acknowledged := false
+	for {
+		deadline := time.Now().Add(sideChannelTimeout)
+		if dl, ok := ctx.Deadline(); ok && dl.Before(deadline) {
+			deadline = dl
+		}
+		_ = conn.SetReadDeadline(deadline)
+
+		_, data, err := conn.ReadMessage()
+		if err != nil {
+			// Includes the read timeout and a normal upstream close.
+			break
+		}
+		if err := caller.WriteMessage(websocket.TextMessage, data); err != nil {
+			// The browser went away; nothing left to forward to.
+			break
+		}
+
+		var parsed map[string]json.RawMessage
+		if err := json.Unmarshal(data, &parsed); err != nil {
+			continue
+		}
+		var evtType string
+		if raw, ok := parsed[eventTypeKey]; ok {
+			_ = json.Unmarshal(raw, &evtType)
+		}
+		if evtType == eventFeedbackAck || evtType == eventTokenRequestAck || evtType == eventError {
+			acknowledged = true
+			break
+		}
+	}
+
+	if acknowledged {
+		_ = conn.WriteControl(websocket.CloseMessage,
+			websocket.FormatCloseMessage(websocket.CloseNormalClosure, "acknowledged"),
+			time.Now().Add(2*time.Second))
+	}
+	return nil
 }

--- a/apps/customer-portal/backend-v2/internal/handler/cases.go
+++ b/apps/customer-portal/backend-v2/internal/handler/cases.go
@@ -32,6 +32,7 @@ type entityCaseClient interface {
 	SearchCases(ctx context.Context, req entity.SearchCasesRequest) (entity.SearchCasesResponse, error)
 	GetCase(ctx context.Context, id string) (entity.CaseView, error)
 	CreateCase(ctx context.Context, req entity.CreateCaseRequest) (entity.CreateCaseResponse, error)
+	UpdateConversation(ctx context.Context, id string, req entity.UpdateConversationRequest) (entity.UpdateConversationResponse, error)
 	UpdateCase(ctx context.Context, id string, req entity.UpdateCaseRequest) (entity.UpdateCaseResponse, error)
 	CreateCaseComment(ctx context.Context, caseID string, req entity.CreateCaseCommentRequest) (entity.CreateCaseCommentResponse, error)
 	SearchCaseActivities(ctx context.Context, caseID string, req entity.SearchCaseActivitiesRequest) (entity.SearchCaseActivitiesResponse, error)
@@ -210,6 +211,19 @@ func (h *CaseHandler) CreateCase(w http.ResponseWriter, r *http.Request) {
 		slog.ErrorContext(r.Context(), "entity CreateCase failed", "userID", user.UserID, "err", summarizeErr(err))
 		mapUpstreamError(w, err, "Failed to create case.")
 		return
+	}
+
+	// A case raised from a Novera chat marks that conversation Converted so it
+	// stops counting as an active chat. Deliberately after the response is
+	// decided and non-blocking: the case already exists, so a conversion failure
+	// must not turn a successful creation into an error. entity-service does not
+	// do this itself even though the id is forwarded on the create request —
+	// same as the Ballerina backend, which forwards payload.conversationId and
+	// still performs this update explicitly.
+	if req.ConversationID != "" && uuidRe.MatchString(req.ConversationID) {
+		if _, err := h.entity.UpdateConversation(r.Context(), req.ConversationID, entity.UpdateConversationRequest{State: conversationStateConverted}); err != nil {
+			slog.ErrorContext(r.Context(), "entity UpdateConversation failed to mark the source conversation converted", "userID", user.UserID, "conversationID", req.ConversationID, "err", summarizeErr(err))
+		}
 	}
 
 	writeJSONValue(w, http.StatusCreated, dto.MapCaseCreate(result))

--- a/apps/customer-portal/backend-v2/internal/handler/response.go
+++ b/apps/customer-portal/backend-v2/internal/handler/response.go
@@ -173,3 +173,8 @@ func readBinaryBody(w http.ResponseWriter, r *http.Request, maxBytes int64) (bod
 	}
 	return body, true
 }
+
+// conversationStateConverted is the conversation state set when a case has been
+// created from a chat. It outranks RESOLVED — see handleMessage's resolved
+// branch in websocket.go, which refuses to downgrade it.
+const conversationStateConverted = "CONVERTED"

--- a/apps/customer-portal/backend-v2/internal/handler/websocket.go
+++ b/apps/customer-portal/backend-v2/internal/handler/websocket.go
@@ -450,6 +450,19 @@ func (h *WebSocketHandler) handleMessage(ctx context.Context, conn *websocket.Co
 		// A failed lookup deliberately does not block the transition — the
 		// pre-existing behaviour (resolve) is the safer default when the current
 		// state is unknown, and this whole branch is best-effort bookkeeping.
+		//
+		// This read-then-write is NOT atomic, and cannot be made so from here:
+		// entity.UpdateConversationRequest carries a state and nothing else, and
+		// entity-service's conversation API has no conditional-update
+		// precondition (no expected-state field, no If-Match/ETag). So a case
+		// created from this chat in the window between the read and the write
+		// still gets downgraded to RESOLVED. The window is short and one-
+		// directional — a CONVERTED write landing after this one wins correctly —
+		// and the result is a mis-stated state, recoverable via
+		// PATCH /conversations/{id}, which accepts "converted". Closing it
+		// properly needs a conditional update upstream; do not simulate one with
+		// a re-read-and-correct loop here, which can lose the same way and would
+		// fight a legitimate concurrent update.
 		current, err := h.entity.GetConversation(ctx, conversationID)
 		if err != nil {
 			slog.WarnContext(ctx, "entity GetConversation failed before auto-resolve; proceeding", "userID", user.UserID, "conversationID", conversationID, "err", summarizeErr(err))

--- a/apps/customer-portal/backend-v2/internal/handler/websocket.go
+++ b/apps/customer-portal/backend-v2/internal/handler/websocket.go
@@ -35,6 +35,7 @@ import (
 // WebSocketHandler.
 type wsStreamer interface {
 	StreamChat(ctx context.Context, sessionID, payload string, caller aichatagent.BrowserConn) (map[string]json.RawMessage, error)
+	SendSideChannel(ctx context.Context, sessionID, payload string, caller aichatagent.BrowserConn) error
 }
 
 // wsMaxMessageBytes bounds the size of a single WebSocket frame this handler
@@ -54,12 +55,27 @@ const wsIdleTimeout = 5 * time.Minute
 type entityCommentCreator interface {
 	CreateComment(ctx context.Context, req entity.CreateCommentRequest) (entity.CreateCommentResponse, error)
 	UpdateConversation(ctx context.Context, id string, req entity.UpdateConversationRequest) (entity.UpdateConversationResponse, error)
+	GetConversation(ctx context.Context, id string) (entity.ConversationDetails, error)
 	GetProject(ctx context.Context, id string) (entity.ProjectDetailsView, error)
 }
 
 // wsAutoResolveState is entity-service's ConversationState value used to
 // auto-resolve a conversation when the AI agent reports the issue solved.
 const wsAutoResolveState = "RESOLVED"
+
+// msgTypeFeedback/msgTypeTokenIncreaseRequest are the inbound side-channel
+// message types — a thumbs up/down on an answer, and a request asking support to
+// raise a token limit. Mirrors MSG_TYPE_FEEDBACK/MSG_TYPE_TOKEN_INCREASE_REQUEST
+// in apps/customer-portal/backend's modules/ai_chat_agent/constants.bal.
+const (
+	msgTypeFeedback             = "feedback"
+	msgTypeTokenIncreaseRequest = "token_increase_request"
+)
+
+// requestedByField names the actor on a token-increase request. It is always
+// rewritten server-side from the authenticated session — never trusted from the
+// browser — because it lands in a durable audit trail. See handleSideChannel.
+const requestedByField = "requestedBy"
 
 // wsSubprotocol is the WebSocket subprotocol this endpoint negotiates. The
 // frontend offers it (see WS_CUSTOMER_PORTAL in the webapp's apiConstants.ts)
@@ -339,6 +355,23 @@ func (h *WebSocketHandler) handleMessage(ctx context.Context, conn *websocket.Co
 		return
 	}
 
+	// Side-channel messages — an answer rating, or a request to raise a token
+	// limit. Dispatched before everything below, because none of it applies to
+	// them and all of it causes harm:
+	//
+	//   - StreamChat reads until a "final" event, which the agent never sends
+	//     for these (it answers with a "*_ack"), so the turn stalled until the
+	//     read deadline. The browser-facing read loop is strictly sequential, so
+	//     that stalled the whole connection: the customer's next message was not
+	//     even read off the socket. The chat looked dead while it was fine.
+	//   - persisting the "user query" makes no sense for a rating, which carries
+	//     no message at all.
+	//   - the resolved/auto-resolve bookkeeping likewise does not apply.
+	if msgType, _ := parsed["type"].(string); msgType == msgTypeFeedback || msgType == msgTypeTokenIncreaseRequest {
+		h.handleSideChannel(ctx, conn, user, projectID, msgType, parsed)
+		return
+	}
+
 	conversationID, _ := parsed["conversationId"].(string)
 	if conversationID == "" || !uuidRe.MatchString(conversationID) {
 		_ = writeWSJSON(conn, wsEvent{
@@ -399,10 +432,91 @@ func (h *WebSocketHandler) handleMessage(ctx context.Context, conn *websocket.Co
 		_ = json.Unmarshal(raw, &resolved)
 	}
 	if resolved {
+		// Never downgrade a conversation a case was created from: CONVERTED
+		// outranks RESOLVED. Without this check the agent reporting the issue
+		// solved would silently overwrite the converted state, and the chat
+		// stopped being attributable to the case it produced.
+		//
+		// A failed lookup deliberately does not block the transition — the
+		// pre-existing behaviour (resolve) is the safer default when the current
+		// state is unknown, and this whole branch is best-effort bookkeeping.
+		current, err := h.entity.GetConversation(ctx, conversationID)
+		if err != nil {
+			slog.WarnContext(ctx, "entity GetConversation failed before auto-resolve; proceeding", "userID", user.UserID, "conversationID", conversationID, "err", summarizeErr(err))
+		} else if isConvertedState(current.State) {
+			slog.DebugContext(ctx, "conversation already converted; skipping the resolved transition", "conversationID", conversationID)
+			return
+		}
 		if _, err := h.entity.UpdateConversation(ctx, conversationID, entity.UpdateConversationRequest{State: wsAutoResolveState}); err != nil {
 			slog.ErrorContext(ctx, "entity UpdateConversation failed to auto-resolve", "userID", user.UserID, "conversationID", conversationID, "err", summarizeErr(err))
 		}
 	}
+}
+
+// handleSideChannel forwards a rating or token-increase request to the AI agent
+// and pipes the acknowledgement back, bypassing the chat-turn path entirely.
+//
+// The requester is stamped from the authenticated session rather than trusted
+// from the browser, and rewritten unconditionally: when there is no session
+// email to stamp, any requestedBy the client supplied is *removed* rather than
+// forwarded. Otherwise that one path would let a caller write someone else's
+// name into a durable audit row. So the field is either this session's user or
+// absent, never client-supplied — the upstream falls back to the account when it
+// is absent. Mirrors the Ballerina backend's onMessage side-channel branch.
+func (h *WebSocketHandler) handleSideChannel(ctx context.Context, conn *websocket.Conn, user *middleware.UserInfo, projectID, msgType string, parsed map[string]any) {
+	conversationID, _ := parsed["conversationId"].(string)
+	if conversationID == "" || !uuidRe.MatchString(conversationID) {
+		// The client knows which answer it is rating even when this connection
+		// has not carried a turn yet, so a missing id is a client bug, not a
+		// resumable state. Dropped rather than surfaced: a failed rating must not
+		// interrupt the chat.
+		slog.ErrorContext(ctx, "discarding side-channel message: no usable conversation id", "userID", user.UserID, "msgType", msgType)
+		return
+	}
+
+	payload, dropped, err := stampRequestedBy(parsed, user.Email)
+	if err != nil {
+		slog.ErrorContext(ctx, "failed to re-encode side-channel payload", "userID", user.UserID, "msgType", msgType, "err", summarizeErr(err))
+		return
+	}
+	if dropped {
+		// Should not happen: an authenticated session always carries an email.
+		// Logged because the difference is a named requester versus an anonymous
+		// audit row.
+		slog.WarnContext(ctx, "dropping client-supplied requestedBy: no authenticated email on this session", "userID", user.UserID, "msgType", msgType)
+	}
+
+	agentSessionID := projectID + ":" + conversationID
+	if err := h.ai.SendSideChannel(ctx, agentSessionID, string(payload), conn); err != nil {
+		slog.ErrorContext(ctx, "aichatagent SendSideChannel failed", "userID", user.UserID, "conversationID", conversationID, "msgType", msgType, "err", summarizeErr(err))
+	}
+}
+
+// stampRequestedBy rewrites the requester on a side-channel payload from the
+// authenticated session, returning the re-encoded bytes and whether a
+// client-supplied value had to be discarded.
+//
+// The rewrite is unconditional: when email is empty, any requestedBy the client
+// supplied is *removed* rather than forwarded. Otherwise that one path would let
+// a caller write someone else's name into a durable audit row. So the field is
+// either this session's user or absent, never client-supplied — the upstream
+// falls back to the account when it is absent.
+func stampRequestedBy(parsed map[string]any, email string) (payload []byte, dropped bool, err error) {
+	if email != "" {
+		parsed[requestedByField] = email
+	} else if _, present := parsed[requestedByField]; present {
+		delete(parsed, requestedByField)
+		dropped = true
+	}
+	payload, err = json.Marshal(parsed)
+	return payload, dropped, err
+}
+
+// isConvertedState reports whether a conversation has already been converted
+// into a case. Compared case-insensitively because the state is a plain string
+// on the wire, and nil-safe because entity-service types it as optional.
+func isConvertedState(state *string) bool {
+	return state != nil && strings.EqualFold(strings.TrimSpace(*state), conversationStateConverted)
 }
 
 func writeWSJSON(conn *websocket.Conn, v any) error {

--- a/apps/customer-portal/backend-v2/internal/handler/websocket.go
+++ b/apps/customer-portal/backend-v2/internal/handler/websocket.go
@@ -367,6 +367,16 @@ func (h *WebSocketHandler) handleMessage(ctx context.Context, conn *websocket.Co
 	//   - persisting the "user query" makes no sense for a rating, which carries
 	//     no message at all.
 	//   - the resolved/auto-resolve bookkeeping likewise does not apply.
+	//
+	// Called synchronously, on purpose. It blocks the read loop for as long as
+	// the acknowledgement takes, which is bounded by sideChannelTimeout and in
+	// practice well under a second. Forwarding it in a goroutine instead would
+	// mean two writers on one *websocket.Conn — gorilla permits only one at a
+	// time for WriteMessage — so it would need a write mutex *and* coordination
+	// with HandleWebSocket's deferred conn.Close(), or the loop could close the
+	// connection underneath an in-flight write. That trades a bounded stall for
+	// a write-after-close race, and it would diverge from the Ballerina backend,
+	// whose onMessage also forwards these inline.
 	if msgType, _ := parsed["type"].(string); msgType == msgTypeFeedback || msgType == msgTypeTokenIncreaseRequest {
 		h.handleSideChannel(ctx, conn, user, projectID, msgType, parsed)
 		return

--- a/apps/customer-portal/backend-v2/internal/handler/websocket_side_channel_test.go
+++ b/apps/customer-portal/backend-v2/internal/handler/websocket_side_channel_test.go
@@ -1,0 +1,135 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestStampRequestedBy_UsesTheSessionNotTheBrowser is the security assertion for
+// the token-increase audit trail: requestedBy becomes the authenticated user's
+// email regardless of what the browser claimed.
+func TestStampRequestedBy_UsesTheSessionNotTheBrowser(t *testing.T) {
+	parsed := map[string]any{
+		"type":           msgTypeTokenIncreaseRequest,
+		"conversationId": "11111111-1111-1111-1111-111111111111",
+		// A caller trying to write someone else into the audit row.
+		"requestedBy": "attacker@evil.invalid",
+	}
+
+	payload, dropped, err := stampRequestedBy(parsed, "real.user@wso2.com")
+	if err != nil {
+		t.Fatalf("stampRequestedBy: %v", err)
+	}
+	if dropped {
+		t.Error("dropped = true, want false: there was a session email to stamp")
+	}
+
+	var out map[string]any
+	if err := json.Unmarshal(payload, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got := out[requestedByField]; got != "real.user@wso2.com" {
+		t.Errorf("requestedBy = %v, want the session email; the browser's value must never survive", got)
+	}
+}
+
+// TestStampRequestedBy_RemovesTheFieldWhenThereIsNoSessionEmail covers the one
+// path that would otherwise let a caller name themselves: with no email to
+// stamp, a client-supplied requestedBy must be removed, never forwarded. The
+// upstream falls back to the account when the field is absent.
+func TestStampRequestedBy_RemovesTheFieldWhenThereIsNoSessionEmail(t *testing.T) {
+	parsed := map[string]any{
+		"type":        msgTypeTokenIncreaseRequest,
+		"requestedBy": "attacker@evil.invalid",
+	}
+
+	payload, dropped, err := stampRequestedBy(parsed, "")
+	if err != nil {
+		t.Fatalf("stampRequestedBy: %v", err)
+	}
+	if !dropped {
+		t.Error("dropped = false, want true: a client-supplied value was discarded")
+	}
+
+	var out map[string]any
+	if err := json.Unmarshal(payload, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if v, present := out[requestedByField]; present {
+		t.Errorf("requestedBy is still present (%v); it must be absent rather than client-supplied", v)
+	}
+}
+
+// TestStampRequestedBy_PreservesEverythingElse checks the rest of the payload is
+// forwarded verbatim — only the requester is rewritten.
+func TestStampRequestedBy_PreservesEverythingElse(t *testing.T) {
+	parsed := map[string]any{
+		"type":           msgTypeFeedback,
+		"conversationId": "11111111-1111-1111-1111-111111111111",
+		"rating":         "up",
+		"messageId":      "abc-123",
+	}
+
+	payload, _, err := stampRequestedBy(parsed, "real.user@wso2.com")
+	if err != nil {
+		t.Fatalf("stampRequestedBy: %v", err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(payload, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for k, want := range map[string]any{
+		"type":           msgTypeFeedback,
+		"conversationId": "11111111-1111-1111-1111-111111111111",
+		"rating":         "up",
+		"messageId":      "abc-123",
+	} {
+		if out[k] != want {
+			t.Errorf("%s = %v, want %v", k, out[k], want)
+		}
+	}
+}
+
+// TestIsConvertedState guards the rule that CONVERTED outranks RESOLVED: the
+// agent reporting an issue solved must not silently overwrite the state of a
+// conversation a case was created from, or the chat stops being attributable to
+// the case it produced.
+func TestIsConvertedState(t *testing.T) {
+	converted := "CONVERTED"
+	lower := "converted"
+	padded := "  Converted  "
+	resolved := "RESOLVED"
+	empty := ""
+
+	for name, tc := range map[string]struct {
+		in   *string
+		want bool
+	}{
+		"exact":             {&converted, true},
+		"lowercase":         {&lower, true},
+		"padded mixed case": {&padded, true},
+		"resolved":          {&resolved, false},
+		"empty":             {&empty, false},
+		"nil":               {nil, false},
+	} {
+		if got := isConvertedState(tc.in); got != tc.want {
+			t.Errorf("%s: isConvertedState = %v, want %v", name, got, tc.want)
+		}
+	}
+}

--- a/apps/customer-portal/backend-v2/internal/handler/websocket_test.go
+++ b/apps/customer-portal/backend-v2/internal/handler/websocket_test.go
@@ -270,6 +270,14 @@ type stubEntity struct {
 	project entity.ProjectDetailsView
 	err     error
 	calls   int
+
+	// conversation/conversationErr script GetConversation, which handleMessage
+	// consults before downgrading a CONVERTED conversation to RESOLVED.
+	conversation    entity.ConversationDetails
+	conversationErr error
+	// updatedStates records every state UpdateConversation was asked to set, so
+	// a test can assert the transition was skipped rather than merely reordered.
+	updatedStates []string
 }
 
 func (s *stubEntity) GetProject(_ context.Context, _ string) (entity.ProjectDetailsView, error) {
@@ -281,8 +289,13 @@ func (s *stubEntity) CreateComment(_ context.Context, _ entity.CreateCommentRequ
 	return entity.CreateCommentResponse{}, nil
 }
 
-func (s *stubEntity) UpdateConversation(_ context.Context, _ string, _ entity.UpdateConversationRequest) (entity.UpdateConversationResponse, error) {
+func (s *stubEntity) UpdateConversation(_ context.Context, _ string, req entity.UpdateConversationRequest) (entity.UpdateConversationResponse, error) {
+	s.updatedStates = append(s.updatedStates, req.State)
 	return entity.UpdateConversationResponse{}, nil
+}
+
+func (s *stubEntity) GetConversation(_ context.Context, _ string) (entity.ConversationDetails, error) {
+	return s.conversation, s.conversationErr
 }
 
 // TestHandleWebSocket_ProjectAccessGatesTheUpgrade asserts the account lookup


### PR DESCRIPTION
## Purpose

Four behaviours the Ballerina backend gained were never ported to backend-v2. Their Ballerina commits are **not on `dev-app-csm-portal`**, which is why this backend never picked them up: `15eda8597`, `0c459a561`, `5048bb148`, `6167db970`.

## Side-channel messages no longer stall the connection

A `feedback` (answer rating) or `token_increase_request` message fell through into the chat-turn path, where `StreamChat` reads until a `final` event. The agent answers these with a `*_ack` and **never** sends a `final`, so the read ran to the five-minute idle deadline and the customer got `"Failed to process message."` — even though the rating had been stored.

**This was worse than the Ballerina symptom.** There, the streaming lock at least rejected the next message with an explicit error. Here the browser-facing read loop is strictly sequential — it does not read the next frame until the current one is handled — so the whole connection stalled for those five minutes and the customer's next message was never read off the socket at all. The chat looked dead while the socket was healthy.

Both types are now dispatched **before** the conversation guard, the streaming call, and the post-stream bookkeeping, none of which applies to them:

- persisting the "user query" makes no sense for a rating, which carries no `message`
- the resolved/auto-resolve bookkeeping does not apply either

`SendSideChannel` is a separate client method with its own **30-second** bound (vs the 5-minute chat idle timeout), terminating on `feedback_ack`, `token_request_ack` or `error`. A read timeout is reported as **success**: the write already succeeded, so the rating may well have been stored, and telling the customer it failed would be worse than saying nothing.

## `requestedBy` is stamped from the session, never the browser

The requester on a token-increase request was forwarded **verbatim from the client**, so a caller could name anyone as the actor on a durable audit row.

It is now rewritten unconditionally from the authenticated session. When there is no session email to stamp, a client-supplied value is **removed** rather than forwarded — otherwise that one path would preserve the same hole. The field is therefore either this session's user or absent; the upstream falls back to the account when absent.

## `CONVERTED` is no longer downgraded to `RESOLVED`

The resolved branch set `RESOLVED` unconditionally, so the agent reporting an issue solved silently overwrote the state of a conversation a case had been created from — and the chat stopped being attributable to the case it produced. It now checks the current state first and skips the transition when already converted.

A failed lookup deliberately does **not** block the transition: resolving is the safer default when the current state is unknown, and this branch is best-effort bookkeeping.

## A case created from a chat marks its conversation Converted

`POST /cases` forwards `conversationId` to entity-service, but entity-service does not act on it, so the source conversation kept counting as an active chat. The handler now marks it Converted after a successful create — non-blocking, since the case already exists and a conversion failure must not turn a successful creation into an error. Same as the Ballerina backend, which forwards the id and still performs this update explicitly.

`PATCH /conversations/{id}` already accepted `"converted"` (`3003eb6fe`'s equivalent), so no change was needed there.

## Testing

The `requestedBy` stamping and the converted check are extracted as **pure helpers**, so both are unit-testable without a live socket. Tests cover:

- the audit-trail substitution (a browser-supplied `requestedBy` never survives)
- the no-email removal path
- verbatim forwarding of every other field
- case / whitespace / nil handling of the state comparison

`go build`, `go vet`, `gofmt -l`, `go test -race ./...` all pass; `gosec -fmt=text ./...` reports **0 issues** (103 files).

### UI verification

1. Rate an answer in the Novera chat, then send another message — it must be answered normally rather than the chat going silent
2. Request a token increase; the audit row shows the signed-in user, not whatever the page sent
3. Create a case from a chat, then let the agent resolve it — the conversation stays **Converted**, not **Resolved**

## Deployment

**backend-v2 only** — no entity-service change. Independent of #1487 and #1489.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for feedback and token-increase requests during live chat.
  * Automatically records when a chat conversation is converted into a case.
  * Preserves converted conversation status during automatic resolution.
  * Forwards side-channel responses through the live chat connection.

* **Security**
  * Ensures feedback requests use the authenticated session identity.

* **Tests**
  * Added coverage for request identity, payload handling, and converted conversation states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->