### PR TITLE
[CSM Portal] stop ProtectedRoute crashing every signed-out visit

### DIFF
--- a/apps/csm-portal/webapp/src/layouts/AuthGuard.protectedRoute.test.tsx
+++ b/apps/csm-portal/webapp/src/layouts/AuthGuard.protectedRoute.test.tsx
@@ -44,6 +44,11 @@ vi.mock("@context/current-user/CurrentUserContext", () => ({
   ),
 }));
 
+const isTopLevel = { value: true };
+vi.mock("@utils/isTopLevelWindow", () => ({
+  isTopLevelWindow: () => isTopLevel.value,
+}));
+
 vi.mock("@hooks/useLogger", () => ({
   useLogger: () => ({
     debug: vi.fn(),
@@ -69,6 +74,7 @@ describe("AuthGuard against the real ProtectedRoute", () => {
     sessionStorage.clear();
     authState.isSignedIn = false;
     authState.isLoading = false;
+    isTopLevel.value = true;
   });
 
   it("keeps the shell up and starts sign-in instead of crashing when signed out", async () => {
@@ -101,6 +107,23 @@ describe("AuthGuard against the real ProtectedRoute", () => {
 
     expect(screen.queryByTestId("current-user-provider")).not.toBeNull();
     expect(signIn).not.toHaveBeenCalled();
+  });
+
+  it("starts no sign-in from the silent-re-auth iframe's own boot of the app", async () => {
+    // That iframe shares this origin (and so sessionStorage) with the real page:
+    // a nested authorize round-trip nobody awaits, and the real page's deep link
+    // overwritten with the iframe's URL.
+    isTopLevel.value = false;
+    sessionStorage.setItem(POST_LOGIN_REDIRECT_KEY, "/cases/the-real-one");
+
+    renderAt("/?error=login_required&state=instance_0_request_0");
+
+    await waitFor(() => expect(screen.queryByTestId("app-layout")).not.toBeNull());
+    expect(signIn).not.toHaveBeenCalled();
+    expect(signInSilently).not.toHaveBeenCalled();
+    expect(sessionStorage.getItem(POST_LOGIN_REDIRECT_KEY)).toBe(
+      "/cases/the-real-one",
+    );
   });
 
   it("shows the loader without starting sign-in while auth is resolving", () => {

--- a/apps/csm-portal/webapp/src/layouts/AuthGuard.protectedRoute.test.tsx
+++ b/apps/csm-portal/webapp/src/layouts/AuthGuard.protectedRoute.test.tsx
@@ -1,0 +1,113 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import AuthGuard from "./AuthGuard";
+import { POST_LOGIN_REDIRECT_KEY } from "@layouts/postLoginRedirect";
+
+const signIn = vi.fn<() => Promise<unknown>>(() => Promise.resolve());
+const signInSilently = vi.fn<() => Promise<unknown>>(() => Promise.resolve(false));
+const authState = { isSignedIn: false, isLoading: false };
+
+// Only `useAsgardeo` is stubbed. The real `@asgardeo/react-router`
+// ProtectedRoute stays in the tree on purpose: stubbing it out would hide the
+// exact behaviour these tests exist to pin down — its `onSignIn` branch falls
+// through to an unconditional throw, so AuthGuard has to drive sign-in from
+// `fallback` instead.
+vi.mock("@asgardeo/react", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@asgardeo/react")>()),
+  useAsgardeo: () => ({ ...authState, signIn, signInSilently }),
+}));
+
+vi.mock("@layouts/AppLayout", () => ({
+  default: () => <div data-testid="app-layout">App layout</div>,
+}));
+
+vi.mock("@context/current-user/CurrentUserContext", () => ({
+  CurrentUserProvider: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="current-user-provider">{children}</div>
+  ),
+}));
+
+vi.mock("@hooks/useLogger", () => ({
+  useLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <AuthGuard />
+    </MemoryRouter>,
+  );
+}
+
+describe("AuthGuard against the real ProtectedRoute", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    signIn.mockResolvedValue(undefined);
+    signInSilently.mockResolvedValue(false);
+    sessionStorage.clear();
+    authState.isSignedIn = false;
+    authState.isLoading = false;
+  });
+
+  it("keeps the shell up and starts sign-in instead of crashing when signed out", async () => {
+    renderAt("/cases/abc123");
+
+    expect(screen.queryByTestId("app-layout")).not.toBeNull();
+    expect(screen.queryByTestId("current-user-provider")).toBeNull();
+    await waitFor(() => expect(signIn).toHaveBeenCalledTimes(1));
+    expect(sessionStorage.getItem(POST_LOGIN_REDIRECT_KEY)).toBe("/cases/abc123");
+  });
+
+  it("tries a silent sign-in before the interactive redirect", async () => {
+    signInSilently.mockResolvedValue(true);
+    renderAt("/cases/abc123");
+
+    await waitFor(() => expect(signInSilently).toHaveBeenCalledTimes(1));
+    expect(signIn).not.toHaveBeenCalled();
+  });
+
+  it("does not save the bare root as a post-login redirect", async () => {
+    renderAt("/");
+
+    await waitFor(() => expect(signIn).toHaveBeenCalledTimes(1));
+    expect(sessionStorage.getItem(POST_LOGIN_REDIRECT_KEY)).toBeNull();
+  });
+
+  it("renders the protected tree when signed in", () => {
+    authState.isSignedIn = true;
+    renderAt("/cases/abc123");
+
+    expect(screen.queryByTestId("current-user-provider")).not.toBeNull();
+    expect(signIn).not.toHaveBeenCalled();
+  });
+
+  it("shows the loader without starting sign-in while auth is resolving", () => {
+    authState.isLoading = true;
+    renderAt("/cases/abc123");
+
+    expect(screen.queryByTestId("app-layout")).not.toBeNull();
+    expect(signIn).not.toHaveBeenCalled();
+  });
+});

--- a/apps/csm-portal/webapp/src/layouts/AuthGuard.test.tsx
+++ b/apps/csm-portal/webapp/src/layouts/AuthGuard.test.tsx
@@ -19,38 +19,40 @@ import { act, render, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-// `ProtectedRoute`'s real implementation polls `isSignedIn` on ~1s interval
-// and only calls `onSignIn` once it decides the user isn't authenticated —
-// that's exactly the race under test here (see AuthGuard.tsx), but it's not
-// something worth re-implementing under jsdom. Stub it down to "call
-// onSignIn immediately with a fake defaultSignIn, so the assertions below
-// are about AuthGuard's own onSignIn handler, not ProtectedRoute internals.
+// Mutable so individual tests can flip `isSignedIn` across rerenders to
+// simulate a token expiring mid-session, after an initial successful sign-in.
+// Declared above the `vi.mock` factories below, which close over it.
+const asgardeoState = { isSignedIn: false };
+
+// Stubbed down to the branch order of the real component: children once
+// signed in, otherwise the `fallback` element. Re-implementing its polling
+// under jsdom isn't worth it, and the assertions below are about AuthGuard's
+// own sign-in handling rather than ProtectedRoute internals.
+//
+// Because this stub never throws, it cannot catch the upstream
+// `@asgardeo/react-router` 2.0.0 fall-through that crashed every signed-out
+// visit — AuthGuard.protectedRoute.test.tsx runs the real component for that.
 // It also renders a marker so tests can assert whether ProtectedRoute (and
 // therefore its loader-swap behaviour) is even in the tree for a given render.
-const defaultSignInMock = vi.fn();
 const protectedRouteRenderCount = vi.fn();
 vi.mock("@asgardeo/react-router", () => ({
   ProtectedRoute: ({
-    onSignIn,
     children,
+    fallback,
+    loader,
   }: {
-    onSignIn?: (
-      defaultSignIn: (options?: Record<string, unknown>) => void,
-      signInOptions?: Record<string, unknown>,
-    ) => void;
     children?: React.ReactNode;
+    fallback?: React.ReactNode;
+    loader?: React.ReactNode;
   }) => {
     protectedRouteRenderCount();
-    onSignIn?.(defaultSignInMock, { some: "option" });
-    return children ?? null;
+    if (asgardeoState.isSignedIn) return children ?? null;
+    return fallback ?? loader ?? null;
   },
 }));
 
 const signInSilentlyMock = vi.fn();
 const signInMock = vi.fn();
-// Mutable so individual tests can flip `isSignedIn` across rerenders to
-// simulate a token expiring mid-session, after an initial successful sign-in.
-const asgardeoState = { isSignedIn: false };
 vi.mock("@asgardeo/react", () => ({
   useAsgardeo: () => ({
     isSignedIn: asgardeoState.isSignedIn,
@@ -82,11 +84,12 @@ function renderAuthGuard() {
   );
 }
 
-describe("AuthGuard onSignIn (before any successful sign-in)", () => {
+describe("AuthGuard sign-in fallback (before any successful sign-in)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     sessionStorage.clear();
     asgardeoState.isSignedIn = false;
+    signInMock.mockResolvedValue(undefined);
   });
 
   it("attempts a silent re-auth first and does not force a full sign-in redirect when it succeeds", async () => {
@@ -97,7 +100,7 @@ describe("AuthGuard onSignIn (before any successful sign-in)", () => {
     });
 
     await waitFor(() => expect(signInSilentlyMock).toHaveBeenCalledTimes(1));
-    expect(defaultSignInMock).not.toHaveBeenCalled();
+    expect(signInMock).not.toHaveBeenCalled();
   });
 
   it("falls back to the full sign-in redirect when silent re-auth resolves falsy", async () => {
@@ -107,9 +110,7 @@ describe("AuthGuard onSignIn (before any successful sign-in)", () => {
       renderAuthGuard();
     });
 
-    await waitFor(() =>
-      expect(defaultSignInMock).toHaveBeenCalledWith({ some: "option" }),
-    );
+    await waitFor(() => expect(signInMock).toHaveBeenCalledTimes(1));
   });
 
   it("falls back to the full sign-in redirect when silent re-auth rejects", async () => {
@@ -119,12 +120,23 @@ describe("AuthGuard onSignIn (before any successful sign-in)", () => {
       renderAuthGuard();
     });
 
-    await waitFor(() =>
-      expect(defaultSignInMock).toHaveBeenCalledWith({ some: "option" }),
-    );
+    await waitFor(() => expect(signInMock).toHaveBeenCalledTimes(1));
     expect(loggerDebugMock).toHaveBeenCalledWith(
       "[auth] silent sign-in failed",
       "iframe blocked",
+    );
+  });
+
+  it("saves the intended deep link before redirecting to the IdP", async () => {
+    signInSilentlyMock.mockResolvedValue(false);
+
+    await act(async () => {
+      renderAuthGuard();
+    });
+
+    await waitFor(() => expect(signInMock).toHaveBeenCalledTimes(1));
+    expect(sessionStorage.getItem("post_login_redirect")).toBe(
+      "/some/protected/path",
     );
   });
 });
@@ -172,7 +184,6 @@ describe("AuthGuard after an initial successful sign-in (transient token-clock e
     expect(protectedRouteRenderCount).not.toHaveBeenCalled();
     expect(signInSilentlyMock).not.toHaveBeenCalled();
     expect(signInMock).not.toHaveBeenCalled();
-    expect(defaultSignInMock).not.toHaveBeenCalled();
   });
 
   it("resets the latch on an explicit sign-out (app:signing-out), falling back to ProtectedRoute instead of continuing to render stale protected content", async () => {

--- a/apps/csm-portal/webapp/src/layouts/AuthGuard.tsx
+++ b/apps/csm-portal/webapp/src/layouts/AuthGuard.tsx
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { type JSX, useEffect, useState } from "react";
+import { type JSX, useEffect, useRef, useState } from "react";
 import { useAsgardeo } from "@asgardeo/react";
 import { ProtectedRoute } from "@asgardeo/react-router";
 import { useLocation, useNavigate } from "react-router";
@@ -23,6 +23,73 @@ import { POST_LOGIN_REDIRECT_KEY } from "@layouts/postLoginRedirect";
 import { CurrentUserProvider } from "@context/current-user/CurrentUserContext";
 import { useLogger } from "@hooks/useLogger";
 import { trySilentSignInOnce } from "@hooks/silentSignIn";
+
+/**
+ * Starts sign-in for a signed-out visitor and renders the app shell while the
+ * browser navigates to the IdP.
+ *
+ * This is passed to `ProtectedRoute` as `fallback` rather than driving sign-in
+ * from its `onSignIn` prop. In `@asgardeo/react-router` 2.0.0 the `onSignIn`
+ * branch does not return: it invokes the handler and then falls straight
+ * through to an unconditional `throw new AsgardeoRuntimeError("ProtectedRoute
+ * misconfiguration.")`. Sign-in here is asynchronous (a silent attempt first,
+ * then the interactive redirect), so the throw always won the race and every
+ * signed-out visit — an expired session, a case deep link opened in a cold tab
+ * — hit the app error boundary before the redirect could start. Only the
+ * `fallback` and `redirectTo` branches return early, so `fallback` is the one
+ * place that can both start sign-in and keep the tree alive. Go back to
+ * `onSignIn` only once that upstream fall-through is fixed.
+ *
+ * The intended URL is saved first so the deep link survives the round-trip, and
+ * the ref guard keeps a re-render (or StrictMode's double-invoked effect) from
+ * firing a second authorize request.
+ *
+ * @returns {JSX.Element} The app shell, held until the IdP redirect lands.
+ */
+function SignInRedirect(): JSX.Element {
+  const { signIn, signInSilently } = useAsgardeo();
+  const location = useLocation();
+  const logger = useLogger();
+  const started = useRef(false);
+  // Only a sign-in that cannot even start belongs on the error boundary. It is
+  // stored and rethrown from render rather than thrown from the effect, which
+  // React would otherwise leave as an unhandled rejection.
+  const [fatal, setFatal] = useState<Error | null>(null);
+  if (fatal) throw fatal;
+
+  useEffect(() => {
+    if (started.current) return;
+    started.current = true;
+
+    const intended = location.pathname + location.search + location.hash;
+    if (intended !== "/") {
+      sessionStorage.setItem(POST_LOGIN_REDIRECT_KEY, intended);
+    }
+
+    void (async () => {
+      const recovered = await trySilentSignInOnce(signInSilently, (message) =>
+        logger.debug("[auth] silent sign-in failed", message),
+      );
+      // A silent success flips `isSignedIn`, and ProtectedRoute swaps this
+      // fallback out for the real tree — nothing more to do here.
+      if (recovered) return;
+      try {
+        await signIn();
+      } catch (error) {
+        setFatal(error instanceof Error ? error : new Error(String(error)));
+      }
+    })();
+  }, [
+    signIn,
+    signInSilently,
+    logger,
+    location.pathname,
+    location.search,
+    location.hash,
+  ]);
+
+  return <AppLayout />;
+}
 
 /**
  * AuthGuard renders AppLayout (header/footer) so loading state is visible
@@ -40,10 +107,9 @@ import { trySilentSignInOnce } from "@hooks/silentSignIn";
  * @returns {JSX.Element} AppLayout or redirect to home.
  */
 export default function AuthGuard(): JSX.Element {
-  const { isSignedIn, signInSilently } = useAsgardeo();
+  const { isSignedIn } = useAsgardeo();
   const location = useLocation();
   const navigate = useNavigate();
-  const logger = useLogger();
 
   // Latches true the first time `isSignedIn` is observed true, and never
   // resets — see the render branch below for why. Set directly in the render
@@ -136,23 +202,7 @@ export default function AuthGuard(): JSX.Element {
   }
 
   return (
-    <ProtectedRoute
-      loader={<AppLayout />}
-      onSignIn={(defaultSignIn, signInOptions) => {
-        const intended =
-          location.pathname + location.search + location.hash;
-        if (intended !== "/") {
-          sessionStorage.setItem(POST_LOGIN_REDIRECT_KEY, intended);
-        }
-        trySilentSignInOnce(signInSilently, (message) =>
-          logger.debug("[auth] silent sign-in failed", message),
-        ).then((result) => {
-          if (!result) {
-            defaultSignIn(signInOptions);
-          }
-        });
-      }}
-    >
+    <ProtectedRoute loader={<AppLayout />} fallback={<SignInRedirect />}>
       <CurrentUserProvider>
         <AppLayout />
       </CurrentUserProvider>

--- a/apps/csm-portal/webapp/src/layouts/AuthGuard.tsx
+++ b/apps/csm-portal/webapp/src/layouts/AuthGuard.tsx
@@ -20,9 +20,32 @@ import { ProtectedRoute } from "@asgardeo/react-router";
 import { useLocation, useNavigate } from "react-router";
 import AppLayout from "@layouts/AppLayout";
 import { POST_LOGIN_REDIRECT_KEY } from "@layouts/postLoginRedirect";
+import { isTopLevelWindow } from "@utils/isTopLevelWindow";
 import { CurrentUserProvider } from "@context/current-user/CurrentUserContext";
+import RouteSuspenseFallback from "@components/route-fallback/RouteSuspenseFallback";
 import { useLogger } from "@hooks/useLogger";
 import { trySilentSignInOnce } from "@hooks/silentSignIn";
+
+/**
+ * The app shell with the routed page deliberately suppressed.
+ *
+ * `AppLayout` renders `children || <Outlet />`, so passing children keeps the
+ * chrome visible without mounting the route underneath. That matters before a
+ * session exists: pages reached this way call `useCurrentUser`, which throws
+ * outside `CurrentUserProvider` — a bare `<AppLayout />` here took down the
+ * whole tree on any deep link (`/cases/:id` among them) while auth was still
+ * resolving or the sign-in redirect was in flight. Suppressing the page also
+ * keeps it from firing authenticated requests that are certain to 401.
+ *
+ * @returns {JSX.Element} The app shell showing progress in the content region.
+ */
+function AuthPendingShell(): JSX.Element {
+  return (
+    <AppLayout>
+      <RouteSuspenseFallback />
+    </AppLayout>
+  );
+}
 
 /**
  * Starts sign-in for a signed-out visitor and renders the app shell while the
@@ -59,6 +82,11 @@ function SignInRedirect(): JSX.Element {
 
   useEffect(() => {
     if (started.current) return;
+    // The silent-re-auth iframe boots the whole app on this same origin and
+    // lands here too, signed out. Starting a sign-in from inside it would run a
+    // second, nested authorize round-trip that no one is waiting on, and clobber
+    // the real page's saved deep link. The SDK drives that frame; leave it be.
+    if (!isTopLevelWindow()) return;
     started.current = true;
 
     const intended = location.pathname + location.search + location.hash;
@@ -88,7 +116,7 @@ function SignInRedirect(): JSX.Element {
     location.hash,
   ]);
 
-  return <AppLayout />;
+  return <AuthPendingShell />;
 }
 
 /**
@@ -202,7 +230,7 @@ export default function AuthGuard(): JSX.Element {
   }
 
   return (
-    <ProtectedRoute loader={<AppLayout />} fallback={<SignInRedirect />}>
+    <ProtectedRoute loader={<AuthPendingShell />} fallback={<SignInRedirect />}>
       <CurrentUserProvider>
         <AppLayout />
       </CurrentUserProvider>

--- a/apps/csm-portal/webapp/src/main.tsx
+++ b/apps/csm-portal/webapp/src/main.tsx
@@ -19,6 +19,7 @@ import React from "react";
 import { createRoot } from "react-dom/client";
 import AppWithConfig from "./AppWithConfig";
 import { POST_LOGIN_REDIRECT_KEY } from "@layouts/postLoginRedirect";
+import { isTopLevelWindow } from "@utils/isTopLevelWindow";
 
 if (typeof window !== "undefined") {
   (window as unknown as { Prism: typeof Prism }).Prism = Prism;
@@ -29,8 +30,13 @@ if (typeof window !== "undefined") {
 // the SDK restores the session synchronously (in which case ProtectedRoute's
 // `onSignIn` never fires and the SDK navigates straight to `afterSignInUrl`).
 // AuthGuard reads/clears `post_login_redirect` once signed in. Skip the bare
-// root and the OAuth callback (which carries `?code=&state=`).
-if (typeof window !== "undefined") {
+// root, the OAuth callback (which carries `?code=&state=`), and any boot that
+// is not the top-level page (see below).
+// The `isTopLevelWindow()` guard keeps the silent-re-auth iframe's own boot of
+// this module from overwriting the real deep link with the iframe's URL
+// (`/?error=login_required&state=…` with no IdP session, `/?state=…` with one),
+// which otherwise lands the user on that instead of the page they asked for.
+if (typeof window !== "undefined" && isTopLevelWindow()) {
   try {
     // Include the hash so permalinks like `/cases/:id#description` (per-comment /
     // per-section anchors) survive the IdP round-trip, not just pathname+search.

--- a/apps/csm-portal/webapp/src/utils/isTopLevelWindow.test.ts
+++ b/apps/csm-portal/webapp/src/utils/isTopLevelWindow.test.ts
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { isTopLevelWindow } from "./isTopLevelWindow";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("isTopLevelWindow", () => {
+  it("is true for the top-level page", () => {
+    expect(isTopLevelWindow()).toBe(true);
+  });
+
+  it("is false inside a frame", () => {
+    vi.spyOn(window, "top", "get").mockReturnValue({} as Window);
+    expect(isTopLevelWindow()).toBe(false);
+  });
+
+  it("treats a cross-origin parent that throws on access as framed", () => {
+    vi.spyOn(window, "top", "get").mockImplementation(() => {
+      throw new Error("blocked a frame with origin ... from accessing a cross-origin frame");
+    });
+    expect(isTopLevelWindow()).toBe(false);
+  });
+});

--- a/apps/csm-portal/webapp/src/utils/isTopLevelWindow.ts
+++ b/apps/csm-portal/webapp/src/utils/isTopLevelWindow.ts
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+ * Whether this document is the top-level page rather than a frame.
+ *
+ * The IdP SDK runs its silent re-auth in a hidden iframe whose redirect_uri is
+ * this app's own origin, so that iframe boots the whole app a second time —
+ * sharing sessionStorage with the real page. Anything that assumes "this
+ * document is what the user navigated to" has to be gated on this: recording
+ * the entry deep link (main.tsx) and starting a sign-in redirect (AuthGuard)
+ * are both meaningless, and actively harmful, from inside that frame.
+ *
+ * @returns {boolean} `true` for the top-level page, `false` inside a frame.
+ */
+export function isTopLevelWindow(): boolean {
+  try {
+    return window.top === window.self;
+  } catch {
+    // Cross-origin parent: not our own silent-auth frame, but not a page the
+    // user deep-linked to either. Treat it as framed.
+    return false;
+  }
+}

--- a/apps/csm-portal/webapp/vite.config.ts
+++ b/apps/csm-portal/webapp/vite.config.ts
@@ -121,6 +121,10 @@ const vitestConfig = defineVitestConfig({
           "@wso2/oxygen-ui-charts-react",
           "@mui/x-data-grid",
           "@asgardeo/browser",
+          // Inlined so `vi.mock("@asgardeo/react")` reaches ProtectedRoute's
+          // own import of the hook; without it the router package stays
+          // external and keeps the real `useAsgardeo`, which no test can steer.
+          "@asgardeo/react-router",
           "buffer",
         ],
       },


### PR DESCRIPTION
## Purpose

Every signed-out visit to the CSM portal crashed to the app error boundary with
`AsgardeoRuntimeError: ProtectedRoute misconfiguration.` instead of redirecting to the
identity provider. Reproduced on both staging and production, in Chrome and Firefox, on
plain case deep links.

The cause is in `@asgardeo/react-router@2.0.0`. Its `ProtectedRoute` does not return after
the `onSignIn` branch:

```js
if (!isSignedIn) {
  if (signInUrl)     { navigate(signInUrl); }
  else if (onSignIn) { onSignIn(signIn, overriddenSignInOptions); }
  else               { /* async signIn */ }
}
throw new AsgardeoRuntimeError('ProtectedRoute misconfiguration.', ...);  // unconditional
```

Only the `isLoading`, `isSignedIn`, `fallback` and `redirectTo` branches return early.
`AuthGuard` passed `loader` + `onSignIn` and neither `fallback` nor `redirectTo`, so a
signed-out render invoked the handler and then threw. Our handler is asynchronous (a silent
re-auth attempt, then the interactive redirect), so the throw always won the race: the
redirect was never reached and its continuation was left to reject in the background.

Resolves the signed-out crash reported against the case detail route.

Running the fix against the staging backend then surfaced two further defects on the same
signed-out path, both fixed here.

**The auth-pending shell mounted the routed page.** `AppLayout` renders
`children || <Outlet />`, so the bare `<AppLayout />` used for the loader mounted the page
underneath it. Pages reached that way call `useCurrentUser`, which throws outside
`CurrentUserProvider` — enough to take down the tree on any deep link while auth was still
resolving. `ProtectedRoute`'s own throw had been masking it.

**The silent-re-auth iframe destroyed the deep link.** The SDK runs its silent attempt in a
hidden iframe whose redirect_uri is this app's own origin, so the iframe boots the entire app
a second time and shares `sessionStorage` with the real page. That boot overwrote the saved
deep link with the iframe's own URL, and reached the sign-in fallback itself, starting a
nested authorize round-trip nobody awaits. Measured on the live stack: a deep link to a case
came back as `/?error_description=Authentication+required&…`, so signing in landed the user
on that rather than the case they clicked.

## Goals

- A signed-out visitor reaches the IdP sign-in page instead of the error wall.
- The deep link survives the round-trip intact, and the silent re-auth attempt still runs
  first.
- Nothing under the auth-pending shell mounts a page or fires a request before there is a
  session.
- A sign-in that genuinely cannot start is still visible, rather than silently swallowed.
- Regression coverage that exercises the real `ProtectedRoute`, so this cannot come back
  unnoticed.

## Approach

Sign-in now runs from a `fallback` element (`SignInRedirect`) instead of the `onSignIn`
prop. `fallback` is the only branch that both returns early and leaves room for our own
sign-in logic; `redirectTo` would need a dedicated sign-in route this app does not have.

`SignInRedirect` saves the intended URL, runs the shared single-flight silent re-auth, and
falls back to the interactive redirect, all from an effect with a ref guard so a re-render
cannot fire a second authorize request. It renders the app shell meanwhile, matching the
previous loading appearance. If the interactive sign-in itself rejects, the error is stored
and rethrown from render so the error boundary still reports it, rather than stranding the
user on an empty shell.

Reverting to `onSignIn` is a one-line change once the upstream fall-through is fixed; the
reason is recorded in a comment on the component.

Both the loader and the fallback now render `RouteSuspenseFallback` as `AppLayout`'s
children, so the chrome stays visible without mounting the page underneath. Recording the
entry URL (`main.tsx`) and starting a sign-in redirect (`AuthGuard`) are both gated on a new
`isTopLevelWindow()` helper, since neither is meaningful from inside the SDK's silent-auth
frame.

No UI text or visual change, so no screenshot: the user-visible difference is that the
error wall no longer appears.

## User stories

As a CS engineer opening a case link with an expired session, I am taken to the sign-in
page and then to the case I asked for, instead of an error page.

## Release note

Fixed the CSM portal showing an error page instead of the sign-in redirect when a session
had expired or a link was opened in a new browser session.

## Documentation

N/A — internal auth-flow fix with no user-facing documentation or configuration impact.

## Training

N/A — no change to product behaviour that training content covers.

## Certification

N/A — no certification impact; this is an internal defect fix.

## Marketing

N/A — internal defect fix.

## Automation tests

- Unit tests

  `AuthGuard.protectedRoute.test.tsx` is new and runs the **real**
  `@asgardeo/react-router` `ProtectedRoute`, covering: signed-out keeps the shell up and
  starts sign-in without throwing, the silent attempt precedes the interactive redirect, the
  deep link is saved (and the bare root is not), the signed-in tree renders, and the loader
  shows while auth is resolving. Checked in both directions: against the previous
  `AuthGuard.tsx` three of these fail with the exact production error
  (`AsgardeoRuntimeError: ProtectedRoute misconfiguration.`), and all pass with the fix.

  The pre-existing `AuthGuard.test.tsx` stubbed `ProtectedRoute` out entirely, which is why
  this defect shipped. Its stub now mirrors the real branch order (children when signed in,
  otherwise `fallback`) and its sign-in cases assert against the new path; the latch and
  sign-out cases are unchanged. Because `vi.mock` is per-file, the real-component suite has
  to live in its own file.

  This required adding `@asgardeo/react-router` to Vitest's `server.deps.inline`, otherwise
  the package stays external and keeps the real `useAsgardeo`, which no test can steer.

  Also covered: the sign-in fallback starts nothing from a framed boot and leaves an
  already-saved deep link alone, plus unit tests for `isTopLevelWindow` including the
  cross-origin access-throws case.

  Full suite: 181 files, 1793 tests, 0 failures. `tsc --noEmit`, `eslint`, and
  `npm run build` all clean.

- Integration tests

  N/A — no new API surface. Verified manually instead, running this branch's webapp against
  the staging backend with real Asgardeo and a fresh (signed-out) browser profile:

  - A signed-out load of `/cases/:id` reaches the Asgardeo login form. No error wall, and no
    `ProtectedRoute misconfiguration` anywhere in the console.
  - `post_login_redirect` holds `/cases/fc0414…` at the point of redirect. On the same stack
    before this change it held
    `/?error_description=Authentication+required&state=…&error=login_required`.

  Worth stating plainly: the original crash is timing-dependent and did **not** reproduce on
  the local stack — the dev server is slow enough to init that `isLoading` stays true past
  the redirect, so the throw is never reached. The proof that the crash is fixed is the unit
  test against the real `ProtectedRoute`, which fails on the previous code with the exact
  production error. The live run proves the sign-in flow is not regressed and that the deep
  link now survives.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
- Ran FindSecurityBugs plugin and verified report? **N/A** — TypeScript, no Java. `eslint`
  and `tsc --noEmit` ran clean on the changed files.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**

This changes when sign-in is initiated, not what is trusted: no change to token handling,
scopes, session storage of credentials, or any authorization decision. The only value
written to storage is the in-app path the user was heading to, which is what the previous
code stored as well.

## Samples

N/A — no sample impact.

## Related PRs

None.

## Migrations (if applicable)

N/A — no data or configuration migration.

## Test environment

Node 22, pnpm 11.1.2, macOS 15. Unit suite under Vitest 4 / jsdom. Original defect observed
in Chrome and Firefox against the deployed staging and production webapps.

## Learning

The error message names the caller ("ProtectedRoute misconfiguration"), but reading the
shipped `@asgardeo/react-router` source shows the throw is unconditional once execution
reaches the end of the component: any consumer using `onSignIn` without `fallback` or
`redirectTo` hits it. Worth noting that a test which stubs out the third-party component it
is guarding against will pass no matter how badly that component behaves.

Two of the three defects here were invisible to unit tests and only showed up when the app
ran against a real IdP: the shell crash needed a real route mounted under it, and the deep
link corruption needed the SDK's actual silent-auth iframe. Worth remembering that a hidden
iframe pointed at your own origin is a second instance of your app sharing your storage.

One thing left alone: the SDK's silent attempt logs an uncaught
`login_required` rejection of its own when there is no IdP session. It is internal to
`@asgardeo/browser`, does not affect the flow (the interactive redirect proceeds normally),
and is present before this change too.
