### PR TITLE
feat(entity-service): conversation counts grouped by state

### DIFF
--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -2495,7 +2495,7 @@ type ProjectContact struct {
 	// than treating it as an error. A pointer keeps "no id" distinguishable from an
 	// empty id internally; on the wire both a nil and an absent id are omitted, so the
 	// published shape is unchanged.
-	ID                   *string  `json:"id,omitempty"`
+	ID *string `json:"id,omitempty"`
 	// Name is nil when the row has no contact record linked -- the name is only ever
 	// known from that record.
 	Name *string `json:"name"`
@@ -4052,4 +4052,42 @@ type SearchConversationsResponse struct {
 	Total         int                      `json:"total"`
 	Offset        int                      `json:"offset"`
 	Limit         int                      `json:"limit"`
+}
+
+// SearchConversationStatsFilters narrows which conversations are counted by
+// POST /conversations/stats/search. Deliberately mirrors SearchConversationsFilters
+// minus States, so a caller can reuse the same filter object it already builds for
+// the search endpoint. States is absent because the response is grouped by state —
+// filtering by it would only ever zero the other rows.
+type SearchConversationStatsFilters struct {
+	ProjectIDs  []string `json:"projectIds"`
+	SearchQuery string   `json:"searchQuery"`
+	Number      *string  `json:"number,omitempty"`
+	CreatedByMe bool     `json:"createdByMe"`
+	CreatedBy   []string `json:"createdBy"`
+}
+
+// SearchConversationStatsRequest is the input for POST /conversations/stats/search.
+// There is no pagination: the response is one row per state, and the set of states
+// is fixed and small.
+type SearchConversationStatsRequest struct {
+	Filters SearchConversationStatsFilters `json:"filters"`
+}
+
+// ConversationStateCount is the number of matching conversations in one state.
+type ConversationStateCount struct {
+	State ConversationState `json:"state"`
+	Count int               `json:"count"`
+}
+
+// SearchConversationStatsResponse is the outcome breakdown for the matched
+// conversations.
+//
+// StateCounts always carries one entry per known state, zeros included. A state
+// missing from the list and a state with no conversations are different claims,
+// and a caller computing a deflection or abandonment rate needs the zero rows to
+// build a denominator it can trust.
+type SearchConversationStatsResponse struct {
+	TotalCount  int                      `json:"totalCount"`
+	StateCounts []ConversationStateCount `json:"stateCounts"`
 }

--- a/entity-service/internal/handler/conversation_handler.go
+++ b/entity-service/internal/handler/conversation_handler.go
@@ -34,6 +34,22 @@ func NewConversationHandler(svc service.ConversationService) *ConversationHandle
 	return &ConversationHandler{svc: svc}
 }
 
