### PR TITLE
[Customer Portal v2] Send project type as an {id, label} ref

### DIFF
--- a/apps/customer-portal/backend-v2/internal/dto/project.go
+++ b/apps/customer-portal/backend-v2/internal/dto/project.go
@@ -29,14 +29,17 @@ import (
 // complianceViolationDate and suspensionProcessState — these are WSO2-internal
 // closure/compliance workflow fields not meant for customer display.
 type ProjectSummary struct {
-	ID               string     `json:"id"`
-	Name             string     `json:"name"`
-	Key              string     `json:"key"`
-	SubscriptionType string     `json:"subscriptionType"`
-	StartDate        *time.Time `json:"startDate,omitempty"`
-	EndDate          *time.Time `json:"endDate,omitempty"`
-	CreatedOn        time.Time  `json:"createdOn"`
-	ClosureState     *string    `json:"closureState,omitempty"`
+	ID               string `json:"id"`
+	Name             string `json:"name"`
+	Key              string `json:"key"`
+	SubscriptionType string `json:"subscriptionType"`
+	// Type is what the frontend actually reads (project.type.label); see
+	// projectTypeRef. subscriptionType is kept for existing consumers.
+	Type         *IDLabelRef `json:"type,omitempty"`
+	StartDate    *time.Time  `json:"startDate,omitempty"`
+	EndDate      *time.Time  `json:"endDate,omitempty"`
+	CreatedOn    time.Time   `json:"createdOn"`
+	ClosureState *string     `json:"closureState,omitempty"`
 	// No omitempty: the frontend's ProjectListItem types activeCasesCount as a
 	// required number, so a project with no active cases must still send 0.
 	ActiveCasesCount int `json:"activeCasesCount"`
@@ -62,6 +65,7 @@ func MapSearchProjects(r entity.SearchProjectsResponse) SearchProjectsResponse {
 			Name:             p.Name,
 			Key:              p.Key,
 			SubscriptionType: p.SubscriptionType,
+			Type:             projectTypeRef(p.SubscriptionType),
 			StartDate:        p.StartDate,
 			EndDate:          p.EndDate,
 			CreatedOn:        p.CreatedOn,
@@ -134,11 +138,14 @@ type ProjectDetails struct {
 	Name             string         `json:"name"`
 	Key              string         `json:"key"`
 	SubscriptionType string         `json:"subscriptionType"`
-	StartDate        time.Time      `json:"startDate"`
-	EndDate          time.Time      `json:"endDate"`
-	CreatedOn        time.Time      `json:"createdOn"`
-	UpdatedOn        time.Time      `json:"updatedOn"`
-	ClosureState     *string        `json:"closureState,omitempty"`
+	// Type is what the frontend actually reads (project.type.label); see
+	// projectTypeRef. subscriptionType is kept for existing consumers.
+	Type         *IDLabelRef `json:"type,omitempty"`
+	StartDate    time.Time   `json:"startDate"`
+	EndDate      time.Time   `json:"endDate"`
+	CreatedOn    time.Time   `json:"createdOn"`
+	UpdatedOn    time.Time   `json:"updatedOn"`
+	ClosureState *string     `json:"closureState,omitempty"`
 
 	// Query/onboarding entitlement balances and onboarding milestones, named as
 	// the frontend's ProjectDetails type declares them
@@ -181,6 +188,7 @@ func MapProjectDetails(p entity.ProjectDetailsView) ProjectDetails {
 		Name:             p.Name,
 		Key:              p.Key,
 		SubscriptionType: p.SubscriptionType,
+		Type:             projectTypeRef(p.SubscriptionType),
 		StartDate:        p.StartDate,
 		EndDate:          p.EndDate,
 		CreatedOn:        p.CreatedOn,

--- a/apps/customer-portal/backend-v2/internal/dto/project_enum_mapping.go
+++ b/apps/customer-portal/backend-v2/internal/dto/project_enum_mapping.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dto
+
+import "strings"
+
+// projectTypeDisplayLabels turns entity-service's subscription-type enum into the
+// label the portal matches on.
+//
+// These strings are not cosmetic — they are compared for equality against the
+// frontend's ProjectType enum (src/types/permission.ts) and drive real behaviour:
+//
+//   - Development Support locks case severity to S4
+//   - Cloud Support and Cloud Evaluation Support auto-pick the primary product on
+//     case and service-request creation
+//   - anything other than Managed Cloud Subscription has S0 (Catastrophic)
+//     filtered out of the severity options
+//
+// So a wrong label is worse than a missing one: it silently changes which
+// severities a customer can pick. Keep them byte-identical to that enum.
+//
+// entity-service derives its enum mechanically from the ServiceNow display name
+// (lowercase, spaces to underscores — see snTypeNameToSubscriptionType), but an
+// explicit table is used here rather than reversing that transform, because
+// title-casing would mangle any future value containing an acronym.
+var projectTypeDisplayLabels = map[string]string{
+	"managed_cloud_subscription": "Managed Cloud Subscription",
+	"cloud_support":              "Cloud Support",
+	"cloud_evaluation_support":   "Cloud Evaluation Support",
+	"evaluation_subscription":    "Evaluation Subscription",
+	"subscription":               "Subscription",
+	"development_support":        "Development Support",
+	"professional_services":      "Professional Services",
+	// No frontend ProjectType entry exists for these two, so no behaviour keys
+	// off them; they are mapped anyway so the field is never blank.
+	"internal":                "Internal",
+	"platformer_subscription": "Platformer Subscription",
+}
+
+// projectTypeRef builds the {id, label} reference the frontend reads as
+// project.type.
+//
+// entity-service returns the subscription type as a plain enum string, while the
+// frontend's ProjectListItem and ProjectDetails both declare `type: IdLabelRef`
+// and read `type.label`. Sending only the enum under a different key left
+// project.type undefined, which hid the Operations nav item outright
+// (SideBar.tsx gates it on isProjectTypeResolved) and made every project-type
+// rule above take its "not that type" branch.
+//
+// The id carries the enum value rather than a numeric choice-list id: no such id
+// is available from entity-service, nothing in the portal reads project
+// type.id (only deployment type.id is read), and a stable non-empty value beats
+// inventing a fake number. An unrecognised enum passes through as its own label
+// rather than blanking the field, the same tolerance the case *Ref helpers use.
+func projectTypeRef(subscriptionType string) *IDLabelRef {
+	key := strings.ToLower(strings.TrimSpace(subscriptionType))
+	if key == "" {
+		return nil
+	}
+	label, ok := projectTypeDisplayLabels[key]
+	if !ok {
+		label = subscriptionType
+	}
+	return &IDLabelRef{ID: key, Label: label}
+}

--- a/apps/customer-portal/backend-v2/internal/dto/project_type_ref_test.go
+++ b/apps/customer-portal/backend-v2/internal/dto/project_type_ref_test.go
@@ -1,0 +1,140 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dto
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+)
+
+// TestProjectTypeRef_LabelsMatchTheFrontendEnum pins every label byte-for-byte
+// against src/types/permission.ts's ProjectType enum.
+//
+// These are compared for equality in the frontend and drive behaviour, not just
+// display: Development Support locks severity to S4, Cloud Support and Cloud
+// Evaluation Support auto-pick the primary product, and anything other than
+// Managed Cloud Subscription has S0 filtered out of the severity options. A
+// wrong label is worse than a missing one — it silently changes which severities
+// a customer can choose.
+func TestProjectTypeRef_LabelsMatchTheFrontendEnum(t *testing.T) {
+	for enum, want := range map[string]string{
+		"managed_cloud_subscription": "Managed Cloud Subscription",
+		"cloud_support":              "Cloud Support",
+		"cloud_evaluation_support":   "Cloud Evaluation Support",
+		"evaluation_subscription":    "Evaluation Subscription",
+		"subscription":               "Subscription",
+		"development_support":        "Development Support",
+		"professional_services":      "Professional Services",
+	} {
+		got := projectTypeRef(enum)
+		if got == nil {
+			t.Errorf("projectTypeRef(%q) = nil, want a ref", enum)
+			continue
+		}
+		if got.Label != want {
+			t.Errorf("projectTypeRef(%q).Label = %q, want %q (must match ProjectType in permission.ts exactly)", enum, got.Label, want)
+		}
+		if got.ID == "" {
+			t.Errorf("projectTypeRef(%q).ID is empty", enum)
+		}
+	}
+}
+
+// TestProjectTypeRef_EdgeCases covers an absent type and an unrecognised one. An
+// unknown enum passes through as its own label rather than blanking the field,
+// matching the tolerance the case *Ref helpers apply.
+func TestProjectTypeRef_EdgeCases(t *testing.T) {
+	if got := projectTypeRef(""); got != nil {
+		t.Errorf("projectTypeRef(\"\") = %+v, want nil so the field is omitted", got)
+	}
+	got := projectTypeRef("some_future_type")
+	if got == nil || got.Label != "some_future_type" {
+		t.Errorf("unknown enum: got %+v, want the value passed through as its own label", got)
+	}
+}
+
+// TestProjectDetails_EmitsTypeObject is the regression guard for the missing
+// Operations nav item. SideBar.tsx computes
+// `selectedProject?.type?.label ?? projectDetails?.type?.label` and filters the
+// Operations item out when that resolves to nothing, so the object shape — not
+// just the value — is what matters.
+func TestProjectDetails_EmitsTypeObject(t *testing.T) {
+	b, err := json.Marshal(MapProjectDetails(entity.ProjectDetailsView{
+		ID:               "6fa0b42d-1bfa-a694-a002-c9d3604bcb77",
+		SubscriptionType: "managed_cloud_subscription",
+	}))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out struct {
+		Type *struct {
+			ID    string `json:"id"`
+			Label string `json:"label"`
+		} `json:"type"`
+		SubscriptionType string `json:"subscriptionType"`
+	}
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Type == nil {
+		t.Fatal("type is absent; the frontend reads project.type.label and hides the Operations nav without it")
+	}
+	if out.Type.Label != "Managed Cloud Subscription" {
+		t.Errorf("type.label = %q, want %q", out.Type.Label, "Managed Cloud Subscription")
+	}
+	// The existing key stays, so nothing already reading it breaks.
+	if out.SubscriptionType != "managed_cloud_subscription" {
+		t.Errorf("subscriptionType = %q, want it preserved alongside type", out.SubscriptionType)
+	}
+}
+
+// TestSearchProjects_EmitsTypeObject covers the search item, which SideBar reads
+// first (selectedProject) and only falls back to the detail if it is absent.
+func TestSearchProjects_EmitsTypeObject(t *testing.T) {
+	b, err := json.Marshal(MapSearchProjects(entity.SearchProjectsResponse{
+		Projects: []entity.ProjectView{
+			{ID: "a", SubscriptionType: "development_support"},
+			{ID: "b", SubscriptionType: ""},
+		},
+	}))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out struct {
+		Projects []struct {
+			Type *struct {
+				Label string `json:"label"`
+			} `json:"type"`
+		} `json:"projects"`
+	}
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(out.Projects) != 2 {
+		t.Fatalf("got %d projects, want 2", len(out.Projects))
+	}
+	if out.Projects[0].Type == nil || out.Projects[0].Type.Label != "Development Support" {
+		t.Errorf("first project type = %+v, want Development Support", out.Projects[0].Type)
+	}
+	// An empty upstream type omits the object rather than sending an empty one,
+	// so the frontend's ?? fallback to the detail still works.
+	if out.Projects[1].Type != nil {
+		t.Errorf("second project type = %+v, want omitted for an empty upstream value", out.Projects[1].Type)
+	}
+}

--- a/apps/customer-portal/backend-v2/openapi.yaml
+++ b/apps/customer-portal/backend-v2/openapi.yaml
@@ -6328,6 +6328,12 @@ components:
         activeCasesCount:
           type: integer
           description: Number of currently active cases on the project. Always present.
+        # Project type as an {id, label} reference. The label matches the portal's
+        # ProjectType enum exactly: it gates the Operations navigation item and
+        # drives severity and product-default rules. Omitted when the upstream
+        # subscription type is empty.
+        type:
+          $ref: '#/components/schemas/IdLabelRef'
         id:
           type: string
         name:
@@ -6430,6 +6436,12 @@ components:
         onboardingStatus:
           type: string
           description: Onboarding status.
+        # Project type as an {id, label} reference. The label matches the portal's
+        # ProjectType enum exactly: it gates the Operations navigation item and
+        # drives severity and product-default rules. Omitted when the upstream
+        # subscription type is empty.
+        type:
+          $ref: '#/components/schemas/IdLabelRef'
         id:
           type: string
         account:


### PR DESCRIPTION
## Why the Operations nav item was missing

`SideBar.tsx` filters it out unless `isProjectTypeResolved`:

```js
const projectTypeLabel = selectedProject?.type?.label ?? projectDetails?.type?.label;
const isProjectTypeResolved = projectTypeLabel != null && String(projectTypeLabel).trim() !== "";
```

backend-v2 sent the project type only as a plain `subscriptionType` string, so `type` was `undefined` on **both** the search item and the detail, and the item was always dropped.

Same shape of bug as the case status/severity labels: the value was present, under a key and shape the frontend does not read. `hasSR`/`hasCR` were fine — those come from `/features` and are correct.

## The nav item was the visible symptom, not the whole problem

Those label strings are compared **for equality** against the frontend's `ProjectType` enum (`src/types/permission.ts`) and drive behaviour:

- **Development Support** → case severity locked to S4
- **Cloud Support** / **Cloud Evaluation Support** → auto-pick the primary product on case and service-request creation
- **anything other than Managed Cloud Subscription** → S0 (Catastrophic) filtered out of the severity options

With `type` absent, every one of those silently took its *"not that type"* branch — so severity options and product defaults have been wrong for those project types, not merely a nav item hidden.

A wrong label would be worse than a missing one: it would silently change which severities a customer can choose. So the labels are **pinned byte-for-byte against `permission.ts` by a test**, not derived. entity-service builds its enum mechanically from the ServiceNow name (lowercase, spaces → underscores), but reversing that transform would mangle any future value containing an acronym, so an explicit table is used.

## Design notes

- **`id`** carries the enum value. entity-service normalises the type and exposes no numeric choice-list id; nothing in the portal reads project `type.id` (only *deployment* `type.id`), and a stable value beats inventing a fake number.
- **`subscriptionType` is kept** alongside `type`, so anything already reading it is unaffected.
- **An empty upstream value omits the object** rather than sending a blank one, preserving the frontend's `??` fallback from the search item to the detail.

## Testing

- `go build`, `go vet`, `gofmt -l`, `go test -race ./...` — all pass
- `gosec -fmt=text ./...` (with `GOTOOLCHAIN=auto`) — **0 issues** (104 files)
- Tests pin all seven labels against the frontend enum, cover the empty and unrecognised cases, and assert the emitted **object shape** on both the detail and the search item — the shape is what the nav gate depends on, not just the value
- `openapi.yaml` updated for both schemas; I initially referenced a non-existent `IDLabelRef` schema and corrected it to the existing `IdLabelRef`, then verified the spec has **no dangling `$ref`s** anywhere

### UI verification

Open a project: the **Operations** item appears in the side nav. On a Development Support project, case creation should offer only S4; on a non-Managed-Cloud-Subscription project, S0 should not be offered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project summaries and details now include a `type` field with a standardized ID and display label.
  * Recognized project types show consistent frontend-friendly labels.
  * Unknown project types remain available, while empty values are omitted.
  * Existing subscription type information remains supported.

* **Documentation**
  * Updated the API specification to document the new project type field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->