### PR TITLE
[CSM Portal] Fix Security Report Analysis case create always failing

### DIFF
--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -524,10 +524,11 @@ export interface BeCaseAttachmentPayload {
 
 /**
  * Security report analysis (`type: "security_report_analysis"`). ServiceNow-only;
- * requires a subject and description. Attachments are optional here — the case
- * is created first, then attachments upload separately via the post-case
- * attachment endpoint (see `CreateSecurityReportPage.tsx`), so a failed upload
- * never blocks or masks a successful report creation.
+ * requires a subject and description. Unlike the other case-creation flows,
+ * at least one attachment is also required and must be included in this same
+ * create payload — the backing service validates it atomically at creation
+ * time, so uploading via the post-case attachment endpoint afterward doesn't
+ * satisfy it (see `CreateSecurityReportPage.tsx`).
  */
 export interface BeSecurityReportCreatePayload {
   type: "security_report_analysis";

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/uploadAttachmentsToCase.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/uploadAttachmentsToCase.ts
@@ -19,10 +19,14 @@ import type { PostCsmCaseAttachmentInput } from "@features/csm-cases/api/useCsmC
 
 /**
  * Upload create-form attachments to an already-created case via
- * `POST /attachments` (`referenceType: "case"`). Every case-creation flow
- * (standard case, service request, security report) attaches files this way
- * after the case exists, rather than bundling them into the create request,
- * so a failed attachment upload never blocks or masks a successful create.
+ * `POST /attachments` (`referenceType: "case"`). The standard case and
+ * service request creation flows attach files this way after the case
+ * exists, rather than bundling them into the create request, so a failed
+ * attachment upload never blocks or masks a successful create. (Security
+ * report analysis is the exception: it requires at least one attachment in
+ * the create payload itself, validated atomically at creation time, so it
+ * sends attachments there instead of through this post-create path — see
+ * `CreateSecurityReportPage.tsx`.)
  *
  * Uploads run concurrently and independently; returns the number that failed
  * so the caller can warn without blocking navigation to the created case.

--- a/apps/csm-portal/webapp/src/features/csm-security-center/pages/CreateSecurityReportPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-security-center/pages/CreateSecurityReportPage.test.tsx
@@ -1,0 +1,182 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+
+const navigateMock = vi.fn();
+const postCaseMutateAsyncMock = vi.fn();
+const showErrorMock = vi.fn();
+
+vi.mock("react-router", () => ({
+  useNavigate: () => navigateMock,
+  useLocation: () => ({ state: undefined }),
+  useSearchParams: () => [new URLSearchParams()],
+}));
+vi.mock("@context/error-banner/ErrorBannerContext", () => ({
+  useErrorBanner: () => ({ showError: showErrorMock }),
+}));
+vi.mock("@features/csm-cases/api/usePostCsmCase", () => ({
+  usePostCsmCase: () => ({ mutateAsync: postCaseMutateAsyncMock }),
+}));
+// The project/deployment/product cascade is exercised elsewhere
+// (CsmCaseCreatePage) — stub them here to fixed, already-loaded options so
+// this file can focus on the attachment-required submit path.
+vi.mock("@features/csm-cases/api/useSearchDeployments", () => ({
+  useSearchDeployments: () => ({
+    data: [{ id: "dep-1", name: "Production" }],
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+  }),
+}));
+vi.mock("@features/csm-cases/api/useDeployedProductOptions", () => ({
+  useDeployedProductOptions: () => ({
+    data: [{ id: "dp-1", label: "API Manager 4.3.0" }],
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+  }),
+}));
+vi.mock("@features/csm-cases/components/ProjectSelectionField", () => ({
+  default: ({
+    value,
+    onChange,
+  }: {
+    value: string;
+    onChange: (next: string) => void;
+  }) => (
+    <input
+      aria-label="Project"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  ),
+}));
+vi.mock("@components/rich-text-editor/Editor", () => ({
+  default: ({ value, onChange }: { value: string; onChange: (v: string) => void }) => (
+    <textarea aria-label="editor" value={value} onChange={(e) => onChange(e.target.value)} />
+  ),
+}));
+// CreateSecurityReportPage imports BackendApiError from the real API client
+// module, which reads window.config at module load and throws outside a
+// configured runtime. Mock it with a real class (so `instanceof` still
+// works), mirroring CreateChangeRequestPage.test.tsx.
+vi.mock("@api/backend/client", () => ({
+  BackendApiError: class BackendApiError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+      super(message);
+      this.status = status;
+    }
+  },
+}));
+
+// Imported after the mocks above so the module picks them up.
+import CreateSecurityReportPage from "@features/csm-security-center/pages/CreateSecurityReportPage";
+
+/** A minimal File the jsdom FileReader used by AttachmentsField can read. */
+function makeFile(name: string, content = "scan results"): File {
+  return new File([content], name, { type: "text/plain" });
+}
+
+/** Fills every field the form requires except attachments. */
+function fillRequiredFieldsExceptAttachments(): void {
+  fireEvent.change(screen.getByLabelText("Project"), { target: { value: "proj-1" } });
+  fireEvent.mouseDown(screen.getByLabelText(/deployment/i));
+  fireEvent.click(screen.getByRole("option", { name: "Production" }));
+  fireEvent.mouseDown(screen.getByLabelText(/deployed product/i));
+  fireEvent.click(screen.getByRole("option", { name: "API Manager 4.3.0" }));
+  fireEvent.change(screen.getByLabelText(/subject/i), {
+    target: { value: "Suspicious access pattern" },
+  });
+  fireEvent.change(screen.getByLabelText("editor"), {
+    target: { value: "<p>Please review the attached scan.</p>" },
+  });
+}
+
+async function addAttachment(name = "scan.txt"): Promise<void> {
+  const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+  await fireEvent.change(input, { target: { files: [makeFile(name)] } });
+  // Reading the file to base64 is async; let the microtask settle.
+  await screen.findByText(name);
+}
+
+describe("CreateSecurityReportPage — attachment required at create time", () => {
+  beforeEach(() => {
+    navigateMock.mockReset();
+    postCaseMutateAsyncMock.mockReset();
+    showErrorMock.mockReset();
+  });
+
+  it("keeps Create disabled until every required field, including an attachment, is filled", () => {
+    render(<CreateSecurityReportPage />);
+    const submit = screen.getByRole("button", { name: /create security report/i });
+    expect(submit).toBeDisabled();
+
+    fillRequiredFieldsExceptAttachments();
+    // Every other required field is now filled, but there is still no attachment.
+    expect(submit).toBeDisabled();
+  });
+
+  it("shows the Attachments field as required, not optional", () => {
+    render(<CreateSecurityReportPage />);
+    expect(screen.getByText(/attachments \*/i)).toBeInTheDocument();
+    expect(screen.getByText(/at least one required/i)).toBeInTheDocument();
+  });
+
+  it("enables Create once an attachment is added, and sends it inside the POST /cases payload", async () => {
+    postCaseMutateAsyncMock.mockResolvedValue({ id: "sra-1" });
+    render(<CreateSecurityReportPage />);
+
+    fillRequiredFieldsExceptAttachments();
+    await addAttachment("scan.txt");
+
+    const submit = screen.getByRole("button", { name: /create security report/i });
+    expect(submit).toBeEnabled();
+
+    fireEvent.click(submit);
+    await screen.findByRole("button", { name: /creating/i });
+
+    expect(postCaseMutateAsyncMock).toHaveBeenCalledTimes(1);
+    const payload = postCaseMutateAsyncMock.mock.calls[0][0];
+    expect(payload.type).toBe("security_report_analysis");
+    expect(payload.attachments).toEqual([
+      { name: "scan.txt", file: expect.any(String) },
+    ]);
+    expect(navigateMock).toHaveBeenCalledWith("/security-center/security-reports/sra-1", {
+      state: { from: "/security-center" },
+    });
+  });
+
+  it("surfaces a create-mutation error via the shared error banner instead of navigating", async () => {
+    postCaseMutateAsyncMock.mockRejectedValue(new Error("network down"));
+    render(<CreateSecurityReportPage />);
+
+    fillRequiredFieldsExceptAttachments();
+    await addAttachment("scan.txt");
+    fireEvent.click(screen.getByRole("button", { name: /create security report/i }));
+
+    await vi.waitFor(() => {
+      expect(showErrorMock).toHaveBeenCalledWith(
+        "Could not create the security report. Please try again.",
+        expect.any(Error),
+      );
+    });
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-security-center/pages/CreateSecurityReportPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-security-center/pages/CreateSecurityReportPage.tsx
@@ -44,9 +44,6 @@ import ProjectSelectionField from "@features/csm-cases/components/ProjectSelecti
 import { useSearchDeployments } from "@features/csm-cases/api/useSearchDeployments";
 import { useDeployedProductOptions } from "@features/csm-cases/api/useDeployedProductOptions";
 import { usePostCsmCase } from "@features/csm-cases/api/usePostCsmCase";
-import { usePostCsmCaseAttachment } from "@features/csm-cases/api/useCsmCaseAttachments";
-import { uploadAttachmentsToCase } from "@features/csm-cases/api/uploadAttachmentsToCase";
-import { useEngineerDisplayName } from "@hooks/useEngineerDisplayName";
 import { useNavTransition } from "@hooks/useNavTransition";
 
 /** The rich-text editor emits `<p></p>` when empty; check the stripped text. */
@@ -94,9 +91,6 @@ export default function CreateSecurityReportPage(): JSX.Element {
   const deployments = useSearchDeployments(projectId || undefined);
   const deployedProducts = useDeployedProductOptions(deploymentId || undefined);
   const postCase = usePostCsmCase();
-  const postAttachment = usePostCsmCaseAttachment();
-  const uploadedBy = useEngineerDisplayName();
-  // Spans the whole submit (create + post-create attachment uploads).
   const [submitting, setSubmitting] = useState(false);
 
   const overLimit = totalEncodedBytes(attachments) > POST_CREATE_ATTACHMENTS_MAX_ENCODED_BYTES;
@@ -134,9 +128,9 @@ export default function CreateSecurityReportPage(): JSX.Element {
     if (deployedProducts.isError) void deployedProducts.refetch();
   };
 
-  // Attachments are optional here: the case is created first, then attachments
-  // upload separately (see handleSubmit), so a failed upload never blocks or
-  // masks a successful report creation.
+  // At least one attachment is required here: the backing service validates
+  // the create request atomically for this case type, so an attachment added
+  // only after creation would never satisfy it.
   const canSubmit = useMemo(
     () =>
       !!projectId &&
@@ -144,6 +138,7 @@ export default function CreateSecurityReportPage(): JSX.Element {
       !!deployedProductId &&
       subject.trim().length > 0 &&
       !isEmptyHtml(description) &&
+      attachments.length > 0 &&
       !overLimit &&
       !submitting,
     [
@@ -152,6 +147,7 @@ export default function CreateSecurityReportPage(): JSX.Element {
       deployedProductId,
       subject,
       description,
+      attachments,
       overLimit,
       submitting,
     ],
@@ -168,18 +164,8 @@ export default function CreateSecurityReportPage(): JSX.Element {
         deployedProductId,
         subject: subject.trim(),
         description,
+        attachments: attachments.map((a) => ({ name: a.name, file: a.file })),
       });
-      const failed = await uploadAttachmentsToCase(
-        postAttachment.mutateAsync,
-        created.id,
-        attachments,
-        uploadedBy,
-      );
-      if (failed > 0) {
-        showError(
-          `The security report was created, but ${failed} attachment${failed === 1 ? "" : "s"} failed to upload. You can add ${failed === 1 ? "it" : "them"} from the report page.`,
-        );
-      }
       navigate(`/security-center/security-reports/${created.id}`, {
         state: { from: backTarget },
       });
@@ -352,13 +338,14 @@ export default function CreateSecurityReportPage(): JSX.Element {
               color="text.secondary"
               sx={{ display: "block", mb: 0.5 }}
             >
-              Attachments
+              Attachments *
             </Typography>
             <AttachmentsField
               attachments={attachments}
               onChange={setAttachments}
               onError={showError}
               maxEncodedBytes={POST_CREATE_ATTACHMENTS_MAX_ENCODED_BYTES}
+              required
               disabled={submitting}
             />
           </Grid>


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Creating a Security Report Analysis (SRA) case in the CSM portal always fails in staging. The entity-service now requires at least one attachment to be present inside the `POST /cases` create request itself for the `security_report_analysis` case type — it's an atomic, all-or-nothing validation at creation time. The create form uploads any selected attachments in separate `POST /attachments` requests *after* the case is created, so that requirement is never satisfied and every SRA create fails with a 400.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

Include the selected attachments directly in the initial case-create payload, require at least one attachment before the form can be submitted, and remove the now-redundant post-create attachment upload for this flow only.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

In `CreateSecurityReportPage.tsx`:
- `canSubmit` now also requires `attachments.length > 0`.
- `handleSubmit` maps the selected `EncodedAttachment[]` to `{ name, file }` and includes them in the initial `postCase.mutateAsync({...})` call (the wire type, `BeSecurityReportCreatePayload.attachments`, already supported this).
- Removed the separate post-create `uploadAttachmentsToCase` call for this page, since the backend now accepts the full attachment array atomically at creation.
- The Attachments field label now reads "Attachments *" and is passed `required` to `AttachmentsField`, which already had copy for that state ("At least one required" vs "Optional").

Also updated stale doc comments that described the old "create then upload separately" design for this case type, in `types.ts` and `uploadAttachmentsToCase.ts` (the latter is unchanged in behavior — it's still used as-is by the standard case and service request create flows).

This is a frontend-only fix: the wire contract (`BeSecurityReportCreatePayload.attachments`) and the CSM entity-service already accept and forward attachments correctly when present.

## User stories
> Summary of user stories addressed by this change

As a CS engineer, I can create a Security Report Analysis case with at least one attachment, and the create no longer fails.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Fixed: creating a Security Report Analysis case in the CSM portal always failed because attachments were uploaded after case creation instead of inside the create request, which the backend now requires. At least one attachment is now required and sent with the initial create request.

## Documentation
N/A — no published end-user documentation describes this internal CSM-portal creation flow's attachment timing.

## Training
N/A — no training content references this flow.

## Certification
N/A — no certification exam content covers this internal CSM-portal flow.

## Marketing
N/A — internal bug fix, not a marketable feature.

## Automation tests
 - Unit tests
   > Added `CreateSecurityReportPage.test.tsx` (React Testing Library / Vitest): Create stays disabled until an attachment is added (all other required fields filled), the Attachments field renders as required (not optional), a selected attachment is included in the `POST /cases` payload and the page navigates to the created report on success, and a create-mutation failure surfaces via the shared error banner without navigating. Full existing suite (185 files / 1900 tests) still passes.
 - Integration tests
   > None added; this is a frontend-only change against an already-documented wire contract. Manually reasoned through the flow against the entity-service's documented validation behavior described in this PR.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — TypeScript/React frontend, not a JVM codebase this tool applies to
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no new sample apps or code samples introduced.

## Related PRs
N/A

## Migrations (if applicable)
N/A — no data or schema migration involved.

## Test environment
Node.js/pnpm toolchain in this repo's `apps/csm-portal/webapp` workspace: `pnpm run lint`, `pnpm run test` (vitest, jsdom), `pnpm run build` (`tsc -b && vite build`) all run and pass locally.

## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

Traced the staging failure to the entity-service's create-time validation for `security_report_analysis`, confirmed the wire type (`BeSecurityReportCreatePayload.attachments`) already modeled this correctly, and found the create form simply never populated it — attachments were only ever sent through the separate post-create upload path used by the other case-creation flows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Security reports now require at least one attachment during creation.
  * Attachments are submitted together with the initial security report request.
  * Required fields are clearly marked.

* **Bug Fixes**
  * Improved validation and error handling for security report creation.
  * Added confirmation of successful submission and navigation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->