### PR TITLE
[CSM Portal] Service-request answers, change-request lifecycle actions, and editable watch lists

### DIFF
--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -1967,9 +1967,10 @@ export interface BeChangeRequestDetail extends BeChangeRequestSearchView {
   /**
    * Backend-supplied legal transitions out of the CR's current state, mirroring
    * `nextStates` on a case (`CaseActionBar.tsx`) — render one action per entry
-   * rather than hardcoding a `state === 'new'` check. Intentionally narrow today:
-   * the only transition modeled so far is New -> Assess, so this is only ever
-   * `["assess"]` or `[]`.
+   * rather than hardcoding a `state === 'new'` check. Deliberately typed as an
+   * open `string[]`, not `BeChangeRequestState[]`: `ChangeRequestActionBar`
+   * renders an entry it has no curated config for via a generic fallback, so a
+   * transition added on the backend needs no frontend change to appear.
    */
   legalNextStates?: string[];
 }
@@ -2218,17 +2219,39 @@ export interface BeConfigurationItemSearchResponse {
 
 /**
  * `PATCH /change-requests/{id}` body (ServiceNow data source only). At least
- * one field is required by the BE (`minProperties: 1`). `plannedStartOn` is a
- * `YYYY-MM-DD HH:MM:SS` string. `requestApproval` is mutually exclusive with
- * the other fields here — it drives the New -> Assess transition (see
- * `legalNextStates` on {@link BeChangeRequestDetail}) rather than editing a value.
+ * one field is required by the BE (`minProperties: 1`). `plannedStartOn` and
+ * `plannedEndOn` are `YYYY-MM-DD HH:MM:SS` strings.
+ *
+ * `isCustomerApproved`, `isCustomerReviewed` and `requestApproval` are
+ * mutually exclusive with each other — at most one of the three may be set in
+ * a single patch.
+ *
+ * This is a subset of what the endpoint accepts, not the whole contract: only
+ * the fields the portal actually writes are modeled here. Add a field when a
+ * UI starts sending it, after checking it against the published contract.
  */
 export interface BePatchChangeRequestPayload {
   plannedStartOn?: string;
+  plannedEndOn?: string;
   isCustomerApproved?: boolean;
   isCustomerReviewed?: boolean;
   assignedTeamId?: string;
   requestApproval?: true;
+  /**
+   * Target lifecycle state, for a transition listed in the record's own
+   * `legalNextStates` (see {@link BeChangeRequestDetail}). Typed open rather
+   * than as `BeChangeRequestState` so a transition the backend adds can be
+   * driven straight from `legalNextStates` without a frontend change.
+   *
+   * The New -> Assess transition is the one exception: it goes through
+   * `requestApproval` instead, because that also kicks off the approval
+   * request, which setting `state` alone does not.
+   */
+  state?: string;
+  /** Backout plan. Long-form; stored and re-rendered as rich text. */
+  rollbackPlan?: string;
+  /** Test plan. Long-form; stored and re-rendered as rich text. */
+  testPlan?: string;
   /**
    * UUID of the service-request case this change request was raised from.
    * Only settable via PATCH — `POST /change-requests` does not accept it, so

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -704,7 +704,14 @@ export type BeCaseUpdatePayload =
   | (Omit<BeCaseUpdateNever, "workState"> & { workState: BeCaseWorkState })
   /** Email of the engineer to assign (ServiceNow only). */
   | (Omit<BeCaseUpdateNever, "assigneeEmail"> & { assigneeEmail: string })
-  /** Full replacement watch list as emails (ServiceNow only). */
+  /**
+   * Full replacement watch list, as platform user UUIDs — not a delta, and
+   * not emails: the backend resolves each id to whatever identifier the
+   * backing data source's own payload declares. Cannot be empty: the request
+   * shape can't distinguish an empty list from an absent field, so `[]` is
+   * rejected as an empty update (an incident's watch list *can* be cleared —
+   * see {@link BeUpdateIncidentPayload}).
+   */
   | (Omit<BeCaseUpdateNever, "watchList"> & { watchList: string[] })
   /**
    * UUID of another case, incident, change request, or problem to link this
@@ -2530,6 +2537,11 @@ export interface BeUpdateIncidentPayload {
   configurationItemId?: string | null;
   assignmentGroupId?: string | null;
   assignedEngineerId?: string | null;
+  /**
+   * Full replacement watch list, as platform user UUIDs — not a delta. An
+   * explicitly empty array is meaningful and clears the watch list; omitting
+   * the key leaves it unchanged.
+   */
   watchList?: string[];
   workNotes?: string | null;
   additionalComments?: string | null;

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -284,6 +284,16 @@ export interface BeCaseAccountRef {
 }
 
 /**
+ * One answered catalog-item question on a service request, as returned inside
+ * `GET /cases/{id}`. Both fields are always present and non-null; `value` is
+ * `""` when the question was asked but left blank.
+ */
+export interface BeCaseVariableAnswer {
+  name: string;
+  value: string;
+}
+
+/**
  * `GET /cases/{id}` response — the rich CaseView. Unlike {@link BeCase} (the
  * flat create/legacy shape), it embeds the related entities as objects, so the
  * UI gets account / project / deployment / deployed-product / reporter names
@@ -344,6 +354,14 @@ export interface BeCaseView {
   /** SR catalog refs (managed-cloud); null for non-catalog cases. */
   catalog?: BeEntityRef | null;
   catalogItem?: BeEntityRef | null;
+  /**
+   * The answers the requester gave to the catalog item's questions, in the
+   * backing data source's display order. Omitted entirely (never `null`,
+   * never `[]`) when the case has no answers or is not a catalog request, so
+   * "omitted" and "asked but left blank" stay distinguishable: `value` is
+   * always a string and may be `""` for a question that was left blank.
+   */
+  variables?: BeCaseVariableAnswer[];
   /** Assigned team and linked chat conversation; null when not set. */
   assignedTeam?: BeEntityRef | null;
   conversation?: BeEntityRef | null;
@@ -594,15 +612,37 @@ export interface BeSearchCatalogsResponse {
 }
 
 /**
+ * One selectable option on a choice-type catalog-item variable. Note the
+ * asymmetry with {@link BeCatalogItemVariable.choices}: the array itself is
+ * omitted when the variable has no choices, but once present every option
+ * object carries all three keys, each of which may be `null`. An option whose
+ * `value` is `null` cannot be submitted and is skipped by the form.
+ */
+export interface BeCatalogItemVariableChoice {
+  /** Submitted value. `null` for a malformed option — not renderable. */
+  value: string | null;
+  /** Display label; falls back to `value` when `null`. */
+  text: string | null;
+  /** Display order within the choice list. */
+  order: number | null;
+}
+
+/**
  * A catalog-item variable (form field). The contract carries the question
- * text, display order, and a free-form `type` hint, but no choice/option list
- * or mandatory flag — so the portal renders every variable as a text field.
+ * text, display order, a free-form `type` hint and, for choice-type
+ * variables, the list of selectable options. There is still no mandatory
+ * flag, so the portal decides required-ness client-side.
  */
 export interface BeCatalogItemVariable {
   id: string;
   questionText?: string;
   order?: number;
   type?: string;
+  /**
+   * Selectable options for a choice-type variable. Omitted entirely (never
+   * `null`, never `[]`) on non-choice variables.
+   */
+  choices?: BeCatalogItemVariableChoice[];
 }
 
 /** `GET /catalogs/{catalogId}/items/{catalogItemId}/variables` response. */

--- a/apps/csm-portal/webapp/src/components/AsyncEntitySelect.tsx
+++ b/apps/csm-portal/webapp/src/components/AsyncEntitySelect.tsx
@@ -52,6 +52,11 @@ export interface AsyncEntitySelectProps<T> {
   knownLabel?: string;
   /** Forwarded as `useSearch`'s third argument — see `useSearch` above. */
   searchExtra?: string;
+  /** Ids to drop from the results — for pickers that add to a list the entity
+   * is already on (e.g. a watch list), so an already-added person can't be
+   * offered again. The currently selected `value` is never excluded, so the
+   * field stays labelled. */
+  excludeIds?: readonly string[];
 }
 
 /**
@@ -76,6 +81,7 @@ export default function AsyncEntitySelect<T>({
   getLabel,
   knownLabel,
   searchExtra,
+  excludeIds,
 }: AsyncEntitySelectProps<T>): JSX.Element {
   const [searchTerm, setSearchTerm] = useState("");
   const [open, setOpen] = useState(false);
@@ -83,7 +89,12 @@ export default function AsyncEntitySelect<T>({
   const query = debounced.trim();
 
   const { data, isFetching, isError } = useSearch(query, open, searchExtra);
-  const items = useMemo(() => data ?? [], [data]);
+  const items = useMemo(() => {
+    const all = data ?? [];
+    if (!excludeIds?.length) return all;
+    const skip = new Set(excludeIds);
+    return all.filter((item) => getId(item) === value || !skip.has(getId(item)));
+  }, [data, excludeIds, getId, value]);
 
   // Captured at selection time so the field stays labelled once the search
   // term (and its results) move on to something else.

--- a/apps/csm-portal/webapp/src/components/rich-text-editor/richTextEditor.tsx
+++ b/apps/csm-portal/webapp/src/components/rich-text-editor/richTextEditor.tsx
@@ -72,15 +72,13 @@ export function htmlToPlainText(html: string): string {
 
 /**
  * Escapes HTML entities in a string.
+ *
+ * Re-exported from `@utils/sanitizeHtml`, which owns the single implementation
+ * — importing it from this module would otherwise pull the whole editor (and
+ * its editor-framework dependencies) into any bundle that only wanted to
+ * escape a string.
  */
-export function escapeHtml(text: string): string {
-  return text
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#039;");
-}
+export { escapeHtml } from "@utils/sanitizeHtml";
 
 /**
  * Sanitizes a URL by allowing only safe protocols.

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCaseDetail.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCaseDetail.ts
@@ -91,6 +91,13 @@ function detailFromBeCase(
       : undefined,
     linkedServiceRequests: c.linkedServiceRequests ?? undefined,
     linkedChangeRequests: c.linkedChangeRequests ?? undefined,
+    catalog: c.catalog ? { id: c.catalog.id, name: c.catalog.name } : undefined,
+    catalogItem: c.catalogItem
+      ? { id: c.catalogItem.id, name: c.catalogItem.name }
+      : undefined,
+    // Passed through in the backend's order — the display order the catalog
+    // item defines for its questions. Never re-sorted.
+    requestVariables: c.variables?.map((v) => ({ name: v.name, value: v.value })),
     autoclosureStep: c.autoclosureStep ?? undefined,
     autoclosureStateTime: c.autoclosureStateTime ?? undefined,
     acknowledgedBy: c.acknowledgedBy

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.test.tsx
@@ -32,6 +32,7 @@ vi.mock("@api/backend/client", () => ({
 import {
   AttachmentsWidget,
   CustomerContextWidget,
+  RequestDetailsWidget,
   TagsWidget,
   WatchersWidget,
 } from "@features/csm-cases/components/CaseDetailWidgets";
@@ -39,6 +40,7 @@ import { useSearchUsers } from "@features/csm-users/api/useSearchUsers";
 import type {
   CaseAttachment,
   CaseCustomerContext,
+  CaseRequestVariable,
   CaseTag,
   CaseWatcher,
 } from "@features/csm-cases/types/csmCases";
@@ -474,5 +476,109 @@ describe("CustomerContextWidget", () => {
     );
     expect(screen.getByText("SRE Beta")).toBeInTheDocument();
     expect(screen.queryByText("CRE Alpha")).not.toBeInTheDocument();
+  });
+});
+
+describe("RequestDetailsWidget", () => {
+  const CATALOG = { id: "catalog-1", name: "Managed Cloud" };
+  const CATALOG_ITEM = { id: "catalog-item-1", name: "Product Update" };
+
+  // Deliberately not in alphabetical order — the widget must preserve the
+  // order the backing data source returned, not impose one of its own.
+  const VARIABLES: CaseRequestVariable[] = [
+    { name: "Reason For Migration", value: "End of support" },
+    { name: "Approval Reference", value: "CHG-0001" },
+    { name: "Additional Notes", value: "" },
+  ];
+
+  it("renders the catalog and catalog item", () => {
+    renderWithRouter(
+      <RequestDetailsWidget
+        catalog={CATALOG}
+        catalogItem={CATALOG_ITEM}
+        variables={VARIABLES}
+      />,
+    );
+
+    expect(screen.getByText("Catalog")).toBeInTheDocument();
+    expect(screen.getByText("Managed Cloud")).toBeInTheDocument();
+    expect(screen.getByText("Catalog item")).toBeInTheDocument();
+    expect(screen.getByText("Product Update")).toBeInTheDocument();
+  });
+
+  it("renders an em dash for a catalog/catalog item the record does not carry", () => {
+    renderWithRouter(
+      <RequestDetailsWidget
+        variables={[{ name: "Reason For Migration", value: "End of support" }]}
+      />,
+    );
+
+    // Exactly two: the Catalog cell and the Catalog item cell. The single
+    // answer is non-blank, so it contributes none.
+    expect(screen.getAllByText("\u2014")).toHaveLength(2);
+  });
+
+  it("renders the answers in the order the backend returned them", () => {
+    const { container } = renderWithRouter(
+      <RequestDetailsWidget
+        catalog={CATALOG}
+        catalogItem={CATALOG_ITEM}
+        variables={VARIABLES}
+      />,
+    );
+
+    const questions = Array.from(container.querySelectorAll("dt")).map(
+      (dt) => dt.textContent,
+    );
+    expect(questions).toEqual([
+      "Reason For Migration",
+      "Approval Reference",
+      "Additional Notes",
+    ]);
+  });
+
+  it("pairs each question with its answer", () => {
+    const { container } = renderWithRouter(
+      <RequestDetailsWidget
+        catalog={CATALOG}
+        catalogItem={CATALOG_ITEM}
+        variables={VARIABLES}
+      />,
+    );
+
+    const answers = Array.from(container.querySelectorAll("dd")).map(
+      (dd) => dd.textContent,
+    );
+    expect(answers).toEqual(["End of support", "CHG-0001", "\u2014"]);
+  });
+
+  it("renders an em dash — not nothing — for a question that was asked and left blank", () => {
+    const { container } = renderWithRouter(
+      <RequestDetailsWidget
+        catalog={CATALOG}
+        catalogItem={CATALOG_ITEM}
+        variables={[{ name: "Additional Notes", value: "" }]}
+      />,
+    );
+
+    const dd = container.querySelector("dd");
+    expect(dd).not.toBeNull();
+    expect(dd).toHaveTextContent("\u2014");
+  });
+
+  it("renders the empty state rather than hiding the card when there are no answers", () => {
+    renderWithRouter(
+      <RequestDetailsWidget catalog={CATALOG} catalogItem={CATALOG_ITEM} />,
+    );
+
+    expect(screen.getByText("Request details")).toBeInTheDocument();
+    expect(screen.getByText("No request details captured.")).toBeInTheDocument();
+    expect(screen.getByText("Managed Cloud")).toBeInTheDocument();
+  });
+
+  it("renders the empty state for an explicitly empty answer list too", () => {
+    renderWithRouter(<RequestDetailsWidget variables={[]} />);
+
+    expect(screen.getByText("No request details captured.")).toBeInTheDocument();
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.test.tsx
@@ -36,13 +36,13 @@ import {
   TagsWidget,
   WatchersWidget,
 } from "@features/csm-cases/components/CaseDetailWidgets";
-import { useSearchUsers } from "@features/csm-users/api/useSearchUsers";
+import { useSearchUsersByName } from "@api/useSearchUsersByName";
+import type { WatchListMember } from "@features/csm-cases/components/CaseDetailWidgets";
 import type {
   CaseAttachment,
   CaseCustomerContext,
   CaseRequestVariable,
   CaseTag,
-  CaseWatcher,
 } from "@features/csm-cases/types/csmCases";
 import type { ProjectDetails } from "@features/csm-projects/types/csmProjects";
 
@@ -73,30 +73,31 @@ function AttachmentsWidgetHarness({
   );
 }
 
-vi.mock("@features/csm-users/api/useSearchUsers", () => ({
-  useSearchUsers: vi.fn(),
+vi.mock("@api/useSearchUsersByName", () => ({
+  useSearchUsersByName: vi.fn(),
 }));
 
-const mockUseSearchUsers = vi.mocked(useSearchUsers);
+const mockUseSearchUsersByName = vi.mocked(useSearchUsersByName);
 
+/** Two searchable people, one of whom (`WATCHER_TWO_ID`) is already watching. */
 function mockCandidates(): void {
-  mockUseSearchUsers.mockReturnValue({
-    data: {
-      users: [
-        {
-          id: "u-2",
-          userName: "jsmith",
-          name: "Jane Smith",
-          email: "jane.smith@example.com",
-          timezone: null,
-          active: true,
-        },
-      ],
-      total: 1,
-      limit: 8,
-      offset: 0,
-      hasMore: false,
-    },
+  mockUseSearchUsersByName.mockReturnValue({
+    data: [
+      {
+        id: CANDIDATE_ID,
+        userName: "jsmith",
+        firstName: "Jane",
+        lastName: "Smith",
+        email: "jane.smith@example.com",
+      },
+      {
+        id: WATCHER_TWO_ID,
+        userName: "jsmith2",
+        firstName: "John",
+        lastName: "Smith",
+        email: "john.smith@example.com",
+      },
+    ],
     isFetching: false,
     isError: false,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- partial UseQueryResult stub
@@ -108,10 +109,18 @@ const TAGS: CaseTag[] = [
   { id: "tag-2", label: "ws-policy" },
 ];
 
-const WATCHERS: CaseWatcher[] = [
-  { id: "w-1", name: "Jane Doe", email: "jane.doe@example.com" },
-  { id: "w-2", name: "John Smith", isMe: true },
+// Watch-list entries are keyed by platform user UUID — that id is exactly what
+// a write resends, so the fixtures use real UUID shapes rather than "w-1".
+const WATCHER_ONE_ID = "00000000-0000-0000-0000-000000000001";
+const WATCHER_TWO_ID = "00000000-0000-0000-0000-000000000002";
+const CANDIDATE_ID = "00000000-0000-0000-0000-000000000003";
+
+const WATCHERS: WatchListMember[] = [
+  { id: WATCHER_ONE_ID, name: "Jane Doe", email: "jane.doe@example.com" },
+  { id: WATCHER_TWO_ID, name: "John Smith", isMe: true },
 ];
+
+const ONE_WATCHER: WatchListMember[] = [WATCHERS[0]];
 
 // `WatchersWidget` links each watcher's name to their profile page via
 // `UserRefLink`, which renders a `react-router` `Link` and resolves its id
@@ -196,67 +205,144 @@ describe("TagsWidget", () => {
   });
 });
 
+/**
+ * Opens the "Add a watcher" type-ahead and returns its listbox options. The
+ * picker only queries once the dropdown is open, so a test has to open it
+ * before any candidate is on screen.
+ */
+function openWatcherPicker(): HTMLElement[] {
+  fireEvent.mouseDown(screen.getByRole("combobox", { name: /add a watcher/i }));
+  return screen.getAllByRole("option");
+}
+
+function removeButton(name: string): HTMLElement {
+  return screen.getByRole("button", {
+    name: new RegExp(`remove ${name} from the watch list`, "i"),
+  });
+}
+
 describe("WatchersWidget", () => {
-  it("renders an empty state when there are no watchers", () => {
-    renderWithRouter(<WatchersWidget watchers={[]} />);
+  beforeEach(() => {
+    mockCandidates();
+  });
+
+  it("names the record type in its empty state", () => {
+    renderWithRouter(<WatchersWidget entityKind="case" watchers={[]} />);
+    expect(screen.getByText("No one is watching this case.")).toBeInTheDocument();
+
+    renderWithRouter(<WatchersWidget entityKind="incident" watchers={[]} />);
     expect(
-      screen.getByText("No one is watching this case."),
+      screen.getByText("No one is watching this incident."),
     ).toBeInTheDocument();
   });
 
-  it("renders every watcher as a chip, marking the current user", () => {
-    renderWithRouter(<WatchersWidget watchers={WATCHERS} />);
+  it("lists every watcher, marking the current user", () => {
+    renderWithRouter(<WatchersWidget entityKind="case" watchers={WATCHERS} />);
     expect(screen.getByText("Jane Doe")).toBeInTheDocument();
     expect(screen.getByText("John Smith (you)")).toBeInTheDocument();
   });
 
-  it("hides the Add watcher action when onAdd is omitted", () => {
-    renderWithRouter(<WatchersWidget watchers={WATCHERS} />);
+  it("renders read-only — no picker, no remove controls — when onReplace is omitted", () => {
+    renderWithRouter(<WatchersWidget entityKind="case" watchers={WATCHERS} />);
     expect(
-      screen.queryByRole("button", { name: /add watcher/i }),
+      screen.queryByRole("combobox", { name: /add a watcher/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /from the watch list/i }),
     ).not.toBeInTheDocument();
   });
 
-  it("omits the per-chip remove affordance when onRemove is omitted", () => {
-    renderWithRouter(<WatchersWidget watchers={WATCHERS} />);
-    const chip = screen.getByText("Jane Doe").closest(".MuiChip-root");
-    expect(chip?.querySelector(".MuiChip-deleteIcon")).toBeFalsy();
+  it("still offers the picker when nobody is watching yet, so the first watcher can be added", () => {
+    const onReplace = vi.fn();
+    renderWithRouter(
+      <WatchersWidget entityKind="case" watchers={[]} onReplace={onReplace} />,
+    );
+    fireEvent.click(openWatcherPicker()[0]);
+    expect(onReplace).toHaveBeenCalledWith([CANDIDATE_ID], "add");
   });
 
-  it("calls onRemove with the watcher when its chip delete icon is clicked", () => {
-    const onRemove = vi.fn();
-    renderWithRouter(<WatchersWidget watchers={WATCHERS} onRemove={onRemove} />);
-    const chip = screen.getByText("Jane Doe").closest(".MuiChip-root");
-    const deleteIcon = chip?.querySelector(".MuiChip-deleteIcon");
-    expect(deleteIcon).toBeTruthy();
-    fireEvent.click(deleteIcon as Element);
-    expect(onRemove).toHaveBeenCalledWith(WATCHERS[0]);
+  it("adds by sending the whole existing list plus the new user, not just the new one", () => {
+    const onReplace = vi.fn();
+    renderWithRouter(
+      <WatchersWidget entityKind="case" watchers={WATCHERS} onReplace={onReplace} />,
+    );
+    fireEvent.click(openWatcherPicker()[0]);
+    expect(onReplace).toHaveBeenCalledWith(
+      [WATCHER_ONE_ID, WATCHER_TWO_ID, CANDIDATE_ID],
+      "add",
+    );
   });
 
-  it("opens an inline search panel on Add watcher and calls onAdd for a picked candidate — no dialog involved", () => {
-    mockCandidates();
-    const onAdd = vi.fn();
-    renderWithRouter(<WatchersWidget watchers={WATCHERS} onAdd={onAdd} />);
-
-    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: /add watcher/i }));
-    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole("button", { name: /jane smith/i }));
-    expect(onAdd).toHaveBeenCalledWith("jane.smith@example.com", "Jane Smith");
+  it("keeps people who are already watching out of the picker", () => {
+    renderWithRouter(
+      <WatchersWidget entityKind="case" watchers={WATCHERS} onReplace={vi.fn()} />,
+    );
+    const options = openWatcherPicker();
+    expect(options).toHaveLength(1);
+    expect(options[0]).toHaveTextContent("Jane Smith");
   });
 
-  it("closes the inline search panel when its cancel button is clicked", () => {
-    mockCandidates();
-    renderWithRouter(<WatchersWidget watchers={WATCHERS} onAdd={() => {}} />);
-    fireEvent.click(screen.getByRole("button", { name: /add watcher/i }));
+  it("removes by sending the whole list minus that watcher", () => {
+    const onReplace = vi.fn();
+    renderWithRouter(
+      <WatchersWidget entityKind="case" watchers={WATCHERS} onReplace={onReplace} />,
+    );
+    fireEvent.click(removeButton("Jane Doe"));
+    expect(onReplace).toHaveBeenCalledWith([WATCHER_TWO_ID], "remove");
+  });
+
+  it("blocks removing a case's only watcher, with the reason reachable by assistive tech", () => {
+    const onReplace = vi.fn();
+    renderWithRouter(
+      <WatchersWidget entityKind="case" watchers={ONE_WATCHER} onReplace={onReplace} />,
+    );
+
+    const button = removeButton("Jane Doe");
+    expect(button).toHaveAttribute("aria-disabled", "true");
+    // Focusable, not `disabled` — a disabled button leaves the tab order and
+    // takes the explanation for its own state with it.
+    expect(button).not.toBeDisabled();
+    const reason = document.getElementById(
+      button.getAttribute("aria-describedby") ?? "",
+    );
+    expect(reason).toHaveTextContent("A case must keep at least one watcher.");
+
+    fireEvent.click(button);
+    expect(onReplace).not.toHaveBeenCalled();
+  });
+
+  it("allows removing an incident's only watcher, clearing the list", () => {
+    const onReplace = vi.fn();
+    renderWithRouter(
+      <WatchersWidget
+        entityKind="incident"
+        watchers={ONE_WATCHER}
+        onReplace={onReplace}
+      />,
+    );
+
+    const button = removeButton("Jane Doe");
+    expect(button).not.toHaveAttribute("aria-disabled");
+    fireEvent.click(button);
+    expect(onReplace).toHaveBeenCalledWith([], "remove");
+  });
+
+  it("blocks add and remove while a write is in flight, so a double-click can't fire two replacements", () => {
+    const onReplace = vi.fn();
+    renderWithRouter(
+      <WatchersWidget
+        entityKind="case"
+        watchers={WATCHERS}
+        onReplace={onReplace}
+        isSaving
+      />,
+    );
+
+    fireEvent.click(removeButton("Jane Doe"));
+    expect(onReplace).not.toHaveBeenCalled();
     expect(
-      screen.getByPlaceholderText(/search people to add/i),
-    ).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: /cancel adding a watcher/i }));
-    expect(
-      screen.queryByPlaceholderText(/search people to add/i),
-    ).not.toBeInTheDocument();
+      screen.getByRole("combobox", { name: /add a watcher/i }),
+    ).toBeDisabled();
   });
 });
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.tsx
@@ -33,6 +33,7 @@ import {
   ArrowUpRight,
   Building,
   CheckCircle,
+  ClipboardList,
   Clock,
   Download,
   Eye,
@@ -50,7 +51,15 @@ import {
   Users,
   X,
 } from "@wso2/oxygen-ui-icons-react";
-import { useMemo, useRef, useState, type ChangeEvent, type JSX, type ReactNode } from "react";
+import {
+  Fragment,
+  useMemo,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type JSX,
+  type ReactNode,
+} from "react";
 import { Link as RouterLink } from "react-router";
 import { formatBytes } from "@utils/formatBytes";
 import DirectoryEntityChip from "@features/csm-admin/components/DirectoryEntityChip";
@@ -64,6 +73,7 @@ import type {
   CaseAuditEntry,
   CaseCustomerContext,
   CaseProductContext,
+  CaseRequestVariable,
   CaseTag,
   CaseTimeLogEntry,
   CaseWatcher,
@@ -1083,6 +1093,102 @@ export function AuditTimelineWidget({
             ))
         )}
       </Box>
+    </WidgetCard>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 8. Service-request "Request details"
+// ---------------------------------------------------------------------------
+
+/** Placeholder for a value the backing data source did not give us. */
+const NO_VALUE = "\u2014";
+
+/**
+ * The catalog, catalog item, and the answers the requester gave to that
+ * item's questions — the payload a service request is actually made of, and
+ * which the engineer working it otherwise cannot see anywhere in the portal.
+ *
+ * Renders even when `variables` is empty: an SR with no captured answers is a
+ * real upstream data problem, and hiding the card would make it invisible.
+ * An answer that is present but blank renders as an em dash, so "asked and
+ * left blank" stays distinguishable from "never asked".
+ */
+export function RequestDetailsWidget({
+  catalog,
+  catalogItem,
+  variables,
+}: {
+  catalog?: { id: string; name: string };
+  catalogItem?: { id: string; name: string };
+  /** In the backing data source's display order — never re-sorted here. */
+  variables?: CaseRequestVariable[];
+}): JSX.Element {
+  const answers = variables ?? [];
+  return (
+    <WidgetCard title="Request details" icon={<ClipboardList size={16} />}>
+      <MetaRow label="Catalog">
+        <Typography variant="body2">{catalog?.name || NO_VALUE}</Typography>
+      </MetaRow>
+      <MetaRow label="Catalog item">
+        <Typography variant="body2">{catalogItem?.name || NO_VALUE}</Typography>
+      </MetaRow>
+      {answers.length === 0 ? (
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 1.5 }}>
+          No request details captured.
+        </Typography>
+      ) : (
+        <Box
+          component="dl"
+          sx={{
+            display: "grid",
+            // Single column on narrow viewports so a long question and its
+            // answer stack instead of squeezing; two columns from sm up.
+            gridTemplateColumns: {
+              xs: "minmax(0, 1fr)",
+              sm: "minmax(0, 12rem) minmax(0, 1fr)",
+            },
+            columnGap: 1.5,
+            rowGap: 0.75,
+            alignItems: "baseline",
+            m: 0,
+            mt: 1.5,
+            pt: 1.5,
+            borderTop: 1,
+            borderColor: "divider",
+          }}
+        >
+          {answers.map((v, i) => (
+            // The data source guarantees no id per answer and question text
+            // is not guaranteed unique, so the index is part of the key.
+            <Fragment key={`${v.name}-${i}`}>
+              <Typography
+                component="dt"
+                variant="caption"
+                color="text.secondary"
+                sx={{ minWidth: 0, overflowWrap: "anywhere" }}
+              >
+                {v.name}
+              </Typography>
+              <Typography
+                component="dd"
+                variant="body2"
+                color={v.value ? "text.primary" : "text.secondary"}
+                sx={{
+                  m: 0,
+                  minWidth: 0,
+                  // Long single-token answers (paths, ids, URLs) must wrap
+                  // rather than push a horizontal scrollbar onto the page.
+                  overflowWrap: "anywhere",
+                  whiteSpace: "pre-wrap",
+                }}
+              >
+                {v.value || NO_VALUE}
+              </Typography>
+            </Fragment>
+          ))}
+        </Box>
+      )}
     </WidgetCard>
   );
 }

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.tsx
@@ -21,10 +21,7 @@ import {
   Chip,
   CircularProgress,
   IconButton,
-  InputAdornment,
   LinearProgress,
-  Skeleton,
-  TextField,
   Tooltip,
   Typography,
 } from "@wso2/oxygen-ui";
@@ -41,7 +38,6 @@ import {
   Link as LinkIcon,
   Paperclip,
   Plus,
-  Search,
   Server,
   Shield,
   Trash2,
@@ -53,9 +49,10 @@ import {
 } from "@wso2/oxygen-ui-icons-react";
 import {
   Fragment,
+  useCallback,
+  useId,
   useMemo,
   useRef,
-  useState,
   type ChangeEvent,
   type JSX,
   type ReactNode,
@@ -63,9 +60,8 @@ import {
 import { Link as RouterLink } from "react-router";
 import { formatBytes } from "@utils/formatBytes";
 import DirectoryEntityChip from "@features/csm-admin/components/DirectoryEntityChip";
-import { useDebouncedValue } from "@hooks/useDebouncedValue";
-import { useSearchUsers } from "@features/csm-users/api/useSearchUsers";
-import type { NormalizedUser } from "@features/csm-users/types/csmUsers";
+import { useSearchUsersByName } from "@api/useSearchUsersByName";
+import { userLabel } from "@features/csm-operations/utils/incidentFormOptions";
 import AttachmentPreviewDialog from "@features/csm-cases/components/AttachmentPreviewDialog";
 import { getAttachmentPreviewKind } from "@features/csm-cases/utils/attachmentPreview";
 import type {
@@ -76,7 +72,6 @@ import type {
   CaseRequestVariable,
   CaseTag,
   CaseTimeLogEntry,
-  CaseWatcher,
 } from "@features/csm-cases/types/csmCases";
 import { tierColor, tierLabel } from "@features/csm-cases/utils/caseTier";
 import {
@@ -84,7 +79,9 @@ import {
   formatDeploymentDate,
 } from "@features/csm-projects/utils/deployments";
 import type { ProjectDetails } from "@features/csm-projects/types/csmProjects";
-import type { BeDeployment } from "@api/backend/types";
+import type { BeDeployment, BeUser } from "@api/backend/types";
+import type { UserReference } from "@/types/userReference";
+import AsyncEntitySelect from "@components/AsyncEntitySelect";
 import RelativeTime from "@components/RelativeTime";
 import UserRefLink from "@components/UserRefLink";
 import RefreshButton from "@components/RefreshButton";
@@ -430,166 +427,119 @@ export function TagsWidget({
 // 3b. Watchers
 // ---------------------------------------------------------------------------
 
-function watcherFullName(u: NormalizedUser): string {
-  return u.name.trim() || u.userName;
+/**
+ * One entry on a record's watch list, in the shape both the case and the
+ * incident detail read models expose. `id` is the platform user UUID, which
+ * is also what the write side is keyed by — see {@link WatchersWidget}.
+ */
+export interface WatchListMember {
+  id: string;
+  name: string;
+  email?: string;
+  /** True for the signed-in engineer; renders a "(you)" suffix. */
+  isMe?: boolean;
+  /** Canonical user reference, when the read model carries one. */
+  user?: UserReference;
 }
 
 /**
- * Inline "search people, click to add" panel used by {@link WatchersWidget}.
- * Mounted only while the caller's "Add watcher" toggle is open, so the user
- * search (`POST /users/search`) isn't issued in the background — same pattern
- * as {@link AssignEngineerDialog} mounting only while its dialog is open.
+ * The single place the per-record-type watch-list rules live, so the two
+ * detail pages rendering {@link WatchersWidget} can't drift apart or carry
+ * their own copy of the "may the last watcher go?" flag.
+ *
+ * `minWatchers` is the asymmetry between the two. The incident update request
+ * declares its watch list as an *optional* list, so an explicitly empty one
+ * survives the round trip and clears the list. The case update request
+ * declares a plain list, which makes an empty one indistinguishable from an
+ * absent field, and the backend then rejects the whole request as changing
+ * nothing. Removing a case's only watcher is therefore not expressible at
+ * all, so the control is blocked rather than fired at a request already known
+ * to fail. Lifting it needs a deliberate change to the case update contract.
  */
-function WatcherAddPicker({
-  existingEmails,
-  disabled,
-  onPick,
-  onCancel,
-}: {
-  /** Lower-cased emails already on the watch list, filtered out of the results. */
-  existingEmails: string[];
-  disabled?: boolean;
-  onPick: (email: string, name: string) => void;
-  onCancel: () => void;
-}): JSX.Element {
-  const [input, setInput] = useState("");
-  const search = useDebouncedValue(input.trim(), 300);
-  const { data, isFetching, isError } = useSearchUsers({
-    filters: {
-      ...(search.length > 0 && { searchQuery: search }),
-      active: true,
-    },
-    pagination: { limit: 8, offset: 0 },
-  });
+const WATCH_LIST_RULES = {
+  case: {
+    noun: "case",
+    minWatchers: 1,
+    minWatchersReason: "A case must keep at least one watcher.",
+  },
+  incident: {
+    noun: "incident",
+    minWatchers: 0,
+    minWatchersReason: "",
+  },
+} as const;
 
-  const candidates = useMemo(
-    () =>
-      (data?.users ?? []).filter(
-        (u) =>
-          !!u.email &&
-          u.active !== false &&
-          !existingEmails.includes(u.email.toLowerCase()),
-      ),
-    [data, existingEmails],
-  );
+/** Record types that have an editable watch list. */
+export type WatchedEntityKind = keyof typeof WATCH_LIST_RULES;
 
-  return (
-    <Box
-      sx={{
-        mt: 1,
-        border: 1,
-        borderColor: "divider",
-        borderRadius: 1,
-        p: 1,
-        display: "flex",
-        flexDirection: "column",
-        gap: 0.75,
-      }}
-    >
-      <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
-        <TextField
-          value={input}
-          onChange={(e) => setInput(e.target.value)}
-          placeholder="Search people to add…"
-          size="small"
-          fullWidth
-          autoFocus
-          slotProps={{
-            input: {
-              startAdornment: (
-                <InputAdornment position="start">
-                  <Search size={14} />
-                </InputAdornment>
-              ),
-            },
-          }}
-        />
-        <IconButton
-          size="small"
-          onClick={onCancel}
-          aria-label="Cancel adding a watcher"
-        >
-          <X size={14} />
-        </IconButton>
-      </Box>
-      <Box sx={{ minHeight: 36 }}>
-        {isFetching ? (
-          <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5 }}>
-            {[0, 1].map((i) => (
-              <Skeleton key={i} variant="rounded" height={28} />
-            ))}
-          </Box>
-        ) : isError ? (
-          <Typography variant="caption" color="error">
-            Could not load people. Try again.
-          </Typography>
-        ) : candidates.length === 0 ? (
-          <Typography variant="caption" color="text.secondary">
-            {search ? "No matches." : "Type to search people…"}
-          </Typography>
-        ) : (
-          <Box sx={{ display: "flex", flexDirection: "column" }}>
-            {candidates.map((u) => (
-              <Button
-                key={u.id}
-                variant="text"
-                color="inherit"
-                size="small"
-                disabled={disabled}
-                onClick={() => onPick(u.email, watcherFullName(u))}
-                sx={{
-                  justifyContent: "flex-start",
-                  textTransform: "none",
-                  px: 0.75,
-                  py: 0.5,
-                  gap: 0.5,
-                }}
-              >
-                {watcherFullName(u)}
-                <Typography variant="caption" color="text.secondary">
-                  {u.email}
-                </Typography>
-              </Button>
-            ))}
-          </Box>
-        )}
-      </Box>
-    </Box>
-  );
-}
-
+/**
+ * Watch list for a case or an incident, with add/remove.
+ *
+ * Neither backend has an add-one/remove-one endpoint: both take the **whole**
+ * watch list as user UUIDs and replace what is stored. Sending only the user
+ * that changed silently wipes everyone else. So this widget — not its callers
+ * — computes the replacement list in {@link addWatcher}/{@link removeWatcher}
+ * and hands the finished array to `onReplace`; a page can only forward it.
+ *
+ * `entityKind` selects the rules in {@link WATCH_LIST_RULES}; nothing else
+ * about this component varies by record type.
+ */
 export function WatchersWidget({
+  entityKind,
   watchers,
-  onAdd,
-  onRemove,
+  onReplace,
   isSaving,
   onRefresh,
   isRefreshing,
   refreshedAt,
 }: {
-  watchers: CaseWatcher[];
-  /** Add a watcher by email — the caller PATCHes the full replacement watch
-   * list (`PATCH /cases/{id}` `{ watchList }`). Omit to hide the "Add
-   * watcher" control. */
-  onAdd?: (email: string, name: string) => void;
-  /** Remove a single watcher — the caller PATCHes the full replacement watch
-   * list minus this one. Omit to hide the per-chip remove affordance. */
-  onRemove?: (watcher: CaseWatcher) => void;
-  /** True while a watch-list PATCH is in flight; disables add/remove. */
+  /** Which record's watch list this is. Drives the copy and the rules. */
+  entityKind: WatchedEntityKind;
+  watchers: WatchListMember[];
+  /**
+   * Persist `nextWatcherIds` as the record's complete new watch list. Already
+   * the full replacement list, never a delta. Omit to render read-only.
+   */
+  onReplace?: (nextWatcherIds: string[], action: "add" | "remove") => void;
+  /** True while a watch-list write is in flight; blocks add and remove so a
+   * double-click can't fire two conflicting replacements. */
   isSaving?: boolean;
-  /** Re-runs the case-detail query the watch list comes from. Omit to hide
-   * the refresh control. */
+  /** Re-runs the detail query the watch list comes from. Omit to hide the
+   * refresh control. */
   onRefresh?: () => void;
   isRefreshing?: boolean;
   refreshedAt?: number;
 }): JSX.Element {
-  const [addOpen, setAddOpen] = useState(false);
-  const existingEmails = useMemo(
-    () =>
-      watchers
-        .filter((w): w is CaseWatcher & { email: string } => !!w.email)
-        .map((w) => w.email.toLowerCase()),
-    [watchers],
+  const rules = WATCH_LIST_RULES[entityKind];
+  const reasonId = useId();
+  const watcherIds = useMemo(() => watchers.map((w) => w.id), [watchers]);
+
+  // Below the floor the record type allows, removal isn't expressible at all
+  // (see WATCH_LIST_RULES), so the control is blocked with the reason rather
+  // than firing a request that is known to be rejected.
+  const belowFloorAfterRemoval = watchers.length <= rules.minWatchers;
+  const removalBlockedReason = belowFloorAfterRemoval ? rules.minWatchersReason : "";
+
+  const addWatcher = useCallback(
+    (userId: string) => {
+      if (!onReplace || !userId || isSaving) return;
+      // Already watching: nothing to write, and resending the same list would
+      // burn a request for no change.
+      if (watcherIds.includes(userId)) return;
+      onReplace([...watcherIds, userId], "add");
+    },
+    [onReplace, isSaving, watcherIds],
+  );
+
+  const removeWatcher = useCallback(
+    (watcher: WatchListMember) => {
+      if (!onReplace || isSaving || belowFloorAfterRemoval) return;
+      onReplace(
+        watcherIds.filter((id) => id !== watcher.id),
+        "remove",
+      );
+    },
+    [onReplace, isSaving, belowFloorAfterRemoval, watcherIds],
   );
 
   return (
@@ -597,66 +547,118 @@ export function WatchersWidget({
       title="Watchers"
       icon={<Users size={16} />}
       action={
-        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-          {onRefresh && (
-            <RefreshButton
-              onRefresh={onRefresh}
-              isFetching={!!isRefreshing}
-              updatedAt={refreshedAt}
-              label="Refresh watchers"
-            />
-          )}
-          {onAdd && (
-            <Button
-              size="small"
-              variant="text"
-              startIcon={<Plus size={14} />}
-              disabled={isSaving}
-              onClick={() => setAddOpen((v) => !v)}
-            >
-              Add watcher
-            </Button>
-          )}
-        </Box>
+        onRefresh && (
+          <RefreshButton
+            onRefresh={onRefresh}
+            isFetching={!!isRefreshing}
+            updatedAt={refreshedAt}
+            label="Refresh watchers"
+          />
+        )
       }
     >
       {watchers.length === 0 ? (
         <Typography variant="body2" color="text.secondary">
-          No one is watching this case.
+          {`No one is watching this ${rules.noun}.`}
         </Typography>
       ) : (
-        <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5 }}>
-          {watchers.map((w) => (
-            <Chip
-              key={w.id}
-              size="small"
-              variant="outlined"
-              icon={<User size={14} />}
-              label={
-                <UserRefLink
-                  name={w.isMe ? `${w.name} (you)` : w.name}
-                  email={w.user?.email || w.email}
-                  userId={w.user?.id}
-                />
-              }
-              disabled={isSaving}
-              onDelete={
-                onRemove && w.email ? () => onRemove(w) : undefined
-              }
-            />
-          ))}
+        <Box
+          component="ul"
+          aria-label="Watchers"
+          sx={{ listStyle: "none", m: 0, p: 0, display: "flex", flexDirection: "column" }}
+        >
+          {watchers.map((w) => {
+            const label = w.isMe ? `${w.name} (you)` : w.name;
+            return (
+              <Box
+                component="li"
+                key={w.id}
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 1,
+                  py: 0.5,
+                  minWidth: 0,
+                  borderBottom: 1,
+                  borderColor: "divider",
+                  "&:last-of-type": { borderBottom: 0 },
+                }}
+              >
+                <User size={14} />
+                <Typography
+                  variant="body2"
+                  component="span"
+                  sx={{ flex: 1, minWidth: 0, overflowWrap: "anywhere" }}
+                >
+                  <UserRefLink
+                    name={label}
+                    email={w.user?.email || w.email}
+                    userId={w.user?.id}
+                  />
+                </Typography>
+                {onReplace && (
+                  <Tooltip title={removalBlockedReason}>
+                    {/* aria-disabled, not disabled: a disabled button drops out
+                        of the tab order, taking the reason for its own
+                        disabling with it. This stays focusable, keeps its
+                        tooltip, and points at that reason via
+                        aria-describedby. */}
+                    <IconButton
+                      size="small"
+                      aria-label={`Remove ${label} from the watch list`}
+                      aria-disabled={belowFloorAfterRemoval || isSaving || undefined}
+                      aria-describedby={belowFloorAfterRemoval ? reasonId : undefined}
+                      onClick={() => removeWatcher(w)}
+                      sx={{
+                        color: "text.secondary",
+                        opacity: belowFloorAfterRemoval || isSaving ? 0.5 : 1,
+                      }}
+                    >
+                      <X size={14} />
+                    </IconButton>
+                  </Tooltip>
+                )}
+              </Box>
+            );
+          })}
         </Box>
       )}
-      {addOpen && onAdd && (
-        <WatcherAddPicker
-          existingEmails={existingEmails}
-          disabled={isSaving}
-          onPick={(email, name) => {
-            onAdd(email, name);
-            setAddOpen(false);
+      {onReplace && (
+        <Box sx={{ mt: 1.5 }}>
+          <AsyncEntitySelect<BeUser>
+            id={`${entityKind}-watchers-add`}
+            label="Add a watcher"
+            placeholder="Search people…"
+            // Held at "" so the field clears itself after each pick and reads
+            // as an "add another" control rather than a current selection.
+            value=""
+            onChange={addWatcher}
+            disabled={isSaving}
+            useSearch={useSearchUsersByName}
+            // useSearchUsersByName drops any user without an id, so every
+            // option here is guaranteed to have one.
+            getId={(u) => u.id!}
+            getLabel={userLabel}
+            excludeIds={watcherIds}
+            helperText={`Notified on updates to this ${rules.noun}.`}
+          />
+        </Box>
+      )}
+      {belowFloorAfterRemoval && onReplace && watchers.length > 0 && (
+        <Box
+          component="span"
+          id={reasonId}
+          sx={{
+            position: "absolute",
+            width: 1,
+            height: 1,
+            overflow: "hidden",
+            clip: "rect(0 0 0 0)",
+            whiteSpace: "nowrap",
           }}
-          onCancel={() => setAddOpen(false)}
-        />
+        >
+          {removalBlockedReason}
+        </Box>
       )}
     </WidgetCard>
   );

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.test.tsx
@@ -15,7 +15,7 @@
 // under the License.
 
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { JSX } from "react";
 import {
   MemoryRouter,
@@ -305,6 +305,10 @@ vi.mock("@features/csm-cases/components/CaseDetailWidgets", () => ({
   AttachmentsWidget: () => null,
   CustomerContextWidget: () => null,
   ProductContextWidget: () => null,
+  // Stubbed to a probe rather than `null`: the tests below assert only that
+  // the page mounts it for a service request and not for a plain case. The
+  // widget's own rendering is covered in CaseDetailWidgets.test.tsx.
+  RequestDetailsWidget: () => <div data-testid="request-details-widget" />,
   TagsWidget: () => null,
   WatchersWidget: () => null,
 }));
@@ -740,4 +744,58 @@ describe("CsmCaseDetailPage — time-card edit dialog reset on case change", () 
       screen.queryByTestId("log-time-card-dialog-probe"),
     ).not.toBeInTheDocument();
   });
+});
+
+describe("CsmCaseDetailPage — Request details card", () => {
+  function mockCaseType(caseType?: string): void {
+    useGetCsmCaseDetailMock.mockImplementation((id: string | undefined) => ({
+      data: id ? { ...buildCase(id), caseType } : undefined,
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+      isFetching: false,
+      dataUpdatedAt: 0,
+    }));
+  }
+
+  afterEach(() => {
+    useGetCsmCaseDetailMock.mockImplementation((id: string | undefined) => ({
+      data: id ? buildCase(id) : undefined,
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+      isFetching: false,
+      dataUpdatedAt: 0,
+    }));
+  });
+
+  it("renders the card in the Details tab of a service request", () => {
+    mockCaseType("service_request");
+
+    renderPageAt(
+      "/operations/service-requests/case-1?tab=details",
+      "/operations/service-requests/:caseId",
+    );
+
+    expect(screen.getByTestId("request-details-widget")).toBeInTheDocument();
+  });
+
+  it("does not render the card in the Details tab of a plain case", () => {
+    mockCaseType(undefined);
+
+    renderPageAt("/cases/case-1?tab=details");
+
+    expect(
+      screen.queryByTestId("request-details-widget"),
+    ).not.toBeInTheDocument();
+  });
+
+  // Not covered here: a service request opened through the generic
+  // /cases/:id route. The page's canonical-redirect gate bounces it to
+  // /operations/service-requests/:id behind a skeleton before any tab body
+  // renders, so `caseType`'s half of the signal can't be observed from that
+  // entry point. It is the same `isServiceRequest` value either way — the
+  // page computes it once (route || caseType) and this card reuses it.
 });

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.test.tsx
@@ -64,8 +64,9 @@ vi.mock("@hooks/useIdTokenClaims", () => ({
   }),
 }));
 
+const showErrorMock = vi.fn();
 vi.mock("@context/error-banner/ErrorBannerContext", () => ({
-  useErrorBanner: () => ({ showError: vi.fn() }),
+  useErrorBanner: () => ({ showError: showErrorMock }),
 }));
 vi.mock("@context/success-banner/SuccessBannerContext", () => ({
   useSuccessBanner: () => ({ showSuccess: vi.fn() }),
@@ -125,6 +126,9 @@ function buildCase(id: string): CsmCaseDetail {
   };
 }
 
+const WATCHER_ID = "00000000-0000-0000-0000-000000000001";
+const NEW_WATCHER_ID = "00000000-0000-0000-0000-000000000002";
+
 const useGetCsmCaseDetailMock = vi.fn();
 vi.mock("@features/csm-cases/api/useGetCsmCaseDetail", () => ({
   useGetCsmCaseDetail: (id: string | undefined) => useGetCsmCaseDetailMock(id),
@@ -139,9 +143,10 @@ useGetCsmCaseDetailMock.mockImplementation((id: string | undefined) => ({
   dataUpdatedAt: 0,
 }));
 
+const patchCaseMutateMock = vi.fn();
 vi.mock("@features/csm-cases/api/usePatchCsmCase", () => ({
   usePatchCsmCase: () => ({
-    mutate: vi.fn(),
+    mutate: patchCaseMutateMock,
     mutateAsync: vi.fn(),
     isPending: false,
   }),
@@ -310,7 +315,30 @@ vi.mock("@features/csm-cases/components/CaseDetailWidgets", () => ({
   // widget's own rendering is covered in CaseDetailWidgets.test.tsx.
   RequestDetailsWidget: () => <div data-testid="request-details-widget" />,
   TagsWidget: () => null,
-  WatchersWidget: () => null,
+  // Probe, not `null`: the real widget computes the replacement watch list and
+  // enforces the per-record-type rules (covered in CaseDetailWidgets.test.tsx).
+  // Here it just hands the page a finished list so these tests can see what
+  // the page does with it.
+  WatchersWidget: ({
+    entityKind,
+    watchers,
+    onReplace,
+  }: {
+    entityKind: string;
+    watchers: Array<{ id: string; name: string }>;
+    onReplace?: (nextWatcherIds: string[], action: "add" | "remove") => void;
+  }) => (
+    <div data-testid="watchers-widget" data-entity-kind={entityKind}>
+      <button
+        type="button"
+        onClick={() =>
+          onReplace?.([...watchers.map((w) => w.id), NEW_WATCHER_ID], "add")
+        }
+      >
+        stub add watcher
+      </button>
+    </div>
+  ),
 }));
 vi.mock("@features/csm-cases/components/CallRequestsWidget", () => ({
   CallRequestsWidget: () => null,
@@ -368,6 +396,7 @@ vi.mock("@features/csm-timecards/components/LogTimeCardDialog", () => ({
 }));
 
 // Imported after the mocks above so the module picks them up.
+import { BackendApiError } from "@api/backend/client";
 import CsmCaseDetailPage from "@features/csm-cases/pages/CsmCaseDetailPage";
 
 // Renders the real route pathname, so the test can assert the router itself
@@ -798,4 +827,65 @@ describe("CsmCaseDetailPage — Request details card", () => {
   // renders, so `caseType`'s half of the signal can't be observed from that
   // entry point. It is the same `isServiceRequest` value either way — the
   // page computes it once (route || caseType) and this card reuses it.
+});
+
+describe("CsmCaseDetailPage — Watchers tab", () => {
+  function openWatchers(): void {
+    useGetCsmCaseDetailMock.mockImplementation((id: string | undefined) => ({
+      data: id
+        ? {
+            ...buildCase(id),
+            watchers: [
+              {
+                id: WATCHER_ID,
+                name: "Jane Doe",
+                email: "jane.doe@example.com",
+              },
+            ],
+          }
+        : undefined,
+      isLoading: false,
+      isError: false,
+    }));
+    renderPage();
+    fireEvent.click(screen.getByRole("tab", { name: /watchers/i }));
+  }
+
+  it("renders the watch list as a case's, so the last-watcher rule applies", () => {
+    openWatchers();
+    expect(screen.getByTestId("watchers-widget")).toHaveAttribute(
+      "data-entity-kind",
+      "case",
+    );
+  });
+
+  it("PATCHes the whole replacement list, keeping the watchers already on it", () => {
+    openWatchers();
+    fireEvent.click(screen.getByRole("button", { name: /stub add watcher/i }));
+
+    expect(patchCaseMutateMock).toHaveBeenCalledWith(
+      { watchList: [WATCHER_ID, NEW_WATCHER_ID] },
+      expect.anything(),
+    );
+  });
+
+  it("surfaces the backend's own message when the write is rejected, leaving the list untouched", () => {
+    openWatchers();
+    fireEvent.click(screen.getByRole("button", { name: /stub add watcher/i }));
+
+    const handlers = patchCaseMutateMock.mock.calls.at(-1)?.[1] as {
+      onError: (err: unknown) => void;
+    };
+    handlers.onError(
+      new BackendApiError(400, 'watchList contains invalid UUID: "not-a-uuid"'),
+    );
+
+    expect(showErrorMock).toHaveBeenCalledWith(
+      'watchList contains invalid UUID: "not-a-uuid"',
+      expect.anything(),
+    );
+    // No optimistic write happened, so nothing needs unwinding: the widget is
+    // still showing the server's list.
+    expect(screen.getByTestId("watchers-widget")).toBeInTheDocument();
+  });
 });

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -117,6 +117,7 @@ import {
   AttachmentsWidget,
   CustomerContextWidget,
   ProductContextWidget,
+  RequestDetailsWidget,
   TagsWidget,
   WatchersWidget,
 } from "@features/csm-cases/components/CaseDetailWidgets";
@@ -2240,6 +2241,19 @@ export default function CsmCaseDetailPage(): JSX.Element {
                 }}
               />
             </Card>
+          )}
+          {/* Service-request-only: the catalog answers the requester filled
+              in. Reuses the page's single `isServiceRequest` signal (route +
+              loaded caseType) rather than adding a parallel one. Always
+              rendered for an SR — the widget itself shows the empty state, so
+              a request that captured no answers stays visible as a data
+              problem instead of silently vanishing. */}
+          {isServiceRequest && (
+            <RequestDetailsWidget
+              catalog={c.catalog}
+              catalogItem={c.catalogItem}
+              variables={c.requestVariables}
+            />
           )}
           <CustomerContextWidget
             ctx={c.customerContext}

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -160,7 +160,6 @@ import { CASE_TYPE_LABEL } from "@features/csm-cases/utils/caseType";
 import type {
   CaseAttachment,
   CaseLifecycleAction,
-  CaseWatcher,
   CreateChangeRequestFromCaseNavState,
   CreateIncidentFromCaseNavState,
   CreateRelatedCaseNavState,
@@ -187,14 +186,6 @@ function MetaCell({
     </Box>
   );
 }
-
-// Watcher add/remove PATCHes resubmit the full watch list as an array of
-// emails (ServiceNow's watch_list only round-trips as `EmailString[]`), so a
-// watcher with no email on file can't be represented at all — see
-// onAddWatcher/onRemoveWatcher below.
-const EMAILLESS_WATCHER_ERROR =
-  "Can't update watchers: one or more current watchers has no email on file, " +
-  "so this list can't be safely resubmitted.";
 
 const LIFECYCLE_TOAST: Record<CaseLifecycleAction, string> = {
   start_work: "Started work on this case.",
@@ -1338,69 +1329,41 @@ export default function CsmCaseDetailPage(): JSX.Element {
     [patchCase, showError],
   );
 
-  // Watchers are edited inline in the Watchers tab (see WatchersWidget); the
-  // backend has no add/remove-one endpoint, only a full-list-replace
-  // `PATCH /cases/{id}` (`watchList`), and that PATCH is an array of emails
-  // (ServiceNow's watch_list only round-trips as `EmailString[]`), so both add
-  // and remove compute the next full list from the currently loaded case.
-  // A watcher with no email on file can't be represented in that list at all —
-  // rather than silently dropping them from the watch list, block the mutation
-  // and surface it. ServiceNow only; the backend rejects it on another data
-  // source and the error surfaces via showError.
-  const onAddWatcher = useCallback(
-    (email: string) => {
-      if (!data) return;
-      if (data.watchers.some((w) => !w.email)) {
-        showError(EMAILLESS_WATCHER_ERROR);
-        return;
-      }
-      const current = data.watchers
-        .filter((w): w is CaseWatcher & { email: string } => !!w.email)
-        .map((w) => w.email);
-      if (current.some((e) => e.toLowerCase() === email.toLowerCase())) return;
+  // Watchers are edited inline in the Watchers tab. There is no
+  // add-one/remove-one endpoint: `PATCH /cases/{id}` takes the *whole*
+  // `watchList` as user UUIDs and replaces what is stored. WatchersWidget
+  // computes that replacement list (add and remove alike) and hands it over
+  // finished, so this page only forwards it — see WatchersWidget's doc
+  // comment for why the last watcher on a case can't be removed. Supported by
+  // one data source only; the backend rejects it on the others and the error
+  // surfaces via showError.
+  const onReplaceWatchers = useCallback(
+    (nextWatcherIds: string[], action: "add" | "remove") => {
       patchCase.mutate(
-        { watchList: [...current, email] },
+        { watchList: nextWatcherIds },
         {
           onSuccess: () =>
             setFeedback({
-              message: "Watcher added.",
+              message: action === "add" ? "Watcher added." : "Watcher removed.",
               severity: "success",
               sticky: false,
             }),
-          onError: (err) => showError("Could not add the watcher.", err),
+          onError: (err) => {
+            // The watch-list 400s name the offending value (an unknown or
+            // malformed user id), which is far more actionable than a generic
+            // string — same treatment as every other 4xx on this page.
+            const msg =
+              err instanceof BackendApiError && err.status < 500 && err.message
+                ? err.message
+                : action === "add"
+                  ? "Could not add the watcher."
+                  : "Could not remove the watcher.";
+            showError(msg, err);
+          },
         },
       );
     },
-    [data, patchCase, showError],
-  );
-
-  const onRemoveWatcher = useCallback(
-    (watcher: CaseWatcher) => {
-      if (!data || !watcher.email) return;
-      if (data.watchers.some((w) => !w.email && w.id !== watcher.id)) {
-        showError(EMAILLESS_WATCHER_ERROR);
-        return;
-      }
-      const next = data.watchers
-        .filter(
-          (w): w is CaseWatcher & { email: string } =>
-            !!w.email && w.email.toLowerCase() !== watcher.email?.toLowerCase(),
-        )
-        .map((w) => w.email);
-      patchCase.mutate(
-        { watchList: next },
-        {
-          onSuccess: () =>
-            setFeedback({
-              message: "Watcher removed.",
-              severity: "success",
-              sticky: false,
-            }),
-          onError: (err) => showError("Could not remove the watcher.", err),
-        },
-      );
-    },
-    [data, patchCase, showError],
+    [patchCase, showError],
   );
 
   const onSetAutocloseHold = useCallback(
@@ -2358,9 +2321,9 @@ export default function CsmCaseDetailPage(): JSX.Element {
               linked record. Add/remove are inline here (no separate dialog);
               "Manage watchers…" in the action bar just jumps to this tab. */}
           <WatchersWidget
+            entityKind="case"
             watchers={c.watchers}
-            onAdd={onAddWatcher}
-            onRemove={onRemoveWatcher}
+            onReplace={onReplaceWatchers}
             isSaving={patchCase.isPending}
             onRefresh={() => void refetchCaseDetail()}
             isRefreshing={isFetchingCaseDetail}

--- a/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
@@ -268,6 +268,16 @@ export interface CaseLinkedItem {
   href?: string;
 }
 
+/**
+ * One answered catalog-item question on a service request. `value` is `""`
+ * when the question was asked and left blank — the UI renders that as an em
+ * dash so it stays distinguishable from a question that was never asked.
+ */
+export interface CaseRequestVariable {
+  name: string;
+  value: string;
+}
+
 export interface CaseTag {
   id: string;
   label: string;
@@ -531,6 +541,20 @@ export interface CsmCaseDetail extends CsmCaseRow {
     /** Subject, or `null` when the record has none — never `""`. */
     name: string | null;
   }[];
+  /**
+   * The catalog and catalog item a service request was raised against.
+   * Absent for every other case type.
+   */
+  catalog?: { id: string; name: string };
+  catalogItem?: { id: string; name: string };
+  /**
+   * The answers the requester gave to the catalog item's questions, in the
+   * backing data source's display order. Absent when the request carried no
+   * answers; an individual `value` of `""` means the question was asked and
+   * left blank, which is deliberately distinct from the question never being
+   * asked at all.
+   */
+  requestVariables?: CaseRequestVariable[];
   /**
    * Where the case sits in the backing data source's staged auto-closure
    * sequence (ServiceNow only). Read-only; `undefined`/`"DEFAULT"` means no

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/CatalogVariableFields.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/CatalogVariableFields.test.tsx
@@ -1,0 +1,222 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import type { BeCatalogItemVariable } from "@api/backend/types";
+
+// The rich-text editor pulls in the whole Lexical stack for the Description
+// field, which none of these assertions touch — stub it to a marker so the
+// suite stays a fast, focused test of control selection.
+vi.mock("@components/rich-text-editor/Editor", () => ({
+  default: () => <div data-testid="rich-text-editor" />,
+}));
+
+import CatalogVariableFields from "@features/csm-operations/components/CatalogVariableFields";
+
+/** Opens a MUI select by its accessible name and returns its option list. */
+function openSelect(name: RegExp | string): HTMLElement {
+  fireEvent.mouseDown(screen.getByRole("combobox", { name }));
+  return screen.getByRole("listbox");
+}
+
+function renderFields(
+  variables: BeCatalogItemVariable[],
+  values: Record<string, string> = {},
+): { onChange: ReturnType<typeof vi.fn> } {
+  const onChange = vi.fn();
+  render(
+    <CatalogVariableFields
+      variables={variables}
+      values={values}
+      onChange={onChange}
+    />,
+  );
+  return { onChange };
+}
+
+const TARGET_CLOUD: BeCatalogItemVariable = {
+  id: "11111111-1111-1111-1111-111111111111",
+  questionText: "Target cloud",
+  order: 100,
+  type: "select",
+  choices: [
+    { value: "aws", text: "AWS", order: 100 },
+    { value: "azure", text: "Azure", order: 200 },
+  ],
+};
+
+const NOTES: BeCatalogItemVariable = {
+  id: "22222222-2222-2222-2222-222222222222",
+  questionText: "Notes",
+  order: 200,
+  type: "multi_line_text",
+};
+
+describe("CatalogVariableFields — choice lists", () => {
+  it("renders a variable with choices as a select labelled by its question text", () => {
+    renderFields([TARGET_CLOUD]);
+
+    const select = screen.getByRole("combobox", { name: /target cloud/i });
+    expect(select).toBeInTheDocument();
+  });
+
+  it("offers the supplied choices, using `text` as the visible label", () => {
+    renderFields([TARGET_CLOUD]);
+
+    const listbox = openSelect(/target cloud/i);
+    expect(within(listbox).getByRole("option", { name: "AWS" })).toBeInTheDocument();
+    expect(within(listbox).getByRole("option", { name: "Azure" })).toBeInTheDocument();
+    expect(within(listbox).getAllByRole("option")).toHaveLength(2);
+  });
+
+  it("submits the choice's `value`, not its display `text`", () => {
+    const { onChange } = renderFields([TARGET_CLOUD]);
+
+    openSelect(/target cloud/i);
+    fireEvent.click(screen.getByRole("option", { name: "AWS" }));
+
+    expect(onChange).toHaveBeenCalledWith(TARGET_CLOUD.id, "aws");
+  });
+
+  it("falls back to `value` as the label when `text` is null", () => {
+    renderFields([
+      {
+        ...TARGET_CLOUD,
+        choices: [{ value: "aws", text: null, order: 100 }],
+      },
+    ]);
+
+    const listbox = openSelect(/target cloud/i);
+    expect(within(listbox).getByRole("option", { name: "aws" })).toBeInTheDocument();
+  });
+
+  it("skips a malformed choice whose `value` is null", () => {
+    renderFields([
+      {
+        ...TARGET_CLOUD,
+        choices: [
+          { value: "aws", text: "AWS", order: 100 },
+          { value: null, text: null, order: null },
+        ],
+      },
+    ]);
+
+    const listbox = openSelect(/target cloud/i);
+    expect(within(listbox).getAllByRole("option")).toHaveLength(1);
+    expect(within(listbox).getByRole("option", { name: "AWS" })).toBeInTheDocument();
+  });
+
+  it("preserves the order the backend returned the choices in", () => {
+    renderFields([
+      {
+        ...TARGET_CLOUD,
+        // Reversed relative to `order` on purpose: the array order wins.
+        choices: [
+          { value: "azure", text: "Azure", order: 200 },
+          { value: "aws", text: "AWS", order: 100 },
+        ],
+      },
+    ]);
+
+    const listbox = openSelect(/target cloud/i);
+    expect(
+      within(listbox)
+        .getAllByRole("option")
+        .map((o) => o.textContent),
+    ).toEqual(["Azure", "AWS"]);
+  });
+
+  it("keeps the select keyboard-operable and reflects the current value", () => {
+    renderFields([TARGET_CLOUD], { [TARGET_CLOUD.id]: "azure" });
+
+    const select = screen.getByRole("combobox", { name: /target cloud/i });
+    expect(select).toHaveTextContent("Azure");
+    // MUI renders the trigger as a focusable, ARIA-labelled combobox.
+    expect(select).toHaveAttribute("tabindex", "0");
+  });
+
+  it("falls back to a text input when every choice is unusable", () => {
+    renderFields([
+      {
+        id: "33333333-3333-3333-3333-333333333333",
+        questionText: "Ticket reference",
+        order: 100,
+        type: "single_line_text",
+        choices: [{ value: null, text: "Broken", order: null }],
+      },
+    ]);
+
+    expect(
+      screen.queryByRole("combobox", { name: /ticket reference/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("textbox", { name: /ticket reference/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("still renders a text control for a variable with no `choices` key at all", () => {
+    renderFields([NOTES]);
+
+    expect(
+      screen.queryByRole("combobox", { name: /notes/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: /notes/i })).toBeInTheDocument();
+  });
+
+  it("keeps the Yes/No fallback for a choice-type variable the data source sent no list for", () => {
+    renderFields([
+      {
+        id: "44444444-4444-4444-4444-444444444444",
+        questionText: "Requires downtime",
+        order: 100,
+        type: "Select Box",
+      },
+    ]);
+
+    const listbox = openSelect(/requires downtime/i);
+    expect(
+      within(listbox)
+        .getAllByRole("option")
+        .map((o) => o.textContent),
+    ).toEqual(["Yes", "No"]);
+  });
+
+  it("leaves the required flag on a choice field unchanged", () => {
+    renderFields([TARGET_CLOUD]);
+
+    expect(screen.getByRole("combobox", { name: /target cloud/i })).toHaveAttribute(
+      "aria-required",
+      "true",
+    );
+  });
+
+  it("keeps a File Copy Path field optional even when it carries choices", () => {
+    renderFields([
+      {
+        id: "55555555-5555-5555-5555-555555555555",
+        questionText: "File Copy Path",
+        order: 100,
+        type: "single_line_text",
+        choices: [{ value: "/srv/data", text: "/srv/data", order: 100 }],
+      },
+    ]);
+
+    const select = screen.getByRole("combobox", { name: /file copy path/i });
+    expect(select).not.toHaveAttribute("aria-required", "true");
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/CatalogVariableFields.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/CatalogVariableFields.tsx
@@ -35,6 +35,7 @@ import {
   isDescriptionField,
   isFileCopyPathField,
   isMultiLineField,
+  usableChoices,
   variableLabel,
 } from "@features/csm-operations/utils/catalogVariables";
 import { formatDateTimeLocal, parseDateTimeLocal } from "@utils/dateTime";
@@ -49,11 +50,12 @@ interface CatalogVariableFieldsProps {
 }
 
 /**
- * Renders a catalog item's user-editable variables, one input per variable,
- * picking the control from the ServiceNow variable `type`/label: Yes/No select,
- * multi-line text, datetime picker, rich-text Description, or single-line text.
- * File Copy Path fields are optional; attachment fields are handled by the
- * page's shared attachments section and are not rendered here.
+ * Renders a catalog item's user-editable variables, one input per variable.
+ * A variable that carries a usable choice list becomes a real select over
+ * those options; otherwise the control comes from the variable `type`/label:
+ * Yes/No select, multi-line text, datetime picker, rich-text Description, or
+ * single-line text. File Copy Path fields are optional; attachment fields are
+ * handled by the page's shared attachments section and are not rendered here.
  */
 export default function CatalogVariableFields({
   variables,
@@ -66,6 +68,42 @@ export default function CatalogVariableFields({
         {variables.map((v) => {
           const value = values[v.id] ?? "";
           const label = variableLabel(v);
+
+          // A supplied choice list wins over every type heuristic below: it
+          // is the backing data source's own answer set for this question, so
+          // the field must offer exactly those options. `choices` is omitted
+          // for non-choice variables, and an all-malformed list yields none —
+          // both fall through to the heuristics rather than rendering an
+          // empty dropdown.
+          const choices = usableChoices(v);
+          if (choices.length > 0) {
+            const labelId = `sr-var-${v.id}-label`;
+            // Same required rule as the control this replaces for a given
+            // variable — File Copy Path stays optional, everything else is
+            // mandatory. No mandatory flag exists in the contract yet.
+            const required = !isFileCopyPathField(v);
+            return (
+              <Grid key={v.id} size={{ xs: 12, sm: 6 }}>
+                <FormControl fullWidth size="small" required={required}>
+                  <InputLabel id={labelId}>{label}</InputLabel>
+                  <Select
+                    labelId={labelId}
+                    label={label}
+                    value={value}
+                    onChange={(e) => onChange(v.id, String(e.target.value))}
+                  >
+                    {choices.map((c) => (
+                      // The submitted value is the option's `value`; `text`
+                      // is display only.
+                      <MenuItem key={c.value} value={c.value}>
+                        {c.label}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+              </Grid>
+            );
+          }
 
           if (isChoiceField(v)) {
             const labelId = `sr-var-${v.id}-label`;

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestActionBar.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestActionBar.test.tsx
@@ -1,0 +1,244 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import ChangeRequestActionBar from "@features/csm-operations/components/ChangeRequestActionBar";
+import type { BeChangeRequestDetail } from "@api/backend/types";
+
+const BASE_CR: BeChangeRequestDetail = {
+  id: "chg-1",
+  number: "CHG0009988",
+  subject: "Upgrade the gateway cluster",
+  createdOn: "2026-01-01T00:00:00Z",
+  state: "new",
+  type: "normal",
+  assignedTeam: { id: "team-1", name: "Platform" },
+};
+
+function renderBar(
+  overrides: Partial<BeChangeRequestDetail>,
+  { isPending = false, onAction = vi.fn() } = {},
+): { onAction: ReturnType<typeof vi.fn>; container: HTMLElement } {
+  const { container } = render(
+    <ChangeRequestActionBar
+      cr={{ ...BASE_CR, ...overrides }}
+      isPending={isPending}
+      onAction={onAction}
+    />,
+  );
+  return { onAction, container };
+}
+
+/** Open the overflow menu, which must exist for this to succeed. */
+function openMenu(): void {
+  fireEvent.click(screen.getByRole("button", { name: /change state/i }));
+}
+
+describe("ChangeRequestActionBar — driven only by legalNextStates", () => {
+  it("renders nothing when legalNextStates is absent", () => {
+    const { container } = renderBar({ legalNextStates: undefined });
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when legalNextStates is empty", () => {
+    const { container } = renderBar({ legalNextStates: [] });
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when the only entry is the CR's own current state", () => {
+    const { container } = renderBar({ state: "assess", legalNextStates: ["assess"] });
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("offers only the states present in legalNextStates, not the whole lifecycle", () => {
+    renderBar({ state: "scheduled", legalNextStates: ["implement", "canceled"] });
+    // "Start implementation" is the forward move -> primary button.
+    expect(
+      screen.getByRole("button", { name: /start implementation/i }),
+    ).toBeInTheDocument();
+    openMenu();
+    expect(screen.getByRole("menuitem", { name: /cancel change/i })).toBeInTheDocument();
+    // Never offered: legal elsewhere in the lifecycle, but not in this array.
+    expect(screen.queryByRole("menuitem", { name: /^close$/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: /roll back/i })).not.toBeInTheDocument();
+  });
+
+  it("renders a state it has no curated config for, via the generic fallback", () => {
+    renderBar({ state: "review", legalNextStates: ["closed", "awaiting_vendor"] });
+    openMenu();
+    // Sentence-cased from the raw value — no frontend change was needed for it.
+    expect(
+      screen.getByRole("menuitem", { name: /^awaiting vendor$/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("dispatches an uncurated state verbatim, not a normalised guess at it", () => {
+    const { onAction } = renderBar({
+      state: "review",
+      legalNextStates: ["closed", "awaiting_vendor"],
+    });
+    openMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: /^awaiting vendor$/i }));
+    expect(onAction).toHaveBeenCalledWith("awaiting_vendor");
+  });
+});
+
+describe("ChangeRequestActionBar — exactly one primary button", () => {
+  it("promotes only the first forward move, even with six legal targets", () => {
+    renderBar({
+      state: "new",
+      legalNextStates: [
+        "closed",
+        "customer_review",
+        "review",
+        "implement",
+        "scheduled",
+        "assess",
+        "rollback",
+        "canceled",
+      ],
+    });
+    const contained = screen
+      .getAllByRole("button")
+      .filter((b) => b.className.includes("MuiButton-contained"));
+    expect(contained).toHaveLength(1);
+    expect(contained[0]).toHaveTextContent(/request approval/i);
+  });
+
+  it("puts every non-promoted target behind the Change state menu", () => {
+    renderBar({ state: "new", legalNextStates: ["assess", "scheduled", "canceled"] });
+    expect(screen.getByRole("button", { name: /request approval/i })).toBeInTheDocument();
+    openMenu();
+    expect(screen.getByRole("menuitem", { name: /^schedule$/i })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /cancel change/i })).toBeInTheDocument();
+  });
+
+  it("renders no overflow menu at all when the single legal target is the primary one", () => {
+    renderBar({ state: "scheduled", legalNextStates: ["implement"] });
+    expect(screen.getByRole("button", { name: /start implementation/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /change state/i })).not.toBeInTheDocument();
+  });
+
+  it("never promotes a destructive target: with only rollback and cancel legal, there is no primary button", () => {
+    renderBar({ state: "implement", legalNextStates: ["rollback", "canceled"] });
+    expect(screen.queryByRole("button", { name: /roll back/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /cancel change/i })).not.toBeInTheDocument();
+    openMenu();
+    expect(screen.getByRole("menuitem", { name: /roll back/i })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /cancel change/i })).toBeInTheDocument();
+  });
+
+  it("never promotes an uncurated target, even when it is the only legal one", () => {
+    renderBar({ state: "review", legalNextStates: ["awaiting_vendor"] });
+    expect(
+      screen.queryByRole("button", { name: /^awaiting vendor$/i }),
+    ).not.toBeInTheDocument();
+    openMenu();
+    expect(screen.getByRole("menuitem", { name: /^awaiting vendor$/i })).toBeInTheDocument();
+  });
+});
+
+describe("ChangeRequestActionBar — labels are the action, not the destination", () => {
+  it.each([
+    ["assess", /request approval/i],
+    ["scheduled", /^schedule$/i],
+    ["implement", /start implementation/i],
+    ["review", /mark implemented/i],
+    ["customer_review", /send for customer review/i],
+    ["closed", /^close$/i],
+  ])("labels the %s transition as the action taken", (target, label) => {
+    renderBar({ state: "new", legalNextStates: [target] });
+    expect(screen.getByRole("button", { name: label })).toBeInTheDocument();
+  });
+});
+
+describe("ChangeRequestActionBar — dispatch", () => {
+  it("calls onAction with the target when the primary button is clicked", () => {
+    const { onAction } = renderBar({ state: "new", legalNextStates: ["assess"] });
+    fireEvent.click(screen.getByRole("button", { name: /request approval/i }));
+    expect(onAction).toHaveBeenCalledWith("assess");
+  });
+
+  it("calls onAction with the target when a menu item is clicked, and closes the menu", () => {
+    const { onAction } = renderBar({
+      state: "implement",
+      legalNextStates: ["review", "rollback"],
+    });
+    openMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: /roll back/i }));
+    expect(onAction).toHaveBeenCalledWith("rollback");
+  });
+});
+
+describe("ChangeRequestActionBar — pending state", () => {
+  it("disables the primary button while a transition is in flight", () => {
+    renderBar({ state: "new", legalNextStates: ["assess", "canceled"] }, { isPending: true });
+    expect(screen.getByRole("button", { name: /request approval/i })).toBeDisabled();
+  });
+
+  it("disables the Change state menu trigger while a transition is in flight", () => {
+    renderBar({ state: "new", legalNextStates: ["assess", "canceled"] }, { isPending: true });
+    expect(screen.getByRole("button", { name: /change state/i })).toBeDisabled();
+  });
+});
+
+describe("ChangeRequestActionBar — per-target blocked reasons", () => {
+  it("disables the assess transition when the CR has no assigned team", () => {
+    const { onAction } = renderBar({
+      state: "new",
+      legalNextStates: ["assess"],
+      assignedTeam: null,
+    });
+    const button = screen.getByRole("button", { name: /request approval/i });
+    expect(button).toBeDisabled();
+    fireEvent.click(button);
+    expect(onAction).not.toHaveBeenCalled();
+  });
+
+  it("exposes the blocked reason to keyboard users via a focusable, labelled wrapper", () => {
+    renderBar({ state: "new", legalNextStates: ["assess"], assignedTeam: null });
+    const focusTarget = screen
+      .getByRole("button", { name: /request approval/i })
+      .closest('[tabindex="0"]');
+    expect(focusTarget).not.toBeNull();
+    expect(focusTarget).toHaveAttribute(
+      "aria-label",
+      "Request approval: Set an assigned team before requesting approval",
+    );
+  });
+
+  it("leaves the transition enabled once the prerequisite is met", () => {
+    renderBar({ state: "new", legalNextStates: ["assess"] });
+    expect(screen.getByRole("button", { name: /request approval/i })).toBeEnabled();
+  });
+
+  it("blocks only the target with the unmet prerequisite, leaving the others clickable", () => {
+    // `assess` is blocked *and* is first in FORWARD_ORDER, so it stays the
+    // promoted (disabled) primary while `scheduled` stays usable behind the
+    // menu — a blocked target must not take the rest of the bar down with it.
+    const { onAction } = renderBar({
+      state: "new",
+      legalNextStates: ["scheduled", "assess"],
+      assignedTeam: null,
+    });
+    expect(screen.getByRole("button", { name: /request approval/i })).toBeDisabled();
+    openMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: /^schedule$/i }));
+    expect(onAction).toHaveBeenCalledWith("scheduled");
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestActionBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestActionBar.tsx
@@ -1,0 +1,282 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Box, Button, Menu, MenuItem, Tooltip, Typography } from "@wso2/oxygen-ui";
+import {
+  ArrowRight,
+  Ban,
+  CalendarClock,
+  CheckCircle,
+  ChevronDown,
+  Play,
+  Send,
+  Undo2,
+  UserCheck,
+} from "@wso2/oxygen-ui-icons-react";
+import { useState, type JSX } from "react";
+import {
+  changeRequestTransitionLabel,
+  isDestructiveChangeRequestTransition,
+} from "@features/csm-operations/utils/changeRequests";
+import type { BeChangeRequestDetail } from "@api/backend/types";
+
+/**
+ * Icon and colour for a transition *into* a given state. The button LABEL is
+ * never stored here — it always comes from `changeRequestTransitionLabel`,
+ * same "no invented verbs" convention as `IncidentActionBar`'s `TargetConfig`.
+ */
+type TargetConfig = {
+  color: "primary" | "success" | "warning" | "error";
+  icon: JSX.Element;
+};
+
+const TARGET_CONFIG: Record<string, TargetConfig> = {
+  assess: { color: "primary", icon: <Send size={16} /> },
+  scheduled: { color: "primary", icon: <CalendarClock size={16} /> },
+  implement: { color: "primary", icon: <Play size={16} /> },
+  review: { color: "primary", icon: <CheckCircle size={16} /> },
+  customer_review: { color: "primary", icon: <UserCheck size={16} /> },
+  closed: { color: "primary", icon: <CheckCircle size={16} /> },
+  rollback: { color: "error", icon: <Undo2 size={16} /> },
+  canceled: { color: "error", icon: <Ban size={16} /> },
+};
+
+/**
+ * Presentation for a transition this bar has no curated config for — a state
+ * the backend added, or one of the lifecycle states with no agreed action
+ * verb yet. Same fallback convention as `IncidentActionBar`'s
+ * `DEFAULT_TARGET_CONFIG`, so a new backend state stays renderable and
+ * clickable with no frontend change.
+ */
+const DEFAULT_TARGET_CONFIG: TargetConfig = {
+  color: "primary",
+  icon: <ArrowRight size={16} />,
+};
+
+/**
+ * Forward progression through the lifecycle. Used for one thing only: picking
+ * which single target gets the primary button when several are legal at once.
+ * This array owns ordering, never legality.
+ *
+ * Membership doubles as primary-button eligibility, so it deliberately
+ * excludes the destructive off-ramps and every uncurated state: without a
+ * curated action label there is no evidence a target is *the* expected
+ * forward move, so it goes in the overflow menu instead.
+ */
+const FORWARD_ORDER: readonly string[] = [
+  "assess",
+  "scheduled",
+  "implement",
+  "review",
+  "customer_review",
+  "closed",
+];
+
+/** Menu ordering: forward moves first, destructive off-ramps last. */
+const MENU_ORDER: readonly string[] = [...FORWARD_ORDER, "rollback", "canceled"];
+
+/** Sort key for a target: curated order first, uncurated states after. */
+function menuRank(target: string): number {
+  const index = MENU_ORDER.indexOf(target);
+  return index === -1 ? MENU_ORDER.length : index;
+}
+
+/**
+ * Prerequisites the state machine itself doesn't express. A target can be
+ * legal per `legalNextStates` and still be blocked by a missing field the
+ * backing system checks on write — offering it anyway just round-trips into a
+ * rejection, so it renders disabled with the reason instead.
+ *
+ * Deliberately a per-target map rather than a special case for `assess`: the
+ * same situation (legal transition, unmet prerequisite) can apply to any
+ * target.
+ */
+const TARGET_BLOCKED_REASON: Record<
+  string,
+  (cr: BeChangeRequestDetail) => string | null
+> = {
+  assess: (cr) =>
+    cr.assignedTeam ? null : "Set an assigned team before requesting approval",
+};
+
+interface ChangeRequestActionBarProps {
+  cr: BeChangeRequestDetail;
+  /** True while a state-changing request for this CR is in flight. */
+  isPending: boolean;
+  /**
+   * Fired with the target state the engineer picked. The caller decides how
+   * to apply it — a direct patch for most targets, or (for the destructive
+   * ones flagged by `changeRequestTransitionRequiresReason`) opening a dialog
+   * to collect the reason first. Same split of responsibility as
+   * `IncidentActionBar` + `CsmIncidentDetailPage`.
+   */
+  onAction: (target: string) => void;
+}
+
+/**
+ * Lifecycle action bar for the change-request detail page. Every button comes
+ * straight from the record's own `legalNextStates` — there is no client-side
+ * state machine here and no hardcoded state list, so a transition the backend
+ * starts offering appears with no frontend change. Renders nothing when
+ * `legalNextStates` is empty or absent (a terminal state, or a record the
+ * caller may not transition).
+ *
+ * Exactly one target — the first forward move present, by `FORWARD_ORDER` —
+ * gets a primary button; everything else sits behind a "Change state"
+ * overflow menu. The header this sits in already carries Back, Clone and
+ * Edit, so a row of eight buttons would bury the one action the engineer
+ * actually wants.
+ */
+export default function ChangeRequestActionBar({
+  cr,
+  isPending,
+  onAction,
+}: ChangeRequestActionBarProps): JSX.Element | null {
+  const [stateMenuAnchor, setStateMenuAnchor] = useState<HTMLElement | null>(null);
+
+  const targets = Array.from(
+    new Set((cr.legalNextStates ?? []).filter((s) => !!s && s !== cr.state)),
+  ).sort((a, b) => menuRank(a) - menuRank(b));
+  if (targets.length === 0) return null;
+
+  const primaryTarget = targets.find((t) => FORWARD_ORDER.includes(t));
+  const menuTargets = targets.filter((t) => t !== primaryTarget);
+
+  const dispatch = (target: string): void => {
+    setStateMenuAnchor(null);
+    onAction(target);
+  };
+
+  const configFor = (target: string): TargetConfig =>
+    TARGET_CONFIG[target] ?? DEFAULT_TARGET_CONFIG;
+
+  const blockedReason = (target: string): string | null =>
+    TARGET_BLOCKED_REASON[target]?.(cr) ?? null;
+
+  const renderPrimary = (target: string): JSX.Element => {
+    const { color, icon } = configFor(target);
+    const label = changeRequestTransitionLabel(target);
+    const reason = blockedReason(target);
+    if (reason) {
+      return (
+        <Tooltip title={reason}>
+          {/* A disabled button is not focusable, so the tooltip alone would be
+              unreachable by keyboard — this focusable, labelled wrapper is
+              what exposes the reason to assistive tech. */}
+          <Box
+            component="span"
+            tabIndex={0}
+            aria-label={`${label}: ${reason}`}
+            sx={{ flexShrink: 0 }}
+          >
+            <Button
+              size="small"
+              variant="contained"
+              color={color}
+              startIcon={icon}
+              disabled
+              sx={{ flexShrink: 0 }}
+            >
+              {label}
+            </Button>
+          </Box>
+        </Tooltip>
+      );
+    }
+    return (
+      <Button
+        size="small"
+        variant="contained"
+        color={color}
+        startIcon={icon}
+        loading={isPending}
+        onClick={() => dispatch(target)}
+        sx={{ flexShrink: 0 }}
+      >
+        {label}
+      </Button>
+    );
+  };
+
+  return (
+    <Box sx={{ display: "flex", gap: 1, flexShrink: 0 }}>
+      {primaryTarget && renderPrimary(primaryTarget)}
+      {menuTargets.length > 0 && (
+        <>
+          <Button
+            size="small"
+            variant={primaryTarget ? "outlined" : "contained"}
+            color="primary"
+            endIcon={<ChevronDown size={16} />}
+            disabled={isPending}
+            aria-haspopup="menu"
+            onClick={(e) => setStateMenuAnchor(e.currentTarget)}
+          >
+            Change state
+          </Button>
+          <Menu
+            anchorEl={stateMenuAnchor}
+            open={!!stateMenuAnchor}
+            onClose={() => setStateMenuAnchor(null)}
+            // `disabledItemsFocusable` keeps a blocked entry reachable by
+            // keyboard so its reason can actually be read, instead of the item
+            // being skipped over silently.
+            MenuListProps={{
+              "aria-label": "Change state",
+              disabledItemsFocusable: true,
+            }}
+          >
+            {menuTargets.map((target) => {
+              const { color, icon } = configFor(target);
+              const label = changeRequestTransitionLabel(target);
+              const reason = blockedReason(target);
+              const destructive = isDestructiveChangeRequestTransition(target);
+              return (
+                <MenuItem
+                  key={target}
+                  disabled={isPending || !!reason}
+                  aria-label={reason ? `${label}: ${reason}` : label}
+                  onClick={() => {
+                    if (reason) return;
+                    dispatch(target);
+                  }}
+                  sx={{ gap: 1.25, minHeight: 36, alignItems: "flex-start", py: 1 }}
+                >
+                  <Box sx={{ color: `${color}.main`, display: "flex", mt: 0.25 }}>
+                    {icon}
+                  </Box>
+                  <Box sx={{ display: "flex", flexDirection: "column", minWidth: 0 }}>
+                    <Box
+                      component="span"
+                      sx={{ color: destructive ? "error.main" : "inherit" }}
+                    >
+                      {label}
+                    </Box>
+                    {reason && (
+                      <Typography variant="caption" color="text.secondary">
+                        {reason}
+                      </Typography>
+                    )}
+                  </Box>
+                </MenuItem>
+              );
+            })}
+          </Menu>
+        </>
+      )}
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestTransitionReasonDialog.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestTransitionReasonDialog.test.tsx
@@ -14,6 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import type { ComponentProps } from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
@@ -21,7 +22,7 @@ import ChangeRequestTransitionReasonDialog from "@features/csm-operations/compon
 
 function renderDialog(
   props: Partial<
-    React.ComponentProps<typeof ChangeRequestTransitionReasonDialog>
+    ComponentProps<typeof ChangeRequestTransitionReasonDialog>
   > = {},
 ): {
   onConfirm: ReturnType<typeof vi.fn>;

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestTransitionReasonDialog.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestTransitionReasonDialog.test.tsx
@@ -1,0 +1,139 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import ChangeRequestTransitionReasonDialog from "@features/csm-operations/components/ChangeRequestTransitionReasonDialog";
+
+function renderDialog(
+  props: Partial<
+    React.ComponentProps<typeof ChangeRequestTransitionReasonDialog>
+  > = {},
+): {
+  onConfirm: ReturnType<typeof vi.fn>;
+  onClose: ReturnType<typeof vi.fn>;
+} {
+  const onConfirm = vi.fn();
+  const onClose = vi.fn();
+  render(
+    <ChangeRequestTransitionReasonDialog
+      target="canceled"
+      isSubmitting={false}
+      onClose={onClose}
+      onConfirm={onConfirm}
+      {...props}
+    />,
+  );
+  return { onConfirm, onClose };
+}
+
+const reasonField = (): HTMLElement => screen.getByLabelText(/reason/i);
+
+describe("ChangeRequestTransitionReasonDialog — reason is required", () => {
+  it("disables the confirm action while the reason is empty", () => {
+    renderDialog();
+    expect(screen.getByRole("button", { name: /cancel change/i })).toBeDisabled();
+  });
+
+  it("keeps the confirm action disabled for a whitespace-only reason", () => {
+    renderDialog();
+    fireEvent.change(reasonField(), { target: { value: "   \n  " } });
+    expect(screen.getByRole("button", { name: /cancel change/i })).toBeDisabled();
+  });
+
+  it("enables the confirm action once the reason has content", () => {
+    renderDialog();
+    fireEvent.change(reasonField(), { target: { value: "Superseded by CHG0009999." } });
+    expect(screen.getByRole("button", { name: /cancel change/i })).toBeEnabled();
+  });
+
+  it("passes the trimmed reason to onConfirm", () => {
+    const { onConfirm } = renderDialog();
+    fireEvent.change(reasonField(), {
+      target: { value: "  Superseded by another change.  " },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /cancel change/i }));
+    expect(onConfirm).toHaveBeenCalledWith("Superseded by another change.");
+  });
+});
+
+describe("ChangeRequestTransitionReasonDialog — per-target copy", () => {
+  it("uses rollback wording and confirm label for the rollback target", () => {
+    renderDialog({ target: "rollback" });
+    expect(screen.getByRole("heading", { name: /roll back this change/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^roll back$/i })).toBeInTheDocument();
+  });
+
+  it("uses cancellation wording and confirm label for the canceled target", () => {
+    renderDialog({ target: "canceled" });
+    expect(
+      screen.getByRole("heading", { name: /cancel this change request/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /cancel change/i })).toBeInTheDocument();
+  });
+
+  it("still renders for a target it has no curated copy for", () => {
+    renderDialog({ target: "awaiting_vendor" });
+    expect(screen.getByRole("heading", { name: /awaiting vendor/i })).toBeInTheDocument();
+    expect(reasonField()).toBeInTheDocument();
+  });
+});
+
+describe("ChangeRequestTransitionReasonDialog — in-flight and error states", () => {
+  it("disables both actions and the field while submitting", () => {
+    renderDialog({ isSubmitting: true });
+    expect(screen.getByRole("button", { name: /close/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /cancel change/i })).toBeDisabled();
+    expect(reasonField()).toBeDisabled();
+  });
+
+  it("renders no alert by default", () => {
+    renderDialog();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("surfaces the caller's error message inline", () => {
+    renderDialog({
+      error: "Your reason was recorded as a comment, but the state did not change.",
+    });
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      /recorded as a comment, but the state did not change/i,
+    );
+  });
+
+  it("locks the reason field once it has already been recorded, so a retry can't post it twice", () => {
+    renderDialog({ reasonRecorded: true });
+    expect(reasonField()).toBeDisabled();
+    expect(
+      screen.getByText(/already recorded as a comment/i),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("ChangeRequestTransitionReasonDialog — dismissal", () => {
+  it("closes on Escape", () => {
+    const { onClose } = renderDialog();
+    fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape", code: "Escape" });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("does not close on Escape while submitting", () => {
+    const { onClose } = renderDialog({ isSubmitting: true });
+    fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape", code: "Escape" });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestTransitionReasonDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestTransitionReasonDialog.tsx
@@ -1,0 +1,155 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Alert,
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  TextField,
+} from "@wso2/oxygen-ui";
+import { useState, type JSX } from "react";
+import { changeRequestTransitionLabel } from "@features/csm-operations/utils/changeRequests";
+
+/** Per-target copy for the two destructive transitions. */
+const TRANSITION_COPY: Record<
+  string,
+  { title: string; body: string; confirmLabel: string }
+> = {
+  rollback: {
+    title: "Roll back this change?",
+    body:
+      "This moves the change request into Rollback to record that the implemented change is being reversed. It can't be undone from here.",
+    confirmLabel: "Roll back",
+  },
+  canceled: {
+    title: "Cancel this change request?",
+    body:
+      "This closes the change request as canceled. It can't be reopened from here, and any approvals already given are lost.",
+    confirmLabel: "Cancel change",
+  },
+};
+
+function copyFor(target: string): { title: string; body: string; confirmLabel: string } {
+  return (
+    TRANSITION_COPY[target] ?? {
+      title: `${changeRequestTransitionLabel(target)}?`,
+      body: "This change to the record can't be undone from here.",
+      confirmLabel: changeRequestTransitionLabel(target),
+    }
+  );
+}
+
+interface ChangeRequestTransitionReasonDialogProps {
+  /** Target lifecycle state being confirmed, e.g. `rollback` or `canceled`. */
+  target: string;
+  /** True while the reason comment and/or the state change are in flight. */
+  isSubmitting: boolean;
+  /**
+   * User-facing message for the most recent failed attempt, if any. Rendered
+   * inline so the engineer sees exactly how far the attempt got — in
+   * particular whether the reason was already recorded and must not be
+   * retyped.
+   */
+  error?: string | null;
+  /**
+   * True once the reason has been recorded as a comment. The field locks and
+   * a retry re-sends only the state change, so retrying after a failed patch
+   * can't post the same reason twice.
+   */
+  reasonRecorded?: boolean;
+  onClose: () => void;
+  onConfirm: (reason: string) => void;
+}
+
+/**
+ * Confirmation for a destructive change-request transition (`rollback`,
+ * `canceled`). Both are effectively irreversible and process requires a
+ * stated reason, so the confirm action stays disabled until the Reason field
+ * has content.
+ *
+ * The reason is *not* part of the patch body — the change-request PATCH
+ * contract has no reason or comment field. The caller records it as an
+ * ordinary comment on the change request and only then patches the state; see
+ * `CsmChangeRequestDetailPage`. This dialog only collects it.
+ */
+export default function ChangeRequestTransitionReasonDialog({
+  target,
+  isSubmitting,
+  error,
+  reasonRecorded,
+  onClose,
+  onConfirm,
+}: ChangeRequestTransitionReasonDialogProps): JSX.Element {
+  const [reason, setReason] = useState("");
+  const { title, body, confirmLabel } = copyFor(target);
+  const canSubmit = reason.trim().length > 0 && !isSubmitting;
+
+  return (
+    <Dialog
+      open
+      onClose={() => {
+        if (!isSubmitting) onClose();
+      }}
+      maxWidth="xs"
+      fullWidth
+      aria-labelledby="cr-transition-reason-title"
+    >
+      <DialogTitle id="cr-transition-reason-title">{title}</DialogTitle>
+      <DialogContent dividers>
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 2, pt: 0.5 }}>
+          {error && <Alert severity="error">{error}</Alert>}
+          <DialogContentText variant="body2">{body}</DialogContentText>
+          <TextField
+            label="Reason"
+            required
+            autoFocus
+            multiline
+            minRows={3}
+            fullWidth
+            size="small"
+            value={reason}
+            disabled={isSubmitting || reasonRecorded}
+            onChange={(e) => setReason(e.target.value)}
+            helperText={
+              reasonRecorded
+                ? "Already recorded as a comment — retrying will only change the state."
+                : "Recorded as a comment on this change request before the state changes."
+            }
+          />
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button color="inherit" onClick={onClose} disabled={isSubmitting}>
+          Close
+        </Button>
+        <Button
+          variant="contained"
+          color="error"
+          onClick={() => onConfirm(reason.trim())}
+          disabled={!canSubmit}
+          loading={isSubmitting}
+        >
+          {confirmLabel}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/EditChangeRequestDialog.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/EditChangeRequestDialog.test.tsx
@@ -18,6 +18,10 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 import type { BeChangeRequestDetail, BePatchChangeRequestPayload } from "@api/backend/types";
+import {
+  sanitizeRichTextHtml,
+  stripHtmlTagsPreservingLineBreaks,
+} from "@utils/sanitizeHtml";
 
 // The "Assignment group" picker goes through useSearchGroups, which hits the
 // backend client via react-query — stub it out (same approach as
@@ -186,8 +190,9 @@ describe("EditChangeRequestDialog — rollback and test plans", () => {
       target: { value: "Redeploy the previous image tag." },
     });
     fireEvent.click(saveButton());
+    // Sent as rich text: the field stores and re-renders HTML.
     expect(onSave).toHaveBeenCalledWith({
-      rollbackPlan: "Redeploy the previous image tag.",
+      rollbackPlan: "<p>Redeploy the previous image tag.</p>",
     });
   });
 
@@ -195,7 +200,9 @@ describe("EditChangeRequestDialog — rollback and test plans", () => {
     const { onSave } = renderDialog();
     fireEvent.change(testPlanField(), { target: { value: "Run the regression suite." } });
     fireEvent.click(saveButton());
-    expect(onSave).toHaveBeenCalledWith({ testPlan: "Run the regression suite." });
+    expect(onSave).toHaveBeenCalledWith({
+      testPlan: "<p>Run the regression suite.</p>",
+    });
   });
 
   it("sends both plans, and nothing else, when both were edited", () => {
@@ -204,8 +211,8 @@ describe("EditChangeRequestDialog — rollback and test plans", () => {
     fireEvent.change(testPlanField(), { target: { value: "Run the regression suite." } });
     fireEvent.click(saveButton());
     expect(onSave).toHaveBeenCalledWith({
-      rollbackPlan: "Roll the image back.",
-      testPlan: "Run the regression suite.",
+      rollbackPlan: "<p>Roll the image back.</p>",
+      testPlan: "<p>Run the regression suite.</p>",
     });
   });
 
@@ -219,11 +226,42 @@ describe("EditChangeRequestDialog — rollback and test plans", () => {
     expect(onSave).toHaveBeenCalledWith({ isCustomerApproved: true });
   });
 
+  // An intentional clear must stay an empty string, not become an empty
+  // paragraph: `<p></p>` would read as "this plan says nothing" rather than
+  // "there is no plan".
   it("treats clearing a stored plan as a real edit and sends the empty value", () => {
     const { onSave } = renderDialog({ rollbackPlan: "<p>Restore the previous release.</p>" });
     fireEvent.change(rollbackPlanField(), { target: { value: "" } });
     fireEvent.click(saveButton());
     expect(onSave).toHaveBeenCalledWith({ rollbackPlan: "" });
+  });
+
+  it("sends \"\" rather than an empty paragraph for a whitespace-only plan", () => {
+    const { onSave } = renderDialog({ rollbackPlan: "<p>Restore the previous release.</p>" });
+    fireEvent.change(rollbackPlanField(), { target: { value: "   \n  " } });
+    fireEvent.click(saveButton());
+    expect(onSave).toHaveBeenCalledWith({ rollbackPlan: "" });
+  });
+
+  // The other half of the seeding fix: an edited plan is sent as rich text, so
+  // the line breaks the engineer typed survive the round trip and a typed `<`
+  // or `&` can't drop the rest of the plan when it is rendered back.
+  it("escapes and keeps the line breaks of an edited plan", () => {
+    const typed = "Stop the rollout if error rate < 1% & rising.\nRedeploy the previous tag.";
+    const { onSave } = renderDialog();
+    fireEvent.change(rollbackPlanField(), { target: { value: typed } });
+    fireEvent.click(saveButton());
+
+    const patch = onSave.mock.calls[0][0];
+    expect(patch.rollbackPlan).toBe(
+      "<p>Stop the rollout if error rate &lt; 1% &amp; rising.<br />Redeploy the previous tag.</p>",
+    );
+    // What is stored has to survive the render-side sanitizer and come back
+    // as exactly what was typed — this is the same value the dialog will
+    // re-seed from next time it opens.
+    expect(
+      stripHtmlTagsPreservingLineBreaks(sanitizeRichTextHtml(patch.rollbackPlan ?? "")),
+    ).toBe(typed);
   });
 
   it("leaves Save disabled until a plan is actually changed", () => {

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/EditChangeRequestDialog.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/EditChangeRequestDialog.test.tsx
@@ -230,6 +230,38 @@ describe("EditChangeRequestDialog — rollback and test plans", () => {
     renderDialog({ rollbackPlan: "<p>Restore the previous release.</p>" });
     expect(saveButton()).toBeDisabled();
   });
+
+  // Regression: the strip used to drop block boundaries, so a stored
+  // multi-paragraph plan was seeded into the field as one run-on line. Because
+  // dirty-tracking is a string compare against the seeded value, saving any
+  // unrelated field afterwards could write that flattened text back over the
+  // stored content.
+  it("keeps paragraph boundaries when seeding a multi-paragraph stored plan", () => {
+    renderDialog({
+      rollbackPlan: "<p>Stop the rollout.</p><p>Redeploy the previous tag.</p>",
+    });
+    expect(rollbackPlanField()).toHaveValue(
+      "Stop the rollout.\n\nRedeploy the previous tag.",
+    );
+  });
+
+  it("keeps <br> line breaks and list items on separate lines", () => {
+    renderDialog({
+      rollbackPlan: "line one<br />line two",
+      testPlan: "<ul><li>check health</li><li>check latency</li></ul>",
+    });
+    expect(rollbackPlanField()).toHaveValue("line one\nline two");
+    expect(testPlanField()).toHaveValue("check health\n\ncheck latency");
+  });
+
+  it("still keeps a multi-paragraph plan out of the patch when it was not edited", () => {
+    const { onSave } = renderDialog({
+      rollbackPlan: "<p>Stop the rollout.</p><p>Redeploy the previous tag.</p>",
+    });
+    fireEvent.click(approvedSwitch());
+    fireEvent.click(saveButton());
+    expect(onSave).toHaveBeenCalledWith({ isCustomerApproved: true });
+  });
 });
 
 describe("EditChangeRequestDialog — planned end must be after planned start", () => {
@@ -241,6 +273,18 @@ describe("EditChangeRequestDialog — planned end must be after planned start", 
     // legend) — hence `getAllByText`.
     expect(screen.getAllByText("Planned start").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Planned end").length).toBeGreaterThan(0);
+  });
+
+  // The patch payload cannot express "remove the planned date" (an omitted key
+  // means "leave it alone"), so a clear affordance would look like it worked
+  // and then save nothing. Removed from both pickers until the payload can
+  // express it.
+  it("offers no clear affordance on either picker", () => {
+    renderDialog({
+      plannedStartOn: "2026-03-01 10:00:00",
+      plannedEndOn: "2026-03-01 12:00:00",
+    });
+    expect(screen.queryByRole("button", { name: /clear/i })).not.toBeInTheDocument();
   });
 
   it("flags an end that is before the start, and blocks the save", () => {

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/EditChangeRequestDialog.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/EditChangeRequestDialog.test.tsx
@@ -14,14 +14,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 import type { BeChangeRequestDetail, BePatchChangeRequestPayload } from "@api/backend/types";
-import {
-  sanitizeRichTextHtml,
-  stripHtmlTagsPreservingLineBreaks,
-} from "@utils/sanitizeHtml";
+
 
 // The "Assignment group" picker goes through useSearchGroups, which hits the
 // backend client via react-query — stub it out (same approach as
@@ -30,6 +27,57 @@ const useSearchGroupsMock = vi.fn(() => ({ data: [], isFetching: false, isError:
 vi.mock("@api/useSearchGroups", () => ({
   useSearchGroups: (...args: unknown[]) => useSearchGroupsMock(...(args as [])),
 }));
+
+/**
+ * Stand-in for the rich-text editor: a textarea whose value is the HTML.
+ *
+ * It deliberately reproduces the two behaviours the dialog's dirty-tracking
+ * has to cope with, because a simpler stub would let the "untouched field
+ * stays out of the patch" tests pass for the wrong reason:
+ *
+ *  - it rewrites the markup it loads (the real editor wraps text in
+ *    `<span style="white-space: pre-wrap;">`), so the HTML coming out never
+ *    equals the stored HTML going in, and
+ *  - it emits that rewritten value once on mount — but only when there was
+ *    something to load, exactly as the real one does.
+ */
+const normalizeLikeEditor = (html: string): string =>
+  html.replace(
+    /<p>([\s\S]*?)<\/p>/g,
+    '<p><span style="white-space: pre-wrap;">$1</span></p>',
+  );
+
+vi.mock("@components/rich-text-editor/Editor", async () => {
+  const { useEffect, useRef, useState } = await import("react");
+  function EditorStub({
+    value,
+    onChange,
+    disabled,
+  }: {
+    value?: string;
+    onChange?: (html: string) => void;
+    disabled?: boolean;
+  }) {
+    const [html, setHtml] = useState(value ? normalizeLikeEditor(value) : "");
+    const seededRef = useRef(false);
+    useEffect(() => {
+      if (seededRef.current || !value?.trim()) return;
+      seededRef.current = true;
+      onChange?.(normalizeLikeEditor(value));
+    }, [value, onChange]);
+    return (
+      <textarea
+        value={html}
+        disabled={disabled}
+        onChange={(e) => {
+          setHtml(e.target.value);
+          onChange?.(e.target.value);
+        }}
+      />
+    );
+  }
+  return { default: EditorStub };
+});
 
 import EditChangeRequestDialog from "@features/csm-operations/components/EditChangeRequestDialog";
 
@@ -164,18 +212,29 @@ describe("EditChangeRequestDialog — save error surfacing", () => {
 // ---------------------------------------------------------------------------
 
 /** The "Rollback plan" textarea. */
-const rollbackPlanField = (): HTMLElement => screen.getByLabelText(/rollback plan/i);
+// The editor takes no native label, so each plan is reached through the
+// labelled group wrapping it — the same association assistive tech uses.
+const planEditor = (name: RegExp): HTMLElement =>
+  within(screen.getByRole("group", { name })).getByRole("textbox");
+
+const rollbackPlanField = (): HTMLElement => planEditor(/rollback plan/i);
 /** The "Test plan" textarea. */
-const testPlanField = (): HTMLElement => screen.getByLabelText(/test plan/i);
+const testPlanField = (): HTMLElement => planEditor(/test plan/i);
 
 describe("EditChangeRequestDialog — rollback and test plans", () => {
-  it("seeds each plan field from the stored value, with the stored markup stripped", () => {
+  it("seeds each plan field from the stored rich text, markup and all", () => {
     renderDialog({
       rollbackPlan: "<p>Restore the previous release.</p>",
       testPlan: "<p>Smoke the gateway health endpoint.</p>",
     });
-    expect(rollbackPlanField()).toHaveValue("Restore the previous release.");
-    expect(testPlanField()).toHaveValue("Smoke the gateway health endpoint.");
+    // Whatever the editor makes of the stored HTML, the stored content is
+    // what it was handed — no plain-text round trip in between.
+    expect(rollbackPlanField()).toHaveValue(
+      normalizeLikeEditor("<p>Restore the previous release.</p>"),
+    );
+    expect(testPlanField()).toHaveValue(
+      normalizeLikeEditor("<p>Smoke the gateway health endpoint.</p>"),
+    );
   });
 
   it("renders both fields empty when the change request has no plans yet", () => {
@@ -187,10 +246,9 @@ describe("EditChangeRequestDialog — rollback and test plans", () => {
   it("sends only the rollback plan when only that field was edited", () => {
     const { onSave } = renderDialog();
     fireEvent.change(rollbackPlanField(), {
-      target: { value: "Redeploy the previous image tag." },
+      target: { value: "<p>Redeploy the previous image tag.</p>" },
     });
     fireEvent.click(saveButton());
-    // Sent as rich text: the field stores and re-renders HTML.
     expect(onSave).toHaveBeenCalledWith({
       rollbackPlan: "<p>Redeploy the previous image tag.</p>",
     });
@@ -198,7 +256,9 @@ describe("EditChangeRequestDialog — rollback and test plans", () => {
 
   it("sends only the test plan when only that field was edited", () => {
     const { onSave } = renderDialog();
-    fireEvent.change(testPlanField(), { target: { value: "Run the regression suite." } });
+    fireEvent.change(testPlanField(), {
+      target: { value: "<p>Run the regression suite.</p>" },
+    });
     fireEvent.click(saveButton());
     expect(onSave).toHaveBeenCalledWith({
       testPlan: "<p>Run the regression suite.</p>",
@@ -207,8 +267,12 @@ describe("EditChangeRequestDialog — rollback and test plans", () => {
 
   it("sends both plans, and nothing else, when both were edited", () => {
     const { onSave } = renderDialog();
-    fireEvent.change(rollbackPlanField(), { target: { value: "Roll the image back." } });
-    fireEvent.change(testPlanField(), { target: { value: "Run the regression suite." } });
+    fireEvent.change(rollbackPlanField(), {
+      target: { value: "<p>Roll the image back.</p>" },
+    });
+    fireEvent.change(testPlanField(), {
+      target: { value: "<p>Run the regression suite.</p>" },
+    });
     fireEvent.click(saveButton());
     expect(onSave).toHaveBeenCalledWith({
       rollbackPlan: "<p>Roll the image back.</p>",
@@ -216,6 +280,10 @@ describe("EditChangeRequestDialog — rollback and test plans", () => {
     });
   });
 
+  // The load-time rewrite makes this the sharp edge of the whole dialog: the
+  // editor's HTML never equals the stored HTML, so a naive string compare
+  // against `cr.rollbackPlan` would mark both plans dirty on open and patch
+  // fields nobody touched.
   it("keeps an untouched plan out of the patch even when the CR already has one stored", () => {
     const { onSave } = renderDialog({
       rollbackPlan: "<p>Restore the previous release.</p>",
@@ -226,9 +294,23 @@ describe("EditChangeRequestDialog — rollback and test plans", () => {
     expect(onSave).toHaveBeenCalledWith({ isCustomerApproved: true });
   });
 
-  // An intentional clear must stay an empty string, not become an empty
-  // paragraph: `<p></p>` would read as "this plan says nothing" rather than
-  // "there is no plan".
+  it("keeps an untouched multi-paragraph plan out of the patch", () => {
+    const { onSave } = renderDialog({
+      rollbackPlan: "<p>Stop the rollout.</p><p>Redeploy the previous tag.</p>",
+    });
+    fireEvent.click(approvedSwitch());
+    fireEvent.click(saveButton());
+    expect(onSave).toHaveBeenCalledWith({ isCustomerApproved: true });
+  });
+
+  it("leaves Save disabled on open when a plan is already stored", () => {
+    renderDialog({ rollbackPlan: "<p>Restore the previous release.</p>" });
+    expect(saveButton()).toBeDisabled();
+  });
+
+  // An intentional clear must stay an empty string, not become the editor's
+  // empty paragraph: `<p><br></p>` would read as "this plan says nothing"
+  // rather than "there is no plan".
   it("treats clearing a stored plan as a real edit and sends the empty value", () => {
     const { onSave } = renderDialog({ rollbackPlan: "<p>Restore the previous release.</p>" });
     fireEvent.change(rollbackPlanField(), { target: { value: "" } });
@@ -236,69 +318,49 @@ describe("EditChangeRequestDialog — rollback and test plans", () => {
     expect(onSave).toHaveBeenCalledWith({ rollbackPlan: "" });
   });
 
-  it("sends \"\" rather than an empty paragraph for a whitespace-only plan", () => {
+  it("sends \"\" rather than an empty paragraph when the editor is emptied", () => {
     const { onSave } = renderDialog({ rollbackPlan: "<p>Restore the previous release.</p>" });
-    fireEvent.change(rollbackPlanField(), { target: { value: "   \n  " } });
+    fireEvent.change(rollbackPlanField(), { target: { value: "<p><br></p>" } });
     fireEvent.click(saveButton());
     expect(onSave).toHaveBeenCalledWith({ rollbackPlan: "" });
   });
 
-  // The other half of the seeding fix: an edited plan is sent as rich text, so
-  // the line breaks the engineer typed survive the round trip and a typed `<`
-  // or `&` can't drop the rest of the plan when it is rendered back.
-  it("escapes and keeps the line breaks of an edited plan", () => {
-    const typed = "Stop the rollout if error rate < 1% & rising.\nRedeploy the previous tag.";
-    const { onSave } = renderDialog();
-    fireEvent.change(rollbackPlanField(), { target: { value: typed } });
-    fireEvent.click(saveButton());
-
-    const patch = onSave.mock.calls[0][0];
-    expect(patch.rollbackPlan).toBe(
-      "<p>Stop the rollout if error rate &lt; 1% &amp; rising.<br />Redeploy the previous tag.</p>",
-    );
-    // What is stored has to survive the render-side sanitizer and come back
-    // as exactly what was typed — this is the same value the dialog will
-    // re-seed from next time it opens.
-    expect(
-      stripHtmlTagsPreservingLineBreaks(sanitizeRichTextHtml(patch.rollbackPlan ?? "")),
-    ).toBe(typed);
-  });
-
-  it("leaves Save disabled until a plan is actually changed", () => {
-    renderDialog({ rollbackPlan: "<p>Restore the previous release.</p>" });
+  it("does not treat emptying an already-empty plan as an edit", () => {
+    renderDialog();
+    fireEvent.change(rollbackPlanField(), { target: { value: "<p><br></p>" } });
     expect(saveButton()).toBeDisabled();
   });
 
-  // Regression: the strip used to drop block boundaries, so a stored
-  // multi-paragraph plan was seeded into the field as one run-on line. Because
-  // dirty-tracking is a string compare against the seeded value, saving any
-  // unrelated field afterwards could write that flattened text back over the
-  // stored content.
-  it("keeps paragraph boundaries when seeding a multi-paragraph stored plan", () => {
-    renderDialog({
-      rollbackPlan: "<p>Stop the rollout.</p><p>Redeploy the previous tag.</p>",
-    });
-    expect(rollbackPlanField()).toHaveValue(
-      "Stop the rollout.\n\nRedeploy the previous tag.",
-    );
-  });
-
-  it("keeps <br> line breaks and list items on separate lines", () => {
-    renderDialog({
-      rollbackPlan: "line one<br />line two",
-      testPlan: "<ul><li>check health</li><li>check latency</li></ul>",
-    });
-    expect(rollbackPlanField()).toHaveValue("line one\nline two");
-    expect(testPlanField()).toHaveValue("check health\n\ncheck latency");
-  });
-
-  it("still keeps a multi-paragraph plan out of the patch when it was not edited", () => {
-    const { onSave } = renderDialog({
-      rollbackPlan: "<p>Stop the rollout.</p><p>Redeploy the previous tag.</p>",
-    });
-    fireEvent.click(approvedSwitch());
+  // The point of editing these as rich text: the markup the engineer applies
+  // is what gets stored, with no lossy conversion on either side.
+  it("keeps the markup of an edited plan intact, through the sanitizer", () => {
+    const authored =
+      "<p><strong>Stop</strong> the rollout.</p><ul><li>Redeploy the previous tag.</li></ul>";
+    const { onSave } = renderDialog();
+    fireEvent.change(rollbackPlanField(), { target: { value: authored } });
     fireEvent.click(saveButton());
-    expect(onSave).toHaveBeenCalledWith({ isCustomerApproved: true });
+    expect(onSave).toHaveBeenCalledWith({ rollbackPlan: authored });
+  });
+
+  it("keeps escaped entities escaped rather than letting them collapse into markup", () => {
+    const authored = "<p>Stop if error rate &lt; 1% &amp; rising.</p>";
+    const { onSave } = renderDialog();
+    fireEvent.change(rollbackPlanField(), { target: { value: authored } });
+    fireEvent.click(saveButton());
+
+    const patch = onSave.mock.calls[0][0];
+    const rendered = document.createElement("div");
+    rendered.innerHTML = patch.rollbackPlan ?? "";
+    expect(rendered.textContent).toBe("Stop if error rate < 1% & rising.");
+  });
+
+  it("strips anything the sanitizer would reject before it is stored", () => {
+    const { onSave } = renderDialog();
+    fireEvent.change(rollbackPlanField(), {
+      target: { value: "<p>Roll back.</p><script>steal()</script>" },
+    });
+    fireEvent.click(saveButton());
+    expect(onSave).toHaveBeenCalledWith({ rollbackPlan: "<p>Roll back.</p>" });
   });
 });
 

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/EditChangeRequestDialog.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/EditChangeRequestDialog.test.tsx
@@ -153,3 +153,137 @@ describe("EditChangeRequestDialog — save error surfacing", () => {
     ).toHaveTextContent(/mutually exclusive/i);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Fields added so the plan and schedule can actually be entered somewhere:
+// rollback plan, test plan, and planned end.
+// ---------------------------------------------------------------------------
+
+/** The "Rollback plan" textarea. */
+const rollbackPlanField = (): HTMLElement => screen.getByLabelText(/rollback plan/i);
+/** The "Test plan" textarea. */
+const testPlanField = (): HTMLElement => screen.getByLabelText(/test plan/i);
+
+describe("EditChangeRequestDialog — rollback and test plans", () => {
+  it("seeds each plan field from the stored value, with the stored markup stripped", () => {
+    renderDialog({
+      rollbackPlan: "<p>Restore the previous release.</p>",
+      testPlan: "<p>Smoke the gateway health endpoint.</p>",
+    });
+    expect(rollbackPlanField()).toHaveValue("Restore the previous release.");
+    expect(testPlanField()).toHaveValue("Smoke the gateway health endpoint.");
+  });
+
+  it("renders both fields empty when the change request has no plans yet", () => {
+    renderDialog();
+    expect(rollbackPlanField()).toHaveValue("");
+    expect(testPlanField()).toHaveValue("");
+  });
+
+  it("sends only the rollback plan when only that field was edited", () => {
+    const { onSave } = renderDialog();
+    fireEvent.change(rollbackPlanField(), {
+      target: { value: "Redeploy the previous image tag." },
+    });
+    fireEvent.click(saveButton());
+    expect(onSave).toHaveBeenCalledWith({
+      rollbackPlan: "Redeploy the previous image tag.",
+    });
+  });
+
+  it("sends only the test plan when only that field was edited", () => {
+    const { onSave } = renderDialog();
+    fireEvent.change(testPlanField(), { target: { value: "Run the regression suite." } });
+    fireEvent.click(saveButton());
+    expect(onSave).toHaveBeenCalledWith({ testPlan: "Run the regression suite." });
+  });
+
+  it("sends both plans, and nothing else, when both were edited", () => {
+    const { onSave } = renderDialog();
+    fireEvent.change(rollbackPlanField(), { target: { value: "Roll the image back." } });
+    fireEvent.change(testPlanField(), { target: { value: "Run the regression suite." } });
+    fireEvent.click(saveButton());
+    expect(onSave).toHaveBeenCalledWith({
+      rollbackPlan: "Roll the image back.",
+      testPlan: "Run the regression suite.",
+    });
+  });
+
+  it("keeps an untouched plan out of the patch even when the CR already has one stored", () => {
+    const { onSave } = renderDialog({
+      rollbackPlan: "<p>Restore the previous release.</p>",
+      testPlan: "<p>Smoke the gateway health endpoint.</p>",
+    });
+    fireEvent.click(approvedSwitch());
+    fireEvent.click(saveButton());
+    expect(onSave).toHaveBeenCalledWith({ isCustomerApproved: true });
+  });
+
+  it("treats clearing a stored plan as a real edit and sends the empty value", () => {
+    const { onSave } = renderDialog({ rollbackPlan: "<p>Restore the previous release.</p>" });
+    fireEvent.change(rollbackPlanField(), { target: { value: "" } });
+    fireEvent.click(saveButton());
+    expect(onSave).toHaveBeenCalledWith({ rollbackPlan: "" });
+  });
+
+  it("leaves Save disabled until a plan is actually changed", () => {
+    renderDialog({ rollbackPlan: "<p>Restore the previous release.</p>" });
+    expect(saveButton()).toBeDisabled();
+  });
+});
+
+describe("EditChangeRequestDialog — planned end must be after planned start", () => {
+  it("renders a Planned end picker alongside Planned start", () => {
+    renderDialog();
+    // The MUI date-time picker renders a segmented group (day/month/year/…),
+    // so each picker matches `getByLabelText` several times over, and the
+    // outlined field renders its label twice (visible label plus the fieldset
+    // legend) — hence `getAllByText`.
+    expect(screen.getAllByText("Planned start").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Planned end").length).toBeGreaterThan(0);
+  });
+
+  it("flags an end that is before the start, and blocks the save", () => {
+    renderDialog({
+      plannedStartOn: "2026-03-01 10:00:00",
+      plannedEndOn: "2026-03-01 09:00:00",
+    });
+    // Make the form dirty so Save would otherwise be enabled — this proves the
+    // date check, not the dirty check, is what disables it.
+    fireEvent.click(approvedSwitch());
+    expect(
+      screen.getByText(/planned end must be after planned start/i),
+    ).toBeInTheDocument();
+    expect(saveButton()).toBeDisabled();
+  });
+
+  it("flags an end equal to the start — a zero-length change window is not a window", () => {
+    renderDialog({
+      plannedStartOn: "2026-03-01 10:00:00",
+      plannedEndOn: "2026-03-01 10:00:00",
+    });
+    fireEvent.click(approvedSwitch());
+    expect(saveButton()).toBeDisabled();
+  });
+
+  it("accepts an end after the start", () => {
+    renderDialog({
+      plannedStartOn: "2026-03-01 10:00:00",
+      plannedEndOn: "2026-03-01 12:00:00",
+    });
+    fireEvent.click(approvedSwitch());
+    expect(
+      screen.queryByText(/planned end must be after planned start/i),
+    ).not.toBeInTheDocument();
+    expect(saveButton()).toBeEnabled();
+  });
+
+  it("does not flag anything when only one end of the window is set", () => {
+    renderDialog({ plannedStartOn: "2026-03-01 10:00:00" });
+    fireEvent.click(approvedSwitch());
+    expect(
+      screen.queryByText(/planned end must be after planned start/i),
+    ).not.toBeInTheDocument();
+    expect(saveButton()).toBeEnabled();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/EditChangeRequestDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/EditChangeRequestDialog.tsx
@@ -27,6 +27,7 @@ import {
   FormControlLabel,
   FormHelperText,
   Switch,
+  TextField,
 } from "@wso2/oxygen-ui";
 import { useMemo, useState, type JSX } from "react";
 import { useSearchGroups } from "@api/useSearchGroups";
@@ -41,6 +42,7 @@ import {
   isPastDateTime,
   parseDateTimeLocal,
 } from "@utils/dateTime";
+import { stripHtmlTags } from "@utils/sanitizeHtml";
 
 const { DateTimePicker, LocalizationProvider } = DatePickers;
 
@@ -77,10 +79,22 @@ function toBackendDateTime(local: string): string {
 }
 
 /**
- * Edit the change-request fields the BE allows updating: planned start, the
- * assignment group, and the customer approved / reviewed flags. Only changed
- * fields are sent, and the BE requires at least one, so Save is disabled
- * until something differs.
+ * The long-form plan fields come back as rich-text HTML but are edited here as
+ * plain multiline text, so the stored markup is stripped for the initial
+ * value. That is deliberately one-way: dirty-tracking compares against this
+ * stripped value, so an untouched field is never part of the patch and the
+ * stored markup survives. Editing one is an explicit rewrite of that field,
+ * and plain text is a valid value for it.
+ */
+function toPlainTextValue(raw?: string | null): string {
+  return raw ? stripHtmlTags(raw).trim() : "";
+}
+
+/**
+ * Edit the change-request fields the BE allows updating: the planned window,
+ * the assignment group, the customer approved / reviewed flags, and the
+ * rollback and test plans. Only changed fields are sent, and the BE requires
+ * at least one, so Save is disabled until something differs.
  */
 export default function EditChangeRequestDialog({
   cr,
@@ -93,30 +107,64 @@ export default function EditChangeRequestDialog({
     () => toDateTimeLocal(cr.plannedStartOn),
     [cr.plannedStartOn],
   );
+  const initialPlannedEnd = useMemo(
+    () => toDateTimeLocal(cr.plannedEndOn),
+    [cr.plannedEndOn],
+  );
+  const initialRollbackPlan = useMemo(
+    () => toPlainTextValue(cr.rollbackPlan),
+    [cr.rollbackPlan],
+  );
+  const initialTestPlan = useMemo(() => toPlainTextValue(cr.testPlan), [cr.testPlan]);
   const initialAssignedTeamId = cr.assignedTeam?.id ?? "";
   const [plannedStart, setPlannedStart] = useState(initialPlannedStart);
+  const [plannedEnd, setPlannedEnd] = useState(initialPlannedEnd);
   const [approved, setApproved] = useState(!!cr.hasCustomerApproved);
   const [reviewed, setReviewed] = useState(!!cr.hasCustomerReviewed);
   const [assignedTeamId, setAssignedTeamId] = useState(initialAssignedTeamId);
+  const [rollbackPlan, setRollbackPlan] = useState(initialRollbackPlan);
+  const [testPlan, setTestPlan] = useState(initialTestPlan);
+
+  // Client-side only, and only when both ends are set: the backing system
+  // does its own validation and this must not become the thing that blocks a
+  // legitimate save, so it surfaces inline rather than being enforced
+  // server-side.
+  const startDate = parseDateTimeLocal(plannedStart);
+  const endDate = parseDateTimeLocal(plannedEnd);
+  const plannedEndBeforeStart =
+    !!startDate && !!endDate && endDate.getTime() <= startDate.getTime();
 
   const patch = useMemo<BePatchChangeRequestPayload>(() => {
     const next: BePatchChangeRequestPayload = {};
     if (plannedStart !== initialPlannedStart && plannedStart) {
       next.plannedStartOn = toBackendDateTime(plannedStart);
     }
+    if (plannedEnd !== initialPlannedEnd && plannedEnd) {
+      next.plannedEndOn = toBackendDateTime(plannedEnd);
+    }
     if (approved !== !!cr.hasCustomerApproved) next.isCustomerApproved = approved;
     if (reviewed !== !!cr.hasCustomerReviewed) next.isCustomerReviewed = reviewed;
     if (assignedTeamId !== initialAssignedTeamId && assignedTeamId) {
       next.assignedTeamId = assignedTeamId;
     }
+    // Unlike the pickers above, an emptied plan field is a real edit the BE
+    // can accept, so "" is sent rather than skipped.
+    if (rollbackPlan !== initialRollbackPlan) next.rollbackPlan = rollbackPlan;
+    if (testPlan !== initialTestPlan) next.testPlan = testPlan;
     return next;
   }, [
     plannedStart,
     initialPlannedStart,
+    plannedEnd,
+    initialPlannedEnd,
     approved,
     reviewed,
     assignedTeamId,
     initialAssignedTeamId,
+    rollbackPlan,
+    initialRollbackPlan,
+    testPlan,
+    initialTestPlan,
     cr.hasCustomerApproved,
     cr.hasCustomerReviewed,
   ]);
@@ -125,7 +173,7 @@ export default function EditChangeRequestDialog({
   // Non-blocking: editing a CR's planned start to a past instant is unusual
   // but not forbidden (e.g. recording when it actually started), so this
   // only warns.
-  const plannedStartIsPast = isPastDateTime(parseDateTimeLocal(plannedStart));
+  const plannedStartIsPast = isPastDateTime(startDate);
 
   // The backend rejects a patch containing both isCustomerApproved and
   // isCustomerReviewed outright — they, and requestApproval, are mutually
@@ -139,7 +187,7 @@ export default function EditChangeRequestDialog({
   const reviewedLocked = approvedChanged;
 
   return (
-    <Dialog open onClose={onClose} maxWidth="xs" fullWidth>
+    <Dialog open onClose={onClose} maxWidth="sm" fullWidth>
       <DialogTitle>Edit change request</DialogTitle>
       <DialogContent dividers>
         <Box sx={{ display: "flex", flexDirection: "column", gap: 2, pt: 0.5 }}>
@@ -151,7 +199,7 @@ export default function EditChangeRequestDialog({
           <LocalizationProvider dateAdapter={AdapterDateFns}>
             <DateTimePicker
               label="Planned start"
-              value={parseDateTimeLocal(plannedStart)}
+              value={startDate}
               onChange={(next) =>
                 setPlannedStart(
                   next instanceof Date && !Number.isNaN(next.getTime())
@@ -165,6 +213,28 @@ export default function EditChangeRequestDialog({
                   fullWidth: true,
                   helperText: plannedStartIsPast
                     ? "This date is in the past."
+                    : undefined,
+                },
+                field: { clearable: true },
+              }}
+            />
+            <DateTimePicker
+              label="Planned end"
+              value={endDate}
+              onChange={(next) =>
+                setPlannedEnd(
+                  next instanceof Date && !Number.isNaN(next.getTime())
+                    ? formatDateTimeLocal(next)
+                    : "",
+                )
+              }
+              slotProps={{
+                textField: {
+                  size: "small",
+                  fullWidth: true,
+                  error: plannedEndBeforeStart,
+                  helperText: plannedEndBeforeStart
+                    ? "Planned end must be after planned start."
                     : undefined,
                 },
                 field: { clearable: true },
@@ -229,6 +299,28 @@ export default function EditChangeRequestDialog({
             knownLabel={cr.assignedTeam?.name}
             helperText="Required before approval can be requested."
           />
+          <TextField
+            label="Rollback plan"
+            value={rollbackPlan}
+            onChange={(e) => setRollbackPlan(e.target.value)}
+            disabled={isSaving}
+            multiline
+            minRows={3}
+            fullWidth
+            size="small"
+            helperText="How this change is backed out if it goes wrong."
+          />
+          <TextField
+            label="Test plan"
+            value={testPlan}
+            onChange={(e) => setTestPlan(e.target.value)}
+            disabled={isSaving}
+            multiline
+            minRows={3}
+            fullWidth
+            size="small"
+            helperText="How the change is verified once implemented."
+          />
         </Box>
       </DialogContent>
       <DialogActions>
@@ -238,7 +330,7 @@ export default function EditChangeRequestDialog({
         <Button
           variant="contained"
           onClick={() => onSave(patch)}
-          disabled={isSaving || !hasChanges}
+          disabled={isSaving || !hasChanges || plannedEndBeforeStart}
         >
           {isSaving ? "Saving…" : "Save"}
         </Button>

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/EditChangeRequestDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/EditChangeRequestDialog.tsx
@@ -27,9 +27,9 @@ import {
   FormControlLabel,
   FormHelperText,
   Switch,
-  TextField,
+  Typography,
 } from "@wso2/oxygen-ui";
-import { useMemo, useState, type JSX } from "react";
+import { useCallback, useMemo, useState, type JSX } from "react";
 import { useSearchGroups } from "@api/useSearchGroups";
 import type {
   BeChangeRequestDetail,
@@ -37,15 +37,13 @@ import type {
   BePatchChangeRequestPayload,
 } from "@api/backend/types";
 import AsyncEntitySelect from "@components/AsyncEntitySelect";
+import Editor from "@components/rich-text-editor/Editor";
 import {
   formatDateTimeLocal,
   isPastDateTime,
   parseDateTimeLocal,
 } from "@utils/dateTime";
-import {
-  plainTextToHtml,
-  stripHtmlTagsPreservingLineBreaks,
-} from "@utils/sanitizeHtml";
+import { isBlankHtml, sanitizeRichTextHtml } from "@utils/sanitizeHtml";
 
 const { DateTimePicker, LocalizationProvider } = DatePickers;
 
@@ -81,21 +79,72 @@ function toBackendDateTime(local: string): string {
   return `${local.replace("T", " ")}:00`;
 }
 
+/** One long-form plan field, edited as rich text. */
+interface RichTextPlanField {
+  /** Frozen seed handed to the editor; never re-sent as the editor changes. */
+  initialHtml: string;
+  /** Current editor HTML. */
+  html: string;
+  onChange: (next: string) => void;
+  /** True once the user has actually changed the content. */
+  isDirty: boolean;
+  /** What to put in the patch: `""` for a cleared field, else the HTML. */
+  outgoing: string;
+}
+
 /**
- * The long-form plan fields come back as rich-text HTML but are edited here as
- * plain multiline text, so the stored markup is stripped for the initial
- * value. That is deliberately one-way: dirty-tracking compares against this
- * stripped value, so an untouched field is never part of the patch and the
- * stored markup survives. Editing one is an explicit rewrite of that field,
- * and plain text is a valid value for it.
+ * State for a plan field that is edited as rich text rather than plain text.
  *
- * Block boundaries have to survive the strip. A stored multi-paragraph plan
- * flattened to one run-on line is a value the user never typed, and because
- * dirty-tracking is a string compare against it, the flattened text is what a
- * later edit would write back over the stored content.
+ * Dirty-tracking is the whole difficulty here. The editor normalizes markup
+ * when it loads a stored value — `<p>A</p>` comes back out as
+ * `<p><span style="white-space: pre-wrap;">A</span></p>` — so comparing the
+ * editor's HTML against the stored HTML as strings marks every seeded field
+ * dirty before the user has touched anything, and the dialog would then patch
+ * fields nobody edited.
+ *
+ * So the baseline is the editor's *own* first emission rather than the stored
+ * string: whatever it produces from the seed is, by definition, the unedited
+ * state. Two cases, and they differ because the editor only emits on load when
+ * there is something to load:
+ *
+ * - Stored content is non-blank: the editor injects it and emits once before
+ *   any user input, so the first emission is the baseline.
+ * - Stored content is blank: nothing is injected and nothing is emitted, so
+ *   the first emission would be the user's own typing. Baseline is fixed to
+ *   "blank" up front instead, and dirtiness is `!isBlankHtml`.
+ *
+ * A cleared field goes out as `""`, not the editor's `<p><br></p>` — an empty
+ * paragraph reads as "the plan says nothing" rather than "there is no plan".
  */
-function toPlainTextValue(raw?: string | null): string {
-  return raw ? stripHtmlTagsPreservingLineBreaks(raw) : "";
+function useRichTextPlanField(storedHtml?: string | null): RichTextPlanField {
+  const stored = storedHtml ?? "";
+  // Frozen at mount: the editor treats its `value` as an initial value, and
+  // feeding the live HTML back in makes it re-seed itself mid-edit.
+  const [initialHtml] = useState(stored);
+  const [html, setHtml] = useState(stored);
+  // `null` means "waiting for the editor's first emission"; `""` means the
+  // baseline is known to be blank.
+  const [baseline, setBaseline] = useState<string | null>(
+    isBlankHtml(stored) ? "" : null,
+  );
+
+  const onChange = useCallback((next: string) => {
+    setBaseline((current) => (current === null ? next : current));
+    setHtml(next);
+  }, []);
+
+  const isDirty =
+    baseline === null
+      ? false
+      : baseline === ""
+        ? !isBlankHtml(html)
+        : html !== baseline;
+
+  // Sanitized on the way out, the same policy the detail page renders it back
+  // through, so nothing the editor emits can widen what ends up stored.
+  const outgoing = isBlankHtml(html) ? "" : sanitizeRichTextHtml(html);
+
+  return { initialHtml, html, onChange, isDirty, outgoing };
 }
 
 /**
@@ -119,19 +168,14 @@ export default function EditChangeRequestDialog({
     () => toDateTimeLocal(cr.plannedEndOn),
     [cr.plannedEndOn],
   );
-  const initialRollbackPlan = useMemo(
-    () => toPlainTextValue(cr.rollbackPlan),
-    [cr.rollbackPlan],
-  );
-  const initialTestPlan = useMemo(() => toPlainTextValue(cr.testPlan), [cr.testPlan]);
   const initialAssignedTeamId = cr.assignedTeam?.id ?? "";
   const [plannedStart, setPlannedStart] = useState(initialPlannedStart);
   const [plannedEnd, setPlannedEnd] = useState(initialPlannedEnd);
   const [approved, setApproved] = useState(!!cr.hasCustomerApproved);
   const [reviewed, setReviewed] = useState(!!cr.hasCustomerReviewed);
   const [assignedTeamId, setAssignedTeamId] = useState(initialAssignedTeamId);
-  const [rollbackPlan, setRollbackPlan] = useState(initialRollbackPlan);
-  const [testPlan, setTestPlan] = useState(initialTestPlan);
+  const rollbackPlan = useRichTextPlanField(cr.rollbackPlan);
+  const testPlan = useRichTextPlanField(cr.testPlan);
 
   // Client-side only, and only when both ends are set: the backing system
   // does its own validation and this must not become the thing that blocks a
@@ -156,23 +200,11 @@ export default function EditChangeRequestDialog({
       next.assignedTeamId = assignedTeamId;
     }
     // Unlike the pickers above, an emptied plan field is a real edit the BE
-    // can accept, so "" is sent rather than skipped.
-    //
-    // Two different representations, deliberately: the *comparison* is against
-    // the plain-text seed (so an untouched field never enters the patch, and
-    // the stored markup survives untouched), while the *outgoing* value is
-    // converted back to rich text. These fields are stored and re-rendered as
-    // HTML, so sending raw plain text would drop the engineer's line breaks
-    // and let a typed `<` or `&` mangle the rest of the plan. Never compare
-    // the converted HTML against the stored HTML — the stored markup is not
-    // reproducible from plain text, so every field would read as dirty.
-    //
-    // `plainTextToHtml` maps blank input to "", not `<p></p>`, so clearing a
-    // plan still sends the empty value the BE treats as "remove it".
-    if (rollbackPlan !== initialRollbackPlan) {
-      next.rollbackPlan = plainTextToHtml(rollbackPlan);
-    }
-    if (testPlan !== initialTestPlan) next.testPlan = plainTextToHtml(testPlan);
+    // can accept, so "" is sent rather than skipped. Both plans are rich text
+    // on both sides now — see `useRichTextPlanField` for why "changed" is not
+    // a comparison against the stored string.
+    if (rollbackPlan.isDirty) next.rollbackPlan = rollbackPlan.outgoing;
+    if (testPlan.isDirty) next.testPlan = testPlan.outgoing;
     return next;
   }, [
     plannedStart,
@@ -183,10 +215,10 @@ export default function EditChangeRequestDialog({
     reviewed,
     assignedTeamId,
     initialAssignedTeamId,
-    rollbackPlan,
-    initialRollbackPlan,
-    testPlan,
-    initialTestPlan,
+    rollbackPlan.isDirty,
+    rollbackPlan.outgoing,
+    testPlan.isDirty,
+    testPlan.outgoing,
     cr.hasCustomerApproved,
     cr.hasCustomerReviewed,
   ]);
@@ -207,6 +239,39 @@ export default function EditChangeRequestDialog({
   const reviewedChanged = reviewed !== !!cr.hasCustomerReviewed;
   const approvedLocked = reviewedChanged;
   const reviewedLocked = approvedChanged;
+
+  // Rich-text plan field. The editor takes no `id`/native label, so the
+  // visible label is a separate Typography tied to the control via
+  // role="group" + aria-labelledby, and the helper text is referenced by
+  // aria-describedby — same convention as the create page's Planning fields.
+  const renderPlanField = (
+    id: string,
+    label: string,
+    field: RichTextPlanField,
+    helperText: string,
+  ): JSX.Element => (
+    <Box>
+      <Typography
+        id={`${id}-label`}
+        variant="caption"
+        color="text.secondary"
+        sx={{ display: "block", mb: 0.5 }}
+      >
+        {label}
+      </Typography>
+      <Box role="group" aria-labelledby={`${id}-label`} aria-describedby={`${id}-help`}>
+        <Editor
+          value={field.initialHtml}
+          onChange={field.onChange}
+          minHeight={100}
+          maxHeight={300}
+          toolbarVariant="full"
+          disabled={isSaving}
+        />
+      </Box>
+      <FormHelperText id={`${id}-help`}>{helperText}</FormHelperText>
+    </Box>
+  );
 
   return (
     <Dialog open onClose={onClose} maxWidth="sm" fullWidth>
@@ -327,28 +392,18 @@ export default function EditChangeRequestDialog({
             knownLabel={cr.assignedTeam?.name}
             helperText="Required before approval can be requested."
           />
-          <TextField
-            label="Rollback plan"
-            value={rollbackPlan}
-            onChange={(e) => setRollbackPlan(e.target.value)}
-            disabled={isSaving}
-            multiline
-            minRows={3}
-            fullWidth
-            size="small"
-            helperText="How this change is backed out if it goes wrong."
-          />
-          <TextField
-            label="Test plan"
-            value={testPlan}
-            onChange={(e) => setTestPlan(e.target.value)}
-            disabled={isSaving}
-            multiline
-            minRows={3}
-            fullWidth
-            size="small"
-            helperText="How the change is verified once implemented."
-          />
+          {renderPlanField(
+            "cr-edit-rollback-plan",
+            "Rollback plan",
+            rollbackPlan,
+            "How this change is backed out if it goes wrong.",
+          )}
+          {renderPlanField(
+            "cr-edit-test-plan",
+            "Test plan",
+            testPlan,
+            "How the change is verified once implemented.",
+          )}
         </Box>
       </DialogContent>
       <DialogActions>

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/EditChangeRequestDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/EditChangeRequestDialog.tsx
@@ -42,7 +42,7 @@ import {
   isPastDateTime,
   parseDateTimeLocal,
 } from "@utils/dateTime";
-import { stripHtmlTags } from "@utils/sanitizeHtml";
+import { stripHtmlTagsPreservingLineBreaks } from "@utils/sanitizeHtml";
 
 const { DateTimePicker, LocalizationProvider } = DatePickers;
 
@@ -85,9 +85,14 @@ function toBackendDateTime(local: string): string {
  * stripped value, so an untouched field is never part of the patch and the
  * stored markup survives. Editing one is an explicit rewrite of that field,
  * and plain text is a valid value for it.
+ *
+ * Block boundaries have to survive the strip. A stored multi-paragraph plan
+ * flattened to one run-on line is a value the user never typed, and because
+ * dirty-tracking is a string compare against it, the flattened text is what a
+ * later edit would write back over the stored content.
  */
 function toPlainTextValue(raw?: string | null): string {
-  return raw ? stripHtmlTags(raw).trim() : "";
+  return raw ? stripHtmlTagsPreservingLineBreaks(raw) : "";
 }
 
 /**
@@ -196,6 +201,14 @@ export default function EditChangeRequestDialog({
               {saveError}
             </Alert>
           )}
+          {/*
+            No `clearable` on either picker. The patch payload has no way to
+            express "remove the planned date" — `plannedStartOn`/`plannedEndOn`
+            are `string | undefined`, and an omitted key means "leave it
+            alone" — so a clear affordance would appear to work and then
+            silently save nothing. Widening the payload to express a null
+            clear is the fix if this is ever actually needed.
+          */}
           <LocalizationProvider dateAdapter={AdapterDateFns}>
             <DateTimePicker
               label="Planned start"
@@ -215,7 +228,6 @@ export default function EditChangeRequestDialog({
                     ? "This date is in the past."
                     : undefined,
                 },
-                field: { clearable: true },
               }}
             />
             <DateTimePicker
@@ -237,7 +249,6 @@ export default function EditChangeRequestDialog({
                     ? "Planned end must be after planned start."
                     : undefined,
                 },
-                field: { clearable: true },
               }}
             />
           </LocalizationProvider>

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/EditChangeRequestDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/EditChangeRequestDialog.tsx
@@ -42,7 +42,10 @@ import {
   isPastDateTime,
   parseDateTimeLocal,
 } from "@utils/dateTime";
-import { stripHtmlTagsPreservingLineBreaks } from "@utils/sanitizeHtml";
+import {
+  plainTextToHtml,
+  stripHtmlTagsPreservingLineBreaks,
+} from "@utils/sanitizeHtml";
 
 const { DateTimePicker, LocalizationProvider } = DatePickers;
 
@@ -154,8 +157,22 @@ export default function EditChangeRequestDialog({
     }
     // Unlike the pickers above, an emptied plan field is a real edit the BE
     // can accept, so "" is sent rather than skipped.
-    if (rollbackPlan !== initialRollbackPlan) next.rollbackPlan = rollbackPlan;
-    if (testPlan !== initialTestPlan) next.testPlan = testPlan;
+    //
+    // Two different representations, deliberately: the *comparison* is against
+    // the plain-text seed (so an untouched field never enters the patch, and
+    // the stored markup survives untouched), while the *outgoing* value is
+    // converted back to rich text. These fields are stored and re-rendered as
+    // HTML, so sending raw plain text would drop the engineer's line breaks
+    // and let a typed `<` or `&` mangle the rest of the plan. Never compare
+    // the converted HTML against the stored HTML — the stored markup is not
+    // reproducible from plain text, so every field would read as dirty.
+    //
+    // `plainTextToHtml` maps blank input to "", not `<p></p>`, so clearing a
+    // plan still sends the empty value the BE treats as "remove it".
+    if (rollbackPlan !== initialRollbackPlan) {
+      next.rollbackPlan = plainTextToHtml(rollbackPlan);
+    }
+    if (testPlan !== initialTestPlan) next.testPlan = plainTextToHtml(testPlan);
     return next;
   }, [
     plannedStart,

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.test.tsx
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 import type { JSX } from "react";
@@ -27,6 +27,8 @@ import { BackendApiError } from "@api/backend/client";
 const navigateMock = vi.fn();
 const useGetChangeRequestMock = vi.fn();
 const patchMutateMock = vi.fn();
+const patchMutateAsyncMock = vi.fn<(input: unknown) => Promise<unknown>>();
+const postCommentMutateAsyncMock = vi.fn<(input: unknown) => Promise<unknown>>();
 const patchResetMock = vi.fn();
 const showErrorMock = vi.fn();
 const editChangeRequestDialogMock = vi.fn();
@@ -60,6 +62,7 @@ vi.mock("@features/csm-operations/api/useGetChangeRequest", () => ({
 vi.mock("@features/csm-operations/api/usePatchChangeRequest", () => ({
   usePatchChangeRequest: () => ({
     mutate: patchMutateMock,
+    mutateAsync: patchMutateAsyncMock,
     reset: patchResetMock,
     isPending: patchIsPending,
     isError: patchIsError,
@@ -79,7 +82,11 @@ vi.mock("@features/csm-operations/components/EditChangeRequestDialog", () => ({
 }));
 vi.mock("@features/csm-operations/api/useCsmChangeRequestComments", () => ({
   useGetCsmChangeRequestComments: () => ({ data: [] }),
-  usePostCsmChangeRequestComment: () => ({ isPending: false, mutate: vi.fn() }),
+  usePostCsmChangeRequestComment: () => ({
+    isPending: false,
+    mutate: vi.fn(),
+    mutateAsync: postCommentMutateAsyncMock,
+  }),
 }));
 vi.mock("@features/csm-cases/api/useCsmCaseAttachments", () => ({
   useGetCsmCaseAttachments: () => ({ data: [] }),
@@ -128,6 +135,10 @@ beforeEach(() => {
   patchError = null;
   patchResetMock.mockClear();
   editChangeRequestDialogMock.mockClear();
+  patchMutateAsyncMock.mockReset();
+  patchMutateAsyncMock.mockResolvedValue({ id: "chg-1" });
+  postCommentMutateAsyncMock.mockReset();
+  postCommentMutateAsyncMock.mockResolvedValue({ id: "comment-1" });
 });
 
 /** Surfaces the router's current search string, for the `?tab=` sync tests
@@ -425,5 +436,192 @@ describe("CsmChangeRequestDetailPage — Edit dialog error wiring", () => {
     fireEvent.click(screen.getByRole("button", { name: /^edit$/i }));
     const [props] = editChangeRequestDialogMock.mock.calls.at(-1)!;
     expect(props.saveError).toBe("Could not update the change request.");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Lifecycle transitions. `ChangeRequestActionBar` is exercised in isolation by
+// its own test; these cover this page's half of the contract — which patch
+// each target produces, and the comment-then-patch ordering the destructive
+// ones go through.
+// ---------------------------------------------------------------------------
+
+/** Open the action bar's overflow menu. */
+function openStateMenu(): void {
+  fireEvent.click(screen.getByRole("button", { name: /change state/i }));
+}
+
+describe("CsmChangeRequestDetailPage — direct (non-destructive) transitions", () => {
+  it("PATCHes { state: target } for a forward move that is not New -> Assess", () => {
+    mockQueryResult({
+      data: { ...BASE_CR, state: "scheduled", legalNextStates: ["implement"] },
+    });
+    renderPage();
+    fireEvent.click(screen.getByRole("button", { name: /start implementation/i }));
+    expect(patchMutateMock).toHaveBeenCalledWith(
+      { id: "chg-1", patch: { state: "implement" } },
+      expect.objectContaining({ onError: expect.any(Function) }),
+    );
+  });
+
+  it("keeps the requestApproval flag for New -> Assess rather than sending state", () => {
+    mockQueryResult({ data: { ...BASE_CR, legalNextStates: ["assess"] } });
+    renderPage();
+    fireEvent.click(screen.getByRole("button", { name: /request approval/i }));
+    const [{ patch }] = patchMutateMock.mock.calls[0];
+    expect(patch).toEqual({ requestApproval: true });
+  });
+
+  it("sends a state the backend added verbatim, with no frontend change", () => {
+    mockQueryResult({
+      data: { ...BASE_CR, state: "review", legalNextStates: ["awaiting_vendor"] },
+    });
+    renderPage();
+    openStateMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: /^awaiting vendor$/i }));
+    expect(patchMutateMock).toHaveBeenCalledWith(
+      { id: "chg-1", patch: { state: "awaiting_vendor" } },
+      expect.anything(),
+    );
+  });
+
+  it("surfaces the backend's real 4xx rejection reason for a transition", () => {
+    mockQueryResult({
+      data: { ...BASE_CR, state: "scheduled", legalNextStates: ["implement"] },
+    });
+    renderPage();
+    fireEvent.click(screen.getByRole("button", { name: /start implementation/i }));
+    const [, options] = patchMutateMock.mock.calls[0];
+    const err = new BackendApiError(409, "Change window has not opened yet");
+    options.onError(err);
+    expect(showErrorMock).toHaveBeenCalledWith("Change window has not opened yet", err);
+  });
+
+  it("falls back to a target-specific generic message for a 5xx", () => {
+    mockQueryResult({
+      data: { ...BASE_CR, state: "scheduled", legalNextStates: ["implement"] },
+    });
+    renderPage();
+    fireEvent.click(screen.getByRole("button", { name: /start implementation/i }));
+    const [, options] = patchMutateMock.mock.calls[0];
+    const err = new BackendApiError(500, "internal error detail");
+    options.onError(err);
+    expect(showErrorMock).toHaveBeenCalledWith(
+      "Could not move this change request to Implement.",
+      err,
+    );
+  });
+});
+
+describe("CsmChangeRequestDetailPage — destructive transitions need a reason first", () => {
+  /** Render a CR that can be rolled back, and open the confirmation dialog. */
+  function openRollbackDialog(): void {
+    mockQueryResult({
+      data: { ...BASE_CR, state: "implement", legalNextStates: ["review", "rollback"] },
+    });
+    renderPage();
+    openStateMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: /roll back/i }));
+  }
+
+  function typeReason(text: string): void {
+    fireEvent.change(screen.getByLabelText(/reason/i), { target: { value: text } });
+  }
+
+  it("opens the confirmation dialog instead of patching immediately", () => {
+    openRollbackDialog();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(patchMutateMock).not.toHaveBeenCalled();
+    expect(patchMutateAsyncMock).not.toHaveBeenCalled();
+  });
+
+  it("posts the reason as a comment BEFORE patching the state", async () => {
+    openRollbackDialog();
+    typeReason("Latency regression in production.");
+    fireEvent.click(screen.getByRole("button", { name: /^roll back$/i }));
+
+    await waitFor(() => expect(patchMutateAsyncMock).toHaveBeenCalled());
+    expect(postCommentMutateAsyncMock).toHaveBeenCalledWith({
+      changeRequestId: "chg-1",
+      bodyHtml: "Latency regression in production.",
+      internal: true,
+    });
+    expect(patchMutateAsyncMock).toHaveBeenCalledWith({
+      id: "chg-1",
+      patch: { state: "rollback" },
+    });
+    // Ordering, not just co-occurrence: an unexplained rollback is worse than
+    // a failed one, so the comment must land first.
+    expect(
+      postCommentMutateAsyncMock.mock.invocationCallOrder[0],
+    ).toBeLessThan(patchMutateAsyncMock.mock.invocationCallOrder[0]);
+  });
+
+  it("closes the dialog once both halves succeed", async () => {
+    openRollbackDialog();
+    typeReason("Latency regression in production.");
+    fireEvent.click(screen.getByRole("button", { name: /^roll back$/i }));
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+  });
+
+  it("does NOT patch the state when the reason comment fails", async () => {
+    postCommentMutateAsyncMock.mockRejectedValueOnce(
+      new BackendApiError(403, "Comments are disabled on this change request"),
+    );
+    openRollbackDialog();
+    typeReason("Latency regression in production.");
+    fireEvent.click(screen.getByRole("button", { name: /^roll back$/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        /comments are disabled on this change request/i,
+      ),
+    );
+    expect(patchMutateAsyncMock).not.toHaveBeenCalled();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("tells the engineer the reason was recorded when only the state change failed", async () => {
+    patchMutateAsyncMock.mockRejectedValueOnce(
+      new BackendApiError(409, "Rollback is not permitted from this state"),
+    );
+    openRollbackDialog();
+    typeReason("Latency regression in production.");
+    fireEvent.click(screen.getByRole("button", { name: /^roll back$/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        /reason was recorded as a comment, but the state did not change/i,
+      ),
+    );
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      /rollback is not permitted from this state/i,
+    );
+    expect(screen.getByRole("alert")).toHaveTextContent(/don't need to retype it/i);
+  });
+
+  it("retrying after a failed patch re-sends only the state change, never the comment twice", async () => {
+    patchMutateAsyncMock.mockRejectedValueOnce(new BackendApiError(409, "Rejected"));
+    openRollbackDialog();
+    typeReason("Latency regression in production.");
+    fireEvent.click(screen.getByRole("button", { name: /^roll back$/i }));
+    await waitFor(() => expect(screen.getByRole("alert")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("button", { name: /^roll back$/i }));
+    await waitFor(() => expect(patchMutateAsyncMock).toHaveBeenCalledTimes(2));
+    expect(postCommentMutateAsyncMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("routes the cancel transition through the same dialog", () => {
+    mockQueryResult({
+      data: { ...BASE_CR, state: "scheduled", legalNextStates: ["implement", "canceled"] },
+    });
+    renderPage();
+    openStateMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: /cancel change/i }));
+    expect(
+      screen.getByRole("heading", { name: /cancel this change request/i }),
+    ).toBeInTheDocument();
+    expect(patchMutateAsyncMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.test.tsx
@@ -23,6 +23,10 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { UseQueryResult } from "@tanstack/react-query";
 import type { BeChangeRequestDetail } from "@api/backend/types";
 import { BackendApiError } from "@api/backend/client";
+import {
+  sanitizeRichTextHtml,
+  stripHtmlTagsPreservingLineBreaks,
+} from "@utils/sanitizeHtml";
 
 const navigateMock = vi.fn();
 const useGetChangeRequestMock = vi.fn();
@@ -543,7 +547,8 @@ describe("CsmChangeRequestDetailPage — destructive transitions need a reason f
     await waitFor(() => expect(patchMutateAsyncMock).toHaveBeenCalled());
     expect(postCommentMutateAsyncMock).toHaveBeenCalledWith({
       changeRequestId: "chg-1",
-      bodyHtml: "Latency regression in production.",
+      // The dialog collects plain text; the comment field is rich text.
+      bodyHtml: "<p>Latency regression in production.</p>",
       internal: true,
     });
     expect(patchMutateAsyncMock).toHaveBeenCalledWith({
@@ -610,6 +615,26 @@ describe("CsmChangeRequestDetailPage — destructive transitions need a reason f
     fireEvent.click(screen.getByRole("button", { name: /^roll back$/i }));
     await waitFor(() => expect(patchMutateAsyncMock).toHaveBeenCalledTimes(2));
     expect(postCommentMutateAsyncMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("escapes the reason and keeps its line breaks, so the audit note is not mangled", async () => {
+    const typed = "Latency < 50ms breached & customer impacted.\nRolled back by Jane Doe.";
+    openRollbackDialog();
+    typeReason(typed);
+    fireEvent.click(screen.getByRole("button", { name: /^roll back$/i }));
+
+    await waitFor(() => expect(postCommentMutateAsyncMock).toHaveBeenCalled());
+    const posted = postCommentMutateAsyncMock.mock.calls[0][0] as {
+      bodyHtml: string;
+    };
+    expect(posted.bodyHtml).toBe(
+      "<p>Latency &lt; 50ms breached &amp; customer impacted.<br />Rolled back by Jane Doe.</p>",
+    );
+    // The audit record has to survive both the escape and the render-side
+    // sanitizer with every character the engineer typed still in it.
+    expect(
+      stripHtmlTagsPreservingLineBreaks(sanitizeRichTextHtml(posted.bodyHtml)),
+    ).toBe(typed);
   });
 
   it("routes the cancel transition through the same dialog", () => {

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.test.tsx
@@ -23,10 +23,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { UseQueryResult } from "@tanstack/react-query";
 import type { BeChangeRequestDetail } from "@api/backend/types";
 import { BackendApiError } from "@api/backend/client";
-import {
-  sanitizeRichTextHtml,
-  stripHtmlTagsPreservingLineBreaks,
-} from "@utils/sanitizeHtml";
+import { sanitizeRichTextHtml } from "@utils/sanitizeHtml";
 
 const navigateMock = vi.fn();
 const useGetChangeRequestMock = vi.fn();
@@ -632,9 +629,12 @@ describe("CsmChangeRequestDetailPage — destructive transitions need a reason f
     );
     // The audit record has to survive both the escape and the render-side
     // sanitizer with every character the engineer typed still in it.
-    expect(
-      stripHtmlTagsPreservingLineBreaks(sanitizeRichTextHtml(posted.bodyHtml)),
-    ).toBe(typed);
+    const rendered = document.createElement("div");
+    rendered.innerHTML = sanitizeRichTextHtml(posted.bodyHtml).replace(
+      /<br\s*\/?>/gi,
+      "\n",
+    );
+    expect(rendered.textContent).toBe(typed);
   });
 
   it("routes the cancel transition through the same dialog", () => {

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.test.tsx
@@ -23,7 +23,6 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { UseQueryResult } from "@tanstack/react-query";
 import type { BeChangeRequestDetail } from "@api/backend/types";
 import { BackendApiError } from "@api/backend/client";
-import { sanitizeRichTextHtml } from "@utils/sanitizeHtml";
 
 const navigateMock = vi.fn();
 const useGetChangeRequestMock = vi.fn();
@@ -515,14 +514,14 @@ describe("CsmChangeRequestDetailPage — direct (non-destructive) transitions", 
 });
 
 describe("CsmChangeRequestDetailPage — destructive transitions need a reason first", () => {
-  /** Render a CR that can be rolled back, and open the confirmation dialog. */
-  function openRollbackDialog(): void {
+  /** Render a CR that can be canceled, and open the confirmation dialog. */
+  function openCancelDialog(): void {
     mockQueryResult({
-      data: { ...BASE_CR, state: "implement", legalNextStates: ["review", "rollback"] },
+      data: { ...BASE_CR, state: "implement", legalNextStates: ["review", "canceled"] },
     });
     renderPage();
     openStateMenu();
-    fireEvent.click(screen.getByRole("menuitem", { name: /roll back/i }));
+    fireEvent.click(screen.getByRole("menuitem", { name: /cancel change/i }));
   }
 
   function typeReason(text: string): void {
@@ -530,39 +529,39 @@ describe("CsmChangeRequestDetailPage — destructive transitions need a reason f
   }
 
   it("opens the confirmation dialog instead of patching immediately", () => {
-    openRollbackDialog();
+    openCancelDialog();
     expect(screen.getByRole("dialog")).toBeInTheDocument();
     expect(patchMutateMock).not.toHaveBeenCalled();
     expect(patchMutateAsyncMock).not.toHaveBeenCalled();
   });
 
   it("posts the reason as a comment BEFORE patching the state", async () => {
-    openRollbackDialog();
+    openCancelDialog();
     typeReason("Latency regression in production.");
-    fireEvent.click(screen.getByRole("button", { name: /^roll back$/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^cancel change$/i }));
 
     await waitFor(() => expect(patchMutateAsyncMock).toHaveBeenCalled());
     expect(postCommentMutateAsyncMock).toHaveBeenCalledWith({
       changeRequestId: "chg-1",
-      // The dialog collects plain text; the comment field is rich text.
-      bodyHtml: "<p>Latency regression in production.</p>",
+      // Posted verbatim: the backing store for these notes is plain text.
+      bodyHtml: "Latency regression in production.",
       internal: true,
     });
     expect(patchMutateAsyncMock).toHaveBeenCalledWith({
       id: "chg-1",
-      patch: { state: "rollback" },
+      patch: { state: "canceled" },
     });
-    // Ordering, not just co-occurrence: an unexplained rollback is worse than
-    // a failed one, so the comment must land first.
+    // Ordering, not just co-occurrence: an unexplained cancellation is worse
+    // than a failed one, so the comment must land first.
     expect(
       postCommentMutateAsyncMock.mock.invocationCallOrder[0],
     ).toBeLessThan(patchMutateAsyncMock.mock.invocationCallOrder[0]);
   });
 
   it("closes the dialog once both halves succeed", async () => {
-    openRollbackDialog();
+    openCancelDialog();
     typeReason("Latency regression in production.");
-    fireEvent.click(screen.getByRole("button", { name: /^roll back$/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^cancel change$/i }));
     await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
   });
 
@@ -570,9 +569,9 @@ describe("CsmChangeRequestDetailPage — destructive transitions need a reason f
     postCommentMutateAsyncMock.mockRejectedValueOnce(
       new BackendApiError(403, "Comments are disabled on this change request"),
     );
-    openRollbackDialog();
+    openCancelDialog();
     typeReason("Latency regression in production.");
-    fireEvent.click(screen.getByRole("button", { name: /^roll back$/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^cancel change$/i }));
 
     await waitFor(() =>
       expect(screen.getByRole("alert")).toHaveTextContent(
@@ -585,11 +584,11 @@ describe("CsmChangeRequestDetailPage — destructive transitions need a reason f
 
   it("tells the engineer the reason was recorded when only the state change failed", async () => {
     patchMutateAsyncMock.mockRejectedValueOnce(
-      new BackendApiError(409, "Rollback is not permitted from this state"),
+      new BackendApiError(409, "Cancellation is not permitted from this state"),
     );
-    openRollbackDialog();
+    openCancelDialog();
     typeReason("Latency regression in production.");
-    fireEvent.click(screen.getByRole("button", { name: /^roll back$/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^cancel change$/i }));
 
     await waitFor(() =>
       expect(screen.getByRole("alert")).toHaveTextContent(
@@ -597,44 +596,38 @@ describe("CsmChangeRequestDetailPage — destructive transitions need a reason f
       ),
     );
     expect(screen.getByRole("alert")).toHaveTextContent(
-      /rollback is not permitted from this state/i,
+      /cancellation is not permitted from this state/i,
     );
     expect(screen.getByRole("alert")).toHaveTextContent(/don't need to retype it/i);
   });
 
   it("retrying after a failed patch re-sends only the state change, never the comment twice", async () => {
     patchMutateAsyncMock.mockRejectedValueOnce(new BackendApiError(409, "Rejected"));
-    openRollbackDialog();
+    openCancelDialog();
     typeReason("Latency regression in production.");
-    fireEvent.click(screen.getByRole("button", { name: /^roll back$/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^cancel change$/i }));
     await waitFor(() => expect(screen.getByRole("alert")).toBeInTheDocument());
 
-    fireEvent.click(screen.getByRole("button", { name: /^roll back$/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^cancel change$/i }));
     await waitFor(() => expect(patchMutateAsyncMock).toHaveBeenCalledTimes(2));
     expect(postCommentMutateAsyncMock).toHaveBeenCalledTimes(1);
   });
 
-  it("escapes the reason and keeps its line breaks, so the audit note is not mangled", async () => {
-    const typed = "Latency < 50ms breached & customer impacted.\nRolled back by Jane Doe.";
-    openRollbackDialog();
+  it("posts the reason verbatim as plain text, with no markup added around it", async () => {
+    // The backing store for these notes is a plain-text field: production
+    // entries carry raw newlines and no escaped entities, so anything the
+    // portal wraps in markup shows up as literal tags at the source. What the
+    // engineer typed is what gets written, character for character.
+    const typed = "Latency < 50ms breached & customer impacted.\nCanceled by Jane Doe.";
+    openCancelDialog();
     typeReason(typed);
-    fireEvent.click(screen.getByRole("button", { name: /^roll back$/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^cancel change$/i }));
 
     await waitFor(() => expect(postCommentMutateAsyncMock).toHaveBeenCalled());
     const posted = postCommentMutateAsyncMock.mock.calls[0][0] as {
       bodyHtml: string;
     };
-    expect(posted.bodyHtml).toBe(
-      "<p>Latency &lt; 50ms breached &amp; customer impacted.<br />Rolled back by Jane Doe.</p>",
-    );
-    // The audit record has to survive both the escape and the render-side
-    // sanitizer with every character the engineer typed still in it.
-    const rendered = document.createElement("div");
-    rendered.innerHTML = sanitizeRichTextHtml(posted.bodyHtml).replace(
-      /<br\s*\/?>/gi,
-      "\n",
-    );
-    expect(rendered.textContent).toBe(typed);
+    expect(posted.bodyHtml).toBe(typed);
   });
 
   it("routes the cancel transition through the same dialog", () => {

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.tsx
@@ -46,7 +46,7 @@ import {
 } from "react";
 import { useLocation } from "react-router";
 import { formatBackendTimestampForDisplay } from "@utils/dateTime";
-import { isBlankHtml, sanitizeRichTextHtml } from "@utils/sanitizeHtml";
+import { isBlankHtml, plainTextToHtml, sanitizeRichTextHtml } from "@utils/sanitizeHtml";
 import { BackendApiError } from "@api/backend/client";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 import { useEngineerDisplayName } from "@hooks/useEngineerDisplayName";
@@ -382,7 +382,12 @@ export default function CsmChangeRequestDetailPage(): JSX.Element {
       try {
         await postComment.mutateAsync({
           changeRequestId: cr.id,
-          bodyHtml: reason,
+          // The dialog collects plain text, the comment field stores and
+          // re-renders rich text. Converting is not cosmetic here: this note
+          // is the audit record for an irreversible transition, so an
+          // unescaped `<` or `&` would silently drop part of it and the
+          // engineer's line breaks would vanish on render.
+          bodyHtml: plainTextToHtml(reason),
           internal: true,
         });
         setReasonRecorded(true);

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.tsx
@@ -22,7 +22,6 @@ import {
   Skeleton,
   Tab,
   Tabs,
-  Tooltip,
   Typography,
 } from "@wso2/oxygen-ui";
 import {
@@ -35,7 +34,6 @@ import {
   MessageSquarePlus,
   Paperclip,
   Pencil,
-  Send,
   X,
 } from "@wso2/oxygen-ui-icons-react";
 import {
@@ -59,12 +57,15 @@ import {
   useGetCsmChangeRequestComments,
   usePostCsmChangeRequestComment,
 } from "@features/csm-operations/api/useCsmChangeRequestComments";
+import ChangeRequestActionBar from "@features/csm-operations/components/ChangeRequestActionBar";
 import ChangeRequestApprovals from "@features/csm-operations/components/ChangeRequestApprovals";
+import ChangeRequestTransitionReasonDialog from "@features/csm-operations/components/ChangeRequestTransitionReasonDialog";
 import EditChangeRequestDialog from "@features/csm-operations/components/EditChangeRequestDialog";
 import EntityRefLink from "@features/csm-operations/components/EntityRefLink";
 import {
   buildCloneChangeRequestNavState,
   changeRequestCommentGateReason,
+  changeRequestTransitionRequiresReason,
   changeRequestImpactColor,
   changeRequestImpactLabel,
   changeRequestStateColor,
@@ -78,7 +79,7 @@ import {
   usePostCsmCaseAttachment,
   useDownloadCsmCaseAttachment,
 } from "@features/csm-cases/api/useCsmCaseAttachments";
-import type { BeEntityRef } from "@api/backend/types";
+import type { BeEntityRef, BePatchChangeRequestPayload } from "@api/backend/types";
 import { useNavTransition } from "@hooks/useNavTransition";
 import { useNormalizedIdParam } from "@hooks/useNormalizedIdParam";
 import { useQueryParamTabs } from "@hooks/useSectionTabs";
@@ -94,6 +95,30 @@ function backendErrorMessage(err: unknown, fallback: string): string {
   return err instanceof BackendApiError && err.status < 500 && err.message
     ? err.message
     : fallback;
+}
+
+/**
+ * The patch that performs a transition into `target`.
+ *
+ * Every target goes through the generic `state` field except `assess`: the
+ * New -> Assess move has its own `requestApproval` flag, which additionally
+ * raises the approval request that setting `state` alone does not. Both are
+ * accepted on the same endpoint; `state` is not mutually exclusive with
+ * anything (only `isCustomerApproved`/`isCustomerReviewed`/`requestApproval`
+ * are, with each other), but a transition is always sent on its own anyway so
+ * a rejection can only ever be about the transition.
+ */
+function buildTransitionPatch(target: string): BePatchChangeRequestPayload {
+  return target === "assess" ? { requestApproval: true } : { state: target };
+}
+
+/**
+ * Fallback message for a failed transition, used only when the backend gave
+ * no usable 4xx reason of its own.
+ */
+function transitionFallbackMessage(target: string): string {
+  if (target === "assess") return "Could not request approval for this change request.";
+  return `Could not move this change request to ${changeRequestStateLabel(target)}.`;
 }
 
 function formatDateTime(value?: string | null): string {
@@ -210,6 +235,13 @@ export default function CsmChangeRequestDetailPage(): JSX.Element {
   const postAttachment = usePostCsmCaseAttachment();
   const downloadAttachment = useDownloadCsmCaseAttachment();
   const [composerOpen, setComposerOpen] = useState(false);
+  // Destructive transition awaiting confirmation (`rollback`/`canceled`), the
+  // inline error for that attempt, and whether its reason comment already
+  // landed — the last one so a retry after a failed patch re-sends only the
+  // state change instead of duplicating the comment.
+  const [reasonTarget, setReasonTarget] = useState<string | null>(null);
+  const [reasonError, setReasonError] = useState<string | null>(null);
+  const [reasonRecorded, setReasonRecorded] = useState(false);
 
   const attachmentList = useMemo(() => attachments ?? [], [attachments]);
 
@@ -298,44 +330,85 @@ export default function CsmChangeRequestDetailPage(): JSX.Element {
   }
 
   const cr = data;
-  // Data-driven, like CaseActionBar's nextStates handling: only "assess" is
-  // ever modeled today (New -> Assess), but this checks membership rather
-  // than hardcoding `cr.state === "new"` so a backend-added transition needs
-  // no FE change to show up. This is the state gate: the button renders at
-  // all only when the record's *current* state (as reflected by this list)
-  // legally transitions to "assess" — it is not offered from any other
-  // state. `usePatchChangeRequest` refetches this detail after every patch
-  // attempt, success or error, precisely so this list can't go stale after
-  // an ambiguous outcome (a write that commits upstream but is reported as
-  // a failure here) and re-offer an action that has already happened.
-  //
-  // The state machine alone isn't sufficient: the backing data source also
-  // enforces that an assigned team is set before this transition is allowed,
-  // so require `assignedTeam` too or the request round-trips and fails there.
-  // (A `plannedStartOn` requirement was proposed for this same gate, but the
-  // only confirmed rejection for this transition is the state-transition
-  // error below, and the contract for `requestApproval` documents only the
-  // state transition, not a planned-start dependency — so no gate is added
-  // for it here without stronger evidence.)
-  const stateAllowsRequestApproval = !!cr.legalNextStates?.includes("assess");
-  const requestApprovalBlockedReason = stateAllowsRequestApproval && !cr.assignedTeam
-    ? "Set an assigned team before requesting approval"
-    : null;
+  // A transition is in flight whenever either half of a destructive
+  // transition (the reason comment, then the patch) or a plain patch is
+  // running, so the bar stays disabled across both and a double-click can't
+  // fire two transitions.
+  const transitionPending = patchCr.isPending || postComment.isPending;
 
-  const requestApproval = (): void => {
+  /**
+   * Apply `target` to this change request. Destructive targets are diverted
+   * into the confirmation dialog first — see `confirmReasonTransition` for
+   * the comment-then-patch ordering they then follow.
+   */
+  const onTransition = (target: string): void => {
+    if (changeRequestTransitionRequiresReason(target)) {
+      setReasonError(null);
+      setReasonRecorded(false);
+      setReasonTarget(target);
+      return;
+    }
     patchCr.mutate(
-      { id: cr.id, patch: { requestApproval: true } },
+      { id: cr.id, patch: buildTransitionPatch(target) },
       {
         onError: (err) =>
-          showError(
-            backendErrorMessage(
-              err,
-              "Could not request approval for this change request.",
-            ),
-            err,
-          ),
+          showError(backendErrorMessage(err, transitionFallbackMessage(target)), err),
       },
     );
+  };
+
+  /**
+   * Confirmed destructive transition. The reason is recorded as an ordinary
+   * comment *before* the state changes, deliberately in that order: the PATCH
+   * contract carries no reason field, and a silent unexplained rollback or
+   * cancellation is worse than a failed one. So a failed comment aborts
+   * without touching the state.
+   *
+   * The reverse failure (comment recorded, patch rejected) is not rolled back
+   * — there is no comment-delete endpoint — so it reports exactly that, and
+   * `reasonRecorded` keeps the already-saved reason from being posted twice on
+   * a retry.
+   *
+   * Posted as an internal work note rather than a customer-visible comment:
+   * whether a rollback/cancellation reason should be shown to the customer
+   * hasn't been decided, and a work note is the choice that can't leak.
+   */
+  const confirmReasonTransition = async (reason: string): Promise<void> => {
+    const target = reasonTarget;
+    if (!target) return;
+    setReasonError(null);
+
+    if (!reasonRecorded) {
+      try {
+        await postComment.mutateAsync({
+          changeRequestId: cr.id,
+          bodyHtml: reason,
+          internal: true,
+        });
+        setReasonRecorded(true);
+      } catch (err) {
+        setReasonError(
+          backendErrorMessage(
+            err,
+            "Could not record the reason, so the state was left unchanged. Try again.",
+          ),
+        );
+        return;
+      }
+    }
+
+    try {
+      await patchCr.mutateAsync({ id: cr.id, patch: buildTransitionPatch(target) });
+      setReasonTarget(null);
+      setReasonRecorded(false);
+    } catch (err) {
+      setReasonError(
+        `Your reason was recorded as a comment, but the state did not change: ${backendErrorMessage(
+          err,
+          transitionFallbackMessage(target),
+        )} You don't need to retype it.`,
+      );
+    }
   };
 
   // Opens the create form pre-filled from this record, so promoting the same
@@ -373,65 +446,45 @@ export default function CsmChangeRequestDetailPage(): JSX.Element {
               label={`${changeRequestImpactLabel(cr.impact)} impact`}
             />
           )}
-          {stateAllowsRequestApproval && (
-            requestApprovalBlockedReason ? (
-              <Tooltip title={requestApprovalBlockedReason}>
-                <Box
-                  component="span"
-                  tabIndex={0}
-                  aria-label={`Request approval: ${requestApprovalBlockedReason}`}
-                  sx={{ ml: "auto", flexShrink: 0 }}
-                >
-                  <Button
-                    variant="contained"
-                    color="primary"
-                    size="small"
-                    startIcon={<Send size={14} />}
-                    disabled
-                    sx={{ flexShrink: 0 }}
-                  >
-                    Request approval
-                  </Button>
-                </Box>
-              </Tooltip>
-            ) : (
-              <Button
-                variant="contained"
-                color="primary"
-                size="small"
-                startIcon={<Send size={14} />}
-                onClick={requestApproval}
-                loading={patchCr.isPending}
-                sx={{ ml: "auto", flexShrink: 0 }}
-              >
-                Request approval
-              </Button>
-            )
-          )}
-          <Button
-            variant="outlined"
-            size="small"
-            startIcon={<CopyPlus size={14} />}
-            onClick={cloneChangeRequest}
-            sx={{ ml: stateAllowsRequestApproval ? 0 : "auto", flexShrink: 0 }}
-          >
-            Clone
-          </Button>
-          <Button
-            variant="outlined"
-            size="small"
-            startIcon={<Pencil size={14} />}
-            onClick={() => {
-              // Clear any error left over from a previous save (or from the
-              // Request approval button, which shares this mutation) so a
-              // stale rejection doesn't appear to belong to this edit.
-              patchCr.reset();
-              setEditOpen(true);
+          <Box
+            sx={{
+              ml: "auto",
+              display: "flex",
+              alignItems: "center",
+              gap: 1,
+              flexShrink: 0,
             }}
-            sx={{ flexShrink: 0 }}
           >
-            Edit
-          </Button>
+            <ChangeRequestActionBar
+              cr={cr}
+              isPending={transitionPending}
+              onAction={onTransition}
+            />
+            <Button
+              variant="outlined"
+              size="small"
+              startIcon={<CopyPlus size={14} />}
+              onClick={cloneChangeRequest}
+              sx={{ flexShrink: 0 }}
+            >
+              Clone
+            </Button>
+            <Button
+              variant="outlined"
+              size="small"
+              startIcon={<Pencil size={14} />}
+              onClick={() => {
+                // Clear any error left over from a previous save (or from a
+                // lifecycle transition, which shares this mutation) so a
+                // stale rejection doesn't appear to belong to this edit.
+                patchCr.reset();
+                setEditOpen(true);
+              }}
+              sx={{ flexShrink: 0 }}
+            >
+              Edit
+            </Button>
+          </Box>
         </Box>
         <Typography variant="body2" color="text.secondary" sx={{ fontFamily: "monospace" }}>
           {cr.number || cr.id}
@@ -644,6 +697,22 @@ export default function CsmChangeRequestDetailPage(): JSX.Element {
             onDownload={onDownloadAttachment}
           />
         </Card>
+      )}
+
+      {reasonTarget && (
+        <ChangeRequestTransitionReasonDialog
+          target={reasonTarget}
+          isSubmitting={transitionPending}
+          error={reasonError}
+          reasonRecorded={reasonRecorded}
+          onClose={() => {
+            if (transitionPending) return;
+            setReasonTarget(null);
+            setReasonError(null);
+            setReasonRecorded(false);
+          }}
+          onConfirm={(reason) => void confirmReasonTransition(reason)}
+        />
       )}
 
       {editOpen && (

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.tsx
@@ -46,7 +46,7 @@ import {
 } from "react";
 import { useLocation } from "react-router";
 import { formatBackendTimestampForDisplay } from "@utils/dateTime";
-import { isBlankHtml, plainTextToHtml, sanitizeRichTextHtml } from "@utils/sanitizeHtml";
+import { isBlankHtml, sanitizeRichTextHtml } from "@utils/sanitizeHtml";
 import { BackendApiError } from "@api/backend/client";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 import { useEngineerDisplayName } from "@hooks/useEngineerDisplayName";
@@ -382,12 +382,17 @@ export default function CsmChangeRequestDetailPage(): JSX.Element {
       try {
         await postComment.mutateAsync({
           changeRequestId: cr.id,
-          // The dialog collects plain text, the comment field stores and
-          // re-renders rich text. Converting is not cosmetic here: this note
-          // is the audit record for an irreversible transition, so an
-          // unescaped `<` or `&` would silently drop part of it and the
-          // engineer's line breaks would vanish on render.
-          bodyHtml: plainTextToHtml(reason),
+          // Posted verbatim, as plain text with real line breaks. The
+          // backing store for these notes is a plain-text journal field, not
+          // an HTML one: a sample of production entries carries raw newlines
+          // and no escaped entities, so wrapping the reason in markup would
+          // show literal tags to anyone reading the record at the source.
+          // The portal's own renderer treats the note as HTML, which renders
+          // `<` and line breaks imperfectly here; that mismatch is
+          // pre-existing, applies equally to notes authored outside the
+          // portal, and is being fixed on the render path, not by re-encoding
+          // on the way in.
+          bodyHtml: reason,
           internal: true,
         });
         setReasonRecorded(true);

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmIncidentDetailPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmIncidentDetailPage.test.tsx
@@ -72,15 +72,56 @@ vi.mock("@features/csm-cases/api/useCsmCaseAttachments", () => ({
 vi.mock("@features/csm-cases/components/CaseActivitiesFeed", () => ({
   default: () => null,
 }));
+// The real WatchersWidget's list arithmetic and its case-vs-incident rules are
+// covered in CaseDetailWidgets.test.tsx. Here it's a probe: it reports the
+// props the page hands it and gives a test two buttons to fire `onReplace`
+// with, so these tests assert what the *page* does with the finished list.
 vi.mock("@features/csm-cases/components/CaseDetailWidgets", () => ({
   AttachmentsWidget: () => null,
+  WatchersWidget: ({
+    entityKind,
+    watchers,
+    onReplace,
+    isSaving,
+  }: {
+    entityKind: string;
+    watchers: Array<{ id: string; name: string }>;
+    onReplace?: (nextWatcherIds: string[], action: "add" | "remove") => void;
+    isSaving?: boolean;
+  }) => (
+    <div data-testid="watchers-widget" data-entity-kind={entityKind}>
+      {watchers.map((w) => (
+        <span key={w.id}>{w.name}</span>
+      ))}
+      <button
+        type="button"
+        disabled={isSaving}
+        onClick={() =>
+          onReplace?.([...watchers.map((w) => w.id), NEW_WATCHER_ID], "add")
+        }
+      >
+        stub add watcher
+      </button>
+      <button
+        type="button"
+        disabled={isSaving}
+        onClick={() => onReplace?.([], "remove")}
+      >
+        stub clear watch list
+      </button>
+    </div>
+  ),
 }));
 vi.mock("@api/useSearchUsersByName", () => ({
   useSearchUsersByName: () => ({ data: [], isFetching: false, isError: false }),
 }));
 
 // Imported after the mocks above so the module picks them up.
+import { BackendApiError } from "@api/backend/client";
 import CsmIncidentDetailPage from "@features/csm-operations/pages/CsmIncidentDetailPage";
+
+const WATCHER_ID = "00000000-0000-0000-0000-000000000001";
+const NEW_WATCHER_ID = "00000000-0000-0000-0000-000000000002";
 
 const BASE_INCIDENT: BeIncidentDetail = {
   id: "inc-1",
@@ -216,7 +257,9 @@ describe("CsmIncidentDetailPage — tabs", () => {
     mockQueryResult({
       data: {
         ...BASE_INCIDENT,
-        watchList: [{ id: "u1", name: "Jane Doe", email: "jane.doe@example.com" }],
+        watchList: [
+          { id: WATCHER_ID, name: "Jane Doe", email: "jane.doe@example.com" },
+        ],
       },
     });
     renderPage();
@@ -240,28 +283,86 @@ describe("CsmIncidentDetailPage — tabs", () => {
   });
 });
 
-describe("CsmIncidentDetailPage — Watchers tab is read-only (watchList PATCH is a confirmed-live 404)", () => {
-  it("renders watcher chips with no remove affordance", () => {
-    mockQueryResult({
-      data: {
-        ...BASE_INCIDENT,
-        watchList: [{ id: "u1", name: "Jane Doe", email: "jane.doe@example.com" }],
-      },
-    });
+describe("CsmIncidentDetailPage — Watchers tab is editable", () => {
+  const WATCHING: BeIncidentDetail = {
+    ...BASE_INCIDENT,
+    watchList: [
+      { id: WATCHER_ID, name: "Jane Doe", email: "jane.doe@example.com" },
+    ],
+  };
+
+  function openWatchers(incident: BeIncidentDetail = WATCHING): void {
+    mockQueryResult({ data: incident });
     renderPage();
     goToTab(/watchers/i);
+  }
 
-    const chip = screen.getByText("Jane Doe").closest(".MuiChip-root");
-    expect(chip?.querySelector(".MuiChip-deleteIcon")).toBeNull();
+  it("renders the watch list as an incident's, not a case's", () => {
+    openWatchers();
+    expect(screen.getByTestId("watchers-widget")).toHaveAttribute(
+      "data-entity-kind",
+      "incident",
+    );
   });
 
-  it("disables the 'Add watcher' button", () => {
-    mockQueryResult({ data: { ...BASE_INCIDENT, watchList: [] } });
-    renderPage();
-    goToTab(/watchers/i);
+  it("PATCHes the whole replacement list on an add, keeping the existing watcher", () => {
+    openWatchers();
+    fireEvent.click(screen.getByRole("button", { name: /stub add watcher/i }));
 
-    expect(screen.getByRole("button", { name: /add watcher/i })).toBeDisabled();
-    expect(patchMutateMock).not.toHaveBeenCalled();
+    expect(patchMutateMock).toHaveBeenCalledWith(
+      { id: "inc-1", patch: { watchList: [WATCHER_ID, NEW_WATCHER_ID] } },
+      expect.anything(),
+    );
+  });
+
+  it("sends an explicitly empty list to clear an incident's watch list", () => {
+    openWatchers();
+    fireEvent.click(
+      screen.getByRole("button", { name: /stub clear watch list/i }),
+    );
+
+    expect(patchMutateMock).toHaveBeenCalledWith(
+      { id: "inc-1", patch: { watchList: [] } },
+      expect.anything(),
+    );
+  });
+
+  it("surfaces the backend's own message when a watch-list write is rejected, leaving the list as it was", () => {
+    openWatchers();
+    fireEvent.click(screen.getByRole("button", { name: /stub add watcher/i }));
+
+    const handlers = patchMutateMock.mock.calls.at(-1)?.[1] as {
+      onError: (err: unknown) => void;
+    };
+    handlers.onError(
+      new BackendApiError(
+        400,
+        `watchList contains an unknown user id: "${NEW_WATCHER_ID}"`,
+      ),
+    );
+
+    expect(showErrorMock).toHaveBeenCalledWith(
+      `watchList contains an unknown user id: "${NEW_WATCHER_ID}"`,
+      expect.anything(),
+    );
+    // Nothing was applied locally ahead of the write, so the failure leaves
+    // the rendered list exactly as the server still has it.
+    expect(screen.getByText("Jane Doe")).toBeInTheDocument();
+  });
+
+  it("falls back to a generic message on a server error, which carries nothing worth showing", () => {
+    openWatchers();
+    fireEvent.click(screen.getByRole("button", { name: /stub add watcher/i }));
+
+    const handlers = patchMutateMock.mock.calls.at(-1)?.[1] as {
+      onError: (err: unknown) => void;
+    };
+    handlers.onError(new BackendApiError(500, "sql: no rows in result set"));
+
+    expect(showErrorMock).toHaveBeenCalledWith(
+      "Could not update the watch list. Please try again.",
+      expect.anything(),
+    );
   });
 });
 

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmIncidentDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmIncidentDetailPage.tsx
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Box, Button, Card, Chip, Skeleton, Tab, Tabs, Tooltip, Typography } from "@wso2/oxygen-ui";
+import { Box, Button, Card, Chip, Skeleton, Tab, Tabs, Typography } from "@wso2/oxygen-ui";
 import {
   Activity,
   ArrowLeft,
@@ -24,7 +24,6 @@ import {
   MessageSquarePlus,
   Paperclip,
   Pencil,
-  Plus,
 } from "@wso2/oxygen-ui-icons-react";
 import {
   type JSX,
@@ -60,7 +59,10 @@ import {
 } from "@features/csm-operations/utils/incidents";
 import CaseActivitiesFeed from "@features/csm-cases/components/CaseActivitiesFeed";
 import CsmCaseCommentInput from "@features/csm-cases/components/CsmCaseCommentInput";
-import { AttachmentsWidget } from "@features/csm-cases/components/CaseDetailWidgets";
+import {
+  AttachmentsWidget,
+  WatchersWidget,
+} from "@features/csm-cases/components/CaseDetailWidgets";
 import {
   useGetCsmCaseAttachments,
   usePostCsmCaseAttachment,
@@ -79,19 +81,6 @@ import { useNormalizedIdParam } from "@hooks/useNormalizedIdParam";
 import { useQueryParamTabs } from "@hooks/useSectionTabs";
 
 const OPERATIONS_INCIDENTS_PATH = "/operations/incidents";
-
-/**
- * `watchList` 404s ("The requested resource was not found!") on
- * `PATCH /incidents/{id}` for *any* id, in the correct UUID-array shape —
- * confirmed live (an anonymous service account, a real named user, and a
- * fresh retest during PR review all reproduce it identically), so it isn't a
- * bad-id or bad-payload-shape problem on our side. Until the upstream
- * (entity-service/ServiceNow) endpoint actually works, the Watchers tab shows
- * the current list read-only rather than exposing an add/remove action that
- * would always fail.
- */
-const WATCH_LIST_UNAVAILABLE_REASON =
-  "Editing the watch list isn't available yet — the upstream API for this is broken (always returns 404), independent of this portal.";
 
 /**
  * A single confirmed-live upstream limitation of `PATCH /incidents/{id}`
@@ -209,7 +198,18 @@ export default function CsmIncidentDetailPage(): JSX.Element {
   const [previewTarget, setPreviewTarget] = useState<CaseAttachment | null>(null);
 
   const attachmentList = useMemo(() => attachments ?? [], [attachments]);
-  const watchList = useMemo(() => data?.watchList ?? [], [data?.watchList]);
+  // The read model's entries already carry the platform user UUID the write
+  // side is keyed by, so the widget can compute a replacement list straight
+  // from what is on screen.
+  const watchList = useMemo(
+    () =>
+      (data?.watchList ?? []).map((w) => ({
+        id: w.id,
+        name: w.name || w.email,
+        email: w.email || undefined,
+      })),
+    [data?.watchList],
+  );
 
   const recordView = useRecordRecentView();
   useEffect(() => {
@@ -245,6 +245,36 @@ export default function CsmIncidentDetailPage(): JSX.Element {
       );
     },
     [downloadAttachment, showError],
+  );
+
+  /**
+   * Persist a new watch list. There is no add-one/remove-one endpoint:
+   * `PATCH /incidents/{id}` takes the whole `watchList` as user UUIDs and
+   * replaces what is stored, so `WatchersWidget` computes the full
+   * replacement list (for a removal as much as an addition) and this only
+   * forwards it. An explicitly empty list is meaningful here — it clears the
+   * watch list — which is why the widget allows removing an incident's last
+   * watcher.
+   */
+  const onReplaceWatchers = useCallback(
+    (nextWatcherIds: string[]) => {
+      if (!id) return;
+      patchIncident.mutate(
+        { id, patch: { watchList: nextWatcherIds } },
+        {
+          onError: (err) => {
+            // The watch-list 400s name the offending value (an unknown or
+            // malformed user id), which is worth surfacing verbatim.
+            const msg =
+              err instanceof BackendApiError && err.status < 500 && err.message
+                ? err.message
+                : "Could not update the watch list. Please try again.";
+            showError(msg, err);
+          },
+        },
+      );
+    },
+    [id, patchIncident, showError],
   );
 
   /**
@@ -632,38 +662,12 @@ export default function CsmIncidentDetailPage(): JSX.Element {
       )}
 
       {activeTab === "watchers" && (
-        <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 1.5 }}>
-          <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
-            <Typography variant="subtitle2">Watch list</Typography>
-            <Tooltip title={WATCH_LIST_UNAVAILABLE_REASON}>
-              {/* span wrapper: Tooltip needs a non-disabled child to attach its listeners to */}
-              <span>
-                <Button
-                  size="small"
-                  variant="text"
-                  startIcon={<Plus size={14} />}
-                  disabled
-                >
-                  Add watcher
-                </Button>
-              </span>
-            </Tooltip>
-          </Box>
-          {watchList.length > 0 ? (
-            <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
-              {watchList.map((w) => (
-                <Chip key={w.id} size="small" variant="outlined" label={w.name || w.email} />
-              ))}
-            </Box>
-          ) : (
-            <Typography variant="body2" color="text.secondary">
-              No one is watching this incident.
-            </Typography>
-          )}
-          <Typography variant="caption" color="text.secondary">
-            {WATCH_LIST_UNAVAILABLE_REASON}
-          </Typography>
-        </Card>
+        <WatchersWidget
+          entityKind="incident"
+          watchers={watchList}
+          onReplace={onReplaceWatchers}
+          isSaving={patchIncident.isPending}
+        />
       )}
 
       {activeTab === "attachments" && (

--- a/apps/csm-portal/webapp/src/features/csm-operations/utils/catalogVariables.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/utils/catalogVariables.ts
@@ -23,7 +23,10 @@
 // customer-portal reference (operations/utils/serviceRequestValidation.ts).
 
 import { htmlToPlainText } from "@components/rich-text-editor/richTextEditor";
-import type { BeCatalogItemVariable } from "@api/backend/types";
+import type {
+  BeCatalogItemVariable,
+  BeCatalogItemVariableChoice,
+} from "@api/backend/types";
 
 // Variable `type` strings ServiceNow emits (matched case-insensitively).
 export const VARIABLE_TYPE_SINGLE_LINE = "Single Line Text";
@@ -32,7 +35,36 @@ export const VARIABLE_TYPE_SELECT = "Select Box";
 export const VARIABLE_TYPE_CHECKBOX = "Checkbox";
 export const VARIABLE_TYPE_RADIO = "Radio Buttons";
 
-/** Boolean-ish field that renders a Yes/No dropdown (no choice list in the API). */
+/**
+ * A choice whose `value` can actually be submitted, paired with the label to
+ * show for it. The contract makes every key inside a choice nullable, so an
+ * option with no `value` is dropped: it would submit nothing and render as a
+ * blank row. A blank `value` is dropped for the same reason — in a select it
+ * is the "nothing selected" sentinel, so it cannot be told apart from an
+ * unanswered field. `text` falls back to `value` when absent.
+ */
+export interface UsableChoice {
+  value: string;
+  label: string;
+}
+
+/**
+ * The submittable options on a variable, in the order the backing data source
+ * returned them (never re-sorted). Empty when the variable carries no choice
+ * list, or when every option in it is malformed — in which case the form
+ * falls back to a plain text input rather than showing an empty dropdown.
+ */
+export function usableChoices(variable: BeCatalogItemVariable): UsableChoice[] {
+  const choices: BeCatalogItemVariableChoice[] = variable.choices ?? [];
+  return choices
+    .filter((c): c is BeCatalogItemVariableChoice & { value: string } =>
+      typeof c?.value === "string" && c.value !== "",
+    )
+    .map((c) => ({ value: c.value, label: c.text ?? c.value }));
+}
+
+/** Boolean-ish field that renders a Yes/No dropdown (used only when the
+ *  backing data source supplied no choice list for the field). */
 export function isChoiceField(variable: BeCatalogItemVariable): boolean {
   // Case-insensitive, matching the documented contract and the other classifiers.
   const t = (variable.type ?? "").trim().toLowerCase();

--- a/apps/csm-portal/webapp/src/features/csm-operations/utils/changeRequests.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/utils/changeRequests.ts
@@ -143,6 +143,72 @@ export function approvalStatusColor(status?: string | null): ChipColor {
   return APPROVAL_STATUS_COLOR[status.toUpperCase()] ?? "default";
 }
 
+// ---------------------------------------------------------------------------
+// Lifecycle transitions
+//
+// The backing system owns transition legality — a change request carries its
+// own `legalNextStates`, and nothing here re-derives or second-guesses it.
+// These maps only supply the *presentation* of a transition the record has
+// already declared legal.
+// ---------------------------------------------------------------------------
+
+/**
+ * Action-phrased label for a transition *into* a given state. Phrased as the
+ * action being taken ("Schedule", "Mark implemented"), not as the destination,
+ * because the state chip next to the action bar already names the state —
+ * same "no invented verbs for the state itself" convention as
+ * `IncidentActionBar`/`CaseActionBar`.
+ *
+ * Deliberately partial: `new`, `authorize` and `customer_approval` have no
+ * agreed action verb yet, and a state the backend adds later has none by
+ * definition. Both fall back to a sentence-cased version of the raw value via
+ * {@link changeRequestTransitionLabel}, so they still render and still work.
+ */
+const TRANSITION_LABEL: Record<string, string> = {
+  assess: "Request approval",
+  scheduled: "Schedule",
+  implement: "Start implementation",
+  review: "Mark implemented",
+  customer_review: "Send for customer review",
+  closed: "Close",
+  rollback: "Roll back",
+  canceled: "Cancel change",
+};
+
+/**
+ * Transitions that are destructive and effectively irreversible. These are
+ * never offered as a primary button, always render in the error colour, and
+ * require a stated reason before they fire.
+ */
+const DESTRUCTIVE_TRANSITIONS: readonly string[] = ["rollback", "canceled"];
+
+/** `customer_review` -> `Customer review`. */
+function sentenceCase(raw: string): string {
+  const words = raw.replace(/_/g, " ").trim();
+  if (!words) return raw;
+  return words.charAt(0).toUpperCase() + words.slice(1).toLowerCase();
+}
+
+/** The action-phrased label for a transition target, curated or generic. */
+export function changeRequestTransitionLabel(target: string): string {
+  return TRANSITION_LABEL[target] ?? sentenceCase(target);
+}
+
+/** True when this transition is destructive: menu-only, error-coloured. */
+export function isDestructiveChangeRequestTransition(target: string): boolean {
+  return DESTRUCTIVE_TRANSITIONS.includes(target);
+}
+
+/**
+ * True when moving to `target` must not happen without a stated reason. The
+ * reason is recorded as an ordinary comment on the change request *before*
+ * the state is patched — the PATCH contract has no reason or comment field of
+ * its own. See `ChangeRequestTransitionReasonDialog`.
+ */
+export function changeRequestTransitionRequiresReason(target: string): boolean {
+  return isDestructiveChangeRequestTransition(target);
+}
+
 export interface ChangeRequestFilters {
   search: string;
   states: BeChangeRequestState[];

--- a/apps/csm-portal/webapp/src/utils/sanitizeHtml.test.ts
+++ b/apps/csm-portal/webapp/src/utils/sanitizeHtml.test.ts
@@ -22,8 +22,6 @@ import {
   plainTextToHtml,
   sanitizeDescriptionHtml,
   sanitizeRichTextHtml,
-  stripHtmlTags,
-  stripHtmlTagsPreservingLineBreaks,
   stripLightModeInlineStyles,
 } from "./sanitizeHtml";
 
@@ -160,45 +158,6 @@ describe("stripLightModeInlineStyles", () => {
   });
 });
 
-describe("stripHtmlTagsPreservingLineBreaks", () => {
-  it("keeps the boundary between two paragraphs (regression: used to collapse to 'AB')", () => {
-    expect(stripHtmlTags("<p>A</p><p>B</p>")).toBe("AB");
-    expect(stripHtmlTagsPreservingLineBreaks("<p>A</p><p>B</p>")).toBe("A\n\nB");
-  });
-
-  it("turns <br> into a single newline", () => {
-    expect(stripHtmlTagsPreservingLineBreaks("first<br />second")).toBe(
-      "first\nsecond",
-    );
-  });
-
-  it("keeps list items on separate lines", () => {
-    expect(
-      stripHtmlTagsPreservingLineBreaks("<ul><li>one</li><li>two</li></ul>"),
-    ).toBe("one\n\ntwo");
-  });
-
-  it("does not double up when the source HTML is itself newline-formatted", () => {
-    expect(
-      stripHtmlTagsPreservingLineBreaks("<p>A</p>\n  <p>B</p>\n"),
-    ).toBe("A\n\nB");
-  });
-
-  it("still strips markup and decodes entities like the single-line variant", () => {
-    expect(
-      stripHtmlTagsPreservingLineBreaks("<p>a &amp; b<script>x()</script></p>"),
-    ).toBe("a & b");
-  });
-
-  it("leaves plain text with comparison operators intact", () => {
-    expect(stripHtmlTagsPreservingLineBreaks("x < y > z")).toBe("x < y > z");
-  });
-
-  it("returns an empty string for markup with no visible text", () => {
-    expect(stripHtmlTagsPreservingLineBreaks("<p></p>")).toBe("");
-  });
-});
-
 describe("escapeHtml", () => {
   it("escapes the HTML-significant characters", () => {
     expect(escapeHtml(`&<>"'`)).toBe("&amp;&lt;&gt;&quot;&#039;");
@@ -208,6 +167,17 @@ describe("escapeHtml", () => {
     expect(escapeHtml("a & <b>")).toBe("a &amp; &lt;b&gt;");
   });
 });
+
+/**
+ * Read a fragment of HTML back as the text a user would see, with `<br>`
+ * counted as a line break. The inverse of `plainTextToHtml` for assertion
+ * purposes only — production code has no reason to un-render stored markup.
+ */
+function renderedTextOf(html: string): string {
+  const container = document.createElement("div");
+  container.innerHTML = html.replace(/<br\s*\/?>/gi, "\n");
+  return container.textContent ?? "";
+}
 
 describe("plainTextToHtml", () => {
   it("wraps a single line in a paragraph", () => {
@@ -236,13 +206,15 @@ describe("plainTextToHtml", () => {
 
   it("round-trips a reason containing <, & and a newline back to the typed text", () => {
     const typed = "Rolled back: latency < 5ms & error rate spiked.\nOwner: Jane Doe";
-    const posted = plainTextToHtml(typed);
-    expect(stripHtmlTagsPreservingLineBreaks(posted)).toBe(typed);
+    expect(renderedTextOf(plainTextToHtml(typed))).toBe(typed);
   });
 
   it("survives the render-side sanitizer with the text and the break intact", () => {
     const typed = "a < b & c\nsecond line";
-    const rendered = sanitizeRichTextHtml(plainTextToHtml(typed));
-    expect(stripHtmlTagsPreservingLineBreaks(rendered)).toBe(typed);
+    const posted = plainTextToHtml(typed);
+    // Nothing is dropped on the way to the DOM. The sanitizer reserialises the
+    // void tag (`<br />` becomes `<br>`), which is why this compares the text
+    // it reads back as rather than the markup byte-for-byte.
+    expect(renderedTextOf(sanitizeRichTextHtml(posted))).toBe(typed);
   });
 });

--- a/apps/csm-portal/webapp/src/utils/sanitizeHtml.test.ts
+++ b/apps/csm-portal/webapp/src/utils/sanitizeHtml.test.ts
@@ -19,7 +19,6 @@ import { describe, expect, it } from "vitest";
 import {
   escapeHtml,
   isBlankHtml,
-  plainTextToHtml,
   sanitizeDescriptionHtml,
   sanitizeRichTextHtml,
   stripLightModeInlineStyles,
@@ -168,53 +167,3 @@ describe("escapeHtml", () => {
   });
 });
 
-/**
- * Read a fragment of HTML back as the text a user would see, with `<br>`
- * counted as a line break. The inverse of `plainTextToHtml` for assertion
- * purposes only — production code has no reason to un-render stored markup.
- */
-function renderedTextOf(html: string): string {
-  const container = document.createElement("div");
-  container.innerHTML = html.replace(/<br\s*\/?>/gi, "\n");
-  return container.textContent ?? "";
-}
-
-describe("plainTextToHtml", () => {
-  it("wraps a single line in a paragraph", () => {
-    expect(plainTextToHtml("Superseded by a later change.")).toBe(
-      "<p>Superseded by a later change.</p>",
-    );
-  });
-
-  it("keeps line breaks as <br />", () => {
-    expect(plainTextToHtml("first\nsecond")).toBe("<p>first<br />second</p>");
-  });
-
-  it("escapes markup-significant characters so no text is dropped on render", () => {
-    expect(plainTextToHtml("latency < 5ms & rising")).toBe(
-      "<p>latency &lt; 5ms &amp; rising</p>",
-    );
-  });
-
-  it("normalizes CRLF so a pasted reason does not gain blank lines", () => {
-    expect(plainTextToHtml("first\r\nsecond")).toBe("<p>first<br />second</p>");
-  });
-
-  it("returns an empty string for blank input", () => {
-    expect(plainTextToHtml("   \n  ")).toBe("");
-  });
-
-  it("round-trips a reason containing <, & and a newline back to the typed text", () => {
-    const typed = "Rolled back: latency < 5ms & error rate spiked.\nOwner: Jane Doe";
-    expect(renderedTextOf(plainTextToHtml(typed))).toBe(typed);
-  });
-
-  it("survives the render-side sanitizer with the text and the break intact", () => {
-    const typed = "a < b & c\nsecond line";
-    const posted = plainTextToHtml(typed);
-    // Nothing is dropped on the way to the DOM. The sanitizer reserialises the
-    // void tag (`<br />` becomes `<br>`), which is why this compares the text
-    // it reads back as rather than the markup byte-for-byte.
-    expect(renderedTextOf(sanitizeRichTextHtml(posted))).toBe(typed);
-  });
-});

--- a/apps/csm-portal/webapp/src/utils/sanitizeHtml.test.ts
+++ b/apps/csm-portal/webapp/src/utils/sanitizeHtml.test.ts
@@ -17,9 +17,13 @@
 import DOMPurify from "dompurify";
 import { describe, expect, it } from "vitest";
 import {
+  escapeHtml,
   isBlankHtml,
+  plainTextToHtml,
   sanitizeDescriptionHtml,
   sanitizeRichTextHtml,
+  stripHtmlTags,
+  stripHtmlTagsPreservingLineBreaks,
   stripLightModeInlineStyles,
 } from "./sanitizeHtml";
 
@@ -153,5 +157,92 @@ describe("stripLightModeInlineStyles", () => {
     );
     expect(out).toContain("background-color: #1a1a1a");
     expect(out).toContain("color: red");
+  });
+});
+
+describe("stripHtmlTagsPreservingLineBreaks", () => {
+  it("keeps the boundary between two paragraphs (regression: used to collapse to 'AB')", () => {
+    expect(stripHtmlTags("<p>A</p><p>B</p>")).toBe("AB");
+    expect(stripHtmlTagsPreservingLineBreaks("<p>A</p><p>B</p>")).toBe("A\n\nB");
+  });
+
+  it("turns <br> into a single newline", () => {
+    expect(stripHtmlTagsPreservingLineBreaks("first<br />second")).toBe(
+      "first\nsecond",
+    );
+  });
+
+  it("keeps list items on separate lines", () => {
+    expect(
+      stripHtmlTagsPreservingLineBreaks("<ul><li>one</li><li>two</li></ul>"),
+    ).toBe("one\n\ntwo");
+  });
+
+  it("does not double up when the source HTML is itself newline-formatted", () => {
+    expect(
+      stripHtmlTagsPreservingLineBreaks("<p>A</p>\n  <p>B</p>\n"),
+    ).toBe("A\n\nB");
+  });
+
+  it("still strips markup and decodes entities like the single-line variant", () => {
+    expect(
+      stripHtmlTagsPreservingLineBreaks("<p>a &amp; b<script>x()</script></p>"),
+    ).toBe("a & b");
+  });
+
+  it("leaves plain text with comparison operators intact", () => {
+    expect(stripHtmlTagsPreservingLineBreaks("x < y > z")).toBe("x < y > z");
+  });
+
+  it("returns an empty string for markup with no visible text", () => {
+    expect(stripHtmlTagsPreservingLineBreaks("<p></p>")).toBe("");
+  });
+});
+
+describe("escapeHtml", () => {
+  it("escapes the HTML-significant characters", () => {
+    expect(escapeHtml(`&<>"'`)).toBe("&amp;&lt;&gt;&quot;&#039;");
+  });
+
+  it("escapes the ampersand first, so an escaped entity is not double-escaped wrongly", () => {
+    expect(escapeHtml("a & <b>")).toBe("a &amp; &lt;b&gt;");
+  });
+});
+
+describe("plainTextToHtml", () => {
+  it("wraps a single line in a paragraph", () => {
+    expect(plainTextToHtml("Superseded by a later change.")).toBe(
+      "<p>Superseded by a later change.</p>",
+    );
+  });
+
+  it("keeps line breaks as <br />", () => {
+    expect(plainTextToHtml("first\nsecond")).toBe("<p>first<br />second</p>");
+  });
+
+  it("escapes markup-significant characters so no text is dropped on render", () => {
+    expect(plainTextToHtml("latency < 5ms & rising")).toBe(
+      "<p>latency &lt; 5ms &amp; rising</p>",
+    );
+  });
+
+  it("normalizes CRLF so a pasted reason does not gain blank lines", () => {
+    expect(plainTextToHtml("first\r\nsecond")).toBe("<p>first<br />second</p>");
+  });
+
+  it("returns an empty string for blank input", () => {
+    expect(plainTextToHtml("   \n  ")).toBe("");
+  });
+
+  it("round-trips a reason containing <, & and a newline back to the typed text", () => {
+    const typed = "Rolled back: latency < 5ms & error rate spiked.\nOwner: Jane Doe";
+    const posted = plainTextToHtml(typed);
+    expect(stripHtmlTagsPreservingLineBreaks(posted)).toBe(typed);
+  });
+
+  it("survives the render-side sanitizer with the text and the break intact", () => {
+    const typed = "a < b & c\nsecond line";
+    const rendered = sanitizeRichTextHtml(plainTextToHtml(typed));
+    expect(stripHtmlTagsPreservingLineBreaks(rendered)).toBe(typed);
   });
 });

--- a/apps/csm-portal/webapp/src/utils/sanitizeHtml.ts
+++ b/apps/csm-portal/webapp/src/utils/sanitizeHtml.ts
@@ -235,3 +235,75 @@ export function stripHtmlTags(text: string): string {
   container.innerHTML = withoutTags;
   return container.textContent ?? "";
 }
+
+// Tags whose close marks the end of a visible block of text. Used by
+// {@link stripHtmlTagsPreservingLineBreaks} to turn structure into newlines
+// before the markup is discarded.
+const BLOCK_LEVEL_TAGS =
+  "p|div|li|ul|ol|tr|table|h[1-6]|blockquote|pre|section|article|header|footer|figcaption|dd|dt|dl";
+
+/**
+ * Opt-in sibling of {@link stripHtmlTags} that preserves block boundaries:
+ * `<p>A</p><p>B</p>` comes back as `"A\n\nB"` rather than `"AB"`.
+ *
+ * Deliberately a separate function rather than a change to `stripHtmlTags`.
+ * That one feeds single-line labels (recent-view titles and subtitles, the
+ * pinned-tab rename value, a case subject), where an injected newline would
+ * be a regression: it would show up in an `<input>` value and in a one-line
+ * ellipsised label. Use this one only where the text is displayed or edited
+ * as multi-line content.
+ *
+ * The boundary markers are inserted into the raw string *before* stripping,
+ * which is safe because the result still goes through `stripHtmlTags` — i.e.
+ * DOMPurify with an empty tag allow-list — so nothing here can smuggle markup
+ * through. Whitespace around the inserted newlines is collapsed so source
+ * formatting (`</p>\n<p>`) doesn't double up, and runs of three or more
+ * newlines collapse to a single blank line.
+ */
+export function stripHtmlTagsPreservingLineBreaks(text: string): string {
+  const withBoundaries = text
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(new RegExp(`</(?:${BLOCK_LEVEL_TAGS})\\s*>`, "gi"), "\n\n");
+  return stripHtmlTags(withBoundaries)
+    .replace(/\r\n?/g, "\n")
+    .replace(/[ \t]*\n[ \t]*/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+/**
+ * Escape the five HTML-significant characters so a plain-text string can be
+ * embedded in markup verbatim.
+ *
+ * Canonical implementation for the app; `components/rich-text-editor` re-exports
+ * this rather than keeping its own copy, and nothing should hand-roll a third.
+ */
+export function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
+
+/**
+ * Convert plain text typed by a user into the rich-text HTML the comment and
+ * long-text endpoints store and re-render.
+ *
+ * Both halves matter for anything that is an audit record. Without escaping, a
+ * `<` or `&` the engineer typed is parsed as markup and part of the text is
+ * silently dropped on render; without the `<br />`s, every line break they
+ * typed disappears. The output round-trips back through
+ * {@link stripHtmlTagsPreservingLineBreaks} with the text intact (that pair
+ * normalizes surrounding whitespace and collapses runs of three or more
+ * newlines to one blank line, so those are the only differences).
+ *
+ * Empty or whitespace-only input yields `""` rather than an empty paragraph,
+ * so callers that treat blank as "nothing to post" keep working.
+ */
+export function plainTextToHtml(text: string): string {
+  if (!text.trim()) return "";
+  const lines = text.replace(/\r\n?/g, "\n").split("\n").map(escapeHtml);
+  return `<p>${lines.join("<br />")}</p>`;
+}

--- a/apps/csm-portal/webapp/src/utils/sanitizeHtml.ts
+++ b/apps/csm-portal/webapp/src/utils/sanitizeHtml.ts
@@ -236,41 +236,6 @@ export function stripHtmlTags(text: string): string {
   return container.textContent ?? "";
 }
 
-// Tags whose close marks the end of a visible block of text. Used by
-// {@link stripHtmlTagsPreservingLineBreaks} to turn structure into newlines
-// before the markup is discarded.
-const BLOCK_LEVEL_TAGS =
-  "p|div|li|ul|ol|tr|table|h[1-6]|blockquote|pre|section|article|header|footer|figcaption|dd|dt|dl";
-
-/**
- * Opt-in sibling of {@link stripHtmlTags} that preserves block boundaries:
- * `<p>A</p><p>B</p>` comes back as `"A\n\nB"` rather than `"AB"`.
- *
- * Deliberately a separate function rather than a change to `stripHtmlTags`.
- * That one feeds single-line labels (recent-view titles and subtitles, the
- * pinned-tab rename value, a case subject), where an injected newline would
- * be a regression: it would show up in an `<input>` value and in a one-line
- * ellipsised label. Use this one only where the text is displayed or edited
- * as multi-line content.
- *
- * The boundary markers are inserted into the raw string *before* stripping,
- * which is safe because the result still goes through `stripHtmlTags` — i.e.
- * DOMPurify with an empty tag allow-list — so nothing here can smuggle markup
- * through. Whitespace around the inserted newlines is collapsed so source
- * formatting (`</p>\n<p>`) doesn't double up, and runs of three or more
- * newlines collapse to a single blank line.
- */
-export function stripHtmlTagsPreservingLineBreaks(text: string): string {
-  const withBoundaries = text
-    .replace(/<br\s*\/?>/gi, "\n")
-    .replace(new RegExp(`</(?:${BLOCK_LEVEL_TAGS})\\s*>`, "gi"), "\n\n");
-  return stripHtmlTags(withBoundaries)
-    .replace(/\r\n?/g, "\n")
-    .replace(/[ \t]*\n[ \t]*/g, "\n")
-    .replace(/\n{3,}/g, "\n\n")
-    .trim();
-}
-
 /**
  * Escape the five HTML-significant characters so a plain-text string can be
  * embedded in markup verbatim.
@@ -294,10 +259,8 @@ export function escapeHtml(text: string): string {
  * Both halves matter for anything that is an audit record. Without escaping, a
  * `<` or `&` the engineer typed is parsed as markup and part of the text is
  * silently dropped on render; without the `<br />`s, every line break they
- * typed disappears. The output round-trips back through
- * {@link stripHtmlTagsPreservingLineBreaks} with the text intact (that pair
- * normalizes surrounding whitespace and collapses runs of three or more
- * newlines to one blank line, so those are the only differences).
+ * typed disappears. The output survives the render-side sanitizer unchanged,
+ * so what is stored is exactly what the engineer typed.
  *
  * Empty or whitespace-only input yields `""` rather than an empty paragraph,
  * so callers that treat blank as "nothing to post" keep working.

--- a/apps/csm-portal/webapp/src/utils/sanitizeHtml.ts
+++ b/apps/csm-portal/webapp/src/utils/sanitizeHtml.ts
@@ -252,21 +252,3 @@ export function escapeHtml(text: string): string {
     .replace(/'/g, "&#039;");
 }
 
-/**
- * Convert plain text typed by a user into the rich-text HTML the comment and
- * long-text endpoints store and re-render.
- *
- * Both halves matter for anything that is an audit record. Without escaping, a
- * `<` or `&` the engineer typed is parsed as markup and part of the text is
- * silently dropped on render; without the `<br />`s, every line break they
- * typed disappears. The output survives the render-side sanitizer unchanged,
- * so what is stored is exactly what the engineer typed.
- *
- * Empty or whitespace-only input yields `""` rather than an empty paragraph,
- * so callers that treat blank as "nothing to post" keep working.
- */
-export function plainTextToHtml(text: string): string {
-  if (!text.trim()) return "";
-  const lines = text.replace(/\r\n?/g, "\n").split("\n").map(escapeHtml);
-  return `<p>${lines.join("<br />")}</p>`;
-}

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -1219,8 +1219,13 @@ type CaseView struct {
 	DeployedProductDetails *DeployedProductRef `json:"deployedProduct"`
 	Catalog                *EntityRef          `json:"catalog"`
 	CatalogItem            *EntityRef          `json:"catalogItem"`
-	AssignedTeam           *EntityRef          `json:"assignedTeam"`
-	Conversation           *EntityRef          `json:"conversation"`
+	// Variables are the answers given to the catalog item's questions when the
+	// service request was raised, in the order the backing data source returns
+	// them. Only service-request cases carry them; the field is omitted
+	// entirely for every other case type.
+	Variables    []CaseVariable `json:"variables,omitempty"`
+	AssignedTeam *EntityRef     `json:"assignedTeam"`
+	Conversation *EntityRef     `json:"conversation"`
 	// AssignedEngineer is the canonical user reference for the assigned
 	// engineer. Its id is populated: the assignee's own id already arrives with
 	// the response, so no extra lookup is involved. Null when the case is
@@ -1745,6 +1750,15 @@ type UpdatedCase struct {
 	// request set it or found it already set. Present only when the update set
 	// acknowledge.
 	AcknowledgedBy *AssignedEngineerRef `json:"acknowledgedBy,omitempty"`
+}
+
+// CaseVariable is one answered question on a service request: Name is the
+// question as it was shown on the request form, Value the answer recorded
+// against it. Both are plain strings on the backing data source, which stores
+// every answer -- including numbers, dates and choice selections -- as text.
+type CaseVariable struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
 }
 
 // WatchListUser is a compact user reference within the watch list.
@@ -2435,6 +2449,22 @@ type CatalogItemVariable struct {
 	QuestionText string `json:"questionText"`
 	Order        int    `json:"order"`
 	Type         string `json:"type"`
+	// Choices lists the selectable options for a choice-based variable, in the
+	// order the backing data source returns them. Most variables are free-text
+	// and carry none, so the field is omitted entirely rather than emitted as
+	// an empty list on every variable.
+	Choices []CatalogVariableChoice `json:"choices,omitempty"`
+}
+
+// CatalogVariableChoice is one selectable option on a choice-based catalog item
+// variable: Value is what a case create submits for it, Text the label shown to
+// the user, and Order its position in the list. All three are pointers because
+// the backing data source can genuinely leave any of them unset, and an absent
+// value must be null rather than "" or 0.
+type CatalogVariableChoice struct {
+	Value *string `json:"value"`
+	Text  *string `json:"text"`
+	Order *int    `json:"order"`
 }
 
 // GetCatalogItemVariablesResponse is the response for

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -72,6 +72,11 @@ type snCase struct {
 	RelatedCase           *snCaseRef                  `json:"relatedCase"`
 	Account               *snCaseAccount              `json:"account"`
 	LinkedServiceRequests []snLinkedServiceRequestRef `json:"linkedServiceRequests"`
+	// Variables carries the answers to the catalog item's questions on a service
+	// request, keyed as `variables` upstream. Present on the Choreo GET /cases/{id}
+	// response for service-request cases only; absent for every other case type, so
+	// this must tolerate absence.
+	Variables []snCaseVariableAnswer `json:"variables"`
 	// ChangeRequests carries the change requests raised from this case, keyed as
 	// `changeRequests` upstream. Only populated for service-request cases.
 	//
@@ -128,6 +133,14 @@ type snCase struct {
 	// request set includeExtendedFields — nil otherwise, so this must tolerate
 	// absence.
 	WorstCaseFixEta *string `json:"worstCaseFixEta"`
+}
+
+// snCaseVariableAnswer mirrors one answered catalog-item question on a service
+// request as the backing service returns it (CaseResponse.variables). Distinct
+// from snCaseVariable, which is the {id, value} shape a case create submits.
+type snCaseVariableAnswer struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
 }
 
 // snWatchListUser mirrors the watch-list user shape ServiceNow/Ballerina returns on both
@@ -743,7 +756,14 @@ func (s *snCaseService) CreateCase(ctx context.Context, req domain.CreateCaseReq
 	}
 
 	if len(req.WatchList) > 0 {
-		payload.WatchList = req.WatchList
+		// The backing service's case-create payload declares the watch list as
+		// email addresses, not user ids, so the incoming platform UUIDs are
+		// resolved to emails first.
+		emails, err := watchListEmails(ctx, s.client, token, "watchList", req.WatchList)
+		if err != nil {
+			return domain.CreateCaseResponse{}, err
+		}
+		payload.WatchList = emails
 	}
 	if req.RelatedCaseID != "" {
 		if err := validateUUIDs("relatedCaseId", []string{req.RelatedCaseID}); err != nil {
@@ -928,6 +948,15 @@ func (s *snCaseService) GetCaseByID(ctx context.Context, id string) (domain.Case
 			lcr = append(lcr, domain.LinkedChangeRequestRef{ID: sysidToUUID(r.ID), Number: r.Number, Name: name})
 		}
 		cv.LinkedChangeRequests = lcr
+	}
+	if len(c.Variables) > 0 {
+		vars := make([]domain.CaseVariable, 0, len(c.Variables))
+		for _, v := range c.Variables {
+			// Order is the backing data source's own question order; it carries
+			// meaning on the request form, so it is passed through untouched.
+			vars = append(vars, domain.CaseVariable{Name: v.Name, Value: v.Value})
+		}
+		cv.Variables = vars
 	}
 	if c.ResolutionCode != nil {
 		if rc, ok := snResolutionCodeByID[c.ResolutionCode.ID.String()]; ok {
@@ -1499,7 +1528,15 @@ func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReq
 		payload.WorkStateKey = &id
 	}
 	if len(req.WatchList) > 0 {
-		payload.WatchList = req.WatchList
+		// As on create, the backing service's case-update payload declares the
+		// watch list as email addresses. Note this path cannot express "clear the
+		// watch list": UpdateCaseRequest.WatchList is a plain slice, so an
+		// explicitly empty list is indistinguishable from an absent one.
+		emails, err := watchListEmails(ctx, s.client, token, "watchList", req.WatchList)
+		if err != nil {
+			return domain.UpdateCaseResponse{}, err
+		}
+		payload.WatchList = emails
 	}
 	if req.AssigneeEmail != nil {
 		payload.AssigneeEmail = req.AssigneeEmail

--- a/entity-service/internal/service/sn_case_variables_test.go
+++ b/entity-service/internal/service/sn_case_variables_test.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package service
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+)
+
+// TestSNCaseService_GetCaseByID_MapsVariables verifies that the catalog answers a
+// service request was raised with reach the case detail response, in the backing
+// data source's own order, and that a case carrying none reports no variables at
+// all rather than an empty list.
+func TestSNCaseService_GetCaseByID_MapsVariables(t *testing.T) {
+	tests := []struct {
+		name          string
+		variablesJSON string
+		want          []domain.CaseVariable
+	}{
+		{
+			name: "service request with answers keeps order",
+			variablesJSON: `,
+		"variables": [
+			{"name": "Existing Product Version/s", "value": "WSO2 API Manager 3.2.0"},
+			{"name": "Reason For Migration", "value": "End of support"},
+			{"name": "Target Date", "value": "2026-09-01"}
+		]`,
+			want: []domain.CaseVariable{
+				{Name: "Existing Product Version/s", Value: "WSO2 API Manager 3.2.0"},
+				{Name: "Reason For Migration", Value: "End of support"},
+				{Name: "Target Date", Value: "2026-09-01"},
+			},
+		},
+		{
+			name:          "field absent",
+			variablesJSON: ``,
+			want:          nil,
+		},
+		{
+			name:          "field present but empty",
+			variablesJSON: `, "variables": []`,
+			want:          nil,
+		},
+		{
+			name:          "field null",
+			variablesJSON: `, "variables": null`,
+			want:          nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := `{
+				"id": "` + testWLCaseSysid + `",
+				"internalId": "WSO2-002",
+				"number": "CS0001002",
+				"title": "Migration request",
+				"description": "Migrate to the latest version",
+				"createdOn": "2026-01-01 10:00:00",
+				"updatedOn": "2026-01-02 10:00:00",
+				"createdBy": "reporter@example.com",
+				"project": {"id": "` + testProjectSysid + `", "name": "Project A"},
+				"deployment": {"id": "", "name": ""},
+				"deployedProduct": {"id": "", "name": "", "version": ""},
+				"state": {"id": 1, "label": "Open"}` + tt.variablesJSON + `
+			}`
+
+			client := newTestCaseClient(t, func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(body))
+			})
+
+			svc := NewServiceNowCaseService(client, nil)
+
+			cv, err := svc.GetCaseByID(contextWithUserIDToken("token"), sysidToUUID(testWLCaseSysid))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(cv.Variables) != len(tt.want) {
+				t.Fatalf("Variables = %+v, want %+v", cv.Variables, tt.want)
+			}
+			for i, want := range tt.want {
+				if cv.Variables[i] != want {
+					t.Fatalf("Variables[%d] = %+v, want %+v", i, cv.Variables[i], want)
+				}
+			}
+		})
+	}
+}

--- a/entity-service/internal/service/sn_catalog_service.go
+++ b/entity-service/internal/service/sn_catalog_service.go
@@ -60,6 +60,19 @@ type snCatalogItemVariable struct {
 	QuestionText string `json:"questionText"`
 	Order        int    `json:"order"`
 	Type         string `json:"type"`
+	// Choices carries the selectable options for a choice-based variable. Absent
+	// for free-text variable types, which are the majority, so this must tolerate
+	// absence.
+	Choices []snCatalogVariableChoice `json:"choices"`
+}
+
+// snCatalogVariableChoice mirrors one option on a choice-based catalog item
+// variable. Every field is nullable upstream, so all three are pointers and an
+// unset one stays null rather than becoming "" or 0.
+type snCatalogVariableChoice struct {
+	Value *string `json:"value"`
+	Text  *string `json:"text"`
+	Order *int    `json:"order"`
 }
 
 // snCatalogItemVariablesResponse mirrors the Choreo GET /catalogs/{id}/items/{id}/variables response.
@@ -157,12 +170,26 @@ func (s *snCatalogService) GetCatalogItemVariables(ctx context.Context, catalogI
 
 	variables := make([]domain.CatalogItemVariable, 0, len(snResp.Variables))
 	for _, v := range snResp.Variables {
-		variables = append(variables, domain.CatalogItemVariable{
+		variable := domain.CatalogItemVariable{
 			ID:           sysidToUUID(v.ID),
 			QuestionText: v.QuestionText,
 			Order:        v.Order,
 			Type:         v.Type,
-		})
+		}
+		if len(v.Choices) > 0 {
+			// Choice order is the backing data source's own, and drives how the
+			// options are listed on the form, so it is passed through untouched.
+			choices := make([]domain.CatalogVariableChoice, 0, len(v.Choices))
+			for _, c := range v.Choices {
+				choices = append(choices, domain.CatalogVariableChoice{
+					Value: c.Value,
+					Text:  c.Text,
+					Order: c.Order,
+				})
+			}
+			variable.Choices = choices
+		}
+		variables = append(variables, variable)
 	}
 
 	return domain.GetCatalogItemVariablesResponse{Variables: variables}, nil

--- a/entity-service/internal/service/sn_catalog_service_test.go
+++ b/entity-service/internal/service/sn_catalog_service_test.go
@@ -1,0 +1,145 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package service
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+)
+
+// TestSNCatalogService_GetCatalogItemVariables_MapsChoices verifies that the
+// selectable options on a choice-based variable reach the response in the backing
+// data source's own order, and that a free-text variable carries no choices at all
+// rather than an empty list.
+func TestSNCatalogService_GetCatalogItemVariables_MapsChoices(t *testing.T) {
+	tests := []struct {
+		name        string
+		choicesJSON string
+		want        []domain.CatalogVariableChoice
+	}{
+		{
+			name: "choice variable keeps order",
+			choicesJSON: `, "choices": [
+				{"value": "aws", "text": "AWS", "order": 100},
+				{"value": "azure", "text": "Azure", "order": 200},
+				{"value": "gcp", "text": "GCP", "order": 300}
+			]`,
+			want: []domain.CatalogVariableChoice{
+				{Value: strPtr("aws"), Text: strPtr("AWS"), Order: intPtr(100)},
+				{Value: strPtr("azure"), Text: strPtr("Azure"), Order: intPtr(200)},
+				{Value: strPtr("gcp"), Text: strPtr("GCP"), Order: intPtr(300)},
+			},
+		},
+		{
+			name:        "free-text variable has no choices",
+			choicesJSON: ``,
+			want:        nil,
+		},
+		{
+			name:        "empty choices list",
+			choicesJSON: `, "choices": []`,
+			want:        nil,
+		},
+		{
+			name:        "null choices",
+			choicesJSON: `, "choices": null`,
+			want:        nil,
+		},
+		{
+			name:        "null option fields stay null",
+			choicesJSON: `, "choices": [{"value": null, "text": null, "order": null}]`,
+			want:        []domain.CatalogVariableChoice{{}},
+		},
+	}
+
+	catalogUUID := sysidToUUID(sysid32('1'))
+	catalogItemUUID := sysidToUUID(sysid32('2'))
+	variableSysid := sysid32('3')
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := `{"variables": [
+				{"id": "` + variableSysid + `", "questionText": "Target cloud", "order": 100, "type": "select"` + tt.choicesJSON + `}
+			]}`
+
+			client := newTestCaseClient(t, func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet {
+					t.Fatalf("expected GET, got %s", r.Method)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(body))
+			})
+
+			svc := NewServiceNowCatalogService(client)
+
+			resp, err := svc.GetCatalogItemVariables(contextWithUserIDToken("token"), catalogUUID, catalogItemUUID)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(resp.Variables) != 1 {
+				t.Fatalf("expected 1 variable, got %d", len(resp.Variables))
+			}
+
+			got := resp.Variables[0]
+			if got.ID != sysidToUUID(variableSysid) || got.QuestionText != "Target cloud" ||
+				got.Order != 100 || got.Type != "select" {
+				t.Fatalf("unexpected variable mapping: %+v", got)
+			}
+			if len(got.Choices) != len(tt.want) {
+				t.Fatalf("Choices = %+v, want %+v", got.Choices, tt.want)
+			}
+			for i, want := range tt.want {
+				assertOptStr(t, "Choices["+itoa(i)+"].Value", got.Choices[i].Value, want.Value)
+				assertOptStr(t, "Choices["+itoa(i)+"].Text", got.Choices[i].Text, want.Text)
+				assertOptInt(t, "Choices["+itoa(i)+"].Order", got.Choices[i].Order, want.Order)
+			}
+		})
+	}
+}
+
+func assertOptStr(t *testing.T, field string, got, want *string) {
+	t.Helper()
+	switch {
+	case got == nil && want == nil:
+	case got == nil || want == nil:
+		t.Fatalf("%s: got %v, want %v", field, deref(got), deref(want))
+	case *got != *want:
+		t.Fatalf("%s: got %q, want %q", field, *got, *want)
+	}
+}
+
+func assertOptInt(t *testing.T, field string, got, want *int) {
+	t.Helper()
+	switch {
+	case got == nil && want == nil:
+	case got == nil || want == nil:
+		t.Fatalf("%s: got %v, want %v", field, got, want)
+	case *got != *want:
+		t.Fatalf("%s: got %d, want %d", field, *got, *want)
+	}
+}
+
+func intPtr(n int) *int { return &n }
+
+func deref(s *string) string {
+	if s == nil {
+		return "<nil>"
+	}
+	return *s
+}

--- a/entity-service/internal/service/sn_incident_service.go
+++ b/entity-service/internal/service/sn_incident_service.go
@@ -647,11 +647,15 @@ func (s *snIncidentService) CreateIncident(ctx context.Context, req domain.Creat
 			}
 		}
 	}
-	if err := validateUUIDs("watchList", req.WatchList); err != nil {
+	token := middleware.UserIDTokenFromContext(ctx)
+
+	// The backing service's incident-create payload declares the watch list as
+	// email addresses, not user ids, so the incoming platform UUIDs are resolved
+	// to emails first.
+	watchList, err := watchListEmails(ctx, s.client, token, "watchList", req.WatchList)
+	if err != nil {
 		return domain.CreateIncidentResponse{}, err
 	}
-
-	token := middleware.UserIDTokenFromContext(ctx)
 
 	payload := snCreateIncidentPayload{
 		CallerID:           uuidToSysid(req.CallerID),
@@ -660,7 +664,7 @@ func (s *snIncidentService) CreateIncident(ctx context.Context, req domain.Creat
 		ImpactKey:          snIncidentImpactKeyMap[req.Impact],
 		UrgencyKey:         snIncidentUrgencyKeyMap[req.Urgency],
 		Subject:            req.Subject,
-		WatchList:          uuidsToSysids(req.WatchList),
+		WatchList:          watchList,
 		AdditionalComments: req.AdditionalComments,
 		WorkNotes:          req.WorkNotes,
 	}
@@ -1088,8 +1092,15 @@ func (s *snIncidentService) UpdateIncident(ctx context.Context, req domain.Updat
 		WorkNotes:          req.WorkNotes,
 	}
 	if req.WatchList != nil {
-		v := uuidsToSysids(*req.WatchList)
-		payload.WatchList = &v
+		// The backing service's incident-update payload declares the watch list as
+		// usernames -- not emails as its create counterpart does, and not ids --
+		// and it replaces the whole list, so an explicitly empty list must still be
+		// sent to clear it rather than be skipped.
+		userNames, err := watchListUserNames(ctx, s.client, token, "watchList", *req.WatchList)
+		if err != nil {
+			return domain.UpdateIncidentResponse{}, err
+		}
+		payload.WatchList = &userNames
 	}
 	if req.Priority != nil {
 		v := snIncidentPriorityKeyMap[*req.Priority]

--- a/entity-service/internal/service/sn_incident_service_test.go
+++ b/entity-service/internal/service/sn_incident_service_test.go
@@ -47,13 +47,15 @@ func validCreateIncidentRequest() domain.CreateIncidentRequest {
 	}
 }
 
-// TestSNIncidentService_CreateIncident_WatchListConvertedToSysids verifies that
-// every watchList UUID is converted to a ServiceNow sysid before it reaches the
-// outgoing payload, so SN resolves sys_user records instead of 404ing on a raw
-// platform UUID.
-func TestSNIncidentService_CreateIncident_WatchListConvertedToSysids(t *testing.T) {
+// TestSNIncidentService_CreateIncident_WatchListResolvedToEmails verifies that
+// every watchList UUID is resolved to the watcher's email address before it
+// reaches the outgoing payload: the backing service's incident-create payload
+// declares the watch list as emails, so forwarding ids -- raw or reformatted --
+// silently drops every watcher.
+func TestSNIncidentService_CreateIncident_WatchListResolvedToEmails(t *testing.T) {
 	var gotBody map[string]any
 	mux := http.NewServeMux()
+	mux.HandleFunc("/users/search", watchListUserSearchStub(t))
 	mux.HandleFunc("/incidents", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			t.Fatalf("expected POST, got %s", r.Method)
@@ -82,13 +84,13 @@ func TestSNIncidentService_CreateIncident_WatchListConvertedToSysids(t *testing.
 	if !ok {
 		t.Fatalf("expected watchList array in payload, got %+v", gotBody["watchList"])
 	}
-	want := []string{testIncidentWatcherSysid1, testIncidentWatcherSysid2}
+	want := []string{testWatcherEmail1, testWatcherEmail2}
 	if len(gotWatchList) != len(want) {
 		t.Fatalf("watchList length: got %d, want %d", len(gotWatchList), len(want))
 	}
 	for i, w := range want {
 		if gotWatchList[i] != w {
-			t.Fatalf("watchList[%d]: got %v, want %q (raw UUID must not be sent to SN)", i, gotWatchList[i], w)
+			t.Fatalf("watchList[%d]: got %v, want %q (an id must never be sent as a watcher)", i, gotWatchList[i], w)
 		}
 	}
 }
@@ -108,11 +110,14 @@ func TestSNIncidentService_CreateIncident_WatchList_InvalidUUID(t *testing.T) {
 	}
 }
 
-// TestSNIncidentService_UpdateIncident_WatchListConvertedToSysids mirrors the
-// create-path coverage above for the PATCH /incidents/{id} path.
-func TestSNIncidentService_UpdateIncident_WatchListConvertedToSysids(t *testing.T) {
+// TestSNIncidentService_UpdateIncident_WatchListResolvedToUserNames mirrors the
+// create-path coverage above for the PATCH /incidents/{id} path, which declares
+// its watch list as usernames rather than the emails its create counterpart
+// takes.
+func TestSNIncidentService_UpdateIncident_WatchListResolvedToUserNames(t *testing.T) {
 	var gotBody map[string]any
 	mux := http.NewServeMux()
+	mux.HandleFunc("/users/search", watchListUserSearchStub(t))
 	mux.HandleFunc("/incidents/"+testIncidentSysid, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPatch {
 			t.Fatalf("expected PATCH, got %s", r.Method)
@@ -143,13 +148,13 @@ func TestSNIncidentService_UpdateIncident_WatchListConvertedToSysids(t *testing.
 	if !ok {
 		t.Fatalf("expected watchList array in payload, got %+v", gotBody["watchList"])
 	}
-	want := []string{testIncidentWatcherSysid1, testIncidentWatcherSysid2}
+	want := []string{testWatcherUserName1, testWatcherUserName2}
 	if len(gotWatchList) != len(want) {
 		t.Fatalf("watchList length: got %d, want %d", len(gotWatchList), len(want))
 	}
 	for i, w := range want {
 		if gotWatchList[i] != w {
-			t.Fatalf("watchList[%d]: got %v, want %q (raw UUID must not be sent to SN)", i, gotWatchList[i], w)
+			t.Fatalf("watchList[%d]: got %v, want %q (an id must never be sent as a watcher)", i, gotWatchList[i], w)
 		}
 	}
 }

--- a/entity-service/internal/service/sn_watch_list.go
+++ b/entity-service/internal/service/sn_watch_list.go
@@ -1,0 +1,163 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
+	integrationservice "github.com/wso2-open-operations/cs-tools/entity-service/internal/servicenow-integration-service"
+)
+
+// Watch lists arrive at this service as platform user UUIDs, but the backing
+// service's write payloads are not keyed by id at all: the case create, case
+// update and incident create payloads declare the watch list as email
+// addresses, and the incident update payload declares it as usernames.
+// Forwarding the ids verbatim is silently accepted upstream and drops every
+// watcher, so each id is resolved to the identity value its target payload
+// actually declares before the write goes out.
+//
+// snWatchListIdentity holds both values from the one lookup, so a caller can
+// pick the one its payload needs without a second round trip.
+type snWatchListIdentity struct {
+	Email    string
+	UserName string
+}
+
+// resolveWatchListIdentities resolves watch-list user UUIDs to their upstream
+// identity values, preserving the caller's order. field names the request field
+// being validated so a bad value produces the same class of validation error as
+// every other id field on the same request.
+//
+// An id that resolves to no user is a validation error rather than a silent
+// omission: a dropped watcher is invisible to the caller, who sees a successful
+// write and no watcher.
+func resolveWatchListIdentities(
+	ctx context.Context, client *integrationservice.Client, token, field string, ids []string,
+) ([]snWatchListIdentity, error) {
+	if err := validateUUIDs(field, ids); err != nil {
+		return nil, err
+	}
+
+	out := make([]snWatchListIdentity, 0, len(ids))
+	if len(ids) == 0 {
+		return out, nil
+	}
+	// The backing user search caps a page at maxUserLimit, and the whole watch
+	// list has to resolve in one page for the lookup to stay a single call.
+	if len(ids) > maxUserLimit {
+		return nil, &apierror.ValidationError{
+			Msg: fmt.Sprintf("%s cannot contain more than %d values", field, maxUserLimit),
+		}
+	}
+
+	// One search for the whole list rather than a lookup per id: the filter takes
+	// a set of ids, and a watch list routinely carries several users.
+	sysIDs := make([]string, 0, len(ids))
+	seen := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		sysID := uuidToSysid(id)
+		if _, dup := seen[sysID]; dup {
+			continue
+		}
+		seen[sysID] = struct{}{}
+		sysIDs = append(sysIDs, sysID)
+	}
+
+	payload := snUserSearchPayload{
+		Filters:    snUserFilters{UserIDs: sysIDs},
+		Pagination: snProjectPagination{Limit: len(sysIDs), Offset: 0},
+	}
+
+	raw, err := client.Post(ctx, "/users/search", token, payload)
+	if err != nil {
+		return nil, err
+	}
+
+	var snResp snUsersResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return nil, fmt.Errorf("sn resolve watch list: parse response: %w", err)
+	}
+
+	byID := make(map[string]snUser, len(snResp.Users))
+	for _, u := range snResp.Users {
+		byID[u.ID] = u
+	}
+
+	for _, id := range ids {
+		u, ok := byID[uuidToSysid(id)]
+		if !ok {
+			return nil, &apierror.ValidationError{
+				Msg: fmt.Sprintf("%s contains an unknown user id: %q", field, id),
+			}
+		}
+		out = append(out, snWatchListIdentity{Email: u.Email, UserName: u.UserName})
+	}
+
+	return out, nil
+}
+
+// watchListEmails resolves watch-list user UUIDs to email addresses, for the
+// payloads that declare the watch list that way. The returned slice is non-nil
+// and in the caller's order.
+func watchListEmails(
+	ctx context.Context, client *integrationservice.Client, token, field string, ids []string,
+) ([]string, error) {
+	identities, err := resolveWatchListIdentities(ctx, client, token, field, ids)
+	if err != nil {
+		return nil, err
+	}
+
+	emails := make([]string, 0, len(identities))
+	for i, identity := range identities {
+		if identity.Email == "" {
+			return nil, &apierror.ValidationError{
+				Msg: fmt.Sprintf("%s contains a user with no email address: %q", field, ids[i]),
+			}
+		}
+		emails = append(emails, identity.Email)
+	}
+
+	return emails, nil
+}
+
+// watchListUserNames resolves watch-list user UUIDs to usernames, for the
+// payloads that declare the watch list that way. The returned slice is non-nil
+// and in the caller's order, so an explicitly empty watch list still reaches the
+// backing service as an empty list rather than being dropped.
+func watchListUserNames(
+	ctx context.Context, client *integrationservice.Client, token, field string, ids []string,
+) ([]string, error) {
+	identities, err := resolveWatchListIdentities(ctx, client, token, field, ids)
+	if err != nil {
+		return nil, err
+	}
+
+	userNames := make([]string, 0, len(identities))
+	for i, identity := range identities {
+		if identity.UserName == "" {
+			return nil, &apierror.ValidationError{
+				Msg: fmt.Sprintf("%s contains a user with no username: %q", field, ids[i]),
+			}
+		}
+		userNames = append(userNames, identity.UserName)
+	}
+
+	return userNames, nil
+}

--- a/entity-service/internal/service/sn_watch_list_test.go
+++ b/entity-service/internal/service/sn_watch_list_test.go
@@ -1,0 +1,303 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package service
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+)
+
+const (
+	testWatcherEmail1    = "jane.doe@example.com"
+	testWatcherEmail2    = "john.doe@example.com"
+	testWatcherUserName1 = "jane.doe"
+	testWatcherUserName2 = "john.doe"
+	// testUnknownWatcherUUID resolves to no user in watchListUserSearchStub.
+	testUnknownWatcherUUID = "00000000-0000-0000-0000-000000000000"
+)
+
+// watchListUserSearchStub answers POST /users/search from a two-user directory,
+// returning only the users whose ids the request asked for. Results come back in
+// the directory's own order rather than the request's, so a caller that relies on
+// the response order instead of re-ordering by id fails these tests.
+func watchListUserSearchStub(t *testing.T) http.HandlerFunc {
+	t.Helper()
+
+	directory := map[string]map[string]any{
+		testIncidentWatcherSysid1: {
+			"id": testIncidentWatcherSysid1, "userName": testWatcherUserName1,
+			"name": "Jane Doe", "email": testWatcherEmail1, "active": true,
+		},
+		testIncidentWatcherSysid2: {
+			"id": testIncidentWatcherSysid2, "userName": testWatcherUserName2,
+			"name": "John Doe", "email": testWatcherEmail2, "active": true,
+		},
+	}
+	// Directory order, deliberately the reverse of the order the tests request.
+	order := []string{testIncidentWatcherSysid2, testIncidentWatcherSysid1}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("expected POST on /users/search, got %s", r.Method)
+		}
+		var body struct {
+			Filters struct {
+				UserIDs []string `json:"userIds"`
+			} `json:"filters"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode /users/search body: %v", err)
+		}
+		asked := make(map[string]struct{}, len(body.Filters.UserIDs))
+		for _, id := range body.Filters.UserIDs {
+			asked[id] = struct{}{}
+		}
+
+		users := []map[string]any{}
+		for _, id := range order {
+			if _, ok := asked[id]; ok {
+				users = append(users, directory[id])
+			}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"users": users, "totalRecords": len(users), "limit": len(users), "offset": 0,
+		})
+	}
+}
+
+// TestSNCaseService_CreateCase_WatchListResolvedToEmails verifies the case-create
+// path resolves watch-list user ids to email addresses, in the caller's order --
+// the backing service's create payload declares emails, so an id reaches it as an
+// unresolvable value and the watcher is silently lost.
+func TestSNCaseService_CreateCase_WatchListResolvedToEmails(t *testing.T) {
+	var gotBody map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/users/search", watchListUserSearchStub(t))
+	mux.HandleFunc("/cases", func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{
+			"message": "Case created successfully",
+			"case": {"id": "` + testWLCaseSysid + `", "number": "CS0000010", "createdBy": "engineer@example.com", "createdOn": "2026-01-02 10:00:00", "state": {"id": 1, "label": "Open"}}
+		}`))
+	})
+
+	svc := NewServiceNowCaseService(newTestSNClient(t, mux), nil)
+
+	req := domain.CreateCaseRequest{
+		Type:              "engagement",
+		ProjectID:         testProjectUUID,
+		DeploymentID:      testDeploymentUUID,
+		DeployedProductID: testDeployedProdID,
+		Subject:           "Migration planning",
+		Description:       "Plan the migration",
+		EngagementType:    domain.EngagementTypeMigration,
+		WatchList:         []string{testIncidentWatcherUUID1, testIncidentWatcherUUID2},
+	}
+
+	if _, err := svc.CreateCase(contextWithUserIDToken("token"), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertWatchListPayload(t, gotBody, []string{testWatcherEmail1, testWatcherEmail2})
+}
+
+// TestSNCaseService_UpdateCase_WatchListResolvedToEmails mirrors the create-path
+// coverage for PATCH /cases/{id}, whose payload declares emails as well.
+func TestSNCaseService_UpdateCase_WatchListResolvedToEmails(t *testing.T) {
+	var gotBody map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/users/search", watchListUserSearchStub(t))
+	mux.HandleFunc("/cases/"+testWLCaseSysid, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Fatalf("expected PATCH, got %s", r.Method)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"message": "Case updated successfully",
+			"case": {"id": "` + testWLCaseSysid + `", "updatedOn": "2026-01-03 10:00:00", "updatedBy": "engineer@example.com"}
+		}`))
+	})
+
+	svc := NewServiceNowCaseService(newTestSNClient(t, mux), nil)
+
+	_, err := svc.UpdateCase(contextWithUserIDToken("token"), domain.UpdateCaseRequest{
+		ID:        sysidToUUID(testWLCaseSysid),
+		WatchList: []string{testIncidentWatcherUUID1, testIncidentWatcherUUID2},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertWatchListPayload(t, gotBody, []string{testWatcherEmail1, testWatcherEmail2})
+}
+
+// TestSNIncidentService_UpdateIncident_WatchListClearedByEmptyList verifies an
+// explicitly empty watch list still reaches the backing service as an empty list.
+// The incident-update payload replaces the whole watch list, so an empty list is
+// the only way to clear it; a length guard on the outgoing field would turn "clear
+// the watch list" into a silent no-op.
+func TestSNIncidentService_UpdateIncident_WatchListClearedByEmptyList(t *testing.T) {
+	var gotBody map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/users/search", func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("clearing the watch list must not trigger a user lookup")
+	})
+	mux.HandleFunc("/incidents/"+testIncidentSysid, func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"message": "Incident updated successfully.",
+			"incident": {"id": "` + testIncidentSysid + `", "number": "INC0001", "createdOn": "2026-01-01 00:00:00", "createdBy": "engineer@example.com"}
+		}`))
+	})
+
+	svc := NewServiceNowIncidentService(newTestSNClient(t, mux))
+
+	watchList := []string{}
+	_, err := svc.UpdateIncident(contextWithUserIDToken("token"), domain.UpdateIncidentRequest{
+		ID:        testIncidentUUID,
+		WatchList: &watchList,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, present := gotBody["watchList"]
+	if !present {
+		t.Fatalf("watchList absent from payload %+v, want an empty list so the watch list is cleared", gotBody)
+	}
+	list, ok := got.([]any)
+	if !ok || len(list) != 0 {
+		t.Fatalf("watchList = %#v, want an empty list", got)
+	}
+}
+
+// TestWatchListResolution_UnknownUserID verifies that a well-formed id matching no
+// user is a validation error on every watch-list path, rather than a watcher that
+// vanishes from an otherwise successful write.
+func TestWatchListResolution_UnknownUserID(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/users/search", watchListUserSearchStub(t))
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("unexpected write to %s: an unresolvable watcher must fail before the write", r.URL.Path)
+	})
+	client := newTestSNClient(t, mux)
+
+	caseSvc := NewServiceNowCaseService(client, nil)
+	incidentSvc := NewServiceNowIncidentService(client)
+	unknown := []string{testIncidentWatcherUUID1, testUnknownWatcherUUID}
+
+	tests := []struct {
+		name string
+		call func() error
+	}{
+		{
+			name: "case create",
+			call: func() error {
+				_, err := caseSvc.CreateCase(contextWithUserIDToken("token"), domain.CreateCaseRequest{
+					Type:              "engagement",
+					ProjectID:         testProjectUUID,
+					DeploymentID:      testDeploymentUUID,
+					DeployedProductID: testDeployedProdID,
+					Subject:           "Migration planning",
+					Description:       "Plan the migration",
+					EngagementType:    domain.EngagementTypeMigration,
+					WatchList:         unknown,
+				})
+				return err
+			},
+		},
+		{
+			name: "case update",
+			call: func() error {
+				_, err := caseSvc.UpdateCase(contextWithUserIDToken("token"), domain.UpdateCaseRequest{
+					ID:        sysidToUUID(testWLCaseSysid),
+					WatchList: unknown,
+				})
+				return err
+			},
+		},
+		{
+			name: "incident create",
+			call: func() error {
+				req := validCreateIncidentRequest()
+				req.WatchList = unknown
+				_, err := incidentSvc.CreateIncident(contextWithUserIDToken("token"), req)
+				return err
+			},
+		},
+		{
+			name: "incident update",
+			call: func() error {
+				watchList := unknown
+				_, err := incidentSvc.UpdateIncident(contextWithUserIDToken("token"), domain.UpdateIncidentRequest{
+					ID:        testIncidentUUID,
+					WatchList: &watchList,
+				})
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.call()
+			verr, ok := err.(*apierror.ValidationError)
+			if !ok {
+				t.Fatalf("expected *apierror.ValidationError, got %T: %v", err, err)
+			}
+			if !strings.Contains(verr.Msg, testUnknownWatcherUUID) {
+				t.Fatalf("error %q does not name the offending id %q", verr.Msg, testUnknownWatcherUUID)
+			}
+		})
+	}
+}
+
+// assertWatchListPayload checks the outgoing payload's watchList against want,
+// order included.
+func assertWatchListPayload(t *testing.T, body map[string]any, want []string) {
+	t.Helper()
+
+	got, ok := body["watchList"].([]any)
+	if !ok {
+		t.Fatalf("expected watchList array in payload, got %+v", body["watchList"])
+	}
+	if len(got) != len(want) {
+		t.Fatalf("watchList length: got %d, want %d", len(got), len(want))
+	}
+	for i, w := range want {
+		if got[i] != w {
+			t.Fatalf("watchList[%d]: got %v, want %q", i, got[i], w)
+		}
+	}
+}

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -5670,6 +5670,14 @@ components:
             type. This is a one-to-many relationship: promoting the same change
             through each environment produces one change request per environment,
             all pointing back at the same service request.
+        variables:
+          type: array
+          items:
+            $ref: '#/components/schemas/CaseVariable'
+          description: >-
+            Answers given to the catalog item's questions when the service request
+            was raised, in the backing data source's own order. Only service-request
+            cases carry them; absent for every other case type.
         resolvedOn:
           type: string
           format: date-time
@@ -6676,6 +6684,16 @@ components:
         offset:
           type: integer
 
+    CaseVariable:
+      type: object
+      properties:
+        name:
+          type: string
+          description: The question as it was shown on the service-request form.
+        value:
+          type: string
+          description: The answer recorded against that question.
+
     CatalogItemVariable:
       type: object
       properties:
@@ -6691,6 +6709,30 @@ components:
         type:
           type: string
           description: Variable type (e.g. text, select).
+        choices:
+          type: array
+          items:
+            $ref: '#/components/schemas/CatalogVariableChoice'
+          description: >-
+            Selectable options for a choice-based variable, in the backing data
+            source's own order. Absent for free-text variable types, which are the
+            majority.
+
+    CatalogVariableChoice:
+      type: object
+      properties:
+        value:
+          type: string
+          nullable: true
+          description: The value a case create submits when this option is selected.
+        text:
+          type: string
+          nullable: true
+          description: The label shown to the user for this option.
+        order:
+          type: integer
+          nullable: true
+          description: Position of this option within the list.
 
     GetCatalogItemVariablesResponse:
       type: object

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -6686,6 +6686,7 @@ components:
 
     CaseVariable:
       type: object
+      required: [name, value]
       properties:
         name:
           type: string
@@ -6720,6 +6721,7 @@ components:
 
     CatalogVariableChoice:
       type: object
+      required: [value, text, order]
       properties:
         value:
           type: string


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Several operations workflows the CS engineering team relies on were only partially supported in the CSM portal. This PR adds the missing capability across the entity service and the webapp:

- **Service request answers were not visible anywhere.** A service request is raised by answering a catalog item's questions. Those answers were submitted successfully but never surfaced again, so an engineer opening the request could see its subject and description but not what was actually asked for.
- **Choice-type catalog fields were free-text.** Their option lists were not carried through to the form, so a field with a fixed set of valid values accepted arbitrary text.
- **The change-request detail page could drive only one lifecycle transition.** The contract already returns the legal next states for a record; the UI consumed exactly one of them.
- **Rollback plan, test plan and planned end date were displayable but not editable.** All three were already accepted by the update contract; the webapp simply had no field for them.
- **Watch lists were inconsistent.** The incident watch list was not editable at all, and the case watch list identified users differently from the rest of the portal.

Resolves: N/A — no public tracking issue; this work is tracked internally.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

- Show a service request's submitted answers, plus its catalog and catalog item, on the request detail page.
- Render choice-type catalog fields as real selects backed by their option lists.
- Let an engineer drive every lifecycle transition the backing contract offers for a change request, from one action bar.
- Capture a required reason when a change request is cancelled, recorded as an internal note.
- Add rollback plan, test plan and planned end date to the change-request edit dialog.
- Make the watch list editable on both cases and incidents, on one consistent identifier.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

Bottom-up, one layer at a time.

**Entity service.** Two of these gaps were purely a matter of the entity service not passing on data the backing layer already returns: a service request's answers, and a catalog variable's option list. Both are now mapped into the existing responses, omitted entirely when absent rather than emitted as `null` or `[]`. The published contract in `openapi.yaml` is updated to match.

The watch list needed a real fix rather than a passthrough. The backing contract expects a different identifier per operation, and the service was forwarding the caller's user ids unchanged. A small helper now resolves the caller's user ids to the shape each operation declares, in a single bulk lookup that preserves list order, and returns a validation error naming any id that resolves to no user rather than silently dropping it.

**Backend-for-frontend.** No change required. It round-trips both responses without reshaping them, so the new fields reach the webapp unchanged.

**Webapp.** The change-request action bar is modelled directly on the existing incident action bar — the same curated-config-plus-generic-fallback structure, so a transition added later needs no frontend change to appear. At most one primary button renders; everything else sits behind an overflow menu. Cancellation opens a confirmation dialog with a required reason; because the update contract has no reason field, the reason is posted as an internal note **before** the state change, and the transition is abandoned if that post fails, so a state change is never recorded without its explanation.

The watch-list editor is one shared widget used by both the case and incident pages, with the per-record-type differences held in a single lookup table rather than duplicated on each page. Both operations send a complete replacement list; the pages forward an array the widget builds, so a page cannot send a partial update by mistake.

**These commits must land together.** The watch-list identifier change spans the entity service and the webapp. Merging only the entity-service commit would break the existing case watch-list editor, so this is deliberately not split into per-layer PRs.

**A note on size, for the automated reviewer.** This PR is 32 files, and three exceed the 300-line window for line-by-line review: `CaseDetailWidgets.tsx`, its test file, and the new watch-list test. Splitting along the natural seam would produce the broken intermediate state described above, so the size is accepted rather than worked around. Expect summary-only review on those three.

## User stories
> Summary of user stories addressed by this change>

- As a CS engineer, I can see what a customer actually asked for when I open a service request, without leaving the portal.
- As a CS engineer raising a service request, I pick from the valid values of a choice field instead of guessing at free text.
- As a CS engineer, I can move a change request through its lifecycle from the record itself, and I must give a reason before cancelling one.
- As a CS engineer, I can record the rollback plan, test plan and planned end date I am already expected to supply.
- As a CS engineer, I can add and remove watchers on a case or an incident.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Operations: service request detail now shows the submitted request answers; catalog choice fields render as selects; change requests can be driven through their full lifecycle with a required reason on cancellation; rollback plan, test plan and planned end date are editable; case and incident watch lists are editable.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter "N/A" plus brief explanation of why there's no doc impact

N/A — internal-facing portal screens with no published end-user documentation. The API surface change is captured in the entity service's own `openapi.yaml`, updated in this PR.

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

N/A — no training content covers this internal portal.

## Certification
> Type "Sent" when you have provided new/updated certification questions...

N/A — no certification exam covers this internal portal.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature...

N/A — internal tooling, not a customer-facing or promoted capability.

## Automation tests
 - Unit tests
   > Code coverage information

Added throughout, following the existing style in each package.

Entity service: new table-driven tests for the answers mapping (present, absent, empty, null), the option-list mapping (present, absent, empty, null, null-valued options), and watch-list resolution across all four operations including the unresolvable-id error path and the explicit-clear path. Two pre-existing tests that asserted the previous, incorrect identifier behaviour were rewritten rather than left in place.

Webapp: coverage for the action bar (which targets render, single-primary invariant, unknown-state fallback, empty-list behaviour), the reason dialog (submit blocked while empty, note-posted-before-transition ordering, and the note-fails-so-no-transition path), the edit dialog fields, the request-details card (ordering, blank-value rendering, empty state, and that it does not render for a non-service-request), the choice-field select (submits the stored value, skips unusable options, falls back to text input), and the watch-list editor (full-replacement arrays on both add and remove, the per-record-type removal rule, and error surfacing).

`vitest` across the two touched feature areas: 69 files, 699 tests passing. `go test ./...` green across the entity service.

 - Integration tests
   > Details about the test cases and coverage

No automated integration suite exists for these paths. Verified manually instead: the entity service was built from this branch and run against a development instance of the backing data source, and each change was exercised with real requests and the affected record read back afterwards — a success status alone is not treated as proof of persistence. Covered: watch-list writes of one and two users on both record types, the unresolvable-id and malformed-id error paths, the explicit-clear path, a service request's answers returned in the backing layer's order, a plain case correctly omitting the field, option lists returned on a choice field and absent on others, and a change-request lifecycle transition read back after the write.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **N/A** — FindSecurityBugs targets Java. This PR is Go and TypeScript; `go vet ./...` and `eslint` both run clean, and the change adds no new lint findings.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes** — no configuration or environment files are touched.

## Samples
> Provide high-level details about the samples related to this feature

N/A — no samples accompany internal portal screens.

## Related PRs
> List any other related PRs

None. A follow-up is expected to add approve/reject against the caller's own approval record, which is the remaining half of the change-request lifecycle.

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

N/A — no schema change and no data migration. All new response fields are additive and omitted when absent, so existing consumers are unaffected.

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested

macOS. Entity service built and tested with the repository's pinned Go toolchain; webapp type-checked and unit-tested with the repository's pinned Node toolchain. Backend paths exercised against a development instance of the backing data source. No manual cross-browser pass was performed — the webapp changes are covered by unit tests only, and a reviewer wanting visual confirmation should run the affected screens locally.

## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

No external research. The two significant findings both came from reading the existing contract rather than from adding to it: the answers and option lists were already being returned and merely discarded a layer later, and the watch-list failures were a payload-shape mismatch rather than a broken endpoint, which an earlier investigation had diagnosed incorrectly twice. The action bar deliberately reuses the incident action bar's existing pattern rather than introducing a second approach to the same problem.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Service-request cases now display catalog, catalog-item, and answered request details in their original order.
  * Catalog fields support backend-provided selectable choices with appropriate fallbacks.
  * Case and incident watch lists can be updated, including clearing incident watchers.
  * Change requests now offer backend-defined lifecycle actions with accessible menus and prerequisite guidance.
  * Rollback and cancellation require a confirmation reason; planned end dates, rollback plans, and test plans are supported.

* **Bug Fixes**
  * Improved validation, error handling, loading behavior, and safe HTML handling for updates and rich-text content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->