### PR TITLE
[CSM Portal] dashboard widget fixes: crash, call-req filters, incident-tasks

### DIFF
--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -91,6 +91,7 @@ func main() {
 	taskHandler := handler.NewTaskHandler(customerEntityClient)
 	incidentHandler := handler.NewIncidentHandler(customerEntityClient)
 	problemHandler := handler.NewProblemHandler(customerEntityClient)
+	incidentTaskHandler := handler.NewIncidentTaskHandler(customerEntityClient)
 
 	// Google Chat is not yet configured for every deployment, so its spaces
 	// are read with os.Getenv (never mustEnv) — a missing or malformed value
@@ -222,6 +223,8 @@ func main() {
 	mux.HandleFunc("POST /problems", problemHandler.CreateProblem)
 	mux.HandleFunc("GET /problems/{id}", problemHandler.GetProblem)
 	mux.HandleFunc("POST /problems/search", problemHandler.SearchProblems)
+	mux.HandleFunc("GET /incident-tasks/{id}", incidentTaskHandler.GetIncidentTask)
+	mux.HandleFunc("POST /incident-tasks/search", incidentTaskHandler.SearchIncidentTasks)
 	// Called manually today; not yet wired into real incident/case creation.
 	mux.HandleFunc("POST /notifications/google-chat/alerts", notificationHandler.PostGoogleChatAlert)
 

--- a/apps/csm-portal/backend/internal/entity/customer.go
+++ b/apps/csm-portal/backend/internal/entity/customer.go
@@ -206,6 +206,18 @@ func (c *CustomerEntityClient) GetProblem(ctx context.Context, id string) ([]byt
 	return c.do(ctx, http.MethodGet, fmt.Sprintf("/problems/%s", url.PathEscape(id)), nil)
 }
 
+// SearchIncidentTasks calls POST /incident-tasks/search on the entity service.
+// Response is returned as raw JSON; field filtering to the portal shape is deferred.
+func (c *CustomerEntityClient) SearchIncidentTasks(ctx context.Context, body []byte) ([]byte, error) {
+	return c.do(ctx, http.MethodPost, "/incident-tasks/search", body)
+}
+
+// GetIncidentTask calls GET /incident-tasks/{id} on the entity service.
+// Response is returned as raw JSON; typed response structs are deferred.
+func (c *CustomerEntityClient) GetIncidentTask(ctx context.Context, id string) ([]byte, error) {
+	return c.do(ctx, http.MethodGet, fmt.Sprintf("/incident-tasks/%s", url.PathEscape(id)), nil)
+}
+
 // PostDeployment calls POST /deployments on the entity service to create a new deployment.
 // Response is returned as raw JSON; typed response structs are deferred.
 func (c *CustomerEntityClient) PostDeployment(ctx context.Context, body []byte) ([]byte, error) {

--- a/apps/csm-portal/backend/internal/handler/helpers_test.go
+++ b/apps/csm-portal/backend/internal/handler/helpers_test.go
@@ -563,6 +563,27 @@ func (m *mockEntityProblemClient) CreateProblem(ctx context.Context, body []byte
 	return []byte(`{}`), nil
 }
 
+// ----- mock entity incident task client -----
+
+type mockEntityIncidentTaskClient struct {
+	searchIncidentTasksFn func(ctx context.Context, body []byte) ([]byte, error)
+	getIncidentTaskFn     func(ctx context.Context, id string) ([]byte, error)
+}
+
+func (m *mockEntityIncidentTaskClient) SearchIncidentTasks(ctx context.Context, body []byte) ([]byte, error) {
+	if m.searchIncidentTasksFn != nil {
+		return m.searchIncidentTasksFn(ctx, body)
+	}
+	return []byte(`{}`), nil
+}
+
+func (m *mockEntityIncidentTaskClient) GetIncidentTask(ctx context.Context, id string) ([]byte, error) {
+	if m.getIncidentTaskFn != nil {
+		return m.getIncidentTaskFn(ctx, id)
+	}
+	return []byte(`{}`), nil
+}
+
 // ----- mock entity change request client -----
 
 type mockEntityChangeRequestClient struct {

--- a/apps/csm-portal/backend/internal/handler/incident_tasks.go
+++ b/apps/csm-portal/backend/internal/handler/incident_tasks.go
@@ -1,0 +1,106 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+
+	"github.com/wso2-open-operations/cs-tools/apps/csm-portal/backend/internal/middleware"
+)
+
+// entityIncidentTaskClient abstracts the entity service incident-task operations used
+// by IncidentTaskHandler. Search and get only -- there is no create/update path, same
+// as the entity service's own IncidentTaskHandler.
+type entityIncidentTaskClient interface {
+	SearchIncidentTasks(ctx context.Context, body []byte) ([]byte, error)
+	GetIncidentTask(ctx context.Context, id string) ([]byte, error)
+}
+
+// IncidentTaskHandler handles HTTP requests for incident-task operations, delegating
+// to the entity service for data access.
+type IncidentTaskHandler struct {
+	entity entityIncidentTaskClient
+}
+
+// NewIncidentTaskHandler creates an IncidentTaskHandler backed by the given entity client.
+func NewIncidentTaskHandler(entity entityIncidentTaskClient) *IncidentTaskHandler {
+	return &IncidentTaskHandler{entity: entity}
+}
+
+// SearchIncidentTasks handles POST /incident-tasks/search.
+func (h *IncidentTaskHandler) SearchIncidentTasks(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			writeError(w, http.StatusRequestEntityTooLarge, ErrMsgTooLarge)
+			return
+		}
+		writeError(w, http.StatusBadRequest, errMsgReadBody)
+		return
+	}
+
+	if !json.Valid(body) {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.SearchIncidentTasks(r.Context(), body)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity SearchIncidentTasks failed", "userID", user.UserID, "err", err)
+		mapUpstreamErrorGeneric(w, err, "Failed to search incident tasks.")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, result)
+}
+
+// GetIncidentTask handles GET /incident-tasks/{id}.
+func (h *IncidentTaskHandler) GetIncidentTask(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	id := r.PathValue("id")
+	if id == "" || !uuidRe.MatchString(id) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	result, err := h.entity.GetIncidentTask(r.Context(), id)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity GetIncidentTask failed", "userID", user.UserID, "id", id, "err", err)
+		mapUpstreamErrorGeneric(w, err, "Failed to retrieve incident task.")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, result)
+}

