### PR TITLE
Add updates, settings, announcements list and change requests in e2e …

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -46,6 +46,16 @@ on:
       #- customer-portal-milestone-1
   workflow_dispatch:
 
+# The specs write to a single shared staging tenant: a service request comment, a
+# kept attachment per case, a call request, deployments. Two runs overlapping
+# would interleave those writes — two dispatches could both find a record absent
+# and both create it. Serialised rather than cancelled, because a half-finished
+# run leaves records behind either way and cancelling mid-write is worse than
+# queueing.
+concurrency:
+  group: e2e-tests
+  cancel-in-progress: false
+
 jobs:
   e2e:
     name: Run Playwright E2E tests

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,134 +1,134 @@
-# Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
-#
-# WSO2 LLC. licenses this file to you under the Apache License,
-# Version 2.0 (the "License"); you may not use this file except
-# in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+# # Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+# #
+# # WSO2 LLC. licenses this file to you under the Apache License,
+# # Version 2.0 (the "License"); you may not use this file except
+# # in compliance with the License.
+# # You may obtain a copy of the License at
+# #
+# # http://www.apache.org/licenses/LICENSE-2.0
+# #
+# # Unless required by applicable law or agreed to in writing,
+# # software distributed under the License is distributed on an
+# # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# # KIND, either express or implied.  See the License for the
+# # specific language governing permissions and limitations
+# # under the License.
 
-# ⚠️ NOT RUNNABLE IN CI YET — session provisioning is unsolved.
-#
-# The specs authenticate by replaying a captured browser session from
-# apps/customer-portal/webapp/tests/e2e/storageState/session.json. That file
-# holds real tokens and is git-ignored, so it does not exist on a runner. Without
-# it withSession() skips every test and the job exits 0 — a green tick that means
-# "nothing ran", not "E2E passed". The guard step below turns that into an
-# explicit failure instead.
-#
-# Before enabling this on push/PR, three things need settling:
-#   1. Session provisioning — inject a bundle from a secret, or drive a real
-#      login. Access tokens expire in well under an hour, so a stored secret goes
-#      stale between runs.
-#   2. Target environment — .env.e2e points at staging with E2E_NO_WEBSERVER=1,
-#      so the build/preview steps below are currently inert: the tests never hit
-#      localhost:3000. (They could not anyway — public/config.js is git-ignored,
-#      so a preview build boots without runtime config.) Either drop those steps
-#      or capture a localhost session and override E2E_BASE_URL here.
-#   3. Test data — the creation specs write to a REAL backend and there is no
-#      delete endpoint, so every run leaves permanent cases and service requests.
-#      Only the "Create Case — validation" suite is side-effect free.
-#
-# Kept as workflow_dispatch-only until the above is resolved.
+# # ⚠️ NOT RUNNABLE IN CI YET — session provisioning is unsolved.
+# #
+# # The specs authenticate by replaying a captured browser session from
+# # apps/customer-portal/webapp/tests/e2e/storageState/session.json. That file
+# # holds real tokens and is git-ignored, so it does not exist on a runner. Without
+# # it withSession() skips every test and the job exits 0 — a green tick that means
+# # "nothing ran", not "E2E passed". The guard step below turns that into an
+# # explicit failure instead.
+# #
+# # Before enabling this on push/PR, three things need settling:
+# #   1. Session provisioning — inject a bundle from a secret, or drive a real
+# #      login. Access tokens expire in well under an hour, so a stored secret goes
+# #      stale between runs.
+# #   2. Target environment — .env.e2e points at staging with E2E_NO_WEBSERVER=1,
+# #      so the build/preview steps below are currently inert: the tests never hit
+# #      localhost:3000. (They could not anyway — public/config.js is git-ignored,
+# #      so a preview build boots without runtime config.) Either drop those steps
+# #      or capture a localhost session and override E2E_BASE_URL here.
+# #   3. Test data — the creation specs write to a REAL backend and there is no
+# #      delete endpoint, so every run leaves permanent cases and service requests.
+# #      Only the "Create Case — validation" suite is side-effect free.
+# #
+# # Kept as workflow_dispatch-only until the above is resolved.
 
-name: END TO END TESTS
+# name: END TO END TESTS
 
-on:
-  #push:
-    #branches:
-      #- customer-portal-milestone-1
-  workflow_dispatch:
+# on:
+#   #push:
+#     #branches:
+#       #- customer-portal-milestone-1
+#   workflow_dispatch:
 
-# The specs write to a single shared staging tenant: a service request comment, a
-# kept attachment per case, a call request, deployments. Two runs overlapping
-# would interleave those writes — two dispatches could both find a record absent
-# and both create it. Serialised rather than cancelled, because a half-finished
-# run leaves records behind either way and cancelling mid-write is worse than
-# queueing.
-concurrency:
-  group: e2e-tests
-  cancel-in-progress: false
+# # The specs write to a single shared staging tenant: a service request comment, a
+# # kept attachment per case, a call request, deployments. Two runs overlapping
+# # would interleave those writes — two dispatches could both find a record absent
+# # and both create it. Serialised rather than cancelled, because a half-finished
+# # run leaves records behind either way and cancelling mid-write is worse than
+# # queueing.
+# concurrency:
+#   group: e2e-tests
+#   cancel-in-progress: false
 
-jobs:
-  e2e:
-    name: Run Playwright E2E tests
-    runs-on: ubuntu-latest
+# jobs:
+#   e2e:
+#     name: Run Playwright E2E tests
+#     runs-on: ubuntu-latest
 
-    defaults:
-      run:
-        working-directory: apps/customer-portal/webapp
+#     defaults:
+#       run:
+#         working-directory: apps/customer-portal/webapp
 
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+#     steps:
+#       - name: Checkout repository
+#         uses: actions/checkout@v4
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9
+#       - name: Setup pnpm
+#         uses: pnpm/action-setup@v4
+#         with:
+#           version: 9
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: pnpm
-          cache-dependency-path: apps/customer-portal/webapp/pnpm-lock.yaml
+#       - name: Setup Node.js
+#         uses: actions/setup-node@v4
+#         with:
+#           node-version: 20
+#           cache: pnpm
+#           cache-dependency-path: apps/customer-portal/webapp/pnpm-lock.yaml
 
-      # Fail fast rather than reporting a green "all skipped" run. withSession()
-      # skips every spec when the bundle is absent, which Playwright counts as
-      # success — so without this check the job passes having tested nothing.
-      - name: Verify E2E session bundle is present
-        run: |
-          if [ ! -f tests/e2e/storageState/session.json ]; then
-            echo "::error::No tests/e2e/storageState/session.json on the runner."
-            echo "::error::Every spec would skip and this job would pass without testing anything."
-            echo "::error::See the header of .github/workflows/e2e-tests.yml — CI session provisioning is not solved yet."
-            exit 1
-          fi
+#       # Fail fast rather than reporting a green "all skipped" run. withSession()
+#       # skips every spec when the bundle is absent, which Playwright counts as
+#       # success — so without this check the job passes having tested nothing.
+#       - name: Verify E2E session bundle is present
+#         run: |
+#           if [ ! -f tests/e2e/storageState/session.json ]; then
+#             echo "::error::No tests/e2e/storageState/session.json on the runner."
+#             echo "::error::Every spec would skip and this job would pass without testing anything."
+#             echo "::error::See the header of .github/workflows/e2e-tests.yml — CI session provisioning is not solved yet."
+#             exit 1
+#           fi
 
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+#       - name: Install dependencies
+#         run: pnpm install --frozen-lockfile
 
-      - name: Install Playwright Chromium browser
-        run: pnpm exec playwright install --with-deps chromium
+#       - name: Install Playwright Chromium browser
+#         run: pnpm exec playwright install --with-deps chromium
 
-      - name: Build application
-        run: pnpm run build
+#       - name: Build application
+#         run: pnpm run build
 
-      - name: Start preview server
-        run: pnpm run preview -- --host 0.0.0.0 --port 3000 &
+#       - name: Start preview server
+#         run: pnpm run preview -- --host 0.0.0.0 --port 3000 &
 
-      - name: Wait for preview server
-        run: |
-          for i in {1..30}; do
-            if curl -sSf http://localhost:3000 > /dev/null; then
-              echo "Server is up"
-              exit 0
-            fi
-            echo "Waiting for server to be ready..."
-            sleep 2
-          done
-          echo "Server did not start in time" >&2
-          exit 1
+#       - name: Wait for preview server
+#         run: |
+#           for i in {1..30}; do
+#             if curl -sSf http://localhost:3000 > /dev/null; then
+#               echo "Server is up"
+#               exit 0
+#             fi
+#             echo "Waiting for server to be ready..."
+#             sleep 2
+#           done
+#           echo "Server did not start in time" >&2
+#           exit 1
 
-      - name: Run Playwright tests
-        env:
-          CI: true
-        run: pnpm run test:e2e
+#       - name: Run Playwright tests
+#         env:
+#           CI: true
+#         run: pnpm run test:e2e
 
-      - name: Upload Playwright artifacts
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: playwright-report
-          path: |
-            apps/customer-portal/webapp/playwright-report/
-            apps/customer-portal/webapp/test-results/
-          retention-days: 7
+#       - name: Upload Playwright artifacts
+#         if: always()
+#         uses: actions/upload-artifact@v4
+#         with:
+#           name: playwright-report
+#           path: |
+#             apps/customer-portal/webapp/playwright-report/
+#             apps/customer-portal/webapp/test-results/
+#           retention-days: 7

--- a/apps/customer-portal/webapp/tests/e2e/config/testData.ts
+++ b/apps/customer-portal/webapp/tests/e2e/config/testData.ts
@@ -460,6 +460,52 @@ export const DEPLOYMENT_PRODUCT_INPUT = {
 } as const;
 
 /**
+ * The update-level search the updates suite runs.
+ *
+ * Product and version are the API's own identifiers as the selects render them,
+ * not display names — the options come from `GET /updates/product-update-levels`.
+ *
+ * Updates access is a per-project feature flag; Cloud Support does not have it
+ * (see SIDE_NAV_VISIBILITY), so this runs against Subscription.
+ */
+export const UPDATES_SEARCH_INPUT = {
+  projectType: ProjectType.SUBSCRIPTION,
+  productName: "wso2am",
+  productVersion: "4.4.0",
+  startLevel: "0",
+  endLevel: "10",
+  /** The level whose details are opened from the results table. Must fall inside
+   * the range above. */
+  viewLevel: "1",
+} as const;
+
+/**
+ * The user whose roles the settings suite edits.
+ *
+ * ⚠️ This is the signed-in account itself — the only user the suite can safely
+ * change, since it can restore what it altered. The Lead role is removed and put
+ * back within one test.
+ *
+ * Lead matters beyond the settings page: it implies Portal User on save, and is
+ * required to escalate a case past EL3. A run that dies between the two saves
+ * leaves the account without it, so the restore runs from `finally`.
+ */
+export const SETTINGS_USER_INPUT = {
+  projectType: ProjectType.SUBSCRIPTION,
+  email: "paraparan@wso2.com",
+  /** The role toggled off and back on. */
+  role: "Lead",
+  /**
+   * The backend refuses role changes on an account whose supported email domains
+   * are not configured, answering 500 with this message. Verified live on
+   * staging, where every role save fails this way — so the edit test recognises
+   * it and skips rather than reporting a product bug it cannot act on.
+   */
+  unconfiguredDomainsMessage:
+    "supported email domains list for your account has not been defined",
+} as const;
+
+/**
  * Project types whose Deployments tab is reachable.
  *
  * The tab is gated on `permissions.hasDeployments`
@@ -686,6 +732,18 @@ export const SERVICE_REQUEST_VIEWS: ServiceRequestView[] = [
   },
 ];
 
+/**
+ * Content the service-request comment and attachment suite adds.
+ *
+ * The comment text is fixed rather than stamped per run: comments cannot be
+ * deleted, so the spec recognises its own earlier one and does not post again.
+ * The attachment reuses the shared fixture file for the same reason the case
+ * suite does — one upload that stays put.
+ */
+export const SERVICE_REQUEST_ACTIVITY_INPUT = {
+  comment: "This is a test comment on a service request from Automation Test",
+} as const;
+
 /** Subject of the announcement published to all three automation projects. */
 export const SHARED_ANNOUNCEMENT_SUBJECT =
   "[SECURITY Announcement] Lack of access control in the keymanager-operations " +
@@ -742,8 +800,19 @@ export type SideNavVisibility = Record<string, boolean>;
  * the suite.
  *
  * Note "Settings" also renders for these projects but is deliberately not
- * asserted — it is outside the set under test.
+ * asserted per-item — it is outside the gated set. It is accounted for by
+ * SIDE_NAV_UNGATED_ITEMS when checking the list is exhaustive.
  */
