### PR TITLE
[CSM Portal] add customisable columns across case, engagement, announcement, and CR tables

### DIFF
--- a/apps/csm-portal/webapp/src/components/column-customizer/ColumnCustomizerButton.test.tsx
+++ b/apps/csm-portal/webapp/src/components/column-customizer/ColumnCustomizerButton.test.tsx
@@ -1,0 +1,95 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import ColumnCustomizerButton from "@components/column-customizer/ColumnCustomizerButton";
+import type { ColumnOption } from "@hooks/useColumnPreferences";
+
+const COLUMNS: ColumnOption[] = [
+  { id: "a", label: "Column A" },
+  { id: "b", label: "Column B" },
+  { id: "c", label: "Column C" },
+];
+
+function setup(visible: string[] = ["a", "b", "c"]) {
+  const onToggle = vi.fn();
+  const onMove = vi.fn();
+  const onReset = vi.fn();
+  render(
+    <ColumnCustomizerButton
+      allColumns={COLUMNS}
+      isVisible={(id) => visible.includes(id)}
+      onToggle={onToggle}
+      onMove={onMove}
+      onReset={onReset}
+    />,
+  );
+  return { onToggle, onMove, onReset };
+}
+
+describe("ColumnCustomizerButton", () => {
+  it("opens the popover listing every known column on trigger click", () => {
+    setup();
+    fireEvent.click(screen.getByRole("button", { name: "Customise columns" }));
+
+    expect(screen.getByText("Column A")).toBeInTheDocument();
+    expect(screen.getByText("Column B")).toBeInTheDocument();
+    expect(screen.getByText("Column C")).toBeInTheDocument();
+  });
+
+  it("calls onToggle when a column row is clicked", () => {
+    const { onToggle } = setup();
+    fireEvent.click(screen.getByRole("button", { name: "Customise columns" }));
+
+    fireEvent.click(screen.getByText("Column B"));
+    expect(onToggle).toHaveBeenCalledWith("b");
+  });
+
+  it("calls onMove when a reorder arrow is clicked, without also toggling that row", () => {
+    const { onMove, onToggle } = setup();
+    fireEvent.click(screen.getByRole("button", { name: "Customise columns" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Move Column B up" }));
+    expect(onMove).toHaveBeenCalledWith("b", "up");
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+
+  it("disables the up arrow for the first column and the down arrow for the last", () => {
+    setup();
+    fireEvent.click(screen.getByRole("button", { name: "Customise columns" }));
+
+    expect(screen.getByRole("button", { name: "Move Column A up" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Move Column C down" })).toBeDisabled();
+  });
+
+  it("disables unchecking the last remaining visible column", () => {
+    setup(["a"]);
+    fireEvent.click(screen.getByRole("button", { name: "Customise columns" }));
+
+    const checkboxes = screen.getAllByRole("checkbox");
+    expect(checkboxes[0]).toBeDisabled();
+  });
+
+  it("calls onReset when Reset to default is clicked", () => {
+    const { onReset } = setup();
+    fireEvent.click(screen.getByRole("button", { name: "Customise columns" }));
+
+    fireEvent.click(screen.getByText("Reset to default"));
+    expect(onReset).toHaveBeenCalled();
+  });
+});

--- a/apps/csm-portal/webapp/src/components/column-customizer/ColumnCustomizerButton.tsx
+++ b/apps/csm-portal/webapp/src/components/column-customizer/ColumnCustomizerButton.tsx
@@ -20,9 +20,10 @@ import {
   Checkbox,
   Divider,
   IconButton,
+  List,
+  ListItem,
+  ListItemButton,
   ListItemText,
-  MenuItem,
-  MenuList,
   Popover,
   Tooltip,
   Typography,
@@ -87,37 +88,41 @@ export default function ColumnCustomizerButton({
           >
             Columns
           </Typography>
-          <MenuList dense aria-label={label} sx={{ maxHeight: 320, overflowY: "auto" }}>
+          <List
+            dense
+            disablePadding
+            aria-label={label}
+            sx={{ maxHeight: 320, overflowY: "auto" }}
+          >
             {allColumns.map((column, index) => {
               const checked = isVisible(column.id);
               const disableUncheck = checked && visibleCount <= 1;
               return (
-                <MenuItem
-                  key={column.id}
-                  disableRipple
-                  onClick={() => !disableUncheck && onToggle(column.id)}
-                  sx={{ py: 0.25 }}
-                >
+                <ListItem key={column.id} disableGutters sx={{ px: 2, py: 0.25 }}>
                   <Checkbox
                     size="small"
                     checked={checked}
                     disabled={disableUncheck}
-                    tabIndex={-1}
+                    onChange={() => !disableUncheck && onToggle(column.id)}
                     sx={{ mr: 1, p: 0.25 }}
                   />
-                  <ListItemText
-                    primary={column.label}
-                    slotProps={{ primary: { style: { fontSize: 13 } } }}
-                  />
+                  <ListItemButton
+                    disableRipple
+                    disabled={disableUncheck}
+                    onClick={() => !disableUncheck && onToggle(column.id)}
+                    sx={{ py: 0, px: 0, borderRadius: 1 }}
+                  >
+                    <ListItemText
+                      primary={column.label}
+                      slotProps={{ primary: { style: { fontSize: 13 } } }}
+                    />
+                  </ListItemButton>
                   <Box sx={{ display: "flex", ml: 1 }}>
                     <IconButton
                       size="small"
                       aria-label={`Move ${column.label} up`}
                       disabled={index === 0}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onMove(column.id, "up");
-                      }}
+                      onClick={() => onMove(column.id, "up")}
                       sx={{ p: 0.25 }}
                     >
                       <ChevronUp size={14} />
@@ -126,19 +131,16 @@ export default function ColumnCustomizerButton({
                       size="small"
                       aria-label={`Move ${column.label} down`}
                       disabled={index === allColumns.length - 1}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onMove(column.id, "down");
-                      }}
+                      onClick={() => onMove(column.id, "down")}
                       sx={{ p: 0.25 }}
                     >
                       <ChevronDown size={14} />
                     </IconButton>
                   </Box>
-                </MenuItem>
+                </ListItem>
               );
             })}
-          </MenuList>
+          </List>
           <Divider sx={{ my: 0.5 }} />
           <Box sx={{ px: 1.5 }}>
             <Button size="small" variant="text" onClick={onReset} sx={{ textTransform: "none" }}>

--- a/apps/csm-portal/webapp/src/components/column-customizer/ColumnCustomizerButton.tsx
+++ b/apps/csm-portal/webapp/src/components/column-customizer/ColumnCustomizerButton.tsx
@@ -1,0 +1,152 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Box,
+  Button,
+  Checkbox,
+  Divider,
+  IconButton,
+  ListItemText,
+  MenuItem,
+  MenuList,
+  Popover,
+  Tooltip,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { ChevronDown, ChevronUp, ColumnsSettings } from "@wso2/oxygen-ui-icons-react";
+import { useState, type JSX, type MouseEvent } from "react";
+import type { ColumnOption } from "@hooks/useColumnPreferences";
+
+export interface ColumnCustomizerButtonProps {
+  /** All known columns for this table, in the user's current order —
+   * `useColumnPreferences`'s `allColumns`. */
+  allColumns: ColumnOption[];
+  isVisible: (id: string) => boolean;
+  onToggle: (id: string) => void;
+  onMove: (id: string, direction: "up" | "down") => void;
+  onReset: () => void;
+  /** Accessible label for the trigger button; defaults to "Customise
+   * columns". Override when a page has more than one table on screen. */
+  label?: string;
+}
+
+/**
+ * "Customise columns" trigger + popover: check/uncheck to add or remove a
+ * column, up/down arrows to reorder it. Shared across every table that adopts
+ * `useColumnPreferences` — the table itself owns what each column id renders
+ * as; this component only edits the visibility/order state.
+ */
+export default function ColumnCustomizerButton({
+  allColumns,
+  isVisible,
+  onToggle,
+  onMove,
+  onReset,
+  label = "Customise columns",
+}: ColumnCustomizerButtonProps): JSX.Element {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const open = Boolean(anchorEl);
+  const visibleCount = allColumns.filter((c) => isVisible(c.id)).length;
+
+  const handleOpen = (e: MouseEvent<HTMLElement>): void => setAnchorEl(e.currentTarget);
+  const handleClose = (): void => setAnchorEl(null);
+
+  return (
+    <>
+      <Tooltip title={label}>
+        <IconButton size="small" aria-label={label} onClick={handleOpen}>
+          <ColumnsSettings size={16} />
+        </IconButton>
+      </Tooltip>
+      <Popover
+        open={open}
+        anchorEl={anchorEl}
+        onClose={handleClose}
+        anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+        transformOrigin={{ vertical: "top", horizontal: "right" }}
+      >
+        <Box sx={{ width: 280, py: 1 }}>
+          <Typography
+            variant="caption"
+            color="text.secondary"
+            sx={{ px: 2, py: 0.5, display: "block", fontWeight: 600 }}
+          >
+            Columns
+          </Typography>
+          <MenuList dense aria-label={label} sx={{ maxHeight: 320, overflowY: "auto" }}>
+            {allColumns.map((column, index) => {
+              const checked = isVisible(column.id);
+              const disableUncheck = checked && visibleCount <= 1;
+              return (
+                <MenuItem
+                  key={column.id}
+                  disableRipple
+                  onClick={() => !disableUncheck && onToggle(column.id)}
+                  sx={{ py: 0.25 }}
+                >
+                  <Checkbox
+                    size="small"
+                    checked={checked}
+                    disabled={disableUncheck}
+                    tabIndex={-1}
+                    sx={{ mr: 1, p: 0.25 }}
+                  />
+                  <ListItemText
+                    primary={column.label}
+                    slotProps={{ primary: { style: { fontSize: 13 } } }}
+                  />
+                  <Box sx={{ display: "flex", ml: 1 }}>
+                    <IconButton
+                      size="small"
+                      aria-label={`Move ${column.label} up`}
+                      disabled={index === 0}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onMove(column.id, "up");
+                      }}
+                      sx={{ p: 0.25 }}
+                    >
+                      <ChevronUp size={14} />
+                    </IconButton>
+                    <IconButton
+                      size="small"
+                      aria-label={`Move ${column.label} down`}
+                      disabled={index === allColumns.length - 1}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onMove(column.id, "down");
+                      }}
+                      sx={{ p: 0.25 }}
+                    >
+                      <ChevronDown size={14} />
+                    </IconButton>
+                  </Box>
+                </MenuItem>
+              );
+            })}
+          </MenuList>
+          <Divider sx={{ my: 0.5 }} />
+          <Box sx={{ px: 1.5 }}>
+            <Button size="small" variant="text" onClick={onReset} sx={{ textTransform: "none" }}>
+              Reset to default
+            </Button>
+          </Box>
+        </Box>
+      </Popover>
+    </>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-accounts/pages/CsmAccountsPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-accounts/pages/CsmAccountsPage.test.tsx
@@ -1,0 +1,157 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { ReactElement } from "react";
+import { fireEvent, render as rtlRender, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router";
+import "@testing-library/jest-dom/vitest";
+import CsmAccountsPage from "@features/csm-accounts/pages/CsmAccountsPage";
+import { useSearchAccounts } from "@features/csm-accounts/api/useSearchAccounts";
+import type { Account } from "@features/csm-accounts/types/csmAccounts";
+
+// The backend client reads runtime config at module load, which isn't
+// present under vitest — same approach as CsmAnnouncementsPage.test.tsx.
+vi.mock("@api/backend/client", () => ({
+  BackendApiError: class BackendApiError extends Error {},
+  useBackendApi: () => ({ post: vi.fn() }),
+}));
+
+vi.mock("@features/csm-accounts/api/useSearchAccounts", () => ({
+  useSearchAccounts: vi.fn(),
+}));
+
+vi.mock("@context/current-user/CurrentUserContext", () => ({
+  useCurrentUser: () => ({ user: { id: "user-1" }, isLoading: false, isError: false }),
+}));
+vi.mock("@hooks/useIdTokenClaims", () => ({
+  useIdTokenClaims: () => ({ email: "user@example.test" }),
+}));
+
+const mockedUseSearch = vi.mocked(useSearchAccounts);
+// Name, SF ID, Tier, Region, Activated, Deactivated, Account manager,
+// Technical owner, CRE team.
+const ACCOUNT_COLUMN_COUNT = 9;
+
+function render(ui: ReactElement): ReturnType<typeof rtlRender> {
+  return rtlRender(<MemoryRouter>{ui}</MemoryRouter>);
+}
+
+const ACCOUNT: Account = {
+  id: "acct-1",
+  sfId: "SF-1001",
+  name: "Acme Corp",
+  tier: "enterprise",
+  region: "APAC",
+  activationDate: "2024-01-01T00:00:00Z",
+  deactivationDate: null,
+  ownerId: "owner-1",
+  accountManager: { id: "u-1", name: "Jane Doe" },
+  technicalOwner: { id: "u-2", name: "John Roe" },
+  creTeam: { id: "team-1", name: "APAC CRE" },
+  agentEnabled: true,
+  kbReferencesEnabled: true,
+  createdOn: "2024-01-01T00:00:00Z",
+  updatedOn: "2024-01-01T00:00:00Z",
+};
+
+function mockResult(overrides: Partial<ReturnType<typeof useSearchAccounts>>): void {
+  mockedUseSearch.mockReturnValue({
+    data: undefined,
+    isLoading: false,
+    isFetching: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+    dataUpdatedAt: 0,
+    ...overrides,
+  } as unknown as ReturnType<typeof useSearchAccounts>);
+}
+
+beforeEach(() => {
+  mockedUseSearch.mockReset();
+  window.localStorage.clear();
+});
+
+describe("CsmAccountsPage — list states", () => {
+  it("renders a row from the search result", () => {
+    mockResult({ data: { accounts: [ACCOUNT], total: 1, limit: 20, offset: 0, hasMore: false } });
+    render(<CsmAccountsPage />);
+    expect(screen.getByText("Acme Corp")).toBeInTheDocument();
+    expect(screen.getByText("SF-1001")).toBeInTheDocument();
+  });
+
+  it("shows the empty state when there are no accounts", () => {
+    mockResult({ data: { accounts: [], total: 0, limit: 20, offset: 0, hasMore: false } });
+    render(<CsmAccountsPage />);
+    expect(screen.getByText(/no accounts found/i)).toBeInTheDocument();
+  });
+});
+
+describe("CsmAccountsPage — customise columns", () => {
+  it("shows the default columns and hides Account manager until added", () => {
+    mockResult({ data: { accounts: [ACCOUNT], total: 1, limit: 20, offset: 0, hasMore: false } });
+    render(<CsmAccountsPage />);
+
+    expect(screen.getByRole("columnheader", { name: "Name" })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Deactivated" })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("columnheader", { name: "Account manager" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("adds the Account manager column when checked, rendering the row's owner name", () => {
+    mockResult({ data: { accounts: [ACCOUNT], total: 1, limit: 20, offset: 0, hasMore: false } });
+    render(<CsmAccountsPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Customise accounts columns" }));
+    // Column order: Name, SF ID, Tier, Region, Activated, Deactivated,
+    // Account manager (7th), Technical owner, CRE team.
+    const checkboxes = screen.getAllByRole("checkbox");
+    fireEvent.click(checkboxes[6]);
+
+    expect(
+      screen.getByRole("columnheader", { name: "Account manager", hidden: true }),
+    ).toBeInTheDocument();
+  });
+
+  it("never lets every column be unchecked", () => {
+    mockResult({ data: { accounts: [ACCOUNT], total: 1, limit: 20, offset: 0, hasMore: false } });
+    render(<CsmAccountsPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Customise accounts columns" }));
+    for (let i = 0; i < ACCOUNT_COLUMN_COUNT; i++) {
+      const checkbox = screen.getAllByRole("checkbox")[i];
+      if (!checkbox.hasAttribute("disabled") && (checkbox as HTMLInputElement).checked) {
+        fireEvent.click(checkbox);
+      }
+    }
+
+    expect(screen.getAllByRole("columnheader", { hidden: true }).length).toBeGreaterThan(0);
+  });
+
+  it("persists a toggled column across a remount for the same user", () => {
+    mockResult({ data: { accounts: [ACCOUNT], total: 1, limit: 20, offset: 0, hasMore: false } });
+    const { unmount } = render(<CsmAccountsPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Customise accounts columns" }));
+    fireEvent.click(screen.getAllByRole("checkbox")[6]); // Account manager
+    unmount();
+
+    render(<CsmAccountsPage />);
+    expect(screen.getByRole("columnheader", { name: "Account manager" })).toBeInTheDocument();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-accounts/pages/CsmAccountsPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-accounts/pages/CsmAccountsPage.test.tsx
@@ -126,6 +126,7 @@ describe("CsmAccountsPage — customise columns", () => {
     expect(
       screen.getByRole("columnheader", { name: "Account manager", hidden: true }),
     ).toBeInTheDocument();
+    expect(screen.getByText("Jane Doe")).toBeInTheDocument();
   });
 
   it("never lets every column be unchecked", () => {

--- a/apps/csm-portal/webapp/src/features/csm-accounts/pages/CsmAccountsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-accounts/pages/CsmAccountsPage.tsx
@@ -30,14 +30,23 @@ import {
   Typography,
 } from "@wso2/oxygen-ui";
 import { ArrowLeft } from "@wso2/oxygen-ui-icons-react";
-import { useMemo, useState, type ChangeEvent, type JSX, type KeyboardEvent } from "react";
+import { useMemo, useState, type ChangeEvent, type JSX, type KeyboardEvent, type ReactNode } from "react";
 import { useLocation } from "react-router";
+import ColumnCustomizerButton from "@components/column-customizer/ColumnCustomizerButton";
 import QueryErrorState from "@components/QueryErrorState";
+import { useCurrentUser } from "@context/current-user/CurrentUserContext";
 import { useDebouncedValue } from "@hooks/useDebouncedValue";
+import { useIdTokenClaims } from "@hooks/useIdTokenClaims";
+import {
+  getColumnPreferencesUserKey,
+  useColumnPreferences,
+  type ColumnOption,
+} from "@hooks/useColumnPreferences";
 import { useNavTransition } from "@hooks/useNavTransition";
 import { useSearchAccounts } from "@features/csm-accounts/api/useSearchAccounts";
 import {
   resolveAccountTier,
+  type Account,
   type SearchAccountsRequest,
 } from "@features/csm-accounts/types/csmAccounts";
 import { BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
@@ -46,6 +55,41 @@ import RefreshButton from "@components/RefreshButton";
 const DEFAULT_ROWS_PER_PAGE = 20;
 // Top option is the backend's max page limit; larger requests are rejected.
 const ROWS_PER_PAGE_OPTIONS = [10, 20, BE_MAX_PAGE_LIMIT];
+
+type AccountColumnId =
+  | "name"
+  | "sfId"
+  | "tier"
+  | "region"
+  | "activationDate"
+  | "deactivationDate"
+  | "accountManager"
+  | "technicalOwner"
+  | "creTeam";
+
+const ACCOUNT_COLUMNS: { id: AccountColumnId; label: string }[] = [
+  { id: "name", label: "Name" },
+  { id: "sfId", label: "SF ID" },
+  { id: "tier", label: "Tier" },
+  { id: "region", label: "Region" },
+  { id: "activationDate", label: "Activated" },
+  { id: "deactivationDate", label: "Deactivated" },
+  { id: "accountManager", label: "Account manager" },
+  { id: "technicalOwner", label: "Technical owner" },
+  { id: "creTeam", label: "CRE team" },
+];
+
+// Matches the table's original, always-shown set. Account manager, technical
+// owner, and CRE team are already on the account detail page — available
+// here, but opt-in, for anyone who wants them in the list view too.
+const DEFAULT_ACCOUNT_COLUMN_IDS: AccountColumnId[] = [
+  "name",
+  "sfId",
+  "tier",
+  "region",
+  "activationDate",
+  "deactivationDate",
+];
 
 function formatDate(value?: string | null): string {
   if (!value) return "—";
@@ -57,6 +101,44 @@ function formatDate(value?: string | null): string {
         month: "short",
         day: "numeric",
       });
+}
+
+function renderAccountCell(id: AccountColumnId, a: Account): ReactNode {
+  switch (id) {
+    case "name":
+      return (
+        <Typography variant="body2" noWrap>
+          {a.name}
+        </Typography>
+      );
+    case "sfId":
+      return a.sfId || "—";
+    case "tier": {
+      const tier = resolveAccountTier(a);
+      return tier ? (
+        <Chip
+          size="small"
+          label={tier}
+          color={tier === "enterprise" ? "primary" : "default"}
+          variant="outlined"
+        />
+      ) : (
+        "—"
+      );
+    }
+    case "region":
+      return a.region ?? "—";
+    case "activationDate":
+      return formatDate(a.activationDate);
+    case "deactivationDate":
+      return formatDate(a.deactivationDate);
+    case "accountManager":
+      return a.accountManager?.name ?? "—";
+    case "technicalOwner":
+      return a.technicalOwner?.name ?? "—";
+    case "creTeam":
+      return a.creTeam?.name ?? "—";
+  }
 }
 
 export default function CsmAccountsPage(): JSX.Element {
@@ -94,6 +176,20 @@ export default function CsmAccountsPage(): JSX.Element {
     setPage(0);
   };
 
+  const columnOptions = useMemo<ColumnOption[]>(
+    () => ACCOUNT_COLUMNS.map(({ id, label }) => ({ id, label })),
+    [],
+  );
+  const currentUser = useCurrentUser().user;
+  const currentUserEmail = useIdTokenClaims()?.email;
+  const columnPrefs = useColumnPreferences({
+    viewId: "accounts",
+    userKey: getColumnPreferencesUserKey({ id: currentUser?.id, email: currentUserEmail }),
+    columns: columnOptions,
+    defaultVisibleIds: DEFAULT_ACCOUNT_COLUMN_IDS,
+  });
+  const visibleColumnIds = columnPrefs.visibleColumns.map((c) => c.id as AccountColumnId);
+
   const accounts = data?.accounts ?? [];
   const total = data?.total ?? 0;
 
@@ -115,12 +211,22 @@ export default function CsmAccountsPage(): JSX.Element {
         <Typography variant="body2" color="text.secondary">
           Search across account name and Salesforce ID (case-insensitive).
         </Typography>
-        <RefreshButton
-          onRefresh={() => void refetch()}
-          isFetching={isFetching}
-          updatedAt={dataUpdatedAt}
-          label="Refresh accounts"
-        />
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+          <RefreshButton
+            onRefresh={() => void refetch()}
+            isFetching={isFetching}
+            updatedAt={dataUpdatedAt}
+            label="Refresh accounts"
+          />
+          <ColumnCustomizerButton
+            allColumns={columnPrefs.allColumns}
+            isVisible={columnPrefs.isVisible}
+            onToggle={columnPrefs.toggleColumn}
+            onMove={columnPrefs.moveColumn}
+            onReset={columnPrefs.resetToDefault}
+            label="Customise accounts columns"
+          />
+        </Box>
       </Box>
 
       <TextField
@@ -138,29 +244,27 @@ export default function CsmAccountsPage(): JSX.Element {
           <Table size="small" sx={{ "& .MuiTableCell-root": { borderColor: "divider" } }}>
             <TableHead>
               <TableRow sx={{ bgcolor: "action.hover" }}>
-                <TableCell>Name</TableCell>
-                <TableCell>SF ID</TableCell>
-                <TableCell>Tier</TableCell>
-                <TableCell>Region</TableCell>
-                <TableCell>Activated</TableCell>
-                <TableCell>Deactivated</TableCell>
+                {visibleColumnIds.map((id) => (
+                  <TableCell key={id}>
+                    {ACCOUNT_COLUMNS.find((c) => c.id === id)?.label}
+                  </TableCell>
+                ))}
               </TableRow>
             </TableHead>
             <TableBody>
               {isLoading || isFetching ? (
                 Array.from({ length: rowsPerPage }).map((_, i) => (
                   <TableRow key={i}>
-                    <TableCell><Skeleton variant="rounded" width="80%" height={18} /></TableCell>
-                    <TableCell><Skeleton variant="rounded" width="65%" height={18} /></TableCell>
-                    <TableCell><Skeleton variant="rounded" width={70} height={22} /></TableCell>
-                    <TableCell><Skeleton variant="rounded" width="60%" height={18} /></TableCell>
-                    <TableCell><Skeleton variant="rounded" width={80} height={18} /></TableCell>
-                    <TableCell><Skeleton variant="rounded" width={80} height={18} /></TableCell>
+                    {visibleColumnIds.map((id) => (
+                      <TableCell key={id}>
+                        <Skeleton variant="rounded" width="70%" height={18} />
+                      </TableCell>
+                    ))}
                   </TableRow>
                 ))
               ) : isError ? (
                 <TableRow>
-                  <TableCell colSpan={6} align="center">
+                  <TableCell colSpan={visibleColumnIds.length} align="center">
                     <QueryErrorState
                       message={error instanceof Error && error.message.trim() ? error.message : "Failed to load accounts."}
                       error={error}
@@ -169,7 +273,7 @@ export default function CsmAccountsPage(): JSX.Element {
                 </TableRow>
               ) : accounts.length === 0 ? (
                 <TableRow>
-                  <TableCell colSpan={6} align="center" sx={{ py: 4 }}>
+                  <TableCell colSpan={visibleColumnIds.length} align="center" sx={{ py: 4 }}>
                     <Typography variant="body2" color="text.secondary">
                       No accounts found.
                     </Typography>
@@ -177,7 +281,6 @@ export default function CsmAccountsPage(): JSX.Element {
                 </TableRow>
               ) : (
                 accounts.map((a) => {
-                  const tier = resolveAccountTier(a);
                   const goToAccount = (): void =>
                     navigate(`/customers/accounts/${a.id}`, {
                       state: { from: `${location.pathname}${location.search}` },
@@ -205,27 +308,9 @@ export default function CsmAccountsPage(): JSX.Element {
                         },
                       }}
                     >
-                      <TableCell>
-                        <Typography variant="body2" noWrap>
-                          {a.name}
-                        </Typography>
-                      </TableCell>
-                      <TableCell>{a.sfId || "—"}</TableCell>
-                      <TableCell>
-                        {tier ? (
-                          <Chip
-                            size="small"
-                            label={tier}
-                            color={tier === "enterprise" ? "primary" : "default"}
-                            variant="outlined"
-                          />
-                        ) : (
-                          "—"
-                        )}
-                      </TableCell>
-                      <TableCell>{a.region ?? "—"}</TableCell>
-                      <TableCell>{formatDate(a.activationDate)}</TableCell>
-                      <TableCell>{formatDate(a.deactivationDate)}</TableCell>
+                      {visibleColumnIds.map((id) => (
+                        <TableCell key={id}>{renderAccountCell(id, a)}</TableCell>
+                      ))}
                     </TableRow>
                   );
                 })

--- a/apps/csm-portal/webapp/src/features/csm-announcements/api/useSearchAnnouncements.ts
+++ b/apps/csm-portal/webapp/src/features/csm-announcements/api/useSearchAnnouncements.ts
@@ -103,6 +103,7 @@ export function useSearchAnnouncements(
       const announcements: CsmAnnouncementRow[] = (res.cases ?? []).map((c) => ({
         id: c.id,
         number: c.number,
+        wso2CaseId: c.internalId,
         subject: c.subject ?? "(no subject)",
         projectName: c.project?.name ?? "—",
         // The search view returns display-cased states (e.g. "Closed"); normalize

--- a/apps/csm-portal/webapp/src/features/csm-announcements/pages/CsmAnnouncementsPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-announcements/pages/CsmAnnouncementsPage.test.tsx
@@ -58,8 +58,8 @@ vi.mock("@hooks/useIdTokenClaims", () => ({
 }));
 
 const mockedUseSearch = vi.mocked(useSearchAnnouncements);
-// Number, Subject, Project, State, Created by, Created, Updated.
-const ANNOUNCEMENT_COLUMN_COUNT = 7;
+// Number, Reference, Subject, Project, State, Created by, Created, Updated.
+const ANNOUNCEMENT_COLUMN_COUNT = 8;
 
 /** `CsmAnnouncementsPage` renders a `RouterLink` per row, so every render
  * here needs router context. */
@@ -169,17 +169,40 @@ describe("CsmAnnouncementsPage — customise columns", () => {
     render(<CsmAnnouncementsPage />);
 
     fireEvent.click(screen.getByRole("button", { name: "Customise announcements columns" }));
-    // Column order is Number, Subject, Project, State, Created by, Created,
-    // Updated — "Created" is the 6th checkbox, the one available-but-hidden
-    // column (see DEFAULT_ANNOUNCEMENT_COLUMN_IDS).
+    // Column order is Number, Reference, Subject, Project, State, Created by,
+    // Created, Updated — "Created" is the 7th checkbox, one of the two
+    // available-but-hidden columns (see DEFAULT_ANNOUNCEMENT_COLUMN_IDS).
     const checkboxes = screen.getAllByRole("checkbox");
-    fireEvent.click(checkboxes[5]);
+    fireEvent.click(checkboxes[6]);
 
     // The open popover marks the rest of the page `aria-hidden` (MUI's Modal
     // machinery) — `hidden: true` looks past that to the table underneath.
     expect(
       screen.getByRole("columnheader", { name: "Created", hidden: true }),
     ).toBeInTheDocument();
+  });
+
+  it("adds the Reference column when checked in the picker, and it renders the row's wso2CaseId", () => {
+    mockResult({
+      data: {
+        announcements: [{ ...ROW, wso2CaseId: "ACMESUB-42" }],
+        total: 1,
+        limit: 20,
+        offset: 0,
+        hasMore: false,
+      },
+    });
+    render(<CsmAnnouncementsPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Customise announcements columns" }));
+    // "Reference" is the 2nd checkbox — see the column order comment above.
+    const checkboxes = screen.getAllByRole("checkbox");
+    fireEvent.click(checkboxes[1]);
+
+    expect(
+      screen.getByRole("columnheader", { name: "Reference", hidden: true }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("ACMESUB-42")).toBeInTheDocument();
   });
 
   it("never lets every column be unchecked", () => {

--- a/apps/csm-portal/webapp/src/features/csm-announcements/pages/CsmAnnouncementsPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-announcements/pages/CsmAnnouncementsPage.test.tsx
@@ -47,7 +47,19 @@ vi.mock("@features/csm-cases/components/AsyncProjectMultiSelect", () => ({
   default: () => <div data-testid="project-filter" />,
 }));
 
+// The signed-in user's profile/id-token claims aren't relevant to this page's
+// own behavior — only the column picker's storage key derives from them
+// (see useColumnPreferences.test.ts for that logic).
+vi.mock("@context/current-user/CurrentUserContext", () => ({
+  useCurrentUser: () => ({ user: { id: "user-1" }, isLoading: false, isError: false }),
+}));
+vi.mock("@hooks/useIdTokenClaims", () => ({
+  useIdTokenClaims: () => ({ email: "user@example.test" }),
+}));
+
 const mockedUseSearch = vi.mocked(useSearchAnnouncements);
+// Number, Subject, Project, State, Created by, Created, Updated.
+const ANNOUNCEMENT_COLUMN_COUNT = 7;
 
 /** `CsmAnnouncementsPage` renders a `RouterLink` per row, so every render
  * here needs router context. */
@@ -81,6 +93,7 @@ function mockResult(
 
 beforeEach(() => {
   mockedUseSearch.mockReset();
+  window.localStorage.clear();
 });
 
 describe("CsmAnnouncementsPage — list states", () => {
@@ -134,6 +147,61 @@ describe("CsmAnnouncementsPage — filters default to show-all", () => {
     // The most recent render's filters carry the selected state.
     const lastCall = mockedUseSearch.mock.calls.at(-1)!;
     expect(lastCall[0].states).toContain("closed");
+  });
+});
+
+describe("CsmAnnouncementsPage — customise columns", () => {
+  it("shows the default columns and hides Created until the user adds it", () => {
+    mockResult({
+      data: { announcements: [ROW], total: 1, limit: 20, offset: 0, hasMore: false },
+    });
+    render(<CsmAnnouncementsPage />);
+
+    expect(screen.getByRole("columnheader", { name: "Number" })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Updated" })).toBeInTheDocument();
+    expect(screen.queryByRole("columnheader", { name: "Created" })).not.toBeInTheDocument();
+  });
+
+  it("adds the Created column when checked in the picker, and it renders the row's createdAt", () => {
+    mockResult({
+      data: { announcements: [ROW], total: 1, limit: 20, offset: 0, hasMore: false },
+    });
+    render(<CsmAnnouncementsPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Customise announcements columns" }));
+    // Column order is Number, Subject, Project, State, Created by, Created,
+    // Updated — "Created" is the 6th checkbox, the one available-but-hidden
+    // column (see DEFAULT_ANNOUNCEMENT_COLUMN_IDS).
+    const checkboxes = screen.getAllByRole("checkbox");
+    fireEvent.click(checkboxes[5]);
+
+    // The open popover marks the rest of the page `aria-hidden` (MUI's Modal
+    // machinery) — `hidden: true` looks past that to the table underneath.
+    expect(
+      screen.getByRole("columnheader", { name: "Created", hidden: true }),
+    ).toBeInTheDocument();
+  });
+
+  it("never lets every column be unchecked", () => {
+    mockResult({
+      data: { announcements: [ROW], total: 1, limit: 20, offset: 0, hasMore: false },
+    });
+    render(<CsmAnnouncementsPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Customise announcements columns" }));
+    // Uncheck every column in turn (re-query each time — a re-render can
+    // change stale element references — and skip whichever one the hook has
+    // disabled as the last remaining visible column).
+    for (let i = 0; i < ANNOUNCEMENT_COLUMN_COUNT; i++) {
+      const checkbox = screen.getAllByRole("checkbox")[i];
+      if (!checkbox.hasAttribute("disabled") && (checkbox as HTMLInputElement).checked) {
+        fireEvent.click(checkbox);
+      }
+    }
+
+    // At least one column (the last remaining) is still rendered underneath
+    // the (still open) popover.
+    expect(screen.getAllByRole("columnheader", { hidden: true }).length).toBeGreaterThan(0);
   });
 });
 

--- a/apps/csm-portal/webapp/src/features/csm-announcements/pages/CsmAnnouncementsPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-announcements/pages/CsmAnnouncementsPage.test.tsx
@@ -27,6 +27,7 @@ import "@testing-library/jest-dom/vitest";
 import CsmAnnouncementsPage from "@features/csm-announcements/pages/CsmAnnouncementsPage";
 import { useSearchAnnouncements } from "@features/csm-announcements/api/useSearchAnnouncements";
 import type { CsmAnnouncementRow } from "@features/csm-announcements/types/csmAnnouncements";
+import { formatBackendTimestampForDisplay } from "@utils/dateTime";
 
 // The backend client reads runtime config (`CSM_PORTAL_BACKEND_BASE_URL`) at
 // module load, which isn't present under vitest. QueryErrorState imports
@@ -180,6 +181,13 @@ describe("CsmAnnouncementsPage — customise columns", () => {
     expect(
       screen.getByRole("columnheader", { name: "Created", hidden: true }),
     ).toBeInTheDocument();
+    // Same format the component's own formatDate() uses for createdAt/updatedAt.
+    const expectedCreatedAt = formatBackendTimestampForDisplay(ROW.createdAt, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+    expect(screen.getByText(expectedCreatedAt!)).toBeInTheDocument();
   });
 
   it("adds the Reference column when checked in the picker, and it renders the row's wso2CaseId", () => {

--- a/apps/csm-portal/webapp/src/features/csm-announcements/pages/CsmAnnouncementsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-announcements/pages/CsmAnnouncementsPage.tsx
@@ -32,18 +32,27 @@ import {
   Typography,
 } from "@wso2/oxygen-ui";
 import { Search, X } from "@wso2/oxygen-ui-icons-react";
-import { useState, type ChangeEvent, type JSX } from "react";
+import { useMemo, useState, type ChangeEvent, type JSX, type ReactNode } from "react";
 import { Link as RouterLink } from "react-router";
+import ColumnCustomizerButton from "@components/column-customizer/ColumnCustomizerButton";
 import MultiSelectField from "@components/MultiSelectField";
 import QueryErrorState from "@components/QueryErrorState";
 import SemanticChip from "@components/SemanticChip";
 import AsyncProjectMultiSelect from "@features/csm-cases/components/AsyncProjectMultiSelect";
+import { useCurrentUser } from "@context/current-user/CurrentUserContext";
+import { useIdTokenClaims } from "@hooks/useIdTokenClaims";
 import { useDebouncedValue } from "@hooks/useDebouncedValue";
+import {
+  getColumnPreferencesUserKey,
+  useColumnPreferences,
+  type ColumnOption,
+} from "@hooks/useColumnPreferences";
 import { formatBackendTimestampForDisplay } from "@utils/dateTime";
 import { useSearchAnnouncements } from "@features/csm-announcements/api/useSearchAnnouncements";
 import {
   DEFAULT_ANNOUNCEMENT_FILTERS,
   type AnnouncementFilters,
+  type CsmAnnouncementRow,
 } from "@features/csm-announcements/types/csmAnnouncements";
 import { announcementStateRole } from "@features/csm-announcements/utils/announcementState";
 import { STATE_LABEL } from "@features/csm-dashboard/utils/abtDashboard";
@@ -52,6 +61,37 @@ import RefreshButton from "@components/RefreshButton";
 
 const DEFAULT_ROWS_PER_PAGE = 20;
 const ROWS_PER_PAGE_OPTIONS = [10, 20, 50];
+
+type AnnouncementColumnId =
+  | "number"
+  | "subject"
+  | "project"
+  | "state"
+  | "createdBy"
+  | "createdAt"
+  | "updatedAt";
+
+const ANNOUNCEMENT_COLUMNS: { id: AnnouncementColumnId; label: string }[] = [
+  { id: "number", label: "Number" },
+  { id: "subject", label: "Subject" },
+  { id: "project", label: "Project" },
+  { id: "state", label: "State" },
+  { id: "createdBy", label: "Created by" },
+  { id: "createdAt", label: "Created" },
+  { id: "updatedAt", label: "Updated" },
+];
+
+// Matches the list's original, always-shown set — "Created" is the one
+// available-but-not-default column (the row already carries `createdAt`,
+// just not surfaced until now).
+const DEFAULT_ANNOUNCEMENT_COLUMN_IDS: AnnouncementColumnId[] = [
+  "number",
+  "subject",
+  "project",
+  "state",
+  "createdBy",
+  "updatedAt",
+];
 
 // `reopened` is intentionally excluded — it only appears as a `nextStates`
 // signal, never as a case's own state (see CaseState's doc).
@@ -76,6 +116,46 @@ function formatDate(value?: string | null): string {
   );
 }
 
+function renderAnnouncementCell(id: AnnouncementColumnId, a: CsmAnnouncementRow): ReactNode {
+  switch (id) {
+    case "number":
+      return a.number || "—";
+    case "subject":
+      return (
+        <Typography
+          variant="body2"
+          title={a.subject}
+          sx={{
+            display: "-webkit-box",
+            WebkitLineClamp: 2,
+            WebkitBoxOrient: "vertical",
+            overflow: "hidden",
+          }}
+        >
+          {a.subject}
+        </Typography>
+      );
+    case "project":
+      return a.projectName;
+    case "state":
+      return a.state ? (
+        <SemanticChip
+          role={announcementStateRole(a.state)}
+          label={STATE_LABEL[a.state] ?? a.state}
+          variant="outlined"
+        />
+      ) : (
+        "—"
+      );
+    case "createdBy":
+      return a.createdBy || "—";
+    case "createdAt":
+      return formatDate(a.createdAt);
+    case "updatedAt":
+      return formatDate(a.updatedAt);
+  }
+}
+
 /**
  * Read-only announcements list. Announcements are cases of
  * `type: "announcement"` surfaced via `POST /cases/search`. Filterable by
@@ -94,6 +174,20 @@ export default function CsmAnnouncementsPage(): JSX.Element {
 
   const announcements = data?.announcements ?? [];
   const total = data?.total ?? 0;
+
+  const columnOptions = useMemo<ColumnOption[]>(
+    () => ANNOUNCEMENT_COLUMNS.map(({ id, label }) => ({ id, label })),
+    [],
+  );
+  const currentUser = useCurrentUser().user;
+  const currentUserEmail = useIdTokenClaims()?.email;
+  const columnPrefs = useColumnPreferences({
+    viewId: "announcements",
+    userKey: getColumnPreferencesUserKey({ id: currentUser?.id, email: currentUserEmail }),
+    columns: columnOptions,
+    defaultVisibleIds: DEFAULT_ANNOUNCEMENT_COLUMN_IDS,
+  });
+  const visibleColumnIds = columnPrefs.visibleColumns.map((c) => c.id as AnnouncementColumnId);
 
   // Any filter change resets to the first page.
   const patchFilters = (patch: Partial<AnnouncementFilters>): void => {
@@ -117,12 +211,22 @@ export default function CsmAnnouncementsPage(): JSX.Element {
             Customer-facing announcements published across projects and tiers.
           </Typography>
         </Box>
-        <RefreshButton
-          onRefresh={() => void refetch()}
-          isFetching={isFetching}
-          updatedAt={dataUpdatedAt}
-          label="Refresh announcements"
-        />
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+          <RefreshButton
+            onRefresh={() => void refetch()}
+            isFetching={isFetching}
+            updatedAt={dataUpdatedAt}
+            label="Refresh announcements"
+          />
+          <ColumnCustomizerButton
+            allColumns={columnPrefs.allColumns}
+            isVisible={columnPrefs.isVisible}
+            onToggle={columnPrefs.toggleColumn}
+            onMove={columnPrefs.moveColumn}
+            onReset={columnPrefs.resetToDefault}
+            label="Customise announcements columns"
+          />
+        </Box>
       </Box>
 
       {/* Filters — search + state + project, all "show all" by default */}
@@ -198,29 +302,27 @@ export default function CsmAnnouncementsPage(): JSX.Element {
           <Table size="small" sx={{ "& .MuiTableCell-root": { borderColor: "divider" } }}>
             <TableHead>
               <TableRow sx={{ bgcolor: "action.hover" }}>
-                <TableCell>Number</TableCell>
-                <TableCell sx={{ width: "28%" }}>Subject</TableCell>
-                <TableCell>Project</TableCell>
-                <TableCell>State</TableCell>
-                <TableCell>Created by</TableCell>
-                <TableCell>Updated</TableCell>
+                {visibleColumnIds.map((id) => (
+                  <TableCell key={id} sx={id === "subject" ? { width: "28%" } : undefined}>
+                    {ANNOUNCEMENT_COLUMNS.find((c) => c.id === id)?.label}
+                  </TableCell>
+                ))}
               </TableRow>
             </TableHead>
             <TableBody>
               {isLoading ? (
                 Array.from({ length: rowsPerPage }).map((_, i) => (
                   <TableRow key={i}>
-                    <TableCell><Skeleton variant="rounded" width="80%" height={18} /></TableCell>
-                    <TableCell><Skeleton variant="rounded" width="90%" height={18} /></TableCell>
-                    <TableCell><Skeleton variant="rounded" width="85%" height={18} /></TableCell>
-                    <TableCell><Skeleton variant="rounded" width={72} height={22} /></TableCell>
-                    <TableCell><Skeleton variant="rounded" width="70%" height={18} /></TableCell>
-                    <TableCell><Skeleton variant="rounded" width={80} height={18} /></TableCell>
+                    {visibleColumnIds.map((id) => (
+                      <TableCell key={id}>
+                        <Skeleton variant="rounded" width="80%" height={18} />
+                      </TableCell>
+                    ))}
                   </TableRow>
                 ))
               ) : isError ? (
                 <TableRow>
-                  <TableCell colSpan={6} align="center">
+                  <TableCell colSpan={visibleColumnIds.length} align="center">
                     <QueryErrorState
                       message={error instanceof Error && error.message.trim() ? error.message : "Failed to load announcements."}
                       error={error}
@@ -229,7 +331,7 @@ export default function CsmAnnouncementsPage(): JSX.Element {
                 </TableRow>
               ) : announcements.length === 0 ? (
                 <TableRow>
-                  <TableCell colSpan={6} align="center" sx={{ py: 4 }}>
+                  <TableCell colSpan={visibleColumnIds.length} align="center" sx={{ py: 4 }}>
                     <Typography variant="body2" color="text.secondary">
                       No announcements found.
                     </Typography>
@@ -255,37 +357,20 @@ export default function CsmAnnouncementsPage(): JSX.Element {
                       },
                     }}
                   >
-                    <TableCell>{a.number || "—"}</TableCell>
-                    <TableCell sx={{ width: "28%" }}>
-                      <Typography
-                        variant="body2"
-                        title={a.subject}
-                        sx={{
-                          display: "-webkit-box",
-                          WebkitLineClamp: 2,
-                          WebkitBoxOrient: "vertical",
-                          overflow: "hidden",
-                        }}
+                    {visibleColumnIds.map((id) => (
+                      <TableCell
+                        key={id}
+                        sx={
+                          id === "subject"
+                            ? { width: "28%" }
+                            : id === "updatedAt" || id === "createdAt"
+                              ? { whiteSpace: "nowrap" }
+                              : undefined
+                        }
                       >
-                        {a.subject}
-                      </Typography>
-                    </TableCell>
-                    <TableCell>{a.projectName}</TableCell>
-                    <TableCell>
-                      {a.state ? (
-                        <SemanticChip
-                          role={announcementStateRole(a.state)}
-                          label={STATE_LABEL[a.state] ?? a.state}
-                          variant="outlined"
-                        />
-                      ) : (
-                        "—"
-                      )}
-                    </TableCell>
-                    <TableCell>{a.createdBy || "—"}</TableCell>
-                    <TableCell sx={{ whiteSpace: "nowrap" }}>
-                      {formatDate(a.updatedAt)}
-                    </TableCell>
+                        {renderAnnouncementCell(id, a)}
+                      </TableCell>
+                    ))}
                   </TableRow>
                 ))
               )}

--- a/apps/csm-portal/webapp/src/features/csm-announcements/pages/CsmAnnouncementsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-announcements/pages/CsmAnnouncementsPage.tsx
@@ -62,8 +62,17 @@ import RefreshButton from "@components/RefreshButton";
 const DEFAULT_ROWS_PER_PAGE = 20;
 const ROWS_PER_PAGE_OPTIONS = [10, 20, 50];
 
+// Every field `CsmAnnouncementRow` carries is offered as a column below
+// except `id` (a raw UUID, never human-facing). Fields on the underlying
+// case search view that never made it into `CsmAnnouncementRow` at all —
+// `severity` (announcements carry no severity, see `AnnouncementFilters`'s
+// doc), `issueType`, `deployment`/`deployedProduct`/`product`, and
+// `assignedEngineer` — aren't meaningful for an announcement (a broadcast,
+// not a worked case with an owner or an affected deployment), so there was
+// nothing there worth adding as a column either.
 type AnnouncementColumnId =
   | "number"
+  | "wso2CaseId"
   | "subject"
   | "project"
   | "state"
@@ -73,6 +82,7 @@ type AnnouncementColumnId =
 
 const ANNOUNCEMENT_COLUMNS: { id: AnnouncementColumnId; label: string }[] = [
   { id: "number", label: "Number" },
+  { id: "wso2CaseId", label: "Reference" },
   { id: "subject", label: "Subject" },
   { id: "project", label: "Project" },
   { id: "state", label: "State" },
@@ -120,6 +130,8 @@ function renderAnnouncementCell(id: AnnouncementColumnId, a: CsmAnnouncementRow)
   switch (id) {
     case "number":
       return a.number || "—";
+    case "wso2CaseId":
+      return a.wso2CaseId || "—";
     case "subject":
       return (
         <Typography

--- a/apps/csm-portal/webapp/src/features/csm-announcements/types/csmAnnouncements.ts
+++ b/apps/csm-portal/webapp/src/features/csm-announcements/types/csmAnnouncements.ts
@@ -45,6 +45,12 @@ export const DEFAULT_ANNOUNCEMENT_FILTERS: AnnouncementFilters = {
 export interface CsmAnnouncementRow {
   id: string;
   number?: string;
+  /**
+   * Project-scoped WSO2 case reference (BE `internalId`), same field
+   * `CsmCaseRow.wso2CaseId` carries for regular cases. Distinct from
+   * {@link number}; optional since not every announcement gets one.
+   */
+  wso2CaseId?: string;
   subject: string;
   /** Owning project display name, or "—" when cross-customer / unset. */
   projectName: string;

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.test.tsx
@@ -265,3 +265,48 @@ describe("CasesList quick preview", () => {
     expect(screen.getByRole("link", { name: "View full details" })).toBeInTheDocument();
   });
 });
+
+describe("CasesList optional columns", () => {
+  it("renders the widened optional column set (customer, created) when passed explicitly", () => {
+    renderWithProviders(
+      <Routes>
+        <Route
+          path="/cases"
+          element={
+            <CasesList
+              cases={[CASE]}
+              isLoading={false}
+              optionalColumns={["customer", "createdAt"]}
+            />
+          }
+        />
+        <Route path="/cases/:id" element={<DetailStub />} />
+      </Routes>,
+      ["/cases"],
+    );
+
+    expect(screen.getByText("Customer")).toBeInTheDocument();
+    expect(screen.getByText("Created")).toBeInTheDocument();
+    expect(screen.getByText("Acme Corp")).toBeInTheDocument();
+    // Neither of the legacy fixed-set columns is asked for here.
+    expect(screen.queryByText("Product")).not.toBeInTheDocument();
+    expect(screen.queryByText("Assignee")).not.toBeInTheDocument();
+  });
+
+  it("keeps rendering the legacy fixed optional set when optionalColumns is omitted", () => {
+    renderWithProviders(
+      <Routes>
+        <Route
+          path="/cases"
+          element={<CasesList cases={[CASE]} isLoading={false} />}
+        />
+        <Route path="/cases/:id" element={<DetailStub />} />
+      </Routes>,
+      ["/cases"],
+    );
+
+    expect(screen.getByText("Product")).toBeInTheDocument();
+    expect(screen.queryByText("Customer")).not.toBeInTheDocument();
+    expect(screen.queryByText("Created")).not.toBeInTheDocument();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.tsx
@@ -43,6 +43,10 @@ import {
   caseTypeHasSeverity,
 } from "@features/csm-cases/utils/caseType";
 import { effectiveWorkState } from "@features/csm-cases/utils/caseWorkState";
+import {
+  CASE_OPTIONAL_COLUMNS,
+  type CaseOptionalColumnId,
+} from "@features/csm-cases/utils/caseListColumns";
 
 interface CasesListProps {
   cases: CsmCaseRow[];
@@ -57,8 +61,16 @@ interface CasesListProps {
   detailBasePath?: string;
   /** Hide the Severity column. Severity (S1-S4) is a support-case concept, so
    * non-case lists (service requests, engagements, security reports) hide it —
-   * the main case list keeps it. */
+   * the main case list keeps it. Ignored when `optionalColumns` is passed
+   * explicitly (that list is the sole source of truth for which optional
+   * columns render, and in what order). */
   hideSeverityColumn?: boolean;
+  /** Which optional columns to render, and in what order — driven by a
+   * caller's `useColumnPreferences` (e.g. `CsmIssuesView`'s "Customise
+   * columns" picker on the Engagements list). Omit to keep this list's
+   * long-standing fixed set, gated only by `hideSeverityColumn`, exactly as
+   * every other caller of `CasesList` already gets it. */
+  optionalColumns?: CaseOptionalColumnId[];
   /** Current sort order for the "Updated" column, when the caller wants it
    * sortable. Omit both `sortOrder` and `onSortOrderChange` for a plain
    * (non-interactive) header — the list is always server-sorted by
@@ -67,24 +79,47 @@ interface CasesListProps {
   onSortOrderChange?: (order: CasesSortOrder) => void;
 }
 
-// Every column is left-aligned for a consistent scan line down the table.
-// Type (case / service request / security report / ...) is gated by the same
-// flag as Severity: both are noise in a list already locked to one case type
-// (see `hideSeverityColumn`'s callers), useful in the mixed, general list.
-const HEADER_CELLS_WITH_SEVERITY: string[] = [
-  "Case ID",
-  "Subject",
-  "Product",
-  "Type",
-  "Severity",
-  "State",
-];
-const HEADER_CELLS_WITHOUT_SEVERITY: string[] = [
-  "Case ID",
-  "Subject",
-  "Product",
-  "State",
-];
+function renderOptionalCell(id: CaseOptionalColumnId, c: CsmCaseRow): JSX.Element {
+  switch (id) {
+    case "product":
+      return (
+        <Typography variant="body2" noWrap title={c.product || undefined}>
+          {c.product}
+        </Typography>
+      );
+    case "type":
+      return (
+        <Box sx={{ justifySelf: "start" }}>
+          {c.caseType ? (
+            <Chip
+              size="small"
+              variant="outlined"
+              color={CASE_TYPE_COLOR[c.caseType]}
+              label={CASE_TYPE_LABEL[c.caseType]}
+            />
+          ) : (
+            "—"
+          )}
+        </Box>
+      );
+    case "severity":
+      return (
+        <Box sx={{ justifySelf: "start" }}>
+          {caseTypeHasSeverity(c.caseType) ? (
+            <SeverityChip severity={c.severity} clickable />
+          ) : (
+            "—"
+          )}
+        </Box>
+      );
+    case "assignee":
+      return (
+        <Typography variant="body2" noWrap title={c.assignee || undefined}>
+          {c.assignee}
+        </Typography>
+      );
+  }
+}
 
 // Subject gets the lion's share of the row; the ids sit in their own narrow
 // column so a long subject no longer has to share one cell with them.
@@ -93,10 +128,9 @@ const HEADER_CELLS_WITHOUT_SEVERITY: string[] = [
 // `auto` track (unlabeled in the header) holds the per-row quick-preview
 // action — kept at the left edge so it's reachable without hunting across
 // the row, with the preview drawer itself opening on the right.
-const GRID_WITH_SEVERITY =
-  "auto minmax(120px, 0.9fr) minmax(280px, 3fr) minmax(140px, 1fr) auto auto minmax(110px, 1fr) auto";
-const GRID_WITHOUT_SEVERITY =
-  "auto minmax(120px, 0.9fr) minmax(280px, 3fr) minmax(140px, 1fr) minmax(110px, 1fr) auto";
+const CASE_ID_TRACK = "minmax(120px, 0.9fr)";
+const SUBJECT_TRACK = "minmax(280px, 3fr)";
+const STATE_TRACK = "minmax(110px, 1fr)";
 
 export default function CasesList({
   cases,
@@ -104,6 +138,7 @@ export default function CasesList({
   skeletonCount = 6,
   detailBasePath,
   hideSeverityColumn = false,
+  optionalColumns,
   sortOrder,
   onSortOrderChange,
 }: CasesListProps): JSX.Element {
@@ -111,12 +146,27 @@ export default function CasesList({
   const location = useLocation();
   const navigate = useNavTransition();
   const [previewRow, setPreviewRow] = useState<CsmCaseRow | null>(null);
-  const headerCells = hideSeverityColumn
-    ? HEADER_CELLS_WITHOUT_SEVERITY
-    : HEADER_CELLS_WITH_SEVERITY;
-  const gridTemplateColumns = hideSeverityColumn
-    ? GRID_WITHOUT_SEVERITY
-    : GRID_WITH_SEVERITY;
+
+  // Legacy fixed sets, kept byte-for-byte identical to this list's original
+  // behavior for every caller that doesn't pass `optionalColumns` explicitly
+  // (dashboard widgets, mini tables, project work items, …).
+  const effectiveOptionalColumns: CaseOptionalColumnId[] =
+    optionalColumns ?? (hideSeverityColumn ? ["product"] : ["product", "type", "severity"]);
+
+  const headerCells = [
+    "Case ID",
+    "Subject",
+    ...effectiveOptionalColumns.map((id) => CASE_OPTIONAL_COLUMNS[id].label),
+    "State",
+  ];
+  const gridTemplateColumns = [
+    "auto",
+    CASE_ID_TRACK,
+    SUBJECT_TRACK,
+    ...effectiveOptionalColumns.map((id) => CASE_OPTIONAL_COLUMNS[id].track),
+    STATE_TRACK,
+    "auto",
+  ].join(" ");
 
   return (
     <Box
@@ -348,32 +398,11 @@ export default function CasesList({
                   {c.projectName}
                 </Typography>
               </Box>
-              <Typography variant="body2" noWrap title={c.product || undefined}>
-                {c.product}
-              </Typography>
-              {!hideSeverityColumn && (
-                <Box sx={{ justifySelf: "start" }}>
-                  {c.caseType ? (
-                    <Chip
-                      size="small"
-                      variant="outlined"
-                      color={CASE_TYPE_COLOR[c.caseType]}
-                      label={CASE_TYPE_LABEL[c.caseType]}
-                    />
-                  ) : (
-                    "—"
-                  )}
+              {effectiveOptionalColumns.map((id) => (
+                <Box key={id} sx={{ minWidth: 0 }}>
+                  {renderOptionalCell(id, c)}
                 </Box>
-              )}
-              {!hideSeverityColumn && (
-                <Box sx={{ justifySelf: "start" }}>
-                  {caseTypeHasSeverity(c.caseType) ? (
-                    <SeverityChip severity={c.severity} clickable />
-                  ) : (
-                    "—"
-                  )}
-                </Box>
-              )}
+              ))}
               {/* State chip, with the work-state chip stacked beneath it (the
                   latter only for WIP cases). */}
               <Box

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.tsx
@@ -118,6 +118,18 @@ function renderOptionalCell(id: CaseOptionalColumnId, c: CsmCaseRow): JSX.Elemen
           {c.assignee}
         </Typography>
       );
+    case "customer":
+      return (
+        <Typography variant="body2" noWrap title={c.customer || undefined}>
+          {c.customer}
+        </Typography>
+      );
+    case "createdAt":
+      return (
+        <Typography variant="caption" color="text.secondary" noWrap>
+          <RelativeTime iso={c.createdAt} />
+        </Typography>
+      );
   }
 }
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmIssuesView.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmIssuesView.test.tsx
@@ -16,7 +16,7 @@
 
 import { fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter, Route, Routes, useLocation } from "react-router";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 
 vi.mock("@api/backend/client", () => ({
@@ -63,6 +63,10 @@ vi.mock("@components/RefreshButton", () => ({
 
 import CsmIssuesView from "@features/csm-cases/components/CsmIssuesView";
 
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
 function LocationProbe() {
   const location = useLocation();
   return <div data-testid="location-probe">{location.pathname}</div>;
@@ -104,5 +108,60 @@ describe("CsmIssuesView back navigation", () => {
   it("suppresses its own Back button when hideBackButton is set, even with a `from` state present", () => {
     renderAt({ from: "/dashboard" }, true);
     expect(screen.queryByRole("button", { name: "Back" })).not.toBeInTheDocument();
+  });
+});
+
+describe("CsmIssuesView column customization", () => {
+  function renderEngagementsLike() {
+    return render(
+      <MemoryRouter initialEntries={["/engagements"]}>
+        <CsmIssuesView
+          title="Engagements"
+          entityNoun="engagements"
+          hideSeverityColumn
+          enableColumnCustomization
+          columnsViewId="engagements"
+        />
+      </MemoryRouter>,
+    );
+  }
+
+  it("is off by default (no picker rendered for a plain CsmIssuesView)", () => {
+    renderAt(null);
+    expect(
+      screen.queryByRole("button", { name: /Customise .* columns/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the picker and lists Product/Assignee (not Type/Severity) when hideSeverityColumn is set", () => {
+    renderEngagementsLike();
+    fireEvent.click(screen.getByRole("button", { name: "Customise engagements columns" }));
+
+    expect(screen.getByText("Product")).toBeInTheDocument();
+    expect(screen.getByText("Assignee")).toBeInTheDocument();
+    expect(screen.queryByText("Type")).not.toBeInTheDocument();
+    expect(screen.queryByText("Severity")).not.toBeInTheDocument();
+  });
+
+  it("defaults Assignee to hidden so a returning user sees no change until they opt in", () => {
+    renderEngagementsLike();
+    fireEvent.click(screen.getByRole("button", { name: "Customise engagements columns" }));
+
+    const checkboxes = screen.getAllByRole("checkbox");
+    // Product first (checked, default-visible), Assignee second (unchecked).
+    expect(checkboxes[0]).toBeChecked();
+    expect(checkboxes[1]).not.toBeChecked();
+  });
+
+  it("persists a toggled column across a remount for the same user + view", () => {
+    const { unmount } = renderEngagementsLike();
+    fireEvent.click(screen.getByRole("button", { name: "Customise engagements columns" }));
+    fireEvent.click(screen.getByText("Assignee"));
+    unmount();
+
+    renderEngagementsLike();
+    fireEvent.click(screen.getByRole("button", { name: "Customise engagements columns" }));
+    const checkboxes = screen.getAllByRole("checkbox");
+    expect(checkboxes[1]).toBeChecked();
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmIssuesView.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmIssuesView.test.tsx
@@ -112,12 +112,16 @@ describe("CsmIssuesView back navigation", () => {
 });
 
 describe("CsmIssuesView column customization", () => {
+  // Mirrors the real `CsmEngagementsPage`: locked to one case type (so Type
+  // is offered but not default-visible — see `isLockedToSingleType`'s doc in
+  // `CsmIssuesView`) and severity hidden (Engagements has no severity concept).
   function renderEngagementsLike() {
     return render(
       <MemoryRouter initialEntries={["/engagements"]}>
         <CsmIssuesView
           title="Engagements"
           entityNoun="engagements"
+          lockedFilters={{ caseTypes: ["engagement"] }}
           hideSeverityColumn
           enableColumnCustomization
           columnsViewId="engagements"
@@ -133,24 +137,31 @@ describe("CsmIssuesView column customization", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("renders the picker and lists Product/Assignee (not Type/Severity) when hideSeverityColumn is set", () => {
+  it("renders the picker and lists Product/Type/Assignee/Customer/Created (not Severity) when hideSeverityColumn is set", () => {
     renderEngagementsLike();
     fireEvent.click(screen.getByRole("button", { name: "Customise engagements columns" }));
 
     expect(screen.getByText("Product")).toBeInTheDocument();
+    expect(screen.getByText("Type")).toBeInTheDocument();
     expect(screen.getByText("Assignee")).toBeInTheDocument();
-    expect(screen.queryByText("Type")).not.toBeInTheDocument();
+    expect(screen.getByText("Customer")).toBeInTheDocument();
+    expect(screen.getByText("Created")).toBeInTheDocument();
     expect(screen.queryByText("Severity")).not.toBeInTheDocument();
   });
 
-  it("defaults Assignee to hidden so a returning user sees no change until they opt in", () => {
+  it("defaults every optional column but Product to hidden, since the view is locked to one case type, so a returning user sees no change until they opt in", () => {
     renderEngagementsLike();
     fireEvent.click(screen.getByRole("button", { name: "Customise engagements columns" }));
 
+    // Order mirrors `CASE_OPTIONAL_COLUMNS`: Product, Type, Assignee, Customer, Created
+    // (Severity is excluded entirely here via hideSeverityColumn).
     const checkboxes = screen.getAllByRole("checkbox");
-    // Product first (checked, default-visible), Assignee second (unchecked).
-    expect(checkboxes[0]).toBeChecked();
-    expect(checkboxes[1]).not.toBeChecked();
+    expect(checkboxes).toHaveLength(5);
+    expect(checkboxes[0]).toBeChecked(); // Product — the one default-visible column
+    expect(checkboxes[1]).not.toBeChecked(); // Type
+    expect(checkboxes[2]).not.toBeChecked(); // Assignee
+    expect(checkboxes[3]).not.toBeChecked(); // Customer
+    expect(checkboxes[4]).not.toBeChecked(); // Created
   });
 
   it("persists a toggled column across a remount for the same user + view", () => {
@@ -162,6 +173,6 @@ describe("CsmIssuesView column customization", () => {
     renderEngagementsLike();
     fireEvent.click(screen.getByRole("button", { name: "Customise engagements columns" }));
     const checkboxes = screen.getAllByRole("checkbox");
-    expect(checkboxes[1]).toBeChecked();
+    expect(checkboxes[2]).toBeChecked(); // Assignee, toggled on above
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmIssuesView.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmIssuesView.tsx
@@ -29,6 +29,11 @@ import {
 import { useLocation, useSearchParams } from "react-router";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 import { useCurrentUser } from "@context/current-user/CurrentUserContext";
+import ColumnCustomizerButton from "@components/column-customizer/ColumnCustomizerButton";
+import {
+  getColumnPreferencesUserKey,
+  useColumnPreferences,
+} from "@hooks/useColumnPreferences";
 import { useDebouncedValue } from "@hooks/useDebouncedValue";
 import { useIdTokenClaims } from "@hooks/useIdTokenClaims";
 import { useNavTransition } from "@hooks/useNavTransition";
@@ -39,6 +44,10 @@ import CasesFilterBar, {
   type CasesFilters,
 } from "@features/csm-cases/components/CasesFilterBar";
 import CasesList from "@features/csm-cases/components/CasesList";
+import {
+  CASE_OPTIONAL_COLUMNS,
+  type CaseOptionalColumnId,
+} from "@features/csm-cases/utils/caseListColumns";
 import { useGetCsmCases } from "@features/csm-cases/api/useGetCsmCases";
 import {
   ASSIGNEE_FILTER_RESOLVED_EMPTY,
@@ -138,6 +147,19 @@ interface CsmIssuesViewProps {
    * same destination as the outer page's.
    */
   hideBackButton?: boolean;
+  /**
+   * Opt into the "Customise columns" control for this view's list (add,
+   * remove, and reorder the optional columns between Subject and State),
+   * persisted per user via `useColumnPreferences`. Off by default — enable
+   * per view deliberately rather than changing every `CsmIssuesView` caller
+   * (cases, service requests, security reports) at once. `columnsViewId`
+   * must be unique across enabled views (defaults to `entityNoun`).
+   */
+  enableColumnCustomization?: boolean;
+  /** Storage key suffix for this view's column layout. Defaults to
+   * `entityNoun`; override only if two enabled views would otherwise share
+   * an `entityNoun`. */
+  columnsViewId?: string;
 }
 
 /**
@@ -159,6 +181,8 @@ export default function CsmIssuesView({
   detailBasePath,
   hideSeverityColumn,
   hideBackButton,
+  enableColumnCustomization,
+  columnsViewId,
 }: CsmIssuesViewProps): JSX.Element {
   const [searchParams, setSearchParams] = useSearchParams();
   const filters = useMemo<CasesFilters>(
@@ -270,6 +294,22 @@ export default function CsmIssuesView({
   const api = useBackendApi();
   const currentUserEmail = useIdTokenClaims()?.email;
   const currentUserId = useCurrentUser().user?.id;
+
+  // "Customise columns" — off unless a caller opts in (see `enableColumnCustomization`'s
+  // doc). Available optional columns mirror `CasesList`'s own legacy default set so a
+  // returning user who never opens the picker sees the exact same columns as before.
+  const availableOptionalColumns: CaseOptionalColumnId[] = hideSeverityColumn
+    ? ["product", "assignee"]
+    : ["product", "type", "severity", "assignee"];
+  const defaultVisibleOptionalColumns: CaseOptionalColumnId[] = hideSeverityColumn
+    ? ["product"]
+    : ["product", "type", "severity"];
+  const columnPrefs = useColumnPreferences({
+    viewId: `case-list:${columnsViewId ?? entityNoun}`,
+    userKey: getColumnPreferencesUserKey({ id: currentUserId, email: currentUserEmail }),
+    columns: availableOptionalColumns.map((id) => ({ id, label: CASE_OPTIONAL_COLUMNS[id].label })),
+    defaultVisibleIds: defaultVisibleOptionalColumns,
+  });
   const exportSearch = queryFilters.search.trim();
   const fetchCasesExportPage = useCallback(
     async (offset: number, limit: number) => {
@@ -448,6 +488,16 @@ export default function CsmIssuesView({
             fetchPage={fetchCasesExportPage}
             disabled={isError || total === 0}
           />
+          {enableColumnCustomization && (
+            <ColumnCustomizerButton
+              allColumns={columnPrefs.allColumns}
+              isVisible={columnPrefs.isVisible}
+              onToggle={columnPrefs.toggleColumn}
+              onMove={columnPrefs.moveColumn}
+              onReset={columnPrefs.resetToDefault}
+              label={`Customise ${entityNoun} columns`}
+            />
+          )}
           {actions}
         </Box>
       </Box>
@@ -473,6 +523,11 @@ export default function CsmIssuesView({
         skeletonCount={rowsPerPage}
         detailBasePath={detailBasePath}
         hideSeverityColumn={isServiceRequestOnly || hideSeverityColumn}
+        optionalColumns={
+          enableColumnCustomization
+            ? columnPrefs.visibleColumns.map((c) => c.id as CaseOptionalColumnId)
+            : undefined
+        }
         sortOrder={sortOrder}
         onSortOrderChange={handleSortOrderChange}
       />

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmIssuesView.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmIssuesView.tsx
@@ -296,14 +296,31 @@ export default function CsmIssuesView({
   const currentUserId = useCurrentUser().user?.id;
 
   // "Customise columns" — off unless a caller opts in (see `enableColumnCustomization`'s
-  // doc). Available optional columns mirror `CasesList`'s own legacy default set so a
-  // returning user who never opens the picker sees the exact same columns as before.
-  const availableOptionalColumns: CaseOptionalColumnId[] = hideSeverityColumn
-    ? ["product", "assignee"]
-    : ["product", "type", "severity", "assignee"];
-  const defaultVisibleOptionalColumns: CaseOptionalColumnId[] = hideSeverityColumn
-    ? ["product"]
-    : ["product", "type", "severity"];
+  // doc). `showSeverityColumn` mirrors the exact gate `CasesList` itself is given below
+  // (`isServiceRequestOnly || hideSeverityColumn`) so the picker can never offer a
+  // Severity column that would just render "—" for every row (service requests have no
+  // severity concept at all).
+  const showSeverityColumn = !(isServiceRequestOnly || hideSeverityColumn);
+  // Every current caller of this view locks the case type via `lockedFilters` (Case, SR,
+  // SRA, Engagements each fix `caseTypes` to one value) — the Type column would then show
+  // the same chip on every row, so it's still offered (a legacy row that predates type
+  // tagging renders "—" there, which is a genuine signal) but left off by default. An
+  // unlocked, multi-type view (none exists among today's callers) would want it on by
+  // default, hence the `isLockedToSingleType` check rather than hard-coding this off.
+  const isLockedToSingleType = lockedFilters?.caseTypes?.length === 1;
+  const availableOptionalColumns: CaseOptionalColumnId[] = [
+    "product",
+    "type",
+    ...(showSeverityColumn ? (["severity"] as const) : []),
+    "assignee",
+    "customer",
+    "createdAt",
+  ];
+  const defaultVisibleOptionalColumns: CaseOptionalColumnId[] = [
+    "product",
+    ...(isLockedToSingleType ? [] : (["type"] as const)),
+    ...(showSeverityColumn ? (["severity"] as const) : []),
+  ];
   const columnPrefs = useColumnPreferences({
     viewId: `case-list:${columnsViewId ?? entityNoun}`,
     userKey: getColumnPreferencesUserKey({ id: currentUserId, email: currentUserEmail }),

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCasesPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCasesPage.tsx
@@ -35,6 +35,8 @@ export default function CsmCasesPage(): JSX.Element {
       // out here (and the type filter is hidden since it's fixed to `case`).
       lockedFilters={{ caseTypes: ["case"] }}
       hideTypeFilter
+      enableColumnCustomization
+      columnsViewId="cases"
       actions={
         <Button
           variant="contained"

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/caseListColumns.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/caseListColumns.test.ts
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { describe, expect, it } from "vitest";
+import { CASE_OPTIONAL_COLUMNS, type CaseOptionalColumnId } from "./caseListColumns";
+
+describe("CASE_OPTIONAL_COLUMNS", () => {
+  it("offers the widened optional column set", () => {
+    const ids = Object.keys(CASE_OPTIONAL_COLUMNS).sort();
+    const expected: CaseOptionalColumnId[] = [
+      "product",
+      "type",
+      "severity",
+      "assignee",
+      "customer",
+      "createdAt",
+    ];
+    expect(ids).toEqual([...expected].sort());
+  });
+
+  it("gives every optional column both a label and a grid track", () => {
+    Object.values(CASE_OPTIONAL_COLUMNS).forEach((column) => {
+      expect(column.label.length).toBeGreaterThan(0);
+      expect(column.track.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/caseListColumns.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/caseListColumns.ts
@@ -21,8 +21,35 @@
  * optional: they carry the row's identity, its own sort control, or (Case ID)
  * the row's real anchor link, so removing them would break navigation/sort
  * rather than just decluttering.
+ *
+ * Fields on `CsmCaseRow` deliberately left off this list, and why:
+ * - `id`, `accountId`, `projectId` — raw UUIDs, never human-facing.
+ * - `wso2CaseId` / `caseNumber` — already rendered together in the fixed
+ *   Case ID column; a separate column would just repeat it.
+ * - `projectName` — already rendered under Subject on every row (see
+ *   `CasesList`), regardless of which optional columns are on; adding it here
+ *   too would show the same value twice.
+ * - `state` / `updatedAt` — fixed columns (State, Updated).
+ * - `workState` — only meaningful for `work_in_progress` cases, and already
+ *   rendered stacked under the State chip for exactly those rows; a standalone
+ *   column would be blank for everything else.
+ * - `assigneeIsMe`, `hasSla` — booleans that drive other UI (assignee-filter
+ *   defaults, the SLA clock's "unknown" fallback), not stand-alone facts worth
+ *   a column of their own.
+ * - `slaClockType`, `minutesToBreach` — no existing list-row formatter/chip to
+ *   reuse, and `hasSla`'s own doc comment says the backend doesn't have real
+ *   SLA data for every row yet (LIVE rows deliberately report `hasSla: false`
+ *   rather than a misleading countdown) — a column built on that today would
+ *   show "unknown" for rows that do have a real SLA and could reasonably be
+ *   revisited once SLA data is reliably populated across all sources.
  */
-export type CaseOptionalColumnId = "product" | "type" | "severity" | "assignee";
+export type CaseOptionalColumnId =
+  | "product"
+  | "type"
+  | "severity"
+  | "assignee"
+  | "customer"
+  | "createdAt";
 
 export const CASE_OPTIONAL_COLUMNS: Record<
   CaseOptionalColumnId,
@@ -32,4 +59,6 @@ export const CASE_OPTIONAL_COLUMNS: Record<
   type: { label: "Type", track: "auto" },
   severity: { label: "Severity", track: "auto" },
   assignee: { label: "Assignee", track: "minmax(140px, 1fr)" },
+  customer: { label: "Customer", track: "minmax(140px, 1fr)" },
+  createdAt: { label: "Created", track: "minmax(100px, 0.7fr)" },
 };

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/caseListColumns.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/caseListColumns.ts
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+ * The "optional" middle columns `CasesList` can render between Subject and
+ * State — everything a caller can add, remove, or reorder via
+ * `ColumnCustomizerButton`. Case ID, Subject, State, and Updated are never
+ * optional: they carry the row's identity, its own sort control, or (Case ID)
+ * the row's real anchor link, so removing them would break navigation/sort
+ * rather than just decluttering.
+ */
+export type CaseOptionalColumnId = "product" | "type" | "severity" | "assignee";
+
+export const CASE_OPTIONAL_COLUMNS: Record<
+  CaseOptionalColumnId,
+  { label: string; track: string }
+> = {
+  product: { label: "Product", track: "minmax(140px, 1fr)" },
+  type: { label: "Type", track: "auto" },
+  severity: { label: "Severity", track: "auto" },
+  assignee: { label: "Assignee", track: "minmax(140px, 1fr)" },
+};

--- a/apps/csm-portal/webapp/src/features/csm-engagements/pages/CsmEngagementsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-engagements/pages/CsmEngagementsPage.tsx
@@ -38,6 +38,8 @@ export default function CsmEngagementsPage(): JSX.Element {
       showEngagementTypeFilter
       detailBasePath="/engagements"
       hideSeverityColumn
+      enableColumnCustomization
+      columnsViewId="engagements"
       actions={
         <Button
           variant="contained"

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestsTab.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestsTab.test.tsx
@@ -1,0 +1,185 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { ReactElement } from "react";
+import { fireEvent, render as rtlRender, screen } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { MemoryRouter } from "react-router";
+import "@testing-library/jest-dom/vitest";
+import ChangeRequestsTab from "@features/csm-operations/components/ChangeRequestsTab";
+import { useSearchChangeRequests } from "@features/csm-operations/api/useSearchChangeRequests";
+import type { BeChangeRequestSearchView } from "@api/backend/types";
+
+// The backend client reads runtime config at module load, which isn't present
+// under vitest (same approach as CsmAnnouncementsPage.test.tsx).
+vi.mock("@api/backend/client", () => ({
+  BackendApiError: class BackendApiError extends Error {},
+  useBackendApi: () => ({ post: vi.fn() }),
+}));
+
+vi.mock("@features/csm-operations/api/useSearchChangeRequests", () => ({
+  useSearchChangeRequests: vi.fn(),
+}));
+
+// Only the column picker's storage key derives from the signed-in user.
+vi.mock("@context/current-user/CurrentUserContext", () => ({
+  useCurrentUser: () => ({ user: { id: "user-1" }, isLoading: false, isError: false }),
+}));
+vi.mock("@hooks/useIdTokenClaims", () => ({
+  useIdTokenClaims: () => ({ email: "user@example.test" }),
+}));
+
+// The real export button needs an `ErrorBannerProvider` ancestor this test
+// doesn't set up (same approach as CsmIssuesView.test.tsx) — it's unrelated
+// to the column-customization behavior under test here.
+vi.mock("@components/FilteredCsvExportButton", () => ({
+  default: () => <div>ExportButton</div>,
+}));
+
+const mockedUseSearch = vi.mocked(useSearchChangeRequests);
+// The picker only lists the 10 optional columns (Number/Subject/State/Updated
+// are fixed and never appear in it).
+const CR_OPTIONAL_COLUMN_COUNT = 10;
+
+function render(ui: ReactElement): ReturnType<typeof rtlRender> {
+  return rtlRender(<MemoryRouter>{ui}</MemoryRouter>);
+}
+
+const CR: BeChangeRequestSearchView = {
+  id: "cr-1",
+  number: "CHG-1001",
+  subject: "Upgrade cluster to WSO2 IS 7.1",
+  project: { id: "proj-1", name: "Acme Project" },
+  impact: "low",
+  state: "new",
+  plannedStartOn: "2026-08-01T00:00:00Z",
+  plannedEndOn: "2026-08-02T00:00:00Z",
+  product: { id: "prod-1", name: "WSO2 Identity Server" },
+  assignedEngineer: { id: "user-2", name: "Jane Doe" },
+  assignedTeam: { id: "team-1", name: "Platform CRE" },
+  type: "Standard",
+  case: { id: "case-1", name: "CS-2001" },
+  createdOn: "2026-07-01T00:00:00Z",
+  updatedOn: "2026-07-05T00:00:00Z",
+};
+
+function mockResult(
+  overrides: Partial<ReturnType<typeof useSearchChangeRequests>>,
+): void {
+  mockedUseSearch.mockReturnValue({
+    data: undefined,
+    isLoading: false,
+    isFetching: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+    dataUpdatedAt: 0,
+    ...overrides,
+  } as unknown as ReturnType<typeof useSearchChangeRequests>);
+}
+
+beforeEach(() => {
+  mockedUseSearch.mockReset();
+  window.localStorage.clear();
+});
+
+describe("ChangeRequestsTab — list states", () => {
+  it("renders a row from the search result with its default-visible columns", () => {
+    mockResult({ data: { changeRequests: [CR], total: 1, limit: 20, offset: 0 } });
+    render(<ChangeRequestsTab />);
+
+    expect(screen.getByText("CHG-1001")).toBeInTheDocument();
+    expect(screen.getByText("Upgrade cluster to WSO2 IS 7.1")).toBeInTheDocument();
+    // Default-visible optional columns: Project, Impact, Planned start.
+    expect(screen.getByText("Acme Project")).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Planned start" })).toBeInTheDocument();
+    // Not default-visible.
+    expect(screen.queryByRole("columnheader", { name: "Product" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("columnheader", { name: "Assigned engineer" })).not.toBeInTheDocument();
+  });
+
+  it("shows the empty state when there are no change requests", () => {
+    mockResult({ data: { changeRequests: [], total: 0, limit: 20, offset: 0 } });
+    render(<ChangeRequestsTab />);
+    expect(screen.getByText(/no change requests found/i)).toBeInTheDocument();
+  });
+});
+
+describe("ChangeRequestsTab — customise columns", () => {
+  it("offers every widened optional column in the picker", () => {
+    mockResult({ data: { changeRequests: [CR], total: 1, limit: 20, offset: 0 } });
+    render(<ChangeRequestsTab />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Customise change request columns" }),
+    );
+
+    // Project/Impact/Planned start are already default-visible, so they
+    // render twice (once as a column header, once in the picker) — assert
+    // those via their column header instead of `getByText` to avoid an
+    // ambiguous match.
+    for (const label of ["Project", "Impact", "Planned start"]) {
+      expect(screen.getByRole("columnheader", { name: label, hidden: true })).toBeInTheDocument();
+    }
+    // The rest are only offered, not shown yet — unambiguous with `getByText`.
+    for (const label of [
+      "Planned end",
+      "Product",
+      "Assigned engineer",
+      "Assigned team",
+      "Type",
+      "Case",
+      "Created",
+    ]) {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
+  });
+
+  it("adds the Product column when checked, and it renders the row's product name", () => {
+    mockResult({ data: { changeRequests: [CR], total: 1, limit: 20, offset: 0 } });
+    render(<ChangeRequestsTab />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Customise change request columns" }),
+    );
+    // Column order matches `CHANGE_REQUEST_OPTIONAL_COLUMNS`: Project(0),
+    // Impact(1), Planned start(2), Planned end(3), Product(4), ...
+    const checkboxes = screen.getAllByRole("checkbox");
+    fireEvent.click(checkboxes[4]);
+
+    expect(
+      screen.getByRole("columnheader", { name: "Product", hidden: true }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("WSO2 Identity Server")).toBeInTheDocument();
+  });
+
+  it("never lets every column be unchecked", () => {
+    mockResult({ data: { changeRequests: [CR], total: 1, limit: 20, offset: 0 } });
+    render(<ChangeRequestsTab />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Customise change request columns" }),
+    );
+    for (let i = 0; i < CR_OPTIONAL_COLUMN_COUNT; i++) {
+      const checkbox = screen.getAllByRole("checkbox")[i];
+      if (checkbox && !checkbox.hasAttribute("disabled") && (checkbox as HTMLInputElement).checked) {
+        fireEvent.click(checkbox);
+      }
+    }
+
+    expect(screen.getAllByRole("columnheader", { hidden: true }).length).toBeGreaterThan(0);
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestsTab.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestsTab.test.tsx
@@ -180,6 +180,14 @@ describe("ChangeRequestsTab — customise columns", () => {
       }
     }
 
-    expect(screen.getAllByRole("columnheader", { hidden: true }).length).toBeGreaterThan(0);
+    // The invariant under test: the hook refuses to let the last visible
+    // optional column be unchecked. Fixed columns (Number/Subject/State/
+    // Updated) always render a header regardless, so assert the checkbox
+    // state directly rather than counting headers.
+    const remainingChecked = screen
+      .getAllByRole("checkbox")
+      .filter((checkbox) => (checkbox as HTMLInputElement).checked);
+    expect(remainingChecked.length).toBe(1);
+    expect(remainingChecked[0]).toBeDisabled();
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestsTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestsTab.tsx
@@ -34,7 +34,11 @@ import { useLocation, useSearchParams } from "react-router";
 import { useNavTransition } from "@hooks/useNavTransition";
 import QueryErrorState from "@components/QueryErrorState";
 import FilteredCsvExportButton from "@components/FilteredCsvExportButton";
+import ColumnCustomizerButton from "@components/column-customizer/ColumnCustomizerButton";
+import { useCurrentUser } from "@context/current-user/CurrentUserContext";
+import { getColumnPreferencesUserKey, useColumnPreferences } from "@hooks/useColumnPreferences";
 import { useDebouncedValue } from "@hooks/useDebouncedValue";
+import { useIdTokenClaims } from "@hooks/useIdTokenClaims";
 import { useBackendApi } from "@api/backend/client";
 import { formatBackendTimestampForDisplay } from "@utils/dateTime";
 import { useSearchChangeRequests } from "@features/csm-operations/api/useSearchChangeRequests";
@@ -51,6 +55,11 @@ import {
   readChangeRequestFiltersFromUrl,
   writeChangeRequestFiltersToUrl,
 } from "@features/csm-operations/utils/changeRequestsFiltersUrl";
+import {
+  CHANGE_REQUEST_OPTIONAL_COLUMNS,
+  DEFAULT_VISIBLE_CHANGE_REQUEST_COLUMNS,
+  type ChangeRequestOptionalColumnId,
+} from "@features/csm-operations/utils/changeRequestListColumns";
 import ChangeRequestsFilterBar from "@features/csm-operations/components/ChangeRequestsFilterBar";
 import RefreshButton from "@components/RefreshButton";
 import type {
@@ -58,6 +67,47 @@ import type {
   BeChangeRequestSearchResponse,
   BeChangeRequestSearchView,
 } from "@api/backend/types";
+
+const CHANGE_REQUEST_OPTIONAL_COLUMN_IDS = Object.keys(
+  CHANGE_REQUEST_OPTIONAL_COLUMNS,
+) as ChangeRequestOptionalColumnId[];
+
+function renderOptionalCell(
+  id: ChangeRequestOptionalColumnId,
+  cr: BeChangeRequestSearchView,
+): JSX.Element {
+  switch (id) {
+    case "project":
+      return <>{cr.project?.name || "—"}</>;
+    case "impact":
+      return cr.impact ? (
+        <Chip
+          size="small"
+          variant="outlined"
+          color={changeRequestImpactColor(cr.impact)}
+          label={changeRequestImpactLabel(cr.impact)}
+        />
+      ) : (
+        <>—</>
+      );
+    case "plannedStart":
+      return <>{formatDate(cr.plannedStartOn)}</>;
+    case "plannedEnd":
+      return <>{formatDate(cr.plannedEndOn)}</>;
+    case "product":
+      return <>{cr.product?.name || "—"}</>;
+    case "assignedEngineer":
+      return <>{cr.assignedEngineer?.name || "—"}</>;
+    case "assignedTeam":
+      return <>{cr.assignedTeam?.name || "—"}</>;
+    case "type":
+      return <>{cr.type || "—"}</>;
+    case "case":
+      return <>{cr.case?.name || "—"}</>;
+    case "createdOn":
+      return <>{formatDate(cr.createdOn)}</>;
+  }
+}
 
 const DEFAULT_ROWS_PER_PAGE = 20;
 const ROWS_PER_PAGE_OPTIONS = [10, 20, 50];
@@ -124,6 +174,25 @@ export default function ChangeRequestsTab(): JSX.Element {
 
   const changeRequests = data?.changeRequests ?? [];
   const total = data?.total ?? 0;
+
+  // "Customise columns" — see `caseListColumns.ts`'s equivalent doc comment;
+  // the default visible set below is exactly the table's pre-existing fixed
+  // set so a returning user sees no change until they open the picker.
+  const currentUserEmail = useIdTokenClaims()?.email;
+  const currentUserId = useCurrentUser().user?.id;
+  const columnPrefs = useColumnPreferences({
+    viewId: "change-requests",
+    userKey: getColumnPreferencesUserKey({ id: currentUserId, email: currentUserEmail }),
+    columns: CHANGE_REQUEST_OPTIONAL_COLUMN_IDS.map((id) => ({
+      id,
+      label: CHANGE_REQUEST_OPTIONAL_COLUMNS[id].label,
+    })),
+    defaultVisibleIds: DEFAULT_VISIBLE_CHANGE_REQUEST_COLUMNS,
+  });
+  const visibleOptionalColumns = columnPrefs.visibleColumns.map(
+    (c) => c.id as ChangeRequestOptionalColumnId,
+  );
+  const columnCount = 4 + visibleOptionalColumns.length; // Number, Subject, State, Updated + optional
 
   const setFilters = useCallback(
     (next: ChangeRequestFilters) => {
@@ -202,6 +271,14 @@ export default function ChangeRequestsTab(): JSX.Element {
           fetchPage={fetchChangeRequestsPage}
           disabled={isError}
         />
+        <ColumnCustomizerButton
+          allColumns={columnPrefs.allColumns}
+          isVisible={columnPrefs.isVisible}
+          onToggle={columnPrefs.toggleColumn}
+          onMove={columnPrefs.moveColumn}
+          onReset={columnPrefs.resetToDefault}
+          label="Customise change request columns"
+        />
         <Button
           variant="contained"
           color="primary"
@@ -228,10 +305,10 @@ export default function ChangeRequestsTab(): JSX.Element {
               <TableRow sx={{ bgcolor: "action.hover" }}>
                 <TableCell>Number</TableCell>
                 <TableCell>Subject</TableCell>
-                <TableCell>Project</TableCell>
+                {visibleOptionalColumns.map((id) => (
+                  <TableCell key={id}>{CHANGE_REQUEST_OPTIONAL_COLUMNS[id].label}</TableCell>
+                ))}
                 <TableCell>State</TableCell>
-                <TableCell>Impact</TableCell>
-                <TableCell>Planned start</TableCell>
                 <TableCell>Updated</TableCell>
               </TableRow>
             </TableHead>
@@ -241,16 +318,16 @@ export default function ChangeRequestsTab(): JSX.Element {
                   <TableRow key={i}>
                     <TableCell><Skeleton variant="rounded" width="80%" height={18} /></TableCell>
                     <TableCell><Skeleton variant="rounded" width="90%" height={18} /></TableCell>
-                    <TableCell><Skeleton variant="rounded" width="85%" height={18} /></TableCell>
+                    {visibleOptionalColumns.map((id) => (
+                      <TableCell key={id}><Skeleton variant="rounded" width="80%" height={18} /></TableCell>
+                    ))}
                     <TableCell><Skeleton variant="rounded" width={72} height={22} /></TableCell>
-                    <TableCell><Skeleton variant="rounded" width={60} height={22} /></TableCell>
-                    <TableCell><Skeleton variant="rounded" width={80} height={18} /></TableCell>
                     <TableCell><Skeleton variant="rounded" width={80} height={18} /></TableCell>
                   </TableRow>
                 ))
               ) : isError ? (
                 <TableRow>
-                  <TableCell colSpan={7} align="center">
+                  <TableCell colSpan={columnCount} align="center">
                     <QueryErrorState
                       message={error instanceof Error && error.message.trim() ? error.message : "Failed to load change requests."}
                       error={error}
@@ -259,7 +336,7 @@ export default function ChangeRequestsTab(): JSX.Element {
                 </TableRow>
               ) : changeRequests.length === 0 ? (
                 <TableRow>
-                  <TableCell colSpan={7} align="center" sx={{ py: 4 }}>
+                  <TableCell colSpan={columnCount} align="center" sx={{ py: 4 }}>
                     <Typography variant="body2" color="text.secondary">
                       No change requests found.
                     </Typography>
@@ -283,7 +360,9 @@ export default function ChangeRequestsTab(): JSX.Element {
                         {cr.subject || "—"}
                       </Typography>
                     </TableCell>
-                    <TableCell>{cr.project?.name || "—"}</TableCell>
+                    {visibleOptionalColumns.map((id) => (
+                      <TableCell key={id}>{renderOptionalCell(id, cr)}</TableCell>
+                    ))}
                     <TableCell>
                       {cr.state ? (
                         <Chip
@@ -296,19 +375,6 @@ export default function ChangeRequestsTab(): JSX.Element {
                         "—"
                       )}
                     </TableCell>
-                    <TableCell>
-                      {cr.impact ? (
-                        <Chip
-                          size="small"
-                          variant="outlined"
-                          color={changeRequestImpactColor(cr.impact)}
-                          label={changeRequestImpactLabel(cr.impact)}
-                        />
-                      ) : (
-                        "—"
-                      )}
-                    </TableCell>
-                    <TableCell>{formatDate(cr.plannedStartOn)}</TableCell>
                     <TableCell>{formatDate(cr.updatedOn)}</TableCell>
                   </TableRow>
                 ))

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/OperationsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/OperationsPage.tsx
@@ -77,6 +77,8 @@ export default function OperationsPage(): JSX.Element {
           lockedFilters={{ caseTypes: ["service_request"] }}
           hideTypeFilter
           detailBasePath="/operations/service-requests"
+          enableColumnCustomization
+          columnsViewId="service-requests"
           actions={
             <Button
               variant="contained"

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/OperationsTabFiltersUrl.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/OperationsTabFiltersUrl.test.tsx
@@ -48,6 +48,15 @@ vi.mock("@context/error-banner/ErrorBannerContext", () => ({
 vi.mock("@context/success-banner/SuccessBannerContext", () => ({
   useSuccessBanner: () => ({ showSuccess: vi.fn() }),
 }));
+// ChangeRequestsTab now also renders a "customise columns" picker, whose
+// storage key derives from the signed-in user — not under test here, so
+// stubbed the same way ChangeRequestsTab.test.tsx / CsmAnnouncementsPage.test.tsx do.
+vi.mock("@context/current-user/CurrentUserContext", () => ({
+  useCurrentUser: () => ({ user: { id: "user-1" }, isLoading: false, isError: false }),
+}));
+vi.mock("@hooks/useIdTokenClaims", () => ({
+  useIdTokenClaims: () => ({ email: "user@example.test" }),
+}));
 
 vi.mock("@features/csm-operations/api/useSearchChangeRequests", () => ({
   useSearchChangeRequests: vi.fn(),

--- a/apps/csm-portal/webapp/src/features/csm-operations/utils/changeRequestListColumns.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/utils/changeRequestListColumns.ts
@@ -1,0 +1,71 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+ * The "optional" columns `ChangeRequestsTab` can render between Subject and
+ * State — everything a user can add, remove, or reorder via
+ * `ColumnCustomizerButton`. Number, Subject, State, and Updated are never
+ * optional: Number/Subject carry the row's identity and its real link,
+ * State is the at-a-glance lifecycle signal, and Updated is the list's
+ * implicit sort order.
+ *
+ * Fields on `BeChangeRequestSearchView` deliberately left off this list, and
+ * why:
+ * - `id` — a raw UUID, never human-facing.
+ * - `description` — long-form text, not table-friendly; read on the detail page.
+ * - `duration` — derived from `plannedStartOn`/`plannedEndOn`, both already
+ *   offered individually; showing all three would be redundant.
+ * - `deployment`, `deployedProduct` — deployment-level detail that's one more
+ *   click away on the CR detail page; `product` and `project` already give
+ *   enough at-a-glance context for a list row.
+ * - `createdOn` vs `updatedOn` — `updatedOn` is the fixed "Updated" column;
+ *   `createdOn` is still offered separately below since a CR's creation date
+ *   and its last-touched date are genuinely different facts, same reasoning
+ *   as `CsmCaseRow.createdAt`.
+ */
+export type ChangeRequestOptionalColumnId =
+  | "project"
+  | "impact"
+  | "plannedStart"
+  | "plannedEnd"
+  | "product"
+  | "assignedEngineer"
+  | "assignedTeam"
+  | "type"
+  | "case"
+  | "createdOn";
+
+export const CHANGE_REQUEST_OPTIONAL_COLUMNS: Record<
+  ChangeRequestOptionalColumnId,
+  { label: string }
+> = {
+  project: { label: "Project" },
+  impact: { label: "Impact" },
+  plannedStart: { label: "Planned start" },
+  plannedEnd: { label: "Planned end" },
+  product: { label: "Product" },
+  assignedEngineer: { label: "Assigned engineer" },
+  assignedTeam: { label: "Assigned team" },
+  type: { label: "Type" },
+  case: { label: "Case" },
+  createdOn: { label: "Created" },
+};
+
+/** The columns rendered before this feature existed — kept as the default
+ * visible set so a returning user sees the exact same table until they open
+ * the picker themselves. */
+export const DEFAULT_VISIBLE_CHANGE_REQUEST_COLUMNS: ChangeRequestOptionalColumnId[] =
+  ["project", "impact", "plannedStart"];

--- a/apps/csm-portal/webapp/src/features/csm-security-center/pages/CsmSecurityCenterPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-security-center/pages/CsmSecurityCenterPage.tsx
@@ -78,6 +78,8 @@ export default function CsmSecurityCenterPage(): JSX.Element {
           hideTypeFilter
           hideSeverityColumn
           detailBasePath="/security-center/security-reports"
+          enableColumnCustomization
+          columnsViewId="security-reports"
           actions={
             <Button
               variant="contained"

--- a/apps/csm-portal/webapp/src/hooks/useColumnPreferences.test.ts
+++ b/apps/csm-portal/webapp/src/hooks/useColumnPreferences.test.ts
@@ -1,0 +1,195 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  getColumnPreferencesUserKey,
+  useColumnPreferences,
+  type ColumnOption,
+} from "@hooks/useColumnPreferences";
+
+const COLUMNS: ColumnOption[] = [
+  { id: "a", label: "Column A" },
+  { id: "b", label: "Column B" },
+  { id: "c", label: "Column C" },
+];
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe("getColumnPreferencesUserKey", () => {
+  it("prefers the platform user id", () => {
+    expect(getColumnPreferencesUserKey({ id: "u-1", email: "jane.doe@example.com" })).toBe("u-1");
+  });
+
+  it("falls back to email when id is missing", () => {
+    expect(getColumnPreferencesUserKey({ email: "jane.doe@example.com" })).toBe(
+      "jane.doe@example.com",
+    );
+  });
+
+  it("falls back to a shared anonymous bucket when neither is available", () => {
+    expect(getColumnPreferencesUserKey(undefined)).toBe("anonymous");
+    expect(getColumnPreferencesUserKey({})).toBe("anonymous");
+  });
+});
+
+describe("useColumnPreferences", () => {
+  it("starts with the default visible columns, in definition order", () => {
+    const { result } = renderHook(() =>
+      useColumnPreferences({
+        viewId: "test-view",
+        userKey: "user-1",
+        columns: COLUMNS,
+        defaultVisibleIds: ["a", "c"],
+      }),
+    );
+
+    expect(result.current.allColumns.map((c) => c.id)).toEqual(["a", "b", "c"]);
+    expect(result.current.visibleColumns.map((c) => c.id)).toEqual(["a", "c"]);
+    expect(result.current.isVisible("b")).toBe(false);
+  });
+
+  it("toggles a column on and off, and persists across a fresh hook instance", () => {
+    const args = {
+      viewId: "test-view",
+      userKey: "user-1",
+      columns: COLUMNS,
+      defaultVisibleIds: ["a"],
+    };
+    const { result, rerender } = renderHook(useColumnPreferences, { initialProps: args });
+
+    act(() => result.current.toggleColumn("b"));
+    expect(result.current.visibleColumns.map((c) => c.id)).toEqual(["a", "b"]);
+
+    rerender(args);
+    expect(result.current.visibleColumns.map((c) => c.id)).toEqual(["a", "b"]);
+
+    // A brand new hook instance for the same user + view picks up the saved state.
+    const { result: reloaded } = renderHook(() => useColumnPreferences(args));
+    expect(reloaded.current.visibleColumns.map((c) => c.id)).toEqual(["a", "b"]);
+  });
+
+  it("refuses to hide the last visible column", () => {
+    const { result } = renderHook(() =>
+      useColumnPreferences({
+        viewId: "test-view",
+        userKey: "user-1",
+        columns: COLUMNS,
+        defaultVisibleIds: ["a"],
+      }),
+    );
+
+    act(() => result.current.toggleColumn("a"));
+    expect(result.current.visibleColumns.map((c) => c.id)).toEqual(["a"]);
+  });
+
+  it("reorders columns with moveColumn, both visible and hidden together", () => {
+    const { result } = renderHook(() =>
+      useColumnPreferences({
+        viewId: "test-view",
+        userKey: "user-1",
+        columns: COLUMNS,
+        defaultVisibleIds: ["a", "b", "c"],
+      }),
+    );
+
+    act(() => result.current.moveColumn("c", "up"));
+    expect(result.current.allColumns.map((c) => c.id)).toEqual(["a", "c", "b"]);
+    expect(result.current.visibleColumns.map((c) => c.id)).toEqual(["a", "c", "b"]);
+
+    // No-ops past either end.
+    act(() => result.current.moveColumn("a", "up"));
+    expect(result.current.allColumns.map((c) => c.id)).toEqual(["a", "c", "b"]);
+    act(() => result.current.moveColumn("b", "down"));
+    expect(result.current.allColumns.map((c) => c.id)).toEqual(["a", "c", "b"]);
+  });
+
+  it("resets to the table's built-in default order and visibility", () => {
+    const { result } = renderHook(() =>
+      useColumnPreferences({
+        viewId: "test-view",
+        userKey: "user-1",
+        columns: COLUMNS,
+        defaultVisibleIds: ["a"],
+      }),
+    );
+
+    act(() => result.current.toggleColumn("b"));
+    act(() => result.current.moveColumn("c", "up"));
+    act(() => result.current.resetToDefault());
+
+    expect(result.current.allColumns.map((c) => c.id)).toEqual(["a", "b", "c"]);
+    expect(result.current.visibleColumns.map((c) => c.id)).toEqual(["a"]);
+  });
+
+  it("keys storage per user and per view, so neither leaks into the other", () => {
+    const base = { columns: COLUMNS, defaultVisibleIds: ["a"] };
+    const view1User1 = renderHook(() =>
+      useColumnPreferences({ ...base, viewId: "view-1", userKey: "user-1" }),
+    );
+    act(() => view1User1.result.current.toggleColumn("b"));
+
+    const view1User2 = renderHook(() =>
+      useColumnPreferences({ ...base, viewId: "view-1", userKey: "user-2" }),
+    );
+    expect(view1User2.result.current.visibleColumns.map((c) => c.id)).toEqual(["a"]);
+
+    const view2User1 = renderHook(() =>
+      useColumnPreferences({ ...base, viewId: "view-2", userKey: "user-1" }),
+    );
+    expect(view2User1.result.current.visibleColumns.map((c) => c.id)).toEqual(["a"]);
+  });
+
+  it("drops columns the table no longer defines and appends new ones the saved state predates", () => {
+    const key = "csm:user-1:test-view:columns";
+    window.localStorage.setItem(
+      key,
+      JSON.stringify({ order: ["a", "removed"], visible: ["a", "removed"] }),
+    );
+
+    const { result } = renderHook(() =>
+      useColumnPreferences({
+        viewId: "test-view",
+        userKey: "user-1",
+        columns: COLUMNS,
+        defaultVisibleIds: ["a", "b"],
+      }),
+    );
+
+    // "removed" is gone; "b" and "c" (unknown to the saved state) are appended.
+    expect(result.current.allColumns.map((c) => c.id)).toEqual(["a", "b", "c"]);
+    // "b" is newly appended and its default says visible; "c" defaults hidden.
+    expect(result.current.visibleColumns.map((c) => c.id)).toEqual(["a", "b"]);
+  });
+
+  it("falls back to defaults when the stored value is corrupt", () => {
+    window.localStorage.setItem("csm:user-1:test-view:columns", "not json");
+
+    const { result } = renderHook(() =>
+      useColumnPreferences({
+        viewId: "test-view",
+        userKey: "user-1",
+        columns: COLUMNS,
+        defaultVisibleIds: ["a"],
+      }),
+    );
+
+    expect(result.current.visibleColumns.map((c) => c.id)).toEqual(["a"]);
+  });
+});

--- a/apps/csm-portal/webapp/src/hooks/useColumnPreferences.test.ts
+++ b/apps/csm-portal/webapp/src/hooks/useColumnPreferences.test.ts
@@ -218,6 +218,30 @@ describe("useColumnPreferences", () => {
     expect(saved.visible).toEqual(["b", "a", "c"]);
   });
 
+  it("dedupes duplicate ids in a persisted order/visible array on reconcile", () => {
+    // A hand-edited (or otherwise corrupted) localStorage value with a
+    // duplicate id — every consumer keys off `allColumns`/`visibleColumns`
+    // ids (e.g. `TableCell key={id}`), so a surviving duplicate is a React
+    // duplicate-key rendering bug, not just untidy data.
+    const key = "csm:user-1:test-view:columns";
+    window.localStorage.setItem(
+      key,
+      JSON.stringify({ order: ["a", "a", "b", "c"], visible: ["a", "a", "c"] }),
+    );
+
+    const { result } = renderHook(() =>
+      useColumnPreferences({
+        viewId: "test-view",
+        userKey: "user-1",
+        columns: COLUMNS,
+        defaultVisibleIds: ["a", "b"],
+      }),
+    );
+
+    expect(result.current.allColumns.map((c) => c.id)).toEqual(["a", "b", "c"]);
+    expect(result.current.visibleColumns.map((c) => c.id)).toEqual(["a", "c"]);
+  });
+
   it("falls back to defaults when the stored value is corrupt", () => {
     window.localStorage.setItem("csm:user-1:test-view:columns", "not json");
 

--- a/apps/csm-portal/webapp/src/hooks/useColumnPreferences.test.ts
+++ b/apps/csm-portal/webapp/src/hooks/useColumnPreferences.test.ts
@@ -178,6 +178,46 @@ describe("useColumnPreferences", () => {
     expect(result.current.visibleColumns.map((c) => c.id)).toEqual(["a", "b"]);
   });
 
+  it("re-reconciles against the new key when userKey changes after mount", () => {
+    // Mirrors the real call sites: on first render, the signed-in user's id
+    // hasn't resolved yet (useCurrentUser()/useIdTokenClaims() are both async),
+    // so the hook is first rendered with userKey "anonymous", then rerendered
+    // once the real id lands.
+    window.localStorage.setItem(
+      "csm:anonymous:test-view:columns",
+      JSON.stringify({ order: ["c", "a", "b"], visible: ["c"] }),
+    );
+    window.localStorage.setItem(
+      "csm:user-1:test-view:columns",
+      JSON.stringify({ order: ["b", "a", "c"], visible: ["b", "a"] }),
+    );
+
+    const base = { viewId: "test-view", columns: COLUMNS, defaultVisibleIds: ["a"] };
+    const { result, rerender } = renderHook(useColumnPreferences, {
+      initialProps: { ...base, userKey: "anonymous" },
+    });
+
+    // First render picks up the anonymous bucket, as expected.
+    expect(result.current.allColumns.map((c) => c.id)).toEqual(["c", "a", "b"]);
+    expect(result.current.visibleColumns.map((c) => c.id)).toEqual(["c"]);
+
+    // The real user id resolves a render or two later.
+    rerender({ ...base, userKey: "user-1" });
+
+    // The hook must now reflect user-1's saved layout, not the anonymous
+    // state it happened to start with.
+    expect(result.current.allColumns.map((c) => c.id)).toEqual(["b", "a", "c"]);
+    expect(result.current.visibleColumns.map((c) => c.id)).toEqual(["b", "a"]);
+
+    // And a subsequent toggle must save under user-1's key, not clobber it
+    // with the anonymous session's stale state.
+    act(() => result.current.toggleColumn("c"));
+    const saved = JSON.parse(
+      window.localStorage.getItem("csm:user-1:test-view:columns") ?? "null",
+    );
+    expect(saved.visible).toEqual(["b", "a", "c"]);
+  });
+
   it("falls back to defaults when the stored value is corrupt", () => {
     window.localStorage.setItem("csm:user-1:test-view:columns", "not json");
 

--- a/apps/csm-portal/webapp/src/hooks/useColumnPreferences.ts
+++ b/apps/csm-portal/webapp/src/hooks/useColumnPreferences.ts
@@ -157,6 +157,23 @@ export function useColumnPreferences({
     reconcile(loadPersisted(key), columns, defaultVisibleIds),
   );
 
+  // `key` starts wrong on first render for any caller whose `userKey` resolves
+  // asynchronously (e.g. `useCurrentUser()`/`useIdTokenClaims()` are both
+  // still `undefined` on mount, so `getColumnPreferencesUserKey` falls back
+  // to the shared "anonymous" bucket) and then changes once the real id
+  // lands. `useState`'s lazy initializer only runs once, so without this it
+  // keeps serving the state it loaded under the stale key forever. Re-derive
+  // `state` from `localStorage` whenever `key` actually changes, using
+  // React's "adjust state during render" pattern (tracked via a second piece
+  // of state, not a ref — refs must not be read/written during render)
+  // instead of an effect, so there's no extra commit where the table renders
+  // the wrong user's columns before catching up.
+  const [prevKey, setPrevKey] = useState(key);
+  if (prevKey !== key) {
+    setPrevKey(key);
+    setState(reconcile(loadPersisted(key), columns, defaultVisibleIds));
+  }
+
   const update = useCallback(
     (next: PersistedColumnState) => {
       setState(next);

--- a/apps/csm-portal/webapp/src/hooks/useColumnPreferences.ts
+++ b/apps/csm-portal/webapp/src/hooks/useColumnPreferences.ts
@@ -1,0 +1,218 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useCallback, useMemo, useState } from "react";
+
+/** A single column a table can show/hide/reorder. `id` is a stable key (not
+ * necessarily the display order) — `label` is what the picker shows. */
+export interface ColumnOption {
+  id: string;
+  label: string;
+}
+
+export interface UseColumnPreferencesArgs {
+  /** Identifies this particular table/view, e.g. `"engagements"` or
+   * `"announcements"`. Combined with the signed-in user's id to build the
+   * `localStorage` key, so two tables (or two users on a shared browser
+   * profile) never clobber each other's saved layout. */
+  viewId: string;
+  /** Stable id for the signed-in user (falls back to email, then
+   * `"anonymous"` — see `useColumnPreferencesStorageUserKey`). */
+  userKey: string;
+  /** Every column this table knows how to render, in the table's own default
+   * order. New columns a later deploy adds just show up appended at the end
+   * of a returning user's saved order, already visible if `defaultVisibleIds`
+   * says so. */
+  columns: ColumnOption[];
+  /** Which column ids are visible the first time a user opens this table
+   * (before they've ever touched the picker). */
+  defaultVisibleIds: string[];
+}
+
+export interface UseColumnPreferencesResult {
+  /** All known columns, in the user's chosen order — what the "customise
+   * columns" popover renders, checked or not. */
+  allColumns: ColumnOption[];
+  /** Only the visible columns, in the user's chosen order — what the table
+   * itself should render. */
+  visibleColumns: ColumnOption[];
+  isVisible: (id: string) => boolean;
+  /** Flip a column's visibility. No-ops if this would hide the last visible
+   * column — a table with zero columns is never a valid state to save. */
+  toggleColumn: (id: string) => void;
+  /** Move a column one slot up/down in the shared order (visible and hidden
+   * columns share one order, so a column already keeps its relative slot if
+   * it's later re-checked). No-ops at either end of the list. */
+  moveColumn: (id: string, direction: "up" | "down") => void;
+  /** Back to the table's built-in default order + visibility. */
+  resetToDefault: () => void;
+}
+
+function storageKey(viewId: string, userKey: string): string {
+  return `csm:${userKey}:${viewId}:columns`;
+}
+
+/**
+ * Stable per-user key for {@link useColumnPreferences}'s `userKey`. Prefers
+ * the platform user id; falls back to email (still stable, just less
+ * canonical) when the id hasn't resolved yet, and finally to a shared
+ * `"anonymous"` bucket so the picker still works (just not durably scoped to
+ * one person) before either is available. Colons are stripped since they're
+ * the key's own field separator — emails don't contain them today, but this
+ * keeps the key well-formed even if that ever changes.
+ */
+export function getColumnPreferencesUserKey(user?: {
+  id?: string;
+  email?: string;
+}): string {
+  const raw = user?.id || user?.email || "anonymous";
+  return raw.replace(/:/g, "_");
+}
+
+interface PersistedColumnState {
+  order: string[];
+  visible: string[];
+}
+
+function loadPersisted(key: string): PersistedColumnState | undefined {
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (!raw) return undefined;
+    const parsed = JSON.parse(raw) as Partial<PersistedColumnState>;
+    if (!Array.isArray(parsed.order) || !Array.isArray(parsed.visible)) return undefined;
+    return { order: parsed.order, visible: parsed.visible };
+  } catch {
+    // Corrupt/inaccessible storage (private browsing, hand-edited value, …) —
+    // fall back to the table's own default rather than throwing.
+    return undefined;
+  }
+}
+
+function savePersisted(key: string, state: PersistedColumnState): void {
+  try {
+    window.localStorage.setItem(key, JSON.stringify(state));
+  } catch {
+    // Storage full/unavailable — the picker still works for this session,
+    // it just won't survive a reload. Not worth surfacing to the user.
+  }
+}
+
+/** Reconciles a persisted order/visible set against the table's current
+ * column definitions: drops ids the table no longer knows about, and appends
+ * any new ones (in their default position/visibility) the persisted state
+ * predates. */
+function reconcile(
+  persisted: PersistedColumnState | undefined,
+  columns: ColumnOption[],
+  defaultVisibleIds: string[],
+): PersistedColumnState {
+  const knownIds = new Set(columns.map((c) => c.id));
+  if (!persisted) {
+    return { order: columns.map((c) => c.id), visible: [...defaultVisibleIds] };
+  }
+  const order = persisted.order.filter((id) => knownIds.has(id));
+  const orderedIds = new Set(order);
+  columns.forEach((c) => {
+    if (!orderedIds.has(c.id)) order.push(c.id);
+  });
+  const visible = persisted.visible.filter((id) => knownIds.has(id));
+  const visibleIds = new Set(visible);
+  columns.forEach((c) => {
+    if (!orderedIds.has(c.id) && defaultVisibleIds.includes(c.id) && !visibleIds.has(c.id)) {
+      visible.push(c.id);
+    }
+  });
+  return { order, visible };
+}
+
+/**
+ * Per-user, per-view "customise columns" state, persisted to `localStorage`
+ * (no backend round trip — this is presentation-only and never needs to sync
+ * across devices). One hook instance owns one table's column layout; render
+ * `visibleColumns` in the table body and pair with `ColumnCustomizerButton`
+ * (or an equivalent control) for the add/remove/reorder UI.
+ */
+export function useColumnPreferences({
+  viewId,
+  userKey,
+  columns,
+  defaultVisibleIds,
+}: UseColumnPreferencesArgs): UseColumnPreferencesResult {
+  const key = storageKey(viewId, userKey);
+
+  const [state, setState] = useState<PersistedColumnState>(() =>
+    reconcile(loadPersisted(key), columns, defaultVisibleIds),
+  );
+
+  const update = useCallback(
+    (next: PersistedColumnState) => {
+      setState(next);
+      savePersisted(key, next);
+    },
+    [key],
+  );
+
+  const columnsById = useMemo(() => {
+    const map = new Map<string, ColumnOption>();
+    columns.forEach((c) => map.set(c.id, c));
+    return map;
+  }, [columns]);
+
+  const allColumns = useMemo(
+    () => state.order.map((id) => columnsById.get(id)).filter((c): c is ColumnOption => !!c),
+    [state.order, columnsById],
+  );
+
+  const visibleSet = useMemo(() => new Set(state.visible), [state.visible]);
+
+  const visibleColumns = useMemo(
+    () => allColumns.filter((c) => visibleSet.has(c.id)),
+    [allColumns, visibleSet],
+  );
+
+  const isVisible = useCallback((id: string) => visibleSet.has(id), [visibleSet]);
+
+  const toggleColumn = useCallback(
+    (id: string) => {
+      const currentlyVisible = state.visible.includes(id);
+      if (currentlyVisible && state.visible.length <= 1) return; // never zero columns
+      const visible = currentlyVisible
+        ? state.visible.filter((v) => v !== id)
+        : [...state.visible, id];
+      update({ order: state.order, visible });
+    },
+    [state, update],
+  );
+
+  const moveColumn = useCallback(
+    (id: string, direction: "up" | "down") => {
+      const index = state.order.indexOf(id);
+      if (index === -1) return;
+      const swapWith = direction === "up" ? index - 1 : index + 1;
+      if (swapWith < 0 || swapWith >= state.order.length) return;
+      const order = [...state.order];
+      [order[index], order[swapWith]] = [order[swapWith], order[index]];
+      update({ order, visible: state.visible });
+    },
+    [state, update],
+  );
+
+  const resetToDefault = useCallback(() => {
+    update({ order: columns.map((c) => c.id), visible: [...defaultVisibleIds] });
+  }, [columns, defaultVisibleIds, update]);
+
+  return { allColumns, visibleColumns, isVisible, toggleColumn, moveColumn, resetToDefault };
+}

--- a/apps/csm-portal/webapp/src/hooks/useColumnPreferences.ts
+++ b/apps/csm-portal/webapp/src/hooks/useColumnPreferences.ts
@@ -123,12 +123,16 @@ function reconcile(
   if (!persisted) {
     return { order: columns.map((c) => c.id), visible: [...defaultVisibleIds] };
   }
-  const order = persisted.order.filter((id) => knownIds.has(id));
+  // A hand-edited or otherwise corrupted `localStorage` value can contain
+  // duplicate ids (e.g. `order: ["a", "a", "b"]`) — dedupe alongside the
+  // known-id filter so a duplicate never survives into `allColumns`/
+  // `visibleColumns`, where every consumer uses the id as a React list key.
+  const order = [...new Set(persisted.order.filter((id) => knownIds.has(id)))];
   const orderedIds = new Set(order);
   columns.forEach((c) => {
     if (!orderedIds.has(c.id)) order.push(c.id);
   });
-  const visible = persisted.visible.filter((id) => knownIds.has(id));
+  const visible = [...new Set(persisted.visible.filter((id) => knownIds.has(id)))];
   const visibleIds = new Set(visible);
   columns.forEach((c) => {
     if (!orderedIds.has(c.id) && defaultVisibleIds.includes(c.id) && !visibleIds.has(c.id)) {


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

CS engineers triage different fields depending on their focus (product, SLA, account, assignee, etc.), but every table across the CSM portal today shows a fixed set of columns. There was no way to add a field you care about or drop one you never look at, so seeing an uncommon field meant opening every row individually.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

Let each CS engineer customise which columns show, in what order, per table, and have that choice persist across reloads and future logins.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

- Added a shared `useColumnPreferences` hook (order/visibility state, `localStorage`-backed, keyed per signed-in user and per view) and a `ColumnCustomizerButton` control (gear icon → popover with checkboxes and up/down reordering, no new dependency).
- Wired it into six views sharing the same underlying data: Engagements, Cases, Service Requests, Security Report Analysis (all via `CsmIssuesView`/`CasesList`), Change Requests (`ChangeRequestsTab`, a separate table component), and Announcements (`CsmAnnouncementsPage`), plus the Customers/Accounts table (`CsmAccountsPage`).
- Each view offers the optional columns that are actually meaningful for its underlying record (e.g. customer, created date, assignee for case-typed views; account manager/technical owner/CRE team for Accounts; a reference/case-id column for Announcements) — a few candidate fields were deliberately left out as raw ids, already-shown elsewhere, or not yet backed by reliable data (documented inline in each view's column-list file).
- Persistence is `localStorage`-only for now (per-user, per-view key) — no backend/schema change. This is deliberate: durable DB-backed storage is deferred until ServiceNow is fully retired from this stack, at which point it's a natural follow-up.
- Along the way, fixed a bug where Service Requests could offer/default a "Severity" column that always renders empty (was gated on the wrong flag), and a related bug in the shared hook where a signed-in user's real saved layout could be silently ignored on load because the storage key is derived from an id that resolves asynchronously after sign-in.

## User stories
> Summary of user stories addressed by this change

As a CS engineer, I want to add or remove columns on the tables I use daily, and have my choice remembered, so I don't have to open every row to see a field I care about.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Added a "Customise columns" control to the Engagements, Cases, Service Requests, Security Report Analysis, Change Requests, Announcements, and Customers tables — add, remove, and reorder columns, with your choice remembered per table.

## Documentation
N/A — no external product documentation exists for this portal yet; the in-app help guide (`src/features/help/content/`) doesn't exist in this codebase either, so there's nothing to update.

## Training
N/A — internal CS tooling, not covered by WSO2 Training content.

## Certification
N/A — no certification exam covers this internal tooling.

## Marketing
N/A — internal CS tooling, not a customer-facing product feature.

## Automation tests
 - Unit tests
   > New/updated: `useColumnPreferences.test.ts`, `ColumnCustomizerButton.test.tsx`, `caseListColumns.test.ts`, `CasesList.test.tsx`, `CsmIssuesView.test.tsx`, `CsmAnnouncementsPage.test.tsx`, `CsmAccountsPage.test.tsx`, `ChangeRequestsTab.test.tsx`. Full suite passes locally.
 - Integration tests
   > None added — this app has no integration-test layer distinct from its component/unit tests.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — FE TypeScript, not a Java target; `eslint` ran clean (0 errors) as the equivalent static check
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no sample apps ship for this portal.

## Related PRs
None.

## Migrations (if applicable)
N/A — no schema/data migration; persistence is client-side `localStorage` only.

## Test environment
Verified locally: Node/npm toolchain for this webapp (`apps/csm-portal/webapp`), Chromium-based `vitest`/`jsdom` test environment. `npm run lint`, `npm run build`, and the full `npm run test` suite all pass.

## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

Reused React's documented "adjust state during render" pattern (rather than `useEffect`) to reload persisted preferences the moment the resolved per-user storage key changes, avoiding a visible flash of the wrong user's column layout on load.

---
_Note on size: this PR touches 24 files. It's kept as one PR rather than split because it's a single cohesive feature (one shared mechanism rolled out to every view it applies to) with no natural seam that wouldn't leave an intermediate PR half-working; no individual file exceeds ~235 changed lines._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added customizable table columns across accounts, announcements, cases, engagements, security reports, and service requests.
  - Users can show, hide, reorder, and reset columns, with preferences saved per view and user.
  - Prevented users from hiding all columns.
  - Added optional case, account, announcement, and service-request details to table views.
- **Bug Fixes**
  - Announcement results now display the correct case reference.
- **Tests**
  - Added coverage for column customization, persistence, ordering, reset behavior, and empty states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->