--- a/apps/csm-portal/backend/internal/handler/incident_tasks_test.go
+++ b/apps/csm-portal/backend/internal/handler/incident_tasks_test.go
@@ -1,0 +1,185 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+const testIncidentTaskID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+func TestSearchIncidentTasks(t *testing.T) {
+	t.Run("requires authenticated user", func(t *testing.T) {
+		h := NewIncidentTaskHandler(&mockEntityIncidentTaskClient{})
+		r := httptest.NewRequest(http.MethodPost, "/incident-tasks/search", strings.NewReader(`{}`))
+		w := httptest.NewRecorder()
+		h.SearchIncidentTasks(w, r)
+		assertStatus(t, w, http.StatusUnauthorized)
+		assertErrorMessage(t, w, ErrMsgUnauthorized)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects body exceeding 1 MiB", func(t *testing.T) {
+		h := NewIncidentTaskHandler(&mockEntityIncidentTaskClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/incident-tasks/search", strings.NewReader(strings.Repeat("x", maxRequestBodyBytes+1))))
+		w := httptest.NewRecorder()
+		h.SearchIncidentTasks(w, r)
+		assertStatus(t, w, http.StatusRequestEntityTooLarge)
+		assertErrorMessage(t, w, ErrMsgTooLarge)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects invalid JSON body", func(t *testing.T) {
+		h := NewIncidentTaskHandler(&mockEntityIncidentTaskClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/incident-tasks/search", strings.NewReader(`not-json`)))
+		w := httptest.NewRecorder()
+		h.SearchIncidentTasks(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("forwards body to upstream and returns 200 with response", func(t *testing.T) {
+		const reqPayload = `{"filters":{"assignmentGroupId":["6c3db375-1b1c-b2d0-a002-c9d3604bcb0c"]},"pagination":{"limit":10,"offset":0}}`
+		var capturedBody []byte
+		client := &mockEntityIncidentTaskClient{
+			searchIncidentTasksFn: func(_ context.Context, body []byte) ([]byte, error) {
+				capturedBody = body
+				return []byte(`{"incidentTasks":[{"id":"` + testIncidentTaskID + `","number":"SCTASK0001"}],"total":1}`), nil
+			},
+		}
+		h := NewIncidentTaskHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPost, "/incident-tasks/search", strings.NewReader(reqPayload)))
+		w := httptest.NewRecorder()
+		h.SearchIncidentTasks(w, r)
+
+		assertStatus(t, w, http.StatusOK)
+		assertContentType(t, w, "application/json")
+		if string(capturedBody) != reqPayload {
+			t.Errorf("upstream received body %q, want %q", capturedBody, reqPayload)
+		}
+		resp := decodeJSON[map[string]any](t, w)
+		if resp["total"] != float64(1) {
+			t.Errorf("total = %v, want 1", resp["total"])
+		}
+	})
+
+	t.Run("upstream errors are mapped correctly", func(t *testing.T) {
+		for _, tc := range upstreamErrorsGeneric("Failed to search incident tasks.") {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				client := &mockEntityIncidentTaskClient{
+					searchIncidentTasksFn: func(_ context.Context, _ []byte) ([]byte, error) {
+						return nil, tc.err
+					},
+				}
+				h := NewIncidentTaskHandler(client)
+				r := withUser(httptest.NewRequest(http.MethodPost, "/incident-tasks/search", strings.NewReader(`{}`)))
+				w := httptest.NewRecorder()
+				h.SearchIncidentTasks(w, r)
+				assertStatus(t, w, tc.wantCode)
+				assertErrorMessage(t, w, tc.wantMsg)
+				assertContentType(t, w, "application/json")
+			})
+		}
+	})
+}
+
+func TestGetIncidentTask(t *testing.T) {
+	t.Run("requires authenticated user", func(t *testing.T) {
+		h := NewIncidentTaskHandler(&mockEntityIncidentTaskClient{})
+		r := httptest.NewRequest(http.MethodGet, "/incident-tasks/"+testIncidentTaskID, nil)
+		r.SetPathValue("id", testIncidentTaskID)
+		w := httptest.NewRecorder()
+		h.GetIncidentTask(w, r)
+		assertStatus(t, w, http.StatusUnauthorized)
+		assertErrorMessage(t, w, ErrMsgUnauthorized)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects malformed UUID", func(t *testing.T) {
+		h := NewIncidentTaskHandler(&mockEntityIncidentTaskClient{})
+		r := withUser(httptest.NewRequest(http.MethodGet, "/incident-tasks/not-a-uuid", nil))
+		r.SetPathValue("id", "not-a-uuid")
+		w := httptest.NewRecorder()
+		h.GetIncidentTask(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgInvalidUUID)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects empty id", func(t *testing.T) {
+		h := NewIncidentTaskHandler(&mockEntityIncidentTaskClient{})
+		r := withUser(httptest.NewRequest(http.MethodGet, "/incident-tasks/", nil))
+		w := httptest.NewRecorder()
+		h.GetIncidentTask(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgInvalidUUID)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("forwards id to upstream and returns 200", func(t *testing.T) {
+		var capturedID string
+		client := &mockEntityIncidentTaskClient{
+			getIncidentTaskFn: func(_ context.Context, id string) ([]byte, error) {
+				capturedID = id
+				return []byte(`{"id":"` + testIncidentTaskID + `","number":"SCTASK0001"}`), nil
+			},
+		}
+		h := NewIncidentTaskHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodGet, "/incident-tasks/"+testIncidentTaskID, nil))
+		r.SetPathValue("id", testIncidentTaskID)
+		w := httptest.NewRecorder()
+		h.GetIncidentTask(w, r)
+
+		assertStatus(t, w, http.StatusOK)
+		assertContentType(t, w, "application/json")
+
+		if capturedID != testIncidentTaskID {
+			t.Errorf("upstream received id %q, want %q", capturedID, testIncidentTaskID)
+		}
+		resp := decodeJSON[map[string]any](t, w)
+		if resp["number"] != "SCTASK0001" {
+			t.Errorf("response number = %v, want SCTASK0001", resp["number"])
+		}
+	})
+
+	t.Run("upstream errors are mapped correctly", func(t *testing.T) {
+		for _, tc := range upstreamErrorsGeneric("Failed to retrieve incident task.") {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				client := &mockEntityIncidentTaskClient{
+					getIncidentTaskFn: func(_ context.Context, _ string) ([]byte, error) {
+						return nil, tc.err
+					},
+				}
+				h := NewIncidentTaskHandler(client)
+				r := withUser(httptest.NewRequest(http.MethodGet, "/incident-tasks/"+testIncidentTaskID, nil))
+				r.SetPathValue("id", testIncidentTaskID)
+				w := httptest.NewRecorder()
+				h.GetIncidentTask(w, r)
+				assertStatus(t, w, tc.wantCode)
+				assertErrorMessage(t, w, tc.wantMsg)
+				assertContentType(t, w, "application/json")
+			})
+		}
+	})
+}

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -9020,6 +9020,27 @@ components:
                   - notes_pending
                   - concluded
               description: Filter by one or more states.
