### PR TITLE
[CSM Portal] shared dashboard sections and filter presets: reference them, design them, deploy them

### DIFF
--- a/apps/csm-portal/backend/.env.example
+++ b/apps/csm-portal/backend/.env.example
@@ -79,6 +79,23 @@ DASHBOARDS_HOT_RELOAD=false
 # presets, same as an unset DASHBOARDS_DIR itself.
 # DASHBOARD_PRESETS_FILE=./dashboards.example/_presets.json
 
+# Optional: a JSON file of sectionKey -> {"displayName": "...", "widgets":
+# [...]}, the shared, reusable widget sections a dashboard pulls in by name.
+# A dashboard references one from its own top-level "includeSections" array:
+#   "includeSections": [
+#     {"section": "my-work", "idPrefix": "ob_", "position": "start",
+#      "extraFilters": [{"preset": "onboarded-projects"}]}
+#   ]
+# so a section like "My Work" is authored and corrected once instead of being
+# copy-pasted into every dashboard and drifting apart. Each include may
+# prefix the section's widget ids, override its heading, place it before
+# ("start", the default) or after ("end") the dashboard's own widgets, and
+# AND extra scoping predicates into every case widget it brings in.
+# Expanded into literal widgets at startup, never visible past that. Same
+# leading-underscore convention as the presets file, and unset is equally
+# legal — it means no shared sections.
+# DASHBOARD_SECTIONS_FILE=./dashboards.example/_sections.json
+
 # DEPRECATED: the whole dashboard registry crammed into one variable. Honoured
 # only when DASHBOARDS_DIR is unset, and warns when used. Set DASHBOARDS_DIR
 # instead — a definition in its own file is reviewable in a diff and an error

--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -307,6 +307,14 @@ func main() {
 //	                       to keep a presets file alongside. Unset is legal
 //	                       and means no shared presets, same as unset
 //	                       DASHBOARDS_DIR itself.
+//	DASHBOARD_SECTIONS_FILE a JSON file of sectionKey -> {"displayName",
+//	                       "widgets": [...]}, the shared, reusable widget
+//	                       sections a dashboard pulls in by name with
+//	                       "includeSections" so a section like "My Work" is
+//	                       authored once instead of copy-pasted per
+//	                       dashboard. Same scope rules as
+//	                       DASHBOARD_PRESETS_FILE: DASHBOARDS_DIR path only,
+//	                       unset is legal and means no shared sections.
 //
 // Neither DASHBOARDS_DIR nor DASHBOARDS_CONFIG set is legal and yields no
 // dashboards: a deployment that has not configured any must still start and
@@ -323,6 +331,7 @@ func loadDashboards() *dashboard.Registry {
 	}
 
 	presetsFile := strings.TrimSpace(os.Getenv("DASHBOARD_PRESETS_FILE"))
+	sectionsFile := strings.TrimSpace(os.Getenv("DASHBOARD_SECTIONS_FILE"))
 
 	// ParseBool rather than a "true" string compare: the latter silently reads
 	// 1, yes and on as OFF, and never reports a typo at all -- the operator
@@ -339,9 +348,9 @@ func loadDashboards() *dashboard.Registry {
 		}
 		hotReload = parsed
 	}
