### PR TITLE
[CSM Portal] show case description fallback + add engagement payment type

### DIFF
--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -552,6 +552,7 @@ export interface BeEngagementCreatePayload {
   subject: string;
   description: string;
   engagementType: BeEngagementType;
+  engagementPaymentType: BeEngagementPaymentType;
 }
 
 /**
@@ -851,6 +852,9 @@ export type BeEngagementType =
   | "new_feature_improvement"
   | "follow_up"
   | "onboarding";
+
+/** Whether an engagement is billed to the customer or delivered free of charge. */
+export type BeEngagementPaymentType = "paid" | "foc";
 
 /**
  * `field` enum accepted by {@link BeCaseFieldFilter}. Mirrors the

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.test.tsx
@@ -169,16 +169,27 @@ vi.mock("@features/csm-cases/api/usePatchCsmCase", () => ({
 vi.mock("@features/csm-cases/api/useFindMyOngoingCases", () => ({
   useFindMyOngoingCases: () => vi.fn(),
 }));
+const useGetCsmCaseCommentsMock = vi.fn();
 vi.mock("@features/csm-cases/api/useCsmCaseComments", () => ({
-  useGetCsmCaseComments: () => ({
+  useGetCsmCaseComments: (id: string | undefined) =>
+    useGetCsmCaseCommentsMock(id),
+  usePostCsmCaseComment: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+function defaultCommentsImpl(): unknown {
+  return {
     data: [],
     isLoading: false,
     isError: false,
     refetch: vi.fn(),
     isFetching: false,
-  }),
-  usePostCsmCaseComment: () => ({ mutateAsync: vi.fn(), isPending: false }),
-}));
+  };
+}
+useGetCsmCaseCommentsMock.mockImplementation(defaultCommentsImpl);
+// Same reset reasoning as useGetCsmCaseDetailMock above — a test that swaps
+// in its own comments list must not leak it into the next test.
+afterEach(() => {
+  useGetCsmCaseCommentsMock.mockImplementation(defaultCommentsImpl);
+});
 vi.mock("@features/csm-cases/api/useCsmConversationMessages", () => ({
   useGetCsmConversationMessages: () => ({
     data: undefined,
@@ -879,10 +890,11 @@ describe("CsmCaseDetailPage — announcement description rendering", () => {
     ).toBeTruthy();
   });
 
-  it("does not render a standalone description card for a non-announcement case", () => {
-    // Regular cases already get their description via the comments feed's
-    // opening entry (CaseActivitiesFeed, stubbed to null here) — rendering it
-    // a second time here would duplicate it.
+  it("does not render the announcement-only description card for a non-announcement case", () => {
+    // This card is gated on isAnnouncement specifically — a plain case never
+    // gets it here regardless of the Details-tab dedupe fallback (covered in
+    // its own describe block below), since it stays on the default
+    // Activities tab in this render.
     renderCaseDetailPage(
       "/cases/case-1",
       "/cases/:caseId",
@@ -902,6 +914,122 @@ describe("CsmCaseDetailPage — announcement description rendering", () => {
     );
 
     expect(screen.queryByText("Description")).not.toBeInTheDocument();
+  });
+});
+
+describe("CsmCaseDetailPage — Details tab description fallback card", () => {
+  function mockComments(
+    comments: Array<{ id: string; bodyHtml: string; createdAt: string }>,
+  ): void {
+    useGetCsmCaseCommentsMock.mockImplementation(() => ({
+      data: comments.map((c) => ({
+        id: c.id,
+        caseId: "case-1",
+        authorName: "Jane Doe",
+        authorRole: "customer",
+        bodyHtml: c.bodyHtml,
+        createdAt: c.createdAt,
+      })),
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+      isFetching: false,
+    }));
+  }
+
+  it("shows the description card when there is no origin comment at all", () => {
+    useGetCsmCaseDetailMock.mockImplementation((id: string | undefined) => ({
+      data: id ? buildCase(id, { description: "<p>Sample description</p>" }) : undefined,
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+      isFetching: false,
+      dataUpdatedAt: 0,
+    }));
+    mockComments([]);
+
+    renderPageAt("/cases/case-1?tab=details");
+
+    expect(screen.getByText("Sample description")).toBeInTheDocument();
+  });
+
+  it("shows the description card when the origin comment doesn't reproduce the description", () => {
+    useGetCsmCaseDetailMock.mockImplementation((id: string | undefined) => ({
+      data: id ? buildCase(id, { description: "<p>Sample description</p>" }) : undefined,
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+      isFetching: false,
+      dataUpdatedAt: 0,
+    }));
+    mockComments([
+      {
+        id: "comment-1",
+        bodyHtml: "<p>Unrelated internal note added by automation</p>",
+        createdAt: "2026-01-01T00:00:00Z",
+      },
+    ]);
+
+    renderPageAt("/cases/case-1?tab=details");
+
+    expect(screen.getByText("Sample description")).toBeInTheDocument();
+  });
+
+  it("hides the description card when the origin comment reproduces the description", () => {
+    useGetCsmCaseDetailMock.mockImplementation((id: string | undefined) => ({
+      data: id ? buildCase(id, { description: "<p>Sample description</p>" }) : undefined,
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+      isFetching: false,
+      dataUpdatedAt: 0,
+    }));
+    mockComments([
+      {
+        id: "comment-1",
+        // Real-world echoes often carry extra wrapper text (e.g. a
+        // signature) around the description — the check tolerates that.
+        bodyHtml: "<p>Hi team,</p><p>Sample description</p><p>Thanks</p>",
+        createdAt: "2026-01-01T00:00:00Z",
+      },
+    ]);
+
+    renderPageAt("/cases/case-1?tab=details");
+
+    expect(screen.queryByText("Sample description")).not.toBeInTheDocument();
+  });
+
+  it("picks the earliest comment by createdAt as the origin comment, not array order", () => {
+    useGetCsmCaseDetailMock.mockImplementation((id: string | undefined) => ({
+      data: id ? buildCase(id, { description: "<p>Sample description</p>" }) : undefined,
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+      isFetching: false,
+      dataUpdatedAt: 0,
+    }));
+    // Later comment listed first, earliest (matching) comment listed second —
+    // the fallback must still find the earliest one and hide the card.
+    mockComments([
+      {
+        id: "comment-2",
+        bodyHtml: "<p>A later, unrelated follow-up</p>",
+        createdAt: "2026-01-02T00:00:00Z",
+      },
+      {
+        id: "comment-1",
+        bodyHtml: "<p>Sample description</p>",
+        createdAt: "2026-01-01T00:00:00Z",
+      },
+    ]);
+
+    renderPageAt("/cases/case-1?tab=details");
+
+    expect(screen.queryByText("Sample description")).not.toBeInTheDocument();
   });
 });
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -141,6 +141,7 @@ import { caseIdLabel } from "@features/csm-cases/utils/caseIdentity";
 import { formatAbsoluteForUser } from "@utils/dateTime";
 import {
   isBlankHtml,
+  isDescriptionEchoedInComment,
   sanitizeDescriptionHtml,
   stripHtmlTags,
   stripLightModeInlineStyles,
@@ -1597,6 +1598,23 @@ export default function CsmCaseDetailPage(): JSX.Element {
     [comments, chatMessages],
   );
 
+  // The origin comment — the earliest comment on the case, sorted rather
+  // than assumed to already be `comments[0]`. Cases created by customers
+  // consistently echo the description as this comment (often with a wrapper
+  // like a signature); cases created by internal automation frequently don't
+  // — sometimes there's no first comment at all. `descriptionEchoed` below
+  // decides whether the description still needs its own card.
+  const originComment = useMemo(() => {
+    if (!comments || comments.length === 0) return undefined;
+    return [...comments].sort(
+      (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
+    )[0];
+  }, [comments]);
+  const descriptionEchoedInOriginComment = isDescriptionEchoedInComment(
+    data?.description ?? "",
+    originComment?.bodyHtml,
+  );
+
   const onUploadAttachment = useCallback(
     (file: File) => {
       if (!caseId) return;
@@ -1751,11 +1769,13 @@ export default function CsmCaseDetailPage(): JSX.Element {
   const closeBlockedReason = hasOpenTask
     ? "This case has an open task. Closing may be rejected until it's resolved or closed."
     : undefined;
-  // The case description is already returned by `comments/search` as the
-  // opening comment, so the stream renders it directly — no synthetic entry is
-  // injected (that duplicated the first comment). The linked chat transcript
-  // (if any) is appended; the feed sorts chronologically, so the chat — being
-  // oldest — sinks below the case comments in the default newest-first view.
+  // The case description usually arrives as the opening comment too, so the
+  // stream renders that directly rather than injecting a synthetic entry —
+  // but not always (see `descriptionEchoedInOriginComment` above): the
+  // Details tab below carries a fallback card for whenever it doesn't. The
+  // linked chat transcript (if any) is appended; the feed sorts
+  // chronologically, so the chat — being oldest — sinks below the case
+  // comments in the default newest-first view.
   const safeComments = mergedComments;
 
   return (
@@ -2251,18 +2271,19 @@ export default function CsmCaseDetailPage(): JSX.Element {
               </MetaCell>
             </Box>
           </Card>
-          {/* The case description is not passively re-displayed here — it
+          {/* The case description usually doesn't need its own card — it
               already renders as the opening entry in the Activities tab's
-              feed (see the note near `safeComments` above). Editing it is
+              feed (see the note near `safeComments` above), and editing it is
               still available via the action bar's "Edit case details…" item
-              (EditCaseDetailsDialog), which is the only place the description
-              is shown for editing.
+              (EditCaseDetailsDialog).
 
-              Exception: if comments/search failed, safeComments is empty and
-              the description never renders anywhere — fall back to a
-              read-only card here so the description isn't invisible whenever
-              the activity feed is unavailable. */}
-          {isCommentsError && !isBlankHtml(c.description) && (
+              But that's only true when the origin comment actually
+              reproduces the description. It often doesn't for cases created
+              by internal automation — sometimes there's no origin comment at
+              all — so `descriptionEchoedInOriginComment` (content-based, not
+              just "did comments/search error") decides here rather than
+              assuming the feed already covered it. */}
+          {!isBlankHtml(c.description) && !descriptionEchoedInOriginComment && (
             <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 1.5 }}>
               <Typography variant="subtitle2">Description</Typography>
               <Box

--- a/apps/csm-portal/webapp/src/features/csm-engagements/pages/CsmEngagementCreatePage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-engagements/pages/CsmEngagementCreatePage.tsx
@@ -37,7 +37,7 @@ import { useSearchDeployments } from "@features/csm-cases/api/useSearchDeploymen
 import { useDeployedProductOptions } from "@features/csm-cases/api/useDeployedProductOptions";
 import { usePostCsmCase } from "@features/csm-cases/api/usePostCsmCase";
 import { useNavTransition } from "@hooks/useNavTransition";
-import type { BeEngagementType } from "@api/backend/types";
+import type { BeEngagementPaymentType, BeEngagementType } from "@api/backend/types";
 
 const ENGAGEMENT_TYPES: { value: BeEngagementType; label: string }[] = [
   { value: "migration", label: "Migration" },
@@ -45,6 +45,11 @@ const ENGAGEMENT_TYPES: { value: BeEngagementType; label: string }[] = [
   { value: "new_feature_improvement", label: "New feature / improvement" },
   { value: "follow_up", label: "Follow up" },
   { value: "onboarding", label: "Onboarding" },
+];
+
+const ENGAGEMENT_PAYMENT_TYPES: { value: BeEngagementPaymentType; label: string }[] = [
+  { value: "paid", label: "Paid" },
+  { value: "foc", label: "FOC" },
 ];
 
 /** The rich-text editor emits `<p></p>` when empty; check the stripped text. */
@@ -72,6 +77,9 @@ export default function CsmEngagementCreatePage(): JSX.Element {
   const [deploymentId, setDeploymentId] = useState("");
   const [deployedProductId, setDeployedProductId] = useState("");
   const [engagementType, setEngagementType] = useState<BeEngagementType | "">("");
+  const [engagementPaymentType, setEngagementPaymentType] = useState<
+    BeEngagementPaymentType | ""
+  >("");
   const [subject, setSubject] = useState("");
   const [description, setDescription] = useState("");
 
@@ -92,6 +100,7 @@ export default function CsmEngagementCreatePage(): JSX.Element {
       !!deploymentId &&
       !!deployedProductId &&
       !!engagementType &&
+      !!engagementPaymentType &&
       subject.trim().length > 0 &&
       !isEmptyHtml(description) &&
       !submitting,
@@ -100,6 +109,7 @@ export default function CsmEngagementCreatePage(): JSX.Element {
       deploymentId,
       deployedProductId,
       engagementType,
+      engagementPaymentType,
       subject,
       description,
       submitting,
@@ -117,7 +127,7 @@ export default function CsmEngagementCreatePage(): JSX.Element {
   };
 
   const handleSubmit = async (): Promise<void> => {
-    if (!canSubmit || !engagementType) return;
+    if (!canSubmit || !engagementType || !engagementPaymentType) return;
     setSubmitting(true);
     try {
       const created = await postCase.mutateAsync({
@@ -128,6 +138,7 @@ export default function CsmEngagementCreatePage(): JSX.Element {
         subject: subject.trim(),
         description,
         engagementType,
+        engagementPaymentType,
       });
       navigate(`/engagements/${created.id}`, { state: { from: backTarget } });
     } catch (err) {
@@ -264,6 +275,33 @@ export default function CsmEngagementCreatePage(): JSX.Element {
                 {ENGAGEMENT_TYPES.map((et) => (
                   <MenuItem key={et.value} value={et.value}>
                     {et.label}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </Grid>
+
+          <Grid size={{ xs: 12, md: 4 }}>
+            <FormControl fullWidth size="small" required>
+              <InputLabel
+                id="engagement-payment-type-label"
+                shrink={engagementPaymentType !== ""}
+                sx={{ top: "0px !important" }}
+              >
+                Engagement payment type
+              </InputLabel>
+              <Select
+                labelId="engagement-payment-type-label"
+                label="Engagement payment type"
+                value={engagementPaymentType}
+                onChange={(e) =>
+                  setEngagementPaymentType(e.target.value as BeEngagementPaymentType)
+                }
+                notched={engagementPaymentType !== ""}
+              >
+                {ENGAGEMENT_PAYMENT_TYPES.map((ept) => (
+                  <MenuItem key={ept.value} value={ept.value}>
+                    {ept.label}
                   </MenuItem>
                 ))}
               </Select>

--- a/apps/csm-portal/webapp/src/utils/sanitizeHtml.ts
+++ b/apps/csm-portal/webapp/src/utils/sanitizeHtml.ts
@@ -237,6 +237,38 @@ export function stripHtmlTags(text: string): string {
 }
 
 /**
+ * Plain-text form of an HTML string used for a loose content comparison —
+ * tags stripped, whitespace collapsed, case-folded. Not meant for display,
+ * only for deciding whether two HTML snippets carry the same text.
+ */
+function normalizeForComparison(html: string): string {
+  return stripHtmlTags(html).replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+/**
+ * True when `commentHtml` reproduces `descriptionHtml`'s text content —
+ * e.g. an origin comment that echoes the record's description, sometimes
+ * with extra wrapper text (a signature, a greeting) around it.
+ *
+ * Deliberately a plain substring check on normalized text, not a similarity
+ * score: cheap, legible, and matches the one real shape this needs to
+ * handle (an exact echo, possibly wrapped) rather than fuzzy near-matches.
+ * A blank description has nothing to echo, so it counts as "reproduced"
+ * (the caller should already be gating display on a non-blank description).
+ * A missing/absent comment can't reproduce anything.
+ */
+export function isDescriptionEchoedInComment(
+  descriptionHtml: string,
+  commentHtml: string | undefined,
+): boolean {
+  const normalizedDescription = normalizeForComparison(descriptionHtml);
+  if (!normalizedDescription) return true;
+  if (!commentHtml) return false;
+  const normalizedComment = normalizeForComparison(commentHtml);
+  return normalizedComment.includes(normalizedDescription);
+}
+
+/**
  * Escape the five HTML-significant characters so a plain-text string can be
  * embedded in markup verbatim.
  *

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -1007,6 +1007,15 @@ const (
 	EngagementTypeOnboarding            EngagementType = "onboarding"
 )
 
+// EngagementPaymentType classifies whether an engagement case is paid or
+// covered free of charge.
+type EngagementPaymentType string
+
+const (
+	EngagementPaymentTypePaid EngagementPaymentType = "paid"
+	EngagementPaymentTypeFOC  EngagementPaymentType = "foc"
+)
+
 // CaseSortField enumerates the columns available for sorting case search results.
 type CaseSortField string
 
@@ -1861,7 +1870,8 @@ type CreateCaseRequest struct {
 	// For security_report_analysis type
 	Attachments []CaseAttachment `json:"attachments"`
 	// For engagement type
-	EngagementType EngagementType `json:"engagementType"`
+	EngagementType        EngagementType        `json:"engagementType"`
+	EngagementPaymentType EngagementPaymentType `json:"engagementPaymentType"`
 }
 
 // CommentType classifies the type of a case comment.

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -60,6 +60,11 @@ var validEngagementType = map[domain.EngagementType]bool{
 	domain.EngagementTypeOnboarding:            true,
 }
 
+var validEngagementPaymentType = map[domain.EngagementPaymentType]bool{
+	domain.EngagementPaymentTypePaid: true,
+	domain.EngagementPaymentTypeFOC:  true,
+}
+
 var validCaseSortOrder = map[domain.CaseSortOrder]bool{
 	domain.CaseSortOrderAsc:  true,
 	domain.CaseSortOrderDesc: true,
@@ -178,6 +183,9 @@ func validateCreateCaseRequest(req domain.CreateCaseRequest) error {
 		}
 		if !validEngagementType[req.EngagementType] {
 			return &apierror.ValidationError{Msg: "engagementType contains invalid value: " + string(req.EngagementType)}
+		}
+		if !validEngagementPaymentType[req.EngagementPaymentType] {
+			return &apierror.ValidationError{Msg: "engagementPaymentType contains invalid value: " + string(req.EngagementPaymentType)}
 		}
 	}
 

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -519,6 +519,13 @@ var snEngagementTypeIDMap = map[domain.EngagementType]int{
 	domain.EngagementTypeOnboarding:            5,
 }
 
+// snEngagementPaymentTypeIDMap maps domain EngagementPaymentType enums to SN numeric
+// engagement-payment-type IDs.
+var snEngagementPaymentTypeIDMap = map[domain.EngagementPaymentType]int{
+	domain.EngagementPaymentTypePaid: 1,
+	domain.EngagementPaymentTypeFOC:  2,
+}
+
 func domainStatesToSNIDs(states []domain.CaseState) []int {
 	ids := make([]int, 0, len(states))
 	for _, s := range states {
@@ -645,22 +652,23 @@ var snIssueTypeID = map[domain.CaseIssueType]int{
 }
 
 type snCreateCasePayload struct {
-	Type              string             `json:"type"`
-	ProjectID         string             `json:"projectId"`
-	DeploymentID      string             `json:"deploymentId"`
-	DeployedProductID string             `json:"deployedProductId"`
-	Title             string             `json:"title,omitempty"`
-	Description       string             `json:"description,omitempty"`
-	SeverityKey       int                `json:"severityKey,omitempty"`
-	IssueTypeKey      int                `json:"issueTypeKey,omitempty"`
-	EngagementType    int                `json:"engagementType,omitempty"`
-	CatalogID         string             `json:"catalogId,omitempty"`
-	CatalogItemID     string             `json:"catalogItemId,omitempty"`
-	Variables         []snCaseVariable   `json:"variables,omitempty"`
-	RelatedCaseID     string             `json:"relatedCaseId,omitempty"`
-	ConversationID    string             `json:"conversationId,omitempty"`
-	WatchList         []string           `json:"watchList,omitempty"`
-	Attachments       []snCaseAttachment `json:"attachments,omitempty"`
+	Type                  string             `json:"type"`
+	ProjectID             string             `json:"projectId"`
+	DeploymentID          string             `json:"deploymentId"`
+	DeployedProductID     string             `json:"deployedProductId"`
+	Title                 string             `json:"title,omitempty"`
+	Description           string             `json:"description,omitempty"`
+	SeverityKey           int                `json:"severityKey,omitempty"`
+	IssueTypeKey          int                `json:"issueTypeKey,omitempty"`
+	EngagementType        int                `json:"engagementType,omitempty"`
+	EngagementPaymentType int                `json:"engagementPaymentType,omitempty"`
+	CatalogID             string             `json:"catalogId,omitempty"`
+	CatalogItemID         string             `json:"catalogItemId,omitempty"`
+	Variables             []snCaseVariable   `json:"variables,omitempty"`
+	RelatedCaseID         string             `json:"relatedCaseId,omitempty"`
+	ConversationID        string             `json:"conversationId,omitempty"`
+	WatchList             []string           `json:"watchList,omitempty"`
+	Attachments           []snCaseAttachment `json:"attachments,omitempty"`
 }
 
 type snCaseVariable struct {
@@ -753,6 +761,7 @@ func (s *snCaseService) CreateCase(ctx context.Context, req domain.CreateCaseReq
 		payload.Title = req.Subject
 		payload.Description = req.Description
 		payload.EngagementType = snEngagementTypeIDMap[req.EngagementType]
+		payload.EngagementPaymentType = snEngagementPaymentTypeIDMap[req.EngagementPaymentType]
 	}
 
 	if len(req.WatchList) > 0 {

--- a/entity-service/internal/service/sn_case_service_create_test.go
+++ b/entity-service/internal/service/sn_case_service_create_test.go
@@ -49,6 +49,22 @@ func TestSNCaseService_CreateCase_EngagementValidation(t *testing.T) {
 			r.Subject = "Migration planning"
 			r.Description = "Plan the migration"
 			r.EngagementType = "not_a_real_type"
+			r.EngagementPaymentType = domain.EngagementPaymentTypePaid
+			return r
+		}()},
+		{name: "missing engagementPaymentType", req: func() domain.CreateCaseRequest {
+			r := baseReq
+			r.Subject = "Migration planning"
+			r.Description = "Plan the migration"
+			r.EngagementType = domain.EngagementTypeMigration
+			return r
+		}()},
+		{name: "invalid engagementPaymentType", req: func() domain.CreateCaseRequest {
+			r := baseReq
+			r.Subject = "Migration planning"
+			r.Description = "Plan the migration"
+			r.EngagementType = domain.EngagementTypeMigration
+			r.EngagementPaymentType = "not_a_real_payment_type"
 			return r
 		}()},
 	}
@@ -88,13 +104,14 @@ func TestSNCaseService_CreateCase_Engagement(t *testing.T) {
 
 	svc := NewServiceNowCaseService(client, nil)
 	req := domain.CreateCaseRequest{
-		Type:              "engagement",
-		ProjectID:         testProjectUUID,
-		DeploymentID:      testDeploymentUUID,
-		DeployedProductID: testDeployedProdID,
-		Subject:           "Migration planning",
-		Description:       "Plan the migration",
-		EngagementType:    domain.EngagementTypeMigration,
+		Type:                  "engagement",
+		ProjectID:             testProjectUUID,
+		DeploymentID:          testDeploymentUUID,
+		DeployedProductID:     testDeployedProdID,
+		Subject:               "Migration planning",
+		Description:           "Plan the migration",
+		EngagementType:        domain.EngagementTypeMigration,
+		EngagementPaymentType: domain.EngagementPaymentTypeFOC,
 	}
 
 	resp, err := svc.CreateCase(contextWithUserIDToken("token"), req)
@@ -113,6 +130,9 @@ func TestSNCaseService_CreateCase_Engagement(t *testing.T) {
 	}
 	if gotBody["engagementType"] != float64(1) {
 		t.Fatalf("payload engagementType: got %v, want 1", gotBody["engagementType"])
+	}
+	if gotBody["engagementPaymentType"] != float64(2) {
+		t.Fatalf("payload engagementPaymentType: got %v, want 2", gotBody["engagementPaymentType"])
 	}
 	if gotBody["type"] != "engagement" {
 		t.Fatalf("payload type: got %v, want %q", gotBody["type"], "engagement")

--- a/entity-service/internal/service/sn_watch_list_test.go
+++ b/entity-service/internal/service/sn_watch_list_test.go
@@ -109,14 +109,15 @@ func TestSNCaseService_CreateCase_WatchListResolvedToEmails(t *testing.T) {
 	svc := NewServiceNowCaseService(newTestSNClient(t, mux), nil)
 
 	req := domain.CreateCaseRequest{
-		Type:              "engagement",
-		ProjectID:         testProjectUUID,
-		DeploymentID:      testDeploymentUUID,
-		DeployedProductID: testDeployedProdID,
-		Subject:           "Migration planning",
-		Description:       "Plan the migration",
-		EngagementType:    domain.EngagementTypeMigration,
-		WatchList:         []string{testIncidentWatcherUUID1, testIncidentWatcherUUID2},
+		Type:                  "engagement",
+		ProjectID:             testProjectUUID,
+		DeploymentID:          testDeploymentUUID,
+		DeployedProductID:     testDeployedProdID,
+		Subject:               "Migration planning",
+		Description:           "Plan the migration",
+		EngagementType:        domain.EngagementTypeMigration,
+		EngagementPaymentType: domain.EngagementPaymentTypePaid,
+		WatchList:             []string{testIncidentWatcherUUID1, testIncidentWatcherUUID2},
 	}
 
 	if _, err := svc.CreateCase(contextWithUserIDToken("token"), req); err != nil {
@@ -408,14 +409,15 @@ func TestWatchListResolution_UnknownUserID(t *testing.T) {
 			name: "case create",
 			call: func() error {
 				_, err := caseSvc.CreateCase(contextWithUserIDToken("token"), domain.CreateCaseRequest{
-					Type:              "engagement",
-					ProjectID:         testProjectUUID,
-					DeploymentID:      testDeploymentUUID,
-					DeployedProductID: testDeployedProdID,
-					Subject:           "Migration planning",
-					Description:       "Plan the migration",
-					EngagementType:    domain.EngagementTypeMigration,
-					WatchList:         unknown,
+					Type:                  "engagement",
+					ProjectID:             testProjectUUID,
+					DeploymentID:          testDeploymentUUID,
+					DeployedProductID:     testDeployedProdID,
+					Subject:               "Migration planning",
+					Description:           "Plan the migration",
+					EngagementType:        domain.EngagementTypeMigration,
+					EngagementPaymentType: domain.EngagementPaymentTypePaid,
+					WatchList:             unknown,
 				})
 				return err
 			},

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -5109,12 +5109,13 @@ components:
       properties:
         type:
           type: string
-          enum: [case, service_request, security_report_analysis]
+          enum: [case, service_request, security_report_analysis, engagement]
           description: |
             Case type.
             - `case`: standard support case; requires `subject`, `description`, `severity`, `issueType`.
             - `service_request`: catalog-based service request (ServiceNow only); requires `catalogId`, `catalogItemId`, `variables`.
             - `security_report_analysis`: security report (ServiceNow only); requires `subject`, `description`, and at least one entry in `attachments`.
+            - `engagement`: professional-services engagement (e.g. migration, onboarding); requires `subject`, `description`, `engagementType`, `engagementPaymentType`.
         projectId:
           type: string
           format: uuid
@@ -5126,10 +5127,10 @@ components:
           format: uuid
         subject:
           type: string
-          description: Required for `case` and `security_report_analysis` types.
+          description: Required for `case`, `security_report_analysis`, and `engagement` types.
         description:
           type: string
-          description: Required for `case` and `security_report_analysis` types.
+          description: Required for `case`, `security_report_analysis`, and `engagement` types.
         severity:
           type: string
           enum: [catastrophic, critical, high, medium, low]
@@ -5158,6 +5159,14 @@ components:
           items:
             $ref: '#/components/schemas/CaseAttachment'
           description: Required for `security_report_analysis` type (at least one entry).
+        engagementType:
+          type: string
+          enum: [migration, consultancy, new_feature_improvement, follow_up, onboarding]
+          description: Required for `engagement` type.
+        engagementPaymentType:
+          type: string
+          enum: [paid, foc]
+          description: Required for `engagement` type. `foc` means "free of charge".
         relatedCaseId:
           type: string
           format: uuid

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -5114,7 +5114,7 @@ components:
             Case type.
             - `case`: standard support case; requires `subject`, `description`, `severity`, `issueType`.
             - `service_request`: catalog-based service request (ServiceNow only); requires `catalogId`, `catalogItemId`, `variables`.
-            - `security_report_analysis`: security report (ServiceNow only); requires `subject`, `description`, and at least one entry in `attachments`.
+            - `security_report_analysis`: security report (ServiceNow only); requires `subject`, `description`. `attachments` is optional and not backend-enforced.
             - `engagement`: professional-services engagement (e.g. migration, onboarding); requires `subject`, `description`, `engagementType`, `engagementPaymentType`.
         projectId:
           type: string
@@ -5155,10 +5155,9 @@ components:
           description: Required for `service_request` type.
         attachments:
           type: array
-          minItems: 1
           items:
             $ref: '#/components/schemas/CaseAttachment'
-          description: Required for `security_report_analysis` type (at least one entry).
+          description: Optional for `security_report_analysis` type; not enforced by the backend.
         engagementType:
           type: string
           enum: [migration, consultancy, new_feature_improvement, follow_up, onboarding]


### PR DESCRIPTION
## Purpose
This PR now bundles two independent CSM portal fixes from the same session.

**1. Case description hidden on the Details tab.** On the case detail page, the case's `description` field was always suppressed once the comments fetch succeeded, on the assumption it's always duplicated as the first comment. That assumption doesn't hold for every case: cases created by internal automation can have a first comment that differs from the description, or no first comment at all — leaving the description effectively invisible with no way to see it outside the edit dialog.

**2. Adding a payment type to engagement case creation.** Creating an engagement-type case from the CSM portal leaves a required backing field unset because the create flow never collected or forwarded it, which then makes the case fail to load afterward. We're adding a "payment type" selection (Paid / FOC) to engagement creation so the field is always populated.

## Goals
1. Show the description as its own card on the Details tab whenever it isn't actually reproduced by the case's earliest comment (including when there's no first comment to compare against), and keep it hidden only when the comparison confirms it's genuinely duplicated there.
2. Add a required "Engagement payment type" selection to the Create Engagement form and thread it through the entity-service's case-creation request so every engagement case created via the portal carries it.

## Approach

**Description fix** — Frontend-only display fix in `CsmCaseDetailPage.tsx`:
- Compute the case's earliest comment (sorted by `createdAt`, not assumed to already be first in the array).
- Compare its text content against the description using a new `isDescriptionEchoedInComment` helper (`src/utils/sanitizeHtml.ts`): strip HTML, collapse whitespace, lowercase, then a normalized substring check — not a fuzzy/similarity algorithm, so real-world wrapper text (e.g. a signature) around an echoed description still counts as a match.
- Replace the old `isCommentsError`-only gate on the Details-tab fallback card with this content comparison, so the decision is based on what's actually in the data rather than only on whether the comments request itself failed.
- No backend/API changes — the case object already returns `description`.

**Engagement payment type** — spans the Go entity-service and the webapp:
- `entity-service/internal/domain/entity.go`: new `EngagementPaymentType` string enum (`paid`/`foc`), added to `CreateCaseRequest`.
- `entity-service/internal/service/case_service.go`: `validateCreateCaseRequest` now requires a valid `engagementPaymentType` for `type=engagement`, mirroring the existing `engagementType` check.
- `entity-service/internal/service/sn_case_service.go`: new `snEngagementPaymentTypeIDMap` (paid→1, foc→2) and payload field on `CreateCase`'s engagement branch, mirroring the existing `engagementType` mapping.
- `entity-service/openapi.yaml`: documented `engagement` as a `CreateCaseRequest.type` value along with `engagementType` and the new `engagementPaymentType` (both were previously undocumented in this spec despite being supported in code).
- Webapp: `CsmEngagementCreatePage.tsx` gets a new required "Engagement payment type" dropdown (Paid/FOC), mirroring the existing "Engagement type" dropdown pattern exactly (a hardcoded constant list, matching how engagement type is already implemented — there is no metadata-fetch backing either field client-side).
- A corresponding fix in the private Ballerina entity-service (separate repo, tracked separately) is required alongside this for the field to reach ServiceNow — without it, creation will fail validation with a clear error rather than silently dropping the field.

## User stories
1. As a CS engineer viewing a case whose origin comment doesn't carry the description (or has none), I can still see the description on the case's Details tab instead of it being silently hidden.
2. As a CS engineer creating an onboarding/professional-services engagement, I select a payment type so the resulting case is created correctly and its detail page loads afterward.

## Release note
- Fixed: the case description is now shown on the Details tab whenever it isn't already reproduced in the case's earliest comment, instead of being hidden any time the comments list loaded successfully.
- Added: a required "Engagement payment type" (Paid/FOC) field to engagement case creation.

## Documentation
N/A — this checkout has no `/help` in-app guide content directory (`src/features/help/content/`) to check against; nothing to update.

## Training
N/A — no training content impact; these are a display-logic fix and a new required form field on an existing flow, no new workflow.

## Certification
N/A — no certification exam impact from these internal-portal changes.

## Marketing
N/A — internal CS-engineer tooling changes, not customer/marketing facing.

## Automation tests
 - Unit tests
   > Description fix: added to the existing `CsmCaseDetailPage.test.tsx` (new describe block "Details tab description fallback card", 4 tests). All 29 tests in the file pass, plus the 19 existing `sanitizeHtml.test.ts` tests.
   > Engagement payment type: updated two pre-existing entity-service tests whose engagement fixtures needed the new required field (`sn_case_service_create_test.go`, `sn_watch_list_test.go`), and added new validation subtests (missing/invalid `engagementPaymentType`).
 - Integration tests
   > None added; both changes are additive to existing request/response shapes with no new integration surface.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — Go and TypeScript project; ran `go build`, `go vet`, `go test`, and `gosec -fmt=text` on entity-service (all clean, 0 gosec issues) and `eslint`/`tsc` on the webapp (clean) instead.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no new samples for these fixes.

## Related PRs
A corresponding change to the private Ballerina entity-service is required for engagement case creation to reach ServiceNow with the new field populated — tracked separately in that repo.

## Migrations (if applicable)
N/A — no data or schema migration involved.

## Test environment
- Description fix: verified with `pnpm run build` (tsc -b && vite build) and `pnpm exec vitest run` locally.
- Engagement payment type: verified end-to-end against a live ServiceNow dev instance via a full local stack (webapp → BFF → Go entity-service → local Ballerina entity-service → ServiceNow dev) — created a real engagement case through the actual Create Engagement form and confirmed its detail page loads correctly on a fresh reload.

## Learning
N/A — no external research; both fixes follow patterns already established elsewhere in the same files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Engagement case creation now includes a required payment type: **Paid** or **FOC**.
  - Added validation to reject unsupported payment-type values.
  - Engagement case requests now transmit payment information correctly.
  - Case details display descriptions when they are not already represented in the activity history.

- **Bug Fixes**
  - Prevented duplicate display of descriptions echoed in the earliest comment.
  - Improved description fallback behavior when comments are missing or unrelated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->