### PR TITLE
[CSM Portal] Quick-preview drawer click-through fix, group-by dashboard widgets, and type/family-based default dashboards

### DIFF
--- a/apps/csm-portal/backend/internal/dashboard/registry.go
+++ b/apps/csm-portal/backend/internal/dashboard/registry.go
@@ -28,15 +28,12 @@ import (
 )
 
 // Type classifies a dashboard by the audience it is built for. It is the
-// field automatic dashboard selection is intended to key off: a caller whose
-// team family is cre-abt/cre would land on the default TypeCRE dashboard,
-// sre-abt/sre on the default TypeSRE one, and a caller with no team at all on
-// the default TypeCS one.
-//
-// That selection is NOT implemented yet. The frontend still picks its landing
-// dashboard on IsDefault plus IsTeamBased and never reads Type, which is why
-// validate below still permits only one IsDefault dashboard in total rather
-// than one per type.
+// field automatic dashboard selection keys off: a caller whose team family is
+// cre-abt/cre lands on the default TypeCRE dashboard, sre-abt/sre on the
+// default TypeSRE one, and a caller with no team at all on the default
+// TypeCS one. validate enforces at most one IsDefault dashboard per Type, so
+// a default of each type can coexist without either resolving by nothing
+// more than file ordering.
 type Type string
 
 const (
@@ -357,18 +354,20 @@ func finalize(loaded []sourced, requireType bool, sharedPresets map[string]map[s
 //   - type cs with isTeamBased true. cs is the organisation-wide dashboard,
 //     and it is what a caller with no team at all falls back to. A team
 //     picker on it contradicts both roles.
-//   - more than one isDefault dashboard, of any type. This is deliberately
-//     stricter than the eventual rule. Once the frontend keys default
-//     selection off "type" it will be one default PER type; today it does
-//     not -- CsmDashboardPage picks on isDefault + isTeamBased, and "type"
-//     is not even carried on the dashboard-list response yet -- so a second
-//     typed default would be accepted here and then resolved by nothing more
-//     than LoadDir's filename ordering. Loosen this to one-per-type in the
-//     same change that makes the frontend type-aware, not before.
+//   - more than one isDefault dashboard of the same type -- or, on the
+//     deprecated untyped DASHBOARDS_CONFIG path, more than one untyped
+//     isDefault dashboard. One isDefault dashboard per type is legal and by
+//     design: the frontend selects its landing dashboard from the caller's
+//     own team family against Type, so a cre default and an sre default (and
+//     a cs default) can all coexist without any of them resolving by nothing
+//     more than LoadDir's filename ordering. An untyped default does not
+//     share a "slot" with any typed default -- it has no type to key off --
+//     so it only ever collides with another untyped default, which is only
+//     reachable via the deprecated single-variable path.
 func validate(loaded []sourced, requireType bool) error {
 	byID := make(map[string]string, len(loaded))
-	defaultSource := ""
-	defaultType := Type("")
+	defaultByType := make(map[Type]string, len(loaded))
+	untypedDefaultSource := ""
 
 	for _, l := range loaded {
 		d := l.dashboard
@@ -392,14 +391,22 @@ func validate(loaded []sourced, requireType bool) error {
 		// Before the type branch below, which skips the rest of the loop for an
 		// untyped definition: an untyped isDefault dashboard counts here too,
 		// so two of them on the deprecated DASHBOARDS_CONFIG path are caught
-		// rather than left to file ordering.
+		// rather than left to file ordering. It is kept in its own bucket,
+		// separate from defaultByType, so it never collides with a typed
+		// default -- there is no type to key on, so there is no shared slot.
 		if d.IsDefault {
-			if defaultSource != "" {
-				return fmt.Errorf("dashboard definitions: %s (id %q, type %q): a second \"isDefault\" dashboard; %s (type %q) already claims it, and selection needs exactly one. Automatic selection is not type-aware yet, so which of the two you land on would depend only on filename ordering",
-					l.source, d.ID, d.Type, defaultSource, defaultType)
+			if d.Type == "" {
+				if untypedDefaultSource != "" {
+					return fmt.Errorf("dashboard definitions: %s (id %q): a second untyped \"isDefault\" dashboard; %s already claims the untyped default slot, and selection needs exactly one. This is only reachable via the deprecated DASHBOARDS_CONFIG path, which predates \"type\"",
+						l.source, d.ID, untypedDefaultSource)
+				}
+				untypedDefaultSource = l.source
+			} else if prev, claimed := defaultByType[d.Type]; claimed {
+				return fmt.Errorf("dashboard definitions: %s (id %q, type %q): a second \"isDefault\" dashboard of type %q; %s already claims that type's default, and selection needs exactly one default per type",
+					l.source, d.ID, d.Type, d.Type, prev)
+			} else {
+				defaultByType[d.Type] = l.source
 			}
-			defaultSource = l.source
-			defaultType = d.Type
 		}
 
 		if d.Type == "" {

--- a/apps/csm-portal/backend/internal/dashboard/registry.go
+++ b/apps/csm-portal/backend/internal/dashboard/registry.go
@@ -493,6 +493,18 @@ func validateWidgets(d Dashboard, source string) error {
 			return fmt.Errorf("dashboard definitions: %s (id %q): widget %q: \"gridWidth\" is %d; it is a column count out of 12 and must be between 1 and 12",
 				source, d.ID, w.ID, w.GridWidth)
 		}
+		if (w.Shape == ShapePie || w.Shape == ShapeBar) && len(w.Slices) > 0 && w.GroupBy != nil {
+			return fmt.Errorf("dashboard definitions: %s (id %q): widget %q: carries both \"slices\" and \"groupBy\"; a %q/%q widget must use exactly one",
+				source, d.ID, w.ID, ShapePie, ShapeBar)
+		}
+		if (w.Shape == ShapePie || w.Shape == ShapeBar) && len(w.Slices) == 0 && w.GroupBy == nil {
+			return fmt.Errorf("dashboard definitions: %s (id %q): widget %q: shape %q needs either \"slices\" or \"groupBy\"",
+				source, d.ID, w.ID, w.Shape)
+		}
+		if w.GroupBy != nil && strings.TrimSpace(w.GroupBy.Field) == "" {
+			return fmt.Errorf("dashboard definitions: %s (id %q): widget %q: \"groupBy.field\" is empty",
+				source, d.ID, w.ID)
+		}
 	}
 
 	return nil

--- a/apps/csm-portal/backend/internal/dashboard/registry.go
+++ b/apps/csm-portal/backend/internal/dashboard/registry.go
@@ -368,6 +368,7 @@ func validate(loaded []sourced, requireType bool) error {
 	byID := make(map[string]string, len(loaded))
 	defaultByType := make(map[Type]string, len(loaded))
 	untypedDefaultSource := ""
+	defaultForTeamKeySource := make(map[string]string, len(loaded))
 
 	for _, l := range loaded {
 		d := l.dashboard
@@ -386,6 +387,20 @@ func validate(loaded []sourced, requireType bool) error {
 
 		if err := validateWidgets(d, l.source); err != nil {
 			return err
+		}
+
+		// CsmDashboardPage selects a caller's landing dashboard by matching
+		// its team key against DefaultForTeamKeys, taking the first list
+		// entry with find. If two dashboards claimed the same team key, that
+		// choice would silently fall to list order instead of config intent.
+		// Track which dashboard claims each key and reject a second claim
+		// from a different source.
+		for _, teamKey := range d.DefaultForTeamKeys {
+			if prev, claimed := defaultForTeamKeySource[teamKey]; claimed && prev != l.source {
+				return fmt.Errorf("dashboard definitions: %s (id %q): defaultForTeamKeys key %q is already claimed by %s; each team key must resolve to exactly one dashboard",
+					l.source, d.ID, teamKey, prev)
+			}
+			defaultForTeamKeySource[teamKey] = l.source
 		}
 
 		// Before the type branch below, which skips the rest of the loop for an

--- a/apps/csm-portal/backend/internal/dashboard/registry.go
+++ b/apps/csm-portal/backend/internal/dashboard/registry.go
@@ -368,7 +368,7 @@ func validate(loaded []sourced, requireType bool) error {
 	byID := make(map[string]string, len(loaded))
 	defaultByType := make(map[Type]string, len(loaded))
 	untypedDefaultSource := ""
-	defaultForTeamKeySource := make(map[string]string, len(loaded))
+	defaultForTeamKeyOwner := make(map[string]string, len(loaded))
 
 	for _, l := range loaded {
 		d := l.dashboard
@@ -394,13 +394,17 @@ func validate(loaded []sourced, requireType bool) error {
 		// entry with find. If two dashboards claimed the same team key, that
 		// choice would silently fall to list order instead of config intent.
 		// Track which dashboard claims each key and reject a second claim
-		// from a different source.
+		// from a different dashboard. Ownership is keyed by dashboard id, not
+		// source file: the deprecated DASHBOARDS_CONFIG path can decode
+		// multiple distinct dashboard objects from one source value, so two
+		// different dashboards sharing that source would otherwise both look
+		// like the same owner and never trip this check.
 		for _, teamKey := range d.DefaultForTeamKeys {
-			if prev, claimed := defaultForTeamKeySource[teamKey]; claimed && prev != l.source {
+			if prev, claimed := defaultForTeamKeyOwner[teamKey]; claimed && prev != d.ID {
 				return fmt.Errorf("dashboard definitions: %s (id %q): defaultForTeamKeys key %q is already claimed by %s; each team key must resolve to exactly one dashboard",
 					l.source, d.ID, teamKey, prev)
 			}
-			defaultForTeamKeySource[teamKey] = l.source
+			defaultForTeamKeyOwner[teamKey] = d.ID
 		}
 
 		// Before the type branch below, which skips the rest of the loop for an

--- a/apps/csm-portal/backend/internal/dashboard/registry_test.go
+++ b/apps/csm-portal/backend/internal/dashboard/registry_test.go
@@ -898,6 +898,11 @@ func TestLoadDir_DefaultForTeamKeysWithNoConflictIsFine(t *testing.T) {
 // load, and CsmDashboardPage's find() would silently pick whichever came
 // first in dashboard list order -- an outcome driven by LoadDir's filename
 // ordering rather than by any config author's intent.
+//
+// Ownership is tracked by dashboard id (see
+// TestParseDashboardsConfig_RejectsDuplicateDefaultForTeamKeysOwnershipAcrossSharedSource
+// for why source alone is not enough), so the rejection here names the
+// owning dashboard's id, not its source file.
 func TestLoadDir_RejectsDuplicateDefaultForTeamKeysOwnership(t *testing.T) {
 	dir := t.TempDir()
 	writeDefinition(t, dir, "a.json", `{"id": "onboarding-engineer", "displayName": "Onboarding Engineer", "type": "cs", "defaultForTeamKeys": ["customer_onboarding"], "widgets": []}`)
@@ -907,7 +912,32 @@ func TestLoadDir_RejectsDuplicateDefaultForTeamKeysOwnership(t *testing.T) {
 	if err == nil {
 		t.Fatal("LoadDir accepted two dashboards claiming the same defaultForTeamKeys entry; expected an error")
 	}
-	for _, want := range []string{"a.json", "b.json", "customer_onboarding", "defaultForTeamKeys"} {
+	for _, want := range []string{"b.json", "migration-engineer", "onboarding-engineer", "customer_onboarding", "defaultForTeamKeys"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("err = %q, want it to contain %q", err.Error(), want)
+		}
+	}
+}
+
+// TestParseDashboardsConfig_RejectsDuplicateDefaultForTeamKeysOwnershipAcrossSharedSource
+// is the regression test for the bug in the fix above (commit faa5265a6):
+// ownership was tracked by l.source, which is fine for LoadDir (one source
+// file per dashboard) but not for the deprecated DASHBOARDS_CONFIG path,
+// where ParseDashboardsConfig decodes many distinct dashboard objects out of
+// one JSON payload -- so every dashboard in that payload shares the exact
+// same l.source string. Two different dashboards in that single payload
+// claiming the same defaultForTeamKeys entry used to pass validation because
+// prev == l.source for both; tracking by d.ID instead means they no longer
+// share an owner and the second claim is correctly rejected.
+func TestParseDashboardsConfig_RejectsDuplicateDefaultForTeamKeysOwnershipAcrossSharedSource(t *testing.T) {
+	_, err := ParseDashboardsConfig(`[
+		{"id": "onboarding-engineer", "displayName": "Onboarding Engineer", "defaultForTeamKeys": ["customer_onboarding"], "widgets": []},
+		{"id": "migration-engineer", "displayName": "Migration Engineer", "defaultForTeamKeys": ["customer_onboarding"], "widgets": []}
+	]`)
+	if err == nil {
+		t.Fatal("ParseDashboardsConfig accepted two dashboards (sharing one DASHBOARDS_CONFIG source) claiming the same defaultForTeamKeys entry; expected an error")
+	}
+	for _, want := range []string{"migration-engineer", "onboarding-engineer", "customer_onboarding", "defaultForTeamKeys"} {
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("err = %q, want it to contain %q", err.Error(), want)
 		}

--- a/apps/csm-portal/backend/internal/dashboard/registry_test.go
+++ b/apps/csm-portal/backend/internal/dashboard/registry_test.go
@@ -774,6 +774,24 @@ func TestLoadDir_RejectsInvalidWidgets(t *testing.T) {
 			widgets: `{"id": "w", "displayName": "W", "resourceType": "case", "shape": "count", "gridWidth": 13}`,
 			want:    `widget "w": "gridWidth" is 13`,
 		},
+		{
+			name: "pie widget with neither slices nor groupBy",
+			widgets: `{"id": "w", "displayName": "W", "resourceType": "case", "shape": "pie", "gridWidth": 3,
+			 "query": {}}`,
+			want: `widget "w": shape "pie" needs either "slices" or "groupBy"`,
+		},
+		{
+			name: "bar widget with both slices and groupBy",
+			widgets: `{"id": "w", "displayName": "W", "resourceType": "case", "shape": "bar", "gridWidth": 3,
+			 "query": {}, "slices": [{"label": "A", "query": {}}], "groupBy": {"field": "account"}}`,
+			want: `widget "w": carries both "slices" and "groupBy"`,
+		},
+		{
+			name: "groupBy with an empty field",
+			widgets: `{"id": "w", "displayName": "W", "resourceType": "case", "shape": "pie", "gridWidth": 3,
+			 "query": {}, "groupBy": {"field": ""}}`,
+			want: `widget "w": "groupBy.field" is empty`,
+		},
 	}
 
 	for _, tc := range cases {

--- a/apps/csm-portal/backend/internal/dashboard/registry_test.go
+++ b/apps/csm-portal/backend/internal/dashboard/registry_test.go
@@ -312,26 +312,67 @@ func TestLoadDir_ContradictoryCombinations(t *testing.T) {
 	}
 }
 
-// Two defaults of DIFFERENT types are rejected too, for now. One default per
-// type is where this ends up, but only once the frontend selects on "type" --
-// today CsmDashboardPage picks on isDefault + isTeamBased and the
-// dashboard-list response does not even carry "type", so a second typed
-// default would be resolved by nothing but LoadDir's filename ordering.
-// Rejecting is the conservative half of that pair. When the frontend becomes
-// type-aware, this test flips to asserting they coexist.
-func TestLoadDir_RejectsASecondDefaultEvenOfADifferentType(t *testing.T) {
+// Two defaults of DIFFERENT types coexist: the frontend selects its landing
+// dashboard from the caller's own team family against "type", so a cre
+// default and an sre default (or a cs default) do not compete for one
+// global slot -- each type gets its own.
+func TestLoadDir_AllowsDefaultsOfDifferentTypesToCoexist(t *testing.T) {
 	dir := t.TempDir()
 	writeDefinition(t, dir, "a.json", `{"id": "a", "displayName": "A", "type": "cs", "isDefault": true, "widgets": []}`)
 	writeDefinition(t, dir, "b.json", `{"id": "b", "displayName": "B", "type": "cre", "isDefault": true, "isTeamBased": true, "widgets": []}`)
 
+	got, err := LoadDir(dir)
+	if err != nil {
+		t.Fatalf("LoadDir rejected two isDefault dashboards of different types: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("LoadDir returned %d dashboards, want 2", len(got))
+	}
+	if !got[0].IsDefault || got[0].Type != TypeCS {
+		t.Fatalf("a = %+v; want isDefault true, type cs", got[0])
+	}
+	if !got[1].IsDefault || got[1].Type != TypeCRE {
+		t.Fatalf("b = %+v; want isDefault true, type cre", got[1])
+	}
+}
+
+// A second isDefault dashboard of the SAME type is still rejected, exactly as
+// before -- the one-per-type rule is not "no rule at all".
+func TestLoadDir_RejectsASecondDefaultOfTheSameType(t *testing.T) {
+	dir := t.TempDir()
+	writeDefinition(t, dir, "a.json", `{"id": "a", "displayName": "A", "type": "cre", "isDefault": true, "isTeamBased": true, "widgets": []}`)
+	writeDefinition(t, dir, "b.json", `{"id": "b", "displayName": "B", "type": "cre", "isDefault": true, "isTeamBased": true, "widgets": []}`)
+
 	_, err := LoadDir(dir)
 	if err == nil {
-		t.Fatal("LoadDir accepted two isDefault dashboards of different types; expected an error")
+		t.Fatal("LoadDir accepted two isDefault dashboards of the same type; expected an error")
 	}
-	for _, want := range []string{"a.json", "b.json", "isDefault"} {
+	for _, want := range []string{"a.json", "b.json", "isDefault", "cre"} {
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("err = %q, want it to contain %q", err.Error(), want)
 		}
+	}
+}
+
+// An untyped isDefault dashboard (only reachable via the deprecated
+// DASHBOARDS_CONFIG path) does not share a "slot" with a typed isDefault
+// dashboard -- it has no type to key off, so it must not collide with one.
+func TestParseDashboardsConfig_UntypedDefaultDoesNotCollideWithTypedDefault(t *testing.T) {
+	got, err := ParseDashboardsConfig(`[
+		{"id":"a","displayName":"A","isDefault":true,"widgets":[]},
+		{"id":"b","displayName":"B","type":"cs","isDefault":true,"widgets":[]}
+	]`)
+	if err != nil {
+		t.Fatalf("ParseDashboardsConfig rejected an untyped default alongside a typed one: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("ParseDashboardsConfig returned %d dashboards, want 2", len(got))
+	}
+	if !got[0].IsDefault || got[0].Type != "" {
+		t.Fatalf("a = %+v; want isDefault true, no type", got[0])
+	}
+	if !got[1].IsDefault || got[1].Type != TypeCS {
+		t.Fatalf("b = %+v; want isDefault true, type cs", got[1])
 	}
 }
 

--- a/apps/csm-portal/backend/internal/dashboard/registry_test.go
+++ b/apps/csm-portal/backend/internal/dashboard/registry_test.go
@@ -875,6 +875,45 @@ func TestParseDashboardsConfig_RejectsInvalidWidgets(t *testing.T) {
 	}
 }
 
+// A dashboard may claim a defaultForTeamKeys entry without any conflict --
+// the common case, and the one every real deployment relies on to land a
+// team's members on their own specialist dashboard.
+func TestLoadDir_DefaultForTeamKeysWithNoConflictIsFine(t *testing.T) {
+	dir := t.TempDir()
+	writeDefinition(t, dir, "a.json", `{"id": "onboarding-engineer", "displayName": "Onboarding Engineer", "type": "cs", "defaultForTeamKeys": ["customer_onboarding"], "widgets": []}`)
+	writeDefinition(t, dir, "b.json", `{"id": "migration-engineer", "displayName": "Migration Engineer", "type": "cs", "defaultForTeamKeys": ["cs_migrations_team"], "widgets": []}`)
+
+	got, err := LoadDir(dir)
+	if err != nil {
+		t.Fatalf("LoadDir returned error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("LoadDir returned %d dashboards, want 2", len(got))
+	}
+}
+
+// TestLoadDir_RejectsDuplicateDefaultForTeamKeysOwnership is the fix for the
+// gap CodeRabbit flagged: validate did not track defaultForTeamKeys
+// ownership at all, so two dashboards claiming the same team key would both
+// load, and CsmDashboardPage's find() would silently pick whichever came
+// first in dashboard list order -- an outcome driven by LoadDir's filename
+// ordering rather than by any config author's intent.
+func TestLoadDir_RejectsDuplicateDefaultForTeamKeysOwnership(t *testing.T) {
+	dir := t.TempDir()
+	writeDefinition(t, dir, "a.json", `{"id": "onboarding-engineer", "displayName": "Onboarding Engineer", "type": "cs", "defaultForTeamKeys": ["customer_onboarding"], "widgets": []}`)
+	writeDefinition(t, dir, "b.json", `{"id": "migration-engineer", "displayName": "Migration Engineer", "type": "cs", "defaultForTeamKeys": ["customer_onboarding"], "widgets": []}`)
+
+	_, err := LoadDir(dir)
+	if err == nil {
+		t.Fatal("LoadDir accepted two dashboards claiming the same defaultForTeamKeys entry; expected an error")
+	}
+	for _, want := range []string{"a.json", "b.json", "customer_onboarding", "defaultForTeamKeys"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("err = %q, want it to contain %q", err.Error(), want)
+		}
+	}
+}
+
 // The committed dashboards.example/ directory is what .env.example's
 // DASHBOARDS_DIR points at, so `cp .env.example .env && go run ./cmd/server`
 // works on a fresh clone (./dashboards is gitignored and a missing directory

--- a/apps/csm-portal/backend/internal/dashboard/widgets.go
+++ b/apps/csm-portal/backend/internal/dashboard/widgets.go
@@ -270,6 +270,19 @@ type Dashboard struct {
 	IsTeamBased bool             `json:"isTeamBased"`
 	Widgets     []WidgetTemplate `json:"widgets"`
 
+	// DefaultForTeamKeys lists team registry keys (BeTeam.id on the
+	// frontend, the values in this deployment's team registry -- not a
+	// group id) that should land a signed-in user on this dashboard by
+	// default, regardless of this dashboard's own IsDefault/IsTeamBased/
+	// Type -- an identity override resolved client-side against the
+	// signed-in user's own team.teamKey. Most dashboards should leave this
+	// empty and rely on Type-based selection instead (see Type's own doc
+	// comment); this exists for a dashboard that doesn't fit the
+	// type/family model at all -- e.g. a single-purpose specialist
+	// dashboard built for one specific team's own workflow rather than a
+	// team-scoped ABT dashboard.
+	DefaultForTeamKeys []string `json:"defaultForTeamKeys,omitempty"`
+
 	// FilterPresets is this dashboard's own map of presetKey -> literal
 	// filter fragment ({"field":...,"op":...,"values":...}), the
 	// dashboard-local half of the preset mechanism (see

--- a/apps/csm-portal/backend/internal/dashboard/widgets.go
+++ b/apps/csm-portal/backend/internal/dashboard/widgets.go
@@ -70,9 +70,34 @@ type Shape string
 const (
 	ShapeCount Shape = "count" // single resolved number
 	ShapeList  Shape = "list"  // top-N matching records
-	ShapePie   Shape = "pie"   // one search per Slices entry, each resolved via its own total — see PieSlice
-	ShapeBar   Shape = "bar"   // same resolution as ShapePie (one search per Slices entry); differs only in how the frontend renders the resolved data
+	ShapePie   Shape = "pie"   // one search per Slices entry (or one server-side aggregation via GroupBy), each resolved via its own total — see PieSlice and GroupByConfig
+	ShapeBar   Shape = "bar"   // same resolution as ShapePie; differs only in how the frontend renders the resolved data
 )
+
+// GroupByConfig configures a Shape "pie"/"bar" widget to resolve via a single
+// server-side aggregation call instead of one search per literal Slices
+// entry -- the alternative for a resourceType/field with too many distinct
+// values to enumerate by hand (e.g. "cases grouped by account, top 12 +
+// Others"). A widget carries exactly one of Slices or GroupBy for pie/bar
+// (see the registry's own load-time validation); GroupBy is resolved
+// entirely client-side, same as Slices -- the frontend calls that
+// ResourceType's own new POST /{resourceType}/group-by endpoint once and
+// maps the response's groups/othersCount into the same per-slice shape
+// Slices already produces, so the renderer itself needs no per-shape branch.
+type GroupByConfig struct {
+	// Field is which field to group by. Each ResourceType enforces its own
+	// small allowlist server-side (see the corresponding SN Utils script
+	// include's group{X}By method) -- an unsupported value is rejected by
+	// that call with a 400, not caught here.
+	Field string `json:"field"`
+	// MaxGroups is the top-N cutoff by count, descending; the remainder is
+	// summed into one "Others" bucket. Omitted/zero defers to the backing
+	// group-by endpoint's own default (12).
+	MaxGroups int `json:"maxGroups,omitempty"`
+	// OthersLabel overrides the default "Others" label for the summed
+	// remainder bucket. Omitted uses "Others".
+	OthersLabel string `json:"othersLabel,omitempty"`
+}
 
 // PieSlice is one wedge of a Shape "pie" widget. The caller resolves its
 // value by issuing that widget's own ResourceType's /search with Query
@@ -162,9 +187,13 @@ type WidgetTemplate struct {
 	Shape        Shape          `json:"shape"`
 	GridWidth    int            `json:"gridWidth"` // 1-12, CSS grid columns out of 12
 	Query        map[string]any `json:"query"`
-	GroupBy      string         `json:"groupBy,omitempty"`   // unused
 	ListLimit    int            `json:"listLimit,omitempty"` // only meaningful for Shape list; how many records to show
-	Slices       []PieSlice     `json:"slices,omitempty"`    // only meaningful for Shape pie/bar; one search per slice
+	// Slices and GroupBy are the two mutually exclusive ways to configure a
+	// Shape pie/bar widget's data -- see GroupByConfig's doc comment. Exactly
+	// one must be set for pie/bar (enforced at directory-load time); both
+	// are meaningless for count/list.
+	Slices  []PieSlice     `json:"slices,omitempty"`
+	GroupBy *GroupByConfig `json:"groupBy,omitempty"`
 	// Section groups widgets sharing the same (non-empty) value under a
 	// titled sub-section within the dashboard, in the order that value
 	// first appears among the dashboard's widgets — e.g. a handful of

--- a/apps/csm-portal/backend/internal/handler/dashboards.go
+++ b/apps/csm-portal/backend/internal/handler/dashboards.go
@@ -76,6 +76,12 @@ type dashboardListItemView struct {
 	Type        dashboard.Type `json:"type,omitempty"`
 	IsDefault   bool           `json:"isDefault"`
 	IsTeamBased bool           `json:"isTeamBased"`
+	// DefaultForTeamKeys is this dashboard's identity-override list (see
+	// dashboard.Dashboard.DefaultForTeamKeys). It has to be on the list
+	// view, not just the detail view: the frontend resolves default
+	// dashboard selection against the caller's own team key before it ever
+	// fetches a dashboard's detail.
+	DefaultForTeamKeys []string `json:"defaultForTeamKeys,omitempty"`
 }
 
 // dashboardDetailView is a dashboard's full metadata plus its resolved
@@ -121,11 +127,12 @@ func (h *DashboardHandler) GetDashboards(w http.ResponseWriter, r *http.Request)
 	views := make([]dashboardListItemView, 0, len(dashboards))
 	for _, d := range dashboards {
 		views = append(views, dashboardListItemView{
-			ID:          d.ID,
-			DisplayName: d.DisplayName,
-			Type:        d.Type,
-			IsDefault:   d.IsDefault,
-			IsTeamBased: d.IsTeamBased,
+			ID:                 d.ID,
+			DisplayName:        d.DisplayName,
+			Type:               d.Type,
+			IsDefault:          d.IsDefault,
+			IsTeamBased:        d.IsTeamBased,
+			DefaultForTeamKeys: d.DefaultForTeamKeys,
 		})
 	}
 

--- a/apps/csm-portal/backend/internal/handler/dashboards.go
+++ b/apps/csm-portal/backend/internal/handler/dashboards.go
@@ -41,17 +41,17 @@ type dashboardPieSliceView struct {
 // resolves each widget's own data by issuing its own POST /{resourceType}s/search
 // request (see ResourceType), passing Query as that request's filters.
 type dashboardWidgetView struct {
-	WidgetID     string                  `json:"widgetId"`
-	DisplayName  string                  `json:"displayName"`
-	Description  string                  `json:"description,omitempty"`
-	ResourceType dashboard.ResourceType  `json:"resourceType"`
-	Shape        dashboard.Shape         `json:"shape"`
-	GridWidth    int                     `json:"gridWidth"`
-	Query        map[string]any          `json:"query"`
-	GroupBy      string                  `json:"groupBy,omitempty"`
-	ListLimit    int                     `json:"listLimit,omitempty"`
-	Slices       []dashboardPieSliceView `json:"slices,omitempty"`
-	Section      string                  `json:"section,omitempty"`
+	WidgetID     string                   `json:"widgetId"`
+	DisplayName  string                   `json:"displayName"`
+	Description  string                   `json:"description,omitempty"`
+	ResourceType dashboard.ResourceType   `json:"resourceType"`
+	Shape        dashboard.Shape          `json:"shape"`
+	GridWidth    int                      `json:"gridWidth"`
+	Query        map[string]any           `json:"query"`
+	GroupBy      *dashboard.GroupByConfig `json:"groupBy,omitempty"`
+	ListLimit    int                      `json:"listLimit,omitempty"`
+	Slices       []dashboardPieSliceView  `json:"slices,omitempty"`
+	Section      string                   `json:"section,omitempty"`
 	// Columns and SortBy are only meaningful for Shape "list" — see
 	// dashboard.WidgetTemplate.Columns/SortBy. Forwarded verbatim: Columns
 	// is display config the BE never resolves, and SortBy is opaque search

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -5617,10 +5617,11 @@ components:
             - bar
           description: >
             How the widget's data should be rendered once resolved. shapes
-            "pie" and "bar" both resolve one search per slices entry, the
-            same way "count" resolves its own single search (see slices
-            below) — they differ only in how the frontend renders the same
-            resolved data (wedges vs. bars), not in how it's fetched.
+            "pie" and "bar" resolve via either "slices" (one search per
+            entry) or "groupBy" (one server-side aggregation call) — see
+            both below — and differ from each other only in how the
+            frontend renders the same resolved data (wedges vs. bars), not
+            in how it's fetched.
         gridWidth:
           type: integer
           minimum: 1
@@ -5640,18 +5641,47 @@ components:
             (caller-side; slices entry keys win on conflict) rather than
             queried on its own.
         groupBy:
-          type: string
-          description: Unused
+          type: object
+          description: >
+            Only meaningful for shapes "pie"/"bar", as an alternative to
+            "slices" — a widget carries exactly one of the two (enforced at
+            dashboard-load time). Configures a single server-side
+            aggregation call instead of one search per literal slice: the
+            caller issues one POST /{resourceType}/group-by request (filters
+            = this widget's own query) and maps the response's groups/
+            othersCount into the same per-slice shape "slices" already
+            produces.
+          properties:
+            field:
+              type: string
+              description: >
+                Which field to group by. Each resourceType enforces its own
+                small allowlist server-side; an unsupported value is
+                rejected by the group-by call itself with a 400, not caught
+                here.
+            maxGroups:
+              type: integer
+              description: >
+                Top-N cutoff by count, descending; the remainder is summed
+                into one "Others" bucket. Omitted/zero defers to the
+                group-by endpoint's own default (12).
+            othersLabel:
+              type: string
+              description: >
+                Overrides the default "Others" label for the summed
+                remainder bucket.
+          required: [field]
         listLimit:
           type: integer
           description: Only meaningful for shape list; how many records to show
         slices:
           type: array
           description: >
-            Only meaningful for shapes "pie"/"bar": one search per entry,
-            each resolved via its own total, the same mechanism shape
-            "count" uses. Merge each entry's query under this widget's
-            own query (entry keys win on conflict) before searching.
+            Only meaningful for shapes "pie"/"bar", as an alternative to
+            "groupBy": one search per entry, each resolved via its own
+            total, the same mechanism shape "count" uses. Merge each
+            entry's query under this widget's own query (entry keys win on
+            conflict) before searching.
           items:
             type: object
             properties:

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -5765,13 +5765,10 @@ components:
           enum: [cre, sre, cs]
           description: >
             Who the dashboard is built for. This is the field automatic
-            dashboard selection is intended to key off: a caller whose team
-            family is `cre-abt`/`cre` would land on the default `cre`
-            dashboard, `sre-abt`/`sre` on the default `sre` one, and a caller
-            with no team on the default `cs` one. That selection is NOT
-            implemented yet: the frontend still picks on isDefault plus
-            isTeamBased, and the loader correspondingly permits only one
-            isDefault dashboard in total.
+            dashboard selection keys off: a caller whose team family is
+            `cre-abt`/`cre` lands on the default `cre` dashboard,
+            `sre-abt`/`sre` on the default `sre` one, and a caller with no
+            team on the default `cs` one.
             `cre` and `sre` are team-scoped and always carry
             isTeamBased true; `cs` is organisation-wide and always carries it
             false — the loader rejects any other combination at startup.
@@ -5780,9 +5777,24 @@ components:
         isDefault:
           type: boolean
           description: >
-            Whether this is the default dashboard to show first. At most one
-            dashboard in the registry may set it: the loader rejects a second
-            at startup, of any type, until selection becomes type-aware.
+            Whether this is the default dashboard to show first for its
+            type. At most one dashboard per type may set it: the loader
+            rejects a second isDefault dashboard of the same type (or, for a
+            definition with no type at all, a second untyped one) at
+            startup, but isDefault dashboards of different types coexist by
+            design.
+        defaultForTeamKeys:
+          type: array
+          items:
+            type: string
+          description: >
+            Team registry keys (not group ids) that should land a
+            signed-in user on this dashboard by default, regardless of its
+            own type/isDefault/isTeamBased — an identity override resolved
+            client-side against the signed-in user's own team key. Most
+            dashboards leave this empty and rely on type-based selection
+            instead; it exists for a dashboard built for one specific
+            team's own workflow rather than the type/family model.
         isTeamBased:
           type: boolean
           description: >
@@ -5804,13 +5816,10 @@ components:
           enum: [cre, sre, cs]
           description: >
             Who the dashboard is built for. This is the field automatic
-            dashboard selection is intended to key off: a caller whose team
-            family is `cre-abt`/`cre` would land on the default `cre`
-            dashboard, `sre-abt`/`sre` on the default `sre` one, and a caller
-            with no team on the default `cs` one. That selection is NOT
-            implemented yet: the frontend still picks on isDefault plus
-            isTeamBased, and the loader correspondingly permits only one
-            isDefault dashboard in total.
+            dashboard selection keys off: a caller whose team family is
+            `cre-abt`/`cre` lands on the default `cre` dashboard,
+            `sre-abt`/`sre` on the default `sre` one, and a caller with no
+            team on the default `cs` one.
             `cre` and `sre` are team-scoped and always carry
             isTeamBased true; `cs` is organisation-wide and always carries it
             false — the loader rejects any other combination at startup.
@@ -5819,9 +5828,12 @@ components:
         isDefault:
           type: boolean
           description: >
-            Whether this is the default dashboard to show first. At most one
-            dashboard in the registry may set it: the loader rejects a second
-            at startup, of any type, until selection becomes type-aware.
+            Whether this is the default dashboard to show first for its
+            type. At most one dashboard per type may set it: the loader
+            rejects a second isDefault dashboard of the same type (or, for a
+            definition with no type at all, a second untyped one) at
+            startup, but isDefault dashboards of different types coexist by
+            design.
         targetTeam:
           type: string
           description: >

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -3123,6 +3123,14 @@ export interface BeDashboardListItem {
    * `__current_team__` filter placeholder (see `teamFilterPlaceholder.ts`
    * in the webapp). */
   isTeamBased: boolean;
+  /** Team keys (the signed-in user's own `team.teamKey`) that should land
+   * on this dashboard outright as their default, regardless of this
+   * dashboard's own `isDefault`/`isTeamBased`/`type` — for specialist,
+   * non-team-based dashboards the `isDefault`+`isTeamBased`+`type` default
+   * mechanism can't reach (e.g. `onboarding-engineer` for
+   * `customer_onboarding`). Omitted where unused; see `CsmDashboardPage`'s
+   * module doc comment for how this tier fits into default selection. */
+  defaultForTeamKeys?: string[];
 }
 
 /**

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -2986,6 +2986,38 @@ export interface BeDashboardPieSlice {
   query: Record<string, unknown>;
 }
 
+/** Alternative to {@link BeDashboardPieSlice}[] for shapes "pie"/"bar":
+ * one server-side `POST /{resourceType}/group-by` call instead of one
+ * `search` per hand-authored slice. Mutually exclusive with `slices` —
+ * the backend enforces exactly one of the two at config-load time. */
+export interface BeDashboardGroupByConfig {
+  /** The field to aggregate on — forwarded verbatim as that request's
+   * `groupBy` key. */
+  field: string;
+  /** Caps the number of returned buckets; anything beyond that rolls up
+   * into the response's `othersCount`. */
+  maxGroups?: number;
+  /** Label for the synthetic "everything else" bucket built from
+   * `othersCount`. Defaults to `"Others"` when omitted. */
+  othersLabel?: string;
+}
+
+/** One bucket of a `POST /{resourceType}/group-by` response. */
+export interface BeGroupByBucket {
+  key: string;
+  label: string;
+  count: number;
+}
+
+/** Response shape of `POST /{resourceType}/group-by`. `othersCount` covers
+ * every record outside the returned `groups` (capped by `maxGroups`);
+ * `totalRecords` is the grand total across `groups` plus `othersCount`. */
+export interface BeGroupByResponse {
+  groups: BeGroupByBucket[];
+  othersCount: number;
+  totalRecords: number;
+}
+
 /** Rendering hint for a {@link BeDashboardWidgetColumn}'s resolved value.
  * Omitted (or `"text"`) renders plain text; `"date"` formats a date/
  * date-time string the same way the app's existing hardcoded list renderers
@@ -3037,11 +3069,13 @@ export interface BeDashboardWidget {
    * than queried on its own.
    */
   query: Record<string, unknown>;
-  /** Present on the wire; unused today — `slices` is what actually drives
-   * pie/bar grouping. */
-  groupBy?: string;
+  /** Only meaningful for shapes "pie"/"bar": one server-side
+   * `POST /{resourceType}/group-by` call instead of one `search` per
+   * slice. Mutually exclusive with `slices` — the backend enforces
+   * exactly one of the two for those shapes (never both, never neither). */
+  groupBy?: BeDashboardGroupByConfig;
   /** Only meaningful for shapes "pie"/"bar": one search per slice, each
-   * read via its own `total`. */
+   * read via its own `total`. Mutually exclusive with `groupBy`. */
   slices?: BeDashboardPieSlice[];
   /** Only meaningful for shape list; how many records to show. */
   listLimit?: number;

--- a/apps/csm-portal/webapp/src/components/FloatingSlidePanel.test.tsx
+++ b/apps/csm-portal/webapp/src/components/FloatingSlidePanel.test.tsx
@@ -85,4 +85,21 @@ describe("FloatingSlidePanel", () => {
     expect(hiddenRegion).toBeInTheDocument();
     expect(hiddenRegion).toHaveStyle({ visibility: "hidden" });
   });
+
+  it("stacks below modal dialogs (theme.zIndex.drawer, not theme.zIndex.modal + 1) so a dialog opened while the panel is exiting stays on top", () => {
+    render(
+      <FloatingSlidePanel open ariaLabel="Test panel">
+        <span>Panel content</span>
+      </FloatingSlidePanel>,
+    );
+
+    const region = document.body.querySelector('[role="region"]');
+    expect(region).toBeInTheDocument();
+    const panelZIndex = Number(window.getComputedStyle(region as Element).zIndex);
+    // MUI's default scale: drawer (1200) < modal (1300). The panel must sit
+    // at drawer level so TimeCardReviewDialog (a Modal-backed Dialog) can
+    // still cover it if opened while the panel is mid exit-transition.
+    expect(panelZIndex).toBe(1200);
+    expect(panelZIndex).toBeLessThan(1300);
+  });
 });

--- a/apps/csm-portal/webapp/src/components/FloatingSlidePanel.test.tsx
+++ b/apps/csm-portal/webapp/src/components/FloatingSlidePanel.test.tsx
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import FloatingSlidePanel from "@components/FloatingSlidePanel";
+
+describe("FloatingSlidePanel", () => {
+  it("renders its children and the region landmark when open", () => {
+    render(
+      <FloatingSlidePanel open ariaLabel="Test panel">
+        <button type="button">Inside content</button>
+      </FloatingSlidePanel>,
+    );
+
+    const region = screen.getByRole("region", { name: "Test panel" });
+    expect(region).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Inside content" })).toBeInTheDocument();
+  });
+
+  it("portals to document.body rather than rendering inline in its parent", () => {
+    const { container } = render(
+      <div data-testid="parent-wrapper">
+        <FloatingSlidePanel open ariaLabel="Test panel">
+          <span>Panel content</span>
+        </FloatingSlidePanel>
+      </div>,
+    );
+
+    // The panel's own content shouldn't be a descendant of the component's
+    // React-tree parent -- it should be a portalled sibling under body.
+    expect(container.querySelector('[role="region"]')).not.toBeInTheDocument();
+    expect(document.body.querySelector('[role="region"]')).toBeInTheDocument();
+  });
+
+  it("does not add any modal isolation to the rest of the page (no backdrop, no aria-hidden siblings)", () => {
+    render(
+      <>
+        <button type="button">Sibling button</button>
+        <FloatingSlidePanel open ariaLabel="Test panel">
+          <span>Panel content</span>
+        </FloatingSlidePanel>
+      </>,
+    );
+
+    // A Modal-backed Drawer would mark this sibling (or an ancestor of it)
+    // `aria-hidden="true"` while open -- this panel must not.
+    const sibling = screen.getByRole("button", { name: "Sibling button" });
+    expect(sibling.closest('[aria-hidden="true"]')).not.toBeInTheDocument();
+    expect(document.body).not.toHaveAttribute("aria-hidden");
+
+    // No backdrop element intercepting clicks on the rest of the page.
+    expect(document.querySelector(".MuiBackdrop-root")).not.toBeInTheDocument();
+
+    sibling.focus();
+    expect(sibling).toHaveFocus();
+  });
+
+  it("keeps the panel out of the accessibility tree while closed, without unmounting its children", () => {
+    render(
+      <FloatingSlidePanel open={false} ariaLabel="Test panel">
+        <button type="button">Inside content</button>
+      </FloatingSlidePanel>,
+    );
+
+    // `Slide` marks a fully-closed panel `visibility: hidden` -- not
+    // perceivable and not focusable -- rather than removing it from the DOM,
+    // so a subsequent open can play its enter transition from a known state.
+    expect(screen.queryByRole("region", { name: "Test panel" })).not.toBeInTheDocument();
+    const hiddenRegion = document.body.querySelector('[role="region"]');
+    expect(hiddenRegion).toBeInTheDocument();
+    expect(hiddenRegion).toHaveStyle({ visibility: "hidden" });
+  });
+});

--- a/apps/csm-portal/webapp/src/components/FloatingSlidePanel.tsx
+++ b/apps/csm-portal/webapp/src/components/FloatingSlidePanel.tsx
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Paper, Slide } from "@wso2/oxygen-ui";
+import type { JSX, ReactNode } from "react";
+import { createPortal } from "react-dom";
+
+interface FloatingSlidePanelProps {
+  /** Whether the panel is slid into view. Toggling this plays the same
+   * slide transition a `Drawer` would (see below) -- it does not mount or
+   * unmount this component itself; the caller decides what, if anything,
+   * to render as `children` while closed. */
+  open: boolean;
+  /** Accessible name for the panel's `role="region"` landmark. Needed here
+   * specifically because there is no backdrop or focus trap to otherwise
+   * signal to assistive tech that this is a distinct panel rather than
+   * part of the underlying page's own content. */
+  ariaLabel: string;
+  /** Matches `Drawer`'s own `PaperProps`/`slotProps.paper` width usage in
+   * the two callers this replaced. */
+  width?: number | string | Record<string, number | string>;
+  children: ReactNode;
+}
+
+const DEFAULT_WIDTH = { xs: "100%", sm: 420 };
+
+/**
+ * A right-anchored floating panel that looks and animates like a MUI
+ * `Drawer` (`anchor="right"`, default `variant="temporary"`) but isn't
+ * built on `Modal` -- so it never enforces a focus trap or marks the rest
+ * of the page `aria-hidden` while it's open, unlike `Drawer` (see the
+ * CodeRabbit review discussion on cs-tools#1498: `pointerEvents: "none"`
+ * plus `hideBackdrop` only ever stopped *pointer* clicks from being
+ * swallowed by `Drawer`'s `Modal` base -- keyboard and screen-reader users
+ * were still fully isolated from the rest of the page by `Modal`'s own
+ * focus-trap and sibling `aria-hidden` behavior, which those props don't
+ * touch).
+ *
+ * Built from `Slide` -- the same transition component `Drawer` uses
+ * internally for its own slide animation, so the timing/easing match it
+ * exactly by relying on the same theme defaults -- wrapping a plain
+ * `position: fixed` `Paper`, neither of which carry any of `Modal`'s
+ * accessibility-isolation behavior. Portalled to `document.body` (like
+ * `RecentViewsButton`'s own floating panel) so its `position: fixed`
+ * isn't at the mercy of some ancestor's stacking context (a CSS
+ * `transform`/`filter`/`contain` anywhere between its mount point and the
+ * page root would otherwise silently break the fixed positioning).
+ *
+ * `Slide` itself makes the panel `visibility: hidden` while fully closed --
+ * neither focusable nor perceivable by a screen reader -- which is what
+ * lets a caller keep this panel's content mounted (rather than
+ * conditionally rendering the whole component) so the close transition can
+ * play out instead of the panel vanishing mid-animation, without that
+ * closed content being reachable in the meantime.
+ */
+export default function FloatingSlidePanel({
+  open,
+  ariaLabel,
+  width = DEFAULT_WIDTH,
+  children,
+}: FloatingSlidePanelProps): JSX.Element {
+  return createPortal(
+    <Slide in={open} direction="left">
+      <Paper
+        role="region"
+        aria-label={ariaLabel}
+        elevation={16}
+        square
+        sx={{
+          position: "fixed",
+          top: 0,
+          right: 0,
+          bottom: 0,
+          width,
+          zIndex: (theme) => theme.zIndex.modal + 1,
+          overflow: "hidden",
+        }}
+      >
+        {children}
+      </Paper>
+    </Slide>,
+    document.body,
+  );
+}

--- a/apps/csm-portal/webapp/src/components/FloatingSlidePanel.tsx
+++ b/apps/csm-portal/webapp/src/components/FloatingSlidePanel.tsx
@@ -85,7 +85,7 @@ export default function FloatingSlidePanel({
           right: 0,
           bottom: 0,
           width,
-          zIndex: (theme) => theme.zIndex.modal + 1,
+          zIndex: (theme) => theme.zIndex.drawer,
           overflow: "hidden",
         }}
       >

--- a/apps/csm-portal/webapp/src/features/csm-admin/dashboards/components/WidgetEditorDialog.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/dashboards/components/WidgetEditorDialog.test.tsx
@@ -576,6 +576,63 @@ describe("WidgetEditorDialog", () => {
     expect(newPathInput).toHaveValue("new.field");
   });
 
+  it("clears a groupBy config when the shape changes away from pie/bar", () => {
+    const existing: BeDashboardWidget = {
+      widgetId: "w1",
+      displayName: "Cases by severity",
+      resourceType: "case",
+      shape: "pie",
+      gridWidth: 4,
+      query: {},
+      groupBy: { field: "severity" },
+    };
+    const { onSave } = renderDialog({ widget: existing });
+
+    fireEvent.mouseDown(screen.getByRole("combobox", { name: "Shape" }));
+    fireEvent.click(screen.getByRole("option", { name: "count" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Save widget" }));
+    const saved = onSave.mock.calls[0][0] as BeDashboardWidget;
+    expect(saved.groupBy).toBeUndefined();
+  });
+
+  it("clears a groupBy config when the resource type changes", () => {
+    const existing: BeDashboardWidget = {
+      widgetId: "w1",
+      displayName: "Cases by severity",
+      resourceType: "case",
+      shape: "pie",
+      gridWidth: 4,
+      query: {},
+      groupBy: { field: "severity" },
+    };
+    const { onSave } = renderDialog({ widget: existing });
+
+    fireEvent.mouseDown(screen.getByRole("combobox", { name: "Resource type" }));
+    fireEvent.click(screen.getByRole("option", { name: "incident" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Save widget" }));
+    const saved = onSave.mock.calls[0][0] as BeDashboardWidget;
+    expect(saved.groupBy).toBeUndefined();
+  });
+
+  it("retains an existing groupBy config when neither shape nor resource type changes", () => {
+    const existing: BeDashboardWidget = {
+      widgetId: "w1",
+      displayName: "Cases by severity",
+      resourceType: "case",
+      shape: "pie",
+      gridWidth: 4,
+      query: {},
+      groupBy: { field: "severity", maxGroups: 5 },
+    };
+    const { onSave } = renderDialog({ widget: existing });
+
+    fireEvent.click(screen.getByRole("button", { name: "Save widget" }));
+    const saved = onSave.mock.calls[0][0] as BeDashboardWidget;
+    expect(saved.groupBy).toEqual({ field: "severity", maxGroups: 5 });
+  });
+
   it("clearing Row limit entirely unsets it, rather than writing NaN through", () => {
     const existing: BeDashboardWidget = {
       widgetId: "w1",

--- a/apps/csm-portal/webapp/src/features/csm-admin/dashboards/components/WidgetEditorDialog.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/dashboards/components/WidgetEditorDialog.test.tsx
@@ -633,6 +633,36 @@ describe("WidgetEditorDialog", () => {
     expect(saved.groupBy).toEqual({ field: "severity", maxGroups: 5 });
   });
 
+  it("hides the manual slice editor for a widget with an existing groupBy, and saves slices as undefined even if drafts exist in local state", () => {
+    const existing: BeDashboardWidget = {
+      widgetId: "w1",
+      displayName: "Cases by severity",
+      resourceType: "case",
+      shape: "pie",
+      gridWidth: 4,
+      query: {},
+      groupBy: { field: "severity" },
+      // A grouped widget shouldn't carry `slices` at all (the two are
+      // mutually exclusive), but this simulates local state somehow still
+      // holding slice drafts (e.g. leftover from before this widget was
+      // converted to group-by) to prove `buildWidget` omits them on save
+      // regardless, rather than trusting the hidden editor alone.
+      slices: [{ label: "Stale slice", query: {} }],
+    };
+    const { onSave } = renderDialog({ widget: existing });
+
+    // The manual slice editor UI itself must not be shown for a grouped
+    // widget — showing it would let an admin edit something that's
+    // silently dropped on save.
+    expect(screen.queryByRole("button", { name: /add slice/i })).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Slice label")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Save widget" }));
+    const saved = onSave.mock.calls[0][0] as BeDashboardWidget;
+    expect(saved.groupBy).toEqual({ field: "severity" });
+    expect(saved.slices).toBeUndefined();
+  });
+
   it("clearing Row limit entirely unsets it, rather than writing NaN through", () => {
     const existing: BeDashboardWidget = {
       widgetId: "w1",

--- a/apps/csm-portal/webapp/src/features/csm-admin/dashboards/components/WidgetEditorDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/dashboards/components/WidgetEditorDialog.tsx
@@ -300,8 +300,17 @@ export default function WidgetEditorDialog({
       // gate here rather than trusting state alone stayed in sync.
       groupBy: shape === "pie" || shape === "bar" ? existingGroupBy : undefined,
       listLimit: shape === "list" ? listLimit : undefined,
+      // `groupBy` and `slices` are mutually exclusive on the wire (the
+      // backend enforces this — see `existingGroupBy`'s own doc comment) —
+      // an admin can still have stale rows sitting in `sliceDrafts` (the
+      // manual slice editor below is hidden, not cleared, while
+      // `existingGroupBy` is set), so this omits `slices` outright rather
+      // than trusting the UI having hidden the editor was enough on its
+      // own.
       slices:
-        shape === "pie" || shape === "bar" ? draftsToSlices(resourceType, sliceDrafts) : undefined,
+        (shape === "pie" || shape === "bar") && existingGroupBy === undefined
+          ? draftsToSlices(resourceType, sliceDrafts)
+          : undefined,
       columns: builtColumns.length > 0 ? builtColumns : undefined,
     };
   };
@@ -523,7 +532,21 @@ export default function WidgetEditorDialog({
             </>
           )}
 
-          {isChartShape && (
+          {isChartShape && existingGroupBy !== undefined && (
+            <>
+              <Divider />
+              <Typography variant="subtitle2">Slices</Typography>
+              <Typography variant="body2" color="text.secondary">
+                This widget groups its data by {existingGroupBy.field} instead of manual
+                slices — the two are mutually exclusive. There's no authoring UI yet to edit
+                or clear a group-by config from here (see this dialog's own doc comment); to
+                switch back to manual slices, change the shape away from pie/bar and back,
+                which clears it.
+              </Typography>
+            </>
+          )}
+
+          {isChartShape && existingGroupBy === undefined && (
             <>
               <Divider />
               <Typography variant="subtitle2">

--- a/apps/csm-portal/webapp/src/features/csm-admin/dashboards/components/WidgetEditorDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/dashboards/components/WidgetEditorDialog.tsx
@@ -180,7 +180,13 @@ export default function WidgetEditorDialog({
   const [section, setSection] = useState(widget?.section ?? defaultSection ?? "");
   const [gridWidth, setGridWidth] = useState(widget?.gridWidth ?? 3);
   const [listLimit, setListLimit] = useState<number | undefined>(widget?.listLimit);
-  const [groupBy, setGroupBy] = useState(widget?.groupBy ?? "");
+  // No authoring UI for `groupBy` yet (it's now a real object config, not
+  // the stale unused string this dialog used to expose as a raw text
+  // field) — round-trip an existing widget's own `groupBy` verbatim so
+  // editing a slices-based field on a groupBy widget through this dialog
+  // doesn't silently drop it, but there's nothing here to author or clear
+  // it with.
+  const existingGroupBy = widget?.groupBy;
   const [conditions, setConditions] = useState<FilterCondition[]>(() =>
     filterConditionsFromQuery(widget?.resourceType ?? "case", widget?.query),
   );
@@ -265,7 +271,7 @@ export default function WidgetEditorDialog({
       gridWidth,
       query: queryFromFilterConditions(resourceType, conditions),
       section: section.trim() || undefined,
-      groupBy: groupBy.trim() || undefined,
+      groupBy: existingGroupBy,
       listLimit: shape === "list" ? listLimit : undefined,
       slices:
         shape === "pie" || shape === "bar" ? draftsToSlices(resourceType, sliceDrafts) : undefined,
@@ -400,14 +406,6 @@ export default function WidgetEditorDialog({
                 slotProps={{ htmlInput: { min: 1 } }}
               />
             )}
-            <TextField
-              label="Group by (optional)"
-              value={groupBy}
-              onChange={(e) => setGroupBy(e.target.value)}
-              size="small"
-              sx={{ minWidth: 180 }}
-              helperText="Present on the wire; not used by the frontend today."
-            />
           </Box>
 
           <Divider />
@@ -586,6 +584,7 @@ export default function WidgetEditorDialog({
                 filters={previewSnapshot.query}
                 listLimit={previewSnapshot.listLimit}
                 slices={previewSnapshot.slices}
+                groupBy={previewSnapshot.groupBy}
                 columns={previewSnapshot.columns}
                 sortBy={previewSnapshot.sortBy}
                 selectedTeamCreGroupId={selectedTeamCreGroupId}

--- a/apps/csm-portal/webapp/src/features/csm-admin/dashboards/components/WidgetEditorDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/dashboards/components/WidgetEditorDialog.tsx
@@ -183,10 +183,16 @@ export default function WidgetEditorDialog({
   // No authoring UI for `groupBy` yet (it's now a real object config, not
   // the stale unused string this dialog used to expose as a raw text
   // field) — round-trip an existing widget's own `groupBy` verbatim so
-  // editing a slices-based field on a groupBy widget through this dialog
-  // doesn't silently drop it, but there's nothing here to author or clear
-  // it with.
-  const existingGroupBy = widget?.groupBy;
+  // editing this dialog without touching shape/resourceType doesn't
+  // silently drop it. `groupBy.field` is only meaningful for the
+  // resourceType it was configured under (there's no per-resourceType
+  // groupBy field list to validate against, unlike `slices`' filter
+  // conditions, so a resourceType change can't be reconciled — it's
+  // cleared outright, same as `conditions`/`columns` below) and only for
+  // shape `"pie"`/`"bar"` (the backend enforces `groupBy`/`slices` as
+  // mutually exclusive) — cleared on either change so a widget edited away
+  // from its original group-by config doesn't save a stale one.
+  const [existingGroupBy, setExistingGroupBy] = useState(widget?.groupBy);
   const [conditions, setConditions] = useState<FilterCondition[]>(() =>
     filterConditionsFromQuery(widget?.resourceType ?? "case", widget?.query),
   );
@@ -216,6 +222,22 @@ export default function WidgetEditorDialog({
     setSliceDrafts((prev) => prev.map((d) => ({ ...d, conditions: [] })));
     setColumnDrafts([]);
     setPreviewSnapshot(undefined);
+    // See `existingGroupBy`'s own doc comment: its `field` is only valid
+    // for the resourceType it was configured under, and there's nothing
+    // here to reconcile it against the new one.
+    setExistingGroupBy(undefined);
+  };
+
+  // See `existingGroupBy`'s own doc comment: `groupBy` only makes sense for
+  // shape `"pie"`/`"bar"` — clear it the moment the admin moves off either,
+  // so re-selecting "pie" a moment later doesn't accidentally resurrect it
+  // (the admin would need to know it was silently retained in state to
+  // expect that) and so `buildWidget`'s own shape check below and this
+  // state agree, rather than one masking a stale value the other would
+  // otherwise expose again.
+  const handleShapeChange = (next: BeWidgetShape): void => {
+    setShape(next);
+    if (next !== "pie" && next !== "bar") setExistingGroupBy(undefined);
   };
 
   const { user } = useCurrentUser();
@@ -271,7 +293,12 @@ export default function WidgetEditorDialog({
       gridWidth,
       query: queryFromFilterConditions(resourceType, conditions),
       section: section.trim() || undefined,
-      groupBy: existingGroupBy,
+      // Belt-and-suspenders alongside `existingGroupBy` already being
+      // cleared in state on an incompatible shape/resourceType change
+      // (see its own doc comment): `buildWidget` is the actual
+      // save-time serialization, so it re-asserts the same "pie"/"bar"
+      // gate here rather than trusting state alone stayed in sync.
+      groupBy: shape === "pie" || shape === "bar" ? existingGroupBy : undefined,
       listLimit: shape === "list" ? listLimit : undefined,
       slices:
         shape === "pie" || shape === "bar" ? draftsToSlices(resourceType, sliceDrafts) : undefined,
@@ -349,7 +376,7 @@ export default function WidgetEditorDialog({
               select
               label="Shape"
               value={shape}
-              onChange={(e) => setShape(e.target.value as BeWidgetShape)}
+              onChange={(e) => handleShapeChange(e.target.value as BeWidgetShape)}
               size="small"
               sx={{ minWidth: 160 }}
             >

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasePreviewDrawer.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasePreviewDrawer.tsx
@@ -14,10 +14,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Drawer } from "@wso2/oxygen-ui";
-import type { JSX } from "react";
+import { Box, Drawer } from "@wso2/oxygen-ui";
+import { useRef, type JSX } from "react";
 import CasePreviewContent from "@features/csm-cases/components/CasePreviewContent";
+import { QUICK_PREVIEW_EYE_SELECTOR } from "@features/csm-cases/utils/quickPreviewEye";
 import type { CsmCaseRow } from "@features/csm-cases/types/csmCases";
+import { useCloseOnOutsideClick } from "@hooks/useCloseOnOutsideClick";
 
 interface CasePreviewDrawerProps {
   /** The row being previewed. `null` keeps the drawer mounted-but-closed, so
@@ -38,22 +40,34 @@ interface CasePreviewDrawerProps {
  * a time card's own summary, rather than duplicating it.
  */
 export default function CasePreviewDrawer({ row, onClose }: CasePreviewDrawerProps): JSX.Element {
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  useCloseOnOutsideClick(!!row, contentRef, QUICK_PREVIEW_EYE_SELECTOR, onClose);
+
   return (
     <Drawer
       anchor="right"
       open={!!row}
       onClose={onClose}
-      // No backdrop: a temporary Drawer's default backdrop intercepts
-      // pointer events on the rest of the page, which would block clicking
-      // a different row's quick-preview eye while one preview is already
-      // open -- exactly the "switch straight to another row" behavior this
-      // drawer exists for. Closing still works via the eye toggle or the
-      // drawer's own close button; there's no click-outside-to-close to
-      // preserve here since those are already the two ways to close it.
+      // No backdrop, and the modal's own full-viewport root made
+      // click-through (via slotProps.root below) -- a temporary Drawer's
+      // default backdrop (and, even hidden, its still-present modal root
+      // container) intercepts pointer events on the rest of the page, which
+      // would block clicking a different row's quick-preview eye while one
+      // preview is already open. `useCloseOnOutsideClick` above replaces the
+      // backdrop's own click-to-close behavior, minus the eye buttons (their
+      // own onClick already decides the next state -- open a different row,
+      // or toggle the current one closed).
       hideBackdrop
-      slotProps={{ paper: { sx: { width: { xs: "100%", sm: 420 } } } }}
+      slotProps={{
+        root: { sx: { pointerEvents: "none" } },
+        paper: { sx: { pointerEvents: "auto", width: { xs: "100%", sm: 420 } } },
+      }}
     >
-      {row && <CasePreviewContent row={row} onClose={onClose} />}
+      {row && (
+        <Box ref={contentRef} sx={{ height: "100%" }}>
+          <CasePreviewContent row={row} onClose={onClose} />
+        </Box>
+      )}
     </Drawer>
   );
 }

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasePreviewDrawer.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasePreviewDrawer.tsx
@@ -14,8 +14,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Box, Drawer } from "@wso2/oxygen-ui";
+import { Box } from "@wso2/oxygen-ui";
 import { useRef, type JSX } from "react";
+import FloatingSlidePanel from "@components/FloatingSlidePanel";
 import CasePreviewContent from "@features/csm-cases/components/CasePreviewContent";
 import { QUICK_PREVIEW_EYE_SELECTOR } from "@features/csm-cases/utils/quickPreviewEye";
 import type { CsmCaseRow } from "@features/csm-cases/types/csmCases";
@@ -44,30 +45,25 @@ export default function CasePreviewDrawer({ row, onClose }: CasePreviewDrawerPro
   useCloseOnOutsideClick(!!row, contentRef, QUICK_PREVIEW_EYE_SELECTOR, onClose);
 
   return (
-    <Drawer
-      anchor="right"
-      open={!!row}
-      onClose={onClose}
-      // No backdrop, and the modal's own full-viewport root made
-      // click-through (via slotProps.root below) -- a temporary Drawer's
-      // default backdrop (and, even hidden, its still-present modal root
-      // container) intercepts pointer events on the rest of the page, which
-      // would block clicking a different row's quick-preview eye while one
-      // preview is already open. `useCloseOnOutsideClick` above replaces the
-      // backdrop's own click-to-close behavior, minus the eye buttons (their
-      // own onClick already decides the next state -- open a different row,
-      // or toggle the current one closed).
-      hideBackdrop
-      slotProps={{
-        root: { sx: { pointerEvents: "none" } },
-        paper: { sx: { pointerEvents: "auto", width: { xs: "100%", sm: 420 } } },
-      }}
-    >
+    // `FloatingSlidePanel` (not `Drawer`) -- a `Drawer` is `Modal`-backed,
+    // which enforces a focus trap and marks the rest of the page
+    // `aria-hidden` for as long as it's open, regardless of `hideBackdrop`
+    // or pointer-events tricks (those only ever affected mouse clicks, not
+    // `Modal`'s own accessibility isolation). This panel has no backdrop
+    // and no modal behavior at all, so the rest of the page stays fully
+    // interactive for every input method -- not just the mouse -- letting
+    // a click on a different row's quick-preview eye land normally while
+    // this preview is already open. `useCloseOnOutsideClick` below replaces
+    // the click-to-close behavior a `Drawer`'s backdrop would otherwise
+    // give, minus the eye buttons (their own onClick already decides the
+    // next state -- open a different row, or toggle the current one
+    // closed).
+    <FloatingSlidePanel open={!!row} ariaLabel="Case preview">
       {row && (
         <Box ref={contentRef} sx={{ height: "100%" }}>
           <CasePreviewContent row={row} onClose={onClose} />
         </Box>
       )}
-    </Drawer>
+    </FloatingSlidePanel>
   );
 }

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.test.tsx
@@ -179,12 +179,59 @@ describe("CasesList quick preview", () => {
     // that click actually land in a browser: without it, MUI's default
     // temporary-Drawer backdrop covers the rest of the page and intercepts
     // pointer events, which would silently swallow this exact click.
-    fireEvent.click(
-      screen.getByRole("button", { name: "Quick preview CS-1008", hidden: true }),
-    );
+    //
+    // A real click fires `mousedown` then `click` -- firing both (not just
+    // `click`) exercises `useCloseOnOutsideClick`'s own `mousedown` listener
+    // too, proving it excludes this eye button rather than racing its click
+    // handler and undoing the switch.
+    const otherEye = screen.getByRole("button", { name: "Quick preview CS-1008", hidden: true });
+    fireEvent.mouseDown(otherEye);
+    fireEvent.click(otherEye);
     expect(screen.getByRole("link", { name: "View full details" })).toHaveAttribute(
       "href",
       expect.stringContaining("/case-2"),
     );
+  });
+
+  it("closes the preview when clicking outside it, without needing the close button or the eye again", () => {
+    renderWithProviders(
+      <Routes>
+        <Route
+          path="/cases"
+          element={<CasesList cases={[CASE]} isLoading={false} />}
+        />
+        <Route path="/cases/:id" element={<DetailStub />} />
+      </Routes>,
+      ["/cases"],
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Quick preview CS-1007" }));
+    expect(screen.getByText("View full details")).toBeInTheDocument();
+
+    // Any outside element -- here, the page body itself, well outside the
+    // drawer's own content -- should close it via the mousedown-level
+    // click-away listener, matching a real click's actual first event.
+    fireEvent.mouseDown(document.body);
+
+    expect(screen.queryByText("View full details")).not.toBeInTheDocument();
+  });
+
+  it("does not close the preview when clicking inside its own content", () => {
+    renderWithProviders(
+      <Routes>
+        <Route
+          path="/cases"
+          element={<CasesList cases={[CASE]} isLoading={false} />}
+        />
+        <Route path="/cases/:id" element={<DetailStub />} />
+      </Routes>,
+      ["/cases"],
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Quick preview CS-1007" }));
+    const detailsLink = screen.getByRole("link", { name: "View full details" });
+    fireEvent.mouseDown(detailsLink);
+
+    expect(screen.getByRole("link", { name: "View full details" })).toBeInTheDocument();
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.test.tsx
@@ -172,25 +172,55 @@ describe("CasesList quick preview", () => {
       expect.stringContaining("/case-1"),
     );
 
-    // The open drawer marks the rest of the page `aria-hidden` (MUI Modal's
-    // background containment for screen readers, independent of the
-    // backdrop) — `hidden: true` reaches it the same way a real click would,
-    // since the drawer's `hideBackdrop` (CasePreviewDrawer.tsx) is what makes
-    // that click actually land in a browser: without it, MUI's default
-    // temporary-Drawer backdrop covers the rest of the page and intercepts
-    // pointer events, which would silently swallow this exact click.
+    // The open preview is a non-modal `FloatingSlidePanel`, not a `Drawer` --
+    // it has no backdrop and doesn't mark the rest of the page `aria-hidden`,
+    // so the other row's eye button is a normal, reachable element (no
+    // `hidden: true` needed to find it, unlike a `Modal`-backed `Drawer`).
     //
     // A real click fires `mousedown` then `click` -- firing both (not just
     // `click`) exercises `useCloseOnOutsideClick`'s own `mousedown` listener
     // too, proving it excludes this eye button rather than racing its click
     // handler and undoing the switch.
-    const otherEye = screen.getByRole("button", { name: "Quick preview CS-1008", hidden: true });
+    const otherEye = screen.getByRole("button", { name: "Quick preview CS-1008" });
     fireEvent.mouseDown(otherEye);
     fireEvent.click(otherEye);
     expect(screen.getByRole("link", { name: "View full details" })).toHaveAttribute(
       "href",
       expect.stringContaining("/case-2"),
     );
+  });
+
+  it("does not isolate the rest of the page from assistive tech while the preview is open (no focus trap, no aria-hidden)", () => {
+    renderWithProviders(
+      <Routes>
+        <Route
+          path="/cases"
+          element={<CasesList cases={[CASE]} isLoading={false} />}
+        />
+        <Route path="/cases/:id" element={<DetailStub />} />
+      </Routes>,
+      ["/cases"],
+    );
+
+    // A `Modal`-backed `Drawer` would mark this sibling row's own subject
+    // text `aria-hidden` (and remove it from the accessibility tree, so
+    // `getByText` without `hidden: true` would throw) for as long as it's
+    // open, regardless of any pointer-events workaround -- exactly the
+    // CodeRabbit-flagged accessibility bug `FloatingSlidePanel` fixes.
+    fireEvent.click(screen.getByRole("button", { name: "Quick preview CS-1007" }));
+    expect(screen.getByText("View full details")).toBeInTheDocument();
+
+    // The case's subject renders twice once the preview is open (once in
+    // the row itself, once inside the preview content) -- assert on the
+    // row's own copy specifically.
+    const [rowSubject] = screen.getAllByText("Cluster fails to start");
+    expect(rowSubject.closest('[aria-hidden="true"]')).not.toBeInTheDocument();
+    expect(document.body).not.toHaveAttribute("aria-hidden");
+
+    // Still keyboard-reachable, not stranded behind a focus trap.
+    const quickPreviewButton = screen.getByRole("button", { name: "Quick preview CS-1007" });
+    quickPreviewButton.focus();
+    expect(quickPreviewButton).toHaveFocus();
   });
 
   it("closes the preview when clicking outside it, without needing the close button or the eye again", () => {

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.tsx
@@ -274,6 +274,7 @@ export default function CasesList({
                   size="small"
                   aria-label={`Quick preview ${rowLabel}`}
                   aria-pressed={previewRow?.id === c.id}
+                  data-quick-preview-eye="true"
                   onClick={(e) => {
                     e.stopPropagation();
                     setPreviewRow((prev) => (prev?.id === c.id ? null : c));

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/quickPreviewEye.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/quickPreviewEye.ts
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/** Data attribute every quick-preview eye button (case list, time card
+ * table) carries, and the selector `useCloseOnOutsideClick` excludes so a
+ * click on one of them is left to its own onClick handler -- which already
+ * decides the next preview state (open a different row, or toggle the
+ * current one closed) -- rather than being raced by the drawer's own
+ * click-outside-closes listener. */
+export const QUICK_PREVIEW_EYE_ATTRIBUTE = "data-quick-preview-eye";
+export const QUICK_PREVIEW_EYE_SELECTOR = `[${QUICK_PREVIEW_EYE_ATTRIBUTE}]`;

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useTeams.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useTeams.ts
@@ -48,6 +48,25 @@ export function abtFamilyForDashboardType(
 }
 
 /**
+ * The rough inverse of `abtFamilyForDashboardType`: maps a team's own
+ * `family` (e.g. `"sre-abt"`, `"cre"`) to the dashboard `type` its default
+ * selection should prefer — any family starting with `"cre"` to the `cre`
+ * type, any starting with `"sre"` to `sre`. Returns `undefined` for a
+ * family that doesn't start with either prefix (or an unresolved
+ * family), which callers must treat as "no type preference," not as a
+ * dashboard-selection dead end — see `preferredEntry` in
+ * `CsmDashboardPage.tsx`.
+ */
+export function dashboardTypeForTeamFamily(
+  family: string | undefined,
+): BeDashboardListItem["type"] {
+  if (!family) return undefined;
+  if (family.startsWith("cre")) return "cre";
+  if (family.startsWith("sre")) return "sre";
+  return undefined;
+}
+
+/**
  * Every team from `POST /teams/search`, for the team selector a team-based
  * dashboard shows alongside the dashboard switcher (see
  * `AbtDashboardHeader`), and for `CsmDashboardPage` to resolve the selected

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetGroupByData.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetGroupByData.test.tsx
@@ -1,0 +1,208 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { ReactNode } from "react";
+
+const postMock = vi.fn();
+
+vi.mock("@api/backend/client", () => ({
+  useBackendApi: () => ({ post: postMock }),
+}));
+
+import { useWidgetGroupByData } from "@features/csm-dashboard/api/useWidgetGroupByData";
+import { CURRENT_TEAM_PLACEHOLDER } from "@features/csm-dashboard/utils/teamFilterPlaceholder";
+import { CURRENT_USER_PLACEHOLDER } from "@features/csm-dashboard/utils/currentUserFilterPlaceholder";
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+describe("useWidgetGroupByData", () => {
+  beforeEach(() => {
+    postMock.mockReset();
+  });
+
+  it("issues a single group-by request and maps buckets + a synthetic Others bucket into slices", async () => {
+    postMock.mockResolvedValue({
+      groups: [
+        { key: "critical", label: "Critical", count: 3 },
+        { key: "high", label: "High", count: 5 },
+      ],
+      othersCount: 2,
+      totalRecords: 10,
+    });
+
+    const { result } = renderHook(
+      () =>
+        useWidgetGroupByData("widget-1", "case", { states: ["open"] }, {
+          field: "severity",
+          maxGroups: 2,
+        }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(postMock).toHaveBeenCalledTimes(1);
+    expect(postMock).toHaveBeenCalledWith(
+      "/cases/group-by",
+      {
+        filters: { states: ["open"] },
+        groupBy: "severity",
+        maxGroups: 2,
+      },
+      { signal: expect.any(AbortSignal) },
+    );
+
+    expect(result.current.slices).toEqual([
+      { label: "Critical", query: {}, value: 3 },
+      { label: "High", query: {}, value: 5 },
+      { label: "Others", query: {}, value: 2 },
+    ]);
+    expect(result.current.total).toBe(10);
+  });
+
+  it("uses the configured othersLabel instead of the default 'Others'", async () => {
+    postMock.mockResolvedValue({
+      groups: [{ key: "critical", label: "Critical", count: 3 }],
+      othersCount: 4,
+      totalRecords: 7,
+    });
+
+    const { result } = renderHook(
+      () =>
+        useWidgetGroupByData("widget-1", "case", {}, {
+          field: "severity",
+          othersLabel: "Everything else",
+        }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.slices).toEqual([
+      { label: "Critical", query: {}, value: 3 },
+      { label: "Everything else", query: {}, value: 4 },
+    ]);
+    expect(result.current.total).toBe(7);
+  });
+
+  it("appends no synthetic bucket when othersCount is 0", async () => {
+    postMock.mockResolvedValue({
+      groups: [{ key: "critical", label: "Critical", count: 3 }],
+      othersCount: 0,
+      totalRecords: 3,
+    });
+
+    const { result } = renderHook(
+      () => useWidgetGroupByData("widget-1", "case", {}, { field: "severity" }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.slices).toEqual([{ label: "Critical", query: {}, value: 3 }]);
+    expect(result.current.total).toBe(3);
+  });
+
+  it("fires no query and returns a zero result when groupBy is undefined", () => {
+    const { result } = renderHook(
+      () => useWidgetGroupByData("widget-1", "case", { states: ["open"] }, undefined),
+      { wrapper },
+    );
+
+    expect(postMock).not.toHaveBeenCalled();
+    expect(result.current.slices).toEqual([]);
+    expect(result.current.total).toBe(0);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isError).toBe(false);
+  });
+
+  it("resolves __current_team__ in the base filters using the selected team's creGroupId", async () => {
+    postMock.mockResolvedValue({ groups: [], othersCount: 0, totalRecords: 0 });
+
+    renderHook(
+      () =>
+        useWidgetGroupByData(
+          "widget-1",
+          "case",
+          { filters: [{ field: "creTeam", op: "in", values: [CURRENT_TEAM_PLACEHOLDER] }] },
+          { field: "severity" },
+          "22222222-2222-2222-2222-222222222222",
+          undefined,
+        ),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(postMock).toHaveBeenCalled());
+
+    expect(postMock).toHaveBeenCalledWith(
+      "/cases/group-by",
+      {
+        filters: {
+          filters: [
+            {
+              field: "creTeam",
+              op: "in",
+              values: ["22222222-2222-2222-2222-222222222222"],
+            },
+          ],
+        },
+        groupBy: "severity",
+        maxGroups: undefined,
+      },
+      { signal: expect.any(AbortSignal) },
+    );
+  });
+
+  it("holds the request while a __current_user__ placeholder is unresolved, rather than sending it literally", async () => {
+    postMock.mockResolvedValue({ groups: [], othersCount: 0, totalRecords: 0 });
+
+    const { result } = renderHook(
+      () =>
+        useWidgetGroupByData(
+          "widget-1",
+          "case",
+          { filters: [{ field: "assignedUserId", op: "in", values: [CURRENT_USER_PLACEHOLDER] }] },
+          { field: "severity" },
+          undefined,
+          undefined,
+          undefined,
+        ),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(true));
+    expect(postMock).not.toHaveBeenCalled();
+  });
+
+  it("surfaces isError when the group-by request fails", async () => {
+    postMock.mockRejectedValue(new Error("boom"));
+
+    const { result } = renderHook(
+      () => useWidgetGroupByData("widget-1", "case", {}, { field: "severity" }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetGroupByData.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetGroupByData.test.tsx
@@ -74,11 +74,54 @@ describe("useWidgetGroupByData", () => {
     );
 
     expect(result.current.slices).toEqual([
-      { label: "Critical", query: {}, value: 3 },
-      { label: "High", query: {}, value: 5 },
-      { label: "Others", query: {}, value: 2 },
+      {
+        label: "Critical",
+        query: { filters: [{ field: "severity", op: "eq", values: ["critical"] }] },
+        value: 3,
+      },
+      {
+        label: "High",
+        query: { filters: [{ field: "severity", op: "eq", values: ["high"] }] },
+        value: 5,
+      },
+      { label: "Others", query: {}, navigable: false, value: 2 },
     ]);
     expect(result.current.total).toBe(10);
+  });
+
+  it("scopes a non-case resourceType's named bucket to a flat top-level key", async () => {
+    postMock.mockResolvedValue({
+      groups: [{ key: "P1", label: "P1", count: 4 }],
+      othersCount: 0,
+      totalRecords: 4,
+    });
+
+    const { result } = renderHook(
+      () => useWidgetGroupByData("widget-1", "incident", {}, { field: "priority" }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.slices).toEqual([{ label: "P1", query: { priority: "P1" }, value: 4 }]);
+  });
+
+  it("marks the synthetic Others bucket non-navigable rather than giving it an unscoped query", async () => {
+    postMock.mockResolvedValue({
+      groups: [{ key: "critical", label: "Critical", count: 3 }],
+      othersCount: 2,
+      totalRecords: 5,
+    });
+
+    const { result } = renderHook(
+      () => useWidgetGroupByData("widget-1", "case", {}, { field: "severity" }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    const others = result.current.slices.find((s) => s.label === "Others");
+    expect(others).toEqual({ label: "Others", query: {}, navigable: false, value: 2 });
   });
 
   it("uses the configured othersLabel instead of the default 'Others'", async () => {
@@ -100,8 +143,12 @@ describe("useWidgetGroupByData", () => {
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
     expect(result.current.slices).toEqual([
-      { label: "Critical", query: {}, value: 3 },
-      { label: "Everything else", query: {}, value: 4 },
+      {
+        label: "Critical",
+        query: { filters: [{ field: "severity", op: "eq", values: ["critical"] }] },
+        value: 3,
+      },
+      { label: "Everything else", query: {}, navigable: false, value: 4 },
     ]);
     expect(result.current.total).toBe(7);
   });
@@ -120,7 +167,13 @@ describe("useWidgetGroupByData", () => {
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    expect(result.current.slices).toEqual([{ label: "Critical", query: {}, value: 3 }]);
+    expect(result.current.slices).toEqual([
+      {
+        label: "Critical",
+        query: { filters: [{ field: "severity", op: "eq", values: ["critical"] }] },
+        value: 3,
+      },
+    ]);
     expect(result.current.total).toBe(3);
   });
 

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetGroupByData.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetGroupByData.ts
@@ -1,0 +1,149 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useQuery } from "@tanstack/react-query";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import { useBackendApi } from "@api/backend/client";
+import type {
+  BeDashboardGroupByConfig,
+  BeGroupByResponse,
+  BeWidgetResourceType,
+} from "@api/backend/types";
+import { WIDGET_RESOURCE_CONFIG } from "@features/csm-dashboard/config/widgetResourceConfig";
+import { resolveTeamPlaceholder } from "@features/csm-dashboard/utils/teamFilterPlaceholder";
+import { resolveRelativeDateFilters } from "@features/csm-dashboard/utils/resolveRelativeDateFilters";
+import {
+  hasCurrentUserPlaceholder,
+  resolveCurrentUserPlaceholder,
+} from "@features/csm-dashboard/utils/currentUserFilterPlaceholder";
+import {
+  shouldRetryWidgetFetch,
+  withWidgetFetchSlot,
+} from "@features/csm-dashboard/utils/widgetFetchConcurrency";
+import type { PieSliceResult, WidgetPieData } from "@features/csm-dashboard/api/useWidgetPieData";
+
+/**
+ * Resolves a `shape: "pie"` widget's per-bucket values via a single
+ * server-side `POST {resourceType}/group-by` call — the `groupBy`
+ * counterpart of `useWidgetPieData`'s per-slice `search` calls. The
+ * widget's own base `query` is resolved through the exact same
+ * placeholder pipeline `useWidgetPieData` applies per-slice
+ * (`resolveTeamPlaceholder` -> `resolveRelativeDateFilters` ->
+ * `resolveCurrentUserPlaceholder`), just once — there's no per-slice
+ * query to merge it under, since there are no slices. A `groupBy` of
+ * `undefined` (widget doesn't use this mode) fires no query at all and
+ * returns an empty/zero result, mirroring `useWidgetPieData`'s own
+ * behavior for an empty `slices` array.
+ */
+export function useWidgetGroupByData(
+  widgetId: string,
+  resourceType: BeWidgetResourceType,
+  baseFilters: Record<string, unknown>,
+  groupBy: BeDashboardGroupByConfig | undefined,
+  /** See `useWidgetPieData`'s own doc comment for each of these — same
+   * parameters, same resolution order, same reasoning. */
+  selectedTeamCreGroupId?: string | string[],
+  selectedTeamSreGroupId?: string | string[],
+  currentUserId?: string,
+  enabled = true,
+): WidgetPieData {
+  const api = useBackendApi();
+  const config = WIDGET_RESOURCE_CONFIG[resourceType];
+
+  const resolvedFilters = resolveCurrentUserPlaceholder(
+    resolveRelativeDateFilters(
+      resolveTeamPlaceholder(baseFilters, selectedTeamCreGroupId, selectedTeamSreGroupId),
+    ),
+    currentUserId,
+  );
+  // See useWidgetPieData: a surviving `__current_user__` means the
+  // signed-in user's profile hasn't landed yet, so the query holds rather
+  // than searching unscoped.
+  const awaitingCurrentUser = hasCurrentUserPlaceholder(resolvedFilters);
+
+  const query = useQuery({
+    queryKey: [
+      ApiQueryKeys.CSM_DASHBOARD_WIDGET_DATA,
+      "group-by",
+      widgetId,
+      resourceType,
+      resolvedFilters,
+      groupBy,
+    ],
+    queryFn: async (): Promise<BeGroupByResponse> => {
+      if (!groupBy) {
+        return { groups: [], othersCount: 0, totalRecords: 0 };
+      }
+      if (!config?.groupByEndpoint) {
+        throw new Error(`Unsupported group-by widget resourceType: ${resourceType}`);
+      }
+      // Same shared concurrency slot (and timeout) useWidgetPieData's own
+      // slice fetches use — a groupBy widget fires one call on top of every
+      // other widget's own call, so it needs both at least as much.
+      return withWidgetFetchSlot(async (signal) => {
+        return api.post<
+          { filters: Record<string, unknown>; groupBy: string; maxGroups?: number },
+          BeGroupByResponse
+        >(
+          config.groupByEndpoint as string,
+          {
+            filters: resolvedFilters,
+            groupBy: groupBy.field,
+            maxGroups: groupBy.maxGroups,
+          },
+          { signal },
+        );
+      });
+    },
+    enabled: enabled && !!groupBy && !awaitingCurrentUser,
+    // Same per-query retry override as useWidgetPieData's own slice
+    // fetches, same reasoning (see shouldRetryWidgetFetch).
+    retry: shouldRetryWidgetFetch,
+    staleTime: 60_000,
+  });
+
+  // Mirrors useWidgetPieData's own isLoading semantics: `!enabled` or a
+  // still-unresolved current-user placeholder reports as loading rather
+  // than passing through react-query's own `isLoading` for a disabled
+  // query (which is `false`).
+  const isLoading = !enabled || (!!groupBy && awaitingCurrentUser) || (!!groupBy && query.isLoading);
+  const isError = !!groupBy && query.isError;
+
+  const buckets = query.data?.groups ?? [];
+  const othersCount = query.data?.othersCount ?? 0;
+
+  const slices: PieSliceResult[] = buckets.map((bucket) => ({
+    label: bucket.label,
+    query: {},
+    value: bucket.count,
+  }));
+  if (othersCount > 0) {
+    slices.push({
+      label: groupBy?.othersLabel ?? "Others",
+      query: {},
+      value: othersCount,
+    });
+  }
+  // Summed from the returned slices themselves (top-N plus the synthetic
+  // Others entry) rather than taken from the response's own
+  // `totalRecords` directly — same approach useWidgetPieData's own `total`
+  // uses (sum of its returned slices), so this hook's `total` always stays
+  // internally consistent with what it actually returns even if
+  // `totalRecords` and (groups + othersCount) could ever disagree upstream.
+  const total = slices.reduce((sum, s) => sum + s.value, 0);
+
+  return { slices, total, isLoading, isError };
+}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetGroupByData.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetGroupByData.ts
@@ -33,7 +33,28 @@ import {
   shouldRetryWidgetFetch,
   withWidgetFetchSlot,
 } from "@features/csm-dashboard/utils/widgetFetchConcurrency";
+import { usesCaseFieldFilterDsl } from "@features/csm-admin/dashboards/utils/widgetQueryConditions";
 import type { PieSliceResult, WidgetPieData } from "@features/csm-dashboard/api/useWidgetPieData";
+
+/**
+ * Builds a named bucket's own click-through `query` — the same shape
+ * `DashboardWidgetTile`'s slice navigation merges under the widget's base
+ * `query` via `mergeWidgetFilters` (see that function's own doc comment for
+ * why the two resourceType families below are handled differently). A
+ * `case`-DSL resourceType's search contract has no flat top-level key for
+ * an arbitrary aggregated field, so it goes through the generic
+ * `field`/`op`/`values` predicate array; every other resourceType's own
+ * bespoke search contract keys straight off the field name.
+ */
+function bucketQuery(
+  resourceType: BeWidgetResourceType,
+  field: string,
+  key: string,
+): Record<string, unknown> {
+  return usesCaseFieldFilterDsl(resourceType)
+    ? { filters: [{ field, op: "eq", values: [key] }] }
+    : { [field]: key };
+}
 
 /**
  * Resolves a `shape: "pie"` widget's per-bucket values via a single
@@ -127,13 +148,26 @@ export function useWidgetGroupByData(
 
   const slices: PieSliceResult[] = buckets.map((bucket) => ({
     label: bucket.label,
-    query: {},
+    // Scopes this slice's own click-through to exactly this bucket (see
+    // `bucketQuery`'s own doc comment) — an empty `query` here would merge
+    // to the widget's unfiltered base result set instead of this bucket's,
+    // since `mergeWidgetFilters({...}, {})` is a no-op.
+    query: groupBy ? bucketQuery(resourceType, groupBy.field, bucket.key) : {},
     value: bucket.count,
   }));
   if (othersCount > 0) {
     slices.push({
       label: groupBy?.othersLabel ?? "Others",
+      // Unlike a named bucket, "Others" has no `key` of its own — the
+      // response only carries a rolled-up count, not a selector for
+      // "everything not in a named bucket" this hook could turn into a
+      // query. Leaving `query` empty would silently navigate to the
+      // widget's unscoped base result set (the exact bug this hook exists
+      // to fix for the named buckets above), so this slice is marked
+      // non-navigable instead — `DashboardWidgetTile` skips its
+      // click-through for a slice carrying this flag.
       query: {},
+      navigable: false,
       value: othersCount,
     });
   }

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetPieData.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetPieData.ts
@@ -33,6 +33,12 @@ import {
 
 export interface PieSliceResult extends BeDashboardPieSlice {
   value: number;
+  /** Defaults to `true` (every hand-authored slice is click-through by
+   * design). `false` only for a groupBy widget's synthetic "Others" bucket
+   * when the API gives it no safe selector of its own to navigate to (see
+   * `useWidgetGroupByData`) — `DashboardWidgetTile` skips click-through for
+   * a slice carrying this. */
+  navigable?: boolean;
 }
 
 export interface WidgetPieData {

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetGrid.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetGrid.tsx
@@ -118,17 +118,19 @@ export default function DashboardWidgetGrid({
 
   /**
    * Invalidates only the widget-data queries belonging to `widgetIds` —
-   * both shapes' query keys carry a widget id, just at a different
+   * every shape's query key carries a widget id, just at a different
    * position: `[KEY, widgetId, ...]` for count/list (see `useWidgetData`),
-   * `[KEY, "pie-slice", widgetId, ...]` for pie/bar (see
-   * `useWidgetPieData`).
+   * `[KEY, "pie-slice", widgetId, ...]` for pie/bar via `slices` (see
+   * `useWidgetPieData`), `[KEY, "group-by", widgetId, ...]` for pie/bar via
+   * `groupBy` (see `useWidgetGroupByData`).
    */
   const invalidateWidgets = (widgetIds: Set<string>): Promise<void> =>
     queryClient.invalidateQueries({
       predicate: (query) => {
         const key = query.queryKey;
         if (key[0] !== ApiQueryKeys.CSM_DASHBOARD_WIDGET_DATA) return false;
-        const widgetId = key[1] === "pie-slice" ? key[2] : key[1];
+        const widgetId =
+          key[1] === "pie-slice" || key[1] === "group-by" ? key[2] : key[1];
         return typeof widgetId === "string" && widgetIds.has(widgetId);
       },
     });
@@ -159,6 +161,7 @@ export default function DashboardWidgetGrid({
           filters={widget.query}
           listLimit={widget.listLimit}
           slices={widget.slices}
+          groupBy={widget.groupBy}
           columns={widget.columns}
           sortBy={widget.sortBy}
           selectedTeamCreGroupId={selectedTeamCreGroupId}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.test.tsx
@@ -1150,6 +1150,42 @@ describe("DashboardWidgetTile", () => {
     );
   });
 
+  it("shape pie: renders a groupBy-configured widget via a single group-by call, including a synthetic Others slice", async () => {
+    postMock.mockResolvedValue({
+      groups: [
+        { key: "critical", label: "S1 · Critical", count: 1 },
+        { key: "high", label: "S2 · High", count: 3 },
+      ],
+      othersCount: 4,
+      totalRecords: 8,
+    });
+
+    renderWithClient(
+      <DashboardWidgetTile
+        widgetId="cases-by-severity"
+        displayName="Cases by severity"
+        resourceType="case"
+        shape="pie"
+        filters={{ filters: [{ field: "state", op: "in", values: ["open"] }] }}
+        groupBy={{ field: "severity", maxGroups: 2 }}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByText("slice:S1 · Critical:1")).toBeInTheDocument());
+    expect(screen.getByText("slice:S2 · High:3")).toBeInTheDocument();
+    expect(screen.getByText("slice:Others:4")).toBeInTheDocument();
+    expect(postMock).toHaveBeenCalledTimes(1);
+    expect(postMock).toHaveBeenCalledWith(
+      "/cases/group-by",
+      {
+        filters: { filters: [{ field: "state", op: "in", values: ["open"] }] },
+        groupBy: "severity",
+        maxGroups: 2,
+      },
+      { signal: expect.any(AbortSignal) },
+    );
+  });
+
   it("shape pie: clicking a slice navigates to /cases with the widget's base filters merged under that slice's own filters", async () => {
     postMock.mockResolvedValue({ total: 2 });
 

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
@@ -529,15 +529,21 @@ export default function DashboardWidgetTile({
               total={pieData.total}
               isLoading={pieData.isLoading}
               isError={pieData.isError}
-              onSliceClick={(slice: PieSliceResult) =>
+              onSliceClick={(slice: PieSliceResult) => {
+                // See `PieSliceResult.navigable`'s own doc comment: a
+                // groupBy widget's synthetic "Others" bucket has no safe
+                // selector to navigate to, so it opts out of click-through
+                // entirely rather than falling through to the widget's own
+                // unscoped base result set.
+                if (slice.navigable === false) return;
                 navigate(
                   config.buildHref(resolvePlaceholders(mergeWidgetFilters(filters, slice.query)), {
                     widgetId,
                     displayName: resolvedDisplayName,
                   }),
                   { state: dashboardReturnState },
-                )
-              }
+                );
+              }}
             />
           </Box>
         </Box>

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
@@ -20,6 +20,7 @@ import { useRef, type JSX, type KeyboardEvent, type ReactNode } from "react";
 import { Link as RouterLink, useLocation, useNavigate } from "react-router";
 import { useElementVisibleOnce } from "@hooks/useElementVisibleOnce";
 import type {
+  BeDashboardGroupByConfig,
   BeDashboardPieSlice,
   BeDashboardWidgetColumn,
   BeWidgetResourceType,
@@ -28,6 +29,7 @@ import type {
 import { useCurrentUser } from "@context/current-user/CurrentUserContext";
 import { useWidgetData } from "@features/csm-dashboard/api/useWidgetData";
 import { useWidgetPieData, type PieSliceResult } from "@features/csm-dashboard/api/useWidgetPieData";
+import { useWidgetGroupByData } from "@features/csm-dashboard/api/useWidgetGroupByData";
 import { WIDGET_RESOURCE_CONFIG } from "@features/csm-dashboard/config/widgetResourceConfig";
 import { WIDGET_LIST_RENDERERS } from "@features/csm-dashboard/config/widgetListConfig";
 import GenericColumnList from "@features/csm-dashboard/components/GenericColumnList";
@@ -62,8 +64,13 @@ interface DashboardWidgetTileProps {
   listLimit?: number;
   /** Only meaningful for shape "pie"/"bar"; one search per slice (see
    * `useWidgetPieData`). Empty/absent renders an empty chart rather than
-   * crashing. */
+   * crashing. Mutually exclusive with `groupBy` — a widget carries at most
+   * one of the two (backend-enforced). */
   slices?: BeDashboardPieSlice[];
+  /** Only meaningful for shape "pie"/"bar"; a single server-side
+   * `POST {resourceType}/group-by` call instead of one search per slice
+   * (see `useWidgetGroupByData`). Mutually exclusive with `slices`. */
+  groupBy?: BeDashboardGroupByConfig;
   /** Only meaningful for shape "list". When set (non-empty), this widget
    * renders through the generic `GenericColumnList` (resolving each
    * column's dot-path against every response item) instead of
@@ -127,6 +134,7 @@ export default function DashboardWidgetTile({
   filters,
   listLimit,
   slices,
+  groupBy,
   columns,
   sortBy,
   selectedTeamCreGroupId,
@@ -206,7 +214,7 @@ export default function DashboardWidgetTile({
     sortBy,
     currentUserId,
   );
-  const pieData = useWidgetPieData(
+  const sliceData = useWidgetPieData(
     widgetId,
     resourceType,
     filters,
@@ -216,6 +224,23 @@ export default function DashboardWidgetTile({
     currentUserId,
     isVisible,
   );
+  // groupBy is the alternative to slices for shapes "pie"/"bar" — mutually
+  // exclusive, backend-enforced (never both, never neither for those
+  // shapes). Both hooks are called unconditionally (rules of hooks; a
+  // widget's shape/config never changes across this component's lifetime)
+  // and only one of them ever actually fires a request, gated by its own
+  // `groupBy`/`slices` argument being empty/undefined.
+  const groupByData = useWidgetGroupByData(
+    widgetId,
+    resourceType,
+    filters,
+    shape === "pie" || shape === "bar" ? groupBy : undefined,
+    selectedTeamCreGroupId,
+    selectedTeamSreGroupId,
+    currentUserId,
+    isVisible,
+  );
+  const pieData = groupBy ? groupByData : sliceData;
   // True while this widget carries a `__current_user__` filter and the
   // signed-in user's profile hasn't loaded yet. `useWidgetData`/
   // `useWidgetPieData` hold their requests in that window (see

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.ts
@@ -67,6 +67,12 @@ type WidgetItem = Record<string, unknown>;
 export interface WidgetResourceConfig {
   /** `POST` endpoint this resource's own search lives at. */
   searchEndpoint: string;
+  /** `POST` endpoint for a server-side group-by aggregation, for a
+   * `shape: "pie"`/`"bar"` widget configured with `groupBy` instead of
+   * `slices` (see `useWidgetGroupByData`). Only the resourceTypes backed
+   * by an entity-service group-by endpoint carry this — omitted means that
+   * resourceType doesn't support `groupBy` widgets at all. */
+  groupByEndpoint?: string;
   /** Key the response's item array is nested under. */
   itemsKey: string;
   /** Primary (bold) line for one list-shape row. */
@@ -412,6 +418,7 @@ export const WIDGET_RESOURCE_CONFIG: Record<
 > = {
   case: {
     searchEndpoint: "/cases/search",
+    groupByEndpoint: "/cases/group-by",
     itemsKey: "cases",
     primaryLabel: numberSubjectLabel,
     secondaryLabel: stateSecondaryLabel,
@@ -429,9 +436,13 @@ export const WIDGET_RESOURCE_CONFIG: Record<
   // Rows are still case rows (same `BeCaseSearchView` shape), so these reuse
   // `case`'s own primaryLabel/secondaryLabel/list renderer verbatim; only the
   // icon/color/click-through destination differ per type, mirroring
-  // `CASE_TYPE_COLOR`'s own per-type palette in `caseType.ts`.
+  // `CASE_TYPE_COLOR`'s own per-type palette in `caseType.ts`. Same reasoning
+  // extends `groupByEndpoint`: they share `/cases/group-by` with `case` too
+  // (the implied `type` filter is just another entry in the resolved
+  // `filters` posted to that endpoint, same as it is for `/cases/search`).
   service_request: {
     searchEndpoint: "/cases/search",
+    groupByEndpoint: "/cases/group-by",
     itemsKey: "cases",
     detailHref: caseDetailHref,
     primaryLabel: numberSubjectLabel,
@@ -450,6 +461,7 @@ export const WIDGET_RESOURCE_CONFIG: Record<
   },
   security_report_analysis: {
     searchEndpoint: "/cases/search",
+    groupByEndpoint: "/cases/group-by",
     itemsKey: "cases",
     detailHref: caseDetailHref,
     primaryLabel: numberSubjectLabel,
@@ -468,6 +480,7 @@ export const WIDGET_RESOURCE_CONFIG: Record<
   },
   announcement: {
     searchEndpoint: "/cases/search",
+    groupByEndpoint: "/cases/group-by",
     itemsKey: "cases",
     detailHref: caseDetailHref,
     primaryLabel: numberSubjectLabel,
@@ -483,6 +496,7 @@ export const WIDGET_RESOURCE_CONFIG: Record<
   },
   engagement: {
     searchEndpoint: "/cases/search",
+    groupByEndpoint: "/cases/group-by",
     itemsKey: "cases",
     detailHref: caseDetailHref,
     primaryLabel: numberSubjectLabel,
@@ -494,6 +508,7 @@ export const WIDGET_RESOURCE_CONFIG: Record<
   },
   incident: {
     searchEndpoint: "/incidents/search",
+    groupByEndpoint: "/incidents/group-by",
     itemsKey: "incidents",
     primaryLabel: numberSubjectLabel,
     secondaryLabel: (item) => asString(item.priority),
@@ -513,6 +528,7 @@ export const WIDGET_RESOURCE_CONFIG: Record<
   },
   change_request: {
     searchEndpoint: "/change-requests/search",
+    groupByEndpoint: "/change-requests/group-by",
     itemsKey: "changeRequests",
     primaryLabel: numberSubjectLabel,
     secondaryLabel: stateSecondaryLabel,
@@ -532,6 +548,7 @@ export const WIDGET_RESOURCE_CONFIG: Record<
   },
   problem: {
     searchEndpoint: "/problems/search",
+    groupByEndpoint: "/problems/group-by",
     itemsKey: "problems",
     primaryLabel: numberSubjectLabel,
     secondaryLabel: stateSecondaryLabel,
@@ -556,6 +573,7 @@ export const WIDGET_RESOURCE_CONFIG: Record<
   // same fallback `call_request` uses for landing on its owning case.
   incident_task: {
     searchEndpoint: "/incident-tasks/search",
+    groupByEndpoint: "/incident-tasks/group-by",
     itemsKey: "incidentTasks",
     primaryLabel: numberSubjectLabel,
     secondaryLabel: incidentTaskStateSecondaryLabel,

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/pages/CsmDashboardPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/pages/CsmDashboardPage.test.tsx
@@ -502,4 +502,108 @@ describe("CsmDashboardPage", () => {
       );
     });
   });
+
+  describe("team-identity default dashboard override", () => {
+    // Registered dashboards for the two mapped teams, plus the usual
+    // isDefault/!isTeamBased fallback and an isTeamBased dashboard, so these
+    // tests can also confirm the override wins over both.
+    const LIST_WITH_MAPPED_DASHBOARDS = [
+      { id: "agents_pilot", displayName: "Engineer overview", isDefault: true, isTeamBased: false },
+      { id: "team_performance", displayName: "Team performance", isDefault: true, isTeamBased: true },
+      { id: "onboarding-engineer", displayName: "Onboarding engineer", isDefault: false, isTeamBased: false },
+      { id: "migration-engineer", displayName: "Migration engineer", isDefault: false, isTeamBased: false },
+    ];
+
+    it("defaults a customer_onboarding-team user onto the onboarding-engineer dashboard", () => {
+      mockListResult({ data: LIST_WITH_MAPPED_DASHBOARDS, isLoading: false });
+      mockCurrentUser({
+        user: { team: { teamKey: "customer_onboarding", teamName: "Customer Onboarding" } },
+        isLoading: false,
+      });
+
+      renderAt("/dashboard");
+
+      expect(screen.getByTestId("agents-landing-pilot")).toHaveTextContent(
+        "onboarding-engineer",
+      );
+      expect(currentPath()).toBe("/dashboard/onboarding-engineer");
+    });
+
+    it("defaults a cs_migrations_team user onto the migration-engineer dashboard", () => {
+      mockListResult({ data: LIST_WITH_MAPPED_DASHBOARDS, isLoading: false });
+      mockCurrentUser({
+        user: { team: { teamKey: "cs_migrations_team", teamName: "CS Migrations" } },
+        isLoading: false,
+      });
+
+      renderAt("/dashboard");
+
+      expect(screen.getByTestId("agents-landing-pilot")).toHaveTextContent(
+        "migration-engineer",
+      );
+      expect(currentPath()).toBe("/dashboard/migration-engineer");
+    });
+
+    it("leaves an unmapped (e.g. ABT) team's existing default-selection behavior completely unchanged", () => {
+      mockListResult({ data: LIST_WITH_MAPPED_DASHBOARDS, isLoading: false });
+      mockCurrentUser({
+        user: { team: { teamKey: "cs_team_leads", teamName: "CS Team Leads" } },
+        isLoading: false,
+      });
+
+      renderAt("/dashboard");
+
+      // cs_team_leads isn't in TEAM_DEFAULT_DASHBOARD_ID, so this falls
+      // through to the existing preferredEntry (isDefault && isTeamBased).
+      expect(screen.getByTestId("agents-landing-pilot")).toHaveTextContent(
+        "team_performance",
+      );
+    });
+
+    it("leaves a no-team user's existing default-selection behavior completely unchanged", () => {
+      mockListResult({ data: LIST_WITH_MAPPED_DASHBOARDS, isLoading: false });
+      mockCurrentUser({ user: { team: undefined }, isLoading: false });
+
+      renderAt("/dashboard");
+
+      expect(screen.getByTestId("agents-landing-pilot")).toHaveTextContent(
+        "agents_pilot",
+      );
+    });
+
+    it("lets a URL naming a different valid dashboard win over the team-identity default", () => {
+      mockListResult({ data: LIST_WITH_MAPPED_DASHBOARDS, isLoading: false });
+      mockCurrentUser({
+        user: { team: { teamKey: "customer_onboarding", teamName: "Customer Onboarding" } },
+        isLoading: false,
+      });
+
+      renderAt("/dashboard/agents_pilot");
+
+      expect(screen.getByTestId("agents-landing-pilot")).toHaveTextContent(
+        "agents_pilot",
+      );
+      expect(currentPath()).toBe("/dashboard/agents_pilot");
+    });
+
+    it("falls through cleanly to the existing fallback chain when the mapped dashboard id isn't in the BE-returned list", () => {
+      // onboarding-engineer/migration-engineer deliberately absent here —
+      // the mapped team key still resolves, but the target dashboard isn't
+      // registered, so teamDefaultEntry must resolve to undefined and this
+      // must not throw.
+      mockListResult({ data: DASHBOARD_LIST, isLoading: false });
+      mockCurrentUser({
+        user: { team: { teamKey: "customer_onboarding", teamName: "Customer Onboarding" } },
+        isLoading: false,
+      });
+
+      renderAt("/dashboard");
+
+      // Falls through to preferredEntry (no isDefault+isTeamBased entry in
+      // DASHBOARD_LIST) -> anyDefaultEntry ("agents_pilot").
+      expect(screen.getByTestId("agents-landing-pilot")).toHaveTextContent(
+        "agents_pilot",
+      );
+    });
+  });
 });

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/pages/CsmDashboardPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/pages/CsmDashboardPage.test.tsx
@@ -502,4 +502,95 @@ describe("CsmDashboardPage", () => {
       );
     });
   });
+
+  describe("team-identity default dashboard override (SRE ABT)", () => {
+    // Registered dashboards including sre-abt, plus the usual
+    // isDefault/!isTeamBased fallback and an isTeamBased dashboard, so these
+    // tests can also confirm the override wins over both.
+    const LIST_WITH_SRE_ABT = [
+      { id: "agents_pilot", displayName: "Engineer overview", isDefault: true, isTeamBased: false },
+      { id: "team_performance", displayName: "Team performance", isDefault: true, isTeamBased: true },
+      { id: "sre-abt", displayName: "SRE ABT Dashboard", isDefault: false, isTeamBased: true, type: "sre" as const },
+    ];
+
+    it("defaults an apollo_sre_group-team user onto the sre-abt dashboard", () => {
+      mockListResult({ data: LIST_WITH_SRE_ABT, isLoading: false });
+      mockCurrentUser({
+        user: { team: { teamKey: "apollo_sre_group", teamName: "Apollo SRE Group" } },
+        isLoading: false,
+      });
+
+      renderAt("/dashboard");
+
+      expect(screen.getByTestId("agents-landing-pilot")).toHaveTextContent("sre-abt");
+      // The team selector's own derived default (the user's own teamKey)
+      // stays derived UI state, not written into the URL, until the user
+      // (or a shared URL) names a team explicitly — same as any other
+      // isTeamBased dashboard's cold-load canonicalization.
+      expect(currentPath()).toBe("/dashboard/sre-abt");
+    });
+
+    it("defaults an artemis_sre_group-team user onto the sre-abt dashboard", () => {
+      mockListResult({ data: LIST_WITH_SRE_ABT, isLoading: false });
+      mockCurrentUser({
+        user: { team: { teamKey: "artemis_sre_group", teamName: "Artemis SRE Group" } },
+        isLoading: false,
+      });
+
+      renderAt("/dashboard");
+
+      expect(screen.getByTestId("agents-landing-pilot")).toHaveTextContent("sre-abt");
+      expect(currentPath()).toBe("/dashboard/sre-abt");
+    });
+
+    it("leaves an unmapped team's existing default-selection behavior completely unchanged", () => {
+      mockListResult({ data: LIST_WITH_SRE_ABT, isLoading: false });
+      mockCurrentUser({
+        user: { team: { teamKey: "cs_team_leads", teamName: "CS Team Leads" } },
+        isLoading: false,
+      });
+
+      renderAt("/dashboard");
+
+      // cs_team_leads isn't in TEAM_DEFAULT_DASHBOARD_ID, so this falls
+      // through to the existing preferredEntry (isDefault && isTeamBased).
+      expect(screen.getByTestId("agents-landing-pilot")).toHaveTextContent(
+        "team_performance",
+      );
+    });
+
+    it("lets a URL naming a different valid dashboard win over the team-identity default", () => {
+      mockListResult({ data: LIST_WITH_SRE_ABT, isLoading: false });
+      mockCurrentUser({
+        user: { team: { teamKey: "apollo_sre_group", teamName: "Apollo SRE Group" } },
+        isLoading: false,
+      });
+
+      renderAt("/dashboard/agents_pilot");
+
+      expect(screen.getByTestId("agents-landing-pilot")).toHaveTextContent(
+        "agents_pilot",
+      );
+      expect(currentPath()).toBe("/dashboard/agents_pilot");
+    });
+
+    it("falls through cleanly to the existing fallback chain when sre-abt isn't in the BE-returned list", () => {
+      // sre-abt deliberately absent here — the mapped team key still
+      // resolves, but the target dashboard isn't registered, so
+      // teamDefaultEntry must resolve to undefined and this must not throw.
+      mockListResult({ data: DASHBOARD_LIST, isLoading: false });
+      mockCurrentUser({
+        user: { team: { teamKey: "apollo_sre_group", teamName: "Apollo SRE Group" } },
+        isLoading: false,
+      });
+
+      renderAt("/dashboard");
+
+      // Falls through to preferredEntry (no isDefault+isTeamBased entry in
+      // DASHBOARD_LIST) -> anyDefaultEntry ("agents_pilot").
+      expect(screen.getByTestId("agents-landing-pilot")).toHaveTextContent(
+        "agents_pilot",
+      );
+    });
+  });
 });

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/pages/CsmDashboardPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/pages/CsmDashboardPage.test.tsx
@@ -512,6 +512,7 @@ describe("CsmDashboardPage", () => {
       { id: "team_performance", displayName: "Team performance", isDefault: true, isTeamBased: true },
       { id: "onboarding-engineer", displayName: "Onboarding engineer", isDefault: false, isTeamBased: false },
       { id: "migration-engineer", displayName: "Migration engineer", isDefault: false, isTeamBased: false },
+      { id: "sre-abt", displayName: "SRE ABT Dashboard", isDefault: false, isTeamBased: true },
     ];
 
     it("defaults a customer_onboarding-team user onto the onboarding-engineer dashboard", () => {
@@ -542,6 +543,36 @@ describe("CsmDashboardPage", () => {
         "migration-engineer",
       );
       expect(currentPath()).toBe("/dashboard/migration-engineer");
+    });
+
+    it("defaults an apollo_sre_group-team user onto the sre-abt dashboard", () => {
+      mockListResult({ data: LIST_WITH_MAPPED_DASHBOARDS, isLoading: false });
+      mockCurrentUser({
+        user: { team: { teamKey: "apollo_sre_group", teamName: "Apollo SRE Group" } },
+        isLoading: false,
+      });
+
+      renderAt("/dashboard");
+
+      expect(screen.getByTestId("agents-landing-pilot")).toHaveTextContent(
+        "sre-abt",
+      );
+      expect(currentPath()).toBe("/dashboard/sre-abt");
+    });
+
+    it("defaults an artemis_sre_group-team user onto the sre-abt dashboard", () => {
+      mockListResult({ data: LIST_WITH_MAPPED_DASHBOARDS, isLoading: false });
+      mockCurrentUser({
+        user: { team: { teamKey: "artemis_sre_group", teamName: "Artemis SRE Group" } },
+        isLoading: false,
+      });
+
+      renderAt("/dashboard");
+
+      expect(screen.getByTestId("agents-landing-pilot")).toHaveTextContent(
+        "sre-abt",
+      );
+      expect(currentPath()).toBe("/dashboard/sre-abt");
     });
 
     it("leaves an unmapped (e.g. ABT) team's existing default-selection behavior completely unchanged", () => {

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/pages/CsmDashboardPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/pages/CsmDashboardPage.test.tsx
@@ -21,7 +21,9 @@ import "@testing-library/jest-dom/vitest";
 import type { JSX } from "react";
 import CsmDashboardPage from "@features/csm-dashboard/pages/CsmDashboardPage";
 import { useDashboardList } from "@features/csm-dashboard/api/useDashboardList";
+import { useTeams } from "@features/csm-dashboard/api/useTeams";
 import { useCurrentUser } from "@context/current-user/CurrentUserContext";
+import type { BeTeam } from "@api/backend/types";
 
 /** Surfaces the router's current pathname for assertions — the
  * `MemoryRouter`'s history is in-memory, not reflected on `window.location`,
@@ -80,14 +82,26 @@ vi.mock("@features/csm-dashboard/api/useDashboardList", () => ({
 
 // None of these dashboards are team-based, so the header's team selector
 // never renders/fetches here, but useTeams still needs mocking since
-// AbtDashboardHeader (and now CsmDashboardPage itself, to resolve the
-// selected team's creGroupId/sreGroupId) call it unconditionally (the fetch
-// itself is disabled via its `enabled` param) — without this, the real hook
-// reaches the real API client, which throws under vitest (no runtime
-// config).
+// AbtDashboardHeader and CsmDashboardPage itself (to resolve the signed-in
+// user's own team family, and the selected team's creGroupId/sreGroupId)
+// call it unconditionally (the fetch itself is disabled via its `enabled`
+// param where applicable) — without this, the real hook reaches the real
+// API client, which throws under vitest (no runtime config).
+// `dashboardTypeForTeamFamily` is reimplemented here rather than imported
+// via `vi.importActual`: the real module transitively pulls in the
+// backend API client, which throws under vitest without runtime config
+// (see the real `useTeams` mock above for the same reason). It's a tiny,
+// pure function, so duplicating it is cheap; keep this in sync with the
+// real implementation in useTeams.ts if that one changes.
 vi.mock("@features/csm-dashboard/api/useTeams", () => ({
   useTeams: vi.fn(() => ({ data: undefined })),
   abtFamilyForDashboardType: vi.fn(() => undefined),
+  dashboardTypeForTeamFamily: (family: string | undefined) => {
+    if (!family) return undefined;
+    if (family.startsWith("cre")) return "cre";
+    if (family.startsWith("sre")) return "sre";
+    return undefined;
+  },
 }));
 
 vi.mock("@context/current-user/CurrentUserContext", () => ({
@@ -132,6 +146,7 @@ vi.mock("@features/csm-dashboard/components/AgentsLandingPagePilot", () => ({
 
 const mockedUseDashboardList = vi.mocked(useDashboardList);
 const mockedUseCurrentUser = vi.mocked(useCurrentUser);
+const mockedUseTeams = vi.mocked(useTeams);
 
 const DASHBOARD_LIST = [
   { id: "operations", displayName: "Operations", isDefault: false, isTeamBased: false },
@@ -161,13 +176,37 @@ function mockCurrentUser(
   } as unknown as ReturnType<typeof useCurrentUser>);
 }
 
+/** Mocks the unscoped `useTeams` call CsmDashboardPage makes to resolve the
+ * signed-in user's own team `family` (for type-based default selection) and
+ * the selected team's creGroupId/sreGroupId. Each mocked team should carry
+ * a `family` when the test cares about type/family-based default
+ * selection. */
+function mockTeams(
+  teams: BeTeam[],
+  overrides: Partial<ReturnType<typeof useTeams>> = {},
+): void {
+  mockedUseTeams.mockReturnValue({
+    data: teams,
+    isLoading: false,
+    isError: false,
+    ...overrides,
+  } as unknown as ReturnType<typeof useTeams>);
+}
+
 beforeEach(() => {
   mockedUseDashboardList.mockReset();
   mockedUseCurrentUser.mockReset();
+  mockedUseTeams.mockReset();
   // Default: a resolved profile with no team — most tests aren't about the
   // team-default-dashboard behavior, so this keeps them on the old
   // BE-isDefault-only path.
   mockCurrentUser({});
+  // Default: no teams resolved — most tests aren't about type/family-based
+  // default selection, so this keeps them on the existing permissive
+  // (family-blind) fallback path.
+  mockedUseTeams.mockReturnValue({ data: undefined } as unknown as ReturnType<
+    typeof useTeams
+  >);
 });
 
 describe("CsmDashboardPage", () => {
@@ -503,24 +542,103 @@ describe("CsmDashboardPage", () => {
     });
   });
 
-  describe("team-identity default dashboard override", () => {
-    // Registered dashboards for the mapped teams, plus the usual
-    // isDefault/!isTeamBased fallback and an isTeamBased dashboard, so these
-    // tests can also confirm the override wins over both.
-    const LIST_WITH_MAPPED_DASHBOARDS = [
+  describe("type/family-based default dashboard selection", () => {
+    // Two isDefault+isTeamBased dashboards of different types — the case
+    // the old (type-blind) predicate could never have handled, since it
+    // matched the first one it found regardless of the user's own team.
+    const LIST_WITH_TWO_TYPED_DEFAULTS = [
       { id: "agents_pilot", displayName: "Engineer overview", isDefault: true, isTeamBased: false },
-      { id: "team_performance", displayName: "Team performance", isDefault: true, isTeamBased: true },
-      { id: "onboarding-engineer", displayName: "Onboarding engineer", isDefault: false, isTeamBased: false },
-      { id: "migration-engineer", displayName: "Migration engineer", isDefault: false, isTeamBased: false },
-      { id: "sre-abt", displayName: "SRE ABT Dashboard", isDefault: false, isTeamBased: true, type: "sre" as const },
+      {
+        id: "cre-abt",
+        displayName: "CRE ABT Dashboard",
+        isDefault: true,
+        isTeamBased: true,
+        type: "cre" as const,
+      },
+      {
+        id: "sre-abt",
+        displayName: "SRE ABT Dashboard",
+        isDefault: true,
+        isTeamBased: true,
+        type: "sre" as const,
+      },
     ];
 
-    it("defaults a customer_onboarding-team user onto the onboarding-engineer dashboard", () => {
-      mockListResult({ data: LIST_WITH_MAPPED_DASHBOARDS, isLoading: false });
+    it("lands a user whose team family is sre-abt on the sre-typed default, not the cre one", () => {
+      mockListResult({ data: LIST_WITH_TWO_TYPED_DEFAULTS, isLoading: false });
+      mockCurrentUser({
+        user: { team: { teamKey: "artemis_sre_group", teamName: "Artemis SRE Group" } },
+        isLoading: false,
+      });
+      mockTeams([{ id: "artemis_sre_group", name: "Artemis SRE Group", family: "sre-abt" }]);
+
+      renderAt("/dashboard");
+
+      expect(screen.getByTestId("agents-landing-pilot")).toHaveTextContent("sre-abt");
+      expect(currentPath()).toBe("/dashboard/sre-abt");
+    });
+
+    it("lands a user whose team family is cre-abt on the cre-typed default, not the sre one", () => {
+      mockListResult({ data: LIST_WITH_TWO_TYPED_DEFAULTS, isLoading: false });
+      mockCurrentUser({
+        user: { team: { teamKey: "castor_cre_group", teamName: "Castor CRE Group" } },
+        isLoading: false,
+      });
+      mockTeams([{ id: "castor_cre_group", name: "Castor CRE Group", family: "cre-abt" }]);
+
+      renderAt("/dashboard");
+
+      expect(screen.getByTestId("agents-landing-pilot")).toHaveTextContent("cre-abt");
+      expect(currentPath()).toBe("/dashboard/cre-abt");
+    });
+
+    it("falls back to the non-team-based default for a user with no team, even with two typed defaults present", () => {
+      mockListResult({ data: LIST_WITH_TWO_TYPED_DEFAULTS, isLoading: false });
+      mockCurrentUser({ user: { team: undefined }, isLoading: false });
+      mockTeams([]);
+
+      renderAt("/dashboard");
+
+      expect(screen.getByTestId("agents-landing-pilot")).toHaveTextContent("agents_pilot");
+    });
+
+    it("still lands on SOME isDefault+isTeamBased entry when the user's team family is unresolved (permissive fallback)", () => {
+      mockListResult({ data: LIST_WITH_TWO_TYPED_DEFAULTS, isLoading: false });
+      mockCurrentUser({
+        user: { team: { teamKey: "unknown_team", teamName: "Unknown Team" } },
+        isLoading: false,
+      });
+      // The team isn't in the loaded teams list at all, so its family
+      // can't resolve.
+      mockTeams([]);
+
+      renderAt("/dashboard");
+
+      const rendered = screen.getByTestId("agents-landing-pilot").textContent;
+      expect(["cre-abt", "sre-abt"]).toContain(rendered);
+    });
+  });
+
+  describe("defaultForTeamKeys default dashboard selection", () => {
+    const LIST_WITH_DEFAULT_FOR_TEAM_KEYS = [
+      { id: "agents_pilot", displayName: "Engineer overview", isDefault: true, isTeamBased: false },
+      { id: "team_performance", displayName: "Team performance", isDefault: true, isTeamBased: true },
+      {
+        id: "onboarding-engineer",
+        displayName: "Onboarding engineer",
+        isDefault: false,
+        isTeamBased: false,
+        defaultForTeamKeys: ["customer_onboarding"],
+      },
+    ];
+
+    it("wins over preferredEntry for a user whose team key is named in defaultForTeamKeys", () => {
+      mockListResult({ data: LIST_WITH_DEFAULT_FOR_TEAM_KEYS, isLoading: false });
       mockCurrentUser({
         user: { team: { teamKey: "customer_onboarding", teamName: "Customer Onboarding" } },
         isLoading: false,
       });
+      mockTeams([{ id: "customer_onboarding", name: "Customer Onboarding" }]);
 
       renderAt("/dashboard");
 
@@ -530,103 +648,28 @@ describe("CsmDashboardPage", () => {
       expect(currentPath()).toBe("/dashboard/onboarding-engineer");
     });
 
-    it("defaults a cs_migrations_team user onto the migration-engineer dashboard", () => {
-      mockListResult({ data: LIST_WITH_MAPPED_DASHBOARDS, isLoading: false });
-      mockCurrentUser({
-        user: { team: { teamKey: "cs_migrations_team", teamName: "CS Migrations" } },
-        isLoading: false,
-      });
-
-      renderAt("/dashboard");
-
-      expect(screen.getByTestId("agents-landing-pilot")).toHaveTextContent(
-        "migration-engineer",
-      );
-      expect(currentPath()).toBe("/dashboard/migration-engineer");
-    });
-
-    it("defaults an apollo_sre_group-team user onto the sre-abt dashboard", () => {
-      mockListResult({ data: LIST_WITH_MAPPED_DASHBOARDS, isLoading: false });
-      mockCurrentUser({
-        user: { team: { teamKey: "apollo_sre_group", teamName: "Apollo SRE Group" } },
-        isLoading: false,
-      });
-
-      renderAt("/dashboard");
-
-      expect(screen.getByTestId("agents-landing-pilot")).toHaveTextContent("sre-abt");
-      // The team selector's own derived default (the user's own teamKey)
-      // stays derived UI state, not written into the URL, until the user
-      // (or a shared URL) names a team explicitly — same as any other
-      // isTeamBased dashboard's cold-load canonicalization.
-      expect(currentPath()).toBe("/dashboard/sre-abt");
-    });
-
-    it("defaults an artemis_sre_group-team user onto the sre-abt dashboard", () => {
-      mockListResult({ data: LIST_WITH_MAPPED_DASHBOARDS, isLoading: false });
-      mockCurrentUser({
-        user: { team: { teamKey: "artemis_sre_group", teamName: "Artemis SRE Group" } },
-        isLoading: false,
-      });
-
-      renderAt("/dashboard");
-
-      expect(screen.getByTestId("agents-landing-pilot")).toHaveTextContent("sre-abt");
-      expect(currentPath()).toBe("/dashboard/sre-abt");
-    });
-
-    it("leaves an unmapped (e.g. ABT) team's existing default-selection behavior completely unchanged", () => {
-      mockListResult({ data: LIST_WITH_MAPPED_DASHBOARDS, isLoading: false });
+    it("leaves an unmapped team's default-selection behavior unchanged", () => {
+      mockListResult({ data: LIST_WITH_DEFAULT_FOR_TEAM_KEYS, isLoading: false });
       mockCurrentUser({
         user: { team: { teamKey: "cs_team_leads", teamName: "CS Team Leads" } },
         isLoading: false,
       });
+      mockTeams([{ id: "cs_team_leads", name: "CS Team Leads" }]);
 
       renderAt("/dashboard");
 
-      // cs_team_leads isn't in TEAM_DEFAULT_DASHBOARD_ID, so this falls
-      // through to the existing preferredEntry (isDefault && isTeamBased).
       expect(screen.getByTestId("agents-landing-pilot")).toHaveTextContent(
         "team_performance",
       );
     });
 
-    it("leaves a no-team user's existing default-selection behavior completely unchanged", () => {
-      mockListResult({ data: LIST_WITH_MAPPED_DASHBOARDS, isLoading: false });
-      mockCurrentUser({ user: { team: undefined }, isLoading: false });
-
-      renderAt("/dashboard");
-
-      expect(screen.getByTestId("agents-landing-pilot")).toHaveTextContent(
-        "agents_pilot",
-      );
-    });
-
-    it("lets a URL naming a different valid dashboard win over the team-identity default", () => {
-      mockListResult({ data: LIST_WITH_MAPPED_DASHBOARDS, isLoading: false });
-      mockCurrentUser({
-        user: { team: { teamKey: "customer_onboarding", teamName: "Customer Onboarding" } },
-        isLoading: false,
-      });
-
-      renderAt("/dashboard/agents_pilot");
-
-      expect(screen.getByTestId("agents-landing-pilot")).toHaveTextContent(
-        "agents_pilot",
-      );
-      expect(currentPath()).toBe("/dashboard/agents_pilot");
-    });
-
-    it("falls through cleanly to the existing fallback chain when the mapped dashboard id isn't in the BE-returned list", () => {
-      // onboarding-engineer/migration-engineer/sre-abt deliberately absent
-      // here — the mapped team key still resolves, but the target
-      // dashboard isn't registered, so teamDefaultEntry must resolve to
-      // undefined and this must not throw.
+    it("falls through cleanly when defaultForTeamKeys names a dashboard id absent from the loaded list", () => {
       mockListResult({ data: DASHBOARD_LIST, isLoading: false });
       mockCurrentUser({
         user: { team: { teamKey: "customer_onboarding", teamName: "Customer Onboarding" } },
         isLoading: false,
       });
+      mockTeams([]);
 
       renderAt("/dashboard");
 
@@ -635,6 +678,22 @@ describe("CsmDashboardPage", () => {
       expect(screen.getByTestId("agents-landing-pilot")).toHaveTextContent(
         "agents_pilot",
       );
+    });
+
+    it("lets a URL naming a different valid dashboard win over the defaultForTeamKeys default", () => {
+      mockListResult({ data: LIST_WITH_DEFAULT_FOR_TEAM_KEYS, isLoading: false });
+      mockCurrentUser({
+        user: { team: { teamKey: "customer_onboarding", teamName: "Customer Onboarding" } },
+        isLoading: false,
+      });
+      mockTeams([{ id: "customer_onboarding", name: "Customer Onboarding" }]);
+
+      renderAt("/dashboard/agents_pilot");
+
+      expect(screen.getByTestId("agents-landing-pilot")).toHaveTextContent(
+        "agents_pilot",
+      );
+      expect(currentPath()).toBe("/dashboard/agents_pilot");
     });
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/pages/CsmDashboardPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/pages/CsmDashboardPage.tsx
@@ -38,6 +38,23 @@ import { ALL_TEAMS_SENTINEL } from "@features/csm-dashboard/utils/teamFilterPlac
  * empty selection. The URL always wins over all of that when it names a
  * (valid) dashboard.
  *
+ * Above even that team-based preferred predicate sits one more, narrower
+ * tier: `TEAM_DEFAULT_DASHBOARD_ID` maps a small, explicit set of team keys
+ * (the signed-in user's own `team.teamKey`, resolved the same way as above)
+ * straight onto a specific dashboard `id` — e.g. a
+ * `customer_onboarding`-team user always lands on `onboarding-engineer`,
+ * regardless of that dashboard's own `isDefault`/`isTeamBased` flags. This is
+ * deliberately a team-*identity* override, not a generalization of the
+ * `isDefault`/`isTeamBased`/`type` mechanism above (see the warning in the
+ * `preferredEntry` comment below about coupling default-selection to `type`
+ * — this tier doesn't touch that at all): it's additive and inert for every
+ * user whose `teamKey` isn't a key in the map (e.g. every ABT-team member),
+ * who falls straight through to `preferredEntry` exactly as before. A
+ * mapped team key whose target dashboard id isn't present in the BE-loaded
+ * list (e.g. not yet registered, or a stale map entry) also falls straight
+ * through rather than erroring. Adding a further team to this treatment is a
+ * one-line addition to the map, never a new branch.
+ *
  * The selection is a real path segment — `/dashboard/:dashboardId`, and for a
  * team-based dashboard `/dashboard/:dashboardId/:teamId` — rather than a
  * query param or fragment, matched by three sibling routes in App.tsx all
@@ -56,6 +73,20 @@ import { ALL_TEAMS_SENTINEL } from "@features/csm-dashboard/utils/teamFilterPlac
  * least one real (config-driven) widget, so this always renders the real
  * widget grid.
  */
+
+/**
+ * Team-identity override tier for default-dashboard selection — see the
+ * module doc comment above. Keyed by the signed-in user's own
+ * `team.teamKey`; a team not listed here is simply not in this map, which is
+ * the common case (every ABT team) and a deliberate no-op. Extend this map
+ * (never add another single-team branch) when a further team needs the same
+ * treatment.
+ */
+const TEAM_DEFAULT_DASHBOARD_ID: Record<string, string> = {
+  customer_onboarding: "onboarding-engineer",
+  cs_migrations_team: "migration-engineer",
+};
+
 export default function CsmDashboardPage(): JSX.Element {
   const navigate = useNavigate();
   const { dashboardId: urlDashboardId, teamId: urlTeamIdRaw } = useParams<{
@@ -70,6 +101,15 @@ export default function CsmDashboardPage(): JSX.Element {
   const urlEntry = list?.find((d) => d.id === urlDashboardId);
 
   const userHasTeam = Boolean(currentUser.user?.team);
+  // Team-identity override (see module doc comment): a mapped teamKey wins
+  // outright over the isDefault/isTeamBased-based preferredEntry below —
+  // but only when that mapped dashboard id is actually in the BE-loaded
+  // list; otherwise this is `undefined` and falls through untouched.
+  const teamKey = currentUser.user?.team?.teamKey;
+  const teamDefaultDashboardId = teamKey ? TEAM_DEFAULT_DASHBOARD_ID[teamKey] : undefined;
+  const teamDefaultEntry = teamDefaultDashboardId
+    ? list?.find((d) => d.id === teamDefaultDashboardId)
+    : undefined;
   // The preferred predicate per the user's own team membership: BOTH
   // isDefault and isTeamBased must match (not isTeamBased alone, and not
   // isDefault alone) — see the module doc comment above.
@@ -107,7 +147,7 @@ export default function CsmDashboardPage(): JSX.Element {
     if (userProfilePending) {
       currentEntry = undefined;
     } else {
-      currentEntry = preferredEntry ?? anyDefaultEntry ?? firstEntry;
+      currentEntry = teamDefaultEntry ?? preferredEntry ?? anyDefaultEntry ?? firstEntry;
     }
   }
 

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/pages/CsmDashboardPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/pages/CsmDashboardPage.tsx
@@ -20,7 +20,11 @@ import { useNavigate, useParams } from "react-router";
 import AbtDashboardHeader from "@features/csm-dashboard/components/AbtDashboardHeader";
 import AgentsLandingPagePilot from "@features/csm-dashboard/components/AgentsLandingPagePilot";
 import { useDashboardList } from "@features/csm-dashboard/api/useDashboardList";
-import { abtFamilyForDashboardType, useTeams } from "@features/csm-dashboard/api/useTeams";
+import {
+  abtFamilyForDashboardType,
+  dashboardTypeForTeamFamily,
+  useTeams,
+} from "@features/csm-dashboard/api/useTeams";
 import { useCurrentUser } from "@context/current-user/CurrentUserContext";
 import type { DashboardKey } from "@features/csm-dashboard/types/abtDashboard";
 import { ALL_TEAMS_SENTINEL } from "@features/csm-dashboard/utils/teamFilterPlaceholder";
@@ -28,44 +32,32 @@ import { ALL_TEAMS_SENTINEL } from "@features/csm-dashboard/utils/teamFilterPlac
 /**
  * Top-level CSM dashboard. The dashboard list is BE-driven (`GET
  * /dashboards`), and the initial selection depends on the signed-in user's
- * own ABT team membership (`GET /users/me`'s `team`, via `useCurrentUser`):
- * a user WITH a resolved team defaults to the first dashboard with BOTH
- * `isDefault` and `isTeamBased` set (with that team auto-selected — see
- * `selectedTeamId` below); a user with no team defaults to the first
- * dashboard with `isDefault` set and `isTeamBased` NOT set. If no dashboard
- * matches that preferred predicate, this falls back to the BE's own (any)
- * `isDefault` entry, then to the first dashboard in the list — never to an
- * empty selection. The URL always wins over all of that when it names a
- * (valid) dashboard.
+ * own ABT team membership (`GET /users/me`'s `team`, via `useCurrentUser`)
+ * through two independent tiers, checked in this order:
  *
- * Above even that team-based preferred predicate sits one more, narrower
- * tier: `TEAM_DEFAULT_DASHBOARD_ID` maps a small, explicit set of team keys
- * (the signed-in user's own `team.teamKey`, resolved the same way as above)
- * straight onto a specific dashboard `id` — e.g. a
- * `customer_onboarding`-team user always lands on `onboarding-engineer`,
- * and an `apollo_sre_group`-team user always lands on `sre-abt`, regardless
- * of that dashboard's own `isDefault`/`isTeamBased` flags (`sre-abt.json`
- * has `isDefault: false` — flipping it to `true` would fail the backend's
- * own "at most one isDefault dashboard, of any type" validation, since a
- * CRE dashboard already claims it; see `registry.go`'s validation and the
- * `preferredEntry` comment below for why default-selection isn't
- * type-aware). This is deliberately a team-*identity* override, not a
- * generalization of the `isDefault`/`isTeamBased`/`type` mechanism above
- * (see the warning in the `preferredEntry` comment below about coupling
- * default-selection to `type` — this tier doesn't touch that at all): it's
- * additive and inert for every user whose `teamKey` isn't a key in the map
- * (e.g. every non-mapped ABT team), who falls straight through to
- * `preferredEntry` exactly as before. A mapped team key whose target
- * dashboard id isn't present in the BE-loaded list (e.g. not yet
- * registered, or a stale map entry) also falls straight through rather than
- * erroring. Adding a further team to this treatment is a one-line addition
- * to the map, never a new branch. For a team-based target dashboard (e.g.
- * `sre-abt`), the team dropdown itself needs no separate wiring —
- * `defaultTeamId` below already auto-selects the signed-in user's own
- * `teamKey`, and `AbtDashboardHeader`'s picker already resolves
- * apollo_sre_group/artemis_sre_group generically via
- * `abtFamilyForDashboardType("sre") === "sre-abt"` against the team
- * registry, same as every other ABT family.
+ * 1. `defaultForTeamKeys` (see `BeDashboardListItem`): a dashboard can name
+ *    the exact team keys that should land on it outright, regardless of its
+ *    own `isDefault`/`isTeamBased`/`type` — for specialist, non-team-based
+ *    dashboards tier 2 below can never reach (e.g. `onboarding-engineer` for
+ *    a `customer_onboarding`-team user, `migration-engineer` for
+ *    `cs_migrations_team`). A team key naming a dashboard id that isn't in
+ *    the BE-loaded list (not yet registered, or a stale config entry) falls
+ *    straight through to tier 2 rather than erroring — see
+ *    `defaultForTeamKeyEntry` below.
+ * 2. The `isDefault`/`isTeamBased`/`type` predicate (`preferredEntry`
+ *    below): a user WITH a resolved team defaults to the dashboard with
+ *    BOTH `isDefault` and `isTeamBased` set, further narrowed by `type` when
+ *    the user's own team's `family` resolves to one (cre-abt/cre families to
+ *    the `cre` type, sre-abt/sre to `sre` — see `dashboardTypeForTeamFamily`
+ *    in `useTeams.ts`) — an unresolved family falls back to matching on
+ *    `isDefault && isTeamBased` alone, so this tier never regresses to
+ *    matching nothing. A user with no team defaults to the dashboard with
+ *    `isDefault` set and `isTeamBased` NOT set.
+ *
+ * If neither tier matches, this falls back to the BE's own (any)
+ * `isDefault` entry, then to the first dashboard in the list — never to an
+ * empty selection. The URL always wins over all of the above when it names
+ * a (valid) dashboard.
  *
  * The selection is a real path segment — `/dashboard/:dashboardId`, and for a
  * team-based dashboard `/dashboard/:dashboardId/:teamId` — rather than a
@@ -86,21 +78,6 @@ import { ALL_TEAMS_SENTINEL } from "@features/csm-dashboard/utils/teamFilterPlac
  * widget grid.
  */
 
-/**
- * Team-identity override tier for default-dashboard selection — see the
- * module doc comment above. Keyed by the signed-in user's own
- * `team.teamKey`; a team not listed here is simply not in this map, which is
- * the common case (every non-mapped ABT team) and a deliberate no-op. Extend
- * this map (never add another single-team branch) when a further team needs
- * the same treatment.
- */
-const TEAM_DEFAULT_DASHBOARD_ID: Record<string, string> = {
-  customer_onboarding: "onboarding-engineer",
-  cs_migrations_team: "migration-engineer",
-  apollo_sre_group: "sre-abt",
-  artemis_sre_group: "sre-abt",
-};
-
 export default function CsmDashboardPage(): JSX.Element {
   const navigate = useNavigate();
   const { dashboardId: urlDashboardId, teamId: urlTeamIdRaw } = useParams<{
@@ -115,29 +92,63 @@ export default function CsmDashboardPage(): JSX.Element {
   const urlEntry = list?.find((d) => d.id === urlDashboardId);
 
   const userHasTeam = Boolean(currentUser.user?.team);
-  // Team-identity override (see module doc comment): a mapped teamKey wins
-  // outright over the isDefault/isTeamBased-based preferredEntry below —
-  // but only when that mapped dashboard id is actually in the BE-loaded
-  // list; otherwise this is `undefined` and falls through untouched.
-  const teamKey = currentUser.user?.team?.teamKey;
-  const teamDefaultDashboardId = teamKey ? TEAM_DEFAULT_DASHBOARD_ID[teamKey] : undefined;
-  const teamDefaultEntry = teamDefaultDashboardId
-    ? list?.find((d) => d.id === teamDefaultDashboardId)
+  // Every team, unfiltered — needed for three independent reasons: (1)
+  // resolving the signed-in user's OWN team's `family`, to derive
+  // `preferredDashboardType` below BEFORE the initial dashboard is even
+  // picked; (2) resolving the selected team's `creGroupId`/`sreGroupId` (the
+  // `__current_team__` filter placeholder's real values) once a dashboard
+  // IS picked; (3) "All ABTs" family filtering further down. Deliberately
+  // NOT scoped to any one family the way AbtDashboardHeader's own picker
+  // query is (see abtFamilyForDashboardType): the signed-in user's own team
+  // can be outside the current (or eventual) dashboard's family (e.g. a
+  // `cre` non-ABT team member viewing a `cre` dashboard, whose picker only
+  // offers `cre-abt` teams). Enabled unconditionally rather than gated on
+  // the current dashboard's `isTeamBased` — that used to be fine because
+  // this query was only needed once a dashboard was already selected, but
+  // it's now also an input to selecting one, so it can't wait on a value it
+  // helps produce. A separate, differently-scoped query from the header's —
+  // react-query no longer dedupes these into one fetch. Cheap: a 5-minute
+  // stale time and this list rarely changes mid-session.
+  const teams = useTeams(true);
+
+  // The user's own team's family, and the dashboard `type` it prefers (see
+  // `dashboardTypeForTeamFamily`) — `undefined` for a user with no team, an
+  // unresolved team (not yet in the teams list), or a family that doesn't
+  // map to a known dashboard type.
+  const userTeamFamily = teams.data?.find(
+    (t) => t.id === currentUser.user?.team?.teamKey,
+  )?.family;
+  const preferredDashboardType = dashboardTypeForTeamFamily(userTeamFamily);
+
+  // Tier 1 (see module doc comment): a dashboard naming the signed-in
+  // user's own teamKey in its own `defaultForTeamKeys` wins outright over
+  // the isDefault/isTeamBased/type-based `preferredEntry` below — but only
+  // when that dashboard id is actually in the BE-loaded list; otherwise
+  // this is `undefined` and falls through untouched.
+  const defaultForTeamKeyEntry = currentUser.user?.team?.teamKey
+    ? list?.find((d) => d.defaultForTeamKeys?.includes(currentUser.user!.team!.teamKey))
     : undefined;
-  // The preferred predicate per the user's own team membership: BOTH
-  // isDefault and isTeamBased must match (not isTeamBased alone, and not
-  // isDefault alone) — see the module doc comment above.
+  // Tier 2: the preferred predicate per the user's own team membership.
+  // BOTH isDefault and isTeamBased must match (not isTeamBased alone, and
+  // not isDefault alone) — see the module doc comment above — further
+  // narrowed by `type` when the user's own team's family resolves to one.
+  // An unresolved `preferredDashboardType` falls back to matching on
+  // isDefault && isTeamBased alone, so this predicate must never regress to
+  // matching nothing just because the type couldn't be resolved.
   //
-  // Deliberately type-blind: `type` IS on `BeDashboardListItem` now (added
-  // for the team picker's family filter, see abtFamilyForDashboardType in
-  // useTeams.ts), but default-dashboard selection still isn't keyed off it.
-  // The backend loader is held to ONE isDefault dashboard in total to match
-  // — without that, a second typed default would be perfectly valid config
-  // and which one a user landed on would come down to the backend's filename
-  // ordering. Making this type-aware and loosening the loader to one default
-  // per type are the same change; do not do either alone.
+  // The backend loader (registry.go's `validate`) still only permits ONE
+  // isDefault dashboard in the WHOLE registry, not one per type — so in
+  // today's real config this type check is inert (there is only ever one
+  // isDefault+isTeamBased dashboard to begin with) until that validation is
+  // loosened to one-per-type. It's added here now so this predicate
+  // doesn't need a second frontend change when that lands.
   const preferredEntry = userHasTeam
-    ? list?.find((d) => d.isDefault && d.isTeamBased)
+    ? list?.find(
+        (d) =>
+          d.isDefault &&
+          d.isTeamBased &&
+          (preferredDashboardType ? d.type === preferredDashboardType : true),
+      )
     : list?.find((d) => d.isDefault && !d.isTeamBased);
   // Fallback 1: the BE's own (any) isDefault entry, regardless of
   // isTeamBased — covers a registry that has no isDefault+isTeamBased (or
@@ -147,9 +158,13 @@ export default function CsmDashboardPage(): JSX.Element {
   // because the registry has no isDefault entry configured.
   const firstEntry = list && list.length > 0 ? list[0] : undefined;
   // True only while we genuinely don't know yet whether this user has a
-  // team — a failed profile fetch (isError) must not hang this forever, so
-  // it falls straight through to the defaults below instead.
-  const userProfilePending = currentUser.isLoading && !currentUser.isError;
+  // team, or (when they do) what that team's family is — a failed fetch
+  // (isError) on EITHER query must not hang this forever, so it falls
+  // straight through to the defaults below instead.
+  const userProfilePending =
+    (currentUser.isLoading || (userHasTeam && teams.isLoading)) &&
+    !currentUser.isError &&
+    !teams.isError;
 
   // The URL always wins when it names a dashboard actually in the loaded
   // list (stale/hand-edited hash falls through to the defaults below,
@@ -161,7 +176,7 @@ export default function CsmDashboardPage(): JSX.Element {
     if (userProfilePending) {
       currentEntry = undefined;
     } else {
-      currentEntry = teamDefaultEntry ?? preferredEntry ?? anyDefaultEntry ?? firstEntry;
+      currentEntry = defaultForTeamKeyEntry ?? preferredEntry ?? anyDefaultEntry ?? firstEntry;
     }
   }
 
@@ -186,18 +201,6 @@ export default function CsmDashboardPage(): JSX.Element {
         : ALL_TEAMS_SENTINEL
       : undefined;
   const selectedTeamId = urlTeamId ?? defaultTeamId;
-
-  // Every team, unfiltered, for resolving the selected team's `creGroupId`
-  // and `sreGroupId` (the `__current_team__` filter placeholder's real
-  // values). Deliberately NOT scoped to the current dashboard's family the
-  // way AbtDashboardHeader's own picker query is (see
-  // abtFamilyForDashboardType): the signed-in user's own team can be
-  // outside that family (e.g. a `cre` non-ABT team member viewing a `cre`
-  // dashboard, whose picker only offers `cre-abt` teams), and
-  // `defaultTeamId` still needs it resolved to real group ids. A separate,
-  // differently-scoped query from the header's — react-query no longer
-  // dedupes these into one fetch.
-  const teams = useTeams(isTeamBased);
 
   // "All ABTs" resolves to every team in the CURRENT DASHBOARD's own family
   // specifically (not the signed-in user's own team's family, which is what

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/pages/CsmDashboardPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/pages/CsmDashboardPage.tsx
@@ -51,11 +51,50 @@ import { ALL_TEAMS_SENTINEL } from "@features/csm-dashboard/utils/teamFilterPlac
  * refresh or share always lands on an explicit dashboard id, never the bare
  * index.
  *
+ * Above even that team-based preferred predicate sits one more, narrower
+ * tier: `TEAM_DEFAULT_DASHBOARD_ID` maps a small, explicit set of team keys
+ * (the signed-in user's own `team.teamKey`, resolved the same way as above)
+ * straight onto a specific dashboard `id` — e.g. an `apollo_sre_group`-team
+ * user always lands on `sre-abt`, regardless of that dashboard's own
+ * `isDefault`/`isTeamBased` flags (`sre-abt.json` has `isDefault: false` —
+ * flipping it to `true` would fail the backend's own "at most one isDefault
+ * dashboard, of any type" validation, since a CRE dashboard already claims
+ * it; see `registry.go`'s validation and the `preferredEntry` comment below
+ * for why default-selection isn't type-aware). This is deliberately a
+ * team-*identity* override, not a generalization of the
+ * `isDefault`/`isTeamBased`/`type` mechanism below: it's additive and inert
+ * for every user whose `teamKey` isn't a key in the map, who falls straight
+ * through to `preferredEntry` exactly as before. A mapped team key whose
+ * target dashboard id isn't present in the BE-loaded list (e.g. not yet
+ * registered, or a stale map entry) also falls straight through rather than
+ * erroring. Adding a further team to this treatment is a one-line addition
+ * to the map, never a new branch. Once a user is on `sre-abt`, the team
+ * dropdown itself needs no separate wiring — `defaultTeamId` below already
+ * auto-selects the signed-in user's own `teamKey` for any team-based
+ * dashboard, and `AbtDashboardHeader`'s picker already resolves
+ * apollo_sre_group/artemis_sre_group generically via
+ * `abtFamilyForDashboardType("sre") === "sre-abt"` against the team
+ * registry, same as every other ABT family.
+ *
  * Dashboards are selected purely by dropdown — there is no other
  * per-dashboard scoping control. Every dashboard in the registry has at
  * least one real (config-driven) widget, so this always renders the real
  * widget grid.
  */
+
+/**
+ * Team-identity override tier for default-dashboard selection — see the
+ * module doc comment above. Keyed by the signed-in user's own
+ * `team.teamKey`; a team not listed here is simply not in this map, which is
+ * the common case (every non-mapped ABT team) and a deliberate no-op. Extend
+ * this map (never add another single-team branch) when a further team needs
+ * the same treatment.
+ */
+const TEAM_DEFAULT_DASHBOARD_ID: Record<string, string> = {
+  apollo_sre_group: "sre-abt",
+  artemis_sre_group: "sre-abt",
+};
+
 export default function CsmDashboardPage(): JSX.Element {
   const navigate = useNavigate();
   const { dashboardId: urlDashboardId, teamId: urlTeamIdRaw } = useParams<{
@@ -70,6 +109,15 @@ export default function CsmDashboardPage(): JSX.Element {
   const urlEntry = list?.find((d) => d.id === urlDashboardId);
 
   const userHasTeam = Boolean(currentUser.user?.team);
+  // Team-identity override (see module doc comment): a mapped teamKey wins
+  // outright over the isDefault/isTeamBased-based preferredEntry below —
+  // but only when that mapped dashboard id is actually in the BE-loaded
+  // list; otherwise this is `undefined` and falls through untouched.
+  const teamKey = currentUser.user?.team?.teamKey;
+  const teamDefaultDashboardId = teamKey ? TEAM_DEFAULT_DASHBOARD_ID[teamKey] : undefined;
+  const teamDefaultEntry = teamDefaultDashboardId
+    ? list?.find((d) => d.id === teamDefaultDashboardId)
+    : undefined;
   // The preferred predicate per the user's own team membership: BOTH
   // isDefault and isTeamBased must match (not isTeamBased alone, and not
   // isDefault alone) — see the module doc comment above.
@@ -107,7 +155,7 @@ export default function CsmDashboardPage(): JSX.Element {
     if (userProfilePending) {
       currentEntry = undefined;
     } else {
-      currentEntry = preferredEntry ?? anyDefaultEntry ?? firstEntry;
+      currentEntry = teamDefaultEntry ?? preferredEntry ?? anyDefaultEntry ?? firstEntry;
     }
   }
 

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/pages/CsmDashboardPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/pages/CsmDashboardPage.tsx
@@ -85,6 +85,8 @@ import { ALL_TEAMS_SENTINEL } from "@features/csm-dashboard/utils/teamFilterPlac
 const TEAM_DEFAULT_DASHBOARD_ID: Record<string, string> = {
   customer_onboarding: "onboarding-engineer",
   cs_migrations_team: "migration-engineer",
+  apollo_sre_group: "sre-abt",
+  artemis_sre_group: "sre-abt",
 };
 
 export default function CsmDashboardPage(): JSX.Element {

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardCasePreviewDrawer.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardCasePreviewDrawer.tsx
@@ -16,14 +16,16 @@
 
 import { Box, Button, Divider, Drawer, IconButton, Skeleton, Stack, Typography } from "@wso2/oxygen-ui";
 import { Check, X } from "@wso2/oxygen-ui-icons-react";
-import type { JSX, ReactNode } from "react";
+import { useRef, type JSX, type ReactNode } from "react";
 import RelativeDate from "@components/RelativeDate";
 import CasePreviewContent from "@features/csm-cases/components/CasePreviewContent";
 import { useGetCsmCaseDetail } from "@features/csm-cases/api/useGetCsmCaseDetail";
+import { QUICK_PREVIEW_EYE_SELECTOR } from "@features/csm-cases/utils/quickPreviewEye";
 import TimeCardStatusChip from "@features/csm-timecards/components/TimeCardStatusChip";
 import { billableLabel } from "@features/csm-timecards/constants/timeCardConstants";
 import { decisionSummary } from "@features/csm-timecards/utils/timeCardDecision";
 import { isBlankHtml, sanitizeRichTextHtml } from "@utils/sanitizeHtml";
+import { useCloseOnOutsideClick } from "@hooks/useCloseOnOutsideClick";
 import type { TimecardAction } from "@features/csm-timecards/utils/timeSheetState";
 import type { CsmTimeCard } from "@features/csm-timecards/types/timeCards";
 
@@ -103,23 +105,33 @@ export default function TimeCardCasePreviewDrawer({
 }: TimeCardCasePreviewDrawerProps): JSX.Element {
   const { data: caseDetail, isLoading, isError } = useGetCsmCaseDetail(card?.caseId);
   const decision = card ? decisionSummary(card) : null;
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  useCloseOnOutsideClick(!!card, contentRef, QUICK_PREVIEW_EYE_SELECTOR, onClose);
 
   return (
     <Drawer
       anchor="right"
       open={!!card}
       onClose={onClose}
-      // No backdrop: a temporary Drawer's default backdrop intercepts
-      // pointer events on the rest of the page, which would block clicking
-      // a different row's quick-preview eye while one preview is already
-      // open -- exactly the "switch straight to another row" behavior this
-      // drawer exists for. Closing still works via the eye toggle or the
-      // drawer's own close button.
+      // No backdrop, and the modal's own full-viewport root made
+      // click-through (via slotProps.root below) -- a temporary Drawer's
+      // default backdrop (and, even hidden, its still-present modal root
+      // container) intercepts pointer events on the rest of the page, which
+      // would block clicking a different row's quick-preview eye while one
+      // preview is already open. `useCloseOnOutsideClick` above replaces the
+      // backdrop's own click-to-close behavior, minus the eye buttons (their
+      // own onClick already decides the next state).
       hideBackdrop
-      slotProps={{ paper: { sx: { width: { xs: "100%", sm: 420 } } } }}
+      slotProps={{
+        root: { sx: { pointerEvents: "none" } },
+        paper: { sx: { pointerEvents: "auto", width: { xs: "100%", sm: 420 } } },
+      }}
     >
       {card && (
-        <Box sx={{ display: "flex", flexDirection: "column", height: "100%", overflowY: "auto" }}>
+        <Box
+          ref={contentRef}
+          sx={{ display: "flex", flexDirection: "column", height: "100%", overflowY: "auto" }}
+        >
           <Box sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 1.5 }}>
             <Box sx={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 1 }}>
               <Typography variant="subtitle2" color="text.secondary">

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardCasePreviewDrawer.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardCasePreviewDrawer.tsx
@@ -14,9 +14,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Box, Button, Divider, Drawer, IconButton, Skeleton, Stack, Typography } from "@wso2/oxygen-ui";
+import { Box, Button, Divider, IconButton, Skeleton, Stack, Typography } from "@wso2/oxygen-ui";
 import { Check, X } from "@wso2/oxygen-ui-icons-react";
 import { useRef, type JSX, type ReactNode } from "react";
+import FloatingSlidePanel from "@components/FloatingSlidePanel";
 import RelativeDate from "@components/RelativeDate";
 import CasePreviewContent from "@features/csm-cases/components/CasePreviewContent";
 import { useGetCsmCaseDetail } from "@features/csm-cases/api/useGetCsmCaseDetail";
@@ -109,24 +110,19 @@ export default function TimeCardCasePreviewDrawer({
   useCloseOnOutsideClick(!!card, contentRef, QUICK_PREVIEW_EYE_SELECTOR, onClose);
 
   return (
-    <Drawer
-      anchor="right"
-      open={!!card}
-      onClose={onClose}
-      // No backdrop, and the modal's own full-viewport root made
-      // click-through (via slotProps.root below) -- a temporary Drawer's
-      // default backdrop (and, even hidden, its still-present modal root
-      // container) intercepts pointer events on the rest of the page, which
-      // would block clicking a different row's quick-preview eye while one
-      // preview is already open. `useCloseOnOutsideClick` above replaces the
-      // backdrop's own click-to-close behavior, minus the eye buttons (their
-      // own onClick already decides the next state).
-      hideBackdrop
-      slotProps={{
-        root: { sx: { pointerEvents: "none" } },
-        paper: { sx: { pointerEvents: "auto", width: { xs: "100%", sm: 420 } } },
-      }}
-    >
+    // `FloatingSlidePanel` (not `Drawer`) -- a `Drawer` is `Modal`-backed,
+    // which enforces a focus trap and marks the rest of the page
+    // `aria-hidden` for as long as it's open, regardless of `hideBackdrop`
+    // or pointer-events tricks (those only ever affected mouse clicks, not
+    // `Modal`'s own accessibility isolation). This panel has no backdrop
+    // and no modal behavior at all, so the rest of the page stays fully
+    // interactive for every input method -- not just the mouse -- letting
+    // a click on a different row's quick-preview eye land normally while
+    // this preview is already open. `useCloseOnOutsideClick` below replaces
+    // the click-to-close behavior a `Drawer`'s backdrop would otherwise
+    // give, minus the eye buttons (their own onClick already decides the
+    // next state).
+    <FloatingSlidePanel open={!!card} ariaLabel="Time card preview">
       {card && (
         <Box
           ref={contentRef}
@@ -225,6 +221,6 @@ export default function TimeCardCasePreviewDrawer({
           )}
         </Box>
       )}
-    </Drawer>
+    </FloatingSlidePanel>
   );
 }

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardsTable.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardsTable.test.tsx
@@ -511,9 +511,36 @@ describe("TimeCardsTable View details drawer", () => {
     fireEvent.click(screen.getByTestId("timecard-view-tc-1"));
     expect(screen.getByText("Jane Doe")).toBeInTheDocument();
 
-    fireEvent.click(screen.getByTestId("timecard-view-tc-2"));
+    // A real click fires `mousedown` then `click` -- firing both (not just
+    // `click`) exercises `useCloseOnOutsideClick`'s own `mousedown` listener
+    // too, proving it excludes this eye button rather than racing its click
+    // handler and undoing the switch.
+    const otherEye = screen.getByTestId("timecard-view-tc-2");
+    fireEvent.mouseDown(otherEye);
+    fireEvent.click(otherEye);
     expect(screen.getByText("John Roe")).toBeInTheDocument();
     expect(screen.queryByText("Jane Doe")).not.toBeInTheDocument();
+  });
+
+  it("closes the preview when clicking outside it, without needing the close button or the eye again", () => {
+    getMock.mockReturnValue(new Promise(() => {}));
+    renderWithClient(
+      <TimeCardsTable
+        cards={[CARD]}
+        isLoading={false}
+        emptyText="No cards"
+        groupBy="case"
+        roleFor={() => ROLE_CTX}
+        onCardAction={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("timecard-view-tc-1"));
+    expect(screen.getByText("Time card")).toBeInTheDocument();
+
+    fireEvent.mouseDown(document.body);
+
+    expect(screen.queryByText("Time card")).not.toBeInTheDocument();
   });
 });
 

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardsTable.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardsTable.tsx
@@ -287,7 +287,9 @@ export default function TimeCardsTable({
                   <IconButton
                     size="small"
                     aria-label="View details"
+                    aria-pressed={detailCard?.id === c.id}
                     data-testid={`timecard-view-${c.id}`}
+                    data-quick-preview-eye="true"
                     onClick={() =>
                       setDetailCard((prev) => (prev?.id === c.id ? null : c))
                     }

--- a/apps/csm-portal/webapp/src/hooks/useCloseOnOutsideClick.test.tsx
+++ b/apps/csm-portal/webapp/src/hooks/useCloseOnOutsideClick.test.tsx
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render } from "@testing-library/react";
+import { useRef } from "react";
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { useCloseOnOutsideClick } from "./useCloseOnOutsideClick";
+
+function Harness({
+  active,
+  onClose,
+}: {
+  active: boolean;
+  onClose: () => void;
+}) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  useCloseOnOutsideClick(active, ref, "[data-excluded]", onClose);
+  return (
+    <div>
+      <div ref={ref} data-testid="content">
+        content
+      </div>
+      <button type="button" data-testid="outside">
+        outside
+      </button>
+      <button type="button" data-testid="excluded" data-excluded="true">
+        excluded
+      </button>
+    </div>
+  );
+}
+
+describe("useCloseOnOutsideClick", () => {
+  it("calls onClose on a mousedown outside the content ref", () => {
+    const onClose = vi.fn();
+    const { getByTestId } = render(<Harness active onClose={onClose} />);
+    fireEvent.mouseDown(getByTestId("outside"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call onClose on a mousedown inside the content ref", () => {
+    const onClose = vi.fn();
+    const { getByTestId } = render(<Harness active onClose={onClose} />);
+    fireEvent.mouseDown(getByTestId("content"));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("does not call onClose on a mousedown matching the exclude selector", () => {
+    const onClose = vi.fn();
+    const { getByTestId } = render(<Harness active onClose={onClose} />);
+    fireEvent.mouseDown(getByTestId("excluded"));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("does nothing while inactive", () => {
+    const onClose = vi.fn();
+    const { getByTestId } = render(<Harness active={false} onClose={onClose} />);
+    fireEvent.mouseDown(getByTestId("outside"));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/apps/csm-portal/webapp/src/hooks/useCloseOnOutsideClick.ts
+++ b/apps/csm-portal/webapp/src/hooks/useCloseOnOutsideClick.ts
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useEffect, type RefObject } from "react";
+
+/**
+ * Closes a non-modal panel (e.g. a `hideBackdrop` Drawer used so the rest of
+ * the page stays interactive while it's open) when the user clicks outside
+ * it -- without fighting a toggle button's own click handler for state.
+ *
+ * A plain "close on any outside click" listener races a toggle button that
+ * both opens a *different* item and (via the same click) would otherwise get
+ * immediately closed again by this listener: whichever of the two state
+ * updates lands second wins. Excluding clicks matched by `excludeSelector`
+ * (e.g. every quick-preview eye button) sidesteps the race entirely -- a
+ * click on one of those elements is left untouched here, so only that
+ * button's own handler decides the next state (open a different item, or
+ * toggle the current one closed).
+ *
+ * Listens on `mousedown` (capture phase, like MUI's own ClickAwayListener)
+ * rather than `click`, so the close registers before whatever the click
+ * target's own `click` handler does (e.g. a row navigating away).
+ */
+export function useCloseOnOutsideClick(
+  active: boolean,
+  contentRef: RefObject<HTMLElement | null>,
+  excludeSelector: string,
+  onClose: () => void,
+): void {
+  useEffect(() => {
+    if (!active) return;
+
+    function handlePointerDown(e: MouseEvent): void {
+      const target = e.target;
+      if (!(target instanceof Element)) return;
+      if (contentRef.current?.contains(target)) return;
+      if (target.closest(excludeSelector)) return;
+      onClose();
+    }
+
+    document.addEventListener("mousedown", handlePointerDown, true);
+    return () => document.removeEventListener("mousedown", handlePointerDown, true);
+  }, [active, contentRef, excludeSelector, onClose]);
+}

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -1481,11 +1481,52 @@ type SearchCasesRequest struct {
 	GroupBy string `json:"groupBy,omitempty"`
 }
 
+// GroupCasesByRequest is the input for the dedicated case group-by
+// aggregation endpoint. Unlike SearchCasesRequest.GroupBy (which returns a
+// bucket per value of a small fixed enum, computed client-side as one search
+// per value), this drives a single server-side aggregation over an
+// open-ended field such as account, capped to the top MaxGroups buckets with
+// the remainder folded into GroupByResponse.OthersCount.
+type GroupCasesByRequest struct {
+	Filters SearchCasesFilters `json:"filters"`
+	// GroupBy selects the field to aggregate by (e.g. "account", "state",
+	// "severity", "type"). Required.
+	GroupBy string `json:"groupBy"`
+	// MaxGroups caps the number of returned buckets to the top MaxGroups by
+	// count; the rest are folded into GroupByResponse.OthersCount (optional;
+	// the backing service applies a default when omitted).
+	MaxGroups int `json:"maxGroups,omitempty"`
+}
+
 // CaseGroup is one bucket in a grouped case-search result: Key is the group's
 // field value (e.g. a CaseState string), Count is the number of matching cases.
 type CaseGroup struct {
 	Key   string `json:"key"`
 	Count int    `json:"count"`
+}
+
+// GroupByBucket is one aggregated bucket in a server-side group-by result.
+// Key is the backing service's raw group value; Label is its human-readable
+// display form (identical to Key when the grouped field has no separate
+// label, e.g. an already-friendly account name). Count is the number of
+// matching records whose value of the grouped field falls in this bucket.
+type GroupByBucket struct {
+	Key   string `json:"key"`
+	Label string `json:"label"`
+	Count int    `json:"count"`
+}
+
+// GroupByResponse is the shared result shape for every resource's dedicated
+// group-by aggregation endpoint (cases, incidents, problems, change requests,
+// incident tasks). Groups holds the top buckets by count, capped at the
+// request's MaxGroups when set; OthersCount folds every bucket beyond that
+// cap into a single count. TotalRecords is the total number of records
+// matching the request's filters, and always equals the sum of Groups'
+// counts plus OthersCount.
+type GroupByResponse struct {
+	Groups       []GroupByBucket `json:"groups"`
+	OthersCount  int             `json:"othersCount"`
+	TotalRecords int             `json:"totalRecords"`
 }
 
 // SearchCaseView is the unified case representation returned in search results.
@@ -2312,6 +2353,21 @@ type SearchChangeRequestsRequest struct {
 	Filters    SearchChangeRequestsFilters `json:"filters"`
 	SortBy     ChangeRequestSort           `json:"sortBy"`
 	Pagination Pagination                  `json:"pagination"`
+}
+
+// GroupChangeRequestsByRequest is the input for the dedicated change request
+// group-by aggregation endpoint: a single server-side aggregation over the
+// requested field, capped to the top MaxGroups buckets with the remainder
+// folded into GroupByResponse.OthersCount.
+type GroupChangeRequestsByRequest struct {
+	Filters SearchChangeRequestsFilters `json:"filters"`
+	// GroupBy selects the field to aggregate by (e.g. "state",
+	// "assignmentGroup"). Required.
+	GroupBy string `json:"groupBy"`
+	// MaxGroups caps the number of returned buckets to the top MaxGroups by
+	// count; the rest are folded into GroupByResponse.OthersCount (optional;
+	// the backing service applies a default when omitted).
+	MaxGroups int `json:"maxGroups,omitempty"`
 }
 
 // SearchChangeRequestView is the unified change request representation returned in search results.
@@ -3391,6 +3447,21 @@ type SearchIncidentsRequest struct {
 	Pagination Pagination             `json:"pagination"`
 }
 
+// GroupIncidentsByRequest is the input for the dedicated incident group-by
+// aggregation endpoint: a single server-side aggregation over the requested
+// field, capped to the top MaxGroups buckets with the remainder folded into
+// GroupByResponse.OthersCount.
+type GroupIncidentsByRequest struct {
+	Filters SearchIncidentsFilters `json:"filters"`
+	// GroupBy selects the field to aggregate by (e.g. "state",
+	// "assignmentGroup", "businessService"). Required.
+	GroupBy string `json:"groupBy"`
+	// MaxGroups caps the number of returned buckets to the top MaxGroups by
+	// count; the rest are folded into GroupByResponse.OthersCount (optional;
+	// the backing service applies a default when omitted).
+	MaxGroups int `json:"maxGroups,omitempty"`
+}
+
 // SearchIncidentView is the unified incident representation returned in search results.
 type SearchIncidentView struct {
 	ID              *string    `json:"id"`
@@ -3682,6 +3753,21 @@ type SearchProblemsRequest struct {
 	Pagination Pagination            `json:"pagination"`
 }
 
+// GroupProblemsByRequest is the input for the dedicated problem group-by
+// aggregation endpoint: a single server-side aggregation over the requested
+// field, capped to the top MaxGroups buckets with the remainder folded into
+// GroupByResponse.OthersCount.
+type GroupProblemsByRequest struct {
+	Filters SearchProblemsFilters `json:"filters"`
+	// GroupBy selects the field to aggregate by (e.g. "state",
+	// "assignmentGroup"). Required.
+	GroupBy string `json:"groupBy"`
+	// MaxGroups caps the number of returned buckets to the top MaxGroups by
+	// count; the rest are folded into GroupByResponse.OthersCount (optional;
+	// the backing service applies a default when omitted).
+	MaxGroups int `json:"maxGroups,omitempty"`
+}
+
 // SearchProblemView is the problem representation returned in search results.
 type SearchProblemView struct {
 	ID              *string    `json:"id"`
@@ -3776,6 +3862,21 @@ type SearchIncidentTasksFilters struct {
 type SearchIncidentTasksRequest struct {
 	Filters    SearchIncidentTasksFilters `json:"filters"`
 	Pagination Pagination                 `json:"pagination"`
+}
+
+// GroupIncidentTasksByRequest is the input for the dedicated incident task
+// group-by aggregation endpoint: a single server-side aggregation over the
+// requested field, capped to the top MaxGroups buckets with the remainder
+// folded into GroupByResponse.OthersCount.
+type GroupIncidentTasksByRequest struct {
+	Filters SearchIncidentTasksFilters `json:"filters"`
+	// GroupBy selects the field to aggregate by (e.g. "state",
+	// "assignmentGroup"). Required.
+	GroupBy string `json:"groupBy"`
+	// MaxGroups caps the number of returned buckets to the top MaxGroups by
+	// count; the rest are folded into GroupByResponse.OthersCount (optional;
+	// the backing service applies a default when omitted).
+	MaxGroups int `json:"maxGroups,omitempty"`
 }
 
 // IncidentTask is the incident-task representation returned in search results.

--- a/entity-service/internal/handler/case_handler.go
+++ b/entity-service/internal/handler/case_handler.go
@@ -184,6 +184,21 @@ func (h *CaseHandler) SearchCases(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(resp)
 }
 
+// GroupCasesBy handles POST /cases/group-by.
+func (h *CaseHandler) GroupCasesBy(w http.ResponseWriter, r *http.Request) {
+	var req domain.GroupCasesByRequest
+	if !decodeRequest(w, r, &req) {
+		return
+	}
+	resp, err := h.svc.GroupCasesBy(r.Context(), req)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
 // CreateCaseAttachment handles POST /attachments.
 func (h *CaseHandler) CreateCaseAttachment(w http.ResponseWriter, r *http.Request) {
 	var req domain.CreateAttachmentRequest

--- a/entity-service/internal/handler/change_request_handler.go
+++ b/entity-service/internal/handler/change_request_handler.go
@@ -65,6 +65,21 @@ func (h *ChangeRequestHandler) SearchChangeRequests(w http.ResponseWriter, r *ht
 	_ = json.NewEncoder(w).Encode(resp)
 }
 
+// GroupChangeRequestsBy handles POST /change-requests/group-by.
+func (h *ChangeRequestHandler) GroupChangeRequestsBy(w http.ResponseWriter, r *http.Request) {
+	var req domain.GroupChangeRequestsByRequest
+	if !decodeRequest(w, r, &req) {
+		return
+	}
+	resp, err := h.svc.GroupChangeRequestsBy(r.Context(), req)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
 // PatchChangeRequest handles PATCH /change-requests/{id}.
 func (h *ChangeRequestHandler) PatchChangeRequest(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")

--- a/entity-service/internal/handler/incident_handler.go
+++ b/entity-service/internal/handler/incident_handler.go
@@ -111,3 +111,19 @@ func (h *IncidentHandler) SearchIncidents(w http.ResponseWriter, r *http.Request
 	w.WriteHeader(http.StatusOK)
 	_ = json.NewEncoder(w).Encode(resp)
 }
+
+// GroupIncidentsBy handles POST /incidents/group-by.
+func (h *IncidentHandler) GroupIncidentsBy(w http.ResponseWriter, r *http.Request) {
+	var req domain.GroupIncidentsByRequest
+	if !decodeRequest(w, r, &req) {
+		return
+	}
+	resp, err := h.svc.GroupIncidentsBy(r.Context(), req)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(resp)
+}

--- a/entity-service/internal/handler/incident_task_handler.go
+++ b/entity-service/internal/handler/incident_task_handler.go
@@ -51,6 +51,22 @@ func (h *IncidentTaskHandler) SearchIncidentTasks(w http.ResponseWriter, r *http
 	_ = json.NewEncoder(w).Encode(resp)
 }
 
+// GroupIncidentTasksBy handles POST /incident-tasks/group-by.
+func (h *IncidentTaskHandler) GroupIncidentTasksBy(w http.ResponseWriter, r *http.Request) {
+	var req domain.GroupIncidentTasksByRequest
+	if !decodeRequest(w, r, &req) {
+		return
+	}
+	resp, err := h.svc.GroupIncidentTasksBy(r.Context(), req)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
 // GetIncidentTask handles GET /incident-tasks/{id}.
 func (h *IncidentTaskHandler) GetIncidentTask(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")

--- a/entity-service/internal/handler/problem_handler.go
+++ b/entity-service/internal/handler/problem_handler.go
@@ -50,6 +50,22 @@ func (h *ProblemHandler) SearchProblems(w http.ResponseWriter, r *http.Request) 
 	_ = json.NewEncoder(w).Encode(resp)
 }
 
+// GroupProblemsBy handles POST /problems/group-by.
+func (h *ProblemHandler) GroupProblemsBy(w http.ResponseWriter, r *http.Request) {
+	var req domain.GroupProblemsByRequest
+	if !decodeRequest(w, r, &req) {
+		return
+	}
+	resp, err := h.svc.GroupProblemsBy(r.Context(), req)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
 // GetProblem handles GET /problems/{id}.
 func (h *ProblemHandler) GetProblem(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -275,6 +275,7 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 	mux.HandleFunc("PATCH /cases/{id}", caseHandler.PatchCase)
 	mux.HandleFunc("POST /cases", caseHandler.CreateCase)
 	mux.HandleFunc("POST /cases/search", caseHandler.SearchCases)
+	mux.HandleFunc("POST /cases/group-by", caseHandler.GroupCasesBy)
 	mux.HandleFunc("POST /cases/{id}/comments", caseHandler.CreateCaseComment)
 	mux.HandleFunc("POST /cases/{id}/activities/search", caseHandler.SearchCaseActivities)
 	mux.HandleFunc("POST /attachments", caseHandler.CreateCaseAttachment)
@@ -304,6 +305,7 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 	if changeRequestHandler != nil {
 		mux.HandleFunc("POST /change-requests", changeRequestHandler.CreateChangeRequest)
 		mux.HandleFunc("POST /change-requests/search", changeRequestHandler.SearchChangeRequests)
+		mux.HandleFunc("POST /change-requests/group-by", changeRequestHandler.GroupChangeRequestsBy)
 		mux.HandleFunc("GET /change-requests/{id}", changeRequestHandler.GetChangeRequest)
 		mux.HandleFunc("PATCH /change-requests/{id}", changeRequestHandler.PatchChangeRequest)
 		mux.HandleFunc("GET /change-requests/{id}/approvals", changeRequestHandler.GetChangeRequestApprovals)
@@ -366,17 +368,20 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 		mux.HandleFunc("PATCH /incidents/{id}", incidentHandler.PatchIncident)
 		mux.HandleFunc("POST /incidents", incidentHandler.CreateIncident)
 		mux.HandleFunc("POST /incidents/search", incidentHandler.SearchIncidents)
+		mux.HandleFunc("POST /incidents/group-by", incidentHandler.GroupIncidentsBy)
 		mux.HandleFunc("POST /incidents/{id}/activities/search", incidentHandler.SearchIncidentActivities)
 	}
 
 	if problemHandler != nil {
 		mux.HandleFunc("POST /problems", problemHandler.CreateProblem)
 		mux.HandleFunc("POST /problems/search", problemHandler.SearchProblems)
+		mux.HandleFunc("POST /problems/group-by", problemHandler.GroupProblemsBy)
 		mux.HandleFunc("GET /problems/{id}", problemHandler.GetProblem)
 	}
 
 	if incidentTaskHandler != nil {
 		mux.HandleFunc("POST /incident-tasks/search", incidentTaskHandler.SearchIncidentTasks)
+		mux.HandleFunc("POST /incident-tasks/group-by", incidentTaskHandler.GroupIncidentTasksBy)
 		mux.HandleFunc("GET /incident-tasks/{id}", incidentTaskHandler.GetIncidentTask)
 	}
 

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -83,6 +83,15 @@ var validCaseSeverity = map[domain.CaseSeverity]bool{
 	domain.CaseSeverityLow:          true,
 }
 
+// validCaseGroupByField is the allow-list for GroupCasesByRequest.GroupBy,
+// matching openapi.yaml's GroupCasesByRequest.groupBy enum exactly.
+var validCaseGroupByField = map[string]bool{
+	"account":  true,
+	"state":    true,
+	"severity": true,
+	"type":     true,
+}
+
 var validCaseIssueType = map[domain.CaseIssueType]bool{
 	domain.CaseIssueTypeError:                  true,
 	domain.CaseIssueTypePartialOutage:          true,

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -523,6 +523,10 @@ func (s *caseService) SearchCases(ctx context.Context, req domain.SearchCasesReq
 	}, nil
 }
 
+func (s *caseService) GroupCasesBy(_ context.Context, _ domain.GroupCasesByRequest) (domain.GroupByResponse, error) {
+	return domain.GroupByResponse{}, &apierror.ServiceUnavailableError{Msg: "groupBy is only supported for the ServiceNow data source"}
+}
+
 func (s *caseService) CreateCaseAttachment(_ context.Context, _ domain.CreateAttachmentRequest) (domain.CreateAttachmentResponse, error) {
 	return domain.CreateAttachmentResponse{}, &apierror.ServiceUnavailableError{Msg: "attachments are only supported for the ServiceNow data source"}
 }

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -184,6 +184,11 @@ type CaseService interface {
 	// A ValidationError is returned for invalid input; any other error indicates an
 	// infrastructure failure.
 	SearchCases(ctx context.Context, req domain.SearchCasesRequest) (domain.SearchCasesResponse, error)
+	// GroupCasesBy returns server-side aggregated counts of cases per value of
+	// req.GroupBy (e.g. account), capped to the top req.MaxGroups buckets with
+	// the remainder folded into GroupByResponse.OthersCount. A ValidationError
+	// is returned for invalid input.
+	GroupCasesBy(ctx context.Context, req domain.GroupCasesByRequest) (domain.GroupByResponse, error)
 	// CreateCaseComment creates a new comment on the case identified by req.CaseID.
 	// A ValidationError is returned for invalid input or constraint violations.
 	CreateCaseComment(ctx context.Context, req domain.CreateCaseCommentRequest) (domain.CreateCaseCommentResponse, error)
@@ -279,6 +284,12 @@ type ChangeRequestService interface {
 	// SearchChangeRequests returns a paginated list of change requests filtered by optional
 	// project IDs, state keys, impact keys, date ranges, and search query.
 	SearchChangeRequests(ctx context.Context, req domain.SearchChangeRequestsRequest) (domain.SearchChangeRequestsResponse, error)
+
+	// GroupChangeRequestsBy returns server-side aggregated counts of change requests
+	// per value of req.GroupBy, capped to the top req.MaxGroups buckets with the
+	// remainder folded into GroupByResponse.OthersCount. A ValidationError is
+	// returned for invalid input.
+	GroupChangeRequestsBy(ctx context.Context, req domain.GroupChangeRequestsByRequest) (domain.GroupByResponse, error)
 
 	// GetChangeRequest returns the full detail of a single change request by its UUID.
 	GetChangeRequest(ctx context.Context, id string) (domain.ChangeRequest, error)
@@ -408,6 +419,12 @@ type IncidentService interface {
 	// priority keys, and parent IDs. A ValidationError is returned for invalid input.
 	SearchIncidents(ctx context.Context, req domain.SearchIncidentsRequest) (domain.SearchIncidentsResponse, error)
 
+	// GroupIncidentsBy returns server-side aggregated counts of incidents per
+	// value of req.GroupBy, capped to the top req.MaxGroups buckets with the
+	// remainder folded into GroupByResponse.OthersCount. A ValidationError is
+	// returned for invalid input.
+	GroupIncidentsBy(ctx context.Context, req domain.GroupIncidentsByRequest) (domain.GroupByResponse, error)
+
 	// CreateIncident creates a new incident in ServiceNow.
 	// callerId, category, serviceId, impact, urgency, and subject are required.
 	CreateIncident(ctx context.Context, req domain.CreateIncidentRequest) (domain.CreateIncidentResponse, error)
@@ -431,6 +448,12 @@ type ProblemService interface {
 	// A ValidationError is returned for invalid input.
 	SearchProblems(ctx context.Context, req domain.SearchProblemsRequest) (domain.SearchProblemsResponse, error)
 
+	// GroupProblemsBy returns server-side aggregated counts of problems per
+	// value of req.GroupBy, capped to the top req.MaxGroups buckets with the
+	// remainder folded into GroupByResponse.OthersCount. A ValidationError is
+	// returned for invalid input.
+	GroupProblemsBy(ctx context.Context, req domain.GroupProblemsByRequest) (domain.GroupByResponse, error)
+
 	// GetProblem returns the full detail of a single problem by its UUID.
 	// A NotFoundError is returned if the problem does not exist.
 	GetProblem(ctx context.Context, id string) (domain.ProblemDetail, error)
@@ -447,6 +470,12 @@ type IncidentTaskService interface {
 	// optional search query and field filters. A ValidationError is returned for
 	// invalid input.
 	SearchIncidentTasks(ctx context.Context, req domain.SearchIncidentTasksRequest) (domain.SearchIncidentTasksResponse, error)
+
+	// GroupIncidentTasksBy returns server-side aggregated counts of incident
+	// tasks per value of req.GroupBy, capped to the top req.MaxGroups buckets
+	// with the remainder folded into GroupByResponse.OthersCount. A
+	// ValidationError is returned for invalid input.
+	GroupIncidentTasksBy(ctx context.Context, req domain.GroupIncidentTasksByRequest) (domain.GroupByResponse, error)
 
 	// GetIncidentTask returns the full detail of a single incident task by its UUID.
 	// A NotFoundError is returned if the incident task does not exist.

--- a/entity-service/internal/service/sn_case_group_by_test.go
+++ b/entity-service/internal/service/sn_case_group_by_test.go
@@ -1,0 +1,175 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package service
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+)
+
+// TestSNCaseService_GroupCasesBy_CallsGroupByEndpointAndMapsResponse proves
+// GroupCasesBy posts to the dedicated /cases/group-by endpoint (not
+// /cases/search), forwards groupBy/maxGroups alongside the parsed filter
+// payload, and maps the response into the shared domain.GroupByResponse
+// shape untouched.
+func TestSNCaseService_GroupCasesBy_CallsGroupByEndpointAndMapsResponse(t *testing.T) {
+	var gotBody struct {
+		Filters struct {
+			CaseTypes  []string `json:"caseTypes"`
+			StateKeys  []string `json:"stateKeys"`
+			ProjectIDs []string `json:"projectIds"`
+		} `json:"filters"`
+		GroupBy   string `json:"groupBy"`
+		MaxGroups int    `json:"maxGroups"`
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/cases/group-by", func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"groups": []map[string]any{
+				{"key": "acme", "label": "Acme Corp", "count": 12},
+				{"key": "globex", "label": "Globex Inc", "count": 7},
+			},
+			"othersCount":  3,
+			"totalRecords": 22,
+		})
+	})
+	// A request that lands here instead means GroupCasesBy called the wrong
+	// endpoint (the plain search path) rather than the dedicated group-by one.
+	mux.HandleFunc("/cases/search", func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("GroupCasesBy must not call /cases/search")
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowCaseService(client, nil)
+	ctx := contextWithUserIDToken(fakeJWTWithEmail(t, "jane.doe@example.com"))
+
+	req := domain.GroupCasesByRequest{
+		Filters: domain.SearchCasesFilters{
+			Filters: []domain.CaseFieldFilter{
+				{Field: "type", Op: "in", Values: []string{"case"}},
+			},
+		},
+		GroupBy:   "account",
+		MaxGroups: 12,
+	}
+
+	resp, err := svc.GroupCasesBy(ctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if gotBody.GroupBy != "account" {
+		t.Fatalf("groupBy = %q, want %q", gotBody.GroupBy, "account")
+	}
+	if gotBody.MaxGroups != 12 {
+		t.Fatalf("maxGroups = %d, want 12", gotBody.MaxGroups)
+	}
+	// "case" is SN's "default_case" wire value -- same translation SearchCases
+	// applies via snCaseTypeMap/domainTypeKeysToSN.
+	if len(gotBody.Filters.CaseTypes) != 1 || gotBody.Filters.CaseTypes[0] != "default_case" {
+		t.Fatalf("caseTypes = %v, want [default_case] (filters must be parsed/forwarded exactly as search does)", gotBody.Filters.CaseTypes)
+	}
+
+	want := domain.GroupByResponse{
+		Groups: []domain.GroupByBucket{
+			{Key: "acme", Label: "Acme Corp", Count: 12},
+			{Key: "globex", Label: "Globex Inc", Count: 7},
+		},
+		OthersCount:  3,
+		TotalRecords: 22,
+	}
+	if len(resp.Groups) != len(want.Groups) {
+		t.Fatalf("groups = %+v, want %+v", resp.Groups, want.Groups)
+	}
+	for i := range want.Groups {
+		if resp.Groups[i] != want.Groups[i] {
+			t.Fatalf("groups[%d] = %+v, want %+v", i, resp.Groups[i], want.Groups[i])
+		}
+	}
+	if resp.OthersCount != want.OthersCount {
+		t.Fatalf("othersCount = %d, want %d", resp.OthersCount, want.OthersCount)
+	}
+	if resp.TotalRecords != want.TotalRecords {
+		t.Fatalf("totalRecords = %d, want %d", resp.TotalRecords, want.TotalRecords)
+	}
+	// Sum of groups' counts + othersCount must equal totalRecords, matching
+	// the live-verified SN/Ballerina contract's own arithmetic invariant.
+	sum := want.OthersCount
+	for _, g := range want.Groups {
+		sum += g.Count
+	}
+	if sum != want.TotalRecords {
+		t.Fatalf("groups+othersCount = %d, want totalRecords %d", sum, want.TotalRecords)
+	}
+}
+
+// TestSNCaseService_GroupCasesBy_RejectsBadFilterFieldAndCombo proves a
+// filter-parse rejection from ParseCaseFieldFilters propagates through
+// GroupCasesBy exactly as it does through SearchCases, and that no request
+// reaches ServiceNow when that happens.
+func TestSNCaseService_GroupCasesBy_RejectsBadFilterFieldAndCombo(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/cases/group-by", func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("GroupCasesBy must not call ServiceNow when filter parsing fails")
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowCaseService(client, nil)
+	ctx := contextWithUserIDToken(fakeJWTWithEmail(t, "jane.doe@example.com"))
+
+	t.Run("bad field name", func(t *testing.T) {
+		req := domain.GroupCasesByRequest{
+			Filters: domain.SearchCasesFilters{
+				Filters: []domain.CaseFieldFilter{{Field: "bogusField", Op: "in", Values: []string{"x"}}},
+			},
+			GroupBy: "account",
+		}
+		_, err := svc.GroupCasesBy(ctx, req)
+		if _, ok := err.(*apierror.ValidationError); !ok {
+			t.Fatalf("expected *apierror.ValidationError, got %T: %v", err, err)
+		}
+	})
+
+	t.Run("bad field+op combo", func(t *testing.T) {
+		req := domain.GroupCasesByRequest{
+			Filters: domain.SearchCasesFilters{
+				Filters: []domain.CaseFieldFilter{{Field: "type", Op: "gte", Values: []string{"case"}}},
+			},
+			GroupBy: "account",
+		}
+		_, err := svc.GroupCasesBy(ctx, req)
+		if _, ok := err.(*apierror.ValidationError); !ok {
+			t.Fatalf("expected *apierror.ValidationError, got %T: %v", err, err)
+		}
+	})
+
+	t.Run("missing groupBy", func(t *testing.T) {
+		req := domain.GroupCasesByRequest{}
+		_, err := svc.GroupCasesBy(ctx, req)
+		if _, ok := err.(*apierror.ValidationError); !ok {
+			t.Fatalf("expected *apierror.ValidationError, got %T: %v", err, err)
+		}
+	})
+}

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -2539,6 +2539,9 @@ func (s *snCaseService) GroupCasesBy(ctx context.Context, req domain.GroupCasesB
 	if req.GroupBy == "" {
 		return domain.GroupByResponse{}, &apierror.ValidationError{Msg: "groupBy is required"}
 	}
+	if !validCaseGroupByField[req.GroupBy] {
+		return domain.GroupByResponse{}, &apierror.ValidationError{Msg: "groupBy contains invalid value: " + req.GroupBy}
+	}
 	if err := validateSearchQuery(req.Filters.SearchQuery); err != nil {
 		return domain.GroupByResponse{}, err
 	}
@@ -2651,6 +2654,15 @@ func (s *snCaseService) GroupCasesBy(ctx context.Context, req domain.GroupCasesB
 	var resp domain.GroupByResponse
 	if err := json.Unmarshal(raw, &resp); err != nil {
 		return domain.GroupByResponse{}, fmt.Errorf("sn cases: parse group-by response: %w", err)
+	}
+	// "account" is the only ID-valued field in validCaseGroupByField; SN
+	// returns its bucket keys as raw sys_ids, so convert them to this
+	// platform's UUIDs before returning. Every other allowed field (state,
+	// severity, type) is a plain enum and is left as-is.
+	if req.GroupBy == "account" {
+		for i := range resp.Groups {
+			resp.Groups[i].Key = sysidToUUID(resp.Groups[i].Key)
+		}
 	}
 	return resp, nil
 }

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -2516,6 +2516,145 @@ func (s *snCaseService) SearchCases(ctx context.Context, req domain.SearchCasesR
 	}, nil
 }
 
+// snCaseGroupByPayload is the Choreo POST /cases/group-by request body.
+type snCaseGroupByPayload struct {
+	Filters   snCaseFilters `json:"filters,omitempty"`
+	GroupBy   string        `json:"groupBy"`
+	MaxGroups int           `json:"maxGroups,omitempty"`
+}
+
+// GroupCasesBy implements CaseService by calling the Choreo POST
+// /cases/group-by endpoint: a single server-side aggregation over the
+// requested field (e.g. account), capped to the top MaxGroups buckets with
+// the remainder folded into GroupByResponse.OthersCount. This is distinct
+// from SearchCases' own GroupBy, which only supports small fixed-enum
+// fields and computes each bucket as a separate client-side search.
+//
+// Filter parsing and validation mirror SearchCases exactly -- same
+// ParseCaseFieldFilters/ParseCaseFieldFilterGroups calls, same enum and
+// range checks -- so a request that would be rejected by search is rejected
+// here too, rather than silently reaching ServiceNow with a narrower filter
+// set than the caller intended.
+func (s *snCaseService) GroupCasesBy(ctx context.Context, req domain.GroupCasesByRequest) (domain.GroupByResponse, error) {
+	if req.GroupBy == "" {
+		return domain.GroupByResponse{}, &apierror.ValidationError{Msg: "groupBy is required"}
+	}
+	if err := validateSearchQuery(req.Filters.SearchQuery); err != nil {
+		return domain.GroupByResponse{}, err
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+	callerEmail, callerEmailErr := resolveCaseFilterCallerEmail(token)
+	parsed, err := ParseCaseFieldFilters(req.Filters.Filters, callerEmail, callerEmailErr, time.Now().UTC())
+	if err != nil {
+		return domain.GroupByResponse{}, err
+	}
+
+	orGroups, err := ParseCaseFieldFilterGroups(req.Filters.AnyOf)
+	if err != nil {
+		return domain.GroupByResponse{}, err
+	}
+	parsed.OrGroups = orGroups
+
+	if parsed.ClosedEndDate != nil && parsed.ClosedStartDate != nil &&
+		parsed.ClosedEndDate.Before(*parsed.ClosedStartDate) {
+		return domain.GroupByResponse{}, &apierror.ValidationError{Msg: "closedOn: lte value must not be before gte value"}
+	}
+	if parsed.ResolvedEndDate != nil && parsed.ResolvedStartDate != nil &&
+		parsed.ResolvedEndDate.Before(*parsed.ResolvedStartDate) {
+		return domain.GroupByResponse{}, &apierror.ValidationError{Msg: "resolvedOn: lte value must not be before gte value"}
+	}
+	if parsed.EndCreatedDate != nil && parsed.StartCreatedDate != nil &&
+		parsed.EndCreatedDate.Before(*parsed.StartCreatedDate) {
+		return domain.GroupByResponse{}, &apierror.ValidationError{Msg: "createdOn: lte value must not be before gte value"}
+	}
+	if parsed.EndUpdatedDate != nil && parsed.StartUpdatedDate != nil &&
+		parsed.EndUpdatedDate.Before(*parsed.StartUpdatedDate) {
+		return domain.GroupByResponse{}, &apierror.ValidationError{Msg: "updatedOn: lte value must not be before gte value"}
+	}
+	for _, ws := range parsed.WorkStates {
+		if ws != domain.CaseWorkStateOngoing && ws != domain.CaseWorkStatePaused {
+			return domain.GroupByResponse{}, &apierror.ValidationError{Msg: "workState contains invalid value: " + string(ws)}
+		}
+	}
+	if err := validateUUIDs("assignedUserId", parsed.AssignedUserIDs); err != nil {
+		return domain.GroupByResponse{}, err
+	}
+	if parsed.ParentID != nil {
+		if err := validateUUIDs("parentId", []string{*parsed.ParentID}); err != nil {
+			return domain.GroupByResponse{}, err
+		}
+	}
+	if err := validateUUIDs("creTeam", parsed.CreTeamIDs); err != nil {
+		return domain.GroupByResponse{}, err
+	}
+	if err := validateUUIDs("sreTeam", parsed.SreTeamIDs); err != nil {
+		return domain.GroupByResponse{}, err
+	}
+	if err := validateUUIDs("accountId", parsed.AccountIDs); err != nil {
+		return domain.GroupByResponse{}, err
+	}
+	for _, t := range parsed.Types {
+		if _, ok := snCaseTypeMap[t]; !ok {
+			return domain.GroupByResponse{}, &apierror.ValidationError{Msg: "type contains invalid value: " + t}
+		}
+	}
+	for _, st := range parsed.States {
+		if !validCaseState[st] {
+			return domain.GroupByResponse{}, &apierror.ValidationError{Msg: "state contains invalid value: " + string(st)}
+		}
+	}
+	for _, st := range parsed.ExcludeStates {
+		if !validCaseState[st] {
+			return domain.GroupByResponse{}, &apierror.ValidationError{Msg: "state (notIn) contains invalid value: " + string(st)}
+		}
+	}
+	for _, sv := range parsed.Severities {
+		if !validCaseSeverity[sv] {
+			return domain.GroupByResponse{}, &apierror.ValidationError{Msg: "severity contains invalid value: " + string(sv)}
+		}
+	}
+	for _, it := range parsed.IssueTypes {
+		if !validCaseIssueType[it] {
+			return domain.GroupByResponse{}, &apierror.ValidationError{Msg: "issueType contains invalid value: " + string(it)}
+		}
+	}
+	for _, et := range parsed.EngagementTypes {
+		if !validEngagementType[et] {
+			return domain.GroupByResponse{}, &apierror.ValidationError{Msg: "engagementType contains invalid value: " + string(et)}
+		}
+	}
+	for _, lvl := range parsed.EscalationLevels {
+		if !validEscalationLevel[lvl] {
+			return domain.GroupByResponse{}, &apierror.ValidationError{Msg: "escalationLevel contains invalid value: " + lvl}
+		}
+	}
+	for i, group := range parsed.OrGroups {
+		if err := validateOrGroupEnums(i, group); err != nil {
+			return domain.GroupByResponse{}, err
+		}
+	}
+
+	snFilters := buildSNCaseFilters(parsed, req.Filters.SearchQuery)
+
+	payload := snCaseGroupByPayload{
+		Filters:   snFilters,
+		GroupBy:   req.GroupBy,
+		MaxGroups: req.MaxGroups,
+	}
+
+	raw, err := s.client.Post(ctx, "/cases/group-by", token, payload)
+	if err != nil {
+		return domain.GroupByResponse{}, err
+	}
+
+	var resp domain.GroupByResponse
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return domain.GroupByResponse{}, fmt.Errorf("sn cases: parse group-by response: %w", err)
+	}
+	return resp, nil
+}
+
 // searchCasesGroupCount returns the total matching-record count for one
 // groupBy bucket: parsed's existing filters, with any prior filter on
 // groupByField replaced by exactly value (a groupBy request describes the

--- a/entity-service/internal/service/sn_change_request_service.go
+++ b/entity-service/internal/service/sn_change_request_service.go
@@ -399,6 +399,14 @@ type snChangeRequestGroupByPayload struct {
 	MaxGroups int                    `json:"maxGroups,omitempty"`
 }
 
+// validChangeRequestGroupByField is the allow-list for
+// GroupChangeRequestsByRequest.GroupBy, matching openapi.yaml's
+// GroupChangeRequestsByRequest.groupBy enum exactly.
+var validChangeRequestGroupByField = map[string]bool{
+	"state":           true,
+	"assignmentGroup": true,
+}
+
 // GroupChangeRequestsBy implements ChangeRequestService by calling the
 // Choreo POST /change-requests/group-by endpoint: a single server-side
 // aggregation over the requested field, capped to the top MaxGroups buckets
@@ -407,6 +415,9 @@ type snChangeRequestGroupByPayload struct {
 func (s *snChangeRequestService) GroupChangeRequestsBy(ctx context.Context, req domain.GroupChangeRequestsByRequest) (domain.GroupByResponse, error) {
 	if req.GroupBy == "" {
 		return domain.GroupByResponse{}, &apierror.ValidationError{Msg: "groupBy is required"}
+	}
+	if !validChangeRequestGroupByField[req.GroupBy] {
+		return domain.GroupByResponse{}, &apierror.ValidationError{Msg: "groupBy contains invalid value: " + req.GroupBy}
 	}
 	if err := validateSearchQuery(req.Filters.SearchQuery); err != nil {
 		return domain.GroupByResponse{}, err

--- a/entity-service/internal/service/sn_change_request_service.go
+++ b/entity-service/internal/service/sn_change_request_service.go
@@ -391,6 +391,87 @@ func (s *snChangeRequestService) SearchChangeRequests(ctx context.Context, req d
 	}, nil
 }
 
+// snChangeRequestGroupByPayload is the Choreo POST /change-requests/group-by
+// request body.
+type snChangeRequestGroupByPayload struct {
+	Filters   snChangeRequestFilters `json:"filters,omitempty"`
+	GroupBy   string                 `json:"groupBy"`
+	MaxGroups int                    `json:"maxGroups,omitempty"`
+}
+
+// GroupChangeRequestsBy implements ChangeRequestService by calling the
+// Choreo POST /change-requests/group-by endpoint: a single server-side
+// aggregation over the requested field, capped to the top MaxGroups buckets
+// with the remainder folded into GroupByResponse.OthersCount. Filter
+// parsing and validation mirror SearchChangeRequests.
+func (s *snChangeRequestService) GroupChangeRequestsBy(ctx context.Context, req domain.GroupChangeRequestsByRequest) (domain.GroupByResponse, error) {
+	if req.GroupBy == "" {
+		return domain.GroupByResponse{}, &apierror.ValidationError{Msg: "groupBy is required"}
+	}
+	if err := validateSearchQuery(req.Filters.SearchQuery); err != nil {
+		return domain.GroupByResponse{}, err
+	}
+	if err := validateExactNumber("number", req.Filters.Number); err != nil {
+		return domain.GroupByResponse{}, err
+	}
+
+	if req.Filters.ClosedEndDate != nil && req.Filters.ClosedStartDate != nil &&
+		req.Filters.ClosedEndDate.Before(*req.Filters.ClosedStartDate) {
+		return domain.GroupByResponse{}, &apierror.ValidationError{Msg: "closedEndDate must not be before closedStartDate"}
+	}
+	for _, s := range req.Filters.States {
+		if !validChangeRequestState[s] {
+			return domain.GroupByResponse{}, &apierror.ValidationError{Msg: "states contains invalid value: " + string(s)}
+		}
+	}
+	for _, i := range req.Filters.Impacts {
+		if !validChangeRequestImpact[i] {
+			return domain.GroupByResponse{}, &apierror.ValidationError{Msg: "impacts contains invalid value: " + string(i)}
+		}
+	}
+	if err := validateUUIDs("projectIds", req.Filters.ProjectIDs); err != nil {
+		return domain.GroupByResponse{}, err
+	}
+	parsedFilters, err := ParseChangeRequestFieldFilters(req.Filters.Filters, time.Now().UTC())
+	if err != nil {
+		return domain.GroupByResponse{}, err
+	}
+	if parsedFilters.CreatedEndDate != nil && parsedFilters.CreatedStartDate != nil &&
+		parsedFilters.CreatedEndDate.Before(*parsedFilters.CreatedStartDate) {
+		return domain.GroupByResponse{}, &apierror.ValidationError{Msg: "createdOn: lte value must not be before gte value"}
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+
+	payload := snChangeRequestGroupByPayload{
+		Filters: snChangeRequestFilters{
+			ProjectIDs:         uuidsToSysids(req.Filters.ProjectIDs),
+			SearchQuery:        req.Filters.SearchQuery,
+			StateKeys:          domainCRStatesToSNIDs(req.Filters.States),
+			ImpactKeys:         domainCRImpactsToSNIDs(req.Filters.Impacts),
+			ClosedStartDate:    formatSNDateTimeUTC(req.Filters.ClosedStartDate),
+			ClosedEndDate:      formatSNDateTimeUTC(req.Filters.ClosedEndDate),
+			Number:             stringPtrValue(req.Filters.Number),
+			CreatedStartDate:   formatSNDateTimeUTC(parsedFilters.CreatedStartDate),
+			CreatedEndDate:     formatSNDateTimeUTC(parsedFilters.CreatedEndDate),
+			AssignmentGroupIDs: uuidsToSysids(parsedFilters.AssignmentGroupIDs),
+		},
+		GroupBy:   req.GroupBy,
+		MaxGroups: req.MaxGroups,
+	}
+
+	raw, err := s.client.Post(ctx, "/change-requests/group-by", token, payload)
+	if err != nil {
+		return domain.GroupByResponse{}, err
+	}
+
+	var resp domain.GroupByResponse
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return domain.GroupByResponse{}, fmt.Errorf("sn change requests: parse group-by response: %w", err)
+	}
+	return resp, nil
+}
+
 // snCreateChangeRequestPayload is the Choreo POST /change-requests request body.
 type snCreateChangeRequestPayload struct {
 	Subject             string  `json:"subject"`

--- a/entity-service/internal/service/sn_incident_service.go
+++ b/entity-service/internal/service/sn_incident_service.go
@@ -317,6 +317,80 @@ func (s *snIncidentService) SearchIncidents(ctx context.Context, req domain.Sear
 	}, nil
 }
 
+// snIncidentGroupByPayload is the Choreo POST /incidents/group-by request body.
+type snIncidentGroupByPayload struct {
+	Filters   snIncidentFilters `json:"filters,omitempty"`
+	GroupBy   string            `json:"groupBy"`
+	MaxGroups int               `json:"maxGroups,omitempty"`
+}
+
+// GroupIncidentsBy implements IncidentService by calling the Choreo POST
+// /incidents/group-by endpoint: a single server-side aggregation over the
+// requested field, capped to the top MaxGroups buckets with the remainder
+// folded into GroupByResponse.OthersCount. Filter parsing and validation
+// mirror SearchIncidents.
+func (s *snIncidentService) GroupIncidentsBy(ctx context.Context, req domain.GroupIncidentsByRequest) (domain.GroupByResponse, error) {
+	if req.GroupBy == "" {
+		return domain.GroupByResponse{}, &apierror.ValidationError{Msg: "groupBy is required"}
+	}
+	if err := validateSearchQuery(req.Filters.SearchQuery); err != nil {
+		return domain.GroupByResponse{}, err
+	}
+	if err := validateExactNumber("number", req.Filters.Number); err != nil {
+		return domain.GroupByResponse{}, err
+	}
+	for _, p := range req.Filters.Priorities {
+		if !validIncidentPriority[p] {
+			return domain.GroupByResponse{}, &apierror.ValidationError{Msg: "priorities contains invalid value: " + string(p)}
+		}
+	}
+	if err := validateUUIDs("parentIds", req.Filters.ParentIDs); err != nil {
+		return domain.GroupByResponse{}, err
+	}
+	parsedFilters, err := ParseIncidentFieldFilters(req.Filters.Filters, time.Now().UTC())
+	if err != nil {
+		return domain.GroupByResponse{}, err
+	}
+	if parsedFilters.EndCreatedDate != nil && parsedFilters.StartCreatedDate != nil &&
+		parsedFilters.EndCreatedDate.Before(*parsedFilters.StartCreatedDate) {
+		return domain.GroupByResponse{}, &apierror.ValidationError{Msg: "createdOn: lte value must not be before gte value"}
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+
+	priorityKeys := make([]int, 0, len(req.Filters.Priorities))
+	for _, p := range req.Filters.Priorities {
+		priorityKeys = append(priorityKeys, snIncidentPriorityKeyMap[p])
+	}
+
+	payload := snIncidentGroupByPayload{
+		Filters: snIncidentFilters{
+			SearchQuery:        req.Filters.SearchQuery,
+			PriorityKeys:       priorityKeys,
+			ParentIDs:          uuidsToSysids(req.Filters.ParentIDs),
+			Number:             stringPtrValue(req.Filters.Number),
+			StateKeys:          parsedFilters.StateKeys,
+			AssignmentGroupIDs: uuidsToSysids(parsedFilters.AssignmentGroupIDs),
+			BusinessServiceIDs: uuidsToSysids(parsedFilters.BusinessServiceIDs),
+			StartCreatedDate:   formatSNDateTimeUTC(parsedFilters.StartCreatedDate),
+			EndCreatedDate:     formatSNDateTimeUTC(parsedFilters.EndCreatedDate),
+		},
+		GroupBy:   req.GroupBy,
+		MaxGroups: req.MaxGroups,
+	}
+
+	raw, err := s.client.Post(ctx, "/incidents/group-by", token, payload)
+	if err != nil {
+		return domain.GroupByResponse{}, err
+	}
+
+	var resp domain.GroupByResponse
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return domain.GroupByResponse{}, fmt.Errorf("sn incidents: parse group-by response: %w", err)
+	}
+	return resp, nil
+}
+
 // snIncidentCategoryKeyMap maps domain IncidentCategory enums to SN category string values.
 var snIncidentCategoryKeyMap = map[domain.IncidentCategory]string{
 	domain.IncidentCategoryInquiry:             "inquiry",

--- a/entity-service/internal/service/sn_incident_service.go
+++ b/entity-service/internal/service/sn_incident_service.go
@@ -324,6 +324,15 @@ type snIncidentGroupByPayload struct {
 	MaxGroups int               `json:"maxGroups,omitempty"`
 }
 
+// validIncidentGroupByField is the allow-list for
+// GroupIncidentsByRequest.GroupBy, matching openapi.yaml's
+// GroupIncidentsByRequest.groupBy enum exactly.
+var validIncidentGroupByField = map[string]bool{
+	"state":           true,
+	"assignmentGroup": true,
+	"businessService": true,
+}
+
 // GroupIncidentsBy implements IncidentService by calling the Choreo POST
 // /incidents/group-by endpoint: a single server-side aggregation over the
 // requested field, capped to the top MaxGroups buckets with the remainder
@@ -332,6 +341,9 @@ type snIncidentGroupByPayload struct {
 func (s *snIncidentService) GroupIncidentsBy(ctx context.Context, req domain.GroupIncidentsByRequest) (domain.GroupByResponse, error) {
 	if req.GroupBy == "" {
 		return domain.GroupByResponse{}, &apierror.ValidationError{Msg: "groupBy is required"}
+	}
+	if !validIncidentGroupByField[req.GroupBy] {
+		return domain.GroupByResponse{}, &apierror.ValidationError{Msg: "groupBy contains invalid value: " + req.GroupBy}
 	}
 	if err := validateSearchQuery(req.Filters.SearchQuery); err != nil {
 		return domain.GroupByResponse{}, err

--- a/entity-service/internal/service/sn_incident_task_service.go
+++ b/entity-service/internal/service/sn_incident_task_service.go
@@ -150,6 +150,14 @@ type snIncidentTaskGroupByPayload struct {
 	MaxGroups int                   `json:"maxGroups,omitempty"`
 }
 
+// validIncidentTaskGroupByField is the allow-list for
+// GroupIncidentTasksByRequest.GroupBy, matching openapi.yaml's
+// GroupIncidentTasksByRequest.groupBy enum exactly.
+var validIncidentTaskGroupByField = map[string]bool{
+	"state":           true,
+	"assignmentGroup": true,
+}
+
 // GroupIncidentTasksBy implements IncidentTaskService by calling the Choreo
 // POST /incident_tasks/group-by endpoint: a single server-side aggregation
 // over the requested field, capped to the top MaxGroups buckets with the
@@ -158,6 +166,9 @@ type snIncidentTaskGroupByPayload struct {
 func (s *snIncidentTaskService) GroupIncidentTasksBy(ctx context.Context, req domain.GroupIncidentTasksByRequest) (domain.GroupByResponse, error) {
 	if req.GroupBy == "" {
 		return domain.GroupByResponse{}, &apierror.ValidationError{Msg: "groupBy is required"}
+	}
+	if !validIncidentTaskGroupByField[req.GroupBy] {
+		return domain.GroupByResponse{}, &apierror.ValidationError{Msg: "groupBy contains invalid value: " + req.GroupBy}
 	}
 	if err := validateSearchQuery(req.Filters.SearchQuery); err != nil {
 		return domain.GroupByResponse{}, err
@@ -192,6 +203,15 @@ func (s *snIncidentTaskService) GroupIncidentTasksBy(ctx context.Context, req do
 	var resp domain.GroupByResponse
 	if err := json.Unmarshal(raw, &resp); err != nil {
 		return domain.GroupByResponse{}, fmt.Errorf("sn incident tasks: parse group-by response: %w", err)
+	}
+	// "assignmentGroup" is the only ID-valued field in
+	// validIncidentTaskGroupByField; SN returns its bucket keys as raw
+	// sys_ids, so convert them to this platform's UUIDs before returning.
+	// "state" is a plain enum and is left as-is.
+	if req.GroupBy == "assignmentGroup" {
+		for i := range resp.Groups {
+			resp.Groups[i].Key = sysidToUUID(resp.Groups[i].Key)
+		}
 	}
 	return resp, nil
 }

--- a/entity-service/internal/service/sn_incident_task_service.go
+++ b/entity-service/internal/service/sn_incident_task_service.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/middleware"
 	integrationservice "github.com/wso2-open-operations/cs-tools/entity-service/internal/servicenow-integration-service"
@@ -139,6 +140,60 @@ func (s *snIncidentTaskService) SearchIncidentTasks(ctx context.Context, req dom
 		Limit:         req.Pagination.Limit,
 		Offset:        req.Pagination.Offset,
 	}, nil
+}
+
+// snIncidentTaskGroupByPayload is the Choreo POST /incident_tasks/group-by
+// request body.
+type snIncidentTaskGroupByPayload struct {
+	Filters   snIncidentTaskFilters `json:"filters,omitempty"`
+	GroupBy   string                `json:"groupBy"`
+	MaxGroups int                   `json:"maxGroups,omitempty"`
+}
+
+// GroupIncidentTasksBy implements IncidentTaskService by calling the Choreo
+// POST /incident_tasks/group-by endpoint: a single server-side aggregation
+// over the requested field, capped to the top MaxGroups buckets with the
+// remainder folded into GroupByResponse.OthersCount. Filter parsing and
+// validation mirror SearchIncidentTasks.
+func (s *snIncidentTaskService) GroupIncidentTasksBy(ctx context.Context, req domain.GroupIncidentTasksByRequest) (domain.GroupByResponse, error) {
+	if req.GroupBy == "" {
+		return domain.GroupByResponse{}, &apierror.ValidationError{Msg: "groupBy is required"}
+	}
+	if err := validateSearchQuery(req.Filters.SearchQuery); err != nil {
+		return domain.GroupByResponse{}, err
+	}
+	if err := validateExactNumber("number", req.Filters.Number); err != nil {
+		return domain.GroupByResponse{}, err
+	}
+	parsedFilters, err := ParseIncidentTaskFieldFilters(req.Filters.Filters)
+	if err != nil {
+		return domain.GroupByResponse{}, err
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+
+	payload := snIncidentTaskGroupByPayload{
+		Filters: snIncidentTaskFilters{
+			SearchQuery:        req.Filters.SearchQuery,
+			Number:             stringPtrValue(req.Filters.Number),
+			StateKeys:          parsedFilters.StateKeys,
+			AssignmentGroupIDs: uuidsToSysids(parsedFilters.AssignmentGroupIDs),
+			IncidentIDs:        uuidsToSysids(parsedFilters.IncidentIDs),
+		},
+		GroupBy:   req.GroupBy,
+		MaxGroups: req.MaxGroups,
+	}
+
+	raw, err := s.client.Post(ctx, "/incident_tasks/group-by", token, payload)
+	if err != nil {
+		return domain.GroupByResponse{}, err
+	}
+
+	var resp domain.GroupByResponse
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return domain.GroupByResponse{}, fmt.Errorf("sn incident tasks: parse group-by response: %w", err)
+	}
+	return resp, nil
 }
 
 // mapSNIncidentTaskToView maps a Choreo incident-task search-result payload

--- a/entity-service/internal/service/sn_problem_service.go
+++ b/entity-service/internal/service/sn_problem_service.go
@@ -166,6 +166,14 @@ type snProblemGroupByPayload struct {
 	MaxGroups int              `json:"maxGroups,omitempty"`
 }
 
+// validProblemGroupByField is the allow-list for
+// GroupProblemsByRequest.GroupBy, matching openapi.yaml's
+// GroupProblemsByRequest.groupBy enum exactly.
+var validProblemGroupByField = map[string]bool{
+	"state":           true,
+	"assignmentGroup": true,
+}
+
 // GroupProblemsBy implements ProblemService by calling the Choreo POST
 // /problems/group-by endpoint: a single server-side aggregation over the
 // requested field, capped to the top MaxGroups buckets with the remainder
@@ -174,6 +182,9 @@ type snProblemGroupByPayload struct {
 func (s *snProblemService) GroupProblemsBy(ctx context.Context, req domain.GroupProblemsByRequest) (domain.GroupByResponse, error) {
 	if req.GroupBy == "" {
 		return domain.GroupByResponse{}, &apierror.ValidationError{Msg: "groupBy is required"}
+	}
+	if !validProblemGroupByField[req.GroupBy] {
+		return domain.GroupByResponse{}, &apierror.ValidationError{Msg: "groupBy contains invalid value: " + req.GroupBy}
 	}
 	if err := validateSearchQuery(req.Filters.SearchQuery); err != nil {
 		return domain.GroupByResponse{}, err

--- a/entity-service/internal/service/sn_problem_service.go
+++ b/entity-service/internal/service/sn_problem_service.go
@@ -159,6 +159,58 @@ func (s *snProblemService) SearchProblems(ctx context.Context, req domain.Search
 	}, nil
 }
 
+// snProblemGroupByPayload is the Choreo POST /problems/group-by request body.
+type snProblemGroupByPayload struct {
+	Filters   snProblemFilters `json:"filters,omitempty"`
+	GroupBy   string           `json:"groupBy"`
+	MaxGroups int              `json:"maxGroups,omitempty"`
+}
+
+// GroupProblemsBy implements ProblemService by calling the Choreo POST
+// /problems/group-by endpoint: a single server-side aggregation over the
+// requested field, capped to the top MaxGroups buckets with the remainder
+// folded into GroupByResponse.OthersCount. Filter parsing and validation
+// mirror SearchProblems.
+func (s *snProblemService) GroupProblemsBy(ctx context.Context, req domain.GroupProblemsByRequest) (domain.GroupByResponse, error) {
+	if req.GroupBy == "" {
+		return domain.GroupByResponse{}, &apierror.ValidationError{Msg: "groupBy is required"}
+	}
+	if err := validateSearchQuery(req.Filters.SearchQuery); err != nil {
+		return domain.GroupByResponse{}, err
+	}
+	if err := validateExactNumber("number", req.Filters.Number); err != nil {
+		return domain.GroupByResponse{}, err
+	}
+	parsedFilters, err := ParseProblemFieldFilters(req.Filters.Filters)
+	if err != nil {
+		return domain.GroupByResponse{}, err
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+
+	payload := snProblemGroupByPayload{
+		Filters: snProblemFilters{
+			SearchQuery:        req.Filters.SearchQuery,
+			Number:             stringPtrValue(req.Filters.Number),
+			StateKeys:          parsedFilters.StateKeys,
+			AssignmentGroupIDs: uuidsToSysids(parsedFilters.AssignmentGroupIDs),
+		},
+		GroupBy:   req.GroupBy,
+		MaxGroups: req.MaxGroups,
+	}
+
+	raw, err := s.client.Post(ctx, "/problems/group-by", token, payload)
+	if err != nil {
+		return domain.GroupByResponse{}, err
+	}
+
+	var resp domain.GroupByResponse
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return domain.GroupByResponse{}, fmt.Errorf("sn problems: parse group-by response: %w", err)
+	}
+	return resp, nil
+}
+
 // snProblemEntityRef is a compact id+number reference used for the problem's
 // origin case / primary incident / linked incidents / linked change request.
 type snProblemEntityRef struct {

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -862,6 +862,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        "503":
+          description: >-
+            groupBy is only supported for the ServiceNow data source.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
   /cases/{id}/comments:
     post:

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -825,6 +825,44 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /cases/group-by:
+    post:
+      summary: >-
+        Server-side aggregation of cases by a single field (e.g. account, top
+        N + Others).
+      description: >-
+        Unlike the searchCases operation's own groupBy parameter (which is
+        limited to a small fixed enum computed as a fan-out of per-value
+        searches), this drives a single aggregation query over an open-ended
+        field such as account, capped to the top maxGroups buckets with the
+        remainder folded into othersCount.
+      operationId: groupCasesBy
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GroupCasesByRequest'
+      responses:
+        "200":
+          description: Aggregated case counts per value of groupBy.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupByResponse'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /cases/{id}/comments:
     post:
       summary: Create a comment on a support case.
@@ -2206,6 +2244,38 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /change-requests/group-by:
+    post:
+      summary: >-
+        Server-side aggregation of change requests by a single field
+        (ServiceNow data source only).
+      operationId: groupChangeRequestsBy
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GroupChangeRequestsByRequest'
+      responses:
+        "200":
+          description: Aggregated change request counts per value of groupBy.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupByResponse'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /time-cards/search:
     post:
       summary: Search time cards (ServiceNow data source only).
@@ -2959,6 +3029,38 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /incidents/group-by:
+    post:
+      summary: >-
+        Server-side aggregation of incidents by a single field (ServiceNow
+        data source only).
+      operationId: groupIncidentsBy
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GroupIncidentsByRequest'
+      responses:
+        "200":
+          description: Aggregated incident counts per value of groupBy.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupByResponse'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /problems:
     post:
       summary: Create a new problem (available on data sources that support problem management).
@@ -3026,6 +3128,38 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         "401":
           description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /problems/group-by:
+    post:
+      summary: >-
+        Server-side aggregation of problems by a single field (ServiceNow
+        data source only).
+      operationId: groupProblemsBy
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GroupProblemsByRequest'
+      responses:
+        "200":
+          description: Aggregated problem counts per value of groupBy.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupByResponse'
+        "400":
+          description: Bad request.
           content:
             application/json:
               schema:
@@ -3105,6 +3239,38 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         "401":
           description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /incident-tasks/group-by:
+    post:
+      summary: >-
+        Server-side aggregation of incident tasks by a single field
+        (ServiceNow data source only).
+      operationId: groupIncidentTasksBy
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GroupIncidentTasksByRequest'
+      responses:
+        "200":
+          description: Aggregated incident task counts per value of groupBy.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupByResponse'
+        "400":
+          description: Bad request.
           content:
             application/json:
               schema:
@@ -5183,6 +5349,23 @@ components:
             fan-out of per-value count queries against the ServiceNow data
             source; not supported by the Postgres data source.
 
+    GroupCasesByRequest:
+      type: object
+      required: [groupBy]
+      properties:
+        filters:
+          $ref: '#/components/schemas/SearchCasesFilters'
+        groupBy:
+          type: string
+          enum: [account, state, severity, type]
+          description: The field to aggregate case counts by.
+        maxGroups:
+          type: integer
+          description: >-
+            Caps the response to the top maxGroups buckets by count; the
+            remainder is folded into GroupByResponse.othersCount. Optional; a
+            default is applied when omitted.
+
     UserReference:
       type: object
       nullable: true
@@ -5679,6 +5862,49 @@ components:
           type: integer
           description: Number of matching cases in this group.
 
+    GroupByBucket:
+      type: object
+      required: [key, label, count]
+      description: >-
+        One aggregated bucket in a server-side group-by result. Shared by
+        every resource's dedicated group-by endpoint (cases, incidents,
+        problems, change requests, incident tasks).
+      properties:
+        key:
+          type: string
+          description: The raw value of the grouped field for this bucket.
+        label:
+          type: string
+          description: >-
+            Human-readable display form of key (identical to key when the
+            grouped field has no separate label).
+        count:
+          type: integer
+          description: Number of matching records in this bucket.
+
+    GroupByResponse:
+      type: object
+      required: [groups, othersCount, totalRecords]
+      description: >-
+        The shared result shape for every resource's dedicated group-by
+        aggregation endpoint.
+      properties:
+        groups:
+          type: array
+          items:
+            $ref: '#/components/schemas/GroupByBucket'
+          description: The top buckets by count, capped at the request's maxGroups.
+        othersCount:
+          type: integer
+          description: >-
+            The number of matching records folded together because their
+            bucket fell outside the top maxGroups.
+        totalRecords:
+          type: integer
+          description: >-
+            Total number of records matching the request's filters; always
+            equals the sum of groups' counts plus othersCount.
+
     AddCaseTagRequest:
       type: object
       required: [label]
@@ -6140,6 +6366,64 @@ components:
               minimum: 1
               maximum: 50
               default: 20
+
+    GroupChangeRequestsByRequest:
+      type: object
+      required: [groupBy]
+      properties:
+        filters:
+          type: object
+          description: Same shape as SearchChangeRequestsRequest.filters.
+          properties:
+            projectIds:
+              type: array
+              items:
+                type: string
+                format: uuid
+            searchQuery:
+              type: string
+            states:
+              type: array
+              items:
+                type: string
+                enum: [new, assess, authorize, customer_approval, scheduled, implement, review, customer_review, rollback, closed, canceled]
+            impacts:
+              type: array
+              items:
+                type: string
+                enum: [high, medium, low]
+            closedStartDate:
+              type: string
+              format: date-time
+              description: "ISO-8601 UTC datetime (YYYY-MM-DDTHH:MM:SSZ)"
+            closedEndDate:
+              type: string
+              format: date-time
+              description: "ISO-8601 UTC datetime (YYYY-MM-DDTHH:MM:SSZ)"
+            number:
+              type: string
+              description: >-
+                A single change request number (e.g. "CHG0010001"); matches
+                exactly. Routed as a first-class filter rather than through
+                the free-text searchQuery scan.
+            filters:
+              type: array
+              items:
+                $ref: '#/components/schemas/ChangeRequestFieldFilter'
+              description: >-
+                A generic field/op/values filter array, additive to the named
+                filters above. See ChangeRequestFieldFilter for the supported
+                field/op combinations.
+        groupBy:
+          type: string
+          enum: [state, assignmentGroup]
+          description: The field to aggregate change request counts by.
+        maxGroups:
+          type: integer
+          description: >-
+            Caps the response to the top maxGroups buckets by count; the
+            remainder is folded into GroupByResponse.othersCount. Optional; a
+            default is applied when omitted.
 
     SearchChangeRequestView:
       type: object
@@ -8132,6 +8416,50 @@ components:
         pagination:
           $ref: '#/components/schemas/Pagination'
 
+    GroupIncidentsByRequest:
+      type: object
+      required: [groupBy]
+      properties:
+        filters:
+          type: object
+          description: Same shape as SearchIncidentsRequest.filters.
+          properties:
+            searchQuery:
+              type: string
+            priorities:
+              type: array
+              items:
+                type: string
+                enum: [CRITICAL, HIGH, MODERATE, LOW, PLANNING]
+            parentIds:
+              type: array
+              items:
+                type: string
+                format: uuid
+            number:
+              type: string
+              description: >-
+                A single incident number (e.g. "INC0010001"); matches
+                exactly. Routed as a first-class filter rather than through
+                the free-text searchQuery scan.
+            filters:
+              type: array
+              items:
+                $ref: '#/components/schemas/IncidentFieldFilter'
+              description: >-
+                A generic field/op/values filter array. See
+                IncidentFieldFilter for the supported field/op combinations.
+        groupBy:
+          type: string
+          enum: [state, assignmentGroup, businessService]
+          description: The field to aggregate incident counts by.
+        maxGroups:
+          type: integer
+          description: >-
+            Caps the response to the top maxGroups buckets by count; the
+            remainder is folded into GroupByResponse.othersCount. Optional; a
+            default is applied when omitted.
+
     SearchIncidentView:
       type: object
       properties:
@@ -8595,6 +8923,40 @@ components:
         pagination:
           $ref: '#/components/schemas/Pagination'
 
+    GroupProblemsByRequest:
+      type: object
+      required: [groupBy]
+      properties:
+        filters:
+          type: object
+          description: Same shape as SearchProblemsRequest.filters.
+          properties:
+            searchQuery:
+              type: string
+            number:
+              type: string
+              description: >-
+                A single problem number (e.g. "PRB0010001"); matches exactly.
+                Routed as a first-class filter rather than through the
+                free-text searchQuery scan.
+            filters:
+              type: array
+              items:
+                $ref: '#/components/schemas/ProblemFieldFilter'
+              description: >-
+                A generic field/op/values filter array. See
+                ProblemFieldFilter for the supported field/op combinations.
+        groupBy:
+          type: string
+          enum: [state, assignmentGroup]
+          description: The field to aggregate problem counts by.
+        maxGroups:
+          type: integer
+          description: >-
+            Caps the response to the top maxGroups buckets by count; the
+            remainder is folded into GroupByResponse.othersCount. Optional; a
+            default is applied when omitted.
+
     SearchProblemView:
       type: object
       properties:
@@ -8748,6 +9110,40 @@ components:
                 IncidentTaskFieldFilter for the supported field/op combinations.
         pagination:
           $ref: '#/components/schemas/Pagination'
+
+    GroupIncidentTasksByRequest:
+      type: object
+      required: [groupBy]
+      properties:
+        filters:
+          type: object
+          description: Same shape as SearchIncidentTasksRequest.filters.
+          properties:
+            searchQuery:
+              type: string
+            number:
+              type: string
+              description: >-
+                A single incident task number (e.g. "TASK0082453"); matches
+                exactly. Routed as a first-class filter rather than through
+                the free-text searchQuery scan.
+            filters:
+              type: array
+              items:
+                $ref: '#/components/schemas/IncidentTaskFieldFilter'
+              description: >-
+                A generic field/op/values filter array. See
+                IncidentTaskFieldFilter for the supported field/op combinations.
+        groupBy:
+          type: string
+          enum: [state, assignmentGroup]
+          description: The field to aggregate incident task counts by.
+        maxGroups:
+          type: integer
+          description: >-
+            Caps the response to the top maxGroups buckets by count; the
+            remainder is folded into GroupByResponse.othersCount. Optional; a
+            default is applied when omitted.
 
     IncidentTask:
       type: object


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

This PR has grown into a bundle of three independent changes that landed on the same branch/session batch (see this repo's own convention of bundling same-session fixes into one PR rather than opening several):

1. **Quick-preview drawer click-through fix.** Follow-up to #1496 (merged). That PR moved the case-list/time-card quick-preview eye to the row's left edge and added `hideBackdrop` to both preview drawers so clicking a different row's eye while one preview was open wouldn't be blocked by the modal backdrop. Live testing after merge found `hideBackdrop` alone wasn't enough: MUI's Drawer/Modal root container still covers the full viewport and intercepts pointer events there regardless of the backdrop's own visibility, so the rest of the page became entirely unclickable while a preview was open — the opposite of the intended behavior, and a regression users would hit immediately.
2. **Group-by dashboard widgets.** A pie/bar dashboard widget previously had to be authored as a hand-written list of "slices," one search request each. Several real dashboard widgets (WOW cases, in-progress breakdowns, PDP SRs) need a true server-side group-by instead — one aggregation call instead of N slice-shaped searches.
3. **Type/family-based default dashboard selection, replacing a hardcoded team-to-dashboard map.** Signed-in users on a handful of specific teams (`customer_onboarding`, `cs_migrations_team`, and later `apollo_sre_group`/`artemis_sre_group`) were landing on the wrong default dashboard, because nothing mapped their team to the right one. The first attempt at fixing this (visible in this PR's earlier commit history) hardcoded each team key directly into frontend source — rejected on review as exactly the kind of team-identity-in-code this platform's dashboard config is supposed to avoid. The real fix generalizes the mechanism instead of hardcoding another entry every time a new team needs it.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

**Drawer fix:**
- Clicking a different row's quick-preview eye while a preview is open closes the current one and opens the new one, with the rest of the page genuinely interactive in between (not just visually unblocked).
- Clicking the same eye again closes the preview.
- Clicking anywhere else on the page (not an eye button, not inside the preview itself) closes the preview.

**Group-by widgets:**
- A pie/bar widget can be configured with a single server-side `groupBy` aggregation instead of a hand-authored `slices` list, for any resource type that exposes the new group-by endpoint.

**Default dashboard selection:**
- Any CRE-ABT or SRE-ABT team member lands on the correctly-typed default dashboard for their team's family, with zero per-team code — generalizes to every current and future ABT team, not just the ones fixed here.
- The two non-ABT specialist dashboards (`onboarding-engineer`, `migration-engineer`) still land their specific teams correctly, via a config field on the dashboard itself rather than a hardcoded map in source.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

### 1. Drawer click-through fix

Set `pointerEvents: "none"` on the Drawer's Modal root (via `slotProps.root`) and `pointerEvents: "auto"` on its Paper (the actual visible surface), so clicks pass through to the rest of the page everywhere except the drawer itself — `hideBackdrop` alone only removes the backdrop's visible fill, not its structural pointer-event interception.

That reintroduces the need for click-outside-to-close, which the backdrop used to provide for free. Added `useCloseOnOutsideClick` (new shared hook in `src/hooks/`): a `mousedown`-capture listener that closes the drawer for any click outside its own content ref, *except* clicks matching an exclude selector. Every quick-preview eye button now carries a `data-quick-preview-eye` attribute, so a click on one is left entirely to its own `onClick` handler (open a different row, or toggle the current one closed) instead of racing this listener for the same state. Listening on `mousedown` (not `click`) matches MUI's own `ClickAwayListener` and registers the close before whatever the click target's own `click` handler does.

Applied to both `CasePreviewDrawer` (case list) and `TimeCardCasePreviewDrawer` (time card table) — the two drawers #1496 introduced this behavior for.

A CodeRabbit review on this PR separately flagged that `pointerEvents: "none"` doesn't disable MUI Modal's focus-trap/`aria-hidden` sibling isolation, so a screen-reader/keyboard-only user is still isolated from the rest of the page even though a mouse click passes through. Agreed as a real finding; not fixed here — a real fix means either a non-modal reimplementation of the floating preview or a product decision to move to a persistent-sidebar layout, both bigger design calls than this PR should make unilaterally. Replied in-thread, filed as a tracked follow-up.

### 2. Group-by dashboard widgets

`WidgetTemplate.GroupBy` (previously an unused bare string) becomes a real `GroupByConfig{field, maxGroups, othersLabel}` on the backend, with load-time validation: a pie/bar widget must carry exactly one of `slices`/`groupBy`, and `groupBy.field` must be non-empty. The backend never resolves this itself (same as `slices`) — it's passthrough config. On the frontend, a new `useWidgetGroupByData` hook fires one `POST /{resourceType}/group-by` call (vs. `useWidgetPieData`'s one-per-slice) and maps the response into the same slice shape, so `DashboardWidgetTile`'s rendering path is unchanged. Also fixes a real bug in `DashboardWidgetGrid`'s cache-invalidation predicate, which only recognized the "pie-slice" query-key tag position — the new hook's "group-by" tag would have been silently misread as the widget id and never invalidated on refresh. The corresponding server-side group-by endpoint (mirroring each resource's existing SearchX filter-parsing/payload pattern) lands in the entity-service; the Ballerina/SN-facing layer behind it is tracked separately in the private ops repo, not referenced here.

### 3. Type/family-based default dashboard selection

Two independent attempts at the "signed-in SRE-ABT user lands on the wrong dashboard" bug landed on this branch in parallel (visible in the commit history as two near-identical `TEAM_DEFAULT_DASHBOARD_ID` additions, later merged into one). Both hardcoded team registry keys directly into `CsmDashboardPage.tsx` — rejected on review. The real fix, replacing that map entirely:

- **Type/family matching** (generalizes to every CRE-ABT/SRE-ABT team, zero code per team): a team's own `family` (e.g. `sre-abt`) now narrows the existing `isDefault && isTeamBased` predicate by dashboard `type` via a new `dashboardTypeForTeamFamily` helper, instead of matching on `isDefault && isTeamBased` alone (which couldn't tell two differently-typed default dashboards apart). This required loosening the backend's dashboard-loader validation from "one `isDefault` dashboard total" to "one per `type`" — previously blocked exactly this fix, which is why both hardcoded-map attempts existed in the first place. The frontend's own unscoped team fetch (already used elsewhere to resolve `creGroupId`/`sreGroupId`) is now enabled unconditionally so the signed-in user's own team family resolves before the initial dashboard is picked; the pending/skeleton guard waits on that fetch too, without hanging on either query's error.
- **`defaultForTeamKeys` on the dashboard itself**, for the two specialist, non-team-based dashboards (`onboarding-engineer`, `migration-engineer`) that the type/family mechanism can't reach (they're `type: "cs"`, `isTeamBased: false`) — a new field on `Dashboard`/`GET /dashboards`'s list response, populated per-dashboard in this deployment's own `config/dashboards/*.json` (a separate, sanitized-for-public-repo config tracked in the platform's private planning repo, not in this one).

`sre-abt.json`'s `isDefault` is now `true` (alongside `abt-engineer`'s `cre`-typed default) now that the backend allows one default per type.

## User stories
> Summary of user stories addressed by this change>

- As a CS engineer scanning the case list or time card table, I can open a row's preview, switch straight to a different row's preview, close it by clicking the same eye again, or dismiss it by clicking anywhere else — without the rest of the page becoming unresponsive while it's open.
- As a dashboard config author, I can configure a pie/bar widget with a single server-side group-by instead of hand-authoring a slice per value.
- As an SRE-ABT or CRE-ABT team member, I land on my own team's dashboard by default without anyone needing to hardcode my team into frontend source first.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

- Fixes a regression from the quick-preview eye redesign where opening a preview made the rest of the case list / time card table page unclickable. The preview now also closes when clicking anywhere outside it.
- Dashboard pie/bar widgets can now be configured with a server-side group-by aggregation instead of a hand-authored slice list.
- Signed-in users on any CRE-ABT or SRE-ABT team, plus the onboarding/migration specialist teams, now land on the correct default dashboard.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter "N/A" plus brief explanation of why there's no doc impact

N/A — internal CSM portal behavior/config, no external docs cover these screens.

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

N/A — no training content covers this screen.

## Certification
> Type "Sent" when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type "N/A" and explain why.

N/A — internal tool change, not covered by any certification exam.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

N/A — internal-only change.

## Automation tests
 - Unit tests
   > Code coverage information

**Drawer fix:** New `useCloseOnOutsideClick.test.tsx` (4 cases). Updated the existing row-switching tests in `CasesList.test.tsx`/`TimeCardsTable.test.tsx` to fire both `mousedown` and `click`, plus two new tests each for outside/inside click. Full sweep: `vitest run src/features/csm-cases src/features/csm-timecards src/hooks` (60 files, 532 tests) passing, `tsc -p tsconfig.app.json --noEmit` clean.

**Default dashboard selection:** `vitest run src/features/csm-dashboard` — 25 files, 272 tests passing (`CsmDashboardPage.test.tsx` itself: 30 tests, including new coverage for type/family discrimination between two differently-typed default dashboards, the `defaultForTeamKeys` override winning over the generic match, the permissive fallback for an unresolved team family, and a stale `defaultForTeamKeys` entry falling through cleanly). `tsc -p tsconfig.app.json --noEmit` and `eslint` on all changed files clean. Backend: `go build ./...`, `go vet ./...`, `go test -race ./internal/dashboard/... ./internal/handler/...` all clean/passing, including new/updated `registry_test.go` cases proving two same-typed `isDefault` dashboards still error while two different-typed ones now coexist, and that an untyped `isDefault` (deprecated config path) still only conflicts with another untyped one.

 - Integration tests
   > Details about the test cases and coverage

Drawer fix verified live against the running local stack (real ServiceNow DEV + Asgardeo) — confirmed the rest of the page was clickable again and outside-click-to-close worked as expected.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — TypeScript/React/Go changes, not JVM
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> Provide high-level details about the samples related to this feature

N/A

## Related PRs
> List any other related PRs

Follow-up to #1496 (merged) — fixes a regression found in that PR's `hideBackdrop` approach after merge, via live testing. The group-by widget feature also depends on a corresponding Ballerina entity-service change, tracked separately in the private ops repo.

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

N/A — no data or schema migration. The dashboard-config field additions (`groupBy`, `defaultForTeamKeys`) are additive and optional; existing dashboard definitions without them are unaffected.

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested

Verified against a true-local stack (webapp → CSM BFF → Go entity-service → local Ballerina entity-service → real ServiceNow DEV `wso2sndev.service-now.com` + Asgardeo) on macOS, plus the automated test suites described above.

## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

`hideBackdrop` on a MUI Drawer only removes the backdrop element's own visible fill — the Drawer's underlying Modal root container still occupies the full viewport and intercepts pointer events structurally, independent of the backdrop's presence. Achieving genuine click-through requires explicitly setting `pointerEvents: "none"` on the Modal root and `"auto"` back on the Paper. This wasn't caught in the original PR's unit tests because jsdom's `fireEvent.click` doesn't model real browser click-interception by an overlapping element at all — the bug was only visible via live manual testing in an actual browser.

For default dashboard selection: the backend's `Type` field and its dashboard-loader validation already anticipated exactly this fix in their own doc comments ("Loosen this to one-per-type in the same change that makes the frontend type-aware, not before") — the two hardcoded-map attempts both hit that same "can't flip `isDefault` on a second dashboard" wall and worked around it instead of implementing the change the code was already pointing at.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added grouped data support for pie and bar dashboard widgets, including “Others” totals.
  * Dashboard defaults can now vary by dashboard type and team.
  * Case and time-card previews close on outside clicks and support direct row switching.
  * Time-card preview controls indicate when a preview is open.

* **Bug Fixes**
  * Improved preview interactions with surrounding page content and assistive technology.

* **Tests**
  * Expanded coverage for dashboard grouping, default selection, widget configuration, and preview behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