+            caseStates:
+              type: array
+              items:
+                type: string
+                enum: [open, work_in_progress, waiting_on_wso2, awaiting_info, reopened, solution_proposed, closed]
+              description: Filter to call requests whose parent case is in one of these states.
+            excludeCaseStates:
+              type: array
+              items:
+                type: string
+                enum: [open, work_in_progress, waiting_on_wso2, awaiting_info, reopened, solution_proposed, closed]
+              description: >-
+                Filter to call requests whose parent case is NOT in any of these states.
+                Inverse of caseStates; the two are independent and either, both, or
+                neither may be supplied.
+            assignmentTeamIds:
+              type: array
+              items:
+                type: string
+                format: uuid
+              description: Filter by the parent case's assigned team(s).
         sortBy:
           type: object
           additionalProperties: false

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -2983,7 +2983,13 @@ export interface BeDashboardPieSlice {
   label: string;
   /** Falls back to a fixed rotation over the same palette if omitted. */
   color?: BeWidgetPaletteColor;
-  query: Record<string, unknown>;
+  /** `null` when a hand-authored dashboard config's slice omits its own
+   * `query` entirely — the backend's `PieSlice.Query` (a bare
+   * `map[string]any`) has no load-time requirement that a slice carry one,
+   * so it marshals to JSON `null` rather than `{}` when absent. Treat the
+   * same as an empty object: this slice contributes only the widget's own
+   * base `query` (see {@link BeDashboardWidget.query}). */
+  query: Record<string, unknown> | null;
 }
 
 /** Alternative to {@link BeDashboardPieSlice}[] for shapes "pie"/"bar":
@@ -3067,8 +3073,16 @@ export interface BeDashboardWidget {
    * `query`. For shapes "pie"/"bar" this is a shared base merged under
    * every slice's own `query` (see {@link BeDashboardPieSlice}), rather
    * than queried on its own.
+   *
+   * `null` for a shape "pie"/"bar" widget that carries no top-level
+   * criteria of its own — a legitimate, backend-accepted config where every
+   * slice supplies its own complete `query` (the backend's own
+   * `WidgetTemplate.Query` requirement is only "slices OR groupBy OR
+   * query", never "query" unconditionally — see
+   * `apps/csm-portal/backend/internal/dashboard/registry.go`). Treat the
+   * same as an empty object.
    */
