### PR TITLE
entity-service: fix incident-tasks Choreo call path to dash notation

### DIFF
--- a/entity-service/internal/handler/incident_task_handler.go
+++ b/entity-service/internal/handler/incident_task_handler.go
@@ -24,7 +24,7 @@ import (
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/service"
 )
 
-// IncidentTaskHandler handles HTTP requests for the incident_tasks resource.
+// IncidentTaskHandler handles HTTP requests for the incident-tasks resource.
 // Search and get only -- there is no create/update path.
 type IncidentTaskHandler struct {
 	svc service.IncidentTaskService

--- a/entity-service/internal/service/sn_incident_task_service.go
+++ b/entity-service/internal/service/sn_incident_task_service.go
@@ -27,7 +27,7 @@ import (
 	integrationservice "github.com/wso2-open-operations/cs-tools/entity-service/internal/servicenow-integration-service"
 )
 
-// snIncidentTasksResponse mirrors the Choreo POST /incident_tasks/search response.
+// snIncidentTasksResponse mirrors the Choreo POST /incident-tasks/search response.
 type snIncidentTasksResponse struct {
 	IncidentTasks []snIncidentTask `json:"incidentTasks"`
 	TotalRecords  int              `json:"totalRecords"`
@@ -60,7 +60,7 @@ type snIncidentTaskUserRef struct {
 	Name string `json:"name"`
 }
 
-// snIncidentTaskSearchPayload is the Choreo POST /incident_tasks/search request body.
+// snIncidentTaskSearchPayload is the Choreo POST /incident-tasks/search request body.
 type snIncidentTaskSearchPayload struct {
 	Filters    snIncidentTaskFilters `json:"filters,omitempty"`
 	Pagination snProjectPagination   `json:"pagination"`
@@ -119,7 +119,7 @@ func (s *snIncidentTaskService) SearchIncidentTasks(ctx context.Context, req dom
 		Pagination: snProjectPagination{Limit: req.Pagination.Limit, Offset: req.Pagination.Offset},
 	}
 
-	raw, err := s.client.Post(ctx, "/incident_tasks/search", token, payload)
+	raw, err := s.client.Post(ctx, "/incident-tasks/search", token, payload)
 	if err != nil {
 		return domain.SearchIncidentTasksResponse{}, err
 	}
@@ -142,7 +142,7 @@ func (s *snIncidentTaskService) SearchIncidentTasks(ctx context.Context, req dom
 	}, nil
 }
 
-// snIncidentTaskGroupByPayload is the Choreo POST /incident_tasks/group-by
+// snIncidentTaskGroupByPayload is the Choreo POST /incident-tasks/group-by
 // request body.
 type snIncidentTaskGroupByPayload struct {
 	Filters   snIncidentTaskFilters `json:"filters,omitempty"`
@@ -159,7 +159,7 @@ var validIncidentTaskGroupByField = map[string]bool{
 }
 
 // GroupIncidentTasksBy implements IncidentTaskService by calling the Choreo
-// POST /incident_tasks/group-by endpoint: a single server-side aggregation
+// POST /incident-tasks/group-by endpoint: a single server-side aggregation
 // over the requested field, capped to the top MaxGroups buckets with the
 // remainder folded into GroupByResponse.OthersCount. Filter parsing and
 // validation mirror SearchIncidentTasks.
@@ -195,7 +195,7 @@ func (s *snIncidentTaskService) GroupIncidentTasksBy(ctx context.Context, req do
 		MaxGroups: req.MaxGroups,
 	}
 
-	raw, err := s.client.Post(ctx, "/incident_tasks/group-by", token, payload)
+	raw, err := s.client.Post(ctx, "/incident-tasks/group-by", token, payload)
 	if err != nil {
 		return domain.GroupByResponse{}, err
 	}
@@ -241,7 +241,7 @@ func mapSNIncidentTaskToView(it snIncidentTask) domain.IncidentTask {
 	return view
 }
 
-// snIncidentTaskDetailResponse mirrors the Choreo GET /incident_tasks/{id} response.
+// snIncidentTaskDetailResponse mirrors the Choreo GET /incident-tasks/{id} response.
 type snIncidentTaskDetailResponse struct {
 	ID              string                 `json:"id"`
 	Number          *string                `json:"number"`
@@ -265,7 +265,7 @@ func (s *snIncidentTaskService) GetIncidentTask(ctx context.Context, id string) 
 		return domain.IncidentTaskDetail{}, err
 	}
 
-	raw, err := s.client.Get(ctx, "/incident_tasks/"+uuidToSysid(id), token)
+	raw, err := s.client.Get(ctx, "/incident-tasks/"+uuidToSysid(id), token)
 	if err != nil {
 		return domain.IncidentTaskDetail{}, err
 	}


### PR DESCRIPTION
## Purpose
The Ballerina entity-service's `incident-tasks` collection endpoints were recently renamed from underscore to dash notation (`incident_tasks` -> `incident-tasks`) to match this platform's collection-naming convention, used everywhere else (`cases`, `incidents`, `problems`, `change-requests`). This Go entity-service's outbound calls to that layer were never updated, so `SearchIncidentTasks`, `GroupIncidentTasksBy`, and `GetIncidentTask` would now 404 against the corrected upstream.

## Goals
Update this service's three outbound calls (and their doc comments) to the new `/incident-tasks/...` path so incident-task search, group-by, and detail lookups keep working.

## Approach
Renamed the literal path strings in `sn_incident_task_service.go`:
- `POST /incident_tasks/search` -> `POST /incident-tasks/search`
- `POST /incident_tasks/group-by` -> `POST /incident-tasks/group-by`
- `GET /incident_tasks/{id}` -> `GET /incident-tasks/{id}`

Also fixed a stale doc comment in `incident_task_handler.go` referring to "the incident_tasks resource" for consistency with the naming used in every other handler's doc comment (e.g. "the change-request resource").

No other layer needed changes: this service's own exposed `/incident-tasks/...` HTTP routes (`routes.go`) already used dash notation, and neither the CSM BFF nor webapp build this URL directly — they only carry the `incident_task` resource-type string as an internal identifier.

## User stories
As a CS engineer, I want incident-task search, group-by, and detail views to keep working against the corrected upstream path.

## Release note
Fixes incident-task search/group-by/detail calls 404ing after the upstream entity-service's collection path was renamed to dash notation.

## Documentation
N/A — internal fix, no product documentation impact.

## Training
N/A — no training content impact.

## Certification
N/A — no certification exam impact.

## Marketing
N/A — internal fix, no customer-facing feature.

## Automation tests
 - Unit tests
   `go build ./...` clean; `go test ./internal/service/...` passing.
 - Integration tests
   N/A — no test coverage exercises the literal path string against a live upstream; verified by code inspection against the corrected upstream contract.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — Go module, not a JVM/Java target this plugin covers
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no new sample application.

## Related PRs
A corresponding upstream entity-service change (adding dash notation for this same collection) is tracked separately.

## Migrations (if applicable)
N/A — path rename only, no schema/data migration.

## Test environment
Verified with `go build`/`go test` locally (macOS).

## Learning
N/A.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated incident task API routes and resource descriptions to use consistent hyphenated paths.
  * Corrected incident task documentation for search, grouping, and detail operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->