### PR TITLE
[CSM][Web] Fix dashboard notIn filters click-through sign flip; add Team bar control

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.test.tsx
@@ -167,72 +167,187 @@ describe("CasesFilterBar — removed bar controls fall back to chips", () => {
 
 
   /**
-   * The CS-team and tag bar controls were removed as clutter, so a chip is now
-   * the ONLY way these filters are visible or clearable after a dashboard
-   * click-through. If these break, a user lands on a filtered list with no way
-   * to see or undo why.
+   * The tag bar controls (and, briefly, CS team's) were removed as clutter,
+   * so a chip is the ONLY way these filters are visible or clearable after a
+   * dashboard click-through. If these break, a user lands on a filtered
+   * list with no way to see or undo why. CS team has its own "Team" bar
+   * control again (see the describe block below) and is deliberately NOT
+   * chipped, to avoid showing the same selection twice.
    */
-  it("renders chips for csTeams/tags/excludeTags now that their bar controls are gone", () => {
+  it("renders chips for tags/excludeTags now that their bar controls are gone", () => {
     const { onChange } = renderBar({
       ...DEFAULT_CASES_FILTERS,
-      csTeams: ["g1"],
       tags: ["micro-gw"],
       excludeTags: ["s_dip"],
     });
 
     expect(screen.getByText("Tag: micro-gw")).toBeInTheDocument();
     expect(screen.getByText("Excluding tag: s_dip")).toBeInTheDocument();
-    // Team name is unresolved here (no teams fetched), so it falls back to the
-    // id rather than hiding the chip.
-    expect(screen.getByText(/CS team: /)).toBeInTheDocument();
 
     fireEvent.click(screen.getByText("Excluding tag: s_dip").closest(".MuiChip-root")!.querySelector("svg")!);
     expect(onChange).toHaveBeenCalledWith(
-      expect.objectContaining({ excludeTags: [], tags: ["micro-gw"], csTeams: ["g1"] }),
+      expect.objectContaining({ excludeTags: [], tags: ["micro-gw"] }),
     );
   });
 
-  it("no longer renders the removed CS team / Tags / Exclude tags bar controls", () => {
+  it("does not render a chip for csTeams — it has its own 'Team' bar control", () => {
+    renderBar({ ...DEFAULT_CASES_FILTERS, csTeams: ["g1"] });
+    expect(screen.queryByText(/^CS team:/)).not.toBeInTheDocument();
+  });
+
+  it("no longer renders the removed Tags / Exclude tags bar controls", () => {
     renderBar({ ...DEFAULT_CASES_FILTERS });
-    expect(screen.queryByLabelText(/^CS team$/)).not.toBeInTheDocument();
     expect(screen.queryByLabelText(/^Tags$/)).not.toBeInTheDocument();
     expect(screen.queryByLabelText(/^Exclude tags$/)).not.toBeInTheDocument();
   });
+
+  // Regression: reported live against a dashboard widget's `state`/
+  // `projectOnboardingStatus notIn` click-through, which showed an INCLUDE
+  // chip (the exact opposite of the widget's own filter) because the
+  // exclusion had nowhere of its own to render. `excludeStates` has no bar
+  // control (same as `excludeTags`), so its chip is the only way to see or
+  // clear it. `excludeOnboardingStatuses` is the same for any value OTHER
+  // than "In-Progress" -- that one specific value gets its own checkbox
+  // (tested separately below).
+  it("renders distinct chips for excludeStates/excludeOnboardingStatuses, never conflated with their include counterparts", () => {
+    const { onChange } = renderBar({
+      ...DEFAULT_CASES_FILTERS,
+      states: ["open"],
+      excludeStates: ["closed"],
+      onboardingStatuses: ["completed"],
+      excludeOnboardingStatuses: ["On-Hold"],
+    });
+
+    expect(screen.getByText("Excluding state: Closed")).toBeInTheDocument();
+    expect(screen.getByText("Onboarding: Completed")).toBeInTheDocument();
+    expect(screen.getByText("Excluding onboarding: On-hold")).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByText("Excluding onboarding: On-hold").closest(".MuiChip-root")!
+        .querySelector("svg")!,
+    );
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        excludeOnboardingStatuses: [],
+        onboardingStatuses: ["completed"],
+        excludeStates: ["closed"],
+      }),
+    );
+  });
 });
 