-  query: Record<string, unknown>;
+  query: Record<string, unknown> | null;
   /** Only meaningful for shapes "pie"/"bar": one server-side
    * `POST /{resourceType}/group-by` call instead of one `search` per
    * slice. Mutually exclusive with `slices` — the backend enforces

--- a/apps/csm-portal/webapp/src/features/csm-admin/dashboards/components/WidgetEditorDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/dashboards/components/WidgetEditorDialog.tsx
@@ -631,7 +631,7 @@ export default function WidgetEditorDialog({
                 description={previewSnapshot.description}
                 resourceType={previewSnapshot.resourceType}
                 shape={previewSnapshot.shape}
-                filters={previewSnapshot.query}
+                filters={previewSnapshot.query ?? {}}
                 listLimit={previewSnapshot.listLimit}
                 slices={previewSnapshot.slices}
                 groupBy={previewSnapshot.groupBy}

--- a/apps/csm-portal/webapp/src/features/csm-admin/dashboards/utils/widgetQueryConditions.ts
+++ b/apps/csm-portal/webapp/src/features/csm-admin/dashboards/utils/widgetQueryConditions.ts
@@ -179,7 +179,7 @@ function isFilterOp(v: unknown): v is FilterConditionOp {
  * retype a row that came out empty. */
 export function filterConditionsFromQuery(
   resourceType: BeWidgetResourceType,
-  query: Record<string, unknown> | undefined,
+  query: Record<string, unknown> | null | undefined,
 ): FilterCondition[] {
   if (!query) return [];
 

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetGrid.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetGrid.tsx
@@ -158,7 +158,11 @@ export default function DashboardWidgetGrid({
           description={widget.description}
           resourceType={widget.resourceType}
           shape={widget.shape}
-          filters={widget.query}
+          // `widget.query` is legally absent for a slices-only pie/bar
+          // widget (see `BeDashboardWidget.query`'s doc comment) — default
+          // to `{}` here too, at the source, on top of `mergeWidgetFilters`
+          // and `useWidgetData`/`useWidgetPieData` already tolerating it.
+          filters={widget.query ?? {}}
           listLimit={widget.listLimit}
           slices={widget.slices}
           groupBy={widget.groupBy}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/GenericColumnList.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/GenericColumnList.tsx
@@ -102,7 +102,7 @@ export default function GenericColumnList({
       <DashboardMiniTable
         isLoading={isLoading}
         emptyMessage="No records match this widget's filters."
-        columns={[...columns.map((c) => ({ label: c.label })), { label: "Preview", width: "auto" }]}
+        columns={[{ label: "Preview", width: "auto" }, ...columns.map((c) => ({ label: c.label }))]}
         rows={items.map((item, i) => {
           const id = typeof item.id === "string" ? item.id : undefined;
           const href = config?.detailHref?.(item);
@@ -111,11 +111,6 @@ export default function GenericColumnList({
             key: id ?? `row-${i}`,
             onClick: href ? () => navigate(href, { state: dashboardReturnState }) : undefined,
             cells: [
-              ...columns.map((c) => (
-                <Typography key={c.path} variant="body2" noWrap>
-                  {formatColumnValue(resolveColumnPath(item, c.path), c.format)}
-                </Typography>
-              )),
               <Tooltip key="preview" title={`Quick preview ${label}`}>
                 <IconButton
                   size="small"
@@ -128,6 +123,11 @@ export default function GenericColumnList({
                   <Eye size={16} />
                 </IconButton>
               </Tooltip>,
+              ...columns.map((c) => (
+                <Typography key={c.path} variant="body2" noWrap>
+                  {formatColumnValue(resolveColumnPath(item, c.path), c.format)}
+                </Typography>
+              )),
             ],
           };
         })}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetListConfig.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetListConfig.tsx
@@ -181,12 +181,12 @@ function IncidentWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.
         isLoading={isLoading}
         emptyMessage="No incidents match this widget's filters."
         columns={[
+          PREVIEW_COLUMN,
           { label: "Number", width: "minmax(90px, 0.7fr)" },
           { label: "Subject", width: "minmax(160px, 2fr)" },
           { label: "State", width: "minmax(90px, 1fr)" },
           { label: "Priority", width: "minmax(90px, 1fr)" },
           { label: "Updated", width: "minmax(90px, 1fr)" },
-          PREVIEW_COLUMN,
         ]}
         rows={incidents.map((incident, i) => {
           const href = incident.id ? `/operations/incidents/${incident.id}` : undefined;
@@ -195,6 +195,7 @@ function IncidentWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.
             key: incident.id ?? `incident-${i}`,
             onClick: href ? () => navigate(href, { state: dashboardReturnState }) : undefined,
             cells: [
+              previewCell(label, () => setPreviewIncident(incident)),
               <Typography key="number" variant="body2" noWrap>
                 {incident.number || "—"}
               </Typography>,
@@ -230,7 +231,6 @@ function IncidentWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.
               <Typography key="updated" variant="caption" color="text.secondary" noWrap>
                 {formatDate(incident.updatedOn)}
               </Typography>,
-              previewCell(label, () => setPreviewIncident(incident)),
             ],
           };
         })}
@@ -252,12 +252,12 @@ function ChangeRequestWidgetList({ items, isLoading }: WidgetListRendererProps):
         isLoading={isLoading}
         emptyMessage="No change requests match this widget's filters."
         columns={[
+          PREVIEW_COLUMN,
           { label: "Number", width: "minmax(90px, 0.7fr)" },
           { label: "Subject", width: "minmax(160px, 2fr)" },
           { label: "State", width: "minmax(100px, 1fr)" },
           { label: "Impact", width: "minmax(90px, 1fr)" },
           { label: "Updated", width: "minmax(90px, 1fr)" },
-          PREVIEW_COLUMN,
         ]}
         rows={changeRequests.map((cr, i) => {
           const href = cr.id ? `/operations/change-requests/${cr.id}` : undefined;
@@ -266,6 +266,7 @@ function ChangeRequestWidgetList({ items, isLoading }: WidgetListRendererProps):
             key: cr.id ?? `cr-${i}`,
             onClick: href ? () => navigate(href, { state: dashboardReturnState }) : undefined,
             cells: [
+              previewCell(label, () => setPreviewChangeRequest(cr)),
               <Typography key="number" variant="body2" noWrap>
                 {cr.number || "—"}
               </Typography>,
@@ -301,7 +302,6 @@ function ChangeRequestWidgetList({ items, isLoading }: WidgetListRendererProps):
               <Typography key="updated" variant="caption" color="text.secondary" noWrap>
                 {formatDate(cr.updatedOn)}
               </Typography>,
-              previewCell(label, () => setPreviewChangeRequest(cr)),
             ],
           };
         })}
@@ -325,11 +325,11 @@ function ProblemWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.E
         isLoading={isLoading}
         emptyMessage="No problems match this widget's filters."
         columns={[
+          PREVIEW_COLUMN,
           { label: "Number", width: "minmax(90px, 0.7fr)" },
           { label: "Subject", width: "minmax(160px, 2fr)" },
           { label: "State", width: "minmax(100px, 1fr)" },
           { label: "Assigned to", width: "minmax(100px, 1fr)" },
-          PREVIEW_COLUMN,
         ]}
         rows={problems.map((problem, i) => {
           const href = problem.id ? `/operations/problems/${problem.id}` : undefined;
@@ -338,6 +338,7 @@ function ProblemWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.E
             key: problem.id ?? `problem-${i}`,
             onClick: href ? () => navigate(href, { state: dashboardReturnState }) : undefined,
             cells: [
+              previewCell(label, () => setPreviewProblem(problem)),
               <Typography key="number" variant="body2" noWrap>
                 {problem.number || "—"}
               </Typography>,
@@ -360,7 +361,6 @@ function ProblemWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.E
               <Typography key="assignedTo" variant="body2" noWrap>
                 {problem.assignedTo?.name || "—"}
               </Typography>,
-              previewCell(label, () => setPreviewProblem(problem)),
             ],
           };
         })}
@@ -439,10 +439,10 @@ function AccountWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.E
         isLoading={isLoading}
         emptyMessage="No accounts match this widget's filters."
         columns={[
+          PREVIEW_COLUMN,
           { label: "Name", width: "minmax(140px, 2fr)" },
           { label: "Tier", width: "minmax(90px, 1fr)" },
           { label: "Region", width: "minmax(90px, 1fr)" },
-          PREVIEW_COLUMN,
         ]}
         rows={accounts.map((a) => {
           const tier = resolveAccountTier(a);
@@ -450,6 +450,7 @@ function AccountWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.E
             key: a.id,
             onClick: () => navigate(`/customers/accounts/${a.id}`, { state: dashboardReturnState }),
             cells: [
+              previewCell(a.name, () => setPreviewAccount(a)),
               <Typography key="name" variant="body2" noWrap title={a.name}>
                 {a.name}
               </Typography>,
@@ -463,7 +464,6 @@ function AccountWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.E
               <Typography key="region" variant="body2" noWrap>
                 {a.region ?? "—"}
               </Typography>,
-              previewCell(a.name, () => setPreviewAccount(a)),
             ],
           };
         })}
@@ -484,15 +484,16 @@ function ProjectWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.E
         isLoading={isLoading}
         emptyMessage="No projects match this widget's filters."
         columns={[
+          PREVIEW_COLUMN,
           { label: "Name", width: "minmax(140px, 2fr)" },
           { label: "Project key", width: "minmax(90px, 1fr)" },
           { label: "State", width: "minmax(100px, 1fr)" },
-          PREVIEW_COLUMN,
         ]}
         rows={projects.map((p) => ({
           key: p.id,
           onClick: () => navigate(`/customers/projects/${p.id}`, { state: dashboardReturnState }),
           cells: [
+            previewCell(p.name, () => setPreviewProject(p)),
             <Typography key="name" variant="body2" noWrap title={p.name}>
               {p.name}
             </Typography>,
@@ -500,7 +501,6 @@ function ProjectWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.E
               {p.key}
             </Typography>,
             <ClosureStateChip key="state" closureState={p.closureState} emptyFallback="—" />,
-            previewCell(p.name, () => setPreviewProject(p)),
           ],
         }))}
       />
@@ -520,10 +520,10 @@ function UserWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.Elem
         isLoading={isLoading}
         emptyMessage="No users match this widget's filters."
         columns={[
+          PREVIEW_COLUMN,
           { label: "User", width: "minmax(140px, 2fr)" },
           { label: "Email", width: "minmax(140px, 2fr)" },
           { label: "Status", width: "minmax(80px, 1fr)" },
-          PREVIEW_COLUMN,
         ]}
         rows={users.map((u) => ({
           key: u.id,
@@ -536,6 +536,7 @@ function UserWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.Elem
           // is already the link (with state), matching every sibling widget's
           // "name" cell (see AccountWidgetList/ProjectWidgetList above).
           cells: [
+            previewCell(u.name || u.userName, () => setPreviewUser(u)),
             <Typography key="user" variant="body2" noWrap>
               {u.userName}
             </Typography>,
@@ -545,7 +546,6 @@ function UserWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.Elem
             <Typography key="status" variant="body2">
               {u.active === undefined ? "—" : u.active ? "Active" : "Inactive"}
             </Typography>,
-            previewCell(u.name || u.userName, () => setPreviewUser(u)),
           ],
         }))}
       />
@@ -566,10 +566,10 @@ function ProductVulnerabilityWidgetList({ items, isLoading }: WidgetListRenderer
         isLoading={isLoading}
         emptyMessage="No vulnerabilities match this widget's filters."
         columns={[
+          PREVIEW_COLUMN,
           { label: "CVE / ID", width: "minmax(100px, 1fr)" },
           { label: "Product", width: "minmax(120px, 2fr)" },
           { label: "Priority", width: "minmax(90px, 1fr)" },
-          PREVIEW_COLUMN,
         ]}
         rows={vulnerabilities.map((vuln) => {
           const label = vuln.cveId || vuln.vulnerabilityId || "vulnerability";
@@ -580,6 +580,7 @@ function ProductVulnerabilityWidgetList({ items, isLoading }: WidgetListRenderer
                 state: dashboardReturnState,
               }),
             cells: [
+              previewCell(label, () => setPreviewVulnerability(vuln)),
               <Typography key="cve" variant="body2" noWrap sx={{ fontFamily: "monospace" }}>
                 {vuln.cveId || vuln.vulnerabilityId || "—"}
               </Typography>,
@@ -599,7 +600,6 @@ function ProductVulnerabilityWidgetList({ items, isLoading }: WidgetListRenderer
                   —
                 </Typography>
               ),
-              previewCell(label, () => setPreviewVulnerability(vuln)),
             ],
           };
         })}
@@ -685,11 +685,11 @@ function CallRequestWidgetList({ items, isLoading }: WidgetListRendererProps): J
         isLoading={isLoading}
         emptyMessage="No call requests match this widget's filters."
         columns={[
+          PREVIEW_COLUMN,
           { label: "Number", width: "minmax(90px, 0.7fr)" },
           { label: "Reason", width: "minmax(160px, 2fr)" },
           { label: "State", width: "minmax(100px, 1fr)" },
           { label: "Scheduled", width: "minmax(90px, 1fr)" },
-          PREVIEW_COLUMN,
         ]}
         rows={callRequests.map((cr, i) => {
           const href = cr.case?.id ? `/cases/${cr.case.id}` : undefined;
@@ -698,6 +698,7 @@ function CallRequestWidgetList({ items, isLoading }: WidgetListRendererProps): J
             key: cr.id ?? `call-request-${i}`,
             onClick: href ? () => navigate(href, { state: dashboardReturnState }) : undefined,
             cells: [
+              previewCell(label, () => setPreviewCallRequest(cr)),
               <Typography key="number" variant="body2" noWrap>
                 {cr.number || "—"}
               </Typography>,
@@ -714,7 +715,6 @@ function CallRequestWidgetList({ items, isLoading }: WidgetListRendererProps): J
               <Typography key="scheduled" variant="caption" color="text.secondary" noWrap>
                 {formatDateTime(cr.scheduleTime)}
               </Typography>,
-              previewCell(label, () => setPreviewCallRequest(cr)),
             ],
           };
         })}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/utils/teamFilterPlaceholder.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/utils/teamFilterPlaceholder.test.ts
@@ -253,4 +253,85 @@ describe("resolveTeamPlaceholder", () => {
       filters: [{ field: "creTeam", op: "in", values: ["single-group-id"] }],
     });
   });
