### PR TITLE
[CSM Portal] Clear case watch lists, correct the watch-list contract, and hide automation-only transitions

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestActionBar.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestActionBar.test.tsx
@@ -134,12 +134,10 @@ describe("ChangeRequestActionBar — exactly one primary button", () => {
     expect(screen.queryByRole("button", { name: /change state/i })).not.toBeInTheDocument();
   });
 
-  it("never promotes a destructive target: with only rollback and cancel legal, there is no primary button", () => {
-    renderBar({ state: "implement", legalNextStates: ["rollback", "canceled"] });
-    expect(screen.queryByRole("button", { name: /roll back/i })).not.toBeInTheDocument();
+  it("never promotes a destructive target: with only cancel legal, there is no primary button", () => {
+    renderBar({ state: "implement", legalNextStates: ["canceled"] });
     expect(screen.queryByRole("button", { name: /cancel change/i })).not.toBeInTheDocument();
     openMenu();
-    expect(screen.getByRole("menuitem", { name: /roll back/i })).toBeInTheDocument();
     expect(screen.getByRole("menuitem", { name: /cancel change/i })).toBeInTheDocument();
   });
 
@@ -177,11 +175,64 @@ describe("ChangeRequestActionBar — dispatch", () => {
   it("calls onAction with the target when a menu item is clicked, and closes the menu", () => {
     const { onAction } = renderBar({
       state: "implement",
-      legalNextStates: ["review", "rollback"],
+      legalNextStates: ["review", "canceled"],
     });
     openMenu();
-    fireEvent.click(screen.getByRole("menuitem", { name: /roll back/i }));
-    expect(onAction).toHaveBeenCalledWith("rollback");
+    fireEvent.click(screen.getByRole("menuitem", { name: /cancel change/i }));
+    expect(onAction).toHaveBeenCalledWith("canceled");
+  });
+});
+
+/**
+ * Neither state is human-enterable in the backing system, so the bar must not
+ * offer them however they arrive in `legalNextStates`. See
+ * `NEVER_OFFERED_TARGETS` for why the filter exists — these tests are what
+ * stops it being removed as dead code.
+ */
+describe("ChangeRequestActionBar — states the bar never offers", () => {
+  it("renders neither rollback nor customer approval, as a button or a menu item", () => {
+    renderBar({
+      state: "implement",
+      legalNextStates: ["review", "rollback", "customer_approval", "canceled"],
+    });
+    expect(screen.queryByRole("button", { name: /roll back/i })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /customer approval/i }),
+    ).not.toBeInTheDocument();
+    openMenu();
+    expect(screen.queryByRole("menuitem", { name: /roll back/i })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("menuitem", { name: /customer approval/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("still renders the other legal targets normally alongside them", () => {
+    renderBar({
+      state: "implement",
+      legalNextStates: ["review", "rollback", "customer_approval", "canceled"],
+    });
+    expect(screen.getByRole("button", { name: /mark implemented/i })).toBeInTheDocument();
+    openMenu();
+    expect(screen.getByRole("menuitem", { name: /cancel change/i })).toBeInTheDocument();
+  });
+
+  it("excludes them even when they would otherwise render through the generic fallback", () => {
+    // `customer_approval` has no curated action label, so without the
+    // exclusion it would still be renderable via `DEFAULT_TARGET_CONFIG`.
+    renderBar({ state: "assess", legalNextStates: ["customer_approval", "awaiting_vendor"] });
+    openMenu();
+    expect(screen.getByRole("menuitem", { name: /^awaiting vendor$/i })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("menuitem", { name: /customer approval/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders no bar at all when every legal target is excluded", () => {
+    const { container } = renderBar({
+      state: "implement",
+      legalNextStates: ["rollback", "customer_approval"],
+    });
+    expect(container).toBeEmptyDOMElement();
   });
 });
 

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestActionBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestActionBar.tsx
@@ -88,6 +88,21 @@ const FORWARD_ORDER: readonly string[] = [
 /** Menu ordering: forward moves first, destructive off-ramps last. */
 const MENU_ORDER: readonly string[] = [...FORWARD_ORDER, "rollback", "canceled"];
 
+/**
+ * States this bar never offers, no matter what `legalNextStates` contains.
+ *
+ * Do not delete this filter because "the list doesn't include them anyway".
+ * Neither state is human-enterable in the backing system: of its 38 UI
+ * actions on the change-request table, none sets either one. Both are reached
+ * only by automation — rollback is written by the workflow that handles a
+ * rejected review, customer approval by the approval process itself. Setting
+ * either by hand from here would leave a record sitting in an approval state
+ * with no approver record behind it, which is an audit hole rather than a
+ * shortcut. The exclusion is deliberately unconditional so a future backend
+ * change that starts returning them cannot silently reopen it.
+ */
+const NEVER_OFFERED_TARGETS: readonly string[] = ["rollback", "customer_approval"];
+
 /** Sort key for a target: curated order first, uncurated states after. */
 function menuRank(target: string): number {
   const index = MENU_ORDER.indexOf(target);
@@ -147,8 +162,15 @@ export default function ChangeRequestActionBar({
 }: ChangeRequestActionBarProps): JSX.Element | null {
   const [stateMenuAnchor, setStateMenuAnchor] = useState<HTMLElement | null>(null);
 
+  // Single choke point for what is renderable: the exclusion below therefore
+  // covers the primary button, the overflow menu, and states rendered through
+  // `DEFAULT_TARGET_CONFIG` alike.
   const targets = Array.from(
-    new Set((cr.legalNextStates ?? []).filter((s) => !!s && s !== cr.state)),
+    new Set(
+      (cr.legalNextStates ?? []).filter(
+        (s) => !!s && s !== cr.state && !NEVER_OFFERED_TARGETS.includes(s),
+      ),
+    ),
   ).sort((a, b) => menuRank(a) - menuRank(b));
   if (targets.length === 0) return null;
 

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -1621,14 +1621,19 @@ type SearchCasesResponse struct {
 // WatchList, AssigneeEmail, ParentID, RelatedCaseID, AutocloseHoldUntil, Subject, Description,
 // DeploymentID, DeployedProductID, BestCaseFixEta, MostLikelyFixEta, and WorstCaseFixEta
 // are only supported for the ServiceNow data source.
+// An explicitly empty WatchList clears the case's watch list and counts as a provided field.
 // ResolutionCode, Cause, and CloseNotes are optional resolution fields only allowed when
 // State is closed or solution_proposed.
 type UpdateCaseRequest struct {
-	ID             string              `json:"-"`
-	State          *CaseState          `json:"state"`
-	Severity       *CaseSeverity       `json:"severity"`
-	WorkState      *CaseWorkState      `json:"workState"`
-	WatchList      []string            `json:"watchList"`
+	ID        string         `json:"-"`
+	State     *CaseState     `json:"state"`
+	Severity  *CaseSeverity  `json:"severity"`
+	WorkState *CaseWorkState `json:"workState"`
+	// WatchList replaces the case's watch list wholesale with the given platform
+	// user UUIDs. It is a pointer so an absent field and an explicitly empty list
+	// are distinguishable: nil leaves the watch list untouched, while an empty
+	// list clears it.
+	WatchList      *[]string           `json:"watchList"`
 	AssigneeEmail  *string             `json:"assigneeEmail"`
 	ResolutionCode *CaseResolutionCode `json:"resolutionCode"`
 	Cause          *CaseCause          `json:"cause"`

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -314,7 +314,7 @@ func (s *caseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReque
 	if err := validateUUIDs("id", []string{req.ID}); err != nil {
 		return domain.UpdateCaseResponse{}, err
 	}
-	if len(req.WatchList) > 0 || req.AssigneeEmail != nil ||
+	if req.WatchList != nil || req.AssigneeEmail != nil ||
 		req.RelatedCaseID != nil || req.ParentID != nil || req.AutocloseHoldUntil != nil ||
 		req.Subject != nil || req.Description != nil || req.DeploymentID != nil || req.DeployedProductID != nil ||
 		req.BestCaseFixEta != nil || req.MostLikelyFixEta != nil || req.WorstCaseFixEta != nil {

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -1210,11 +1210,13 @@ func (s *snCaseService) SearchCaseComments(ctx context.Context, req domain.Searc
 }
 
 type snUpdateCasePayload struct {
-	StateKey      *int     `json:"stateKey,omitempty"`
-	SeverityKey   *int     `json:"severityKey,omitempty"`
-	WorkStateKey  *int     `json:"workStateKey,omitempty"`
-	WatchList     []string `json:"watchList,omitempty"`
-	AssigneeEmail *string  `json:"assigneeEmail,omitempty"`
+	StateKey     *int `json:"stateKey,omitempty"`
+	SeverityKey  *int `json:"severityKey,omitempty"`
+	WorkStateKey *int `json:"workStateKey,omitempty"`
+	// WatchList replaces the whole list, so an explicitly empty list must still be
+	// sent to clear it rather than be omitted -- hence the pointer.
+	WatchList     *[]string `json:"watchList,omitempty"`
+	AssigneeEmail *string   `json:"assigneeEmail,omitempty"`
 	// Acknowledge claims the case for the calling engineer, first-write-wins. Only
 	// true is ever sent -- there is no unacknowledge -- and the backing service keeps
 	// it mutually exclusive with every other field in this payload.
@@ -1420,7 +1422,7 @@ func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReq
 	if req.WorkState != nil {
 		exclusiveCount++
 	}
-	if len(req.WatchList) > 0 {
+	if req.WatchList != nil {
 		exclusiveCount++
 	}
 	if req.AssigneeEmail != nil {
@@ -1527,16 +1529,16 @@ func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReq
 		}
 		payload.WorkStateKey = &id
 	}
-	if len(req.WatchList) > 0 {
+	if req.WatchList != nil {
 		// As on create, the backing service's case-update payload declares the
-		// watch list as email addresses. Note this path cannot express "clear the
-		// watch list": UpdateCaseRequest.WatchList is a plain slice, so an
-		// explicitly empty list is indistinguishable from an absent one.
-		emails, err := watchListEmails(ctx, s.client, token, "watchList", req.WatchList)
+		// watch list as email addresses, and it replaces the whole list, so an
+		// explicitly empty list must still be sent to clear it rather than be
+		// skipped.
+		emails, err := watchListEmails(ctx, s.client, token, "watchList", *req.WatchList)
 		if err != nil {
 			return domain.UpdateCaseResponse{}, err
 		}
-		payload.WatchList = emails
+		payload.WatchList = &emails
 	}
 	if req.AssigneeEmail != nil {
 		payload.AssigneeEmail = req.AssigneeEmail

--- a/entity-service/internal/service/sn_watch_list_test.go
+++ b/entity-service/internal/service/sn_watch_list_test.go
@@ -148,9 +148,10 @@ func TestSNCaseService_UpdateCase_WatchListResolvedToEmails(t *testing.T) {
 
 	svc := NewServiceNowCaseService(newTestSNClient(t, mux), nil)
 
+	watchList := []string{testIncidentWatcherUUID1, testIncidentWatcherUUID2}
 	_, err := svc.UpdateCase(contextWithUserIDToken("token"), domain.UpdateCaseRequest{
 		ID:        sysidToUUID(testWLCaseSysid),
-		WatchList: []string{testIncidentWatcherUUID1, testIncidentWatcherUUID2},
+		WatchList: &watchList,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -202,6 +203,188 @@ func TestSNIncidentService_UpdateIncident_WatchListClearedByEmptyList(t *testing
 	}
 }
 
+// TestSNCaseService_UpdateCase_WatchListAbsentVsEmpty covers the three states the
+// case-update watch list can be in. UpdateCaseRequest.WatchList is a pointer so
+// "not mentioned" and "explicitly empty" stay distinguishable: only the former may
+// leave the field out of the outgoing payload, and only the latter clears the list.
+func TestSNCaseService_UpdateCase_WatchListAbsentVsEmpty(t *testing.T) {
+	emptyWatchList := []string{}
+	populatedWatchList := []string{testIncidentWatcherUUID1, testIncidentWatcherUUID2}
+	assignee := "jane.doe@example.com"
+
+	tests := []struct {
+		name           string
+		req            domain.UpdateCaseRequest
+		wantPresent    bool
+		wantWatchList  []string
+		wantUserLookup bool
+	}{
+		{
+			name: "absent watch list is not sent",
+			req: domain.UpdateCaseRequest{
+				ID:            sysidToUUID(testWLCaseSysid),
+				AssigneeEmail: &assignee,
+			},
+			wantPresent: false,
+		},
+		{
+			name: "explicitly empty watch list is sent as an empty list",
+			req: domain.UpdateCaseRequest{
+				ID:        sysidToUUID(testWLCaseSysid),
+				WatchList: &emptyWatchList,
+			},
+			wantPresent:   true,
+			wantWatchList: []string{},
+		},
+		{
+			name: "populated watch list still resolves to identities in order",
+			req: domain.UpdateCaseRequest{
+				ID:        sysidToUUID(testWLCaseSysid),
+				WatchList: &populatedWatchList,
+			},
+			wantPresent:    true,
+			wantWatchList:  []string{testWatcherEmail1, testWatcherEmail2},
+			wantUserLookup: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotBody map[string]any
+			userLookupCalled := false
+			mux := http.NewServeMux()
+			mux.HandleFunc("/users/search", func(w http.ResponseWriter, r *http.Request) {
+				userLookupCalled = true
+				watchListUserSearchStub(t)(w, r)
+			})
+			mux.HandleFunc("/cases/"+testWLCaseSysid, func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPatch {
+					t.Fatalf("expected PATCH, got %s", r.Method)
+				}
+				if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+					t.Fatalf("decode request body: %v", err)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{
+					"message": "Case updated successfully",
+					"case": {"id": "` + testWLCaseSysid + `", "updatedOn": "2026-01-03 10:00:00", "updatedBy": "engineer@example.com"}
+				}`))
+			})
+
+			svc := NewServiceNowCaseService(newTestSNClient(t, mux), nil)
+			if _, err := svc.UpdateCase(contextWithUserIDToken("token"), tt.req); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			got, present := gotBody["watchList"]
+			if present != tt.wantPresent {
+				t.Fatalf("watchList present = %v, want %v (payload %+v)", present, tt.wantPresent, gotBody)
+			}
+			if tt.wantPresent {
+				list, ok := got.([]any)
+				if !ok {
+					t.Fatalf("watchList = %#v, want an array", got)
+				}
+				if len(list) != len(tt.wantWatchList) {
+					t.Fatalf("watchList length: got %d, want %d", len(list), len(tt.wantWatchList))
+				}
+				for i, w := range tt.wantWatchList {
+					if list[i] != w {
+						t.Fatalf("watchList[%d]: got %v, want %q", i, list[i], w)
+					}
+				}
+			}
+			if userLookupCalled != tt.wantUserLookup {
+				t.Fatalf("user lookup called = %v, want %v", userLookupCalled, tt.wantUserLookup)
+			}
+		})
+	}
+}
+
+// TestSNCaseService_UpdateCase_EmptyWatchListFieldAccounting verifies an explicitly
+// empty watch list participates in the request's field accounting exactly as a
+// populated one does: it satisfies the at-least-one-field rule on its own, and it
+// is still subject to the rule that keeps the exclusive fields out of any
+// combination.
+func TestSNCaseService_UpdateCase_EmptyWatchListFieldAccounting(t *testing.T) {
+	emptyWatchList := []string{}
+	populatedWatchList := []string{testIncidentWatcherUUID1}
+	assignee := "jane.doe@example.com"
+	relatedCase := testRelatedCaseUUID
+
+	tests := []struct {
+		name    string
+		req     domain.UpdateCaseRequest
+		wantErr bool
+	}{
+		{
+			name: "empty watch list alone satisfies the at-least-one-field rule",
+			req: domain.UpdateCaseRequest{
+				ID:        sysidToUUID(testWLCaseSysid),
+				WatchList: &emptyWatchList,
+			},
+		},
+		{
+			name: "empty watch list cannot be combined with another exclusive field",
+			req: domain.UpdateCaseRequest{
+				ID:            sysidToUUID(testWLCaseSysid),
+				WatchList:     &emptyWatchList,
+				AssigneeEmail: &assignee,
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty watch list cannot be combined with a combinable field",
+			req: domain.UpdateCaseRequest{
+				ID:            sysidToUUID(testWLCaseSysid),
+				WatchList:     &emptyWatchList,
+				RelatedCaseID: &relatedCase,
+			},
+			wantErr: true,
+		},
+		{
+			name: "populated watch list is rejected in the same combination",
+			req: domain.UpdateCaseRequest{
+				ID:            sysidToUUID(testWLCaseSysid),
+				WatchList:     &populatedWatchList,
+				RelatedCaseID: &relatedCase,
+			},
+			wantErr: true,
+		},
+		{
+			name:    "no field at all is still rejected",
+			req:     domain.UpdateCaseRequest{ID: sysidToUUID(testWLCaseSysid)},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			mux.HandleFunc("/users/search", watchListUserSearchStub(t))
+			mux.HandleFunc("/cases/"+testWLCaseSysid, func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{
+					"message": "Case updated successfully",
+					"case": {"id": "` + testWLCaseSysid + `", "updatedOn": "2026-01-03 10:00:00", "updatedBy": "engineer@example.com"}
+				}`))
+			})
+
+			svc := NewServiceNowCaseService(newTestSNClient(t, mux), nil)
+			_, err := svc.UpdateCase(contextWithUserIDToken("token"), tt.req)
+			if tt.wantErr {
+				if _, ok := err.(*apierror.ValidationError); !ok {
+					t.Fatalf("expected *apierror.ValidationError, got %T: %v", err, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
 // TestWatchListResolution_UnknownUserID verifies that a well-formed id matching no
 // user is a validation error on every watch-list path, rather than a watcher that
 // vanishes from an otherwise successful write.
@@ -240,9 +423,10 @@ func TestWatchListResolution_UnknownUserID(t *testing.T) {
 		{
 			name: "case update",
 			call: func() error {
+				watchList := unknown
 				_, err := caseSvc.UpdateCase(contextWithUserIDToken("token"), domain.UpdateCaseRequest{
 					ID:        sysidToUUID(testWLCaseSysid),
-					WatchList: unknown,
+					WatchList: &watchList,
 				})
 				return err
 			},

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -4733,7 +4733,10 @@ components:
           items:
             type: string
             format: email
-          description: List of email addresses to set as the case watch list (ServiceNow only).
+          description: |
+            The full set of users to set as the case watch list, replacing whatever is
+            there (ServiceNow only). An empty array clears the watch list, and counts as
+            providing the field.
         assigneeEmail:
           type: string
           format: email

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -4732,11 +4732,11 @@ components:
           type: array
           items:
             type: string
-            format: email
+            format: uuid
           description: |
-            The full set of users to set as the case watch list, replacing whatever is
-            there (ServiceNow only). An empty array clears the watch list, and counts as
-            providing the field.
+            The full set of user identifiers to set as the case watch list, replacing
+            whatever is there (ServiceNow only). An empty array clears the watch list,
+            and counts as providing the field.
         assigneeEmail:
           type: string
           format: email
@@ -5107,7 +5107,8 @@ components:
           type: array
           items:
             type: string
-          description: Optional list of user IDs to notify.
+            format: uuid
+          description: Optional list of identifiers of the users to add to the case watch list.
 
     CreateCaseResponse:
       type: object
@@ -8655,6 +8656,8 @@ components:
           type: array
           items:
             type: string
+            format: uuid
+          description: Optional list of identifiers of the users to add to the incident watch list.
         additionalComments:
           type: string
           nullable: true
@@ -8917,6 +8920,10 @@ components:
           type: array
           items:
             type: string
+            format: uuid
+          description: |
+            The full set of user identifiers to set as the incident watch list, replacing
+            whatever is there. An empty array clears the watch list.
 
     UpdateIncidentResponse:
       type: object


### PR DESCRIPTION
> **Stacked on #1519.** This branch is cut from that PR's branch, so until #1519 merges this one transiently shows its commits too. **Its own change is the last three commits / 7 files.** Per the repo convention for stacked PRs, please review only #1519 with the automated reviewer — this one should not be triggered separately.

## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Three corrections that came out of validating the operations work in #1519 against the real backing system:

- **A case's watch list could not be emptied.** The update request modelled the watch list as a plain list, so "no watch list supplied" and "an explicitly empty watch list" were indistinguishable on the wire. Removing the last watcher from a case was therefore impossible — the request was rejected as containing no fields. Incidents already handled this correctly. Confirmed against a development instance that the backing store clears cleanly on both record types when given an empty value, so the limitation was entirely ours.
- **The published contract told callers to send the wrong thing.** Earlier work in #1519 made the watch-list endpoints resolve platform user identifiers. The specification still described the items as email addresses, against an implementation that now rejects exactly that. All four affected request shapes were checked; none has ever accepted an email.
- **The change-request action bar could offer two transitions that no human should perform.** The backing system has no user-facing action for either of them — they are reached only by automation, one when a review is rejected and one by the approval process. Entering them by hand produces a record sitting in an approval state with no approver recorded against it.

Resolves: N/A — no public tracking issue; tracked internally.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

- Allow a case's watch list to be cleared, matching the behaviour incidents already have.
- Make the published request contract describe what the endpoints actually accept.
- Prevent the two automation-only transitions from ever being offered as manual actions.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

**Clearing a watch list.** The case update request now models the watch list as an optional pointer rather than a plain list, so absent and explicitly-empty are distinguishable, matching the shape the incident path already used. An explicit empty list now counts as a supplied field for the "at least one field" rule and participates in the existing mutual-exclusivity rule exactly as a populated list does. One subtlety worth flagging for review: the outgoing payload field had to become a pointer as well, because omit-when-empty would otherwise have dropped an empty list one layer lower and silently swallowed the clear. Clearing costs no identity lookups, and that is asserted in a test rather than assumed.

**Contract correction.** All four watch-list request shapes now declare their items as user identifiers, using the format convention this specification already uses for user-identifier arrays elsewhere rather than a new one. Only one of the four actively misdescribed itself; the other three were under-specified, two with no description at all. The two *response* shapes are deliberately unchanged — reads legitimately return watcher objects rather than identifiers — and the assignee field genuinely does take an email address and is left alone. No behaviour changed; this commit is specification-only.

**Action-bar exclusion.** Applied inside the single computation that produces the renderable target list, which is the only source for both the primary button and the overflow menu, so states rendered through the generic fallback are covered as well as curated ones. The constant is named and commented with the reason, because a bare filter would read as arbitrary and get removed later. This is defensive today — the backing layer currently returns no legal transitions past the first one — but the exclusion should not depend on that remaining true.

## User stories
> Summary of user stories addressed by this change>

- As a CS engineer, I can remove the last remaining watcher from a case, not just from an incident.
- As an integrator reading the published contract, the watch-list fields tell me what the endpoint actually accepts.
- As a change approver, I can trust that a record in an approval state has an approver recorded against it, because the portal cannot place it there by hand.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Operations: a case's watch list can now be cleared; the change-request action bar no longer offers the two automation-only transitions; the published watch-list request contract corrected to describe user identifiers.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter "N/A" plus brief explanation of why there's no doc impact

N/A — internal-facing screens with no published end-user documentation. The API surface change is captured in the entity service's own specification, updated here.

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

N/A — no training content covers this internal portal.

## Certification
> Type "Sent" when you have provided new/updated certification questions...

N/A — no certification exam covers this internal portal.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature...

N/A — internal tooling.

## Automation tests
 - Unit tests
   > Code coverage information

Entity service: new table-driven tests covering absent versus explicitly-empty versus populated watch lists, that a clear triggers no identity lookup, and how an empty list interacts with both an exclusive and a combinable companion field.

Webapp: tests that neither excluded state renders anywhere, including the case where one would otherwise appear through the generic fallback; that the remaining targets still render; and that a legal-transition list containing only excluded states renders no action bar at all.

Full webapp suite passes (179 files, 1748 tests). Entity service `go build`, `go vet` and `go test ./...` all clean, run without the test cache.

 - Integration tests
   > Details about the test cases and coverage

No automated integration suite exists for these paths. The behaviour this depends on was confirmed by hand against a development instance before the change was written — an empty value clears the watch list on both record types and the value reads back empty, with nothing repopulating it. The specification correction was verified by round-tripping the file through a parser and asserting the four request schemas, not by reading the diff.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **N/A** — that plugin targets Java. This is Go and TypeScript; `go vet` and `eslint` both run clean and this change adds no new lint findings.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes** — no configuration or environment files are touched.

## Samples
> Provide high-level details about the samples related to this feature

N/A — no samples accompany internal portal screens.

## Related PRs

Stacked on #1519 and should merge after it.

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

N/A — no schema change and no data migration. The request-shape change is source-compatible for every caller that was already working, since the previously-impossible empty list was rejected rather than accepted.

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested

macOS. Entity service built and tested with the repository's pinned Go toolchain; webapp type-checked and unit-tested with the repository's pinned Node toolchain. Watch-list clearing behaviour confirmed against a development instance of the backing data source. No manual cross-browser pass — the webapp change is a filter on which buttons render and is covered by unit tests.

## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

No external research. Two of the three changes came from checking assumptions against the backing system rather than reasoning from our own code: the watch-list limitation turned out to be self-inflicted rather than imposed from below, and the two excluded transitions were identified by enumerating the actions the source system itself exposes and finding neither among them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Watch lists now accept user UUIDs when creating or updating cases and incidents.
  * Case and incident watch lists can be fully replaced or cleared by submitting an empty list.
  * Omitted watch-list fields leave existing watchers unchanged.
* **Bug Fixes**
  * Change-request actions now keep cancellation available in the overflow menu when it is the only permitted action.
  * Rollback and customer-approval actions are no longer displayed.
  * Action bars are hidden when no permitted actions remain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->