### PR TITLE
[Customer Portal v2] Sanitize and validate URL configuration at startup

### DIFF
--- a/apps/customer-portal/backend-v2/.env.example
+++ b/apps/customer-portal/backend-v2/.env.example
@@ -1,3 +1,8 @@
+# NOTE: every *_BASE_URL / *_URL / *_ENDPOINT below must be an absolute URL with
+# a scheme and host (http/https; ws/wss for AI_CHAT_AGENT_WS_BASE_URL). The server
+# strips surrounding quotes and whitespace, then validates at startup and exits
+# with the offending variable named rather than failing per-request later.
+
 # Shared OAuth2 client credentials — entity-service, the updates service, and
 # SCIM all authenticate as this same app; only each service's base URL and
 # scopes differ. Optional — only needed if a service sits behind a gateway

--- a/apps/customer-portal/backend-v2/cmd/server/main.go
+++ b/apps/customer-portal/backend-v2/cmd/server/main.go
@@ -24,8 +24,10 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
+	"slices"
 	"strconv"
 	"strings"
 	"syscall"
@@ -51,10 +53,10 @@ func main() {
 	// scopes differ.
 	oauth2ClientID := os.Getenv("OAUTH2_CLIENT_ID")
 	oauth2ClientSecret := os.Getenv("OAUTH2_CLIENT_SECRET")
-	oauth2TokenURL := os.Getenv("OAUTH2_TOKEN_URL")
+	oauth2TokenURL := optionalURL("OAUTH2_TOKEN_URL", "http", "https")
 
 	entityCfg := entity.Config{
-		BaseURL:      mustEnv("ENTITY_SERVICE_BASE_URL"),
+		BaseURL:      mustURL("ENTITY_SERVICE_BASE_URL", "http", "https"),
 		TokenURL:     oauth2TokenURL,
 		ClientID:     oauth2ClientID,
 		ClientSecret: oauth2ClientSecret,
@@ -63,7 +65,7 @@ func main() {
 	entityClient := entity.NewClient(entityCfg)
 
 	updatesCfg := updates.Config{
-		BaseURL:      mustEnv("UPDATES_BASE_URL"),
+		BaseURL:      mustURL("UPDATES_BASE_URL", "http", "https"),
 		TokenURL:     oauth2TokenURL,
 		ClientID:     oauth2ClientID,
 		ClientSecret: oauth2ClientSecret,
@@ -72,7 +74,7 @@ func main() {
 	updatesClient := updates.NewClient(updatesCfg)
 
 	scimCfg := scim.Config{
-		BaseURL:      mustEnv("SCIM_BASE_URL"),
+		BaseURL:      mustURL("SCIM_BASE_URL", "http", "https"),
 		TokenURL:     oauth2TokenURL,
 		ClientID:     oauth2ClientID,
 		ClientSecret: oauth2ClientSecret,
@@ -84,7 +86,7 @@ func main() {
 	// but authenticates as the same shared OAuth2 client-credentials app as
 	// entity/updates/scim above; only its base URLs differ.
 	aiChatAgentCfg := aichatagent.Config{
-		BaseURL:      mustEnv("AI_CHAT_AGENT_BASE_URL"),
+		BaseURL:      mustURL("AI_CHAT_AGENT_BASE_URL", "http", "https"),
 		TokenURL:     oauth2TokenURL,
 		ClientID:     oauth2ClientID,
 		ClientSecret: oauth2ClientSecret,
@@ -93,7 +95,7 @@ func main() {
 	aiChatAgentClient := aichatagent.NewClient(aiChatAgentCfg)
 
 	aiChatAgentWsCfg := aichatagent.WSConfig{
-		BaseURL:      mustEnv("AI_CHAT_AGENT_WS_BASE_URL"),
+		BaseURL:      mustURL("AI_CHAT_AGENT_WS_BASE_URL", "ws", "wss"),
 		TokenURL:     oauth2TokenURL,
 		ClientID:     oauth2ClientID,
 		ClientSecret: oauth2ClientSecret,
@@ -108,8 +110,8 @@ func main() {
 	// defaults to PRODUCT_CONSUMPTION_SUBSCRIPTION_URL when unset, for
 	// deployments where both happen to point at the same host.
 	productConsumptionCfg := productconsumption.Config{
-		SubscriptionBaseURL: mustEnv("PRODUCT_CONSUMPTION_SUBSCRIPTION_URL"),
-		TrackingBaseURL:     os.Getenv("PRODUCT_CONSUMPTION_TRACKING_BASE_URL"),
+		SubscriptionBaseURL: mustURL("PRODUCT_CONSUMPTION_SUBSCRIPTION_URL", "http", "https"),
+		TrackingBaseURL:     optionalURL("PRODUCT_CONSUMPTION_TRACKING_BASE_URL", "http", "https"),
 		TokenURL:            oauth2TokenURL,
 		ClientID:            oauth2ClientID,
 		ClientSecret:        oauth2ClientSecret,
@@ -121,7 +123,7 @@ func main() {
 	// separate microservice (not entity-service), authenticating as the same
 	// shared OAuth2 app.
 	registryCfg := registry.Config{
-		BaseURL:      mustEnv("REGISTRY_BASE_URL"),
+		BaseURL:      mustURL("REGISTRY_BASE_URL", "http", "https"),
 		TokenURL:     oauth2TokenURL,
 		ClientID:     oauth2ClientID,
 		ClientSecret: oauth2ClientSecret,
@@ -137,7 +139,7 @@ func main() {
 	// is a separate microservice (not entity-service, not SCIM),
 	// authenticating as the same shared OAuth2 app.
 	userManagementCfg := usermanagement.Config{
-		BaseURL:      mustEnv("USER_MANAGEMENT_BASE_URL"),
+		BaseURL:      mustURL("USER_MANAGEMENT_BASE_URL", "http", "https"),
 		TokenURL:     oauth2TokenURL,
 		ClientID:     oauth2ClientID,
 		ClientSecret: oauth2ClientSecret,
@@ -154,7 +156,7 @@ func main() {
 	adminRole := mustEnv("AUTH_ADMIN_ROLE")
 
 	authCfg := middleware.Config{
-		JWKSEndpoint:          mustEnv("AUTH_JWKS_ENDPOINT"),
+		JWKSEndpoint:          mustURL("AUTH_JWKS_ENDPOINT", "http", "https"),
 		Issuer:                mustEnv("AUTH_ISSUER"),
 		Audiences:             splitComma(mustEnv("AUTH_AUDIENCE")),
 		ClockSkew:             5 * time.Second,
@@ -486,6 +488,123 @@ func dispatchDeploymentsProductsMetricsSearch(instances *handler.InstanceHandler
 		}
 		http.NotFound(w, r)
 	}
+}
+
+// sanitizeURLValue trims surrounding whitespace and strips a matched pair of
+// enclosing quotes from a URL taken from configuration.
+//
+// Both are real deployment failures, not hypotheticals: a value stored as
+// `"https://host/path"` (with literal quotes) or with a leading space never
+// parses as a URL at all — url.Parse stops recognising the scheme and reports
+// `first path segment in URL cannot contain colon`. That took down
+// POST /conversations/recommendations/search in staging with a 500 on every
+// call, and the value looked perfectly correct in the config UI.
+func sanitizeURLValue(v string) string {
+	v = strings.TrimSpace(v)
+	for len(v) >= 2 {
+		first, last := v[0], v[len(v)-1]
+		if (first == '"' && last == '"') || (first == '\'' && last == '\'') {
+			v = strings.TrimSpace(v[1 : len(v)-1])
+			continue
+		}
+		break
+	}
+	return v
+}
+
+// urlProblem classifies why a configured URL is unusable.
+//
+// Deliberately a code rather than a message built from the value: the reason is
+// logged, and interpolating anything derived from configuration into a log line
+// lets a newline in that value forge log entries (gosec G706). Each code maps to
+// a fixed string below, so nothing input-derived is ever logged.
+type urlProblem int
+
+const (
+	urlOK urlProblem = iota
+	urlUnparseable
+	urlNoScheme
+	urlBadScheme
+	urlNoHost
+)
+
+func (p urlProblem) String() string {
+	switch p {
+	case urlUnparseable:
+		return "not a valid URL (check for stray quotes or whitespace)"
+	case urlNoScheme:
+		return "missing a scheme, expected http:// or https:// (or ws://, wss:// for a WebSocket URL)"
+	case urlBadScheme:
+		return "scheme is not accepted for this setting"
+	case urlNoHost:
+		return "missing a host (check for a single slash after the scheme)"
+	default:
+		return "ok"
+	}
+}
+
+// checkURLValue reports why v is unusable as a base URL with one of schemes, or
+// urlOK if it is fine.
+func checkURLValue(v string, schemes ...string) urlProblem {
+	u, err := url.Parse(v)
+	if err != nil {
+		return urlUnparseable
+	}
+	if u.Scheme == "" {
+		return urlNoScheme
+	}
+	if !slices.Contains(schemes, u.Scheme) {
+		return urlBadScheme
+	}
+	if u.Host == "" {
+		return urlNoHost
+	}
+	return urlOK
+}
+
+// mustURL is mustEnv for a URL: it sanitizes the value, then validates it is
+// absolute with an accepted scheme and a host, exiting at startup if not.
+//
+// Validating here rather than at first use is deliberate. A URL that cannot be
+// parsed fails inside the HTTP client on every request, which surfaces as a 500
+// on one endpoint while the rest of the service looks healthy — the failure is
+// per-request and easily mistaken for an upstream problem. A misconfiguration
+// should stop the deployment instead, the same reasoning as the JWKS panic in
+// middleware.NewTokenValidator.
+func mustURL(key string, schemes ...string) string {
+	raw := os.Getenv(key)
+	v := sanitizeURLValue(raw)
+	if v == "" {
+		slog.Error("required environment variable is not set", "key", key)
+		os.Exit(1)
+	}
+	if v != raw {
+		// Worth a warning even though it now works: the stored value is still
+		// malformed and the next person to copy it hits the same thing.
+		slog.Warn("stripped surrounding quotes/whitespace from URL configuration", "key", key)
+	}
+	if problem := checkURLValue(v, schemes...); problem != urlOK {
+		slog.Error("environment variable is not a usable URL", "key", key, "reason", problem.String())
+		os.Exit(1)
+	}
+	return v
+}
+
+// optionalURL is mustURL for a value that may legitimately be unset.
+func optionalURL(key string, schemes ...string) string {
+	raw := os.Getenv(key)
+	v := sanitizeURLValue(raw)
+	if v == "" {
+		return ""
+	}
+	if v != raw {
+		slog.Warn("stripped surrounding quotes/whitespace from URL configuration", "key", key)
+	}
+	if problem := checkURLValue(v, schemes...); problem != urlOK {
+		slog.Error("environment variable is not a usable URL", "key", key, "reason", problem.String())
+		os.Exit(1)
+	}
+	return v
 }
 
 func mustEnv(key string) string {

--- a/apps/customer-portal/backend-v2/cmd/server/url_config_test.go
+++ b/apps/customer-portal/backend-v2/cmd/server/url_config_test.go
@@ -1,0 +1,129 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package main
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+const goodBase = "https://apis-stg.example.invalid/zjma/chat/default-endpoint/v1.0"
+
+// TestSanitizeURLValue_RecoversTheStagingMisconfiguration is the regression
+// guard for the recommendations 500: AI_CHAT_AGENT_BASE_URL was stored with a
+// character before "https", so url.Parse never recognised the scheme and every
+// call failed with "first path segment in URL cannot contain colon" — before any
+// network I/O, which is why it returned in 4ms and looked like an upstream fault.
+func TestSanitizeURLValue_RecoversTheStagingMisconfiguration(t *testing.T) {
+	for name, in := range map[string]string{
+		"double quoted":       `"` + goodBase + `"`,
+		"single quoted":       `'` + goodBase + `'`,
+		"leading space":       " " + goodBase,
+		"trailing space":      goodBase + " ",
+		"surrounding spaces":  "  " + goodBase + "  ",
+		"trailing newline":    goodBase + "\n",
+		"quoted with padding": `  "` + goodBase + `"  `,
+		"quoted with inner":   `" ` + goodBase + ` "`,
+		"already clean":       goodBase,
+	} {
+		if got := sanitizeURLValue(in); got != goodBase {
+			t.Errorf("%s: sanitizeURLValue(%q) = %q, want %q", name, in, got, goodBase)
+		}
+	}
+}
+
+// TestSanitizeURLValue_LeavesLegitimateValuesAlone checks the stripping is
+// conservative — an unmatched quote is not silently removed, since that would
+// mask a genuinely corrupt value rather than fix a formatting slip.
+func TestSanitizeURLValue_LeavesLegitimateValuesAlone(t *testing.T) {
+	for _, in := range []string{
+		`"` + goodBase, // opening quote only
+		goodBase + `"`, // closing quote only
+		"",
+	} {
+		got := sanitizeURLValue(in)
+		if want := strings.TrimSpace(in); got != want {
+			t.Errorf("sanitizeURLValue(%q) = %q, want it left as %q", in, got, want)
+		}
+	}
+}
+
+// TestCheckURLValue_RejectsUnusableURLs covers the other shapes that fail inside
+// the HTTP client rather than at parse time, so they are caught at startup
+// instead of becoming a per-request 500 on one endpoint.
+func TestCheckURLValue_RejectsUnusableURLs(t *testing.T) {
+	for name, tc := range map[string]struct {
+		in      string
+		schemes []string
+		wantBad bool
+	}{
+		"valid https":       {goodBase, []string{"http", "https"}, false},
+		"valid ws":          {"ws://localhost:8080", []string{"ws", "wss"}, false},
+		"no scheme":         {"apis-stg.example.invalid/v1.0", []string{"http", "https"}, true},
+		"single slash":      {"https:/apis-stg.example.invalid/v1.0", []string{"http", "https"}, true},
+		"wrong scheme":      {"ws://apis-stg.example.invalid", []string{"http", "https"}, true},
+		"ws where https":    {goodBase, []string{"ws", "wss"}, true},
+		"host only, scheme": {"https://", []string{"http", "https"}, true},
+	} {
+		problem := checkURLValue(tc.in, tc.schemes...)
+		if tc.wantBad && problem == urlOK {
+			t.Errorf("%s: checkURLValue(%q) accepted it, want a rejection", name, tc.in)
+		}
+		if !tc.wantBad && problem != urlOK {
+			t.Errorf("%s: checkURLValue(%q) rejected it: %s", name, tc.in, problem)
+		}
+	}
+}
+
+// TestSanitizedValueIsActuallyRequestable is the end-to-end check that matters:
+// the sanitized value must survive the same construction the upstream clients
+// perform (baseURL + path), which is where the original failure occurred.
+func TestSanitizedValueIsActuallyRequestable(t *testing.T) {
+	raw := `"` + goodBase + `"` // the shape that broke staging
+	clean := sanitizeURLValue(raw)
+
+	if _, err := http.NewRequest(http.MethodPost, raw+"/recommendations", nil); err == nil {
+		t.Fatal("expected the unsanitized value to fail request construction; the test fixture no longer reproduces the bug")
+	}
+	req, err := http.NewRequest(http.MethodPost, clean+"/recommendations", nil)
+	if err != nil {
+		t.Fatalf("sanitized value still fails request construction: %v", err)
+	}
+	if req.URL.Host == "" || req.URL.Scheme != "https" {
+		t.Errorf("sanitized request URL = %q, want an absolute https URL", req.URL.String())
+	}
+}
+
+// TestURLProblem_MessagesAreConstant asserts every classification maps to a
+// fixed, non-empty message. The reason is logged, so it must never be built from
+// the configured value — a newline in that value could otherwise forge a log
+// entry (gosec G706).
+func TestURLProblem_MessagesAreConstant(t *testing.T) {
+	for _, p := range []urlProblem{urlUnparseable, urlNoScheme, urlBadScheme, urlNoHost} {
+		msg := p.String()
+		if msg == "" || msg == "ok" {
+			t.Errorf("urlProblem(%d).String() = %q, want a descriptive constant", p, msg)
+		}
+		if strings.ContainsAny(msg, "\n\r") {
+			t.Errorf("urlProblem(%d) message contains a newline: %q", p, msg)
+		}
+	}
+	if urlOK.String() != "ok" {
+		t.Errorf("urlOK.String() = %q, want \"ok\"", urlOK.String())
+	}
+}


### PR DESCRIPTION
## Purpose

`AI_CHAT_AGENT_BASE_URL` was stored in staging with a character before `https`, so `url.Parse` never recognised the scheme and every recommendations call failed with:

```
upstream parse failed: first path segment in URL cannot contain colon
```

That happened **before any network I/O**, which is why `POST /conversations/recommendations/search` returned a 500 in **4ms** while the rest of the service looked healthy — and why it read as an upstream, credentials, or subscription problem rather than a formatting one. The value looked perfectly correct in the config UI.

All **eleven** URL settings were read raw, so any of them could fail the same way.

## What changes

`mustURL` / `optionalURL` now sanitize and validate every URL setting:

- **Trim surrounding whitespace and strip a matched pair of enclosing quotes** — so `"https://host/path"` and `" https://host/path"` both work
- **Require a parseable absolute URL** with an accepted scheme (`http`/`https`, or `ws`/`wss` for `AI_CHAT_AGENT_WS_BASE_URL`) and a non-empty host — which also catches a missing scheme and a single-slash `https:/host` that leaves `Host` empty

A sanitized-but-malformed value still logs a **warning**: it works now, but the stored value is wrong and the next person to copy it hits the same thing.

### Why startup, not first use

An unparseable URL fails inside the HTTP client on *every request*, surfacing as a 500 on one endpoint while everything else looks fine — a per-request failure easily mistaken for an upstream fault. A misconfiguration should stop the deployment instead, the same reasoning as the JWKS panic in `middleware.NewTokenValidator`.

### Conservative on purpose

An **unmatched** quote is left alone rather than silently removed — stripping it would mask a genuinely corrupt value as a formatting slip.

## Security

The rejection reason is a **code mapped to a constant message**, never a string built from the configured value. Interpolating input-derived text into a log lets a newline forge log entries — gosec **G706 flagged exactly that** in my first version of this change, and the enum is the fix rather than a `#nosec`.

## Testing

- `go build`, `go vet`, `gofmt -l`, `go test -race ./...` — all pass
- `gosec -fmt=text ./...` — **0 issues** (103 files)
- Tests cover all eight malformations (quoted, single-quoted, leading/trailing space, newline, padded combinations), the conservative unmatched-quote cases, every rejection class, and — the one that matters — that the sanitized value survives the same `baseURL + path` construction the upstream clients perform, with a guard that the fixture still reproduces the original failure

`.env.example` documents the contract.

## Relationship to #1504

#1504 made this diagnosable — it is what turned an opaque 500 into `upstream parse failed: first path segment in URL cannot contain colon` and identified the cause in a single request. This PR stops the class from breaking a deployment at all. Both are worth having: one for when a *new* upstream misbehaves, one to prevent this specific footgun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)