### PR TITLE
[CSM][Web] Real filter bar on case-widget preview pages; Tags multi-select; wider Project

### DIFF
--- a/apps/csm-portal/webapp/src/components/MultiSelectField.tsx
+++ b/apps/csm-portal/webapp/src/components/MultiSelectField.tsx
@@ -24,7 +24,7 @@ import {
   Select,
   Tooltip,
 } from "@wso2/oxygen-ui";
-import type { JSX } from "react";
+import { useRef, useState, type JSX } from "react";
 
 export interface MultiSelectFieldProps<T extends string> {
   id: string;
@@ -62,8 +62,26 @@ export default function MultiSelectField<T extends string>({
   // enabled, unselected siblings.
   const hasValue = values.length > 0;
 
+  // MUI's Select already pins the popup's `min-width` to the field's own
+  // rendered width, but never caps its `max-width` -- a long option label
+  // (e.g. a team name) otherwise stretches the popup far past the field it
+  // dropped down from, wider than every other filter's popup. Measuring the
+  // field's own width on open and pinning the popup to exactly that (not
+  // just a generic cap) is what makes it match, whatever width this
+  // particular instance happens to render at in its own grid slot; long
+  // labels wrap onto a second line instead of widening the popup.
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [open, setOpen] = useState(false);
+  const [menuWidth, setMenuWidth] = useState<number>();
+
+  const handleOpen = (): void => {
+    const width = rootRef.current?.getBoundingClientRect().width;
+    if (width) setMenuWidth(width);
+    setOpen(true);
+  };
+
   const field = (
-    <FormControl fullWidth size="small" disabled={disabled}>
+    <FormControl ref={rootRef} fullWidth size="small" disabled={disabled}>
       {/*
        * oxygen-ui's own theme (MuiInputLabel styleOverrides) targets
        * `.MuiFormControl-root:has(.MuiSelect-select) &:not(.MuiInputLabel-shrink)`
@@ -85,6 +103,17 @@ export default function MultiSelectField<T extends string>({
         id={id}
         value={values}
         label={label}
+        open={open}
+        onOpen={handleOpen}
+        onClose={() => setOpen(false)}
+        MenuProps={{
+          slotProps: {
+            // Falls back to a generic cap for the one frame before a width
+            // is ever measured (and in a non-layout environment like jsdom,
+            // where `getBoundingClientRect` always reports 0).
+            paper: { sx: menuWidth ? { width: menuWidth } : { maxWidth: 280 } },
+          },
+        }}
         onChange={(event) => {
           const val = event.target.value;
           onChange(Array.isArray(val) ? (val as T[]) : []);
@@ -114,15 +143,28 @@ export default function MultiSelectField<T extends string>({
         }}
       >
         {options.map((option) => (
-          <MenuItem key={option.value} value={option.value} sx={{ py: 0.5 }}>
+          // MUI's `MenuItem` sets `white-space: nowrap` by default (it
+          // expects a single-line label) — with the popup now pinned to
+          // the field's own width (see `menuWidth` above), a label longer
+          // than that width needs to wrap onto a second line instead of
+          // just getting clipped at the edge. `alignItems: "flex-start"`
+          // keeps the checkbox pinned to the first line's height instead
+          // of centering against the item's full two-line height.
+          <MenuItem
+            key={option.value}
+            value={option.value}
+            sx={{ py: 0.5, alignItems: "flex-start", whiteSpace: "normal" }}
+          >
             <Checkbox
               size="small"
               checked={values.includes(option.value)}
-              sx={{ mr: 1, p: 0.25 }}
+              sx={{ mr: 1, p: 0.25, mt: "1px" }}
             />
             <ListItemText
               primary={option.label}
-              slotProps={{ primary: { style: { fontSize: 13 } } }}
+              slotProps={{
+                primary: { style: { fontSize: 13, whiteSpace: "normal", wordBreak: "break-word" } },
+              }}
             />
           </MenuItem>
         ))}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncAssigneeMultiSelect.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncAssigneeMultiSelect.tsx
@@ -183,7 +183,7 @@ export default function AsyncAssigneeMultiSelect({
         const content = (
           <Box
             component="span"
-            sx={{ flex: "1 1 0", minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
+            sx={{ flex: "1 1 0", minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", pl: 1 }}
           >
             {displayText}
           </Box>
@@ -201,12 +201,17 @@ export default function AsyncAssigneeMultiSelect({
         return (
           <li key={key} {...liProps} style={{ paddingTop: 2, paddingBottom: 2 }}>
             <Checkbox size="small" checked={selected} sx={{ mr: 1, p: 0.25 }} />
+            {/* An email (the secondary line) has no spaces to wrap at --
+                without `overflowWrap`, it only breaks at the `@`/`.`
+                (browsers don't reliably treat those as break points
+                either), then overflows and gets clipped by the popup's
+                own overflow instead of wrapping onto a further line. */}
             <ListItemText
               primary={option.name}
               secondary={secondary}
               slotProps={{
-                primary: { style: { fontSize: 13 } },
-                secondary: { style: { fontSize: 11 } },
+                primary: { style: { fontSize: 13, overflowWrap: "anywhere" } },
+                secondary: { style: { fontSize: 11, overflowWrap: "anywhere" } },
               }}
             />
           </li>

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncProjectMultiSelect.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncProjectMultiSelect.tsx
@@ -162,7 +162,7 @@ export default function AsyncProjectMultiSelect({
         const content = (
           <Box
             component="span"
-            sx={{ flex: "1 1 0", minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
+            sx={{ flex: "1 1 0", minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", pl: 1 }}
           >
             {displayText}
           </Box>
@@ -178,9 +178,16 @@ export default function AsyncProjectMultiSelect({
         return (
           <li key={key} {...liProps} style={{ paddingTop: 2, paddingBottom: 2 }}>
             <Checkbox size="small" checked={selected} sx={{ mr: 1, p: 0.25 }} />
+            {/* A project name can run long with no space near the end
+                (e.g. a slash-joined account/subscription name) --
+                without `overflowWrap`, it only breaks at a space/hyphen,
+                then overflows and gets clipped by the popup's own
+                overflow instead of wrapping onto a further line. */}
             <ListItemText
               primary={option.name}
-              slotProps={{ primary: { style: { fontSize: 13 } } }}
+              slotProps={{
+                primary: { style: { fontSize: 13, overflowWrap: "anywhere" } },
+              }}
             />
           </li>
         );

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.test.tsx
@@ -23,6 +23,7 @@ import CasesFilterBar, {
   type CasesFilters,
 } from "@features/csm-cases/components/CasesFilterBar";
 import { DEFAULT_CASES_FILTERS } from "@features/csm-cases/utils/casesFiltersUrl";
+import { useSearchTags } from "@features/csm-cases/api/useSearchTags";
 
 const postMock = vi.fn();
 
@@ -33,6 +34,30 @@ vi.mock("@api/backend/client", () => ({
 vi.mock("@config/apiConfig", () => ({
   apiConfig: { backendUrl: "https://example.test" },
 }));
+
+// Mocked directly (same approach as AddTagDialog.test.tsx) so tests don't
+// have to drive the real 300ms debounce in TagsMultiSelect.
+vi.mock("@features/csm-cases/api/useSearchTags", () => ({
+  useSearchTags: vi.fn(),
+}));
+const mockedUseSearchTags = vi.mocked(useSearchTags);
+function mockTagSearchResult(
+  overrides: Partial<ReturnType<typeof useSearchTags>>,
+): void {
+  mockedUseSearchTags.mockReturnValue({
+    data: [],
+    isFetching: false,
+    isError: false,
+    ...overrides,
+  } as unknown as ReturnType<typeof useSearchTags>);
+}
+// `TagsMultiSelect` (and its `useSearchTags` call) now renders unconditionally
+// as part of every `CasesFilterBar`, so every describe block below needs a
+// default mock return value -- set once here, at file scope, rather than
+// repeating it in each describe block's own `beforeEach`.
+beforeEach(() => {
+  mockTagSearchResult({});
+});
 
 function renderBar(
   filters: CasesFilters,
@@ -146,26 +171,32 @@ describe("CasesFilterBar — removed bar controls fall back to chips", () => {
 
 
   /**
-   * The tag bar controls (and, briefly, CS team's) were removed as clutter,
-   * so a chip is the ONLY way these filters are visible or clearable after a
-   * dashboard click-through. If these break, a user lands on a filtered
-   * list with no way to see or undo why. CS team has its own "Team" bar
-   * control again (see the describe block below) and is deliberately NOT
-   * chipped, to avoid showing the same selection twice.
+   * `tags` has its own "Tags" bar control now (tested separately below),
+   * same as CS team's "Team" control (see the describe block below) —
+   * deliberately NOT chipped, to avoid showing the same selection twice.
+   * `excludeTags` has no bar control of its own on this general filter bar
+   * — only ever set via a dashboard click-through (or, for a case-family
+   * widget's own preview page, seeded as `tags`' own complement before it
+   * ever reaches this component — see `CaseFamilyWidgetPreview` in
+   * `DashboardWidgetPreviewPage.tsx`) — so a chip is still the only way to
+   * see or clear it here.
    */
-  it("renders chips for tags/excludeTags now that their bar controls are gone", () => {
+  it("does not render a chip for tags — it has its own 'Tags' bar control", () => {
+    renderBar({ ...DEFAULT_CASES_FILTERS, tags: ["micro-gw"] });
+    expect(screen.queryByText(/^Tag: /)).not.toBeInTheDocument();
+  });
+
+  it("renders a chip for excludeTags, since it has no bar control of its own", () => {
     const { onChange } = renderBar({
       ...DEFAULT_CASES_FILTERS,
-      tags: ["micro-gw"],
       excludeTags: ["s_dip"],
     });
 
-    expect(screen.getByText("Tag: micro-gw")).toBeInTheDocument();
     expect(screen.getByText("Excluding tag: s_dip")).toBeInTheDocument();
 
     fireEvent.click(screen.getByText("Excluding tag: s_dip").closest(".MuiChip-root")!.querySelector("svg")!);
     expect(onChange).toHaveBeenCalledWith(
-      expect.objectContaining({ excludeTags: [], tags: ["micro-gw"] }),
+      expect.objectContaining({ excludeTags: [] }),
     );
   });
 
@@ -174,18 +205,12 @@ describe("CasesFilterBar — removed bar controls fall back to chips", () => {
     expect(screen.queryByText(/^CS team:/)).not.toBeInTheDocument();
   });
 
-  it("no longer renders the removed Tags / Exclude tags bar controls", () => {
-    renderBar({ ...DEFAULT_CASES_FILTERS });
-    expect(screen.queryByLabelText(/^Tags$/)).not.toBeInTheDocument();
-    expect(screen.queryByLabelText(/^Exclude tags$/)).not.toBeInTheDocument();
-  });
-
   // Regression: reported live against a dashboard widget's `state notIn`
   // click-through, which showed an INCLUDE chip (the exact opposite of the
   // widget's own filter) because the exclusion had nowhere of its own to
-  // render. `excludeStates` has no bar control (same as `excludeTags`), so
-  // its chip is the only way to see or clear it. `onboardingStatuses` has
-  // its own "Onboarding status" bar control (tested separately below) and
+  // render. `excludeStates` has no bar control of its own, so its chip is
+  // the only way to see or clear it. `onboardingStatuses` has its own
+  // "Onboarding status" bar control (tested separately below) and
   // is deliberately NOT chipped, same as `csTeams`.
   it("renders a distinct chip for excludeStates, never conflated with its include counterpart", () => {
     const { onChange } = renderBar({
@@ -240,6 +265,62 @@ describe("CasesFilterBar — 'Team' control (replaces the removed 'Work state' o
     fireEvent.click(await screen.findByRole("option", { name: "ABT One" }));
 
     expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ csTeams: ["g-1"] }));
+  });
+});
+
+describe("CasesFilterBar — 'Tags' control (replaces the removed chip-only field)", () => {
+  it("renders matching tag suggestions from the search endpoint", () => {
+    mockTagSearchResult({ data: [{ id: "t1", label: "micro-gw" }] });
+    renderBar({ ...DEFAULT_CASES_FILTERS });
+
+    fireEvent.mouseDown(screen.getByRole("combobox", { name: "Tags" }));
+    expect(screen.getByText("micro-gw")).toBeInTheDocument();
+  });
+
+  it("selecting a suggested tag adds it to the filter", () => {
+    mockTagSearchResult({ data: [{ id: "t1", label: "micro-gw" }] });
+    const { onChange } = renderBar({ ...DEFAULT_CASES_FILTERS });
+
+    fireEvent.mouseDown(screen.getByRole("combobox", { name: "Tags" }));
+    fireEvent.click(screen.getByText("micro-gw"));
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ tags: ["micro-gw"] }),
+    );
+  });
+
+  // Tags are genuinely free-text (see TagsMultiSelect.tsx's doc comment) --
+  // typing one with no matching suggestion must still work, not just picking
+  // from the search results.
+  it("still accepts a free-typed tag with no matching suggestion", () => {
+    const { onChange } = renderBar({ ...DEFAULT_CASES_FILTERS });
+
+    const input = screen.getByRole("combobox", { name: "Tags" });
+    fireEvent.change(input, { target: { value: "brand-new-tag" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ tags: ["brand-new-tag"] }),
+    );
+  });
+});
+
+// Regression: reported live — with every control the same width, a project
+// name of any real length ellipsized almost immediately, and the control sat
+// mid-row rather than having room to grow. Moved to the end of the grid and
+// widened.
+describe("CasesFilterBar — 'Project' control is last and wider than its siblings", () => {
+  it("renders after every other filter control in document order", () => {
+    renderBar({ ...DEFAULT_CASES_FILTERS });
+
+    const project = screen.getByRole("combobox", { name: "Project" });
+    const tags = screen.getByRole("combobox", { name: "Tags" });
+    const onboarding = screen.getByRole("combobox", { name: "Onboarding status" });
+
+    expect(project.compareDocumentPosition(tags) & Node.DOCUMENT_POSITION_PRECEDING).toBeTruthy();
+    expect(
+      project.compareDocumentPosition(onboarding) & Node.DOCUMENT_POSITION_PRECEDING,
+    ).toBeTruthy();
   });
 });
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
@@ -81,6 +81,7 @@ import {
 import MultiSelectField from "@components/MultiSelectField";
 import AsyncAssigneeMultiSelect from "@features/csm-cases/components/AsyncAssigneeMultiSelect";
 import ProductNameMultiSelect from "@features/csm-cases/components/ProductNameMultiSelect";
+import TagsMultiSelect from "@features/csm-cases/components/TagsMultiSelect";
 
 
 /**
@@ -272,15 +273,15 @@ interface ActiveFilterChip {
  * removable, though, or a user landing on a dashboard-filtered cases list
  * has no way to see (or undo) *why* it's filtered — hence one chip per
  * active value here, shown regardless of whether the filter grid itself is
- * expanded. `sreTeams`/`tags`/`excludeTags`/`workStates` are included here
- * too: their bar controls were removed as clutter (they are advanced,
- * rarely hand-picked, and a better home for advanced filters is still to be
+ * expanded. `sreTeams`/`excludeTags`/`workStates` are included here too:
+ * their bar controls were removed as clutter (they are advanced, rarely
+ * hand-picked, and a better home for advanced filters is still to be
  * designed), so a chip is now the ONLY way a user can see or clear them
- * after arriving from a dashboard click-through. `csTeams`/`onboardingStatuses`
- * each have their own bar control (see the filter grid below) and are
- * deliberately NOT chipped here too — every other bar-controlled field
- * (`states`, `severities`, ...) shows its selection inside its own control,
- * not as a second, redundant chip.
+ * after arriving from a dashboard click-through. `csTeams`/
+ * `onboardingStatuses`/`tags` each have their own bar control (see the
+ * filter grid below) and are deliberately NOT chipped here too — every
+ * other bar-controlled field (`states`, `severities`, ...) shows its
+ * selection inside its own control, not as a second, redundant chip.
  */
 function buildActiveFilterChips(
   filters: CasesFilters,
@@ -303,14 +304,13 @@ function buildActiveFilterChips(
     });
   });
 
-  filters.tags.forEach((tag) => {
-    chips.push({
-      key: `tag-${tag}`,
-      label: `Tag: ${tag}`,
-      onRemove: (f) => ({ ...f, tags: f.tags.filter((t) => t !== tag) }),
-    });
-  });
-
+  // `tags` has its own "Tags" bar control now (see the filter grid below)
+  // -- not chipped here, same as `csTeams`/`onboardingStatuses`.
+  // `excludeTags` has no bar control of its own on this general filter bar
+  // (only ever set via a dashboard click-through, or seeded as `tags`'
+  // own complement -- see `CaseFamilyWidgetPreview` in
+  // `DashboardWidgetPreviewPage.tsx` -- before it ever reaches this
+  // component), so its chip is still the only way to see or clear it here.
   filters.excludeTags.forEach((tag) => {
     chips.push({
       key: `excludeTag-${tag}`,
@@ -819,15 +819,6 @@ export default function CasesFilterBar({
                 nameSeed={assigneeNameSeed}
               />
             </Grid>
-            {!hideProjectFilter && (
-              <Grid size={{ xs: 12, sm: 6, md: 4, lg: 2 }}>
-                <AsyncProjectMultiSelect
-                  values={filters.projects}
-                  onChange={(next) => onChange({ ...filters, projects: next })}
-                  nameSeed={projectNameSeed}
-                />
-              </Grid>
-            )}
             <Grid size={{ xs: 12, sm: 6, md: 4, lg: 2 }}>
               {/* Product family filter; the selected names map straight to
                   `productNames` (SN matches product.name, all versions). */}
@@ -845,6 +836,29 @@ export default function CasesFilterBar({
                 onChange={(next) => onChange({ ...filters, onboardingStatuses: next })}
               />
             </Grid>
+            <Grid size={{ xs: 12, sm: 6, md: 4, lg: 2 }}>
+              <TagsMultiSelect
+                values={filters.tags}
+                onChange={(next) => onChange({ ...filters, tags: next })}
+              />
+            </Grid>
+            {!hideProjectFilter && (
+              // Last, and wider than every other control: selected project
+              // names render as one ellipsized line (see
+              // `AsyncProjectMultiSelect`'s `renderTags`), not a wrap, but at
+              // the same `lg: 2` width as everything else that single line
+              // was cramped enough to ellipsize almost immediately with more
+              // than one project picked. Moved to the end of the grid and
+              // widened so it has room to actually show a project name or two
+              // before truncating.
+              <Grid size={{ xs: 12, sm: 12, md: 6, lg: 4 }}>
+                <AsyncProjectMultiSelect
+                  values={filters.projects}
+                  onChange={(next) => onChange({ ...filters, projects: next })}
+                  nameSeed={projectNameSeed}
+                />
+              </Grid>
+            )}
           </Grid>
           {activeCount > 0 && (
             <Box sx={{ display: "flex", justifyContent: "flex-end" }}>

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/TagsMultiSelect.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/TagsMultiSelect.tsx
@@ -14,8 +14,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Autocomplete, Box, TextField, Tooltip } from "@wso2/oxygen-ui";
-import type { JSX } from "react";
+import { Autocomplete, Box, Checkbox, ListItemText, TextField, Tooltip } from "@wso2/oxygen-ui";
+import { useMemo, useState, type JSX } from "react";
+import type * as React from "react";
+import { useDebouncedValue } from "@hooks/useDebouncedValue";
+import { useSearchTags } from "@features/csm-cases/api/useSearchTags";
 
 interface TagsMultiSelectProps {
   id?: string;
@@ -26,12 +29,16 @@ interface TagsMultiSelectProps {
 }
 
 /**
- * Tag filter for the cases list. Unlike {@link ProductNameMultiSelect} (a
- * bounded catalogue), tags are genuinely free-text on the backing data source
- * (SN's generic label mechanism, e.g. `micro-gw`, `ws-policy`) — there is no
- * "list all tags" endpoint to seed suggestions from, so this is a plain
- * `freeSolo` multi-value input: type a label and press Enter/comma to add it,
- * no fixed option list.
+ * Tag filter for the cases list, searching already-used tag labels from the
+ * backend as the user types (`useSearchTags`, the same `/tags/search`
+ * type-ahead {@link AddTagDialog} uses) — the tag-side twin of
+ * {@link AsyncProjectMultiSelect}/{@link AsyncAssigneeMultiSelect}. Stays
+ * `freeSolo`: unlike a project or an engineer, a tag is a genuinely free-text
+ * label (SN's generic label mechanism, e.g. `micro-gw`, `ws-policy`) with no
+ * canonical existence check — filtering by a label the search didn't
+ * surface (a typo, or one used by a case outside the current query's top 20)
+ * is still a meaningful, harmless filter, so typing one in and pressing
+ * Enter/comma must keep working even with no matching suggestion.
  */
 export default function TagsMultiSelect({
   id = "cases-filter-tags",
@@ -39,18 +46,82 @@ export default function TagsMultiSelect({
   values,
   onChange,
 }: TagsMultiSelectProps): JSX.Element {
+  const [input, setInput] = useState("");
+  const [open, setOpen] = useState(false);
+  const debounced = useDebouncedValue(input, 300);
+  const query = debounced.trim();
+
+  // Enabled while the dropdown is open, so it loads a first batch of
+  // suggestions on open (no typing needed) and re-queries as the user types.
+  const { data, isFetching, isError } = useSearchTags(query, open);
+
+  // Pool = current selection (so the field renders its chips) + the search
+  // results' labels, de-duplicated.
+  const options: string[] = useMemo(() => {
+    const seen = new Set(values);
+    const results = (data ?? [])
+      .map((t) => t.label)
+      .filter((l) => l.length > 0 && !seen.has(l));
+    return [...values, ...results];
+  }, [data, values]);
+
   return (
     <Autocomplete<string, true, false, true>
       multiple
       freeSolo
+      // MUI hides the dropdown chevron by default for any `freeSolo`
+      // Autocomplete (`hasPopupIcon` in its source is `!freeSolo` unless
+      // this is set) -- every other filter control in this bar (Select- and
+      // Autocomplete-based alike) shows one, so force it back on here too.
+      forcePopupIcon
       size="small"
       id={id}
-      options={[]}
+      options={options}
       value={values}
-      sx={{ "& .MuiAutocomplete-inputRoot": { flexWrap: "nowrap" } }}
+      open={open}
+      onOpen={() => setOpen(true)}
+      onClose={() => setOpen(false)}
+      // Stays open across a selection -- same reasoning as
+      // AsyncProjectMultiSelect/AsyncAssigneeMultiSelect: this is a
+      // multi-select, so picking one tag shouldn't close the dropdown on
+      // someone about to pick several from the same search.
+      disableCloseOnSelect
+      loading={isFetching && (data ?? []).length === 0}
+      // The backend already filtered by the typed term; don't re-filter
+      // locally (that would also drop the currently-selected values, which
+      // must stay in `options` so their chips render).
+      filterOptions={(opts) => opts}
+      sx={{ "& .MuiAutocomplete-inputRoot": { flexWrap: "nowrap", minHeight: 40 } }}
       onChange={(_event, next) =>
         onChange(next.map((v) => v.trim()).filter((v) => v.length > 0))
       }
+      inputValue={input}
+      onInputChange={(_event, value, reason) => {
+        // Keep the typed term after a selection (reason "reset") so the user
+        // can pick several from one search; clear only on explicit input/clear.
+        if (reason === "input" || reason === "clear") setInput(value);
+      }}
+      noOptionsText={
+        isError
+          ? "Couldn't load tags. Try again."
+          : isFetching
+            ? "Loading tags…"
+            : "No matching tags — press Enter to filter by it anyway"
+      }
+      renderOption={(props, option, { selected }) => {
+        const { key, ...liProps } = props as React.HTMLAttributes<HTMLLIElement> & {
+          key: string;
+        };
+        return (
+          <li key={key} {...liProps} style={{ paddingTop: 2, paddingBottom: 2 }}>
+            <Checkbox size="small" checked={selected} sx={{ mr: 1, p: 0.25 }} />
+            <ListItemText
+              primary={option}
+              slotProps={{ primary: { style: { fontSize: 13 } } }}
+            />
+          </li>
+        );
+      }}
       renderTags={(value) => {
         const displayText = value.join(", ");
         const content = (
@@ -69,7 +140,7 @@ export default function TagsMultiSelect({
         <TextField
           {...params}
           label={label}
-          placeholder={values.length ? undefined : "Type a tag and press Enter…"}
+          placeholder={values.length ? undefined : "Search tags…"}
         />
       )}
     />

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/TagsMultiSelect.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/TagsMultiSelect.tsx
@@ -115,9 +115,16 @@ export default function TagsMultiSelect({
         return (
           <li key={key} {...liProps} style={{ paddingTop: 2, paddingBottom: 2 }}>
             <Checkbox size="small" checked={selected} sx={{ mr: 1, p: 0.25 }} />
+            {/* A tag label often has no spaces to wrap at (e.g.
+                "Change-Tracking/Infrastructure") -- without
+                `overflowWrap`, a long one only breaks at a hyphen, then
+                overflows and gets clipped by the popup's own overflow
+                instead of wrapping onto a further line. */}
             <ListItemText
               primary={option}
-              slotProps={{ primary: { style: { fontSize: 13 } } }}
+              slotProps={{
+                primary: { style: { fontSize: 13, overflowWrap: "anywhere" } },
+              }}
             />
           </li>
         );
@@ -127,7 +134,7 @@ export default function TagsMultiSelect({
         const content = (
           <Box
             component="span"
-            sx={{ flex: "1 1 0", minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
+            sx={{ flex: "1 1 0", minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", pl: 1 }}
           >
             {displayText}
           </Box>

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.ts
@@ -236,8 +236,13 @@ function caseFilterEntry(
  * value-less `isEmpty`/`isNotEmpty` map to the explicit tri-state
  * `hasEscalation` (`false`/`true`), never silently defaulted when absent
  * (`undefined`, i.e. not touched in `out`).
+ *
+ * Exported (not just used internally for `buildHref`) so
+ * `DashboardWidgetPreviewPage.tsx` can seed a real, editable `CasesFilterBar`
+ * from a case-family widget's own opaque filters, rather than only ever
+ * building a one-shot click-through URL from them.
  */
-function translateCaseDashboardFilters(
+export function translateCaseDashboardFilters(
   filters: Record<string, unknown>,
 ): Partial<CasesFilters> {
   const out: Partial<CasesFilters> = {};

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/pages/DashboardWidgetPreviewPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/pages/DashboardWidgetPreviewPage.test.tsx
@@ -68,6 +68,27 @@ function renderAt(initialEntry: string) {
   );
 }
 
+/** Same as {@link renderAt}, but also hands back the `QueryClient` so a
+ * test can force a real background refetch of a shared cache entry (e.g.
+ * `useSearchTags("", ...)`'s), the same way another mounted "Tags" control
+ * elsewhere in the app would once its own `staleTime` elapses. */
+function renderAtWithQueryClient(initialEntry: string) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const result = render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <Routes>
+          <Route path="/dashboard" element={<div>Dashboard landing</div>} />
+          <Route path="/dashboard/preview/:previewSlug" element={<DashboardWidgetPreviewPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+  return { ...result, queryClient };
+}
+
 /** Routes `postMock` by URL, since a case-family widget's preview page
  * fires up to three different POST endpoints at once: `/teams/search`
  * (`CasesFilterBar`'s "Team" control loads unconditionally on mount),
@@ -528,5 +549,91 @@ describe("DashboardWidgetPreviewPage — case-family widgets get the real, edita
       expect(postMock).toHaveBeenCalledWith("/cases/search", expect.anything()),
     );
     expect(postMock).not.toHaveBeenCalledWith("/tags/search", expect.anything());
+  });
+
+  // CodeRabbit finding: `useSearchTags("", ...)`'s cache entry is shared,
+  // by query key, with every other "Tags" control mounted anywhere in the
+  // app (e.g. the real one inside this very `CasesFilterBar`, or another
+  // preview page open in a different tab) -- once its own `staleTime`
+  // elapses, any of those refetches the exact same cache entry, which
+  // flips `isFetching` back to true here too, even though this page never
+  // asked for it. Reset must still restore the widget's own starting
+  // filters through that window, not fall back to `DEFAULT_CASES_FILTERS`
+  // just because the shared query happens to be mid-refetch at that exact
+  // moment.
+  it("Reset still restores the widget's own filters during a later background refetch of the shared tag-catalog query", async () => {
+    // The initial catalog fetch resolves normally; a *second* call (the
+    // simulated background refetch below) is held open on a promise this
+    // test controls, so `isFetching` on the shared query stays true for as
+    // long as needed instead of racing a click against a promise that
+    // resolves in the same microtask it was created in.
+    let tagsCallCount = 0;
+    let resolveSecondTagsCall: (value: unknown) => void = () => {};
+    postMock.mockImplementation((url: string) => {
+      if (url === "/tags/search") {
+        tagsCallCount += 1;
+        if (tagsCallCount === 1) {
+          return Promise.resolve({
+            tags: [{ id: "t1", label: "s_dip" }, { id: "t2", label: "other-tag" }],
+          });
+        }
+        return new Promise((resolve) => {
+          resolveSecondTagsCall = resolve;
+        });
+      }
+      if (url === "/teams/search") return Promise.resolve({ teams: [] });
+      if (url === "/cases/search") {
+        return Promise.resolve({ cases: [], total: 0, limit: 10, offset: 0 });
+      }
+      return Promise.resolve({});
+    });
+
+    const { queryClient } = renderAtWithQueryClient(
+      buildWidgetPreviewHref({
+        previewSlug: "cases",
+        widgetId: "excl_tag_widget",
+        displayName: "Discussions on Going",
+        filters: {
+          filters: [
+            { field: "state", op: "in", values: ["open"] },
+            { field: "tag", op: "notIn", values: ["s_dip"] },
+          ],
+        },
+      }),
+    );
+
+    // Let the initial catalog fetch (and the /cases/search it feeds) settle
+    // to the widget's own resolved starting point.
+    await waitFor(() => {
+      const lastCasesCall = postMock.mock.calls.filter((c) => c[0] === "/cases/search").at(-1);
+      expect(lastCasesCall).toBeDefined();
+      expect(lastCasesCall?.[1]).toMatchObject({
+        filters: {
+          filters: expect.arrayContaining([{ field: "state", op: "in", values: ["open"] }]),
+        },
+      });
+    });
+
+    // Simulate another "Tags" control elsewhere refetching the exact same
+    // shared cache entry -- not an action this page itself takes. Held open
+    // by `resolveSecondTagsCall` above, so `isFetching` on
+    // `["csm-tags-search", ""]` stays true through the click below rather
+    // than flipping back before this test can observe it.
+    void queryClient.refetchQueries({ queryKey: ["csm-tags-search", ""] });
+    await waitFor(() => {
+      expect(queryClient.getQueryState(["csm-tags-search", ""])?.fetchStatus).toBe("fetching");
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /clear filters/i }));
+    resolveSecondTagsCall({ tags: [{ id: "t1", label: "s_dip" }, { id: "t2", label: "other-tag" }] });
+
+    await waitFor(() => {
+      const lastCasesCall = postMock.mock.calls.filter((c) => c[0] === "/cases/search").at(-1);
+      expect(lastCasesCall?.[1]).toMatchObject({
+        filters: {
+          filters: expect.arrayContaining([{ field: "state", op: "in", values: ["open"] }]),
+        },
+      });
+    });
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/pages/DashboardWidgetPreviewPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/pages/DashboardWidgetPreviewPage.test.tsx
@@ -39,6 +39,15 @@ vi.mock("@context/current-user/CurrentUserContext", () => ({
     isError: false,
   }),
 }));
+// `useGetCsmCases` (pulled in transitively once a case-family widget renders
+// the real CasesFilterBar/CasesList) reads `useLogger`, which needs a
+// `LoggerProvider` this test doesn't otherwise set up.
+vi.mock("@hooks/useLogger", () => ({
+  useLogger: () => ({ warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() }),
+}));
+vi.mock("@hooks/useIdTokenClaims", () => ({
+  useIdTokenClaims: () => ({ email: "agent@wso2.com" }),
+}));
 
 import DashboardWidgetPreviewPage from "@features/csm-dashboard/pages/DashboardWidgetPreviewPage";
 import { buildWidgetPreviewHref } from "@features/csm-dashboard/utils/widgetPreviewUrl";
@@ -59,9 +68,33 @@ function renderAt(initialEntry: string) {
   );
 }
 
+/** Routes `postMock` by URL, since a case-family widget's preview page
+ * fires up to three different POST endpoints at once: `/teams/search`
+ * (`CasesFilterBar`'s "Team" control loads unconditionally on mount),
+ * `/tags/search` (only when the widget's own filter needs the tag
+ * complement — see `DashboardWidgetPreviewPage.tsx`), and `/cases/search`
+ * itself. */
+function mockPost(responses: {
+  teams?: unknown;
+  tags?: unknown;
+  cases?: unknown;
+}): void {
+  postMock.mockImplementation((url: string) => {
+    if (url === "/teams/search") return Promise.resolve(responses.teams ?? { teams: [] });
+    if (url === "/tags/search") return Promise.resolve(responses.tags ?? { tags: [] });
+    if (url === "/cases/search") {
+      return Promise.resolve(
+        responses.cases ?? { cases: [], total: 0, limit: 10, offset: 0 },
+      );
+    }
+    return Promise.resolve({});
+  });
+}
+
 describe("DashboardWidgetPreviewPage", () => {
   beforeEach(() => {
     postMock.mockReset();
+    mockPost({});
   });
 
   it("prompts to open from a widget's View more link when the URL carries no widget params", () => {
@@ -85,194 +118,6 @@ describe("DashboardWidgetPreviewPage", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders the widget's table and paginates using the URL-provided widget id/filters", async () => {
-    postMock.mockResolvedValue({
-      total: 12,
-      cases: [{ id: "11111111-1111-1111-1111-111111111111", number: "CS-1", subject: "Disk full", state: "open" }],
-      limit: 10,
-      offset: 0,
-      hasMore: true,
-    });
-
-    renderAt(
-      buildWidgetPreviewHref({
-        previewSlug: "cases",
-        widgetId: "my_critical_open",
-        displayName: "My Critical & High Cases",
-        filters: { severities: ["critical"] },
-      }),
-    );
-
-    expect(screen.getByText("My Critical & High Cases")).toBeInTheDocument();
-    await waitFor(() => expect(screen.getByText("CS-1")).toBeInTheDocument());
-    expect(postMock).toHaveBeenCalledWith(
-      "/cases/search",
-      {
-        filters: { severities: ["critical"] },
-        pagination: { offset: 0, limit: 10 },
-      },
-      { signal: expect.any(AbortSignal) },
-    );
-
-    // TablePagination's "next page" button.
-    fireEvent.click(screen.getByRole("button", { name: /next page/i }));
-    await waitFor(() =>
-      expect(postMock).toHaveBeenCalledWith(
-        "/cases/search",
-        {
-          filters: { severities: ["critical"] },
-          pagination: { offset: 10, limit: 10 },
-        },
-        { signal: expect.any(AbortSignal) },
-      ),
-    );
-  });
-
-  it("resolves the masked @me sentinel back to the signed-in user's own id before querying", async () => {
-    postMock.mockResolvedValue({
-      total: 1,
-      cases: [{ id: "11111111-1111-1111-1111-111111111111", number: "CS-1", subject: "Disk full", state: "open" }],
-      limit: 10,
-      offset: 0,
-      hasMore: false,
-    });
-
-    renderAt(
-      buildWidgetPreviewHref({
-        previewSlug: "cases",
-        widgetId: "my_cases",
-        displayName: "My Cases",
-        filters: { assignedUserIds: [CURRENT_USER_ID] },
-        currentUserId: CURRENT_USER_ID,
-      }),
-    );
-
-    await waitFor(() => expect(screen.getByText("CS-1")).toBeInTheDocument());
-    expect(postMock).toHaveBeenCalledWith(
-      "/cases/search",
-      {
-        filters: { assignedUserIds: [CURRENT_USER_ID] },
-        pagination: { offset: 0, limit: 10 },
-      },
-      { signal: expect.any(AbortSignal) },
-    );
-  });
-
-  it("merges a typed search term into the widget's own filters as searchQuery", async () => {
-    postMock.mockResolvedValue({
-      total: 1,
-      cases: [{ id: "11111111-1111-1111-1111-111111111111", number: "CS-1", subject: "Disk full", state: "open" }],
-      limit: 10,
-      offset: 0,
-      hasMore: false,
-    });
-
-    renderAt(
-      buildWidgetPreviewHref({
-        previewSlug: "cases",
-        widgetId: "my_critical_open",
-        displayName: "My Critical & High Cases",
-        filters: { severities: ["critical"] },
-      }),
-    );
-    await waitFor(() => expect(screen.getByText("CS-1")).toBeInTheDocument());
-
-    fireEvent.change(screen.getByLabelText("Search"), { target: { value: "disk" } });
-
-    await waitFor(() =>
-      expect(postMock).toHaveBeenCalledWith(
-        "/cases/search",
-        {
-          filters: { severities: ["critical"], searchQuery: "disk" },
-          pagination: { offset: 0, limit: 10 },
-        },
-        { signal: expect.any(AbortSignal) },
-      ),
-    );
-  });
-
-  it("renders a visible summary of the active filter criteria (flat filter shape)", async () => {
-    postMock.mockResolvedValue({
-      total: 1,
-      cases: [{ id: "11111111-1111-1111-1111-111111111111", number: "CS-1", subject: "Disk full", state: "open" }],
-      limit: 10,
-      offset: 0,
-      hasMore: false,
-    });
-
-    renderAt(
-      buildWidgetPreviewHref({
-        previewSlug: "cases",
-        widgetId: "my_critical_open",
-        displayName: "My Critical & High Cases",
-        filters: { severities: ["critical", "high"] },
-      }),
-    );
-
-    await waitFor(() => expect(screen.getByText("CS-1")).toBeInTheDocument());
-    const group = screen.getByRole("group", { name: "Active filters" });
-    expect(group).toHaveTextContent("severities: critical, high");
-  });
-
-  it("renders a visible summary of the active filter criteria (case field/op/values DSL shape), including the resolved team filter", async () => {
-    postMock.mockResolvedValue({
-      total: 1,
-      cases: [{ id: "11111111-1111-1111-1111-111111111111", number: "CS-1", subject: "Disk full", state: "open" }],
-      limit: 10,
-      offset: 0,
-      hasMore: false,
-    });
-
-    renderAt(
-      buildWidgetPreviewHref({
-        previewSlug: "cases",
-        widgetId: "team_open_cases",
-        displayName: "Team Open Cases",
-        filters: {
-          filters: [
-            { field: "state", op: "in", values: ["open"] },
-            { field: "tag", op: "notIn", values: ["s_dip"] },
-            {
-              field: "creTeam",
-              op: "in",
-              values: ["22222222-2222-2222-2222-222222222222"],
-            },
-          ],
-        },
-      }),
-    );
-
-    await waitFor(() => expect(screen.getByText("CS-1")).toBeInTheDocument());
-    const group = screen.getByRole("group", { name: "Active filters" });
-    expect(group).toHaveTextContent("state: open");
-    expect(group).toHaveTextContent("tag (notIn): s_dip");
-    expect(group).toHaveTextContent(
-      "creTeam: 22222222-2222-2222-2222-222222222222",
-    );
-  });
-
-  it("does not render an active-filters summary when the widget has no filters", async () => {
-    postMock.mockResolvedValue({
-      total: 1,
-      cases: [{ id: "11111111-1111-1111-1111-111111111111", number: "CS-1", subject: "Disk full", state: "open" }],
-      limit: 10,
-      offset: 0,
-      hasMore: false,
-    });
-
-    renderAt(
-      buildWidgetPreviewHref({
-        previewSlug: "cases",
-        widgetId: "my_critical_open",
-        displayName: "My Critical & High Cases",
-        filters: {},
-      }),
-    );
-
-    await waitFor(() => expect(screen.getByText("CS-1")).toBeInTheDocument());
-    expect(screen.queryByRole("group", { name: "Active filters" })).not.toBeInTheDocument();
-  });
-
   it("returns to the dashboard when Back is clicked", () => {
     renderAt(
       buildWidgetPreviewHref({
@@ -284,5 +129,321 @@ describe("DashboardWidgetPreviewPage", () => {
     );
     fireEvent.click(screen.getByRole("button", { name: /back/i }));
     expect(screen.getByText("Dashboard landing")).toBeInTheDocument();
+  });
+});
+
+/**
+ * `resourceType: "incident"` never routes through `CaseFamilyWidgetPreview`
+ * (see `CASE_FAMILY_RESOURCE_TYPES` in `DashboardWidgetPreviewPage.tsx`), so
+ * this generic `useWidgetData` + `WIDGET_LIST_RENDERERS` + "Filtered by:"
+ * chip-summary path stays exactly as it always has. These were originally
+ * written against `previewSlug: "cases"` fixtures purely as a convenient
+ * generic resourceType — moved to "incidents" once "cases" gained its own,
+ * behaviorally different branch (see the describe block below).
+ */
+describe("DashboardWidgetPreviewPage — generic resourceTypes keep the read-only summary + search box", () => {
+  beforeEach(() => {
+    postMock.mockReset();
+  });
+
+  it("renders the widget's table and paginates using the URL-provided widget id/filters", async () => {
+    postMock.mockResolvedValue({
+      total: 12,
+      incidents: [{ id: "11111111-1111-1111-1111-111111111111", number: "INC-1", subject: "Disk full" }],
+      limit: 10,
+      offset: 0,
+      hasMore: true,
+    });
+
+    renderAt(
+      buildWidgetPreviewHref({
+        previewSlug: "incidents",
+        widgetId: "my_critical_open",
+        displayName: "My Critical & High Incidents",
+        filters: { priorities: ["critical"] },
+      }),
+    );
+
+    expect(screen.getByText("My Critical & High Incidents")).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText("INC-1")).toBeInTheDocument());
+    expect(postMock).toHaveBeenCalledWith(
+      "/incidents/search",
+      {
+        filters: { priorities: ["critical"] },
+        pagination: { offset: 0, limit: 10 },
+      },
+      { signal: expect.any(AbortSignal) },
+    );
+
+    // TablePagination's "next page" button.
+    fireEvent.click(screen.getByRole("button", { name: /next page/i }));
+    await waitFor(() =>
+      expect(postMock).toHaveBeenCalledWith(
+        "/incidents/search",
+        {
+          filters: { priorities: ["critical"] },
+          pagination: { offset: 10, limit: 10 },
+        },
+        { signal: expect.any(AbortSignal) },
+      ),
+    );
+  });
+
+  it("resolves the masked @me sentinel back to the signed-in user's own id before querying", async () => {
+    postMock.mockResolvedValue({
+      total: 1,
+      incidents: [{ id: "11111111-1111-1111-1111-111111111111", number: "INC-1", subject: "Disk full" }],
+      limit: 10,
+      offset: 0,
+      hasMore: false,
+    });
+
+    renderAt(
+      buildWidgetPreviewHref({
+        previewSlug: "incidents",
+        widgetId: "my_incidents",
+        displayName: "My Incidents",
+        filters: { assignedUserIds: [CURRENT_USER_ID] },
+        currentUserId: CURRENT_USER_ID,
+      }),
+    );
+
+    await waitFor(() => expect(screen.getByText("INC-1")).toBeInTheDocument());
+    expect(postMock).toHaveBeenCalledWith(
+      "/incidents/search",
+      {
+        filters: { assignedUserIds: [CURRENT_USER_ID] },
+        pagination: { offset: 0, limit: 10 },
+      },
+      { signal: expect.any(AbortSignal) },
+    );
+  });
+
+  it("merges a typed search term into the widget's own filters as searchQuery", async () => {
+    postMock.mockResolvedValue({
+      total: 1,
+      incidents: [{ id: "11111111-1111-1111-1111-111111111111", number: "INC-1", subject: "Disk full" }],
+      limit: 10,
+      offset: 0,
+      hasMore: false,
+    });
+
+    renderAt(
+      buildWidgetPreviewHref({
+        previewSlug: "incidents",
+        widgetId: "my_critical_open",
+        displayName: "My Critical & High Incidents",
+        filters: { priorities: ["critical"] },
+      }),
+    );
+    await waitFor(() => expect(screen.getByText("INC-1")).toBeInTheDocument());
+
+    fireEvent.change(screen.getByLabelText("Search"), { target: { value: "disk" } });
+
+    await waitFor(() =>
+      expect(postMock).toHaveBeenCalledWith(
+        "/incidents/search",
+        {
+          filters: { priorities: ["critical"], searchQuery: "disk" },
+          pagination: { offset: 0, limit: 10 },
+        },
+        { signal: expect.any(AbortSignal) },
+      ),
+    );
+  });
+
+  it("renders a visible summary of the active filter criteria (flat filter shape)", async () => {
+    postMock.mockResolvedValue({
+      total: 1,
+      incidents: [{ id: "11111111-1111-1111-1111-111111111111", number: "INC-1", subject: "Disk full" }],
+      limit: 10,
+      offset: 0,
+      hasMore: false,
+    });
+
+    renderAt(
+      buildWidgetPreviewHref({
+        previewSlug: "incidents",
+        widgetId: "my_critical_open",
+        displayName: "My Critical & High Incidents",
+        filters: { priorities: ["critical", "high"] },
+      }),
+    );
+
+    await waitFor(() => expect(screen.getByText("INC-1")).toBeInTheDocument());
+    const group = screen.getByRole("group", { name: "Active filters" });
+    expect(group).toHaveTextContent("priorities: critical, high");
+  });
+
+  it("does not render an active-filters summary when the widget has no filters", async () => {
+    postMock.mockResolvedValue({
+      total: 1,
+      incidents: [{ id: "11111111-1111-1111-1111-111111111111", number: "INC-1", subject: "Disk full" }],
+      limit: 10,
+      offset: 0,
+      hasMore: false,
+    });
+
+    renderAt(
+      buildWidgetPreviewHref({
+        previewSlug: "incidents",
+        widgetId: "my_critical_open",
+        displayName: "My Critical & High Incidents",
+        filters: {},
+      }),
+    );
+
+    await waitFor(() => expect(screen.getByText("INC-1")).toBeInTheDocument());
+    expect(screen.queryByRole("group", { name: "Active filters" })).not.toBeInTheDocument();
+  });
+});
+
+/**
+ * Reported live: a case-family widget's "View more" landed on a static
+ * "Filtered by:" chip summary, unlike every other list page in the app,
+ * which has a real, editable filter bar. `CaseFamilyWidgetPreview` (in
+ * `DashboardWidgetPreviewPage.tsx`) fixes this by seeding the actual
+ * `CasesFilterBar` + `useGetCsmCases` + `CasesList` from the widget's own
+ * filters instead.
+ */
+describe("DashboardWidgetPreviewPage — case-family widgets get the real, editable Cases filter bar", () => {
+  beforeEach(() => {
+    postMock.mockReset();
+  });
+
+  it("renders the real CasesFilterBar (not the read-only chip summary), seeded from the widget's own field/op/values filters", async () => {
+    mockPost({
+      cases: {
+        cases: [{ id: "c1", number: "CS-1", subject: "Disk full", state: "open" }],
+        total: 1,
+        limit: 10,
+        offset: 0,
+      },
+    });
+
+    renderAt(
+      buildWidgetPreviewHref({
+        previewSlug: "cases",
+        widgetId: "team_open_cases",
+        displayName: "Team Open Cases",
+        filters: { filters: [{ field: "state", op: "in", values: ["open"] }] },
+      }),
+    );
+
+    await waitFor(() => expect(screen.getByText("CS-1")).toBeInTheDocument());
+    expect(screen.getByRole("combobox", { name: "Severity" })).toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: "State" })).toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: "Tags" })).toBeInTheDocument();
+    expect(screen.queryByRole("group", { name: "Active filters" })).not.toBeInTheDocument();
+
+    expect(postMock).toHaveBeenCalledWith(
+      "/cases/search",
+      expect.objectContaining({
+        filters: expect.objectContaining({
+          filters: expect.arrayContaining([
+            { field: "state", op: "in", values: ["open"] },
+          ]),
+        }),
+      }),
+    );
+  });
+
+  it("re-queries /cases/search when a filter is edited in the real filter bar", async () => {
+    mockPost({
+      cases: {
+        cases: [{ id: "c1", number: "CS-1", subject: "Disk full", state: "open" }],
+        total: 1,
+        limit: 10,
+        offset: 0,
+      },
+    });
+
+    renderAt(
+      buildWidgetPreviewHref({
+        previewSlug: "cases",
+        widgetId: "team_open_cases",
+        displayName: "Team Open Cases",
+        filters: {},
+      }),
+    );
+    await waitFor(() => expect(screen.getByText("CS-1")).toBeInTheDocument());
+    const callsBefore = postMock.mock.calls.filter((c) => c[0] === "/cases/search").length;
+
+    fireEvent.change(screen.getByPlaceholderText(/search by case #/i), {
+      target: { value: "disk" },
+    });
+
+    await waitFor(() => {
+      const callsAfter = postMock.mock.calls.filter((c) => c[0] === "/cases/search").length;
+      expect(callsAfter).toBeGreaterThan(callsBefore);
+    });
+    const lastCall = postMock.mock.calls
+      .filter((c) => c[0] === "/cases/search")
+      .at(-1);
+    expect(lastCall?.[1]).toMatchObject({ filters: { searchQuery: "disk" } });
+  });
+
+  // The core regression: a tag has no small, fixed universe of values (see
+  // `CaseFamilyWidgetPreview`'s own doc comment), so a widget's
+  // `tag notIn ["s_dip"]` can't be represented by a real `excludeTags`
+  // control (there isn't one here) -- it's seeded into the single "Tags"
+  // control as the complement over the currently-known tag catalog instead.
+  it("seeds the single 'Tags' control with the complement of the tag catalog for a tag notIn widget filter", async () => {
+    mockPost({
+      tags: { tags: [{ id: "t1", label: "s_dip" }, { id: "t2", label: "other-tag" }] },
+      cases: { cases: [], total: 0, limit: 10, offset: 0 },
+    });
+
+    renderAt(
+      buildWidgetPreviewHref({
+        previewSlug: "cases",
+        widgetId: "excl_tag_widget",
+        displayName: "Discussions on Going",
+        filters: { filters: [{ field: "tag", op: "notIn", values: ["s_dip"] }] },
+      }),
+    );
+
+    await waitFor(() =>
+      expect(postMock).toHaveBeenCalledWith("/tags/search", expect.anything()),
+    );
+
+    await waitFor(() => {
+      const lastCasesCall = postMock.mock.calls
+        .filter((c) => c[0] === "/cases/search")
+        .at(-1);
+      expect(lastCasesCall).toBeDefined();
+      expect(lastCasesCall?.[1]).toMatchObject({
+        filters: {
+          filters: expect.arrayContaining([
+            { field: "tag", op: "in", values: ["other-tag"] },
+          ]),
+        },
+      });
+    });
+
+    // The excluded tag itself never appears as a selected/included value.
+    const lastCasesCall = postMock.mock.calls.filter((c) => c[0] === "/cases/search").at(-1);
+    const tagEntry = (
+      lastCasesCall?.[1] as { filters: { filters: { field: string; values: string[] }[] } }
+    ).filters.filters.find((f) => f.field === "tag");
+    expect(tagEntry?.values).not.toContain("s_dip");
+  });
+
+  it("does not fetch the tag catalog at all when the widget has no tag exclusion", async () => {
+    mockPost({ cases: { cases: [], total: 0, limit: 10, offset: 0 } });
+
+    renderAt(
+      buildWidgetPreviewHref({
+        previewSlug: "cases",
+        widgetId: "plain_widget",
+        displayName: "Plain Widget",
+        filters: { filters: [{ field: "state", op: "in", values: ["open"] }] },
+      }),
+    );
+
+    await waitFor(() =>
+      expect(postMock).toHaveBeenCalledWith("/cases/search", expect.anything()),
+    );
+    expect(postMock).not.toHaveBeenCalledWith("/tags/search", expect.anything());
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/pages/DashboardWidgetPreviewPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/pages/DashboardWidgetPreviewPage.test.tsx
@@ -429,6 +429,89 @@ describe("DashboardWidgetPreviewPage — case-family widgets get the real, edita
     expect(tagEntry?.values).not.toContain("s_dip");
   });
 
+  // CodeRabbit finding: overwriting `tags` with the complement would
+  // silently drop a widget's own "must have one of these tags" requirement
+  // when it also excludes a tag. Intersecting instead preserves both.
+  it("intersects an existing tag-in list with the complement, rather than overwriting it, when a widget has both tag in and tag notIn", async () => {
+    mockPost({
+      tags: {
+        tags: [
+          { id: "t1", label: "s_dip" },
+          { id: "t2", label: "required-tag" },
+          { id: "t3", label: "other-tag" },
+        ],
+      },
+      cases: { cases: [], total: 0, limit: 10, offset: 0 },
+    });
+
+    renderAt(
+      buildWidgetPreviewHref({
+        previewSlug: "cases",
+        widgetId: "in_and_notin_widget",
+        displayName: "In and NotIn Widget",
+        filters: {
+          filters: [
+            { field: "tag", op: "in", values: ["required-tag"] },
+            { field: "tag", op: "notIn", values: ["s_dip"] },
+          ],
+        },
+      }),
+    );
+
+    await waitFor(() => {
+      const lastCasesCall = postMock.mock.calls
+        .filter((c) => c[0] === "/cases/search")
+        .at(-1);
+      expect(lastCasesCall).toBeDefined();
+      expect(lastCasesCall?.[1]).toMatchObject({
+        filters: {
+          filters: expect.arrayContaining([
+            { field: "tag", op: "in", values: ["required-tag"] },
+          ]),
+        },
+      });
+    });
+  });
+
+  // CodeRabbit finding: silently dropping the exclusion on a catalog-fetch
+  // failure would broaden the search to every tag instead of failing safe.
+  it("falls back to the widget's raw excludeTags (still applied, just not shown as checked) when the tag catalog fails to load", async () => {
+    postMock.mockImplementation((url: string) => {
+      if (url === "/tags/search") return Promise.reject(new Error("network error"));
+      if (url === "/cases/search") {
+        return Promise.resolve({ cases: [], total: 0, limit: 10, offset: 0 });
+      }
+      return Promise.resolve({ teams: [] });
+    });
+
+    renderAt(
+      buildWidgetPreviewHref({
+        previewSlug: "cases",
+        widgetId: "excl_tag_catalog_fails",
+        displayName: "Discussions on Going",
+        filters: { filters: [{ field: "tag", op: "notIn", values: ["s_dip"] }] },
+      }),
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText(/couldn.t load the tag catalog/i)).toBeInTheDocument(),
+    );
+
+    await waitFor(() => {
+      const lastCasesCall = postMock.mock.calls
+        .filter((c) => c[0] === "/cases/search")
+        .at(-1);
+      expect(lastCasesCall).toBeDefined();
+      expect(lastCasesCall?.[1]).toMatchObject({
+        filters: {
+          filters: expect.arrayContaining([
+            { field: "tag", op: "notIn", values: ["s_dip"] },
+          ]),
+        },
+      });
+    });
+  });
+
   it("does not fetch the tag catalog at all when the widget has no tag exclusion", async () => {
     mockPost({ cases: { cases: [], total: 0, limit: 10, offset: 0 } });
 

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/pages/DashboardWidgetPreviewPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/pages/DashboardWidgetPreviewPage.tsx
@@ -187,7 +187,19 @@ interface CaseFamilyWidgetPreviewProps {
  * single multi-select. This is a deliberately approximate complement (the
  * catalog is "recently/commonly used tags", not literally every tag that
  * has ever existed), accepted as a known tradeoff rather than the exact
- * complement `onboardingStatuses` gets over its 4 fixed values.
+ * complement `onboardingStatuses` gets over its 4 fixed values — in
+ * particular, a case with no tags at all can't be represented as "one of
+ * the complement's tags" and is wrongly excluded by this approximation, a
+ * gap this deliberately doesn't try to work around (doing so would mean
+ * going back to a separate, non-dropdown representation of the exclusion,
+ * which is exactly what was asked against). Two narrower correctness gaps
+ * *are* worth guarding even within this approximation, though: a widget
+ * that also has its own `tag in [...]` gets that list intersected with the
+ * complement rather than overwritten (so the widget's "must have one of
+ * these tags" requirement survives alongside the exclusion), and a failed
+ * tag-catalog fetch falls back to the widget's raw, un-complemented
+ * `excludeTags` (still correctly scoped, just not shown as checked items)
+ * rather than silently dropping the exclusion and broadening the search.
  */
 function CaseFamilyWidgetPreview({
   displayName,
@@ -208,22 +220,36 @@ function CaseFamilyWidgetPreview({
     if (!needsTagComplement) {
       return { ...DEFAULT_CASES_FILTERS, ...rawTranslated };
     }
-    // Waiting on the catalog (or it failed) -- resolved below once
-    // `tagCatalog` lands; a failure falls through to no tags pre-selected
-    // (broader, not narrower, than the widget's own intent) rather than
-    // blocking the page forever.
     if (isCatalogFetching) return null;
+    if (isCatalogError || !tagCatalog) {
+      // The catalog failed to load -- fall back to the widget's own raw
+      // `excludeTags` rather than dropping it, so the search itself stays
+      // correctly scoped (just excluded, not narrowed to a wrong "in"
+      // list either) even though the "Tags" control has no way to *show*
+      // an exclusion as checked items.
+      return { ...DEFAULT_CASES_FILTERS, ...rawTranslated };
+    }
     const excluded = new Set(rawTranslated.excludeTags);
-    const complementTags = (tagCatalog ?? [])
+    const complementTags = tagCatalog
       .map((t) => t.label)
       .filter((label) => !excluded.has(label));
+    // A widget that also requires specific tags (`tag in [...]` alongside
+    // `tag notIn [...]`) must keep both conditions ANDed -- intersect with
+    // the complement rather than overwriting the required list outright,
+    // or the widget's own "must have one of these tags" requirement is
+    // silently lost.
+    const priorTags = rawTranslated.tags;
+    const tags =
+      priorTags && priorTags.length > 0
+        ? priorTags.filter((t) => complementTags.includes(t))
+        : complementTags;
     return {
       ...DEFAULT_CASES_FILTERS,
       ...rawTranslated,
-      tags: complementTags,
+      tags,
       excludeTags: [],
     };
-  }, [needsTagComplement, isCatalogFetching, tagCatalog, rawTranslated]);
+  }, [needsTagComplement, isCatalogFetching, isCatalogError, tagCatalog, rawTranslated]);
 
   const [casesFilters, setCasesFilters] = useState<CasesFilters | null>(null);
   // Seeds `casesFilters` from `initialCasesFilters` exactly once, as soon as
@@ -282,14 +308,15 @@ function CaseFamilyWidgetPreview({
       </Box>
       {isCatalogError && (
         <Typography variant="caption" color="text.secondary">
-          Couldn&rsquo;t load the tag catalog to reflect this widget&rsquo;s tag exclusion — no
-          tags are pre-selected below; pick them manually if needed.
+          Couldn&rsquo;t load the tag catalog — this widget&rsquo;s tag exclusion is still
+          applied to the results below, it just isn&rsquo;t shown as checked items in the Tags
+          control.
         </Typography>
       )}
       <CasesFilterBar
         filters={casesFilters}
         onChange={handleFiltersChange}
-        onReset={() => setCasesFilters(initialCasesFilters ?? DEFAULT_CASES_FILTERS)}
+        onReset={() => handleFiltersChange(initialCasesFilters ?? DEFAULT_CASES_FILTERS)}
         isFiltersOpen={isFiltersOpen}
         onFiltersToggle={() => setIsFiltersOpen((prev) => !prev)}
         availableAssigneeUsers={[]}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/pages/DashboardWidgetPreviewPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/pages/DashboardWidgetPreviewPage.tsx
@@ -25,16 +25,46 @@ import { useDebouncedValue } from "@hooks/useDebouncedValue";
 import { useWidgetData } from "@features/csm-dashboard/api/useWidgetData";
 import RefreshButton from "@components/RefreshButton";
 import { WIDGET_LIST_RENDERERS } from "@features/csm-dashboard/config/widgetListConfig";
-import { resourceTypeForPreviewSlug } from "@features/csm-dashboard/config/widgetResourceConfig";
+import {
+  resourceTypeForPreviewSlug,
+  translateCaseDashboardFilters,
+} from "@features/csm-dashboard/config/widgetResourceConfig";
 import {
   describeWidgetFilters,
   parseWidgetPreviewFilters,
   resolveCurrentUserSentinels,
 } from "@features/csm-dashboard/utils/widgetPreviewUrl";
+import CasesFilterBar, {
+  type CasesFilters,
+} from "@features/csm-cases/components/CasesFilterBar";
+import CasesList from "@features/csm-cases/components/CasesList";
+import { useGetCsmCases } from "@features/csm-cases/api/useGetCsmCases";
+import { useSearchTags } from "@features/csm-cases/api/useSearchTags";
+import { DEFAULT_CASES_FILTERS } from "@features/csm-cases/utils/casesFiltersUrl";
 
 const DEFAULT_ROWS_PER_PAGE = 10;
 const ROWS_PER_PAGE_OPTIONS = [10, 20, BE_MAX_PAGE_LIMIT];
 const SEARCH_DEBOUNCE_MS = 300;
+
+/**
+ * Every widget `resourceType` that ultimately queries `/cases/search` (see
+ * `WIDGET_RESOURCE_CONFIG` in `widgetResourceConfig.ts` — they all share the
+ * same response shape and the same `CaseWidgetList` renderer). Reported
+ * live: for these, a static "Filtered by:" chip summary read wrong next to
+ * every other list page in the app, which uses a real, editable filter bar
+ * — so this "View more" destination stays its own dedicated, bookmarkable
+ * route (that part was correct), but its filter UI is now the actual
+ * `CasesFilterBar` + `useGetCsmCases` + `CasesList`, the same trio the Cases
+ * tab itself uses, seeded from the widget's own filters via
+ * `translateCaseDashboardFilters` and then fully editable from there.
+ */
+const CASE_FAMILY_RESOURCE_TYPES = new Set<BeWidgetResourceType>([
+  "case",
+  "service_request",
+  "security_report_analysis",
+  "announcement",
+  "engagement",
+]);
 
 /**
  * "View more" landing for a dashboard `shape: "list"` widget tile — the same
@@ -110,6 +140,16 @@ export default function DashboardWidgetPreviewPage(): JSX.Element {
 
   const filters = resolveCurrentUserSentinels(rawFilters, user?.id);
 
+  if (CASE_FAMILY_RESOURCE_TYPES.has(resourceType)) {
+    return (
+      <CaseFamilyWidgetPreview
+        displayName={displayName}
+        filters={filters}
+        backButton={backButton}
+      />
+    );
+  }
+
   return (
     <DashboardWidgetPreviewContent
       widgetId={widgetId}
@@ -118,6 +158,164 @@ export default function DashboardWidgetPreviewPage(): JSX.Element {
       filters={filters}
       backButton={backButton}
     />
+  );
+}
+
+interface CaseFamilyWidgetPreviewProps {
+  displayName: string;
+  filters: Record<string, unknown>;
+  backButton: JSX.Element;
+}
+
+/**
+ * The case-family "View more" landing: a real, editable `CasesFilterBar`
+ * seeded from the widget's own filters (translated once via
+ * `translateCaseDashboardFilters`, the same function that already builds
+ * the tile's own click-through URL), feeding the actual `useGetCsmCases` +
+ * `CasesList` the Cases tab itself uses — not a read-only render of
+ * whatever the widget happened to be configured with.
+ *
+ * `CasesFilterBar` has exactly one "Tags" control, not a second "Exclude
+ * tags" one (a tag has no small, fixed universe of values, unlike
+ * `onboardingStatuses`, so a real, independent `excludeTags` field/control
+ * still exists everywhere else `CasesFilterBar` is used — the general Cases
+ * list included). Here specifically, though, a widget's own `tag notIn [X]`
+ * is seeded into that single "Tags" control as its complement over the
+ * currently-known tag catalog (every other tag currently on offer) rather
+ * than surfacing as a separate `excludeTags` value the control can't show —
+ * reported live as confusing next to a control explicitly asked to stay a
+ * single multi-select. This is a deliberately approximate complement (the
+ * catalog is "recently/commonly used tags", not literally every tag that
+ * has ever existed), accepted as a known tradeoff rather than the exact
+ * complement `onboardingStatuses` gets over its 4 fixed values.
+ */
+function CaseFamilyWidgetPreview({
+  displayName,
+  filters,
+  backButton,
+}: CaseFamilyWidgetPreviewProps): JSX.Element {
+  // Stable across this component's lifetime (a fresh "View more" click is a
+  // fresh mount) so the tag-complement effect below only ever fires once.
+  const [rawTranslated] = useState(() => translateCaseDashboardFilters(filters));
+  const needsTagComplement = rawTranslated.excludeTags?.length ? true : false;
+
+  // Only the complement path needs the catalog -- an ordinary `tags`/no-tag
+  // widget never issues this request at all.
+  const { data: tagCatalog, isFetching: isCatalogFetching, isError: isCatalogError } =
+    useSearchTags("", needsTagComplement);
+
+  const initialCasesFilters = useMemo<CasesFilters | null>(() => {
+    if (!needsTagComplement) {
+      return { ...DEFAULT_CASES_FILTERS, ...rawTranslated };
+    }
+    // Waiting on the catalog (or it failed) -- resolved below once
+    // `tagCatalog` lands; a failure falls through to no tags pre-selected
+    // (broader, not narrower, than the widget's own intent) rather than
+    // blocking the page forever.
+    if (isCatalogFetching) return null;
+    const excluded = new Set(rawTranslated.excludeTags);
+    const complementTags = (tagCatalog ?? [])
+      .map((t) => t.label)
+      .filter((label) => !excluded.has(label));
+    return {
+      ...DEFAULT_CASES_FILTERS,
+      ...rawTranslated,
+      tags: complementTags,
+      excludeTags: [],
+    };
+  }, [needsTagComplement, isCatalogFetching, tagCatalog, rawTranslated]);
+
+  const [casesFilters, setCasesFilters] = useState<CasesFilters | null>(null);
+  // Seeds `casesFilters` from `initialCasesFilters` exactly once, as soon as
+  // it resolves (immediately for a non-tag-complement widget; after the
+  // catalog fetch settles otherwise) -- never re-seeds afterward, so it
+  // can't clobber an edit the viewer already made while the catalog was
+  // still loading.
+  if (casesFilters === null && initialCasesFilters !== null) {
+    setCasesFilters(initialCasesFilters);
+  }
+
+  const [isFiltersOpen, setIsFiltersOpen] = useState(true);
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_ROWS_PER_PAGE);
+
+  const handleFiltersChange = (next: CasesFilters): void => {
+    setCasesFilters(next);
+    setPage(0);
+  };
+
+  const handleRowsPerPageChange = (e: ChangeEvent<HTMLInputElement>): void => {
+    setRowsPerPage(parseInt(e.target.value, 10));
+    setPage(0);
+  };
+
+  const { data, isLoading, isError, isFetching, refetch, dataUpdatedAt } = useGetCsmCases(
+    casesFilters ?? DEFAULT_CASES_FILTERS,
+    page,
+    rowsPerPage,
+    casesFilters !== null,
+  );
+
+  if (casesFilters === null) {
+    return (
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+        {backButton}
+        <Typography variant="h5">{displayName}</Typography>
+        <Typography variant="body2" color="text.secondary">
+          Loading…
+        </Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+      {backButton}
+      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 1 }}>
+        <Typography variant="h5">{displayName}</Typography>
+        <RefreshButton
+          onRefresh={() => void refetch()}
+          isFetching={isFetching}
+          updatedAt={dataUpdatedAt}
+          label={`Refresh ${displayName}`}
+        />
+      </Box>
+      {isCatalogError && (
+        <Typography variant="caption" color="text.secondary">
+          Couldn&rsquo;t load the tag catalog to reflect this widget&rsquo;s tag exclusion — no
+          tags are pre-selected below; pick them manually if needed.
+        </Typography>
+      )}
+      <CasesFilterBar
+        filters={casesFilters}
+        onChange={handleFiltersChange}
+        onReset={() => setCasesFilters(initialCasesFilters ?? DEFAULT_CASES_FILTERS)}
+        isFiltersOpen={isFiltersOpen}
+        onFiltersToggle={() => setIsFiltersOpen((prev) => !prev)}
+        availableAssigneeUsers={[]}
+        availableProjects={[]}
+      />
+      {isError ? (
+        <Typography variant="body2" color="text.secondary">
+          Could not load this widget.
+        </Typography>
+      ) : (
+        <>
+          <CasesList cases={data?.cases ?? []} isLoading={isLoading} skeletonCount={rowsPerPage} />
+          <TablePagination
+            component="div"
+            count={data?.total ?? 0}
+            page={page}
+            onPageChange={(_, newPage) => setPage(newPage)}
+            rowsPerPage={rowsPerPage}
+            onRowsPerPageChange={handleRowsPerPageChange}
+            rowsPerPageOptions={ROWS_PER_PAGE_OPTIONS}
+            showFirstButton
+            showLastButton
+          />
+        </>
+      )}
+    </Box>
   );
 }
 

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/pages/DashboardWidgetPreviewPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/pages/DashboardWidgetPreviewPage.tsx
@@ -251,14 +251,29 @@ function CaseFamilyWidgetPreview({
     };
   }, [needsTagComplement, isCatalogFetching, isCatalogError, tagCatalog, rawTranslated]);
 
+  // `initialCasesFilters` is reactive, not actually "initial" -- it goes
+  // back to `null` whenever `isCatalogFetching` is true, including on a
+  // *later* background refetch of `useSearchTags("", ...)`'s cache entry
+  // (shared, by query key, with every other open "Tags" dropdown in the
+  // app, e.g. the real one inside `CasesFilterBar` below, once its own
+  // `staleTime` elapses). Freezing the first resolved value here, once,
+  // is what makes both the initial seed below and `onReset` immune to that
+  // later refetch -- without it, clicking Reset during that window would
+  // fall back to `DEFAULT_CASES_FILTERS` and silently drop every one of
+  // the widget's own starting filters, not just the tag complement.
+  const [resetBaseline, setResetBaseline] = useState<CasesFilters | null>(null);
+  if (resetBaseline === null && initialCasesFilters !== null) {
+    setResetBaseline(initialCasesFilters);
+  }
+
   const [casesFilters, setCasesFilters] = useState<CasesFilters | null>(null);
-  // Seeds `casesFilters` from `initialCasesFilters` exactly once, as soon as
-  // it resolves (immediately for a non-tag-complement widget; after the
+  // Seeds `casesFilters` from `resetBaseline` exactly once, as soon as it
+  // resolves (immediately for a non-tag-complement widget; after the
   // catalog fetch settles otherwise) -- never re-seeds afterward, so it
   // can't clobber an edit the viewer already made while the catalog was
   // still loading.
-  if (casesFilters === null && initialCasesFilters !== null) {
-    setCasesFilters(initialCasesFilters);
+  if (casesFilters === null && resetBaseline !== null) {
+    setCasesFilters(resetBaseline);
   }
 
   const [isFiltersOpen, setIsFiltersOpen] = useState(true);
@@ -316,7 +331,7 @@ function CaseFamilyWidgetPreview({
       <CasesFilterBar
         filters={casesFilters}
         onChange={handleFiltersChange}
-        onReset={() => handleFiltersChange(initialCasesFilters ?? DEFAULT_CASES_FILTERS)}
+        onReset={() => handleFiltersChange(resetBaseline ?? DEFAULT_CASES_FILTERS)}
         isFiltersOpen={isFiltersOpen}
         onFiltersToggle={() => setIsFiltersOpen((prev) => !prev)}
         availableAssigneeUsers={[]}


### PR DESCRIPTION
## Summary

**Cases filter bar layout** — Project's selected names ellipsized almost immediately at the same width as every other control (long project names, no room). Moved "Project" to the very end of the grid and gave it a wider slot; "Onboarding status" moved up into the main row where Project used to sit.

**"Tags" filter control** — added a real, async multi-select ("Tags") that searches existing tag labels via `/tags/search` as you type, `freeSolo` so a typed-but-unlisted tag still works as a filter. It replaces a plain chip-only field that had been sitting unused since an earlier round. Also fixed two things about it once built:
- It had no `renderOption`, so it rendered as MUI's default plain-highlight list instead of the checkbox-per-row style every other multi-select in this app uses.
- MUI hides an `Autocomplete`'s dropdown chevron by default whenever `freeSolo` is set — forced it back on (`forcePopupIcon`) so it's visually consistent with every other filter dropdown.

**Dropdown popup width** — reported live: the "Team" control's popup was much wider than the field itself once a team name was long, unlike every other filter. `MultiSelectField`'s `Select` now measures the field's own rendered width when opened and pins the popup to exactly that (not just a generic cap), and long option labels now wrap onto a second line instead of getting clipped (MUI's `MenuItem` forces `white-space: nowrap` by default).

**Dashboard widget "View more" page** — reported live: a case-family widget's ("case"/"service_request"/"security_report_analysis"/"announcement"/"engagement") preview page showed a static, read-only "Filtered by:" chip summary (raw field names like `projectOnboardingStatus (notIn): In-Progress`), unlike every other list page in the app, which has a real, editable filter bar. This page now renders the actual `CasesFilterBar` + `useGetCsmCases` + `CasesList` — the same trio the Cases tab itself uses — seeded from the widget's own filters (`translateCaseDashboardFilters`, now exported for this reuse) and fully editable from there. Every other resourceType's preview page is unchanged.

A tag `notIn` widget filter needed special handling here: unlike `onboardingStatuses` (a closed, 4-value domain, so `notIn(X)` has an *exact* complement), a tag has no fixed universe of values. Rather than add a second "Exclude tags" control (considered, but explicitly asked to keep this a single "Tags" multi-select), a `tag notIn [X]` widget filter is seeded into that one control as the complement over the *currently-known tag catalog* — an approximation, called out as such in the code, not a lossless conversion.

## Test plan
- [x] `tsc -b` — clean
- [x] `eslint .` — 0 errors (2 pre-existing warnings, unrelated files)
- [x] Full `vitest run` — **181/181 test files, 1801/1801 tests pass**, including new/updated coverage for the Tags control, the Project reorder, and a rewritten `DashboardWidgetPreviewPage.test.tsx` (case-family widgets now get their own describe block against the real filter bar + `/cases/search`/`/tags/search` calls; the pre-existing generic-resourceType tests were moved from a `"cases"` fixture to `"incidents"`, since `"cases"` now takes the new branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added editable filtering for case-based dashboard widget previews, including tag selection and exclusion.
  * Added backend-powered tag search with debounced input, loading/error states, free-text entry, and checkbox selections.
  * Added filter reset, refresh, pagination, and improved navigation for case previews.
  * Improved project selector layout and placement in the case filter bar.

* **Bug Fixes**
  * Multi-select dropdowns now match field width and wrap long option labels without clipping.
  * Long assignee and project names now wrap correctly instead of overflowing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->