### PR TITLE
[CSM] Expose project and onboarding fields in backend-v2

### DIFF
--- a/apps/customer-portal/backend-v2/internal/dto/project.go
+++ b/apps/customer-portal/backend-v2/internal/dto/project.go
@@ -37,6 +37,9 @@ type ProjectSummary struct {
 	EndDate          *time.Time `json:"endDate,omitempty"`
 	CreatedOn        time.Time  `json:"createdOn"`
 	ClosureState     *string    `json:"closureState,omitempty"`
+	// No omitempty: the frontend's ProjectListItem types activeCasesCount as a
+	// required number, so a project with no active cases must still send 0.
+	ActiveCasesCount int `json:"activeCasesCount"`
 }
 
 // SearchProjectsResponse is the portal's response for POST /projects/search.
@@ -63,6 +66,7 @@ func MapSearchProjects(r entity.SearchProjectsResponse) SearchProjectsResponse {
 			EndDate:          p.EndDate,
 			CreatedOn:        p.CreatedOn,
 			ClosureState:     p.ClosureState,
+			ActiveCasesCount: p.ActiveCasesCount,
 		})
 	}
 	return SearchProjectsResponse{
@@ -112,6 +116,11 @@ type ProjectAccount struct {
 	HasAgent        bool       `json:"hasAgent"`
 	HasKbReferences bool       `json:"hasKbReferences"`
 	ActivationDate  *time.Time `json:"activationDate,omitempty"`
+	// The owning and technical contacts belong to the account, matching the
+	// frontend's ProjectDetailsAccount type.
+	DeactivationDate    *time.Time `json:"deactivationDate,omitempty"`
+	OwnerEmail          *string    `json:"ownerEmail,omitempty"`
+	TechnicalOwnerEmail *string    `json:"technicalOwnerEmail,omitempty"`
 }
 
 // ProjectDetails is the portal's response for GET /projects/{id}.
@@ -130,6 +139,26 @@ type ProjectDetails struct {
 	CreatedOn        time.Time      `json:"createdOn"`
 	UpdatedOn        time.Time      `json:"updatedOn"`
 	ClosureState     *string        `json:"closureState,omitempty"`
+
+	// Query/onboarding entitlement balances and onboarding milestones, named as
+	// the frontend's ProjectDetails type declares them
+	// (features/project-hub/types/projects.ts). Customer-appropriate: these are
+	// the customer's own entitlement and onboarding progress, and the portal has
+	// always shown them — the Ballerina backend served all of them.
+	//
+	// omitempty on a pointer omits only nil, so a genuine zero balance still
+	// serialises: "tracked, none remaining" stays distinguishable from
+	// "not tracked".
+	TotalQueryHours          *float64   `json:"totalQueryHours,omitempty"`
+	ConsumedQueryHours       *float64   `json:"consumedQueryHours,omitempty"`
+	RemainingQueryHours      *float64   `json:"remainingQueryHours,omitempty"`
+	TotalOnboardingHours     *float64   `json:"totalOnboardingHours,omitempty"`
+	ConsumedOnboardingHours  *float64   `json:"consumedOnboardingHours,omitempty"`
+	RemainingOnboardingHours *float64   `json:"remainingOnboardingHours,omitempty"`
+	GoLiveDate               *time.Time `json:"goLiveDate,omitempty"`
+	GoLivePlanDate           *time.Time `json:"goLivePlanDate,omitempty"`
+	OnboardingExpiryDate     *time.Time `json:"onboardingExpiryDate,omitempty"`
+	OnboardingStatus         *string    `json:"onboardingStatus,omitempty"`
 }
 
 // MapProjectDetails builds the portal response from entity-service's ProjectDetailsView.
@@ -144,6 +173,10 @@ func MapProjectDetails(p entity.ProjectDetailsView) ProjectDetails {
 			HasAgent:        p.Account.AgentEnabled,
 			HasKbReferences: p.Account.KbReferencesEnabled,
 			ActivationDate:  p.Account.ActivationDate,
+
+			DeactivationDate:    p.Account.DeactivationDate,
+			OwnerEmail:          p.Account.OwnerEmail,
+			TechnicalOwnerEmail: p.Account.TechnicalOwnerEmail,
 		},
 		Name:             p.Name,
 		Key:              p.Key,
@@ -153,5 +186,16 @@ func MapProjectDetails(p entity.ProjectDetailsView) ProjectDetails {
 		CreatedOn:        p.CreatedOn,
 		UpdatedOn:        p.UpdatedOn,
 		ClosureState:     p.ClosureState,
+
+		TotalQueryHours:          p.TotalQueryHours,
+		ConsumedQueryHours:       p.ConsumedQueryHours,
+		RemainingQueryHours:      p.RemainingQueryHours,
+		TotalOnboardingHours:     p.TotalOnboardingHours,
+		ConsumedOnboardingHours:  p.ConsumedOnboardingHours,
+		RemainingOnboardingHours: p.RemainingOnboardingHours,
+		GoLiveDate:               p.GoLiveDate,
+		GoLivePlanDate:           p.GoLivePlanDate,
+		OnboardingExpiryDate:     p.OnboardingExpiryDate,
+		OnboardingStatus:         p.OnboardingStatus,
 	}
 }

