### PR TITLE
[CSM Portal] Add an in-app Help section with static Markdown docs

### DIFF
--- a/apps/csm-portal/webapp/src/App.tsx
+++ b/apps/csm-portal/webapp/src/App.tsx
@@ -178,6 +178,7 @@ const CsmTimeCardsPage = lazy(
 const CsmAnnouncementsPage = lazy(
   () => import("@features/csm-announcements/pages/CsmAnnouncementsPage"),
 );
+const HelpPage = lazy(() => import("@features/help/pages/HelpPage"));
 
 /**
  * Landing for `/`. Defers to AuthGuard's post-login deep-link restore when a
@@ -570,6 +571,13 @@ export default function App(): JSX.Element {
                     path="announcements/:caseId"
                     element={<CsmCaseDetailPage />}
                   />
+
+                  {/* Help — static, bundled Markdown docs, all rendered on
+                      one scrollable page with a table of contents at the top
+                      (see HelpPage). Every topic is an in-page anchor rather
+                      than its own route, so unlike Customers/Settings above
+                      there is nothing to redirect an index route to. */}
+                  <Route path="help" element={<HelpPage />} />
                 </Route>
               </Route>
 

--- a/apps/csm-portal/webapp/src/config/csmNavItems.test.ts
+++ b/apps/csm-portal/webapp/src/config/csmNavItems.test.ts
@@ -46,6 +46,32 @@ describe("nav tree invariants", () => {
   });
 });
 