+/**
+ * Sidebar items that render for every project, whatever its flags.
+ *
+ * "Settings" is a footer item with no permission filter in SideBar.tsx, so it is
+ * not part of the gated table above — but it *is* part of the rendered list, and
+ * an exhaustiveness check has to expect it or it would read as an unexpected
+ * extra.
+ */
+export const SIDE_NAV_UNGATED_ITEMS: string[] = ["Settings"];
+
 export const SIDE_NAV_VISIBILITY: Partial<
   Record<ProjectType, SideNavVisibility>
 > = {

--- a/apps/customer-portal/webapp/tests/e2e/pages/AnnouncementsPage.ts
+++ b/apps/customer-portal/webapp/tests/e2e/pages/AnnouncementsPage.ts
@@ -250,6 +250,11 @@ export class AnnouncementsPage {
   /**
    * The range the pagination reports.
    *
+   * Guarded on the control existing: `innerText` on a missing element waits for
+   * it and then throws, so without this the "not rendered" case — an empty list,
+   * or a total that fits on one page — would surface as a timeout rather than as
+   * the null a caller can skip on.
+   *
    * @returns from/to/total, or null when the range is not rendered.
    */
   async displayedRange(): Promise<{
@@ -257,6 +262,8 @@ export class AnnouncementsPage {
     to: number;
     total: number;
   } | null> {
+    if ((await this.displayedRows().count()) === 0) return null;
+
     const match = MUI_PAGINATION.displayedRowsPattern.exec(
       await this.displayedRows().innerText(),
     );

--- a/apps/customer-portal/webapp/tests/e2e/pages/AnnouncementsPage.ts
+++ b/apps/customer-portal/webapp/tests/e2e/pages/AnnouncementsPage.ts
@@ -251,9 +251,14 @@ export class AnnouncementsPage {
    * The range the pagination reports.
    *
    * Guarded on the control existing: `innerText` on a missing element waits for
-   * it and then throws, so without this the "not rendered" case — an empty list,
-   * or a total that fits on one page — would surface as a timeout rather than as
-   * the null a caller can skip on.
+   * it and then throws, so without this the "not rendered" case would surface as
+   * a timeout rather than as the null a caller can act on.
+   *
+   * Absent is a normal state, not only an empty-list one: ListPagination returns
+   * null whenever `totalRecords <= rowsPerPage`, so raising the page size can
+   * remove the control that was there a moment ago. A caller reading this after a
+   * resize has to treat null as "everything fits on one page" and count the rows
+   * instead.
    *
    * @returns from/to/total, or null when the range is not rendered.
    */

--- a/apps/customer-portal/webapp/tests/e2e/pages/AnnouncementsPage.ts
+++ b/apps/customer-portal/webapp/tests/e2e/pages/AnnouncementsPage.ts
@@ -1,0 +1,284 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { type Locator, type Page, expect } from "../fixtures/test";
+import {
+  ANNOUNCEMENTS_LIST,
+  CASE_DETAIL,
+  MUI_PAGINATION,
+} from "../utils/selectors";
+import { SideNavPage } from "./SideNavPage";
+
+/** How long to allow for the list and its search to resolve. */
+const LOAD_TIMEOUT_MS = 60_000;
+
+/**
+ * Page object for the announcements list.
+ */
+export class AnnouncementsPage {
+  constructor(private readonly page: Page) {}
+
+  private main(): Locator {
+    return this.page.getByTestId(CASE_DETAIL.mainTestId);
+  }
+
+  /**
+   * Opens the list through the side nav, as a user would.
+   *
+   * @param projectId - Project whose announcements to list.
+   */
+  async openViaSideNav(projectId: string): Promise<void> {
+    const sideNav = new SideNavPage(this.page);
+    await sideNav.open(projectId);
+    await sideNav.clickItem(
+      ANNOUNCEMENTS_LIST.navItem,
+      new RegExp(`/projects/${projectId}/${ANNOUNCEMENTS_LIST.pathSegment}`),
+    );
+    await expect(this.heading()).toBeVisible({ timeout: LOAD_TIMEOUT_MS });
+  }
+
+  /** The list's heading. */
+  heading(): Locator {
+    return this.main().getByRole("heading", {
+      name: ANNOUNCEMENTS_LIST.title,
+      exact: true,
+    });
+  }
+
+  /** The list's description, beneath the heading. */
+  description(): Locator {
+    return this.main().getByText(ANNOUNCEMENTS_LIST.description, {
+      exact: true,
+    });
+  }
+
+  /**
+   * The announcement rows.
+   *
+   * Each row is a clickable card carrying the announcement's case number, which
+   * is what separates a row from the page's other controls.
+   */
+  rows(): Locator {
+    return this.main()
+      .getByRole("button")
+      .filter({ hasText: ANNOUNCEMENTS_LIST.numberPattern });
+  }
+
+  /** The copy shown when a project has no announcements. */
+  emptyMessage(): Locator {
+    return this.main().getByText(ANNOUNCEMENTS_LIST.emptyMessage);
+  }
+
+  /**
+   * Waits for the list to settle into one of its two real states — rows, or the
+   * empty copy — so a caller cannot assert against a still-loading page.
+   */
+  async waitForList(): Promise<void> {
+    await expect(this.rows().first().or(this.emptyMessage())).toBeVisible({
+      timeout: LOAD_TIMEOUT_MS,
+    });
+  }
+
+  /** The "Showing X of Y announcements" bar. */
+  resultsBar(): Locator {
+    return this.main().getByText(ANNOUNCEMENTS_LIST.resultsCountPattern);
+  }
+
+  /**
+   * The totals the results bar reports.
+   *
+   * @returns The shown and total counts, or null when the bar is absent.
+   */
+  async resultsCounts(): Promise<{ shown: number; total: number } | null> {
+    const match = ANNOUNCEMENTS_LIST.resultsCountPattern.exec(
+      await this.resultsBar().innerText(),
+    );
+    return match
+      ? { shown: Number(match[1]), total: Number(match[2]) }
+      : null;
+  }
+
+  //
+  // Filters.
+  //
+
+  /** Opens the filter panel. Reads "Clear Filters (n)" once one is applied. */
+  filtersButton(): Locator {
+    return this.main().getByRole("button", {
+      name: ANNOUNCEMENTS_LIST.filtersButton,
+      exact: true,
+    });
+  }
+
+  /**
+   * The same control once a filter is applied, where it clears rather than
+   * toggles the panel.
+   *
+   * @param activeCount - How many filters are active, which the label carries.
+   */
+  clearFiltersButton(activeCount: number): Locator {
+    return this.main().getByRole("button", {
+      name: ANNOUNCEMENTS_LIST.clearFiltersButton(activeCount),
+      exact: true,
+    });
+  }
+
+  /** The Status filter select, addressed by the id its definition sets. */
+  statusFilterSelect(): Locator {
+    return this.main().locator(`#${ANNOUNCEMENTS_LIST.statusFilter.selectId}`);
+  }
+
+  /**
+   * Reads the options the Status filter offers.
+   *
+   * Waits for the first option before reading: `allInnerTexts` does not retry, so
+   * reading straight after the click can return an empty list while the portal
+   * mounts.
+   *
+   * @returns The option labels, in order.
+   */
+  async statusFilterOptions(): Promise<string[]> {
+    await this.statusFilterSelect().click();
+
+    const options = this.page.getByRole("option");
+    await expect(options.first()).toBeVisible({ timeout: LOAD_TIMEOUT_MS });
+    const labels = await options.allInnerTexts();
+
+    await this.page.keyboard.press("Escape");
+    return labels.map((label) => label.trim());
+  }
+
+  /**
+   * Chooses a status in the filter panel.
+   *
+   * The select is multi-select, so its menu stays open after a click — Escape
+   * closes it, which also clears the overlay that would intercept later clicks.
+   *
+   * @param label - Option label to choose.
+   */
+  async selectStatusFilter(label: string): Promise<void> {
+    await this.statusFilterSelect().click();
+    await this.page.getByRole("option", { name: label, exact: true }).click();
+    await this.page.keyboard.press("Escape");
+  }
+
+  //
+  // Sorting.
+  //
+
+  /** The Sort by select. */
+  sortFieldSelect(): Locator {
+    return this.main().locator(`#${ANNOUNCEMENTS_LIST.sort.fieldSelectId}`);
+  }
+
+  /** The Order by select. */
+  sortOrderSelect(): Locator {
+    return this.main().locator(`#${ANNOUNCEMENTS_LIST.sort.orderSelectId}`);
+  }
+
+  /**
+   * Chooses a sort field or order.
+   *
+   * @param select - The select to operate.
+   * @param label - Exact option label.
+   */
+  async chooseSortOption(select: Locator, label: string): Promise<void> {
+    await select.click();
+    await this.page.getByRole("option", { name: label, exact: true }).click();
+  }
+
+  //
+  // Pagination.
+  //
+
+  /** The Rows per page control. Accepts either role, as MUI changed the
+   * trigger's role across versions. */
+  rowsPerPageSelect(): Locator {
+    const name = new RegExp(MUI_PAGINATION.rowsPerPageLabel.replace(":", ":?"));
+    return this.main()
+      .getByRole("combobox", { name })
+      .or(this.main().getByRole("button", { name }))
+      .first();
+  }
+
+  /**
+   * Changes the list's page size.
+   *
+   * @param rows - Page size to choose.
+   */
+  async selectRowsPerPage(rows: number): Promise<void> {
+    await this.rowsPerPageSelect().click();
+    await this.page
+      .getByRole("option", { name: String(rows), exact: true })
+      .click();
+  }
+
+  /** Next-page control. Disabled on the last page. */
+  nextPageButton(): Locator {
+    return this.main().getByRole("button", {
+      name: MUI_PAGINATION.nextPageButton,
+      exact: true,
+    });
+  }
+
+  /** Previous-page control. Disabled on the first page. */
+  previousPageButton(): Locator {
+    return this.main().getByRole("button", {
+      name: MUI_PAGINATION.previousPageButton,
+      exact: true,
+    });
+  }
+
+  /** The "1–10 of 24" range text beside the page controls. */
+  displayedRows(): Locator {
+    return this.main().getByText(MUI_PAGINATION.displayedRowsPattern);
+  }
+
+  /**
+   * The range the pagination reports.
+   *
+   * @returns from/to/total, or null when the range is not rendered.
+   */
+  async displayedRange(): Promise<{
+    from: number;
+    to: number;
+    total: number;
+  } | null> {
+    const match = MUI_PAGINATION.displayedRowsPattern.exec(
+      await this.displayedRows().innerText(),
+    );
+    return match
+      ? {
+          from: Number(match[1]),
+          to: Number(match[2]),
+          total: Number(match[3]),
+        }
+      : null;
+  }
+
+  /**
+   * The case number a row carries.
+   *
+   * @param index - Zero-based row.
+   * @returns The number, or null when the row has none.
+   */
+  async rowNumber(index: number): Promise<string | null> {
+    const match = ANNOUNCEMENTS_LIST.numberPattern.exec(
+      await this.rows().nth(index).innerText(),
+    );
+    return match ? match[0] : null;
+  }
+}

--- a/apps/customer-portal/webapp/tests/e2e/pages/ChangeRequestsPage.ts
+++ b/apps/customer-portal/webapp/tests/e2e/pages/ChangeRequestsPage.ts
@@ -1,0 +1,119 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { type Locator, type Page, expect } from "../fixtures/test";
+import { CASE_DETAIL, CHANGE_REQUESTS_LIST } from "../utils/selectors";
+
+/** How long to allow for the list and its search to resolve. */
+const LOAD_TIMEOUT_MS = 60_000;
+
+/**
+ * Page object for the change requests list and its two view modes.
+ */
+export class ChangeRequestsPage {
+  constructor(private readonly page: Page) {}
+
+  private main(): Locator {
+    return this.page.getByTestId(CASE_DETAIL.mainTestId);
+  }
+
+  /**
+   * Opens the list directly.
+   *
+   * Always lands on the unfiltered view: the filtered variants are selected by
+   * router state that the hub and the dashboard donut pass, and a URL cannot
+   * carry it.
+   *
+   * @param projectId - Project whose change requests to list.
+   */
+  async open(projectId: string): Promise<void> {
+    await this.page.goto(
+      `/projects/${projectId}/${CHANGE_REQUESTS_LIST.pathSegment}`,
+    );
+    await expect(this.heading(CHANGE_REQUESTS_LIST.titles.all)).toBeVisible({
+      timeout: LOAD_TIMEOUT_MS,
+    });
+  }
+
+  /**
+   * The list's heading.
+   *
+   * @param title - Expected title.
+   */
+  heading(title: string): Locator {
+    return this.main().getByRole("heading", { name: title, exact: true });
+  }
+
+  /**
+   * A view tab — List View or Calendar View.
+   *
+   * @param label - The tab's label.
+   */
+  viewTab(label: string): Locator {
+    return this.main().getByRole("tab", { name: label, exact: true });
+  }
+
+  /**
+   * Switches view and waits for the tab to be selected.
+   *
+   * @param label - The view to open.
+   */
+  async openView(label: string): Promise<void> {
+    await this.viewTab(label).click();
+    await expect(this.viewTab(label)).toHaveAttribute("aria-selected", "true", {
+      timeout: LOAD_TIMEOUT_MS,
+    });
+  }
+
+  /**
+   * The change request rows.
+   *
+   * Each row is a clickable card carrying the request's number, which is what
+   * separates a row from the surrounding controls.
+   */
+  rows(): Locator {
+    return this.main()
+      .getByRole("button")
+      .filter({ hasText: CHANGE_REQUESTS_LIST.numberPattern });
+  }
+
+  /** The copy shown when the list has nothing to show. */
+  emptyMessage(): Locator {
+    return this.main().getByText(CHANGE_REQUESTS_LIST.emptyMessage);
+  }
+
+  /**
+   * Waits for the list to settle into one of its two real states — rows, or the
+   * empty copy — so a caller cannot assert against a still-loading page.
+   */
+  async waitForList(): Promise<void> {
+    await expect(this.rows().first().or(this.emptyMessage())).toBeVisible({
+      timeout: LOAD_TIMEOUT_MS,
+    });
+  }
+
+  /**
+   * The change request number a row carries.
+   *
+   * @param index - Zero-based row.
+   * @returns The number, or null when the row has none.
+   */
+  async rowNumber(index: number): Promise<string | null> {
+    const text = await this.rows().nth(index).innerText();
+    const match = /CHG\d+/.exec(text);
+    return match ? match[0] : null;
+  }
+}

--- a/apps/customer-portal/webapp/tests/e2e/pages/SettingsPage.ts
+++ b/apps/customer-portal/webapp/tests/e2e/pages/SettingsPage.ts
@@ -1,0 +1,240 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  type Locator,
+  type Page,
+  type Response,
+  expect,
+} from "../fixtures/test";
+import { CASE_DETAIL, SETTINGS } from "../utils/selectors";
+import { SideNavPage } from "./SideNavPage";
+
+/** How long to allow for the page and its queries to resolve. */
+const LOAD_TIMEOUT_MS = 60_000;
+
+/**
+ * Page object for the settings page and its four tabs.
+ */
+export class SettingsPage {
+  constructor(private readonly page: Page) {}
+
+  private main(): Locator {
+    return this.page.getByTestId(CASE_DETAIL.mainTestId);
+  }
+
+  /**
+   * Opens settings through the side nav's footer item, as a user would.
+   *
+   * @param projectId - Project whose settings to open.
+   */
+  async openViaSideNav(projectId: string): Promise<void> {
+    const sideNav = new SideNavPage(this.page);
+    await sideNav.open(projectId);
+    await sideNav.clickItem(
+      SETTINGS.navItem,
+      new RegExp(`/projects/${projectId}/${SETTINGS.pathSegment}`),
+    );
+    await expect(this.tab(SETTINGS.tabs.userManagement)).toBeVisible({
+      timeout: LOAD_TIMEOUT_MS,
+    });
+  }
+
+  /**
+   * A settings tab.
+   *
+   * @param label - The tab's label.
+   */
+  tab(label: string): Locator {
+    return this.main().getByRole("tab", { name: label, exact: true });
+  }
+
+  /**
+   * Switches tab and waits for it to be selected.
+   *
+   * @param label - The tab to open.
+   */
+  async openTab(label: string): Promise<void> {
+    await this.tab(label).click();
+    await expect(this.tab(label)).toHaveAttribute("aria-selected", "true", {
+      timeout: LOAD_TIMEOUT_MS,
+    });
+  }
+
+  //
+  // User Management tab.
+  //
+
+  /** A column header of the user list. */
+  columnHeader(label: string): Locator {
+    return this.main().getByRole("columnheader", { name: label, exact: true });
+  }
+
+  searchInput(): Locator {
+    return this.main().getByPlaceholder(
+      SETTINGS.userManagement.searchPlaceholder,
+    );
+  }
+
+  /** The Add User button, which only renders for an admin. */
+  addUserButton(): Locator {
+    return this.main().getByRole("button", {
+      name: SETTINGS.userManagement.addUserButton,
+      exact: true,
+    });
+  }
+
+  /**
+   * The row for a user, found by the email it lists.
+   *
+   * @param email - The user's email address.
+   */
+  userRow(email: string): Locator {
+    return this.main().getByRole("row").filter({ hasText: email });
+  }
+
+  /** Every user row currently listed, identified by their edit control. */
+  userRows(): Locator {
+    return this.main().getByRole("row").filter({
+      has: this.page.getByRole("button", {
+        name: SETTINGS.userManagement.editUserButton,
+        exact: true,
+      }),
+    });
+  }
+
+  /**
+   * The edit control on a user's row.
+   *
+   * The control's accessible name is the same on every row, so it has to be
+   * reached through the row it belongs to.
+   *
+   * @param email - The user's email address.
+   */
+  editUserButton(email: string): Locator {
+    return this.userRow(email).getByRole("button", {
+      name: SETTINGS.userManagement.editUserButton,
+      exact: true,
+    });
+  }
+
+  /**
+   * The remove control on a user's row.
+   *
+   * @param email - The user's email address.
+   */
+  removeUserButton(email: string): Locator {
+    return this.userRow(email).getByRole("button", {
+      name: SETTINGS.userManagement.removeUserButton,
+      exact: true,
+    });
+  }
+
+  modal(): Locator {
+    return this.page.getByRole("dialog");
+  }
+
+  /**
+   * Opens the Edit User Roles modal for a user.
+   *
+   * @param email - The user's email address.
+   */
+  async openEditUserModal(email: string): Promise<void> {
+    await this.editUserButton(email).click();
+
+    const modal = this.modal();
+    await expect(modal).toBeVisible({ timeout: LOAD_TIMEOUT_MS });
+    await expect(
+      modal.getByText(SETTINGS.userManagement.editModal.title),
+    ).toBeVisible();
+  }
+
+  /**
+   * A role checkbox in the Edit User Roles modal.
+   *
+   * Matched loosely on the role name: the checkbox carries no `aria-label`, so
+   * its accessible name is the whole label — the role plus its description
+   * ("Lead A portal user who can escalate an issue beyond level 3") — and an
+   * exact match finds nothing. No role's description contains another role's
+   * name, so a substring match still resolves to one.
+   *
+   * @param label - The role's label.
+   */
+  roleCheckbox(label: string): Locator {
+    return this.modal().getByRole("checkbox", { name: label });
+  }
+
+  /** The modal's save control. Disabled until something actually changes. */
+  saveRolesButton(): Locator {
+    return this.modal().getByRole("button", {
+      name: SETTINGS.userManagement.editModal.saveButton,
+      exact: true,
+    });
+  }
+
+  /**
+   * Saves the role change and waits for the PATCH to land.
+   *
+   * @param projectId - Project the contact belongs to.
+   * @returns The update response.
+   */
+  async saveRoles(projectId: string): Promise<Response> {
+    const [response] = await Promise.all([
+      this.page.waitForResponse(
+        (r) =>
+          new RegExp(`/projects/${projectId}/contacts/`).test(
+            new URL(r.url()).pathname,
+          ) && r.request().method() === "PATCH",
+        { timeout: LOAD_TIMEOUT_MS },
+      ),
+      this.saveRolesButton().click(),
+    ]);
+    return response;
+  }
+
+  //
+  // Display tab.
+  //
+
+  /**
+   * A font-size option.
+   *
+   * These are radios, not buttons — the group is a radiogroup of `div`s, each
+   * carrying an "Font size: <label>" aria-label.
+   *
+   * @param label - The option's label, e.g. "Large".
+   */
+  fontSizeOption(label: string): Locator {
+    return this.main().getByRole("radio", {
+      name: SETTINGS.display.fontSizeOption(label),
+      exact: true,
+    });
+  }
+
+  /**
+   * The root font size the document is currently rendered at.
+   *
+   * Choosing an option writes this onto `<html>`, so it is the observable effect
+   * of the setting rather than a class name or a highlighted control.
+   *
+   * @returns The computed `font-size` of the root element.
+   */
+  async rootFontSize(): Promise<string> {
+    return this.page.evaluate(
+      () => document.documentElement.style.fontSize,
+    );
+  }
+}

--- a/apps/customer-portal/webapp/tests/e2e/pages/SideNavPage.ts
+++ b/apps/customer-portal/webapp/tests/e2e/pages/SideNavPage.ts
@@ -79,6 +79,32 @@ export class SideNavPage {
   }
 
   /**
+   * Every item the sidebar renders, in order.
+   *
+   * Read from the items' accessible names — the gated items carry an
+   * `aria-label`, the footer's Settings only its text — so this returns the whole
+   * rendered list rather than probing for names the caller already expects. That
+   * is what lets a spec notice an item it has never heard of.
+   *
+   * @returns The item labels, in render order.
+   */
+  async itemNames(): Promise<string[]> {
+    return this.sidebar()
+      .getByRole("button")
+      .evaluateAll((elements) =>
+        elements
+          .map((element) =>
+            (
+              element.getAttribute("aria-label") ??
+              element.textContent ??
+              ""
+            ).trim(),
+          )
+          .filter((name) => name.length > 0),
+      );
+  }
+
+  /**
    * Clicks a navigation item and waits for it to take effect.
    *
    * Retries the click-and-navigate as a unit rather than clicking once. The

--- a/apps/customer-portal/webapp/tests/e2e/pages/UpdatesPage.ts
+++ b/apps/customer-portal/webapp/tests/e2e/pages/UpdatesPage.ts
@@ -1,0 +1,312 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  type Download,
+  type Locator,
+  type Page,
+  type Response,
+  expect,
+} from "../fixtures/test";
+import { CASE_DETAIL, UPDATES } from "../utils/selectors";
+import { SideNavPage } from "./SideNavPage";
+
+/** How long to allow for the page and its filter options to resolve. */
+const LOAD_TIMEOUT_MS = 60_000;
+
+/**
+ * Page object for the Updates page's update-level search.
+ */
+export class UpdatesPage {
+  constructor(private readonly page: Page) {}
+
+  private main(): Locator {
+    return this.page.getByTestId(CASE_DETAIL.mainTestId);
+  }
+
+  /**
+   * Opens the page through the side nav, as a user would.
+   *
+   * @param projectId - Project whose updates to open.
+   */
+  async openViaSideNav(projectId: string): Promise<void> {
+    const sideNav = new SideNavPage(this.page);
+    await sideNav.open(projectId);
+    await sideNav.clickItem(
+      UPDATES.navItem,
+      new RegExp(`/projects/${projectId}/${UPDATES.pathSegment}`),
+    );
+    await expect(this.sectionTitle()).toBeVisible({ timeout: LOAD_TIMEOUT_MS });
+  }
+
+  /** The filter section's heading. */
+  sectionTitle(): Locator {
+    return this.main().getByText(UPDATES.sectionTitle, { exact: true });
+  }
+
+  /** The hint shown before any search has been run. */
+  idleHint(): Locator {
+    return this.main().getByText(UPDATES.idleHint, { exact: true });
+  }
+
+  productSelect(): Locator {
+    return this.main().locator(`#${UPDATES.ids.product}`);
+  }
+
+  versionSelect(): Locator {
+    return this.main().locator(`#${UPDATES.ids.version}`);
+  }
+
+  startLevelSelect(): Locator {
+    return this.main().locator(`#${UPDATES.ids.startLevel}`);
+  }
+
+  endLevelSelect(): Locator {
+    return this.main().locator(`#${UPDATES.ids.endLevel}`);
+  }
+
+  /**
+   * Opens a select and picks an option.
+   *
+   * The options render in a portal at the document root, so they are looked up
+   * page-wide. Waits for the control to be enabled first: the selects cascade,
+   * and each stays disabled until the one before it has a value.
+   *
+   * @param select - The select to operate.
+   * @param option - Exact option label.
+   */
+  async chooseOption(select: Locator, option: string): Promise<void> {
+    await expect(select).toBeEnabled({ timeout: LOAD_TIMEOUT_MS });
+    await select.click();
+    await this.page
+      .getByRole("option", { name: option, exact: true })
+      .click({ timeout: LOAD_TIMEOUT_MS });
+  }
+
+  /**
+   * Reads the options a select offers, then closes it again.
+   *
+   * Waits for the first option before reading: `allInnerTexts` resolves against
+   * whatever matches at that moment and does not retry, so reading straight after
+   * the click can return an empty list while the portal mounts.
+   *
+   * @param select - The select to open.
+   * @returns The option labels, in order, with the disabled placeholder dropped.
+   */
+  async optionLabels(select: Locator): Promise<string[]> {
+    await expect(select).toBeEnabled({ timeout: LOAD_TIMEOUT_MS });
+    await select.click();
+
+    const options = this.page.getByRole("option");
+    await expect(options.first()).toBeVisible({ timeout: LOAD_TIMEOUT_MS });
+    const labels = await options.allInnerTexts();
+
+    await this.page.keyboard.press("Escape");
+
+    const placeholders: string[] = Object.values(UPDATES.placeholders);
+    return labels
+      .map((label) => label.trim())
+      .filter((label) => label.length > 0 && !placeholders.includes(label));
+  }
+
+  /**
+   * Fills the whole filter row, in the order the cascade requires.
+   *
+   * @param productName - Product option label.
+   * @param productVersion - Version option label.
+   * @param startLevel - Starting update level.
+   * @param endLevel - Ending update level.
+   */
+  async fillSearch(
+    productName: string,
+    productVersion: string,
+    startLevel: string,
+    endLevel: string,
+  ): Promise<void> {
+    await this.chooseOption(this.productSelect(), productName);
+    await this.chooseOption(this.versionSelect(), productVersion);
+    await this.chooseOption(this.startLevelSelect(), startLevel);
+    await this.chooseOption(this.endLevelSelect(), endLevel);
+  }
+
+  /**
+   * A column header of the results table.
+   *
+   * @param label - The header's text.
+   */
+  resultsColumnHeader(label: string): Locator {
+    return this.main().getByRole("columnheader", { name: label, exact: true });
+  }
+
+  /** The copy shown when the searched range holds no update levels. */
+  noResultsMessage(): Locator {
+    return this.main().getByText(UPDATES.results.emptyMessage, {
+      exact: true,
+    });
+  }
+
+  /**
+   * Waits for a search to finish rendering.
+   *
+   * The table replaces a skeleton, so the response landing is not the same as the
+   * results being on screen. Settles on either the table's first column header or
+   * the no-results copy — a range with nothing in it is a legitimate outcome.
+   */
+  async waitForResults(): Promise<void> {
+    await expect(
+      this.resultsColumnHeader(UPDATES.results.headers[0]).or(
+        this.noResultsMessage(),
+      ),
+    ).toBeVisible({ timeout: LOAD_TIMEOUT_MS });
+  }
+
+  /**
+   * The View control on a results row.
+   *
+   * The control's label is the same on every row, so it has to be reached through
+   * the row carrying the level — and the row is identified by that level's *cell*,
+   * not by its text. `hasText` matches `textContent`, which concatenates the cells
+   * without separators ("1SecurityView"), so a word-boundary pattern on the level
+   * finds no boundary after the digit and matches nothing. Verified live.
+   *
+   * @param level - The update level the row lists.
+   */
+  viewLevelButton(level: string): Locator {
+    return this.main()
+      .getByRole("row")
+      .filter({
+        has: this.page.getByRole("cell", { name: level, exact: true }),
+      })
+      .getByRole("button", {
+        name: UPDATES.results.viewButton,
+        exact: true,
+      });
+  }
+
+  //
+  // Update level details page.
+  //
+
+  /**
+   * A summary label on the details page.
+   *
+   * @param label - The label's text.
+   */
+  levelSummaryLabel(label: string): Locator {
+    return this.main().getByText(label, { exact: true });
+  }
+
+  /**
+   * One of the details page's update filters — All, Security or Regular.
+   *
+   * @param label - The filter's label.
+   */
+  levelFilterButton(label: string): Locator {
+    return this.main().getByRole("button", { name: label, exact: true });
+  }
+
+  /**
+   * The back control on the level details page.
+   *
+   * It goes back through history rather than to a fixed route, so where it lands
+   * depends on how the page was opened.
+   */
+  levelBackButton(): Locator {
+    return this.main().getByRole("button", {
+      name: UPDATES.levelDetails.backButton,
+      exact: true,
+    });
+  }
+
+  /** The listed updates, each rendering its number inline. */
+  levelUpdateNumbers(): Locator {
+    return this.main().getByText(
+      new RegExp(`${UPDATES.levelDetails.updateNumberPrefix}\\s*\\S+`),
+    );
+  }
+
+  //
+  // Report download.
+  //
+
+  /**
+   * The Download Report button.
+   *
+   * Disabled until a search has produced report data, and while the PDF is being
+   * generated. There is no dialog behind it — it saves the file directly.
+   */
+  downloadReportButton(): Locator {
+    return this.main().getByRole("button", {
+      name: UPDATES.report.downloadButton,
+      exact: true,
+    });
+  }
+
+  /**
+   * Downloads the report and returns the captured download.
+   *
+   * The PDF is built in the browser by jsPDF and saved through a generated
+   * anchor, which the browser surfaces as a download event — so the listener has
+   * to be armed before the click.
+   *
+   * @returns The captured download.
+   */
+  async downloadReport(): Promise<Download> {
+    const [download] = await Promise.all([
+      this.page.waitForEvent("download", { timeout: LOAD_TIMEOUT_MS }),
+      this.downloadReportButton().click(),
+    ]);
+    return download;
+  }
+
+  /** The Search button. Disabled until all four filters are set. */
+  searchButton(): Locator {
+    return this.main().getByRole("button", {
+      name: UPDATES.searchButton,
+      exact: true,
+    });
+  }
+
+  /** The Clear Filters button. */
+  clearFiltersButton(): Locator {
+    return this.main().getByRole("button", {
+      name: UPDATES.clearFiltersButton,
+      exact: true,
+    });
+  }
+
+  /**
+   * Runs the search and waits for the levels request to land.
+   *
+   * Waits whatever the status, then leaves the caller to assert on it: requiring
+   * 2xx in the predicate would mean a rejected search never matches and the test
+   * times out with no clue as to why.
+   *
+   * @returns The search response.
+   */
+  async search(): Promise<Response> {
+    const [response] = await Promise.all([
+      this.page.waitForResponse(
+        (r) =>
+          new URL(r.url()).pathname.endsWith("/updates/levels/search") &&
+          r.request().method() === "POST",
+        { timeout: LOAD_TIMEOUT_MS },
+      ),
+      this.searchButton().click(),
+    ]);
+    return response;
+  }
+}

--- a/apps/customer-portal/webapp/tests/e2e/specs/announcements/announcements-list.spec.ts
+++ b/apps/customer-portal/webapp/tests/e2e/specs/announcements/announcements-list.spec.ts
@@ -1,0 +1,327 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//
+// The announcements list, reached the way a user reaches it: the side nav's
+// Announcements item. Run against every project type — the item is visible on
+// all three (see SIDE_NAV_VISIBILITY).
+//
+// ✅ READ-ONLY. Announcements are published to the project rather than raised
+// from the portal, so nothing here creates or changes one.
+//
+// Opening an announcement by URL is already covered by view-announcement.spec.ts;
+// what that spec cannot show is that the list actually leads there, which is the
+// third test below.
+//
+
+import { test, expect, withSession } from "../../fixtures/test";
+import { AnnouncementsPage } from "../../pages/AnnouncementsPage";
+import { CaseDetailPage } from "../../pages/CaseDetailPage";
+import { PROJECTS, ProjectType } from "../../config/testData";
+import { ANNOUNCEMENTS_LIST } from "../../utils/selectors";
+import { expectSuccess } from "../../utils/caseFlows";
+import {
+  caseSearchWithSort,
+  caseSearchWithStatusFilter,
+} from "../../utils/listSearch";
+
+withSession(test);
+
+test.describe("Announcements", () => {
+  // A shell load, a nav navigation and the list's own search request; the 30s
+  // default is not enough.
+  test.describe.configure({ timeout: 180_000 });
+
+  for (const projectType of Object.values(ProjectType)) {
+    const project = PROJECTS[projectType];
+
+    test.describe(projectType, () => {
+      test("opens from the side menu", async ({ page }) => {
+        test.skip(
+          !project.id,
+          `${projectType} needs a project id. ` +
+            `Fill it in tests/e2e/config/testData.ts.`,
+        );
+
+        const announcements = new AnnouncementsPage(page);
+        await announcements.openViaSideNav(project.id);
+
+        await expect(page).toHaveURL(
+          new RegExp(
+            `/projects/${project.id}/${ANNOUNCEMENTS_LIST.pathSegment}$`,
+          ),
+        );
+        await expect(announcements.heading()).toBeVisible();
+        await expect(announcements.description()).toBeVisible();
+      });
+
+      test("lists announcements with a results count", async ({ page }) => {
+        test.skip(!project.id, `${projectType} needs a project id.`);
+
+        const announcements = new AnnouncementsPage(page);
+        await announcements.openViaSideNav(project.id);
+
+        // Settle into rows or the empty copy first — the results bar renders
+        // while the search is still in flight and reads zero until it lands.
+        await announcements.waitForList();
+
+        const rows = await announcements.rows().count();
+        const counts = await announcements.resultsCounts();
+        expect(counts, "the results bar should report counts").not.toBeNull();
+
+        // The bar and the rows have to agree: the shown count is what is on this
+        // page, so a mismatch means one of the two is stale.
+        expect((counts as { shown: number }).shown).toBe(rows);
+        expect((counts as { total: number }).total).toBeGreaterThanOrEqual(rows);
+
+        console.log(
+          `Announcements (${projectType}): ${rows} of ` +
+            `${(counts as { total: number }).total} listed`,
+        );
+      });
+
+
+      test("offers the status filter once the panel is opened", async ({
+        page,
+      }) => {
+        test.skip(!project.id, `${projectType} needs a project id.`);
+
+        const announcements = new AnnouncementsPage(page);
+        await announcements.openViaSideNav(project.id);
+        await announcements.waitForList();
+
+        // The panel is collapsed on load and its contents unmounted, so the
+        // select does not exist until it is opened — without this check the
+        // assertion below would pass against an already-open panel.
+        await expect(announcements.statusFilterSelect()).toHaveCount(0);
+        await announcements.filtersButton().click();
+
+        await expect(announcements.statusFilterSelect()).toBeVisible();
+        await expect(
+          page
+            .getByText(ANNOUNCEMENTS_LIST.statusFilter.label, { exact: true })
+            .first(),
+        ).toBeVisible();
+
+        // Status is the only filter announcements offer, and it has options to
+        // choose from — an empty list would mean the metadata never arrived.
+        const options = await announcements.statusFilterOptions();
+        expect(options.length, "the status filter should offer options").toBeGreaterThan(0);
+
+        console.log(
+          `Announcements (${projectType}): status filter offers ` +
+            `${options.length} options`,
+        );
+      });
+
+      test("filters by status and clears it", async ({ page }) => {
+        test.skip(!project.id, `${projectType} needs a project id.`);
+
+        const announcements = new AnnouncementsPage(page);
+        await announcements.openViaSideNav(project.id);
+        await announcements.waitForList();
+
+        await announcements.filtersButton().click();
+        await expect(announcements.statusFilterSelect()).toBeVisible();
+
+        const options = await announcements.statusFilterOptions();
+        test.skip(
+          options.length === 0,
+          `${projectType} offers no status options to filter by.`,
+        );
+
+        // Armed before the choice: the status ids on the wire are what show the
+        // filter was applied, rather than merely ticked in the menu.
+        const filtered = caseSearchWithStatusFilter(page, true);
+        await announcements.selectStatusFilter(options[0]);
+        await expectSuccess(await filtered, "filtered announcements search");
+
+        // The control turns into the clear action, counting what is active.
+        await expect(announcements.clearFiltersButton(1)).toBeVisible();
+        await expect(announcements.filtersButton()).toHaveCount(0);
+
+        // Clearing drops the statuses from the request. Armed before the click,
+        // because the page's own first load matches this predicate too.
+        const cleared = caseSearchWithStatusFilter(page, false);
+        await announcements.clearFiltersButton(1).click();
+        await expectSuccess(await cleared, "announcements search after clearing");
+
+        await expect(announcements.filtersButton()).toBeVisible();
+
+        console.log(
+          `Announcements (${projectType}): filtered by "${options[0]}" and cleared`,
+        );
+      });
+
+      test("sorts by field and order", async ({ page }) => {
+        test.skip(!project.id, `${projectType} needs a project id.`);
+
+        const announcements = new AnnouncementsPage(page);
+        await announcements.openViaSideNav(project.id);
+        await announcements.waitForList();
+
+        const { fields, orders } = ANNOUNCEMENTS_LIST.sort;
+
+        // Switching the field to Status. The field travels in `sortBy`, at the
+        // root of the request body rather than inside `filters`.
+        const sortedByStatus = caseSearchWithSort(
+          page,
+          fields.status.value,
+          orders.ordinalDesc.value,
+        );
+        await announcements.chooseSortOption(
+          announcements.sortFieldSelect(),
+          fields.status.label,
+        );
+        await expectSuccess(await sortedByStatus, "announcements sorted by status");
+
+        // The order options are worded for the field: an ordinal sort reads
+        // Descending/Ascending where a chronological one reads Newest/Oldest
+        // first, so the label changes with the field above.
+        const ascending = caseSearchWithSort(
+          page,
+          fields.status.value,
+          orders.ordinalAsc.value,
+        );
+        await announcements.chooseSortOption(
+          announcements.sortOrderSelect(),
+          orders.ordinalAsc.label,
+        );
+        await expectSuccess(await ascending, "announcements sorted ascending");
+
+        // And back to the chronological field, whose order labels differ again.
+        const byDate = caseSearchWithSort(
+          page,
+          fields.updatedDate.value,
+          orders.chronologicalAsc.value,
+        );
+        await announcements.chooseSortOption(
+          announcements.sortFieldSelect(),
+          fields.updatedDate.label,
+        );
+        await expectSuccess(await byDate, "announcements sorted by updated date");
+
+        console.log(
+          `Announcements (${projectType}): sorted by status and by updated date`,
+        );
+      });
+
+      test("pages the list and changes its page size", async ({ page }) => {
+        test.skip(!project.id, `${projectType} needs a project id.`);
+
+        const announcements = new AnnouncementsPage(page);
+        await announcements.openViaSideNav(project.id);
+        await announcements.waitForList();
+
+        const range = await announcements.displayedRange();
+        test.skip(
+          range === null,
+          `${projectType} shows no pagination range — the list is empty.`,
+        );
+
+        const { from, total } = range as { from: number; total: number };
+        expect(from).toBe(1);
+        await expect(announcements.previousPageButton()).toBeDisabled();
+
+        const next = announcements.nextPageButton();
+
+        // A project whose announcements fit on one page has nothing to page
+        // through, and a disabled control is the right behaviour there.
+        if (await next.isEnabled()) {
+          await next.click();
+          await expect
+            .poll(async () => (await announcements.displayedRange())?.from, {
+              timeout: 30_000,
+            })
+            .toBe(ANNOUNCEMENTS_LIST.defaultRowsPerPage + 1);
+          await expect(announcements.previousPageButton()).toBeEnabled();
+
+          await announcements.previousPageButton().click();
+          await expect
+            .poll(async () => (await announcements.displayedRange())?.from, {
+              timeout: 30_000,
+            })
+            .toBe(1);
+          await expect(announcements.previousPageButton()).toBeDisabled();
+        } else {
+          console.log(
+            `Announcements (${projectType}): ${total} fit on one page`,
+          );
+        }
+
+        // A larger page shows up to however many exist — the expectation comes
+        // from the list's own total rather than assuming there is more than one
+        // page's worth.
+        const larger = 25;
+        await announcements.selectRowsPerPage(larger);
+        await expect
+          .poll(
+            async () => {
+              const current = await announcements.displayedRange();
+              return current ? current.to - current.from + 1 : null;
+            },
+            { timeout: 30_000 },
+          )
+          .toBe(Math.min(larger, total));
+
+        console.log(
+          `Announcements (${projectType}): paged and resized to ${larger} per page`,
+        );
+      });
+
+      test("opens an announcement from the list", async ({ page }) => {
+        test.skip(!project.id, `${projectType} needs a project id.`);
+
+        const announcements = new AnnouncementsPage(page);
+        await announcements.openViaSideNav(project.id);
+        await announcements.waitForList();
+
+        const rowCount = await announcements.rows().count();
+        test.skip(
+          rowCount === 0,
+          `${projectType} has no announcements to open. This test needs at ` +
+            `least one published to the project.`,
+        );
+
+        // Read the number off the row before clicking, so the detail page can be
+        // checked against the row that was actually opened rather than against a
+        // sysid from config — which is what the view spec already does.
+        const number = await announcements.rowNumber(0);
+        expect(number, "the row should carry a case number").toBeTruthy();
+
+        await announcements.rows().first().click();
+
+        // An announcement sysid is a 32-character hex string; anchoring rules out
+        // landing back on the list.
+        await expect(page).toHaveURL(
+          new RegExp(
+            `/projects/${project.id}/${ANNOUNCEMENTS_LIST.pathSegment}/[0-9a-f]{32}$`,
+          ),
+        );
+
+        // The announcement that was clicked, not merely some announcement. The
+        // detail page reuses the case header, so the number renders there the
+        // same way.
+        const detail = new CaseDetailPage(page);
+        await expect(detail.caseNumber()).toHaveText(number as string, {
+          timeout: 30_000,
+        });
+
+        console.log(`Announcements (${projectType}): opened ${number}`);
+      });
+    });
+  }
+});

--- a/apps/customer-portal/webapp/tests/e2e/specs/announcements/announcements-list.spec.ts
+++ b/apps/customer-portal/webapp/tests/e2e/specs/announcements/announcements-list.spec.ts
@@ -265,15 +265,26 @@ test.describe("Announcements", () => {
         // A larger page shows up to however many exist — the expectation comes
         // from the list's own total rather than assuming there is more than one
         // page's worth.
+        //
+        // Raising the size can also take the pagination away: ListPagination
+        // renders nothing once `totalRecords <= rowsPerPage`. So the count comes
+        // from the range while there is one, and from the rows themselves once
+        // everything fits on a single page — waiting for a range that cannot
+        // appear would just time out.
         const larger = 25;
         await announcements.selectRowsPerPage(larger);
         await expect
           .poll(
             async () => {
               const current = await announcements.displayedRange();
-              return current ? current.to - current.from + 1 : null;
+              if (current) return current.to - current.from + 1;
+              return announcements.rows().count();
             },
-            { timeout: 30_000 },
+            {
+              message:
+                "the resized page should show every announcement it can fit",
+              timeout: 30_000,
+            },
           )
           .toBe(Math.min(larger, total));
 

--- a/apps/customer-portal/webapp/tests/e2e/specs/navigation/side-menu.spec.ts
+++ b/apps/customer-portal/webapp/tests/e2e/specs/navigation/side-menu.spec.ts
@@ -38,9 +38,11 @@
 
 import { test, expect, withSession } from "../../fixtures/test";
 import { SideNavPage } from "../../pages/SideNavPage";
+import { SIDE_NAV } from "../../utils/selectors";
 import {
   PROJECTS,
   ProjectType,
+  SIDE_NAV_UNGATED_ITEMS,
   SIDE_NAV_VISIBILITY,
 } from "../../config/testData";
 
@@ -80,6 +82,78 @@ test.describe("Side Menu", () => {
               .toHaveCount(0);
           }
         }
+      });
+
+      test("lists exactly those items and nothing else", async ({ page }) => {
+        test.skip(
+          !project.id,
+          `${projectType} needs a project id. Fill it in tests/e2e/config/testData.ts.`,
+        );
+
+        const sideNav = new SideNavPage(page);
+        await sideNav.open(project.id);
+
+        // The per-item test above proves every expected item is there. This one
+        // proves nothing *unexpected* is: an item the suite has never heard of —
+        // a new feature shipped without a visibility expectation, or one whose
+        // gate stopped working — is invisible to a loop over known labels.
+        const expectedItems = [
+          ...Object.entries(expected)
+            .filter(([, isVisible]) => isVisible)
+            .map(([label]) => label),
+          // Settings has no permission filter, so it is not in the gated table
+          // but is always in the rendered list.
+          ...SIDE_NAV_UNGATED_ITEMS,
+        ].sort();
+
+        const actual = (await sideNav.itemNames()).sort();
+
+        expect(
+          actual,
+          "the sidebar should render exactly the expected items",
+        ).toEqual(expectedItems);
+
+        console.log(`Side nav (${projectType}): ${actual.length} items`);
+      });
+
+      test("opens the route behind every visible item", async ({ page }) => {
+        test.skip(
+          !project.id,
+          `${projectType} needs a project id. Fill it in tests/e2e/config/testData.ts.`,
+        );
+
+        const sideNav = new SideNavPage(page);
+        await sideNav.open(project.id);
+
+        // One shell load, then a click per item: the sidebar persists across
+        // routes, so there is no need to return to the dashboard between them.
+        //
+        // Visibility is asserted above; this is about where each item actually
+        // goes. An item rendered but wired to the wrong route — or to none —
+        // passes every visibility check there is.
+        const visible = [
+          ...Object.entries(expected)
+            .filter(([, isVisible]) => isVisible)
+            .map(([label]) => label),
+          ...SIDE_NAV_UNGATED_ITEMS,
+        ];
+
+        for (const label of visible) {
+          const path = SIDE_NAV.paths[label];
+          expect(path, `no route recorded for the "${label}" item`).toBeTruthy();
+
+          // Unanchored: a section that redirects to a child route — a default tab,
+          // say — has still done its job, and pinning the exact landing path would
+          // make this assert routing internals rather than the item.
+          await sideNav.clickItem(
+            label,
+            new RegExp(`/projects/${project.id}/${path}`),
+          );
+        }
+
+        console.log(
+          `Side nav (${projectType}): ${visible.length} items opened their routes`,
+        );
       });
     });
   }

--- a/apps/customer-portal/webapp/tests/e2e/specs/operations/change-requests.spec.ts
+++ b/apps/customer-portal/webapp/tests/e2e/specs/operations/change-requests.spec.ts
@@ -1,0 +1,156 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//
+// The change requests list: its unfiltered view, the List/Calendar switch, and
+// opening a request from a row.
+//
+// ✅ READ-ONLY. Nothing here approves, rejects or otherwise changes a request —
+// those are irreversible from the portal and would consume a real record.
+//
+// Scoped to Managed Cloud Subscription: change requests need CR access, which is
+// the same flag that puts Operations in the side nav, and only that project has
+// it.
+//
+// The filtered variants of this page — Outstanding, Action Required, Upcoming —
+// are selected by router state rather than by the URL, so they cannot be reached
+// by navigating directly and are covered where they are actually opened from:
+// the dashboard's operations donut, and (once written) the Operations hub cards.
+//
+
+import { test, expect, withSession } from "../../fixtures/test";
+import { ChangeRequestsPage } from "../../pages/ChangeRequestsPage";
+import { PROJECTS, ProjectType } from "../../config/testData";
+import { CHANGE_REQUESTS_LIST } from "../../utils/selectors";
+
+withSession(test);
+
+test.describe("Change Requests", () => {
+  // A cold list load behind a project-features query; the 30s default is not
+  // enough.
+  test.describe.configure({ timeout: 180_000 });
+
+  const project = PROJECTS[ProjectType.MANAGED_CLOUD_SUBSCRIPTION];
+
+  test(`${ProjectType.MANAGED_CLOUD_SUBSCRIPTION} — lists all change requests`, async ({
+    page,
+  }) => {
+    test.skip(
+      !project.id,
+      `${ProjectType.MANAGED_CLOUD_SUBSCRIPTION} needs a project id. ` +
+        `Fill it in tests/e2e/config/testData.ts.`,
+    );
+
+    const changeRequests = new ChangeRequestsPage(page);
+    await changeRequests.open(project.id);
+
+    // Navigating directly gets the unfiltered view — the other titles come from
+    // state the hub passes, which a URL cannot carry.
+    await expect(
+      changeRequests.heading(CHANGE_REQUESTS_LIST.titles.all),
+    ).toBeVisible();
+
+    // Both view modes are on offer, with the list selected to begin with.
+    await expect(
+      changeRequests.viewTab(CHANGE_REQUESTS_LIST.viewTabs.list),
+    ).toHaveAttribute("aria-selected", "true");
+    await expect(
+      changeRequests.viewTab(CHANGE_REQUESTS_LIST.viewTabs.calendar),
+    ).toBeVisible();
+
+    await changeRequests.waitForList();
+
+    // How many requests exist is environment data, so an empty list is a
+    // legitimate result — what matters is that the list resolved into one of its
+    // real states rather than a skeleton.
+    const rows = await changeRequests.rows().count();
+    console.log(
+      `Change requests (${ProjectType.MANAGED_CLOUD_SUBSCRIPTION}): ${rows} listed`,
+    );
+  });
+
+  test(`${ProjectType.MANAGED_CLOUD_SUBSCRIPTION} — switches between list and calendar views`, async ({
+    page,
+  }) => {
+    test.skip(!project.id, `${ProjectType.MANAGED_CLOUD_SUBSCRIPTION} needs a project id.`);
+
+    const changeRequests = new ChangeRequestsPage(page);
+    await changeRequests.open(project.id);
+    await changeRequests.waitForList();
+
+    // Into the calendar. The rows are a list-view rendering, so their absence is
+    // what shows the switch actually changed the view rather than only the tab.
+    await changeRequests.openView(CHANGE_REQUESTS_LIST.viewTabs.calendar);
+    await expect(
+      changeRequests.viewTab(CHANGE_REQUESTS_LIST.viewTabs.list),
+    ).toHaveAttribute("aria-selected", "false");
+    await expect(changeRequests.rows()).toHaveCount(0);
+
+    // And back, where the list returns to whichever state it was in.
+    await changeRequests.openView(CHANGE_REQUESTS_LIST.viewTabs.list);
+    await expect(
+      changeRequests.viewTab(CHANGE_REQUESTS_LIST.viewTabs.calendar),
+    ).toHaveAttribute("aria-selected", "false");
+    await changeRequests.waitForList();
+
+    console.log(
+      `Change requests (${ProjectType.MANAGED_CLOUD_SUBSCRIPTION}): switched to ` +
+        `calendar and back`,
+    );
+  });
+
+  test(`${ProjectType.MANAGED_CLOUD_SUBSCRIPTION} — opens a change request from the list`, async ({
+    page,
+  }) => {
+    test.skip(!project.id, `${ProjectType.MANAGED_CLOUD_SUBSCRIPTION} needs a project id.`);
+
+    const changeRequests = new ChangeRequestsPage(page);
+    await changeRequests.open(project.id);
+    await changeRequests.waitForList();
+
+    const rowCount = await changeRequests.rows().count();
+    test.skip(
+      rowCount === 0,
+      `${ProjectType.MANAGED_CLOUD_SUBSCRIPTION} has no change requests to open. ` +
+        `This test needs at least one on the project.`,
+    );
+
+    // Read the number off the row before clicking, so the detail page can be
+    // checked against the row that was actually opened rather than against an id
+    // from config.
+    const number = await changeRequests.rowNumber(0);
+    expect(number, "the row should carry a change request number").toBeTruthy();
+
+    await changeRequests.rows().first().click();
+
+    // A change request sysid is a 32-character hex string; anchoring rules out
+    // landing back on the list.
+    await expect(page).toHaveURL(
+      new RegExp(
+        `/projects/${project.id}/${CHANGE_REQUESTS_LIST.pathSegment}/[0-9a-f]{32}$`,
+      ),
+    );
+
+    // The request that was clicked, not merely some request.
+    await expect(
+      page.getByTestId("app-main").getByText(number as string, { exact: true }).first(),
+    ).toBeVisible({ timeout: 30_000 });
+
+    console.log(
+      `Change requests (${ProjectType.MANAGED_CLOUD_SUBSCRIPTION}): opened ${number}`,
+    );
+  });
+});

--- a/apps/customer-portal/webapp/tests/e2e/specs/operations/service-request-activity.spec.ts
+++ b/apps/customer-portal/webapp/tests/e2e/specs/operations/service-request-activity.spec.ts
@@ -1,0 +1,146 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//
+// Comments and attachments on a service request.
+//
+// A service request detail page is the case detail page: ServiceRequestDetails
+// renders CaseDetailsContent with `isServiceRequest`, which hides Knowledge Base
+// and Escalation, shows Related Change Requests only when the request has one,
+// and leaves Activity and Attachments exactly as a case has them. The comment
+// and attachment endpoints are the case ones too — `/cases/{id}/comments` and
+// `/cases/{id}/attachments` — so the same page objects serve here.
+//
+// ⚠️ Both tests WRITE, and neither record can be removed:
+//
+// - a comment cannot be deleted, so the spec posts one only when its own earlier
+//   comment is not already on the request, keyed on the fixed text;
+// - the attachment could be deleted, but is deliberately kept — the listing
+//   assertions need a file to be there, so it is uploaded once and left.
+//
+// Scoped to Managed Cloud Subscription, the only project with service requests.
+//
+
+import { test, expect, withSession } from "../../fixtures/test";
+import { CaseAttachmentsPage } from "../../pages/CaseAttachmentsPage";
+import { CaseDetailPage } from "../../pages/CaseDetailPage";
+import {
+  ATTACHMENT_FILES,
+  PROJECTS,
+  SERVICE_REQUEST_ACTIVITY_INPUT,
+  SERVICE_REQUEST_VIEWS,
+} from "../../config/testData";
+import { CASE_ATTACHMENTS } from "../../utils/selectors";
+import { expectSuccess } from "../../utils/caseFlows";
+
+withSession(test);
+
+test.describe("Service Request Activity", () => {
+  // A cold service request load plus a tab switch and an upload; the 30s default
+  // is not enough.
+  test.describe.configure({ timeout: 180_000 });
+
+  const view = SERVICE_REQUEST_VIEWS[0];
+  const project = view ? PROJECTS[view.projectType] : undefined;
+
+  test("comments on a service request", async ({ page }) => {
+    test.skip(
+      !view || !project?.id || !view.serviceRequestId,
+      `A service request fixture is needed. Fill SERVICE_REQUEST_VIEWS in ` +
+        `tests/e2e/config/testData.ts.`,
+    );
+
+    const serviceRequest = new CaseDetailPage(page);
+    await serviceRequest.openServiceRequest(
+      (project as { id: string }).id,
+      view.serviceRequestId,
+    );
+
+    const text = SERVICE_REQUEST_ACTIVITY_INPUT.comment;
+
+    // Post only when absent: comments cannot be deleted, so an unguarded post
+    // would add one on every run.
+    const alreadyPosted = (await serviceRequest.comment(text).count()) > 0;
+
+    if (alreadyPosted) {
+      console.log(`Service request: comment already present`);
+    } else {
+      const response = await serviceRequest.addComment(text);
+      await expectSuccess(response, "add comment to service request");
+    }
+
+    // Listed on the request's activity, whichever run posted it.
+    await expect(serviceRequest.comment(text)).toBeVisible({
+      timeout: 30_000,
+    });
+
+    console.log(
+      `Service request ${view.serviceRequestId}: comment ` +
+        `${alreadyPosted ? "present" : "added"}`,
+    );
+  });
+
+  test("attaches a file to a service request", async ({ page }) => {
+    test.skip(
+      !view || !project?.id || !view.serviceRequestId,
+      `A service request fixture is needed. Fill SERVICE_REQUEST_VIEWS in ` +
+        `tests/e2e/config/testData.ts.`,
+    );
+
+    const serviceRequest = new CaseDetailPage(page);
+    await serviceRequest.openServiceRequest(
+      (project as { id: string }).id,
+      view.serviceRequestId,
+    );
+
+    const attachments = new CaseAttachmentsPage(page);
+    await attachments.openTab();
+
+    const kept = ATTACHMENT_FILES.kept;
+
+    // Upload only when absent, and leave it in place: the listing assertions
+    // below need a file to be there, and nothing removes it between runs.
+    const alreadyAttached = (await attachments.attachment(kept.name).count()) > 0;
+
+    if (alreadyAttached) {
+      console.log(`Service request: ${kept.name} already attached`);
+    } else {
+      const response = await attachments.upload(kept.path);
+      await expectSuccess(response, "upload attachment to service request");
+    }
+
+    // Listed under its own name. Asserted as "at least one row" rather than by
+    // visibility: the list renders each row twice for responsive layout.
+    await expect(attachments.attachment(kept.name)).not.toHaveCount(0);
+
+    const row = attachments.attachmentRow(kept.name);
+    await expect(row).toContainText(kept.name);
+    await expect(row).toContainText(kept.size);
+    await expect
+      .soft(row, "uploader")
+      .toContainText(CASE_ATTACHMENTS.row.uploadedByPrefix);
+
+    // The tab's own count agrees with the number of rows — a mismatch means one
+    // of the two is stale.
+    const names = await attachments.listedFileNames();
+    expect(await attachments.tabCount()).toBe(names.length);
+
+    console.log(
+      `Service request ${view.serviceRequestId}: ${names.length} attachment(s), ` +
+        `${kept.name} ${alreadyAttached ? "present" : "uploaded"}`,
+    );
+  });
+});

--- a/apps/customer-portal/webapp/tests/e2e/specs/settings/settings.spec.ts
+++ b/apps/customer-portal/webapp/tests/e2e/specs/settings/settings.spec.ts
@@ -229,7 +229,9 @@ test.describe("Settings", () => {
       }
     }
 
-    console.log(`Settings: ${role} removed from ${email} and restored`);
+    // The user is not named: the report is no place for an address, and the test
+    // only ever acts on the account in SETTINGS_USER_INPUT anyway.
+    console.log(`Settings: ${role} role removed and restored`);
   });
 
   test("changes the font size from the Display tab", async ({ page }) => {

--- a/apps/customer-portal/webapp/tests/e2e/specs/settings/settings.spec.ts
+++ b/apps/customer-portal/webapp/tests/e2e/specs/settings/settings.spec.ts
@@ -1,0 +1,281 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//
+// The settings page, reached from the side nav's footer item: its four tabs,
+// the user list and its role editing, and the display preferences.
+//
+// ⚠️ One test WRITES, and it writes to the signed-in account's own membership:
+// it removes the Lead role and puts it back. That account is the only one the
+// suite can safely change, because it is the only one it can restore.
+//
+// Lead matters beyond this page — it implies Portal User on save, and is
+// required to escalate a case past EL3 — so the restore runs from `finally`
+// rather than as the next step. A run that died between the two saves would
+// otherwise leave the account short a role for every later spec.
+//
+// Everything else here is read-only.
+//
+// Which tabs and controls render depends on the account's ServiceNow role: AI
+// Assistant, Add User and the per-row actions are admin-only. The assertions
+// below therefore describe an admin's view, which is what the captured session
+// is.
+//
+
+import { test, expect, withSession } from "../../fixtures/test";
+import { SettingsPage } from "../../pages/SettingsPage";
+import { PROJECTS, SETTINGS_USER_INPUT } from "../../config/testData";
+import { SETTINGS } from "../../utils/selectors";
+import { expectSuccess } from "../../utils/caseFlows";
+
+withSession(test);
+
+test.describe("Settings", () => {
+  // A shell load, a nav navigation and the contacts query behind the user list.
+  test.describe.configure({ timeout: 180_000 });
+
+  const project = PROJECTS[SETTINGS_USER_INPUT.projectType];
+
+  test("opens from the side menu and offers its four tabs", async ({
+    page,
+  }) => {
+    test.skip(
+      !project.id,
+      `${SETTINGS_USER_INPUT.projectType} needs a project id. ` +
+        `Fill it in tests/e2e/config/testData.ts.`,
+    );
+
+    const settings = new SettingsPage(page);
+    await settings.openViaSideNav(project.id);
+
+    await expect(page).toHaveURL(
+      new RegExp(`/projects/${project.id}/${SETTINGS.pathSegment}`),
+    );
+
+    // Soft, so one missing tab does not hide the state of the others.
+    for (const label of Object.values(SETTINGS.tabs)) {
+      await expect.soft(settings.tab(label)).toBeVisible();
+    }
+  });
+
+  test("lists users with their roles and per-row actions", async ({ page }) => {
+    test.skip(!project.id, `${SETTINGS_USER_INPUT.projectType} needs a project id.`);
+
+    const settings = new SettingsPage(page);
+    await settings.openViaSideNav(project.id);
+    await settings.openTab(SETTINGS.tabs.userManagement);
+
+    for (const header of SETTINGS.userManagement.headers) {
+      await expect.soft(settings.columnHeader(header)).toBeVisible();
+    }
+
+    // At least one row, and the configured user among them — the role test below
+    // depends on that user being listed at all.
+    await expect(settings.userRows().first()).toBeVisible();
+    await expect(settings.userRow(SETTINGS_USER_INPUT.email)).not.toHaveCount(0);
+
+    // Every listed user offers both actions. Checked across all rows rather than
+    // one, since the controls are rendered per row.
+    const rowCount = await settings.userRows().count();
+    expect(rowCount, "no users listed").toBeGreaterThan(0);
+
+    await expect(
+      settings.editUserButton(SETTINGS_USER_INPUT.email),
+    ).toBeVisible();
+    await expect(
+      settings.removeUserButton(SETTINGS_USER_INPUT.email),
+    ).toBeVisible();
+
+    // Add User is admin-only, and the captured session is an admin.
+    await expect(settings.addUserButton()).toBeVisible();
+
+    console.log(`Settings: ${rowCount} users listed`);
+  });
+
+  test("searches the user list", async ({ page }) => {
+    test.skip(!project.id, `${SETTINGS_USER_INPUT.projectType} needs a project id.`);
+
+    const settings = new SettingsPage(page);
+    await settings.openViaSideNav(project.id);
+    await settings.openTab(SETTINGS.tabs.userManagement);
+
+    await expect(settings.userRows().first()).toBeVisible();
+    const before = await settings.userRows().count();
+
+    await settings.searchInput().fill(SETTINGS_USER_INPUT.email);
+
+    // The searched user survives, and the list is no longer than it was — the
+    // filter is client-side over the loaded contacts, so this is a narrowing
+    // rather than a fetch.
+    await expect(settings.userRow(SETTINGS_USER_INPUT.email)).not.toHaveCount(0);
+    await expect
+      .poll(() => settings.userRows().count(), { timeout: 30_000 })
+      .toBeLessThanOrEqual(before);
+
+    // A term nobody matches empties the list, which is what shows the filter is
+    // actually applied rather than the row surviving by coincidence.
+    await settings.searchInput().fill("no-such-user@example.invalid");
+    await expect(settings.userRows()).toHaveCount(0);
+
+    // Clearing brings everyone back.
+    await settings.searchInput().fill("");
+    await expect
+      .poll(() => settings.userRows().count(), { timeout: 30_000 })
+      .toBe(before);
+
+    console.log(`Settings: search narrowed ${before} users and restored them`);
+  });
+
+  test("removes and restores a user's Lead role", async ({ page }) => {
+    test.skip(!project.id, `${SETTINGS_USER_INPUT.projectType} needs a project id.`);
+
+    const settings = new SettingsPage(page);
+    await settings.openViaSideNav(project.id);
+    await settings.openTab(SETTINGS.tabs.userManagement);
+
+    const email = SETTINGS_USER_INPUT.email;
+    const role = SETTINGS_USER_INPUT.role;
+
+    await expect(settings.userRow(email)).not.toHaveCount(0);
+
+    // The role has to be on to begin with, or there is nothing to remove and the
+    // restore below would be adding something the account never had.
+    await settings.openEditUserModal(email);
+    const wasChecked = await settings.roleCheckbox(role).isChecked();
+    test.skip(
+      !wasChecked,
+      `${email} does not currently have the ${role} role, so this test has ` +
+        `nothing to remove. Restore it before running.`,
+    );
+
+    try {
+      await settings.roleCheckbox(role).uncheck();
+      await expect(settings.roleCheckbox(role)).not.toBeChecked();
+
+      // Save is gated on something having changed, so this also confirms the
+      // toggle registered.
+      await expect(settings.saveRolesButton()).toBeEnabled();
+      const removeResponse = await settings.saveRoles(project.id);
+
+      // ⚠️ Role changes are refused on this tenant: the backend answers 500 with
+      // "the supported email domains list for your account has not been
+      // defined". Nothing is written, so the account keeps its roles — but the
+      // flow cannot be exercised end to end until that is configured.
+      //
+      // Skipped rather than failed, because there is no product defect here to
+      // report and no assertion this suite can make about a feature the
+      // environment refuses to run. The message names the prerequisite so the
+      // skip is actionable.
+      const body = await removeResponse.text().catch(() => "");
+      test.skip(
+        removeResponse.status() === 500 &&
+          body.includes(SETTINGS_USER_INPUT.unconfiguredDomainsMessage),
+        `Role changes are refused for this account — the supported email ` +
+          `domains list is not defined. Configure it for ${email}'s account to ` +
+          `run this test.`,
+      );
+
+      await expectSuccess(removeResponse, `remove the ${role} role`);
+      await expect(settings.modal()).toBeHidden();
+
+      // Reopened, so the state is read back from the record rather than from the
+      // form that was just changed.
+      await settings.openEditUserModal(email);
+      await expect(settings.roleCheckbox(role)).not.toBeChecked({
+        timeout: 30_000,
+      });
+
+      // And back on, which is the half that matters for every later spec.
+      await settings.roleCheckbox(role).check();
+      await expect(settings.saveRolesButton()).toBeEnabled();
+      await expectSuccess(
+        await settings.saveRoles(project.id),
+        `restore the ${role} role`,
+      );
+      await expect(settings.modal()).toBeHidden();
+
+      await settings.openEditUserModal(email);
+      await expect(settings.roleCheckbox(role)).toBeChecked({
+        timeout: 30_000,
+      });
+    } finally {
+      // Whatever happened above, leave the role as it was found. A run that died
+      // between the two saves would otherwise strand the account without a role
+      // that other specs depend on.
+      const modalOpen = await settings.modal().isVisible().catch(() => false);
+      if (!modalOpen) {
+        await settings.openEditUserModal(email).catch(() => undefined);
+      }
+      const stillChecked = await settings
+        .roleCheckbox(role)
+        .isChecked()
+        .catch(() => true);
+      if (!stillChecked) {
+        await settings.roleCheckbox(role).check();
+        await settings.saveRoles(project.id).catch(() => undefined);
+      }
+    }
+
+    console.log(`Settings: ${role} removed from ${email} and restored`);
+  });
+
+  test("changes the font size from the Display tab", async ({ page }) => {
+    test.skip(!project.id, `${SETTINGS_USER_INPUT.projectType} needs a project id.`);
+
+    const settings = new SettingsPage(page);
+    await settings.openViaSideNav(project.id);
+    await settings.openTab(SETTINGS.tabs.display);
+
+    await expect(
+      page.getByText(SETTINGS.display.heading, { exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByText(SETTINGS.display.fontSizeTitle, { exact: true }).first(),
+    ).toBeVisible();
+
+    const original = await settings.rootFontSize();
+
+    try {
+      // Each option writes its size onto the root element, which is what makes
+      // the whole app scale — so that is the effect worth asserting, rather than
+      // a highlighted control.
+      for (const option of SETTINGS.display.fontSizes) {
+        await settings.fontSizeOption(option.label).click();
+        await expect
+          .poll(() => settings.rootFontSize(), {
+            message: `choosing ${option.label} should set the root font size`,
+            timeout: 15_000,
+          })
+          .toBe(option.px);
+      }
+    } finally {
+      // The choice persists across sessions, so leaving the last one applied
+      // would change how every later spec renders — and the sizes shift layout
+      // enough to matter.
+      const defaultSize = SETTINGS.display.fontSizes.find(
+        (option) => option.px === original,
+      );
+      if (defaultSize) {
+        await settings.fontSizeOption(defaultSize.label).click();
+      }
+    }
+
+    console.log(
+      `Settings: font size cycled through ${SETTINGS.display.fontSizes.length} ` +
+        `options and restored to ${original}`,
+    );
+  });
+});

--- a/apps/customer-portal/webapp/tests/e2e/specs/updates/update-levels-search.spec.ts
+++ b/apps/customer-portal/webapp/tests/e2e/specs/updates/update-levels-search.spec.ts
@@ -1,0 +1,691 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//
+// Searching update levels from the Updates side-menu item.
+//
+// ✅ READ-ONLY. The search is a POST — `/updates/levels/search` — but it reads
+// rather than writes, so this is safe to run repeatedly.
+//
+// The four filters cascade: version needs a product, the start level needs a
+// version, and the end level needs a start. Search stays disabled until all four
+// are set, which is what the first test walks.
+//
+// Scoped to Subscription. Updates access is a per-project feature flag and Cloud
+// Support does not have it (see SIDE_NAV_VISIBILITY), so the item is not even in
+// its side menu.
+//
+
+import fs from "node:fs";
+import { test, expect, withSession } from "../../fixtures/test";
+import { UpdatesPage } from "../../pages/UpdatesPage";
+import { PROJECTS, UPDATES_SEARCH_INPUT } from "../../config/testData";
+import { UPDATES } from "../../utils/selectors";
+import { expectSuccess } from "../../utils/caseFlows";
+
+withSession(test);
+
+test.describe("Update Levels", () => {
+  // A shell load, a nav navigation and the filter-options query behind the
+  // product list; the 30s default is not enough.
+  test.describe.configure({ timeout: 180_000 });
+
+  const project = PROJECTS[UPDATES_SEARCH_INPUT.projectType];
+
+  test(`${UPDATES_SEARCH_INPUT.projectType} — searches update levels for a product version`, async ({
+    page,
+  }) => {
+    test.skip(
+      !project.id,
+      `${UPDATES_SEARCH_INPUT.projectType} needs a project id. ` +
+        `Fill it in tests/e2e/config/testData.ts.`,
+    );
+
+    const updates = new UpdatesPage(page);
+    await updates.openViaSideNav(project.id);
+
+    await expect(page).toHaveURL(
+      new RegExp(`/projects/${project.id}/${UPDATES.pathSegment}`),
+    );
+    await expect(updates.sectionTitle()).toBeVisible();
+
+    // Nothing has been searched yet, and Search is withheld until the filters
+    // are complete — the cascade below is what completes them.
+    await expect(updates.idleHint()).toBeVisible();
+    await expect(updates.searchButton()).toBeDisabled();
+
+    // Version, start and end each stay disabled until the one before has a
+    // value, so filling them in order is a requirement rather than a style.
+    await expect(updates.versionSelect()).toBeDisabled();
+    await updates.chooseOption(
+      updates.productSelect(),
+      UPDATES_SEARCH_INPUT.productName,
+    );
+
+    await expect(updates.startLevelSelect()).toBeDisabled();
+    await updates.chooseOption(
+      updates.versionSelect(),
+      UPDATES_SEARCH_INPUT.productVersion,
+    );
+
+    await expect(updates.endLevelSelect()).toBeDisabled();
+    await updates.chooseOption(
+      updates.startLevelSelect(),
+      UPDATES_SEARCH_INPUT.startLevel,
+    );
+
+    // Still incomplete without the end level.
+    await expect(updates.searchButton()).toBeDisabled();
+    await updates.chooseOption(
+      updates.endLevelSelect(),
+      UPDATES_SEARCH_INPUT.endLevel,
+    );
+    await expect(updates.searchButton()).toBeEnabled();
+
+    const response = await updates.search();
+    await expectSuccess(response, "search update levels");
+
+    // The chosen range on the wire. The selects show labels; the request carries
+    // the product name, version and the two levels, so this is where the choice
+    // is actually observable.
+    const payload = JSON.parse(response.request().postData() ?? "{}") as {
+      productName?: string;
+      productVersion?: string;
+      startingUpdateLevel?: number | string;
+      endingUpdateLevel?: number | string;
+    };
+    expect(payload.productName).toBe(UPDATES_SEARCH_INPUT.productName);
+    expect(payload.productVersion).toBe(UPDATES_SEARCH_INPUT.productVersion);
+    expect(String(payload.startingUpdateLevel)).toBe(
+      UPDATES_SEARCH_INPUT.startLevel,
+    );
+    expect(String(payload.endingUpdateLevel)).toBe(
+      UPDATES_SEARCH_INPUT.endLevel,
+    );
+
+    // And onto the URL, which the page writes so a search can be shared or
+    // reloaded. Written with `replace`, so it does not add a history entry.
+    const url = new URL(page.url());
+    expect(url.searchParams.get(UPDATES.urlParams.product)).toBe(
+      UPDATES_SEARCH_INPUT.productName,
+    );
+    expect(url.searchParams.get(UPDATES.urlParams.version)).toBe(
+      UPDATES_SEARCH_INPUT.productVersion,
+    );
+    expect(url.searchParams.get(UPDATES.urlParams.startLevel)).toBe(
+      UPDATES_SEARCH_INPUT.startLevel,
+    );
+    expect(url.searchParams.get(UPDATES.urlParams.endLevel)).toBe(
+      UPDATES_SEARCH_INPUT.endLevel,
+    );
+
+    // The idle hint gives way once a search has run — whether the range holds
+    // updates is environment data, so this asserts the page left its initial
+    // state rather than demanding results.
+    await expect(updates.idleHint()).toHaveCount(0);
+
+    // Wait for the table to replace its skeleton: the response landing is not
+    // the same as the results being rendered.
+    await updates.waitForResults();
+
+    // The range asked for holds updates, so the table is the expected outcome
+    // here — but the wait above tolerates an empty one, and this skips rather
+    // than fails if the environment ever returns none.
+    const hasResults =
+      (await updates.resultsColumnHeader(UPDATES.results.headers[0]).count()) >
+      0;
+    test.skip(
+      !hasResults,
+      `No update levels between ${UPDATES_SEARCH_INPUT.startLevel} and ` +
+        `${UPDATES_SEARCH_INPUT.endLevel} for ${UPDATES_SEARCH_INPUT.productName} ` +
+        `${UPDATES_SEARCH_INPUT.productVersion}, so there is no table to check.`,
+    );
+
+    // Soft, so one missing column does not hide the state of the others.
+    for (const header of UPDATES.results.headers) {
+      await expect.soft(updates.resultsColumnHeader(header)).toBeVisible();
+    }
+
+    console.log(
+      `Update levels (${UPDATES_SEARCH_INPUT.projectType}): searched ` +
+        `${UPDATES_SEARCH_INPUT.productName} ${UPDATES_SEARCH_INPUT.productVersion} ` +
+        `levels ${UPDATES_SEARCH_INPUT.startLevel}–${UPDATES_SEARCH_INPUT.endLevel}`,
+    );
+  });
+
+  test(`${UPDATES_SEARCH_INPUT.projectType} — clears the filters before searching`, async ({
+    page,
+  }) => {
+    test.skip(!project.id, `${UPDATES_SEARCH_INPUT.projectType} needs a project id.`);
+
+    const updates = new UpdatesPage(page);
+    await updates.openViaSideNav(project.id);
+
+    // Nothing selected yet, so there is nothing to clear.
+    await expect(updates.clearFiltersButton()).toBeDisabled();
+
+    await updates.fillSearch(
+      UPDATES_SEARCH_INPUT.productName,
+      UPDATES_SEARCH_INPUT.productVersion,
+      UPDATES_SEARCH_INPUT.startLevel,
+      UPDATES_SEARCH_INPUT.endLevel,
+    );
+    await expect(updates.clearFiltersButton()).toBeEnabled();
+    await expect(updates.searchButton()).toBeEnabled();
+
+    await updates.clearFiltersButton().click();
+
+    // The chosen values are gone. Asserted as their absence rather than against
+    // the placeholder: a closed MUI select with no value renders a zero-width
+    // space, not the placeholder text, so "shows Select Product" would never
+    // hold.
+    await expect(updates.productSelect()).not.toContainText(
+      UPDATES_SEARCH_INPUT.productName,
+    );
+    await expect(updates.versionSelect()).not.toContainText(
+      UPDATES_SEARCH_INPUT.productVersion,
+    );
+
+    // And the cascade is back to its starting state, which is the observable
+    // consequence of the levels being cleared too: with no product chosen the
+    // three dependent selects are disabled again, and neither action is
+    // available.
+    await expect(updates.versionSelect()).toBeDisabled();
+    await expect(updates.startLevelSelect()).toBeDisabled();
+    await expect(updates.endLevelSelect()).toBeDisabled();
+    await expect(updates.searchButton()).toBeDisabled();
+    await expect(updates.clearFiltersButton()).toBeDisabled();
+
+    console.log(
+      `Update levels (${UPDATES_SEARCH_INPUT.projectType}): filters cleared before searching`,
+    );
+  });
+
+  test(`${UPDATES_SEARCH_INPUT.projectType} — clears a completed search`, async ({
+    page,
+  }) => {
+    test.skip(!project.id, `${UPDATES_SEARCH_INPUT.projectType} needs a project id.`);
+
+    const updates = new UpdatesPage(page);
+    await updates.openViaSideNav(project.id);
+
+    await updates.fillSearch(
+      UPDATES_SEARCH_INPUT.productName,
+      UPDATES_SEARCH_INPUT.productVersion,
+      UPDATES_SEARCH_INPUT.startLevel,
+      UPDATES_SEARCH_INPUT.endLevel,
+    );
+    await expectSuccess(await updates.search(), "search update levels");
+
+    // The search left its parameters on the URL; clearing has to take them off
+    // again, which a filter-only reset would not.
+    expect(
+      new URL(page.url()).searchParams.get(UPDATES.urlParams.product),
+    ).toBe(UPDATES_SEARCH_INPUT.productName);
+
+    await updates.clearFiltersButton().click();
+
+    await expect
+      .poll(
+        () => new URL(page.url()).searchParams.get(UPDATES.urlParams.product),
+        {
+          message: "clearing should drop the search from the URL",
+          timeout: 15_000,
+        },
+      )
+      .toBeNull();
+    for (const param of Object.values(UPDATES.urlParams)) {
+      expect(new URL(page.url()).searchParams.get(param)).toBeNull();
+    }
+
+    // The results give way to the idle hint, which is the page's own statement
+    // that no search is in effect.
+    await expect(updates.idleHint()).toBeVisible();
+    await expect(updates.productSelect()).not.toContainText(
+      UPDATES_SEARCH_INPUT.productName,
+    );
+    await expect(updates.clearFiltersButton()).toBeDisabled();
+
+    console.log(
+      `Update levels (${UPDATES_SEARCH_INPUT.projectType}): completed search cleared`,
+    );
+  });
+
+  test(`${UPDATES_SEARCH_INPUT.projectType} — views an update level's details`, async ({
+    page,
+  }) => {
+    test.skip(!project.id, `${UPDATES_SEARCH_INPUT.projectType} needs a project id.`);
+
+    const updates = new UpdatesPage(page);
+    await updates.openViaSideNav(project.id);
+    await updates.fillSearch(
+      UPDATES_SEARCH_INPUT.productName,
+      UPDATES_SEARCH_INPUT.productVersion,
+      UPDATES_SEARCH_INPUT.startLevel,
+      UPDATES_SEARCH_INPUT.endLevel,
+    );
+    await expectSuccess(await updates.search(), "search update levels");
+    await updates.waitForResults();
+
+    const level = UPDATES_SEARCH_INPUT.viewLevel;
+    const view = updates.viewLevelButton(level);
+    test.skip(
+      (await view.count()) === 0,
+      `Level ${level} is not among the results for ` +
+        `${UPDATES_SEARCH_INPUT.productName} ${UPDATES_SEARCH_INPUT.productVersion}, ` +
+        `so there is no row to open.`,
+    );
+
+    await view.first().click();
+
+    // The level's own page, which carries the searched product forward as query
+    // parameters — `productBaseVersion` there, where the search wrote `pv`.
+    await expect(page).toHaveURL(
+      new RegExp(
+        `/projects/${project.id}/${UPDATES.levelDetails.pathSegment}/${level}\\?`,
+      ),
+    );
+
+    const url = new URL(page.url());
+    expect(url.searchParams.get("productName")).toBe(
+      UPDATES_SEARCH_INPUT.productName,
+    );
+    expect(url.searchParams.get("productBaseVersion")).toBe(
+      UPDATES_SEARCH_INPUT.productVersion,
+    );
+
+    // The summary names the product it is describing. Soft, so one missing field
+    // does not hide the state of the others.
+    for (const label of UPDATES.levelDetails.summaryLabels) {
+      await expect
+        .soft(updates.levelSummaryLabel(label).first())
+        .toBeVisible({ timeout: 30_000 });
+    }
+
+    // Each filter is offered, and choosing it keeps the page on this level —
+    // these narrow the listed updates rather than navigating.
+    for (const filter of UPDATES.levelDetails.filterButtons) {
+      const button = updates.levelFilterButton(filter);
+      await expect.soft(button).toBeVisible();
+      await button.click();
+
+      await expect(page).toHaveURL(
+        new RegExp(`/${UPDATES.levelDetails.pathSegment}/${level}\\?`),
+      );
+
+      // Under All there are updates to list; Security and Regular are subsets and
+      // either may legitimately be empty, so only the count is reported for them.
+      const listed = await updates.levelUpdateNumbers().count();
+      if (filter === UPDATES.levelDetails.filterButtons[0]) {
+        expect(
+          listed,
+          `the All view should list the level's updates`,
+        ).toBeGreaterThan(0);
+
+        // Every listed update shows its number, and the section that describes it
+        // is on the page.
+        await expect(updates.levelUpdateNumbers().first()).toBeVisible();
+        await expect
+          .soft(
+            updates
+              .levelSummaryLabel(UPDATES.levelDetails.descriptionHeading)
+              .first(),
+          )
+          .toBeVisible();
+      }
+
+      console.log(
+        `Update level ${level} (${filter}): ${listed} update(s) listed`,
+      );
+    }
+  });
+
+  test(`${UPDATES_SEARCH_INPUT.projectType} — goes back from an update level to the search`, async ({
+    page,
+  }) => {
+    test.skip(!project.id, `${UPDATES_SEARCH_INPUT.projectType} needs a project id.`);
+
+    const updates = new UpdatesPage(page);
+    await updates.openViaSideNav(project.id);
+    await updates.fillSearch(
+      UPDATES_SEARCH_INPUT.productName,
+      UPDATES_SEARCH_INPUT.productVersion,
+      UPDATES_SEARCH_INPUT.startLevel,
+      UPDATES_SEARCH_INPUT.endLevel,
+    );
+    await expectSuccess(await updates.search(), "search update levels");
+    await updates.waitForResults();
+
+    const level = UPDATES_SEARCH_INPUT.viewLevel;
+    const view = updates.viewLevelButton(level);
+    test.skip(
+      (await view.count()) === 0,
+      `Level ${level} is not among the results, so there is no row to open.`,
+    );
+
+    await view.first().click();
+    await expect(page).toHaveURL(
+      new RegExp(`/${UPDATES.levelDetails.pathSegment}/${level}\\?`),
+    );
+
+    await updates.levelBackButton().click();
+
+    // Back on the search, which is what the filter section's heading identifies.
+    await expect(updates.sectionTitle()).toBeVisible({ timeout: 30_000 });
+    await expect(page).toHaveURL(
+      new RegExp(`/projects/${project.id}/${UPDATES.pathSegment}`),
+    );
+    await expect(page).not.toHaveURL(
+      new RegExp(UPDATES.levelDetails.pathSegment),
+    );
+
+    // The control walks history back rather than routing to a fixed path, so the
+    // search that was in effect comes back with it — the parameters were written
+    // onto the URL, and this is where that pays off. Soft, because it is a
+    // consequence of the history behaviour rather than the thing under test.
+    const url = new URL(page.url());
+    await expect
+      .soft(updates.searchButton(), "the search should still be complete")
+      .toBeEnabled();
+    expect
+      .soft(url.searchParams.get(UPDATES.urlParams.product))
+      .toBe(UPDATES_SEARCH_INPUT.productName);
+
+    console.log(
+      `Update level ${level}: went back to the search ` +
+        `(params ${url.searchParams.toString() ? "restored" : "dropped"})`,
+    );
+  });
+
+  //
+  // Validation. Nothing here searches successfully, and nothing is written —
+  // the rules are all about which choices the form allows.
+  //
+  test(`${UPDATES_SEARCH_INPUT.projectType} — downloads the update levels report`, async ({
+    page,
+  }) => {
+    test.skip(!project.id, `${UPDATES_SEARCH_INPUT.projectType} needs a project id.`);
+
+    const updates = new UpdatesPage(page);
+    await updates.openViaSideNav(project.id);
+    await updates.fillSearch(
+      UPDATES_SEARCH_INPUT.productName,
+      UPDATES_SEARCH_INPUT.productVersion,
+      UPDATES_SEARCH_INPUT.startLevel,
+      UPDATES_SEARCH_INPUT.endLevel,
+    );
+    await expectSuccess(await updates.search(), "search update levels");
+    await updates.waitForResults();
+
+    // The button becomes available once the search has results to report on.
+    await expect(updates.downloadReportButton()).toBeEnabled();
+
+    const download = await updates.downloadReport();
+
+    // The file a user ends up with. The name is built from the searched product
+    // and range, so it doubles as a check that the report describes the search
+    // that produced it.
+    expect(download.suggestedFilename()).toBe(
+      UPDATES.report.fileName(
+        UPDATES_SEARCH_INPUT.productName,
+        UPDATES_SEARCH_INPUT.productVersion,
+        UPDATES_SEARCH_INPUT.startLevel,
+        UPDATES_SEARCH_INPUT.endLevel,
+      ),
+    );
+
+    // And it has content: the PDF is generated in the browser, so an empty file
+    // would mean jsPDF produced nothing while still triggering the download.
+    const path = await download.path();
+    expect(path, "the download produced no file").toBeTruthy();
+    expect(
+      fs.statSync(path as string).size,
+      "the report should not be empty",
+    ).toBeGreaterThan(0);
+
+    console.log(
+      `Update levels report: downloaded ${download.suggestedFilename()} ` +
+        `(${fs.statSync(path as string).size} bytes)`,
+    );
+  });
+
+  test(`${UPDATES_SEARCH_INPUT.projectType} — withholds the report until there is something to report`, async ({
+    page,
+  }) => {
+    test.skip(!project.id, `${UPDATES_SEARCH_INPUT.projectType} needs a project id.`);
+
+    // Counted from the start: neither of the states below may produce a file, and
+    // a disabled button alone would not show that nothing was generated.
+    let downloads = 0;
+    page.on("download", () => {
+      downloads += 1;
+    });
+
+    const updates = new UpdatesPage(page);
+    await updates.openViaSideNav(project.id);
+
+    // Nothing searched yet, so there is no report data to build from.
+    await expect(updates.downloadReportButton()).toBeDisabled();
+
+    // Filling the filters is not enough either — the data comes from the search,
+    // not the selection.
+    await updates.fillSearch(
+      UPDATES_SEARCH_INPUT.productName,
+      UPDATES_SEARCH_INPUT.productVersion,
+      UPDATES_SEARCH_INPUT.startLevel,
+      UPDATES_SEARCH_INPUT.endLevel,
+    );
+    await expect(updates.downloadReportButton()).toBeDisabled();
+
+    await expectSuccess(await updates.search(), "search update levels");
+    await updates.waitForResults();
+    await expect(updates.downloadReportButton()).toBeEnabled();
+
+    // And clearing takes it away again, since the results go with it.
+    await updates.clearFiltersButton().click();
+    await expect(updates.downloadReportButton()).toBeDisabled();
+    await expect(updates.idleHint()).toBeVisible();
+
+    expect(
+      downloads,
+      "no report should be produced without downloading one",
+    ).toBe(0);
+
+    console.log(
+      `Update levels report: withheld before searching and after clearing`,
+    );
+  });
+
+  test.describe("validation", () => {
+    test(`${UPDATES_SEARCH_INPUT.projectType} — offers only levels above the start as the end`, async ({
+      page,
+    }) => {
+      test.skip(!project.id, `${UPDATES_SEARCH_INPUT.projectType} needs a project id.`);
+
+      const updates = new UpdatesPage(page);
+      await updates.openViaSideNav(project.id);
+
+      await updates.chooseOption(
+        updates.productSelect(),
+        UPDATES_SEARCH_INPUT.productName,
+      );
+      await updates.chooseOption(
+        updates.versionSelect(),
+        UPDATES_SEARCH_INPUT.productVersion,
+      );
+
+      const startOptions = await updates.optionLabels(updates.startLevelSelect());
+      expect(startOptions.length, "no start levels offered").toBeGreaterThan(1);
+
+      const start = UPDATES_SEARCH_INPUT.viewLevel;
+      await updates.chooseOption(updates.startLevelSelect(), start);
+
+      // The end select lists only levels above the start, which is what makes an
+      // inverted range unreachable: `validateAllUpdatesFilter` also rejects
+      // start > end, but the UI never lets it be submitted in the first place.
+      const endOptions = await updates.optionLabels(updates.endLevelSelect());
+      expect(endOptions.length, "no end levels offered").toBeGreaterThan(0);
+
+      for (const option of endOptions) {
+        expect(
+          Number(option),
+          `end option ${option} should be above the start ${start}`,
+        ).toBeGreaterThan(Number(start));
+      }
+      expect(endOptions).not.toContain(start);
+
+      console.log(
+        `Update levels: end offers ${endOptions.length} levels above ${start}`,
+      );
+    });
+
+    test(`${UPDATES_SEARCH_INPUT.projectType} — resets the end level when the start changes`, async ({
+      page,
+    }) => {
+      test.skip(!project.id, `${UPDATES_SEARCH_INPUT.projectType} needs a project id.`);
+
+      const updates = new UpdatesPage(page);
+      await updates.openViaSideNav(project.id);
+      await updates.fillSearch(
+        UPDATES_SEARCH_INPUT.productName,
+        UPDATES_SEARCH_INPUT.productVersion,
+        UPDATES_SEARCH_INPUT.startLevel,
+        UPDATES_SEARCH_INPUT.endLevel,
+      );
+      await expect(updates.searchButton()).toBeEnabled();
+
+      // A different start invalidates the end that was chosen against the old one,
+      // so the form clears it rather than leaving an inconsistent pair.
+      const startOptions = await updates.optionLabels(updates.startLevelSelect());
+      const nextStart = startOptions.find(
+        (option) => option !== UPDATES_SEARCH_INPUT.startLevel,
+      );
+      test.skip(!nextStart, `only one start level is offered.`);
+
+      await updates.chooseOption(updates.startLevelSelect(), nextStart as string);
+
+      await expect(updates.endLevelSelect()).not.toContainText(
+        UPDATES_SEARCH_INPUT.endLevel,
+      );
+      await expect(updates.searchButton()).toBeDisabled();
+
+      console.log(
+        `Update levels: start ${UPDATES_SEARCH_INPUT.startLevel} → ${nextStart} ` +
+          `cleared the end level`,
+      );
+    });
+
+    test(`${UPDATES_SEARCH_INPUT.projectType} — resets the version and levels when the product changes`, async ({
+      page,
+    }) => {
+      test.skip(!project.id, `${UPDATES_SEARCH_INPUT.projectType} needs a project id.`);
+
+      const updates = new UpdatesPage(page);
+      await updates.openViaSideNav(project.id);
+
+      const products = await updates.optionLabels(updates.productSelect());
+      const otherProduct = products.find(
+        (option) => option !== UPDATES_SEARCH_INPUT.productName,
+      );
+      test.skip(
+        !otherProduct,
+        `only "${UPDATES_SEARCH_INPUT.productName}" is offered, so the product ` +
+          `cannot be changed.`,
+      );
+
+      await updates.fillSearch(
+        UPDATES_SEARCH_INPUT.productName,
+        UPDATES_SEARCH_INPUT.productVersion,
+        UPDATES_SEARCH_INPUT.startLevel,
+        UPDATES_SEARCH_INPUT.endLevel,
+      );
+      await expect(updates.searchButton()).toBeEnabled();
+
+      // Changing the product invalidates everything chosen under it — the version
+      // list belongs to the product, and the levels to the version.
+      await updates.chooseOption(
+        updates.productSelect(),
+        otherProduct as string,
+      );
+
+      await expect(updates.versionSelect()).not.toContainText(
+        UPDATES_SEARCH_INPUT.productVersion,
+      );
+
+      // With no version, the two level selects are disabled again — which is the
+      // observable form of their values having been cleared.
+      await expect(updates.startLevelSelect()).toBeDisabled();
+      await expect(updates.endLevelSelect()).toBeDisabled();
+      await expect(updates.searchButton()).toBeDisabled();
+
+      console.log(
+        `Update levels: product ${UPDATES_SEARCH_INPUT.productName} → ` +
+          `${otherProduct} cleared the version and levels`,
+      );
+    });
+
+    test(`${UPDATES_SEARCH_INPUT.projectType} — resets the levels when the version changes`, async ({
+      page,
+    }) => {
+      test.skip(!project.id, `${UPDATES_SEARCH_INPUT.projectType} needs a project id.`);
+
+      const updates = new UpdatesPage(page);
+      await updates.openViaSideNav(project.id);
+      await updates.chooseOption(
+        updates.productSelect(),
+        UPDATES_SEARCH_INPUT.productName,
+      );
+
+      const versions = await updates.optionLabels(updates.versionSelect());
+      const otherVersion = versions.find(
+        (option) => option !== UPDATES_SEARCH_INPUT.productVersion,
+      );
+      test.skip(
+        !otherVersion,
+        `${UPDATES_SEARCH_INPUT.productName} offers only one version, so it ` +
+          `cannot be changed.`,
+      );
+
+      await updates.chooseOption(
+        updates.versionSelect(),
+        UPDATES_SEARCH_INPUT.productVersion,
+      );
+      await updates.chooseOption(
+        updates.startLevelSelect(),
+        UPDATES_SEARCH_INPUT.startLevel,
+      );
+      await updates.chooseOption(
+        updates.endLevelSelect(),
+        UPDATES_SEARCH_INPUT.endLevel,
+      );
+      await expect(updates.searchButton()).toBeEnabled();
+
+      // The levels belong to the version, so changing it clears both.
+      await updates.chooseOption(
+        updates.versionSelect(),
+        otherVersion as string,
+      );
+
+      await expect(updates.endLevelSelect()).toBeDisabled();
+      await expect(updates.searchButton()).toBeDisabled();
+
+      console.log(
+        `Update levels: version ${UPDATES_SEARCH_INPUT.productVersion} → ` +
+          `${otherVersion} cleared the levels`,
+      );
+    });
+  });
+});

--- a/apps/customer-portal/webapp/tests/e2e/specs/updates/update-levels-search.spec.ts
+++ b/apps/customer-portal/webapp/tests/e2e/specs/updates/update-levels-search.spec.ts
@@ -396,24 +396,28 @@ test.describe("Update Levels", () => {
     // search that was in effect comes back with it — the parameters were written
     // onto the URL, and this is where that pays off. Soft, because it is a
     // consequence of the history behaviour rather than the thing under test.
-    const url = new URL(page.url());
     await expect
       .soft(updates.searchButton(), "the search should still be complete")
       .toBeEnabled();
-    expect
-      .soft(url.searchParams.get(UPDATES.urlParams.product))
-      .toBe(UPDATES_SEARCH_INPUT.productName);
 
+    // Asserted through `toHaveURL`, which retries: the parameters are restored as
+    // the page remounts, so reading `page.url()` once can catch it before they
+    // are back.
+    await expect
+      .soft(page, "the search parameters should be restored")
+      .toHaveURL(
+        new RegExp(
+          `[?&]${UPDATES.urlParams.product}=${UPDATES_SEARCH_INPUT.productName}(&|$)`,
+        ),
+      );
+
+    const restored = new URL(page.url()).searchParams.toString();
     console.log(
       `Update level ${level}: went back to the search ` +
-        `(params ${url.searchParams.toString() ? "restored" : "dropped"})`,
+        `(params ${restored ? "restored" : "dropped"})`,
     );
   });
 
-  //
-  // Validation. Nothing here searches successfully, and nothing is written —
-  // the rules are all about which choices the form allows.
-  //
   test(`${UPDATES_SEARCH_INPUT.projectType} — downloads the update levels report`, async ({
     page,
   }) => {
@@ -509,6 +513,10 @@ test.describe("Update Levels", () => {
     );
   });
 
+  //
+  // Validation. Nothing here searches successfully, and nothing is written —
+  // the rules are all about which choices the form allows.
+  //
   test.describe("validation", () => {
     test(`${UPDATES_SEARCH_INPUT.projectType} — offers only levels above the start as the end`, async ({
       page,
@@ -528,9 +536,22 @@ test.describe("Update Levels", () => {
       );
 
       const startOptions = await updates.optionLabels(updates.startLevelSelect());
-      expect(startOptions.length, "no start levels offered").toBeGreaterThan(1);
+      expect(
+        startOptions.length,
+        "at least two start levels are needed for one to sit above another",
+      ).toBeGreaterThan(1);
 
+      // Guarded like every other runtime discovery here: without this, a level
+      // that is not on offer makes the option click time out on a missing element
+      // rather than saying which fixture value is wrong.
       const start = UPDATES_SEARCH_INPUT.viewLevel;
+      test.skip(
+        !startOptions.includes(start),
+        `Level ${start} is not offered as a start level for ` +
+          `${UPDATES_SEARCH_INPUT.productName} ${UPDATES_SEARCH_INPUT.productVersion}. ` +
+          `Update UPDATES_SEARCH_INPUT.viewLevel in tests/e2e/config/testData.ts.`,
+      );
+
       await updates.chooseOption(updates.startLevelSelect(), start);
 
       // The end select lists only levels above the start, which is what makes an

--- a/apps/customer-portal/webapp/tests/e2e/utils/listSearch.ts
+++ b/apps/customer-portal/webapp/tests/e2e/utils/listSearch.ts
@@ -255,3 +255,68 @@ export function caseSearchWithoutSeverity(page: Page): Promise<Response> {
     { timeout: SEARCH_TIMEOUT_MS },
   );
 }
+
+/**
+ * Starts waiting for a case search carrying — or not carrying — a status filter.
+ *
+ * Call this **before** applying or clearing the filter, then await it after: the
+ * "no filter" form also describes the page's own first load, so arming it
+ * beforehand is what ties the wait to the change under test.
+ *
+ * @param page - Test page.
+ * @param filtered - True to match a request with statuses, false for one without.
+ * @returns Promise for the matching search response.
+ */
+export function caseSearchWithStatusFilter(
+  page: Page,
+  filtered: boolean,
+): Promise<Response> {
+  return page.waitForResponse(
+    (response) => {
+      if (!isCaseSearch(response)) return false;
+      const statusIds = searchFilters(
+        response.request().postData(),
+      )?.statusIds;
+      const hasStatuses = !!statusIds && statusIds.length > 0;
+      return hasStatuses === filtered;
+    },
+    { timeout: SEARCH_TIMEOUT_MS },
+  );
+}
+
+/**
+ * Starts waiting for a case search sorted a particular way.
+ *
+ * `sortBy` sits at the root of the body rather than inside `filters`, so it is
+ * read separately from the filter helpers above.
+ *
+ * @param page - Test page.
+ * @param field - Sort field the request must carry, e.g. "state".
+ * @param order - Sort order, e.g. "asc".
+ * @returns Promise for the matching search response.
+ */
+export function caseSearchWithSort(
+  page: Page,
+  field: string,
+  order: string,
+): Promise<Response> {
+  return page.waitForResponse(
+    (response) => {
+      if (!isCaseSearch(response)) return false;
+      const postData = response.request().postData();
+      if (!postData) return false;
+      try {
+        const body = JSON.parse(postData) as {
+          sortBy?: { field?: string; order?: string };
+        };
+        return (
+          body.sortBy?.field === field &&
+          body.sortBy?.order?.toLowerCase() === order.toLowerCase()
+        );
+      } catch {
+        return false;
+      }
+    },
+    { timeout: SEARCH_TIMEOUT_MS },
+  );
+}

--- a/apps/customer-portal/webapp/tests/e2e/utils/selectors.ts
+++ b/apps/customer-portal/webapp/tests/e2e/utils/selectors.ts
@@ -67,6 +67,25 @@ export const CREATE_CASE = {
 /** Side navigation. Items are buttons inside the sidebar landmark; which ones
  * render depends on the project's feature flags (see SideBar.tsx). */
 export const SIDE_NAV = {
+  /**
+   * The route each item opens, relative to `/projects/{id}/`.
+   *
+   * Taken from APP_SHELL_NAV_ITEMS, where every gated item's path is its label
+   * slugified. Settings is not in that list — it is a footer link — and carries
+   * its own path.
+   */
+  paths: {
+    Dashboard: "dashboard",
+    Support: "support",
+    Operations: "operations",
+    Updates: "updates",
+    "Security Center": "security-center",
+    Engagements: "engagements",
+    "Usage & Metrics": "usage-metrics",
+    "Project Details": "project-details",
+    Announcements: "announcements",
+    Settings: "settings",
+  } as Record<string, string>,
   items: {
     dashboard: "Dashboard",
     support: "Support",
@@ -136,6 +155,243 @@ export const ADD_DEPLOYMENT = {
     type: "#deployment-type",
     description: "#deployment-description",
   },
+} as const;
+
+/** Settings page (`/projects/:projectId/settings`), reached from the side nav's
+ * footer item.
+ *
+ * Which tabs render depends on the signed-in user's ServiceNow role: AI
+ * Assistant is admin-only, as are the Add User button and the per-row actions
+ * (`canAddOrRemoveUsers`). */
+export const SETTINGS = {
+  navItem: "Settings",
+  pathSegment: "settings",
+  tabs: {
+    userManagement: "User Management",
+    aiAssistant: "AI Assistant",
+    registryTokens: "Registry Tokens",
+    display: "Display",
+  },
+  userManagement: {
+    /** Column headers of the user list. */
+    headers: ["User", "Role", "Status", "Actions"],
+    searchPlaceholder: "Search users by name, email, or role...",
+    addUserButton: "Add User",
+    editUserButton: "Edit user",
+    removeUserButton: "Remove user",
+    editModal: {
+      title: "Edit User Roles",
+      saveButton: "Save Changes",
+      cancelButton: "Cancel",
+      /** Role checkboxes, by their rendered label. */
+      roles: {
+        admin: "Admin",
+        lead: "Lead",
+      },
+    },
+  },
+  display: {
+    heading: "Display Preferences",
+    fontSizeTitle: "Font Size",
+    /** Each option's control is labelled "Font size: <label>", and choosing one
+     * sets `document.documentElement.style.fontSize` to the matching value. */
+    fontSizeOption: (label: string) => `Font size: ${label}`,
+    fontSizes: [
+      { label: "Small", px: "13px" },
+      { label: "Default", px: "16px" },
+      { label: "Large", px: "18px" },
+      { label: "Extra Large", px: "20px" },
+    ],
+  },
+} as const;
+
+/** Updates page (`/projects/:projectId/updates`), reached from the side nav.
+ *
+ * The page is the All Updates tab: a filter row over update levels, plus results.
+ * The four selects cascade — version needs a product, the start level needs a
+ * version, the end level needs a start — and Search stays disabled until all
+ * four are set. */
+export const UPDATES = {
+  navItem: "Updates",
+  pathSegment: "updates",
+  sectionTitle: "Search Update Levels",
+  labels: {
+    product: "Product Name *",
+    version: "Product Version *",
+    startLevel: "Starting Update Level *",
+    endLevel: "Ending Update Level *",
+  },
+  ids: {
+    product: "all-updates-product",
+    version: "all-updates-version",
+    startLevel: "all-updates-start",
+    endLevel: "all-updates-end",
+  },
+  searchButton: "Search",
+  /** Disabled until something is selected or a search has been run
+   * (`canClear`). Clearing resets the filters, the search and the URL. */
+  clearFiltersButton: "Clear Filters",
+  /** The placeholder MenuItem's text. Only rendered inside the open menu — a
+   * closed select with no value displays a zero-width space, not this, so it
+   * cannot be used to assert that a select has been reset. Verified live. */
+  placeholders: {
+    product: "Select Product",
+    version: "Select Version",
+    level: "Select Level",
+  },
+  /** Shown before a search has been run. */
+  idleHint:
+    "Select product, version, and update level range, then click Search to view updates.",
+  /**
+   * The results table a search renders (PendingUpdatesList), and the copy shown
+   * instead when the range holds nothing.
+   *
+   * The table replaces a skeleton, so a caller has to wait for one of these two
+   * states rather than reading straight after the response.
+   */
+  results: {
+    headers: ["Update Level", "Update Type", "Details"],
+    emptyMessage: "No update levels found for the selected criteria.",
+    /** The Details column's control, one per row. */
+    viewButton: "View",
+  },
+  /**
+   * The update level details page
+   * (`/projects/:id/updates/pending/level/:level`), opened by a row's View.
+   *
+   * Carries the searched product forward as query parameters — note
+   * `productBaseVersion` here where the search used `pv`.
+   */
+  levelDetails: {
+    pathSegment: "updates/pending/level",
+    summaryLabels: ["Product Name", "Product Version", "Released Update Level"],
+    /** Filters over the listed updates. */
+    filterButtons: ["All", "Security", "Regular"],
+    /** Each listed update shows its number and, when it has one, a description
+     * section. The number is rendered inline as "Update Number: <n>". */
+    updateNumberPrefix: "Update Number:",
+    descriptionHeading: "Description",
+    /** Returns to whatever opened this page — it navigates history back
+     * (ROUTE_PREVIOUS_PAGE = -1) rather than to a fixed route. */
+    backButton: "Back",
+  },
+  /**
+   * The report download, offered beside Search once a search has produced
+   * results.
+   *
+   * There is no intermediate dialog: the button builds the PDF in the browser
+   * with jsPDF and saves it as
+   * `Update-Summary-<product>-<version>-<start>-<end>.pdf`, which the browser
+   * surfaces as a download. (`UpdateLevelsReportModal` exists in the codebase but
+   * nothing renders it — only its unit test refers to it.)
+   */
+  report: {
+    downloadButton: "Download Report",
+    /** The label while the PDF is being produced; the button is disabled then. */
+    generatingButton: "Generating...",
+    fileName: (
+      product: string,
+      version: string,
+      startLevel: string,
+      endLevel: string,
+    ) => `Update-Summary-${product}-${version}-${startLevel}-${endLevel}.pdf`,
+  },
+  /** Query parameters a search writes onto the URL (replace, not push). */
+  urlParams: {
+    product: "pn",
+    version: "pv",
+    startLevel: "sl",
+    endLevel: "el",
+  },
+} as const;
+
+/** Announcements list (`/projects/:projectId/announcements`), reached from the
+ * side nav. Announcements are cases underneath, so their rows carry a "CS"
+ * number and the detail page reuses the case header. */
+export const ANNOUNCEMENTS_LIST = {
+  navItem: "Announcements",
+  pathSegment: "announcements",
+  title: "Announcements",
+  description: "View and manage announcements for your project",
+  searchPlaceholder: "Search announcements...",
+  /** ListResultsBar with `entityLabel: "announcements"`. */
+  resultsCountPattern: /Showing (\d+) of (\d+) announcements/,
+  emptyMessage: "No announcements yet.",
+  /** Row number, matched within the card's whole text — so unanchored, for the
+   * same reason the change-request pattern is. */
+  numberPattern: /CS\d+/,
+  /** Opens the filter panel; becomes "Clear Filters (n)" once one is applied. */
+  filtersButton: "Filters",
+  clearFiltersButton: (activeCount: number) => `Clear Filters (${activeCount})`,
+  /** The only filter announcements offer (ANNOUNCEMENT_FILTER_DEFINITIONS), and
+   * it is multi-select. Its element id comes from the definition's `id`, its
+   * label from `deriveFilterLabels`. */
+  statusFilter: {
+    selectId: "status",
+    label: "Status",
+  },
+  /** Sort controls, from the shared ListResultsBar. The order labels depend on
+   * the field: a chronological sort reads "Newest first"/"Oldest first", an
+   * ordinal one "Descending"/"Ascending" — Updated date is chronological, Status
+   * is ordinal. */
+  sort: {
+    fieldSelectId: "list-sort-field",
+    orderSelectId: "list-sort-order",
+    fields: {
+      updatedDate: { label: "Updated date", value: "updatedOn" },
+      status: { label: "Status", value: "state" },
+    },
+    orders: {
+      chronologicalDesc: { label: "Newest first", value: "desc" },
+      chronologicalAsc: { label: "Oldest first", value: "asc" },
+      ordinalDesc: { label: "Descending", value: "desc" },
+      ordinalAsc: { label: "Ascending", value: "asc" },
+    },
+  },
+  /** ListPagination is given no explicit page sizes here, so it uses its own
+   * defaults; the list starts at ANNOUNCEMENTS_PAGE_SIZE. */
+  defaultRowsPerPage: 10,
+  rowsPerPageOptions: [5, 10, 25, 50],
+} as const;
+
+/** Change requests list (`/projects/:projectId/operations/change-requests`),
+ * reached from the Operations hub or the dashboard's operations donut.
+ *
+ * The title depends on router *state* rather than the URL — `outstandingOnly`,
+ * `actionRequired` and `scheduledOnly` all land on this same path — so a direct
+ * navigation always gets the unfiltered "All Change Requests" view. */
+export const CHANGE_REQUESTS_LIST = {
+  pathSegment: "operations/change-requests",
+  titles: {
+    all: "All Change Requests",
+    outstanding: "Outstanding Change Requests",
+    actionRequired: "Action Required Change Requests",
+    scheduled: "Upcoming Change Requests",
+  },
+  descriptions: {
+    outstanding: "Manage and track outstanding change requests",
+    scheduled: "Upcoming scheduled change requests",
+  },
+  /** The list/calendar switch (CHANGE_REQUESTS_VIEW_TABS_CONFIG), rendered by
+   * TabBar as `role="tab"` with `aria-selected`. */
+  viewTabs: {
+    list: "List View",
+    calendar: "Calendar View",
+  },
+  /** Shown when the list has nothing to show — the second only once a search or
+   * filter has been applied. */
+  emptyMessage: "No change requests yet.",
+  emptyRefinedMessage:
+    "No change requests found. Try adjusting your filters or search query.",
+  /**
+   * A change request's number, as the row and the detail header render it.
+   *
+   * Deliberately unanchored: it is used with `hasText` to pick rows out, and a
+   * row's text is the whole card — "Medium Add/Remove Certificates CHG0038759
+   * Scheduled | SR: CS0441440 …" — so an anchored pattern matches nothing and the
+   * list reads as empty.
+   */
+  numberPattern: /CHG\d+/,
 } as const;
 
 /** MUI TablePagination's default labels.


### PR DESCRIPTION
Adds 42 tests across four areas that had little or no coverage, plus two tests to
the existing side-menu suite. Four new page objects, no changes to app code.

### Update levels (11 tests, new suite)

The Updates side-menu item, end to end:

- **Search** — the four filters cascade (version needs a product, the start level a
  version, the end level a start) and Search is withheld until all four are set.
  Asserts the chosen range on the wire *and* on the URL, then waits for the
  results table and its Update Level / Update Type / Details columns.
- **Clear Filters** — before searching (values gone, cascade reset, both actions
  disabled) and after (the search's URL parameters dropped, idle hint back).
- **A level's details** — opens level 1 from the Details column, checks Product
  Name / Product Version / Released Update Level, and walks the All, Security and
  Regular filters. On this tenant All lists 5, Security 2, Regular 3.
- **Back** — returns to the search with "Search Update Levels" showing, and the
  search itself restored (the parameters were on the URL).
- **Download Report** — captures the PDF and asserts its name is built from the
  searched range (`Update-Summary-wso2am-4.4.0-0-10.pdf`, ~150KB), plus that the
  button is withheld until there is something to report and counts zero downloads
  when it is.
- **Validation (4)** — the end select offers only levels above the start, and the
  three dependent resets: product clears version and levels, version clears
  levels, start clears end.

### Settings (5 tests, new suite)

The four tabs, the user list with its columns and per-row actions, the search, and
the Display tab's font sizes — which assert
`document.documentElement.style.fontSize` becomes 13/16/18/20px and restore the
original, since the choice persists to the browser and would otherwise change how
every later spec renders.

⚠️ The role-editing test **skips**: every role save is refused with
`500 {"message":"…the supported email domains list for your account has not been
defined…"}`. Nothing is written, so the account keeps its roles. The test performs
the whole flow, recognises that specific failure and skips with the prerequisite
named; it will start asserting the full remove-and-restore once the domains list
is configured.

### Announcements list (21 tests, new suite — 7 × 3 project types)

Reaching the list from the side menu, its results count against the row count,
the status filter (open, apply, clear), sorting by field and order, pagination,
and opening an announcement from a row. That last one closes the gap left by
`view-announcement.spec.ts`, which navigates by sysid and so never showed the list
leads anywhere.

### Change requests (3 tests, new suite)

The list, the List/Calendar switch, and opening a request from a row. Read-only —
approve and reject are irreversible and would consume a real record.

### Service request activity (2 tests, new suite)

Comments and attachments on a service request. The SR detail page *is* the case
detail page (`CaseDetailsContent` with `isServiceRequest`), and the endpoints are
the case ones, so the existing page objects serve unchanged. Both records persist,
so both are guarded on their own content.

### Side menu (2 tests added to the existing suite)

- **The item list is exactly what is expected** — the per-item loop could not
  notice an item nobody wrote an expectation for.
- **Every visible item opens its route** — 25 navigations across the three
  projects, including the six that had no navigation coverage anywhere.

### Behaviours worth knowing, found while writing this

**`hasText` matches `textContent`, which concatenates table cells without
separators.** A row reads `"1SecurityView"`, so a word-boundary pattern on the
level matches nothing — and the test *skipped*, claiming the row was absent. Rows
are now identified by the level's cell. The same anchoring mistake made the change
request list look empty (`/^CHG\d+$/` against a whole card).

**A cleared MUI select renders a zero-width space**, not its placeholder — the
placeholder text only exists inside the open menu. Reset is asserted as the value
being absent plus dependent controls disabling.

**`UpdateLevelsReportModal` is dead code.** Nothing renders it; the tab's
"Download Report" builds the PDF directly. Both report tests were originally built
around that modal and were wrong end to end.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded end-to-end coverage for announcements, change requests, service-request activity, settings, update-level searches, and sidebar navigation.
  * Added validation for filtering, sorting, pagination, downloads, role management, display preferences, comments, and attachments.
  * Added checks for navigation routes, visible menu items, empty states, search results, and detail-page links.
  * Improved coverage for unsupported email-domain errors and universally visible Settings access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->