### PR TITLE
[CSM] Decode project and onboarding fields in entity-service

### DIFF
--- a/entity-service/CLAUDE.md
+++ b/entity-service/CLAUDE.md
@@ -195,4 +195,14 @@ Missing a `sysidToUUID()` call on a response ID means callers receive a bare sys
 - Never log request bodies, passwords, or tokens; log only IDs and sanitised error summaries
 - All SQL uses parameterized queries; never interpolate user input into query strings
 - Validate and reject unexpected input at the handler boundary before it reaches the service or repository
+- **Running gosec** — this module's `go.mod` floor is newer than the Go bundled in
+  `securego/gosec:latest`, and that image sets `GOTOOLCHAIN=local`, so the scan
+  silently loads **zero files** and reports `Issues: 0` — a pass that examined
+  nothing. Pass `GOTOOLCHAIN=auto` and check the `Files:` count is non-zero:
+
+  ```bash
+  docker run --rm -v "$PWD":/src -v gomod:/go/pkg/mod -w /src \
+    -e GOTOOLCHAIN=auto securego/gosec:latest -fmt=text ./...
+  ```
+
 - **Security fixes in PRs** — when a change is made to fix a security issue (gosec findings, input sanitization, etc.), do not mention it in the PR title or description; describe the change in neutral functional terms only

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -497,6 +497,12 @@ type ProjectAccountRef struct {
 	Region              *string    `json:"region"`
 	AgentEnabled        bool       `json:"agentEnabled"`
 	KbReferencesEnabled bool       `json:"kbReferencesEnabled"`
+	DeactivationDate    *time.Time `json:"deactivationDate"`
+	// OwnerEmail/TechnicalOwnerEmail are the account's owning and technical
+	// contacts. They sit on the account rather than the project, matching
+	// Ballerina's ProjectResponse.account and the portal's ProjectDetailsAccount.
+	OwnerEmail          *string `json:"ownerEmail"`
+	TechnicalOwnerEmail *string `json:"technicalOwnerEmail"`
 }
 
 // ProjectClosureFields groups the ServiceNow-only closure-tracking fields