+
+  describe("the flat assignmentTeamIds shape (e.g. the call_request resourceType)", () => {
+    it("substitutes the placeholder in assignmentTeamIds with the selected team's creGroupId", () => {
+      const filters = {
+        states: ["open"],
+        assignmentTeamIds: [CURRENT_TEAM_PLACEHOLDER],
+      };
+
+      const resolved = resolveTeamPlaceholder(
+        filters,
+        "22222222-2222-2222-2222-222222222222",
+        undefined,
+      );
+
+      expect(resolved).toEqual({
+        states: ["open"],
+        assignmentTeamIds: ["22222222-2222-2222-2222-222222222222"],
+      });
+    });
+
+    it("never resolves assignmentTeamIds from selectedTeamSreGroupId, only from the cre group id", () => {
+      const filters = { assignmentTeamIds: [CURRENT_TEAM_PLACEHOLDER] };
+
+      const resolved = resolveTeamPlaceholder(filters, undefined, "sre-group-id");
+
+      expect(resolved).toEqual({});
+    });
+
+    it("drops assignmentTeamIds entirely when no creGroupId is available", () => {
+      const filters = {
+        states: ["open"],
+        assignmentTeamIds: [CURRENT_TEAM_PLACEHOLDER],
+      };
+
+      const resolved = resolveTeamPlaceholder(filters, undefined, undefined);
+
+      expect(resolved).toEqual({ states: ["open"] });
+    });
+
+    it("drops assignmentTeamIds entirely when the creGroupId is an array ('All ABTs')", () => {
+      const filters = {
+        states: ["open"],
+        assignmentTeamIds: [CURRENT_TEAM_PLACEHOLDER],
+      };
+
+      const resolved = resolveTeamPlaceholder(filters, ["group-a", "group-b"], undefined);
+
+      expect(resolved).toEqual({ states: ["open"] });
+    });
+
+    it("leaves assignmentTeamIds alone when it doesn't contain the placeholder", () => {
+      const filters = { assignmentTeamIds: ["some-literal-group-id"] };
+
+      const resolved = resolveTeamPlaceholder(
+        filters,
+        "22222222-2222-2222-2222-222222222222",
+        undefined,
+      );
+
+      expect(resolved).toBe(filters);
+    });
+
+    it("only substitutes the placeholder entry within assignmentTeamIds, leaving other literal ids alone", () => {
+      const filters = {
+        assignmentTeamIds: ["some-literal-group-id", CURRENT_TEAM_PLACEHOLDER],
+      };
+
+      const resolved = resolveTeamPlaceholder(filters, "team-group-id", undefined);
+
+      expect(resolved).toEqual({
+        assignmentTeamIds: ["some-literal-group-id", "team-group-id"],
+      });
+    });
+
+    it("passes through a filters object with neither filters.filters nor assignmentTeamIds unchanged", () => {
+      const filters = { states: ["open"], severities: ["critical"] };
+
+      expect(resolveTeamPlaceholder(filters, "team-group-id", "team-group-id")).toBe(filters);
+      expect(resolveTeamPlaceholder(filters, undefined, undefined)).toBe(filters);
+    });
+  });
 });

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/utils/teamFilterPlaceholder.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/utils/teamFilterPlaceholder.ts
@@ -94,10 +94,42 @@ export const SRE_TEAM_FILTER_FIELD = "sreTeam";
  * here" and doesn't.
  *
  * Every other filter entry, and every other resourceType's filters shape