+// SearchConversationStats handles POST /conversations/stats/search.
+func (h *ConversationHandler) SearchConversationStats(w http.ResponseWriter, r *http.Request) {
+	var req domain.SearchConversationStatsRequest
+	if !decodeRequest(w, r, &req) {
+		return
+	}
+	resp, err := h.svc.SearchConversationStats(r.Context(), req)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
 // SearchConversations handles POST /conversations/search.
 func (h *ConversationHandler) SearchConversations(w http.ResponseWriter, r *http.Request) {
 	var req domain.SearchConversationsRequest

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -387,6 +387,7 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 
 	if conversationHandler != nil {
 		mux.HandleFunc("POST /conversations/search", conversationHandler.SearchConversations)
+		mux.HandleFunc("POST /conversations/stats/search", conversationHandler.SearchConversationStats)
 	}
 
 	return middleware.CorrelationID(

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -489,4 +489,11 @@ type ConversationService interface {
 	// project IDs, states, search query, and createdByMe. A ValidationError is returned
 	// for invalid input.
 	SearchConversations(ctx context.Context, req domain.SearchConversationsRequest) (domain.SearchConversationsResponse, error)
+
+	// SearchConversationStats returns conversation counts grouped by state for the
+	// conversations matching the filters. Answers "how many resolved / converted /
+	// abandoned" in one call, without the caller paging the conversations themselves
+	// or fanning out one request per project. A ValidationError is returned for
+	// invalid input.
+	SearchConversationStats(ctx context.Context, req domain.SearchConversationStatsRequest) (domain.SearchConversationStatsResponse, error)
 }

--- a/entity-service/internal/service/sn_conversation_service.go
+++ b/entity-service/internal/service/sn_conversation_service.go
@@ -27,6 +27,8 @@ import (
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/middleware"
 	integrationservice "github.com/wso2-open-operations/cs-tools/entity-service/internal/servicenow-integration-service"
+
+	"golang.org/x/sync/errgroup"
 )
 
 // snConversationsResponse mirrors the Choreo POST /conversations/search response.
@@ -146,6 +148,13 @@ const (
 	maxConversationCreatedByEntries  = 20
 	maxConversationCreatedByEntryLen = 254
 )
+
+// conversationStatsProbeLimit is the page size used by SearchConversationStats.
+// Only the upstream's total is wanted, never the rows, so this asks for the
+// smallest page the search accepts. It must stay >= 1: normalizeConversationPagination
+// replaces a non-positive limit with the default page size, which would fetch and
+// discard 20 conversations per state for no reason.
+const conversationStatsProbeLimit = 1
 
 // validateConversationCreatedBy checks an optional initiator-email filter list.
 func validateConversationCreatedBy(emails []string) error {
@@ -280,5 +289,87 @@ func (s *snConversationService) SearchConversations(ctx context.Context, req dom
 		Total:         snResp.TotalRecords,
 		Limit:         req.Pagination.Limit,
 		Offset:        req.Pagination.Offset,
+	}, nil
+}
+
+// conversationStatsOrder fixes the order of the state rows in the response.
+// A stable order lets a caller diff two responses positionally and keeps the
+// output readable; ranging over snConversationStateKeyMap would not, since Go
+// randomises map iteration.
+var conversationStatsOrder = []domain.ConversationState{
+	domain.ConversationStateActive,
+	domain.ConversationStateResolved,
+	domain.ConversationStateConverted,
+	domain.ConversationStateAbandoned,
+	domain.ConversationStateClosed,
+}
+
+// SearchConversationStats implements ConversationService.
+//
+// Counts come from the upstream search's totalRecords, requested one state at a
+// time with the smallest page the API allows. The rows themselves are discarded —
+// only the count is wanted — so the page size is a floor, not a sample: a state
+// with 4,000 conversations still reports 4,000.
+//
+// The alternative was paging every conversation and tallying client-side, which
+// costs one request per page per project and grows without bound. This is a fixed
+// five requests regardless of how many conversations or projects are involved.
+func (s *snConversationService) SearchConversationStats(
+	ctx context.Context, req domain.SearchConversationStatsRequest,
+) (domain.SearchConversationStatsResponse, error) {
+	if err := validateSearchQuery(req.Filters.SearchQuery); err != nil {
+		return domain.SearchConversationStatsResponse{}, err
+	}
+	if err := validateExactNumber("number", req.Filters.Number); err != nil {
+		return domain.SearchConversationStatsResponse{}, err
+	}
+	if err := validateConversationCreatedBy(req.Filters.CreatedBy); err != nil {
+		return domain.SearchConversationStatsResponse{}, err
+	}
+	if err := validateUUIDs("projectIds", req.Filters.ProjectIDs); err != nil {
+		return domain.SearchConversationStatsResponse{}, err
+	}
+
+	counts := make([]int, len(conversationStatsOrder))
+
+	// errgroup's derived context cancels the siblings as soon as one state fails,
+	// so a partial tally is never assembled. A caller cannot tell a partial count
+	// from a real one, and a wrong deflection rate is worse than an error.
+	g, gCtx := errgroup.WithContext(ctx)
+	for i, state := range conversationStatsOrder {
+		g.Go(func() error {
+			searchReq := domain.SearchConversationsRequest{
+				Filters: domain.SearchConversationsFilters{
+					ProjectIDs:  req.Filters.ProjectIDs,
+					States:      []domain.ConversationState{state},
+					SearchQuery: req.Filters.SearchQuery,
+					Number:      req.Filters.Number,
+					CreatedByMe: req.Filters.CreatedByMe,
+					CreatedBy:   req.Filters.CreatedBy,
+				},
+				Pagination: domain.Pagination{Limit: conversationStatsProbeLimit, Offset: 0},
+			}
+			resp, err := s.SearchConversations(gCtx, searchReq)
+			if err != nil {
+				return fmt.Errorf("conversation stats: state %s: %w", state, err)
+			}
+			counts[i] = resp.Total
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return domain.SearchConversationStatsResponse{}, err
+	}
+
+	stateCounts := make([]domain.ConversationStateCount, 0, len(conversationStatsOrder))
+	total := 0
+	for i, state := range conversationStatsOrder {
+		stateCounts = append(stateCounts, domain.ConversationStateCount{State: state, Count: counts[i]})
+		total += counts[i]
+	}
+
+	return domain.SearchConversationStatsResponse{
+		TotalCount:  total,
+		StateCounts: stateCounts,
 	}, nil
 }

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -3338,6 +3338,48 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /conversations/stats/search:
+    post:
+      summary: Conversation counts grouped by state (ServiceNow data source only).
+      description: >-
+        Returns how many of the matching conversations are in each state, so a
+        caller can compute outcome rates without paging the conversations
+        themselves or issuing one request per project. Accepts the same filters
+        as /conversations/search except states, which is absent because the
+        response is grouped by state.
+      operationId: searchConversationStats
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SearchConversationStatsRequest'
+      responses:
+        "200":
+          description: Conversation counts grouped by state.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchConversationStatsResponse'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /conversations/search:
     post:
       summary: Search conversations (ServiceNow data source only).
@@ -9423,6 +9465,51 @@ components:
           nullable: true
           $ref: '#/components/schemas/UserReference'
 
+    SearchConversationStatsRequest:
+      type: object
+      properties:
+        filters:
+          $ref: '#/components/schemas/SearchConversationStatsFilters'
+    SearchConversationStatsFilters:
+      type: object
+      properties:
+        projectIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+        searchQuery:
+          type: string
+        number:
+          type: string
+        createdByMe:
+          type: boolean
+        createdBy:
+          type: array
+          items:
+            type: string
+    ConversationStateCount:
+      type: object
+      properties:
+        state:
+          type: string
+          enum: [ACTIVE, RESOLVED, CONVERTED, ABANDONED, CLOSED]
+        count:
+          type: integer
+    SearchConversationStatsResponse:
+      type: object
+      properties:
+        totalCount:
+          type: integer
+        stateCounts:
+          type: array
+          description: >-
+            One entry per state, including states with a count of zero. A state
+            absent from the list and a state with no conversations are different
+            claims, and a caller computing a rate needs the zero rows to build a
+            denominator it can trust.
+          items:
+            $ref: '#/components/schemas/ConversationStateCount'
     SearchConversationsResponse:
       type: object
       properties:


### PR DESCRIPTION
## What

`POST /conversations/stats/search` — how many of the matching conversations sit in each state.

```jsonc
// request — same filters as /conversations/search, minus states
{ "filters": { "projectIds": ["…"], "createdBy": ["…"], "searchQuery": "" } }

// response
{ "totalCount": 412,
  "stateCounts": [ {"state":"ACTIVE","count":31},   {"state":"RESOLVED","count":250},
                   {"state":"CONVERTED","count":88}, {"state":"ABANDONED","count":43},
                   {"state":"CLOSED","count":0} ] }
```

## Why

The Novera analytics dashboard needs deflection and abandonment rates across the estate. Today it calls `GET /projects/{id}/conversations/stats` **once per project** and sums the results, so the cost grows with the project list and one slow project holds up the whole figure. This collapses it to a single request.

## How

Built over the existing `POST /conversations/search` rather than a new upstream endpoint: one probe per state, issued concurrently, asking for the smallest page and reading `totalRecords`.

Counts are exact — the page size bounds the **rows returned**, not the total, so a state with 4,000 conversations still reports 4,000. Five upstream requests regardless of how many conversations or projects are involved.

**This needs no change in the ServiceNow integration service**, which is why it can ship independently. A native aggregate (one grouped query instead of five probes) would be better, but that has to be exposed by the integration first — the contract here would not change, only its implementation.

## Two decisions worth reviewing

**Failure is all-or-nothing.** `errgroup`'s derived context cancels the siblings as soon as one state fails, so a partial tally is never returned. A caller cannot distinguish a partial count from a complete one, and a wrong deflection rate is worse than an error — the caller can retry, but it cannot detect a silently-missing state.

**Zero rows are always present.** `stateCounts` carries one entry per state including zeros. A state absent from the list and a state with no conversations are different claims, and a caller computing a rate needs the zero rows to build a denominator it can trust.

`states` is deliberately absent from the filters — the response is grouped by state, so filtering on it would only ever zero the other rows.

## Not included

**No date filtering.** `startDate` / `endDate` would make conversation outcomes reportable over time, which is the thing consumers actually want and cannot currently get — these figures are a live snapshot, so today's number is unrecoverable tomorrow. Neither this endpoint nor `/conversations/search` can offer it until the integration service does; adding a parameter here that the upstream ignores would be worse than not having one.

## Verification

`go build ./...`, `go vet ./internal/...` and `gofmt -l` are all clean. `openapi.yaml` parses and the new path and four schemas resolve.

Not exercised against a live ServiceNow instance — the counts depend on the upstream honouring `stateKeys` and returning an accurate `totalRecords`, which the existing search already relies on, but a staging call against one project would confirm it before anyone builds a KPI on it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an endpoint to retrieve conversation statistics grouped by state.
  - Supports existing conversation search filters, excluding state filtering.
  - Responses include counts for each state, including states with zero results, plus an aggregate total.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->