+describe("help section", () => {
+  it("sits immediately after Settings in the top-level nav order", () => {
+    const ids = CSM_NAV_ITEMS.map((section) => section.id);
+    const adminIndex = ids.indexOf("admin");
+    expect(ids[adminIndex + 1]).toBe("help");
+  });
+
+  it("gives every topic an in-page anchor href on the single /help route", () => {
+    const help = navNodeById("help");
+    for (const topic of help?.children ?? []) {
+      expect(topic.href.startsWith("/help#")).toBe(true);
+      expect(topic.id.startsWith("help.")).toBe(true);
+    }
+  });
+
+  it("resolves the whole /help route (and any of its topic anchors) to the help section, not a topic", () => {
+    expect(navNodeMatchForPath("/help")).toMatchObject({
+      node: { id: "help" },
+      prefix: "/help",
+    });
+    // A topic anchor's own pathname is "/help" too — it must not out-compete
+    // the section for that prefix (see navNodeRoutes's anchor-href handling).
+    expect(navNodeRoutes(navNodeById("help.operations")!)).toEqual([]);
+  });
+});
+
 describe("navNodeMatchForPath", () => {
   it("prefers the most specific node and reports the matched prefix", () => {
     expect(navNodeMatchForPath("/operations/incidents/INC0001")).toMatchObject({

--- a/apps/csm-portal/webapp/src/config/csmNavItems.ts
+++ b/apps/csm-portal/webapp/src/config/csmNavItems.ts
@@ -28,6 +28,7 @@ import {
   GitPullRequest,
   Headset,
   KeyRound,
+  LifeBuoy,
   Megaphone,
   RefreshCw,
   Settings,
@@ -277,6 +278,47 @@ export const CSM_NAV_ITEMS: CsmNavSection[] = [
       },
     ],
   },
+  {
+    id: "help",
+    label: "Help",
+    href: "/help",
+    icon: LifeBuoy,
+    // Every topic is an in-page anchor on the single `/help` route (see
+    // `HelpPage`), not its own route, so `href` carries a `#<topic>` fragment
+    // rather than a path segment — same anchor-vs-path split `navNodeRoutes`
+    // already makes for a query-param tab, and handled there the same way.
+    children: [
+      { id: "help.overview", label: "Overview", href: "/help#overview" },
+      {
+        id: "help.workspace-basics",
+        label: "Navigation & personalization",
+        href: "/help#workspace-basics",
+      },
+      { id: "help.dashboard", label: "Dashboard", href: "/help#dashboard" },
+      { id: "help.support", label: "Support", href: "/help#support" },
+      { id: "help.operations", label: "Operations", href: "/help#operations" },
+      { id: "help.engagements", label: "Engagements", href: "/help#engagements" },
+      {
+        id: "help.security-center",
+        label: "Security Center",
+        href: "/help#security-center",
+      },
+      { id: "help.updates", label: "Updates", href: "/help#updates" },
+      { id: "help.time-cards", label: "Time cards", href: "/help#time-cards" },
+      {
+        id: "help.announcements",
+        label: "Announcements",
+        href: "/help#announcements",
+      },
+      { id: "help.customers", label: "Customers", href: "/help#customers" },
+      {
+        id: "help.people-access",
+        label: "People & project access",
+        href: "/help#people-access",
+      },
+      { id: "help.settings", label: "Settings", href: "/help#settings" },
+    ],
+  },
 ];
 
 /** The pathname part of `href`, dropping any query string or hash. */
@@ -298,15 +340,23 @@ export function navNodeHref(node: CsmNavNode): string {
   return node.href;
 }
 
+/** True when `href` carries a `#` fragment rather than being a distinct path
+ * (a Help topic's `/help#operations`) — the node's pathname is only its
+ * parent's landing route, shared with every sibling anchor. */
+function isAnchorHref(node: CsmNavNode): boolean {
+  return node.href.includes("#");
+}
+
 /**
- * Route path prefixes a node owns. A query-param tab (`tab` set) owns only its
- * explicit {@link CsmNavNode.routes}: its `href` pathname is the *parent's*
- * landing route, which every sibling tab shares, so claiming it would make the
+ * Route path prefixes a node owns. A query-param tab (`tab` set) or an
+ * in-page anchor (`href` with a `#` fragment) owns only its explicit
+ * {@link CsmNavNode.routes}: its `href` pathname is the *parent's* landing
+ * route, which every sibling shares, so claiming it would make the
  * longest-prefix match in {@link navNodeForPath} ambiguous.
  */
 export function navNodeRoutes(node: CsmNavNode): string[] {
   const extra = node.routes ?? [];
-  return node.tab ? extra : [navNodePath(node), ...extra];
+  return node.tab || isAnchorHref(node) ? extra : [navNodePath(node), ...extra];
 }
 
 /** Depth-first walk of the tree, parents before their children. */

--- a/apps/csm-portal/webapp/src/features/help/components/HelpTopicSection.test.tsx
+++ b/apps/csm-portal/webapp/src/features/help/components/HelpTopicSection.test.tsx
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { describe, expect, it } from "vitest";
+import { markdownToHtml } from "@utils/renderMarkdown";
+import { sanitizeRichTextHtml } from "@utils/sanitizeHtml";
+import { resolveHelpImages } from "@features/help/utils/helpImages";
+import HelpTopicSection from "./HelpTopicSection";
+
+describe("HelpTopicSection", () => {
+  it("renders a known topic's sanitized Markdown content from a plain topicId prop", () => {
+    render(<HelpTopicSection topicId="overview" />);
+    expect(screen.getByRole("heading", { name: "Overview" })).toBeVisible();
+  });
+
+  it("shows a not-found message for an unknown topic id rather than throwing", () => {
+    render(<HelpTopicSection topicId="not-a-real-topic" />);
+    expect(
+      screen.getByText(/couldn.?t be found/i),
+    ).toBeVisible();
+  });
+
+  it("never lets a raw <script> tag survive the render pipeline as real markup", () => {
+    const hostile = "# Heading\n\n<script>window.__pwned = true;</script>\n\nSafe text.";
+    const html = sanitizeRichTextHtml(resolveHelpImages(markdownToHtml(hostile)));
+    const container = document.createElement("div");
+    container.innerHTML = html;
+    expect(container.querySelector("script")).toBeNull();
+    expect(container.textContent).toContain("Safe text.");
+  });
+
+  it("never lets a raw onerror handler survive the render pipeline as a real attribute", () => {
+    // A raw HTML img tag with an inline event handler, embedded in Markdown
+    // source. `markdownToHtml` runs with `html: false`, so this is escaped to
+    // inert text rather than parsed as an element -- confirmed here by
+    // checking no live <img> with an "onerror" attribute exists afterwards.
+    const hostile = '<img src="x" onerror="window.__pwned = true">';
+    const html = sanitizeRichTextHtml(resolveHelpImages(markdownToHtml(hostile)));
+    const container = document.createElement("div");
+    container.innerHTML = html;
+    const img = container.querySelector("img");
+    expect(img?.getAttribute("onerror") ?? null).toBeNull();
+    expect(container.querySelector("[onerror]")).toBeNull();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/help/components/HelpTopicSection.tsx
+++ b/apps/csm-portal/webapp/src/features/help/components/HelpTopicSection.tsx
@@ -1,0 +1,125 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Box, Typography } from "@wso2/oxygen-ui";
+import { type JSX, useMemo } from "react";
+import { markdownToHtmlProse } from "@utils/renderMarkdown";
+import { sanitizeRichTextHtml } from "@utils/sanitizeHtml";
+import { HELP_TOPIC_CONTENT } from "@features/help/utils/helpContent";
+import { resolveHelpImages } from "@features/help/utils/helpImages";
+
+export interface HelpTopicSectionProps {
+  /** The topic's bare id (e.g. `"operations"`) — the key `HELP_TOPIC_CONTENT`
+   * and the anchor target on `HelpPage` are both keyed by. */
+  topicId: string;
+}
+
+/**
+ * Renders one Help topic's static Markdown as sanitized HTML. `HelpPage`
+ * renders one of these per topic declared in `csmNavItems.ts`'s `help` node,
+ * each wrapped in its own `<section>` that the page's table-of-contents
+ * anchors link to — this component only resolves `topicId` to its Markdown
+ * source and renders it; it has no topic list of its own to keep in sync,
+ * and (unlike its `HelpTopicPage` route-era predecessor) no route param to
+ * read: the id is a plain prop supplied by the caller.
+ *
+ * Pipeline mirrors `CsmCaseCommentBubble.tsx`'s Markdown rendering, but uses
+ * `markdownToHtmlProse` rather than `markdownToHtml`: Help content is
+ * long-form prose hand-wrapped at a fixed column width in its Markdown
+ * source, and `markdownToHtml`'s `breaks: true` (needed for chat messages)
+ * would render every one of those source line-wraps as a forced `<br>`.
+ * `markdownToHtmlProse` (escapes any raw HTML in the source) -> `resolveHelpImages`
+ * (rewrites `images/<name>` refs to their real bundled asset URL) ->
+ * `sanitizeRichTextHtml` (defence in depth before `dangerouslySetInnerHTML`,
+ * required for every such call in this app regardless of the content's
+ * origin) -> render.
+ */
+export default function HelpTopicSection({ topicId }: HelpTopicSectionProps): JSX.Element {
+  const source = HELP_TOPIC_CONTENT[topicId];
+
+  const html = useMemo(() => {
+    if (source === undefined) return undefined;
+    return sanitizeRichTextHtml(resolveHelpImages(markdownToHtmlProse(source)));
+  }, [source]);
+
+  if (html === undefined) {
+    return (
+      <Typography color="text.secondary">
+        This help topic couldn&apos;t be found.
+      </Typography>
+    );
+  }
+
+  return (
+    <Box
+      sx={{
+        minWidth: 0,
+        maxWidth: "100%",
+        overflowWrap: "break-word",
+        "& p": { m: 0 },
+        "& p + p": { mt: 0.75 },
+        "& ul, & ol": { ml: 3, my: 0.5 },
+        "& code": {
+          bgcolor: "background.default",
+          px: 0.5,
+          borderRadius: 0.5,
+          fontFamily: "monospace",
+          fontSize: "0.85em",
+          overflowWrap: "anywhere",
+        },
+        "& pre": {
+          bgcolor: "background.default",
+          p: 1,
+          borderRadius: 1,
+          overflowX: "auto",
+          maxWidth: "100%",
+          fontFamily: "monospace",
+          fontSize: "0.85em",
+        },
+        "& a": { color: "primary.main" },
+        "& img": { maxWidth: "100%" },
+        "& blockquote": {
+          borderLeft: 3,
+          borderColor: "divider",
+          pl: 1.5,
+          ml: 0,
+          my: 0.75,
+          color: "text.secondary",
+          fontStyle: "italic",
+        },
+        "& h1, & h2, & h3": { mt: 1, mb: 0.5 },
+        "& .md-table-wrap": { overflowX: "auto", maxWidth: "100%", my: 0.75 },
+        "& table": {
+          display: "block",
+          overflowX: "auto",
+          maxWidth: "100%",
+          width: "max-content",
+          minWidth: "100%",
+          borderCollapse: "collapse",
+        },
+        "& th, & td": {
+          border: 1,
+          borderColor: "divider",
+          px: 1,
+          py: 0.5,
+          textAlign: "left",
+        },
+        "& th": { bgcolor: "action.hover", fontWeight: 600 },
+      }}
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
+}

--- a/apps/csm-portal/webapp/src/features/help/components/HelpTopicSection.tsx
+++ b/apps/csm-portal/webapp/src/features/help/components/HelpTopicSection.tsx
@@ -103,9 +103,6 @@ export default function HelpTopicSection({ topicId }: HelpTopicSectionProps): JS
         "& h1, & h2, & h3": { mt: 1, mb: 0.5 },
         "& .md-table-wrap": { overflowX: "auto", maxWidth: "100%", my: 0.75 },
         "& table": {
-          display: "block",
-          overflowX: "auto",
-          maxWidth: "100%",
           width: "max-content",
           minWidth: "100%",
           borderCollapse: "collapse",

--- a/apps/csm-portal/webapp/src/features/help/content/announcements.md
+++ b/apps/csm-portal/webapp/src/features/help/content/announcements.md
@@ -1,0 +1,48 @@
+# Announcements
+
+The Announcements section lists customer-facing announcements published across
+projects and tiers. Under the hood, an announcement is a case of type
+`announcement`, so it shows up here read-only, using the same search and
+detail infrastructure as regular cases, just trimmed down to what makes
+sense for a broadcast.
+
+## Viewing the list
+
+The list shows one row per announcement: number, subject, project, state,
+who created it, and when it was last updated. Rows are real links, so you can
+middle-click or cmd-click to open an announcement in a new tab, or copy its
+URL.
+
+You can narrow the list with:
+
+- **Search**: matches subject or number.
+- **State**: filter to one or more states (open, work in progress, solution
+  proposed, awaiting info, waiting on WSO2, closed).
+- **Project**: filter to one or more projects.
+
+All filters default to "show all"; changing any filter resets the list back
+to the first page. Use **Clear filters** to reset state and project in one
+click.
+
+## Opening an announcement
+
+Selecting a row opens the announcement's detail page. It reuses the same
+case detail view as regular cases, but with the parts that don't apply to a
+broadcast hidden:
+
+- No action bar: announcements aren't assigned, acknowledged, or
+  transitioned by an engineer from this page.
+- No reply or work-note composer: announcements are read-only; there's
+  nothing to reply to.
+- No Related, Watchers, SLA, Time, or Call Requests tabs, since none of
+  those concepts apply to an announcement.
+
+The announcement's body is shown as its Description, rendered as rich text
+(the same HTML editor content used elsewhere in the portal), so formatting,
+links, and lists in the original announcement are preserved.
+
+## What you can't do yet
+
+Creating, targeting, or unpublishing announcements isn't available from the
+CSM portal yet: it depends on a dedicated announcements backend that hasn't
+been built. Until then, this section is view-only.

--- a/apps/csm-portal/webapp/src/features/help/content/customers.md
+++ b/apps/csm-portal/webapp/src/features/help/content/customers.md
@@ -1,0 +1,59 @@
+# Customers
+
+Customers is where you look up an account or a project directly, rather than arriving at one
+through a case or dashboard widget. It has two tabs: **Accounts** and **Projects**.
+
+## Accounts
+
+The Accounts tab lists every customer account, searchable by account name or Salesforce ID.
+Clicking a row opens that account's detail page, which shows:
+
+- **Overview**: tier, region, Salesforce ID, the account's Account Manager, Renewal Account
+  Manager, and Technical Owner, its CRE/SRE team assignment, activation and deactivation
+  dates, and whether the AI chat assistant and Smart KB suggestions are enabled for this
+  account.
+- **Projects**: every project tied to this account (an account can have several), with each
+  project's key, subscription type, and end date. Click through to a project's own detail page
+  from here.
+
+An account with a deactivation date in the past is flagged with a **Deactivated** chip next to
+its name.
+
+## Projects
+
+The Projects tab lists every project across all accounts, searchable by project name, project
+key, or subscription type. A project is tied to a subscription, and its row shows its closure
+state and start/end dates.
+
+Opening a project takes you to its detail page, with four tabs:
+
+- **Overview**: project key, closure state, subscription type, a link back to the owning
+  account, Salesforce ID, and the created/updated/start/end dates.
+- **Deployments**: see below.
+- **Project contacts**: see below.
+- **Work items**: cases, service requests, and other work items filed against this project.
+
+From a project's detail page, the **Create** menu lets you file a new case, service request
+(managed-cloud projects only), engagement, or security report already scoped to this project,
+so it can't end up filed against the wrong one.
+
+### Deployments
+
+A deployment is an environment within a project (for example, a production or staging
+environment), each with its own type, description, and the products deployed to it. The
+Deployments tab lists a project's deployments and lets you create one, edit its details, or
+deactivate it. Deactivating a deployment marks it inactive rather than deleting it.
+
+### Project contacts
+
+The Project contacts tab lists the people registered on a project (name, email, roles, and
+registration state), plus an **Access** column showing whether each row actually grants that
+person visibility into the project's cases in the customer portal, not just whether they're
+listed. A row flagged **No access** (or **Orphaned**) carries an inline reason: either the
+invite never completed (no linked contact record), or the row was invited under an address
+that doesn't match its linked contact's own. Both are worth chasing directly, since either one
+means that person can't see any of this project's cases.
+
+This tab is a per-project list. To look up what access a *specific person* has across all
+their projects, or to dig into their contact record in more detail, see the **People & project
+access** Help topic.

--- a/apps/csm-portal/webapp/src/features/help/content/dashboard.md
+++ b/apps/csm-portal/webapp/src/features/help/content/dashboard.md
@@ -1,0 +1,54 @@
+# Dashboard
+
+Dashboard is your landing page. It shows a grid of widgets (cases, requests, and other work)
+summarized as counts, lists, or charts, so you can see the state of your work at a glance
+without opening the underlying tabs.
+
+## Choosing a dashboard
+
+The dropdown at the top of the page switches between the dashboards available to you. Which
+dashboard you land on by default depends on your own team membership: if you belong to a
+team, the portal picks that team's dashboard; if you don't have a team (or your profile
+hasn't resolved one), you get the general default dashboard instead. Some roles (for example
+onboarding or migration specialists) always land on their own dedicated dashboard regardless
+of team.
+
+Whichever dashboard you're on is reflected in the URL, so a link to a specific dashboard (and,
+for team-based ones, a specific team) is shareable and survives a refresh.
+
+## The team selector
+
+Some dashboards are team-based and show a second dropdown next to the dashboard selector for
+picking a team. It defaults to your own team if you have one, or to **All ABTs** if you
+don't: "All ABTs" combines every team in that dashboard's own family (for example every CRE
+team, or every SRE team), not every team in the portal. Switching the team re-scopes every
+widget on the page to that team's data; switching between two team-based dashboards keeps
+your team selection, while switching to a dashboard that isn't team-based hides the selector.
+
+## Reading a widget
+
+Each widget renders as one of a few shapes:
+
+- **Count**: a single big number (for example, open cases assigned to you). The whole tile
+  is a link: clicking anywhere on it takes you to the filtered list behind that number.
+- **List**: a small table of the most recent matching records, using the same list component
+  as the corresponding tab (for example, cases render through the same table as the Support
+  section). It shows a capped number of rows.
+- **Pie / bar chart**: a breakdown of a widget's records by category. Clicking a slice or bar
+  navigates to the list filtered to just that category; clicking elsewhere on the tile (the
+  title area, the empty space) goes to the widget's unfiltered base list.
+
+A widget with a description shows it as an info icon (count tiles) or as a subtitle (pie/bar
+tiles); hover or focus the icon to read it.
+
+## Seeing more of a list widget
+
+A list-shape widget only shows a handful of rows at a time. When it has more matching records
+than that, a **View more** link appears under the table. It opens a dedicated preview page for
+that widget with the same filters already applied, but with real pagination and (for
+case-based widgets) the full, editable case filter bar, so you can search, filter further, or
+page through everything the widget is summarizing, rather than just its first few rows.
+
+This is different from clicking a count tile or a pie slice, which takes you straight to the
+matching records in the resource's own tab (Support, Operations, and so on) with those same
+filters carried over.

--- a/apps/csm-portal/webapp/src/features/help/content/engagements.md
+++ b/apps/csm-portal/webapp/src/features/help/content/engagements.md
@@ -1,0 +1,59 @@
+# Engagements
+
+Engagements track professional-services work for a customer (migrations, consultancy,
+onboarding, follow-ups, and new-feature/improvement work), separately from support cases.
+Under the hood an engagement is a case of type **Engagement**, so it reuses the same list,
+detail page, comments, activity feed, and time-tracking as a regular case, just scoped to
+this one type and without a severity concept (severity isn't meaningful for this kind of
+work, so the severity column and chip are hidden throughout).
+
+## List view
+
+The Engagements list is the same table used for cases, locked to engagement-type rows: the
+case-type column is hidden (every row is the same type) and a dedicated **Engagement type**
+filter lets you narrow by Migration, Consultancy, New feature / improvement, Follow up, or
+Onboarding. Search, sort, and filter by project, deployment, product, assignee, and state the
+same way you would on the Cases list, and export the filtered results to CSV with the same
+export button.
+
+Click a row to open that engagement's detail page. Use **Create engagement** to start a new
+one.
+
+## Creating an engagement
+
+The creation form asks for:
+
+- **Project**: searchable, or pre-filled and locked if you opened the form from a project's
+  page.
+- **Deployment**: the environments available under the selected project.
+- **Deployed product**: the products available under the selected deployment.
+- **Engagement type**: Migration, Consultancy, New feature / improvement, Follow up, or
+  Onboarding.
+- **Subject**: a short title, up to 200 characters.
+- **Description**: required; a rich-text field describing the engagement.
+
+Project, deployment, and deployed product are dependent selects: choosing a project loads its
+deployments, and choosing a deployment loads its deployed products. If any of those dropdowns
+fail to load, a **Retry** control appears instead of a silent empty list.
+
+Once created, the engagement opens on its own detail page, and its Back button (like the
+form's Cancel/Back buttons) returns you to wherever you started: the Engagements list, or the
+originating project page.
+
+## Detail view
+
+An engagement's detail page is the same case detail page used for support cases, cases,
+service requests, and security reports, so it carries the same building blocks:
+
+- **Header**: case/engagement number, engagement-type chip, lifecycle state chip (Open, Work
+  in progress, Solution proposed, Awaiting info, Waiting on WSO2, Closed, Reopened), and, while
+  in progress, a sub-state chip (ongoing/paused) plus an auto-closure hold indicator if
+  applicable. No severity chip is shown.
+- **Overview**: project, deployment, deployed product, and other case metadata.
+- **Comments and activity feed**: the same threaded comment and history view used on cases.
+- **Time cards**: engineers can log time against an engagement the same way they log time
+  against any other case, from the time cards panel on the detail page; that logged time then
+  shows up in Time cards under this engagement.
+
+Because an engagement is a case under a different type, it can also be transferred to or from
+another case type from the detail page, the same way a case can be reclassified.

--- a/apps/csm-portal/webapp/src/features/help/content/operations.md
+++ b/apps/csm-portal/webapp/src/features/help/content/operations.md
@@ -1,0 +1,100 @@
+# Operations
+
+Operations is mainly built for the SRE team, though any CS engineer can use
+it. It's where the operational record types live: service requests, change
+requests, incidents, and problems. These aren't limited to managed-cloud
+work; they also cover other SaaS offerings. Each has its own tab in the
+Operations sidebar section, its own list, and its own detail view: they
+are separate record types, not case sub-types, even though a few of them link
+back to a case.
+
+## Service requests
+
+The Service requests tab lists service-request cases using the same shared
+issues list and filters as the Support section (case type is locked to
+"Service request" here, so the type filter is hidden). Clicking a row opens
+the same case detail view used everywhere else in the portal: overview,
+comments, attachments, watchers, and the rest of the standard case tabs.
+
+Use **Create service request** to open a form and raise a new one.
+
+## Change requests
+
+The Change requests tab lists change requests with server-side search,
+pagination, and filters for state, impact, and closed-date range, plus a
+CSV export of the filtered results. Each row links to a detail page.
+
+The detail page shows:
+
+- An **overview** card: project, type, linked case, deployment, deployed
+  product, product, assigned engineer/team, duration, planned start/end,
+  and audit fields.
+- Tabs for **Approval**, **Details**, **Comments**, and **Attachments**.
+  - **Approval** shows the customer-approval/review flags plus a full
+    approval-stage breakdown (e.g. Assess, Authorize, Customer Approval) with
+    each individual approver's status.
+  - **Details** shows the description, justification, impact description,
+    service outage notes, and the communication/rollback/test plans.
+
+From the detail page a CS engineer can:
+
+- **Change state**: the action bar's buttons are driven entirely by the
+  record's own legal next states, so only valid transitions are ever offered.
+  Moving to a destructive state (rollback, cancel) requires typing a reason
+  first, which is recorded as an internal note before the state change is
+  applied.
+- **Approve or reject** a pending approval stage, if the engineer is listed
+  as an approver on it: the Approve/Reject buttons only appear on that
+  engineer's own pending approval.
+- **Edit** the change request's fields, or **Clone** it into a new change
+  request pre-filled with this one's values (useful for promoting the same
+  change through another environment).
+- Add comments (public or internal) and upload/download attachments.
+
+## Incidents
+
+The Incidents tab lists incidents with server-side search, pagination, and
+filters for priority, SLA-violated status, created-date range, and product,
+plus a CSV export of the filtered results. Each row links to a detail page.
+
+The detail page shows:
+
+- An **overview** card: caller, assignment group, assigned to, opened date,
+  created by, and last updated.
+- Tabs for **Activities**, **Details**, **Related**, **Watchers**, and
+  **Attachments**.
+  - **Details** covers classification (category, subcategory, contact type,
+    impact, urgency) and service/configuration-item information.
+  - **Related** shows linked records (parent incident, change request,
+    problem, and any linked service requests), plus a "caused by" reference
+    shown as plain text since its target record type isn't confirmed.
+
+From the detail page a CS engineer can:
+
+- **Change state**: again driven by the incident's own legal next states.
+  Moving to Resolved or Closed opens a dialog to collect a resolution code
+  and notes, since those are required by the backing system for those two
+  transitions.
+- **Edit** the incident's fields.
+- Manage the **watch list** (add or remove watchers).
+- Add comments (public or internal) and upload/download attachments, with
+  inline preview for supported attachment types.
+
+## Problem management
+
+The Problem management tab lists problems with server-side search,
+pagination, free-text search, and a state filter. Each row links to a
+detail page.
+
+The detail page shows an overview (priority, category, subcategory, assigned
+to, opened/closed dates), any linked records (origin record, primary
+incident, linked change request, and linked incidents), and, once resolved,
+a resolution section with resolution code, resolved-by, resolved-on, cause
+notes, fix notes, and workaround.
+
+Problem management is read-only in the portal today: there is no Edit dialog
+and no state-changing action bar. Problems are owned by the SRE team, and the
+portal doesn't yet expose a mutation endpoint for them the way it does for
+change requests and incidents. A **Create problem** button on the list opens
+a form to raise a new problem, but nothing on the detail page can be changed
+from here afterward.

--- a/apps/csm-portal/webapp/src/features/help/content/operations.md
+++ b/apps/csm-portal/webapp/src/features/help/content/operations.md
@@ -27,8 +27,8 @@ CSV export of the filtered results. Each row links to a detail page.
 The detail page shows:
 
 - An **overview** card: project, type, linked case, deployment, deployed
-  product, product, assigned engineer/team, duration, planned start/end,
-  and audit fields.
+  product, assigned engineer/team, duration, planned start/end, and audit
+  fields.
 - Tabs for **Approval**, **Details**, **Comments**, and **Attachments**.
   - **Approval** shows the customer-approval/review flags plus a full
     approval-stage breakdown (e.g. Assess, Authorize, Customer Approval) with

--- a/apps/csm-portal/webapp/src/features/help/content/overview.md
+++ b/apps/csm-portal/webapp/src/features/help/content/overview.md
@@ -1,0 +1,40 @@
+# Overview
+
+The CSM portal is the internal tool CS engineers use to handle customer support work:
+cases, service and change requests, incidents, professional-services engagements, security
+findings, product/version updates, time tracking, and the customer/account data those all
+reference. It is separate from the customer-facing portal: customers never see this app.
+
+This Help section lives under **Help** in the left sidebar, right after **Settings**. Each
+topic below covers one part of the portal in more detail than this page does.
+
+## The portal at a glance
+
+The sections below appear in the left sidebar in this order:
+
+- **Dashboard**: your landing page: configurable widgets summarizing cases, requests, and
+  other work.
+- **Support**: cases: the core case list, case detail, and comment trail.
+- **Operations**: four tabs: Service requests, Change requests, Incidents, and Problem
+  management.
+- **Engagements**: professional-services work such as migrations, implementations,
+  onboarding, and training.
+- **Security Center**: two tabs: Security reports and Vulnerabilities.
+- **Updates**: product/version update tracking.
+- **Time cards**: engineer time logged against a case, with an approval flow.
+- **Announcements**: portal-wide announcements.
+- **Customers**: two tabs: Accounts and Projects.
+- **Settings**: user management: users, roles, groups, teams, and permissions.
+- **Help**: this section.
+
+Each of these has its own topic further down this page with the specifics.
+
+## Jumping to a person's profile
+
+Wherever a person's name appears (a case's creator or assignee, a comment's author, and
+similar references throughout the portal), clicking it opens their profile page. If the name
+can't yet be resolved to a profile (no id is available), it's shown as plain, unclickable
+text instead of a broken link.
+
+Shortcuts for navigating between pages and personalizing your workspace (pinning, quick-nav,
+and similar) are covered in the **Navigation & personalization** topic.

--- a/apps/csm-portal/webapp/src/features/help/content/people-access.md
+++ b/apps/csm-portal/webapp/src/features/help/content/people-access.md
@@ -1,0 +1,80 @@
+# People & project access
+
+Almost every name in the portal (a case's creator, its assignee, a watcher, a comment
+author, an attachment uploader) is a link to that person's profile. This section covers
+what the profile page shows, and how to read its project-access table when you're chasing a
+"why can't this customer see their case" question.
+
+Looking someone up this way isn't restricted to admins: any signed-in CS engineer can open
+any user's profile.
+
+## Looking up a person
+
+Click the name wherever it appears: on a case, a request, a comment, an attachment, a
+dashboard widget row. The link only appears once the portal has resolved that name to a user
+id, which is usually instant but occasionally lags a beat behind the rest of the row loading.
+
+The profile page itself shows:
+
+- **Header**: name, email, and whether the account is Internal (WSO2 staff) or Customer,
+  plus a headline status chip. A locked-out account shows **Locked out** here instead of
+  **Active**/**Inactive**: locked-out takes priority in the headline because the account is
+  unusable either way, but both attributes are always shown separately below.
+- **Overview**: username, email, timezone, phone (internal users), team (internal users),
+  account status, locked-out state, and created/updated timestamps. For an external contact
+  who isn't a wso2.com address, there's also an **External account** field showing whether a
+  matching account exists and whether it's locked; this is a separate lock concept from the
+  "Locked out" chip above, and it's a best-effort lookup: if it couldn't be checked, this
+  field reads "Unavailable" rather than a false "Not found".
+- **Permissions & assignments**: platform roles, and (internal users only) group
+  memberships.
+- **Accessible projects**: external contacts only; see below.
+
+## Reading project access status
+
+For an external (customer) contact, the profile adds an **Accessible projects** table: one
+row per project this person has any contact record on, with the project name, its short key,
+their roles on it, and an **Access** column that's the actual verdict.
+
+Two banners can appear above the table before you even get to individual rows:
+
+- If the account itself is **inactive**, an error banner says so up front: an inactive
+  account can't access any project's cases no matter what the per-project rows say below it.
+- If the person's external account is **locked**, a separate error banner flags that they
+  can't sign in at all until it's unlocked.
+
+Each row's **Access** chip is one of:
+
+- **No access** (red): this project does not grant this person case access. The reason line
+  underneath tells you which of two distinct problems it is, because the fix is different for
+  each:
+  - *No contact record is linked to this project for this user*: the invite to this project
+    never completed; there's nothing to fix on the person's own record, the project side needs
+    a contact added.
+  - *Invited as `<address A>` but linked to a contact whose own address is `<address B>`.
+    This project is invisible to both.* The project has a contact row, but it was invited
+    under one email address while the linked contact's actual account uses a different
+    address. Neither address sees this project: not the one the invite named, and not the one
+    the person actually logs in with. This is the case worth specifically checking for when a
+    customer insists "I should have access": the fix is usually correcting the invited
+    address to match the account they actually use.
+- **Invited** (amber): the project does grant case access, but this person hasn't completed
+  registration yet, so they can't see it in practice until they do.
+- **Has access** (green): the project grants case access and registration is complete. If
+  the customer still can't see a case here, look at the account-level banners above (inactive,
+  locked) rather than this row.
+
+Above the table, a warning banner summarizes **"Blocked on N of M projects"** whenever at
+least one row isn't a clean **Has access**: N is every row that's either **No access** or
+**Invited**, so it's a quick read on how much of this person's project access is incomplete
+before you scan the individual reasons.
+
+A couple of caveats worth knowing:
+
+- This table (and the External account field) is only populated for users sourced from the
+  data source that carries group and project-contact records; a person profile from a data
+  source that doesn't track project contacts will simply show no Accessible projects section
+  worth of data, not an error.
+- All three blocks (memberships, project access, external account) are best-effort: if the
+  underlying lookup fails, the section renders empty or absent rather than failing the whole
+  profile page.

--- a/apps/csm-portal/webapp/src/features/help/content/security-center.md
+++ b/apps/csm-portal/webapp/src/features/help/content/security-center.md
@@ -1,0 +1,50 @@
+# Security Center
+
+Security Center is where security-related work for customer deployments lives, split into
+two tabs: **Security reports** and **Vulnerabilities**.
+
+## Security reports
+
+Security reports are a case type (Security Report Analysis) filed against a specific project,
+deployment, and deployed product. The list shows the same table used elsewhere for cases, but
+locked to this case type: the case type column and severity column are hidden since every row
+is the same type.
+
+To file a new report, use **New security report**. The form asks for:
+
+- **Project**: searchable, or pre-filled and locked if you opened the form from a project's
+  page.
+- **Deployment**: the environments available under the selected project.
+- **Deployed product**: the products available under the selected deployment.
+- **Subject**: auto-generated as `{Deployment} - {Product} - {date}` once a product is
+  chosen; edit it and the auto-generation stops so your text isn't overwritten later.
+- **Description**: required; describe what needs security analysis.
+- **Attachments**: optional; uploaded after the report is created, so a failed upload never
+  blocks report creation. If any attachment fails, you'll see a warning and can retry it from
+  the report page.
+
+Once created, the report opens like any other case, and its Back button returns you to
+wherever you started the form from (the Security Center list, or the originating project page).
+
+## Vulnerabilities
+
+The Vulnerabilities tab lists known product vulnerabilities across customer deployments,
+independent of any single case. Each row shows:
+
+- **CVE / Vulnerability ID**: the CVE identifier and/or internal vulnerability ID.
+- **Component**: the affected component and its version.
+- **Product**: the affected product and its version.
+- **Priority**: Critical, High, Medium, Low, Info, or Unknown, shown as a colored chip
+  (Critical/High in red, Medium in amber, Low in blue).
+- **Type**: the vulnerability type.
+- **Update level**: the update level the fix applies to.
+
+Use the search box to filter by free text, or the **Priority** filter to narrow to a single
+priority level. The list is paginated server-side; use **Refresh** to re-run the search and
+pick up any changes.
+
+Click a row to open the vulnerability's detail page, which shows the same overview fields plus
+any available long-form text: **Use case**, **Justification**, and **Resolution**. These
+sections only appear when the underlying data has content. The detail page's Back button
+returns you to the Vulnerabilities list (or, if you reached the vulnerability from elsewhere,
+back to that page).

--- a/apps/csm-portal/webapp/src/features/help/content/settings.md
+++ b/apps/csm-portal/webapp/src/features/help/content/settings.md
@@ -7,7 +7,7 @@ no create, edit, or delete here yet for any of Users, Roles, Groups, or Teams.
 
 Open Settings from the sidebar and you land on a tile grid, one tile per directory, rather
 than a tab strip. A tile marked **WIP** isn't wired up yet; the tiles that aren't marked WIP
-are.
+open their real directory.
 
 ## Users
 

--- a/apps/csm-portal/webapp/src/features/help/content/settings.md
+++ b/apps/csm-portal/webapp/src/features/help/content/settings.md
@@ -1,0 +1,58 @@
+# Settings
+
+Settings is where you look up the platform's identity data: who exists, what roles they
+carry, which assignment groups they belong to, and which team registry entries they're
+part of. It's a set of read-only directories today, not a configuration console; there's
+no create, edit, or delete here yet for any of Users, Roles, Groups, or Teams.
+
+Open Settings from the sidebar and you land on a tile grid, one tile per directory, rather
+than a tab strip. A tile marked **WIP** isn't wired up yet; the tiles that aren't marked WIP
+are.
+
+## Users
+
+The Users directory lists every account on the platform. Search by username or email
+(case-insensitive), and narrow the list with the Roles, Groups, Teams, and Status filters;
+they combine, so picking a role and a team returns only users who match both.
+
+Click any row to open that person's profile, which shows their full role list and other
+details the table truncates. There's no way to change a user's roles, deactivate an account,
+or edit any field from here: this view is for finding people and checking what they're
+assigned, not managing them.
+
+## Roles
+
+Roles shows the platform's curated catalogue of assignable role keys, not every role concept
+the backing identity source knows about, just the ones this platform actually uses. Search by
+name, then click a role to see the list of users who hold it.
+
+Like Users, this is a lookup, not an editor: you can't create a role or add/remove someone's
+role assignment from this screen.
+
+## Groups
+
+Groups mirrors assignment groups from the backing data source with a live search: this list
+can be larger than the curated Roles or Teams catalogues, since it reflects whatever groups
+exist upstream. Click a group to see its member list.
+
+Read-only, same as the others: group membership is managed upstream, not from this page.
+
+## Teams
+
+Teams is the platform's own team registry, a curated list like Roles, rather than a live
+query against an external source. Each team has a name and a family/grouping label; click one
+to see who's on it.
+
+Also read-only for now: no way to create a team or edit its membership from this screen.
+
+## Permissions
+
+Permissions is not built yet. Opening it shows a "coming soon" notice that names what it's
+waiting on: the backend permissions endpoints. When it ships, it's meant to be a fine-grained
+permission catalog and assignment view, but there's nothing to configure there today.
+
+## Who can see this
+
+Settings itself (Users, Roles, Groups, Teams, and Permissions) is visible to every signed-in
+CS engineer, the same as most of the portal; there's no role check hiding the section or its
+directories.

--- a/apps/csm-portal/webapp/src/features/help/content/support.md
+++ b/apps/csm-portal/webapp/src/features/help/content/support.md
@@ -1,0 +1,86 @@
+# Support
+
+Support (`/cases`) is the cases list and case detail view, where most engineers spend most
+of their day. This topic covers finding cases, saving filter combinations you use often, and
+working a case once you're on its detail page.
+
+## Finding cases
+
+The search box at the top of the list matches on case number, subject, customer, project, or
+assignee. Next to it, **Filters** expands a grid of additional controls:
+
+- **Severity**: S0 (Catastrophic) through S4 (Low / Query). S0 is reserved for Managed Cloud
+  projects.
+- **State**: Open, Work in progress, Solution proposed, Awaiting info, Waiting on WSO2,
+  Closed. The state chip's color tells you whose move it is: blue for active states on us
+  (Open, Work in progress), amber for an elevated on-us state (Waiting on WSO2), grey for
+  waiting on the customer (Solution proposed, Awaiting info), green for Closed.
+- **Team**, **Case type**, **Assignee** (search the engineer directory, or pick "Me"),
+  **Product**, **Onboarding status**, **Tags**, and **Project**.
+
+When a case list arrives already filtered, for example after clicking into a dashboard
+widget, any filter that doesn't have its own control in the grid (an excluded state, a tag
+exclusion, an SLA-percent bound, an escalation filter, and so on) still shows up as a removable
+chip above the grid, so you can always see why the list is filtered and undo it with one click.
+
+Once any filter is active, the **Filters** button turns into **Clear filters (N)**, showing
+how many are active and clearing all of them in one click.
+
+## Saved filter views
+
+The **Saved views** button next to search lets you save the filters you currently have set as
+a named view, and reapply it later without rebuilding it by hand, useful for something you
+check every day, like "my open S1/S2."
+
+A few things worth knowing:
+
+- **Saved views live in your browser only.** They're stored in this browser's local storage,
+  not on the server; they don't sync across devices, and a teammate can't see or share your
+  saved views. Switching browsers or clearing site data loses them.
+- You can save up to 50 views. Saving with a name that matches an existing view (case-
+  insensitively) overwrites it rather than creating a duplicate.
+- The menu also lists a fixed set of **Suggested** views (S0/S1 active, Awaiting info, Open
+  (unstarted)) that are always available; they aren't something you saved, and they can't be
+  deleted.
+- Whichever view's filters exactly match what's currently applied is checked in the menu.
+- Delete a saved view with the trash icon next to it in the menu; suggested views don't have
+  one.
+
+## Case detail
+
+Opening a case shows its full detail: overview fields, the comment/activity timeline,
+attachments, and any linked service requests.
+
+**Linked service requests** appear in their own widget on the case, listing each linked
+request's number, name, state, and current assignee. Clicking a row navigates to that
+request's own case page (with a "back" link that returns you here). If a case is closed, the
+**Create service request** action is disabled: closed cases are read-only.
+
+## Comments
+
+The comment composer at the bottom of the timeline sends either a public reply visible to the
+customer, or an **internal note**:
+
+- Toggle **Internal note** (the lock icon) to write a note only WSO2 engineers can see. The
+  composer's background tints and gets a left accent bar while this is on, and existing
+  internal notes are shown the same way in the timeline with an "Internal note" chip, so
+  customer-visible and internal content are never visually ambiguous.
+- If public replies are currently locked for the case (for example, work is paused), the
+  composer forces you into internal-note mode and shows why, with a one-click "Resume work"
+  action when that's the reason, so you don't have to leave the composer to unblock a public
+  reply.
+- The **HTML source** toggle switches the editor to raw HTML for fixing paste formatting or
+  inserting a table; whatever you type there is sent as-is.
+- Attach files from the editor's toolbar before sending; drag-and-drop onto the composer works
+  too.
+
+Comments in the timeline are color/role-tagged (Customer, WSO2, System, AI Agent) so you can
+scan who said what at a glance, and each has a permalink (click the timestamp) for referencing
+a specific comment.
+
+## Attachments
+
+Click an image or PDF attachment to preview it: images open inline in a dialog; PDFs open in a
+new browser tab (this is a browser limitation, not a portal choice: Chrome won't render a PDF
+inside the sandboxed preview). Other file types don't have an inline preview; download them
+instead.

--- a/apps/csm-portal/webapp/src/features/help/content/time-cards.md
+++ b/apps/csm-portal/webapp/src/features/help/content/time-cards.md
@@ -1,0 +1,68 @@
+# Time cards
+
+Time cards track the time engineers spend working a case. Every card is
+logged against a specific case, is submitted immediately, and then goes
+through a lead's approval before it counts as final.
+
+## Logging time
+
+Time is always logged from a case, not from the Time cards page:
+
+1. Open the case and go to its **Time tracking** tab.
+2. Select **Log time**.
+3. Fill in the entry:
+   - **Date**: the day the work was actually done (it can be backdated).
+   - **Time breakdown**: minutes split across five fixed activities:
+     Analysis and debugging, Reproduce, Setting up, Providing solution, and
+     Answering. The total across all five is the card's logged time.
+   - **Issue complexity**: N/A, Low, Medium, or High.
+   - **Billable**: whether the time is billable to the customer. This is
+     locked to non-billable for the most severe cases and can't be changed
+     on those.
+   - **Work log comment**: a short note on what was worked on. Required.
+   - **Approver**: the team lead who will review the card. Search by name
+     or email; you can't pick yourself.
+4. Select **Submit for review**.
+
+A card is created already in the **Submitted** state; there's no draft or
+save-for-later step.
+
+While a card is still **Submitted**, its own submitter can edit or delete it
+from the case's Time tracking tab or from the **My time sheets** tab. Once a
+lead has made a decision, the card is locked and can no longer be edited or
+deleted.
+
+## Approval
+
+A submitted card is reviewed by the approver chosen when it was logged. A
+lead can never approve or reject their own time card, even if they are also
+an approver.
+
+To decide a card, the lead opens **Review** (from the case's Time tracking
+tab, or from the **Approvals** tab on the Time cards page) and selects
+**Accept** or **Reject**. A comment is optional when accepting but required
+when rejecting: it's the only record of why a card was rejected.
+
+Cards move through these states:
+
+- **Submitted**: logged and awaiting a decision.
+- **Approved**: accepted by the lead.
+- **Rejected**: declined by the lead, with a comment explaining why.
+
+On the **Approvals** tab, a lead can also select several submitted cards at
+once and approve them together with **Approve**.
+
+## Finding time cards
+
+The Time cards page has three tabs:
+
+- **My time sheets**: only your own cards.
+- **All**: everyone's cards, for visibility only. No approve, reject, edit,
+  or delete actions are available here, even on your own cards.
+- **Approvals**: visible only to approvers and admins. Shows cards awaiting
+  a decision from you.
+
+Each tab can be filtered by project, work item (case number), state, and
+work date range; the **All** and **Approvals** tabs can also be filtered by
+engineer. Use **Export CSV** to download whatever cards are currently
+loaded on a tab.

--- a/apps/csm-portal/webapp/src/features/help/content/updates.md
+++ b/apps/csm-portal/webapp/src/features/help/content/updates.md
@@ -1,0 +1,55 @@
+# Updates
+
+The Updates section looks up WSO2 product update level release notes, the same
+information published for WUM/update levels, so you can check what changed
+between two update levels of a product version without leaving the portal.
+
+## Searching between two update levels
+
+Pick a product, then a base version of that product, then a start level and an
+end level, and select **Search**:
+
+- **Product** and **Version** are populated from the product catalog. Selecting
+  a product resets the version and level fields below it; selecting a version
+  resets the level fields.
+- **Start level** always offers `0` (meaning "no updates installed yet") in
+  addition to the real update levels available for that version.
+- **End level** only lists levels higher than the chosen start level, so the
+  range is always valid.
+- **Search** is disabled until all four fields are set and the end level is
+  greater than the start level.
+- **Clear** resets all four fields and drops the current results.
+
+The results table lists every update level in the range, its type (**Security**,
+**Regular**, or **Mixed**), and a **View** action.
+
+## Viewing update details
+
+Select **View** on a row to open the full release notes for that update level:
+one block per update number, each with its description, install instructions
+(when there's more than "N/A"), bug fixes, added/modified/removed files, and any
+security advisories with their severity and overview. Descriptions and advisory
+overviews may contain formatted (HTML) release-note text; the portal renders
+that formatting and sanitizes it, or falls back to plain text if the content
+isn't HTML.
+
+## Report preview and PDF export
+
+Once a search returns results, two extra actions become available:
+
+- **Preview report** opens a single scrollable view of every update in the
+  current result set, the same detail shown per level, laid out for reading top
+  to bottom instead of level by level.
+- **Download PDF** generates a PDF of that same report for offline reference or
+  sharing.
+
+Both actions are tied to the exact filter values you searched with. If you
+change any of the Product / Version / Start level / End level dropdowns after
+running a search, both buttons are disabled again until you select **Search**
+with the new values; this avoids downloading or previewing a report that
+doesn't match what's on screen.
+
+## Refreshing results
+
+While a result set is showing, use **Refresh updates** to re-run the search
+against the current filter values and see when it was last updated.

--- a/apps/csm-portal/webapp/src/features/help/content/workspace-basics.md
+++ b/apps/csm-portal/webapp/src/features/help/content/workspace-basics.md
@@ -1,0 +1,106 @@
+# Navigation & personalization
+
+These controls live in the top header bar and work from anywhere in the
+portal: you don't need to be on a case, project, or account page to use
+them.
+
+## Quick navigation
+
+Click the "Search or jump to…" box in the header, or press **⌘K** (Mac) or
+**Ctrl+K** (Windows/Linux), to open the quick-nav palette.
+
+Type to search across:
+
+- Cases, incidents, change requests, problems, and conversations: matched
+  by number/id first, falling back to free-text search of subject and
+  description
+- Your pinned pages and recently viewed items
+- Portal pages themselves (both top-level sections and second-level tabs,
+  such as jumping straight to the Incidents tab instead of just Operations)
+
+If what you type matches a known number pattern (a case number, a WSO2 case
+id, an incident/problem/change-request number, or a conversation number),
+quick nav shows only that exact match with a banner confirming what it
+matched on. Use the "Search in subject and description too" button in that
+banner to widen the search to free text across all of those record types.
+
+If nothing matches a known number pattern, quick nav still searches subject
+and description text across all types and shows a note that it didn't
+recognize a specific number format.
+
+Use the arrow keys to move between results and **Enter** to open the
+selected one, or click any result directly. Press **Esc** or click outside
+the palette to close it without navigating anywhere.
+
+## Pinning a page
+
+Pinning keeps a page one click away in the header, regardless of what else
+you navigate to.
+
+1. Open the page you want to keep handy: a case, project, account, a
+   filtered list view, a dashboard, or any other page in the portal.
+2. Click the pin icon in the header's action area (it reads "Pin this page
+   to top nav bar" when unpinned).
+
+The page appears as a chip in the header's pinned tabs strip, next to the
+quick-nav box. Click a chip to jump back to that page; click its close (×)
+control to unpin it. The chip for whichever pinned page you're currently on
+is visually highlighted so you can tell where you are.
+
+To unpin a page you're currently viewing, click the same header icon again:
+it toggles to "Unpin this page from the top nav bar" once the page is
+pinned.
+
+Pinned pages are not evicted automatically. Unlike your recently viewed
+history, there's no cap on how long a pin sticks around; it stays until
+you unpin it yourself.
+
+## Renaming a pinned tab
+
+Pinned tab chips get an automatically generated title, which is not always
+the label you'd want at a glance (for example, a filtered view's title
+summarizes its filters).
+
+1. Right-click the pinned tab's chip in the header.
+2. Choose **Rename** from the menu that appears.
+3. Edit the name in the "Rename pinned tab" dialog and click **Save**.
+
+An empty or whitespace-only name is rejected: the Save button stays
+disabled until you enter something.
+
+## Recent views
+
+The clock/history icon in the header's action area opens a "Recently
+viewed" panel, separate from your pinned tabs. It lists pages you've
+visited recently, grouped by type (cases, projects, accounts, incidents,
+change requests, problems, searches, pages), most recent first, each with a
+relative timestamp.
+
+Unlike pinning, recent views build up automatically just by visiting pages;
+you don't have to do anything to add an entry. Only your last 12 unpinned
+visits are kept; older ones drop off as you visit new pages. Pinned entries
+are exempt from that cap and always stay in the list, marked so you can
+unpin them from the same panel (via the pin icon on each row) without
+opening the page itself.
+
+Click **Clear history** in the panel to remove your unpinned recent items.
+This never removes pinned entries: clearing history only resets browsing
+history, not your deliberately pinned working set.
+
+## What gets remembered
+
+Both pinned tabs and recent-view entries store a title, not just a URL. For
+case, project, incident, and similar detail pages, that title comes from
+the record itself (for example, a case number and subject). For a page
+without its own recorder (a dashboard, a filtered list, or any other route),
+the title is derived from the page's name in the navigation menu, or, for
+a filtered view, from a short summary of the applied filters (e.g. a quoted
+search term, or a count of active filters). If the route isn't recognized
+by the portal at all, the title falls back to a human-readable guess based
+on the URL itself. This is why a pinned or recent entry can occasionally
+show an unexpected name; you can always fix it via the rename flow above
+for pinned tabs.
+
+Your pinned and recent items are tied to your signed-in account and stored
+in your browser; they don't carry over to a different browser or device,
+and signing out clears them.

--- a/apps/csm-portal/webapp/src/features/help/content/workspace-basics.md
+++ b/apps/csm-portal/webapp/src/features/help/content/workspace-basics.md
@@ -92,7 +92,7 @@ history, not your deliberately pinned working set.
 Both pinned tabs and recent-view entries store a title, not just a URL. For
 case, project, incident, and similar detail pages, that title comes from
 the record itself (for example, a case number and subject). For a page
-without its own recorder (a dashboard, a filtered list, or any other route),
+without its own record (a dashboard, a filtered list, or any other route),
 the title is derived from the page's name in the navigation menu, or, for
 a filtered view, from a short summary of the applied filters (e.g. a quoted
 search term, or a count of active filters). If the route isn't recognized

--- a/apps/csm-portal/webapp/src/features/help/help-raw-modules.d.ts
+++ b/apps/csm-portal/webapp/src/features/help/help-raw-modules.d.ts
@@ -1,0 +1,25 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// `vite/client`'s own ambient types cover `*.svg`/`*.png`/etc. as default-export
+// asset URLs, but not Vite's `?raw` suffix (a source-as-string import) — needed
+// here to pull each help topic's Markdown file in as plain text at build time.
+// Scoped to this feature folder's own declaration file rather than added
+// globally, since it's the only place in the app that currently needs it.
+declare module "*.md?raw" {
+  const content: string;
+  export default content;
+}

--- a/apps/csm-portal/webapp/src/features/help/pages/HelpPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/help/pages/HelpPage.test.tsx
@@ -1,0 +1,98 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { navNodeById } from "@config/csmNavItems";
+import { resetFeatureStatesForTests } from "@config/featureFlags";
+import HelpPage from "./HelpPage";
+
+function setOverrides(value: unknown): void {
+  window.config = {
+    ...window.config,
+    CSM_PORTAL_FEATURE_OVERRIDES: value,
+  } as Window["config"];
+  resetFeatureStatesForTests();
+}
+
+beforeEach(() => {
+  vi.spyOn(console, "warn").mockImplementation(() => undefined);
+  setOverrides(undefined);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("HelpPage", () => {
+  it("renders a table of contents with one anchor link per enabled topic, in nav order", () => {
+    render(<HelpPage />);
+    const nav = screen.getByRole("navigation", { name: "Help topics" });
+    const help = navNodeById("help");
+    const labels = (help?.children ?? []).map((child) => child.label);
+
+    const links = within(nav).getAllByRole("link");
+    expect(links.map((link) => link.textContent)).toEqual(labels);
+  });
+
+  it("points each TOC entry at the matching topic section's in-page anchor", () => {
+    render(<HelpPage />);
+    const link = screen.getByRole("link", { name: "Operations" });
+    expect(link).toHaveAttribute("href", "#operations");
+  });
+
+  it("renders every topic's content below the table of contents, each in its own labelled section", () => {
+    render(<HelpPage />);
+    expect(screen.getByRole("heading", { name: "Overview" })).toBeVisible();
+    expect(
+      document.getElementById("operations")?.tagName.toLowerCase(),
+    ).toBe("section");
+  });
+
+  it("drops a topic from both the table of contents and the rendered sections once it's disabled", () => {
+    setOverrides({ "help.operations": "hidden" });
+    render(<HelpPage />);
+    expect(screen.queryByRole("link", { name: "Operations" })).toBeNull();
+    expect(document.getElementById("operations")).toBeNull();
+  });
+
+  it("shows the back-to-top button only after scrolling past the top of the page", () => {
+    render(<HelpPage />);
+    expect(
+      screen.queryByRole("button", { name: "Back to top" }),
+    ).toBeNull();
+
+    Object.defineProperty(window, "scrollY", { value: 400, configurable: true });
+    fireEvent.scroll(window);
+
+    expect(
+      screen.getByRole("button", { name: "Back to top" }),
+    ).toBeVisible();
+  });
+
+  it("scrolls back to the top of the page when the back-to-top button is clicked", () => {
+    render(<HelpPage />);
+    Object.defineProperty(window, "scrollY", { value: 400, configurable: true });
+    fireEvent.scroll(window);
+
+    const scrollTo = vi.fn();
+    window.scrollTo = scrollTo;
+    fireEvent.click(screen.getByRole("button", { name: "Back to top" }));
+
+    expect(scrollTo).toHaveBeenCalledWith({ top: 0, behavior: "smooth" });
+  });
+});

--- a/apps/csm-portal/webapp/src/features/help/pages/HelpPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/help/pages/HelpPage.test.tsx
@@ -32,10 +32,13 @@ function setOverrides(value: unknown): void {
 beforeEach(() => {
   vi.spyOn(console, "warn").mockImplementation(() => undefined);
   setOverrides(undefined);
+  Element.prototype.scrollIntoView = vi.fn();
+  window.location.hash = "";
 });
 
 afterEach(() => {
   vi.restoreAllMocks();
+  window.location.hash = "";
 });
 
 describe("HelpPage", () => {
@@ -94,5 +97,23 @@ describe("HelpPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "Back to top" }));
 
     expect(scrollTo).toHaveBeenCalledWith({ top: 0, behavior: "smooth" });
+  });
+
+  it("scrolls the matching section into view on a direct /help#<topic> entry", () => {
+    window.location.hash = "#operations";
+    render(<HelpPage />);
+
+    const section = document.getElementById("operations");
+    expect(section?.scrollIntoView).toHaveBeenCalled();
+  });
+
+  it("scrolls the matching section into view when the hash changes after mount", () => {
+    render(<HelpPage />);
+    const section = document.getElementById("operations");
+
+    window.location.hash = "#operations";
+    fireEvent(window, new HashChangeEvent("hashchange"));
+
+    expect(section?.scrollIntoView).toHaveBeenCalled();
   });
 });

--- a/apps/csm-portal/webapp/src/features/help/pages/HelpPage.tsx
+++ b/apps/csm-portal/webapp/src/features/help/pages/HelpPage.tsx
@@ -1,0 +1,147 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Box,
+  Divider,
+  IconButton,
+  List,
+  ListItemButton,
+  ListItemText,
+  Tooltip,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { ArrowUp } from "@wso2/oxygen-ui-icons-react";
+import { type JSX, useEffect, useState } from "react";
+import { navNodeById } from "@config/csmNavItems";
+import { enabledNavChildren } from "@config/featureFlags";
+import HelpTopicSection from "@features/help/components/HelpTopicSection";
+
+/** Bare topic id (e.g. `"operations"`) from a `help.<id>` nav node id — the
+ * key `HELP_TOPIC_CONTENT` and every anchor target on this page share. */
+function bareTopicId(nodeId: string): string {
+  return nodeId.replace(/^help\./, "");
+}
+
+/** Scroll-Y, in px, past which the "back to top" button becomes visible. */
+const BACK_TO_TOP_THRESHOLD = 240;
+
+/**
+ * Floating "back to top" control. Hidden near the top of the page, fades in
+ * once the user has scrolled past the table of contents, and smooth-scrolls
+ * back to the top on click — a plain scroll listener + `window.scrollTo` is
+ * enough for this, no scroll library needed.
+ */
+function BackToTopButton(): JSX.Element {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const onScroll = (): void => {
+      setVisible(window.scrollY > BACK_TO_TOP_THRESHOLD);
+    };
+    onScroll();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  if (!visible) return <></>;
+
+  return (
+    <Tooltip title="Back to top">
+      <IconButton
+        aria-label="Back to top"
+        onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
+        sx={{
+          position: "fixed",
+          bottom: 24,
+          right: 24,
+          zIndex: (theme) => theme.zIndex.tooltip,
+          bgcolor: "background.paper",
+          border: 1,
+          borderColor: "divider",
+          boxShadow: 3,
+          "&:hover": { bgcolor: "action.hover" },
+        }}
+      >
+        <ArrowUp size={20} />
+      </IconButton>
+    </Tooltip>
+  );
+}
+
+/**
+ * The whole Help section: one scrollable page with a table of contents up
+ * top, every topic rendered below it in nav order, and a floating
+ * "back to top" button. Replaces the earlier sidebar-plus-per-topic-route
+ * layout (`HelpLayout` + `HelpTopicPage`, one route per topic) — a long-form
+ * doc reads better as one page you can skim/search/print than as a set of
+ * separate routes, and a floating in-page TOC gets the same "jump to a
+ * topic" behaviour natively, via anchor links, with no router involved.
+ *
+ * Topics are still declared once, in `csmNavItems.ts`'s `help` node, and
+ * filtered here to the ones this deployment has enabled via
+ * `CSM_PORTAL_FEATURE_OVERRIDES` — the same mechanism every other section's
+ * tab strip uses (`enabledNavChildren`), just applied to a plain rendered
+ * list instead of a route guard, since there is no longer a per-topic route
+ * to guard.
+ */
+export default function HelpPage(): JSX.Element {
+  const helpSection = navNodeById("help");
+  const topics = helpSection ? enabledNavChildren(helpSection) : [];
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
+      <Typography variant="h5">Help</Typography>
+
+      <Box
+        component="nav"
+        aria-label="Help topics"
+        sx={{
+          border: 1,
+          borderColor: "divider",
+          borderRadius: 1,
+          overflow: "hidden",
+          maxWidth: 420,
+        }}
+      >
+        <List dense disablePadding>
+          {topics.map((topic) => {
+            const id = bareTopicId(topic.id);
+            return (
+              <ListItemButton key={topic.id} component="a" href={`#${id}`}>
+                <ListItemText primary={topic.label} />
+              </ListItemButton>
+            );
+          })}
+        </List>
+      </Box>
+
+      {topics.map((topic, index) => {
+        const id = bareTopicId(topic.id);
+        return (
+          <Box key={topic.id}>
+            {index > 0 && <Divider sx={{ mb: 3 }} />}
+            <Box component="section" id={id} sx={{ minWidth: 0 }}>
+              <HelpTopicSection topicId={id} />
+            </Box>
+          </Box>
+        );
+      })}
+
+      <BackToTopButton />
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/help/pages/HelpPage.tsx
+++ b/apps/csm-portal/webapp/src/features/help/pages/HelpPage.tsx
@@ -46,13 +46,14 @@ const BACK_TO_TOP_THRESHOLD = 240;
  * enough for this, no scroll library needed.
  */
 function BackToTopButton(): JSX.Element {
-  const [visible, setVisible] = useState(false);
+  const [visible, setVisible] = useState(
+    () => window.scrollY > BACK_TO_TOP_THRESHOLD,
+  );
 
   useEffect(() => {
     const onScroll = (): void => {
       setVisible(window.scrollY > BACK_TO_TOP_THRESHOLD);
     };
-    onScroll();
     window.addEventListener("scroll", onScroll, { passive: true });
     return () => window.removeEventListener("scroll", onScroll);
   }, []);
@@ -98,9 +99,30 @@ function BackToTopButton(): JSX.Element {
  * list instead of a route guard, since there is no longer a per-topic route
  * to guard.
  */
+/**
+ * Scrolls the section matching the current `#<topic>` hash into view, both on
+ * first mount (a direct link like `/help#operations`) and on any later hash
+ * change (the TOC's own anchor links, which the browser can otherwise leave
+ * unhandled since every topic's section is a plain DOM node rendered by this
+ * same component, not a route the router would scroll for on navigation).
+ */
+function useScrollToHashOnMount(): void {
+  useEffect(() => {
+    const scrollToHash = (): void => {
+      const id = window.location.hash.slice(1);
+      if (!id) return;
+      document.getElementById(id)?.scrollIntoView();
+    };
+    scrollToHash();
+    window.addEventListener("hashchange", scrollToHash);
+    return () => window.removeEventListener("hashchange", scrollToHash);
+  }, []);
+}
+
 export default function HelpPage(): JSX.Element {
   const helpSection = navNodeById("help");
   const topics = helpSection ? enabledNavChildren(helpSection) : [];
+  useScrollToHashOnMount();
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>

--- a/apps/csm-portal/webapp/src/features/help/utils/helpContent.test.ts
+++ b/apps/csm-portal/webapp/src/features/help/utils/helpContent.test.ts
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { describe, expect, it } from "vitest";
+import { navNodeById } from "@config/csmNavItems";
+import { HELP_TOPIC_CONTENT } from "@features/help/utils/helpContent";
+
+describe("HELP_TOPIC_CONTENT", () => {
+  it("has a non-empty Markdown source for every topic declared in the nav tree", () => {
+    const help = navNodeById("help");
+    const topicIds = (help?.children ?? []).map((child) =>
+      child.id.replace(/^help\./, ""),
+    );
+    expect(topicIds.length).toBeGreaterThan(0);
+
+    for (const id of topicIds) {
+      expect(HELP_TOPIC_CONTENT[id]).toBeTruthy();
+    }
+  });
+
+  it("declares no orphaned entries beyond the nav tree's topic list", () => {
+    const help = navNodeById("help");
+    const topicIds = new Set(
+      (help?.children ?? []).map((child) => child.id.replace(/^help\./, "")),
+    );
+    for (const key of Object.keys(HELP_TOPIC_CONTENT)) {
+      expect(topicIds.has(key)).toBe(true);
+    }
+  });
+});

--- a/apps/csm-portal/webapp/src/features/help/utils/helpContent.ts
+++ b/apps/csm-portal/webapp/src/features/help/utils/helpContent.ts
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+ * Topic id -> Markdown source, for every Help doc. `csmNavItems.ts`'s `help`
+ * node stays the single source of truth for *which topics exist and their
+ * order* (sidebar, Quick-nav, route guarding); this map only resolves an id to
+ * its content, so it must have an entry for every `help.<id>` child declared
+ * there — `helpContent.test.ts` asserts that.
+ *
+ * Each source is pulled in via Vite's `?raw` suffix, so it's bundled as a
+ * plain string at build time rather than fetched at runtime — there is no
+ * backend endpoint behind this content.
+ */
+
+import overviewMd from "../content/overview.md?raw";
+import workspaceBasicsMd from "../content/workspace-basics.md?raw";
+import dashboardMd from "../content/dashboard.md?raw";
+import supportMd from "../content/support.md?raw";
+import operationsMd from "../content/operations.md?raw";
+import engagementsMd from "../content/engagements.md?raw";
+import securityCenterMd from "../content/security-center.md?raw";
+import updatesMd from "../content/updates.md?raw";
+import timeCardsMd from "../content/time-cards.md?raw";
+import announcementsMd from "../content/announcements.md?raw";
+import customersMd from "../content/customers.md?raw";
+import peopleAccessMd from "../content/people-access.md?raw";
+import settingsMd from "../content/settings.md?raw";
+
+/**
+ * Keyed by the topic's *bare* id (the segment after `help.` in its
+ * `CsmNavNode.id`, e.g. `"overview"` for `"help.overview"` / `/help/overview`)
+ * — the same value `HelpTopicPage` reads out of its `:topicId` route param.
+ */
+export const HELP_TOPIC_CONTENT: Record<string, string> = {
+  overview: overviewMd,
+  "workspace-basics": workspaceBasicsMd,
+  dashboard: dashboardMd,
+  support: supportMd,
+  operations: operationsMd,
+  engagements: engagementsMd,
+  "security-center": securityCenterMd,
+  updates: updatesMd,
+  "time-cards": timeCardsMd,
+  announcements: announcementsMd,
+  customers: customersMd,
+  "people-access": peopleAccessMd,
+  settings: settingsMd,
+};

--- a/apps/csm-portal/webapp/src/features/help/utils/helpImages.test.ts
+++ b/apps/csm-portal/webapp/src/features/help/utils/helpImages.test.ts
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { describe, expect, it } from "vitest";
+import { resolveHelpImages } from "@features/help/utils/helpImages";
+
+describe("resolveHelpImages", () => {
+  // No topic currently embeds an image (the registry is empty — see
+  // helpImages.ts), so there's no "known" name to assert resolves today; this
+  // covers the unresolved/no-op paths that hold regardless.
+
+  it("leaves an unknown image reference untouched", () => {
+    const html = '<img src="images/does-not-exist.png" alt="Missing">';
+    expect(resolveHelpImages(html)).toBe(html);
+  });
+
+  it("leaves HTML with no image references untouched", () => {
+    const html = "<p>No images here.</p>";
+    expect(resolveHelpImages(html)).toBe(html);
+  });
+});

--- a/apps/csm-portal/webapp/src/features/help/utils/helpImages.ts
+++ b/apps/csm-portal/webapp/src/features/help/utils/helpImages.ts
@@ -20,7 +20,8 @@
  * production build). A plain relative path in the raw Markdown string can't
  * resolve on its own — the string is rendered to HTML and injected via
  * `dangerouslySetInnerHTML`, so the browser would resolve it against the
- * *page's* URL (`/help/overview`), not against this file. `resolveHelpImages`
+ * *page's* URL (`/help#<topic>`, all topics share the one `/help` route), not
+ * against this file. `resolveHelpImages`
  * below rewrites `src="images/<name>"` to this map's real URL before the HTML
  * is sanitized and rendered, so an author only ever has to add both the image
  * file and its one entry here — never hand-compute a bundled path.

--- a/apps/csm-portal/webapp/src/features/help/utils/helpImages.ts
+++ b/apps/csm-portal/webapp/src/features/help/utils/helpImages.ts
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+ * File name (as written in a topic's Markdown `![alt](images/<name>)`) to the
+ * actual bundled asset URL Vite assigns it (hashed, under `/assets/...` in a
+ * production build). A plain relative path in the raw Markdown string can't
+ * resolve on its own — the string is rendered to HTML and injected via
+ * `dangerouslySetInnerHTML`, so the browser would resolve it against the
+ * *page's* URL (`/help/overview`), not against this file. `resolveHelpImages`
+ * below rewrites `src="images/<name>"` to this map's real URL before the HTML
+ * is sanitized and rendered, so an author only ever has to add both the image
+ * file and its one entry here — never hand-compute a bundled path.
+ *
+ * Empty today: no topic currently embeds an image. Add
+ * `import x from "../content/images/<name>"` and a `"<name>": x` entry here
+ * alongside any future one that does.
+ */
+const HELP_IMAGE_ASSETS: Record<string, string> = {};
+
+const IMAGE_SRC_PATTERN = /src="images\/([^"]+)"/g;
+
+/**
+ * Rewrites every `images/<name>` Markdown-image reference in already-rendered
+ * topic HTML to its real bundled asset URL. Run this on the `markdownToHtml`
+ * output *before* `sanitizeRichTextHtml`, so sanitization always sees the
+ * final `src` value.
+ *
+ * An unresolvable file name (typo, or an image never added to
+ * `HELP_IMAGE_ASSETS`) is left as the literal `images/<name>` string rather
+ * than swapped to something else — it renders as a broken image with visible
+ * alt text instead of silently pointing somewhere unrelated, which is easier
+ * to notice and fix in review.
+ */
+export function resolveHelpImages(html: string): string {
+  return html.replace(IMAGE_SRC_PATTERN, (match, fileName: string) => {
+    const resolved = HELP_IMAGE_ASSETS[fileName];
+    return resolved ? `src="${resolved}"` : match;
+  });
+}

--- a/apps/csm-portal/webapp/src/utils/renderMarkdown.ts
+++ b/apps/csm-portal/webapp/src/utils/renderMarkdown.ts
@@ -33,12 +33,32 @@ const md: MarkdownIt = new MarkdownIt({
   breaks: true,
 });
 
+/**
+ * Same as {@link md}, but with `breaks: false` for long-form prose (e.g. the
+ * in-app Help docs) that's hand-wrapped at a fixed column width in its
+ * Markdown source for readability — with `breaks: true`, every one of those
+ * source line-wraps renders as a forced `<br>`, breaking each line far short
+ * of its container's real width instead of reflowing normally.
+ */
+const mdProse: MarkdownIt = new MarkdownIt({
+  html: false,
+  linkify: true,
+  breaks: false,
+});
+
 // Wrap tables in a scrollable container instead of making the <table> itself a
 // scroll box: `display: block` on a <table> drops its implicit table/row/cell
 // roles for assistive tech. The wrapper scrolls; the table keeps native display.
-md.renderer.rules.table_open = () => '<div class="md-table-wrap">\n<table>\n';
-md.renderer.rules.table_close = () => "</table>\n</div>\n";
+for (const target of [md, mdProse]) {
+  target.renderer.rules.table_open = () => '<div class="md-table-wrap">\n<table>\n';
+  target.renderer.rules.table_close = () => "</table>\n</div>\n";
+}
 
 export function markdownToHtml(source: string | undefined | null): string {
   return md.render(source ?? "");
+}
+
+/** {@link markdownToHtml}, for hand-wrapped long-form prose — see {@link mdProse}. */
+export function markdownToHtmlProse(source: string | undefined | null): string {
+  return mdProse.render(source ?? "");
 }


### PR DESCRIPTION
## Purpose
The CSM portal has never had an in-app user guide. New CS engineers had no built-in reference for what each section does or how cross-cutting features (pinning pages, saved filter views, checking a user's project access) work.

## Goals
Give every CS engineer a "Help" entry in the sidebar (right after Settings) with a single scrollable page: a table of contents at the top, one section per portal area below it, and a floating back-to-top button.

## Approach
- Static Markdown, one file per topic, committed under `apps/csm-portal/webapp/src/features/help/content/`, bundled at build time via Vite `?raw` imports — no backend storage, no admin editing UI.
- Topics are declared once in `csmNavItems.ts`'s `help` node (single source of truth for the TOC, ordering, and per-deployment enable/disable via the existing feature-flag mechanism).
- Rendering reuses the existing markdown-it → sanitize → `dangerouslySetInnerHTML` pipeline already used for case comments and chat answers (`CsmCaseCommentBubble.tsx`), with a new `markdownToHtmlProse` (breaks: false) variant so hand-wrapped prose doesn't render its source line-wraps as forced `<br>`s the way chat's breaks:true does.
- 13 topics total: the 11 existing nav sections, plus two new cross-cutting ones (Navigation & personalization; People & project access) added because those features don't belong to any single nav section.
- Content for every topic is grounded in the actual current UI/behavior (verified by reading the relevant feature code before writing), not generic filler.

## User stories
As a CS engineer, I can open Help from the sidebar and read what each portal section does, how to pin/rename pages, how saved filter views work, and how to read a person's project-access status — without asking a teammate.

## Release note
Added an in-app Help section to the CSM portal with a guide covering every major area of the app.

## Documentation
N/A — this PR *is* the documentation (in-app).

## Training
N/A

## Certification
N/A — no certification exam impact.

## Marketing
N/A

## Samples
N/A

## Related PRs
None

## Migrations (if applicable)
N/A — no data model or migration involved (static content only).

## Test environment
Verified locally: `pnpm run lint`, `pnpm run test` (188 files / 1913 tests), `pnpm run build`.

## Automation tests
- Unit tests: new/updated tests for the nav config, content registry, image-resolution helper, and the Help page/topic components (including two adversarial tests confirming a raw `<script>` tag and a raw `onerror` attribute never survive the render pipeline).
- Integration tests: none added; covered by unit-level render tests instead.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines: yes
- Ran FindSecurityBugs plugin and verified report: no (JS/TS-only change; not applicable to this toolchain)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets: yes

## Learning
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Help section with a dedicated `/help` page and topic-based navigation.
  * Added comprehensive documentation for portal features, including cases, customers, operations, settings, security, dashboards, time cards, and more.
  * Added formatted Markdown content with responsive tables, code, links, images, and sanitized HTML.
  * Added a floating back-to-top button for easier navigation on long help pages.
* **Tests**
  * Added coverage for navigation, topic rendering, scrolling, content completeness, image handling, and HTML sanitization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->