### PR TITLE
[Customer Portal] Bring Novera answer feedback to dev-app-csm-portal

### DIFF
--- a/apps/customer-portal/webapp/public/config.js.example
+++ b/apps/customer-portal/webapp/public/config.js.example
@@ -131,6 +131,14 @@ window.config = {
   //   false – feature hidden. Keep false until the backend handler is ready.
   CUSTOMER_PORTAL_NOVERA_TOKEN_REQUEST_ENABLED: false,
 
+  // ── Novera answer feedback ──────────────────────────────────────────────────
+  //
+  // CUSTOMER_PORTAL_NOVERA_FEEDBACK_ENABLED  (optional — default: false)
+  //   true  – shows thumbs up/down on each Novera answer, with reason tags once
+  //           a rating is given (sent over the chat WebSocket).
+  //   false – feature hidden. Ratings already stored are unaffected.
+  CUSTOMER_PORTAL_NOVERA_FEEDBACK_ENABLED: false,
+
   // ── Top banners ─────────────────────────────────────────────────────────────
   //
   // CUSTOMER_PORTAL_TOP_BANNERS  (optional — default: [])

--- a/apps/customer-portal/webapp/src/config/portalConfig.ts
+++ b/apps/customer-portal/webapp/src/config/portalConfig.ts
@@ -36,6 +36,8 @@ export interface CustomerPortalWindowConfig {
   CUSTOMER_PORTAL_FLOATING_NOVERA_ENABLED?: boolean;
   /** Enables the Novera chat "request a token limit increase" flow. */
   CUSTOMER_PORTAL_NOVERA_TOKEN_REQUEST_ENABLED?: boolean;
+  /** Enables 👍/👎 answer feedback, with its reason tags, on Novera answers. */
+  CUSTOMER_PORTAL_NOVERA_FEEDBACK_ENABLED?: boolean;
   CUSTOMER_PORTAL_TOP_BANNERS?: Array<{
     enabled: boolean;
     html: string;

--- a/apps/customer-portal/webapp/src/features/support/components/novera-ai-assistant/novera-chat-page/ChatMessageBubble.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/novera-ai-assistant/novera-chat-page/ChatMessageBubble.tsx
@@ -19,13 +19,15 @@ import {
   Avatar,
   Box,
   Button,
+  IconButton,
   Paper,
   Stack,
+  Tooltip,
   Typography,
   alpha,
   useTheme,
 } from "@wso2/oxygen-ui";
-import { Bot, User } from "@wso2/oxygen-ui-icons-react";
+import { Bot, ThumbsDown, ThumbsUp, User } from "@wso2/oxygen-ui-icons-react";
 import { type JSX, useEffect, useMemo, useRef } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -139,6 +141,8 @@ function MarkdownContent({ text }: { text: string }) {
  */
 export default function ChatMessageBubble({
   message,
+  onThumbsUp,
+  onThumbsDown,
   onRequestTokenIncrease,
 }: ChatMessageBubbleProps): JSX.Element {
   const isUser = message.sender === ChatSender.USER;
@@ -183,6 +187,18 @@ export default function ChatMessageBubble({
 
   /** Faded frame wraps analyzing, live thinking steps, and streamed tokens. */
   const showThinkingStreamFrame = hideFeedbackRow;
+
+  /**
+   * Show 👍/👎 on a completed assistant answer that carries a stable
+   * feedbackMessageId (from the WS `final` event). Never on user, error,
+   * streaming, or history messages that lack an id.
+   */
+  const showFeedbackRow =
+    message.sender === ChatSender.BOT &&
+    !message.isError &&
+    !hideFeedbackRow &&
+    !!message.feedbackMessageId &&
+    (!!onThumbsUp || !!onThumbsDown);
 
   const streamBodyText = collapseStreamLineBreaks(displayText);
   const analyzingLeadText = "Novera is analyzing your request...";
@@ -425,6 +441,52 @@ export default function ChatMessageBubble({
               </Box>
             )}
           </Box>
+
+          {showFeedbackRow && (
+            <Stack
+              direction="row"
+              alignItems="center"
+              spacing={0.5}
+              sx={{ mt: 0.25, ml: -0.75 }}
+            >
+              <Tooltip title="Good response">
+                <IconButton
+                  size="small"
+                  aria-label="Good response"
+                  aria-pressed={message.feedbackRating === 1}
+                  onClick={() =>
+                    onThumbsUp?.(message.feedbackMessageId as string)
+                  }
+                  sx={{
+                    color:
+                      message.feedbackRating === 1
+                        ? "primary.main"
+                        : "text.secondary",
+                  }}
+                >
+                  <ThumbsUp size={16} />
+                </IconButton>
+              </Tooltip>
+              <Tooltip title="Bad response">
+                <IconButton
+                  size="small"
+                  aria-label="Bad response"
+                  aria-pressed={message.feedbackRating === -1}
+                  onClick={() =>
+                    onThumbsDown?.(message.feedbackMessageId as string)
+                  }
+                  sx={{
+                    color:
+                      message.feedbackRating === -1
+                        ? "error.main"
+                        : "text.secondary",
+                  }}
+                >
+                  <ThumbsDown size={16} />
+                </IconButton>
+              </Tooltip>
+            </Stack>
+          )}
 
           {showTokenRequestCta && (
             <Box sx={{ mt: 1 }}>

--- a/apps/customer-portal/webapp/src/features/support/components/novera-ai-assistant/novera-chat-page/ChatMessageBubble.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/novera-ai-assistant/novera-chat-page/ChatMessageBubble.tsx
@@ -33,6 +33,11 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { ChatSender } from "@features/support/types/conversations";
 import {
+  MAX_FEEDBACK_TAGS,
+  feedbackTagPrompt,
+  feedbackTagsFor,
+} from "@features/support/constants/feedbackTags";
+import {
   NOVERA_ANALYZING_PLACEHOLDER_TEXT,
   NOVERA_DISPLAY_NAME,
 } from "@features/support/constants/chatConstants";
@@ -143,6 +148,7 @@ export default function ChatMessageBubble({
   message,
   onThumbsUp,
   onThumbsDown,
+  onFeedbackTag,
   onRequestTokenIncrease,
 }: ChatMessageBubbleProps): JSX.Element {
   const isUser = message.sender === ChatSender.USER;
@@ -204,6 +210,20 @@ export default function ChatMessageBubble({
     !hideFeedbackRow &&
     !!message.feedbackMessageId &&
     (!!onThumbsUp || !!onThumbsDown);
+
+  /**
+   * Reason chips appear only once a rating exists, so giving the rating is never
+   * blocked by a second decision — the vote is the signal we most want, and it
+   * is already saved by the time these render. Gated on onFeedbackTag too, so
+   * they disappear with the thumbs when the socket closes.
+   */
+  const selectedTags = message.feedbackTags ?? [];
+  const showFeedbackTags =
+    showFeedbackRow && !!onFeedbackTag && !!message.feedbackRating;
+  const tagOptions = message.feedbackRating
+    ? feedbackTagsFor(message.feedbackRating)
+    : [];
+  const tagLimitReached = selectedTags.length >= MAX_FEEDBACK_TAGS;
 
   const streamBodyText = collapseStreamLineBreaks(displayText);
   const analyzingLeadText = "Novera is analyzing your request...";
@@ -491,6 +511,47 @@ export default function ChatMessageBubble({
                 </IconButton>
               </Tooltip>
             </Stack>
+          )}
+
+          {showFeedbackTags && (
+            <Box sx={{ mt: 0.5 }}>
+              <Typography
+                variant="caption"
+                color="text.secondary"
+                sx={{ display: "block", mb: 0.5 }}
+              >
+                {feedbackTagPrompt(message.feedbackRating as 1 | -1)}
+              </Typography>
+              <Stack direction="row" flexWrap="wrap" useFlexGap spacing={0.5}>
+                {tagOptions.map(({ slug, label }) => {
+                  const selected = selectedTags.includes(slug);
+                  return (
+                    <Button
+                      key={slug}
+                      size="small"
+                      variant={selected ? "contained" : "outlined"}
+                      color={message.feedbackRating === 1 ? "primary" : "error"}
+                      aria-pressed={selected}
+                      // Unselected chips go inert at the cap so the limit is
+                      // discoverable, rather than silently dropping the choice
+                      // server-side.
+                      disabled={!selected && tagLimitReached}
+                      onClick={() =>
+                        onFeedbackTag?.(message.feedbackMessageId as string, slug)
+                      }
+                      sx={{
+                        textTransform: "none",
+                        borderRadius: 4,
+                        py: 0.1,
+                        minWidth: 0,
+                      }}
+                    >
+                      {label}
+                    </Button>
+                  );
+                })}
+              </Stack>
+            </Box>
           )}
 
           {showTokenRequestCta && (

--- a/apps/customer-portal/webapp/src/features/support/components/novera-ai-assistant/novera-chat-page/ChatMessageBubble.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/novera-ai-assistant/novera-chat-page/ChatMessageBubble.tsx
@@ -192,6 +192,11 @@ export default function ChatMessageBubble({
    * Show 👍/👎 on a completed assistant answer that carries a stable
    * feedbackMessageId (from the WS `final` event). Never on user, error,
    * streaming, or history messages that lack an id.
+   *
+   * Feedback is delivered over the chat socket, so it is only offered while
+   * that socket is open: the pages pass the handlers as undefined when
+   * disconnected, and the last clause below then hides the row. Hidden rather
+   * than disabled — a greyed-out thumb invites a click that cannot succeed.
    */
   const showFeedbackRow =
     message.sender === ChatSender.BOT &&

--- a/apps/customer-portal/webapp/src/features/support/components/novera-ai-assistant/novera-chat-page/ChatMessageList.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/novera-ai-assistant/novera-chat-page/ChatMessageList.tsx
@@ -34,6 +34,7 @@ export default function ChatMessageList({
   onCreateCase,
   onThumbsUp,
   onThumbsDown,
+  onFeedbackTag,
   onFetchOlder,
   isFetchingOlder = false,
   onSolutionWorked,
@@ -93,6 +94,7 @@ export default function ChatMessageList({
             onCreateCase={onCreateCase}
             onThumbsUp={onThumbsUp}
             onThumbsDown={onThumbsDown}
+            onFeedbackTag={onFeedbackTag}
             onSolutionWorked={onSolutionWorked}
             onRequestTokenIncrease={onRequestTokenIncrease}
           />

--- a/apps/customer-portal/webapp/src/features/support/components/novera-ai-assistant/novera-chat-page/__tests__/ChatMessageBubble.test.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/novera-ai-assistant/novera-chat-page/__tests__/ChatMessageBubble.test.tsx
@@ -14,10 +14,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { ThemeProvider, createTheme } from "@wso2/oxygen-ui";
 import ChatMessageBubble from "@features/support/components/novera-ai-assistant/novera-chat-page/ChatMessageBubble";
+import type { ChatMessageBubbleProps } from "@features/support/types/supportComponents";
 import {
   ChatSender,
   type Message,
@@ -29,13 +30,25 @@ vi.mock("react-markdown", () => ({
   ),
 }));
 
-function renderBubble(message: Message) {
+function renderBubble(
+  message: Message,
+  props: Partial<ChatMessageBubbleProps> = {},
+) {
   return render(
     <ThemeProvider theme={createTheme()}>
-      <ChatMessageBubble message={message} />
+      <ChatMessageBubble message={message} {...props} />
     </ThemeProvider>,
   );
 }
+
+const botAnswer = (over: Partial<Message> = {}): Message => ({
+  id: "bot-1",
+  text: "Here is your answer",
+  sender: ChatSender.BOT,
+  timestamp: new Date(),
+  feedbackMessageId: "msg-123",
+  ...over,
+});
 
 describe("ChatMessageBubble", () => {
   it("should render user message correctly", () => {
@@ -101,5 +114,63 @@ describe("ChatMessageBubble", () => {
     expect(
       screen.queryByText("NullPointerException at line 42"),
     ).not.toBeInTheDocument();
+  });
+
+  describe("answer feedback (👍/👎)", () => {
+    it("renders thumbs on a completed answer with a feedbackMessageId", () => {
+      renderBubble(botAnswer(), {
+        onThumbsUp: vi.fn(),
+        onThumbsDown: vi.fn(),
+      });
+
+      expect(screen.getByLabelText("Good response")).toBeInTheDocument();
+      expect(screen.getByLabelText("Bad response")).toBeInTheDocument();
+    });
+
+    it("calls onThumbsUp / onThumbsDown with the feedbackMessageId", () => {
+      const onThumbsUp = vi.fn();
+      const onThumbsDown = vi.fn();
+      renderBubble(botAnswer(), { onThumbsUp, onThumbsDown });
+
+      fireEvent.click(screen.getByLabelText("Good response"));
+      expect(onThumbsUp).toHaveBeenCalledWith("msg-123");
+
+      fireEvent.click(screen.getByLabelText("Bad response"));
+      expect(onThumbsDown).toHaveBeenCalledWith("msg-123");
+    });
+
+    it("reflects the chosen rating via aria-pressed", () => {
+      renderBubble(botAnswer({ feedbackRating: 1 }), {
+        onThumbsUp: vi.fn(),
+        onThumbsDown: vi.fn(),
+      });
+
+      expect(screen.getByLabelText("Good response")).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+      expect(screen.getByLabelText("Bad response")).toHaveAttribute(
+        "aria-pressed",
+        "false",
+      );
+    });
+
+    it("hides thumbs when there is no feedbackMessageId", () => {
+      renderBubble(botAnswer({ feedbackMessageId: undefined }), {
+        onThumbsUp: vi.fn(),
+        onThumbsDown: vi.fn(),
+      });
+
+      expect(screen.queryByLabelText("Good response")).not.toBeInTheDocument();
+    });
+
+    it("hides thumbs while the answer is still streaming", () => {
+      renderBubble(botAnswer({ isStreaming: true }), {
+        onThumbsUp: vi.fn(),
+        onThumbsDown: vi.fn(),
+      });
+
+      expect(screen.queryByLabelText("Good response")).not.toBeInTheDocument();
+    });
   });
 });

--- a/apps/customer-portal/webapp/src/features/support/components/novera-ai-assistant/novera-chat-page/__tests__/ChatMessageBubble.test.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/novera-ai-assistant/novera-chat-page/__tests__/ChatMessageBubble.test.tsx
@@ -173,4 +173,75 @@ describe("ChatMessageBubble", () => {
       expect(screen.queryByLabelText("Good response")).not.toBeInTheDocument();
     });
   });
+
+  describe("reason tags", () => {
+    const handlers = () => ({
+      onThumbsUp: vi.fn(),
+      onThumbsDown: vi.fn(),
+      onFeedbackTag: vi.fn(),
+    });
+
+    it("does not offer tags until the answer has been rated", () => {
+      renderBubble(botAnswer(), handlers());
+
+      expect(screen.queryByText("What went wrong?")).not.toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: "Inaccurate" })).not.toBeInTheDocument();
+    });
+
+    it("offers the negative vocabulary after a thumbs down", () => {
+      renderBubble(botAnswer({ feedbackRating: -1 }), handlers());
+
+      expect(screen.getByText("What went wrong?")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Inaccurate" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Too slow" })).toBeInTheDocument();
+      // Positive tags must not leak into the negative set.
+      expect(screen.queryByRole("button", { name: "Saved time" })).not.toBeInTheDocument();
+    });
+
+    it("offers the positive vocabulary after a thumbs up", () => {
+      renderBubble(botAnswer({ feedbackRating: 1 }), handlers());
+
+      expect(screen.getByText("What was good about it?")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Saved time" })).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: "Inaccurate" })).not.toBeInTheDocument();
+    });
+
+    it("reports the chosen tag and marks it pressed", () => {
+      const props = handlers();
+      renderBubble(
+        botAnswer({ feedbackRating: -1, feedbackTags: ["outdated"] }),
+        props,
+      );
+
+      expect(screen.getByRole("button", { name: "Outdated" })).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+      fireEvent.click(screen.getByRole("button", { name: "Incomplete" }));
+      expect(props.onFeedbackTag).toHaveBeenCalledWith("msg-123", "incomplete");
+    });
+
+    it("disables unselected tags once the cap is reached, keeping selected ones clickable", () => {
+      renderBubble(
+        botAnswer({
+          feedbackRating: -1,
+          feedbackTags: ["inaccurate", "incomplete", "irrelevant", "outdated"],
+        }),
+        handlers(),
+      );
+
+      expect(screen.getByRole("button", { name: "Too slow" })).toBeDisabled();
+      // Still removable, otherwise the user is stuck at the cap.
+      expect(screen.getByRole("button", { name: "Outdated" })).toBeEnabled();
+    });
+
+    it("hides tags when the socket is closed (no handler passed)", () => {
+      renderBubble(botAnswer({ feedbackRating: -1 }), {
+        onThumbsUp: vi.fn(),
+        onThumbsDown: vi.fn(),
+      });
+
+      expect(screen.queryByText("What went wrong?")).not.toBeInTheDocument();
+    });
+  });
 });

--- a/apps/customer-portal/webapp/src/features/support/constants/feedbackTags.ts
+++ b/apps/customer-portal/webapp/src/features/support/constants/feedbackTags.ts
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+ * Predefined reason tags offered after rating a Novera answer.
+ *
+ * Deliberately duplicated rather than fetched: the vocabulary changes rarely,
+ * and the backend is the authority — it validates against its own allow-list in
+ * `claude_chatbot/feedback_tags.py` and silently drops anything it does not
+ * recognise. So a client that drifts loses its tags, it cannot corrupt the data.
+ * Keep the slugs here in step with that file; the labels are ours alone.
+ */
+
+export interface FeedbackTagOption {
+  /** Wire value. Must match the backend allow-list exactly. */
+  slug: string;
+  /** What the customer reads. */
+  label: string;
+}
+
+export const NEGATIVE_FEEDBACK_TAGS: readonly FeedbackTagOption[] = [
+  { slug: "inaccurate", label: "Inaccurate" },
+  { slug: "incomplete", label: "Incomplete" },
+  { slug: "irrelevant", label: "Irrelevant" },
+  { slug: "outdated", label: "Outdated" },
+  { slug: "too_slow", label: "Too slow" },
+];
+
+export const POSITIVE_FEEDBACK_TAGS: readonly FeedbackTagOption[] = [
+  { slug: "accurate", label: "Accurate" },
+  { slug: "complete", label: "Complete" },
+  { slug: "clear", label: "Clear" },
+  { slug: "saved_time", label: "Saved time" },
+];
+
+/** Mirrors MAX_TAGS in claude_chatbot/feedback_tags.py — extra tags are dropped. */
+export const MAX_FEEDBACK_TAGS = 4;
+
+/** Prompt shown above the chips, which differs by rating. */
+export function feedbackTagPrompt(rating: 1 | -1): string {
+  return rating === 1 ? "What was good about it?" : "What went wrong?";
+}
+
+export function feedbackTagsFor(rating: 1 | -1): readonly FeedbackTagOption[] {
+  return rating === 1 ? POSITIVE_FEEDBACK_TAGS : NEGATIVE_FEEDBACK_TAGS;
+}

--- a/apps/customer-portal/webapp/src/features/support/pages/ConversationDetailsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/ConversationDetailsPage.tsx
@@ -381,7 +381,9 @@ export default function ConversationDetailsPage(): JSX.Element {
         const idx = prev.findIndex((m) => m.id === activeId);
         if (idx === -1) return prev;
         pendingFinalRef.current = null;
-        const { finalMessage } = pending;
+        const { finalMessage, payload } = pending;
+        const answerId =
+          typeof payload.messageId === "string" ? payload.messageId : undefined;
         const msg = prev[idx];
         const next = [...prev];
         next[idx] = {
@@ -389,6 +391,8 @@ export default function ConversationDetailsPage(): JSX.Element {
           isLoading: false,
           isError: false,
           text: finalMessage || msg.text,
+          showFeedbackActions: !!answerId,
+          feedbackMessageId: answerId,
           isStreaming: false,
           thinkingSteps: [],
           thinkingLabel: null,
@@ -486,6 +490,21 @@ export default function ConversationDetailsPage(): JSX.Element {
           const finalMessage = getFinalMessageFromPayload(payload);
           pendingFinalRef.current = { payload, finalMessage };
           flushPendingFinalIfReady();
+          break;
+        }
+        case "feedback_ack": {
+          const ackId = String(event.messageId ?? "");
+          const ackRating =
+            event.rating === 1 ? 1 : event.rating === -1 ? -1 : null;
+          if (ackId) {
+            setNewMessages((prev) =>
+              prev.map((m) =>
+                m.feedbackMessageId === ackId
+                  ? { ...m, feedbackRating: ackRating }
+                  : m,
+              ),
+            );
+          }
           break;
         }
         case "error":
@@ -592,6 +611,48 @@ export default function ConversationDetailsPage(): JSX.Element {
     await sendViaWebSocket(text);
     return true;
   }, [accountId, isSending, projectId, sendViaWebSocket, setInputValueAndRef]);
+
+  // Answer feedback (👍/👎) over the existing chat socket (#2534). Optimistic
+  // with revert-on-failure; feedback_ack confirms the persisted value.
+  const submitFeedback = useCallback(
+    (messageId: string, rating: 1 | -1) => {
+      if (!projectId) return;
+      setNewMessages((prev) =>
+        prev.map((m) =>
+          m.feedbackMessageId === messageId ? { ...m, feedbackRating: rating } : m,
+        ),
+      );
+      void connect(projectId)
+        .then(() =>
+          sendUserMessage({
+            type: "feedback",
+            messageId,
+            rating,
+            conversationId: conversationId ?? undefined,
+            accountId: accountId || undefined,
+          }),
+        )
+        .catch(() => {
+          setNewMessages((prev) =>
+            prev.map((m) =>
+              m.feedbackMessageId === messageId
+                ? { ...m, feedbackRating: null }
+                : m,
+            ),
+          );
+        });
+    },
+    [accountId, connect, conversationId, projectId, sendUserMessage],
+  );
+
+  const handleThumbsUp = useCallback(
+    (messageId: string) => submitFeedback(messageId, 1),
+    [submitFeedback],
+  );
+  const handleThumbsDown = useCallback(
+    (messageId: string) => submitFeedback(messageId, -1),
+    [submitFeedback],
+  );
 
   const conversationStatus = summary?.status;
   const conversationStatusLabel = conversationStatus ?? "--";
@@ -814,7 +875,12 @@ export default function ConversationDetailsPage(): JSX.Element {
                     m.isLoading ? (
                       <LoadingDotsBubble key={m.id} />
                     ) : (
-                      <ChatMessageBubble key={m.id} message={m} />
+                      <ChatMessageBubble
+                        key={m.id}
+                        message={m}
+                        onThumbsUp={handleThumbsUp}
+                        onThumbsDown={handleThumbsDown}
+                      />
                     ),
                   )}
                 </>

--- a/apps/customer-portal/webapp/src/features/support/pages/ConversationDetailsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/ConversationDetailsPage.tsx
@@ -667,6 +667,12 @@ export default function ConversationDetailsPage(): JSX.Element {
             rating,
             conversationId: conversationId ?? undefined,
             accountId: accountId || undefined,
+            projectId: projectId || undefined,
+            // Names, not just ids: a reviewer reading the dashboard should see
+            // who this came from without resolving sys_ids by hand. Already
+            // loaded for this page, so this costs no extra request.
+            accountName: projectDetails?.account?.name || undefined,
+            projectName: projectDetails?.name || undefined,
             ...(tags ? { tags } : {}),
           }),
         )
@@ -681,7 +687,15 @@ export default function ConversationDetailsPage(): JSX.Element {
           );
         });
     },
-    [accountId, connect, conversationId, projectId, sendUserMessage],
+    [
+      accountId,
+      connect,
+      conversationId,
+      projectId,
+      projectDetails?.account?.name,
+      projectDetails?.name,
+      sendUserMessage,
+    ],
   );
 
   /**

--- a/apps/customer-portal/webapp/src/features/support/pages/ConversationDetailsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/ConversationDetailsPage.tsx
@@ -497,8 +497,12 @@ export default function ConversationDetailsPage(): JSX.Element {
           const ackId = String(event.messageId ?? "");
           const ackRating =
             event.rating === 1 ? 1 : event.rating === -1 ? -1 : null;
-          // The server echoes what it actually stored, after dropping any tag
-          // it does not recognise — so adopt its list rather than ours.
+          // The server echoes what it actually stored, after dropping any tag it
+          // does not recognise — so adopt its list unconditionally. An absent
+          // `tags` field means it stored none (an older backend ignores the
+          // field entirely), so fall back to [] rather than keeping our
+          // optimistic value: showing chips as selected when nothing was saved
+          // tells the user something untrue.
           const ackTags = Array.isArray(event.tags)
             ? (event.tags as unknown[]).filter(
                 (t): t is string => typeof t === "string",
@@ -511,7 +515,7 @@ export default function ConversationDetailsPage(): JSX.Element {
                   ? {
                       ...m,
                       feedbackRating: ackRating,
-                      ...(ackTags ? { feedbackTags: ackTags } : {}),
+                      feedbackTags: ackTags ?? [],
                     }
                   : m,
               ),

--- a/apps/customer-portal/webapp/src/features/support/pages/ConversationDetailsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/ConversationDetailsPage.tsx
@@ -432,7 +432,7 @@ export default function ConversationDetailsPage(): JSX.Element {
     return () => window.clearInterval(id);
   }, [dequeueOneTypedToken, flushPendingFinalIfReady]);
 
-  const { connect, sendUserMessage } = useChatWebSocket({
+  const { connect, sendUserMessage, isConnected } = useChatWebSocket({
     onEvent: (event) => {
       switch (event.type) {
         case "thinking_start":
@@ -878,8 +878,8 @@ export default function ConversationDetailsPage(): JSX.Element {
                       <ChatMessageBubble
                         key={m.id}
                         message={m}
-                        onThumbsUp={handleThumbsUp}
-                        onThumbsDown={handleThumbsDown}
+                        onThumbsUp={isConnected ? handleThumbsUp : undefined}
+                        onThumbsDown={isConnected ? handleThumbsDown : undefined}
                       />
                     ),
                   )}

--- a/apps/customer-portal/webapp/src/features/support/pages/ConversationDetailsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/ConversationDetailsPage.tsx
@@ -702,6 +702,7 @@ export default function ConversationDetailsPage(): JSX.Element {
             // loaded for this page, so this costs no extra request.
             accountName: projectDetails?.account?.name || undefined,
             projectName: projectDetails?.name || undefined,
+            conversationName: summary?.chatNumber || undefined,
             ...(tags ? { tags } : {}),
           }),
         )
@@ -723,6 +724,7 @@ export default function ConversationDetailsPage(): JSX.Element {
       projectId,
       projectDetails?.account?.name,
       projectDetails?.name,
+      summary?.chatNumber,
       sendUserMessage,
     ],
   );

--- a/apps/customer-portal/webapp/src/features/support/pages/ConversationDetailsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/ConversationDetailsPage.tsx
@@ -336,6 +336,11 @@ export default function ConversationDetailsPage(): JSX.Element {
   const [inputValue, setInputValueState] = useState("");
   const [resetTrigger, setResetTrigger] = useState(0);
   const [isSending, setIsSending] = useState(false);
+  // Feature-flagged (config.js): 👍/👎 on Novera answers. Passing the handlers
+  // as undefined is what hides the row — ChatMessageBubble only renders it when
+  // it has somewhere to send a rating — so no separate prop is needed.
+  const feedbackEnabled =
+    window.config?.CUSTOMER_PORTAL_NOVERA_FEEDBACK_ENABLED ?? false;
   // Mirrors isSending for the socket's onClose handler. The hook installs
   // ws.onclose during connect(), so that closure captures the options object
   // from whichever render connected — reading isSending directly there would
@@ -984,8 +989,8 @@ export default function ConversationDetailsPage(): JSX.Element {
                       <ChatMessageBubble
                         key={m.id}
                         message={m}
-                        onThumbsUp={isConnected ? handleThumbsUp : undefined}
-                        onThumbsDown={isConnected ? handleThumbsDown : undefined}
+                        onThumbsUp={feedbackEnabled && isConnected ? handleThumbsUp : undefined}
+                        onThumbsDown={feedbackEnabled && isConnected ? handleThumbsDown : undefined}
                         onFeedbackTag={isConnected ? handleFeedbackTag : undefined}
                       />
                     ),

--- a/apps/customer-portal/webapp/src/features/support/pages/ConversationDetailsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/ConversationDetailsPage.tsx
@@ -614,14 +614,31 @@ export default function ConversationDetailsPage(): JSX.Element {
 
   // Answer feedback (👍/👎) over the existing chat socket (#2534). Optimistic
   // with revert-on-failure; feedback_ack confirms the persisted value.
+  // Latest feedback submission per messageId, so a stale rejection cannot
+  // roll back a newer vote. A ref, not state: it must not trigger a render.
+  const feedbackSeqRef = useRef<Map<string, number>>(new Map());
+
   const submitFeedback = useCallback(
     (messageId: string, rating: 1 | -1) => {
       if (!projectId) return;
+
+      // Mark this as the latest submission for the message. Clicking 👍 then
+      // 👎 leaves two sends in flight; if the first rejects after the second
+      // resolved, its rollback must not undo the newer vote.
+      const seq = (feedbackSeqRef.current.get(messageId) ?? 0) + 1;
+      feedbackSeqRef.current.set(messageId, seq);
+
+      // Remember what was showing so a failure restores it, rather than
+      // clearing a rating the user had already given (and we had persisted).
+      let previousRating: 1 | -1 | null = null;
       setNewMessages((prev) =>
-        prev.map((m) =>
-          m.feedbackMessageId === messageId ? { ...m, feedbackRating: rating } : m,
-        ),
+        prev.map((m) => {
+          if (m.feedbackMessageId !== messageId) return m;
+          previousRating = m.feedbackRating ?? null;
+          return { ...m, feedbackRating: rating };
+        }),
       );
+
       void connect(projectId)
         .then(() =>
           sendUserMessage({
@@ -633,10 +650,11 @@ export default function ConversationDetailsPage(): JSX.Element {
           }),
         )
         .catch(() => {
+          if (feedbackSeqRef.current.get(messageId) !== seq) return;
           setNewMessages((prev) =>
             prev.map((m) =>
               m.feedbackMessageId === messageId
-                ? { ...m, feedbackRating: null }
+                ? { ...m, feedbackRating: previousRating }
                 : m,
             ),
           );

--- a/apps/customer-portal/webapp/src/features/support/pages/ConversationDetailsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/ConversationDetailsPage.tsx
@@ -336,6 +336,14 @@ export default function ConversationDetailsPage(): JSX.Element {
   const [inputValue, setInputValueState] = useState("");
   const [resetTrigger, setResetTrigger] = useState(0);
   const [isSending, setIsSending] = useState(false);
+  // Mirrors isSending for the socket's onClose handler. The hook installs
+  // ws.onclose during connect(), so that closure captures the options object
+  // from whichever render connected — reading isSending directly there would
+  // see a stale value. A ref is always current.
+  const isSendingRef = useRef(false);
+  useEffect(() => {
+    isSendingRef.current = isSending;
+  }, [isSending]);
   const [isInputDisabled, setIsInputDisabled] = useState(false);
   const [newMessages, setNewMessages] = useState<Message[]>([]);
   const inputValueRef = useRef("");
@@ -548,6 +556,27 @@ export default function ConversationDetailsPage(): JSX.Element {
         isLoading: false,
         isError: true,
         text: "WebSocket connection error.",
+        thinkingSteps: [],
+        isStreaming: false,
+      }));
+      setIsSending(false);
+    },
+    // A close is not always an error — the socket can drop mid-exchange (gateway
+    // timeout, upstream reset) without onerror ever firing. Nothing else clears
+    // isSending, and both send paths are guarded by it, so leaving it set makes
+    // the composer permanently dead: the hook reconnects, isConnected flips back
+    // to true, and every later message is silently swallowed with the typing
+    // indicator still spinning. Recover only if a send was actually in flight,
+    // so an idle close does not mark a finished answer as failed.
+    onClose: () => {
+      if (!isSendingRef.current) return;
+      pendingFinalRef.current = null;
+      tokenQueueRef.current = [];
+      upsertActiveBotMessage((msg) => ({
+        ...msg,
+        isLoading: false,
+        isError: true,
+        text: "Connection lost before the answer arrived. Please try again.",
         thinkingSteps: [],
         isStreaming: false,
       }));

--- a/apps/customer-portal/webapp/src/features/support/pages/ConversationDetailsPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/ConversationDetailsPage.tsx
@@ -52,6 +52,7 @@ import type {
   ChatHistoryItem,
 } from "@features/support/types/conversations";
 import { ChatSender } from "@features/support/types/conversations";
+import { MAX_FEEDBACK_TAGS } from "@features/support/constants/feedbackTags";
 import ApiErrorState from "@components/error/ApiErrorState";
 import type { Message } from "@features/support/types/conversations";
 import ConversationKnowledgeRecommendations from "@features/support/components/knowledge-base/ConversationKnowledgeRecommendations";
@@ -496,11 +497,22 @@ export default function ConversationDetailsPage(): JSX.Element {
           const ackId = String(event.messageId ?? "");
           const ackRating =
             event.rating === 1 ? 1 : event.rating === -1 ? -1 : null;
+          // The server echoes what it actually stored, after dropping any tag
+          // it does not recognise — so adopt its list rather than ours.
+          const ackTags = Array.isArray(event.tags)
+            ? (event.tags as unknown[]).filter(
+                (t): t is string => typeof t === "string",
+              )
+            : undefined;
           if (ackId) {
             setNewMessages((prev) =>
               prev.map((m) =>
                 m.feedbackMessageId === ackId
-                  ? { ...m, feedbackRating: ackRating }
+                  ? {
+                      ...m,
+                      feedbackRating: ackRating,
+                      ...(ackTags ? { feedbackTags: ackTags } : {}),
+                    }
                   : m,
               ),
             );
@@ -619,7 +631,7 @@ export default function ConversationDetailsPage(): JSX.Element {
   const feedbackSeqRef = useRef<Map<string, number>>(new Map());
 
   const submitFeedback = useCallback(
-    (messageId: string, rating: 1 | -1) => {
+    (messageId: string, rating: 1 | -1, tags?: string[]) => {
       if (!projectId) return;
 
       // Mark this as the latest submission for the message. Clicking 👍 then
@@ -635,7 +647,11 @@ export default function ConversationDetailsPage(): JSX.Element {
         prev.map((m) => {
           if (m.feedbackMessageId !== messageId) return m;
           previousRating = m.feedbackRating ?? null;
-          return { ...m, feedbackRating: rating };
+          return {
+            ...m,
+            feedbackRating: rating,
+            ...(tags ? { feedbackTags: tags } : {}),
+          };
         }),
       );
 
@@ -647,6 +663,7 @@ export default function ConversationDetailsPage(): JSX.Element {
             rating,
             conversationId: conversationId ?? undefined,
             accountId: accountId || undefined,
+            ...(tags ? { tags } : {}),
           }),
         )
         .catch(() => {
@@ -661,6 +678,28 @@ export default function ConversationDetailsPage(): JSX.Element {
         });
     },
     [accountId, connect, conversationId, projectId, sendUserMessage],
+  );
+
+  /**
+   * Toggle a reason tag on an answer that has already been rated. Re-sends the
+   * same feedback event with the new list — the backend upserts on
+   * (conversation, message), so this replaces rather than accumulating rows.
+   * Capped client-side at MAX_FEEDBACK_TAGS; the server enforces the same limit.
+   */
+  const handleFeedbackTag = useCallback(
+    (messageId: string, tag: string) => {
+      const msg = newMessages.find((m) => m.feedbackMessageId === messageId);
+      if (!msg?.feedbackRating) return;
+      const current = msg.feedbackTags ?? [];
+      const next = current.includes(tag)
+        ? current.filter((t) => t !== tag)
+        : current.length >= MAX_FEEDBACK_TAGS
+          ? current
+          : [...current, tag];
+      if (next === current) return;
+      submitFeedback(messageId, msg.feedbackRating, next);
+    },
+    [newMessages, submitFeedback],
   );
 
   const handleThumbsUp = useCallback(
@@ -898,6 +937,7 @@ export default function ConversationDetailsPage(): JSX.Element {
                         message={m}
                         onThumbsUp={isConnected ? handleThumbsUp : undefined}
                         onThumbsDown={isConnected ? handleThumbsDown : undefined}
+                        onFeedbackTag={isConnected ? handleFeedbackTag : undefined}
                       />
                     ),
                   )}

--- a/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
@@ -793,6 +793,12 @@ export default function NoveraChatPage(): JSX.Element {
             rating,
             conversationId: conversationId ?? undefined,
             accountId: accountId || undefined,
+            projectId: projectId || undefined,
+            // Names, not just ids: a reviewer reading the dashboard should see
+            // who this came from without resolving sys_ids by hand. Already
+            // loaded for this page, so this costs no extra request.
+            accountName: projectDetails?.account?.name || undefined,
+            projectName: projectDetails?.name || undefined,
             ...(tags ? { tags } : {}),
           }),
         )
@@ -807,7 +813,15 @@ export default function NoveraChatPage(): JSX.Element {
           );
         });
     },
-    [accountId, connect, conversationId, projectId, sendUserMessage],
+    [
+      accountId,
+      connect,
+      conversationId,
+      projectId,
+      projectDetails?.account?.name,
+      projectDetails?.name,
+      sendUserMessage,
+    ],
   );
 
   /**

--- a/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
@@ -449,12 +449,16 @@ export default function NoveraChatPage(): JSX.Element {
           ? (payload.actions as NoveraAction[])
           : undefined;
         const next = [...prev];
+        const answerId =
+          typeof payload.messageId === "string" ? payload.messageId : undefined;
         next[idx] = {
           ...msg,
           isLoading: false,
           isError: false,
           text: finalMessage || msg.text,
           showCreateCaseAction: payload.actions != null,
+          showFeedbackActions: !!answerId,
+          feedbackMessageId: answerId,
           slotState: payload.slotState as SlotState | undefined,
           thinkingSteps: [],
           thinkingLabel: null,
@@ -606,6 +610,21 @@ export default function NoveraChatPage(): JSX.Element {
           }
           break;
         }
+        case "feedback_ack": {
+          const ackId = String(event.messageId ?? "");
+          const ackRating =
+            event.rating === 1 ? 1 : event.rating === -1 ? -1 : null;
+          if (ackId) {
+            setMessages((prev) =>
+              prev.map((m) =>
+                m.feedbackMessageId === ackId
+                  ? { ...m, feedbackRating: ackRating }
+                  : m,
+              ),
+            );
+          }
+          break;
+        }
         case "error":
           pendingFinalRef.current = null;
           tokenQueueRef.current = [];
@@ -718,6 +737,49 @@ export default function NoveraChatPage(): JSX.Element {
     void sendViaWebSocket("This Resolved My Issue");
   }, [isSending, sendViaWebSocket]);
 
+  // Answer feedback (👍/👎) over the existing chat socket (#2534). Optimistic:
+  // reflect the vote immediately, revert if the send fails. feedback_ack later
+  // confirms the persisted value.
+  const submitFeedback = useCallback(
+    (messageId: string, rating: 1 | -1) => {
+      if (!projectId) return;
+      setMessages((prev) =>
+        prev.map((m) =>
+          m.feedbackMessageId === messageId ? { ...m, feedbackRating: rating } : m,
+        ),
+      );
+      void connect(projectId)
+        .then(() =>
+          sendUserMessage({
+            type: "feedback",
+            messageId,
+            rating,
+            conversationId: conversationId ?? undefined,
+            accountId: accountId || undefined,
+          }),
+        )
+        .catch(() => {
+          setMessages((prev) =>
+            prev.map((m) =>
+              m.feedbackMessageId === messageId
+                ? { ...m, feedbackRating: null }
+                : m,
+            ),
+          );
+        });
+    },
+    [accountId, connect, conversationId, projectId, sendUserMessage],
+  );
+
+  const handleThumbsUp = useCallback(
+    (messageId: string) => submitFeedback(messageId, 1),
+    [submitFeedback],
+  );
+  const handleThumbsDown = useCallback(
+    (messageId: string) => submitFeedback(messageId, -1),
+    [submitFeedback],
+  );
+
   // Feature-flagged (config.js): request a token limit increase over the chat
   // WebSocket. Kept off until the backend handler is ready.
   const tokenRequestEnabled =
@@ -803,6 +865,8 @@ export default function NoveraChatPage(): JSX.Element {
               messages={messages}
               messagesEndRef={messagesEndRef}
               onCreateCase={handleCreateCase}
+              onThumbsUp={handleThumbsUp}
+              onThumbsDown={handleThumbsDown}
               onSolutionWorked={handleSolutionWorked}
               onRequestTokenIncrease={
                 tokenRequestEnabled

--- a/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
@@ -901,11 +901,12 @@ export default function NoveraChatPage(): JSX.Element {
       await sendUserMessage({
         type: "token_increase_request",
         accountId,
+        accountName: projectDetails?.account?.name || undefined,
         reason,
         limitType: "session",
       });
     },
-    [projectId, accountId, connect, sendUserMessage],
+    [projectId, accountId, projectDetails?.account?.name, connect, sendUserMessage],
   );
 
   const handleSendMessage = useCallback(async (): Promise<boolean> => {

--- a/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
@@ -908,11 +908,19 @@ export default function NoveraChatPage(): JSX.Element {
         type: "token_increase_request",
         accountId,
         accountName: projectDetails?.account?.name || undefined,
+        requestedBy: currentUserEmail || undefined,
         reason,
         limitType: "session",
       });
     },
-    [projectId, accountId, projectDetails?.account?.name, connect, sendUserMessage],
+    [
+      projectId,
+      accountId,
+      projectDetails?.account?.name,
+      currentUserEmail,
+      connect,
+      sendUserMessage,
+    ],
   );
 
   const handleSendMessage = useCallback(async (): Promise<boolean> => {

--- a/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
@@ -60,6 +60,7 @@ import { htmlToPlainText } from "@features/support/utils/richTextEditor";
 import { usePiiGuard } from "@features/support/hooks/usePiiGuard";
 import PiiWarningDialog from "@features/support/components/dialogs/PiiWarningDialog";
 import { ChatSender } from "@features/support/types/conversations";
+import { MAX_FEEDBACK_TAGS } from "@features/support/constants/feedbackTags";
 import type {
   ChatNavState,
   Message,
@@ -614,11 +615,22 @@ export default function NoveraChatPage(): JSX.Element {
           const ackId = String(event.messageId ?? "");
           const ackRating =
             event.rating === 1 ? 1 : event.rating === -1 ? -1 : null;
+          // The server echoes what it actually stored, after dropping any tag
+          // it does not recognise — so adopt its list rather than ours.
+          const ackTags = Array.isArray(event.tags)
+            ? (event.tags as unknown[]).filter(
+                (t): t is string => typeof t === "string",
+              )
+            : undefined;
           if (ackId) {
             setMessages((prev) =>
               prev.map((m) =>
                 m.feedbackMessageId === ackId
-                  ? { ...m, feedbackRating: ackRating }
+                  ? {
+                      ...m,
+                      feedbackRating: ackRating,
+                      ...(ackTags ? { feedbackTags: ackTags } : {}),
+                    }
                   : m,
               ),
             );
@@ -745,7 +757,7 @@ export default function NoveraChatPage(): JSX.Element {
   const feedbackSeqRef = useRef<Map<string, number>>(new Map());
 
   const submitFeedback = useCallback(
-    (messageId: string, rating: 1 | -1) => {
+    (messageId: string, rating: 1 | -1, tags?: string[]) => {
       if (!projectId) return;
 
       // Mark this as the latest submission for the message. Clicking 👍 then
@@ -761,7 +773,11 @@ export default function NoveraChatPage(): JSX.Element {
         prev.map((m) => {
           if (m.feedbackMessageId !== messageId) return m;
           previousRating = m.feedbackRating ?? null;
-          return { ...m, feedbackRating: rating };
+          return {
+            ...m,
+            feedbackRating: rating,
+            ...(tags ? { feedbackTags: tags } : {}),
+          };
         }),
       );
 
@@ -773,6 +789,7 @@ export default function NoveraChatPage(): JSX.Element {
             rating,
             conversationId: conversationId ?? undefined,
             accountId: accountId || undefined,
+            ...(tags ? { tags } : {}),
           }),
         )
         .catch(() => {
@@ -787,6 +804,28 @@ export default function NoveraChatPage(): JSX.Element {
         });
     },
     [accountId, connect, conversationId, projectId, sendUserMessage],
+  );
+
+  /**
+   * Toggle a reason tag on an answer that has already been rated. Re-sends the
+   * same feedback event with the new list — the backend upserts on
+   * (conversation, message), so this replaces rather than accumulating rows.
+   * Capped client-side at MAX_FEEDBACK_TAGS; the server enforces the same limit.
+   */
+  const handleFeedbackTag = useCallback(
+    (messageId: string, tag: string) => {
+      const msg = messages.find((m) => m.feedbackMessageId === messageId);
+      if (!msg?.feedbackRating) return;
+      const current = msg.feedbackTags ?? [];
+      const next = current.includes(tag)
+        ? current.filter((t) => t !== tag)
+        : current.length >= MAX_FEEDBACK_TAGS
+          ? current
+          : [...current, tag];
+      if (next === current) return;
+      submitFeedback(messageId, msg.feedbackRating, next);
+    },
+    [messages, submitFeedback],
   );
 
   const handleThumbsUp = useCallback(
@@ -885,6 +924,7 @@ export default function NoveraChatPage(): JSX.Element {
               onCreateCase={handleCreateCase}
               onThumbsUp={isConnected ? handleThumbsUp : undefined}
               onThumbsDown={isConnected ? handleThumbsDown : undefined}
+            onFeedbackTag={isConnected ? handleFeedbackTag : undefined}
               onSolutionWorked={handleSolutionWorked}
               onRequestTokenIncrease={
                 tokenRequestEnabled

--- a/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
@@ -740,14 +740,31 @@ export default function NoveraChatPage(): JSX.Element {
   // Answer feedback (👍/👎) over the existing chat socket (#2534). Optimistic:
   // reflect the vote immediately, revert if the send fails. feedback_ack later
   // confirms the persisted value.
+  // Latest feedback submission per messageId, so a stale rejection cannot
+  // roll back a newer vote. A ref, not state: it must not trigger a render.
+  const feedbackSeqRef = useRef<Map<string, number>>(new Map());
+
   const submitFeedback = useCallback(
     (messageId: string, rating: 1 | -1) => {
       if (!projectId) return;
+
+      // Mark this as the latest submission for the message. Clicking 👍 then
+      // 👎 leaves two sends in flight; if the first rejects after the second
+      // resolved, its rollback must not undo the newer vote.
+      const seq = (feedbackSeqRef.current.get(messageId) ?? 0) + 1;
+      feedbackSeqRef.current.set(messageId, seq);
+
+      // Remember what was showing so a failure restores it, rather than
+      // clearing a rating the user had already given (and we had persisted).
+      let previousRating: 1 | -1 | null = null;
       setMessages((prev) =>
-        prev.map((m) =>
-          m.feedbackMessageId === messageId ? { ...m, feedbackRating: rating } : m,
-        ),
+        prev.map((m) => {
+          if (m.feedbackMessageId !== messageId) return m;
+          previousRating = m.feedbackRating ?? null;
+          return { ...m, feedbackRating: rating };
+        }),
       );
+
       void connect(projectId)
         .then(() =>
           sendUserMessage({
@@ -759,10 +776,11 @@ export default function NoveraChatPage(): JSX.Element {
           }),
         )
         .catch(() => {
+          if (feedbackSeqRef.current.get(messageId) !== seq) return;
           setMessages((prev) =>
             prev.map((m) =>
               m.feedbackMessageId === messageId
-                ? { ...m, feedbackRating: null }
+                ? { ...m, feedbackRating: previousRating }
                 : m,
             ),
           );

--- a/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
@@ -890,6 +890,12 @@ export default function NoveraChatPage(): JSX.Element {
   // WebSocket. Kept off until the backend handler is ready.
   const tokenRequestEnabled =
     window.config?.CUSTOMER_PORTAL_NOVERA_TOKEN_REQUEST_ENABLED ?? false;
+
+  // Feature-flagged (config.js): 👍/👎 on Novera answers. Passing the handlers
+  // as undefined is what hides the row — ChatMessageBubble only renders it when
+  // it has somewhere to send a rating — so no separate prop is needed.
+  const feedbackEnabled =
+    window.config?.CUSTOMER_PORTAL_NOVERA_FEEDBACK_ENABLED ?? false;
   const [isTokenModalOpen, setIsTokenModalOpen] = useState(false);
 
   const handleTokenIncreaseSubmit = useCallback(
@@ -972,8 +978,8 @@ export default function NoveraChatPage(): JSX.Element {
               messages={messages}
               messagesEndRef={messagesEndRef}
               onCreateCase={handleCreateCase}
-              onThumbsUp={isConnected ? handleThumbsUp : undefined}
-              onThumbsDown={isConnected ? handleThumbsDown : undefined}
+              onThumbsUp={feedbackEnabled && isConnected ? handleThumbsUp : undefined}
+              onThumbsDown={feedbackEnabled && isConnected ? handleThumbsDown : undefined}
             onFeedbackTag={isConnected ? handleFeedbackTag : undefined}
               onSolutionWorked={handleSolutionWorked}
               onRequestTokenIncrease={

--- a/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
@@ -828,6 +828,7 @@ export default function NoveraChatPage(): JSX.Element {
             // loaded for this page, so this costs no extra request.
             accountName: projectDetails?.account?.name || undefined,
             projectName: projectDetails?.name || undefined,
+            conversationName: chatNumber || undefined,
             ...(tags ? { tags } : {}),
           }),
         )
@@ -849,6 +850,7 @@ export default function NoveraChatPage(): JSX.Element {
       projectId,
       projectDetails?.account?.name,
       projectDetails?.name,
+      chatNumber,
       sendUserMessage,
     ],
   );

--- a/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
@@ -396,6 +396,14 @@ export default function NoveraChatPage(): JSX.Element {
   const piiGuard = usePiiGuard();
   const [resetTrigger, setResetTrigger] = useState(0);
   const [isSending, setIsSending] = useState(false);
+  // Mirrors isSending for the socket's onClose handler. The hook installs
+  // ws.onclose during connect(), so that closure captures the options object
+  // from whichever render connected — reading isSending directly there would
+  // see a stale value. A ref is always current.
+  const isSendingRef = useRef(false);
+  useEffect(() => {
+    isSendingRef.current = isSending;
+  }, [isSending]);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const activeBotMessageIdRef = useRef<string | null>(null);
   const initialMessageSentRef = useRef(false);
@@ -666,6 +674,27 @@ export default function NoveraChatPage(): JSX.Element {
         isLoading: false,
         isError: true,
         text: "WebSocket connection error.",
+        thinkingSteps: [],
+        isStreaming: false,
+      }));
+      setIsSending(false);
+    },
+    // A close is not always an error — the socket can drop mid-exchange (gateway
+    // timeout, upstream reset) without onerror ever firing. Nothing else clears
+    // isSending, and both send paths are guarded by it, so leaving it set makes
+    // the composer permanently dead: the hook reconnects, isConnected flips back
+    // to true, and every later message is silently swallowed with the typing
+    // indicator still spinning. Recover only if a send was actually in flight,
+    // so an idle close does not mark a finished answer as failed.
+    onClose: () => {
+      if (!isSendingRef.current) return;
+      pendingFinalRef.current = null;
+      tokenQueueRef.current = [];
+      upsertActiveBotMessage((msg) => ({
+        ...msg,
+        isLoading: false,
+        isError: true,
+        text: "Connection lost before the answer arrived. Please try again.",
         thinkingSteps: [],
         isStreaming: false,
       }));

--- a/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
@@ -508,7 +508,7 @@ export default function NoveraChatPage(): JSX.Element {
     return () => window.clearInterval(id);
   }, [dequeueOneTypedToken, flushPendingFinalIfReady, TYPING_INTERVAL_MS]);
 
-  const { connect, sendUserMessage } = useChatWebSocket({
+  const { connect, sendUserMessage, isConnected } = useChatWebSocket({
     onEvent: (event) => {
       switch (event.type) {
         case "conversation_created": {
@@ -865,8 +865,8 @@ export default function NoveraChatPage(): JSX.Element {
               messages={messages}
               messagesEndRef={messagesEndRef}
               onCreateCase={handleCreateCase}
-              onThumbsUp={handleThumbsUp}
-              onThumbsDown={handleThumbsDown}
+              onThumbsUp={isConnected ? handleThumbsUp : undefined}
+              onThumbsDown={isConnected ? handleThumbsDown : undefined}
               onSolutionWorked={handleSolutionWorked}
               onRequestTokenIncrease={
                 tokenRequestEnabled

--- a/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/NoveraChatPage.tsx
@@ -615,8 +615,12 @@ export default function NoveraChatPage(): JSX.Element {
           const ackId = String(event.messageId ?? "");
           const ackRating =
             event.rating === 1 ? 1 : event.rating === -1 ? -1 : null;
-          // The server echoes what it actually stored, after dropping any tag
-          // it does not recognise — so adopt its list rather than ours.
+          // The server echoes what it actually stored, after dropping any tag it
+          // does not recognise — so adopt its list unconditionally. An absent
+          // `tags` field means it stored none (an older backend ignores the
+          // field entirely), so fall back to [] rather than keeping our
+          // optimistic value: showing chips as selected when nothing was saved
+          // tells the user something untrue.
           const ackTags = Array.isArray(event.tags)
             ? (event.tags as unknown[]).filter(
                 (t): t is string => typeof t === "string",
@@ -629,7 +633,7 @@ export default function NoveraChatPage(): JSX.Element {
                   ? {
                       ...m,
                       feedbackRating: ackRating,
-                      ...(ackTags ? { feedbackTags: ackTags } : {}),
+                      feedbackTags: ackTags ?? [],
                     }
                   : m,
               ),

--- a/apps/customer-portal/webapp/src/features/support/types/conversations.ts
+++ b/apps/customer-portal/webapp/src/features/support/types/conversations.ts
@@ -212,6 +212,10 @@ export type Message = {
   createdOnRaw?: string;
   showFeedbackActions?: boolean;
   showCreateCaseAction?: boolean;
+  /** Stable id of this assistant answer (from the WS `final` event), used to rate it. */
+  feedbackMessageId?: string;
+  /** The rating the user has given this answer, if any (+1 up / -1 down). */
+  feedbackRating?: 1 | -1 | null;
   isLoading?: boolean;
   isError?: boolean;
   slotState?: SlotState;
@@ -252,6 +256,14 @@ export type ChatWebSocketPayload =
       accountId: string;
       reason: string;
       limitType: "session" | "monthly";
+    }
+  | {
+      type: "feedback";
+      messageId: string;
+      rating: 1 | -1;
+      conversationId?: string;
+      accountId?: string;
+      comment?: string;
     };
 
 // Model type for chat WebSocket hook options.

--- a/apps/customer-portal/webapp/src/features/support/types/conversations.ts
+++ b/apps/customer-portal/webapp/src/features/support/types/conversations.ts
@@ -266,6 +266,19 @@ export type ChatWebSocketPayload =
       conversationId?: string;
       accountId?: string;
       comment?: string;
+      /**
+       * Predefined reason slugs from feedbackTags.ts. The backend validates
+       * against its own allow-list and drops anything it does not recognise.
+       */
+      tags?: string[];
+      projectId?: string;
+      /**
+       * Display labels so the analytics dashboard can show "Acme Corp / Billing"
+       * instead of a pair of sys_ids. Cosmetic only — the ids above stay the join
+       * keys, and the backend caps and sanitises these before storing them.
+       */
+      accountName?: string;
+      projectName?: string;
     };
 
 // Model type for chat WebSocket hook options.

--- a/apps/customer-portal/webapp/src/features/support/types/conversations.ts
+++ b/apps/customer-portal/webapp/src/features/support/types/conversations.ts
@@ -261,6 +261,12 @@ export type ChatWebSocketPayload =
        * addresses the account by sys_id. Display only — the id stays the key.
        */
       accountName?: string;
+      /**
+       * The signed-in user, for the admin notification and the audit trail. The
+       * portal proxy overwrites this from the authenticated session whenever it
+       * can, so treat it as a fallback rather than the source of truth.
+       */
+      requestedBy?: string;
       reason: string;
       limitType: "session" | "monthly";
     }

--- a/apps/customer-portal/webapp/src/features/support/types/conversations.ts
+++ b/apps/customer-portal/webapp/src/features/support/types/conversations.ts
@@ -256,6 +256,11 @@ export type ChatWebSocketPayload =
   | {
       type: "token_increase_request";
       accountId: string;
+      /**
+       * Readable customer name for the admin notification, which otherwise
+       * addresses the account by sys_id. Display only — the id stays the key.
+       */
+      accountName?: string;
       reason: string;
       limitType: "session" | "monthly";
     }

--- a/apps/customer-portal/webapp/src/features/support/types/conversations.ts
+++ b/apps/customer-portal/webapp/src/features/support/types/conversations.ts
@@ -216,6 +216,8 @@ export type Message = {
   feedbackMessageId?: string;
   /** The rating the user has given this answer, if any (+1 up / -1 down). */
   feedbackRating?: 1 | -1 | null;
+  /** Reason tags chosen alongside the rating. Slugs, not labels. */
+  feedbackTags?: string[];
   isLoading?: boolean;
   isError?: boolean;
   slotState?: SlotState;

--- a/apps/customer-portal/webapp/src/features/support/types/conversations.ts
+++ b/apps/customer-portal/webapp/src/features/support/types/conversations.ts
@@ -279,6 +279,13 @@ export type ChatWebSocketPayload =
        */
       accountName?: string;
       projectName?: string;
+      /**
+       * The chat's own reference as shown in the UI, e.g. CHAT000002755, so the
+       * analytics drill-down can name the conversation a rating came from rather
+       * than showing a raw id. Absent when this page was deep-linked or
+       * refreshed, since the reference arrives in router state.
+       */
+      conversationName?: string;
     };
 
 // Model type for chat WebSocket hook options.

--- a/apps/customer-portal/webapp/src/features/support/types/supportComponents.ts
+++ b/apps/customer-portal/webapp/src/features/support/types/supportComponents.ts
@@ -533,6 +533,8 @@ export type ChatMessageListProps = {
   onCreateCase?: () => void;
   onThumbsUp?: (messageId: string) => void;
   onThumbsDown?: (messageId: string) => void;
+  /** Toggle a reason tag on an already-rated answer. */
+  onFeedbackTag?: (messageId: string, tag: string) => void;
   onFetchOlder?: () => void;
   isFetchingOlder?: boolean;
   onSolutionWorked?: () => void;
@@ -545,6 +547,8 @@ export type ChatMessageBubbleProps = {
   onCreateCase?: () => void;
   onThumbsUp?: (messageId: string) => void;
   onThumbsDown?: (messageId: string) => void;
+  /** Toggle a reason tag on an already-rated answer. */
+  onFeedbackTag?: (messageId: string, tag: string) => void;
   onSolutionWorked?: () => void;
   /** When provided, usage-limit error bubbles show a "request token increase" CTA. */
   onRequestTokenIncrease?: () => void;


### PR DESCRIPTION
## Purpose

`CUSTOMER_PORTAL_NOVERA_FEEDBACK_ENABLED: true` had no effect on staging — no thumbs up/down appeared on Novera answers. The flag was not the problem: **the feature was never on this branch.**

- All of the answer-feedback commits are on `origin/main`, none on `dev-app-csm-portal`
- `NoveraChatPage.tsx` rendered `<ChatMessageList>` without passing `onThumbsUp`/`onThumbsDown`; the props are optional, so the component received `undefined` and rendered nothing
- `CUSTOMER_PORTAL_NOVERA_FEEDBACK_ENABLED` was read in **0** files here (and not declared in `portalConfig.ts`), versus 3 on `main`

For context, `dev-app-csm-portal` is **95 commits behind `main`** for the customer portal (85 webapp, 11 backend). This PR cherry-picks the answer-feedback slice rather than attempting the whole catch-up.

## What is cherry-picked

Eleven commits, in chronological order, each with `-x` so the original is recorded:

| Commit | |
|---|---|
| `99aa6e86f` | thumbs up/down feedback on Novera answers |
| `4b923cf80` | only offer answer feedback while the chat session is live |
| `5edd139c7` | don't let a failed feedback send clobber a newer or prior vote |
| `81e036f66` | predefined reason tags alongside the answer rating |
| `144e01dde` | always take feedbackTags from the acknowledgement |
| `113eb1434` | send account and project names with answer feedback |
| `5beb0e086` | recover the composer when the chat socket drops mid-send |
| `99d81c9d6` | send the chat reference with answer feedback |
| `0c459a561` | identify who asked for a token increase *(webapp portion only)* |
| `5b10de797` | put Novera answer feedback behind a config flag |
| `5048bb148` | send the signed-in user with a token request *(webapp portion only)* |

`5beb0e086` was not in the original shortlist — it is not described as a feedback change, but it sits inside the same file sequence, so skipping it would have manufactured conflicts and dropped a real fix.

### Two commits applied webapp-only

`0c459a561` and `5048bb148` each also patched the **Ballerina** backend's WebSocket side-channel branch, which does not exist on this branch (`15eda8597` is not here either) — that half could not apply and is deliberately dropped. It is also unnecessary: the deployed backend is **backend-v2**, whose `handleSideChannel` stamps `requestedBy` from the authenticated session and removes any client-supplied value, so the server does not depend on the page sending it. The Ballerina backend is untouched by this PR.

## ⚠️ Deployment ordering

**#1497 must be deployed before or with this.** Once the webapp has this feature it starts sending `feedback` and `token_increase_request` frames. Without #1497, backend-v2 routes those into the chat-turn path, where `StreamChat` waits for a `final` the agent never sends — stalling the connection for the full five-minute idle timeout and making the chat appear dead. Shipping this first would actively regress the chat.

## Testing

- `tsc -b` — **clean** (the real risk in cherry-picking from a branch 95 commits ahead is a dangling dependency on other `main`-only work; there is none)
- `vitest run ChatMessageBubble.test.tsx` — **16/16 pass**
- `eslint` on all five changed source files — clean
- Diff touches **webapp only**: 10 files, +763/−9

### UI verification

With `CUSTOMER_PORTAL_NOVERA_FEEDBACK_ENABLED: true`, open a Novera chat and answer a question: thumbs up/down appear on the agent's answer, a rating offers the predefined reason tags, and the vote survives a subsequent message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)