-describe("CasesFilterBar — work-state filter only usable when state is exactly work_in_progress", () => {
+describe("CasesFilterBar — 'Team' control (replaces the removed 'Work state' one)", () => {
+  beforeEach(() => {
+    postMock.mockReset();
+    postMock.mockResolvedValue({
+      teams: [
+        { id: "abt-1", name: "ABT One", family: "cre-abt", creGroupId: "g-1" },
+        { id: "abt-2", name: "ABT Two", family: "cre-abt", creGroupId: "g-2" },
+        // No creGroupId configured -- must not appear as a selectable option.
+        { id: "abt-3", name: "ABT Three", family: "cre-abt" },
+      ],
+    });
+  });
+
+  it("renders team display names as options, backed by creGroupId (what the filter actually matches on)", async () => {
+    renderBar({ ...DEFAULT_CASES_FILTERS });
+
+    fireEvent.mouseDown(screen.getByRole("combobox", { name: "Team" }));
+    expect(await screen.findByRole("option", { name: "ABT One" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "ABT Two" })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "ABT Three" })).not.toBeInTheDocument();
+  });
+
+  it("selecting a team sets csTeams to its creGroupId, not its registry id", async () => {
+    const { onChange } = renderBar({ ...DEFAULT_CASES_FILTERS });
+
+    fireEvent.mouseDown(screen.getByRole("combobox", { name: "Team" }));
+    fireEvent.click(await screen.findByRole("option", { name: "ABT One" }));
+
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ csTeams: ["g-1"] }));
+  });
+});
+
+describe("CasesFilterBar — 'Hide onboarding in progress' checkbox", () => {
   beforeEach(() => {
     postMock.mockReset();
   });
 
-  it("disables work state when no state is selected", () => {
-    renderBar({ ...DEFAULT_CASES_FILTERS, states: [] });
-    expect(screen.getByRole("combobox", { name: "Work state" })).toHaveAttribute(
-      "aria-disabled",
-      "true",
+  it("is unchecked by default and checking it sets excludeOnboardingStatuses to exactly [\"In-Progress\"]", () => {
+    const { onChange } = renderBar({ ...DEFAULT_CASES_FILTERS });
+    const checkbox = screen.getByRole("checkbox", { name: /hide onboarding in progress/i });
+    expect(checkbox).not.toBeChecked();
+
+    fireEvent.click(checkbox);
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ excludeOnboardingStatuses: ["In-Progress"] }),
     );
   });
 
-  it("enables work state when work_in_progress is the sole selected state", () => {
-    renderBar({ ...DEFAULT_CASES_FILTERS, states: ["work_in_progress"] });
-    expect(screen.getByRole("combobox", { name: "Work state" })).not.toHaveAttribute(
-      "aria-disabled",
-      "true",
-    );
-  });
-
-  it("disables work state when work_in_progress is selected alongside other states", () => {
-    renderBar({
+  it("is checked when excludeOnboardingStatuses already contains \"In-Progress\", and unchecking it clears just that value", () => {
+    const { onChange } = renderBar({
       ...DEFAULT_CASES_FILTERS,
-      states: ["work_in_progress", "open"],
+      excludeOnboardingStatuses: ["In-Progress"],
+    });
+    const checkbox = screen.getByRole("checkbox", { name: /hide onboarding in progress/i });
+    expect(checkbox).toBeChecked();
+    // The checkbox is the only representation of this value now -- no
+    // redundant chip alongside it.
+    expect(screen.queryByText(/Excluding onboarding/)).not.toBeInTheDocument();
+
+    fireEvent.click(checkbox);
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ excludeOnboardingStatuses: [] }),
+    );
+  });
+
+  it("checking it preserves any other excludeOnboardingStatuses value already set (e.g. from a dashboard click-through)", () => {
+    const { onChange } = renderBar({
+      ...DEFAULT_CASES_FILTERS,
+      excludeOnboardingStatuses: ["On-Hold"],
+    });
+    const checkbox = screen.getByRole("checkbox", { name: /hide onboarding in progress/i });
+
+    fireEvent.click(checkbox);
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ excludeOnboardingStatuses: ["On-Hold", "In-Progress"] }),
+    );
+  });
+});
+
+describe("CasesFilterBar — work state has no bar control, only a chip", () => {
+  beforeEach(() => {
+    postMock.mockReset();
+  });
+
+  it("no longer renders a Work state bar control", () => {
+    renderBar({ ...DEFAULT_CASES_FILTERS, states: ["work_in_progress"] });
+    expect(screen.queryByRole("combobox", { name: "Work state" })).not.toBeInTheDocument();
+  });
+
+  it("renders a removable chip when workStates is set (e.g. from a saved view or dashboard click-through)", () => {
+    const { onChange } = renderBar({
+      ...DEFAULT_CASES_FILTERS,
+      states: ["work_in_progress"],
       workStates: ["ongoing"],
     });
-    expect(screen.getByRole("combobox", { name: "Work state" })).toHaveAttribute(
-      "aria-disabled",
-      "true",
+
+    expect(screen.getByText("Work state: Ongoing")).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByText("Work state: Ongoing").closest(".MuiChip-root")!.querySelector("svg")!,
     );
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ workStates: [] }));
   });
 
