### PR TITLE
[Customer Portal v2] Make non-status upstream failures diagnosable in logs

### DIFF
--- a/apps/customer-portal/backend-v2/internal/handler/response.go
+++ b/apps/customer-portal/backend-v2/internal/handler/response.go
@@ -20,11 +20,13 @@
 package handler
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"regexp"
 
 	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/apierror"
@@ -154,6 +156,49 @@ func summarizeErr(err error) string {
 		}
 		return fmt.Sprintf("upstream status %d: %s", apiErr.StatusCode, apiErr.Body)
 	}
+	// Below here the failure carries no upstream HTTP status: a malformed
+	// upstream URL, a transport or TLS failure, a token fetch that never got a
+	// response, a cancelled context, or a response body this backend could not
+	// decode. All of them used to collapse into one opaque "upstream request
+	// failed", which made a 500 from any of these causes indistinguishable in
+	// the logs — a recommendations 500 took several rounds of guesswork to place
+	// because the log could not say whether the URL, the credentials, or the
+	// response shape was at fault.
+	//
+	// Categories and schema facts only. In particular this never logs
+	// err.Error() for a *url.Error, because that appends the full request URL
+	// (which for other clients can carry filter query params); url.Error.Err on
+	// its own does not.
+	switch {
+	case errors.Is(err, context.DeadlineExceeded):
+		return "upstream request timed out"
+	case errors.Is(err, context.Canceled):
+		return "upstream request canceled"
+	}
+
+	// Field/Type/Value here describe the contract, not the payload — e.g.
+	// `field "createdBy" expects string, got object` — so they are safe to log
+	// and they name the exact mismatch, which is the one thing that makes a
+	// Ballerina-to-Go field/type drift immediately obvious.
+	var typeErr *json.UnmarshalTypeError
+	if errors.As(err, &typeErr) {
+		return fmt.Sprintf("response decode failed: field %q expects %s, got %s", typeErr.Field, typeErr.Type, typeErr.Value)
+	}
+	var syntaxErr *json.SyntaxError
+	if errors.As(err, &syntaxErr) {
+		return fmt.Sprintf("response decode failed: malformed JSON at byte %d", syntaxErr.Offset)
+	}
+
+	// Op distinguishes a URL that would not parse ("parse") from a request that
+	// could not be sent ("Post"/"Get"); Err carries the reason without the URL —
+	// "unsupported protocol scheme", "invalid control character in URL", a dial
+	// failure — which is exactly what separates a misconfigured base URL from an
+	// unreachable or unauthorized upstream.
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) && urlErr.Err != nil {
+		return fmt.Sprintf("upstream %s failed: %s", urlErr.Op, urlErr.Err)
+	}
+
 	return "upstream request failed"
 }
 

--- a/apps/customer-portal/backend-v2/internal/handler/summarize_err_test.go
+++ b/apps/customer-portal/backend-v2/internal/handler/summarize_err_test.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/apierror"
+)
+
+// TestSummarizeErr_DistinguishesNonStatusFailures is the regression guard for an
+// observability defect: every failure without an upstream HTTP status used to
+// summarize as the single string "upstream request failed", so a 500 caused by a
+// malformed base URL was indistinguishable in the logs from one caused by bad
+// credentials or an undecodable response body. Diagnosing one meant guessing.
+func TestSummarizeErr_DistinguishesNonStatusFailures(t *testing.T) {
+	// A base URL with no scheme — fails in the transport, before any network I/O.
+	noScheme := &url.Error{Op: "Post", URL: "apis-stg.example.invalid/v1.0/recommendations",
+		Err: errors.New(`unsupported protocol scheme ""`)}
+	// A base URL with a stray newline — fails at url.Parse.
+	badChar := &url.Error{Op: "parse", URL: "https://example.invalid/v1.0\n",
+		Err: errors.New("net/http: invalid control character in URL")}
+
+	var typeErr error
+	if err := json.Unmarshal([]byte(`{"createdBy":{"name":"x"}}`), &struct {
+		CreatedBy string `json:"createdBy"`
+	}{}); err != nil {
+		typeErr = err
+	}
+	if typeErr == nil {
+		t.Fatal("expected an UnmarshalTypeError from the fixture")
+	}
+
+	for name, tc := range map[string]struct {
+		err  error
+		want string
+	}{
+		"missing scheme":   {noScheme, "upstream Post failed: unsupported protocol scheme"},
+		"control char":     {badChar, "upstream parse failed: net/http: invalid control character"},
+		"timeout":          {fmt.Errorf("wrapped: %w", context.DeadlineExceeded), "upstream request timed out"},
+		"canceled":         {fmt.Errorf("wrapped: %w", context.Canceled), "upstream request canceled"},
+		"type mismatch":    {fmt.Errorf("decode: %w", typeErr), `field "createdBy" expects string, got object`},
+		"malformed json":   {fmt.Errorf("decode: %w", &json.SyntaxError{Offset: 17}), "malformed JSON at byte 17"},
+		"unknown fallback": {errors.New("something else entirely"), "upstream request failed"},
+	} {
+		got := summarizeErr(tc.err)
+		if !strings.Contains(got, tc.want) {
+			t.Errorf("%s: summarizeErr = %q, want it to contain %q", name, got, tc.want)
+		}
+	}
+}
+
+// TestSummarizeErr_NeverLogsTheRequestURL keeps the reason this was previously
+// collapsed: url.Error.Error() appends the full request URL, which for other
+// clients can carry filter query params. Only url.Error.Err may be logged.
+func TestSummarizeErr_NeverLogsTheRequestURL(t *testing.T) {
+	secretish := "https://internal.example.invalid/v1/cases?email=someone%40wso2.com&token=abc123"
+	err := &url.Error{Op: "Get", URL: secretish, Err: errors.New("dial tcp: lookup failed")}
+
+	got := summarizeErr(err)
+	for _, leak := range []string{"someone", "token=abc123", secretish, "?email="} {
+		if strings.Contains(got, leak) {
+			t.Errorf("summarizeErr leaked %q in %q", leak, got)
+		}
+	}
+	if !strings.Contains(got, "dial tcp") {
+		t.Errorf("summarizeErr = %q, want the URL-free reason retained", got)
+	}
+}
+
+// TestSummarizeErr_UpstreamStatusStillWins checks the pre-existing behaviour is
+// untouched: a typed upstream error keeps reporting its status and message,
+// which is already caller-safe validation text.
+func TestSummarizeErr_UpstreamStatusStillWins(t *testing.T) {
+	err := apierror.NewUpstreamError(http.StatusBadRequest, []byte(`{"message":"caseTypes must be valid UUIDs"}`))
+	got := summarizeErr(err)
+	if !strings.Contains(got, "upstream status 400") || !strings.Contains(got, "caseTypes must be valid UUIDs") {
+		t.Errorf("summarizeErr = %q, want the status and upstream message preserved", got)
+	}
+}