--- a/apps/customer-portal/backend-v2/internal/dto/project_onboarding_fields_test.go
+++ b/apps/customer-portal/backend-v2/internal/dto/project_onboarding_fields_test.go
@@ -1,0 +1,181 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dto
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+)
+
+func f64(v float64) *float64 { return &v }
+func strp(v string) *string  { return &v }
+
+// TestMapProjectDetails_EmitsFrontendKeyNames is the key-name assertion for this
+// change. The whole class of bug being closed here is a field that exists on both
+// sides but under a name the frontend never reads — productCount vs
+// deployedProductCount is what blanked the Usage & Metrics page. Asserting the
+// emitted JSON keys is what catches that at build time.
+func TestMapProjectDetails_EmitsFrontendKeyNames(t *testing.T) {
+	goLive := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	view := entity.ProjectDetailsView{
+		ID:                       "6fa0b42d-1bfa-a694-a002-c9d3604bcb77",
+		TotalQueryHours:          f64(40),
+		ConsumedQueryHours:       f64(12.5),
+		RemainingQueryHours:      f64(27.5),
+		TotalOnboardingHours:     f64(80),
+		ConsumedOnboardingHours:  f64(80),
+		RemainingOnboardingHours: f64(0),
+		GoLiveDate:               &goLive,
+		OnboardingStatus:         strp("Completed"),
+		Account: entity.ProjectAccountRef{
+			ID:                  "aa11bb22-cc33-dd44-ee55-ff6677889900",
+			OwnerEmail:          strp("owner@acme.invalid"),
+			TechnicalOwnerEmail: strp("tech@acme.invalid"),
+		},
+	}
+
+	b, err := json.Marshal(MapProjectDetails(view))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	for key, want := range map[string]float64{
+		"totalQueryHours":         40,
+		"consumedQueryHours":      12.5,
+		"remainingQueryHours":     27.5,
+		"totalOnboardingHours":    80,
+		"consumedOnboardingHours": 80,
+	} {
+		got, ok := out[key].(float64)
+		if !ok {
+			t.Errorf("%s missing from the payload; the frontend reads this exact key", key)
+			continue
+		}
+		if got != want {
+			t.Errorf("%s = %v, want %v", key, got, want)
+		}
+	}
+	if out["onboardingStatus"] != "Completed" {
+		t.Errorf("onboardingStatus = %v, want Completed", out["onboardingStatus"])
+	}
+	if out["goLiveDate"] == nil {
+		t.Error("goLiveDate missing from the payload")
+	}
+
+	// The contacts must land on the nested account, not the project root —
+	// that is where the frontend's ProjectDetailsAccount reads them.
+	acct, ok := out["account"].(map[string]any)
+	if !ok {
+		t.Fatal("account object missing")
+	}
+	if acct["ownerEmail"] != "owner@acme.invalid" {
+		t.Errorf("account.ownerEmail = %v", acct["ownerEmail"])
+	}
+	if acct["technicalOwnerEmail"] != "tech@acme.invalid" {
+		t.Errorf("account.technicalOwnerEmail = %v", acct["technicalOwnerEmail"])
+	}
+	if _, atRoot := out["ownerEmail"]; atRoot {
+		t.Error("ownerEmail is at the project root; the frontend reads it on account")
+	}
+}
+
+// TestMapProjectDetails_ZeroBalanceSurvives pins the reason every hour field is a
+// pointer: omitempty omits only nil, so a real zero must still serialise.
+// "Tracked, none remaining" and "not tracked at all" are different facts, and
+// collapsing them would show a customer 0 hours they do not actually have.
+func TestMapProjectDetails_ZeroBalanceSurvives(t *testing.T) {
+	b, err := json.Marshal(MapProjectDetails(entity.ProjectDetailsView{
+		RemainingQueryHours: f64(0),
+	}))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	got, present := out["remainingQueryHours"]
+	if !present {
+		t.Fatal("a zero remainingQueryHours was omitted; it must be sent as 0")
+	}
+	if got.(float64) != 0 {
+		t.Errorf("remainingQueryHours = %v, want 0", got)
+	}
+}
+
+// TestMapProjectDetails_UntrackedFieldsAreOmitted is the other half: a project
+// with none of this tracked must not invent zeroes.
+func TestMapProjectDetails_UntrackedFieldsAreOmitted(t *testing.T) {
+	b, err := json.Marshal(MapProjectDetails(entity.ProjectDetailsView{}))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, key := range []string{
+		"totalQueryHours", "consumedQueryHours", "remainingQueryHours",
+		"totalOnboardingHours", "goLiveDate", "onboardingStatus",
+	} {
+		if _, present := out[key]; present {
+			t.Errorf("%s present for an untracked project; want it omitted", key)
+		}
+	}
+}
+
+// TestMapSearchProjects_ActiveCasesCountAlwaysPresent covers the search item:
+// the frontend's ProjectListItem types activeCasesCount as a required number, so
+// it must be sent even when zero — hence no omitempty.
+func TestMapSearchProjects_ActiveCasesCountAlwaysPresent(t *testing.T) {
+	resp := MapSearchProjects(entity.SearchProjectsResponse{
+		Projects: []entity.ProjectView{
+			{ID: "a", ActiveCasesCount: 7},
+			{ID: "b", ActiveCasesCount: 0},
+		},
+	})
+	b, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out struct {
+		Projects []map[string]any `json:"projects"`
+	}
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(out.Projects) != 2 {
+		t.Fatalf("got %d projects, want 2", len(out.Projects))
+	}
+	if got := out.Projects[0]["activeCasesCount"]; got != float64(7) {
+		t.Errorf("first activeCasesCount = %v, want 7", got)
+	}
+	got, present := out.Projects[1]["activeCasesCount"]
+	if !present {
+		t.Fatal("a zero activeCasesCount was omitted; the frontend types it as required")
+	}
+	if got != float64(0) {
+		t.Errorf("second activeCasesCount = %v, want 0", got)
+	}
+}