+  // The underlying invariant (workStates only means something when
+  // work_in_progress is the *sole* selected state) still matters even
+  // without a bar control to disable -- a stale workStates value from a
+  // saved view/URL must not survive the State control widening past
+  // work_in_progress alone.
   it("clears workStates when a second state is added alongside work_in_progress", () => {
     const { onChange } = renderBar({
       ...DEFAULT_CASES_FILTERS,

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
@@ -17,12 +17,14 @@
 import {
   Box,
   Button,
+  Checkbox,
   Chip,
   Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
   Divider,
+  FormControlLabel,
   Grid,
   IconButton,
   InputAdornment,
@@ -91,6 +93,12 @@ export interface CasesFilters {
   search: string;
   severities: Severity[];
   states: CaseState[];
+  /** States the case must NOT be in (`state` op:notIn). Not the inverse of
+   * `states` — a distinct field so `in` and `notIn` can never be conflated
+   * on the round trip, same reasoning as `tags`/`excludeTags`. No dedicated
+   * bar control (like `excludeTags`) — only ever set via a dashboard
+   * click-through, surfaced/removable as a chip. */
+  excludeStates: CaseState[];
   /** Case-type filter (BE `typeKeys`). Empty = all types. */
   caseTypes: BeCaseType[];
   /** Engineer emails (+ the `@me` sentinel) to filter by assigned engineer. */
@@ -117,6 +125,11 @@ export interface CasesFilters {
   excludeTags: string[];
   /** Project onboarding status values (`projectOnboardingStatus` op:in). */
   onboardingStatuses: string[];
+  /** Project onboarding status values the case's project must NOT have
+   * (`projectOnboardingStatus` op:notIn). Not the inverse of
+   * `onboardingStatuses` — a distinct field so `in` and `notIn` can never be
+   * conflated on the round trip, same reasoning as `tags`/`excludeTags`. */
+  excludeOnboardingStatuses: string[];
   /** Inclusive lower bound on the case's active task's SLA business-elapsed
    * percent (`taskSLABusinessElapsedPercent` op:gte). `null` = unset. */
   slaElapsedPctGte: number | null;
@@ -202,13 +215,21 @@ const ENGAGEMENT_TYPE_LABEL: Record<BeEngagementType, string> = {
   onboarding: "Onboarding",
 };
 
-const ALL_WORK_STATES: BeCaseWorkState[] = ["ongoing", "paused"];
+// Work state has no bar control of its own (see `buildActiveFilterChips`'s
+// doc comment) -- this only labels its chip now.
 const WORK_STATE_LABEL: Record<BeCaseWorkState, string> = {
   ongoing: "Ongoing",
   paused: "Paused",
 };
 
 const ALL_SEVERITIES: Severity[] = ["S0", "S1", "S2", "S3", "S4"];
+
+// The one `projectOnboardingStatus` value every dashboard widget's `notIn`
+// actually excludes today (a project still being onboarded). A single
+// checkbox for this specific value -- same simple boolean-toggle pattern as
+// `IncidentsFilterBar`'s "SLA violated" checkbox -- rather than a full
+// multi-select picker for a field with no fixed, known choice list.
+const ONBOARDING_IN_PROGRESS = "In-Progress";
 const PRIMARY_STATES: CaseState[] = [
   "open",
   "work_in_progress",
@@ -260,31 +281,28 @@ interface ActiveFilterChip {
  * individually removable, though, or a user landing on a dashboard-filtered
  * cases list has no way to see (or undo) *why* it's filtered — hence one
  * chip per active value here, shown regardless of whether the filter grid
- * itself is expanded. `csTeams`/`sreTeams`/`tags`/`excludeTags` are included
- * here too: their bar controls were removed as clutter (they are advanced,
- * rarely hand-picked, and a better home for advanced filters is still to be
- * designed), so a chip is now the ONLY way a user can see or clear them
- * after arriving from a dashboard click-through.
+ * itself is expanded. `sreTeams`/`tags`/`excludeTags`/`workStates` are
+ * included here too: their bar controls were removed as clutter (they are
+ * advanced, rarely hand-picked, and a better home for advanced filters is
+ * still to be designed), so a chip is now the ONLY way a user can see or
+ * clear them after arriving from a dashboard click-through. `csTeams` has
+ * its own "Team" bar control (see the filter grid below) and is
+ * deliberately NOT chipped here too — every other bar-controlled field
+ * (`states`, `severities`, ...) shows its selection inside its own control,
+ * not as a second, redundant chip.
  */
 function buildActiveFilterChips(
   filters: CasesFilters,
   /** groupId -> team display name, so a team chip never shows a raw UUID.
    * Falls back to the id when the lookup has not resolved (or the team is
    * unknown) rather than hiding the chip — an unlabelled filter the user can
-   * still see and remove beats an invisible one. Covers both `creGroupId`
-   * and `sreGroupId` keys — a caller passing a merged map lets one lookup
-   * serve both `csTeams` and `sreTeams` chips. */
+   * still see and remove beats an invisible one. Only feeds the `sreTeams`
+   * chip now (`csTeams` has its own bar control), but still covers both
+   * `creGroupId` and `sreGroupId` keys since the caller passes one merged
+   * map either way. */
   teamLabels: Record<string, string> = {},
 ): ActiveFilterChip[] {
   const chips: ActiveFilterChip[] = [];
-
-  filters.csTeams.forEach((groupId) => {
-    chips.push({
-      key: `csTeam-${groupId}`,
-      label: `CS team: ${teamLabels[groupId] ?? groupId}`,
-      onRemove: (f) => ({ ...f, csTeams: f.csTeams.filter((t) => t !== groupId) }),
-    });
-  });
 
   filters.sreTeams.forEach((groupId) => {
     chips.push({
@@ -310,6 +328,28 @@ function buildActiveFilterChips(
     });
   });
 
+  filters.excludeStates.forEach((state) => {
+    chips.push({
+      key: `excludeState-${state}`,
+      label: `Excluding state: ${STATE_LABEL[state] ?? state}`,
+      onRemove: (f) => ({
+        ...f,
+        excludeStates: f.excludeStates.filter((s) => s !== state),
+      }),
+    });
+  });
+
+  filters.workStates.forEach((workState) => {
+    chips.push({
+      key: `workState-${workState}`,
+      label: `Work state: ${WORK_STATE_LABEL[workState] ?? workState}`,
+      onRemove: (f) => ({
+        ...f,
+        workStates: f.workStates.filter((w) => w !== workState),
+      }),
+    });
+  });
+
   filters.onboardingStatuses.forEach((status) => {
     chips.push({
       key: `onboarding-${status}`,
@@ -320,6 +360,23 @@ function buildActiveFilterChips(
       }),
     });
   });
+
+  // ONBOARDING_IN_PROGRESS has its own checkbox in the bar now (see the
+  // filter grid below) -- skip it here so it isn't shown twice. Any other
+  // excluded value (only reachable via a dashboard click-through, since the
+  // field has no fixed choice list) still gets a chip, same as before.
+  filters.excludeOnboardingStatuses
+    .filter((status) => status !== ONBOARDING_IN_PROGRESS)
+    .forEach((status) => {
+      chips.push({
+        key: `excludeOnboarding-${status}`,
+        label: `Excluding onboarding: ${humanizeToken(status)}`,
+        onRemove: (f) => ({
+          ...f,
+          excludeOnboardingStatuses: f.excludeOnboardingStatuses.filter((s) => s !== status),
+        }),
+      });
+    });
 
   if (filters.slaElapsedPctGte !== null) {
     chips.push({
@@ -413,11 +470,12 @@ export default function CasesFilterBar({
   const activeCount = countActiveFilters(filters);
   const hasActive = activeCount > 0;
 
-  // Only fetch the team registry when a CS-team or SRE-team filter is
-  // actually set -- it exists solely to label those chips, and the cases
-  // page should not pay for it on every load now that the team bar control
-  // is gone.
-  const { data: teams } = useTeams(filters.csTeams.length > 0 || filters.sreTeams.length > 0);
+  // Team is a fixed, small enough list to fetch in full (same endpoint/hook
+  // the team-based dashboards use -- see AbtDashboardHeader) rather than a
+  // type-to-search async picker, and doubles as the source for the "CS
+  // team" bar control below and the SRE-team chip label (SRE team has no
+  // bar control of its own -- see `buildActiveFilterChips`).
+  const { data: teams } = useTeams(true);
   const teamLabels = useMemo(() => {
     const labels: Record<string, string> = {};
     for (const t of teams ?? []) {
@@ -426,6 +484,16 @@ export default function CasesFilterBar({
     }
     return labels;
   }, [teams]);
+  // `creGroupId` (not the registry `id`) is what a `creTeam`/`csTeams` filter
+  // entry actually matches on; only teams with one configured are
+  // selectable here (an id-less team has nothing such a filter could hold).
+  const teamOptions = useMemo(
+    () =>
+      (teams ?? [])
+        .filter((t): t is typeof t & { creGroupId: string } => Boolean(t.creGroupId))
+        .map((t) => ({ value: t.creGroupId, label: t.name })),
+    [teams],
+  );
 
   const activeFilterChips = useMemo(
     () => buildActiveFilterChips(filters, teamLabels),
@@ -471,10 +539,6 @@ export default function CasesFilterBar({
   );
   const stateOptions = useMemo(
     () => PRIMARY_STATES.map((s) => ({ value: s, label: STATE_LABEL[s] })),
-    [],
-  );
-  const workStateOptions = useMemo(
-    () => ALL_WORK_STATES.map((s) => ({ value: s, label: WORK_STATE_LABEL[s] })),
     [],
   );
   const caseTypeOptions = useMemo(
@@ -739,24 +803,20 @@ export default function CasesFilterBar({
               />
             </Grid>
             <Grid size={{ xs: 12, sm: 6, md: 4, lg: 2 }}>
-              {/* Only meaningful when `work_in_progress` is the sole selected
-                  state (ongoing/paused are sub-states of it); disabled
-                  otherwise, so the control can't add an inert/unusable
-                  filter when combined with other states. */}
+              {/* CS team the case's project is scoped to (`creTeam`). Options
+                  are `creGroupId`s (what the filter actually matches on);
+                  labels are team display names, never the raw group-id
+                  UUID. `workStates` has no bar control of its own now (it's
+                  a narrow, rarely hand-picked sub-filter of "state") -- it
+                  still round-trips losslessly via the URL/a saved view/a
+                  dashboard click-through, surfaced as a removable chip
+                  instead (see `buildActiveFilterChips`). */}
               <MultiSelectField
-                id="cases-filter-work-state"
-                label="Work state"
-                values={filters.workStates}
-                options={workStateOptions}
-                onChange={(next) => onChange({ ...filters, workStates: next })}
-                disabled={
-                  !(filters.states.length === 1 && filters.states[0] === "work_in_progress")
-                }
-                disabledTooltip={
-                  filters.states.length === 1 && filters.states[0] === "work_in_progress"
-                    ? undefined
-                    : `Select only the "${STATE_LABEL.work_in_progress}" state to filter by work state`
-                }
+                id="cases-filter-cs-team"
+                label="Team"
+                values={filters.csTeams}
+                options={teamOptions}
+                onChange={(next) => onChange({ ...filters, csTeams: next })}
               />
             </Grid>
             {showEngagementTypeFilter && (
@@ -807,6 +867,36 @@ export default function CasesFilterBar({
               <ProductNameMultiSelect
                 values={filters.productNames}
                 onChange={(next) => onChange({ ...filters, productNames: next })}
+              />
+            </Grid>
+            <Grid
+              size={{ xs: 12, sm: 6, md: 4, lg: 2 }}
+              sx={{ display: "flex", alignItems: "center", height: 40 }}
+            >
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    id="cases-filter-exclude-onboarding-in-progress"
+                    size="small"
+                    checked={filters.excludeOnboardingStatuses.includes(ONBOARDING_IN_PROGRESS)}
+                    onChange={(e) =>
+                      onChange({
+                        ...filters,
+                        excludeOnboardingStatuses: e.target.checked
+                          ? [
+                              ...filters.excludeOnboardingStatuses.filter(
+                                (s) => s !== ONBOARDING_IN_PROGRESS,
+                              ),
+                              ONBOARDING_IN_PROGRESS,
+                            ]
+                          : filters.excludeOnboardingStatuses.filter(
+                              (s) => s !== ONBOARDING_IN_PROGRESS,
+                            ),
+                      })
+                    }
+                  />
+                }
+                label="Hide onboarding in progress"
               />
             </Grid>
           </Grid>

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmIssuesView.workStateUrl.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmIssuesView.workStateUrl.test.tsx
@@ -16,7 +16,7 @@
 
 import { fireEvent, render, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { MemoryRouter, Route, Routes } from "react-router";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router";
 import { describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 
@@ -62,13 +62,28 @@ vi.mock("@components/RefreshButton", () => ({
 
 import CsmIssuesView from "@features/csm-cases/components/CsmIssuesView";
 
+/** Exposes the current URL search string so a test can assert on it
+ * directly -- `window.location` doesn't reflect MemoryRouter's history. */
+function LocationSearchProbe() {
+  const location = useLocation();
+  return <div data-testid="search-probe">{location.search}</div>;
+}
+
 function renderAt(initialUrl: string) {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
     <QueryClientProvider client={queryClient}>
       <MemoryRouter initialEntries={[initialUrl]}>
         <Routes>
-          <Route path="/cases" element={<CsmIssuesView title="Cases" />} />
+          <Route
+            path="/cases"
+            element={
+              <>
+                <CsmIssuesView title="Cases" />
+                <LocationSearchProbe />
+              </>
+            }
+          />
         </Routes>
       </MemoryRouter>
     </QueryClientProvider>,
@@ -83,19 +98,27 @@ describe("CsmIssuesView + real CasesFilterBar — work state clears fully from t
   // rewriting from the next filter state) didn't include "workStates", so an
   // empty next.workStates never actually cleared the stale URL param, and
   // the next render read the stale value straight back in.
-  it("deselecting the only checked work state actually clears it, not just toggles it", () => {
+  //
+  // `workStates` no longer has its own bar control (see CasesFilterBar's
+  // "Team" control, which replaced it) -- the State control's own onChange
+  // is what clears a stale `workStates` now, when the selection widens past
+  // "work_in_progress" alone. This exercises that same URL round trip
+  // (not just the in-memory filter object CasesFilterBar.test.tsx already
+  // covers) via the "Work state: Ongoing" chip that renders instead.
+  it("adding a second state clears the stale workStates chip and its URL param, not just the in-memory value", () => {
     renderAt("/cases?states=work_in_progress&workStates=ongoing");
 
-    const workState = screen.getByRole("combobox", { name: "Work state" });
-    expect(workState).toHaveTextContent("Ongoing");
+    expect(screen.getByText("Work state: Ongoing")).toBeInTheDocument();
 
-    // Open the dropdown and uncheck the only selected option.
-    fireEvent.mouseDown(workState);
-    fireEvent.click(screen.getByRole("option", { name: "Ongoing" }));
+    // Open the State dropdown and add a second state alongside
+    // work_in_progress -- CasesFilterBar's own onChange clears workStates
+    // as soon as the selection stops being exactly that one state.
+    fireEvent.mouseDown(screen.getByRole("combobox", { name: "State" }));
+    fireEvent.click(screen.getByRole("option", { name: "Open" }));
 
-    // The control must now show no selection -- not still "Ongoing", and not
-    // forced onto "Paused" either.
-    expect(workState).not.toHaveTextContent("Ongoing");
-    expect(workState).not.toHaveTextContent("Paused");
+    // The chip -- and so the URL param behind it -- must be gone, not just
+    // hidden while the stale value lingers underneath.
+    expect(screen.queryByText("Work state: Ongoing")).not.toBeInTheDocument();
+    expect(screen.getByTestId("search-probe").textContent).not.toContain("workStates");
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/caseSearchPayload.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/caseSearchPayload.test.ts
@@ -81,6 +81,55 @@ describe("buildCaseSearchFilters — new advanced-filter fields", () => {
     ]);
   });
 
+  it("emits state op:in and state op:notIn as two independent entries", () => {
+    const filters: CasesFilters = {
+      ...DEFAULT_CASES_FILTERS,
+      states: ["open"],
+      excludeStates: ["closed"],
+    };
+    expect(filterOf(filters, "state")).toEqual([
+      { field: "state", op: "in", values: ["open"] },
+      { field: "state", op: "notIn", values: ["closed"] },
+    ]);
+  });
+
+  it("does NOT invert excludeStates into an `in` entry", () => {
+    const filters: CasesFilters = { ...DEFAULT_CASES_FILTERS, excludeStates: ["closed"] };
+    const stateEntries = filterOf(filters, "state");
+    expect(stateEntries).toEqual([{ field: "state", op: "notIn", values: ["closed"] }]);
+    expect(stateEntries?.some((e) => e.op === "in")).toBe(false);
+  });
+
+  it("emits projectOnboardingStatus op:in and op:notIn as two independent entries", () => {
+    const filters: CasesFilters = {
+      ...DEFAULT_CASES_FILTERS,
+      onboardingStatuses: ["completed"],
+      excludeOnboardingStatuses: ["In-Progress"],
+    };
+    expect(filterOf(filters, "projectOnboardingStatus")).toEqual([
+      { field: "projectOnboardingStatus", op: "in", values: ["completed"] },
+      { field: "projectOnboardingStatus", op: "notIn", values: ["In-Progress"] },
+    ]);
+  });
+
+  it("does NOT invert excludeOnboardingStatuses into an `in` entry (the reported bug)", () => {
+    // Regression: reported live against a dashboard widget's
+    // `projectOnboardingStatus notIn ["In-Progress"]` -- the click-through
+    // showed an "Onboarding: In-progress" INCLUDE chip, the exact opposite
+    // of the widget's own filter. This asserts the payload builder itself
+    // never produces an `in` entry when only excludeOnboardingStatuses is set
+    // (see widgetResourceConfig.test.ts for the click-through-side fix).
+    const filters: CasesFilters = {
+      ...DEFAULT_CASES_FILTERS,
+      excludeOnboardingStatuses: ["In-Progress"],
+    };
+    const entries = filterOf(filters, "projectOnboardingStatus");
+    expect(entries).toEqual([
+      { field: "projectOnboardingStatus", op: "notIn", values: ["In-Progress"] },
+    ]);
+    expect(entries?.some((e) => e.op === "in")).toBe(false);
+  });
+
   it("emits taskSLABusinessElapsedPercent gte and lte as separate entries", () => {
     const filters: CasesFilters = {
       ...DEFAULT_CASES_FILTERS,

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/caseSearchPayload.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/caseSearchPayload.ts
@@ -67,6 +67,16 @@ export function buildCaseSearchFilters(
       values: filters.states.map(beStateFromUi),
     });
   }
+  // `states`/`excludeStates` both target the `state` field but with
+  // different ops (`in`/`notIn`) — two independent entries, same reasoning
+  // as `tags`/`excludeTags` below.
+  if (filters.excludeStates.length > 0) {
+    fieldFilters.push({
+      field: "state",
+      op: "notIn",
+      values: filters.excludeStates.map(beStateFromUi),
+    });
+  }
   if (filters.caseTypes.length > 0) {
     fieldFilters.push({ field: "type", op: "in", values: filters.caseTypes });
   }
@@ -139,6 +149,13 @@ export function buildCaseSearchFilters(
       field: "projectOnboardingStatus",
       op: "in",
       values: filters.onboardingStatuses,
+    });
+  }
+  if (filters.excludeOnboardingStatuses.length > 0) {
+    fieldFilters.push({
+      field: "projectOnboardingStatus",
+      op: "notIn",
+      values: filters.excludeOnboardingStatuses,
     });
   }
   if (filters.slaElapsedPctGte !== null) {

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.test.ts
@@ -151,6 +151,49 @@ describe("op-awareness (regression: the widgetPreviewUrl field~op bug)", () => {
     expect(round.excludeTags).toEqual(["s_dip"]);
   });
 
+  it("`states` (op:in) and `excludeStates` (op:notIn) never conflate on a round trip", () => {
+    const filters: CasesFilters = { ...DEFAULT_CASES_FILTERS, excludeStates: ["closed"] };
+    const round = readCasesFiltersFromUrl(writeCasesFiltersToUrl(filters));
+    expect(round.excludeStates).toEqual(["closed"]);
+    expect(round.states).toEqual([]);
+  });
+
+  it("`states` and `excludeStates` survive together, independently, when both are set", () => {
+    const filters: CasesFilters = {
+      ...DEFAULT_CASES_FILTERS,
+      states: ["open", "work_in_progress"],
+      excludeStates: ["closed"],
+    };
+    const round = readCasesFiltersFromUrl(writeCasesFiltersToUrl(filters));
+    expect(round.states).toEqual(["open", "work_in_progress"]);
+    expect(round.excludeStates).toEqual(["closed"]);
+  });
+
+  // Regression: reported live against a dashboard widget's
+  // `projectOnboardingStatus notIn ["In-Progress"]` -- the click-through
+  // showed an "Onboarding: In-progress" INCLUDE chip/filter, the exact
+  // opposite of the widget's own filter.
+  it("`onboardingStatuses` (op:in) and `excludeOnboardingStatuses` (op:notIn) never conflate on a round trip (the reported bug)", () => {
+    const filters: CasesFilters = {
+      ...DEFAULT_CASES_FILTERS,
+      excludeOnboardingStatuses: ["In-Progress"],
+    };
+    const round = readCasesFiltersFromUrl(writeCasesFiltersToUrl(filters));
+    expect(round.excludeOnboardingStatuses).toEqual(["In-Progress"]);
+    expect(round.onboardingStatuses).toEqual([]);
+  });
+
+  it("`onboardingStatuses` and `excludeOnboardingStatuses` survive together, independently, when both are set", () => {
+    const filters: CasesFilters = {
+      ...DEFAULT_CASES_FILTERS,
+      onboardingStatuses: ["completed"],
+      excludeOnboardingStatuses: ["In-Progress"],
+    };
+    const round = readCasesFiltersFromUrl(writeCasesFiltersToUrl(filters));
+    expect(round.onboardingStatuses).toEqual(["completed"]);
+    expect(round.excludeOnboardingStatuses).toEqual(["In-Progress"]);
+  });
+
   it("a value-less op (`hasEscalation` / escalation isNotEmpty) survives rather than being dropped", () => {
     const filters: CasesFilters = { ...DEFAULT_CASES_FILTERS, hasEscalation: true };
     const href = writeCasesFiltersToUrl(filters);

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.ts
@@ -30,6 +30,7 @@ export const DEFAULT_CASES_FILTERS: CasesFilters = {
   search: "",
   severities: [],
   states: [],
+  excludeStates: [],
   caseTypes: [],
   assignees: [],
   workStates: [],
@@ -41,6 +42,7 @@ export const DEFAULT_CASES_FILTERS: CasesFilters = {
   tags: [],
   excludeTags: [],
   onboardingStatuses: [],
+  excludeOnboardingStatuses: [],
   slaElapsedPctGte: null,
   slaElapsedPctLte: null,
   hasEscalation: null,
@@ -154,6 +156,7 @@ export function readCasesFiltersFromUrl(
     search: params.get("search") ?? "",
     severities: parseCsv(params.get("severities"), VALID_SEVERITIES),
     states,
+    excludeStates: parseCsv(params.get("excludeStates"), VALID_STATES),
     caseTypes: parseCsv(params.get("types"), VALID_CASE_TYPES),
     assignees: parseFreeFormCsv(params.get("assignees")),
     workStates,
@@ -165,6 +168,7 @@ export function readCasesFiltersFromUrl(
     tags: parseFreeFormCsv(params.get("tags")),
     excludeTags: parseFreeFormCsv(params.get("excludeTags")),
     onboardingStatuses: parseFreeFormCsv(params.get("onboardingStatuses")),
+    excludeOnboardingStatuses: parseFreeFormCsv(params.get("excludeOnboardingStatuses")),
     slaElapsedPctGte: parseNonNegativeInt(params.get("slaPctGte")),
     slaElapsedPctLte: parseNonNegativeInt(params.get("slaPctLte")),
     hasEscalation: parseEscalationParam(params.get("escalation")),
@@ -195,9 +199,14 @@ export function readCasesFiltersFromUrl(
  * struct, not a generic opaque array, so every op that would otherwise
  * collide on one field name already gets its own dedicated field/param
  * instead —
- *   - `tags` (op:in) vs. `excludeTags` (op:notIn) — two arrays, not one
- *     array plus an op flag, so `in` and `notIn` can never be conflated on
- *     the round trip;
+ *   - `tags` (op:in) vs. `excludeTags` (op:notIn), `states` vs.
+ *     `excludeStates`, and `onboardingStatuses` vs.
+ *     `excludeOnboardingStatuses` — each an in/notIn pair as two arrays, not
+ *     one array plus an op flag, so `in` and `notIn` can never be conflated
+ *     on the round trip. These three are the only case-search fields whose
+ *     backend contract accepts `notIn` at all (see `POST /cases/search`'s
+ *     `caseFilterOpSet`/per-field op table) — every other field is `in`-only
+ *     and has no exclude counterpart to conflate with in the first place;
  *   - `slaElapsedPctGte`/`slaElapsedPctLte`, and the `createdOnGte/Lte`,
  *     `updatedOnGte/Lte`, `closedOnGte/Lte` date-range pairs — one param per
  *     bound, not a shared field with an op suffix;
@@ -218,6 +227,7 @@ export function writeCasesFiltersToUrl(f: CasesFilters): URLSearchParams {
   if (f.search) out.set("search", f.search);
   if (f.severities.length) out.set("severities", f.severities.join(","));
   if (f.states.length) out.set("states", f.states.join(","));
+  if (f.excludeStates.length) out.set("excludeStates", f.excludeStates.join(","));
   if (f.caseTypes.length) out.set("types", f.caseTypes.join(","));
   if (f.assignees.length) out.set("assignees", f.assignees.join(","));
   if (f.workStates.length) out.set("workStates", f.workStates.join(","));
@@ -230,6 +240,9 @@ export function writeCasesFiltersToUrl(f: CasesFilters): URLSearchParams {
   if (f.excludeTags.length) out.set("excludeTags", f.excludeTags.join(","));
   if (f.onboardingStatuses.length) {
     out.set("onboardingStatuses", f.onboardingStatuses.join(","));
+  }
+  if (f.excludeOnboardingStatuses.length) {
+    out.set("excludeOnboardingStatuses", f.excludeOnboardingStatuses.join(","));
   }
   if (f.slaElapsedPctGte !== null) out.set("slaPctGte", String(f.slaElapsedPctGte));
   if (f.slaElapsedPctLte !== null) out.set("slaPctLte", String(f.slaElapsedPctLte));
@@ -260,6 +273,7 @@ export function countActiveFilters(f: CasesFilters): number {
   if (f.search.trim()) n += 1;
   if (f.severities.length) n += 1;
   if (f.states.length) n += 1;
+  if (f.excludeStates.length) n += 1;
   if (f.caseTypes.length) n += 1;
   if (f.assignees.length) n += 1;
   if (f.workStates.length) n += 1;
@@ -271,6 +285,7 @@ export function countActiveFilters(f: CasesFilters): number {
   if (f.tags.length) n += 1;
   if (f.excludeTags.length) n += 1;
   if (f.onboardingStatuses.length) n += 1;
+  if (f.excludeOnboardingStatuses.length) n += 1;
   if (f.slaElapsedPctGte !== null) n += 1;
   if (f.slaElapsedPctLte !== null) n += 1;
   if (f.hasEscalation !== null) n += 1;

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.test.ts
@@ -173,6 +173,61 @@ describe("WIDGET_RESOURCE_CONFIG.case — previously-dropped fields", () => {
     expect(parsed.states).toEqual(["open", "work_in_progress"]);
   });
 
+  // Regression: reported live against `abt_overall_open_incident`'s
+  // `projectOnboardingStatus notIn ["In-Progress"]` -- the click-through
+  // landed on the Cases list with an "Onboarding: In-progress" INCLUDE chip
+  // (the exact opposite of the widget's own filter), because the values were
+  // read op-blind and dumped into the same field an `in` filter would use.
+  // `state` has the identical backend-supported notIn and was audited to
+  // have the same latent bug, fixed alongside onboarding status.
+  it("projectOnboardingStatus notIn decodes to excludeOnboardingStatuses, never onboardingStatuses (the reported bug)", () => {
+    const href = WIDGET_RESOURCE_CONFIG.case.buildHref({
+      filters: [
+        { field: "projectOnboardingStatus", op: "notIn", values: ["In-Progress"] },
+      ],
+    });
+    const parsed = readCasesFiltersFromUrl(hrefParams(href));
+
+    expect(parsed.excludeOnboardingStatuses).toEqual(["In-Progress"]);
+    expect(parsed.onboardingStatuses).toEqual([]);
+  });
+
+  it("state notIn decodes to excludeStates, never states", () => {
+    const href = WIDGET_RESOURCE_CONFIG.case.buildHref({
+      filters: [{ field: "state", op: "notIn", values: ["closed"] }],
+    });
+    const parsed = readCasesFiltersFromUrl(hrefParams(href));
+
+    expect(parsed.excludeStates).toEqual(["closed"]);
+    expect(parsed.states).toEqual([]);
+  });
+
+  it("state in and state notIn survive together, independently, on the same widget", () => {
+    const href = WIDGET_RESOURCE_CONFIG.case.buildHref({
+      filters: [
+        { field: "state", op: "in", values: ["open", "work_in_progress"] },
+        { field: "state", op: "notIn", values: ["closed"] },
+      ],
+    });
+    const parsed = readCasesFiltersFromUrl(hrefParams(href));
+
+    expect(parsed.states).toEqual(["open", "work_in_progress"]);
+    expect(parsed.excludeStates).toEqual(["closed"]);
+  });
+
+  it("projectOnboardingStatus in and notIn survive together, independently, on the same widget", () => {
+    const href = WIDGET_RESOURCE_CONFIG.case.buildHref({
+      filters: [
+        { field: "projectOnboardingStatus", op: "in", values: ["completed"] },
+        { field: "projectOnboardingStatus", op: "notIn", values: ["In-Progress"] },
+      ],
+    });
+    const parsed = readCasesFiltersFromUrl(hrefParams(href));
+
+    expect(parsed.onboardingStatuses).toEqual(["completed"]);
+    expect(parsed.excludeOnboardingStatuses).toEqual(["In-Progress"]);
+  });
+
   it("hasEscalation:false (isEmpty) round-trips distinctly from isNotEmpty", () => {
     const href = WIDGET_RESOURCE_CONFIG.case.buildHref({
       filters: [{ field: "escalation", op: "isEmpty" }],

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.ts
@@ -208,14 +208,23 @@ function caseFilterEntry(
  * any non-empty `assignedUserId` maps to the `@me` sentinel rather than an
  * (unresolvable) literal UUID.
  *
- * `tag`'s two ops (`in`/`notIn`) map to the two distinct `CasesFilters`
- * fields `tags`/`excludeTags` — never a single field plus an inferred op —
- * so a `notIn` widget filter can never decode as `tags` (an inclusion) the
- * way the equivalent bug shipped once in the dashboard preview URL (see
- * `casesFiltersUrl.ts`'s `writeCasesFiltersToUrl` doc comment for the full
- * story). Likewise `escalation`'s value-less `isEmpty`/`isNotEmpty` map to
- * the explicit tri-state `hasEscalation` (`false`/`true`), never silently
- * defaulted when absent (`undefined`, i.e. not touched in `out`).
+ * `tag`, `state`, and `projectOnboardingStatus` — the only 3 case-search
+ * fields whose backend contract accepts `notIn` at all (`case_filters.go`'s
+ * per-field op table) — each have their two ops mapped to two distinct
+ * `CasesFilters` fields (`tags`/`excludeTags`, `states`/`excludeStates`,
+ * `onboardingStatuses`/`excludeOnboardingStatuses`) via `caseFilterEntry`
+ * matched on field *and* op together, never a single field read op-blind via
+ * `caseFilterValues` plus an inferred op. A `notIn` widget filter on any of
+ * these can then never silently decode as its own opposite (an inclusion of
+ * exactly the values it meant to exclude) — which is exactly the bug once
+ * reported against a live `projectOnboardingStatus notIn` widget click-through,
+ * and the same bug the dashboard preview URL shipped once for `tag` (see
+ * `casesFiltersUrl.ts`'s `writeCasesFiltersToUrl` doc comment for that full
+ * story). Every other field this function reads is `in`-only per that same
+ * op table, so reading it op-blind carries no equivalent risk. Likewise
+ * `escalation`'s value-less `isEmpty`/`isNotEmpty` map to the explicit
+ * tri-state `hasEscalation` (`false`/`true`), never silently defaulted when
+ * absent (`undefined`, i.e. not touched in `out`).
  */
 function translateCaseDashboardFilters(
   filters: Record<string, unknown>,
@@ -223,8 +232,18 @@ function translateCaseDashboardFilters(
   const out: Partial<CasesFilters> = {};
   const fieldFilters = asCaseFieldFilters(filters.filters);
 
-  const states = caseFilterValues(fieldFilters, "state");
+  // `state` in vs. notIn -> two distinct CasesFilters fields, same reasoning
+  // as `tag` below: `state` is one of only 3 case-search fields whose
+  // backend contract accepts `notIn` at all (`state`, `tag`,
+  // `projectOnboardingStatus` — see `case_filters.go`'s per-field op table),
+  // so a `notIn` widget filter must never be read op-blind and decoded as
+  // an inclusion of the very states it meant to exclude.
+  const states = caseFilterEntry(fieldFilters, "state", "in")?.values;
   if (states && states.length > 0) out.states = states as CasesFilters["states"];
+  const excludeStates = caseFilterEntry(fieldFilters, "state", "notIn")?.values;
+  if (excludeStates && excludeStates.length > 0) {
+    out.excludeStates = excludeStates as CasesFilters["excludeStates"];
+  }
   const severities = caseFilterValues(fieldFilters, "severity");
   if (severities && severities.length > 0) {
     out.severities = severities
@@ -258,9 +277,26 @@ function translateCaseDashboardFilters(
   const excludeTags = caseFilterEntry(fieldFilters, "tag", "notIn")?.values;
   if (excludeTags && excludeTags.length > 0) out.excludeTags = excludeTags;
 
-  const onboardingStatuses = caseFilterValues(fieldFilters, "projectOnboardingStatus");
+  // `projectOnboardingStatus` in vs. notIn -> same in/notIn split as `state`
+  // and `tag` above (the third and last field the backend accepts `notIn`
+  // on). This is the field the click-through sign-flip bug was originally
+  // reported against: a widget's `notIn` was silently decoding as an
+  // inclusion of exactly the onboarding statuses it meant to exclude.
+  const onboardingStatuses = caseFilterEntry(
+    fieldFilters,
+    "projectOnboardingStatus",
+    "in",
+  )?.values;
   if (onboardingStatuses && onboardingStatuses.length > 0) {
     out.onboardingStatuses = onboardingStatuses;
+  }
+  const excludeOnboardingStatuses = caseFilterEntry(
+    fieldFilters,
+    "projectOnboardingStatus",
+    "notIn",
+  )?.values;
+  if (excludeOnboardingStatuses && excludeOnboardingStatuses.length > 0) {
+    out.excludeOnboardingStatuses = excludeOnboardingStatuses;
   }
 
   const slaGte = caseFilterEntry(fieldFilters, "taskSLABusinessElapsedPercent", "gte")


### PR DESCRIPTION
## Summary

**Bug fix** — reported live: clicking a dashboard widget's "Work In Progress" pie slice (from a widget whose base query includes `projectOnboardingStatus notIn ["In-Progress"]`) landed on the Cases list showing an "Onboarding: In-progress" **INCLUDE** chip/filter — the exact opposite of the widget's own filter.

Root cause: `widgetResourceConfig.ts`'s `translateCaseDashboardFilters` read `projectOnboardingStatus`'s values op-blind (ignoring whether the widget said `in` or `notIn`) and always wrote them into the same "include" slot. Per the backend's `POST /cases/search` contract, `state`, `tag`, and `projectOnboardingStatus` are the only 3 case-search fields that accept `notIn` at all — `tag` was already handled correctly (via `tags`/`excludeTags`); `state` and `projectOnboardingStatus` had the identical latent bug (state`s just hadn't been reported yet). Both are now read op-aware, mirroring `tag`'s existing `in`/`notIn` → two-distinct-fields pattern (`states`/`excludeStates`, `onboardingStatuses`/`excludeOnboardingStatuses`), plumbed through the URL codec and the `/cases/search` payload builder.

Added a "Hide onboarding in progress" checkbox to the filter bar (same simple pattern as `IncidentsFilterBar`'s "SLA violated" checkbox) so the one real-world exclude value has more than just a chip.

**UI change** — removed the "Work state" bar control (narrow, rarely hand-picked — `workStates` still round-trips losslessly via the URL/search payload, now surfaced as a removable chip instead) and replaced its slot with a "Team" control (CS team, by `creGroupId`), restoring a control that had been deliberately removed earlier as bar clutter.

## Test plan
- [x] `tsc -b` — clean
- [x] `eslint .` — 0 errors (2 pre-existing warnings, unrelated files)
- [x] Full `vitest run` — **179/179 test files, 1767/1767 tests pass**, including new regression tests reproducing the exact reported bug (`projectOnboardingStatus notIn` decoding to `excludeOnboardingStatuses`, never `onboardingStatuses`) at the translation, URL-codec, search-payload, and chip-rendering layers, plus new tests for the "Team" control and the "Hide onboarding in progress" checkbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)