### PR DESCRIPTION
## Purpose

`summarizeErr` reported **every** failure without an upstream HTTP status as one string:

```go
return "upstream request failed"
```

A malformed base URL, an unsupported scheme, a token fetch that never got a response, a cancelled context, and an undecodable response body all logged identically. A 500 from any of them was indistinguishable, so diagnosing one meant guessing.

This surfaced on `POST /conversations/recommendations/search`, which returns **500 in 4ms** — far too fast for a token fetch or any call to the agent, so the cause is *local* (a URL that will not parse, or one with no scheme). The log gave no way to rule in or out the base URL value, the credentials, or the Choreo subscription, and several rounds were spent on hypotheses the logs could have settled immediately.

## What is now reported

| Cause | Summary |
|---|---|
| deadline / cancellation | `upstream request timed out` / `canceled` |
| `json.UnmarshalTypeError` | `field "createdBy" expects string, got object` |
| `json.SyntaxError` | `malformed JSON at byte 17` |
| `url.Error` | `upstream parse failed: net/http: invalid control character in URL`<br>`upstream Post failed: unsupported protocol scheme ""` |

`Op` is what separates a URL that will not **parse** from a request that could not be **sent** — precisely the distinction needed to tell a misconfigured base URL from an unreachable or unauthorized upstream.

The `UnmarshalTypeError` case is worth calling out: `field "createdBy" expects string, got object` is exactly the drift that caused the case-attachments 500 (#1489), which also took a full round of investigation. That class is now self-diagnosing.

## Security

Logs **categories and schema facts only** — never `err.Error()` for a `*url.Error`, because that appends the full request URL, which for other clients can carry filter query params. `url.Error.Err` on its own does not include the URL.

A test asserts that an email and a token embedded in a URL are not leaked while the underlying reason is still retained.

`json.UnmarshalTypeError`'s `Field`/`Type`/`Value` describe the *contract*, not the payload (`Value` is a type name like `"object"`, not the data), so they are safe to log.

Typed upstream errors are untouched: they still report the status and the upstream's own caller-safe validation message.

## Testing

- `go build`, `go vet`, `gofmt -l`, `go test -race ./...` — all pass
- `gosec -fmt=text ./...` — **0 issues** (103 files)
- New tests cover all six categories plus the fallback, the URL-leak guard, and that existing upstream-status behaviour is preserved. The two pre-existing `summarizeErr` tests still pass.

## Follow-up

Once deployed, the recommendations 500 will name its own cause in one request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for timeouts, cancellations, malformed responses, parsing failures, and connection issues.
  * Preserved meaningful upstream status information when available.
  * Prevented request URLs and sensitive query parameters from appearing in error messages or logs.

* **Tests**
  * Added coverage to verify error classification, status preservation, and protection against exposing request details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->