### PR TITLE
[CSM Portal] fix malformed openapi.yaml response block blocking Choreo deploy

### DIFF
--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -3228,13 +3228,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
-        "413":
         "404":
           description: NotFound
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
+        "413":
           description: RequestEntityTooLarge
           content:
             application/json:


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

The most recently merged aggregate-endpoint change left `/change-requests/aggregate`'s `openapi.yaml` response block malformed: a batch edit adding 404 responses across 6 operations miscalculated one offset, splitting the `413` response into two entries (one with no `description`, one duplicate `404` key). This was valid YAML (so it passed a plain YAML parse) but not a valid OpenAPI document, which caused Choreo to fail deploying the endpoint with "Failed to deploy the Endpoint... Something went wrong."

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

Restore the correct, single `404`/`413` response pair for `POST /change-requests/aggregate`, matching the same convention as the other 5 sibling operations touched by the same prior change.

## Approach
> Describe how you are implementing the solutions.

One-line reorder: move the `"404"` block back after `"403"` and before `"413"`, exactly matching the structure already correct on the other 5 aggregate/incident-tasks operations. No other content changed.

## User stories
As an operator deploying the CSM backend to Choreo, the endpoint deploys successfully instead of failing with an opaque "Failed to deploy the Endpoint" error.

## Release note
Fixed a malformed OpenAPI response block that was blocking Choreo endpoint deployment for the CSM backend.

## Documentation
N/A — internal API spec, no external documentation covers this.

## Training
N/A

## Certification
N/A — no certification exam covers this internal API.

## Marketing
N/A

## Automation tests
 - Unit tests
   > `go build ./...` clean (no Go code changed, spec-only fix).
 - Integration tests
   > Validated the full `openapi.yaml` against the OpenAPI 3.0 schema with `openapi-spec-validator` (not just a YAML parse, which is what let the bug through originally) — passes clean. Also re-validated `entity-service/openapi.yaml` (same PR touched it) for the same class of error — clean.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — spec-only change, no code.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
Follow-up to the just-merged aggregate-endpoint rename/build PR.

## Migrations (if applicable)
N/A

## Test environment
Validated locally with `openapi-spec-validator` 0.9.0, Go 1.26+.

## Learning
N/A
