### PR TITLE
[CSM] Decode the reference-item abbreviation

### DIFF
--- a/apps/customer-portal/backend-v2/internal/dto/project_stats.go
+++ b/apps/customer-portal/backend-v2/internal/dto/project_stats.go
@@ -27,6 +27,13 @@ type ReferenceItem struct {
 	ID    string `json:"id"`
 	Label string `json:"label"`
 	Count *int   `json:"count,omitempty"`
+	// Abbreviation is the short reference name (e.g. "APIM" for "API Manager").
+	// The frontend declares it on its shared IdLabelRef and prefers it over the
+	// label where a compact name is wanted — see recommendedLevelsProductKey in
+	// ManageProductModal.tsx, which falls back to the label when it is absent.
+	// Only entity-service's ReferenceTableItem carries it; ChoiceListItem has no
+	// equivalent, so it stays nil on that path.
+	Abbreviation *string `json:"abbreviation,omitempty"`
 }
 
 func mapChoiceListItem(i entity.ChoiceListItem) ReferenceItem {
@@ -44,7 +51,7 @@ func mapChoiceListItems(items []entity.ChoiceListItem) []ReferenceItem {
 func mapReferenceTableItems(items []entity.ReferenceTableItem) []ReferenceItem {
 	out := make([]ReferenceItem, 0, len(items))
 	for _, i := range items {
-		out = append(out, ReferenceItem{ID: i.ID, Label: i.Name, Count: i.Count})
+		out = append(out, ReferenceItem{ID: i.ID, Label: i.Name, Count: i.Count, Abbreviation: i.Abbreviation})
 	}
 	return out
 }

--- a/apps/customer-portal/backend-v2/internal/dto/reference_abbreviation_test.go
+++ b/apps/customer-portal/backend-v2/internal/dto/reference_abbreviation_test.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dto
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestReferenceItem_AbbreviationKeyAndOmission covers both halves of the
+// contract: the key name the frontend reads, and that it disappears when absent
+// rather than serialising as an empty string.
+//
+// The frontend prefers the abbreviation over the label where a compact name is
+// wanted (recommendedLevelsProductKey in ManageProductModal.tsx) and falls back
+// to the label when it is missing, so an empty-string abbreviation would be worse
+// than no key at all — it would win the fallback and render nothing.
+func TestReferenceItem_AbbreviationKeyAndOmission(t *testing.T) {
+	abbr := "APIM"
+	withAbbr, err := json.Marshal(ReferenceItem{ID: "1", Label: "API Manager", Abbreviation: &abbr})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	// A fresh map per payload: unmarshalling into a non-nil map merges into it
+	// rather than replacing it, so reusing one would carry the first payload's
+	// abbreviation into the second assertion and hide a real regression.
+	decode := func(t *testing.T, payload []byte) map[string]any {
+		t.Helper()
+		out := map[string]any{}
+		if err := json.Unmarshal(payload, &out); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		return out
+	}
+
+	if got := decode(t, withAbbr)["abbreviation"]; got != "APIM" {
+		t.Errorf("abbreviation = %v, want APIM", got)
+	}
+
+	without, err := json.Marshal(ReferenceItem{ID: "2", Label: "Identity Server"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if _, present := decode(t, without)["abbreviation"]; present {
+		t.Error("abbreviation present when nil; it must be omitted so the frontend falls back to the label")
+	}
+}

--- a/apps/customer-portal/backend-v2/internal/entity/types.go
+++ b/apps/customer-portal/backend-v2/internal/entity/types.go
@@ -179,6 +179,9 @@ type ReferenceTableItem struct {
 	Number     *string `json:"number,omitempty"`
 	InternalID *string `json:"internalId,omitempty"`
 	Count      *int    `json:"count,omitempty"`
+	// Abbreviation is the short reference name; entity-service decodes it from
+	// ServiceNow's ReferenceTableItem.
+	Abbreviation *string `json:"abbreviation,omitempty"`
 }
 
 // ProjectFeatures is the feature-access configuration for a project.

--- a/apps/customer-portal/backend-v2/openapi.yaml
+++ b/apps/customer-portal/backend-v2/openapi.yaml
@@ -8693,6 +8693,10 @@ components:
       type: object
       required: [id, label]
       properties:
+        abbreviation:
+          type: string
+          nullable: true
+          description: Short reference name (e.g. "APIM" for "API Manager"). Omitted when the backing record carries none.
         id:
           type: string
         label:

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -685,6 +685,9 @@ type ReferenceTableItem struct {
 	Number     *string `json:"number,omitempty"`
 	InternalID *string `json:"internalId,omitempty"`
 	Count      *int    `json:"count,omitempty"`
+	// Abbreviation is the short reference name (e.g. "APIM" for "API Manager"),
+	// present when the backing record carries one.
+	Abbreviation *string `json:"abbreviation,omitempty"`
 }
 
 // ProjectFeatures is the feature-access configuration for a project.

--- a/entity-service/internal/service/sn_project_stats_service.go
+++ b/entity-service/internal/service/sn_project_stats_service.go
@@ -74,15 +74,21 @@ type snReferenceTableItem struct {
 	Number     *string `json:"number,omitempty"`
 	InternalID *string `json:"internalId,omitempty"`
 	Count      *int    `json:"count,omitempty"`
+	// Abbreviation is the short product/reference name ServiceNow carries
+	// alongside the display name — e.g. "APIM" for "API Manager". Ballerina
+	// declares it on this record too (types.bal ReferenceTableItem); it was the
+	// only field of that record this service did not decode.
+	Abbreviation *string `json:"abbreviation,omitempty"`
 }
 
 func (i snReferenceTableItem) toDomain() domain.ReferenceTableItem {
 	return domain.ReferenceTableItem{
-		ID:         sysidToUUID(i.ID),
-		Name:       i.Name,
-		Number:     i.Number,
-		InternalID: i.InternalID,
-		Count:      i.Count,
+		ID:           sysidToUUID(i.ID),
+		Name:         i.Name,
+		Number:       i.Number,
+		InternalID:   i.InternalID,
+		Count:        i.Count,
+		Abbreviation: i.Abbreviation,
 	}
 }
 

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -9859,6 +9859,10 @@ components:
         WSO2-internal ID, and per-item count.
       required: [id, name]
       properties:
+        abbreviation:
+          type: string
+          nullable: true
+          description: Short reference name (e.g. "APIM" for "API Manager"). Omitted when the backing record carries none.
         id:
           type: string
         name:


### PR DESCRIPTION
Partially closes wso2-enterprise/digiops-cs#2811 — **two of that issue's three fields turned out not to be gaps**, see below.

## The one real gap

ServiceNow carries a short reference name alongside the display name — `"APIM"` for `"API Manager"` — on its reference-table records. Ballerina declares it on `ReferenceTableItem`; it was the **only** field of that record this service did not decode, so `encoding/json` dropped it silently.

The portal does read it: `recommendedLevelsProductKey` in `ManageProductModal.tsx` prefers the abbreviation and falls back to the label, and the frontend's shared `IdLabelRef` declares the field.

```js
const abbr = product?.abbreviation?.trim();
if (abbr) return abbr;
return product?.label?.trim() ?? "";
```

Because that fallback exists, an **empty-string** abbreviation would be worse than a missing one — it would win the fallback and render nothing. So the field is a pointer, omitted when nil, with a test covering both halves.

Mapped only on the `ReferenceTableItem` path. `ChoiceListItem` collapses into the same portal `ReferenceItem` but has no equivalent field, so it stays nil there.

## The other two are not gaps

Verified against the frontend rather than assumed:

| Field | Finding |
|---|---|
| `categories` on `ChangeRequestMetadataResponse` | **No portal type declares it.** The original audit's "5 files" was a bare-name grep matching a *dashboard chart* type, not change-request metadata. |
| `choices` on `CatalogItemVariable`, `text` on `CatalogVariableChoice` | The frontend's `CatalogItemVariable` is exactly `{id, questionText, order, type}` — no `choices` field anywhere. |

Implementing either would have added an unread field and a maintenance surface for nothing. I'd suggest trimming digiops-cs#2811's scope to reflect this rather than leaving them as outstanding work.

## Note on the deployed-product path

`abbreviation` exists on exactly one Ballerina record, and no record uses `ReferenceTableItem` for a `product` field — so the *deployed-product* `product` ref has never carried it, in Ballerina either. The frontend's fallback to `label` covers that case, and this PR does not change it.

## Testing

- `go build`, `go vet`, `gofmt -l`, `go test -race ./...` — pass in **both** services
- `gosec` — 0 issues for backend-v2; entity-service reports the same single pre-existing G704 as before, none added
- `openapi.yaml` updated in both services and both parse

One note on the test: my first version reused a single map across two `json.Unmarshal` calls, which **merges** rather than replaces — so the first payload's abbreviation leaked into the omission assertion and the test failed for its own reasons. Fixed with a fresh map per payload, and the reason is recorded in a comment.

## Deployment

**entity-service first**, then backend-v2 — the usual ordering; backend-v2 cannot read a field entity-service is not yet emitting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)