### PR TITLE
[CSM][Web] Fix filter label positioning on Change requests, Problems, Incidents, Vulnerabilities

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-admin/dashboards/components/WidgetEditorDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/dashboards/components/WidgetEditorDialog.tsx
@@ -374,6 +374,13 @@ export default function WidgetEditorDialog({
               onChange={(e) => handleResourceTypeChange(e.target.value as BeWidgetResourceType)}
               size="small"
               sx={{ minWidth: 200 }}
+              slotProps={{
+                // `resourceType` always holds a real value (never ""), so
+                // the label is always shrunk -- see MultiSelectField.tsx's
+                // doc comment for why this override is needed at all.
+                inputLabel: { shrink: true, sx: { top: "0px !important" } },
+                select: { notched: true },
+              }}
             >
               {RESOURCE_TYPES.map((rt) => (
                 <MenuItem key={rt} value={rt}>
@@ -388,6 +395,12 @@ export default function WidgetEditorDialog({
               onChange={(e) => handleShapeChange(e.target.value as BeWidgetShape)}
               size="small"
               sx={{ minWidth: 160 }}
+              slotProps={{
+                // `shape` always holds a real value (never ""), so the
+                // label is always shrunk.
+                inputLabel: { shrink: true, sx: { top: "0px !important" } },
+                select: { notched: true },
+              }}
             >
               {SHAPES.map((s) => (
                 <MenuItem key={s} value={s}>
@@ -503,6 +516,13 @@ export default function WidgetEditorDialog({
                     }
                     size="small"
                     sx={{ minWidth: 140 }}
+                    slotProps={{
+                      inputLabel: {
+                        shrink: column.format !== "",
+                        sx: { top: "0px !important" },
+                      },
+                      select: { notched: column.format !== "" },
+                    }}
                   >
                     <MenuItem value="">Default (text)</MenuItem>
                     {COLUMN_FORMATS.map((f) => (
@@ -576,6 +596,13 @@ export default function WidgetEditorDialog({
                       }
                       size="small"
                       sx={{ minWidth: 160 }}
+                      slotProps={{
+                        inputLabel: {
+                          shrink: (slice.color ?? "") !== "",
+                          sx: { top: "0px !important" },
+                        },
+                        select: { notched: (slice.color ?? "") !== "" },
+                      }}
                     >
                       <MenuItem value="">Default rotation</MenuItem>
                       {PALETTE_COLORS.map((c) => (

--- a/apps/csm-portal/webapp/src/features/csm-admin/dashboards/components/WidgetFilterConditionEditor.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/dashboards/components/WidgetFilterConditionEditor.tsx
@@ -136,6 +136,14 @@ export default function WidgetFilterConditionEditor({
               value={condition.op}
               onChange={(e) => updateRow(index, { op: e.target.value as FilterConditionOp })}
               sx={{ minWidth: 160 }}
+              slotProps={{
+                // `condition.op` always holds a real value (no empty
+                // option), so the label is always shrunk -- see
+                // MultiSelectField.tsx's doc comment for why this override
+                // is needed at all against oxygen-ui's own theme.
+                inputLabel: { shrink: true, sx: { top: "0px !important" } },
+                select: { notched: true },
+              }}
             >
               {rowOps.map((op) => (
                 <MenuItem key={op} value={op}>

--- a/apps/csm-portal/webapp/src/features/csm-admin/dashboards/pages/CsmDashboardBuilderEditorPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/dashboards/pages/CsmDashboardBuilderEditorPage.tsx
@@ -419,6 +419,13 @@ export default function CsmDashboardBuilderEditorPage(): JSX.Element {
             onChange={(e) => updateWorking({ type: (e.target.value || undefined) as DashboardDraft["type"] })}
             size="small"
             sx={{ minWidth: 160 }}
+            slotProps={{
+              inputLabel: {
+                shrink: (working.type ?? "") !== "",
+                sx: { top: "0px !important" },
+              },
+              select: { notched: (working.type ?? "") !== "" },
+            }}
           >
             <MenuItem value="">None</MenuItem>
             {DASHBOARD_TYPES.map((t) => (

--- a/apps/csm-portal/webapp/src/features/csm-announcements/pages/CsmAnnouncementsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-announcements/pages/CsmAnnouncementsPage.tsx
@@ -17,15 +17,9 @@
 import {
   Box,
   Button,
-  Checkbox,
-  FormControl,
   IconButton,
   InputAdornment,
-  InputLabel,
   LinearProgress,
-  ListItemText,
-  MenuItem,
-  Select,
   Skeleton,
   Table,
   TableBody,
@@ -37,10 +31,10 @@ import {
   TextField,
   Typography,
 } from "@wso2/oxygen-ui";
-import type { SelectChangeEvent } from "@wso2/oxygen-ui";
 import { Search, X } from "@wso2/oxygen-ui-icons-react";
 import { useState, type ChangeEvent, type JSX } from "react";
 import { Link as RouterLink } from "react-router";
+import MultiSelectField from "@components/MultiSelectField";
 import QueryErrorState from "@components/QueryErrorState";
 import SemanticChip from "@components/SemanticChip";
 import AsyncProjectMultiSelect from "@features/csm-cases/components/AsyncProjectMultiSelect";
@@ -79,53 +73,6 @@ function formatDate(value?: string | null): string {
       month: "short",
       day: "numeric",
     }) ?? "—"
-  );
-}
-
-interface MultiSelectProps<T extends string> {
-  id: string;
-  label: string;
-  values: T[];
-  options: { value: T; label: string }[];
-  onChange: (next: T[]) => void;
-}
-
-/** Checkbox multi-select over a fixed enum (State). */
-function MultiSelect<T extends string>({
-  id,
-  label,
-  values,
-  options,
-  onChange,
-}: MultiSelectProps<T>): JSX.Element {
-  const handleChange = (event: SelectChangeEvent<string[]>): void => {
-    const val = event.target.value;
-    onChange((Array.isArray(val) ? val : [val]) as T[]);
-  };
-  return (
-    <FormControl fullWidth size="small">
-      <InputLabel id={`${id}-label`}>{label}</InputLabel>
-      <Select
-        multiple
-        labelId={`${id}-label`}
-        id={id}
-        value={values as unknown as string[]}
-        label={label}
-        onChange={handleChange}
-        renderValue={(selected) =>
-          (Array.isArray(selected) ? selected : [])
-            .map((v) => options.find((o) => o.value === v)?.label ?? v)
-            .join(", ")
-        }
-      >
-        {options.map((opt) => (
-          <MenuItem key={opt.value} value={opt.value} sx={{ py: 0.5 }}>
-            <Checkbox size="small" checked={values.includes(opt.value)} sx={{ mr: 1, p: 0.25 }} />
-            <ListItemText primary={opt.label} />
-          </MenuItem>
-        ))}
-      </Select>
-    </FormControl>
   );
 }
 
@@ -212,7 +159,7 @@ export default function CsmAnnouncementsPage(): JSX.Element {
           />
         </Box>
         <Box sx={{ flex: "1 1 160px", minWidth: 150 }}>
-          <MultiSelect
+          <MultiSelectField
             id="announcements-filter-state"
             label="State"
             values={filters.states}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CallRequestsTable.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CallRequestsTable.tsx
@@ -14,8 +14,15 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Box, Button, Chip, IconButton, Tooltip, Typography } from "@wso2/oxygen-ui";
-import { Eye } from "@wso2/oxygen-ui-icons-react";
+import { Box, Chip, IconButton, Tooltip, Typography } from "@wso2/oxygen-ui";
+import {
+  Ban,
+  CalendarCheck,
+  CalendarClock,
+  CircleX,
+  Eye,
+  MessageSquareText,
+} from "@wso2/oxygen-ui-icons-react";
 import { Fragment, useState, type JSX } from "react";
 import type { BeCallRequestView } from "@api/backend/types";
 import {
@@ -60,7 +67,20 @@ const ACTION_LABEL: Record<CallRequestAgentAction, string> = {
   cancel: "Cancel",
 };
 
-// Every column is left-aligned for a consistent scan line down the table.
+// Icon-only actions read faster in a dense row than a row of text buttons —
+// the label still surfaces on hover/focus via each button's own Tooltip, so
+// nothing here is unlabeled, just not spelled out until asked for.
+const ACTION_ICON: Record<CallRequestAgentAction, typeof CalendarCheck> = {
+  schedule: CalendarCheck,
+  reschedule: CalendarClock,
+  reject: CircleX,
+  sendNotes: MessageSquareText,
+  cancel: Ban,
+};
+
+// Every column is left-aligned for a consistent scan line down the table,
+// except "Actions" -- now a row of icon buttons rather than text, which
+// reads better centered under its own column.
 const HEADER_CELLS: string[] = [
   "Preview",
   "Request",
@@ -132,7 +152,7 @@ export function CallRequestsTable({
               key={label}
               variant="caption"
               color="text.secondary"
-              sx={{ fontWeight: 600, textAlign: "left" }}
+              sx={{ fontWeight: 600, textAlign: label === "Actions" ? "center" : "left" }}
             >
               {label}
             </Typography>
@@ -263,28 +283,47 @@ export function CallRequestsTable({
 
               {/* Actions: any agent actions (schedule/reject/...), with the
                   assignee shown alongside once scheduled. The view-detail
-                  eye icon has its own leading "Preview" column instead. */}
-              <Box sx={{ minWidth: 0 }}>
-                <Box sx={{ display: "flex", gap: 1, alignItems: "center", flexWrap: "wrap" }}>
-                  {actions.map((action, i) => (
-                    <Tooltip
-                      key={action}
-                      title={isClosed ? "This case is closed — it's read-only." : ""}
-                    >
-                      <span>
-                        <Button
-                          size="small"
-                          variant={i === 0 && action !== "cancel" ? "contained" : "outlined"}
-                          color={action === "reject" || action === "cancel" ? "error" : "primary"}
-                          onClick={() => onAction(action, cr)}
-                          disabled={isClosed}
-                          sx={{ textTransform: "none" }}
-                        >
-                          {ACTION_LABEL[action]}
-                        </Button>
-                      </span>
-                    </Tooltip>
-                  ))}
+                  eye icon has its own leading "Preview" column instead.
+                  Centered under the "Actions" header, matching its icon
+                  buttons rather than the left-aligned text every other
+                  column uses. */}
+              <Box sx={{ minWidth: 0, textAlign: "center" }}>
+                <Box
+                  sx={{
+                    display: "flex",
+                    gap: 0.5,
+                    alignItems: "center",
+                    justifyContent: "center",
+                    flexWrap: "wrap",
+                  }}
+                >
+                  {actions.map((action) => {
+                    const ActionIcon = ACTION_ICON[action];
+                    return (
+                      <Tooltip
+                        key={action}
+                        title={
+                          isClosed
+                            ? "This case is closed — it's read-only."
+                            : ACTION_LABEL[action]
+                        }
+                      >
+                        <span>
+                          <IconButton
+                            size="small"
+                            aria-label={ACTION_LABEL[action]}
+                            color={
+                              action === "reject" || action === "cancel" ? "error" : "primary"
+                            }
+                            onClick={() => onAction(action, cr)}
+                            disabled={isClosed}
+                          >
+                            <ActionIcon size={16} />
+                          </IconButton>
+                        </span>
+                      </Tooltip>
+                    );
+                  })}
                 </Box>
                 {cr.assignee && (
                   <Typography

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CallRequestsWidget.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CallRequestsWidget.tsx
@@ -292,11 +292,25 @@ export function CallRequestsWidget({
             />
             {/* State filter */}
             <FormControl size="small" sx={{ minWidth: 180 }}>
-              <InputLabel id="cr-filter-label">Filter by state</InputLabel>
+              <InputLabel
+                id="cr-filter-label"
+                // oxygen-ui's own theme shifts an unshrunk label up by
+                // `top: -7px` for any Select-backed field (see
+                // `MultiSelectField.tsx`'s doc comment) -- tie `shrink` to
+                // whether a state is actually picked, rather than MUI's
+                // focus-driven default, and force the cascade with
+                // `!important` since a plain `sx={{ top: 0 }}` loses to that
+                // theme rule's higher specificity.
+                shrink={stateFilter !== ""}
+                sx={{ top: "0px !important" }}
+              >
+                Filter by state
+              </InputLabel>
               <Select
                 labelId="cr-filter-label"
                 value={stateFilter}
                 label="Filter by state"
+                notched={stateFilter !== ""}
                 onChange={(e) =>
                   setStateFilter(e.target.value as BeCallRequestStateKey | "")
                 }

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/EditCaseDetailsDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/EditCaseDetailsDialog.tsx
@@ -214,11 +214,18 @@ export default function EditCaseDetailsDialog({
           </Box>
 
           <FormControl fullWidth size="small">
-            <InputLabel id="edit-case-deployment-label">Deployment</InputLabel>
+            <InputLabel
+              id="edit-case-deployment-label"
+              shrink={deploymentId !== ""}
+              sx={{ top: "0px !important" }}
+            >
+              Deployment
+            </InputLabel>
             <Select
               labelId="edit-case-deployment-label"
               label="Deployment"
               value={deploymentId}
+              notched={deploymentId !== ""}
               onChange={(e) => onDeploymentChange(String(e.target.value))}
               disabled={isSaving || deployments.isLoading}
             >
@@ -234,11 +241,18 @@ export default function EditCaseDetailsDialog({
           </FormControl>
 
           <FormControl fullWidth size="small">
-            <InputLabel id="edit-case-product-label">Deployed product</InputLabel>
+            <InputLabel
+              id="edit-case-product-label"
+              shrink={deployedProductId !== ""}
+              sx={{ top: "0px !important" }}
+            >
+              Deployed product
+            </InputLabel>
             <Select
               labelId="edit-case-product-label"
               label="Deployed product"
               value={deployedProductId}
+              notched={deployedProductId !== ""}
               onChange={(e) => setDeployedProductId(String(e.target.value))}
               disabled={isSaving || !deploymentId || deployedProducts.isLoading}
             >

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/ResolutionDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/ResolutionDialog.tsx
@@ -113,11 +113,18 @@ export default function ResolutionDialog({
         </Typography>
 
         <FormControl fullWidth size="small" required>
-          <InputLabel id="resolution-code-label">Resolution code</InputLabel>
+          <InputLabel
+            id="resolution-code-label"
+            shrink={resolutionCode !== ""}
+            sx={{ top: "0px !important" }}
+          >
+            Resolution code
+          </InputLabel>
           <Select
             labelId="resolution-code-label"
             label="Resolution code"
             value={resolutionCode}
+            notched={resolutionCode !== ""}
             onChange={(e) =>
               setResolutionCode(e.target.value as BeCaseResolutionCode)
             }
@@ -131,11 +138,18 @@ export default function ResolutionDialog({
         </FormControl>
 
         <FormControl fullWidth size="small" required>
-          <InputLabel id="case-cause-label">Cause</InputLabel>
+          <InputLabel
+            id="case-cause-label"
+            shrink={cause !== ""}
+            sx={{ top: "0px !important" }}
+          >
+            Cause
+          </InputLabel>
           <Select
             labelId="case-cause-label"
             label="Cause"
             value={cause}
+            notched={cause !== ""}
             onChange={(e) => setCause(e.target.value as BeCaseCause)}
           >
             {CASE_CAUSES.map((c) => (

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseCreatePage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseCreatePage.tsx
@@ -330,11 +330,18 @@ export default function CsmCaseCreatePage(): JSX.Element {
           {!isCloudProject && (
             <Grid size={{ xs: 12, md: 4 }}>
               <FormControl fullWidth size="small" required>
-                <InputLabel id="case-deployment-label">Deployment</InputLabel>
+                <InputLabel
+                  id="case-deployment-label"
+                  shrink={deploymentId !== ""}
+                  sx={{ top: "0px !important" }}
+                >
+                  Deployment
+                </InputLabel>
                 <Select
                   labelId="case-deployment-label"
                   label="Deployment"
                   value={deploymentId}
+                  notched={deploymentId !== ""}
                   onChange={(e) => onDeploymentChange(String(e.target.value))}
                   disabled={!projectId || deployments.isLoading}
                 >
@@ -357,11 +364,18 @@ export default function CsmCaseCreatePage(): JSX.Element {
 
           <Grid size={{ xs: 12, md: 4 }}>
             <FormControl fullWidth size="small" required>
-              <InputLabel id="case-product-label">Deployed product</InputLabel>
+              <InputLabel
+                id="case-product-label"
+                shrink={deployedProductId !== ""}
+                sx={{ top: "0px !important" }}
+              >
+                Deployed product
+              </InputLabel>
               <Select
                 labelId="case-product-label"
                 label="Deployed product"
                 value={deployedProductId}
+                notched={deployedProductId !== ""}
                 onChange={(e) => setDeployedProductId(String(e.target.value))}
                 disabled={!effectiveDeploymentId || deployedProducts.isLoading}
               >
@@ -390,11 +404,18 @@ export default function CsmCaseCreatePage(): JSX.Element {
 
           <Grid size={{ xs: 12, sm: 6, md: 3 }}>
             <FormControl fullWidth size="small" required>
-              <InputLabel id="case-severity-label">Severity</InputLabel>
+              <InputLabel
+                id="case-severity-label"
+                shrink={severity !== ""}
+                sx={{ top: "0px !important" }}
+              >
+                Severity
+              </InputLabel>
               <Select
                 labelId="case-severity-label"
                 label="Severity"
                 value={severity}
+                notched={severity !== ""}
                 onChange={(e) => setSeverity(e.target.value as Severity)}
               >
                 {SEVERITIES.map((s) => (
@@ -409,11 +430,18 @@ export default function CsmCaseCreatePage(): JSX.Element {
 
           <Grid size={{ xs: 12, sm: 6, md: 3 }}>
             <FormControl fullWidth size="small" required>
-              <InputLabel id="case-issue-type-label">Issue type</InputLabel>
+              <InputLabel
+                id="case-issue-type-label"
+                shrink={issueType !== ""}
+                sx={{ top: "0px !important" }}
+              >
+                Issue type
+              </InputLabel>
               <Select
                 labelId="case-issue-type-label"
                 label="Issue type"
                 value={issueType}
+                notched={issueType !== ""}
                 onChange={(e) => setIssueType(e.target.value as BeCaseIssueType)}
               >
                 {ISSUE_TYPES.map((it) => (

--- a/apps/csm-portal/webapp/src/features/csm-engagements/pages/CsmEngagementCreatePage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-engagements/pages/CsmEngagementCreatePage.tsx
@@ -181,13 +181,20 @@ export default function CsmEngagementCreatePage(): JSX.Element {
 
           <Grid size={{ xs: 12, md: 4 }}>
             <FormControl fullWidth size="small" required>
-              <InputLabel id="engagement-deployment-label">Deployment</InputLabel>
+              <InputLabel
+                id="engagement-deployment-label"
+                shrink={deploymentId !== ""}
+                sx={{ top: "0px !important" }}
+              >
+                Deployment
+              </InputLabel>
               <Select
                 labelId="engagement-deployment-label"
                 label="Deployment"
                 value={deploymentId}
                 onChange={(e) => onDeploymentChange(String(e.target.value))}
                 disabled={!projectId || deployments.isLoading}
+                notched={deploymentId !== ""}
               >
                 {(deployments.data ?? []).map((d) => (
                   <MenuItem key={d.id} value={d.id}>
@@ -207,13 +214,20 @@ export default function CsmEngagementCreatePage(): JSX.Element {
 
           <Grid size={{ xs: 12, md: 4 }}>
             <FormControl fullWidth size="small" required>
-              <InputLabel id="engagement-product-label">Deployed product</InputLabel>
+              <InputLabel
+                id="engagement-product-label"
+                shrink={deployedProductId !== ""}
+                sx={{ top: "0px !important" }}
+              >
+                Deployed product
+              </InputLabel>
               <Select
                 labelId="engagement-product-label"
                 label="Deployed product"
                 value={deployedProductId}
                 onChange={(e) => setDeployedProductId(String(e.target.value))}
                 disabled={!deploymentId || deployedProducts.isLoading}
+                notched={deployedProductId !== ""}
               >
                 {(deployedProducts.data ?? []).map((dp) => (
                   <MenuItem key={dp.id} value={dp.id}>
@@ -233,12 +247,19 @@ export default function CsmEngagementCreatePage(): JSX.Element {
 
           <Grid size={{ xs: 12, md: 4 }}>
             <FormControl fullWidth size="small" required>
-              <InputLabel id="engagement-type-label">Engagement type</InputLabel>
+              <InputLabel
+                id="engagement-type-label"
+                shrink={engagementType !== ""}
+                sx={{ top: "0px !important" }}
+              >
+                Engagement type
+              </InputLabel>
               <Select
                 labelId="engagement-type-label"
                 label="Engagement type"
                 value={engagementType}
                 onChange={(e) => setEngagementType(e.target.value as BeEngagementType)}
+                notched={engagementType !== ""}
               >
                 {ENGAGEMENT_TYPES.map((et) => (
                   <MenuItem key={et.value} value={et.value}>

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/CatalogVariableFields.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/CatalogVariableFields.tsx
@@ -85,12 +85,15 @@ export default function CatalogVariableFields({
             return (
               <Grid key={v.id} size={{ xs: 12, sm: 6 }}>
                 <FormControl fullWidth size="small" required={required}>
-                  <InputLabel id={labelId}>{label}</InputLabel>
+                  <InputLabel id={labelId} shrink={value !== ""} sx={{ top: "0px !important" }}>
+                    {label}
+                  </InputLabel>
                   <Select
                     labelId={labelId}
                     label={label}
                     value={value}
                     onChange={(e) => onChange(v.id, String(e.target.value))}
+                    notched={value !== ""}
                   >
                     {choices.map((c) => (
                       // The submitted value is the option's `value`; `text`
@@ -110,12 +113,15 @@ export default function CatalogVariableFields({
             return (
               <Grid key={v.id} size={{ xs: 12, sm: 6 }}>
                 <FormControl fullWidth size="small" required>
-                  <InputLabel id={labelId}>{label}</InputLabel>
+                  <InputLabel id={labelId} shrink={value !== ""} sx={{ top: "0px !important" }}>
+                    {label}
+                  </InputLabel>
                   <Select
                     labelId={labelId}
                     label={label}
                     value={value}
                     onChange={(e) => onChange(v.id, String(e.target.value))}
+                    notched={value !== ""}
                   >
                     <MenuItem value="Yes">Yes</MenuItem>
                     <MenuItem value="No">No</MenuItem>

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestsFilterBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestsFilterBar.tsx
@@ -18,23 +18,15 @@ import {
   AdapterDateFns,
   Box,
   Button,
-  Checkbox,
   DatePickers,
   Divider,
-  FormControl,
   Grid,
   IconButton,
   InputAdornment,
-  InputLabel,
-  ListItemText,
-  MenuItem,
   Paper,
-  Select,
   TextField,
-  Tooltip,
   Typography,
 } from "@wso2/oxygen-ui";
-import type { SelectChangeEvent } from "@wso2/oxygen-ui";
 import {
   ChevronDown,
   ChevronUp,
@@ -51,6 +43,7 @@ import {
   countActiveCRFilters,
   type ChangeRequestFilters,
 } from "@features/csm-operations/utils/changeRequests";
+import MultiSelectField from "@components/MultiSelectField";
 
 const { DatePicker, LocalizationProvider } = DatePickers;
 
@@ -80,73 +73,6 @@ interface ChangeRequestsFilterBarProps {
   onFiltersToggle: () => void;
 }
 
-interface MultiSelectFieldProps<T extends string> {
-  id: string;
-  label: string;
-  values: T[];
-  options: { value: T; label: string }[];
-  onChange: (next: T[]) => void;
-}
-
-function MultiSelectField<T extends string>({
-  id,
-  label,
-  values,
-  options,
-  onChange,
-}: MultiSelectFieldProps<T>): JSX.Element {
-  const handleChange = (event: SelectChangeEvent<string[]>): void => {
-    const val = event.target.value;
-    onChange((Array.isArray(val) ? val : [val]) as T[]);
-  };
-  return (
-    <FormControl fullWidth size="small">
-      <InputLabel id={`${id}-label`}>{label}</InputLabel>
-      <Select
-        multiple
-        labelId={`${id}-label`}
-        id={id}
-        value={values as unknown as string[]}
-        label={label}
-        onChange={handleChange}
-        renderValue={(selected) => {
-          if (!Array.isArray(selected) || selected.length === 0) return "";
-          const labels = selected.map(
-            (v) => options.find((o) => o.value === v)?.label ?? v,
-          );
-          const text = labels.join(", ");
-          if (labels.length === 1) return text;
-          return (
-            <Tooltip title={text} placement="top">
-              <Box
-                component="span"
-                sx={{
-                  display: "block",
-                  overflow: "hidden",
-                  textOverflow: "ellipsis",
-                  whiteSpace: "nowrap",
-                }}
-              >
-                {text}
-              </Box>
-            </Tooltip>
-          );
-        }}
-      >
-        {options.map((opt) => (
-          <MenuItem key={opt.value} value={opt.value} sx={{ py: 0.5 }}>
-            <Checkbox
-              size="small"
-              checked={values.includes(opt.value)}
-              sx={{ mr: 1, p: 0.25 }}
-            />
-            <ListItemText primary={opt.label} />
-          </MenuItem>
-        ))}
-      </Select>
-    </FormControl>
-  );
-}
 
 export default function ChangeRequestsFilterBar({
   filters,

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/IncidentsFilterBar.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/IncidentsFilterBar.test.tsx
@@ -96,9 +96,10 @@ describe("IncidentsFilterBar", () => {
     fireEvent.mouseDown(screen.getByRole("combobox", { name: "Priority" }));
     fireEvent.click(screen.getByRole("option", { name: /critical/i }));
 
-    expect(onChange).toHaveBeenCalledWith(
-      expect.objectContaining({ priorities: expect.arrayContaining([expect.any(String)]) }),
-    );
+    expect(onChange).toHaveBeenCalledWith({
+      ...DEFAULT_INCIDENT_FILTERS,
+      priorities: ["CRITICAL"],
+    });
   });
 
   it("surfaces the product filter's coverage caveat as visible helper text", () => {

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/IncidentsFilterBar.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/IncidentsFilterBar.test.tsx
@@ -82,6 +82,25 @@ describe("IncidentsFilterBar", () => {
     expect(screen.getByRole("checkbox", { name: /sla violated/i })).toBeChecked();
   });
 
+  // Regression: this control used to be a raw FormControl/InputLabel/Select
+  // with no `shrink`/`notched` override, which read wrong against
+  // oxygen-ui's own theme (its `MuiInputLabel` styleOverrides shift an
+  // unshrunk label up by `top: -7px` for any Select-backed field) --
+  // reported live as looking broken compared to the Cases tab's filter bar,
+  // which already routes through the shared, fixed `MultiSelectField`. This
+  // exercises the swap functionally: selecting a priority still updates the
+  // filter correctly.
+  it("selecting a priority sets it on the filter object", () => {
+    const { onChange } = renderFilterBar();
+
+    fireEvent.mouseDown(screen.getByRole("combobox", { name: "Priority" }));
+    fireEvent.click(screen.getByRole("option", { name: /critical/i }));
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ priorities: expect.arrayContaining([expect.any(String)]) }),
+    );
+  });
+
   it("surfaces the product filter's coverage caveat as visible helper text", () => {
     renderFilterBar();
     expect(

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/IncidentsFilterBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/IncidentsFilterBar.tsx
@@ -21,20 +21,14 @@ import {
   Checkbox,
   DatePickers,
   Divider,
-  FormControl,
   FormControlLabel,
   Grid,
   IconButton,
   InputAdornment,
-  InputLabel,
-  ListItemText,
-  MenuItem,
   Paper,
-  Select,
   TextField,
   Typography,
 } from "@wso2/oxygen-ui";
-import type { SelectChangeEvent } from "@wso2/oxygen-ui";
 import { ChevronDown, ChevronUp, ListFilter, Search, X } from "@wso2/oxygen-ui-icons-react";
 import { useMemo, type JSX } from "react";
 import type { BeIncidentPriority } from "@api/backend/types";
@@ -45,6 +39,7 @@ import {
   type IncidentFilters,
 } from "@features/csm-operations/utils/incidents";
 import IncidentProductMultiSelect from "@features/csm-operations/components/IncidentProductMultiSelect";
+import MultiSelectField from "@components/MultiSelectField";
 
 const { DatePicker, LocalizationProvider } = DatePickers;
 
@@ -125,12 +120,8 @@ export default function IncidentsFilterBar({
     [],
   );
 
-  const handlePriorityChange = (event: SelectChangeEvent<string[]>): void => {
-    const val = event.target.value;
-    onChange({
-      ...filters,
-      priorities: (Array.isArray(val) ? val : [val]) as BeIncidentPriority[],
-    });
+  const handlePriorityChange = (next: BeIncidentPriority[]): void => {
+    onChange({ ...filters, priorities: next });
   };
 
   /**
@@ -220,33 +211,13 @@ export default function IncidentsFilterBar({
           <Divider />
           <Grid container spacing={2}>
             <Grid size={{ xs: 12, sm: 6, md: 4 }}>
-              <FormControl fullWidth size="small">
-                <InputLabel id="incident-filter-priority-label">Priority</InputLabel>
-                <Select
-                  multiple
-                  labelId="incident-filter-priority-label"
-                  id="incident-filter-priority"
-                  value={filters.priorities}
-                  label="Priority"
-                  onChange={handlePriorityChange}
-                  renderValue={(selected) =>
-                    (selected as string[])
-                      .map((v) => priorityOptions.find((o) => o.value === v)?.label ?? v)
-                      .join(", ")
-                  }
-                >
-                  {priorityOptions.map((opt) => (
-                    <MenuItem key={opt.value} value={opt.value} sx={{ py: 0.5 }}>
-                      <Checkbox
-                        size="small"
-                        checked={filters.priorities.includes(opt.value)}
-                        sx={{ mr: 1, p: 0.25 }}
-                      />
-                      <ListItemText primary={opt.label} />
-                    </MenuItem>
-                  ))}
-                </Select>
-              </FormControl>
+              <MultiSelectField
+                id="incident-filter-priority"
+                label="Priority"
+                values={filters.priorities}
+                options={priorityOptions}
+                onChange={handlePriorityChange}
+              />
             </Grid>
 
             <Grid size={{ xs: 12, sm: 6, md: 4 }}>

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ProblemsFilterBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ProblemsFilterBar.tsx
@@ -17,20 +17,13 @@
 import {
   Box,
   Button,
-  Checkbox,
   Divider,
-  FormControl,
   Grid,
   IconButton,
   InputAdornment,
-  InputLabel,
-  ListItemText,
-  MenuItem,
   Paper,
-  Select,
   TextField,
 } from "@wso2/oxygen-ui";
-import type { SelectChangeEvent } from "@wso2/oxygen-ui";
 import { ChevronDown, ChevronUp, ListFilter, Search, X } from "@wso2/oxygen-ui-icons-react";
 import { useMemo, type JSX } from "react";
 import type { BeProblemState } from "@api/backend/types";
@@ -40,6 +33,7 @@ import {
   problemStateLabel,
   type ProblemFilters,
 } from "@features/csm-operations/utils/problems";
+import MultiSelectField from "@components/MultiSelectField";
 
 interface ProblemsFilterBarProps {
   filters: ProblemFilters;
@@ -73,12 +67,8 @@ export default function ProblemsFilterBar({
     [],
   );
 
-  const handleStateChange = (event: SelectChangeEvent<string[]>): void => {
-    const val = event.target.value;
-    onChange({
-      ...filters,
-      states: (Array.isArray(val) ? val : [val]) as BeProblemState[],
-    });
+  const handleStateChange = (next: BeProblemState[]): void => {
+    onChange({ ...filters, states: next });
   };
 
   return (
@@ -143,33 +133,13 @@ export default function ProblemsFilterBar({
           <Divider />
           <Grid container spacing={2}>
             <Grid size={{ xs: 12, sm: 6, md: 3 }}>
-              <FormControl fullWidth size="small">
-                <InputLabel id="problem-filter-state-label">State</InputLabel>
-                <Select
-                  multiple
-                  labelId="problem-filter-state-label"
-                  id="problem-filter-state"
-                  value={filters.states}
-                  label="State"
-                  onChange={handleStateChange}
-                  renderValue={(selected) =>
-                    (selected as string[])
-                      .map((v) => stateOptions.find((o) => o.value === v)?.label ?? v)
-                      .join(", ")
-                  }
-                >
-                  {stateOptions.map((opt) => (
-                    <MenuItem key={opt.value} value={opt.value} sx={{ py: 0.5 }}>
-                      <Checkbox
-                        size="small"
-                        checked={filters.states.includes(opt.value)}
-                        sx={{ mr: 1, p: 0.25 }}
-                      />
-                      <ListItemText primary={opt.label} />
-                    </MenuItem>
-                  ))}
-                </Select>
-              </FormControl>
+              <MultiSelectField
+                id="problem-filter-state"
+                label="State"
+                values={filters.states}
+                options={stateOptions}
+                onChange={handleStateChange}
+              />
             </Grid>
           </Grid>
         </>

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateServiceRequestPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateServiceRequestPage.tsx
@@ -306,13 +306,20 @@ export default function CreateServiceRequestPage(): JSX.Element {
 
           <Grid size={{ xs: 12, md: 4 }}>
             <FormControl fullWidth size="small" required>
-              <InputLabel id="sr-deployment-label">Deployment</InputLabel>
+              <InputLabel
+                id="sr-deployment-label"
+                shrink={deploymentId !== ""}
+                sx={{ top: "0px !important" }}
+              >
+                Deployment
+              </InputLabel>
               <Select
                 labelId="sr-deployment-label"
                 label="Deployment"
                 value={deploymentId}
                 onChange={(e) => onDeploymentChange(String(e.target.value))}
                 disabled={!projectId || deployments.isLoading}
+                notched={deploymentId !== ""}
               >
                 {(deployments.data ?? []).map((d) => (
                   <MenuItem key={d.id} value={d.id}>
@@ -334,13 +341,20 @@ export default function CreateServiceRequestPage(): JSX.Element {
 
           <Grid size={{ xs: 12, md: 4 }}>
             <FormControl fullWidth size="small" required>
-              <InputLabel id="sr-product-label">Deployed product</InputLabel>
+              <InputLabel
+                id="sr-product-label"
+                shrink={deployedProductId !== ""}
+                sx={{ top: "0px !important" }}
+              >
+                Deployed product
+              </InputLabel>
               <Select
                 labelId="sr-product-label"
                 label="Deployed product"
                 value={deployedProductId}
                 onChange={(e) => onDeployedProductChange(String(e.target.value))}
                 disabled={!deploymentId || deployedProducts.isLoading}
+                notched={deployedProductId !== ""}
               >
                 {(deployedProducts.data ?? []).map((dp) => (
                   <MenuItem key={dp.id} value={dp.id}>
@@ -362,13 +376,20 @@ export default function CreateServiceRequestPage(): JSX.Element {
 
           <Grid size={{ xs: 12, md: 6 }}>
             <FormControl fullWidth size="small" required>
-              <InputLabel id="sr-catalog-label">Catalog</InputLabel>
+              <InputLabel
+                id="sr-catalog-label"
+                shrink={catalogId !== ""}
+                sx={{ top: "0px !important" }}
+              >
+                Catalog
+              </InputLabel>
               <Select
                 labelId="sr-catalog-label"
                 label="Catalog"
                 value={catalogId}
                 onChange={(e) => onCatalogChange(String(e.target.value))}
                 disabled={!deployedProductId || catalogs.isLoading || noCatalogs}
+                notched={catalogId !== ""}
               >
                 {(catalogs.data ?? []).map((c) => (
                   <MenuItem key={c.id} value={c.id}>
@@ -392,13 +413,20 @@ export default function CreateServiceRequestPage(): JSX.Element {
 
           <Grid size={{ xs: 12, md: 6 }}>
             <FormControl fullWidth size="small" required>
-              <InputLabel id="sr-catalog-item-label">Catalog item</InputLabel>
+              <InputLabel
+                id="sr-catalog-item-label"
+                shrink={catalogItemId !== ""}
+                sx={{ top: "0px !important" }}
+              >
+                Catalog item
+              </InputLabel>
               <Select
                 labelId="sr-catalog-item-label"
                 label="Catalog item"
                 value={catalogItemId}
                 onChange={(e) => onCatalogItemChange(String(e.target.value))}
                 disabled={!catalogId}
+                notched={catalogItemId !== ""}
               >
                 {catalogItems.map((ci) => (
                   <MenuItem key={ci.id} value={ci.id}>

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/CreateDeployedProductDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/CreateDeployedProductDialog.tsx
@@ -116,12 +116,19 @@ export default function CreateDeployedProductDialog({
         <Box sx={{ display: "flex", flexDirection: "column", gap: 2, pt: 0.5 }}>
           {/* Product picker */}
           <FormControl size="small" fullWidth required error={productId === "" && tps.length > 0}>
-            <InputLabel id="create-dp-product-label">Product</InputLabel>
+            <InputLabel
+              id="create-dp-product-label"
+              shrink={productId !== ""}
+              sx={{ top: "0px !important" }}
+            >
+              Product
+            </InputLabel>
             <Select
               labelId="create-dp-product-label"
               label="Product"
               value={productId}
               onChange={(e) => handleProductChange(e.target.value as string)}
+              notched={productId !== ""}
               startAdornment={
                 productsLoading ? <CircularProgress size={16} sx={{ mr: 1 }} /> : null
               }
@@ -145,12 +152,19 @@ export default function CreateDeployedProductDialog({
             disabled={!productId}
             error={productId !== "" && versionId === "" && description.length > 0}
           >
-            <InputLabel id="create-dp-version-label">Version</InputLabel>
+            <InputLabel
+              id="create-dp-version-label"
+              shrink={versionId !== ""}
+              sx={{ top: "0px !important" }}
+            >
+              Version
+            </InputLabel>
             <Select
               labelId="create-dp-version-label"
               label="Version"
               value={versionId}
               onChange={(e) => setVersionId(e.target.value as string)}
+              notched={versionId !== ""}
               startAdornment={
                 versionsLoading ? <CircularProgress size={16} sx={{ mr: 1 }} /> : null
               }

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/CreateDeploymentDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/CreateDeploymentDialog.tsx
@@ -109,12 +109,19 @@ export default function CreateDeploymentDialog({
           />
 
           <FormControl size="small" fullWidth required error={type === "" && description.length > 0}>
-            <InputLabel id="create-deployment-type-label">Type</InputLabel>
+            <InputLabel
+              id="create-deployment-type-label"
+              shrink={type !== ""}
+              sx={{ top: "0px !important" }}
+            >
+              Type
+            </InputLabel>
             <Select
               labelId="create-deployment-type-label"
               label="Type"
               value={type}
               onChange={(e) => setType(e.target.value as BeDeploymentType)}
+              notched={type !== ""}
             >
               {DEPLOYMENT_TYPES.map((t) => (
                 <MenuItem key={t} value={t}>

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/EditDeploymentDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/EditDeploymentDialog.tsx
@@ -118,12 +118,19 @@ export default function EditDeploymentDialog({
           />
 
           <FormControl size="small" fullWidth required>
-            <InputLabel id="edit-deployment-type-label">Type</InputLabel>
+            <InputLabel
+              id="edit-deployment-type-label"
+              shrink={type !== ""}
+              sx={{ top: "0px !important" }}
+            >
+              Type
+            </InputLabel>
             <Select
               labelId="edit-deployment-type-label"
               label="Type"
               value={type}
               onChange={(e) => setType(e.target.value as BeDeploymentType)}
+              notched={type !== ""}
             >
               {DEPLOYMENT_TYPES.map((t) => (
                 <MenuItem key={t} value={t}>

--- a/apps/csm-portal/webapp/src/features/csm-security-center/components/ProductVulnerabilitiesTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-security-center/components/ProductVulnerabilitiesTab.tsx
@@ -124,6 +124,18 @@ export default function ProductVulnerabilitiesTab(): JSX.Element {
           sx={{ minWidth: 140 }}
           slotProps={{
             htmlInput: { "aria-label": "Filter by priority" },
+            // oxygen-ui's own theme (MuiInputLabel styleOverrides) shifts an
+            // unshrunk label up by `top: -7px` for any Select-backed field —
+            // see `MultiSelectField.tsx`'s doc comment for the full story.
+            // `shrink`/`notched` (rather than MUI's focus-driven default)
+            // match this field's own value state instead of only reacting
+            // to focus, and `top: "0px !important"` is the only way to win
+            // the cascade against that compound theme selector.
+            inputLabel: {
+              shrink: priorityFilter !== "",
+              sx: { top: "0px !important" },
+            },
+            select: { notched: priorityFilter !== "" },
           }}
         >
           <MenuItem value="">All priorities</MenuItem>

--- a/apps/csm-portal/webapp/src/features/csm-security-center/pages/CreateSecurityReportPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-security-center/pages/CreateSecurityReportPage.tsx
@@ -240,13 +240,20 @@ export default function CreateSecurityReportPage(): JSX.Element {
 
           <Grid size={{ xs: 12, md: 4 }}>
             <FormControl fullWidth size="small" required>
-              <InputLabel id="sra-deployment-label">Deployment</InputLabel>
+              <InputLabel
+                id="sra-deployment-label"
+                shrink={deploymentId !== ""}
+                sx={{ top: "0px !important" }}
+              >
+                Deployment
+              </InputLabel>
               <Select
                 labelId="sra-deployment-label"
                 label="Deployment"
                 value={deploymentId}
                 onChange={(e) => onDeploymentChange(String(e.target.value))}
                 disabled={!projectId || deployments.isLoading}
+                notched={deploymentId !== ""}
               >
                 {(deployments.data ?? []).map((d) => (
                   <MenuItem key={d.id} value={d.id}>
@@ -266,13 +273,20 @@ export default function CreateSecurityReportPage(): JSX.Element {
 
           <Grid size={{ xs: 12, md: 4 }}>
             <FormControl fullWidth size="small" required>
-              <InputLabel id="sra-product-label">Deployed product</InputLabel>
+              <InputLabel
+                id="sra-product-label"
+                shrink={deployedProductId !== ""}
+                sx={{ top: "0px !important" }}
+              >
+                Deployed product
+              </InputLabel>
               <Select
                 labelId="sra-product-label"
                 label="Deployed product"
                 value={deployedProductId}
                 onChange={(e) => onDeployedProductChange(String(e.target.value))}
                 disabled={!deploymentId || deployedProducts.isLoading}
+                notched={deployedProductId !== ""}
               >
                 {(deployedProducts.data ?? []).map((dp) => (
                   <MenuItem key={dp.id} value={dp.id}>

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/LogTimeCardDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/LogTimeCardDialog.tsx
@@ -450,6 +450,14 @@ export default function LogTimeCardDialog({
               value={issueComplexity}
               onChange={(e) => setIssueComplexity(e.target.value as IssueComplexity)}
               sx={{ maxWidth: { sm: 220 }, minWidth: 160 }}
+              slotProps={{
+                // `issueComplexity` always holds a real value (no empty
+                // option), so the label is always shrunk -- see
+                // MultiSelectField.tsx's doc comment for why this override
+                // is needed at all against oxygen-ui's own theme.
+                inputLabel: { shrink: true, sx: { top: "0px !important" } },
+                select: { notched: true },
+              }}
             >
               {ISSUE_COMPLEXITY_OPTIONS.map((o) => (
                 <MenuItem key={o} value={o}>

--- a/apps/csm-portal/webapp/src/features/csm-timecards/pages/CsmTimeCardsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/pages/CsmTimeCardsPage.tsx
@@ -1080,6 +1080,18 @@ function FilterBar({
                   label="State"
                   value={filterState}
                   onChange={(e) => setFilterState(e.target.value as TimeCardState | "")}
+                  slotProps={{
+                    // oxygen-ui's own theme shifts an unshrunk label up by
+                    // `top: -7px` for any Select-backed field (see
+                    // `MultiSelectField.tsx`'s doc comment) -- tie `shrink`
+                    // to whether a state is actually picked, rather than
+                    // MUI's focus-driven default.
+                    inputLabel: {
+                      shrink: filterState !== "",
+                      sx: { top: "0px !important" },
+                    },
+                    select: { notched: filterState !== "" },
+                  }}
                 >
                   <MenuItem value="">All states</MenuItem>
                   {FILTER_STATES.map((s) => (

--- a/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/pages/CsmUsersPage.tsx
@@ -192,10 +192,17 @@ export default function CsmUsersPage(): JSX.Element {
         />
 
         <FormControl size="small" sx={{ width: 200, flexShrink: 0 }}>
-          <InputLabel id="user-roles-label">Roles</InputLabel>
+          <InputLabel
+            id="user-roles-label"
+            shrink={filters.roleIds.length > 0}
+            sx={{ top: "0px !important" }}
+          >
+            Roles
+          </InputLabel>
           <Select
             labelId="user-roles-label"
             multiple
+            notched={filters.roleIds.length > 0}
             value={filters.roleIds}
             onChange={handleRoleChange}
             input={
@@ -263,10 +270,17 @@ export default function CsmUsersPage(): JSX.Element {
         </Box>
 
         <FormControl size="small" sx={{ width: 200, flexShrink: 0 }}>
-          <InputLabel id="user-teams-label">Teams</InputLabel>
+          <InputLabel
+            id="user-teams-label"
+            shrink={filters.teamIds.length > 0}
+            sx={{ top: "0px !important" }}
+          >
+            Teams
+          </InputLabel>
           <Select
             labelId="user-teams-label"
             multiple
+            notched={filters.teamIds.length > 0}
             value={filters.teamIds}
             onChange={handleTeamChange}
             input={
@@ -320,9 +334,16 @@ export default function CsmUsersPage(): JSX.Element {
         </FormControl>
 
         <FormControl size="small" sx={{ minWidth: 140 }}>
-          <InputLabel id="user-active-label">Status</InputLabel>
+          <InputLabel
+            id="user-active-label"
+            shrink={filters.active !== "all"}
+            sx={{ top: "0px !important" }}
+          >
+            Status
+          </InputLabel>
           <Select
             labelId="user-active-label"
+            notched={filters.active !== "all"}
             value={filters.active}
             onChange={handleActiveChange}
             input={<OutlinedInput label="Status" />}

--- a/apps/csm-portal/webapp/src/features/updates/pages/CsmUpdatesPage.tsx
+++ b/apps/csm-portal/webapp/src/features/updates/pages/CsmUpdatesPage.tsx
@@ -683,9 +683,16 @@ export default function CsmUpdatesPage(): JSX.Element {
           <Grid container spacing={2}>
             <Grid size={{ xs: 12, sm: 6, md: 3 }}>
               <FormControl fullWidth size="small" disabled={productLevels.isLoading}>
-                <InputLabel id="upd-product">Product</InputLabel>
+                <InputLabel
+                  id="upd-product"
+                  shrink={filter.productName !== ""}
+                  sx={{ top: "0px !important" }}
+                >
+                  Product
+                </InputLabel>
                 <Select
                   labelId="upd-product"
+                  notched={filter.productName !== ""}
                   value={filter.productName}
                   label="Product"
                   onChange={handleFilterChange("productName")}
@@ -698,9 +705,16 @@ export default function CsmUpdatesPage(): JSX.Element {
             </Grid>
             <Grid size={{ xs: 12, sm: 6, md: 3 }}>
               <FormControl fullWidth size="small" disabled={!filter.productName}>
-                <InputLabel id="upd-version">Version</InputLabel>
+                <InputLabel
+                  id="upd-version"
+                  shrink={filter.productVersion !== ""}
+                  sx={{ top: "0px !important" }}
+                >
+                  Version
+                </InputLabel>
                 <Select
                   labelId="upd-version"
+                  notched={filter.productVersion !== ""}
                   value={filter.productVersion}
                   label="Version"
                   onChange={handleFilterChange("productVersion")}
@@ -713,9 +727,16 @@ export default function CsmUpdatesPage(): JSX.Element {
             </Grid>
             <Grid size={{ xs: 12, sm: 6, md: 3 }}>
               <FormControl fullWidth size="small" disabled={!filter.productVersion}>
-                <InputLabel id="upd-start">Start level</InputLabel>
+                <InputLabel
+                  id="upd-start"
+                  shrink={filter.startLevel !== ""}
+                  sx={{ top: "0px !important" }}
+                >
+                  Start level
+                </InputLabel>
                 <Select
                   labelId="upd-start"
+                  notched={filter.startLevel !== ""}
                   value={filter.startLevel}
                   label="Start level"
                   onChange={handleFilterChange("startLevel")}
@@ -728,9 +749,16 @@ export default function CsmUpdatesPage(): JSX.Element {
             </Grid>
             <Grid size={{ xs: 12, sm: 6, md: 3 }}>
               <FormControl fullWidth size="small" disabled={!filter.startLevel}>
-                <InputLabel id="upd-end">End level</InputLabel>
+                <InputLabel
+                  id="upd-end"
+                  shrink={filter.endLevel !== ""}
+                  sx={{ top: "0px !important" }}
+                >
+                  End level
+                </InputLabel>
                 <Select
                   labelId="upd-end"
+                  notched={filter.endLevel !== ""}
                   value={filter.endLevel}
                   label="End level"
                   onChange={handleFilterChange("endLevel")}


### PR DESCRIPTION
## Summary

Reported live: the **Change requests** / **Problem management** / **Incidents** / **Vulnerabilities** tabs' filter dropdowns ("State", "Impact", "Priority") render their label wrong compared to the **Cases** tab's filter bar, which already looks correct.

**Root cause**: oxygen-ui's own theme (`MuiInputLabel` styleOverrides) shifts an unshrunk label up by `top: -7px` for any Select-backed field via a compound `:has()`/`:not()` CSS selector. `CasesFilterBar`'s controls already work around this through the shared `src/components/MultiSelectField.tsx` — it explicitly ties `shrink`/`notched` to whether a value is actually selected (rather than MUI's focus-driven default) and forces `top: "0px !important"` to win the cascade. The other tabs' filter bars each had their own raw, unfixed `FormControl`/`InputLabel`/`Select` that never got this treatment.

**Fixes**:
- `ChangeRequestsFilterBar.tsx` — removed a locally-shadowed duplicate `MultiSelectField` (used for "State"/"Impact") in favor of importing the shared, fixed one.
- `ProblemsFilterBar.tsx` — "State" control converted to the shared component.
- `IncidentsFilterBar.tsx` — "Priority" control converted to the shared component.
- `ProductVulnerabilitiesTab.tsx` — "Priority" is a single-select `TextField select` (can't reuse `MultiSelectField` as-is, which is multi-select only) — applied the equivalent `shrink`/`notched`/`top`-override fix directly via `slotProps`.

**Round 2 — reported live again, then swept exhaustively**: a case's Call requests tab ("Filter by state") had the exact same bug, plus one more instance on the Time Cards page ("State" filter). Rather than fix those two alone, did a full sweep of the entire `src/` tree for every remaining Select-backed field whose value can be empty and applied the same fix everywhere it was found:
- `CallRequestsWidget.tsx` ("Filter by state") and `CsmTimeCardsPage.tsx` ("State" filter) — the two newly-reported instances.
- Create-case / create-engagement / create-service-request / create-security-report pages' inline deployment/product/severity/type selects; `EditCaseDetailsDialog.tsx`; `ResolutionDialog.tsx`; the deployment create/edit dialogs; catalog-variable dynamic form fields; the Users page's Roles/Teams/Status filters; the Updates page's cascading filter chain; the dashboard builder's Type/Resource-type/Shape/Format/Color selects; the widget filter condition editor's Operator select; time-card logging's Issue-complexity select.
- `CsmAnnouncementsPage.tsx`'s own locally-duplicated `MultiSelect` helper was deleted in favor of the shared, already-fixed `MultiSelectField`.

**Also this round**: `CallRequestsTable`'s Schedule/Reschedule/Reject/Send-notes/Cancel actions are now icon buttons (hover tooltip carries the action name) instead of text buttons, per feedback, and the "Actions" column (header, icons, and the assignee caption beneath them) is center-aligned to match.

## Test plan
- [x] `tsc -b` — clean
- [x] `eslint .` — 0 errors (2 pre-existing warnings, unrelated files)
- [x] Full `vitest run` — **179/179 test files, 1784/1784 tests pass**, including a new regression test in `IncidentsFilterBar.test.tsx` covering the Priority control's swap to the shared component

🤖 Generated with [Claude Code](https://claude.com/claude-code)
