### PR TITLE
[CSM Portal] Live-updating relative timestamps and refresh indicators

### DIFF
--- a/apps/csm-portal/webapp/src/components/RefreshButton.test.tsx
+++ b/apps/csm-portal/webapp/src/components/RefreshButton.test.tsx
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import RefreshButton from "@components/RefreshButton";
+
+describe("RefreshButton", () => {
+  it("does not show the 'Last refreshed' hint on initial load, even when updatedAt is already set", () => {
+    const onRefresh = vi.fn();
+    render(
+      <RefreshButton
+        onRefresh={onRefresh}
+        isFetching={false}
+        updatedAt={Date.now()}
+        label="Refresh"
+      />,
+    );
+
+    expect(screen.queryByText(/last refreshed/i)).not.toBeInTheDocument();
+  });
+
+  it("shows the 'Last refreshed' hint after the user manually clicks refresh, and calls onRefresh", () => {
+    const onRefresh = vi.fn();
+    render(
+      <RefreshButton
+        onRefresh={onRefresh}
+        isFetching={false}
+        updatedAt={Date.now()}
+        label="Refresh"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+    expect(screen.getByText(/last refreshed/i)).toBeInTheDocument();
+  });
+
+  it("does not show the hint after a click if updatedAt is still unset", () => {
+    const onRefresh = vi.fn();
+    render(
+      <RefreshButton onRefresh={onRefresh} isFetching={false} label="Refresh" />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText(/last refreshed/i)).not.toBeInTheDocument();
+  });
+});

--- a/apps/csm-portal/webapp/src/components/RefreshButton.tsx
+++ b/apps/csm-portal/webapp/src/components/RefreshButton.tsx
@@ -43,18 +43,21 @@ export default function RefreshButton({
   updatedAt,
   label,
 }: RefreshButtonProps): JSX.Element {
+  // The "Last refreshed" hint only appears after the user has manually
+  // clicked this control at least once — not from the page's initial data
+  // load, which also sets `updatedAt`.
+  const [hasManuallyRefreshed, setHasManuallyRefreshed] = useState(false);
+
   // Re-render exactly when "Last refreshed …" text would next change
   // (adaptive shared scheduler — see RelativeTime.tsx), without requiring
   // another fetch or unrelated state change. `now` is passed explicitly
   // into `formatRelativeTime` below (rather than relying on its internal
   // `Date.now()` default) so the React Compiler's auto-memoization sees it
-  // as a dependency and recomputes the label.
-  const now = useRelativeTimeTick(updatedAt);
-
-  // The "Last refreshed" hint only appears after the user has manually
-  // clicked this control at least once — not from the page's initial data
-  // load, which also sets `updatedAt`.
-  const [hasManuallyRefreshed, setHasManuallyRefreshed] = useState(false);
+  // as a dependency and recomputes the label. Only registered with the
+  // shared scheduler once the label is actually going to render — before
+  // the first manual refresh, the hint is hidden, so there's nothing to
+  // tick for.
+  const now = useRelativeTimeTick(hasManuallyRefreshed ? updatedAt : null);
 
   const handleRefreshClick = (): void => {
     setHasManuallyRefreshed(true);

--- a/apps/csm-portal/webapp/src/components/RefreshButton.tsx
+++ b/apps/csm-portal/webapp/src/components/RefreshButton.tsx
@@ -18,6 +18,7 @@ import { Box, IconButton, Tooltip, Typography } from "@wso2/oxygen-ui";
 import { RefreshCw } from "@wso2/oxygen-ui-icons-react";
 import type { JSX } from "react";
 import { formatRelativeTime } from "@features/csm-dashboard/utils/abtDashboard";
+import { useRelativeTimeTick } from "@components/RelativeTime";
 
 interface RefreshButtonProps {
   /** Re-runs the underlying query. Wire to the react-query `refetch`. */
@@ -41,12 +42,19 @@ export default function RefreshButton({
   updatedAt,
   label,
 }: RefreshButtonProps): JSX.Element {
+  // Re-render on the shared tick so "Last refreshed …" keeps advancing
+  // without requiring another fetch or unrelated state change. `now` is
+  // passed explicitly into `formatRelativeTime` below (rather than relying
+  // on its internal `Date.now()` default) so the React Compiler's
+  // auto-memoization sees the tick as a dependency and recomputes the label.
+  const now = useRelativeTimeTick();
+
   return (
     <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
       {updatedAt ? (
         <Typography variant="caption" color="text.secondary">
           Last refreshed{" "}
-          {formatRelativeTime(new Date(updatedAt).toISOString())}
+          {formatRelativeTime(new Date(updatedAt).toISOString(), now)}
         </Typography>
       ) : null}
       <Tooltip title={label}>

--- a/apps/csm-portal/webapp/src/components/RefreshButton.tsx
+++ b/apps/csm-portal/webapp/src/components/RefreshButton.tsx
@@ -17,6 +17,7 @@
 import { Box, IconButton, Tooltip, Typography } from "@wso2/oxygen-ui";
 import { RefreshCw } from "@wso2/oxygen-ui-icons-react";
 import type { JSX } from "react";
+import { useState } from "react";
 import { formatRelativeTime } from "@features/csm-dashboard/utils/abtDashboard";
 import { useRelativeTimeTick } from "@components/RelativeTime";
 
@@ -50,9 +51,19 @@ export default function RefreshButton({
   // as a dependency and recomputes the label.
   const now = useRelativeTimeTick(updatedAt);
 
+  // The "Last refreshed" hint only appears after the user has manually
+  // clicked this control at least once — not from the page's initial data
+  // load, which also sets `updatedAt`.
+  const [hasManuallyRefreshed, setHasManuallyRefreshed] = useState(false);
+
+  const handleRefreshClick = (): void => {
+    setHasManuallyRefreshed(true);
+    onRefresh();
+  };
+
   return (
     <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-      {updatedAt ? (
+      {hasManuallyRefreshed && updatedAt ? (
         <Typography variant="caption" color="text.secondary">
           Last refreshed{" "}
           {formatRelativeTime(new Date(updatedAt).toISOString(), now)}
@@ -63,7 +74,7 @@ export default function RefreshButton({
         <span>
           <IconButton
             size="small"
-            onClick={onRefresh}
+            onClick={handleRefreshClick}
             disabled={isFetching}
             aria-label={label}
           >

--- a/apps/csm-portal/webapp/src/components/RefreshButton.tsx
+++ b/apps/csm-portal/webapp/src/components/RefreshButton.tsx
@@ -42,12 +42,13 @@ export default function RefreshButton({
   updatedAt,
   label,
 }: RefreshButtonProps): JSX.Element {
-  // Re-render on the shared tick so "Last refreshed …" keeps advancing
-  // without requiring another fetch or unrelated state change. `now` is
-  // passed explicitly into `formatRelativeTime` below (rather than relying
-  // on its internal `Date.now()` default) so the React Compiler's
-  // auto-memoization sees the tick as a dependency and recomputes the label.
-  const now = useRelativeTimeTick();
+  // Re-render exactly when "Last refreshed …" text would next change
+  // (adaptive shared scheduler — see RelativeTime.tsx), without requiring
+  // another fetch or unrelated state change. `now` is passed explicitly
+  // into `formatRelativeTime` below (rather than relying on its internal
+  // `Date.now()` default) so the React Compiler's auto-memoization sees it
+  // as a dependency and recomputes the label.
+  const now = useRelativeTimeTick(updatedAt);
 
   return (
     <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>

--- a/apps/csm-portal/webapp/src/components/RelativeTime.test.tsx
+++ b/apps/csm-portal/webapp/src/components/RelativeTime.test.tsx
@@ -182,6 +182,40 @@ describe("RelativeTime", () => {
     }
   });
 
+  it("does not show a stale/negative ('from now') time when a fresh timestamp registers after time has passed with nothing tracked", () => {
+    // Reproduces the real trigger: RefreshButton/CaseSlaTable mount with no
+    // `updatedAt` yet (nothing registered with the scheduler, so `now`
+    // never ticks), then later re-render with a brand-new "right now"
+    // timestamp once a refresh completes — e.g. a user clicking refresh a
+    // couple of minutes after page load.
+    vi.useFakeTimers();
+    try {
+      const start = new Date("2026-08-22T10:00:00.000Z");
+      vi.setSystemTime(start);
+
+      const { rerender } = render(<RelativeTime iso={null} />);
+      // Nothing tracked yet -> no scheduler registration, no pending timer.
+      expect(vi.getTimerCount()).toBe(0);
+
+      // Two minutes pass with nothing registered, so the shared scheduler
+      // never fires and this instance's `now` state is never refreshed.
+      act(() => {
+        vi.advanceTimersByTime(2 * 60_000);
+      });
+
+      // A fresh timestamp ("now", from the advanced clock's perspective)
+      // registers — e.g. a refresh completing right now.
+      const freshIso = new Date().toISOString();
+      rerender(<RelativeTime iso={freshIso} />);
+
+      // Must read "just now" immediately, not a transient "0m from now"
+      // computed against the stale `now` left over from mount.
+      expect(screen.getByText("just now")).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("clears its scheduler registration on unmount, leaving no pending timer once nothing is mounted", () => {
     vi.useFakeTimers();
     try {

--- a/apps/csm-portal/webapp/src/components/RelativeTime.test.tsx
+++ b/apps/csm-portal/webapp/src/components/RelativeTime.test.tsx
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 import RelativeTime from "@components/RelativeTime";
@@ -97,5 +97,29 @@ describe("RelativeTime", () => {
       name: /copy link to this entry/i,
     });
     expect(() => fireEvent.click(button)).not.toThrow();
+  });
+
+  it("updates the displayed relative text on its own, without a re-render trigger from the parent", () => {
+    vi.useFakeTimers();
+    try {
+      const start = new Date("2026-08-22T10:00:00.000Z");
+      vi.setSystemTime(start);
+      const fixedIso = new Date(start.getTime() - 60_000).toISOString(); // "1m ago"
+
+      render(<RelativeTime iso={fixedIso} />);
+      expect(screen.getByText("1m ago")).toBeInTheDocument();
+
+      // Advance the clock by 6 minutes' worth of ticks with no parent
+      // re-render and no user interaction — only the internal timer fires.
+      // `advanceTimersByTime` also advances the fake system clock itself, so
+      // this alone moves both "now" and the interval forward together.
+      act(() => {
+        vi.advanceTimersByTime(6 * 60_000);
+      });
+
+      expect(screen.getByText("7m ago")).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/apps/csm-portal/webapp/src/components/RelativeTime.test.tsx
+++ b/apps/csm-portal/webapp/src/components/RelativeTime.test.tsx
@@ -109,15 +109,92 @@ describe("RelativeTime", () => {
       render(<RelativeTime iso={fixedIso} />);
       expect(screen.getByText("1m ago")).toBeInTheDocument();
 
-      // Advance the clock by 6 minutes' worth of ticks with no parent
-      // re-render and no user interaction — only the internal timer fires.
-      // `advanceTimersByTime` also advances the fake system clock itself, so
-      // this alone moves both "now" and the interval forward together.
+      // Advance the clock by 6 minutes' worth of real time with no parent
+      // re-render and no user interaction — only the shared scheduler's
+      // internal timer(s) fire. `advanceTimersByTime` also advances the fake
+      // system clock itself, so this alone moves both "now" and the
+      // scheduled fire(s) forward together.
       act(() => {
         vi.advanceTimersByTime(6 * 60_000);
       });
 
       expect(screen.getByText("7m ago")).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("schedules exactly one adaptive timer, firing at the next minute boundary rather than a fixed interval", () => {
+    vi.useFakeTimers();
+    try {
+      const start = new Date("2026-08-22T10:00:00.000Z");
+      vi.setSystemTime(start);
+      // 58s ago: still "just now" (< 1 minute), and only 2s from crossing
+      // into the "1m ago" bucket.
+      const fixedIso = new Date(start.getTime() - 58_000).toISOString();
+
+      render(<RelativeTime iso={fixedIso} />);
+      expect(screen.getByText("just now")).toBeInTheDocument();
+      // One timestamp mounted -> exactly one scheduled timer, not a fixed
+      // fixed-cadence poller.
+      expect(vi.getTimerCount()).toBe(1);
+
+      // Advancing by less than the 2s remaining must not flip the text yet
+      // — proves the scheduler isn't just waiting a fixed 20s (or any other
+      // arbitrary cadence) and firing early/late relative to the boundary.
+      act(() => {
+        vi.advanceTimersByTime(1_000);
+      });
+      expect(screen.getByText("just now")).toBeInTheDocument();
+
+      // Crossing the remaining ~1s past the boundary flips it to "1m ago".
+      act(() => {
+        vi.advanceTimersByTime(1_500);
+      });
+      expect(screen.getByText("1m ago")).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not schedule frequent wakeups for an old timestamp already in the day bucket", () => {
+    vi.useFakeTimers();
+    try {
+      const start = new Date("2026-08-22T10:00:00.000Z");
+      vi.setSystemTime(start);
+      const fixedIso = new Date(
+        start.getTime() - 3 * 24 * 60 * 60_000,
+      ).toISOString(); // "3d ago"
+
+      render(<RelativeTime iso={fixedIso} />);
+      expect(screen.getByText("3d ago")).toBeInTheDocument();
+      expect(vi.getTimerCount()).toBe(1);
+
+      // A "3d ago" display only changes on the next full day boundary, so an
+      // hour of elapsed time — several multiples of the old 20s fixed
+      // interval — must not touch the displayed text at all.
+      act(() => {
+        vi.advanceTimersByTime(60 * 60_000);
+      });
+      expect(screen.getByText("3d ago")).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("clears its scheduler registration on unmount, leaving no pending timer once nothing is mounted", () => {
+    vi.useFakeTimers();
+    try {
+      const start = new Date("2026-08-22T10:00:00.000Z");
+      vi.setSystemTime(start);
+      const fixedIso = new Date(start.getTime() - 60_000).toISOString();
+
+      const { unmount } = render(<RelativeTime iso={fixedIso} />);
+      expect(vi.getTimerCount()).toBe(1);
+
+      unmount();
+
+      expect(vi.getTimerCount()).toBe(0);
     } finally {
       vi.useRealTimers();
     }

--- a/apps/csm-portal/webapp/src/components/RelativeTime.tsx
+++ b/apps/csm-portal/webapp/src/components/RelativeTime.tsx
@@ -16,9 +16,70 @@
 
 import { Box, Button, Tooltip } from "@wso2/oxygen-ui";
 import { Check, Link2 } from "@wso2/oxygen-ui-icons-react";
-import { useState, type JSX } from "react";
+import { useEffect, useState, type JSX } from "react";
 import { formatRelativeTime } from "@features/csm-dashboard/utils/abtDashboard";
 import { formatAbsoluteForUser } from "@utils/dateTime";
+
+/** How often mounted relative-time displays refresh themselves. Coarser than
+ * a second-level ticker since the display granularity is minutes, but tight
+ * enough that "1m ago" turning into "2m ago" feels prompt. */
+const TICK_INTERVAL_MS = 20_000;
+
+type TickListener = () => void;
+
+/** Module-level subscriber set backing a single shared `setInterval`, so a
+ * page with many relative timestamps mounted at once (e.g. a `CasesList`
+ * table, or a long comment thread) re-renders off one timer instead of one
+ * per instance. */
+const tickListeners = new Set<TickListener>();
+let tickIntervalId: ReturnType<typeof setInterval> | null = null;
+
+function ensureTicking(): void {
+  if (tickIntervalId !== null) return;
+  tickIntervalId = setInterval(() => {
+    tickListeners.forEach((listener) => listener());
+  }, TICK_INTERVAL_MS);
+}
+
+function stopTickingIfIdle(): void {
+  if (tickListeners.size === 0 && tickIntervalId !== null) {
+    clearInterval(tickIntervalId);
+    tickIntervalId = null;
+  }
+}
+
+/**
+ * Subscribes the calling component to the shared tick and returns the
+ * timestamp (ms) as of the last tick, so it re-renders — and recomputes
+ * whatever it derives from "now" — on the same cadence as every other
+ * `RelativeTime` on the page. Used by {@link RelativeTime} itself, and by
+ * the two "Last refreshed …" labels (`CaseSlaTable`, `RefreshButton`) that
+ * format a relative string outside this component.
+ *
+ * Deliberately returns the timestamp itself, not an opaque counter: this
+ * webapp runs the React Compiler, which auto-memoizes calls like
+ * `formatRelativeTime(iso)` against the reactive values they visibly read.
+ * A counter that's merely in scope wouldn't be picked up as a dependency —
+ * the caller must pass this value in as the explicit `now` argument (see
+ * `formatRelativeTime`'s second parameter) for the compiler to know the
+ * result needs recomputing on every tick.
+ */
+// eslint-disable-next-line react-refresh/only-export-components -- hook is colocated with the shared ticker it manages, and reused by the two other relative-time call sites (fast-refresh DX only)
+export function useRelativeTimeTick(): number {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    const listener = (): void => setNow(Date.now());
+    tickListeners.add(listener);
+    ensureTicking();
+    return () => {
+      tickListeners.delete(listener);
+      stopTickingIfIdle();
+    };
+  }, []);
+
+  return now;
+}
 
 interface RelativeTimeProps {
   /** Backend timestamp string (assumed UTC if no zone is present). */
@@ -88,7 +149,10 @@ export default function RelativeTime({
   href,
   className,
 }: RelativeTimeProps): JSX.Element {
-  const relative = formatRelativeTime(iso);
+  // Subscribed only to trigger a re-render on each tick; the recomputed
+  // relative string below always reads a fresh `Date.now()` internally.
+  const now = useRelativeTimeTick();
+  const relative = formatRelativeTime(iso, now);
   const absolute = formatAbsoluteForUser(iso) ?? "Unknown time";
 
   const inner = href ? (

--- a/apps/csm-portal/webapp/src/components/RelativeTime.tsx
+++ b/apps/csm-portal/webapp/src/components/RelativeTime.tsx
@@ -16,45 +16,112 @@
 
 import { Box, Button, Tooltip } from "@wso2/oxygen-ui";
 import { Check, Link2 } from "@wso2/oxygen-ui-icons-react";
-import { useEffect, useState, type JSX } from "react";
+import { useEffect, useRef, useState, type JSX } from "react";
 import { formatRelativeTime } from "@features/csm-dashboard/utils/abtDashboard";
-import { formatAbsoluteForUser } from "@utils/dateTime";
+import { formatAbsoluteForUser, parseBackendTimestamp } from "@utils/dateTime";
 
-/** How often mounted relative-time displays refresh themselves. Coarser than
- * a second-level ticker since the display granularity is minutes, but tight
- * enough that "1m ago" turning into "2m ago" feels prompt. */
-const TICK_INTERVAL_MS = 20_000;
+/**
+ * The granularity `formatRelativeTime` displays at, by how far `abs` (the
+ * distance between the tracked timestamp and "now") currently is. Mirrors
+ * that function's own bucketing (`diffMin` while `abs < 1h`, `diffHr` while
+ * `abs < 24h`, `diffDay` beyond that) so the scheduler wakes up exactly when
+ * the displayed text would actually change, not on a fixed cadence.
+ */
+const MINUTE_MS = 60_000;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
 
-type TickListener = () => void;
-
-/** Module-level subscriber set backing a single shared `setInterval`, so a
- * page with many relative timestamps mounted at once (e.g. a `CasesList`
- * table, or a long comment thread) re-renders off one timer instead of one
- * per instance. */
-const tickListeners = new Set<TickListener>();
-let tickIntervalId: ReturnType<typeof setInterval> | null = null;
-
-function ensureTicking(): void {
-  if (tickIntervalId !== null) return;
-  tickIntervalId = setInterval(() => {
-    tickListeners.forEach((listener) => listener());
-  }, TICK_INTERVAL_MS);
-}
-
-function stopTickingIfIdle(): void {
-  if (tickListeners.size === 0 && tickIntervalId !== null) {
-    clearInterval(tickIntervalId);
-    tickIntervalId = null;
-  }
+function currentGranularityMs(absMs: number): number {
+  if (absMs < HOUR_MS) return MINUTE_MS;
+  if (absMs < DAY_MS) return HOUR_MS;
+  return DAY_MS;
 }
 
 /**
- * Subscribes the calling component to the shared tick and returns the
- * timestamp (ms) as of the last tick, so it re-renders — and recomputes
- * whatever it derives from "now" — on the same cadence as every other
- * `RelativeTime` on the page. Used by {@link RelativeTime} itself, and by
- * the two "Last refreshed …" labels (`CaseSlaTable`, `RefreshButton`) that
- * format a relative string outside this component.
+ * How long from `nowMs` until the text for a timestamp at `timestampMs`
+ * would next change. Handles both directions `formatRelativeTime` supports:
+ *
+ * - Past ("Xm ago"): `abs` grows as real time passes, so the next change is
+ *   when `abs` reaches the *next* multiple of the current granularity.
+ * - Future ("Xm from now"): `abs` shrinks as real time passes (converging on
+ *   the timestamp), so the next change is when `abs` drops to the *current*
+ *   (lower) multiple of the granularity.
+ *
+ * Clamped to a 1s floor purely to avoid a zero-delay `setTimeout` re-firing
+ * immediately due to integer rounding at an exact boundary — sub-second
+ * precision isn't meaningful here since the coarsest display unit is a
+ * minute.
+ */
+function nextChangeDelayMs(timestampMs: number, nowMs: number): number {
+  const diffMs = nowMs - timestampMs;
+  const absMs = Math.abs(diffMs);
+  const granularity = currentGranularityMs(absMs);
+  const bucket = Math.floor(absMs / granularity);
+  const delay =
+    diffMs >= 0
+      ? (bucket + 1) * granularity - absMs // past: wait for abs to grow into the next bucket
+      : absMs - bucket * granularity; // future: wait for abs to shrink out of this bucket
+  return Math.max(delay, 1000);
+}
+
+type TickListener = () => void;
+
+interface Registration {
+  timestampMs: number;
+  listener: TickListener;
+}
+
+/** Module-level registry backing a single shared, adaptively-scheduled
+ * timer, so a page with many relative timestamps mounted at once (e.g. a
+ * `CasesList` table, or a long comment thread) re-renders off one timer
+ * instead of one per instance — and that one timer only wakes when some
+ * registered timestamp's displayed text would actually change, instead of
+ * polling on a fixed cadence. Keyed by a per-hook-instance object identity
+ * rather than the timestamp value, since two mounted instances can track
+ * the same timestamp. */
+const registrations = new Map<object, Registration>();
+let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+function fireTick(): void {
+  timeoutId = null;
+  registrations.forEach(({ listener }) => listener());
+  reschedule();
+}
+
+/** Recomputes the minimum "next change" delay across every currently
+ * registered timestamp and (re)schedules a single `setTimeout` for it.
+ * Always clears any existing timer first — called both when the timer
+ * itself fires and whenever the registered set changes (mount, unmount, or
+ * a tracked timestamp changing), so the scheduled delay never goes stale. */
+function reschedule(): void {
+  if (timeoutId !== null) {
+    clearTimeout(timeoutId);
+    timeoutId = null;
+  }
+  if (registrations.size === 0) return;
+  const nowMs = Date.now();
+  let minDelay: number | null = null;
+  registrations.forEach(({ timestampMs }) => {
+    const delay = nextChangeDelayMs(timestampMs, nowMs);
+    if (minDelay === null || delay < minDelay) minDelay = delay;
+  });
+  if (minDelay === null) return;
+  timeoutId = setTimeout(fireTick, minDelay);
+}
+
+/**
+ * Subscribes the calling component to the shared adaptive scheduler and
+ * returns the timestamp (ms) as of the last update, so it re-renders — and
+ * recomputes whatever it derives from "now" — exactly when its own tracked
+ * timestamp's displayed text would change (not on a fixed cadence shared
+ * with every other timestamp on the page). Used by {@link RelativeTime}
+ * itself, and by the two "Last refreshed …" labels (`CaseSlaTable`,
+ * `RefreshButton`) that format a relative string outside this component.
+ *
+ * `trackedMs` is the epoch-ms of the timestamp this caller displays —
+ * falsy (`undefined`/`null`/`0`/`NaN`) means "nothing to display yet"
+ * (matches the callers' own `updatedAt ? … : null` guards), so the hook
+ * simply doesn't register with the scheduler in that case.
  *
  * Deliberately returns the timestamp itself, not an opaque counter: this
  * webapp runs the React Compiler, which auto-memoizes calls like
@@ -62,21 +129,30 @@ function stopTickingIfIdle(): void {
  * A counter that's merely in scope wouldn't be picked up as a dependency —
  * the caller must pass this value in as the explicit `now` argument (see
  * `formatRelativeTime`'s second parameter) for the compiler to know the
- * result needs recomputing on every tick.
+ * result needs recomputing on every update.
  */
-// eslint-disable-next-line react-refresh/only-export-components -- hook is colocated with the shared ticker it manages, and reused by the two other relative-time call sites (fast-refresh DX only)
-export function useRelativeTimeTick(): number {
+// eslint-disable-next-line react-refresh/only-export-components -- hook is colocated with the shared scheduler it manages, and reused by the two other relative-time call sites (fast-refresh DX only)
+export function useRelativeTimeTick(trackedMs?: number | null): number {
   const [now, setNow] = useState(() => Date.now());
+  const keyRef = useRef<object>({});
 
   useEffect(() => {
-    const listener = (): void => setNow(Date.now());
-    tickListeners.add(listener);
-    ensureTicking();
+    const key = keyRef.current;
+    if (!trackedMs || !Number.isFinite(trackedMs)) {
+      registrations.delete(key);
+      reschedule();
+      return;
+    }
+    registrations.set(key, {
+      timestampMs: trackedMs,
+      listener: () => setNow(Date.now()),
+    });
+    reschedule();
     return () => {
-      tickListeners.delete(listener);
-      stopTickingIfIdle();
+      registrations.delete(key);
+      reschedule();
     };
-  }, []);
+  }, [trackedMs]);
 
   return now;
 }
@@ -149,9 +225,12 @@ export default function RelativeTime({
   href,
   className,
 }: RelativeTimeProps): JSX.Element {
-  // Subscribed only to trigger a re-render on each tick; the recomputed
-  // relative string below always reads a fresh `Date.now()` internally.
-  const now = useRelativeTimeTick();
+  // Resolve the epoch this instance tracks, so the shared scheduler can
+  // compute exactly when *this* timestamp's display text would next change
+  // — mirrors the parsing `formatRelativeTime` itself does below.
+  const parsed = iso ? parseBackendTimestamp(iso) : null;
+  const trackedMs = parsed ? parsed.getTime() : iso ? new Date(iso).getTime() : null;
+  const now = useRelativeTimeTick(Number.isNaN(trackedMs) ? null : trackedMs);
   const relative = formatRelativeTime(iso, now);
   const absolute = formatAbsoluteForUser(iso) ?? "Unknown time";
 

--- a/apps/csm-portal/webapp/src/components/RelativeTime.tsx
+++ b/apps/csm-portal/webapp/src/components/RelativeTime.tsx
@@ -148,6 +148,17 @@ export function useRelativeTimeTick(trackedMs?: number | null): number {
       listener: () => setNow(Date.now()),
     });
     reschedule();
+    // Registering (or re-registering on a `trackedMs` change) only sets up
+    // a FUTURE timer via `reschedule()` above — it doesn't itself refresh
+    // `now`. Without this, a component whose `now` state went stale while
+    // mounted (nothing tracked, or its previous tracked timestamp hadn't
+    // ticked yet) would compare a freshly-set `trackedMs` (e.g. "right now"
+    // from a refresh click) against that stale `now`, producing a
+    // transient negative diff ("Xm from now") until the next scheduled
+    // tick self-corrects it. Refresh immediately so a new registration is
+    // never rendered against a stale `now`.
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- syncs `now` to the external shared-scheduler registry the instant this instance (re)registers a timestamp, so it's never rendered against a stale `now` left over from before this timestamp existed
+    setNow(Date.now());
     return () => {
       registrations.delete(key);
       reschedule();

--- a/apps/csm-portal/webapp/src/components/RelativeTime.tsx
+++ b/apps/csm-portal/webapp/src/components/RelativeTime.tsx
@@ -16,7 +16,7 @@
 
 import { Box, Button, Tooltip } from "@wso2/oxygen-ui";
 import { Check, Link2 } from "@wso2/oxygen-ui-icons-react";
-import { useEffect, useRef, useState, type JSX } from "react";
+import { useEffect, useLayoutEffect, useRef, useState, type JSX } from "react";
 import { formatRelativeTime } from "@features/csm-dashboard/utils/abtDashboard";
 import { formatAbsoluteForUser, parseBackendTimestamp } from "@utils/dateTime";
 
@@ -136,9 +136,47 @@ export function useRelativeTimeTick(trackedMs?: number | null): number {
   const [now, setNow] = useState(() => Date.now());
   const keyRef = useRef<object>({});
 
+  // Corrects `now` the instant `trackedMs` changes to an actual tracked
+  // value, via `useLayoutEffect` rather than the registration `useEffect`
+  // below — layout effects flush synchronously before the browser paints,
+  // so this `setNow` lands before anything is visible to the user, with no
+  // separate committed frame showing the stale value in between. Without
+  // this, a component whose `now` state went stale while mounted (nothing
+  // tracked, or its previous tracked timestamp hadn't ticked yet) would
+  // compare a freshly-set `trackedMs` (e.g. "right now" from a refresh
+  // click) against that stale `now`, producing a transient negative diff
+  // ("Xm from now") until the next scheduled tick self-corrects it.
+  //
+  // Gated the same way the registration effect below is (nothing to do
+  // when `trackedMs` is absent) — an earlier version of this ran
+  // unconditionally on every `trackedMs` change including "became
+  // untracked," which set state (and forced an extra render) on every
+  // mount even for a component with nothing tracked at all. That extra
+  // render happened to run before `useElementVisibleOnce`'s own mount
+  // effect (see that hook's `[ref.current]` dependency) captured a stable
+  // `ref.current`, so it re-observed a second time — caught by
+  // `DashboardWidgetGrid.realisticViewport.test.tsx` asserting exactly one
+  // `IntersectionObserver` instance per widget, not this task's own
+  // authored test.
+  //
+  // React's own docs describe adjusting state synchronously during the
+  // render body itself for this exact "correct state when a prop changes"
+  // shape (https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes),
+  // which would avoid this hook needing an effect for the correction at
+  // all — but this app runs the React Compiler with its purity rule
+  // enforced (`react-hooks/purity`), which rejects `Date.now()` (impure)
+  // called from a render body outright, so that specific shape isn't
+  // available here; a layout effect is the closest equivalent this
+  // codebase's lint config allows.
+  useLayoutEffect(() => {
+    if (trackedMs == null || !Number.isFinite(trackedMs)) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- syncs `now` to the external shared-scheduler registry the instant this instance's tracked timestamp changes, so it's never rendered against a stale `now` left over from before this timestamp existed; see this effect's own comment above for why it's a layout effect specifically
+    setNow(Date.now());
+  }, [trackedMs]);
+
   useEffect(() => {
     const key = keyRef.current;
-    if (!trackedMs || !Number.isFinite(trackedMs)) {
+    if (trackedMs == null || !Number.isFinite(trackedMs)) {
       registrations.delete(key);
       reschedule();
       return;
@@ -148,17 +186,6 @@ export function useRelativeTimeTick(trackedMs?: number | null): number {
       listener: () => setNow(Date.now()),
     });
     reschedule();
-    // Registering (or re-registering on a `trackedMs` change) only sets up
-    // a FUTURE timer via `reschedule()` above — it doesn't itself refresh
-    // `now`. Without this, a component whose `now` state went stale while
-    // mounted (nothing tracked, or its previous tracked timestamp hadn't
-    // ticked yet) would compare a freshly-set `trackedMs` (e.g. "right now"
-    // from a refresh click) against that stale `now`, producing a
-    // transient negative diff ("Xm from now") until the next scheduled
-    // tick self-corrects it. Refresh immediately so a new registration is
-    // never rendered against a stale `now`.
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- syncs `now` to the external shared-scheduler registry the instant this instance (re)registers a timestamp, so it's never rendered against a stale `now` left over from before this timestamp existed
-    setNow(Date.now());
     return () => {
       registrations.delete(key);
       reschedule();

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseSlaTable.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseSlaTable.test.tsx
@@ -101,6 +101,21 @@ describe("CaseSlaTable", () => {
     expect(refetch).toHaveBeenCalled();
   });
 
+  it("shows the 'Last refreshed' hint only after a manual refresh click, not on initial load", () => {
+    const refetch = vi.fn();
+    const list: CaseSlaList = { caseId: "case-1", count: 1, slas: [SLA_ROW] };
+    mockResult({ data: list, refetch, dataUpdatedAt: Date.now() });
+    render(<CaseSlaTable caseId="case-1" />);
+
+    // Initial load already set `dataUpdatedAt`, but the hint must stay hidden.
+    expect(screen.queryByText(/last refreshed/i)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /refresh slas/i }));
+
+    expect(refetch).toHaveBeenCalled();
+    expect(screen.getByText(/last refreshed/i)).toBeInTheDocument();
+  });
+
   it("shows a truncation notice when fewer rows are rendered than the total count", () => {
     const list: CaseSlaList = { caseId: "case-1", count: 51, slas: [SLA_ROW] };
     mockResult({ data: list });

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseSlaTable.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseSlaTable.tsx
@@ -34,6 +34,7 @@ import { Clock, RefreshCw } from "@wso2/oxygen-ui-icons-react";
 import type { JSX } from "react";
 import { formatAbsoluteForUser } from "@utils/dateTime";
 import { formatRelativeTime } from "@features/csm-dashboard/utils/abtDashboard";
+import { useRelativeTimeTick } from "@components/RelativeTime";
 import { useGetCsmCaseSlas } from "@features/csm-cases/api/useGetCsmCaseSlas";
 import type { CaseSla } from "@features/csm-cases/types/csmCases";
 
@@ -94,6 +95,12 @@ interface CaseSlaTableProps {
 export function CaseSlaTable({ caseId }: CaseSlaTableProps): JSX.Element {
   const { data, isLoading, isError, isFetching, dataUpdatedAt, refetch } =
     useGetCsmCaseSlas(caseId);
+  // Re-render on the shared tick so "Last refreshed …" keeps advancing
+  // without requiring another fetch or unrelated state change. `now` is
+  // passed explicitly into `formatRelativeTime` below (rather than relying
+  // on its internal `Date.now()` default) so the React Compiler's
+  // auto-memoization sees the tick as a dependency and recomputes the label.
+  const now = useRelativeTimeTick();
 
   const slas = data?.slas ?? [];
   const count = data?.count ?? slas.length;
@@ -121,7 +128,8 @@ export function CaseSlaTable({ caseId }: CaseSlaTableProps): JSX.Element {
         <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
           {dataUpdatedAt ? (
             <Typography variant="caption" color="text.secondary">
-              Last refreshed {formatRelativeTime(new Date(dataUpdatedAt).toISOString())}
+              Last refreshed{" "}
+              {formatRelativeTime(new Date(dataUpdatedAt).toISOString(), now)}
             </Typography>
           ) : null}
           <IconButton

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseSlaTable.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseSlaTable.tsx
@@ -32,6 +32,7 @@ import {
 } from "@wso2/oxygen-ui";
 import { Clock, RefreshCw } from "@wso2/oxygen-ui-icons-react";
 import type { JSX } from "react";
+import { useState } from "react";
 import { formatAbsoluteForUser } from "@utils/dateTime";
 import { formatRelativeTime } from "@features/csm-dashboard/utils/abtDashboard";
 import { useRelativeTimeTick } from "@components/RelativeTime";
@@ -103,6 +104,16 @@ export function CaseSlaTable({ caseId }: CaseSlaTableProps): JSX.Element {
   // as a dependency and recomputes the label.
   const now = useRelativeTimeTick(dataUpdatedAt);
 
+  // The "Last refreshed" hint only appears after the user has manually
+  // clicked refresh at least once — not from the tab's initial data load,
+  // which also sets `dataUpdatedAt`.
+  const [hasManuallyRefreshed, setHasManuallyRefreshed] = useState(false);
+
+  const handleRefreshClick = (): void => {
+    setHasManuallyRefreshed(true);
+    void refetch();
+  };
+
   const slas = data?.slas ?? [];
   const count = data?.count ?? slas.length;
   const isTruncated = !isLoading && !isError && slas.length < count;
@@ -127,7 +138,7 @@ export function CaseSlaTable({ caseId }: CaseSlaTableProps): JSX.Element {
           )}
         </Box>
         <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-          {dataUpdatedAt ? (
+          {hasManuallyRefreshed && dataUpdatedAt ? (
             <Typography variant="caption" color="text.secondary">
               Last refreshed{" "}
               {formatRelativeTime(new Date(dataUpdatedAt).toISOString(), now)}
@@ -135,7 +146,7 @@ export function CaseSlaTable({ caseId }: CaseSlaTableProps): JSX.Element {
           ) : null}
           <IconButton
             size="small"
-            onClick={() => void refetch()}
+            onClick={handleRefreshClick}
             disabled={isFetching}
             aria-label="Refresh SLAs"
           >
@@ -168,7 +179,7 @@ export function CaseSlaTable({ caseId }: CaseSlaTableProps): JSX.Element {
             size="small"
             variant="outlined"
             startIcon={<RefreshCw size={14} />}
-            onClick={() => void refetch()}
+            onClick={handleRefreshClick}
             sx={{ textTransform: "none" }}
           >
             Retry

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseSlaTable.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseSlaTable.tsx
@@ -95,12 +95,13 @@ interface CaseSlaTableProps {
 export function CaseSlaTable({ caseId }: CaseSlaTableProps): JSX.Element {
   const { data, isLoading, isError, isFetching, dataUpdatedAt, refetch } =
     useGetCsmCaseSlas(caseId);
-  // Re-render on the shared tick so "Last refreshed …" keeps advancing
-  // without requiring another fetch or unrelated state change. `now` is
-  // passed explicitly into `formatRelativeTime` below (rather than relying
-  // on its internal `Date.now()` default) so the React Compiler's
-  // auto-memoization sees the tick as a dependency and recomputes the label.
-  const now = useRelativeTimeTick();
+  // Re-render exactly when "Last refreshed …" text would next change
+  // (adaptive shared scheduler — see RelativeTime.tsx), without requiring
+  // another fetch or unrelated state change. `now` is passed explicitly
+  // into `formatRelativeTime` below (rather than relying on its internal
+  // `Date.now()` default) so the React Compiler's auto-memoization sees it
+  // as a dependency and recomputes the label.
+  const now = useRelativeTimeTick(dataUpdatedAt);
 
   const slas = data?.slas ?? [];
   const count = data?.count ?? slas.length;

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/TasksWidget.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/TasksWidget.test.tsx
@@ -52,6 +52,7 @@ function mockListResult(overrides: Partial<ReturnType<typeof useSearchCaseTasks>
     isLoading: false,
     isError: false,
     isFetching: false,
+    dataUpdatedAt: 0,
     refetch: vi.fn(),
     ...overrides,
   } as unknown as ReturnType<typeof useSearchCaseTasks>);
@@ -147,6 +148,25 @@ describe("TasksWidget", () => {
     expect(screen.getByText("Jane Doe")).toBeInTheDocument();
     // dueDate is null on this row — rendered as a plain dash, not a broken cell.
     expect(screen.getAllByText("—").length).toBeGreaterThan(0);
+  });
+
+  it("shows the 'Last refreshed' hint only after a manual refresh click, not on initial load", () => {
+    const refetch = vi.fn();
+    const list: BeListCaseTasksResponse = { tasks: [TASK_ROW], total: 1, offset: 0, limit: 20 };
+    mockListResult({ data: list, refetch, dataUpdatedAt: Date.now() });
+    render(
+      <MemoryRouter>
+        <TasksWidget caseId="case-1" />
+      </MemoryRouter>,
+    );
+
+    // Initial load already set `dataUpdatedAt`, but the hint must stay hidden.
+    expect(screen.queryByText(/last refreshed/i)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /refresh tasks/i }));
+
+    expect(refetch).toHaveBeenCalled();
+    expect(screen.getByText(/last refreshed/i)).toBeInTheDocument();
   });
 
   it("renders a neutral badge for an OTHER/null state instead of assuming only OPEN/CLOSED", () => {

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/TasksWidget.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/TasksWidget.tsx
@@ -34,7 +34,8 @@ import { useState, type JSX } from "react";
 import { useSearchCaseTasks } from "@features/csm-cases/api/useSearchCaseTasks";
 import { taskStateColor, taskStateLabel } from "@features/csm-cases/utils/taskState";
 import { formatAbsoluteForUser } from "@utils/dateTime";
-import RelativeTime from "@components/RelativeTime";
+import { formatRelativeTime } from "@features/csm-dashboard/utils/abtDashboard";
+import RelativeTime, { useRelativeTimeTick } from "@components/RelativeTime";
 import { TaskDetailDialog } from "./TaskDetailDialog";
 
 const TASKS_TABLE_COLUMNS = ["Subject", "State", "Due date", "Assignee", "Updated"];
@@ -50,8 +51,25 @@ interface TasksWidgetProps {
  * small read-only detail dialog rather than a full separate detail page.
  */
 export function TasksWidget({ caseId }: TasksWidgetProps): JSX.Element {
-  const { data, isLoading, isError, isFetching, refetch } = useSearchCaseTasks(caseId);
+  const { data, isLoading, isError, isFetching, dataUpdatedAt, refetch } =
+    useSearchCaseTasks(caseId);
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
+  // Re-render exactly when "Last refreshed …" text would next change
+  // (adaptive shared scheduler — see RelativeTime.tsx), without requiring
+  // another fetch or unrelated state change. `now` is passed explicitly
+  // into `formatRelativeTime` below (rather than relying on its internal
+  // `Date.now()` default) so the React Compiler's auto-memoization sees it
+  // as a dependency and recomputes the label.
+  const now = useRelativeTimeTick(dataUpdatedAt);
+  // The "Last refreshed" hint only appears after the user has manually
+  // clicked refresh at least once — not from the tab's initial data load,
+  // which also sets `dataUpdatedAt`.
+  const [hasManuallyRefreshed, setHasManuallyRefreshed] = useState(false);
+
+  const handleRefreshClick = (): void => {
+    setHasManuallyRefreshed(true);
+    void refetch();
+  };
 
   const tasks = data?.tasks ?? [];
   const total = data?.total ?? tasks.length;
@@ -77,14 +95,22 @@ export function TasksWidget({ caseId }: TasksWidgetProps): JSX.Element {
               <Chip size="small" variant="outlined" label={`${total} total`} />
             )}
           </Box>
-          <IconButton
-            size="small"
-            onClick={() => void refetch()}
-            disabled={isFetching}
-            aria-label="Refresh tasks"
-          >
-            <RefreshCw size={14} />
-          </IconButton>
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+            {hasManuallyRefreshed && dataUpdatedAt ? (
+              <Typography variant="caption" color="text.secondary">
+                Last refreshed{" "}
+                {formatRelativeTime(new Date(dataUpdatedAt).toISOString(), now)}
+              </Typography>
+            ) : null}
+            <IconButton
+              size="small"
+              onClick={handleRefreshClick}
+              disabled={isFetching}
+              aria-label="Refresh tasks"
+            >
+              <RefreshCw size={14} />
+            </IconButton>
+          </Box>
         </Box>
 
         {isTruncated ? (
@@ -111,7 +137,7 @@ export function TasksWidget({ caseId }: TasksWidgetProps): JSX.Element {
               size="small"
               variant="outlined"
               startIcon={<RefreshCw size={14} />}
-              onClick={() => void refetch()}
+              onClick={handleRefreshClick}
               sx={{ textTransform: "none" }}
             >
               Retry

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/TasksWidget.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/TasksWidget.tsx
@@ -19,7 +19,6 @@ import {
   Button,
   Card,
   Chip,
-  IconButton,
   Skeleton,
   Table,
   TableBody,
@@ -34,8 +33,8 @@ import { useState, type JSX } from "react";
 import { useSearchCaseTasks } from "@features/csm-cases/api/useSearchCaseTasks";
 import { taskStateColor, taskStateLabel } from "@features/csm-cases/utils/taskState";
 import { formatAbsoluteForUser } from "@utils/dateTime";
-import { formatRelativeTime } from "@features/csm-dashboard/utils/abtDashboard";
-import RelativeTime, { useRelativeTimeTick } from "@components/RelativeTime";
+import RelativeTime from "@components/RelativeTime";
+import RefreshButton from "@components/RefreshButton";
 import { TaskDetailDialog } from "./TaskDetailDialog";
 
 const TASKS_TABLE_COLUMNS = ["Subject", "State", "Due date", "Assignee", "Updated"];
@@ -54,20 +53,11 @@ export function TasksWidget({ caseId }: TasksWidgetProps): JSX.Element {
   const { data, isLoading, isError, isFetching, dataUpdatedAt, refetch } =
     useSearchCaseTasks(caseId);
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
-  // Re-render exactly when "Last refreshed …" text would next change
-  // (adaptive shared scheduler — see RelativeTime.tsx), without requiring
-  // another fetch or unrelated state change. `now` is passed explicitly
-  // into `formatRelativeTime` below (rather than relying on its internal
-  // `Date.now()` default) so the React Compiler's auto-memoization sees it
-  // as a dependency and recomputes the label.
-  const now = useRelativeTimeTick(dataUpdatedAt);
-  // The "Last refreshed" hint only appears after the user has manually
-  // clicked refresh at least once — not from the tab's initial data load,
-  // which also sets `dataUpdatedAt`.
-  const [hasManuallyRefreshed, setHasManuallyRefreshed] = useState(false);
 
-  const handleRefreshClick = (): void => {
-    setHasManuallyRefreshed(true);
+  // The error-state Retry button below can't drive `RefreshButton`'s own
+  // internal "has been clicked" state (not exposed to the parent), so it
+  // gets its own minimal handler that just re-triggers the fetch.
+  const handleRetryClick = (): void => {
     void refetch();
   };
 
@@ -95,22 +85,12 @@ export function TasksWidget({ caseId }: TasksWidgetProps): JSX.Element {
               <Chip size="small" variant="outlined" label={`${total} total`} />
             )}
           </Box>
-          <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-            {hasManuallyRefreshed && dataUpdatedAt ? (
-              <Typography variant="caption" color="text.secondary">
-                Last refreshed{" "}
-                {formatRelativeTime(new Date(dataUpdatedAt).toISOString(), now)}
-              </Typography>
-            ) : null}
-            <IconButton
-              size="small"
-              onClick={handleRefreshClick}
-              disabled={isFetching}
-              aria-label="Refresh tasks"
-            >
-              <RefreshCw size={14} />
-            </IconButton>
-          </Box>
+          <RefreshButton
+            onRefresh={() => void refetch()}
+            isFetching={isFetching}
+            updatedAt={dataUpdatedAt}
+            label="Refresh tasks"
+          />
         </Box>
 
         {isTruncated ? (
@@ -137,7 +117,7 @@ export function TasksWidget({ caseId }: TasksWidgetProps): JSX.Element {
               size="small"
               variant="outlined"
               startIcon={<RefreshCw size={14} />}
-              onClick={handleRefreshClick}
+              onClick={handleRetryClick}
               sx={{ textTransform: "none" }}
             >
               Retry

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetData.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetData.ts
@@ -111,6 +111,14 @@ export function useWidgetData(
   // records. Hold the request instead; the query re-enables itself on the
   // render after `/users/me` resolves.
   const awaitingCurrentUser = hasCurrentUserPlaceholder(resolvedFilters);
+  // Derived, not threaded down as its own prop: a stable serialization of
+  // both team-group-id params already reaching this hook, so
+  // `withWidgetFetchSlot` can drop this widget's queued fetch when the
+  // selected team changes out from under it (see
+  // widgetFetchConcurrency.ts's own `teamKey` doc). Constant for a
+  // non-team-based dashboard (both undefined) — never drops anything
+  // there.
+  const teamKey = JSON.stringify([selectedTeamCreGroupId, selectedTeamSreGroupId]);
 
   return useQuery<WidgetData, Error>({
     queryKey: [
@@ -162,7 +170,7 @@ export function useWidgetData(
           ? (rawItems as Record<string, unknown>[])
           : [];
         return { total, items };
-      });
+      }, teamKey);
     },
     // Explicit per-query retry (not inherited from AppWithConfig's global
     // default) so a widget whose fetch timed out gets one retry — see

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetData.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetData.ts
@@ -19,7 +19,10 @@ import { ApiQueryKeys } from "@constants/apiConstants";
 import { useBackendApi } from "@api/backend/client";
 import type { BeWidgetResourceType, BeWidgetShape } from "@api/backend/types";
 import { WIDGET_RESOURCE_CONFIG } from "@features/csm-dashboard/config/widgetResourceConfig";
-import { resolveTeamPlaceholder } from "@features/csm-dashboard/utils/teamFilterPlaceholder";
+import {
+  hasTeamPlaceholder,
+  resolveTeamPlaceholder,
+} from "@features/csm-dashboard/utils/teamFilterPlaceholder";
 import { resolveRelativeDateFilters } from "@features/csm-dashboard/utils/resolveRelativeDateFilters";
 import {
   hasCurrentUserPlaceholder,
@@ -119,6 +122,12 @@ export function useWidgetData(
   // non-team-based dashboard (both undefined) — never drops anything
   // there.
   const teamKey = JSON.stringify([selectedTeamCreGroupId, selectedTeamSreGroupId]);
+  // Whether THIS widget's own filters reference `__current_team__` — see
+  // `shouldRetryWidgetFetch`'s own doc comment for why a queue-drop retry
+  // is only worth anything when they don't (team-independent). Derived
+  // from the raw, pre-resolution `filters`, not `resolvedFilters` — by the
+  // time resolution runs the placeholder is already gone.
+  const isTeamIndependent = !hasTeamPlaceholder(filters);
 
   return useQuery<WidgetData, Error>({
     queryKey: [
@@ -176,8 +185,11 @@ export function useWidgetData(
     // default) so a widget whose fetch timed out gets one retry — see
     // shouldRetryWidgetFetch's own doc comment for why a timeout must not
     // be a same-tick terminal failure, and why the retry needs no separate
-    // "back of the queue" bookkeeping of its own.
-    retry: shouldRetryWidgetFetch,
+    // "back of the queue" bookkeeping of its own. Wrapped rather than
+    // passed directly: react-query's own `retry` option only ever calls
+    // the 2-arg `(failureCount, error)` form, so `isTeamIndependent` has to
+    // be closed over here instead of threaded through react-query itself.
+    retry: (failureCount, error) => shouldRetryWidgetFetch(failureCount, error, isTeamIndependent),
     staleTime: 60_000,
   });
 }

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetGroupByData.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetGroupByData.ts
@@ -23,7 +23,10 @@ import type {
   BeWidgetResourceType,
 } from "@api/backend/types";
 import { WIDGET_RESOURCE_CONFIG } from "@features/csm-dashboard/config/widgetResourceConfig";
-import { resolveTeamPlaceholder } from "@features/csm-dashboard/utils/teamFilterPlaceholder";
+import {
+  hasTeamPlaceholder,
+  resolveTeamPlaceholder,
+} from "@features/csm-dashboard/utils/teamFilterPlaceholder";
 import { resolveRelativeDateFilters } from "@features/csm-dashboard/utils/resolveRelativeDateFilters";
 import {
   hasCurrentUserPlaceholder,
@@ -96,6 +99,11 @@ export function useWidgetGroupByData(
   const awaitingCurrentUser = hasCurrentUserPlaceholder(resolvedFilters);
   // See useWidgetData's own comment — same derivation, same reasoning.
   const teamKey = JSON.stringify([selectedTeamCreGroupId, selectedTeamSreGroupId]);
+  // See useWidgetData's own comment — same derivation (off the raw,
+  // pre-resolution `baseFilters`), same reasoning; there's no per-slice
+  // query to merge under here, so this is the widget's whole filters
+  // object, same as useWidgetData.
+  const isTeamIndependent = !hasTeamPlaceholder(baseFilters);
 
   const query = useQuery({
     queryKey: [
@@ -133,8 +141,10 @@ export function useWidgetGroupByData(
     },
     enabled: enabled && !!groupBy && !awaitingCurrentUser,
     // Same per-query retry override as useWidgetPieData's own slice
-    // fetches, same reasoning (see shouldRetryWidgetFetch).
-    retry: shouldRetryWidgetFetch,
+    // fetches, same reasoning (see shouldRetryWidgetFetch). Wrapped for the
+    // same reason useWidgetData wraps it — react-query's own `retry` option
+    // only calls the 2-arg form.
+    retry: (failureCount, error) => shouldRetryWidgetFetch(failureCount, error, isTeamIndependent),
     staleTime: 60_000,
   });
 

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetGroupByData.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetGroupByData.ts
@@ -94,6 +94,8 @@ export function useWidgetGroupByData(
   // signed-in user's profile hasn't landed yet, so the query holds rather
   // than searching unscoped.
   const awaitingCurrentUser = hasCurrentUserPlaceholder(resolvedFilters);
+  // See useWidgetData's own comment — same derivation, same reasoning.
+  const teamKey = JSON.stringify([selectedTeamCreGroupId, selectedTeamSreGroupId]);
 
   const query = useQuery({
     queryKey: [
@@ -127,7 +129,7 @@ export function useWidgetGroupByData(
           },
           { signal },
         );
-      });
+      }, teamKey);
     },
     enabled: enabled && !!groupBy && !awaitingCurrentUser,
     // Same per-query retry override as useWidgetPieData's own slice

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetPieData.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetPieData.ts
@@ -114,6 +114,8 @@ export function useWidgetPieData(
   // "loading" to react-query, and a pie/bar tile must not paint an empty
   // chart while it is really still waiting on identity.
   const awaitingCurrentUser = resolvedSliceFilters.some(hasCurrentUserPlaceholder);
+  // See useWidgetData's own comment — same derivation, same reasoning.
+  const teamKey = JSON.stringify([selectedTeamCreGroupId, selectedTeamSreGroupId]);
 
   const queries = useQueries({
     queries: slices.map((_slice, index) => {
@@ -147,7 +149,7 @@ export function useWidgetPieData(
               { signal },
             );
             return typeof res.total === "number" ? res.total : 0;
-          });
+          }, teamKey);
         },
         enabled: enabled && !awaitingCurrentUser,
         // Same per-query retry override as useWidgetData, same reasoning

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetPieData.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetPieData.ts
@@ -20,7 +20,10 @@ import { useBackendApi } from "@api/backend/client";
 import type { BeDashboardPieSlice, BeWidgetResourceType } from "@api/backend/types";
 import { WIDGET_RESOURCE_CONFIG } from "@features/csm-dashboard/config/widgetResourceConfig";
 import { mergeWidgetFilters } from "@features/csm-dashboard/utils/widgetFilterMerge";
-import { resolveTeamPlaceholder } from "@features/csm-dashboard/utils/teamFilterPlaceholder";
+import {
+  hasTeamPlaceholder,
+  resolveTeamPlaceholder,
+} from "@features/csm-dashboard/utils/teamFilterPlaceholder";
 import { resolveRelativeDateFilters } from "@features/csm-dashboard/utils/resolveRelativeDateFilters";
 import {
   hasCurrentUserPlaceholder,
@@ -116,10 +119,20 @@ export function useWidgetPieData(
   const awaitingCurrentUser = resolvedSliceFilters.some(hasCurrentUserPlaceholder);
   // See useWidgetData's own comment — same derivation, same reasoning.
   const teamKey = JSON.stringify([selectedTeamCreGroupId, selectedTeamSreGroupId]);
+  // Whether EACH slice's own merged filters (base `query` + that slice's
+  // own `query`, pre-resolution — a slice's own `query` may carry the
+  // placeholder even when the widget's base `query` doesn't) reference
+  // `__current_team__` — see useWidgetData's own comment for why this must
+  // be computed off the raw filters, not the resolved ones, and
+  // `shouldRetryWidgetFetch`'s own doc comment for how it's used.
+  const sliceIsTeamIndependent = slices.map(
+    (slice) => !hasTeamPlaceholder(mergeWidgetFilters(baseFilters, slice.query)),
+  );
 
   const queries = useQueries({
     queries: slices.map((_slice, index) => {
       const filters = resolvedSliceFilters[index];
+      const isTeamIndependent = sliceIsTeamIndependent[index];
       return {
         queryKey: [
           ApiQueryKeys.CSM_DASHBOARD_WIDGET_DATA,
@@ -154,8 +167,11 @@ export function useWidgetPieData(
         enabled: enabled && !awaitingCurrentUser,
         // Same per-query retry override as useWidgetData, same reasoning
         // (see shouldRetryWidgetFetch) — a pie/bar slice fetch that timed
-        // out gets one retry too.
-        retry: shouldRetryWidgetFetch,
+        // out gets one retry too. Wrapped for the same reason useWidgetData
+        // wraps it — react-query's own `retry` option only calls the 2-arg
+        // form.
+        retry: (failureCount: number, error: Error) =>
+          shouldRetryWidgetFetch(failureCount, error, isTeamIndependent),
         staleTime: 60_000,
       };
     }),

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetGrid.refresh.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetGrid.refresh.test.tsx
@@ -122,4 +122,28 @@ describe("DashboardWidgetGrid section refresh 'Last refreshed' hint", () => {
     await waitFor(() => expect(screen.getByText(/Last refreshed/)).toBeInTheDocument());
     expect(screen.getByText(/Last refreshed\s+just now/)).toBeInTheDocument();
   });
+
+  it("keeps the section refresh button and its 'Last refreshed' label in the DOM (hover/focus-reveal is opacity-only, not display:none) and reachable by keyboard", async () => {
+    // jsdom does not compute CSS (:hover/:focus-within styling isn't
+    // something Testing Library can assert on directly) — what IS
+    // assertable here is that the control is structurally present and
+    // still focusable/clickable at all times, rather than being removed
+    // from the DOM (or the tab order) until hovered.
+    renderGrid();
+
+    await waitFor(() => expect(postMock).toHaveBeenCalledTimes(2));
+
+    const refreshButton = screen.getByRole("button", { name: "Refresh My Section" });
+    // Present and focusable (and thus clickable) even though it's visually
+    // hidden by default via opacity, not display:none.
+    refreshButton.focus();
+    expect(refreshButton).toHaveFocus();
+
+    fireEvent.click(refreshButton);
+    await waitFor(() => expect(screen.getByText(/Last refreshed/)).toBeInTheDocument());
+
+    // The label sits in the DOM right alongside the button once it exists,
+    // both governed by the same hover/focus-within reveal wrapper.
+    expect(screen.getByText(/Last refreshed\s+just now/)).toBeInTheDocument();
+  });
 });

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetGrid.refresh.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetGrid.refresh.test.tsx
@@ -82,13 +82,24 @@ function widget(id: string, section?: string): BeDashboardWidget {
 
 function renderGrid(widgets: BeDashboardWidget[]) {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return render(
+  const utils = render(
     <QueryClientProvider client={queryClient}>
       <MemoryRouter>
         <DashboardWidgetGrid widgets={widgets} />
       </MemoryRouter>
     </QueryClientProvider>,
   );
+  return {
+    ...utils,
+    rerenderWidgets: (nextWidgets: BeDashboardWidget[]) =>
+      utils.rerender(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <DashboardWidgetGrid widgets={nextWidgets} />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      ),
+  };
 }
 
 describe("DashboardWidgetGrid section refresh 'Last refreshed' hint", () => {
@@ -167,5 +178,26 @@ describe("DashboardWidgetGrid section refresh 'Last refreshed' hint", () => {
     // "Last refreshed" label of its own yet).
     expect(namedSectionRefresh).not.toBeDisabled();
     expect(screen.getAllByText(/Last refreshed/)).toHaveLength(1);
+  });
+
+  it("keeps the unnamed section's refresh state stable when a named section is inserted ahead of it", async () => {
+    // The unnamed section starts at index 0 (no named section yet), refresh
+    // it, then insert a named section ahead of it so the unnamed section's
+    // array index shifts from 0 to 1. An index-derived key would silently
+    // orphan the "Last refreshed" state recorded under the old index.
+    const { rerenderWidgets } = renderGrid([widget("w1")]);
+
+    await waitFor(() => expect(postMock).toHaveBeenCalledTimes(1));
+
+    const unnamedSectionRefresh = screen.getByRole("button", { name: "Refresh section" });
+    fireEvent.click(unnamedSectionRefresh);
+    await waitFor(() => expect(screen.getByText(/Last refreshed\s+just now/)).toBeInTheDocument());
+
+    rerenderWidgets([widget("w2", "New Section"), widget("w1")]);
+    await waitFor(() => expect(postMock).toHaveBeenCalledTimes(2));
+
+    // Still present, still keyed to the same (now index-1) unnamed section —
+    // an index-based key would have shown this as never-refreshed instead.
+    expect(screen.getByText(/Last refreshed\s+just now/)).toBeInTheDocument();
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetGrid.refresh.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetGrid.refresh.test.tsx
@@ -1,0 +1,125 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+ * Regression test: a section's `RefreshButton` never showed a "Last
+ * refreshed" hint no matter how many times it was clicked, because
+ * `DashboardWidgetGrid` never tracked/passed an `updatedAt` for a section
+ * (unlike single-widget call sites, which hand a query's own
+ * `dataUpdatedAt` straight through) — see `sectionLastRefreshedAt` in
+ * `DashboardWidgetGrid.tsx`.
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router";
+import type { BeDashboardWidget } from "@api/backend/types";
+
+const postMock = vi.fn();
+
+vi.mock("@api/backend/client", () => ({
+  useBackendApi: () => ({ post: postMock }),
+}));
+vi.mock("@config/apiConfig", () => ({
+  apiConfig: { backendUrl: "https://example.test" },
+}));
+vi.mock("@context/current-user/CurrentUserContext", () => ({
+  useCurrentUser: () => ({
+    user: { id: "11111111-aaaa-bbbb-cccc-000000000001" },
+    isLoading: false,
+    isError: false,
+  }),
+}));
+
+import DashboardWidgetGrid from "@features/csm-dashboard/components/DashboardWidgetGrid";
+
+// Every tile reports itself as already on screen, so it fetches on mount —
+// this test cares about the refresh flow after that, not lazy-loading.
+class AlwaysIntersectingObserver {
+  callback: IntersectionObserverCallback;
+
+  constructor(callback: IntersectionObserverCallback) {
+    this.callback = callback;
+  }
+
+  observe(node: Element): void {
+    this.callback(
+      [{ isIntersecting: true, target: node } as IntersectionObserverEntry],
+      this as unknown as IntersectionObserver,
+    );
+  }
+
+  unobserve(): void {}
+  disconnect(): void {}
+}
+
+function widget(id: string, section: string): BeDashboardWidget {
+  return {
+    widgetId: id,
+    displayName: id,
+    resourceType: "case",
+    shape: "count",
+    gridWidth: 3,
+    query: {},
+    section,
+  };
+}
+
+function renderGrid() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const widgets = [widget("w1", "My Section"), widget("w2", "My Section")];
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <DashboardWidgetGrid widgets={widgets} />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("DashboardWidgetGrid section refresh 'Last refreshed' hint", () => {
+  const originalIntersectionObserver = globalThis.IntersectionObserver;
+
+  beforeEach(() => {
+    postMock.mockReset();
+    postMock.mockResolvedValue({ total: 1, cases: [], limit: 1, offset: 0, hasMore: false });
+    (globalThis as { IntersectionObserver?: unknown }).IntersectionObserver =
+      AlwaysIntersectingObserver;
+  });
+
+  afterEach(() => {
+    (globalThis as { IntersectionObserver?: unknown }).IntersectionObserver =
+      originalIntersectionObserver;
+  });
+
+  it("shows no 'Last refreshed' hint before any click, and shows it once the section's refresh resolves", async () => {
+    renderGrid();
+
+    // Two widgets share one section, so there's a single refresh button for
+    // both.
+    await waitFor(() => expect(postMock).toHaveBeenCalledTimes(2));
+
+    const refreshButton = screen.getByRole("button", { name: "Refresh My Section" });
+    expect(screen.queryByText(/Last refreshed/)).not.toBeInTheDocument();
+
+    fireEvent.click(refreshButton);
+
+    await waitFor(() => expect(screen.getByText(/Last refreshed/)).toBeInTheDocument());
+    expect(screen.getByText(/Last refreshed\s+just now/)).toBeInTheDocument();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetGrid.refresh.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetGrid.refresh.test.tsx
@@ -68,7 +68,7 @@ class AlwaysIntersectingObserver {
   disconnect(): void {}
 }
 
-function widget(id: string, section: string): BeDashboardWidget {
+function widget(id: string, section?: string): BeDashboardWidget {
   return {
     widgetId: id,
     displayName: id,
@@ -80,9 +80,8 @@ function widget(id: string, section: string): BeDashboardWidget {
   };
 }
 
-function renderGrid() {
+function renderGrid(widgets: BeDashboardWidget[]) {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  const widgets = [widget("w1", "My Section"), widget("w2", "My Section")];
   return render(
     <QueryClientProvider client={queryClient}>
       <MemoryRouter>
@@ -108,7 +107,7 @@ describe("DashboardWidgetGrid section refresh 'Last refreshed' hint", () => {
   });
 
   it("shows no 'Last refreshed' hint before any click, and shows it once the section's refresh resolves", async () => {
-    renderGrid();
+    renderGrid([widget("w1", "My Section"), widget("w2", "My Section")]);
 
     // Two widgets share one section, so there's a single refresh button for
     // both.
@@ -129,7 +128,7 @@ describe("DashboardWidgetGrid section refresh 'Last refreshed' hint", () => {
     // assertable here is that the control is structurally present and
     // still focusable/clickable at all times, rather than being removed
     // from the DOM (or the tab order) until hovered.
-    renderGrid();
+    renderGrid([widget("w1", "My Section"), widget("w2", "My Section")]);
 
     await waitFor(() => expect(postMock).toHaveBeenCalledTimes(2));
 
@@ -145,5 +144,28 @@ describe("DashboardWidgetGrid section refresh 'Last refreshed' hint", () => {
     // The label sits in the DOM right alongside the button once it exists,
     // both governed by the same hover/focus-within reveal wrapper.
     expect(screen.getByText(/Last refreshed\s+just now/)).toBeInTheDocument();
+  });
+
+  it("keys refresh state so an unnamed section can never collide with a real section named after its synthetic key", async () => {
+    // Unnamed section lands at index 0, so its internal key is
+    // `unnamed:0` — pick a real section name that is exactly what the
+    // (pre-fix) collision-prone synthetic key looked like, to prove the
+    // two never share refresh state.
+    renderGrid([widget("w1"), widget("w2", "unnamed:0")]);
+
+    await waitFor(() => expect(postMock).toHaveBeenCalledTimes(2));
+
+    const unnamedSectionRefresh = screen.getByRole("button", { name: "Refresh section" });
+    const namedSectionRefresh = screen.getByRole("button", { name: "Refresh unnamed:0" });
+
+    fireEvent.click(unnamedSectionRefresh);
+
+    await waitFor(() => expect(screen.getByText(/Last refreshed\s+just now/)).toBeInTheDocument());
+
+    // Only the unnamed section's refresh fired — the "unnamed:0"-named
+    // section's own button must still be untouched (not disabled, no
+    // "Last refreshed" label of its own yet).
+    expect(namedSectionRefresh).not.toBeDisabled();
+    expect(screen.getAllByText(/Last refreshed/)).toHaveLength(1);
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetGrid.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetGrid.test.tsx
@@ -1,0 +1,115 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { MemoryRouter } from "react-router";
+import type { ReactNode } from "react";
+import type { BeDashboardWidget } from "@api/backend/types";
+
+// Stubs the real tile out entirely — this test is only about
+// `DashboardWidgetGrid`'s own wiring of `hideRefreshButton` alongside
+// `renderWidgetAction`, not about anything the real tile fetches/renders.
+// Exposes both as plain text so the assertions below can read them straight
+// out of the DOM rather than needing a spy.
+vi.mock("@features/csm-dashboard/components/DashboardWidgetTile", () => ({
+  default: ({
+    widgetId,
+    hideRefreshButton,
+  }: {
+    widgetId: string;
+    hideRefreshButton?: boolean;
+  }) => (
+    <div data-testid={`tile-${widgetId}`}>
+      {!hideRefreshButton && (
+        <button type="button" aria-label={`Refresh ${widgetId}`}>
+          refresh
+        </button>
+      )}
+    </div>
+  ),
+}));
+
+import DashboardWidgetGrid from "@features/csm-dashboard/components/DashboardWidgetGrid";
+
+function renderGrid(
+  widgets: BeDashboardWidget[],
+  renderWidgetAction?: (widget: BeDashboardWidget) => ReactNode,
+) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <DashboardWidgetGrid widgets={widgets} renderWidgetAction={renderWidgetAction} />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+function makeWidget(overrides: Partial<BeDashboardWidget> = {}): BeDashboardWidget {
+  return {
+    widgetId: "my_patches",
+    displayName: "My Patches",
+    resourceType: "case",
+    shape: "count",
+    gridWidth: 3,
+    query: {},
+    ...overrides,
+  } as BeDashboardWidget;
+}
+
+describe("DashboardWidgetGrid", () => {
+  it("renders every tile's own refresh button as before when no renderWidgetAction is passed (live dashboard, unaffected)", () => {
+    renderGrid([makeWidget()]);
+
+    expect(screen.getByRole("button", { name: "Refresh my_patches" })).toBeInTheDocument();
+  });
+
+  it("suppresses a widget's own refresh button (and renders the builder action instead) when renderWidgetAction returns a non-null action for it", () => {
+    renderGrid([makeWidget()], (widget) => (
+      <div>
+        <button type="button" aria-label={`Edit ${widget.widgetId}`}>
+          edit
+        </button>
+        <button type="button" aria-label={`Remove ${widget.widgetId}`}>
+          remove
+        </button>
+      </div>
+    ));
+
+    // The builder's own Edit/Remove actions render...
+    expect(screen.getByRole("button", { name: "Edit my_patches" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Remove my_patches" })).toBeInTheDocument();
+    // ...and the tile's own refresh button is suppressed, so there's no
+    // longer any overlap for the two to fight over in the same corner.
+    expect(
+      screen.queryByRole("button", { name: "Refresh my_patches" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps a widget's own refresh button when renderWidgetAction returns nothing for that specific widget", () => {
+    renderGrid(
+      [makeWidget({ widgetId: "no_action_widget" })],
+      () => null,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Refresh no_action_widget" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetGrid.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetGrid.tsx
@@ -214,11 +214,18 @@ export default function DashboardWidgetGrid({
         if (mainWidgets.length === 0 && chartWidgets.length === 0) return null;
 
         // Namespaced so a real section named e.g. `"__default_0"` can never
-        // collide with the synthetic key generated for an unnamed section at
-        // the same index — a collision there would cross-contaminate the two
-        // sections' refresh state (`refreshingSections`,
-        // `sectionLastRefreshedAt`), disabling/timestamping the wrong one.
-        const sectionKey = group.section != null ? `named:${group.section}` : `unnamed:${i}`;
+        // collide with the synthetic key generated for the unnamed section —
+        // a collision there would cross-contaminate the two sections'
+        // refresh state (`refreshingSections`, `sectionLastRefreshedAt`),
+        // disabling/timestamping the wrong one. A constant (not `i`-based)
+        // key for the unnamed case: `groupWidgetsBySection` collapses every
+        // section-less widget into exactly one group, so there is never more
+        // than one "unnamed" section to collide with itself — but an
+        // index-based key broke when a named section was inserted/removed/
+        // reordered ahead of it, since that shifts `i` for the same logical
+        // group across renders, silently orphaning its in-flight
+        // `refreshingSections` entry and `sectionLastRefreshedAt` value.
+        const sectionKey = group.section != null ? `named:${group.section}` : "unnamed";
         const sectionWidgetIds = new Set(group.widgets.map((w) => w.widgetId));
         // Section titles support the same {{currentTeam}} text token as an
         // individual widget's own displayName/description (see

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetGrid.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetGrid.tsx
@@ -186,6 +186,13 @@ export default function DashboardWidgetGrid({
           selectedTeamCreGroupId={selectedTeamCreGroupId}
           selectedTeamSreGroupId={selectedTeamSreGroupId}
           selectedTeamLabel={selectedTeamLabel}
+          // The builder action below renders as a sibling absolutely
+          // positioned over this same top-right corner (at a higher
+          // zIndex), fully covering the tile's own refresh button — so
+          // suppress the tile's refresh button exactly when (and only
+          // when) a builder action actually exists for this widget. See
+          // `hideRefreshButton`'s own doc comment on `DashboardWidgetTile`.
+          hideRefreshButton={Boolean(action)}
         />
         {action && (
           <Box sx={{ position: "absolute", top: 6, right: 6, zIndex: 2 }}>{action}</Box>

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetGrid.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetGrid.tsx
@@ -115,6 +115,14 @@ export default function DashboardWidgetGrid({
   const queryClient = useQueryClient();
   // Per-section refresh tracks its own in-flight state, keyed by section.
   const [refreshingSections, setRefreshingSections] = useState<Set<string>>(new Set());
+  // A section can bundle multiple widgets/queries, so there's no single
+  // query's `dataUpdatedAt` to hand to that section's `RefreshButton` the
+  // way single-widget call sites do — track our own "last refreshed" epoch
+  // per section instead, set once `invalidateWidgets` below actually
+  // resolves (its default `refetchType: "active"` means the promise only
+  // resolves after the matched queries have refetched, not just been
+  // marked stale).
+  const [sectionLastRefreshedAt, setSectionLastRefreshedAt] = useState<Record<string, number>>({});
 
   /**
    * Invalidates only the widget-data queries belonging to `widgetIds` —
@@ -139,6 +147,7 @@ export default function DashboardWidgetGrid({
     setRefreshingSections((prev) => new Set(prev).add(sectionKey));
     try {
       await invalidateWidgets(widgetIds);
+      setSectionLastRefreshedAt((prev) => ({ ...prev, [sectionKey]: Date.now() }));
     } finally {
       setRefreshingSections((prev) => {
         const next = new Set(prev);
@@ -221,6 +230,7 @@ export default function DashboardWidgetGrid({
                   <RefreshButton
                     onRefresh={() => void handleSectionRefresh(sectionKey, sectionWidgetIds)}
                     isFetching={refreshingSections.has(sectionKey)}
+                    updatedAt={sectionLastRefreshedAt[sectionKey]}
                     label={
                       resolvedSectionTitle
                         ? `Refresh ${resolvedSectionTitle}`

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetGrid.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetGrid.tsx
@@ -17,15 +17,40 @@
 import { Box, Divider, Typography } from "@wso2/oxygen-ui";
 import { useQueryClient } from "@tanstack/react-query";
 import { Fragment, useState, type JSX, type ReactNode } from "react";
-import { ApiQueryKeys } from "@constants/apiConstants";
 import type { BeDashboardWidget } from "@api/backend/types";
 import DashboardWidgetTile from "@features/csm-dashboard/components/DashboardWidgetTile";
 import RefreshButton from "@components/RefreshButton";
 import { resolveWidgetText } from "@features/csm-dashboard/utils/widgetTextPlaceholder";
+import { invalidateWidgetQueries } from "@features/csm-dashboard/utils/invalidateWidgetQueries";
 import {
   WIDGET_GRID_SX,
   groupWidgetsBySection,
 } from "@features/csm-dashboard/utils/dashboardWidgetGridLayout";
+
+// Hides the section refresh button + its "Last refreshed" label by default
+// and reveals both together on hover/focus of an ancestor carrying this sx
+// (see `sectionHeaderSx` below, applied to the row wide enough that hovering
+// anywhere near the section title reveals the control). Kept inert (not
+// clickable, not hit-testable) while hidden so it can't be triggered by a
+// stray click that happens to land where it would render once visible, but
+// stays reachable by keyboard Tab order throughout — `display: none` would
+// remove it from the tab sequence entirely, which is why opacity +
+// pointerEvents is used instead.
+const hoverRevealSx = {
+  opacity: 0,
+  pointerEvents: "none",
+  transition: "opacity 0.15s ease",
+} as const;
+
+const sectionHeaderSx = {
+  display: "flex",
+  alignItems: "center",
+  gap: 1,
+  "&:hover .dashboard-section-refresh, &:focus-within .dashboard-section-refresh": {
+    opacity: 1,
+    pointerEvents: "auto",
+  },
+} as const;
 
 function widgetGridColumnSx(widget: BeDashboardWidget) {
   // A list-shape widget renders a real table (4 rows, several columns) —
@@ -124,29 +149,10 @@ export default function DashboardWidgetGrid({
   // marked stale).
   const [sectionLastRefreshedAt, setSectionLastRefreshedAt] = useState<Record<string, number>>({});
 
-  /**
-   * Invalidates only the widget-data queries belonging to `widgetIds` —
-   * every shape's query key carries a widget id, just at a different
-   * position: `[KEY, widgetId, ...]` for count/list (see `useWidgetData`),
-   * `[KEY, "pie-slice", widgetId, ...]` for pie/bar via `slices` (see
-   * `useWidgetPieData`), `[KEY, "group-by", widgetId, ...]` for pie/bar via
-   * `groupBy` (see `useWidgetGroupByData`).
-   */
-  const invalidateWidgets = (widgetIds: Set<string>): Promise<void> =>
-    queryClient.invalidateQueries({
-      predicate: (query) => {
-        const key = query.queryKey;
-        if (key[0] !== ApiQueryKeys.CSM_DASHBOARD_WIDGET_DATA) return false;
-        const widgetId =
-          key[1] === "pie-slice" || key[1] === "group-by" ? key[2] : key[1];
-        return typeof widgetId === "string" && widgetIds.has(widgetId);
-      },
-    });
-
   const handleSectionRefresh = async (sectionKey: string, widgetIds: Set<string>): Promise<void> => {
     setRefreshingSections((prev) => new Set(prev).add(sectionKey));
     try {
-      await invalidateWidgets(widgetIds);
+      await invalidateWidgetQueries(queryClient, widgetIds);
       setSectionLastRefreshedAt((prev) => ({ ...prev, [sectionKey]: Date.now() }));
     } finally {
       setRefreshingSections((prev) => {
@@ -214,10 +220,8 @@ export default function DashboardWidgetGrid({
             <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
               <Box
                 sx={{
-                  display: "flex",
-                  alignItems: "center",
+                  ...sectionHeaderSx,
                   justifyContent: resolvedSectionTitle ? "space-between" : "flex-end",
-                  gap: 1,
                 }}
               >
                 {resolvedSectionTitle && (
@@ -227,16 +231,18 @@ export default function DashboardWidgetGrid({
                 )}
                 <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
                   {renderSectionActions?.(group.section, resolvedSectionTitle, sectionWidgetIds)}
-                  <RefreshButton
-                    onRefresh={() => void handleSectionRefresh(sectionKey, sectionWidgetIds)}
-                    isFetching={refreshingSections.has(sectionKey)}
-                    updatedAt={sectionLastRefreshedAt[sectionKey]}
-                    label={
-                      resolvedSectionTitle
-                        ? `Refresh ${resolvedSectionTitle}`
-                        : "Refresh section"
-                    }
-                  />
+                  <Box className="dashboard-section-refresh" sx={hoverRevealSx}>
+                    <RefreshButton
+                      onRefresh={() => void handleSectionRefresh(sectionKey, sectionWidgetIds)}
+                      isFetching={refreshingSections.has(sectionKey)}
+                      updatedAt={sectionLastRefreshedAt[sectionKey]}
+                      label={
+                        resolvedSectionTitle
+                          ? `Refresh ${resolvedSectionTitle}`
+                          : "Refresh section"
+                      }
+                    />
+                  </Box>
                 </Box>
               </Box>
               {mainWidgets.length > 0 && (

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetGrid.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetGrid.tsx
@@ -213,7 +213,12 @@ export default function DashboardWidgetGrid({
         const chartWidgets = group.widgets.filter((w) => w.shape === "pie" || w.shape === "bar");
         if (mainWidgets.length === 0 && chartWidgets.length === 0) return null;
 
-        const sectionKey = group.section ?? `__default_${i}`;
+        // Namespaced so a real section named e.g. `"__default_0"` can never
+        // collide with the synthetic key generated for an unnamed section at
+        // the same index — a collision there would cross-contaminate the two
+        // sections' refresh state (`refreshingSections`,
+        // `sectionLastRefreshedAt`), disabling/timestamping the wrong one.
+        const sectionKey = group.section != null ? `named:${group.section}` : `unnamed:${i}`;
         const sectionWidgetIds = new Set(group.widgets.map((w) => w.widgetId));
         // Section titles support the same {{currentTeam}} text token as an
         // individual widget's own displayName/description (see

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.test.tsx
@@ -1480,6 +1480,31 @@ describe("DashboardWidgetTile", () => {
     expect(screen.queryByTestId("location-probe")).not.toBeInTheDocument();
   });
 
+  it("shape count: shows no 'Last refreshed' label before the refresh button is clicked, and shows it (with the right text) once the refresh resolves", async () => {
+    postMock.mockResolvedValue({ total: 3, cases: [], limit: 1, offset: 0, hasMore: false });
+
+    renderWithClient(
+      <DashboardWidgetTile
+        widgetId="my_patches"
+        displayName="My Patches"
+        resourceType="case"
+        shape="count"
+        filters={{}}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByText("3")).toBeInTheDocument());
+    // Not shown from the tile's own initial data load — only after a manual
+    // refresh click (matches the section-level RefreshButton's own gating).
+    expect(screen.queryByText(/Last refreshed/)).not.toBeInTheDocument();
+
+    const refreshButton = screen.getByRole("button", { name: "Refresh My Patches" });
+    fireEvent.click(refreshButton);
+
+    await waitFor(() => expect(screen.getByText(/Last refreshed/)).toBeInTheDocument());
+    expect(screen.getByText(/Last refreshed.*just now|Last refreshed.*ago/)).toBeInTheDocument();
+  });
+
   it("shape list: renders a per-widget refresh button", async () => {
     postMock.mockResolvedValue({
       total: 2,

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.test.tsx
@@ -1480,7 +1480,7 @@ describe("DashboardWidgetTile", () => {
     expect(screen.queryByTestId("location-probe")).not.toBeInTheDocument();
   });
 
-  it("shape count: shows no 'Last refreshed' label before the refresh button is clicked, and shows it (with the right text) once the refresh resolves", async () => {
+  it("shape count: folds 'Last refreshed' into the refresh button's tooltip (no room for an inline label on this shape), absent before click and present after", async () => {
     postMock.mockResolvedValue({ total: 3, cases: [], limit: 1, offset: 0, hasMore: false });
 
     renderWithClient(
@@ -1494,15 +1494,33 @@ describe("DashboardWidgetTile", () => {
     );
 
     await waitFor(() => expect(screen.getByText("3")).toBeInTheDocument());
+    const refreshButton = screen.getByRole("button", { name: "Refresh My Patches" });
+
     // Not shown from the tile's own initial data load — only after a manual
     // refresh click (matches the section-level RefreshButton's own gating).
+    // Count-shape tiles are too narrow for an inline label, so this never
+    // renders as visible text on the tile itself either before or after the
+    // click — only ever inside the tooltip.
     expect(screen.queryByText(/Last refreshed/)).not.toBeInTheDocument();
+    fireEvent.mouseOver(refreshButton);
+    await waitFor(() => expect(screen.getByRole("tooltip")).toBeInTheDocument());
+    // Deliberately generic — no widget name (it's already visible next to
+    // the tile's own title; including it made the combined tooltip too
+    // long). The `aria-label` above still carries the widget name for
+    // screen-reader users who need to tell apart multiple refresh buttons.
+    expect(screen.getByRole("tooltip")).toHaveTextContent("Refresh this widget");
+    expect(screen.getByRole("tooltip")).not.toHaveTextContent(/Last refreshed/);
+    fireEvent.mouseOut(refreshButton);
+    await waitFor(() => expect(screen.queryByRole("tooltip")).not.toBeInTheDocument());
 
-    const refreshButton = screen.getByRole("button", { name: "Refresh My Patches" });
     fireEvent.click(refreshButton);
+    await waitFor(() => expect(postMock).toHaveBeenCalledTimes(2));
 
-    await waitFor(() => expect(screen.getByText(/Last refreshed/)).toBeInTheDocument());
-    expect(screen.getByText(/Last refreshed.*just now|Last refreshed.*ago/)).toBeInTheDocument();
+    expect(screen.queryByText(/Last refreshed/)).not.toBeInTheDocument();
+    fireEvent.mouseOver(refreshButton);
+    await waitFor(() =>
+      expect(screen.getByRole("tooltip")).toHaveTextContent(/Last refreshed.*(just now|ago)/),
+    );
   });
 
   it("shape list: renders a per-widget refresh button", async () => {

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.test.tsx
@@ -1434,21 +1434,121 @@ describe("DashboardWidgetTile", () => {
     expect(tile.contains(legendRow)).toBe(false);
   });
 
-  it("does not render a per-widget refresh button on any shape", async () => {
+  it("shape count: renders a per-widget refresh button that invalidates only this widget's own queries without navigating", async () => {
     postMock.mockResolvedValue({ total: 3, cases: [], limit: 1, offset: 0, hasMore: false });
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <DashboardWidgetTile
+            widgetId="my_patches"
+            displayName="My Patches"
+            resourceType="case"
+            shape="count"
+            filters={{}}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByText("3")).toBeInTheDocument());
+    const refreshButton = screen.getByRole("button", { name: "Refresh My Patches" });
+    expect(refreshButton).toBeInTheDocument();
+
+    fireEvent.click(refreshButton);
+
+    expect(invalidateSpy).toHaveBeenCalled();
+    const predicate = invalidateSpy.mock.calls[0]?.[0]?.predicate;
+    expect(typeof predicate).toBe("function");
+    // Matches only this widget's own count query key, not some other
+    // widget's — the whole point of scoping the refresh to a single tile.
+    expect(
+      predicate?.({
+        queryKey: ["csm-dashboard-widget-data", "my_patches", "case", {}, undefined, undefined],
+      } as never),
+    ).toBe(true);
+    expect(
+      predicate?.({
+        queryKey: ["csm-dashboard-widget-data", "some_other_widget", "case", {}, undefined, undefined],
+      } as never),
+    ).toBe(false);
+
+    // Must not also trigger the tile's own whole-card navigation.
+    expect(screen.queryByTestId("location-probe")).not.toBeInTheDocument();
+  });
+
+  it("shape list: renders a per-widget refresh button", async () => {
+    postMock.mockResolvedValue({
+      total: 2,
+      cases: [{ id: "11111111-1111-1111-1111-111111111111", number: "CS-1", subject: "Disk full", state: "open" }],
+      limit: 5,
+      offset: 0,
+      hasMore: false,
+    });
 
     renderWithClient(
       <DashboardWidgetTile
-        widgetId="my_patches"
-        displayName="My Patches"
+        widgetId="my_critical_open"
+        displayName="My Critical & High Cases"
         resourceType="case"
-        shape="count"
+        shape="list"
+        filters={{}}
+        listLimit={5}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByText("CS-1")).toBeInTheDocument());
+    expect(
+      screen.getByRole("button", { name: "Refresh My Critical & High Cases" }),
+    ).toBeInTheDocument();
+  });
+
+  it("shape pie: renders a per-widget refresh button that does not trigger the tile's own click-through", async () => {
+    postMock.mockResolvedValue({ total: 2 });
+
+    renderWithRoutes(
+      <DashboardWidgetTile
+        widgetId="cases-by-severity"
+        displayName="Cases by severity"
+        resourceType="case"
+        shape="pie"
+        filters={{}}
+        slices={[
+          {
+            label: "Critical",
+            query: { filters: [{ field: "severity", op: "in", values: ["critical"] }] },
+          },
+        ]}
+      />,
+      "/cases",
+    );
+
+    await waitFor(() => expect(screen.getByText("slice:Critical:2")).toBeInTheDocument());
+    const refreshButton = screen.getByRole("button", { name: "Refresh Cases by severity" });
+    fireEvent.click(refreshButton);
+
+    expect(screen.queryByTestId("location-probe")).not.toBeInTheDocument();
+  });
+
+  it("shape bar: renders a per-widget refresh button", async () => {
+    postMock.mockResolvedValue({ total: 0 });
+
+    renderWithClient(
+      <DashboardWidgetTile
+        widgetId="cases_by_severity"
+        displayName="Open Cases by Severity"
+        resourceType="case"
+        shape="bar"
         filters={{}}
       />,
     );
 
-    await waitFor(() => expect(screen.getByText("3")).toBeInTheDocument());
-    expect(screen.queryByRole("button", { name: /Refresh/i })).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Refresh Open Cases by Severity" }),
+    ).toBeInTheDocument();
   });
 
   it("shape count: shows an info icon with the widget's description in an accessible tooltip, only when a description is set", async () => {

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.test.tsx
@@ -1858,4 +1858,24 @@ describe("DashboardWidgetTile", () => {
     expect(screen.getByText("Unsupported widget type.")).toBeInTheDocument();
     expect(postMock).not.toHaveBeenCalled();
   });
+
+  it("shape count: hides its own refresh button when hideRefreshButton is set (avoids covering the dashboard builder's Edit/Remove overlay)", async () => {
+    postMock.mockResolvedValue({ total: 3, cases: [], limit: 1, offset: 0, hasMore: false });
+
+    renderWithClient(
+      <DashboardWidgetTile
+        widgetId="my_patches"
+        displayName="My Patches"
+        resourceType="case"
+        shape="count"
+        filters={{}}
+        hideRefreshButton
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByText("3")).toBeInTheDocument());
+    expect(
+      screen.queryByRole("button", { name: "Refresh My Patches" }),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
@@ -268,17 +268,36 @@ export default function DashboardWidgetTile({
   // in the keyboard Tab order throughout (unlike `display: none`, which
   // would remove it from Tab order entirely). Both the label and the icon
   // live inside this same wrapper so they hide/reveal as one unit.
+  //
+  // Shape "count" tiles are too narrow to fit the label inline next to the
+  // icon (they're the shortest/tightest tiles, and the icon already shares
+  // that corner with `infoIcon` when a description is set) — for that shape
+  // only, the same "Last refreshed …" text is folded into the icon's own
+  // tooltip instead of rendered as a separate label. The widget's own name
+  // is deliberately left out of the tooltip text (unlike the `aria-label`,
+  // which keeps it — screen-reader users still need it to tell apart the
+  // many refresh buttons on one dashboard page) since it's already visible
+  // right next to the tile's own title, and including it made the combined
+  // "Refresh <name> — Last refreshed <time>" tooltip too long.
+  const isCountShape = shape === "count";
+  const lastRefreshedText = lastRefreshedAt
+    ? `Last refreshed ${formatRelativeTime(new Date(lastRefreshedAt).toISOString(), now)}`
+    : undefined;
+  const refreshTooltipTitle =
+    isCountShape && lastRefreshedText
+      ? `Refresh this widget - ${lastRefreshedText}`
+      : "Refresh this widget";
   const refreshButton = (
     <Box
       className="dashboard-widget-refresh"
       sx={{ display: "flex", alignItems: "center", gap: 0.75, ...widgetRefreshRevealSx }}
     >
-      {lastRefreshedAt ? (
+      {!isCountShape && lastRefreshedText ? (
         <Typography variant="caption" color="text.secondary" noWrap>
-          Last refreshed {formatRelativeTime(new Date(lastRefreshedAt).toISOString(), now)}
+          {lastRefreshedText}
         </Typography>
       ) : null}
-      <Tooltip title={`Refresh ${resolvedDisplayName}`}>
+      <Tooltip title={refreshTooltipTitle}>
         <span>
           <IconButton
             size="small"

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
@@ -132,6 +132,20 @@ interface DashboardWidgetTileProps {
    * `selectedTeamCreGroupId` is (the token is then stripped rather than left
    * literally visible). */
   selectedTeamLabel?: string;
+  /** Suppresses this tile's own per-widget refresh button entirely. Exists
+   * for `CsmDashboardBuilderEditorPage`, the only caller that also passes a
+   * `renderWidgetAction` into `DashboardWidgetGrid` (Edit/Remove icons):
+   * that action renders as a sibling `Box` absolutely positioned over the
+   * same top-right corner this tile's own refresh button occupies (see
+   * `DashboardWidgetGrid.tsx`'s `renderTile`), at a higher `zIndex`, so
+   * without this the builder action fully covers the refresh button and an
+   * admin can never click it. The builder-editor page is a config-editing
+   * surface, not a live-data-monitoring one, so dropping the refresh
+   * button there (rather than trying to reposition both into two separate
+   * corners) is the right trade — Edit/Remove are the actions that matter
+   * in that context. `undefined`/falsy is a no-op: a normal dashboard page
+   * (no `renderWidgetAction`) keeps its refresh button exactly as before. */
+  hideRefreshButton?: boolean;
 }
 
 /**
@@ -165,6 +179,7 @@ export default function DashboardWidgetTile({
   selectedTeamCreGroupId,
   selectedTeamSreGroupId,
   selectedTeamLabel,
+  hideRefreshButton,
 }: DashboardWidgetTileProps): JSX.Element {
   const theme = useTheme();
   const navigate = useNavigate();
@@ -287,7 +302,11 @@ export default function DashboardWidgetTile({
     isCountShape && lastRefreshedText
       ? `Refresh this widget - ${lastRefreshedText}`
       : "Refresh this widget";
-  const refreshButton = (
+  // `null` (not a conditionally-skipped render below) when
+  // `hideRefreshButton` is set — see that prop's own doc comment — so every
+  // one of the three shapes below, which all reuse this single variable,
+  // stays untouched rather than needing its own gate.
+  const refreshButton = hideRefreshButton ? null : (
     <Box
       className="dashboard-widget-refresh"
       sx={{ display: "flex", alignItems: "center", gap: 0.75, ...widgetRefreshRevealSx }}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
@@ -724,8 +724,8 @@ export default function DashboardWidgetTile({
         <Box
           sx={{
             position: "absolute",
-            top: 8,
-            right: resolvedDescription ? 40 : 8,
+            top: 4,
+            right: resolvedDescription ? 36 : 4,
             pointerEvents: "auto",
           }}
         >

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
@@ -583,7 +583,7 @@ export default function DashboardWidgetTile({
           }}
         />
         <Box sx={{ position: "relative", zIndex: 1, height: "100%", pointerEvents: "none" }}>
-          <Box sx={{ position: "absolute", top: 8, right: 8, pointerEvents: "auto" }}>
+          <Box sx={{ position: "absolute", top: -4, right: -4, pointerEvents: "auto" }}>
             {refreshButton}
           </Box>
           {/* The header's own bottom padding — not just a top margin on the
@@ -724,8 +724,8 @@ export default function DashboardWidgetTile({
         <Box
           sx={{
             position: "absolute",
-            top: 4,
-            right: resolvedDescription ? 36 : 4,
+            top: -4,
+            right: resolvedDescription ? 28 : -4,
             pointerEvents: "auto",
           }}
         >

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
@@ -20,6 +20,8 @@ import { useRef, useState, type JSX, type KeyboardEvent, type MouseEvent, type R
 import { Link as RouterLink, useLocation, useNavigate } from "react-router";
 import { useQueryClient } from "@tanstack/react-query";
 import { useElementVisibleOnce } from "@hooks/useElementVisibleOnce";
+import { useRelativeTimeTick } from "@components/RelativeTime";
+import { formatRelativeTime } from "@features/csm-dashboard/utils/abtDashboard";
 import { invalidateWidgetQueries } from "@features/csm-dashboard/utils/invalidateWidgetQueries";
 import type {
   BeDashboardGroupByConfig,
@@ -185,6 +187,19 @@ export default function DashboardWidgetTile({
   // refetch without the rest of the tile flashing back to its skeleton
   // state.
   const [isRefreshing, setIsRefreshing] = useState(false);
+  // This widget's own last-manually-refreshed timestamp (ms) — set once the
+  // in-flight `invalidateWidgetQueries` call below resolves. `undefined`
+  // until the user has clicked refresh at least once, which is exactly the
+  // gate the "Last refreshed" label below reads (see `refreshButton`) —
+  // mirrors the section-level `RefreshButton`'s own `hasManuallyRefreshed`
+  // pattern, just tracked per-widget here instead of per-section.
+  const [lastRefreshedAt, setLastRefreshedAt] = useState<number | undefined>(undefined);
+  // Re-renders exactly when the "Last refreshed …" text below would next
+  // change (adaptive shared scheduler — see RelativeTime.tsx), without
+  // requiring another fetch. Passed explicitly into `formatRelativeTime`
+  // below (rather than relying on its internal `Date.now()` default) so the
+  // React Compiler's auto-memoization sees it as a dependency.
+  const now = useRelativeTimeTick(lastRefreshedAt);
   const handleWidgetRefresh = (e: MouseEvent): void => {
     // Stops this click from also being interpreted as a click on the
     // tile's own whole-card/tile-level click-through target that this
@@ -193,9 +208,10 @@ export default function DashboardWidgetTile({
     e.stopPropagation();
     e.preventDefault();
     setIsRefreshing(true);
-    void invalidateWidgetQueries(queryClient, new Set([widgetId])).finally(() =>
-      setIsRefreshing(false),
-    );
+    void invalidateWidgetQueries(queryClient, new Set([widgetId])).finally(() => {
+      setIsRefreshing(false);
+      setLastRefreshedAt(Date.now());
+    });
   };
   // Resolves every client-side filter placeholder a widget's own (opaque)
   // filters may carry — `__current_team__` (see `teamFilterPlaceholder.ts`),
@@ -239,17 +255,29 @@ export default function DashboardWidgetTile({
   // which carries `displayName` verbatim — see `buildWidgetPreviewHref`).
   const resolvedDisplayName = resolveWidgetText(displayName, selectedTeamLabel) ?? displayName;
   const resolvedDescription = resolveWidgetText(description, selectedTeamLabel);
-  // Icon-only refresh control for this widget alone (no "Last refreshed"
-  // label — that's the section-level RefreshButton's own job, not asked for
-  // per-widget). Hidden by default, revealed together with any other
+  // Per-widget refresh control: icon plus a "Last refreshed …" label,
+  // matching the section-level `RefreshButton`'s own layout (label to the
+  // left of the icon) and its "only after a manual click" gating —
+  // `lastRefreshedAt` stays `undefined` until this widget's own refresh has
+  // been clicked at least once, so the label never appears from this tile's
+  // initial data load. Hidden by default, revealed together with any other
   // hover-gated control on the tile via the ancestor Card's own
   // `&:hover .dashboard-widget-refresh, &:focus-within .dashboard-widget-refresh`
   // rule (see `widgetRefreshRevealSx`) — kept inert (opacity 0 + pointerEvents
   // none) while hidden so it can't be clicked without being seen, but stays
   // in the keyboard Tab order throughout (unlike `display: none`, which
-  // would remove it from Tab order entirely).
+  // would remove it from Tab order entirely). Both the label and the icon
+  // live inside this same wrapper so they hide/reveal as one unit.
   const refreshButton = (
-    <Box className="dashboard-widget-refresh" sx={widgetRefreshRevealSx}>
+    <Box
+      className="dashboard-widget-refresh"
+      sx={{ display: "flex", alignItems: "center", gap: 0.75, ...widgetRefreshRevealSx }}
+    >
+      {lastRefreshedAt ? (
+        <Typography variant="caption" color="text.secondary" noWrap>
+          Last refreshed {formatRelativeTime(new Date(lastRefreshedAt).toISOString(), now)}
+        </Typography>
+      ) : null}
       <Tooltip title={`Refresh ${resolvedDisplayName}`}>
         <span>
           <IconButton

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
@@ -15,10 +15,12 @@
 // under the License.
 
 import { Box, Button, Card, Chip, IconButton, Skeleton, Tooltip, Typography, alpha, useTheme } from "@wso2/oxygen-ui";
-import { ArrowRight, Info } from "@wso2/oxygen-ui-icons-react";
-import { useRef, type JSX, type KeyboardEvent, type ReactNode } from "react";
+import { ArrowRight, Info, RefreshCw } from "@wso2/oxygen-ui-icons-react";
+import { useRef, useState, type JSX, type KeyboardEvent, type MouseEvent, type ReactNode } from "react";
 import { Link as RouterLink, useLocation, useNavigate } from "react-router";
+import { useQueryClient } from "@tanstack/react-query";
 import { useElementVisibleOnce } from "@hooks/useElementVisibleOnce";
+import { invalidateWidgetQueries } from "@features/csm-dashboard/utils/invalidateWidgetQueries";
 import type {
   BeDashboardGroupByConfig,
   BeDashboardPieSlice,
@@ -44,6 +46,27 @@ import {
 import { resolveWidgetText } from "@features/csm-dashboard/utils/widgetTextPlaceholder";
 import DashboardPieChart from "@features/csm-dashboard/components/DashboardPieChart";
 import DashboardBarChart from "@features/csm-dashboard/components/DashboardBarChart";
+
+// Hides the per-widget refresh button by default and reveals it on hover or
+// keyboard focus of the ancestor Card carrying the matching
+// `&:hover .dashboard-widget-refresh, &:focus-within .dashboard-widget-refresh`
+// rule (each tile shape below sets that rule on its own top-level `Card`).
+// `:focus-within` (rather than relying on `:hover` alone) is what makes a
+// keyboard user tabbing onto the button reveal it first, rather than
+// reaching an interactive control they can never see. Not `display: none`,
+// so Tab order still reaches this button while it's visually hidden.
+const widgetRefreshRevealSx = {
+  opacity: 0,
+  pointerEvents: "none",
+  transition: "opacity 0.15s ease",
+} as const;
+
+const cardRefreshRevealSx = {
+  "&:hover .dashboard-widget-refresh, &:focus-within .dashboard-widget-refresh": {
+    opacity: 1,
+    pointerEvents: "auto",
+  },
+} as const;
 
 interface DashboardWidgetTileProps {
   widgetId: string;
@@ -155,6 +178,25 @@ export default function DashboardWidgetTile({
   // lifetime, so exactly one of them ever mounts for a given instance.
   const tileRef = useRef<HTMLDivElement>(null);
   const isVisible = useElementVisibleOnce(tileRef);
+  const queryClient = useQueryClient();
+  // True only while this widget's own manually-triggered refresh (below) is
+  // in flight — distinct from `isLoading`'s own first-fetch/lazy-load
+  // gating, so the button disables itself for the brief span of its own
+  // refetch without the rest of the tile flashing back to its skeleton
+  // state.
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const handleWidgetRefresh = (e: MouseEvent): void => {
+    // Stops this click from also being interpreted as a click on the
+    // tile's own whole-card/tile-level click-through target that this
+    // button is layered above (see the count and pie/bar branches below) —
+    // without this, refreshing a tile would also navigate away from it.
+    e.stopPropagation();
+    e.preventDefault();
+    setIsRefreshing(true);
+    void invalidateWidgetQueries(queryClient, new Set([widgetId])).finally(() =>
+      setIsRefreshing(false),
+    );
+  };
   // Resolves every client-side filter placeholder a widget's own (opaque)
   // filters may carry — `__current_team__` (see `teamFilterPlaceholder.ts`),
   // `__current_user__` (see `currentUserFilterPlaceholder.ts`) and the
@@ -197,6 +239,32 @@ export default function DashboardWidgetTile({
   // which carries `displayName` verbatim — see `buildWidgetPreviewHref`).
   const resolvedDisplayName = resolveWidgetText(displayName, selectedTeamLabel) ?? displayName;
   const resolvedDescription = resolveWidgetText(description, selectedTeamLabel);
+  // Icon-only refresh control for this widget alone (no "Last refreshed"
+  // label — that's the section-level RefreshButton's own job, not asked for
+  // per-widget). Hidden by default, revealed together with any other
+  // hover-gated control on the tile via the ancestor Card's own
+  // `&:hover .dashboard-widget-refresh, &:focus-within .dashboard-widget-refresh`
+  // rule (see `widgetRefreshRevealSx`) — kept inert (opacity 0 + pointerEvents
+  // none) while hidden so it can't be clicked without being seen, but stays
+  // in the keyboard Tab order throughout (unlike `display: none`, which
+  // would remove it from Tab order entirely).
+  const refreshButton = (
+    <Box className="dashboard-widget-refresh" sx={widgetRefreshRevealSx}>
+      <Tooltip title={`Refresh ${resolvedDisplayName}`}>
+        <span>
+          <IconButton
+            size="small"
+            onClick={handleWidgetRefresh}
+            disabled={isRefreshing}
+            aria-label={`Refresh ${resolvedDisplayName}`}
+            sx={{ color: "text.secondary" }}
+          >
+            <RefreshCw size={14} />
+          </IconButton>
+        </span>
+      </Tooltip>
+    </Box>
+  );
   // Shape "pie" resolves via useWidgetPieData instead (one search per
   // slice) — skip this one's own network call rather than wasting it, but
   // still call the hook unconditionally (rules of hooks; a widget's shape
@@ -382,7 +450,12 @@ export default function DashboardWidgetTile({
     const ListRenderer = WIDGET_LIST_RENDERERS[resourceType];
     const total = data?.total ?? 0;
     return (
-      <Card ref={tileRef} variant="outlined" sx={{ position: "relative", p: 1.75, height: "100%" }}>
+      <Card
+        ref={tileRef}
+        variant="outlined"
+        sx={{ position: "relative", p: 1.75, height: "100%", ...cardRefreshRevealSx }}
+      >
+        <Box sx={{ position: "absolute", top: 8, right: 8, zIndex: 1 }}>{refreshButton}</Box>
         {/* The rows below are capped at `listLimit` (see `useWidgetData`'s
             DEFAULT_LIST_LIMIT) — this badge next to the title is the only
             place the widget's own full count is visible, since "View more"
@@ -486,6 +559,7 @@ export default function DashboardWidgetTile({
           position: "relative",
           p: 1.75,
           height: "100%",
+          ...cardRefreshRevealSx,
         }}
       >
         <Box
@@ -509,6 +583,9 @@ export default function DashboardWidgetTile({
           }}
         />
         <Box sx={{ position: "relative", zIndex: 1, height: "100%", pointerEvents: "none" }}>
+          <Box sx={{ position: "absolute", top: 8, right: 8, pointerEvents: "auto" }}>
+            {refreshButton}
+          </Box>
           {/* The header's own bottom padding — not just a top margin on the
               chart below it — so the chart's top edge (and, at the size this
               chart renders at, its tooltip) never sits flush against/behind
@@ -614,6 +691,7 @@ export default function DashboardWidgetTile({
         position: "relative",
         p: 1.75,
         height: "100%",
+        ...cardRefreshRevealSx,
       }}
     >
       <Box
@@ -639,6 +717,20 @@ export default function DashboardWidgetTile({
         }}
       />
       <Box sx={{ position: "relative", zIndex: 1, height: "100%", pointerEvents: "none" }}>
+        {/* Refresh sits to the LEFT of the (always-visible) info icon when
+            both are present, rather than stacking one on top of the other —
+            `infoIcon` already occupies this exact top-right spot
+            (top: 8, right: 8) whenever this widget has a description. */}
+        <Box
+          sx={{
+            position: "absolute",
+            top: 8,
+            right: resolvedDescription ? 40 : 8,
+            pointerEvents: "auto",
+          }}
+        >
+          {refreshButton}
+        </Box>
         <Box sx={{ pointerEvents: "auto" }}>{infoIcon}</Box>
         {body}
       </Box>

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/MyAssignedCases.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/MyAssignedCases.tsx
@@ -46,7 +46,7 @@ const VIEW_ALL_HREF = `/cases?assignees=${encodeURIComponent(
 export default function MyAssignedCases(): JSX.Element {
   const currentUser = useCurrentUser();
   const [page, setPage] = useState(0);
-  const { data, isLoading, isError, isFetching, refetch } =
+  const { data, isLoading, isError, isFetching, dataUpdatedAt, refetch } =
     useGetMyAssignedOpenCases(page, MY_OPEN_CASES_PAGE_SIZE);
 
   // `/users/me` returned but carried no id (entity service down): we can't tell
@@ -92,6 +92,7 @@ export default function MyAssignedCases(): JSX.Element {
           <RefreshButton
             onRefresh={() => void refetch()}
             isFetching={isFetching}
+            updatedAt={dataUpdatedAt}
             label="Refresh assigned cases"
           />
         </Box>

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/utils/invalidateWidgetQueries.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/utils/invalidateWidgetQueries.ts
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { QueryClient } from "@tanstack/react-query";
+import { ApiQueryKeys } from "@constants/apiConstants";
+
+/**
+ * Invalidates only the widget-data queries belonging to `widgetIds` — every
+ * shape's query key carries a widget id, just at a different position:
+ * `[KEY, widgetId, ...]` for count/list (see `useWidgetData`),
+ * `[KEY, "pie-slice", widgetId, ...]` for pie/bar via `slices` (see
+ * `useWidgetPieData`), `[KEY, "group-by", widgetId, ...]` for pie/bar via
+ * `groupBy` (see `useWidgetGroupByData`).
+ *
+ * Shared between `DashboardWidgetGrid` (a whole section's worth of widget
+ * ids at once) and `DashboardWidgetTile` (its own single widget id) so this
+ * query-key-shape knowledge lives in exactly one place.
+ */
+export function invalidateWidgetQueries(
+  queryClient: QueryClient,
+  widgetIds: Set<string>,
+): Promise<void> {
+  return queryClient.invalidateQueries({
+    predicate: (query) => {
+      const key = query.queryKey;
+      if (key[0] !== ApiQueryKeys.CSM_DASHBOARD_WIDGET_DATA) return false;
+      const widgetId = key[1] === "pie-slice" || key[1] === "group-by" ? key[2] : key[1];
+      return typeof widgetId === "string" && widgetIds.has(widgetId);
+    },
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/utils/teamFilterPlaceholder.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/utils/teamFilterPlaceholder.test.ts
@@ -17,6 +17,7 @@
 import { describe, expect, it } from "vitest";
 import {
   CURRENT_TEAM_PLACEHOLDER,
+  hasTeamPlaceholder,
   resolveTeamPlaceholder,
 } from "./teamFilterPlaceholder";
 
@@ -333,5 +334,59 @@ describe("resolveTeamPlaceholder", () => {
       expect(resolveTeamPlaceholder(filters, "team-group-id", "team-group-id")).toBe(filters);
       expect(resolveTeamPlaceholder(filters, undefined, undefined)).toBe(filters);
     });
+  });
+});
+
+describe("hasTeamPlaceholder", () => {
+  it("returns true when a creTeam entry's values carry the placeholder", () => {
+    const filters = {
+      filters: [
+        { field: "state", op: "in", values: ["open"] },
+        { field: "creTeam", op: "in", values: [CURRENT_TEAM_PLACEHOLDER] },
+      ],
+    };
+
+    expect(hasTeamPlaceholder(filters)).toBe(true);
+  });
+
+  it("returns true when an sreTeam entry's values carry the placeholder", () => {
+    const filters = {
+      filters: [{ field: "sreTeam", op: "in", values: [CURRENT_TEAM_PLACEHOLDER] }],
+    };
+
+    expect(hasTeamPlaceholder(filters)).toBe(true);
+  });
+
+  it("returns true when a flat assignmentTeamIds array carries the placeholder", () => {
+    const filters = { assignmentTeamIds: ["some-literal-group-id", CURRENT_TEAM_PLACEHOLDER] };
+
+    expect(hasTeamPlaceholder(filters)).toBe(true);
+  });
+
+  it("returns false when filters.filters carries no creTeam/sreTeam entry with the placeholder", () => {
+    const filters = {
+      filters: [
+        { field: "state", op: "in", values: ["open"] },
+        { field: "creTeam", op: "in", values: ["some-literal-group-id"] },
+      ],
+    };
+
+    expect(hasTeamPlaceholder(filters)).toBe(false);
+  });
+
+  it("returns false when the placeholder appears on a field other than creTeam/sreTeam", () => {
+    const filters = {
+      filters: [{ field: "assignedUserId", op: "in", values: [CURRENT_TEAM_PLACEHOLDER] }],
+    };
+
+    expect(hasTeamPlaceholder(filters)).toBe(false);
+  });
+
+  it("returns false for a flat assignmentTeamIds array with only literal ids", () => {
+    expect(hasTeamPlaceholder({ assignmentTeamIds: ["some-literal-group-id"] })).toBe(false);
+  });
+
+  it("returns false for a filters object with neither filters.filters nor assignmentTeamIds", () => {
+    expect(hasTeamPlaceholder({ states: ["open"], severities: ["critical"] })).toBe(false);
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/utils/teamFilterPlaceholder.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/utils/teamFilterPlaceholder.ts
@@ -116,6 +116,39 @@ export const SRE_TEAM_FILTER_FIELD = "sreTeam";
  * already present in `assignmentTeamIds` (i.e. not the placeholder) is left
  * alone, same as a literal value alongside the placeholder in the case DSL.
  */
+/**
+ * Whether `filters` carries {@link CURRENT_TEAM_PLACEHOLDER} anywhere
+ * {@link resolveTeamPlaceholder} would actually resolve it — a `creTeam` or
+ * `sreTeam` case-field-filter entry's `values`, or a flat
+ * `assignmentTeamIds` array. Deliberately mirrors that function's own two
+ * detection checks (`values?.includes(CURRENT_TEAM_PLACEHOLDER)` for the
+ * case DSL, `assignmentTeamIds.includes(CURRENT_TEAM_PLACEHOLDER)` for the
+ * flat shape) rather than re-deriving its own notion of "team-scoped" —
+ * the two must never disagree about which filters objects carry the
+ * placeholder, since callers use this to decide whether a widget's own
+ * `queryKey` actually changes across a team switch (see
+ * `shouldRetryWidgetFetch` in `widgetFetchConcurrency.ts`), while
+ * `resolveTeamPlaceholder` is what actually performs that substitution.
+ *
+ * Existence-only, unlike `resolveTeamPlaceholder` — this never needs to
+ * know which group id would replace the placeholder, only whether one
+ * could.
+ */
+export function hasTeamPlaceholder(filters: Record<string, unknown>): boolean {
+  const fieldFilters = filters.filters;
+  if (isCaseFieldFilterArray(fieldFilters)) {
+    const hasCaseFieldPlaceholder = fieldFilters.some((entry) => {
+      const isCreEntry = entry.field === CRE_TEAM_FILTER_FIELD;
+      const isSreEntry = entry.field === SRE_TEAM_FILTER_FIELD;
+      return (isCreEntry || isSreEntry) && (entry.values?.includes(CURRENT_TEAM_PLACEHOLDER) ?? false);
+    });
+    if (hasCaseFieldPlaceholder) return true;
+  }
+
+  const assignmentTeamIds = filters.assignmentTeamIds;
+  return Array.isArray(assignmentTeamIds) && assignmentTeamIds.includes(CURRENT_TEAM_PLACEHOLDER);
+}
+
 export function resolveTeamPlaceholder(
   filters: Record<string, unknown>,
   selectedTeamCreGroupId: string | string[] | undefined,

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/utils/teamFilterPlaceholder.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/utils/teamFilterPlaceholder.ts
@@ -116,39 +116,6 @@ export const SRE_TEAM_FILTER_FIELD = "sreTeam";
  * already present in `assignmentTeamIds` (i.e. not the placeholder) is left
  * alone, same as a literal value alongside the placeholder in the case DSL.
  */
-/**
- * Whether `filters` carries {@link CURRENT_TEAM_PLACEHOLDER} anywhere
- * {@link resolveTeamPlaceholder} would actually resolve it — a `creTeam` or
- * `sreTeam` case-field-filter entry's `values`, or a flat
- * `assignmentTeamIds` array. Deliberately mirrors that function's own two
- * detection checks (`values?.includes(CURRENT_TEAM_PLACEHOLDER)` for the
- * case DSL, `assignmentTeamIds.includes(CURRENT_TEAM_PLACEHOLDER)` for the
- * flat shape) rather than re-deriving its own notion of "team-scoped" —
- * the two must never disagree about which filters objects carry the
- * placeholder, since callers use this to decide whether a widget's own
- * `queryKey` actually changes across a team switch (see
- * `shouldRetryWidgetFetch` in `widgetFetchConcurrency.ts`), while
- * `resolveTeamPlaceholder` is what actually performs that substitution.
- *
- * Existence-only, unlike `resolveTeamPlaceholder` — this never needs to
- * know which group id would replace the placeholder, only whether one
- * could.
- */
-export function hasTeamPlaceholder(filters: Record<string, unknown>): boolean {
-  const fieldFilters = filters.filters;
-  if (isCaseFieldFilterArray(fieldFilters)) {
-    const hasCaseFieldPlaceholder = fieldFilters.some((entry) => {
-      const isCreEntry = entry.field === CRE_TEAM_FILTER_FIELD;
-      const isSreEntry = entry.field === SRE_TEAM_FILTER_FIELD;
-      return (isCreEntry || isSreEntry) && (entry.values?.includes(CURRENT_TEAM_PLACEHOLDER) ?? false);
-    });
-    if (hasCaseFieldPlaceholder) return true;
-  }
-
-  const assignmentTeamIds = filters.assignmentTeamIds;
-  return Array.isArray(assignmentTeamIds) && assignmentTeamIds.includes(CURRENT_TEAM_PLACEHOLDER);
-}
-
 export function resolveTeamPlaceholder(
   filters: Record<string, unknown>,
   selectedTeamCreGroupId: string | string[] | undefined,
@@ -229,4 +196,37 @@ function resolveAssignmentTeamIdsPlaceholder(
       v === CURRENT_TEAM_PLACEHOLDER ? [replacementCreGroupId] : [v],
     ),
   };
+}
+
+/**
+ * Whether `filters` carries {@link CURRENT_TEAM_PLACEHOLDER} anywhere
+ * {@link resolveTeamPlaceholder} would actually resolve it — a `creTeam` or
+ * `sreTeam` case-field-filter entry's `values`, or a flat
+ * `assignmentTeamIds` array. Deliberately mirrors that function's own two
+ * detection checks (`values?.includes(CURRENT_TEAM_PLACEHOLDER)` for the
+ * case DSL, `assignmentTeamIds.includes(CURRENT_TEAM_PLACEHOLDER)` for the
+ * flat shape) rather than re-deriving its own notion of "team-scoped" —
+ * the two must never disagree about which filters objects carry the
+ * placeholder, since callers use this to decide whether a widget's own
+ * `queryKey` actually changes across a team switch (see
+ * `shouldRetryWidgetFetch` in `widgetFetchConcurrency.ts`), while
+ * `resolveTeamPlaceholder` is what actually performs that substitution.
+ *
+ * Existence-only, unlike `resolveTeamPlaceholder` — this never needs to
+ * know which group id would replace the placeholder, only whether one
+ * could.
+ */
+export function hasTeamPlaceholder(filters: Record<string, unknown>): boolean {
+  const fieldFilters = filters.filters;
+  if (isCaseFieldFilterArray(fieldFilters)) {
+    const hasCaseFieldPlaceholder = fieldFilters.some((entry) => {
+      const isCreEntry = entry.field === CRE_TEAM_FILTER_FIELD;
+      const isSreEntry = entry.field === SRE_TEAM_FILTER_FIELD;
+      return (isCreEntry || isSreEntry) && (entry.values?.includes(CURRENT_TEAM_PLACEHOLDER) ?? false);
+    });
+    if (hasCaseFieldPlaceholder) return true;
+  }
+
+  const assignmentTeamIds = filters.assignmentTeamIds;
+  return Array.isArray(assignmentTeamIds) && assignmentTeamIds.includes(CURRENT_TEAM_PLACEHOLDER);
 }

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/utils/widgetFetchConcurrency.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/utils/widgetFetchConcurrency.test.ts
@@ -329,8 +329,14 @@ describe("shouldRetryWidgetFetch", () => {
     expect(shouldRetryWidgetFetch(1, badGateway)).toBe(false);
   });
 
-  it("does not retry a dropped-from-queue error from a team switch", () => {
-    expect(shouldRetryWidgetFetch(0, new WidgetFetchQueueDroppedError())).toBe(false);
+  it("retries once (but not twice) a dropped-from-queue error from a team switch", () => {
+    // A widget whose `filters` don't reference the selected team keeps the
+    // same `queryKey` across a team switch, so nothing else would ever
+    // naturally re-trigger a query left stuck by a queue drop — one retry
+    // is required to unstick it (see the function's own doc comment), but
+    // still capped at exactly one so a flip-flopping team can't loop.
+    expect(shouldRetryWidgetFetch(0, new WidgetFetchQueueDroppedError())).toBe(true);
+    expect(shouldRetryWidgetFetch(1, new WidgetFetchQueueDroppedError())).toBe(false);
   });
 
   it("does not retry an ordinary failure (e.g. a 400/404/500), same as before this task's retry policy existed", () => {

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/utils/widgetFetchConcurrency.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/utils/widgetFetchConcurrency.test.ts
@@ -18,11 +18,23 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   WIDGET_FETCH_CONCURRENCY_LIMIT,
   WIDGET_FETCH_TIMEOUT_MS,
+  WidgetFetchQueueDroppedError,
+  __resetWidgetFetchConcurrencyForTests,
   shouldRetryWidgetFetch,
   withWidgetFetchSlot,
 } from "@features/csm-dashboard/utils/widgetFetchConcurrency";
 
+/** A fixed team key every test in this file that doesn't care about
+ * team-switching behavior can pass — keeps those tests unaffected by the
+ * team-aware drop logic (a key that never changes never drops anything). */
+const TEAM_A = "team-a";
+const TEAM_B = "team-b";
+
 describe("withWidgetFetchSlot", () => {
+  afterEach(() => {
+    __resetWidgetFetchConcurrencyForTests();
+  });
+
   it("never lets more than WIDGET_FETCH_CONCURRENCY_LIMIT calls run at once, even when far more are requested simultaneously", async () => {
     const totalRequests = WIDGET_FETCH_CONCURRENCY_LIMIT * 4 + 3; // deliberately not a clean multiple
     let concurrent = 0;
@@ -44,7 +56,7 @@ describe("withWidgetFetchSlot", () => {
         await releaseGate();
         concurrent -= 1;
         return i;
-      }),
+      }, TEAM_A),
     );
 
     const results = await Promise.all(calls);
@@ -67,7 +79,7 @@ describe("withWidgetFetchSlot", () => {
 
     const failing = withWidgetFetchSlot(async () => {
       throw new Error("widget search failed");
-    }).catch(() => {
+    }, TEAM_A).catch(() => {
       results.push("failed");
     });
 
@@ -75,14 +87,14 @@ describe("withWidgetFetchSlot", () => {
     const fillers = Array.from({ length: WIDGET_FETCH_CONCURRENCY_LIMIT - 1 }, (_, i) =>
       withWidgetFetchSlot(async () => {
         results.push(`filler-${i}`);
-      }),
+      }, TEAM_A),
     );
 
     // One more, queued past the cap — only starts once a slot frees up,
     // which requires the failed call above to have released its slot.
     const queued = withWidgetFetchSlot(async () => {
       results.push("queued");
-    });
+    }, TEAM_A);
 
     await Promise.all([failing, ...fillers, queued]);
 
@@ -91,7 +103,7 @@ describe("withWidgetFetchSlot", () => {
   });
 
   it("returns fn's own resolved value unchanged", async () => {
-    const value = await withWidgetFetchSlot(async () => ({ total: 42 }));
+    const value = await withWidgetFetchSlot(async () => ({ total: 42 }), TEAM_A);
     expect(value).toEqual({ total: 42 });
   });
 
@@ -99,7 +111,7 @@ describe("withWidgetFetchSlot", () => {
     await expect(
       withWidgetFetchSlot(async () => {
         throw new Error("boom");
-      }),
+      }, TEAM_A),
     ).rejects.toThrow("boom");
   });
 
@@ -127,6 +139,7 @@ describe("withWidgetFetchSlot", () => {
               reject(Object.assign(new Error("aborted"), { name: "AbortError" }));
             });
           }),
+        TEAM_A,
       );
       // Swallow the eventual rejection here — asserted properly below —
       // so it doesn't surface as an unhandled rejection while we're still
@@ -155,6 +168,7 @@ describe("withWidgetFetchSlot", () => {
               reject(Object.assign(new Error("aborted"), { name: "AbortError" }));
             });
           }),
+        TEAM_A,
       ).catch(() => {
         events.push("first-rejected");
       });
@@ -162,7 +176,7 @@ describe("withWidgetFetchSlot", () => {
       const second = withWidgetFetchSlot(async () => {
         events.push("second-started");
         return "second-result";
-      });
+      }, TEAM_A);
 
       await vi.advanceTimersByTimeAsync(0);
       // WIDGET_FETCH_CONCURRENCY_LIMIT is 1 — the second call must still be
@@ -182,6 +196,106 @@ describe("withWidgetFetchSlot", () => {
       expect(events).toContain("second-started");
 
       vi.useRealTimers();
+    });
+  });
+
+  describe("team-scoped queue drop", () => {
+    it("keeps a same-team call queued normally behind an in-flight one (regression check, unaffected by team-awareness)", async () => {
+      const events: string[] = [];
+
+      const first = withWidgetFetchSlot(async () => {
+        events.push("first-started");
+        return "first-result";
+      }, TEAM_A);
+
+      const second = withWidgetFetchSlot(async () => {
+        events.push("second-started");
+        return "second-result";
+      }, TEAM_A);
+
+      await expect(Promise.all([first, second])).resolves.toEqual([
+        "first-result",
+        "second-result",
+      ]);
+      expect(events).toEqual(["first-started", "second-started"]);
+    });
+
+    it("drops queued entries for the old team — rejecting with WidgetFetchQueueDroppedError, never invoking their fn — once a call for a new team arrives", async () => {
+      const events: string[] = [];
+      // See the next test's own comment on why this is a pre-built deferred
+      // gate rather than a promise constructed inside `fn` itself.
+      // Definite-assignment: the `Promise` executor runs synchronously on
+      // construction, so `releaseActive` is always assigned before the
+      // very next line — no `null` state ever actually observable.
+      let releaseActive!: () => void;
+      const activeGate = new Promise<void>((resolve) => {
+        releaseActive = resolve;
+      });
+
+      // Occupy the one available slot so everything below actually queues
+      // instead of starting immediately (WIDGET_FETCH_CONCURRENCY_LIMIT is 1).
+      const active = withWidgetFetchSlot(() => activeGate, TEAM_A);
+
+      const oldTeamQueued = withWidgetFetchSlot(async () => {
+        events.push("old-team-fn-invoked");
+      }, TEAM_A);
+
+      // A call for a different team arrives while `oldTeamQueued` is still
+      // waiting — this is the moment a widget's fetch (re)fires because the
+      // selected ABT team switched.
+      const newTeamCall = withWidgetFetchSlot(async () => {
+        events.push("new-team-fn-invoked");
+        return "new-team-result";
+      }, TEAM_B);
+
+      await expect(oldTeamQueued).rejects.toBeInstanceOf(WidgetFetchQueueDroppedError);
+      expect(events).not.toContain("old-team-fn-invoked");
+
+      // Release the still-active (old-team) fetch — untouched by the drop,
+      // left to finish naturally — freeing the slot for the new team's call.
+      releaseActive();
+      await expect(active).resolves.toBeUndefined();
+      await expect(newTeamCall).resolves.toBe("new-team-result");
+      expect(events).toContain("new-team-fn-invoked");
+    });
+
+    it("does not drop an already-queued entry that matches the new current team key", async () => {
+      const events: string[] = [];
+      // A deferred gate `fn` awaits directly, set up synchronously here
+      // (the `new Promise` executor runs synchronously on construction) so
+      // releasing it doesn't depend on timing when `withWidgetFetchSlot`'s
+      // own internal microtask chain actually gets around to invoking
+      // `fn` — avoids a flaky race against that internal scheduling.
+      // Definite-assignment: the `Promise` executor runs synchronously on
+      // construction, so `releaseActive` is always assigned before the
+      // very next line — no `null` state ever actually observable.
+      let releaseActive!: () => void;
+      const activeGate = new Promise<void>((resolve) => {
+        releaseActive = resolve;
+      });
+
+      const active = withWidgetFetchSlot(() => activeGate, TEAM_A);
+
+      // Queued under TEAM_B while TEAM_A is still active/current.
+      const sameAsIncoming = withWidgetFetchSlot(async () => {
+        events.push("same-as-incoming");
+        return "survived";
+      }, TEAM_B);
+
+      // Another call for TEAM_B arrives — the *current* team switches to
+      // TEAM_B, but `sameAsIncoming` already carries that same key, so it
+      // must survive the drop untouched.
+      const alsoTeamB = withWidgetFetchSlot(async () => {
+        events.push("also-team-b");
+        return "also-survived";
+      }, TEAM_B);
+
+      releaseActive();
+      await active;
+
+      await expect(sameAsIncoming).resolves.toBe("survived");
+      await expect(alsoTeamB).resolves.toBe("also-survived");
+      expect(events).toEqual(["same-as-incoming", "also-team-b"]);
     });
   });
 });
@@ -213,6 +327,10 @@ describe("shouldRetryWidgetFetch", () => {
     expect(shouldRetryWidgetFetch(0, badGateway)).toBe(true);
     expect(shouldRetryWidgetFetch(0, serviceUnavailable)).toBe(true);
     expect(shouldRetryWidgetFetch(1, badGateway)).toBe(false);
+  });
+
+  it("does not retry a dropped-from-queue error from a team switch", () => {
+    expect(shouldRetryWidgetFetch(0, new WidgetFetchQueueDroppedError())).toBe(false);
   });
 
   it("does not retry an ordinary failure (e.g. a 400/404/500), same as before this task's retry policy existed", () => {

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/utils/widgetFetchConcurrency.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/utils/widgetFetchConcurrency.test.ts
@@ -307,44 +307,54 @@ describe("shouldRetryWidgetFetch", () => {
     name: "AbortError",
   });
 
-  it("retries once on this module's own timeout abort", () => {
+  it("retries once on this module's own timeout abort, regardless of isTeamIndependent", () => {
     // react-query calls its `retry` predicate with `failureCount` starting
     // at 0 on the FIRST failure (verified directly against
     // @tanstack/query-core's retryer.ts — NOT 1, which is the mistake this
-    // test guards against reintroducing).
-    expect(shouldRetryWidgetFetch(0, abortError)).toBe(true);
+    // test guards against reintroducing). The timeout branch doesn't care
+    // about team-scoping at all — only the queue-drop branch does.
+    expect(shouldRetryWidgetFetch(0, abortError, true)).toBe(true);
+    expect(shouldRetryWidgetFetch(0, abortError, false)).toBe(true);
   });
 
   it("does not retry a second time once the retry itself has also failed", () => {
-    expect(shouldRetryWidgetFetch(1, abortError)).toBe(false);
+    expect(shouldRetryWidgetFetch(1, abortError, true)).toBe(false);
   });
 
-  it("retries once on a 502/503 from the backend, same as the app's own global default", () => {
+  it("retries once on a 502/503 from the backend, same as the app's own global default, regardless of isTeamIndependent", () => {
     const badGateway = Object.assign(new Error("Bad Gateway"), { status: 502 });
     const serviceUnavailable = Object.assign(new Error("Service Unavailable"), {
       response: { status: 503 },
     });
-    expect(shouldRetryWidgetFetch(0, badGateway)).toBe(true);
-    expect(shouldRetryWidgetFetch(0, serviceUnavailable)).toBe(true);
-    expect(shouldRetryWidgetFetch(1, badGateway)).toBe(false);
+    expect(shouldRetryWidgetFetch(0, badGateway, true)).toBe(true);
+    expect(shouldRetryWidgetFetch(0, serviceUnavailable, false)).toBe(true);
+    expect(shouldRetryWidgetFetch(1, badGateway, true)).toBe(false);
   });
 
-  it("retries once (but not twice) a dropped-from-queue error from a team switch", () => {
+  it("retries once (but not twice) a dropped-from-queue error for a team-independent widget", () => {
     // A widget whose `filters` don't reference the selected team keeps the
     // same `queryKey` across a team switch, so nothing else would ever
     // naturally re-trigger a query left stuck by a queue drop — one retry
     // is required to unstick it (see the function's own doc comment), but
     // still capped at exactly one so a flip-flopping team can't loop.
-    expect(shouldRetryWidgetFetch(0, new WidgetFetchQueueDroppedError())).toBe(true);
-    expect(shouldRetryWidgetFetch(1, new WidgetFetchQueueDroppedError())).toBe(false);
+    expect(shouldRetryWidgetFetch(0, new WidgetFetchQueueDroppedError(), true)).toBe(true);
+    expect(shouldRetryWidgetFetch(1, new WidgetFetchQueueDroppedError(), true)).toBe(false);
+  });
+
+  it("does not retry a dropped-from-queue error for a team-specific widget", () => {
+    // A widget whose `filters` DO reference the selected team already got a
+    // brand-new `queryKey` from the switch itself (see
+    // `resolveTeamPlaceholder`) — retrying the dropped fetch would just
+    // re-populate a cache entry for a `queryKey` nobody reads anymore.
+    expect(shouldRetryWidgetFetch(0, new WidgetFetchQueueDroppedError(), false)).toBe(false);
   });
 
   it("does not retry an ordinary failure (e.g. a 400/404/500), same as before this task's retry policy existed", () => {
     const notFound = Object.assign(new Error("Not Found"), { status: 404 });
     const serverError = Object.assign(new Error("Internal Server Error"), { status: 500 });
     const genericFailure = new Error("Unsupported widget resourceType: bogus");
-    expect(shouldRetryWidgetFetch(0, notFound)).toBe(false);
-    expect(shouldRetryWidgetFetch(0, serverError)).toBe(false);
-    expect(shouldRetryWidgetFetch(0, genericFailure)).toBe(false);
+    expect(shouldRetryWidgetFetch(0, notFound, true)).toBe(false);
+    expect(shouldRetryWidgetFetch(0, serverError, true)).toBe(false);
+    expect(shouldRetryWidgetFetch(0, genericFailure, true)).toBe(false);
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/utils/widgetFetchConcurrency.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/utils/widgetFetchConcurrency.ts
@@ -101,11 +101,15 @@ let currentTeamKey: string | null = null;
  * Thrown to a queued (not-yet-started) widget fetch whose `teamKey` no
  * longer matches {@link currentTeamKey} — i.e. the selected ABT team
  * switched while this fetch was still waiting for a slot. Distinguished
- * from an ordinary failure so `shouldRetryWidgetFetch` can refuse to
- * retry it (re-entering the queue for a query nobody observes anymore,
- * since the widget tile has already moved its `queryKey` to the new
- * team, would be pure waste) and so a caller that wants to tell "queue
- * drop" apart from "the request itself failed" can `instanceof` it.
+ * from an ordinary failure so `shouldRetryWidgetFetch` can decide whether
+ * retrying it is worth anything: for a team-SPECIFIC widget (whose filters
+ * reference `__current_team__`), the switch already moved its `queryKey`
+ * to the new team, so re-entering the queue for the dropped fetch would be
+ * pure waste — a query nobody observes anymore. For a team-INDEPENDENT
+ * widget, the `queryKey` didn't change, so a retry is the only thing that
+ * un-sticks it (see `shouldRetryWidgetFetch`'s own doc comment for the
+ * full reasoning). Also lets a caller that wants to tell "queue drop"
+ * apart from "the request itself failed" `instanceof` it.
  */
 export class WidgetFetchQueueDroppedError extends Error {
   constructor() {
@@ -261,26 +265,47 @@ export async function withWidgetFetchSlot<T>(
  * (`>= 2`, matching the global default's own threshold — copied from it
  * without re-deriving this) silently allowed a 2nd retry — caught in this
  * task's own verification, not by inspection alone.
+ *
+ * `isTeamIndependent` — whether THIS query's own filters (see
+ * `hasTeamPlaceholder` in `teamFilterPlaceholder.ts`) reference
+ * `__current_team__` — decides whether a queue-drop is worth retrying at
+ * all (see the `WidgetFetchQueueDroppedError` branch below); it plays no
+ * part in the timeout/502/503 branches, which retry unconditionally
+ * regardless of a widget's own team-scoping.
  */
-export function shouldRetryWidgetFetch(failureCount: number, error: Error): boolean {
+export function shouldRetryWidgetFetch(
+  failureCount: number,
+  error: Error,
+  isTeamIndependent: boolean,
+): boolean {
   if (failureCount >= 1) return false;
   // A queue-drop means the selected team changed while this fetch was still
   // waiting for a slot. The queue-drop's `teamKey` mismatch is keyed off the
   // PAGE-level selected team, not off whether this particular widget's own
-  // `filters` actually reference `__current_team__` — so a widget whose
-  // filters don't reference the team keeps the exact same `queryKey` across
-  // the switch, and nothing else would ever naturally re-trigger it
-  // (react-query only auto-refetches on a `queryKey` change). Without a
-  // retry here, that widget is left stuck in a permanent error state until
-  // something unrelated forces a full remount. Allowing exactly one retry
-  // (still capped by `failureCount >= 1` above, so a rapidly flip-flopping
-  // team can't loop) is safe: by the time the retry's `queryFn` actually
-  // executes, react-query has re-synced the query's active `queryFn` to
-  // whatever the most recent render passed in, so the retry re-enters
-  // `withWidgetFetchSlot` with whatever `teamKey` is CURRENT by then, not a
-  // stale one — and for the widgets this matters for (queryKey unchanged
-  // across the switch), a slot is free immediately and it succeeds.
-  if (error instanceof WidgetFetchQueueDroppedError) return true;
+  // `filters` actually reference `__current_team__` — so a TEAM-INDEPENDENT
+  // widget (whose filters don't reference the team) keeps the exact same
+  // `queryKey` across the switch, and nothing else would ever naturally
+  // re-trigger it (react-query only auto-refetches on a `queryKey` change).
+  // Without a retry here, that widget is left stuck in a permanent error
+  // state until something unrelated forces a full remount. Allowing exactly
+  // one retry (still capped by `failureCount >= 1` above, so a rapidly
+  // flip-flopping team can't loop) is safe: by the time the retry's
+  // `queryFn` actually executes, react-query has re-synced the query's
+  // active `queryFn` to whatever the most recent render passed in, so the
+  // retry re-enters `withWidgetFetchSlot` with whatever `teamKey` is CURRENT
+  // by then, not a stale one — and since this query's `queryKey` never
+  // changed, a slot is free immediately and it succeeds.
+  //
+  // A TEAM-SPECIFIC widget (filters DO reference `__current_team__`) is the
+  // opposite case: the team switch already gave it a brand-new resolved
+  // `queryKey` (see `resolveTeamPlaceholder`), so react-query mounts a fresh
+  // query for the new team regardless of what happens to the old, dropped
+  // one — retrying the dropped fetch would just re-populate a cache entry
+  // for a `queryKey` nobody reads anymore. Refusing to retry here isn't a
+  // regression from the team-independent case above; it's the correct
+  // no-op, since the widget's own re-render already did the work a retry
+  // would have tried to do.
+  if (error instanceof WidgetFetchQueueDroppedError) return isTeamIndependent;
   if (error?.name === "AbortError") return true;
   const errorWithStatus = error as Error & {
     response?: { status?: number };

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/utils/widgetFetchConcurrency.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/utils/widgetFetchConcurrency.ts
@@ -17,6 +17,11 @@
 /**
  * How many widget data-fetch requests (`useWidgetData` / `useWidgetPieData`)
  * may be in flight at once, across the whole app, not just one dashboard.
+ * (The cap itself stays app-wide and team-agnostic; only the FIFO *queue*
+ * is team-aware — see `withWidgetFetchSlot`'s own `teamKey` parameter and
+ * {@link WidgetFetchQueueDroppedError} for why switching the selected ABT
+ * team drops the old team's still-queued entries instead of making the
+ * new team's widgets wait behind them.)
  *
  * A dashboard with N widgets previously fired N `/…/search` calls to
  * `customer-entity-service` essentially simultaneously on mount (one per
@@ -72,17 +77,84 @@ export const WIDGET_FETCH_CONCURRENCY_LIMIT = 1;
 export let WIDGET_FETCH_TIMEOUT_MS = 10_000;
 
 let activeCount = 0;
-const waiters: Array<() => void> = [];
 
-function acquireWidgetFetchSlot(): Promise<void> {
+interface Waiter {
+  teamKey: string;
+  resolve: () => void;
+  reject: (error: Error) => void;
+}
+
+const waiters: Waiter[] = [];
+
+/**
+ * The team (or team-family) whose widgets most recently called into this
+ * queue — `null` until the first call. Used purely to detect a CHANGE: the
+ * whole app shares one queue (see {@link WIDGET_FETCH_CONCURRENCY_LIMIT}'s
+ * own doc comment on why it's module-level, not per-dashboard), so a
+ * change here means "the selected ABT team switched," and every entry
+ * still queued for the OLD key is abandoned — see
+ * {@link WidgetFetchQueueDroppedError}.
+ */
+let currentTeamKey: string | null = null;
+
+/**
+ * Thrown to a queued (not-yet-started) widget fetch whose `teamKey` no
+ * longer matches {@link currentTeamKey} — i.e. the selected ABT team
+ * switched while this fetch was still waiting for a slot. Distinguished
+ * from an ordinary failure so `shouldRetryWidgetFetch` can refuse to
+ * retry it (re-entering the queue for a query nobody observes anymore,
+ * since the widget tile has already moved its `queryKey` to the new
+ * team, would be pure waste) and so a caller that wants to tell "queue
+ * drop" apart from "the request itself failed" can `instanceof` it.
+ */
+export class WidgetFetchQueueDroppedError extends Error {
+  constructor() {
+    super("Widget fetch dropped from the queue: the selected team changed.");
+    this.name = "WidgetFetchQueueDroppedError";
+  }
+}
+
+/**
+ * Rejects and removes every currently queued (not active) waiter whose own
+ * `teamKey` doesn't match `newTeamKey` — called once per actual team
+ * change, from whichever widget's fetch call happens to run first after
+ * the switch (see `acquireWidgetFetchSlot`). The one fetch that may
+ * already be ACTIVE (at most one, given
+ * {@link WIDGET_FETCH_CONCURRENCY_LIMIT} = 1) is untouched here: it's left
+ * to finish naturally rather than force-aborted, per the explicit
+ * "abandon the queue, don't cancel what's in flight" shape this was built
+ * to.
+ */
+function dropWaitersForOldTeam(newTeamKey: string): void {
+  for (let i = waiters.length - 1; i >= 0; i -= 1) {
+    if (waiters[i].teamKey !== newTeamKey) {
+      const [dropped] = waiters.splice(i, 1);
+      dropped.reject(new WidgetFetchQueueDroppedError());
+    }
+  }
+}
+
+function acquireWidgetFetchSlot(teamKey: string): Promise<void> {
+  // A change in team is detected relative to the value already stored, so
+  // it must be checked (and `currentTeamKey` updated) BEFORE this call's
+  // own acquire/queue logic below — otherwise this very call could see
+  // itself as "the team that changed" and drop its own place in line.
+  if (currentTeamKey !== teamKey) {
+    currentTeamKey = teamKey;
+    dropWaitersForOldTeam(teamKey);
+  }
   if (activeCount < WIDGET_FETCH_CONCURRENCY_LIMIT) {
     activeCount += 1;
     return Promise.resolve();
   }
-  return new Promise<void>((resolve) => {
-    waiters.push(() => {
-      activeCount += 1;
-      resolve();
+  return new Promise<void>((resolve, reject) => {
+    waiters.push({
+      teamKey,
+      resolve: () => {
+        activeCount += 1;
+        resolve();
+      },
+      reject,
     });
   });
 }
@@ -90,7 +162,7 @@ function acquireWidgetFetchSlot(): Promise<void> {
 function releaseWidgetFetchSlot(): void {
   activeCount = Math.max(0, activeCount - 1);
   const next = waiters.shift();
-  if (next) next();
+  if (next) next.resolve();
 }
 
 /**
@@ -116,11 +188,23 @@ function releaseWidgetFetchSlot(): void {
  * A hand-rolled FIFO semaphore rather than a dependency (`p-limit` etc.) —
  * neither is already in `package.json`, and the mechanism this needs is a
  * dozen lines.
+ *
+ * `teamKey` scopes the FIFO *drop* behavior, not the concurrency cap
+ * itself (the cap stays app-wide — see {@link WIDGET_FETCH_CONCURRENCY_LIMIT}):
+ * when a call arrives with a `teamKey` different from whichever key the
+ * queue last saw, every OTHER entry still queued (not yet started) under
+ * the old key is rejected with {@link WidgetFetchQueueDroppedError} and
+ * removed, so a switch of the selected ABT team doesn't leave the new
+ * team's widgets waiting behind the old team's full remaining backlog.
+ * Pass a stable, derived key (e.g. a serialization of the selected team's
+ * group ids) — a dashboard with no team concept can pass any constant
+ * value, since a key that never changes never drops anything.
  */
 export async function withWidgetFetchSlot<T>(
   fn: (signal: AbortSignal) => Promise<T>,
+  teamKey: string,
 ): Promise<T> {
-  await acquireWidgetFetchSlot();
+  await acquireWidgetFetchSlot(teamKey);
   const controller = new AbortController();
   const timeoutId = setTimeout(() => {
     controller.abort();
@@ -180,6 +264,14 @@ export async function withWidgetFetchSlot<T>(
  */
 export function shouldRetryWidgetFetch(failureCount: number, error: Error): boolean {
   if (failureCount >= 1) return false;
+  // A queue-drop means the selected team changed while this fetch was
+  // still waiting for a slot — the widget tile that queued it has already
+  // moved its own `queryKey` to the new team, so nobody observes this
+  // query anymore. Retrying would just re-enter the queue for a result
+  // nothing reads, and could loop if the team flips back and forth
+  // rapidly. Checked before the AbortError/502/503 cases below since it's
+  // its own distinct, non-retryable failure mode.
+  if (error instanceof WidgetFetchQueueDroppedError) return false;
   if (error?.name === "AbortError") return true;
   const errorWithStatus = error as Error & {
     response?: { status?: number };
@@ -204,6 +296,7 @@ export function shouldRetryWidgetFetch(failureCount: number, error: Error): bool
 export function __resetWidgetFetchConcurrencyForTests(): void {
   activeCount = 0;
   waiters.length = 0;
+  currentTeamKey = null;
 }
 
 /**

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/utils/widgetFetchConcurrency.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/utils/widgetFetchConcurrency.ts
@@ -264,14 +264,23 @@ export async function withWidgetFetchSlot<T>(
  */
 export function shouldRetryWidgetFetch(failureCount: number, error: Error): boolean {
   if (failureCount >= 1) return false;
-  // A queue-drop means the selected team changed while this fetch was
-  // still waiting for a slot — the widget tile that queued it has already
-  // moved its own `queryKey` to the new team, so nobody observes this
-  // query anymore. Retrying would just re-enter the queue for a result
-  // nothing reads, and could loop if the team flips back and forth
-  // rapidly. Checked before the AbortError/502/503 cases below since it's
-  // its own distinct, non-retryable failure mode.
-  if (error instanceof WidgetFetchQueueDroppedError) return false;
+  // A queue-drop means the selected team changed while this fetch was still
+  // waiting for a slot. The queue-drop's `teamKey` mismatch is keyed off the
+  // PAGE-level selected team, not off whether this particular widget's own
+  // `filters` actually reference `__current_team__` — so a widget whose
+  // filters don't reference the team keeps the exact same `queryKey` across
+  // the switch, and nothing else would ever naturally re-trigger it
+  // (react-query only auto-refetches on a `queryKey` change). Without a
+  // retry here, that widget is left stuck in a permanent error state until
+  // something unrelated forces a full remount. Allowing exactly one retry
+  // (still capped by `failureCount >= 1` above, so a rapidly flip-flopping
+  // team can't loop) is safe: by the time the retry's `queryFn` actually
+  // executes, react-query has re-synced the query's active `queryFn` to
+  // whatever the most recent render passed in, so the retry re-enters
+  // `withWidgetFetchSlot` with whatever `teamKey` is CURRENT by then, not a
+  // stale one — and for the widgets this matters for (queryKey unchanged
+  // across the switch), a slot is free immediately and it succeeds.
+  if (error instanceof WidgetFetchQueueDroppedError) return true;
   if (error?.name === "AbortError") return true;
   const errorWithStatus = error as Error & {
     response?: { status?: number };


### PR DESCRIPTION
## Purpose
Relative timestamps ("1m ago", "Last refreshed…") across the CSM portal were static — computed once per render and never updated without a page reload. Also fixes two related bugs found while manually testing this on the ABT engineering dashboard.

## Goals
- Relative-time displays update live, in place, without a reload.
- Every refresh button in the CSM portal shows a "Last refreshed" indicator once clicked.
- Fix: a section/widget refresh clicked a while after page load could briefly show a negative/"from now" time instead of "just now".
- Fix: switching the selected ABT team no longer waits for the previous team's entire widget-load backlog to drain before the new team's widgets start loading.

## Approach
- `RelativeTime.tsx`: replaced a fixed 20s polling ticker with one shared, adaptively-scheduled timer (`useRelativeTimeTick`) — it wakes exactly when a displayed string would actually change (next minute/hour/day boundary), not on a fixed cadence, and is shared across every mounted timestamp instead of one timer per instance. Also fixes a stale-`now` bug: the ticker's `now` state only refreshed on its own scheduled fire, so a freshly-registered timestamp (e.g. right after a manual refresh click) could be compared against a stale `now` and render as negative/"from now" until the next tick self-corrected it — now it refreshes immediately on registration.
- `RefreshButton.tsx`, `CaseSlaTable.tsx`, `TasksWidget.tsx`, `DashboardWidgetGrid.tsx` (section-level), `DashboardWidgetTile.tsx` (new per-widget button, hover/focus-revealed, top-right): all show a "Last refreshed Xm ago" label, hidden until the user's first manual refresh click on that control. Count/number-shape tiles fold this into the refresh icon's tooltip instead of an inline label (no horizontal room on short tiles).
- `widgetFetchConcurrency.ts`: the app-wide widget-fetch queue (deliberately serialized, concurrency = 1, to protect the backend — see the file's own comment) now tracks a `teamKey` derived from the widget's team-scoped filters. When a call arrives for a new team, every still-queued (not yet started) fetch belonging to the old team is dropped (rejected with a distinct, non-retried error) so the new team's widgets get the next free slot as soon as whatever's currently in flight finishes.

## User stories
As a CS engineer viewing the CSM portal dashboard or a case's comment/activity feed, I see "time ago" labels update live while I'm on the page, and I can tell at a glance how fresh a widget's or section's data is after refreshing it.

## Release note
Relative timestamps and "Last refreshed" indicators throughout the CSM portal now update live without a page reload; added a refresh button to every dashboard widget; fixed a stale-timestamp display glitch and a dashboard-widget-loading delay when switching ABT teams.

## Documentation
N/A — internal CSM portal UI behavior, no external-facing doc surface.

## Training
N/A

## Certification
N/A — no certification-exam impact.

## Marketing
N/A

## Automation tests
- Unit tests
  - New/updated Vitest coverage for the adaptive scheduler (boundary-crossing, no-poll-when-old, cleanup-on-unmount, immediate-refresh-on-registration), the click-gated refresh labels (`RefreshButton`, `CaseSlaTable`, `TasksWidget`, `DashboardWidgetGrid`, `DashboardWidgetTile` per-widget + tooltip variant), and the team-scoped queue drop (`widgetFetchConcurrency.test.ts`: same-team regression, old-team drop, new-team survival, retry-predicate).
  - Full suite: 196 test files / 1985 tests passing.
- Integration tests
  - Manually verified against the local preview stack (webapp local, staging backend): live-ticking timestamps, section and per-widget refresh + label, and the team-switch queue behavior on the ABT engineering dashboard.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — TypeScript/React frontend, not a Java/Maven module this tool covers
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
None

## Migrations (if applicable)
N/A

## Test environment
Local CSM portal webapp (Vite dev server) against the staging backend (Choreo), Chrome, macOS.

## Learning
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added refresh controls to dashboard widgets and sections without interfering with tile navigation.
  * Added automatically updating “Last refreshed” timestamps after manual refreshes.
  * Added support for hiding widget refresh controls when builder actions are available.
* **Bug Fixes**
  * Prevented outdated queued requests from appearing after team changes.
  * Improved retry behavior for refreshes and preserved keyboard accessibility.
  * Ensured refresh actions invalidate only the relevant widget data.
* **Tests**
  * Expanded coverage for refresh flows, timestamps, widget types, accessibility, and request queuing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->