@@ -531,6 +537,26 @@ type ProjectClosureFields struct {
 // ProjectDetailsView is the enriched response shape for GET /projects/{id}.
 // It embeds the linked account and uses createdOn/updatedOn for consistency
 // with the ProjectView search result.
+// ProjectEngagementFields carries a project's query/onboarding entitlement
+// balances and onboarding milestones.
+//
+// Grouped and embedded like ProjectClosureFields so the JSON stays flat. Every
+// field is a pointer: ServiceNow may omit any of them, and a nil balance ("not
+// tracked for this project") is a different fact from a zero one ("tracked, none
+// remaining") — a customer seeing 0 of 0 hours is not the same as seeing nothing.
+type ProjectEngagementFields struct {
+	TotalQueryHours          *float64   `json:"totalQueryHours"`
+	ConsumedQueryHours       *float64   `json:"consumedQueryHours"`
+	RemainingQueryHours      *float64   `json:"remainingQueryHours"`
+	TotalOnboardingHours     *float64   `json:"totalOnboardingHours"`
+	ConsumedOnboardingHours  *float64   `json:"consumedOnboardingHours"`
+	RemainingOnboardingHours *float64   `json:"remainingOnboardingHours"`
+	GoLiveDate               *time.Time `json:"goLiveDate"`
+	GoLivePlanDate           *time.Time `json:"goLivePlanDate"`
+	OnboardingExpiryDate     *time.Time `json:"onboardingExpiryDate"`
+	OnboardingStatus         *string    `json:"onboardingStatus"`
+}
+
 type ProjectDetailsView struct {
 	ID               string            `json:"id"`
 	Account          ProjectAccountRef `json:"account"`
@@ -542,6 +568,7 @@ type ProjectDetailsView struct {
 	EndDate          time.Time         `json:"endDate"`
 	CreatedOn        time.Time         `json:"createdOn"`
 	UpdatedOn        time.Time         `json:"updatedOn"`
+	ProjectEngagementFields
 	ProjectClosureFields
 }
 
@@ -620,6 +647,9 @@ type ProjectView struct {
 	// for this project (e.g. ServiceNow leaves it blank).
 	EndDate   *time.Time `json:"endDate"`
 	CreatedOn time.Time  `json:"createdOn"`
+	// ActiveCasesCount is a plain int, not a pointer: the portal's
+	// ProjectListItem types it as a required number.
+	ActiveCasesCount int `json:"activeCasesCount"`
 	// Account is nil when the project has no linked account (ServiceNow data source only).
 	Account *EntityRef `json:"account"`
 	ProjectClosureFields

--- a/entity-service/internal/service/sn_project_fields_test.go
+++ b/entity-service/internal/service/sn_project_fields_test.go
@@ -1,0 +1,154 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package service
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestSNProjectDetails_DecodesEngagementFields is the guard for the bug class
+// this change closes: a field ServiceNow sends but no Go struct declares is
+// dropped silently by encoding/json, with no error anywhere. That is how the
+// Usage & Metrics page went blank (deployedProductCount) and how these ten
+// project fields came to be missing.
+func TestSNProjectDetails_DecodesEngagementFields(t *testing.T) {
+	// Shaped as ServiceNow sends it, including the fields on the nested account.
+	payload := `{
+	  "id": "6fa0b42d1bfaa694a002c9d3604bcb77",
+	  "name": "Acme Production",
+	  "key": "ACME-PROD",
+	  "sfId": "0011x00000ABCDE",
+	  "createdOn": "2026-01-05 09:12:44",
+	  "startDate": "2026-01-06",
+	  "endDate": "2027-01-05",
+	  "type": {"name": "Managed Cloud Subscription"},
+	  "totalQueryHours": 40,
+	  "consumedQueryHours": 12.5,
+	  "remainingQueryHours": 27.5,
+	  "totalOnboardingHours": 80,
+	  "consumedOnboardingHours": 80,
+	  "remainingOnboardingHours": 0,
+	  "goLiveDate": "2026-03-01",
+	  "goLivePlanDate": "2026-02-15",
+	  "onboardingExpiryDate": "2026-06-30",
+	  "onboardingStatus": "Completed",
+	  "account": {
+	    "id": "aa11bb22cc33dd44ee55ff6677889900",
+	    "name": "Acme Corp",
+	    "activationDate": "2026-01-06",
+	    "deactivationDate": "2027-01-06",
+	    "supportTier": "Platinum",
+	    "region": "US",
+	    "hasAgent": true,
+	    "hasKbReferences": true,
+	    "ownerEmail": "owner@acme.invalid",
+	    "technicalOwnerEmail": "tech@acme.invalid"
+	  }
+	}`
+
+	var sn snProjectDetailsResponse
+	if err := json.Unmarshal([]byte(payload), &sn); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if sn.TotalQueryHours == nil || *sn.TotalQueryHours != 40 {
+		t.Errorf("totalQueryHours = %v, want 40", sn.TotalQueryHours)
+	}
+	if sn.ConsumedQueryHours == nil || *sn.ConsumedQueryHours != 12.5 {
+		t.Errorf("consumedQueryHours = %v, want 12.5 (a decimal upstream)", sn.ConsumedQueryHours)
+	}
+	// Zero must survive as a real value, not collapse to nil — "tracked, none
+	// remaining" is a different fact from "not tracked".
+	if sn.RemainingOnboardingHours == nil || *sn.RemainingOnboardingHours != 0 {
+		t.Errorf("remainingOnboardingHours = %v, want a non-nil 0", sn.RemainingOnboardingHours)
+	}
+	if sn.OnboardingStatus == nil || *sn.OnboardingStatus != "Completed" {
+		t.Errorf("onboardingStatus = %v, want Completed", sn.OnboardingStatus)
+	}
+	if sn.GoLiveDate == nil || *sn.GoLiveDate != "2026-03-01" {
+		t.Errorf("goLiveDate = %v, want 2026-03-01", sn.GoLiveDate)
+	}
+	if sn.Account.OwnerEmail == nil || *sn.Account.OwnerEmail != "owner@acme.invalid" {
+		t.Errorf("account.ownerEmail = %v, want it decoded from the nested account", sn.Account.OwnerEmail)
+	}
+	if sn.Account.TechnicalOwnerEmail == nil || *sn.Account.TechnicalOwnerEmail != "tech@acme.invalid" {
+		t.Errorf("account.technicalOwnerEmail = %v", sn.Account.TechnicalOwnerEmail)
+	}
+}
+
+// TestSNProjectDetails_OmittedFieldsStayNil checks a project with none of these
+// tracked decodes cleanly with nil balances rather than zeroes, so the portal can
+// tell "not tracked" from "none remaining".
+func TestSNProjectDetails_OmittedFieldsStayNil(t *testing.T) {
+	var sn snProjectDetailsResponse
+	if err := json.Unmarshal([]byte(`{"id":"x","name":"n","key":"k","account":{"id":"a"}}`), &sn); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	for name, got := range map[string]*float64{
+		"totalQueryHours":      sn.TotalQueryHours,
+		"consumedQueryHours":   sn.ConsumedQueryHours,
+		"totalOnboardingHours": sn.TotalOnboardingHours,
+	} {
+		if got != nil {
+			t.Errorf("%s = %v, want nil when absent upstream", name, *got)
+		}
+	}
+	if sn.OnboardingStatus != nil || sn.Account.OwnerEmail != nil {
+		t.Error("absent optional strings should stay nil")
+	}
+}
+
+// TestSNProjectSearch_DecodesActiveCasesCount covers the search-list item, where
+// activeCasesCount lives — the portal's ProjectListItem types it as required.
+func TestSNProjectSearch_DecodesActiveCasesCount(t *testing.T) {
+	var p snProject
+	if err := json.Unmarshal([]byte(`{
+	  "id":"6fa0b42d1bfaa694a002c9d3604bcb77","name":"Acme","key":"ACME",
+	  "createdOn":"2026-01-05 09:12:44","type":{"name":"Managed Cloud Subscription"},
+	  "account":{"id":"aa11","name":"Acme Corp"},"activeCasesCount":7}`), &p); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if p.ActiveCasesCount != 7 {
+		t.Errorf("activeCasesCount = %d, want 7", p.ActiveCasesCount)
+	}
+}
+
+// TestOptionalSNProjectDate covers the shared helper: absent and empty both yield
+// nil, a valid date parses, and a malformed one is an error rather than a silent
+// nil — matching how account activationDate already behaved.
+func TestOptionalSNProjectDate(t *testing.T) {
+	if got, err := optionalSNProjectDate("goLiveDate", nil); err != nil || got != nil {
+		t.Errorf("nil input: got %v, %v; want nil, nil", got, err)
+	}
+	empty := ""
+	if got, err := optionalSNProjectDate("goLiveDate", &empty); err != nil || got != nil {
+		t.Errorf("empty input: got %v, %v; want nil, nil", got, err)
+	}
+	valid := "2026-03-01"
+	got, err := optionalSNProjectDate("goLiveDate", &valid)
+	if err != nil {
+		t.Fatalf("valid date returned an error: %v", err)
+	}
+	if got == nil || got.Format("2006-01-02") != valid {
+		t.Errorf("got %v, want %s", got, valid)
+	}
+	bad := "01/03/2026"
+	if _, err := optionalSNProjectDate("goLiveDate", &bad); err == nil {
+		t.Error("malformed date returned no error; a silent nil would hide upstream data problems")
+	}
+}

--- a/entity-service/internal/service/sn_project_service.go
+++ b/entity-service/internal/service/sn_project_service.go
@@ -60,6 +60,9 @@ type snProject struct {
 	EndDate   string                  `json:"endDate"`
 	CreatedOn string                  `json:"createdOn"`
 	Account   snProjectSummaryAccount `json:"account"`
+	// ActiveCasesCount is required (not a pointer) because the portal's
+	// ProjectListItem types it as a non-optional number.
+	ActiveCasesCount int `json:"activeCasesCount"`
 	snProjectClosureFields
 }
 
@@ -196,6 +199,7 @@ func (s *snProjectService) SearchProjects(ctx context.Context, req domain.Search
 			EndDate:          endDate,
 			CreatedOn:        createdOn,
 			Account:          account,
+			ActiveCasesCount: p.ActiveCasesCount,
 			ProjectClosureFields: domain.ProjectClosureFields{
 				ClosureState:                    p.ClosureState,
 				EndDateClosureState:             p.EndDateClosureState,
@@ -228,6 +232,21 @@ type snProjectDetailsResponse struct {
 	EndDate   string           `json:"endDate"`
 	Type      snProjectType    `json:"type"`
 	Account   snProjectAccount `json:"account"`
+
+	// Query/onboarding entitlement balances and onboarding milestones.
+	// ServiceNow types the hour fields as decimals and may omit any of them, so
+	// each is a pointer — a nil balance ("not tracked for this project") is a
+	// different fact from a zero one ("tracked, none left").
+	TotalQueryHours          *float64 `json:"totalQueryHours"`
+	ConsumedQueryHours       *float64 `json:"consumedQueryHours"`
+	RemainingQueryHours      *float64 `json:"remainingQueryHours"`
+	TotalOnboardingHours     *float64 `json:"totalOnboardingHours"`
+	ConsumedOnboardingHours  *float64 `json:"consumedOnboardingHours"`
+	RemainingOnboardingHours *float64 `json:"remainingOnboardingHours"`
+	GoLiveDate               *string  `json:"goLiveDate"`
+	GoLivePlanDate           *string  `json:"goLivePlanDate"`
+	OnboardingExpiryDate     *string  `json:"onboardingExpiryDate"`
+	OnboardingStatus         *string  `json:"onboardingStatus"`
 	snProjectClosureFields
 }
 
@@ -239,9 +258,34 @@ type snProjectAccount struct {
 	Region          *string `json:"region"`
 	HasAgent        bool    `json:"hasAgent"`
 	HasKbReferences bool    `json:"hasKbReferences"`
+	// The owning and technical contacts live on the account, not the project —
+	// matching Ballerina's ProjectResponse.account and the portal's
+	// ProjectDetailsAccount type.
+	OwnerEmail          *string `json:"ownerEmail"`
+	TechnicalOwnerEmail *string `json:"technicalOwnerEmail"`
+	DeactivationDate    *string `json:"deactivationDate"`
 }
 
 // GetProjectByID implements ProjectService by calling the Choreo GET /projects/{id} endpoint.
+// optionalSNProjectDate parses an optional ServiceNow date, returning nil when
+// the field is absent or empty.
+//
+// A present-but-malformed value is an error rather than a silent nil, matching
+// how this file already treated account activationDate before these fields were
+// added. Note this means one bad date fails the whole project read; that
+// strictness is inherited deliberately rather than newly introduced, so all
+// optional project dates behave the same way.
+func optionalSNProjectDate(label string, v *string) (*time.Time, error) {
+	if v == nil || *v == "" {
+		return nil, nil
+	}
+	t, err := time.Parse(snDateLayout, *v)
+	if err != nil {
+		return nil, fmt.Errorf("sn projects: parse %s %q: %w", label, *v, err)
+	}
+	return &t, nil
+}
+
 func (s *snProjectService) GetProjectByID(ctx context.Context, id string) (domain.ProjectDetailsView, error) {
 	token := middleware.UserIDTokenFromContext(ctx)
 
@@ -275,13 +319,25 @@ func (s *snProjectService) GetProjectByID(ctx context.Context, id string) (domai
 		return domain.ProjectDetailsView{}, fmt.Errorf("sn projects: project %q: %w", sn.ID, err)
 	}
 
-	var activationDate *time.Time
-	if sn.Account.ActivationDate != nil && *sn.Account.ActivationDate != "" {
-		t, err := time.Parse(snDateLayout, *sn.Account.ActivationDate)
-		if err != nil {
-			return domain.ProjectDetailsView{}, fmt.Errorf("sn projects: parse account activationDate %q: %w", *sn.Account.ActivationDate, err)
-		}
-		activationDate = &t
+	activationDate, err := optionalSNProjectDate("account activationDate", sn.Account.ActivationDate)
+	if err != nil {
+		return domain.ProjectDetailsView{}, err
+	}
+	deactivationDate, err := optionalSNProjectDate("account deactivationDate", sn.Account.DeactivationDate)
+	if err != nil {
+		return domain.ProjectDetailsView{}, err
+	}
+	goLiveDate, err := optionalSNProjectDate("goLiveDate", sn.GoLiveDate)
+	if err != nil {
+		return domain.ProjectDetailsView{}, err
+	}
+	goLivePlanDate, err := optionalSNProjectDate("goLivePlanDate", sn.GoLivePlanDate)
+	if err != nil {
+		return domain.ProjectDetailsView{}, err
+	}
+	onboardingExpiryDate, err := optionalSNProjectDate("onboardingExpiryDate", sn.OnboardingExpiryDate)
+	if err != nil {
+		return domain.ProjectDetailsView{}, err
 	}
 
 	return domain.ProjectDetailsView{
@@ -302,14 +358,29 @@ func (s *snProjectService) GetProjectByID(ctx context.Context, id string) (domai
 			ComplianceViolationDate:         sn.ComplianceViolationDate,
 			SuspensionProcessState:          sn.SuspensionProcessState,
 		},
+		ProjectEngagementFields: domain.ProjectEngagementFields{
+			TotalQueryHours:          sn.TotalQueryHours,
+			ConsumedQueryHours:       sn.ConsumedQueryHours,
+			RemainingQueryHours:      sn.RemainingQueryHours,
+			TotalOnboardingHours:     sn.TotalOnboardingHours,
+			ConsumedOnboardingHours:  sn.ConsumedOnboardingHours,
+			RemainingOnboardingHours: sn.RemainingOnboardingHours,
+			GoLiveDate:               goLiveDate,
+			GoLivePlanDate:           goLivePlanDate,
+			OnboardingExpiryDate:     onboardingExpiryDate,
+			OnboardingStatus:         sn.OnboardingStatus,
+		},
 		Account: domain.ProjectAccountRef{
 			ID:                  sysidToUUID(sn.Account.ID),
 			Name:                sn.Account.Name,
 			ActivationDate:      activationDate,
+			DeactivationDate:    deactivationDate,
 			Tier:                sn.Account.SupportTier,
 			Region:              sn.Account.Region,
 			AgentEnabled:        sn.Account.HasAgent,
 			KbReferencesEnabled: sn.Account.HasKbReferences,
+			OwnerEmail:          sn.Account.OwnerEmail,
+			TechnicalOwnerEmail: sn.Account.TechnicalOwnerEmail,
 		},
 	}, nil
 }

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -5056,6 +5056,19 @@ components:
     ProjectAccountRef:
       type: object
       properties:
+        ownerEmail:
+          type: string
+          nullable: true
+          description: Email of the account owner.
+        technicalOwnerEmail:
+          type: string
+          nullable: true
+          description: Email of the account technical owner.
+        deactivationDate:
+          type: string
+          format: date-time
+          nullable: true
+          description: Date the account was deactivated.
         id:
           type: string
         name:
@@ -5077,6 +5090,49 @@ components:
     ProjectDetailsView:
       type: object
       properties:
+        totalQueryHours:
+          type: number
+          nullable: true
+          description: Total query hours entitlement. Null when not tracked for this project.
+        consumedQueryHours:
+          type: number
+          nullable: true
+          description: Query hours consumed. Null when not tracked.
+        remainingQueryHours:
+          type: number
+          nullable: true
+          description: Query hours remaining. Null when not tracked; 0 means none remaining.
+        totalOnboardingHours:
+          type: number
+          nullable: true
+          description: Total onboarding hours entitlement. Null when not tracked.
+        consumedOnboardingHours:
+          type: number
+          nullable: true
+          description: Onboarding hours consumed. Null when not tracked.
+        remainingOnboardingHours:
+          type: number
+          nullable: true
+          description: Onboarding hours remaining. Null when not tracked; 0 means none remaining.
+        goLiveDate:
+          type: string
+          format: date-time
+          nullable: true
+          description: Actual go-live date.
+        goLivePlanDate:
+          type: string
+          format: date-time
+          nullable: true
+          description: Planned go-live date.
+        onboardingExpiryDate:
+          type: string
+          format: date-time
+          nullable: true
+          description: Date the onboarding entitlement expires.
+        onboardingStatus:
+          type: string
+          nullable: true
+          description: Onboarding status as reported by ServiceNow.
         id:
           type: string
         account:
@@ -5139,6 +5195,9 @@ components:
     ProjectView:
       type: object
       properties:
+        activeCasesCount:
+          type: integer
+          description: Number of currently active cases on the project.
         id:
           type: string
         name:


### PR DESCRIPTION
Part 1 of 2 for wso2-enterprise/digiops-cs#2809. **This must deploy before the backend-v2 half** — backend-v2 cannot read a field entity-service is not yet emitting.

## Purpose

Ten fields the portal reads were declared on no Go struct, so ServiceNow sent them and `encoding/json` dropped every one **silently**. Same failure mode as `deployedProductCount`, which blanked the Usage & Metrics page. Ballerina tolerated it because its records are open (`json...;`).

## The shape was verified, not assumed

Two independent sources agree — and they disagree with the obvious guess, so both were checked first:

- Ballerina's `ProjectResponse` record (`modules/servicenow/types.bal`)
- the portal's own TypeScript (`features/project-hub/types/projects.ts`)

| Fields | Where they actually live |
|---|---|
| the six hour balances, `goLiveDate`, `goLivePlanDate`, `onboardingExpiryDate`, `onboardingStatus` | project **detail** |
| `ownerEmail`, `technicalOwnerEmail` | nested **account** object, not the project |
| `activeCasesCount` | **search** item, not the detail |

## Details

**Detail** — grouped as an embedded `ProjectEngagementFields` so the JSON stays flat, matching the existing `ProjectClosureFields` precedent.

Every hour field is a **pointer**. A nil balance ("not tracked for this project") is a different fact from a zero one ("tracked, none remaining") — a customer seeing *0 of 0 hours* is not the same as seeing nothing. A test pins that a zero survives as a real value rather than collapsing to nil.

**Account** — `ownerEmail`/`technicalOwnerEmail` on the nested account, per both sources above. `deactivationDate` decoded alongside the `activationDate` already there.

**Search** — `activeCasesCount` as a plain `int`, not a pointer, because the portal's `ProjectListItem` types it as required.

## One inherited behaviour, flagged rather than changed

The repeated inline optional-date parsing is now a single helper, which **keeps the existing strictness**: a present-but-malformed date is an error, not a silent nil.

That means one bad date fails the whole project read. I kept it so all optional project dates behave identically rather than having the new ones diverge from `account activationDate` right beside them — but it is a latent fragility of the same family as #1489, and worth a deliberate decision in its own change rather than a silent divergence here.

## Testing

- `go build`, `go vet`, `gofmt -l`, `go test -race ./...` — all pass
- Tests decode a ServiceNow-shaped payload (including the nested account), assert omitted fields stay nil, assert a zero balance is preserved, cover `activeCasesCount` on the search item, and cover the date helper's absent/empty/valid/malformed cases
- `openapi.yaml` updated for all three schemas and parses

### A note on gosec

The documented command reported `Issues: 0` for this module **while scanning zero files**: the image's bundled Go is older than this `go.mod`'s floor and it sets `GOTOOLCHAIN=local`, so package loading failed and the summary still read as a pass. `CLAUDE.md` now documents the working invocation and to check the `Files:` count.

With `GOTOOLCHAIN=auto` it scans 103 files and reports **1** issue: a pre-existing G704 in `servicenow-integration-service/client.go`, present identically on the base branch and untouched here. **This change adds none.** Worth its own look, since it has effectively never been scanned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added project engagement and onboarding metrics, including hours, dates, and status.
  * Added active case counts to project search results.
  * Added account deactivation dates and owner contact details to project information.
  * Updated API documentation to reflect the new project fields.

* **Bug Fixes**
  * Improved handling of optional dates, preserving missing values and reporting malformed dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->