--- a/apps/customer-portal/backend-v2/internal/entity/types.go
+++ b/apps/customer-portal/backend-v2/internal/entity/types.go
@@ -96,6 +96,7 @@ type ProjectView struct {
 	StartDate        *time.Time `json:"startDate"`
 	EndDate          *time.Time `json:"endDate"`
 	CreatedOn        time.Time  `json:"createdOn"`
+	ActiveCasesCount int        `json:"activeCasesCount"`
 	ProjectClosureFields
 }
 
@@ -117,6 +118,9 @@ type ProjectAccountRef struct {
 	Region              *string    `json:"region"`
 	AgentEnabled        bool       `json:"agentEnabled"`
 	KbReferencesEnabled bool       `json:"kbReferencesEnabled"`
+	DeactivationDate    *time.Time `json:"deactivationDate"`
+	OwnerEmail          *string    `json:"ownerEmail"`
+	TechnicalOwnerEmail *string    `json:"technicalOwnerEmail"`
 }
 
 // ProjectDetailsView is entity-service's response for GET /projects/{id}.
@@ -131,6 +135,22 @@ type ProjectDetailsView struct {
 	EndDate          time.Time         `json:"endDate"`
 	CreatedOn        time.Time         `json:"createdOn"`
 	UpdatedOn        time.Time         `json:"updatedOn"`
+
+	// Query/onboarding entitlement balances and onboarding milestones.
+	// entity-service groups these in an embedded ProjectEngagementFields, which
+	// flattens in JSON, so they are declared flat here. Pointers throughout: a
+	// nil balance means "not tracked for this project", which is a different
+	// fact from a zero one, "tracked, none remaining".
+	TotalQueryHours          *float64   `json:"totalQueryHours"`
+	ConsumedQueryHours       *float64   `json:"consumedQueryHours"`
+	RemainingQueryHours      *float64   `json:"remainingQueryHours"`
+	TotalOnboardingHours     *float64   `json:"totalOnboardingHours"`
+	ConsumedOnboardingHours  *float64   `json:"consumedOnboardingHours"`
+	RemainingOnboardingHours *float64   `json:"remainingOnboardingHours"`
+	GoLiveDate               *time.Time `json:"goLiveDate"`
+	GoLivePlanDate           *time.Time `json:"goLivePlanDate"`
+	OnboardingExpiryDate     *time.Time `json:"onboardingExpiryDate"`
+	OnboardingStatus         *string    `json:"onboardingStatus"`
 	ProjectClosureFields
 }
 