-	registry, err := dashboard.NewDirRegistry(dir, hotReload, presetsFile)
+	registry, err := dashboard.NewDirRegistry(dir, hotReload, presetsFile, sectionsFile)
 	if err != nil {
-		slog.Error("invalid dashboard definitions", "dir", dir, "presetsFile", presetsFile, "err", err)
+		slog.Error("invalid dashboard definitions", "dir", dir, "presetsFile", presetsFile, "sectionsFile", sectionsFile, "err", err)
 		os.Exit(1)
 	}
 	if hotReload {

--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -160,6 +160,11 @@ func main() {
 	mux.HandleFunc("POST /cases/search", caseHandler.SearchCases)
 	mux.HandleFunc("POST /cases/aggregate", caseHandler.AggregateCases)
 	mux.HandleFunc("GET /dashboards", dashboardHandler.GetDashboards)
+	// Registered before the {dashboardId} wildcard purely for readability —
+	// net/http's ServeMux resolves by specificity, not registration order,
+	// so these literal paths win over the wildcard regardless.
+	mux.HandleFunc("GET /dashboards/filter-presets", dashboardHandler.GetFilterPresets)
+	mux.HandleFunc("GET /dashboards/sections", dashboardHandler.GetSharedSections)
 	mux.HandleFunc("GET /dashboards/{dashboardId}", dashboardHandler.GetDashboardDetail)
 	mux.HandleFunc("GET /updates/product-update-levels", updatesHandler.GetProductUpdateLevels)
 	mux.HandleFunc("POST /updates/levels/search", updatesHandler.SearchUpdatesBetweenUpdateLevels)

--- a/apps/csm-portal/backend/dashboards.example/_sections.json
+++ b/apps/csm-portal/backend/dashboards.example/_sections.json
@@ -1,0 +1,62 @@
+{
+  "my-work": {
+    "displayName": "My Work",
+    "widgets": [
+      {
+        "id": "my-ongoing-cases",
+        "displayName": "On Going Cases",
+        "resourceType": "case",
+        "shape": "list",
+        "gridWidth": 12,
+        "listLimit": 5,
+        "query": {
+          "filters": [
+            {
+              "field": "assignedUserId",
+              "op": "in",
+              "values": [
+                "__current_user__"
+              ]
+            },
+            {
+              "field": "state",
+              "op": "in",
+              "values": [
+                "open",
+                "work_in_progress",
+                "waiting_on_wso2",
+                "reopened"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "id": "my-pending-closure",
+        "displayName": "Pending Closure",
+        "resourceType": "case",
+        "shape": "list",
+        "gridWidth": 12,
+        "listLimit": 5,
+        "query": {
+          "filters": [
+            {
+              "field": "assignedUserId",
+              "op": "in",
+              "values": [
+                "__current_user__"
+              ]
+            },
+            {
+              "field": "state",
+              "op": "in",
+              "values": [
+                "solution_proposed"
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/apps/csm-portal/backend/internal/dashboard/filter_presets_test.go
+++ b/apps/csm-portal/backend/internal/dashboard/filter_presets_test.go
@@ -172,7 +172,7 @@ func TestFilterPresets_DashboardLocalShadowsSharedOnCollision(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadSharedPresets returned error: %v", err)
 	}
-	got, err := loadDir(dir, sharedPresets)
+	got, err := loadDir(dir, sharedPresets, nil)
 	if err != nil {
 		t.Fatalf("loadDir returned error: %v", err)
 	}
@@ -210,7 +210,7 @@ func TestFilterPresets_SharedFileAlsoResolves(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadSharedPresets returned error: %v", err)
 	}
-	got, err := loadDir(dir, sharedPresets)
+	got, err := loadDir(dir, sharedPresets, nil)
 	if err != nil {
 		t.Fatalf("loadDir returned error: %v", err)
 	}

--- a/apps/csm-portal/backend/internal/dashboard/registry.go
+++ b/apps/csm-portal/backend/internal/dashboard/registry.go
@@ -132,6 +132,11 @@ func NewDirRegistry(dir string, hotReload bool, presetsFile, sectionsFile string
 		if err != nil {
 			return nil, err
 		}
+		// Every section is proven usable here, not just the ones some
+		// dashboard happens to include -- see validateSharedSections.
+		if err := validateSharedSections(sharedSections, sharedPresets, sectionsFile); err != nil {
+			return nil, err
+		}
 		return loadDir(d, sharedPresets, sharedSections)
 	}
 	loadCatalogues := func() (map[string]map[string]any, map[string]SharedSection, error) {

--- a/apps/csm-portal/backend/internal/dashboard/registry.go
+++ b/apps/csm-portal/backend/internal/dashboard/registry.go
@@ -132,12 +132,7 @@ func NewDirRegistry(dir string, hotReload bool, presetsFile, sectionsFile string
 		if err != nil {
 			return nil, err
 		}
-		// Every section is proven usable here, not just the ones some
-		// dashboard happens to include -- see validateSharedSections.
-		if err := validateSharedSections(sharedSections, sharedPresets, sectionsFile); err != nil {
-			return nil, err
-		}
-		return loadDir(d, sharedPresets, sharedSections)
+		return loadDirWithSections(d, sharedPresets, sharedSections, sectionsFile)
 	}
 	loadCatalogues := func() (map[string]map[string]any, map[string]SharedSection, error) {
 		presets, err := LoadSharedPresets(presetsFile)
@@ -375,6 +370,65 @@ func loadDir(dir string, sharedPresets map[string]map[string]any, sharedSections
 	}
 
 	return finalize(loaded, true, sharedPresets, sharedSections)
+}
+
+// loadDirWithSections is loadDir plus catalogue-level validation of every
+// shared section, including the ones no dashboard references.
+//
+// The validation has to happen HERE rather than beside LoadSharedSections,
+// because it needs the decoded dashboards: a section may legitimately
+// reference a preset that only a dashboard's own "filterPresets" defines, so
+// the set a section can resolve against is the union of the shared file and
+// every dashboard's local presets. See validateSharedSections.
+func loadDirWithSections(dir string, sharedPresets map[string]map[string]any, sharedSections map[string]SharedSection, sectionsSource string) ([]Dashboard, error) {
+	if len(sharedSections) > 0 {
+		resolvable, err := resolvablePresets(dir, sharedPresets)
+		if err != nil {
+			return nil, err
+		}
+		if err := validateSharedSections(sharedSections, resolvable, sectionsSource); err != nil {
+			return nil, err
+		}
+	}
+	return loadDir(dir, sharedPresets, sharedSections)
+}
+
+// resolvablePresets is the shared presets plus every dashboard-local
+// "filterPresets" in dir, which together are what a section's preset
+// reference can resolve against once it is expanded into a dashboard.
+//
+// A name defined in more than one place collapses to one entry: this set is
+// only ever asked "does this name resolve anywhere", never "what does it
+// expand to", so which definition wins does not matter here -- that is
+// decided per dashboard by resolveDashboardFilterPresets.
+func resolvablePresets(dir string, sharedPresets map[string]map[string]any) (map[string]map[string]any, error) {
+	out := make(map[string]map[string]any, len(sharedPresets))
+	for k, v := range sharedPresets {
+		out[k] = v
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("dashboard definitions: read directory %q: %w", dir, err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.EqualFold(filepath.Ext(entry.Name()), definitionExt) ||
+			strings.HasPrefix(entry.Name(), "_") {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		raw, err := os.ReadFile(path) //nolint:gosec // path is deployment configuration, not user input
+		if err != nil {
+			return nil, fmt.Errorf("dashboard definitions: read %q: %w", path, err)
+		}
+		var d Dashboard
+		if err := json.Unmarshal(raw, &d); err != nil {
+			return nil, fmt.Errorf("dashboard definitions: parse %q: %w", path, err)
+		}
+		for k, v := range d.FilterPresets {
+			out[k] = v
+		}
+	}
+	return out, nil
 }
 
 // LoadSharedPresets reads path (DASHBOARD_PRESETS_FILE — see

--- a/apps/csm-portal/backend/internal/dashboard/registry.go
+++ b/apps/csm-portal/backend/internal/dashboard/registry.go
@@ -83,6 +83,23 @@ type Registry struct {
 	// times the registry actually touches the disk. nil for a static
 	// registry.
 	load func(dir string) ([]Dashboard, error)
+
+	// presets and sections are the shared catalogues the last successful
+	// load read, retained ONLY so the builder-facing endpoints can list
+	// what an author may reference (see FilterPresets/SharedSections).
+	// Nothing on the dashboard-serving path reads them: by the time a
+	// Dashboard reaches cached, every {"preset": ...} reference and every
+	// includeSections entry has already been expanded away.
+	presets  map[string]map[string]any
+	sections map[string]SharedSection
+
+	// loadCatalogues re-reads just the two shared files, for hot-reload
+	// mode. Deliberately separate from load rather than folded into it:
+	// load's signature is injected by tests that count disk reads, and the
+	// catalogue endpoints are not on the dashboard-serving path, so there
+	// is no reason to make every dashboard read carry this too. nil for a
+	// static registry.
+	loadCatalogues func() (map[string]map[string]any, map[string]SharedSection, error)
 }
 
 // NewStaticRegistry wraps an already-decoded set of dashboards. It never
@@ -117,12 +134,31 @@ func NewDirRegistry(dir string, hotReload bool, presetsFile, sectionsFile string
 		}
 		return loadDir(d, sharedPresets, sharedSections)
 	}
-	r := &Registry{dir: dir, hotReload: hotReload, load: load}
+	loadCatalogues := func() (map[string]map[string]any, map[string]SharedSection, error) {
+		presets, err := LoadSharedPresets(presetsFile)
+		if err != nil {
+			return nil, nil, err
+		}
+		sections, err := LoadSharedSections(sectionsFile)
+		if err != nil {
+			return nil, nil, err
+		}
+		return presets, sections, nil
+	}
+
+	r := &Registry{dir: dir, hotReload: hotReload, load: load, loadCatalogues: loadCatalogues}
 	dashboards, err := r.load(dir)
 	if err != nil {
 		return nil, err
 	}
+	// Cannot fail here: load has already parsed and validated both files.
+	presets, sections, err := r.loadCatalogues()
+	if err != nil {
+		return nil, err
+	}
 	r.cached = dashboards
+	r.presets = presets
+	r.sections = sections
 	return r, nil
 }
 
@@ -167,6 +203,60 @@ func (r *Registry) ByID(id string) (Dashboard, bool) {
 	return Dashboard{}, false
 }
 
+// FilterPresets returns the shared filter-preset catalogue the registry
+// loaded, keyed by preset name.
+//
+// This exists for the dashboard builder, which needs to offer an author the
+// presets they may reference by name. It is NOT used to serve a dashboard:
+// preset references are expanded at load time and erased, so nothing on that
+// path needs the catalogue.
+//
+// The returned map is the registry's own — callers must not mutate it. A
+// static registry (the deprecated DASHBOARDS_CONFIG path) has no catalogue
+// and returns nil, which callers must treat as "none configured" rather than
+// an error: a deployment with no presets file is legal.
+func (r *Registry) FilterPresets() map[string]map[string]any {
+	if r == nil {
+		return nil
+	}
+	r.refreshCatalogues()
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.presets
+}
+
+// SharedSections returns the shared reusable-section catalogue the registry
+// loaded, keyed by section name. Same contract as FilterPresets.
+func (r *Registry) SharedSections() map[string]SharedSection {
+	if r == nil {
+		return nil
+	}
+	r.refreshCatalogues()
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.sections
+}
+
+// refreshCatalogues re-reads the two shared files in hot-reload mode, with
+// the same "keep the last known-good set on failure" behaviour Dashboards
+// documents and for the same reason: an editor mid-save must not blank the
+// builder's picker.
+func (r *Registry) refreshCatalogues() {
+	if !r.hotReload || r.loadCatalogues == nil {
+		return
+	}
+	presets, sections, err := r.loadCatalogues()
+	if err != nil {
+		slog.Error("dashboard shared catalogues: hot reload failed; continuing to serve the last known-good catalogues",
+			"dir", r.dir, "err", err)
+		return
+	}
+	r.mu.Lock()
+	r.presets = presets
+	r.sections = sections
+	r.mu.Unlock()
+}
+
 // active is the registry the HTTP handlers serve from. It is installed once
 // during startup by cmd/server/main.go (and by tests). A nil active registry
 // serves no dashboards rather than panicking: GET /dashboards returns an
@@ -196,6 +286,12 @@ func All() []Dashboard { return Active().Dashboards() }
 
 // ByID looks a dashboard up by id in the active registry.
 func ByID(id string) (Dashboard, bool) { return Active().ByID(id) }
+
+// FilterPresets returns the active registry's shared filter-preset catalogue.
+func FilterPresets() map[string]map[string]any { return Active().FilterPresets() }
+
+// SharedSections returns the active registry's shared reusable-section catalogue.
+func SharedSections() map[string]SharedSection { return Active().SharedSections() }
 
 // LoadDir reads every *.json file in dir whose name does not start with "_"
 // as one dashboard definition. The filename is otherwise not significant in

--- a/apps/csm-portal/backend/internal/dashboard/registry.go
+++ b/apps/csm-portal/backend/internal/dashboard/registry.go
@@ -99,17 +99,23 @@ func NewStaticRegistry(dashboards []Dashboard) *Registry {
 // what happens on subsequent reads.
 //
 // presetsFile is the shared filter-preset file (see LoadSharedPresets and
-// DASHBOARD_PRESETS_FILE in cmd/server/main.go); "" means no shared presets
-// are configured, which is legal, same as an unset DASHBOARDS_DIR. It is
-// re-read on every load alongside dir, so hot-reload mode also picks up an
-// edited presets file without a restart.
-func NewDirRegistry(dir string, hotReload bool, presetsFile string) (*Registry, error) {
+// DASHBOARD_PRESETS_FILE in cmd/server/main.go) and sectionsFile the shared
+// section file (see LoadSharedSections and DASHBOARD_SECTIONS_FILE); "" for
+// either means none is configured, which is legal, same as an unset
+// DASHBOARDS_DIR. Both are re-read on every load alongside dir, so
+// hot-reload mode also picks up an edited presets or sections file without a
+// restart.
+func NewDirRegistry(dir string, hotReload bool, presetsFile, sectionsFile string) (*Registry, error) {
 	load := func(d string) ([]Dashboard, error) {
 		sharedPresets, err := LoadSharedPresets(presetsFile)
 		if err != nil {
 			return nil, err
 		}
-		return loadDir(d, sharedPresets)
+		sharedSections, err := LoadSharedSections(sectionsFile)
+		if err != nil {
+			return nil, err
+		}
+		return loadDir(d, sharedPresets, sharedSections)
 	}
 	r := &Registry{dir: dir, hotReload: hotReload, load: load}
 	dashboards, err := r.load(dir)
@@ -224,11 +230,12 @@ func ByID(id string) (Dashboard, bool) { return Active().ByID(id) }
 // whatever DASHBOARD_PRESETS_FILE resolves to, which may itself be an empty
 // map.
 func LoadDir(dir string) ([]Dashboard, error) {
-	return loadDir(dir, nil)
+	return loadDir(dir, nil, nil)
 }
 
-// loadDir is LoadDir's shared-presets-aware counterpart.
-func loadDir(dir string, sharedPresets map[string]map[string]any) ([]Dashboard, error) {
+// loadDir is LoadDir's shared-presets- and shared-sections-aware
+// counterpart.
+func loadDir(dir string, sharedPresets map[string]map[string]any, sharedSections map[string]SharedSection) ([]Dashboard, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, fmt.Errorf("dashboard definitions: read directory %q: %w", dir, err)
@@ -266,7 +273,7 @@ func loadDir(dir string, sharedPresets map[string]map[string]any) ([]Dashboard, 
 		loaded = append(loaded, sourced{dashboard: d, source: path})
 	}
 
-	return finalize(loaded, true, sharedPresets)
+	return finalize(loaded, true, sharedPresets, sharedSections)
 }
 
 // LoadSharedPresets reads path (DASHBOARD_PRESETS_FILE — see
@@ -299,16 +306,29 @@ func LoadSharedPresets(path string) (map[string]map[string]any, error) {
 }
 
 // finalize runs the shared post-decode pipeline over a decoded set:
-// deprecated-key migration first (so everything after sees the current
+// shared-section expansion first (so every later step sees one flat widget
+// list), then deprecated-key migration (so everything after sees the current
 // shape), then filter-preset expansion and implied-"type"-filter injection
 // (so validation and every caller downstream see fully literal, complete
 // filters), then cross-field validation. requireType is true for the
 // directory loader, where every definition is authored against the current
 // schema, and false for the deprecated DASHBOARDS_CONFIG path, whose
 // already-deployed values predate the type field entirely. sharedPresets is
-// the DASHBOARD_PRESETS_FILE set (see LoadSharedPresets); nil/empty is legal
-// and means no shared presets, same as an unset DASHBOARDS_DIR.
-func finalize(loaded []sourced, requireType bool, sharedPresets map[string]map[string]any) ([]Dashboard, error) {
+// the DASHBOARD_PRESETS_FILE set (see LoadSharedPresets) and sharedSections
+// the DASHBOARD_SECTIONS_FILE set (see LoadSharedSections); nil/empty is
+// legal for either and means none is configured, same as an unset
+// DASHBOARDS_DIR.
+func finalize(loaded []sourced, requireType bool, sharedPresets map[string]map[string]any, sharedSections map[string]SharedSection) ([]Dashboard, error) {
+	// Section expansion runs before everything else so that from here down
+	// an included widget is indistinguishable from an inline one -- key
+	// migration, preset resolution, type injection and validation all see
+	// one flat widget list and need no notion of where a widget came from.
+	for i := range loaded {
+		if err := expandIncludedSections(&loaded[i].dashboard, sharedSections, loaded[i].source); err != nil {
+			return nil, err
+		}
+	}
+
 	for i := range loaded {
 		migrateLegacyWidgetKeys(&loaded[i].dashboard, loaded[i].source)
 	}

--- a/apps/csm-portal/backend/internal/dashboard/registry_test.go
+++ b/apps/csm-portal/backend/internal/dashboard/registry_test.go
@@ -470,7 +470,7 @@ func TestRegistry_DefaultModeReadsDiskExactlyOnce(t *testing.T) {
 	writeDefinition(t, dir, "a.json", csDefinition)
 
 	var reads atomic.Int64
-	r, err := NewDirRegistry(dir, false, "")
+	r, err := NewDirRegistry(dir, false, "", "")
 	if err != nil {
 		t.Fatalf("NewDirRegistry returned error: %v", err)
 	}
@@ -509,7 +509,7 @@ func TestRegistry_HotReloadPicksUpChanges(t *testing.T) {
 	dir := t.TempDir()
 	writeDefinition(t, dir, "a.json", csDefinition)
 
-	r, err := NewDirRegistry(dir, true, "")
+	r, err := NewDirRegistry(dir, true, "", "")
 	if err != nil {
 		t.Fatalf("NewDirRegistry returned error: %v", err)
 	}
@@ -549,7 +549,7 @@ func TestRegistry_HotReloadKeepsLastKnownGoodOnError(t *testing.T) {
 	dir := t.TempDir()
 	writeDefinition(t, dir, "a.json", csDefinition)
 
-	r, err := NewDirRegistry(dir, true, "")
+	r, err := NewDirRegistry(dir, true, "", "")
 	if err != nil {
 		t.Fatalf("NewDirRegistry returned error: %v", err)
 	}
@@ -580,7 +580,7 @@ func TestNewDirRegistry_FailsAtStartupInBothModes(t *testing.T) {
 	for _, hotReload := range []bool{false, true} {
 		dir := t.TempDir()
 		writeDefinition(t, dir, "broken.json", `{"id": "broken", "displayName":`)
-		if _, err := NewDirRegistry(dir, hotReload, ""); err == nil {
+		if _, err := NewDirRegistry(dir, hotReload, "", ""); err == nil {
 			t.Fatalf("NewDirRegistry(hotReload=%v) returned no error for a malformed definition", hotReload)
 		}
 	}

--- a/apps/csm-portal/backend/internal/dashboard/sections.go
+++ b/apps/csm-portal/backend/internal/dashboard/sections.go
@@ -120,7 +120,31 @@ func LoadSharedSections(path string) (map[string]SharedSection, error) {
 	if err := json.Unmarshal(raw, &sections); err != nil {
 		return nil, fmt.Errorf("dashboard sections: parse %q: %w", path, err)
 	}
+	// A document of literal `null` parses fine and leaves the map nil, which
+	// would then behave as "no sections configured" -- but the path WAS set, so
+	// this is a malformed file, not an absent one. Left alone it fails much
+	// later and in the wrong place: every includeSections reference reports
+	// "unknown section", pointing whoever reads the log at the dashboards
+	// rather than at the empty file that is actually wrong. An empty object is
+	// a different thing and stays legal: that really is "none configured".
+	if sections == nil {
+		return nil, fmt.Errorf("dashboard sections: %s: document is null; use {} for no sections, or remove DASHBOARD_SECTIONS_FILE", path)
+	}
 	for key, s := range sections {
+		// A key is looked up by its EXACT text, but expandIncludedSections
+		// trims the reference before looking it up (an include of " my-work"
+		// finds "my-work"). So a definition whose own key is not already
+		// trimmed can never be referenced by any include at all -- it would
+		// sit in the file looking configured and silently match nothing.
+		// Rejected here rather than normalized: silently trimming would make
+		// two keys that differ only in whitespace collide, and quietly picking
+		// a winner between them is worse than refusing the file.
+		if key != strings.TrimSpace(key) {
+			return nil, fmt.Errorf("dashboard sections: %s: section key %q has leading or trailing whitespace; an include is trimmed before lookup, so this key could never be referenced", path, key)
+		}
+		if key == "" {
+			return nil, fmt.Errorf("dashboard sections: %s: has an empty section key; the key is how a dashboard references the section", path)
+		}
 		if strings.TrimSpace(s.DisplayName) == "" {
 			return nil, fmt.Errorf("dashboard sections: %s: section %q has an empty \"displayName\"; it is the heading every widget in the section is grouped under", path, key)
 		}

--- a/apps/csm-portal/backend/internal/dashboard/sections.go
+++ b/apps/csm-portal/backend/internal/dashboard/sections.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 )
 
@@ -153,6 +154,50 @@ func LoadSharedSections(path string) (map[string]SharedSection, error) {
 		}
 	}
 	return sections, nil
+}
+
+// validateSharedSections proves every section in the catalogue is usable
+// BEFORE anything can read it, whether or not a dashboard includes it.
+//
+// Without this, a section's widgets are only ever checked as a side effect of
+// being expanded into a dashboard: finalize resolves presets and validates
+// widgets after expansion, so a section nothing references is never looked at.
+// It is then served by GET /dashboards/sections as though it were fine, offered
+// in the builder as something to include, and fails only later — at the moment
+// some author includes it, blaming their dashboard for a fault that was in the
+// section file all along.
+//
+// Validation runs against a THROWAWAY deep copy put through the real pipeline
+// (resolveDashboardFilterPresets then validateWidgets) rather than a second set
+// of checks written out by hand here: a parallel implementation would drift from
+// the one that actually governs a loaded dashboard, and the whole point is that
+// a section passes exactly the checks its widgets will face once included. The
+// copy is discarded, so the catalogue keeps its authored form — unexpanded
+// {"preset": ...} references and all — which is what the builder edits.
+//
+// Sections are visited in sorted order so a file with more than one broken
+// section always reports the same one first.
+func validateSharedSections(sections map[string]SharedSection, presets map[string]map[string]any, path string) error {
+	names := make([]string, 0, len(sections))
+	for name := range sections {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		section := sections[name]
+		probe := Dashboard{ID: name, Widgets: make([]WidgetTemplate, 0, len(section.Widgets))}
+		for _, w := range section.Widgets {
+			probe.Widgets = append(probe.Widgets, copyWidget(w))
+		}
+		if err := resolveDashboardFilterPresets(&probe, presets, path); err != nil {
+			return fmt.Errorf("dashboard sections: %s: section %q would fail on include: %w", path, name, err)
+		}
+		if err := validateWidgets(probe, path); err != nil {
+			return fmt.Errorf("dashboard sections: %s: section %q would fail on include: %w", path, name, err)
+		}
+	}
+	return nil
 }
 
 // expandIncludedSections replaces d's "includeSections" references with the

--- a/apps/csm-portal/backend/internal/dashboard/sections.go
+++ b/apps/csm-portal/backend/internal/dashboard/sections.go
@@ -1,0 +1,298 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dashboard
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// A shared section is a named, reusable group of widgets defined once and
+// pulled into several dashboards by reference, so a personal-queue section
+// like "My Work" is authored and corrected in exactly one place instead of
+// being copy-pasted per dashboard and drifting apart widget by widget.
+//
+// It is the same idea as a filter preset (see resolveDashboardFilterPresets)
+// one level up: presets deduplicate a filter predicate, sections deduplicate
+// a whole run of widgets. Both are pure config-authoring conveniences,
+// expanded once at load time into literal widgets, so nothing downstream --
+// validation, the handler, the frontend -- ever sees a reference.
+
+// SharedSection is one entry of the shared-section file
+// (DASHBOARD_SECTIONS_FILE, conventionally "_sections.json" alongside
+// DASHBOARD_PRESETS_FILE -- see LoadSharedSections).
+type SharedSection struct {
+	// DisplayName is the section heading every widget in this section is
+	// grouped under: it is written into each expanded widget's own
+	// WidgetTemplate.Section, which is what the frontend actually groups on.
+	// A dashboard can override it per include (see SectionInclude.DisplayName).
+	DisplayName string `json:"displayName"`
+	// Widgets are the section's widget templates, in render order, authored
+	// exactly as they would be inline in a dashboard's own "widgets" array.
+	// Each one's own "section" key, if it carries one, is overwritten by the
+	// effective DisplayName -- the section owns its heading, a widget inside
+	// it cannot secede.
+	Widgets []WidgetTemplate `json:"widgets"`
+}
+
+// SectionInclude is one entry of a dashboard's "includeSections": a
+// reference to a SharedSection plus the per-dashboard adjustments that make
+// one shared definition usable by dashboards that are not identical.
+type SectionInclude struct {
+	// Section is the key into the shared-section set. Unknown keys fail the
+	// load, same as an unknown filter preset.
+	Section string `json:"section"`
+	// IDPrefix is prepended to every included widget's id. Widget ids only
+	// have to be unique within a dashboard, so this is optional -- it exists
+	// so a dashboard that already ships prefixed ids can adopt a shared
+	// section without renaming its widgets (ids are the handle for
+	// click-through URLs and React keys), and so one dashboard can include
+	// the same section twice under different scopes.
+	IDPrefix string `json:"idPrefix,omitempty"`
+	// DisplayName overrides the section's own heading for this dashboard.
+	// Empty keeps SharedSection.DisplayName.
+	DisplayName string `json:"displayName,omitempty"`
+	// Position places the expanded widgets relative to the dashboard's own
+	// "widgets" array: "start" (the default) or "end". Section order in the
+	// rendered dashboard follows the order each section's value first
+	// appears among the widgets, so this is what decides whether a shared
+	// section leads the page or trails it. Several includes with the same
+	// position expand in the order they are written.
+	Position string `json:"position,omitempty"`
+	// ExtraFilters are additional filter predicates ANDed into every
+	// included widget's own query.filters -- the escape hatch that lets a
+	// dashboard with its own permanent scope (e.g. "only projects that have
+	// finished onboarding") share a section with dashboards that do not,
+	// instead of forking it. Entries may be literal filter objects or
+	// {"preset": "key"} references: sections expand before preset
+	// resolution, so a reference here resolves exactly as it would inline.
+	//
+	// Only applied to widgets whose ResourceType is a caseTableResourceTypes
+	// member: those are the only ones whose query is the case-search filter
+	// DSL. Every other resource has its own query shape (call_request's
+	// {assignedUserIds, states, excludeCaseStates}, for instance), where a
+	// case predicate is not merely useless but would be forwarded to that
+	// resource's /search as an unrecognised key.
+	ExtraFilters []map[string]any `json:"extraFilters,omitempty"`
+}
+
+const (
+	sectionPositionStart = "start"
+	sectionPositionEnd   = "end"
+)
+
+// LoadSharedSections reads path (DASHBOARD_SECTIONS_FILE -- see
+// cmd/server/main.go) as a JSON object mapping sectionKey -> SharedSection.
+// An empty path is legal and yields an empty, nil-error map: a deployment
+// with no shared sections is the normal case, and a dashboard that
+// references one anyway still fails loud at expansion time with the unknown
+// key named.
+//
+// A path that is set but unreadable, unparseable, or that defines a section
+// with no widgets or no displayName, is fatal and names the file: a section
+// that silently expands to nothing is a dashboard missing a whole block of
+// widgets with nothing in the logs to say why.
+func LoadSharedSections(path string) (map[string]SharedSection, error) {
+	if strings.TrimSpace(path) == "" {
+		return map[string]SharedSection{}, nil
+	}
+	raw, err := os.ReadFile(path) //nolint:gosec // path is deployment configuration, not user input
+	if err != nil {
+		return nil, fmt.Errorf("dashboard sections: read %q: %w", path, err)
+	}
+	var sections map[string]SharedSection
+	if err := json.Unmarshal(raw, &sections); err != nil {
+		return nil, fmt.Errorf("dashboard sections: parse %q: %w", path, err)
+	}
+	for key, s := range sections {
+		if strings.TrimSpace(s.DisplayName) == "" {
+			return nil, fmt.Errorf("dashboard sections: %s: section %q has an empty \"displayName\"; it is the heading every widget in the section is grouped under", path, key)
+		}
+		if len(s.Widgets) == 0 {
+			return nil, fmt.Errorf("dashboard sections: %s: section %q has no widgets", path, key)
+		}
+	}
+	return sections, nil
+}
+
+// expandIncludedSections replaces d's "includeSections" references with the
+// literal widgets they name, in place, and clears the field so nothing
+// downstream sees a reference.
+//
+// It runs first in finalize's pipeline, before deprecated-key migration,
+// preset resolution and implied-type-filter injection, so an included widget
+// is indistinguishable from an inline one by the time any of those run: one
+// code path handles both, and a section is free to use the same deprecated
+// keys and {"preset": ...} references a dashboard's own widgets can.
+//
+// Every include gets its own deep copy of the section's widgets. Two
+// dashboards including the same section must not end up sharing the decoded
+// maps behind Query/Slices, since the very next pipeline steps mutate those
+// in place -- preset expansion and type-filter injection would otherwise run
+// twice over the same map and leak one dashboard's ExtraFilters into
+// another's widgets.
+func expandIncludedSections(d *Dashboard, sections map[string]SharedSection, source string) error {
+	if len(d.IncludeSections) == 0 {
+		return nil
+	}
+
+	var leading, trailing []WidgetTemplate
+	for i, inc := range d.IncludeSections {
+		ctx := fmt.Sprintf("dashboard definitions: %s (id %q): includeSections[%d]", source, d.ID, i)
+
+		key := strings.TrimSpace(inc.Section)
+		if key == "" {
+			return fmt.Errorf("%s: %q is empty; it must name a section in the shared DASHBOARD_SECTIONS_FILE", ctx, "section")
+		}
+		section, ok := sections[key]
+		if !ok {
+			return fmt.Errorf("%s: references unknown section %q; define it in the shared DASHBOARD_SECTIONS_FILE", ctx, key)
+		}
+
+		position := strings.TrimSpace(inc.Position)
+		if position == "" {
+			position = sectionPositionStart
+		}
+		if position != sectionPositionStart && position != sectionPositionEnd {
+			return fmt.Errorf("%s: unknown \"position\" %q; expected %q or %q", ctx, inc.Position, sectionPositionStart, sectionPositionEnd)
+		}
+
+		heading := section.DisplayName
+		if strings.TrimSpace(inc.DisplayName) != "" {
+			heading = inc.DisplayName
+		}
+
+		expanded := make([]WidgetTemplate, 0, len(section.Widgets))
+		for _, w := range section.Widgets {
+			cw := copyWidget(w)
+			cw.ID = inc.IDPrefix + cw.ID
+			cw.Section = heading
+			applyExtraFilters(&cw, inc.ExtraFilters)
+			expanded = append(expanded, cw)
+		}
+
+		if position == sectionPositionStart {
+			leading = append(leading, expanded...)
+		} else {
+			trailing = append(trailing, expanded...)
+		}
+	}
+
+	widgets := make([]WidgetTemplate, 0, len(leading)+len(d.Widgets)+len(trailing))
+	widgets = append(widgets, leading...)
+	widgets = append(widgets, d.Widgets...)
+	widgets = append(widgets, trailing...)
+	d.Widgets = widgets
+	d.IncludeSections = nil
+	return nil
+}
+
+// applyExtraFilters ANDs each of extra into w's own query.filters, and
+// independently into every one of its slices' query.filters.
+//
+// The per-slice pass is the same reasoning injectImpliedTypeFilters
+// documents: the frontend merges a slice's Query over the widget's Query
+// whole-key, so a slice carrying its own "filters" array replaces the
+// widget's entirely -- including anything added here -- unless the slice's
+// own array carries it too.
+//
+// Non-case widgets are skipped: see SectionInclude.ExtraFilters.
+func applyExtraFilters(w *WidgetTemplate, extra []map[string]any) {
+	if len(extra) == 0 || !caseTableResourceTypes[w.ResourceType] {
+		return
+	}
+	w.Query = appendFilters(w.Query, extra)
+	for si := range w.Slices {
+		w.Slices[si].Query = appendFilters(w.Slices[si].Query, extra)
+	}
+}
+
+// appendFilters returns query (creating it if nil) with a fresh copy of each
+// entry in extra appended to its top-level "filters" array. A "filters" that
+// is present but not an array is left for injectTypeFilter to warn about and
+// replace, exactly as it would for an inline widget -- this does not add a
+// second, differently-worded warning for the same malformed key.
+func appendFilters(query map[string]any, extra []map[string]any) map[string]any {
+	if query == nil {
+		query = map[string]any{}
+	}
+	filters, _ := query["filters"].([]any)
+	for _, f := range extra {
+		filters = append(filters, deepCopyValue(f))
+	}
+	query["filters"] = filters
+	return query
+}
+
+// copyWidget returns a deep copy of w: the WidgetTemplate itself is copied
+// by value, and every decoded-JSON structure hanging off it (Query, SortBy,
+// each slice's Query) is copied deeply, since those are the maps the rest of
+// the load pipeline mutates in place. Columns and Slices are copied as fresh
+// slices so an append to one dashboard's copy cannot reach another's.
+func copyWidget(w WidgetTemplate) WidgetTemplate {
+	out := w
+	out.Query = deepCopyMap(w.Query)
+	out.SortBy = deepCopyMap(w.SortBy)
+	if w.Columns != nil {
+		out.Columns = append([]Column(nil), w.Columns...)
+	}
+	if w.GroupBy != nil {
+		g := *w.GroupBy
+		out.GroupBy = &g
+	}
+	if w.Slices != nil {
+		out.Slices = make([]PieSlice, len(w.Slices))
+		for i, s := range w.Slices {
+			cs := s
+			cs.Query = deepCopyMap(s.Query)
+			out.Slices[i] = cs
+		}
+	}
+	return out
+}
+
+// deepCopyMap and deepCopyValue copy a decoded-JSON value: maps and slices
+// are rebuilt, everything else (string, float64, bool, nil) is immutable and
+// shared. nil in, nil out -- an absent Query stays absent rather than
+// becoming an empty object that later steps would have to distinguish.
+func deepCopyMap(m map[string]any) map[string]any {
+	if m == nil {
+		return nil
+	}
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		out[k] = deepCopyValue(v)
+	}
+	return out
+}
+
+func deepCopyValue(v any) any {
+	switch t := v.(type) {
+	case map[string]any:
+		return deepCopyMap(t)
+	case []any:
+		out := make([]any, len(t))
+		for i, e := range t {
+			out[i] = deepCopyValue(e)
+		}
+		return out
+	default:
+		return v
+	}
+}

--- a/apps/csm-portal/backend/internal/dashboard/sections.go
+++ b/apps/csm-portal/backend/internal/dashboard/sections.go
@@ -175,6 +175,16 @@ func LoadSharedSections(path string) (map[string]SharedSection, error) {
 // copy is discarded, so the catalogue keeps its authored form — unexpanded
 // {"preset": ...} references and all — which is what the builder edits.
 //
+// presets must be every preset a section could legitimately resolve against,
+// NOT just the shared ones. A dashboard may define its own "filterPresets",
+// section expansion runs before dashboard-local presets are merged in, and a
+// section's reference is therefore resolved against the union -- so validating
+// against the shared file alone would reject a section that works perfectly
+// well once included, and take the whole deploy down with it. Referencing a
+// dashboard-local preset from a shared section is still a bad idea (the
+// section only works for dashboards that happen to define it) but that is a
+// design smell, not something to fail a load over.
+//
 // Sections are visited in sorted order so a file with more than one broken
 // section always reports the same one first.
 func validateSharedSections(sections map[string]SharedSection, presets map[string]map[string]any, path string) error {

--- a/apps/csm-portal/backend/internal/dashboard/sections_test.go
+++ b/apps/csm-portal/backend/internal/dashboard/sections_test.go
@@ -525,3 +525,51 @@ func TestValidateSharedSectionsRejectsUnreferencedBreakage(t *testing.T) {
 		}
 	})
 }
+
+// TestSharedSectionMayReferenceDashboardLocalPreset proves catalogue validation
+// resolves a section's preset reference against the UNION of the shared file
+// and every dashboard's own "filterPresets" — the set the reference actually
+// resolves against once the section is expanded. Validating against the shared
+// file alone rejected a section that works, and failed the whole load.
+func TestSharedSectionMayReferenceDashboardLocalPreset(t *testing.T) {
+	dir := t.TempDir()
+	presetsPath := filepath.Join(dir, "_presets.json")
+	sectionsPath := filepath.Join(dir, "_sections.json")
+	write := func(t *testing.T, path, body string) {
+		t.Helper()
+		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+			t.Fatalf("writing %s: %v", path, err)
+		}
+	}
+	sectionWidget := func(presetName string) string {
+		return `{"orphan":{"displayName":"Orphan","widgets":[` +
+			`{"id":"w","displayName":"W","resourceType":"case","shape":"count","gridWidth":3,` +
+			`"query":{"filters":[{"preset":"` + presetName + `"}]}}]}}`
+	}
+
+	// The shared file is deliberately EMPTY of the preset the section wants;
+	// only the dashboard defines it, in its own filterPresets.
+	write(t, presetsPath, `{}`)
+	write(t, filepath.Join(dir, "d.json"), `{"id":"d","displayName":"D","type":"cs","isDefault":true,`+
+		`"filterPresets":{"localOnly":{"field":"state","op":"in","values":["open"]}},`+
+		`"widgets":[{"id":"dw","displayName":"DW","resourceType":"case","shape":"count","gridWidth":3,`+
+		`"query":{"filters":[{"preset":"localOnly"}]}}]}`)
+
+	t.Run("a dashboard-local preset satisfies a section reference", func(t *testing.T) {
+		write(t, sectionsPath, sectionWidget("localOnly"))
+		if _, err := NewDirRegistry(dir, false, presetsPath, sectionsPath); err != nil {
+			t.Fatalf("a section referencing a dashboard-local preset must load, got: %v", err)
+		}
+	})
+
+	t.Run("a name defined nowhere is still fatal", func(t *testing.T) {
+		write(t, sectionsPath, sectionWidget("definedNowhere"))
+		_, err := NewDirRegistry(dir, false, presetsPath, sectionsPath)
+		if err == nil {
+			t.Fatal("expected the load to fail on a preset defined in no file at all")
+		}
+		if !strings.Contains(err.Error(), "orphan") {
+			t.Errorf("error should still name the offending section: %v", err)
+		}
+	})
+}

--- a/apps/csm-portal/backend/internal/dashboard/sections_test.go
+++ b/apps/csm-portal/backend/internal/dashboard/sections_test.go
@@ -439,3 +439,89 @@ func TestLoadSharedSectionsRejectsUnreferenceableKeys(t *testing.T) {
 		}
 	})
 }
+
+// TestValidateSharedSectionsRejectsUnreferencedBreakage proves a broken section
+// fails the load even when no dashboard includes it — the case that previously
+// slipped through to the catalogue and only surfaced when an author included it.
+func TestValidateSharedSectionsRejectsUnreferencedBreakage(t *testing.T) {
+	dir := t.TempDir()
+	presetsPath := filepath.Join(dir, "_presets.json")
+	sectionsPath := filepath.Join(dir, "_sections.json")
+	// One valid dashboard that references NOTHING, so the only way a section
+	// gets looked at is the catalogue-level validation under test.
+	dashPath := filepath.Join(dir, "d.json")
+
+	writeFile := func(t *testing.T, path, body string) {
+		t.Helper()
+		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+			t.Fatalf("writing %s: %v", path, err)
+		}
+	}
+	writeFile(t, presetsPath, `{"activeCaseStates":{"field":"state","op":"in","values":["open"]}}`)
+	writeFile(t, dashPath, `{"id":"d","displayName":"D","type":"cs","isDefault":true,"widgets":[`+
+		`{"id":"w","displayName":"W","resourceType":"case","shape":"count","gridWidth":3,`+
+		`"query":{"filters":[{"field":"state","op":"in","values":["open"]}]}}]}`)
+
+	section := func(widget string) string {
+		return `{"orphan":{"displayName":"Orphan","widgets":[` + widget + `]}}`
+	}
+
+	t.Run("an unknown preset reference in an unincluded section is fatal", func(t *testing.T) {
+		writeFile(t, sectionsPath, section(
+			`{"id":"w1","displayName":"W1","resourceType":"case","shape":"count","gridWidth":3,`+
+				`"query":{"filters":[{"preset":"noSuchPreset"}]}}`))
+		_, err := NewDirRegistry(dir, false, presetsPath, sectionsPath)
+		if err == nil {
+			t.Fatal("expected the load to fail on the unreferenced section's bad preset")
+		}
+		if !strings.Contains(err.Error(), "orphan") {
+			t.Errorf("error should name the offending section: %v", err)
+		}
+	})
+
+	t.Run("a structurally invalid widget in an unincluded section is fatal", func(t *testing.T) {
+		// gridWidth 99 is out of the 1-12 column range.
+		writeFile(t, sectionsPath, section(
+			`{"id":"w1","displayName":"W1","resourceType":"case","shape":"count","gridWidth":99,`+
+				`"query":{"filters":[{"field":"state","op":"in","values":["open"]}]}}`))
+		_, err := NewDirRegistry(dir, false, presetsPath, sectionsPath)
+		if err == nil {
+			t.Fatal("expected the load to fail on the unreferenced section's bad widget")
+		}
+		if !strings.Contains(err.Error(), "orphan") {
+			t.Errorf("error should name the offending section: %v", err)
+		}
+	})
+
+	t.Run("a duplicate widget id within one section is fatal", func(t *testing.T) {
+		writeFile(t, sectionsPath, section(
+			`{"id":"dup","displayName":"A","resourceType":"case","shape":"count","gridWidth":3,`+
+				`"query":{"filters":[{"field":"state","op":"in","values":["open"]}]}},`+
+				`{"id":"dup","displayName":"B","resourceType":"case","shape":"count","gridWidth":3,`+
+				`"query":{"filters":[{"field":"state","op":"in","values":["open"]}]}}`))
+		if _, err := NewDirRegistry(dir, false, presetsPath, sectionsPath); err == nil {
+			t.Fatal("expected the load to fail on duplicate widget ids inside a section")
+		}
+	})
+
+	t.Run("a valid unincluded section loads, and keeps its preset reference authored", func(t *testing.T) {
+		writeFile(t, sectionsPath, section(
+			`{"id":"w1","displayName":"W1","resourceType":"case","shape":"count","gridWidth":3,`+
+				`"query":{"filters":[{"preset":"activeCaseStates"}]}}`))
+		reg, err := NewDirRegistry(dir, false, presetsPath, sectionsPath)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// The validation probe must not have mutated the catalogue: the
+		// builder edits the authored form, so the reference has to survive.
+		got := reg.SharedSections()["orphan"]
+		filters, ok := got.Widgets[0].Query["filters"].([]any)
+		if !ok || len(filters) != 1 {
+			t.Fatalf("query.filters missing: %#v", got.Widgets[0].Query)
+		}
+		entry, ok := filters[0].(map[string]any)
+		if !ok || entry["preset"] != "activeCaseStates" {
+			t.Errorf("validation expanded the catalogue's preset reference: %#v", filters[0])
+		}
+	})
+}

--- a/apps/csm-portal/backend/internal/dashboard/sections_test.go
+++ b/apps/csm-portal/backend/internal/dashboard/sections_test.go
@@ -1,0 +1,370 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dashboard
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// sharedSectionsFile writes a shared-section file into dir and returns its
+// path, mirroring writeDefinition for the DASHBOARD_SECTIONS_FILE half.
+func sharedSectionsFile(t *testing.T, dir, body string) string {
+	t.Helper()
+	return writeDefinition(t, dir, "_sections.json", body)
+}
+
+// oneCaseSection is a minimal shared section: two widgets, one of them a
+// non-case resource, so extraFilters' case-only scoping is observable.
+const oneCaseSection = `{
+  "my-work": {
+    "displayName": "My Work",
+    "widgets": [
+      {"id": "my_cases", "displayName": "My Cases", "resourceType": "case", "shape": "list", "gridWidth": 12,
+       "query": {"filters": [{"field": "assignedUserId", "op": "in", "values": ["__current_user__"]}]}},
+      {"id": "my_call_requests", "displayName": "My Call Requests", "resourceType": "call_request", "shape": "list", "gridWidth": 12,
+       "query": {"assignedUserIds": ["__current_user__"]}}
+    ]
+  }
+}`
+
+func loadWithSections(t *testing.T, dir, sectionsBody string) []Dashboard {
+	t.Helper()
+	path := sharedSectionsFile(t, dir, sectionsBody)
+	sections, err := LoadSharedSections(path)
+	if err != nil {
+		t.Fatalf("LoadSharedSections returned error: %v", err)
+	}
+	got, err := loadDir(dir, nil, sections)
+	if err != nil {
+		t.Fatalf("loadDir returned error: %v", err)
+	}
+	return got
+}
+
+// TestSections_ExpandsIntoLiteralWidgets is the core contract: an
+// includeSections reference becomes real widgets carrying the section's
+// heading, and no reference survives into the loaded Dashboard.
+func TestSections_ExpandsIntoLiteralWidgets(t *testing.T) {
+	dir := t.TempDir()
+	writeDefinition(t, dir, "d.json", `{
+	  "id": "d", "displayName": "D", "type": "cs",
+	  "includeSections": [{"section": "my-work"}],
+	  "widgets": [
+	    {"id": "own", "displayName": "Own", "resourceType": "case", "shape": "count", "gridWidth": 3, "section": "Team"}
+	  ]
+	}`)
+
+	d := loadWithSections(t, dir, oneCaseSection)[0]
+
+	if d.IncludeSections != nil {
+		t.Errorf("Dashboard.IncludeSections = %+v, want nil (cleared once expanded, never visible past load)", d.IncludeSections)
+	}
+	gotIDs := make([]string, 0, len(d.Widgets))
+	for _, w := range d.Widgets {
+		gotIDs = append(gotIDs, w.ID)
+	}
+	want := "my_cases,my_call_requests,own"
+	if strings.Join(gotIDs, ",") != want {
+		t.Errorf("widget ids = %v, want [%s] (position defaults to start)", gotIDs, want)
+	}
+	for _, w := range d.Widgets[:2] {
+		if w.Section != "My Work" {
+			t.Errorf("widget %q section = %q, want %q", w.ID, w.Section, "My Work")
+		}
+	}
+	if d.Widgets[2].Section != "Team" {
+		t.Errorf("the dashboard's own widget section = %q, want %q (untouched)", d.Widgets[2].Section, "Team")
+	}
+}
+
+// TestSections_PositionEndTrailsOwnWidgets covers the other placement, which
+// is what decides whether the shared section leads or trails the page.
+func TestSections_PositionEndTrailsOwnWidgets(t *testing.T) {
+	dir := t.TempDir()
+	writeDefinition(t, dir, "d.json", `{
+	  "id": "d", "displayName": "D", "type": "cs",
+	  "includeSections": [{"section": "my-work", "position": "end"}],
+	  "widgets": [
+	    {"id": "own", "displayName": "Own", "resourceType": "case", "shape": "count", "gridWidth": 3}
+	  ]
+	}`)
+
+	d := loadWithSections(t, dir, oneCaseSection)[0]
+	if d.Widgets[0].ID != "own" || d.Widgets[len(d.Widgets)-1].ID != "my_call_requests" {
+		t.Errorf("widget order = %q..%q, want own first and the section last", d.Widgets[0].ID, d.Widgets[len(d.Widgets)-1].ID)
+	}
+}
+
+// TestSections_IDPrefixAndDisplayNameOverride covers the two per-dashboard
+// adjustments that let a dashboard adopt a shared section without renaming
+// its widgets or accepting the shared heading.
+func TestSections_IDPrefixAndDisplayNameOverride(t *testing.T) {
+	dir := t.TempDir()
+	writeDefinition(t, dir, "d.json", `{
+	  "id": "d", "displayName": "D", "type": "cs",
+	  "includeSections": [{"section": "my-work", "idPrefix": "ob_", "displayName": "My Queue"}],
+	  "widgets": []
+	}`)
+
+	d := loadWithSections(t, dir, oneCaseSection)[0]
+	if d.Widgets[0].ID != "ob_my_cases" {
+		t.Errorf("widget id = %q, want %q", d.Widgets[0].ID, "ob_my_cases")
+	}
+	if d.Widgets[0].Section != "My Queue" {
+		t.Errorf("widget section = %q, want the per-include override %q", d.Widgets[0].Section, "My Queue")
+	}
+}
+
+// TestSections_ExtraFiltersAreCaseOnly is the reason extraFilters exists (a
+// dashboard with its own permanent scope can still share the section) and
+// the reason it is gated (a case predicate on a call_request query would be
+// forwarded to /call-requests/search as an unrecognised key).
+func TestSections_ExtraFiltersAreCaseOnly(t *testing.T) {
+	dir := t.TempDir()
+	writeDefinition(t, dir, "d.json", `{
+	  "id": "d", "displayName": "D", "type": "cs",
+	  "includeSections": [{"section": "my-work", "extraFilters": [
+	    {"field": "projectOnboardingStatus", "op": "in", "values": ["Completed"]}
+	  ]}],
+	  "widgets": []
+	}`)
+
+	d := loadWithSections(t, dir, oneCaseSection)[0]
+
+	caseFilters, ok := d.Widgets[0].Query["filters"].([]any)
+	if !ok {
+		t.Fatalf("case widget Query has no \"filters\" array: %v", d.Widgets[0].Query)
+	}
+	values, ok := filterField(caseFilters, "projectOnboardingStatus")
+	if !ok {
+		t.Fatalf("case widget did not receive the extra filter: %v", caseFilters)
+	}
+	if len(values) != 1 || values[0] != "Completed" {
+		t.Errorf("extra filter values = %v, want [Completed]", values)
+	}
+
+	if raw, present := d.Widgets[1].Query["filters"]; present {
+		t.Errorf("call_request widget Query gained a \"filters\" key %v; extraFilters must only touch case-search widgets", raw)
+	}
+}
+
+// TestSections_ExtraFilterPresetReferencesResolve pins the ordering
+// guarantee: sections expand before preset resolution, so a {"preset": ...}
+// reference written in extraFilters is expanded like any inline one rather
+// than reaching the frontend as a literal object with a "preset" key.
+func TestSections_ExtraFilterPresetReferencesResolve(t *testing.T) {
+	dir := t.TempDir()
+	writeDefinition(t, dir, "d.json", `{
+	  "id": "d", "displayName": "D", "type": "cs",
+	  "includeSections": [{"section": "my-work", "extraFilters": [{"preset": "onboarded"}]}],
+	  "widgets": []
+	}`)
+	sections, err := LoadSharedSections(sharedSectionsFile(t, dir, oneCaseSection))
+	if err != nil {
+		t.Fatalf("LoadSharedSections returned error: %v", err)
+	}
+	presets := map[string]map[string]any{
+		"onboarded": {"field": "projectOnboardingStatus", "op": "in", "values": []any{"Completed"}},
+	}
+
+	got, err := loadDir(dir, presets, sections)
+	if err != nil {
+		t.Fatalf("loadDir returned error: %v", err)
+	}
+	filters, _ := got[0].Widgets[0].Query["filters"].([]any)
+	if _, ok := filterField(filters, "projectOnboardingStatus"); !ok {
+		t.Fatalf("preset reference in extraFilters did not expand: %v", filters)
+	}
+	for _, entry := range filters {
+		if m, ok := entry.(map[string]any); ok && isPresetRef(m) {
+			t.Errorf("an unresolved preset reference survived into the widget query: %v", m)
+		}
+	}
+}
+
+// TestSections_TwoDashboardsDoNotShareState is the deep-copy guarantee. The
+// pipeline mutates Query maps in place (preset expansion, type injection),
+// so a shallow copy would let one dashboard's extraFilters appear in the
+// other's widgets — silently, and only for whichever loaded second.
+func TestSections_TwoDashboardsDoNotShareState(t *testing.T) {
+	dir := t.TempDir()
+	writeDefinition(t, dir, "a.json", `{
+	  "id": "a", "displayName": "A", "type": "cs",
+	  "includeSections": [{"section": "my-work", "extraFilters": [
+	    {"field": "projectOnboardingStatus", "op": "in", "values": ["Completed"]}
+	  ]}],
+	  "widgets": []
+	}`)
+	writeDefinition(t, dir, "b.json", `{
+	  "id": "b", "displayName": "B", "type": "cre", "isTeamBased": true,
+	  "includeSections": [{"section": "my-work"}],
+	  "widgets": []
+	}`)
+
+	got := loadWithSections(t, dir, oneCaseSection)
+	byID := map[string]Dashboard{}
+	for _, d := range got {
+		byID[d.ID] = d
+	}
+	bFilters, _ := byID["b"].Widgets[0].Query["filters"].([]any)
+	if _, leaked := filterField(bFilters, "projectOnboardingStatus"); leaked {
+		t.Errorf("dashboard b's widget carries dashboard a's extraFilters: %v", bFilters)
+	}
+	aFilters, _ := byID["a"].Widgets[0].Query["filters"].([]any)
+	if _, ok := filterField(aFilters, "projectOnboardingStatus"); !ok {
+		t.Errorf("dashboard a lost its own extraFilters: %v", aFilters)
+	}
+}
+
+// TestSections_UnknownSectionFailsLoad — a section that silently expanded to
+// nothing would be a dashboard missing a whole block of widgets with nothing
+// in the logs, the same failure class the loader already refuses for an
+// unknown preset.
+func TestSections_UnknownSectionFailsLoad(t *testing.T) {
+	dir := t.TempDir()
+	writeDefinition(t, dir, "d.json", `{
+	  "id": "d", "displayName": "D", "type": "cs",
+	  "includeSections": [{"section": "nope"}],
+	  "widgets": []
+	}`)
+	sections, err := LoadSharedSections(sharedSectionsFile(t, dir, oneCaseSection))
+	if err != nil {
+		t.Fatalf("LoadSharedSections returned error: %v", err)
+	}
+
+	_, err = loadDir(dir, nil, sections)
+	if err == nil {
+		t.Fatal("loadDir returned no error for an unknown section reference")
+	}
+	if !strings.Contains(err.Error(), "nope") || !strings.Contains(err.Error(), "d.json") {
+		t.Errorf("error %q does not name both the unknown key and the file to edit", err)
+	}
+}
+
+// TestSections_BadPositionFailsLoad — an unrecognised position would
+// silently fall back to one of the two placements and reorder the page.
+func TestSections_BadPositionFailsLoad(t *testing.T) {
+	dir := t.TempDir()
+	writeDefinition(t, dir, "d.json", `{
+	  "id": "d", "displayName": "D", "type": "cs",
+	  "includeSections": [{"section": "my-work", "position": "middle"}],
+	  "widgets": []
+	}`)
+	sections, err := LoadSharedSections(sharedSectionsFile(t, dir, oneCaseSection))
+	if err != nil {
+		t.Fatalf("LoadSharedSections returned error: %v", err)
+	}
+
+	if _, err := loadDir(dir, nil, sections); err == nil {
+		t.Fatal("loadDir returned no error for an unknown position")
+	}
+}
+
+// TestSections_DuplicateWidgetIDsAcrossIncludesFailLoad — including one
+// section twice without distinct idPrefixes collides on widget id, which the
+// existing per-dashboard uniqueness check must still catch after expansion.
+func TestSections_DuplicateWidgetIDsAcrossIncludesFailLoad(t *testing.T) {
+	dir := t.TempDir()
+	writeDefinition(t, dir, "d.json", `{
+	  "id": "d", "displayName": "D", "type": "cs",
+	  "includeSections": [{"section": "my-work"}, {"section": "my-work"}],
+	  "widgets": []
+	}`)
+	sections, err := LoadSharedSections(sharedSectionsFile(t, dir, oneCaseSection))
+	if err != nil {
+		t.Fatalf("LoadSharedSections returned error: %v", err)
+	}
+
+	_, err = loadDir(dir, nil, sections)
+	if err == nil {
+		t.Fatal("loadDir returned no error for a section included twice with no idPrefix")
+	}
+	if !strings.Contains(err.Error(), "duplicate widget id") {
+		t.Errorf("error %q does not name the duplicate widget id", err)
+	}
+}
+
+// TestSections_IncludedWidgetsGetTheImpliedTypeFilter proves an included
+// widget is treated exactly like an inline one by the rest of the pipeline —
+// the whole reason expansion runs first.
+func TestSections_IncludedWidgetsGetTheImpliedTypeFilter(t *testing.T) {
+	dir := t.TempDir()
+	writeDefinition(t, dir, "d.json", `{
+	  "id": "d", "displayName": "D", "type": "cs",
+	  "includeSections": [{"section": "engagements"}],
+	  "widgets": []
+	}`)
+
+	d := loadWithSections(t, dir, `{
+	  "engagements": {
+	    "displayName": "My Work",
+	    "widgets": [
+	      {"id": "my_engagements", "displayName": "My Engagements", "resourceType": "engagement",
+	       "shape": "list", "gridWidth": 12, "query": {"filters": []}}
+	    ]
+	  }
+	}`)[0]
+
+	filters, _ := d.Widgets[0].Query["filters"].([]any)
+	values, ok := filterField(filters, "type")
+	if !ok {
+		t.Fatalf("included widget did not get the auto-injected type filter: %v", filters)
+	}
+	if len(values) != 1 || values[0] != "engagement" {
+		t.Errorf("injected type values = %v, want [engagement]", values)
+	}
+}
+
+// TestLoadSharedSections_EmptyPathIsLegal — a deployment with no shared
+// sections is the normal case and must still boot.
+func TestLoadSharedSections_EmptyPathIsLegal(t *testing.T) {
+	got, err := LoadSharedSections("")
+	if err != nil {
+		t.Fatalf("LoadSharedSections(\"\") returned error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("LoadSharedSections(\"\") = %v, want empty", got)
+	}
+}
+
+// TestLoadSharedSections_RejectsEmptySection — a section with no widgets, or
+// no heading, expands to a hole in the page rather than an error.
+func TestLoadSharedSections_RejectsEmptySection(t *testing.T) {
+	for name, body := range map[string]string{
+		"no widgets":     `{"my-work": {"displayName": "My Work", "widgets": []}}`,
+		"no displayName": `{"my-work": {"widgets": [{"id": "w", "displayName": "W", "resourceType": "case", "shape": "count", "gridWidth": 3}]}}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := sharedSectionsFile(t, dir, body)
+			if _, err := LoadSharedSections(path); err == nil {
+				t.Fatalf("LoadSharedSections returned no error for a section with %s", name)
+			}
+		})
+	}
+}
+
+// TestLoadSharedSections_UnreadableFileIsFatal — a configured-but-missing
+// file must not degrade to "no sections", which would take every including
+// dashboard's section down with it.
+func TestLoadSharedSections_UnreadableFileIsFatal(t *testing.T) {
+	if _, err := LoadSharedSections(filepath.Join(t.TempDir(), "absent.json")); err == nil {
+		t.Fatal("LoadSharedSections returned no error for a missing file")
+	}
+}

--- a/apps/csm-portal/backend/internal/dashboard/sections_test.go
+++ b/apps/csm-portal/backend/internal/dashboard/sections_test.go
@@ -17,6 +17,7 @@
 package dashboard
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -367,4 +368,74 @@ func TestLoadSharedSections_UnreadableFileIsFatal(t *testing.T) {
 	if _, err := LoadSharedSections(filepath.Join(t.TempDir(), "absent.json")); err == nil {
 		t.Fatal("LoadSharedSections returned no error for a missing file")
 	}
+}
+
+// TestLoadSharedSectionsRejectsUnreferenceableKeys covers the two ways a
+// sections file can look configured while being unusable: a null document, and
+// a key that no include could ever match.
+func TestLoadSharedSectionsRejectsUnreferenceableKeys(t *testing.T) {
+	write := func(t *testing.T, body string) string {
+		t.Helper()
+		path := filepath.Join(t.TempDir(), "_sections.json")
+		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+			t.Fatalf("writing sections file: %v", err)
+		}
+		return path
+	}
+
+	const oneGoodSection = `{"my-work":{"displayName":"My Work","widgets":[` +
+		`{"id":"w","displayName":"W","resourceType":"case","shape":"count","gridWidth":3,` +
+		`"query":{"filters":[{"field":"state","op":"in","values":["open"]}]}}]}}`
+
+	t.Run("a null document is rejected, not treated as no sections", func(t *testing.T) {
+		// The path WAS configured, so null is a malformed file. Treating it as
+		// "none configured" defers the failure to every includeSections
+		// reference, each blaming the dashboard instead of this file.
+		_, err := LoadSharedSections(write(t, `null`))
+		if err == nil {
+			t.Fatal("expected an error for a null sections document")
+		}
+		if !strings.Contains(err.Error(), "null") {
+			t.Errorf("error should name the problem: %v", err)
+		}
+	})
+
+	t.Run("an empty object stays legal", func(t *testing.T) {
+		got, err := LoadSharedSections(write(t, `{}`))
+		if err != nil {
+			t.Fatalf("an empty object is 'none configured', not an error: %v", err)
+		}
+		if len(got) != 0 {
+			t.Errorf("got %d sections, want 0", len(got))
+		}
+	})
+
+	t.Run("a whitespace-padded key is rejected", func(t *testing.T) {
+		// expandIncludedSections trims the include before lookup, so this key
+		// is unreachable by any reference.
+		_, err := LoadSharedSections(write(t, `{" my-work":{"displayName":"X","widgets":[]}}`))
+		if err == nil {
+			t.Fatal("expected an error for a whitespace-padded section key")
+		}
+		if !strings.Contains(err.Error(), "whitespace") {
+			t.Errorf("error should name the problem: %v", err)
+		}
+	})
+
+	t.Run("an empty key is rejected", func(t *testing.T) {
+		_, err := LoadSharedSections(write(t, `{"":{"displayName":"X","widgets":[]}}`))
+		if err == nil {
+			t.Fatal("expected an error for an empty section key")
+		}
+	})
+
+	t.Run("a canonical key still loads", func(t *testing.T) {
+		got, err := LoadSharedSections(write(t, oneGoodSection))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 1 {
+			t.Fatalf("got %d sections, want 1", len(got))
+		}
+	})
 }

--- a/apps/csm-portal/backend/internal/dashboard/widgets.go
+++ b/apps/csm-portal/backend/internal/dashboard/widgets.go
@@ -270,6 +270,21 @@ type Dashboard struct {
 	IsTeamBased bool             `json:"isTeamBased"`
 	Widgets     []WidgetTemplate `json:"widgets"`
 
+	// IncludeSections pulls in shared, reusable runs of widgets by name --
+	// a section like "My Work" authored once in DASHBOARD_SECTIONS_FILE and
+	// shared by every dashboard that needs it, instead of copy-pasted per
+	// dashboard. Each entry names a section and carries the per-dashboard
+	// adjustments (id prefix, heading override, extra scoping filters, and
+	// whether it leads or trails this dashboard's own widgets) that let one
+	// definition serve dashboards that are not identical -- see
+	// SectionInclude and expandIncludedSections.
+	//
+	// Expanded into literal Widgets once, at load time, before every other
+	// step of the pipeline, and cleared to nil afterwards: nothing
+	// downstream (validation, the handler, the frontend) ever sees a
+	// section reference, only the widgets it stood for.
+	IncludeSections []SectionInclude `json:"includeSections,omitempty"`
+
 	// DefaultForTeamKeys lists team registry keys (BeTeam.id on the
 	// frontend, the values in this deployment's team registry -- not a
 	// group id) that should land a signed-in user on this dashboard by
@@ -334,11 +349,14 @@ func ParseDashboardsConfig(raw string) ([]Dashboard, error) {
 	for i, d := range dashboards {
 		loaded = append(loaded, sourced{dashboard: d, source: fmt.Sprintf("DASHBOARDS_CONFIG[%d]", i)})
 	}
-	// The deprecated single-variable path has no directory and therefore no
-	// DASHBOARD_PRESETS_FILE of its own to read here — nil shared presets, so
-	// only a dashboard's own "filterPresets" (if any) can resolve a
-	// {"preset": ...} reference on this path.
-	return finalize(loaded, false, nil)
+	// The deprecated single-variable path has no directory and therefore
+	// neither a DASHBOARD_PRESETS_FILE nor a DASHBOARD_SECTIONS_FILE of its
+	// own to read here — nil shared presets, so only a dashboard's own
+	// "filterPresets" (if any) can resolve a {"preset": ...} reference on
+	// this path, and nil shared sections, so an "includeSections" reference
+	// on this path always fails loud with the unknown key named rather than
+	// expanding to nothing.
+	return finalize(loaded, false, nil, nil)
 }
 
 // migrateLegacyWidgetKeys upgrades one pre-rename dashboard definition in

--- a/apps/csm-portal/backend/internal/handler/dashboard_catalogues_test.go
+++ b/apps/csm-portal/backend/internal/handler/dashboard_catalogues_test.go
@@ -1,0 +1,259 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/wso2-open-operations/cs-tools/apps/csm-portal/backend/internal/dashboard"
+)
+
+// The two builder-support catalogue endpoints. These are the only dashboard
+// endpoints that serve the AUTHORED form of a definition rather than the
+// resolved one, so what they must not do is expand anything: the builder
+// edits preset references, it does not want them resolved away.
+
+const cataloguePresetsJSON = `{
+  "activeCaseStates": {"field": "state", "op": "in", "values": ["open", "work_in_progress"]},
+  "productionImpact":  {"field": "severity", "op": "in", "values": ["catastrophic"]}
+}`
+
+const catalogueSectionsJSON = `{
+  "my-work": {
+    "displayName": "My Work",
+    "widgets": [
+      {
+        "id": "my_open",
+        "displayName": "My Open Cases",
+        "resourceType": "case",
+        "shape": "list",
+        "gridWidth": 12,
+        "query": {"filters": [{"preset": "activeCaseStates"}]}
+      }
+    ]
+  }
+}`
+
+const catalogueDashboardJSON = `{
+  "id": "cat-dash",
+  "displayName": "Catalogue Dashboard",
+  "type": "cs",
+  "isDefault": true,
+  "widgets": [
+    {
+      "id": "w1",
+      "displayName": "W1",
+      "resourceType": "case",
+      "shape": "count",
+      "gridWidth": 3,
+      "query": {"filters": [{"preset": "activeCaseStates"}]}
+    }
+  ]
+}`
+
+// seedCatalogueRegistry installs a directory-backed registry carrying both
+// shared files, and restores whatever TestMain installed afterwards so the
+// rest of the package still sees its own static registry.
+func seedCatalogueRegistry(t *testing.T, hotReload bool) string {
+	t.Helper()
+	dir := t.TempDir()
+	presets := filepath.Join(dir, "_presets.json")
+	sections := filepath.Join(dir, "_sections.json")
+	write := func(path, body string) {
+		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+			t.Fatalf("writing %s: %v", path, err)
+		}
+	}
+	write(presets, cataloguePresetsJSON)
+	write(sections, catalogueSectionsJSON)
+	write(filepath.Join(dir, "cat-dash.json"), catalogueDashboardJSON)
+
+	reg, err := dashboard.NewDirRegistry(dir, hotReload, presets, sections)
+	if err != nil {
+		t.Fatalf("NewDirRegistry: %v", err)
+	}
+	previous := dashboard.Active()
+	dashboard.SetActive(reg)
+	t.Cleanup(func() { dashboard.SetActive(previous) })
+	return dir
+}
+
+func TestGetFilterPresets(t *testing.T) {
+	h := NewDashboardHandler()
+
+	t.Run("unauthenticated", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		h.GetFilterPresets(w, httptest.NewRequest(http.MethodGet, "/dashboards/filter-presets", nil))
+		assertStatus(t, w, http.StatusUnauthorized)
+	})
+
+	t.Run("lists every preset, sorted by name", func(t *testing.T) {
+		seedCatalogueRegistry(t, false)
+		w := httptest.NewRecorder()
+		h.GetFilterPresets(w, withUser(httptest.NewRequest(http.MethodGet, "/dashboards/filter-presets", nil)))
+		assertStatus(t, w, http.StatusOK)
+
+		var got []filterPresetView
+		if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+			t.Fatalf("decoding response: %v", err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("got %d presets, want 2: %s", len(got), w.Body.String())
+		}
+		// Sorted, so the order is asserted rather than searched for.
+		if got[0].Name != "activeCaseStates" || got[1].Name != "productionImpact" {
+			t.Fatalf("presets not sorted by name: %q, %q", got[0].Name, got[1].Name)
+		}
+		if got[0].Filter["field"] != "state" || got[0].Filter["op"] != "in" {
+			t.Errorf("preset filter body not forwarded verbatim: %#v", got[0].Filter)
+		}
+	})
+
+	t.Run("no presets configured is an empty array, not null and not an error", func(t *testing.T) {
+		previous := dashboard.Active()
+		dashboard.SetActive(dashboard.NewStaticRegistry(nil))
+		t.Cleanup(func() { dashboard.SetActive(previous) })
+
+		w := httptest.NewRecorder()
+		h.GetFilterPresets(w, withUser(httptest.NewRequest(http.MethodGet, "/dashboards/filter-presets", nil)))
+		assertStatus(t, w, http.StatusOK)
+		// A `null` body would make the frontend's `.map` throw; an empty
+		// array is what "this deployment has no presets" must look like.
+		if body := w.Body.String(); body != "[]\n" && body != "[]" {
+			t.Errorf("body = %q, want an empty JSON array", body)
+		}
+	})
+
+	t.Run("hot reload picks up an edited presets file", func(t *testing.T) {
+		dir := seedCatalogueRegistry(t, true)
+		edited := `{"onlyOne": {"field": "state", "op": "in", "values": ["closed"]}}`
+		if err := os.WriteFile(filepath.Join(dir, "_presets.json"), []byte(edited), 0o600); err != nil {
+			t.Fatalf("rewriting presets: %v", err)
+		}
+
+		w := httptest.NewRecorder()
+		h.GetFilterPresets(w, withUser(httptest.NewRequest(http.MethodGet, "/dashboards/filter-presets", nil)))
+		assertStatus(t, w, http.StatusOK)
+
+		var got []filterPresetView
+		if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+			t.Fatalf("decoding response: %v", err)
+		}
+		if len(got) != 1 || got[0].Name != "onlyOne" {
+			t.Errorf("hot reload did not pick up the edit: %s", w.Body.String())
+		}
+	})
+}
+
+func TestGetSharedSections(t *testing.T) {
+	h := NewDashboardHandler()
+
+	t.Run("unauthenticated", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		h.GetSharedSections(w, httptest.NewRequest(http.MethodGet, "/dashboards/sections", nil))
+		assertStatus(t, w, http.StatusUnauthorized)
+	})
+
+	t.Run("lists sections with their widgets in the dashboard widget shape", func(t *testing.T) {
+		seedCatalogueRegistry(t, false)
+		w := httptest.NewRecorder()
+		h.GetSharedSections(w, withUser(httptest.NewRequest(http.MethodGet, "/dashboards/sections", nil)))
+		assertStatus(t, w, http.StatusOK)
+
+		var got []sharedSectionView
+		if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+			t.Fatalf("decoding response: %v", err)
+		}
+		if len(got) != 1 {
+			t.Fatalf("got %d sections, want 1: %s", len(got), w.Body.String())
+		}
+		if got[0].Name != "my-work" || got[0].DisplayName != "My Work" {
+			t.Errorf("name/displayName = %q/%q", got[0].Name, got[0].DisplayName)
+		}
+		if len(got[0].Widgets) != 1 || got[0].Widgets[0].WidgetID != "my_open" {
+			t.Fatalf("widgets not forwarded: %#v", got[0].Widgets)
+		}
+	})
+
+	t.Run("a section's preset references are NOT expanded", func(t *testing.T) {
+		seedCatalogueRegistry(t, false)
+		w := httptest.NewRecorder()
+		h.GetSharedSections(w, withUser(httptest.NewRequest(http.MethodGet, "/dashboards/sections", nil)))
+		assertStatus(t, w, http.StatusOK)
+
+		var got []sharedSectionView
+		if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+			t.Fatalf("decoding response: %v", err)
+		}
+		filters, ok := got[0].Widgets[0].Query["filters"].([]any)
+		if !ok || len(filters) != 1 {
+			t.Fatalf("query.filters missing or wrong length: %#v", got[0].Widgets[0].Query)
+		}
+		entry, ok := filters[0].(map[string]any)
+		if !ok {
+			t.Fatalf("filter entry is not an object: %#v", filters[0])
+		}
+		// The builder edits the authored form. If this ever starts
+		// returning {field,op,values} instead, the builder silently loses
+		// the ability to show (or keep) the preset reference.
+		if entry["preset"] != "activeCaseStates" {
+			t.Errorf("preset reference was expanded away: %#v", entry)
+		}
+	})
+
+	t.Run("the dashboard endpoint still expands, unlike the section endpoint", func(t *testing.T) {
+		seedCatalogueRegistry(t, false)
+		w := httptest.NewRecorder()
+		h.GetDashboardDetail(w, withUser(withDashboardID(
+			httptest.NewRequest(http.MethodGet, "/dashboards/cat-dash", nil), "cat-dash")))
+		assertStatus(t, w, http.StatusOK)
+
+		var got dashboardDetailView
+		if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+			t.Fatalf("decoding response: %v", err)
+		}
+		filters, ok := got.Widgets[0].Query["filters"].([]any)
+		if !ok || len(filters) == 0 {
+			t.Fatalf("query.filters missing: %#v", got.Widgets[0].Query)
+		}
+		entry := filters[0].(map[string]any)
+		if entry["preset"] != nil {
+			t.Errorf("a served dashboard must have no preset references left: %#v", entry)
+		}
+		if entry["field"] != "state" {
+			t.Errorf("preset was not expanded into its filter: %#v", entry)
+		}
+	})
+
+	t.Run("no sections configured is an empty array", func(t *testing.T) {
+		previous := dashboard.Active()
+		dashboard.SetActive(dashboard.NewStaticRegistry(nil))
+		t.Cleanup(func() { dashboard.SetActive(previous) })
+
+		w := httptest.NewRecorder()
+		h.GetSharedSections(w, withUser(httptest.NewRequest(http.MethodGet, "/dashboards/sections", nil)))
+		assertStatus(t, w, http.StatusOK)
+		if body := w.Body.String(); body != "[]\n" && body != "[]" {
+			t.Errorf("body = %q, want an empty JSON array", body)
+		}
+	})
+}

--- a/apps/csm-portal/backend/internal/handler/dashboards.go
+++ b/apps/csm-portal/backend/internal/handler/dashboards.go
@@ -18,6 +18,7 @@ package handler
 
 import (
 	"net/http"
+	"sort"
 
 	"github.com/wso2-open-operations/cs-tools/apps/csm-portal/backend/internal/dashboard"
 	"github.com/wso2-open-operations/cs-tools/apps/csm-portal/backend/internal/middleware"
@@ -59,6 +60,36 @@ type dashboardWidgetView struct {
 	// request's "sortBy" instead of its "filters".
 	Columns []dashboard.Column `json:"columns,omitempty"`
 	SortBy  map[string]any     `json:"sortBy,omitempty"`
+}
+
+// filterPresetView is one entry of the shared filter-preset catalogue,
+// returned by GET /dashboards/filter-presets. Filter is the single filter
+// predicate the preset stands for, verbatim as authored (field/op/values —
+// see dashboard.LoadSharedPresets).
+//
+// Returned as a sorted array rather than a name-keyed object so the order the
+// builder's picker shows is deterministic and the shape is expressible in
+// OpenAPI without a free-form additionalProperties map.
+type filterPresetView struct {
+	Name   string         `json:"name"`
+	Filter map[string]any `json:"filter"`
+}
+
+// sharedSectionView is one entry of the shared reusable-section catalogue,
+// returned by GET /dashboards/sections. Widgets is the section's widget run
+// in the same shape a dashboard's own widgets are returned in, so the builder
+// has one widget model rather than two.
+//
+// The widgets here are as AUTHORED in the section file: unlike a dashboard's
+// widgets, their {"preset": ...} references are NOT expanded and no implied
+// "type" filter has been injected, because a section is never loaded through
+// a dashboard's finalize pipeline on its own. That is what the builder wants
+// — it edits the authored form — but it means these queries are not directly
+// usable as search criteria.
+type sharedSectionView struct {
+	Name        string                `json:"name"`
+	DisplayName string                `json:"displayName"`
+	Widgets     []dashboardWidgetView `json:"widgets"`
 }
 
 // dashboardListItemView is a dashboard's list-level metadata, returned by
@@ -154,8 +185,26 @@ func (h *DashboardHandler) GetDashboardDetail(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	widgets := make([]dashboardWidgetView, 0, len(d.Widgets))
-	for _, tpl := range d.Widgets {
+	widgets := widgetViews(d.Widgets)
+
+	writeJSONValue(w, http.StatusOK, dashboardDetailView{
+		ID:          d.ID,
+		DisplayName: d.DisplayName,
+		Type:        d.Type,
+		IsDefault:   d.IsDefault,
+		TargetTeam:  d.TargetTeam,
+		IsTeamBased: d.IsTeamBased,
+		Widgets:     widgets,
+	})
+}
+
+// widgetViews maps widget templates onto their wire shape. Shared by
+// GET /dashboards/{dashboardId} and GET /dashboards/sections so a section's
+// widgets and a dashboard's widgets are never two different shapes on the
+// wire.
+func widgetViews(templates []dashboard.WidgetTemplate) []dashboardWidgetView {
+	views := make([]dashboardWidgetView, 0, len(templates))
+	for _, tpl := range templates {
 		var slices []dashboardPieSliceView
 		if len(tpl.Slices) > 0 {
 			slices = make([]dashboardPieSliceView, 0, len(tpl.Slices))
@@ -167,7 +216,7 @@ func (h *DashboardHandler) GetDashboardDetail(w http.ResponseWriter, r *http.Req
 				})
 			}
 		}
-		widgets = append(widgets, dashboardWidgetView{
+		views = append(views, dashboardWidgetView{
 			WidgetID:     tpl.ID,
 			DisplayName:  tpl.DisplayName,
 			Description:  tpl.Description,
@@ -183,14 +232,67 @@ func (h *DashboardHandler) GetDashboardDetail(w http.ResponseWriter, r *http.Req
 			SortBy:       tpl.SortBy,
 		})
 	}
+	return views
+}
 
-	writeJSONValue(w, http.StatusOK, dashboardDetailView{
-		ID:          d.ID,
-		DisplayName: d.DisplayName,
-		Type:        d.Type,
-		IsDefault:   d.IsDefault,
-		TargetTeam:  d.TargetTeam,
-		IsTeamBased: d.IsTeamBased,
-		Widgets:     widgets,
-	})
+// GetFilterPresets handles GET /dashboards/filter-presets.
+//
+// Lists the shared filter presets a dashboard definition may reference by
+// name. This is builder-support, not dashboard-serving: a served dashboard
+// has every preset reference already expanded.
+//
+// A deployment with no presets file configured is legal and returns an empty
+// array, not an error — the builder then simply offers no presets.
+func (h *DashboardHandler) GetFilterPresets(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	presets := dashboard.FilterPresets()
+	names := make([]string, 0, len(presets))
+	for name := range presets {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	views := make([]filterPresetView, 0, len(names))
+	for _, name := range names {
+		views = append(views, filterPresetView{Name: name, Filter: presets[name]})
+	}
+
+	writeJSONValue(w, http.StatusOK, views)
+}
+
+// GetSharedSections handles GET /dashboards/sections.
+//
+// Lists the shared reusable sections a dashboard definition may pull in by
+// name via "includeSections". Same builder-support contract, and same
+// empty-array-not-error behaviour, as GetFilterPresets.
+func (h *DashboardHandler) GetSharedSections(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	sections := dashboard.SharedSections()
+	names := make([]string, 0, len(sections))
+	for name := range sections {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	views := make([]sharedSectionView, 0, len(names))
+	for _, name := range names {
+		s := sections[name]
+		views = append(views, sharedSectionView{
+			Name:        name,
+			DisplayName: s.DisplayName,
+			Widgets:     widgetViews(s.Widgets),
+		})
+	}
+
+	writeJSONValue(w, http.StatusOK, views)
 }

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -7200,9 +7200,13 @@ components:
       description: >
         One project-contact row for a user, reported as stored rather than as filtered. A
         row with no linked contact record makes the project, and every case on it, silently
-        invisible to that user. grantsCaseAccess mirrors contactRecordPresent directly --
-        deliberately not the stricter email-match rule the live access check enforces, since
-        that only diverges for integration/system accounts.
+        invisible to that user. grantsCaseAccess is the access rule applied per row:
+        contactRecordPresent AND contactEmail matching contactRecordEmail, compared
+        case-insensitively. It is deliberately not a restatement of contactRecordPresent --
+        a row invited under one address but linked to a contact whose own address differs is
+        invisible to both people, and that does happen on genuine customer rows. Both halves
+        of the comparison are returned above, so a false verdict can be explained from the
+        row itself.
       required: [projectId, projectName, projectKey, contactEmail, contactRecordPresent, grantsCaseAccess]
       properties:
         projectId:
@@ -7747,7 +7751,10 @@ components:
           properties:
             searchQuery:
               type: string
-              description: Searches across contact name and email (case-insensitive)
+              description: >
+                Searches across the contact's name, the linked record's address, and the
+                address a row was invited under (case-insensitive) — so a row with no linked
+                contact record is findable by the address it is displayed under.
         pagination:
           allOf:
             - $ref: '#/components/schemas/Pagination'
@@ -7769,8 +7776,15 @@ components:
             render the row unlinked rather than treating it as an error.
         name:
           type: string
+          description: >
+            Empty when the row has no contact record linked — the name is only ever known
+            from that record.
         email:
           type: string
+          description: >
+            The contact's address. Falls back to the address the row was invited under when
+            no contact record is linked, so a row whose contact record was never created is
+            still identifiable rather than coming back with no name and no address at all.
         registrationState:
           type: string
         notificationsEnabled:
@@ -7788,8 +7802,11 @@ components:
           type: boolean
           description: >
             Whether this row would actually grant its person visibility into this project's
-            cases. Mirrors `customerContactPresent` directly — a row can be listed here without
-            granting access.
+            cases: a linked contact record AND the address the row was invited under matching
+            that record's own address, compared case-insensitively. Deliberately not a
+            restatement of `customerContactPresent` — a row invited under one address but
+            linked to a contact whose own address differs is invisible to both people, and
+            that does happen on genuine customer rows.
 
     ProjectContactSearchResponse:
       type: object

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -1771,6 +1771,12 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/DashboardListItem'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
         "401":
           description: Unauthorized
           content:
@@ -1779,6 +1785,12 @@ paths:
                 $ref: '#/components/schemas/ErrorPayload'
         "403":
           description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: NotFound
           content:
             application/json:
               schema:
@@ -1813,6 +1825,12 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/DashboardFilterPreset'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
         "401":
           description: Unauthorized
           content:
@@ -1821,6 +1839,12 @@ paths:
                 $ref: '#/components/schemas/ErrorPayload'
         "403":
           description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: NotFound
           content:
             application/json:
               schema:
@@ -1856,6 +1880,12 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/DashboardSharedSection'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
         "401":
           description: Unauthorized
           content:
@@ -1864,6 +1894,12 @@ paths:
                 $ref: '#/components/schemas/ErrorPayload'
         "403":
           description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: NotFound
           content:
             application/json:
               schema:

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -1790,6 +1790,91 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
+  /dashboards/filter-presets:
+    get:
+      summary: List the shared filter presets a dashboard definition may reference.
+      description: >
+        Returns the deployment's shared filter-preset catalogue: each preset's
+        name and the single filter predicate it stands for. A dashboard
+        definition references a preset by name instead of repeating the
+        predicate, and the registry expands every reference at load time, so a
+        dashboard returned by GET /dashboards/{dashboardId} never contains a
+        preset reference. This endpoint exists so an authoring tool can offer
+        the names that may be referenced, and show what each one means. A
+        deployment with no preset catalogue configured returns an empty array,
+        not an error.
+      operationId: getDashboardFilterPresets
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DashboardFilterPreset'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /dashboards/sections:
+    get:
+      summary: List the shared reusable sections a dashboard definition may include.
+      description: >
+        Returns the deployment's shared section catalogue: each section's name,
+        the heading its widgets are grouped under, and its widget run. A
+        dashboard definition pulls a section in by name rather than repeating
+        its widgets, and the registry expands every include at load time.
+        Unlike a dashboard's widgets, the widgets returned here are as
+        authored: filter-preset references are NOT expanded and no implied
+        type filter has been injected, because a section is not loaded through
+        a dashboard's own resolution pipeline on its own. They are therefore
+        for authoring, not for use as search criteria. A deployment with no
+        section catalogue configured returns an empty array, not an error.
+      operationId: getDashboardSections
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DashboardSharedSection'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
   /dashboards/{dashboardId}:
     get:
       summary: Get a dashboard's metadata and widget templates.
@@ -6300,6 +6385,61 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/DashboardWidget'
+
+    DashboardFilterPreset:
+      type: object
+      description: >
+        One named, reusable filter predicate a dashboard definition may
+        reference instead of repeating it. Returned by
+        GET /dashboards/filter-presets for authoring purposes only — a
+        dashboard served by this API has every reference already expanded.
+      properties:
+        name:
+          type: string
+          description: >
+            The name a definition references this preset by. Unique within
+            the catalogue.
+        filter:
+          type: object
+          additionalProperties: true
+          description: >
+            The single filter predicate this preset stands for, verbatim as
+            authored: the same field/op/values object a widget's own
+            query.filters entries use.
+      required:
+        - name
+        - filter
+
+    DashboardSharedSection:
+      type: object
+      description: >
+        One named, reusable run of widgets a dashboard definition may pull in
+        by name instead of repeating them. Returned by GET /dashboards/sections
+        for authoring purposes only.
+      properties:
+        name:
+          type: string
+          description: >
+            The name a definition references this section by. Unique within
+            the catalogue.
+        displayName:
+          type: string
+          description: >
+            The heading every widget in this section is grouped under, unless
+            the referencing definition overrides it.
+        widgets:
+          type: array
+          description: >
+            The section's widget run, as AUTHORED: filter-preset references
+            are not expanded and no implied type filter has been injected.
+            Not usable directly as search criteria — see the endpoint
+            description.
+          items:
+            $ref: '#/components/schemas/DashboardWidget'
+      required:
+        - name
+        - displayName
+        - widgets
 
     Case:
       type: object

--- a/apps/csm-portal/webapp/src/App.tsx
+++ b/apps/csm-portal/webapp/src/App.tsx
@@ -133,6 +133,9 @@ const CsmDashboardBuilderListPage = lazy(
 const CsmDashboardBuilderEditorPage = lazy(
   () => import("@features/csm-admin/dashboards/pages/CsmDashboardBuilderEditorPage"),
 );
+const CsmDashboardSharedConfigPage = lazy(
+  () => import("@features/csm-admin/dashboards/pages/CsmDashboardSharedConfigPage"),
+);
 const CsmCustomersLayout = lazy(
   () => import("@features/csm-customers/pages/CsmCustomersLayout"),
 );
@@ -390,6 +393,10 @@ export default function App(): JSX.Element {
                         only; there is no backend behind this feature. */}
                     <Route path="dashboards" element={<DashboardBuilderRouteGuard />}>
                       <Route index element={<CsmDashboardBuilderListPage />} />
+                      {/* Before the ":draftId" wildcard: "shared" is a
+                          literal segment, and react-router would otherwise
+                          match it as a draft id. */}
+                      <Route path="shared" element={<CsmDashboardSharedConfigPage />} />
                       <Route path="new" element={<CsmDashboardBuilderEditorPage />} />
                       <Route path=":draftId" element={<CsmDashboardBuilderEditorPage />} />
                     </Route>

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -3227,6 +3227,48 @@ export interface BeDashboardListItem {
  * metadata plus every widget template registered for it. `widgets` is
  * always an array; every dashboard in the registry has at least one.
  */
+/**
+ * One entry of the deployment's shared filter-preset catalogue
+ * (`GET /dashboards/filter-presets`).
+ *
+ * A dashboard definition may reference a preset by name in place of a filter
+ * predicate, and the backend expands every reference when it loads the
+ * definition. A dashboard returned by `GET /dashboards/{id}` therefore never
+ * contains a preset reference — which is exactly why this endpoint exists:
+ * the dashboard builder cannot otherwise know a preset exists, or what it
+ * means.
+ */
+export interface BeDashboardFilterPreset {
+  /** The name a definition references this preset by; unique in the catalogue. */
+  name: string;
+  /** The single filter predicate this preset stands for, verbatim as
+   * authored — the same field/op/values shape a widget's own `query.filters`
+   * entries use (see {@link BeCaseFieldFilter}). Typed loosely because the
+   * backend forwards it without interpreting it. */
+  filter: Record<string, unknown>;
+}
+
+/**
+ * One entry of the deployment's shared reusable-section catalogue
+ * (`GET /dashboards/sections`).
+ *
+ * ⚠️ `widgets` here is the AUTHORED form, not the resolved form every other
+ * widget in this app carries: filter-preset references are NOT expanded and
+ * no implied `type` filter has been injected, because a section is never put
+ * through a dashboard's own load pipeline on its own. That is what the
+ * builder wants — it edits the authored form — but it means these `query`
+ * objects must never be handed to a `/search` endpoint as criteria.
+ */
+export interface BeDashboardSharedSection {
+  /** The name a definition includes this section by; unique in the catalogue. */
+  name: string;
+  /** The heading the section's widgets are grouped under, unless the
+   * including definition overrides it. */
+  displayName: string;
+  /** The section's widget run, as authored — see this type's own warning. */
+  widgets: BeDashboardWidget[];
+}
+
 export interface BeDashboard {
   id: string;
   displayName: string;

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -1379,7 +1379,17 @@ export interface BeProjectContact {
    * treating it as an error.
    */
   id?: string;
+  /**
+   * Empty when the row has no contact record linked — the name is only ever
+   * known from that record.
+   */
   name?: string;
+  /**
+   * The contact's address. Falls back to the address the row was invited
+   * under when no contact record is linked, so a row whose contact record was
+   * never created is still identifiable rather than carrying no name and no
+   * address at all.
+   */
   email?: string;
   registrationState?: string;
   notificationsEnabled?: boolean;
@@ -1391,8 +1401,12 @@ export interface BeProjectContact {
   customerContactPresent?: boolean;
   /**
    * Whether this row would actually grant its person visibility into this
-   * project's cases. Mirrors `customerContactPresent` directly — a row can
-   * be listed here without granting access.
+   * project's cases: a linked contact record AND the address the row was
+   * invited under matching that record's own address, compared
+   * case-insensitively. Deliberately not a restatement of
+   * `customerContactPresent` — a row invited under one address but linked to a
+   * contact whose own address differs is invisible to both people, and that
+   * does happen on genuine customer rows.
    */
   grantsCaseAccess?: boolean;
 }

--- a/apps/csm-portal/webapp/src/constants/apiConstants.ts
+++ b/apps/csm-portal/webapp/src/constants/apiConstants.ts
@@ -111,6 +111,8 @@ export const ApiQueryKeys = {
   CSM_DASHBOARD_WIDGET_DATA: "csm-dashboard-widget-data",
   CSM_DASHBOARD_LIST: "csm-dashboard-list",
   CSM_DASHBOARD_DETAIL: "csm-dashboard-detail",
+  CSM_DASHBOARD_FILTER_PRESETS: "csm-dashboard-filter-presets",
+  CSM_DASHBOARD_SECTIONS: "csm-dashboard-sections",
   CSM_TEAMS: "csm-teams",
   CSM_CASE_DETAIL: "csm-case-detail",
   CSM_CASE_COMMENTS: "csm-case-comments",

--- a/apps/csm-portal/webapp/src/features/csm-admin/dashboards/api/useDashboardSharedConfig.ts
+++ b/apps/csm-portal/webapp/src/features/csm-admin/dashboards/api/useDashboardSharedConfig.ts
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import { useBackendApi } from "@api/backend/client";
+import type {
+  BeDashboardFilterPreset,
+  BeDashboardSharedSection,
+} from "@api/backend/types";
+
+/**
+ * The two shared-config catalogues the dashboard builder authors against.
+ *
+ * Both are deployment configuration, not user data: a maintainer deploys
+ * `_presets.json`/`_sections.json` alongside the dashboard definitions, and
+ * neither has a write API (same story as the dashboards themselves — see
+ * `dashboardDraftsStorage`). These queries are read-only and exist so the
+ * builder can show what already exists to reference, and seed an edit of it.
+ *
+ * A deployment with neither file configured returns `[]` from both endpoints,
+ * which is a legitimate state and not an error — the builder then simply
+ * offers nothing to reference.
+ */
+
+/** Long stale time: this is deployment config that only changes on a
+ * redeploy, so re-fetching it while an admin edits a draft is pure noise. */
+const SHARED_CONFIG_STALE_TIME_MS = 5 * 60 * 1000;
+
+export function useDashboardFilterPresets(): UseQueryResult<
+  BeDashboardFilterPreset[],
+  Error
+> {
+  const api = useBackendApi();
+
+  return useQuery<BeDashboardFilterPreset[], Error>({
+    queryKey: [ApiQueryKeys.CSM_DASHBOARD_FILTER_PRESETS],
+    queryFn: async (): Promise<BeDashboardFilterPreset[]> => {
+      const res = await api.get<BeDashboardFilterPreset[]>(
+        "/dashboards/filter-presets",
+      );
+      // The endpoint always 200s with an array, empty when no presets file
+      // is configured. `null` therefore means the endpoint itself 404'd — a
+      // backend older than this feature, or a routing problem — which must
+      // surface as an error rather than as "this deployment has no presets".
+      if (res === null) {
+        throw new Error("GET /dashboards/filter-presets returned 404");
+      }
+      return res;
+    },
+    staleTime: SHARED_CONFIG_STALE_TIME_MS,
+  });
+}
+
+export function useDashboardSharedSections(): UseQueryResult<
+  BeDashboardSharedSection[],
+  Error
+> {
+  const api = useBackendApi();
+
+  return useQuery<BeDashboardSharedSection[], Error>({
+    queryKey: [ApiQueryKeys.CSM_DASHBOARD_SECTIONS],
+    queryFn: async (): Promise<BeDashboardSharedSection[]> => {
+      const res = await api.get<BeDashboardSharedSection[]>(
+        "/dashboards/sections",
+      );
+      // Same reasoning as useDashboardFilterPresets.
+      if (res === null) {
+        throw new Error("GET /dashboards/sections returned 404");
+      }
+      return res;
+    },
+    staleTime: SHARED_CONFIG_STALE_TIME_MS,
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-admin/dashboards/components/PresetEditorDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/dashboards/components/PresetEditorDialog.tsx
@@ -1,0 +1,139 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Alert,
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  TextField,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { useState, type JSX } from "react";
+import WidgetFilterConditionEditor from "@features/csm-admin/dashboards/components/WidgetFilterConditionEditor";
+import {
+  filterConditionsFromQuery,
+  queryFromFilterConditions,
+  type FilterCondition,
+} from "@features/csm-admin/dashboards/utils/widgetQueryConditions";
+import type { PresetDraft } from "@features/csm-admin/dashboards/utils/sharedConfigDraftsStorage";
+
+interface PresetEditorDialogProps {
+  /** `undefined` when designing a brand-new preset. */
+  preset?: PresetDraft;
+  /** Names already taken, so a rename cannot silently overwrite another
+   * preset. Excludes the one being edited. */
+  takenNames: readonly string[];
+  onClose: () => void;
+  onSave: (preset: PresetDraft) => void;
+}
+
+/**
+ * Designs one shared filter preset: a name plus the single filter predicate
+ * it stands for.
+ *
+ * Exactly one predicate, not a list: a preset expands to ONE entry in a
+ * widget's `query.filters` (see the backend's own `LoadSharedPresets`, whose
+ * value type is a single filter object). Letting an admin build two rows here
+ * would produce a file the loader rejects, so the second row is refused with
+ * a reason rather than accepted and then failed on deploy.
+ *
+ * The condition row itself is the same editor a widget's filters use — the
+ * predicate shape is identical, so there is no second filter UI to keep in
+ * step. Presets are not offered inside it: a preset referencing another
+ * preset is rejected by the loader (`validatePresetsNotRecursive`).
+ */
+export default function PresetEditorDialog({
+  preset,
+  takenNames,
+  onClose,
+  onSave,
+}: PresetEditorDialogProps): JSX.Element {
+  const [name, setName] = useState(preset?.name ?? "");
+  const [conditions, setConditions] = useState<FilterCondition[]>(() =>
+    // A preset's body is a single case-DSL predicate, so it is read through
+    // the case reader by wrapping it in the `filters` array that reader
+    // expects — the preset file stores the bare predicate, not the wrapper.
+    preset ? filterConditionsFromQuery("case", { filters: [preset.filter] }) : [],
+  );
+
+  const trimmedName = name.trim();
+  const duplicate = takenNames.some((n) => n === trimmedName);
+  const tooManyConditions = conditions.length > 1;
+  const canSave =
+    trimmedName.length > 0 && !duplicate && conditions.length === 1 && !tooManyConditions;
+
+  const handleSave = (): void => {
+    const query = queryFromFilterConditions("case", conditions);
+    const filters = query.filters;
+    if (!Array.isArray(filters) || filters.length !== 1) return;
+    onSave({ name: trimmedName, filter: filters[0] as Record<string, unknown> });
+  };
+
+  return (
+    <Dialog open onClose={onClose} fullWidth maxWidth="sm">
+      <DialogTitle>{preset ? "Edit preset" : "New preset"}</DialogTitle>
+      <DialogContent>
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 2, pt: 1 }}>
+          <TextField
+            size="small"
+            label="Preset name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            error={duplicate}
+            helperText={
+              duplicate
+                ? "Another preset already uses this name."
+                : "The name a dashboard definition references this preset by, e.g. activeCaseStates."
+            }
+            slotProps={{ htmlInput: { "aria-label": "Preset name" } }}
+          />
+          <Box>
+            <Typography variant="subtitle2" gutterBottom>
+              Condition
+            </Typography>
+            <WidgetFilterConditionEditor
+              resourceType="case"
+              conditions={conditions}
+              onChange={setConditions}
+            />
+          </Box>
+          {tooManyConditions && (
+            <Alert severity="error">
+              A preset stands for exactly one condition. Remove the extra rows,
+              or make two presets — the config loader rejects a preset whose
+              body is a list.
+            </Alert>
+          )}
+          {conditions.length === 0 && (
+            <Alert severity="info">
+              Add the one condition this preset should stand for.
+            </Alert>
+          )}
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button variant="contained" disabled={!canSave} onClick={handleSave}>
+          Save preset
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-admin/dashboards/components/SectionEditorDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/dashboards/components/SectionEditorDialog.tsx
@@ -1,0 +1,223 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Alert,
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  List,
+  ListItem,
+  ListItemText,
+  TextField,
+  Tooltip,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { Pencil, Plus, Trash2 } from "@wso2/oxygen-ui-icons-react";
+import { useState, type JSX } from "react";
+import type { BeDashboardFilterPreset, BeDashboardWidget } from "@api/backend/types";
+import WidgetEditorDialog from "@features/csm-admin/dashboards/components/WidgetEditorDialog";
+import type { SectionDraft } from "@features/csm-admin/dashboards/utils/sharedConfigDraftsStorage";
+
+interface SectionEditorDialogProps {
+  /** `undefined` when designing a brand-new section. */
+  section?: SectionDraft;
+  /** Names already taken, excluding the one being edited. */
+  takenNames: readonly string[];
+  /** Shared presets a widget in this section may reference — passed straight
+   * through to the widget editor. */
+  presets?: readonly BeDashboardFilterPreset[];
+  onClose: () => void;
+  onSave: (section: SectionDraft) => void;
+}
+
+/**
+ * Designs one reusable section: a name, the heading its widgets are grouped
+ * under, and the widgets themselves.
+ *
+ * The widgets are built with the SAME dialog a dashboard's own widgets use.
+ * A section's widget and a dashboard's widget are the same shape — the whole
+ * point of the feature is that one is substitutable for the other — so
+ * forking a second widget editor here would guarantee the two drift.
+ *
+ * A widget's own `section` field is not editable here and is not written out:
+ * within a section, the heading comes from this section's `displayName`, and
+ * the loader overwrites each included widget's `section` with it (or with the
+ * including dashboard's override). Offering it would be a field that silently
+ * does nothing.
+ */
+export default function SectionEditorDialog({
+  section,
+  takenNames,
+  presets,
+  onClose,
+  onSave,
+}: SectionEditorDialogProps): JSX.Element {
+  const [name, setName] = useState(section?.name ?? "");
+  const [displayName, setDisplayName] = useState(section?.displayName ?? "");
+  const [widgets, setWidgets] = useState<BeDashboardWidget[]>(section?.widgets ?? []);
+  const [editingWidget, setEditingWidget] = useState<
+    { widget?: BeDashboardWidget; index?: number } | undefined
+  >(undefined);
+
+  const trimmedName = name.trim();
+  const trimmedDisplayName = displayName.trim();
+  const duplicate = takenNames.some((n) => n === trimmedName);
+  const canSave =
+    trimmedName.length > 0 &&
+    trimmedDisplayName.length > 0 &&
+    !duplicate &&
+    widgets.length > 0;
+
+  const upsertWidget = (widget: BeDashboardWidget): void => {
+    setWidgets((current) =>
+      editingWidget?.index === undefined
+        ? [...current, widget]
+        : current.map((w, i) => (i === editingWidget.index ? widget : w)),
+    );
+    setEditingWidget(undefined);
+  };
+
+  return (
+    <>
+      <Dialog open onClose={onClose} fullWidth maxWidth="md">
+        <DialogTitle>{section ? "Edit section" : "New section"}</DialogTitle>
+        <DialogContent>
+          <Box sx={{ display: "flex", flexDirection: "column", gap: 2, pt: 1 }}>
+            <TextField
+              size="small"
+              label="Section name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              error={duplicate}
+              helperText={
+                duplicate
+                  ? "Another section already uses this name."
+                  : "The name a dashboard definition includes this section by, e.g. my-work."
+              }
+              slotProps={{ htmlInput: { "aria-label": "Section name" } }}
+            />
+            <TextField
+              size="small"
+              label="Section heading"
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+              helperText="Shown above the section's widgets, e.g. My Work. A dashboard including this section can override it."
+              slotProps={{ htmlInput: { "aria-label": "Section heading" } }}
+            />
+
+            <Box>
+              <Typography variant="subtitle2" gutterBottom>
+                Widgets
+              </Typography>
+              {widgets.length === 0 ? (
+                <Alert severity="info">
+                  A section needs at least one widget — the loader rejects an
+                  empty one, because a section that expands to nothing is a
+                  dashboard missing a whole block with nothing in the logs to
+                  say why.
+                </Alert>
+              ) : (
+                <List dense disablePadding>
+                  {widgets.map((widget, index) => (
+                    <ListItem
+                      key={widget.widgetId}
+                      disableGutters
+                      secondaryAction={
+                        <Box>
+                          <Tooltip title="Edit this widget">
+                            <IconButton
+                              size="small"
+                              aria-label={`Edit widget ${widget.displayName}`}
+                              onClick={() => setEditingWidget({ widget, index })}
+                            >
+                              <Pencil size={16} />
+                            </IconButton>
+                          </Tooltip>
+                          <Tooltip title="Remove this widget">
+                            <IconButton
+                              size="small"
+                              aria-label={`Remove widget ${widget.displayName}`}
+                              onClick={() =>
+                                setWidgets((c) => c.filter((_, i) => i !== index))
+                              }
+                            >
+                              <Trash2 size={16} />
+                            </IconButton>
+                          </Tooltip>
+                        </Box>
+                      }
+                    >
+                      <ListItemText
+                        primary={widget.displayName}
+                        secondary={`${widget.resourceType} · ${widget.shape} · ${widget.gridWidth}/12`}
+                      />
+                    </ListItem>
+                  ))}
+                </List>
+              )}
+              <Button
+                size="small"
+                variant="text"
+                startIcon={<Plus size={16} />}
+                onClick={() => setEditingWidget({})}
+                sx={{ mt: 1 }}
+              >
+                Add widget
+              </Button>
+            </Box>
+          </Box>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={onClose}>Cancel</Button>
+          <Button
+            variant="contained"
+            disabled={!canSave}
+            onClick={() =>
+              onSave({
+                name: trimmedName,
+                displayName: trimmedDisplayName,
+                widgets,
+              })
+            }
+          >
+            Save section
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {editingWidget && (
+        <WidgetEditorDialog
+          presets={presets}
+          widget={editingWidget.widget}
+          // Pre-filled with, and only suggesting, this section's own heading:
+          // the loader overwrites every included widget's `section` with the
+          // section's displayName anyway, so anything else here would preview
+          // one grouping and deploy another. It is also dropped on export
+          // (see `widgetToDefinition`) rather than written as dead config.
+          defaultSection={trimmedDisplayName}
+          sectionSuggestions={trimmedDisplayName ? [trimmedDisplayName] : []}
+          onClose={() => setEditingWidget(undefined)}
+          onSave={upsertWidget}
+        />
+      )}
+    </>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-admin/dashboards/components/WidgetEditorDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/dashboards/components/WidgetEditorDialog.tsx
@@ -31,6 +31,7 @@ import {
 import { Eye, Plus, Trash2 } from "@wso2/oxygen-ui-icons-react";
 import { useMemo, useState, type JSX } from "react";
 import type {
+  BeDashboardFilterPreset,
   BeDashboardPieSlice,
   BeDashboardWidget,
   BeDashboardWidgetColumn,
@@ -98,11 +99,19 @@ function draftsToColumns(drafts: ColumnDraft[]): BeDashboardWidgetColumn[] {
     }));
 }
 
-function slicesToDrafts(resourceType: BeWidgetResourceType, slices: BeDashboardPieSlice[] | undefined): SliceDraft[] {
+function slicesToDrafts(
+  resourceType: BeWidgetResourceType,
+  slices: BeDashboardPieSlice[] | undefined,
+  presets?: readonly BeDashboardFilterPreset[],
+): SliceDraft[] {
   return (slices ?? []).map((s) => ({
     label: s.label,
     color: s.color,
-    conditions: filterConditionsFromQuery(resourceType, s.query),
+    // Presets are expanded per-slice too (a slice carrying its own `filters`
+    // replaces the widget's whole array), so a slice's filters need the same
+    // collapse-back as the widget's own or a pie widget silently loses every
+    // preset reference its slices had.
+    conditions: filterConditionsFromQuery(resourceType, s.query, presets),
   }));
 }
 
@@ -117,6 +126,25 @@ function draftsToSlices(resourceType: BeWidgetResourceType, drafts: SliceDraft[]
 }
 
 interface WidgetEditorDialogProps {
+  /**
+   * The shared filter-preset catalogue, resolved by the PAGE before this
+   * dialog is mounted.
+   *
+   * It has to arrive as a prop rather than be fetched here: the filter rows
+   * are seeded in a `useState` initializer, which runs once on mount, and
+   * `filterConditionsFromQuery` needs the catalogue at that moment to show an
+   * already-expanded deployed filter as the preset it came from. Fetching it
+   * inside this component would seed the rows as literal predicates and then
+   * have to overwrite them from an effect — the cascading-render pattern
+   * `react-hooks/set-state-in-effect` (correctly) rejects. The page owns the
+   * query, and this dialog is mounted only once it has settled, so the
+   * initializer always sees the final value.
+   *
+   * `undefined` means the deployment has no presets (or the catalogue failed
+   * to load): rows then render as literal predicates, which is correct
+   * behaviour, just without the preset affordance.
+   */
+  presets?: readonly BeDashboardFilterPreset[];
   /** `undefined` when creating a brand-new widget. */
   widget: BeDashboardWidget | undefined;
   /** Pre-fills the section field for a brand-new widget created via a
@@ -159,6 +187,7 @@ interface WidgetEditorDialogProps {
  * parallel fetch/render logic of its own.
  */
 export default function WidgetEditorDialog({
+  presets,
   widget,
   defaultSection,
   sectionSuggestions,
@@ -194,11 +223,13 @@ export default function WidgetEditorDialog({
   // from its original group-by config doesn't save a stale one.
   const [existingGroupBy, setExistingGroupBy] = useState(widget?.groupBy);
   const [conditions, setConditions] = useState<FilterCondition[]>(() =>
-    filterConditionsFromQuery(widget?.resourceType ?? "case", widget?.query),
+    filterConditionsFromQuery(widget?.resourceType ?? "case", widget?.query, presets),
   );
   const [sliceDrafts, setSliceDrafts] = useState<SliceDraft[]>(() =>
-    slicesToDrafts(widget?.resourceType ?? "case", widget?.slices),
+    slicesToDrafts(widget?.resourceType ?? "case", widget?.slices, presets),
   );
+
+
   const [columnDrafts, setColumnDrafts] = useState<ColumnDraft[]>(() =>
     columnsToDrafts(widget?.columns),
   );
@@ -464,6 +495,7 @@ export default function WidgetEditorDialog({
             resourceType={resourceType}
             conditions={conditions}
             onChange={setConditions}
+            presets={presets}
           />
 
           {isListShape && (
@@ -623,6 +655,7 @@ export default function WidgetEditorDialog({
                     resourceType={resourceType}
                     conditions={slice.conditions}
                     onChange={(next) => updateSlice(index, { conditions: next })}
+                    presets={presets}
                   />
                 </Box>
               ))}

--- a/apps/csm-portal/webapp/src/features/csm-admin/dashboards/components/WidgetFilterConditionEditor.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/dashboards/components/WidgetFilterConditionEditor.test.tsx
@@ -20,15 +20,18 @@ import "@testing-library/jest-dom/vitest";
 import { useState } from "react";
 import WidgetFilterConditionEditor from "@features/csm-admin/dashboards/components/WidgetFilterConditionEditor";
 import type { FilterCondition } from "@features/csm-admin/dashboards/utils/widgetQueryConditions";
+import type { BeDashboardFilterPreset } from "@api/backend/types";
 
 function Harness({
   initial,
   resourceType = "case",
   onChangeSpy,
+  presets,
 }: {
   initial: FilterCondition[];
   resourceType?: "case" | "incident";
   onChangeSpy?: (next: FilterCondition[]) => void;
+  presets?: BeDashboardFilterPreset[];
 }) {
   const [conditions, setConditions] = useState(initial);
   return (
@@ -39,9 +42,18 @@ function Harness({
         setConditions(next);
         onChangeSpy?.(next);
       }}
+      presets={presets}
     />
   );
 }
+
+const TEST_PRESETS: BeDashboardFilterPreset[] = [
+  {
+    name: "activeCaseStates",
+    filter: { field: "state", op: "in", values: ["open", "work_in_progress"] },
+  },
+  { name: "excludeDipTag", filter: { field: "tag", op: "notIn", values: ["s_dip"] } },
+];
 
 describe("WidgetFilterConditionEditor", () => {
   it("shows an empty-filters message and no rows when there are no conditions", () => {
@@ -130,5 +142,100 @@ describe("WidgetFilterConditionEditor", () => {
     // two ops offered for a non-case resourceType, but it must still show up
     // as the Select's own displayed value.
     expect(screen.getByRole("combobox", { name: "Operator" })).toHaveTextContent("is on/after (≥)");
+  });
+});
+
+describe("WidgetFilterConditionEditor — shared presets", () => {
+  it("offers 'Add preset' only when the deployment actually has presets", () => {
+    render(<Harness initial={[]} />);
+    expect(screen.queryByRole("button", { name: /add preset/i })).not.toBeInTheDocument();
+  });
+
+  it("offers 'Add preset' when presets exist for a case-like resourceType", () => {
+    render(<Harness initial={[]} presets={TEST_PRESETS} />);
+    expect(screen.getByRole("button", { name: /add preset/i })).toBeInTheDocument();
+  });
+
+  it("hides 'Add preset' for a non-case resourceType, which cannot express one", () => {
+    // Presets are expanded inside query.filters; no other resourceType's
+    // search contract has that array, so the affordance would be a trap.
+    render(<Harness initial={[]} resourceType="incident" presets={TEST_PRESETS} />);
+    expect(screen.queryByRole("button", { name: /add preset/i })).not.toBeInTheDocument();
+  });
+
+  it("adds a preset row with no name chosen yet", () => {
+    const spy = vi.fn();
+    render(<Harness initial={[]} presets={TEST_PRESETS} onChangeSpy={spy} />);
+    fireEvent.click(screen.getByRole("button", { name: /add preset/i }));
+    expect(spy).toHaveBeenCalledWith([
+      { field: "", op: "eq", values: [], preset: "" },
+    ]);
+    expect(screen.getByLabelText("Filter preset")).toBeInTheDocument();
+  });
+
+  it("renders a preset row as a preset picker, not as field/operator/values", () => {
+    render(
+      <Harness
+        initial={[{ field: "", op: "eq", values: [], preset: "activeCaseStates" }]}
+        presets={TEST_PRESETS}
+      />,
+    );
+    expect(screen.getByLabelText("Filter preset")).toHaveValue("activeCaseStates");
+    expect(screen.queryByLabelText("Filter field")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Filter value")).not.toBeInTheDocument();
+  });
+
+  it("shows what the chosen preset actually filters on", () => {
+    // The name alone does not say which states "active" means, and getting
+    // it wrong silently changes what the widget counts.
+    render(
+      <Harness
+        initial={[{ field: "", op: "eq", values: [], preset: "activeCaseStates" }]}
+        presets={TEST_PRESETS}
+      />,
+    );
+    expect(
+      screen.getByText(/state is any of open, work_in_progress/i),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps rendering a preset row whose name is not in the catalogue", () => {
+    // A definition may reference a preset this deployment does not define;
+    // the editor must not silently drop the row (which would erase it on the
+    // next save) — it shows it with no summary instead.
+    render(
+      <Harness
+        initial={[{ field: "", op: "eq", values: [], preset: "definedElsewhere" }]}
+        presets={TEST_PRESETS}
+      />,
+    );
+    expect(screen.getByLabelText("Filter preset")).toHaveValue("definedElsewhere");
+  });
+
+  it("removes a preset row via its own remove button", () => {
+    const spy = vi.fn();
+    render(
+      <Harness
+        initial={[{ field: "", op: "eq", values: [], preset: "activeCaseStates" }]}
+        presets={TEST_PRESETS}
+        onChangeSpy={spy}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /remove filter/i }));
+    expect(spy).toHaveBeenCalledWith([]);
+  });
+
+  it("keeps literal rows and preset rows side by side", () => {
+    render(
+      <Harness
+        initial={[
+          { field: "severity", op: "in", values: ["critical"] },
+          { field: "", op: "eq", values: [], preset: "excludeDipTag" },
+        ]}
+        presets={TEST_PRESETS}
+      />,
+    );
+    expect(screen.getByLabelText("Filter field")).toHaveValue("severity");
+    expect(screen.getByLabelText("Filter preset")).toHaveValue("excludeDipTag");
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-admin/dashboards/components/WidgetFilterConditionEditor.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/dashboards/components/WidgetFilterConditionEditor.tsx
@@ -26,9 +26,13 @@ import {
 } from "@wso2/oxygen-ui";
 import { Plus, Trash2 } from "@wso2/oxygen-ui-icons-react";
 import type { JSX } from "react";
-import type { BeWidgetResourceType } from "@api/backend/types";
+import type {
+  BeDashboardFilterPreset,
+  BeWidgetResourceType,
+} from "@api/backend/types";
 import {
   CASE_FIELD_OPTIONS,
+  isPresetCondition,
   operatorsForResourceType,
   usesCaseFieldFilterDsl,
   type FilterCondition,
@@ -51,6 +55,33 @@ interface WidgetFilterConditionEditorProps {
   resourceType: BeWidgetResourceType;
   conditions: FilterCondition[];
   onChange: (next: FilterCondition[]) => void;
+  /**
+   * The shared filter presets a row may reference. Omitted/empty hides the
+   * "Add preset" affordance entirely rather than offering an empty picker —
+   * a deployment with no presets file configured is legitimate.
+   */
+  presets?: readonly BeDashboardFilterPreset[];
+}
+
+/** Human-readable rendering of what a preset expands to, for the picker's
+ * helper text — an admin picking "activeCaseStates" from a list of names
+ * alone has no way to know which states that actually is. */
+function describePreset(preset: BeDashboardFilterPreset | undefined): string {
+  if (!preset) return "";
+  const { field, op, values } = preset.filter as {
+    field?: unknown;
+    op?: unknown;
+    values?: unknown;
+  };
+  if (typeof field !== "string" || typeof op !== "string") {
+    // A preset whose body is not the field/op/values shape this editor knows
+    // is still selectable — the backend, not this list, defines what is
+    // valid — it just cannot be summarized.
+    return JSON.stringify(preset.filter);
+  }
+  const label = OP_LABEL[op as FilterConditionOp] ?? op;
+  const rendered = Array.isArray(values) ? values.map(String).join(", ") : "";
+  return rendered.length > 0 ? `${field} ${label} ${rendered}` : `${field} ${label}`;
 }
 
 /**
@@ -64,6 +95,7 @@ export default function WidgetFilterConditionEditor({
   resourceType,
   conditions,
   onChange,
+  presets,
 }: WidgetFilterConditionEditorProps): JSX.Element {
   const isCaseLike = usesCaseFieldFilterDsl(resourceType);
   const fieldOptions = isCaseLike ? CASE_FIELD_OPTIONS : [];
@@ -87,6 +119,24 @@ export default function WidgetFilterConditionEditor({
     onChange([...conditions, { field: "", op: "eq", values: [] }]);
   };
 
+  // Presets only exist inside `query.filters`, which is the case field DSL —
+  // no other resourceType's search contract has that array at all, so a
+  // preset row there could not be serialized (see
+  // `queryFromFilterConditions`). Hidden rather than disabled: an
+  // affordance that can never work for this resourceType is noise.
+  // Array.isArray rather than a nullish check: this is a network-shaped
+  // value, and a 200 carrying something other than an array (a contract
+  // violation, or a caller passing the wrong thing) must degrade to "no
+  // presets offered" rather than throw and take the whole widget editor down
+  // with it. The filter rows themselves still work without a catalogue.
+  const presetOptions = isCaseLike && Array.isArray(presets) ? presets : [];
+  const canAddPreset = presetOptions.length > 0;
+  const presetByName = new Map(presetOptions.map((p) => [p.name, p]));
+
+  const addPresetRow = (): void => {
+    onChange([...conditions, { field: "", op: "eq", values: [], preset: "" }]);
+  };
+
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
       {conditions.length === 0 && (
@@ -104,16 +154,52 @@ export default function WidgetFilterConditionEditor({
         const rowOps = availableOps.includes(condition.op)
           ? availableOps
           : [...availableOps, condition.op];
+        const rowSx = {
+          display: "flex",
+          flexWrap: "wrap",
+          alignItems: "flex-start",
+          gap: 1,
+        } as const;
+
+        if (isPresetCondition(condition) || condition.preset !== undefined) {
+          const chosen = presetByName.get(condition.preset ?? "");
+          return (
+            <Box key={index} sx={rowSx}>
+              <Autocomplete
+                size="small"
+                options={presetOptions.map((p) => p.name)}
+                value={condition.preset ?? ""}
+                onChange={(_e, next) => updateRow(index, { preset: next ?? "" })}
+                sx={{ minWidth: 260, flex: "1 1 260px" }}
+                renderInput={(params) => (
+                  <TextField
+                    {...params}
+                    label="Shared preset"
+                    // The name alone does not say what the preset filters
+                    // on, and getting that wrong silently changes what the
+                    // widget counts.
+                    helperText={describePreset(chosen)}
+                    slotProps={{
+                      htmlInput: { ...params.inputProps, "aria-label": "Filter preset" },
+                    }}
+                  />
+                )}
+              />
+              <Tooltip title="Remove this filter">
+                <IconButton
+                  size="small"
+                  onClick={() => removeRow(index)}
+                  aria-label="Remove filter"
+                >
+                  <Trash2 size={16} />
+                </IconButton>
+              </Tooltip>
+            </Box>
+          );
+        }
+
         return (
-          <Box
-            key={index}
-            sx={{
-              display: "flex",
-              flexWrap: "wrap",
-              alignItems: "flex-start",
-              gap: 1,
-            }}
-          >
+          <Box key={index} sx={rowSx}>
             <Autocomplete
               freeSolo
               size="small"
@@ -180,15 +266,36 @@ export default function WidgetFilterConditionEditor({
           </Box>
         );
       })}
-      <Button
-        size="small"
-        variant="text"
-        startIcon={<Plus size={16} />}
-        onClick={addRow}
-        sx={{ alignSelf: "flex-start" }}
-      >
-        Add filter
-      </Button>
+      <Box sx={{ display: "flex", gap: 1, alignSelf: "flex-start" }}>
+        <Button
+          size="small"
+          variant="text"
+          startIcon={<Plus size={16} />}
+          onClick={addRow}
+        >
+          Add filter
+        </Button>
+        {canAddPreset && (
+          // Deliberately NOT wrapped in a Tooltip: MUI's Tooltip takes over
+          // the child's accessible name, so the button would stop being
+          // findable as "Add preset" by assistive tech (and by its own
+          // tests). The explanation lives in the caption below instead.
+          <Button
+            size="small"
+            variant="text"
+            startIcon={<Plus size={16} />}
+            onClick={addPresetRow}
+          >
+            Add preset
+          </Button>
+        )}
+      </Box>
+      {canAddPreset && (
+        <Typography variant="caption" color="text.secondary">
+          A preset references a shared, named condition by name instead of
+          spelling it out, so every dashboard using it changes together.
+        </Typography>
+      )}
     </Box>
   );
 }

--- a/apps/csm-portal/webapp/src/features/csm-admin/dashboards/pages/CsmDashboardBuilderEditorPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/dashboards/pages/CsmDashboardBuilderEditorPage.tsx
@@ -221,8 +221,11 @@ export default function CsmDashboardBuilderEditorPage(): JSX.Element {
   // initializer that needs the catalogue on the very first render (see
   // WidgetEditorDialogProps.presets). Starting the query at page mount means
   // it is long cached by the time an admin opens a widget.
-  const { data: filterPresets, isPending: filterPresetsPending } =
-    useDashboardFilterPresets();
+  const {
+    data: filterPresets,
+    isError: filterPresetsFailed,
+    refetch: refetchFilterPresets,
+  } = useDashboardFilterPresets();
   const { data: sharedSections } = useDashboardSharedSections();
   const [editingWidget, setEditingWidget] = useState<
     { widget: BeDashboardWidget | undefined; defaultSection?: string } | undefined
@@ -352,7 +355,7 @@ export default function CsmDashboardBuilderEditorPage(): JSX.Element {
   };
 
   const handleCopyJson = async (): Promise<void> => {
-    const deployable = deployableDashboardFromDraft(working);
+    const deployable = deployableDashboardFromDraft(working, filterPresets);
     try {
       await navigator.clipboard.writeText(JSON.stringify(deployable, null, 2));
       setCopyFeedback(true);
@@ -401,6 +404,32 @@ export default function CsmDashboardBuilderEditorPage(): JSX.Element {
         <Alert severity="info">
           Couldn't check this draft against what's currently deployed (GET /dashboards/{draftId}{" "}
           failed) — edits are still saved locally regardless.
+        </Alert>
+      )}
+
+      {filterPresetsFailed && (
+        // The widget editor stays shut while this is showing (see the
+        // editingWidget gate below). That is deliberate: without the preset
+        // catalogue, an existing widget's already-expanded filters cannot be
+        // recognised as the presets they came from, so opening the editor and
+        // saving would rewrite every shared reference on this dashboard as a
+        // literal -- silently, and with no way to tell afterwards. A shut
+        // editor with a reason beats a save that quietly strips references.
+        <Alert
+          severity="error"
+          action={
+            <Button
+              size="small"
+              color="inherit"
+              onClick={() => void refetchFilterPresets()}
+            >
+              Retry
+            </Button>
+          }
+        >
+          Could not load the shared filter presets, so widgets cannot be edited
+          safely right now — saving one would turn its shared preset references
+          into fixed copies. Everything else on this page still works.
         </Alert>
       )}
 
@@ -741,7 +770,13 @@ export default function CsmDashboardBuilderEditorPage(): JSX.Element {
         )}
       </SectionCard>
 
-      {editingWidget && !filterPresetsPending && (
+      {/* A NEW widget needs no catalogue: it has no server-expanded filters to
+          misread, and with no catalogue the editor simply offers no preset rows,
+          so nothing can be lost. Editing an EXISTING widget does need it —
+          without it, that widget's expanded filters would be re-saved as
+          literals and its shared references silently dropped. */}
+      {editingWidget &&
+        (editingWidget.widget === undefined || filterPresets !== undefined) && (
         <WidgetEditorDialog
           presets={filterPresets}
           widget={editingWidget.widget}

--- a/apps/csm-portal/webapp/src/features/csm-admin/dashboards/pages/CsmDashboardBuilderEditorPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/dashboards/pages/CsmDashboardBuilderEditorPage.tsx
@@ -45,13 +45,18 @@ import DashboardWidgetGrid from "@features/csm-dashboard/components/DashboardWid
 import SectionCard from "@features/csm-dashboard/components/SectionCard";
 import { WIDGET_GRID_SX } from "@features/csm-dashboard/utils/dashboardWidgetGridLayout";
 import WidgetEditorDialog from "@features/csm-admin/dashboards/components/WidgetEditorDialog";
-import { useDashboardFilterPresets } from "@features/csm-admin/dashboards/api/useDashboardSharedConfig";
+import {
+  useDashboardFilterPresets,
+  useDashboardSharedSections,
+} from "@features/csm-admin/dashboards/api/useDashboardSharedConfig";
+import { deployableDashboardFromDraft } from "@features/csm-admin/dashboards/utils/sharedConfigDraftsStorage";
 import { isDraftDrifted } from "@features/csm-admin/dashboards/utils/dashboardDrift";
 import {
   newDraftId,
   saveDashboardDraft,
   useDashboardDraft,
   type DashboardDraft,
+  type SectionInclude,
 } from "@features/csm-admin/dashboards/utils/dashboardDraftsStorage";
 
 const DASHBOARD_TYPES = ["cre", "sre", "cs"] as const;
@@ -218,6 +223,7 @@ export default function CsmDashboardBuilderEditorPage(): JSX.Element {
   // it is long cached by the time an admin opens a widget.
   const { data: filterPresets, isPending: filterPresetsPending } =
     useDashboardFilterPresets();
+  const { data: sharedSections } = useDashboardSharedSections();
   const [editingWidget, setEditingWidget] = useState<
     { widget: BeDashboardWidget | undefined; defaultSection?: string } | undefined
   >(undefined);
@@ -346,18 +352,7 @@ export default function CsmDashboardBuilderEditorPage(): JSX.Element {
   };
 
   const handleCopyJson = async (): Promise<void> => {
-    // Only the fields that actually mean something in the deployed
-    // registry's own JSON shape — `id`/`sourceDashboardId`/
-    // `emptySections`/`updatedAt` are this builder's own local bookkeeping
-    // and have no home there (see `DashboardDraft`'s own doc comment).
-    const deployable = {
-      displayName: working.displayName,
-      type: working.type,
-      isDefault: working.isDefault,
-      isTeamBased: working.isTeamBased,
-      targetTeam: working.targetTeam,
-      widgets: working.widgets,
-    };
+    const deployable = deployableDashboardFromDraft(working);
     try {
       await navigator.clipboard.writeText(JSON.stringify(deployable, null, 2));
       setCopyFeedback(true);
@@ -485,6 +480,129 @@ export default function CsmDashboardBuilderEditorPage(): JSX.Element {
             </FormControl>
           )}
         </Box>
+      </SectionCard>
+
+      <SectionCard
+        title="Shared sections"
+        action={
+          <Button
+            size="small"
+            variant="outlined"
+            startIcon={<Plus size={14} />}
+            disabled={(sharedSections ?? []).length === 0}
+            onClick={() =>
+              updateWorking({
+                includeSections: [
+                  ...(working.includeSections ?? []),
+                  { section: (sharedSections ?? [])[0]?.name ?? "", position: "start" },
+                ],
+              })
+            }
+          >
+            Include a section
+          </Button>
+        }
+      >
+        {(sharedSections ?? []).length === 0 ? (
+          <Typography variant="body2" color="text.secondary">
+            This deployment has no shared sections yet. Design one under
+            &ldquo;Shared presets &amp; sections&rdquo; on the dashboards list.
+          </Typography>
+        ) : (working.includeSections ?? []).length === 0 ? (
+          <Typography variant="body2" color="text.secondary">
+            None. Including a shared section pulls its widgets in by reference,
+            so editing the section changes every dashboard that includes it.
+          </Typography>
+        ) : (
+          <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+            {(working.includeSections ?? []).map((include, index) => {
+              const patch = (next: Partial<SectionInclude>): void =>
+                updateWorking({
+                  includeSections: (working.includeSections ?? []).map((inc, i) =>
+                    i === index ? { ...inc, ...next } : inc,
+                  ),
+                });
+              return (
+                <Box
+                  key={index}
+                  sx={{ display: "flex", flexWrap: "wrap", gap: 1, alignItems: "flex-start" }}
+                >
+                  <TextField
+                    select
+                    size="small"
+                    label="Section"
+                    value={include.section}
+                    onChange={(e) => patch({ section: e.target.value })}
+                    sx={{ minWidth: 200 }}
+                    slotProps={{
+                      inputLabel: { shrink: true, sx: { top: "0px !important" } },
+                      select: { notched: true },
+                    }}
+                  >
+                    {(sharedSections ?? []).map((sec) => (
+                      <MenuItem key={sec.name} value={sec.name}>
+                        {sec.name}
+                      </MenuItem>
+                    ))}
+                  </TextField>
+                  <TextField
+                    select
+                    size="small"
+                    label="Position"
+                    value={include.position ?? "start"}
+                    onChange={(e) =>
+                      patch({ position: e.target.value as "start" | "end" })
+                    }
+                    sx={{ minWidth: 140 }}
+                    slotProps={{
+                      inputLabel: { shrink: true, sx: { top: "0px !important" } },
+                      select: { notched: true },
+                    }}
+                  >
+                    <MenuItem value="start">Before own widgets</MenuItem>
+                    <MenuItem value="end">After own widgets</MenuItem>
+                  </TextField>
+                  <TextField
+                    size="small"
+                    label="Widget id prefix"
+                    value={include.idPrefix ?? ""}
+                    onChange={(e) => patch({ idPrefix: e.target.value || undefined })}
+                    helperText="Optional, e.g. ob_"
+                    sx={{ minWidth: 150 }}
+                  />
+                  <TextField
+                    size="small"
+                    label="Heading override"
+                    value={include.displayName ?? ""}
+                    onChange={(e) => patch({ displayName: e.target.value || undefined })}
+                    helperText="Optional"
+                    sx={{ minWidth: 170 }}
+                  />
+                  <Tooltip title="Stop including this section">
+                    <IconButton
+                      size="small"
+                      aria-label={`Remove included section ${include.section}`}
+                      onClick={() =>
+                        updateWorking({
+                          includeSections: (working.includeSections ?? []).filter(
+                            (_, i) => i !== index,
+                          ),
+                        })
+                      }
+                    >
+                      <Trash2 size={16} />
+                    </IconButton>
+                  </Tooltip>
+                </Box>
+              );
+            })}
+            <Typography variant="caption" color="text.secondary">
+              Included widgets are not shown in the preview below: they are
+              resolved when the definition is loaded, from whatever the shared
+              section says at that moment.
+            </Typography>
+          </Box>
+        )}
       </SectionCard>
 
       <SectionCard

--- a/apps/csm-portal/webapp/src/features/csm-admin/dashboards/pages/CsmDashboardBuilderEditorPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/dashboards/pages/CsmDashboardBuilderEditorPage.tsx
@@ -226,7 +226,12 @@ export default function CsmDashboardBuilderEditorPage(): JSX.Element {
     isError: filterPresetsFailed,
     refetch: refetchFilterPresets,
   } = useDashboardFilterPresets();
-  const { data: sharedSections } = useDashboardSharedSections();
+  const {
+    data: sharedSections,
+    isPending: sharedSectionsPending,
+    isError: sharedSectionsFailed,
+    refetch: refetchSharedSections,
+  } = useDashboardSharedSections();
 
   // Exporting without the preset catalogue can only LOSE something when the
   // draft came from a deployed dashboard: those widgets hold the API's
@@ -559,7 +564,39 @@ export default function CsmDashboardBuilderEditorPage(): JSX.Element {
           </Button>
         }
       >
-        {(sharedSections ?? []).length === 0 ? (
+        {/* Three distinct states, not two. Collapsing "still loading" and
+            "the request failed" into the same empty-list message told the
+            admin this deployment has no shared sections, which in both cases
+            is a claim we have no basis for -- and the one case where it IS
+            true looks identical, so there was no way to tell them apart.
+            The failure notice sits ALONGSIDE the list rather than replacing
+            it: whatever this dashboard already includes is still real and
+            still removable, it just cannot be added to until the catalogue
+            loads. */}
+        {sharedSectionsFailed && (
+          <Alert
+            severity="error"
+            sx={{ mb: 1.5 }}
+            action={
+              <Button
+                size="small"
+                color="inherit"
+                onClick={() => void refetchSharedSections()}
+              >
+                Retry
+              </Button>
+            }
+          >
+            Could not load the shared sections, so there is nothing new to
+            choose from right now. Anything this dashboard already includes is
+            unaffected.
+          </Alert>
+        )}
+        {sharedSectionsPending ? (
+          <Typography variant="body2" color="text.secondary">
+            Loading shared sections&hellip;
+          </Typography>
+        ) : !sharedSectionsFailed && (sharedSections ?? []).length === 0 ? (
           <Typography variant="body2" color="text.secondary">
             This deployment has no shared sections yet. Design one under
             &ldquo;Shared presets &amp; sections&rdquo; on the dashboards list.

--- a/apps/csm-portal/webapp/src/features/csm-admin/dashboards/pages/CsmDashboardBuilderEditorPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/dashboards/pages/CsmDashboardBuilderEditorPage.tsx
@@ -45,6 +45,7 @@ import DashboardWidgetGrid from "@features/csm-dashboard/components/DashboardWid
 import SectionCard from "@features/csm-dashboard/components/SectionCard";
 import { WIDGET_GRID_SX } from "@features/csm-dashboard/utils/dashboardWidgetGridLayout";
 import WidgetEditorDialog from "@features/csm-admin/dashboards/components/WidgetEditorDialog";
+import { useDashboardFilterPresets } from "@features/csm-admin/dashboards/api/useDashboardSharedConfig";
 import { isDraftDrifted } from "@features/csm-admin/dashboards/utils/dashboardDrift";
 import {
   newDraftId,
@@ -210,6 +211,13 @@ export default function CsmDashboardBuilderEditorPage(): JSX.Element {
     };
   }, []);
 
+  // Fetched here, not in the widget dialog, and the dialog is not mounted
+  // until it has settled: the dialog seeds its filter rows in a useState
+  // initializer that needs the catalogue on the very first render (see
+  // WidgetEditorDialogProps.presets). Starting the query at page mount means
+  // it is long cached by the time an admin opens a widget.
+  const { data: filterPresets, isPending: filterPresetsPending } =
+    useDashboardFilterPresets();
   const [editingWidget, setEditingWidget] = useState<
     { widget: BeDashboardWidget | undefined; defaultSection?: string } | undefined
   >(undefined);
@@ -615,8 +623,9 @@ export default function CsmDashboardBuilderEditorPage(): JSX.Element {
         )}
       </SectionCard>
 
-      {editingWidget && (
+      {editingWidget && !filterPresetsPending && (
         <WidgetEditorDialog
+          presets={filterPresets}
           widget={editingWidget.widget}
           defaultSection={editingWidget.defaultSection}
           sectionSuggestions={sectionNames}

--- a/apps/csm-portal/webapp/src/features/csm-admin/dashboards/pages/CsmDashboardBuilderEditorPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/dashboards/pages/CsmDashboardBuilderEditorPage.tsx
@@ -227,6 +227,17 @@ export default function CsmDashboardBuilderEditorPage(): JSX.Element {
     refetch: refetchFilterPresets,
   } = useDashboardFilterPresets();
   const { data: sharedSections } = useDashboardSharedSections();
+
+  // Exporting without the preset catalogue can only LOSE something when the
+  // draft came from a deployed dashboard: those widgets hold the API's
+  // already-expanded filters, and collapse-back needs the catalogue to turn
+  // them into references again. A draft that was authored here has its
+  // references stored as {"preset": ...} in the draft already (the editor
+  // wrote them that way), so its export is lossless with or without the
+  // catalogue — blocking that case would break the builder for no gain, the
+  // same reasoning the widget-editor gate uses.
+  const exportCouldLoseReferences =
+    working?.sourceDashboardId !== undefined && filterPresets === undefined;
   const [editingWidget, setEditingWidget] = useState<
     { widget: BeDashboardWidget | undefined; defaultSection?: string } | undefined
   >(undefined);
@@ -355,6 +366,10 @@ export default function CsmDashboardBuilderEditorPage(): JSX.Element {
   };
 
   const handleCopyJson = async (): Promise<void> => {
+    // Guarded here as well as on the button: a disabled button is a UI
+    // affordance, not an invariant, and this must not be reachable from
+    // anywhere else while the catalogue is missing.
+    if (exportCouldLoseReferences) return;
     const deployable = deployableDashboardFromDraft(working, filterPresets);
     try {
       await navigator.clipboard.writeText(JSON.stringify(deployable, null, 2));
@@ -385,8 +400,20 @@ export default function CsmDashboardBuilderEditorPage(): JSX.Element {
           <Typography variant="caption" color="text.secondary">
             {savedAt ? `Saved locally ${new Date(savedAt).toLocaleTimeString()}` : "Not saved yet"}
           </Typography>
-          <Tooltip title="Copy this dashboard's deployable JSON to the clipboard">
-            <Button size="small" variant="outlined" startIcon={<Copy size={14} />} onClick={() => void handleCopyJson()}>
+          <Tooltip
+            title={
+              exportCouldLoseReferences
+                ? "Unavailable while the shared filter presets cannot be loaded: exporting now would turn this dashboard's shared preset references into fixed copies."
+                : "Copy this dashboard's deployable JSON to the clipboard"
+            }
+          >
+            <Button
+              size="small"
+              variant="outlined"
+              startIcon={<Copy size={14} />}
+              disabled={exportCouldLoseReferences}
+              onClick={() => void handleCopyJson()}
+            >
               {copyFeedback ? "Copied!" : "Copy as JSON"}
             </Button>
           </Tooltip>

--- a/apps/csm-portal/webapp/src/features/csm-admin/dashboards/pages/CsmDashboardBuilderListPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/dashboards/pages/CsmDashboardBuilderListPage.tsx
@@ -96,9 +96,21 @@ export default function CsmDashboardBuilderListPage(): JSX.Element {
           Build or adjust a dashboard's widgets, then hand the exported JSON to a maintainer to
           deploy — this builder never writes to the live registry itself.
         </Typography>
-        <Button variant="contained" startIcon={<Plus size={16} />} onClick={handleCreate}>
-          Create new dashboard
-        </Button>
+        <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
+          <Button variant="contained" startIcon={<Plus size={16} />} onClick={handleCreate}>
+            Create new dashboard
+          </Button>
+          {/* Presets and sections are shared ACROSS dashboards and deploy as
+              their own files, so they get their own page rather than living
+              inside one dashboard's editor. */}
+          <Button
+            variant="outlined"
+            startIcon={<LayoutGrid size={16} />}
+            onClick={() => navigate("/admin/dashboards/shared")}
+          >
+            Shared presets &amp; sections
+          </Button>
+        </Box>
       </Box>
 
       {isError ? (

--- a/apps/csm-portal/webapp/src/features/csm-admin/dashboards/pages/CsmDashboardSharedConfigPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/dashboards/pages/CsmDashboardSharedConfigPage.tsx
@@ -1,0 +1,346 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  IconButton,
+  List,
+  ListItem,
+  ListItemText,
+  Tab,
+  Tabs,
+  Tooltip,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { ArrowLeft, Copy, Pencil, Plus, Trash2 } from "@wso2/oxygen-ui-icons-react";
+import { useState, type JSX } from "react";
+import { Link as RouterLink } from "react-router";
+import PresetEditorDialog from "@features/csm-admin/dashboards/components/PresetEditorDialog";
+import SectionEditorDialog from "@features/csm-admin/dashboards/components/SectionEditorDialog";
+import {
+  useDashboardFilterPresets,
+  useDashboardSharedSections,
+} from "@features/csm-admin/dashboards/api/useDashboardSharedConfig";
+import {
+  presetsFileFromDraft,
+  saveSharedConfigDraft,
+  sectionsFileFromDraft,
+  seedSharedConfigDraft,
+  useSharedConfigDraft,
+  type PresetDraft,
+  type SectionDraft,
+} from "@features/csm-admin/dashboards/utils/sharedConfigDraftsStorage";
+
+/**
+ * Designs the two SHARED dashboard config files: the named filter presets and
+ * the reusable sections that dashboard definitions reference by name.
+ *
+ * Same deploy story as the dashboard builder itself, for the same reason —
+ * these are deployment configuration with no write API, so the output of this
+ * page is JSON to hand to a maintainer, and everything until then lives in
+ * `localStorage`. Nothing here changes what is currently deployed.
+ *
+ * Seeded from what IS deployed on first open, so an admin edits reality
+ * rather than retyping it. After that first seed the local draft is
+ * authoritative, so a deletion sticks instead of reappearing (see
+ * `seedSharedConfigDraft`).
+ */
+export default function CsmDashboardSharedConfigPage(): JSX.Element {
+  const { data: deployedPresets, isPending: presetsPending } = useDashboardFilterPresets();
+  const { data: deployedSections, isPending: sectionsPending } = useDashboardSharedSections();
+  const draft = useSharedConfigDraft();
+
+  const [tab, setTab] = useState<"presets" | "sections">("presets");
+  const [editingPreset, setEditingPreset] = useState<
+    { preset?: PresetDraft; index?: number } | undefined
+  >(undefined);
+  const [editingSection, setEditingSection] = useState<
+    { section?: SectionDraft; index?: number } | undefined
+  >(undefined);
+  const [copied, setCopied] = useState<"presets" | "sections" | undefined>(undefined);
+
+  const loading = presetsPending || sectionsPending;
+
+  // Fold the deployed catalogues in once, as a render-time side effect
+  // guarded by the draft's own `seeded` flag rather than an effect: this
+  // writes to localStorage and then re-reads through the storage event, so
+  // there is no React state to cascade (and no set-state-in-effect).
+  if (!loading && !draft.seeded) {
+    seedSharedConfigDraft(
+      (deployedPresets ?? []).map((p) => ({ name: p.name, filter: p.filter })),
+      (deployedSections ?? []).map((s) => ({
+        name: s.name,
+        displayName: s.displayName,
+        widgets: s.widgets,
+      })),
+    );
+  }
+
+  const deployedPresetNames = new Set((deployedPresets ?? []).map((p) => p.name));
+  const deployedSectionNames = new Set((deployedSections ?? []).map((s) => s.name));
+
+  const save = (next: Partial<Pick<typeof draft, "presets" | "sections">>): void => {
+    saveSharedConfigDraft({
+      presets: next.presets ?? draft.presets,
+      sections: next.sections ?? draft.sections,
+      seeded: draft.seeded,
+    });
+  };
+
+  const copyJson = async (which: "presets" | "sections"): Promise<void> => {
+    const payload =
+      which === "presets"
+        ? presetsFileFromDraft(draft.presets)
+        : sectionsFileFromDraft(draft.sections);
+    try {
+      await navigator.clipboard.writeText(JSON.stringify(payload, null, 2));
+      setCopied(which);
+      setTimeout(() => setCopied(undefined), 2000);
+    } catch {
+      // Clipboard can be denied by permissions policy; failing silently is
+      // consistent with the dashboard builder's own copy action.
+    }
+  };
+
+  if (loading) {
+    return (
+      <Box sx={{ display: "flex", justifyContent: "center", py: 6 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+        <Button
+          component={RouterLink}
+          to="/admin/dashboards"
+          size="small"
+          startIcon={<ArrowLeft size={16} />}
+        >
+          Dashboards
+        </Button>
+        <Typography variant="h6">Shared dashboard config</Typography>
+      </Box>
+
+      <Alert severity="info">
+        Presets and sections are shared across dashboards and deployed as their
+        own files. Design them here, then copy the JSON and hand it to a
+        maintainer — nothing on this page changes what is deployed.
+      </Alert>
+
+      <Tabs value={tab} onChange={(_e, next: "presets" | "sections") => setTab(next)}>
+        <Tab value="presets" label={`Presets (${draft.presets.length})`} />
+        <Tab value="sections" label={`Sections (${draft.sections.length})`} />
+      </Tabs>
+
+      {tab === "presets" && (
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+          <Box sx={{ display: "flex", gap: 1 }}>
+            <Button
+              size="small"
+              variant="text"
+              startIcon={<Plus size={16} />}
+              onClick={() => setEditingPreset({})}
+            >
+              New preset
+            </Button>
+            <Button
+              size="small"
+              variant="outlined"
+              startIcon={<Copy size={14} />}
+              onClick={() => void copyJson("presets")}
+            >
+              {copied === "presets" ? "Copied!" : "Copy _presets.json"}
+            </Button>
+          </Box>
+          {draft.presets.length === 0 ? (
+            <Typography variant="body2" color="text.secondary">
+              No presets yet.
+            </Typography>
+          ) : (
+            <List dense disablePadding>
+              {draft.presets.map((preset, index) => (
+                <ListItem
+                  key={preset.name}
+                  disableGutters
+                  secondaryAction={
+                    <Box>
+                      <Tooltip title="Edit this preset">
+                        <IconButton
+                          size="small"
+                          aria-label={`Edit preset ${preset.name}`}
+                          onClick={() => setEditingPreset({ preset, index })}
+                        >
+                          <Pencil size={16} />
+                        </IconButton>
+                      </Tooltip>
+                      <Tooltip title="Remove this preset">
+                        <IconButton
+                          size="small"
+                          aria-label={`Remove preset ${preset.name}`}
+                          onClick={() =>
+                            save({ presets: draft.presets.filter((_, i) => i !== index) })
+                          }
+                        >
+                          <Trash2 size={16} />
+                        </IconButton>
+                      </Tooltip>
+                    </Box>
+                  }
+                >
+                  <ListItemText
+                    primary={
+                      <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                        {preset.name}
+                        {/* Which entries already exist in the deployed file,
+                            so an admin can tell what a maintainer still has
+                            to land. */}
+                        {!deployedPresetNames.has(preset.name) && (
+                          <Chip size="small" label="not deployed" color="warning" />
+                        )}
+                      </Box>
+                    }
+                    secondary={JSON.stringify(preset.filter)}
+                  />
+                </ListItem>
+              ))}
+            </List>
+          )}
+        </Box>
+      )}
+
+      {tab === "sections" && (
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+          <Box sx={{ display: "flex", gap: 1 }}>
+            <Button
+              size="small"
+              variant="text"
+              startIcon={<Plus size={16} />}
+              onClick={() => setEditingSection({})}
+            >
+              New section
+            </Button>
+            <Button
+              size="small"
+              variant="outlined"
+              startIcon={<Copy size={14} />}
+              onClick={() => void copyJson("sections")}
+            >
+              {copied === "sections" ? "Copied!" : "Copy _sections.json"}
+            </Button>
+          </Box>
+          {draft.sections.length === 0 ? (
+            <Typography variant="body2" color="text.secondary">
+              No sections yet.
+            </Typography>
+          ) : (
+            <List dense disablePadding>
+              {draft.sections.map((section, index) => (
+                <ListItem
+                  key={section.name}
+                  disableGutters
+                  secondaryAction={
+                    <Box>
+                      <Tooltip title="Edit this section">
+                        <IconButton
+                          size="small"
+                          aria-label={`Edit section ${section.name}`}
+                          onClick={() => setEditingSection({ section, index })}
+                        >
+                          <Pencil size={16} />
+                        </IconButton>
+                      </Tooltip>
+                      <Tooltip title="Remove this section">
+                        <IconButton
+                          size="small"
+                          aria-label={`Remove section ${section.name}`}
+                          onClick={() =>
+                            save({ sections: draft.sections.filter((_, i) => i !== index) })
+                          }
+                        >
+                          <Trash2 size={16} />
+                        </IconButton>
+                      </Tooltip>
+                    </Box>
+                  }
+                >
+                  <ListItemText
+                    primary={
+                      <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                        {section.name}
+                        {!deployedSectionNames.has(section.name) && (
+                          <Chip size="small" label="not deployed" color="warning" />
+                        )}
+                      </Box>
+                    }
+                    secondary={`${section.displayName} · ${section.widgets.length} widget${
+                      section.widgets.length === 1 ? "" : "s"
+                    }`}
+                  />
+                </ListItem>
+              ))}
+            </List>
+          )}
+        </Box>
+      )}
+
+      {editingPreset && (
+        <PresetEditorDialog
+          preset={editingPreset.preset}
+          takenNames={draft.presets
+            .filter((_, i) => i !== editingPreset.index)
+            .map((p) => p.name)}
+          onClose={() => setEditingPreset(undefined)}
+          onSave={(preset) => {
+            save({
+              presets:
+                editingPreset.index === undefined
+                  ? [...draft.presets, preset]
+                  : draft.presets.map((p, i) => (i === editingPreset.index ? preset : p)),
+            });
+            setEditingPreset(undefined);
+          }}
+        />
+      )}
+
+      {editingSection && (
+        <SectionEditorDialog
+          section={editingSection.section}
+          presets={deployedPresets}
+          takenNames={draft.sections
+            .filter((_, i) => i !== editingSection.index)
+            .map((s) => s.name)}
+          onClose={() => setEditingSection(undefined)}
+          onSave={(section) => {
+            save({
+              sections:
+                editingSection.index === undefined
+                  ? [...draft.sections, section]
+                  : draft.sections.map((s, i) => (i === editingSection.index ? section : s)),
+            });
+            setEditingSection(undefined);
+          }}
+        />
+      )}
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-admin/dashboards/pages/CsmDashboardSharedConfigPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-admin/dashboards/pages/CsmDashboardSharedConfigPage.tsx
@@ -63,8 +63,18 @@ import {
  * `seedSharedConfigDraft`).
  */
 export default function CsmDashboardSharedConfigPage(): JSX.Element {
-  const { data: deployedPresets, isPending: presetsPending } = useDashboardFilterPresets();
-  const { data: deployedSections, isPending: sectionsPending } = useDashboardSharedSections();
+  const {
+    data: deployedPresets,
+    isSuccess: presetsLoaded,
+    isError: presetsFailed,
+    refetch: refetchPresets,
+  } = useDashboardFilterPresets();
+  const {
+    data: deployedSections,
+    isSuccess: sectionsLoaded,
+    isError: sectionsFailed,
+    refetch: refetchSections,
+  } = useDashboardSharedSections();
   const draft = useSharedConfigDraft();
 
   const [tab, setTab] = useState<"presets" | "sections">("presets");
@@ -76,13 +86,19 @@ export default function CsmDashboardSharedConfigPage(): JSX.Element {
   >(undefined);
   const [copied, setCopied] = useState<"presets" | "sections" | undefined>(undefined);
 
-  const loading = presetsPending || sectionsPending;
+  // Both catalogues must have SUCCEEDED, not merely settled. Seeding is a
+  // one-shot, persisted decision (see the `seeded` flag), so seeding from a
+  // failed request would bake a half-empty draft in permanently: the flag
+  // says "already seeded", the retry never runs, and the deployed entries
+  // that failed to load can never be recovered without clearing storage.
+  const catalogueReady = presetsLoaded && sectionsLoaded;
+  const catalogueFailed = presetsFailed || sectionsFailed;
 
   // Fold the deployed catalogues in once, as a render-time side effect
   // guarded by the draft's own `seeded` flag rather than an effect: this
   // writes to localStorage and then re-reads through the storage event, so
   // there is no React state to cascade (and no set-state-in-effect).
-  if (!loading && !draft.seeded) {
+  if (catalogueReady && !draft.seeded) {
     seedSharedConfigDraft(
       (deployedPresets ?? []).map((p) => ({ name: p.name, filter: p.filter })),
       (deployedSections ?? []).map((s) => ({
@@ -108,7 +124,7 @@ export default function CsmDashboardSharedConfigPage(): JSX.Element {
     const payload =
       which === "presets"
         ? presetsFileFromDraft(draft.presets)
-        : sectionsFileFromDraft(draft.sections);
+        : sectionsFileFromDraft(draft.sections, draft.presets);
     try {
       await navigator.clipboard.writeText(JSON.stringify(payload, null, 2));
       setCopied(which);
@@ -119,7 +135,34 @@ export default function CsmDashboardSharedConfigPage(): JSX.Element {
     }
   };
 
-  if (loading) {
+  if (catalogueFailed) {
+    // Deliberately blocks the whole page rather than showing an empty
+    // designer: an empty designer here looks like "nothing is configured",
+    // and copying its JSON would hand a maintainer a file that deletes every
+    // deployed preset and section.
+    return (
+      <Alert
+        severity="error"
+        action={
+          <Button
+            size="small"
+            color="inherit"
+            onClick={() => {
+              void refetchPresets();
+              void refetchSections();
+            }}
+          >
+            Retry
+          </Button>
+        }
+      >
+        Could not load what is currently deployed, so this page cannot show you
+        an accurate starting point. Nothing has been changed.
+      </Alert>
+    );
+  }
+
+  if (!catalogueReady) {
     return (
       <Box sx={{ display: "flex", justifyContent: "center", py: 6 }}>
         <CircularProgress />
@@ -325,7 +368,14 @@ export default function CsmDashboardSharedConfigPage(): JSX.Element {
       {editingSection && (
         <SectionEditorDialog
           section={editingSection.section}
-          presets={deployedPresets}
+          // The local draft's presets, not just the deployed ones: a preset
+          // authored on the Presets tab a moment ago is exactly what an author
+          // wants to reference from a section they are building now, and
+          // offering only deployed ones would make a newly designed preset
+          // unusable until someone deploys it. The draft already contains
+          // every deployed preset (it was seeded from them), so this is a
+          // superset, with local edits winning.
+          presets={draft.presets}
           takenNames={draft.sections
             .filter((_, i) => i !== editingSection.index)
             .map((s) => s.name)}

--- a/apps/csm-portal/webapp/src/features/csm-admin/dashboards/utils/dashboardDraftsStorage.ts
+++ b/apps/csm-portal/webapp/src/features/csm-admin/dashboards/utils/dashboardDraftsStorage.ts
@@ -24,6 +24,32 @@ import type { BeDashboardWidget } from "@api/backend/types";
  * out-of-band by a maintainer). See `DashboardBuilderEditorPage`'s own doc
  * comment for the deploy story.
  */
+/**
+ * One `includeSections` entry: which shared section to pull in, and the
+ * per-dashboard adjustments that let one section definition serve dashboards
+ * that are not identical.
+ *
+ * Mirrors the backend's own `SectionInclude`. `extraFilters` is deliberately
+ * NOT exposed by the builder yet — it is ANDed into every included
+ * case-family widget's filters, which is powerful and easy to get quietly
+ * wrong, and no dashboard needs it from the UI today. A definition that
+ * already carries one keeps it: it round-trips through `unknown[]` untouched
+ * rather than being dropped on save.
+ */
+export interface SectionInclude {
+  /** Name of the section in the shared section catalogue. */
+  section: string;
+  /** Prepended to each included widget's id, so a dashboard already shipping
+   * prefixed widget ids can adopt a section without renaming its widgets. */
+  idPrefix?: string;
+  /** Overrides the section's own heading for this dashboard only. */
+  displayName?: string;
+  /** Whether the section leads or trails this dashboard's own widgets. */
+  position?: "start" | "end";
+  /** Opaque passthrough — see this type's own doc comment. */
+  extraFilters?: unknown[];
+}
+
 export interface DashboardDraft {
   /**
    * Local draft id — the storage key. For a draft opened from a deployed
@@ -57,6 +83,19 @@ export interface DashboardDraft {
    * emergent grouping of `widget.section` values.
    */
   emptySections: string[];
+  /**
+   * Shared sections this dashboard pulls in by name, written to the deployed
+   * definition's own `includeSections` (see the backend's
+   * `expandIncludedSections`).
+   *
+   * Not merged into `widgets`: the whole value of a reference is that the
+   * section's content stays in one place and every dashboard using it changes
+   * together. Expanding it here would produce a copy that silently stops
+   * tracking the original.
+   *
+   * Absent on a draft written before this field existed, hence optional.
+   */
+  includeSections?: SectionInclude[];
   /** ISO timestamp of the last local save, shown in the editor and used to
    * order the builder's own "local drafts" list. */
   updatedAt: string;

--- a/apps/csm-portal/webapp/src/features/csm-admin/dashboards/utils/sharedConfigDraftsStorage.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-admin/dashboards/utils/sharedConfigDraftsStorage.test.ts
@@ -229,3 +229,142 @@ describe("deployableDashboardFromDraft", () => {
     expect(out).not.toHaveProperty("updatedAt");
   });
 });
+
+describe("read() defends the contents of the persisted arrays", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("drops a null preset entry instead of throwing on it later", () => {
+    // Previously survived read() (Array.isArray passes) and then threw on
+    // `p.name` during seeding, leaving the designer unopenable until the
+    // user cleared localStorage by hand.
+    localStorage.setItem(
+      "csm.dashboardSharedConfigDraft",
+      JSON.stringify({ presets: [null, { name: "ok", filter: { a: 1 } }], sections: [] }),
+    );
+    const got = getSharedConfigDraft();
+    expect(got.presets).toEqual([{ name: "ok", filter: { a: 1 } }]);
+  });
+
+  it("drops a preset with no filter body", () => {
+    localStorage.setItem(
+      "csm.dashboardSharedConfigDraft",
+      JSON.stringify({ presets: [{ name: "bad" }], sections: [] }),
+    );
+    expect(getSharedConfigDraft().presets).toEqual([]);
+  });
+
+  it("drops a malformed section and malformed widgets inside a good one", () => {
+    localStorage.setItem(
+      "csm.dashboardSharedConfigDraft",
+      JSON.stringify({
+        presets: [],
+        sections: [
+          null,
+          { name: "no-widgets-array", displayName: "X" },
+          { name: "ok", displayName: "Ok", widgets: [null, { widgetId: "w" }] },
+        ],
+      }),
+    );
+    const got = getSharedConfigDraft();
+    expect(got.sections).toHaveLength(1);
+    expect(got.sections[0].name).toBe("ok");
+    expect(got.sections[0].widgets).toEqual([{ widgetId: "w" }]);
+  });
+
+  it("seeding still works over a draft that had malformed entries", () => {
+    localStorage.setItem(
+      "csm.dashboardSharedConfigDraft",
+      JSON.stringify({ presets: [null], sections: [null] }),
+    );
+    const got = seedSharedConfigDraft([{ name: "p", filter: {} }], []);
+    expect(got.presets).toEqual([{ name: "p", filter: {} }]);
+  });
+});
+
+describe("export-time preset collapse", () => {
+  const presets = [
+    {
+      name: "activeCaseStates",
+      filter: { field: "state", op: "in", values: ["open", "work_in_progress"] },
+    },
+  ];
+  const expanded = {
+    filters: [{ field: "state", op: "in", values: ["open", "work_in_progress"] }],
+  };
+
+  it("rewrites a literal filter back to its preset reference on export", () => {
+    // Covers the widget an admin never opened in the editor: the draft holds
+    // the API's expanded form, so without this the reference is lost purely
+    // because nobody happened to click that widget.
+    const out = deployableDashboardFromDraft(
+      {
+        id: "d",
+        displayName: "D",
+        isDefault: false,
+        isTeamBased: false,
+        widgets: [widget({ query: expanded })],
+      },
+      presets,
+    );
+    const widgets = out.widgets as Record<string, unknown>[];
+    expect(widgets[0].query).toEqual({ filters: [{ preset: "activeCaseStates" }] });
+  });
+
+  it("rewrites slice queries too", () => {
+    const out = deployableDashboardFromDraft(
+      {
+        id: "d",
+        displayName: "D",
+        isDefault: false,
+        isTeamBased: false,
+        widgets: [
+          widget({
+            shape: "pie",
+            query: null,
+            slices: [{ label: "A", query: expanded }],
+          }),
+        ],
+      },
+      presets,
+    );
+    const widgets = out.widgets as Record<string, unknown>[];
+    const slices = widgets[0].slices as { query: unknown }[];
+    expect(slices[0].query).toEqual({ filters: [{ preset: "activeCaseStates" }] });
+  });
+
+  it("leaves a filter no preset accounts for alone", () => {
+    const other = { filters: [{ field: "severity", op: "in", values: ["critical"] }] };
+    const out = deployableDashboardFromDraft(
+      {
+        id: "d",
+        displayName: "D",
+        isDefault: false,
+        isTeamBased: false,
+        widgets: [widget({ query: other })],
+      },
+      presets,
+    );
+    const widgets = out.widgets as Record<string, unknown>[];
+    expect(widgets[0].query).toEqual(other);
+  });
+
+  it("emits literals unchanged when there is no catalogue", () => {
+    const out = deployableDashboardFromDraft({
+      id: "d",
+      displayName: "D",
+      isDefault: false,
+      isTeamBased: false,
+      widgets: [widget({ query: expanded })],
+    });
+    const widgets = out.widgets as Record<string, unknown>[];
+    expect(widgets[0].query).toEqual(expanded);
+  });
+
+  it("collapses inside a designed section's widgets too", () => {
+    const out = sectionsFileFromDraft(
+      [{ name: "s", displayName: "S", widgets: [widget({ query: expanded })] }],
+      presets,
+    );
+    expect(out.s.widgets[0].query).toEqual({ filters: [{ preset: "activeCaseStates" }] });
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-admin/dashboards/utils/sharedConfigDraftsStorage.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-admin/dashboards/utils/sharedConfigDraftsStorage.test.ts
@@ -1,0 +1,178 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { beforeEach, describe, expect, it } from "vitest";
+import type { BeDashboardWidget } from "@api/backend/types";
+import {
+  getSharedConfigDraft,
+  presetsFileFromDraft,
+  saveSharedConfigDraft,
+  sectionsFileFromDraft,
+  seedSharedConfigDraft,
+  widgetToDefinition,
+} from "@features/csm-admin/dashboards/utils/sharedConfigDraftsStorage";
+
+const widget = (overrides: Partial<BeDashboardWidget> = {}): BeDashboardWidget => ({
+  widgetId: "my_open",
+  displayName: "My Open",
+  resourceType: "case",
+  shape: "list",
+  gridWidth: 12,
+  query: { filters: [{ preset: "activeCaseStates" }] },
+  ...overrides,
+});
+
+describe("sharedConfigDraftsStorage", () => {
+  beforeEach(() => localStorage.clear());
+
+  describe("presetsFileFromDraft", () => {
+    it("emits the loader's name-keyed shape, not the endpoint's array shape", () => {
+      expect(
+        presetsFileFromDraft([
+          { name: "b", filter: { field: "state", op: "in", values: ["open"] } },
+          { name: "a", filter: { field: "tag", op: "in", values: ["x"] } },
+        ]),
+      ).toEqual({
+        a: { field: "tag", op: "in", values: ["x"] },
+        b: { field: "state", op: "in", values: ["open"] },
+      });
+    });
+
+    it("emits keys in sorted order so re-exporting an unchanged draft diffs cleanly", () => {
+      const out = presetsFileFromDraft([
+        { name: "zeta", filter: {} },
+        { name: "alpha", filter: {} },
+      ]);
+      expect(Object.keys(out)).toEqual(["alpha", "zeta"]);
+    });
+
+    it("skips an unnamed preset rather than emitting an empty key", () => {
+      expect(presetsFileFromDraft([{ name: "   ", filter: { a: 1 } }])).toEqual({});
+    });
+  });
+
+  describe("sectionsFileFromDraft", () => {
+    it("renames widgetId to id, which is what the definition file requires", () => {
+      const out = sectionsFileFromDraft([
+        { name: "my-work", displayName: "My Work", widgets: [widget()] },
+      ]);
+      expect(out["my-work"].widgets[0].id).toBe("my_open");
+      expect(out["my-work"].widgets[0].widgetId).toBeUndefined();
+    });
+
+    it("keeps an unexpanded preset reference in a section widget's query", () => {
+      // A section file stores the authored form; expanding here would defeat
+      // the entire point of referencing a preset.
+      const out = sectionsFileFromDraft([
+        { name: "my-work", displayName: "My Work", widgets: [widget()] },
+      ]);
+      expect(out["my-work"].widgets[0].query).toEqual({
+        filters: [{ preset: "activeCaseStates" }],
+      });
+    });
+
+    it("omits each widget's own section, which the loader overwrites anyway", () => {
+      const out = sectionsFileFromDraft([
+        {
+          name: "my-work",
+          displayName: "My Work",
+          widgets: [widget({ section: "Something Else" })],
+        },
+      ]);
+      expect(out["my-work"].widgets[0].section).toBeUndefined();
+    });
+  });
+
+  describe("widgetToDefinition", () => {
+    it("drops absent optional keys instead of emitting nulls", () => {
+      const out = widgetToDefinition(widget());
+      expect(out).not.toHaveProperty("groupBy");
+      expect(out).not.toHaveProperty("columns");
+      expect(out).not.toHaveProperty("description");
+    });
+
+    it("carries the optional keys that are present", () => {
+      const out = widgetToDefinition(
+        widget({
+          description: "why",
+          listLimit: 5,
+          sortBy: { field: "updatedOn", order: "asc" },
+          columns: [{ path: "number", label: "Number" }],
+        }),
+      );
+      expect(out.description).toBe("why");
+      expect(out.listLimit).toBe(5);
+      expect(out.sortBy).toEqual({ field: "updatedOn", order: "asc" });
+      expect(out.columns).toEqual([{ path: "number", label: "Number" }]);
+    });
+  });
+
+  describe("seedSharedConfigDraft", () => {
+    it("folds the deployed catalogues in on a fresh draft", () => {
+      const got = seedSharedConfigDraft(
+        [{ name: "activeCaseStates", filter: { field: "state", op: "in", values: ["open"] } }],
+        [{ name: "my-work", displayName: "My Work", widgets: [widget()] }],
+      );
+      expect(got.presets).toHaveLength(1);
+      expect(got.sections).toHaveLength(1);
+      expect(got.seeded).toBe(true);
+    });
+
+    it("does not re-seed once seeded, so a deleted entry stays deleted", () => {
+      seedSharedConfigDraft([{ name: "gone", filter: {} }], []);
+      // The admin deletes it.
+      saveSharedConfigDraft({ presets: [], sections: [], seeded: true });
+      // A later visit re-runs the seed with the same deployed catalogue.
+      const got = seedSharedConfigDraft([{ name: "gone", filter: {} }], []);
+      expect(got.presets).toEqual([]);
+    });
+
+    it("does not clobber an in-progress edit of a deployed entry", () => {
+      saveSharedConfigDraft({
+        presets: [{ name: "activeCaseStates", filter: { field: "state", op: "in", values: ["mine"] } }],
+        sections: [],
+        seeded: false,
+      });
+      const got = seedSharedConfigDraft(
+        [{ name: "activeCaseStates", filter: { field: "state", op: "in", values: ["deployed"] } }],
+        [],
+      );
+      expect(got.presets).toHaveLength(1);
+      expect(got.presets[0].filter).toEqual({ field: "state", op: "in", values: ["mine"] });
+    });
+  });
+
+  it("survives corrupt storage rather than throwing", () => {
+    localStorage.setItem("csm.dashboardSharedConfigDraft", "{not json");
+    expect(getSharedConfigDraft()).toEqual({
+      presets: [],
+      sections: [],
+      updatedAt: "",
+      seeded: false,
+    });
+  });
+
+  it("survives storage whose fields are the wrong types", () => {
+    localStorage.setItem(
+      "csm.dashboardSharedConfigDraft",
+      JSON.stringify({ presets: "nope", sections: 3, seeded: "yes" }),
+    );
+    const got = getSharedConfigDraft();
+    expect(got.presets).toEqual([]);
+    expect(got.sections).toEqual([]);
+    expect(got.seeded).toBe(false);
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-admin/dashboards/utils/sharedConfigDraftsStorage.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-admin/dashboards/utils/sharedConfigDraftsStorage.test.ts
@@ -17,6 +17,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import type { BeDashboardWidget } from "@api/backend/types";
 import {
+  deployableDashboardFromDraft,
   getSharedConfigDraft,
   presetsFileFromDraft,
   saveSharedConfigDraft,
@@ -174,5 +175,57 @@ describe("sharedConfigDraftsStorage", () => {
     expect(got.presets).toEqual([]);
     expect(got.sections).toEqual([]);
     expect(got.seeded).toBe(false);
+  });
+});
+
+describe("deployableDashboardFromDraft", () => {
+  const draft = {
+    id: "draft-abc",
+    displayName: "My Dashboard",
+    type: "cs" as const,
+    isDefault: true,
+    isTeamBased: false,
+    widgets: [widget()],
+  };
+
+  it("emits an id, which the loader requires and the old export omitted", () => {
+    expect(deployableDashboardFromDraft(draft).id).toBe("draft-abc");
+  });
+
+  it("keeps the deployed dashboard's own id when the draft came from one", () => {
+    // Otherwise re-deploying an edit would create a SECOND dashboard rather
+    // than replacing the one being edited.
+    expect(
+      deployableDashboardFromDraft({ ...draft, sourceDashboardId: "abt-engineer" }).id,
+    ).toBe("abt-engineer");
+  });
+
+  it("renames each widget's widgetId to id", () => {
+    const out = deployableDashboardFromDraft(draft);
+    const widgets = out.widgets as Record<string, unknown>[];
+    expect(widgets[0].id).toBe("my_open");
+    expect(widgets[0].widgetId).toBeUndefined();
+  });
+
+  it("omits includeSections entirely when there are none", () => {
+    expect(deployableDashboardFromDraft(draft)).not.toHaveProperty("includeSections");
+  });
+
+  it("carries includeSections when present", () => {
+    const out = deployableDashboardFromDraft({
+      ...draft,
+      includeSections: [{ section: "my-work", position: "start" }],
+    });
+    expect(out.includeSections).toEqual([{ section: "my-work", position: "start" }]);
+  });
+
+  it("drops the builder's own bookkeeping fields", () => {
+    const out = deployableDashboardFromDraft({
+      ...draft,
+      sourceDashboardId: "abt-engineer",
+    });
+    expect(out).not.toHaveProperty("sourceDashboardId");
+    expect(out).not.toHaveProperty("emptySections");
+    expect(out).not.toHaveProperty("updatedAt");
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-admin/dashboards/utils/sharedConfigDraftsStorage.ts
+++ b/apps/csm-portal/webapp/src/features/csm-admin/dashboards/utils/sharedConfigDraftsStorage.ts
@@ -249,3 +249,50 @@ export function widgetToDefinition(
   if (widget.query) out.query = widget.query;
   return out;
 }
+
+/**
+ * One dashboard in deployable definition-file shape.
+ *
+ * Lives here rather than in the editor page because it is the same class of
+ * translation the two shared files need, and it shares `widgetToDefinition`
+ * with them: everything in this module turns builder state into the JSON a
+ * maintainer deploys.
+ *
+ * Two things this must get right, both of which the loader rejects outright
+ * if it does not:
+ *  - `id` is required. It is the dashboard's identity and is never derived
+ *    from the filename.
+ *  - a widget's key is `id`, not the `widgetId` the API returns.
+ *
+ * `sourceDashboardId`/`emptySections`/`updatedAt` are the builder's own
+ * bookkeeping and have no home in a definition.
+ */
+export function deployableDashboardFromDraft(draft: {
+  id: string;
+  sourceDashboardId?: string;
+  displayName: string;
+  type?: "cre" | "sre" | "cs";
+  isDefault: boolean;
+  isTeamBased: boolean;
+  targetTeam?: string;
+  widgets: BeDashboardWidget[];
+  includeSections?: unknown[];
+}): Record<string, unknown> {
+  const out: Record<string, unknown> = {
+    // A draft opened from a deployed dashboard keeps that dashboard's id, so
+    // re-deploying replaces it instead of creating a second one.
+    id: draft.sourceDashboardId ?? draft.id,
+    displayName: draft.displayName,
+    type: draft.type,
+    isDefault: draft.isDefault,
+    isTeamBased: draft.isTeamBased,
+    targetTeam: draft.targetTeam,
+  };
+  // Omitted entirely when empty rather than emitted as [], so a dashboard
+  // referencing nothing produces the same file it did before the feature.
+  if ((draft.includeSections ?? []).length > 0) {
+    out.includeSections = draft.includeSections;
+  }
+  out.widgets = draft.widgets.map(widgetToDefinition);
+  return out;
+}

--- a/apps/csm-portal/webapp/src/features/csm-admin/dashboards/utils/sharedConfigDraftsStorage.ts
+++ b/apps/csm-portal/webapp/src/features/csm-admin/dashboards/utils/sharedConfigDraftsStorage.ts
@@ -1,0 +1,251 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useEffect, useState } from "react";
+import type { BeDashboardWidget } from "@api/backend/types";
+
+/**
+ * Locally designed shared dashboard config: the filter presets and reusable
+ * sections a dashboard definition references by name.
+ *
+ * Persisted to `localStorage` only, exactly like `dashboardDraftsStorage` and
+ * for exactly the same reason: these are deployment configuration files
+ * (`_presets.json`, `_sections.json`) served from a directory a maintainer
+ * deploys, and there is no write API for them. The designer's output is JSON
+ * to hand over, not a saved record.
+ *
+ * Seeded from what is actually deployed (`GET /dashboards/filter-presets` and
+ * `GET /dashboards/sections`) the first time the designer is opened, so
+ * editing starts from reality rather than from an empty page — see
+ * `seedSharedConfigDraft`.
+ */
+
+const STORAGE_KEY = "csm.dashboardSharedConfigDraft";
+
+/** Same in-tab notification idiom as `dashboardDraftsStorage` — the native
+ * `storage` event only fires for OTHER tabs. */
+const STORAGE_EVENT = "csm.dashboardSharedConfigDraft.changed";
+
+/** One designed preset: a name plus the single filter predicate it stands
+ * for. The predicate is the same field/op/values object a widget's own
+ * `query.filters` entries use; typed loosely because neither this app nor the
+ * backend interprets it beyond forwarding it. */
+export interface PresetDraft {
+  name: string;
+  filter: Record<string, unknown>;
+}
+
+/** One designed reusable section: a name, the heading its widgets are
+ * grouped under, and the widget run itself.
+ *
+ * `widgets` is the AUTHORED form: a widget here may carry `{"preset": ...}`
+ * references in its `query.filters`, unexpanded, because that is what gets
+ * written to `_sections.json`. Never hand these queries to a `/search`
+ * endpoint. */
+export interface SectionDraft {
+  name: string;
+  displayName: string;
+  widgets: BeDashboardWidget[];
+}
+
+export interface SharedConfigDraft {
+  presets: PresetDraft[];
+  sections: SectionDraft[];
+  /** ISO timestamp of the last local save. */
+  updatedAt: string;
+  /** Whether the deployed catalogues have already been folded in, so a
+   * later visit does not re-seed over the admin's own edits (including
+   * deletions, which an "is it empty?" check could not distinguish from a
+   * fresh start). */
+  seeded: boolean;
+}
+
+const EMPTY: SharedConfigDraft = {
+  presets: [],
+  sections: [],
+  updatedAt: "",
+  seeded: false,
+};
+
+function read(): SharedConfigDraft {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return EMPTY;
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") return EMPTY;
+    const o = parsed as Partial<SharedConfigDraft>;
+    // Every field defended individually: this is user-editable storage that
+    // can also have been written by an older version of this code.
+    return {
+      presets: Array.isArray(o.presets) ? o.presets : [],
+      sections: Array.isArray(o.sections) ? o.sections : [],
+      updatedAt: typeof o.updatedAt === "string" ? o.updatedAt : "",
+      seeded: o.seeded === true,
+    };
+  } catch {
+    return EMPTY;
+  }
+}
+
+function write(draft: SharedConfigDraft): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(draft));
+    window.dispatchEvent(new CustomEvent(STORAGE_EVENT));
+  } catch {
+    // ignore quota / serialization errors — same reasoning as
+    // dashboardDraftsStorage: only persistence fails, not the in-memory edit.
+  }
+}
+
+export function getSharedConfigDraft(): SharedConfigDraft {
+  return read();
+}
+
+/** Saves the whole draft, stamping `updatedAt`. */
+export function saveSharedConfigDraft(
+  draft: Omit<SharedConfigDraft, "updatedAt">,
+): SharedConfigDraft {
+  const stamped: SharedConfigDraft = {
+    ...draft,
+    updatedAt: new Date().toISOString(),
+  };
+  write(stamped);
+  return stamped;
+}
+
+/**
+ * Folds the deployed catalogues into the local draft, once.
+ *
+ * Deployed entries the draft does not already name are added; an entry the
+ * draft already names is left alone, because the draft's version is the
+ * admin's in-progress edit of it. After the first run `seeded` is set and
+ * this becomes a no-op, so a deleted entry stays deleted instead of
+ * reappearing on the next visit.
+ */
+export function seedSharedConfigDraft(
+  deployedPresets: readonly PresetDraft[],
+  deployedSections: readonly SectionDraft[],
+): SharedConfigDraft {
+  const current = read();
+  if (current.seeded) return current;
+
+  const presetNames = new Set(current.presets.map((p) => p.name));
+  const sectionNames = new Set(current.sections.map((s) => s.name));
+
+  return saveSharedConfigDraft({
+    presets: [
+      ...current.presets,
+      ...deployedPresets.filter((p) => !presetNames.has(p.name)),
+    ],
+    sections: [
+      ...current.sections,
+      ...deployedSections.filter((s) => !sectionNames.has(s.name)),
+    ],
+    seeded: true,
+  });
+}
+
+/** Reactive draft, kept in sync across components and browser tabs the same
+ * way `useDashboardDrafts` is. */
+export function useSharedConfigDraft(): SharedConfigDraft {
+  const [draft, setDraft] = useState<SharedConfigDraft>(() => read());
+  useEffect(() => {
+    const sync = (): void => setDraft(read());
+    sync();
+    window.addEventListener(STORAGE_EVENT, sync);
+    window.addEventListener("storage", sync);
+    return () => {
+      window.removeEventListener(STORAGE_EVENT, sync);
+      window.removeEventListener("storage", sync);
+    };
+  }, []);
+  return draft;
+}
+
+/**
+ * The deployable `_presets.json`: a name-keyed object, which is the shape the
+ * backend's own loader reads (`LoadSharedPresets`), NOT the array shape the
+ * catalogue endpoint returns.
+ *
+ * Keys are emitted in sorted order so re-exporting an unchanged draft
+ * produces an identical file and the config diff stays readable.
+ */
+export function presetsFileFromDraft(
+  presets: readonly PresetDraft[],
+): Record<string, Record<string, unknown>> {
+  const out: Record<string, Record<string, unknown>> = {};
+  for (const p of [...presets].sort((a, b) => a.name.localeCompare(b.name))) {
+    if (p.name.trim().length === 0) continue;
+    out[p.name] = p.filter;
+  }
+  return out;
+}
+
+/**
+ * The deployable `_sections.json`: a name-keyed object of
+ * `{displayName, widgets}`, again the loader's shape rather than the
+ * endpoint's.
+ *
+ * Each widget is written back with `id` rather than the `widgetId` the API
+ * returns — the definition file's key is `id`, and a section file carrying
+ * `widgetId` would fail to load. That rename is the one real translation
+ * between the wire shape the builder edits and the file shape it emits.
+ */
+export function sectionsFileFromDraft(
+  sections: readonly SectionDraft[],
+): Record<string, { displayName: string; widgets: Record<string, unknown>[] }> {
+  const out: Record<
+    string,
+    { displayName: string; widgets: Record<string, unknown>[] }
+  > = {};
+  for (const s of [...sections].sort((a, b) => a.name.localeCompare(b.name))) {
+    if (s.name.trim().length === 0) continue;
+    out[s.name] = {
+      displayName: s.displayName,
+      widgets: s.widgets.map(widgetToDefinition),
+    };
+  }
+  return out;
+}
+
+/**
+ * One widget in definition-file shape: `widgetId` becomes `id`, and keys the
+ * loader has no use for are dropped rather than emitted as nulls.
+ *
+ * `section` is deliberately omitted: within a section file the heading comes
+ * from the section's own `displayName`, and the loader overwrites each
+ * included widget's `section` with it, so carrying one here would be dead
+ * config that silently disagrees with what actually renders.
+ */
+export function widgetToDefinition(
+  widget: BeDashboardWidget,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {
+    id: widget.widgetId,
+    displayName: widget.displayName,
+    resourceType: widget.resourceType,
+    shape: widget.shape,
+    gridWidth: widget.gridWidth,
+  };
+  if (widget.description) out.description = widget.description;
+  if (widget.listLimit !== undefined) out.listLimit = widget.listLimit;
+  if (widget.sortBy) out.sortBy = widget.sortBy;
+  if (widget.columns && widget.columns.length > 0) out.columns = widget.columns;
+  if (widget.groupBy) out.groupBy = widget.groupBy;
+  if (widget.slices && widget.slices.length > 0) out.slices = widget.slices;
+  if (widget.query) out.query = widget.query;
+  return out;
+}

--- a/apps/csm-portal/webapp/src/features/csm-admin/dashboards/utils/sharedConfigDraftsStorage.ts
+++ b/apps/csm-portal/webapp/src/features/csm-admin/dashboards/utils/sharedConfigDraftsStorage.ts
@@ -15,7 +15,12 @@
 // under the License.
 
 import { useEffect, useState } from "react";
-import type { BeDashboardWidget } from "@api/backend/types";
+import type { BeDashboardFilterPreset, BeDashboardWidget } from "@api/backend/types";
+import {
+  filterConditionsFromQuery,
+  queryFromFilterConditions,
+  usesCaseFieldFilterDsl,
+} from "@features/csm-admin/dashboards/utils/widgetQueryConditions";
 
 /**
  * Locally designed shared dashboard config: the filter presets and reusable
@@ -80,6 +85,33 @@ const EMPTY: SharedConfigDraft = {
   seeded: false,
 };
 
+/** A stored preset entry is only usable if it has a name and an object body —
+ * `Array.isArray` on the outer array says nothing about what is inside it, and
+ * a single `null` element is enough to throw on the first `p.name`. */
+function isPresetDraft(v: unknown): v is PresetDraft {
+  if (!v || typeof v !== "object") return false;
+  const o = v as Partial<PresetDraft>;
+  return (
+    typeof o.name === "string" && !!o.filter && typeof o.filter === "object"
+  );
+}
+
+/** Same for a stored section. `widgets` is filtered element-wise too: a widget
+ * with no `widgetId` cannot be rendered in the list or written to the file. */
+function isSectionDraft(v: unknown): v is SectionDraft {
+  if (!v || typeof v !== "object") return false;
+  const o = v as Partial<SectionDraft>;
+  return (
+    typeof o.name === "string" &&
+    typeof o.displayName === "string" &&
+    Array.isArray(o.widgets)
+  );
+}
+
+function isWidget(v: unknown): v is BeDashboardWidget {
+  return !!v && typeof v === "object" && typeof (v as BeDashboardWidget).widgetId === "string";
+}
+
 function read(): SharedConfigDraft {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
@@ -87,11 +119,16 @@ function read(): SharedConfigDraft {
     const parsed: unknown = JSON.parse(raw);
     if (!parsed || typeof parsed !== "object") return EMPTY;
     const o = parsed as Partial<SharedConfigDraft>;
-    // Every field defended individually: this is user-editable storage that
-    // can also have been written by an older version of this code.
+    // Every field defended individually, and every ENTRY within the two
+    // arrays as well: this is user-editable storage that may also have been
+    // written by an older version of this code. A malformed entry is dropped
+    // rather than thrown on — a designer that cannot open until the user
+    // finds and clears localStorage is worse than one missing a row.
     return {
-      presets: Array.isArray(o.presets) ? o.presets : [],
-      sections: Array.isArray(o.sections) ? o.sections : [],
+      presets: (Array.isArray(o.presets) ? o.presets : []).filter(isPresetDraft),
+      sections: (Array.isArray(o.sections) ? o.sections : [])
+        .filter(isSectionDraft)
+        .map((s) => ({ ...s, widgets: s.widgets.filter(isWidget) })),
       updatedAt: typeof o.updatedAt === "string" ? o.updatedAt : "",
       seeded: o.seeded === true,
     };
@@ -206,6 +243,7 @@ export function presetsFileFromDraft(
  */
 export function sectionsFileFromDraft(
   sections: readonly SectionDraft[],
+  presets?: readonly BeDashboardFilterPreset[],
 ): Record<string, { displayName: string; widgets: Record<string, unknown>[] }> {
   const out: Record<
     string,
@@ -215,7 +253,7 @@ export function sectionsFileFromDraft(
     if (s.name.trim().length === 0) continue;
     out[s.name] = {
       displayName: s.displayName,
-      widgets: s.widgets.map(widgetToDefinition),
+      widgets: s.widgets.map((w) => widgetToDefinition(collapsePresetReferences(w, presets))),
     };
   }
   return out;
@@ -230,6 +268,51 @@ export function sectionsFileFromDraft(
  * included widget's `section` with it, so carrying one here would be dead
  * config that silently disagrees with what actually renders.
  */
+/**
+ * Rewrites a widget's filters back to shared-preset references wherever a
+ * literal predicate matches a preset's body.
+ *
+ * This has to happen at EXPORT, not only in the widget editor. A draft opened
+ * from a deployed dashboard holds the API's already-expanded widgets, and only
+ * the widgets an admin actually opens and saves pass through the editor's
+ * collapse. Without this, every widget they did not happen to touch would be
+ * written out as literals and its shared references lost — the same silent
+ * stripping the editor's collapse exists to prevent, just via a different
+ * route. Doing it here covers every widget by construction.
+ *
+ * Slice queries get the same treatment: a slice carrying its own `filters`
+ * replaces the widget's array wholesale, so its references matter just as much.
+ *
+ * No catalogue means no rewriting, which is the honest fallback: emitting
+ * literals is correct, just less maintainable than a reference.
+ */
+function collapsePresetReferences(
+  widget: BeDashboardWidget,
+  presets: readonly BeDashboardFilterPreset[] | undefined,
+): BeDashboardWidget {
+  if (!presets || presets.length === 0) return widget;
+  if (!usesCaseFieldFilterDsl(widget.resourceType)) return widget;
+
+  const rewrite = (
+    query: Record<string, unknown> | null,
+  ): Record<string, unknown> | null => {
+    if (!query || !Array.isArray(query.filters)) return query;
+    const collapsed = queryFromFilterConditions(
+      widget.resourceType,
+      filterConditionsFromQuery(widget.resourceType, query, presets),
+    );
+    // Preserve any sibling keys the condition round-trip does not model
+    // (it only ever rewrites `filters`), so nothing else in the query is lost.
+    return { ...query, ...collapsed };
+  };
+
+  return {
+    ...widget,
+    query: rewrite(widget.query),
+    slices: widget.slices?.map((slice) => ({ ...slice, query: rewrite(slice.query) })),
+  };
+}
+
 export function widgetToDefinition(
   widget: BeDashboardWidget,
 ): Record<string, unknown> {
@@ -277,7 +360,7 @@ export function deployableDashboardFromDraft(draft: {
   targetTeam?: string;
   widgets: BeDashboardWidget[];
   includeSections?: unknown[];
-}): Record<string, unknown> {
+}, presets?: readonly BeDashboardFilterPreset[]): Record<string, unknown> {
   const out: Record<string, unknown> = {
     // A draft opened from a deployed dashboard keeps that dashboard's id, so
     // re-deploying replaces it instead of creating a second one.
@@ -293,6 +376,6 @@ export function deployableDashboardFromDraft(draft: {
   if ((draft.includeSections ?? []).length > 0) {
     out.includeSections = draft.includeSections;
   }
-  out.widgets = draft.widgets.map(widgetToDefinition);
+  out.widgets = draft.widgets.map((w) => widgetToDefinition(collapsePresetReferences(w, presets)));
   return out;
 }

--- a/apps/csm-portal/webapp/src/features/csm-admin/dashboards/utils/widgetQueryConditions.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-admin/dashboards/utils/widgetQueryConditions.test.ts
@@ -20,6 +20,8 @@ import {
   operatorsForResourceType,
   queryFromFilterConditions,
   usesCaseFieldFilterDsl,
+  isPresetCondition,
+  presetNameByFilterBody,
 } from "@features/csm-admin/dashboards/utils/widgetQueryConditions";
 
 describe("usesCaseFieldFilterDsl", () => {
@@ -189,5 +191,114 @@ describe("operatorsForResourceType", () => {
   it("offers only eq/in for a non-case resourceType, since no other op has a real, proven query shape", () => {
     expect(operatorsForResourceType("incident")).toEqual(["eq", "in"]);
     expect(operatorsForResourceType("account")).toEqual(["eq", "in"]);
+  });
+});
+
+describe("shared filter presets", () => {
+  const presets = [
+    {
+      name: "activeCaseStates",
+      filter: { field: "state", op: "in", values: ["open", "work_in_progress"] },
+    },
+    { name: "excludeDipTag", filter: { field: "tag", op: "notIn", values: ["s_dip"] } },
+  ];
+
+  it("reads an authored preset reference as a preset row", () => {
+    const got = filterConditionsFromQuery("case", {
+      filters: [{ preset: "activeCaseStates" }],
+    });
+    expect(got).toEqual([
+      { field: "", op: "eq", values: [], preset: "activeCaseStates" },
+    ]);
+    expect(isPresetCondition(got[0])).toBe(true);
+  });
+
+  it("keeps a preset reference through a full round-trip", () => {
+    const query = { filters: [{ preset: "activeCaseStates" }] };
+    expect(
+      queryFromFilterConditions("case", filterConditionsFromQuery("case", query)),
+    ).toEqual(query);
+  });
+
+  it("collapses an already-expanded filter back to the preset it came from", () => {
+    // This is what GET /dashboards/{id} actually serves: the reference is
+    // gone and only the expansion remains.
+    const got = filterConditionsFromQuery(
+      "case",
+      { filters: [{ field: "state", op: "in", values: ["open", "work_in_progress"] }] },
+      presets,
+    );
+    expect(got).toEqual([
+      { field: "", op: "eq", values: [], preset: "activeCaseStates" },
+    ]);
+  });
+
+  it("collapses regardless of key order in the served filter", () => {
+    const got = filterConditionsFromQuery(
+      "case",
+      { filters: [{ values: ["s_dip"], op: "notIn", field: "tag" }] },
+      presets,
+    );
+    expect(got[0].preset).toBe("excludeDipTag");
+  });
+
+  it("leaves a filter no preset accounts for as a literal row", () => {
+    const got = filterConditionsFromQuery(
+      "case",
+      { filters: [{ field: "severity", op: "in", values: ["critical"] }] },
+      presets,
+    );
+    expect(got).toEqual([{ field: "severity", op: "in", values: ["critical"] }]);
+  });
+
+  it("does not collapse when the values differ, even by one entry", () => {
+    const got = filterConditionsFromQuery(
+      "case",
+      { filters: [{ field: "state", op: "in", values: ["open"] }] },
+      presets,
+    );
+    expect(got[0].preset).toBeUndefined();
+    expect(got[0].field).toBe("state");
+  });
+
+  it("serializes a preset row as the reference alone, never alongside field/op/values", () => {
+    const got = queryFromFilterConditions("case", [
+      { field: "state", op: "in", values: ["open"], preset: "activeCaseStates" },
+    ]);
+    expect(got).toEqual({ filters: [{ preset: "activeCaseStates" }] });
+  });
+
+  it("keeps a preset row that has no name yet out of the output", () => {
+    // A freshly added "Add preset" row before the admin picks one.
+    const got = queryFromFilterConditions("case", [
+      { field: "", op: "eq", values: [], preset: "" },
+    ]);
+    expect(got).toEqual({});
+  });
+
+  it("drops a preset row for a non-case resourceType, which cannot express one", () => {
+    const got = queryFromFilterConditions("incident", [
+      { field: "", op: "eq", values: [], preset: "activeCaseStates" },
+      { field: "priorities", op: "in", values: ["HIGH"] },
+    ]);
+    expect(got).toEqual({ priorities: ["HIGH"] });
+  });
+
+  it("prefers the first preset by name when two share an identical body", () => {
+    const duplicates = [
+      { name: "aaaFirst", filter: { field: "state", op: "in", values: ["open"] } },
+      { name: "zzzSecond", filter: { field: "state", op: "in", values: ["open"] } },
+    ];
+    const index = presetNameByFilterBody(duplicates);
+    expect(index.get(JSON.stringify({ field: "state", op: "in", values: ["open"] }))).toBe(
+      "aaaFirst",
+    );
+  });
+
+  it("treats an undefined catalogue as no collapsing at all", () => {
+    const got = filterConditionsFromQuery("case", {
+      filters: [{ field: "state", op: "in", values: ["open", "work_in_progress"] }],
+    });
+    expect(got[0].preset).toBeUndefined();
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-admin/dashboards/utils/widgetQueryConditions.ts
+++ b/apps/csm-portal/webapp/src/features/csm-admin/dashboards/utils/widgetQueryConditions.ts
@@ -14,7 +14,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import type { BeCaseFieldFilterOp, BeWidgetResourceType } from "@api/backend/types";
+import type {
+  BeCaseFieldFilterOp,
+  BeDashboardFilterPreset,
+  BeWidgetResourceType,
+} from "@api/backend/types";
 
 /**
  * A widget's `query` (opaque to every other part of this app — see
@@ -58,11 +62,33 @@ export const FILTER_CONDITION_OPS: FilterConditionOp[] = [
 ];
 
 /** One editable filter row. `values` is ignored for `isEmpty`/`isNotEmpty`
- * (those two ops are value-less predicates — see `BeCaseFieldFilter`). */
+ * (those two ops are value-less predicates — see `BeCaseFieldFilter`).
+ *
+ * A row is EITHER a literal field predicate or a shared-preset reference,
+ * discriminated by `preset`: when `preset` is a non-empty name, `field`/`op`/
+ * `values` carry no meaning and the row serializes as `{"preset": name}`.
+ * Modelled as one optional key rather than a discriminated union so every
+ * existing call site that constructs or patches a plain field row keeps
+ * working unchanged — `isPresetCondition` is the single place that decides
+ * which kind a row is. */
 export interface FilterCondition {
   field: string;
   op: FilterConditionOp;
   values: string[];
+  /**
+   * Name of a shared filter preset this row references instead of spelling
+   * the predicate out (see `BeDashboardFilterPreset`). Only meaningful for a
+   * resourceType that uses the case field DSL: presets are expanded inside
+   * `query.filters`, and no other resourceType's search contract has such an
+   * array at all.
+   */
+  preset?: string;
+}
+
+/** Whether a row is a shared-preset reference rather than a literal field
+ * predicate. The one authority on that distinction — see `FilterCondition`. */
+export function isPresetCondition(condition: FilterCondition): boolean {
+  return typeof condition.preset === "string" && condition.preset.length > 0;
 }
 
 const NO_VALUE_OPS = new Set<FilterConditionOp>(["isEmpty", "isNotEmpty"]);
@@ -169,6 +195,57 @@ export const CASE_FIELD_OPTIONS: string[] = [
   "internalId",
 ];
 
+/**
+ * Deterministic stringification of a filter object (keys sorted recursively),
+ * so two structurally-equal predicates that merely differ in key order
+ * compare equal. Same technique, and same reason, as `dashboardDrift`'s own
+ * `canonicalize`: the backend's JSON key order is not something this app
+ * should depend on.
+ */
+function canonicalFilter(value: unknown): string {
+  const canonical = (v: unknown): unknown => {
+    if (Array.isArray(v)) return v.map(canonical);
+    if (v && typeof v === "object") {
+      const out: Record<string, unknown> = {};
+      for (const k of Object.keys(v as Record<string, unknown>).sort()) {
+        out[k] = canonical((v as Record<string, unknown>)[k]);
+      }
+      return out;
+    }
+    return v;
+  };
+  return JSON.stringify(canonical(value));
+}
+
+/**
+ * Reverse index from a preset's expanded predicate to its name, used to show
+ * an already-deployed widget's filters as preset rows again.
+ *
+ * This is needed because `GET /dashboards/{id}` serves a dashboard with every
+ * preset reference ALREADY EXPANDED and erased — so without this, opening a
+ * deployed dashboard in the builder would show literal predicates, and saving
+ * it would export those literals, silently stripping every preset reference
+ * the deployed definition had.
+ *
+ * When two presets share an identical predicate the first by name wins, which
+ * is deterministic because the catalogue endpoint returns them name-sorted.
+ * The cost of this approach is the converse case: a hand-authored literal
+ * predicate that happens to equal a preset's body is shown, and re-exported,
+ * as that preset. That is a deliberate trade — the two are semantically
+ * identical by definition, since the preset expands to exactly that predicate
+ * — and it is what keeps this working with no extra field on the widget API.
+ */
+export function presetNameByFilterBody(
+  presets: readonly BeDashboardFilterPreset[] | undefined,
+): Map<string, string> {
+  const index = new Map<string, string>();
+  for (const preset of presets ?? []) {
+    const key = canonicalFilter(preset.filter);
+    if (!index.has(key)) index.set(key, preset.name);
+  }
+  return index;
+}
+
 function isFilterOp(v: unknown): v is FilterConditionOp {
   return typeof v === "string" && (FILTER_CONDITION_OPS as string[]).includes(v);
 }
@@ -180,20 +257,39 @@ function isFilterOp(v: unknown): v is FilterConditionOp {
 export function filterConditionsFromQuery(
   resourceType: BeWidgetResourceType,
   query: Record<string, unknown> | null | undefined,
+  presets?: readonly BeDashboardFilterPreset[],
 ): FilterCondition[] {
   if (!query) return [];
 
   if (usesCaseFieldFilterDsl(resourceType)) {
     const raw = query.filters;
     if (!Array.isArray(raw)) return [];
+    const byBody = presetNameByFilterBody(presets);
     return raw
       .filter((e): e is Record<string, unknown> => !!e && typeof e === "object")
-      .map((e) => ({
-        field: typeof e.field === "string" ? e.field : "",
-        op: isFilterOp(e.op) ? e.op : "eq",
-        values: Array.isArray(e.values) ? e.values.map(String) : [],
-      }))
-      .filter((c) => c.field.length > 0);
+      .map((e): FilterCondition => {
+        // An authored `{"preset": name}` entry, which only reaches here from
+        // a local draft or a section definition — a dashboard served by the
+        // API has had these expanded away.
+        if (typeof e.preset === "string" && e.preset.length > 0) {
+          return { field: "", op: "eq", values: [], preset: e.preset };
+        }
+        // An expanded predicate that a preset accounts for: shown as that
+        // preset again, so a round-trip through this editor does not strip
+        // the reference. See `presetNameByFilterBody`.
+        const collapsed = byBody.get(canonicalFilter(e));
+        if (collapsed !== undefined) {
+          return { field: "", op: "eq", values: [], preset: collapsed };
+        }
+        return {
+          field: typeof e.field === "string" ? e.field : "",
+          op: isFilterOp(e.op) ? e.op : "eq",
+          values: Array.isArray(e.values) ? e.values.map(String) : [],
+        };
+      })
+      // A row with neither a field nor a preset carries no meaning at all
+      // (a malformed entry); dropped rather than crashing the editor.
+      .filter((c) => isPresetCondition(c) || c.field.length > 0);
   }
 
   // Every other resourceType's own search contract is flat named top-level
@@ -216,21 +312,36 @@ export function queryFromFilterConditions(
   resourceType: BeWidgetResourceType,
   conditions: FilterCondition[],
 ): Record<string, unknown> {
-  const valid = conditions.filter((c) => c.field.trim().length > 0);
+  const valid = conditions.filter(
+    (c) => isPresetCondition(c) || c.field.trim().length > 0,
+  );
 
   if (usesCaseFieldFilterDsl(resourceType)) {
     if (valid.length === 0) return {};
     return {
-      filters: valid.map((c) =>
-        NO_VALUE_OPS.has(c.op)
+      filters: valid.map((c) => {
+        // A preset row writes the reference and nothing else: the whole
+        // point is that the predicate lives in the shared catalogue, so
+        // emitting field/op/values alongside it would defeat it (and the
+        // backend rejects an entry carrying both).
+        if (isPresetCondition(c)) return { preset: c.preset };
+        return NO_VALUE_OPS.has(c.op)
           ? { field: c.field, op: c.op }
-          : { field: c.field, op: c.op, values: c.values },
-      ),
+          : { field: c.field, op: c.op, values: c.values };
+      }),
     };
   }
 
+  // A preset row cannot be represented for a non-case resourceType: presets
+  // are expanded inside `query.filters`, and these contracts have no such
+  // array. The editor never offers one here (see the condition editor), so
+  // this can only come from a resourceType switch on an existing widget.
+  // Dropped for the same reason an unsupported op is, below: a visible,
+  // recoverable gap beats a silently reinterpreted filter.
+
   const out: Record<string, unknown> = {};
   for (const c of valid) {
+    if (isPresetCondition(c)) continue;
     // Non-case resourceTypes' own contracts only ever use a scalar or an
     // array (see this module's own doc comment), with no per-field op of
     // their own at all — `in` writes the array, `eq` writes a single

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/ProjectContactsTab.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/ProjectContactsTab.test.tsx
@@ -201,6 +201,46 @@ describe("ProjectContactsTab", () => {
     ).toBeInTheDocument();
   });
 
+  // The two "No access" causes are operationally different — one is a failed
+  // onboarding to chase, the other a row naming the wrong address — so the
+  // reason line has to say which, not just that access is missing.
+  it("gives a linked row whose invited address differs from its contact's own the mismatch reason, not the no-linked-record one", () => {
+    postMock.mockResolvedValue({ users: [] });
+    mockQueryResult({
+      data: [{ ...GRANTED_CONTACT, customerContactPresent: true, grantsCaseAccess: false }],
+    });
+    renderTab();
+    expect(screen.getByText("No access", { selector: ".MuiChip-label" })).toBeInTheDocument();
+    expect(
+      screen.getByText(/invited under a different address than its linked contact's own/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/no linked contact record/i)).not.toBeInTheDocument();
+  });
+
+  // A failed invite has no name (that is only ever known from the contact
+  // record) but does carry the address it was invited under, so the row must
+  // still be identifiable rather than rendering blank.
+  it("renders a failed-invite row by the address it was invited under, with the invite-never-completed reason", () => {
+    postMock.mockResolvedValue({ users: [] });
+    mockQueryResult({
+      data: [
+        {
+          email: "never.onboarded@example.com",
+          registrationState: "INVITED",
+          customerContactPresent: false,
+          grantsCaseAccess: false,
+        },
+      ],
+    });
+    renderTab();
+    expect(screen.getAllByText("never.onboarded@example.com").length).toBeGreaterThan(0);
+    expect(screen.getByText("No access", { selector: ".MuiChip-label" })).toBeInTheDocument();
+    expect(screen.getByText(/the invite never completed/i)).toBeInTheDocument();
+    expect(
+      screen.queryByText(/invited under a different address/i),
+    ).not.toBeInTheDocument();
+  });
+
   it("colours the registration chip by state (registered=success-ish, invited=warning-ish) without changing the visible text", () => {
     postMock.mockResolvedValue({ users: [] });
     mockQueryResult({ data: [GRANTED_CONTACT, INVITED_GRANTED_CONTACT] });

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/ProjectContactsTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/ProjectContactsTab.tsx
@@ -67,10 +67,20 @@ function deriveAccessStatus(c: BeProjectContact): AccessStatus {
     if (c.grantsCaseAccess) {
       return { label: "Has access", color: "success" };
     }
+    // Two distinct faults behind one verdict, and which one it is changes
+    // what you do about it: no contact record means the invite never
+    // completed, so chase the onboarding; a linked record whose own address
+    // differs means the row names the wrong address, so fix the row. When
+    // `customerContactPresent` is absent (a backend that has one field but
+    // not the other), the missing-record reading is the safer default — it is
+    // both the commoner fault and the one that doesn't accuse a healthy row
+    // of naming the wrong person.
     return {
       label: "No access",
       color: "error",
-      reason: "No linked contact record — this person can't see this project's cases.",
+      reason: c.customerContactPresent
+        ? "Invited under a different address than its linked contact's own — this project, and every case on it, is invisible to both of them."
+        : "No linked contact record — the invite never completed, so this person can't see this project's cases.",
     };
   }
   if (!c.id) {
@@ -100,9 +110,10 @@ interface ProjectContactsTabProps {
  * record at all, or a linked contact whose email doesn't match what this row
  * was invited under), and the reason line says which.
  *
- * A real project can return dozens of these rows with `name` *and* `email`
- * both empty (no natural identifier at all, not even an email to show) — the
- * explanatory line is always rendered inline, not tucked behind a hover
+ * A real project can return dozens of failed-invite rows. Those have no
+ * `name` (it is only ever known from the contact record) but do carry the
+ * address they were invited under as `email`, so they are identifiable — and
+ * the explanatory line is always rendered inline, not tucked behind a hover
  * tooltip, so scanning the table surfaces every "can't see their cases" row
  * without hovering each one.
  */

--- a/apps/csm-portal/webapp/src/features/csm-users/pages/UserProfilePage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/pages/UserProfilePage.test.tsx
@@ -251,6 +251,38 @@ describe("UserProfilePage", () => {
     expect(screen.queryByText("Has access", { selector: ".MuiChip-label" })).not.toBeInTheDocument();
   });
 
+  // Same two-causes distinction the project contacts tab makes: "No access"
+  // on its own does not say what to fix.
+  it("names both addresses when a row is linked but invited under a different address", () => {
+    mockQueryResult({
+      data: {
+        ...BLOCKED_EXTERNAL_USER,
+        projectAccess: [
+          {
+            projectId: "proj-4",
+            projectName: "Query Platform",
+            projectKey: "QUERYPLAT",
+            contactEmail: "someone.else@example.com",
+            contactRecordPresent: true,
+            contactRecordEmail: "john.smith@example.com",
+            registrationState: "invited",
+            grantsCaseAccess: false,
+          },
+        ],
+      },
+    });
+    renderPage();
+    expect(screen.getByText("No access", { selector: ".MuiChip-label" })).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Invited as someone\.else@example\.com but linked to a contact whose own address is john\.smith@example\.com/i,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/No contact record is linked to this project/i),
+    ).not.toBeInTheDocument();
+  });
+
   it("renders 'No project access records found' rather than hiding the card for an external user with none", () => {
     mockQueryResult({ data: { ...BLOCKED_EXTERNAL_USER, projectAccess: [] } });
     renderPage();

--- a/apps/csm-portal/webapp/src/features/csm-users/pages/UserProfilePage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-users/pages/UserProfilePage.tsx
@@ -132,18 +132,26 @@ interface ProjectAccessStatus {
 
 /**
  * A project row's access status, folding case-access and registration state
- * into the single "Access" column a support engineer scans: a project with no
- * linked contact record is the fundamental failure ("No access", with the
- * reason called out inline); one that's linked but hasn't completed
+ * into the single "Access" column a support engineer scans: a project that
+ * doesn't grant case access is the fundamental failure ("No access", with the
+ * reason called out inline); one that grants access but hasn't completed
  * registration yet reads "Invited" rather than "Has access", since the
  * person hasn't actually logged in to see it.
+ *
+ * "No access" has two causes and the reason line distinguishes them, because
+ * the fix differs: no contact record linked at all (the invite never
+ * completed), or a row invited under one address while its linked contact's
+ * own address is another (the row names the wrong address, and the project is
+ * invisible to both people).
  */
 function deriveProjectAccessStatus(pa: UserProjectAccess): ProjectAccessStatus {
   if (!pa.grantsCaseAccess) {
     return {
       label: "No access",
       color: "error",
-      reason: "No contact record is linked to this project for this user.",
+      reason: pa.contactRecordPresent
+        ? `Invited as ${pa.contactEmail} but linked to a contact whose own address is ${pa.contactRecordEmail ?? "different"} — this project is invisible to both.`
+        : "No contact record is linked to this project for this user.",
     };
   }
   if ((pa.registrationState ?? "").toLowerCase() === "invited") {

--- a/apps/csm-portal/webapp/src/features/csm-users/types/csmUsers.ts
+++ b/apps/csm-portal/webapp/src/features/csm-users/types/csmUsers.ts
@@ -103,10 +103,14 @@ export interface UserTeamRef {
  * One project-contact row for an external user, reported as stored rather
  * than as filtered. A row with no linked contact record makes the project,
  * and every case on it, silently invisible to that user —
- * {@link grantsCaseAccess} is the verdict, mirroring
- * {@link contactRecordPresent} directly (deliberately not the stricter
- * email-match rule the live access check enforces, since that only diverges
- * for integration/system accounts).
+ * {@link grantsCaseAccess} is the verdict, and it is the access rule applied
+ * per row: {@link contactRecordPresent} AND {@link contactEmail} matching
+ * {@link contactRecordEmail}, compared case-insensitively. Deliberately not a
+ * restatement of {@link contactRecordPresent} — a row invited under one
+ * address but linked to a contact whose own address differs is invisible to
+ * both people, and that does happen on genuine customer rows. Both halves of
+ * the comparison are on this type, so a false verdict can be explained from
+ * the row itself.
  */
 export interface UserProjectAccess {
   projectId: string;

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -181,10 +181,13 @@ type UserGroupRef struct {
 //
 // Rows with no linked contact record make the project, and every case on it, silently
 // invisible to that user, so they are reported here with GrantsCaseAccess spelling out the
-// verdict instead of being dropped. GrantsCaseAccess mirrors ContactRecordPresent directly
-// -- deliberately not the stricter email-match rule the live access check enforces, since
-// that only diverges for integration/system accounts, which aren't the audience this
-// signals for.
+// verdict instead of being dropped. GrantsCaseAccess is the access rule applied per row:
+// ContactRecordPresent AND ContactEmail matching ContactRecordEmail, compared
+// case-insensitively. It is deliberately not a restatement of ContactRecordPresent -- a row
+// invited under one address but linked to a contact whose own address differs is invisible
+// to both people, and that does happen on genuine customer rows, not only on
+// integration/system accounts. Both halves of the comparison are fields on this struct, so
+// a false verdict can be explained from the row itself.
 type UserProjectAccess struct {
 	ProjectID   string `json:"projectId"`
 	ProjectName string `json:"projectName"`
@@ -2493,7 +2496,12 @@ type ProjectContact struct {
 	// empty id internally; on the wire both a nil and an absent id are omitted, so the
 	// published shape is unchanged.
 	ID                   *string  `json:"id,omitempty"`
-	Name                 string   `json:"name"`
+	// Name is empty when the row has no contact record linked -- the name is only ever
+	// known from that record.
+	Name string `json:"name"`
+	// Email falls back to the address the row was invited under when no contact record is
+	// linked, so a row whose contact record was never created stays identifiable instead
+	// of carrying no name and no address at all.
 	Email                string   `json:"email"`
 	RegistrationState    string   `json:"registrationState"`
 	NotificationsEnabled bool     `json:"notificationsEnabled"`
@@ -2502,10 +2510,12 @@ type ProjectContact struct {
 	// this project's cases" per row, not just "are they listed". CustomerContactPresent
 	// is whether a contact record is linked at all (false is the same fault ID==nil
 	// signals, restated as an explicit boolean rather than an absence a caller has to
-	// notice). GrantsCaseAccess mirrors it directly -- deliberately not the stricter
-	// invited-email-matches-account-email rule the portal's access check technically
-	// applies underneath, since that only ever diverges for integration/system accounts,
-	// not the real customers this signals for.
+	// notice). GrantsCaseAccess is the access rule the backing data source actually
+	// applies: a linked contact record AND the address the row was invited under matching
+	// that record's own address, compared case-insensitively. Deliberately not a
+	// restatement of CustomerContactPresent -- a row invited under one address but linked
+	// to a contact whose own address differs is invisible to both people, and that does
+	// happen on genuine customer rows, not only on integration/system accounts.
 	CustomerContactPresent bool `json:"customerContactPresent"`
 	GrantsCaseAccess       bool `json:"grantsCaseAccess"`
 }

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -2496,9 +2496,9 @@ type ProjectContact struct {
 	// empty id internally; on the wire both a nil and an absent id are omitted, so the
 	// published shape is unchanged.
 	ID                   *string  `json:"id,omitempty"`
-	// Name is empty when the row has no contact record linked -- the name is only ever
+	// Name is nil when the row has no contact record linked -- the name is only ever
 	// known from that record.
-	Name string `json:"name"`
+	Name *string `json:"name"`
 	// Email falls back to the address the row was invited under when no contact record is
 	// linked, so a row whose contact record was never created stays identifiable instead
 	// of carrying no name and no address at all.

--- a/entity-service/internal/service/sn_project_service.go
+++ b/entity-service/internal/service/sn_project_service.go
@@ -605,9 +605,15 @@ func (s *snProjectContactService) SearchProjectContacts(ctx context.Context, pro
 			id := sysidToUUID(*c.ID)
 			contactID = &id
 		}
+		// Name is only known when a contact record is linked; a blank upstream name
+		// stays nil rather than an empty string, matching the response-null contract.
+		var name *string
+		if c.Name != "" {
+			name = strPtr(c.Name)
+		}
 		contacts = append(contacts, domain.ProjectContact{
 			ID:                     contactID,
-			Name:                   c.Name,
+			Name:                   name,
 			Email:                  c.Email,
 			RegistrationState:      c.RegistrationState,
 			NotificationsEnabled:   c.NotificationsEnabled,

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -4192,8 +4192,9 @@ components:
             render the row unlinked rather than treating it as an error.
         name:
           type: string
+          nullable: true
           description: >
-            Empty when the row has no contact record linked — the name is only ever known
+            Null when the row has no contact record linked — the name is only ever known
             from that record.
         email:
           type: string

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -3632,9 +3632,13 @@ components:
       description: >
         One project-contact row for a user, reported as stored rather than as filtered. A
         row with no linked contact record makes the project, and every case on it, silently
-        invisible to that user. grantsCaseAccess mirrors contactRecordPresent directly --
-        deliberately not the stricter email-match rule the live access check enforces, since
-        that only diverges for integration/system accounts.
+        invisible to that user. grantsCaseAccess is the access rule applied per row:
+        contactRecordPresent AND contactEmail matching contactRecordEmail, compared
+        case-insensitively. It is deliberately not a restatement of contactRecordPresent --
+        a row invited under one address but linked to a contact whose own address differs is
+        invisible to both people, and that does happen on genuine customer rows. Both halves
+        of the comparison are returned above, so a false verdict can be explained from the
+        row itself.
       required: [projectId, projectName, projectKey, contactEmail, contactRecordPresent, grantsCaseAccess]
       properties:
         projectId:
@@ -4169,7 +4173,10 @@ components:
           properties:
             searchQuery:
               type: string
-              description: Searches across contact name and email (case-insensitive).
+              description: >
+                Searches across the contact's name, the linked record's address, and the
+                address a row was invited under (case-insensitive) — so a row with no linked
+                contact record is findable by the address it is displayed under.
         pagination:
           $ref: '#/components/schemas/Pagination'
 
@@ -4185,8 +4192,15 @@ components:
             render the row unlinked rather than treating it as an error.
         name:
           type: string
+          description: >
+            Empty when the row has no contact record linked — the name is only ever known
+            from that record.
         email:
           type: string
+          description: >
+            The contact's address. Falls back to the address the row was invited under when
+            no contact record is linked, so a row whose contact record was never created is
+            still identifiable rather than coming back with no name and no address at all.
         registrationState:
           type: string
         notificationsEnabled:
@@ -4204,8 +4218,11 @@ components:
           type: boolean
           description: >
             Whether this row would actually grant its person visibility into this project's
-            cases. Mirrors `customerContactPresent` directly — a row can be listed here without
-            granting access.
+            cases: a linked contact record AND the address the row was invited under matching
+            that record's own address, compared case-insensitively. Deliberately not a
+            restatement of `customerContactPresent` — a row invited under one address but
+            linked to a contact whose own address differs is invisible to both people, and
+            that does happen on genuine customer rows.
 
     SearchProjectContactsResponse:
       type: object


### PR DESCRIPTION
## Purpose

Dashboard definitions had exactly one sharing mechanism: a named filter preset
standing in for a single predicate. Everything above that level was copy-paste,
and the copies drifted. The same "My Work" block across three definitions had
different state sets on the same widget, different staleness thresholds for the
same widget, and one definition was missing a widget the other two had. Nothing
detects that, because to the loader they are three unrelated widget lists.

Separately, neither presets nor sections were visible to any client at all. Both
are expanded at load time and erased, so the dashboard builder could not offer
one to reference, could not show what one means, and — because a filter row is
keyed on `field` and a preset reference has no `field` — would silently DELETE
any preset reference in a definition it round-tripped.

And there was nowhere to author either one.

This closes all of it: shared sections as a mechanism, both catalogues exposed
for authoring, the widget editor able to reference and preserve a preset, a
designer for presets and sections, and the builder's export fixed so what it
produces can actually be deployed.

Resolves N/A — no tracked issue; raised from a dashboard configuration audit.

## Goals

- One definition for a section that appears on more than one dashboard.
- A dashboard adopting a shared section keeps what makes it different: its own
  widget id prefix, its own heading, its own ordering, its own scope.
- The builder can reference a preset, show what it means, and never silently
  strip one from a definition it opens.
- Presets and sections can be authored in the UI, not just referenced.
- A misconfiguration fails the load loudly rather than serving a dashboard with
  a block of widgets quietly missing.
- What the builder exports is deployable.

## Approach

Seven commits, in dependency order. Reviewing commit by commit is much easier
than reviewing the combined diff.

**1. `feat(csm-backend)`: shared, reusable dashboard sections**

`DASHBOARD_SECTIONS_FILE` points at a JSON map of named sections, each with a
`displayName` and a `widgets` array in the shape definitions already use. A
definition opts in with a top-level `includeSections`, expanded into literal
widgets before key migration and preset expansion, after which the field is
cleared — so from there down an included widget is indistinguishable from an
inline one and nothing downstream knows the feature exists.

Per-include adjustments so one definition serves dashboards that are not
identical: `idPrefix`, `displayName`, `position` (`start`/`end`), and
`extraFilters` (ANDed into every included case-family widget's filters and each
of its slices'; skipped for non-case resources, whose query is not the
case-search DSL).

Two things worth review attention:

- **Every include gets a deep copy.** The pipeline mutates `Query` maps in
  place, so sharing them would leak one dashboard's `extraFilters` into
  another's widgets — silently, and only for whichever loaded second. Covered by
  a test that depends on load order.
- **Every misconfiguration is fatal**: unknown section, unknown `position`, a
  section with no widgets or no `displayName`, an id collision after prefixing.

**2. `feat(csm-backend)`: expose the shared preset and section catalogues**

    GET /dashboards/filter-presets  ->  [{name, filter}]
    GET /dashboards/sections        ->  [{name, displayName, widgets}]

Read-only, for authoring. Name-sorted arrays rather than name-keyed objects, so
picker order is deterministic and the shape is expressible in OpenAPI without a
free-form `additionalProperties` map.

The section endpoint returns its widgets **as authored**: preset references are
not expanded and no implied `type` filter is injected, because a section is
never put through a dashboard's finalize pipeline on its own. That is what an
authoring tool wants, but it means those queries are not usable as search
criteria — stated in both the OpenAPI description and the response type. A test
asserts the difference in both directions.

No change to the dashboard or widget API shape. Deliberate — see the trade under
commit 3.

**3. `feat(csm-portal)`: reference a shared filter preset from the widget editor**

A filter row is now either a literal predicate or a preset reference,
discriminated by an optional `preset` name — one optional key rather than a
discriminated union, so every existing call site that builds or patches a plain
field row is untouched, with `isPresetCondition` as the single authority. A
preset row serializes as `{"preset": name}` and nothing else.

The harder half is reading an existing dashboard back. `GET /dashboards/{id}`
serves presets already expanded, so without more the editor would show literals
and re-export them as literals, stripping every reference the definition had. So
a filter that deep-equals a preset's expansion is shown as that preset again,
matched on a key-order-independent canonical form.

**The trade this accepts:** a hand-authored literal that happens to equal a
preset's body is re-exported as that preset. The two are semantically identical
at the moment of collapse — the preset expands to exactly that predicate — so
nothing about the dashboard's current behaviour changes; only its future
maintenance becomes shared. The alternative, preserving provenance in the read
contract, means a second authored-form query field on the widget API, an
`openapi.yaml` change, and drift-detection having to compare the authored form
or every draft shows permanent false drift — all carried by the public dashboard
contract for the benefit of one admin-only screen. Considered and rejected on
those grounds; happy to revisit.

**4. `feat(csm-portal)`: design shared presets and sections**

`/admin/dashboards/shared`, behind the same admin gate the builder uses. Same
deploy story as dashboards, for the same reason (deployment config, no write
API): it produces `_presets.json` and `_sections.json` to hand to a maintainer
and keeps everything until then in `localStorage`. Nothing on the page changes
what is deployed, which the page says on its face.

Seeded from what IS deployed on first open, guarded by a persisted `seeded` flag
rather than an "is it empty?" check — those are indistinguishable after an admin
deletes everything, and with the flag a deletion sticks instead of reappearing.
Entries missing from the deployed catalogue are badged "not deployed".

A preset is name plus exactly ONE predicate, and the editor refuses a second row
with the reason rather than failing at deploy: the loader's preset value is a
single filter object. A section is built with the SAME widget dialog a
dashboard's widgets use — they are the same shape, which is the premise of the
feature, so a forked editor would guarantee drift.

**5. `fix(csm-portal)`: make the builder's exported dashboard deployable, and let it include sections**

A dashboard can now include a shared section from the UI, with `idPrefix`,
heading override and position. `extraFilters` is not exposed (powerful, quietly
easy to get wrong, unneeded from the UI today) but round-trips untouched if a
definition already has one.

Adding this surfaced that **the export was already broken**: "Copy as JSON"
produced a definition the loader rejects outright, in two independent ways, so
the builder's stated purpose could not work at all.

1. No `id` — excluded as builder bookkeeping, but the loader treats it as the
   dashboard's identity. `"id" is empty; the id is the dashboard's identity and
   is never derived from the filename`.
2. Widgets carried `widgetId` (the API's key) rather than `id` (the file's key).
   `widgets[0]: "id" is empty`.

Both fixed, sharing the section designer's `widgetToDefinition` so there is one
translation rather than two that drift. The deployable shape is now a pure
function, so it is unit-tested rather than buried in a click handler.

**6. `fix(csm-backend)`: reject a sections file that could never be referenced**

Two ways the file could look configured while being unusable. A document of
literal `null` parsed fine and left the map nil, behaving as "no sections
configured" even though the path WAS set — failing later and in the wrong place,
with every include reporting "unknown section" and pointing the reader at the
dashboards rather than the empty file. And a section key is looked up by exact
text while `expandIncludedSections` trims the include before lookup, so a
definition whose own key is not already trimmed could never be referenced at
all. Rejected rather than normalized: silently trimming would let two keys
differing only in whitespace collide.

That asymmetry is specific to sections — `resolvePresetRef` looks up the raw key,
so presets have no equivalent trap. The preset loader is unchanged.

**7. `fix`: validate every shared section, and stop losing preset references on export**

`finalize` resolved presets and validated widgets only after a section was
expanded into a dashboard, so a section nothing referenced was never checked: it
was served by the catalogue as though fine, offered in the builder, and failed
only when an author included it — blaming their dashboard for a fault in the
section file. Validation now runs over every section at load, against a
throwaway deep copy put through the real pipeline (`resolveDashboardFilterPresets`
then `validateWidgets`) rather than a hand-written second set of checks that
would drift. The copy is discarded, so the catalogue keeps its authored form; a
test asserts the reference survives.

Chasing a review finding also exposed a bigger hole. Collapse-back only ran
inside the widget editor, but a draft opened from a deployed dashboard holds the
API's already-expanded widgets — so every widget the admin never opened was
exported as literals anyway, losing references by the same silent route the
editor's collapse exists to prevent. **Collapse now also runs at export**, the
one point every widget passes through, including slice queries and designed
sections.

Also in this commit: the widget editor stays shut when the catalogue failed to
load, but only for an *existing* widget (a new one has no server-expanded
filters to misread and gets no preset rows, so blocking it would break the
builder for no safety gain); the designer seeds only when both catalogue queries
*succeeded*, since seeding is a one-shot persisted decision and seeding from a
failure baked a half-empty draft in permanently; a section can reference locally
authored presets, not only deployed ones; and persisted arrays are defended
element-wise, because `presets: [null]` threw on read and left the designer
unopenable until localStorage was cleared by hand.

## Not part of this work

Two commits on this branch — `docs: state the access rule a project-contact row
actually applies` and `fix(csm-portal): say which of the two access faults a
contact row hit` — belong to a separate concern that landed on the same branch.
They touch project-contact access reporting and are unrelated to dashboards.
There is one outstanding review finding against them (the `ProjectContact.Name`
null contract) which the owner of that change needs to decide on; it is
deliberately unaddressed here.

## User stories

As a CS engineer, "My Work" means the same thing on every dashboard I open,
instead of quietly showing me a different set of cases depending on which
dashboard I landed on.

As whoever maintains the dashboard definitions, I change a shared section once
instead of editing the same block in three files and missing one; I can see
which presets exist and what they mean while building a widget; I can author a
preset or a section instead of hand-editing JSON; and the JSON the builder hands
me actually deploys.

## Release note

Dashboard definitions can share a named run of widgets via `includeSections`,
resolved from an optional `DASHBOARD_SECTIONS_FILE`, with per-dashboard id
prefix, heading, position and filter scope. The dashboard builder can now
reference shared filter presets, design presets and reusable sections, and
include a shared section in a dashboard. Fixes the builder's exported dashboard
JSON, which could not be deployed.

## Documentation

N/A — dashboard definitions are deployment configuration, not user-facing
product documentation. The formats are documented where the other dashboard keys
are: `dashboards.example/_sections.json` is a working example, `.env.example`
documents `DASHBOARD_SECTIONS_FILE`, and both endpoints are in `openapi.yaml`.

## Training

N/A — internal configuration format; no training content covers it.

## Certification

N/A — no certification exam covers internal dashboard configuration.

## Marketing

N/A — internal tooling change with no external-facing feature.

## Automation tests

- Unit tests

  Backend: `internal/dashboard/sections_test.go` covers expansion, `idPrefix`,
  `displayName`, both `position` values, `extraFilters` into filters and slice
  queries, `extraFilters` skipped for non-case resources, presets inside
  `extraFilters`, the load-order-dependent deep-copy isolation case, every fatal
  path, the null/whitespace-key rejections, and catalogue-level validation of
  unreferenced sections (including that validation does not mutate the authored
  form). `internal/handler/dashboard_catalogues_test.go` covers both endpoints:
  auth, name-sorted output, verbatim filter bodies, hot-reload pickup,
  empty-array-not-null when unconfigured, and the authored-vs-resolved invariant
  in both directions.

  Frontend: `widgetQueryConditions.test.ts` (reference round-trip,
  collapse-on-load, key-order independence, near-miss non-collapse, preset-only
  serialization, unnamed row, non-case drop, duplicate-body tie-break);
  `WidgetFilterConditionEditor.test.tsx` (affordance gating by resourceType and
  catalogue, row rendering, unknown preset retained, removal, mixed rows);
  `sharedConfigDraftsStorage.test.ts` (both file emitters, sorted keys,
  `widgetId`→`id`, unexpanded references preserved, section field dropped,
  seeding semantics including no-clobber and no-resurrect, corrupt and
  wrong-typed storage, element-wise array guards, the deployable dashboard
  shape, and export-time collapse including slices and sections).

  ```
  $ go test ./...
  ok  .../internal/dashboard      ok  .../internal/directory
  ok  .../internal/entity         ok  .../internal/handler
  ok  .../internal/middleware     ok  .../internal/notifications

  $ npx vitest run src/features/csm-admin
  Test Files  17 passed (17)
       Tests  195 passed (195)
  ```

  No coverage tooling is wired into either module, so no percentage figure.

- Integration tests

  Cross-layer, run rather than reasoned about:

  1. A real deployed definition set (6 dashboards, 13 presets, 1 shared section)
     loaded through the real `NewDirRegistry`, with both catalogue endpoints
     called against it over HTTP: 13 presets serialized with correct bodies, and
     the section returned its preset references unexpanded as intended.
  2. The builder's real export written to disk through the actual frontend
     functions and loaded by the real registry. Resolves to 2 widgets: the
     included one carrying its `idPrefix`, placed first per `position`, grouped
     under the section's own heading, the widget's stale inline `section`
     discarded, and the preset reference expanded in both the included widget and
     the dashboard's own. Before commit 5 the same file failed to load at all.
  3. Every case-family widget query, slice query and `groupBy` in that definition
     set — 170 requests — sent to a running entity-service to confirm no filter
     field, field/op combination or `groupBy` field is unsupported. This caught a
     real one: `engagementType` is a valid search filter but is not in
     `validCaseAggregateField`, so a `groupBy` widget on it is rejected. Config
     using it was changed to explicit slices.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
- Ran FindSecurityBugs plugin and verified report? **N/A** — Go module;
  FindSecurityBugs is a Java tool. `go vet` and `gosec` were run instead:

  ```
  $ go vet ./...
  (clean, no output)

  $ gosec -fmt=text ./...
  Files: 55   Issues: 3
  ```

  All three are the same pre-existing G304 (file inclusion via variable) on
  reading a configuration file whose path comes from deployment configuration,
  not user input: two already on `main` in `registry.go`, and the third is this
  PR's equivalent read in `sections.go`, annotated with the same specific
  justification the existing two carry. No new class of finding.

  Frontend: `tsc --noEmit` clean, `eslint src` clean (0 errors; the remaining
  warnings are pre-existing and untouched). Both new endpoints require an
  authenticated caller, asserted by test. Both are read-only; no write API is
  added anywhere.

- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames,
  or other secrets? **yes** — Go and TypeScript source, an `.env.example`
  documentation line, and an example section definition containing only widget
  configuration.

## Samples

`apps/csm-portal/backend/dashboards.example/_sections.json` is a working example
section that loads as-is against the example dashboards.

## Related PRs

None.

## Migrations (if applicable)

No data migration, no schema change. One deployment step: an environment serving
definitions that use `includeSections` must set `DASHBOARD_SECTIONS_FILE`, or the
process exits on start naming the failing file. Environments not using the key
need no change, and `GET /dashboards/sections` then returns an empty array.

## Test environment

Go 1.26.7 (toolchain switch for gosec; the module builds on the repo's declared
version), Node with vitest 4.0.18, macOS 15 (darwin/arm64). No database or JDK
involvement.

## Learning

The design follows the shared-filter-preset mechanism already in this package
rather than inventing a second one: the same "reference by name, expand at load
time, erase the reference" shape, one level up from a predicate to a run of
widgets. Three things worth knowing before adding anything else here: the load
pipeline mutates `Query` maps in place, so anything sharing widget definitions
between dashboards needs a deep copy; the wire shape (`widgetId`) and the
definition-file shape (`id`) differ, which is what commit 5's bug turned out to
be; and a dashboard `groupBy` widget is served by the aggregate endpoint, whose
allowed field set is narrower than the search endpoint's groupable set — the two
are easy to confuse and only one governs config.

### Known limits, stated rather than discovered in review

- A hand-authored literal predicate identical to a preset's body is re-exported
  as that preset (commit 3's trade, above).
- `extraFilters` is authorable in the file but not in the UI.
- This diff is past CodeRabbit's free-tier per-file limit on two files, so expect
  summary-only review there rather than line-by-line.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added reusable dashboard sections and shared filter presets.
  - Added an admin page to manage and deploy shared dashboard configuration.
  - Dashboard builder supports shared sections, ordering, prefixes, heading overrides, and preset-based filters.
  - Added endpoints for viewing available presets and sections.

- **Bug Fixes**
  - Clarified project access explanations for missing contacts and mismatched email addresses.
  - Improved project contact search and email fallback behavior.

- **Documentation**
  - Updated API documentation for dashboard configuration and project contact access rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->