- * (this only touches the case-search generic field/op/values DSL), passes
- * through unchanged.
+ * that does not carry `assignmentTeamIds`, passes through unchanged.
+ *
+ * As of 2026-08-18 this also resolves the placeholder on the other filter
+ * shape a non-case resourceType can carry it in: a flat `assignmentTeamIds`
+ * array (e.g. the `call_request` resourceType's `POST /call-requests/search`
+ * filters, `{ assignmentTeamIds: [...] }` — never the case-search DSL).
+ * Migration teams are treated as CRE for this purpose: `assignmentTeamIds`
+ * only ever resolves from `selectedTeamCreGroupId`, the exact same argument
+ * already used for `creTeam` case filters — there is no separate SRE path
+ * for this flat shape, and no new generic/fallback team-id concept. The two
+ * shapes (`filters.filters` case DSL, and flat `filters.assignmentTeamIds`)
+ * are resolved independently of one another — a filters object could in
+ * principle carry either (never both, since a single widget's `filters`
+ * belongs to exactly one resourceType), and resolving one never affects the
+ * other's output. The same fail-safe drop policy applies here too: when
+ * `selectedTeamCreGroupId` is `undefined` or an array (the "All ABTs"
+ * sentinel), `assignmentTeamIds` is dropped from the returned filters object
+ * entirely rather than sent with the literal placeholder or an empty array —
+ * see the reasoning above, which applies unchanged. A literal team id
+ * already present in `assignmentTeamIds` (i.e. not the placeholder) is left
+ * alone, same as a literal value alongside the placeholder in the case DSL.
  */
 export function resolveTeamPlaceholder(
+  filters: Record<string, unknown>,
+  selectedTeamCreGroupId: string | string[] | undefined,
+  selectedTeamSreGroupId: string | string[] | undefined,
+): Record<string, unknown> {
+  const withCaseFieldFiltersResolved = resolveCaseFieldFilterPlaceholder(
+    filters,
+    selectedTeamCreGroupId,
+    selectedTeamSreGroupId,
+  );
+  return resolveAssignmentTeamIdsPlaceholder(withCaseFieldFiltersResolved, selectedTeamCreGroupId);
+}
+
+function resolveCaseFieldFilterPlaceholder(
   filters: Record<string, unknown>,
   selectedTeamCreGroupId: string | string[] | undefined,
   selectedTeamSreGroupId: string | string[] | undefined,
@@ -134,4 +166,34 @@ export function resolveTeamPlaceholder(
 
   if (!changed) return filters;
   return { ...filters, filters: resolved };
+}
+
+/**
+ * Resolves {@link CURRENT_TEAM_PLACEHOLDER} on a flat `assignmentTeamIds`
+ * array — see the widened doc comment on {@link resolveTeamPlaceholder}.
+ */
+function resolveAssignmentTeamIdsPlaceholder(
+  filters: Record<string, unknown>,
+  selectedTeamCreGroupId: string | string[] | undefined,
+): Record<string, unknown> {
+  const assignmentTeamIds = filters.assignmentTeamIds;
+  if (!Array.isArray(assignmentTeamIds) || !assignmentTeamIds.includes(CURRENT_TEAM_PLACEHOLDER)) {
+    return filters;
+  }
+
+  const replacementCreGroupId =
+    typeof selectedTeamCreGroupId === "string" ? selectedTeamCreGroupId : undefined;
+
+  if (replacementCreGroupId === undefined) {
+    // Drop the field entirely — see the doc comment above.
+    const { assignmentTeamIds: _dropped, ...rest } = filters;
+    return rest;
+  }
+
+  return {
+    ...filters,
+    assignmentTeamIds: assignmentTeamIds.flatMap((v) =>
+      v === CURRENT_TEAM_PLACEHOLDER ? [replacementCreGroupId] : [v],
+    ),
+  };
 }

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/utils/widgetFilterMerge.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/utils/widgetFilterMerge.test.ts
@@ -46,6 +46,22 @@ describe("mergeWidgetFilters", () => {
     expect(merged).toEqual({ states: ["pending"], approverIds: ["u1"] });
   });
 
+  // A slices-only widget (no top-level `query`, e.g. a shape "bar" widget
+  // where every slice supplies its own complete criteria) marshals its base
+  // as JSON `null`, not `{}` -- BeDashboardWidget.query is legally absent
+  // (see its own doc comment). Before this null-safety fix, `base.filters`
+  // threw straight out of `DashboardWidgetTile`.
+  it("treats a null base the same as an empty object", () => {
+    const merged = mergeWidgetFilters(null, { filters: [{ field: "state", op: "in", values: ["open"] }] });
+
+    expect(merged).toEqual({ filters: [{ field: "state", op: "in", values: ["open"] }] });
+  });
+
+  it("treats a null/undefined slice the same as an empty object", () => {
+    expect(mergeWidgetFilters({ states: ["pending"] }, null)).toEqual({ states: ["pending"] });
+    expect(mergeWidgetFilters({ states: ["pending"] }, undefined)).toEqual({ states: ["pending"] });
+  });
+
   // A plain object spread drops the base's `anyOf` wholesale the moment a
   // slice sets its own. That is not a hypothetical shape: the backend loader
   // actively PRODUCES `anyOf` by migrating the legacy `orGroups` key, so a

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/utils/widgetFilterMerge.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/utils/widgetFilterMerge.test.ts
@@ -51,10 +51,13 @@ describe("mergeWidgetFilters", () => {
   // as JSON `null`, not `{}` -- BeDashboardWidget.query is legally absent
   // (see its own doc comment). Before this null-safety fix, `base.filters`
   // threw straight out of `DashboardWidgetTile`.
-  it("treats a null base the same as an empty object", () => {
-    const merged = mergeWidgetFilters(null, { filters: [{ field: "state", op: "in", values: ["open"] }] });
-
-    expect(merged).toEqual({ filters: [{ field: "state", op: "in", values: ["open"] }] });
+  it("treats a null or undefined base the same as an empty object", () => {
+    expect(mergeWidgetFilters(null, { filters: [{ field: "state", op: "in", values: ["open"] }] })).toEqual({
+      filters: [{ field: "state", op: "in", values: ["open"] }],
+    });
+    expect(mergeWidgetFilters(undefined, { filters: [{ field: "state", op: "in", values: ["open"] }] })).toEqual({
+      filters: [{ field: "state", op: "in", values: ["open"] }],
+    });
   });
 
   it("treats a null/undefined slice the same as an empty object", () => {

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/utils/widgetFilterMerge.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/utils/widgetFilterMerge.ts
@@ -88,13 +88,22 @@ function mergeFilterArrays(
 }
 
 export function mergeWidgetFilters(
-  base: Record<string, unknown>,
-  slice: Record<string, unknown>,
+  base: Record<string, unknown> | null | undefined,
+  slice: Record<string, unknown> | null | undefined,
 ): Record<string, unknown> {
-  const merged = { ...base, ...slice };
+  // Both a widget's own base `query` and a slice's own `query` are legally
+  // absent on the wire — a slices-only widget (no top-level `query`, e.g. a
+  // shape "bar" widget whose every slice supplies its own criteria) marshals
+  // its base as JSON `null` (see `BeDashboardWidget.query`'s doc comment),
+  // and a slice with no criteria of its own beyond the base is exactly as
+  // legitimate. Normalizing to `{}` up front means every access below can
+  // assume an object, the same way an always-present `query` always could.
+  const baseObj = base ?? {};
+  const sliceObj = slice ?? {};
+  const merged = { ...baseObj, ...sliceObj };
 
-  const baseArr = base.filters;
-  const sliceArr = slice.filters;
+  const baseArr = baseObj.filters;
+  const sliceArr = sliceObj.filters;
   if (isCaseFieldFilterArrayOrEmpty(baseArr) && isCaseFieldFilterArrayOrEmpty(sliceArr)) {
     merged.filters = mergeFilterArrays(baseArr, sliceArr);
   }
@@ -118,8 +127,8 @@ export function mergeWidgetFilters(
   // adopted). Anything not matching the branch shape falls through to the
   // spread's last-writer-wins rather than being mangled into a query that
   // would be accepted but mean something else.
-  const baseBranches = base.anyOf;
-  const sliceBranches = slice.anyOf;
+  const baseBranches = baseObj.anyOf;
+  const sliceBranches = sliceObj.anyOf;
   if (isBranchArray(baseBranches) && isBranchArray(sliceBranches)) {
     merged.anyOf = baseBranches.flatMap((b) =>
       sliceBranches.map((s) => ({ ...b, ...s, filters: mergeFilterArrays(b.filters, s.filters) })),

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -3094,6 +3094,17 @@ type CallRequestSort struct {
 type SearchAllCallRequestsFilters struct {
 	AssignedUserIDs []string               `json:"assignedUserIds"`
 	States          []CallRequestStateType `json:"states"`
+	// CaseStates filters to call requests whose parent case is in one of these
+	// states (optional). Uses the same case-state enum as the case search's
+	// States filter.
+	CaseStates []CaseState `json:"caseStates"`
+	// ExcludeCaseStates filters to call requests whose parent case is NOT in
+	// any of these states (optional). Inverse of CaseStates, and the two are
+	// independent: a request may carry either, both, or neither.
+	ExcludeCaseStates []CaseState `json:"excludeCaseStates"`
+	// AssignmentTeamIDs filters to call requests whose parent case is assigned
+	// to one of these teams (optional). Same UUID convention as AssignedUserIDs.
+	AssignmentTeamIDs []string `json:"assignmentTeamIds"`
 }
 
 // SearchAllCallRequestsRequest is the input for POST /call-requests/search-all.

--- a/entity-service/internal/service/sn_call_request_service.go
+++ b/entity-service/internal/service/sn_call_request_service.go
@@ -76,8 +76,11 @@ type snCallRequestsSearchAllPayload struct {
 }
 
 type snCallRequestsSearchAllFilters struct {
-	AssignedUserIDs []string `json:"assignedUserIds,omitempty"`
-	StateKeys       []int    `json:"stateKeys,omitempty"`
+	AssignedUserIDs   []string `json:"assignedUserIds,omitempty"`
+	StateKeys         []int    `json:"stateKeys,omitempty"`
+	CaseStates        []int    `json:"caseStates,omitempty"`
+	ExcludeCaseStates []int    `json:"excludeCaseStates,omitempty"`
+	AssignmentTeamIDs []string `json:"assignmentTeamIds,omitempty"`
 }
 
 type snCallRequestSort struct {
@@ -370,6 +373,26 @@ func (s *snCallRequestService) SearchAllCallRequests(ctx context.Context, req do
 	if err := validateUUIDs("filters.assignedUserIds", req.Filters.AssignedUserIDs); err != nil {
 		return domain.SearchCallRequestsResponse{}, err
 	}
+	if err := validateUUIDs("filters.assignmentTeamIds", req.Filters.AssignmentTeamIDs); err != nil {
+		return domain.SearchCallRequestsResponse{}, err
+	}
+	// domainStatesToSNIDs silently skips unrecognized values, which omitempty
+	// then drops from the SN payload entirely -- validate up front so an
+	// unrecognized value errors instead of silently widening the result set,
+	// mirroring the case search's States/ExcludeStates validation.
+	for _, st := range req.Filters.CaseStates {
+		if !validCaseState[st] {
+			return domain.SearchCallRequestsResponse{}, &apierror.ValidationError{Msg: "filters.caseStates contains invalid value: " + string(st)}
+		}
+	}
+	// Same reasoning as CaseStates above, and it matters more here: an
+	// exclusion value that got silently dropped would widen the result set
+	// rather than narrow it, which is the harder failure to notice.
+	for _, st := range req.Filters.ExcludeCaseStates {
+		if !validCaseState[st] {
+			return domain.SearchCallRequestsResponse{}, &apierror.ValidationError{Msg: "filters.excludeCaseStates contains invalid value: " + string(st)}
+		}
+	}
 
 	if req.SortBy.Field == "" {
 		req.SortBy.Field = domain.CallRequestSortFieldUpdatedOn
@@ -405,6 +428,18 @@ func (s *snCallRequestService) SearchAllCallRequests(ctx context.Context, req do
 			keys = append(keys, callRequestStateToKey[st])
 		}
 		filters.StateKeys = keys
+		hasFilters = true
+	}
+	if len(req.Filters.CaseStates) > 0 {
+		filters.CaseStates = domainStatesToSNIDs(req.Filters.CaseStates)
+		hasFilters = true
+	}
+	if len(req.Filters.ExcludeCaseStates) > 0 {
+		filters.ExcludeCaseStates = domainStatesToSNIDs(req.Filters.ExcludeCaseStates)
+		hasFilters = true
+	}
+	if len(req.Filters.AssignmentTeamIDs) > 0 {
+		filters.AssignmentTeamIDs = uuidsToSysids(req.Filters.AssignmentTeamIDs)
 		hasFilters = true
 	}
 	if hasFilters {

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -7542,6 +7542,27 @@ components:
               - notes_pending
               - concluded
           description: Filter by one or more call request states.
+        caseStates:
+          type: array
+          items:
+            type: string
+            enum: [open, work_in_progress, waiting_on_wso2, awaiting_info, reopened, solution_proposed, closed]
+          description: Filter to call requests whose parent case is in one of these states.
+        excludeCaseStates:
+          type: array
+          items:
+            type: string
+            enum: [open, work_in_progress, waiting_on_wso2, awaiting_info, reopened, solution_proposed, closed]
+          description: >-
+            Filter to call requests whose parent case is NOT in any of these states.
+            Inverse of caseStates; the two are independent and either, both, or
+            neither may be supplied.
+        assignmentTeamIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+          description: Filter by the parent case's assigned team(s).
 
     SearchAllCallRequestsRequest:
       type: object


### PR DESCRIPTION
## Purpose
This PR bundles four small, independently-motivated CSM portal fixes found and verified
while auditing dashboard widget failures end-to-end against a real local stack (webapp →
BFF → Go entity-service → Ballerina → ServiceNow DEV):

1. **Null-filters crash on slices-only dashboard widgets.** A `shape: "bar"`/`"pie"`
   widget can legitimately omit its top-level `query` when every `slices` entry supplies
   complete criteria of its own — the backend's widget validation only requires one of
   `slices`/`groupBy`/`query`, never `query` unconditionally
   (`apps/csm-portal/backend/internal/dashboard/registry.go`). That widget marshals to the
   wire as `"query": null`, and loading a dashboard containing one (e.g. widget id
   `cr_trend_by_customer`) crashed with `TypeError: Cannot read properties of null
   (reading 'filters') at DashboardWidgetTile`.
2. **Dashboard widget list preview-icon placement.** Every dashboard list-widget row's
   quick-preview eye icon (`GenericColumnList` and all 8 `WIDGET_LIST_RENDERERS` entries)
   was appended as the trailing/last column, inconsistent with `CasesList`'s existing
   leading-edge placement kept "reachable without hunting across the row." Reorders the
   Preview column/cell to the front of each renderer's columns/cells to match. No
   behavior, styling, or drawer-routing change.
3. **Call-request search missing case-state and team filters.** The cross-case
   call-request search only supported `assignedUserIds`/`states`, so "My Call Requests"
   dashboard widgets couldn't exclude call requests belonging to already-closed cases
   (`excludeCaseStates`), and a team-scoped call-request widget couldn't be built at all
   (`assignmentTeamIds`). Adds both as literal pass-through filters through the Go
   entity-service and BFF spec, plus generalizes the webapp's existing
   `__current_team__` placeholder resolver to also handle a `call_request` widget's flat
   `filters.assignmentTeamIds` array. A corresponding Ballerina entity-service change is
   tracked separately.
4. **Incident-tasks widget resourceType had no BFF route.** The entity service already
   fully implements incident-task search/get, and the webapp already has a full
   `WIDGET_RESOURCE_CONFIG` entry expecting `/incident-tasks/search` and
   `/incident-tasks/{id}` — but the CSM BFF never registered a proxy route for either,
   so any `incident_task` dashboard widget 404'd before ever reaching the entity service.

## Goals
Make every dashboard widget shape and resourceType already accepted by the backend/config
schema actually render and fetch data correctly in the webapp, and fix one visual
consistency nit found alongside them.

## Approach
- `widgetFilterMerge.ts`: `mergeWidgetFilters` now accepts `base`/`slice` as possibly
  `null | undefined` and normalizes each to `{}` before use. `DashboardWidgetGrid.tsx`
  defaults `filters={widget.query ?? {}}` as defense in depth. `types.ts` widens
  `BeDashboardWidget.query`/`BeDashboardPieSlice.query` to `Record<string, unknown> |
  null` to reflect what the backend actually sends. Fixes the two downstream spots this
  surfaced: `filterConditionsFromQuery`'s parameter type and the dashboard builder's own
  widget-preview tile, which had the identical null-passthrough.
- `GenericColumnList.tsx`/`widgetListConfig.tsx`: move the Preview column/cell to index 0
  in every renderer's `columns`/`cells` arrays.
- `entity-service/internal/domain/entity.go` + `sn_call_request_service.go`: add
  `CaseStates`/`ExcludeCaseStates []domain.CaseState` and `AssignmentTeamIDs []string` to
  `SearchAllCallRequestsFilters`, validated per-value (an unrecognized state errors rather
  than silently vanishing via `omitempty`, which would otherwise widen instead of narrow
  an `excludeCaseStates` result). `apps/csm-portal/backend/openapi.yaml` documents the
  same shape (the BFF itself needed no code change — it forwards the request body
  unmodified). `teamFilterPlaceholder.ts` splits into
  `resolveCaseFieldFilterPlaceholder` (unchanged case-DSL logic) +
  `resolveAssignmentTeamIdsPlaceholder` (new flat-shape resolver), composed in
  `resolveTeamPlaceholder`; drops the filter entirely when no team is resolved, matching
  the existing case-DSL fail-safe-widen policy.
- `apps/csm-portal/backend/internal/handler/incident_tasks.go` (new) +
  `internal/entity/customer.go`: `IncidentTaskHandler` mirroring the existing
  `ProblemHandler`'s search+get pattern exactly (no create/update path, matching the
  entity service). Wired into `main.go`.

## User stories
CS engineer viewing the `sre-abt` dashboard no longer hits a crash on a slices-only bar
widget, can see incident-task widgets render real data, and "My Call Requests" widgets
can exclude closed-case call requests.

## Release note
- Fixed a crash loading a CSM dashboard containing a pie/bar widget configured with
  per-slice queries and no shared base query.
- Fixed incident-task dashboard widgets returning nothing (missing backend route).
- Call-request search now supports excluding call requests tied to closed cases, and
  filtering by team.
- Dashboard widget list rows now show the preview icon at the start of the row,
  consistent with the cases list.

## Documentation
N/A — internal bug fixes and an additive, backward-compatible API extension; no
user-facing doc or existing contract change.

## Training
N/A — not a training-relevant change.

## Certification
N/A — not exam-relevant.

## Marketing
N/A — internal bug fixes.

## Automation tests
- Unit tests
  - `widgetFilterMerge.test.ts`: added null/undefined-base and null/undefined-slice
    cases. 10/10 passing.
  - `teamFilterPlaceholder.test.ts`: 7 new tests for the `assignmentTeamIds` resolution
    path. 22/22 passing.
  - `incident_tasks_test.go` (new): table-driven tests mirroring the existing handler
    test style (auth, body-size, JSON validity, forwarding, upstream-error mapping) for
    both `SearchIncidentTasks` and `GetIncidentTask`.
  - Go: `go build ./...`, `go vet ./...`, `go test ./...` clean across both
    `entity-service` and `apps/csm-portal/backend`.
  - `pnpm build` (tsc + vite build) and `pnpm lint` clean; the only lint output present
    is pre-existing, in files this PR does not touch.
- Integration tests
  - Live-verified all four changes end-to-end against a real local stack (webapp → BFF →
    Go entity-service → Ballerina → ServiceNow DEV, all on current `main`): the
    slices-only widget's underlying API calls return 200 for every slice;
    `excludeCaseStates` correctly excludes closed-case call requests (200, real data);
    `POST /incident-tasks/search` returns 200 with real data through the new BFF route.

## Security checks
- Followed secure coding standards in
  http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? N/A — no
  security-sensitive code touched (null-handling/type fix, additive search filters on an
  existing read-only endpoint, a new read-only proxy route mirroring an existing one, and
  a UI column reorder).
- Ran FindSecurityBugs plugin and verified report? N/A for the TypeScript/React portions;
  the Go portions use the same validation/UUID-check patterns already in use elsewhere in
  this codebase (`validateUUIDs`, `validCaseState`).
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other
  secrets? Yes.

## Samples
N/A.

## Related PRs
A corresponding Ballerina entity-service change (case-state/team filters on the
cross-case call-request search proxy) is tracked separately.

## Migrations (if applicable)
N/A — no schema/data migration; all changes are additive filters/routes/types.

## Test environment
Verified with `pnpm build`/`pnpm lint` in `apps/csm-portal/webapp`, `go build`/`go
vet`/`go test` in `entity-service` and `apps/csm-portal/backend`, and a live local-stack
round-trip against real ServiceNow DEV data.

## Learning
Two of the four fixes here were caught by validating live behavior rather than trusting
static reads: the incident-tasks gap only surfaced because the entity service and webapp
both already had full support and only the BFF route was missing (an easy thing to miss
from source alone), and the call-request filter validation logic (rejecting rather than
silently dropping an unrecognized `excludeCaseStates` value) mattered specifically
because `omitempty` would otherwise widen an exclude-filter instead of narrowing it.
