### PR TITLE
[CSM Portal] stop the failed silent-auth frame logging an uncaught error

### DIFF
--- a/apps/csm-portal/webapp/src/AppWithConfig.tsx
+++ b/apps/csm-portal/webapp/src/AppWithConfig.tsx
@@ -20,6 +20,10 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import App from "./App";
 import AppErrorBoundary from "@components/error/AppErrorBoundary";
 import { AsgardeoProvider } from "@asgardeo/react";
+import {
+  isTopLevelWindow,
+  silentAuthFrameCanComplete,
+} from "@utils/isTopLevelWindow";
 import { loggerConfig } from "@config/loggerConfig";
 import LoggerProvider from "@context/logger/LoggerProvider";
 import { ThemePreferenceProvider } from "@context/theme/ThemePreferenceContext";
@@ -49,25 +53,14 @@ function shouldRetryQuery(failureCount: number, error: Error): boolean {
   return statusCode === 502 || statusCode === 503;
 }
 
-// `signInSilently()` (from `@asgardeo/react`) recovers an expired access
-// token by loading the IdP's authorize URL, with prompt=none, inside a
-// hidden, invisible iframe. Because this app's own SPA is served at the
-// same redirect_uri as the top-level app, that hidden iframe's document is
-// a full second load of THIS SAME bundle — `AsgardeoProvider` needs to
-// mount and initialize there to complete the SDK's internal handshake
-// (it detects the silent-sign-in state in the URL and short-circuits), but
-// nothing below it should. Without this guard, the router/`AuthGuard`/page
-// tree fully mounts inside that hidden iframe too, and `AuthGuard`'s own
-// (correct, needed) recovery logic then notices "not signed in yet" INSIDE
-// that iframe and starts its own silent sign-in — recursively nesting
-// another hidden iframe inside this one. Observed live: a single token
-// expiry cascaded into 7 nested iframe loads and dropped an in-flight POST
-// (a case comment was never created) somewhere in that churn. This app is
-// never legitimately embedded by anything else, so `window.self !==
-// window.top` unambiguously means "I am the SDK's own hidden recovery
-// iframe," not a real embedding scenario to support.
-const isInsideHiddenAuthIframe =
-  typeof window !== "undefined" && window.self !== window.top;
+// See `isTopLevelWindow` for why the SDK's hidden silent-auth iframe is a full
+// second load of this bundle, and why nothing below `AsgardeoProvider` may
+// mount inside it. When that frame carries an IdP error rather than a code
+// there is no handshake left to finish, so the provider is skipped too — see
+// `silentAuthFrameCanComplete`.
+const isInsideHiddenAuthIframe = !isTopLevelWindow();
+const isDeadAuthIframe =
+  isInsideHiddenAuthIframe && !silentAuthFrameCanComplete();
 
 const queryClient: QueryClient = new QueryClient({
   defaultOptions: {
@@ -87,6 +80,10 @@ const queryClient: QueryClient = new QueryClient({
 });
 
 export default function AppWithConfig(): JSX.Element {
+  // Nothing to mount: this frame's silent attempt already failed, and the SDK's
+  // own start-up would only reject on the error URL and log it.
+  if (isDeadAuthIframe) return <></>;
+
   return (
     <AsgardeoProvider
       baseUrl={authConfig.baseUrl}

--- a/apps/csm-portal/webapp/src/utils/isTopLevelWindow.test.ts
+++ b/apps/csm-portal/webapp/src/utils/isTopLevelWindow.test.ts
@@ -15,26 +15,56 @@
 // under the License.
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { isTopLevelWindow } from "./isTopLevelWindow";
+import {
+  isTopLevelWindow,
+  silentAuthFrameCanComplete,
+} from "./isTopLevelWindow";
+
+function framed(): void {
+  vi.spyOn(window, "top", "get").mockReturnValue({} as Window);
+}
+
+function search(query: string): void {
+  vi.spyOn(window, "location", "get").mockReturnValue({
+    ...window.location,
+    search: query,
+  } as Location);
+}
 
 afterEach(() => {
-  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
 });
 
 describe("isTopLevelWindow", () => {
-  it("is true for the top-level page", () => {
+  it("is true for the real top-level page", () => {
     expect(isTopLevelWindow()).toBe(true);
   });
 
-  it("is false inside a frame", () => {
-    vi.spyOn(window, "top", "get").mockReturnValue({} as Window);
+  it("is false inside the SDK's hidden auth frame", () => {
+    framed();
     expect(isTopLevelWindow()).toBe(false);
   });
+});
 
-  it("treats a cross-origin parent that throws on access as framed", () => {
-    vi.spyOn(window, "top", "get").mockImplementation(() => {
-      throw new Error("blocked a frame with origin ... from accessing a cross-origin frame");
-    });
-    expect(isTopLevelWindow()).toBe(false);
+describe("silentAuthFrameCanComplete", () => {
+  it("is true for a frame carrying an authorization code", () => {
+    search("?code=abc123&state=instance_0_request_0");
+    expect(silentAuthFrameCanComplete()).toBe(true);
+  });
+
+  it("is false for a frame carrying only an IdP error", () => {
+    // What every browser blocking cross-site cookies returns for prompt=none.
+    search("?error_description=Authentication+required&state=s&error=login_required");
+    expect(silentAuthFrameCanComplete()).toBe(false);
+  });
+
+  it("still allows a frame that carries a code alongside an error", () => {
+    search("?code=abc123&error=some_warning");
+    expect(silentAuthFrameCanComplete()).toBe(true);
+  });
+
+  it("is true when there are no auth params at all", () => {
+    search("");
+    expect(silentAuthFrameCanComplete()).toBe(true);
   });
 });

--- a/apps/csm-portal/webapp/src/utils/isTopLevelWindow.ts
+++ b/apps/csm-portal/webapp/src/utils/isTopLevelWindow.ts
@@ -15,23 +15,51 @@
 // under the License.
 
 /**
- * Whether this document is the top-level page rather than a frame.
+ * Whether this document is the SDK's own hidden silent-auth iframe rather than
+ * the real page.
  *
- * The IdP SDK runs its silent re-auth in a hidden iframe whose redirect_uri is
- * this app's own origin, so that iframe boots the whole app a second time —
- * sharing sessionStorage with the real page. Anything that assumes "this
- * document is what the user navigated to" has to be gated on this: recording
- * the entry deep link (main.tsx) and starting a sign-in redirect (AuthGuard)
- * are both meaningless, and actively harmful, from inside that frame.
+ * `signInSilently()` recovers an expired token by loading the IdP's authorize
+ * URL with `prompt=none` inside a hidden iframe. Because this app is served at
+ * the same redirect_uri as the top-level app, that iframe's document is a full
+ * second load of this same bundle, sharing this origin's `sessionStorage`. Two
+ * things must therefore be gated on this:
  *
- * @returns {boolean} `true` for the top-level page, `false` inside a frame.
+ * - Nothing below `AsgardeoProvider` should mount there (`AppWithConfig`), or
+ *   the router and `AuthGuard` mount too, notice "not signed in" inside the
+ *   frame, and start their own silent sign-in — nesting another frame inside
+ *   this one. Observed live: one token expiry cascading into 7 nested loads,
+ *   dropping an in-flight POST.
+ * - Nothing may record the entry deep link (`main.tsx`) or start a sign-in
+ *   redirect (`AuthGuard`), since the frame's URL is not a user navigation and
+ *   `sessionStorage` is shared with the page that does have one.
+ *
+ * This app is never legitimately embedded by anything else, so being framed
+ * unambiguously means "I am the SDK's hidden auth iframe", not a real embedding
+ * to support.
+ *
+ * @returns {boolean} `true` for the real top-level page, `false` inside a frame.
  */
 export function isTopLevelWindow(): boolean {
-  try {
-    return window.top === window.self;
-  } catch {
-    // Cross-origin parent: not our own silent-auth frame, but not a page the
-    // user deep-linked to either. Treat it as framed.
-    return false;
-  }
+  // Comparing WindowProxy references is allowed cross-origin and never throws;
+  // only reaching into the other window's properties would.
+  return typeof window === "undefined" || window.self === window.top;
+}
+
+/**
+ * Whether this silent-auth frame can still complete the SDK's handshake.
+ *
+ * The SDK detects its silent-sign-in state in the frame's URL and hands the
+ * authorization code back to the opener, so `AsgardeoProvider` does have to
+ * mount in a frame carrying `?code=`. A frame carrying `?error=` instead (the
+ * IdP answering `prompt=none` with `login_required`, which is what every
+ * browser that blocks cross-site cookies will produce) has nothing to hand
+ * back. Mounting the provider there only lets its own start-up effect call
+ * `signIn()` on a URL it then rejects, surfacing as an uncaught
+ * `login_required` in the console on every signed-out visit.
+ *
+ * @returns {boolean} `true` if this frame still has a handshake to finish.
+ */
+export function silentAuthFrameCanComplete(): boolean {
+  const params = new URLSearchParams(window.location.search);
+  return params.has("code") || !params.has("error");
 }


### PR DESCRIPTION
## Purpose

Every signed-out visit to the portal logs an uncaught error in the browser console:

```
Uncaught (in promise) AsgardeoRuntimeError: Sign in failed: Sign in failed:
{"name":"login_required","code":"SPA-AUTH_HELPER-SI-SE01","message":"Authentication required"}
```

Attributing it per-frame on a live stack shows it does not come from the page at all. It
comes from inside the SDK's own hidden silent-auth iframe.

When `prompt=none` finds no IdP session, that frame lands back on this app's origin at
`/?error_description=Authentication+required&state=…&error=login_required`, which loads this
bundle a second time. `AsgardeoProvider` mounts there deliberately, so the SDK can finish its
handshake. But `@asgardeo/react`'s `hasAuthParams` is:

```js
const hasAuthParams = (url, afterSignInUrl) =>
  (hasAuthParamsInUrl() && new URL(url.origin + url.pathname).toString() === new URL(afterSignInUrl).toString())
  || url.searchParams.get("error") !== null;
```

The second clause makes any `error` param satisfy it, with no path check. So the provider's
start-up effect calls `signIn({callOnlyOnRedirect: true})` on a URL that carries an error
instead of a code, the SDK rejects, and the rejection escapes an async IIFE that has no
catch.

This is browser-dependent and becoming more common rather than less: the IdP session cookie
is cross-site inside that frame, so any browser blocking third-party cookies answers
`prompt=none` with `login_required` every time. Reported on Firefox, whose own console
records the cause alongside it (`Cookie … has been rejected because it is in a cross-site
context`).

## Goals

- No uncaught error in the console on an ordinary signed-out visit.
- The silent-auth handshake still completes normally when it can.
- One helper for "am I the SDK's hidden auth frame", not two.

## Approach

A frame carrying an error rather than a code has no code to hand back, so there is no
handshake left to finish. `AppWithConfig` now renders nothing at all in that case, rather
than mounting a provider whose only remaining act is to reject. A frame carrying `?code=`
mounts the provider exactly as before, so silent sign-in is untouched where it can actually
succeed.

This also folds `AppWithConfig`'s `isInsideHiddenAuthIframe` constant into the
`isTopLevelWindow` helper introduced in #1527, which duplicated it. One predicate, and the
reasoning documented once next to it.

No UI change.

## User stories

As a CS engineer, opening the portal signed out does not fill my browser console with errors
that look like the app is broken.

## Release note

Removed a spurious authentication error logged to the browser console on every signed-out
visit to the CSM portal.

## Documentation

N/A — internal auth-flow fix, no user-facing documentation or configuration impact.

## Training

N/A — no change to product behaviour that training content covers.

## Certification

N/A — no certification impact.

## Marketing

N/A — internal defect fix.

## Automation tests

- Unit tests

  `isTopLevelWindow.test.ts` covers the framed/top-level predicate and the new
  `silentAuthFrameCanComplete`: a frame with a code can still complete, a frame with only an
  IdP error cannot, a frame with both is still allowed to proceed, and a frame with no auth
  params at all is not treated as dead.

  Full suite: 181 files, 1797 tests, 0 failures. `tsc --noEmit`, `eslint` (0 errors) and
  `npm run build` all clean.

- Integration tests

  N/A — no API surface. Verified manually instead, on a signed-out `/cases/:id` load against
  the staging backend with real Asgardeo and a fresh browser profile, instrumented to
  attribute every frame load and unhandled rejection to the frame it happened in:

  | | before (current `main`) | after |
  |---|---|---|
  | uncaught rejections | 1 (in the error frame) | 0 |
  | frame loads | 15 | 9 |
  | reaches IdP login page | 12.3s | 12.3s |
  | deep link preserved | yes | yes |

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
- Ran FindSecurityBugs plugin and verified report? **N/A** — TypeScript, no Java. `eslint` and
  `tsc --noEmit` ran clean on the changed files.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**

This narrows what runs in a frame whose authentication has already failed; it grants nothing.
The success path (`?code=`) is unchanged, so no token handling or session behaviour moves.

## Samples

N/A — no sample impact.

## Related PRs

Follows #1527, which fixed the `ProtectedRoute` crash on the same signed-out path.

## Migrations (if applicable)

N/A — no data or configuration migration.

## Test environment

Node 22, pnpm 11.1.2, macOS 15. Unit suite under Vitest 4 / jsdom. Live check against the
staging backend with real Asgardeo, Chromium via Playwright; originally reported on Firefox.

## Learning

Worth separating in future auth debugging: an error in the console is not necessarily an
error on the page. Tagging every frame at document start with `window.top === window.self`
before any app script runs turned an ambiguous stack trace into an unambiguous location, and
changed the diagnosis.

Left deliberately unfixed here, because it is a product trade-off rather than a defect: the
silent attempt costs **8 of the 12.3 seconds** before a signed-out user reaches the login
page (measured at 4.3s with it skipped). It can only ever pay off in a browser that still
sends cross-site cookies, which excludes Firefox and Safari today. Whether to keep paying
that on a cold load, cap it with a short race timeout, or skip it when no session has ever
been established, is worth deciding separately.