--- a/apps/customer-portal/backend-v2/openapi.yaml
+++ b/apps/customer-portal/backend-v2/openapi.yaml
@@ -6325,6 +6325,9 @@ components:
     ProjectSummary:
       type: object
       properties:
+        activeCasesCount:
+          type: integer
+          description: Number of currently active cases on the project. Always present.
         id:
           type: string
         name:
@@ -6366,6 +6369,16 @@ components:
         supportTier (not tier) to match the frontend's read site.
       type: object
       properties:
+        ownerEmail:
+          type: string
+          description: Email of the account owner.
+        technicalOwnerEmail:
+          type: string
+          description: Email of the account technical owner.
+        deactivationDate:
+          type: string
+          format: date-time
+          description: Date the account was deactivated.
         id:
           type: string
         name:
@@ -6384,6 +6397,39 @@ components:
     ProjectDetails:
       type: object
       properties:
+        totalQueryHours:
+          type: number
+          description: Total query hours entitlement. Omitted when not tracked.
+        consumedQueryHours:
+          type: number
+          description: Query hours consumed. Omitted when not tracked.
+        remainingQueryHours:
+          type: number
+          description: Query hours remaining. Omitted when not tracked; 0 means none remaining.
+        totalOnboardingHours:
+          type: number
+          description: Total onboarding hours entitlement. Omitted when not tracked.
+        consumedOnboardingHours:
+          type: number
+          description: Onboarding hours consumed. Omitted when not tracked.
+        remainingOnboardingHours:
+          type: number
+          description: Onboarding hours remaining. Omitted when not tracked; 0 means none remaining.
+        goLiveDate:
+          type: string
+          format: date-time
+          description: Actual go-live date.
+        goLivePlanDate:
+          type: string
+          format: date-time
+          description: Planned go-live date.
+        onboardingExpiryDate:
+          type: string
+          format: date-time
+          description: Date the onboarding entitlement expires.
+        onboardingStatus:
+          type: string
+          description: Onboarding status.
         id:
           type: string
         account:


### PR DESCRIPTION
Part 2 of 2 for wso2-enterprise/digiops-cs#2809.

> [!IMPORTANT]
> **Deploy #1510 (entity-service) first.** backend-v2 cannot read a field entity-service is not yet emitting. Merging this first is harmless but has no effect until the other half is live.

## Purpose

Mirrors the ten project fields, the two account contacts and the search item's `activeCasesCount`, exposing them under the names the frontend actually reads.

## Placement was verified, not assumed

It is not where it looks like it should be, so both sources were checked first — Ballerina's records and the frontend's TypeScript, which agree:

| Fields | Actual location |
|---|---|
| `ownerEmail`, `technicalOwnerEmail` | nested **account** object (`ProjectDetailsAccount`), not the project root |
| `activeCasesCount` | **search** item (`ProjectListItem`), not the detail |
| six hour balances, `goLiveDate`, `goLivePlanDate`, `onboardingExpiryDate`, `onboardingStatus` | project detail |

A test asserts the contacts are **not** at the project root, since that is the mistake the shape invites.

## nil vs zero

Pointers throughout, with `omitempty` on the portal DTO. `omitempty` omits only a **nil** pointer, so a genuine zero balance still serialises — "tracked, none remaining" stays distinguishable from "not tracked for this project". Showing a customer *0 of 0 hours* they were never allocated is wrong in a different way from showing nothing at all.

`activeCasesCount` is the deliberate exception: a plain `int` with no `omitempty`, because the frontend types it as **required**, so a project with no active cases must still send `0`.

## Testing

- `go build`, `go vet`, `gofmt -l`, `go test -race ./...` — all pass
- `gosec -fmt=text ./...` (with `GOTOOLCHAIN=auto`) — **0 issues** (103 files)
- `openapi.yaml` updated for `ProjectDetails`, `ProjectAccount` and `ProjectSummary`; verified each property landed under the right schema, and the spec parses

Tests assert the **emitted JSON key names**, the nested-account placement, that a zero balance survives, that untracked fields are omitted rather than defaulted to zero, and that `activeCasesCount` is present at zero. Key-name assertions are the class of test that would have caught the `productCount`/`deployedProductCount` mismatch behind the blank Usage & Metrics page.

### UI verification (after both halves deploy)

Project overview and onboarding screens show the query/onboarding hour balances, go-live dates and onboarding status; the account section shows the owner and technical owner emails; the project list shows an active-case count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)