### PR TITLE
[CSM Portal] fix CR create speculative fields, unsafe approval toggle, and Plan tab

### DIFF
--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -1998,23 +1998,6 @@ export type BeChangeRequestType =
 
 export type BeChangeRequestPriority = "critical" | "high" | "moderate" | "low";
 
-export type BeChangeRequestRisk = "high" | "moderate" | "low";
-
-export type BeChangeRequestCategory =
-  | "hardware"
-  | "software"
-  | "service"
-  | "system_software"
-  | "applications_software"
-  | "network"
-  | "telecom"
-  | "documentation"
-  | "other"
-  | "regular_release_cloud"
-  | "hotfix_release_cloud"
-  | "devops"
-  | "cloud_computing";
-
 /** List-item / shared shape for a change request (`POST /change-requests/search`). */
 export interface BeChangeRequestSearchView {
   id: string;
@@ -2112,29 +2095,33 @@ export interface BeChangeRequestApprovalDecisionResponse {
 
 /**
  * `POST /change-requests` body (ServiceNow data source only). `subject` is
- * the only required field; every ID field (`serviceId`, `serviceOfferingId`,
- * `configurationItemId`, `groupId`, `assignedEngineerId`, `requestedById`)
- * is a portal UUID resolved server-side against the backing data source, via
- * the matching `/*\/search` endpoint (see `AsyncEntitySelect` usages in
- * `CreateChangeRequestPage.tsx`). `state` accepts any valid lifecycle state,
- * but the create form restricts the selectable options to the pre-workflow
- * states (new/assess/authorize), defaulting to "new", so a CR can't be created
- * already past its own approval flow.
+ * the only required field; every ID field (`groupId`, `assignedEngineerId`,
+ * `requestedById`) is a portal UUID resolved server-side against the backing
+ * data source, via the matching `/*\/search` endpoint (see `AsyncEntitySelect`
+ * usages in `CreateChangeRequestPage.tsx`). `state` accepts any valid
+ * lifecycle state, but the create form restricts the selectable options to
+ * the pre-workflow states (new/assess/authorize), defaulting to "new", so a
+ * CR can't be created already past its own approval flow.
  * `plannedStartDate`/`plannedEndDate` are `YYYY-MM-DD HH:MM:SS` strings.
+ *
+ * `category`, `serviceId`, `serviceOfferingId`, `configurationItemId` and
+ * `risk` are deliberately not part of this type even though the backend
+ * still accepts them: the live ServiceNow CR form has no `Service`/
+ * `Service offering`/`Configuration item`/`Risk` fields at all, and
+ * `category` is left at its default on 99.9% of real change requests, so
+ * neither belongs as an editable control in this portal (see
+ * `notes/2026-08-19-sn-prod-cr-form-spec.md` and the field-usage census in
+ * the planning repo). The backend contract is left untouched — only the
+ * webapp stops sending them.
  */
 export interface BeCreateChangeRequestPayload {
   subject: string;
-  category?: BeChangeRequestCategory;
-  serviceId?: string;
-  serviceOfferingId?: string;
-  configurationItemId?: string;
   priority?: BeChangeRequestPriority;
   impact?: BeChangeRequestImpact;
   type?: BeChangeRequestType;
   state?: BeChangeRequestState;
   groupId?: string;
   assignedEngineerId?: string;
-  risk?: BeChangeRequestRisk;
   requestedById?: string;
   description?: string;
   justification?: string;

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/EditChangeRequestDialog.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/EditChangeRequestDialog.test.tsx
@@ -115,71 +115,20 @@ function renderDialog(
   return { onSave, onClose };
 }
 
-// Queried lazily on each call rather than captured once, because these tests
-// toggle the switches and re-read their state after a re-render.
-
-/** The "Customer approved" switch. */
-const approvedSwitch = (): HTMLElement => screen.getByLabelText(/customer approved/i);
-/** The "Customer reviewed" switch — mutually exclusive with the one above. */
-const reviewedSwitch = (): HTMLElement => screen.getByLabelText(/customer reviewed/i);
 /** The dialog's Save button. */
 const saveButton = (): HTMLElement => screen.getByRole("button", { name: /save/i });
 
-describe("EditChangeRequestDialog — Customer approved / reviewed mutual exclusion", () => {
-  it("allows toggling only 'Customer approved' and saves just that field", () => {
-    const { onSave } = renderDialog();
-    fireEvent.click(approvedSwitch());
-    fireEvent.click(saveButton());
-    expect(onSave).toHaveBeenCalledWith({ isCustomerApproved: true });
-  });
+// "Customer approved"/"Customer reviewed" are deliberately not rendered as
+// switches in this dialog — see EditChangeRequestDialog.tsx's doc comment for
+// why (they drive a gated SN state transition, not a boolean field, and the
+// "off" direction is destructive). This test file only covers what the
+// dialog actually renders.
 
-  it("allows toggling only 'Customer reviewed' and saves just that field", () => {
-    const { onSave } = renderDialog();
-    fireEvent.click(reviewedSwitch());
-    fireEvent.click(saveButton());
-    expect(onSave).toHaveBeenCalledWith({ isCustomerReviewed: true });
-  });
-
-  it("locks 'Customer reviewed' once 'Customer approved' has been changed, so both can never be sent together", () => {
+describe("EditChangeRequestDialog — Customer approved / reviewed are not editable here", () => {
+  it("renders no 'Customer approved' or 'Customer reviewed' control", () => {
     renderDialog();
-    fireEvent.click(approvedSwitch());
-    expect(reviewedSwitch()).toBeDisabled();
-    expect(approvedSwitch()).toBeEnabled();
-  });
-
-  it("locks 'Customer approved' once 'Customer reviewed' has been changed", () => {
-    renderDialog();
-    fireEvent.click(reviewedSwitch());
-    expect(approvedSwitch()).toBeDisabled();
-    expect(reviewedSwitch()).toBeEnabled();
-  });
-
-  it("explains why the other switch is locked", () => {
-    renderDialog();
-    fireEvent.click(approvedSwitch());
-    expect(
-      screen.getByText(/can't be changed in the same save/i),
-    ).toBeInTheDocument();
-  });
-
-  it("unlocks the other switch again once the change is undone", () => {
-    renderDialog();
-    fireEvent.click(approvedSwitch());
-    expect(reviewedSwitch()).toBeDisabled();
-    fireEvent.click(approvedSwitch());
-    expect(reviewedSwitch()).toBeEnabled();
-  });
-
-  it("never builds a patch containing both isCustomerApproved and isCustomerReviewed, even via the disabled control", () => {
-    const { onSave } = renderDialog();
-    fireEvent.click(approvedSwitch());
-    // Attempting to click the now-disabled control is a no-op in the DOM;
-    // this documents that expectation rather than relying on it silently.
-    fireEvent.click(reviewedSwitch());
-    fireEvent.click(saveButton());
-    expect(onSave).toHaveBeenCalledWith({ isCustomerApproved: true });
-    const [patch] = onSave.mock.calls[0];
-    expect(patch).not.toHaveProperty("isCustomerReviewed");
+    expect(screen.queryByLabelText(/customer approved/i)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/customer reviewed/i)).not.toBeInTheDocument();
   });
 });
 
@@ -195,14 +144,14 @@ describe("EditChangeRequestDialog — save error surfacing", () => {
       <EditChangeRequestDialog
         cr={BASE_CR}
         isSaving={false}
-        saveError="isCustomerApproved, isCustomerReviewed, and requestApproval are mutually exclusive"
+        saveError="Could not update the change request."
         onClose={onClose}
         onSave={vi.fn()}
       />,
     );
     expect(
       screen.getByRole("alert"),
-    ).toHaveTextContent(/mutually exclusive/i);
+    ).toHaveTextContent(/could not update/i);
   });
 });
 
@@ -278,29 +227,6 @@ describe("EditChangeRequestDialog — rollback and test plans", () => {
       rollbackPlan: "<p>Roll the image back.</p>",
       testPlan: "<p>Run the regression suite.</p>",
     });
-  });
-
-  // The load-time rewrite makes this the sharp edge of the whole dialog: the
-  // editor's HTML never equals the stored HTML, so a naive string compare
-  // against `cr.rollbackPlan` would mark both plans dirty on open and patch
-  // fields nobody touched.
-  it("keeps an untouched plan out of the patch even when the CR already has one stored", () => {
-    const { onSave } = renderDialog({
-      rollbackPlan: "<p>Restore the previous release.</p>",
-      testPlan: "<p>Smoke the gateway health endpoint.</p>",
-    });
-    fireEvent.click(approvedSwitch());
-    fireEvent.click(saveButton());
-    expect(onSave).toHaveBeenCalledWith({ isCustomerApproved: true });
-  });
-
-  it("keeps an untouched multi-paragraph plan out of the patch", () => {
-    const { onSave } = renderDialog({
-      rollbackPlan: "<p>Stop the rollout.</p><p>Redeploy the previous tag.</p>",
-    });
-    fireEvent.click(approvedSwitch());
-    fireEvent.click(saveButton());
-    expect(onSave).toHaveBeenCalledWith({ isCustomerApproved: true });
   });
 
   it("leaves Save disabled on open when a plan is already stored", () => {
@@ -394,7 +320,7 @@ describe("EditChangeRequestDialog — planned end must be after planned start", 
     });
     // Make the form dirty so Save would otherwise be enabled — this proves the
     // date check, not the dirty check, is what disables it.
-    fireEvent.click(approvedSwitch());
+    fireEvent.change(rollbackPlanField(), { target: { value: "<p>dirty</p>" } });
     expect(
       screen.getByText(/planned end must be after planned start/i),
     ).toBeInTheDocument();
@@ -406,7 +332,7 @@ describe("EditChangeRequestDialog — planned end must be after planned start", 
       plannedStartOn: "2026-03-01 10:00:00",
       plannedEndOn: "2026-03-01 10:00:00",
     });
-    fireEvent.click(approvedSwitch());
+    fireEvent.change(rollbackPlanField(), { target: { value: "<p>dirty</p>" } });
     expect(saveButton()).toBeDisabled();
   });
 
@@ -415,7 +341,7 @@ describe("EditChangeRequestDialog — planned end must be after planned start", 
       plannedStartOn: "2026-03-01 10:00:00",
       plannedEndOn: "2026-03-01 12:00:00",
     });
-    fireEvent.click(approvedSwitch());
+    fireEvent.change(rollbackPlanField(), { target: { value: "<p>dirty</p>" } });
     expect(
       screen.queryByText(/planned end must be after planned start/i),
     ).not.toBeInTheDocument();
@@ -424,7 +350,7 @@ describe("EditChangeRequestDialog — planned end must be after planned start", 
 
   it("does not flag anything when only one end of the window is set", () => {
     renderDialog({ plannedStartOn: "2026-03-01 10:00:00" });
-    fireEvent.click(approvedSwitch());
+    fireEvent.change(rollbackPlanField(), { target: { value: "<p>dirty</p>" } });
     expect(
       screen.queryByText(/planned end must be after planned start/i),
     ).not.toBeInTheDocument();

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/EditChangeRequestDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/EditChangeRequestDialog.tsx
@@ -24,9 +24,7 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
-  FormControlLabel,
   FormHelperText,
-  Switch,
   Typography,
 } from "@wso2/oxygen-ui";
 import { useCallback, useMemo, useState, type JSX } from "react";
@@ -149,9 +147,26 @@ function useRichTextPlanField(storedHtml?: string | null): RichTextPlanField {
 
 /**
  * Edit the change-request fields the BE allows updating: the planned window,
- * the assignment group, the customer approved / reviewed flags, and the
- * rollback and test plans. Only changed fields are sent, and the BE requires
- * at least one, so Save is disabled until something differs.
+ * the assignment group, and the rollback and test plans. Only changed fields
+ * are sent, and the BE requires at least one, so Save is disabled until
+ * something differs.
+ *
+ * `isCustomerApproved`/`isCustomerReviewed` are deliberately NOT exposed here
+ * even though the BE patch contract still accepts them (see
+ * `BePatchChangeRequestPayload`). Traced end to end (webapp -> BFF -> Go
+ * entity-service -> Ballerina -> the SN scripted API's dedicated
+ * `patchCustomerApproved`/`patchCustomerReviewed` handlers): both are gated
+ * (only accepted while the CR is already in the "Customer Approval"/
+ * "Customer Review" state) but flipping either is not a boolean-field edit —
+ * it drives a real state transition, and the "off" direction is destructive
+ * (`isCustomerApproved: false` moves the CR to Cancelled; `isCustomerReviewed:
+ * false` moves it to Rollback, a terminal dead end with no reason capture).
+ * A switch labelled "Customer approved"/"Customer reviewed" strongly implies
+ * a record-keeping boolean, not a one-way cancel/rollback action, so this is
+ * exactly the "inventing a capability the source system doesn't expose"
+ * pattern the CR approval-mechanics review warned about (no SN UI action
+ * exists for either state either). Removed as a UI affordance; the BE/Go
+ * plumbing is left in place since nothing else depends on removing it.
  */
 export default function EditChangeRequestDialog({
   cr,
@@ -171,8 +186,6 @@ export default function EditChangeRequestDialog({
   const initialAssignedTeamId = cr.assignedTeam?.id ?? "";
   const [plannedStart, setPlannedStart] = useState(initialPlannedStart);
   const [plannedEnd, setPlannedEnd] = useState(initialPlannedEnd);
-  const [approved, setApproved] = useState(!!cr.hasCustomerApproved);
-  const [reviewed, setReviewed] = useState(!!cr.hasCustomerReviewed);
   const [assignedTeamId, setAssignedTeamId] = useState(initialAssignedTeamId);
   const rollbackPlan = useRichTextPlanField(cr.rollbackPlan);
   const testPlan = useRichTextPlanField(cr.testPlan);
@@ -194,8 +207,6 @@ export default function EditChangeRequestDialog({
     if (plannedEnd !== initialPlannedEnd && plannedEnd) {
       next.plannedEndOn = toBackendDateTime(plannedEnd);
     }
-    if (approved !== !!cr.hasCustomerApproved) next.isCustomerApproved = approved;
-    if (reviewed !== !!cr.hasCustomerReviewed) next.isCustomerReviewed = reviewed;
     if (assignedTeamId !== initialAssignedTeamId && assignedTeamId) {
       next.assignedTeamId = assignedTeamId;
     }
@@ -211,16 +222,12 @@ export default function EditChangeRequestDialog({
     initialPlannedStart,
     plannedEnd,
     initialPlannedEnd,
-    approved,
-    reviewed,
     assignedTeamId,
     initialAssignedTeamId,
     rollbackPlan.isDirty,
     rollbackPlan.outgoing,
     testPlan.isDirty,
     testPlan.outgoing,
-    cr.hasCustomerApproved,
-    cr.hasCustomerReviewed,
   ]);
 
   const hasChanges = Object.keys(patch).length > 0;
@@ -228,17 +235,6 @@ export default function EditChangeRequestDialog({
   // but not forbidden (e.g. recording when it actually started), so this
   // only warns.
   const plannedStartIsPast = isPastDateTime(startDate);
-
-  // The backend rejects a patch containing both isCustomerApproved and
-  // isCustomerReviewed outright — they, and requestApproval, are mutually
-  // exclusive. Mirror that here: once one of the two has been changed away
-  // from its saved value, lock the other to its current value until this
-  // save goes through (or the first change is undone), so the dialog can
-  // never build the two-key payload the backend always refuses.
-  const approvedChanged = approved !== !!cr.hasCustomerApproved;
-  const reviewedChanged = reviewed !== !!cr.hasCustomerReviewed;
-  const approvedLocked = reviewedChanged;
-  const reviewedLocked = approvedChanged;
 
   // Rich-text plan field. The editor takes no `id`/native label, so the
   // visible label is a separate Typography tied to the control via
@@ -334,51 +330,6 @@ export default function EditChangeRequestDialog({
               }}
             />
           </LocalizationProvider>
-          <Box>
-            <FormControlLabel
-              control={
-                <Switch
-                  checked={approved}
-                  disabled={isSaving || approvedLocked}
-                  // Guard the handler too, not just the `disabled` attribute:
-                  // it's the actual mutual-exclusion enforcement, so it must
-                  // not depend on the DOM ignoring input while disabled.
-                  onChange={(e) => {
-                    if (approvedLocked) return;
-                    setApproved(e.target.checked);
-                  }}
-                />
-              }
-              label="Customer approved"
-            />
-            {approvedLocked && (
-              <FormHelperText>
-                Save the customer-reviewed change first — approved and
-                reviewed can&apos;t be changed in the same save.
-              </FormHelperText>
-            )}
-          </Box>
-          <Box>
-            <FormControlLabel
-              control={
-                <Switch
-                  checked={reviewed}
-                  disabled={isSaving || reviewedLocked}
-                  onChange={(e) => {
-                    if (reviewedLocked) return;
-                    setReviewed(e.target.checked);
-                  }}
-                />
-              }
-              label="Customer reviewed"
-            />
-            {reviewedLocked && (
-              <FormHelperText>
-                Save the customer-approved change first — approved and
-                reviewed can&apos;t be changed in the same save.
-              </FormHelperText>
-            )}
-          </Box>
           <AsyncEntitySelect<BeGroup>
             id="cr-edit-assigned-team"
             label="Assignment group"

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateChangeRequestPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateChangeRequestPage.test.tsx
@@ -144,7 +144,7 @@ describe("CreateChangeRequestPage — Clone prefill", () => {
     locationState = { sourceNumber: "CHG0009988", subject: "Upgrade the gateway cluster" };
     render(<CreateChangeRequestPage />);
     expect(screen.getByText(/cloned from chg0009988/i)).toBeInTheDocument();
-    expect(screen.getByText(/category, priority, risk/i)).toBeInTheDocument();
+    expect(screen.getByText(/priority, implementation plan/i)).toBeInTheDocument();
   });
 
   it("shows a generic banner when the source number is unavailable", () => {

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateChangeRequestPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateChangeRequestPage.tsx
@@ -45,9 +45,6 @@ import { usePostChangeRequest } from "@features/csm-operations/api/usePostChange
 import { usePatchChangeRequest } from "@features/csm-operations/api/usePatchChangeRequest";
 import { useGetUsersMe } from "@features/settings/api/useGetUsersMe";
 import { useSearchGroups } from "@api/useSearchGroups";
-import { useSearchItServices } from "@api/useSearchItServices";
-import { useSearchServiceOfferings } from "@api/useSearchServiceOfferings";
-import { useSearchConfigurationItems } from "@api/useSearchConfigurationItems";
 import { useSearchUsersByName } from "@api/useSearchUsersByName";
 import { useSearchServiceRequestsForSelect } from "@features/csm-operations/api/useSearchServiceRequestsForSelect";
 import AsyncEntitySelect from "@components/AsyncEntitySelect";
@@ -58,18 +55,13 @@ import {
 } from "@features/csm-operations/utils/changeRequests";
 import type { CreateChangeRequestFromCaseNavState } from "@features/csm-cases/types/csmCases";
 import type {
-  BeChangeRequestCategory,
   BeChangeRequestImpact,
   BeChangeRequestPriority,
-  BeChangeRequestRisk,
   BeChangeRequestState,
   BeChangeRequestType,
   BeCaseSearchView,
   BeCreateChangeRequestPayload,
-  BeConfigurationItem,
   BeGroup,
-  BeItService,
-  BeServiceOffering,
   BeUser,
 } from "@api/backend/types";
 
@@ -94,22 +86,6 @@ const TYPE_OPTIONS: Array<{ value: BeChangeRequestType; label: string }> = [
   { value: "azure", label: "Azure" },
 ];
 
-const CATEGORY_OPTIONS: Array<{ value: BeChangeRequestCategory; label: string }> = [
-  { value: "hardware", label: "Hardware" },
-  { value: "software", label: "Software" },
-  { value: "service", label: "Service" },
-  { value: "system_software", label: "System software" },
-  { value: "applications_software", label: "Applications software" },
-  { value: "network", label: "Network" },
-  { value: "telecom", label: "Telecom" },
-  { value: "documentation", label: "Documentation" },
-  { value: "regular_release_cloud", label: "Regular release (cloud)" },
-  { value: "hotfix_release_cloud", label: "Hotfix release (cloud)" },
-  { value: "devops", label: "DevOps" },
-  { value: "cloud_computing", label: "Cloud computing" },
-  { value: "other", label: "Other" },
-];
-
 const IMPACT_OPTIONS: Array<{ value: BeChangeRequestImpact; label: string }> = [
   { value: "high", label: "High" },
   { value: "medium", label: "Medium" },
@@ -118,12 +94,6 @@ const IMPACT_OPTIONS: Array<{ value: BeChangeRequestImpact; label: string }> = [
 
 const PRIORITY_OPTIONS: Array<{ value: BeChangeRequestPriority; label: string }> = [
   { value: "critical", label: "Critical" },
-  { value: "high", label: "High" },
-  { value: "moderate", label: "Moderate" },
-  { value: "low", label: "Low" },
-];
-
-const RISK_OPTIONS: Array<{ value: BeChangeRequestRisk; label: string }> = [
   { value: "high", label: "High" },
   { value: "moderate", label: "Moderate" },
   { value: "low", label: "Low" },
@@ -146,16 +116,6 @@ const STATE_OPTIONS: Array<{ value: BeChangeRequestState; label: string }> =
 /** Display label for a user option: full name, else email, else id. */
 function userLabel(u: BeUser): string {
   return [u.firstName, u.lastName].filter(Boolean).join(" ").trim() || u.email || u.id || "";
-}
-
-/** Display label for an IT service option: name, else id. */
-function itServiceLabel(s: BeItService): string {
-  return s.name ?? s.id;
-}
-
-/** Display label for a configuration item option: name, else id. */
-function configurationItemLabel(ci: BeConfigurationItem): string {
-  return ci.name ?? ci.id;
 }
 
 /**
@@ -252,17 +212,17 @@ export default function CreateChangeRequestPage(): JSX.Element {
   const [subject, setSubject] = useState((cloneState?.subject ?? "").slice(0, SUBJECT_MAX));
   // Pre-selected to match the legacy ServiceNow form's own defaults, rather
   // than leaving every dropdown blank — most change requests are Normal
-  // type, Other category, Low impact, Moderate risk. Priority has no default
-  // there either ("-- None --"), so it stays unset here too. A clone
-  // carries over `type`/`impact` from the source record when present;
-  // category/priority/risk have no source value to carry (see
-  // buildCloneChangeRequestNavState), so they keep the same defaults a
-  // from-scratch change request gets.
+  // type, Low impact. Priority has no default there either ("-- None --"),
+  // so it stays unset here too. A clone carries over `type`/`impact` from
+  // the source record when present; priority has no source value to carry
+  // (see buildCloneChangeRequestNavState), so it keeps the same default a
+  // from-scratch change request gets. `category` and `risk` are not
+  // editable here at all — see BeCreateChangeRequestPayload's doc comment:
+  // `category` is 99.9% left at its default on real records and `risk`
+  // isn't a field on the real ServiceNow CR form.
   const [type, setType] = useState<string>(cloneState?.type ?? "normal");
-  const [category, setCategory] = useState<string>("other");
   const [impact, setImpact] = useState<string>(cloneState?.impact ?? "low");
   const [priority, setPriority] = useState<string>(UNSET);
-  const [risk, setRisk] = useState<string>("moderate");
   // Always "new" regardless of the source record's own state/schedule/
   // approval — cloning must never carry an approval or a stale window
   // across into the new change request.
@@ -275,9 +235,6 @@ export default function CreateChangeRequestPage(): JSX.Element {
   const [riskImpactAnalysis, setRiskImpactAnalysis] = useState("");
   const [backoutPlan, setBackoutPlan] = useState("");
   const [testPlan, setTestPlan] = useState(cloneState?.testPlan ?? "");
-  const [serviceId, setServiceId] = useState("");
-  const [serviceOfferingId, setServiceOfferingId] = useState("");
-  const [configurationItemId, setConfigurationItemId] = useState("");
   const [groupId, setGroupId] = useState("");
   const [assignedEngineerId, setAssignedEngineerId] = useState(
     cloneState?.assignedEngineerId ?? "",
@@ -329,10 +286,8 @@ export default function CreateChangeRequestPage(): JSX.Element {
 
     const payload: BeCreateChangeRequestPayload = { subject: subject.trim() };
     if (type) payload.type = type as BeChangeRequestType;
-    if (category) payload.category = category as BeChangeRequestCategory;
     if (impact) payload.impact = impact as BeChangeRequestImpact;
     if (priority) payload.priority = priority as BeChangeRequestPriority;
-    if (risk) payload.risk = risk as BeChangeRequestRisk;
     if (state) payload.state = state as BeChangeRequestState;
     if (plannedStartDate) payload.plannedStartDate = toBackendDateTime(plannedStartDate);
     if (plannedEndDate) payload.plannedEndDate = toBackendDateTime(plannedEndDate);
@@ -347,9 +302,6 @@ export default function CreateChangeRequestPage(): JSX.Element {
     if (!isBlankHtml(riskImpactAnalysis)) payload.riskImpactAnalysis = riskImpactAnalysis;
     if (!isBlankHtml(backoutPlan)) payload.backoutPlan = backoutPlan;
     if (!isBlankHtml(testPlan)) payload.testPlan = testPlan;
-    if (serviceId.trim()) payload.serviceId = serviceId.trim();
-    if (serviceOfferingId.trim()) payload.serviceOfferingId = serviceOfferingId.trim();
-    if (configurationItemId.trim()) payload.configurationItemId = configurationItemId.trim();
     if (groupId.trim()) payload.groupId = groupId.trim();
     if (assignedEngineerId.trim()) payload.assignedEngineerId = assignedEngineerId.trim();
     if (requestedById.trim()) payload.requestedById = requestedById.trim();
@@ -518,16 +470,10 @@ export default function CreateChangeRequestPage(): JSX.Element {
               {renderSelect("cr-type", "Type", type, setType, TYPE_OPTIONS)}
             </Box>
             <Box sx={{ flex: "1 1 200px" }}>
-              {renderSelect("cr-category", "Category", category, setCategory, CATEGORY_OPTIONS)}
-            </Box>
-            <Box sx={{ flex: "1 1 200px" }}>
               {renderSelect("cr-priority", "Priority", priority, setPriority, PRIORITY_OPTIONS)}
             </Box>
             <Box sx={{ flex: "1 1 200px" }}>
               {renderSelect("cr-impact", "Impact", impact, setImpact, IMPACT_OPTIONS)}
-            </Box>
-            <Box sx={{ flex: "1 1 200px" }}>
-              {renderSelect("cr-risk", "Risk", risk, setRisk, RISK_OPTIONS)}
             </Box>
             <Box sx={{ flex: "1 1 200px" }}>
               {renderSelect("cr-state", "State", state, setState, STATE_OPTIONS)}
@@ -637,52 +583,6 @@ export default function CreateChangeRequestPage(): JSX.Element {
             </AccordionSummary>
             <AccordionDetails sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
               <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
-                <Box sx={{ flex: "1 1 220px" }}>
-                  <AsyncEntitySelect<BeItService>
-                    id="cr-service"
-                    label="Service"
-                    placeholder="Search services…"
-                    value={serviceId}
-                    onChange={(next) => {
-                      setServiceId(next);
-                      // A service offering only makes sense under its own
-                      // service — drop it rather than leave a stale pairing.
-                      setServiceOfferingId("");
-                    }}
-                    disabled={isSubmitting}
-                    useSearch={useSearchItServices}
-                    getId={(s) => s.id}
-                    getLabel={itServiceLabel}
-                  />
-                </Box>
-                <Box sx={{ flex: "1 1 220px" }}>
-                  <AsyncEntitySelect<BeServiceOffering>
-                    id="cr-service-offering"
-                    label="Service offering"
-                    placeholder="Search service offerings…"
-                    value={serviceOfferingId}
-                    onChange={setServiceOfferingId}
-                    disabled={isSubmitting}
-                    useSearch={useSearchServiceOfferings}
-                    searchExtra={serviceId || undefined}
-                    getId={(o) => o.id}
-                    getLabel={(o) => o.name}
-                    helperText={serviceId ? undefined : "Narrows to a Service once one is picked."}
-                  />
-                </Box>
-                <Box sx={{ flex: "1 1 220px" }}>
-                  <AsyncEntitySelect<BeConfigurationItem>
-                    id="cr-configuration-item"
-                    label="Configuration item"
-                    placeholder="Search configuration items…"
-                    value={configurationItemId}
-                    onChange={setConfigurationItemId}
-                    disabled={isSubmitting}
-                    useSearch={useSearchConfigurationItems}
-                    getId={(ci) => ci.id}
-                    getLabel={configurationItemLabel}
-                  />
-                </Box>
                 <Box sx={{ flex: "1 1 220px" }}>
                   <AsyncEntitySelect<BeGroup>
                     id="cr-group"

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.tsx
@@ -190,7 +190,7 @@ function PlanSection({ title, html }: { title: string; html?: string | null }): 
   );
 }
 
-type ChangeRequestTabId = "approval" | "details" | "comments" | "attachments";
+type ChangeRequestTabId = "approval" | "plan" | "comments" | "attachments";
 
 const TAB_DEFS: Array<{
   id: ChangeRequestTabId;
@@ -198,7 +198,7 @@ const TAB_DEFS: Array<{
   icon: JSX.Element;
 }> = [
   { id: "approval", label: "Approval", icon: <ClipboardCheck size={16} /> },
-  { id: "details", label: "Details", icon: <FileText size={16} /> },
+  { id: "plan", label: "Plan", icon: <FileText size={16} /> },
   { id: "comments", label: "Comments", icon: <MessageSquare size={16} /> },
   { id: "attachments", label: "Attachments", icon: <Paperclip size={16} /> },
 ];
@@ -603,29 +603,36 @@ export default function CsmChangeRequestDetailPage(): JSX.Element {
         </Box>
       )}
 
-      {activeTab === "details" && (
+      {activeTab === "plan" && (
+        // Field order here mirrors the SRE change-review packet's reading
+        // order (description/justification first, then the impact and
+        // rollback/test detail, then the two fields the field-usage census
+        // found most often left "N/A" — service outage and communication
+        // plan — grouped last so a mostly-empty CR doesn't bury the fields
+        // that usually carry real content). This is a relabel/reorder only:
+        // the same seven fields the tab already showed, nothing added.
         [
           cr.description,
           cr.justification,
           cr.impactDescription,
-          cr.serviceOutage,
-          cr.communicationPlan,
           cr.rollbackPlan,
           cr.testPlan,
+          cr.serviceOutage,
+          cr.communicationPlan,
         ].some((v) => v && !isBlankHtml(v)) ? (
           <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 2.5 }}>
-            <Typography variant="subtitle2">Details &amp; plans</Typography>
+            <Typography variant="subtitle2">Plan</Typography>
             <PlanSection title="Description" html={cr.description} />
             <PlanSection title="Justification" html={cr.justification} />
             <PlanSection title="Impact description" html={cr.impactDescription} />
-            <PlanSection title="Service outage" html={cr.serviceOutage} />
-            <PlanSection title="Communication plan" html={cr.communicationPlan} />
             <PlanSection title="Rollback plan" html={cr.rollbackPlan} />
             <PlanSection title="Test plan" html={cr.testPlan} />
+            <PlanSection title="Service outage" html={cr.serviceOutage} />
+            <PlanSection title="Communication plan" html={cr.communicationPlan} />
           </Card>
         ) : (
           <Typography variant="body2" color="text.secondary">
-            No details or plans have been recorded for this change request.
+            No plan has been recorded for this change request.
           </Typography>
         )
       )}

--- a/apps/csm-portal/webapp/src/features/csm-operations/utils/changeRequests.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/utils/changeRequests.ts
@@ -249,9 +249,9 @@ export function countActiveCRFilters(filters: ChangeRequestFilters): number {
 // and several fields the detail page can show have no create-time
 // equivalent at all. Concretely (verified against the entity service's own
 // request/response structs, not just the two frontend types):
-//   - `category`, `priority`, and `risk` are write-only — accepted by create,
-//     never present on the read response — so there is no source value to
-//     copy from, ever, regardless of how the form is wired.
+//   - `priority` is write-only — accepted by create, never present on the
+//     read response — so there is no source value to copy from, ever,
+//     regardless of how the form is wired.
 //   - `implementationPlan` and `riskImpactAnalysis` are write-only for the
 //     same reason.
 //   - `impactDescription`, `serviceOutage`, `communicationPlan`, and
@@ -259,13 +259,15 @@ export function countActiveCRFilters(filters: ChangeRequestFilters): number {
 //     for any of them.
 //   - `project`, `case`, `deployment`, `deployedProduct`, and `product` are
 //     read-only refs with no create-time field to set them from at all.
-//   - `serviceId`, `serviceOfferingId`, and `configurationItemId` are the
-//     mirror image: create accepts all three, and the read response carries no
-//     equivalent, so a clone always leaves them blank.
 //   - `assignedTeam` is read-only; create's nearest-sounding field
 //     (`groupId`, "Assignment group") is a *different* underlying reference
 //     with no confirmed equivalence to `assignedTeam` — mapping one into the
 //     other would be a guess, not a verified carry-over, so it's left alone.
+// (`category` and `risk` aren't in this gap analysis at all: `category` has
+// no editable control anywhere in this portal — see
+// `BeCreateChangeRequestPayload`'s doc comment — and `risk`/`serviceId`/
+// `serviceOfferingId`/`configurationItemId` were removed from the create form
+// entirely, since none of them exist on the real ServiceNow CR form.)
 // None of the above can be safely carried over without either fabricating
 // data or guessing at an unconfirmed field mapping, so this only clones the
 // fields that are genuinely the same field on both sides: `subject`,
@@ -327,7 +329,6 @@ export function buildCloneChangeRequestNavState(
  */
 export const CLONE_SOURCE_GAP_MESSAGE =
   "Copied the subject, description, justification, test plan, type, impact, and assigned engineer. " +
-  "Category, priority, risk, implementation plan, risk/impact analysis, backout plan, assignment group, " +
-  "linked project/case, affected product, service, service offering, and configuration item aren't " +
-  "available to copy and need to be re-entered. " +
+  "Priority, implementation plan, risk/impact analysis, backout plan, assignment group, " +
+  "linked project/case, and affected product aren't available to copy and need to be re-entered. " +
   "Deployment, schedule, and approval fields are intentionally left blank for you to set for the new environment.";

--- a/apps/csm-portal/webapp/src/features/help/content/operations.md
+++ b/apps/csm-portal/webapp/src/features/help/content/operations.md
@@ -29,12 +29,14 @@ The detail page shows:
 - An **overview** card: project, type, linked case, deployment, deployed
   product, assigned engineer/team, duration, planned start/end, and audit
   fields.
-- Tabs for **Approval**, **Details**, **Comments**, and **Attachments**.
+- Tabs for **Approval**, **Plan**, **Comments**, and **Attachments**.
   - **Approval** shows the customer-approval/review flags plus a full
     approval-stage breakdown (e.g. Assess, Authorize, Customer Approval) with
-    each individual approver's status.
-  - **Details** shows the description, justification, impact description,
-    service outage notes, and the communication/rollback/test plans.
+    each individual approver's status. These flags are read-only in this
+    portal — see below.
+  - **Plan** shows the change-review packet: description, justification,
+    impact description, rollback plan, test plan, service outage notes, and
+    the communication plan.
 
 From the detail page a CS engineer can:
 
@@ -46,9 +48,12 @@ From the detail page a CS engineer can:
 - **Approve or reject** a pending approval stage, if the engineer is listed
   as an approver on it: the Approve/Reject buttons only appear on that
   engineer's own pending approval.
-- **Edit** the change request's fields, or **Clone** it into a new change
-  request pre-filled with this one's values (useful for promoting the same
-  change through another environment).
+- **Edit** the planned window, assignment group, and rollback/test plans, or
+  **Clone** the change request into a new one pre-filled with this one's
+  values (useful for promoting the same change through another environment).
+  The customer-approved/reviewed flags aren't editable here — they reflect an
+  automation-only stage of the change's lifecycle and have no manual UI
+  action in the backing system either.
 - Add comments (public or internal) and upload/download attachments.
 
 ## Incidents

--- a/apps/csm-portal/webapp/tests/e2e/pages/ChangeRequestCreatePage.ts
+++ b/apps/csm-portal/webapp/tests/e2e/pages/ChangeRequestCreatePage.ts
@@ -19,11 +19,11 @@ import { CHANGE_REQUEST_CREATE } from "../utils/selectors";
 
 /**
  * Page object for `/operations/change-requests/new`. Subject is the only
- * required field (Type/Category/Impact/Risk come pre-selected with sensible
- * defaults — see CreateChangeRequestPage.tsx), so the happy path only needs
- * to fill Subject and submit. There is no delete endpoint for change
- * requests, so every CR this creates is a permanent staging record — the
- * subject must always be E2E-tagged (see `e2eChangeRequestSubject`).
+ * required field (Type/Impact come pre-selected with sensible defaults —
+ * see CreateChangeRequestPage.tsx), so the happy path only needs to fill
+ * Subject and submit. There is no delete endpoint for change requests, so
+ * every CR this creates is a permanent staging record — the subject must
+ * always be E2E-tagged (see `e2eChangeRequestSubject`).
  */
 export class ChangeRequestCreatePage {
   constructor(private readonly page: Page) {}
@@ -43,7 +43,7 @@ export class ChangeRequestCreatePage {
   }
 
   /** Reads a pre-selected enum dropdown's current visible value (Type,
-   * Category, Impact, Risk, Priority) without opening it. */
+   * Impact, Priority) without opening it. */
   selectValue(label: string): Locator {
     const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
     return this.page.getByRole("combobox", { name: new RegExp(`^${escaped}\\s*\\*?$`) });

--- a/apps/csm-portal/webapp/tests/e2e/pages/ChangeRequestDetailPage.ts
+++ b/apps/csm-portal/webapp/tests/e2e/pages/ChangeRequestDetailPage.ts
@@ -78,23 +78,8 @@ export class ChangeRequestDetailPage {
     return this.editDialog().getByRole("group", { name: /^Planned start/ });
   }
 
-  customerApprovedSwitch(): Locator {
-    return this.editDialog().getByRole("switch", { name: "Customer approved" });
-  }
-
-  customerReviewedSwitch(): Locator {
-    return this.editDialog().getByRole("switch", { name: "Customer reviewed" });
-  }
-
-  async setCustomerApproved(value: boolean): Promise<void> {
-    const isChecked = await this.customerApprovedSwitch().isChecked();
-    if (isChecked !== value) await this.customerApprovedSwitch().click();
-  }
-
-  async setCustomerReviewed(value: boolean): Promise<void> {
-    const isChecked = await this.customerReviewedSwitch().isChecked();
-    if (isChecked !== value) await this.customerReviewedSwitch().click();
-  }
+  // "Customer approved"/"Customer reviewed" are deliberately not editable
+  // controls in this dialog — see EditChangeRequestDialog.tsx's doc comment.
 
   saveButton(): Locator {
     return this.editDialog().getByRole("button", { name: /^(Save|Saving…)$/ });

--- a/apps/csm-portal/webapp/tests/e2e/specs/operations/change-request-detail.spec.ts
+++ b/apps/csm-portal/webapp/tests/e2e/specs/operations/change-request-detail.spec.ts
@@ -15,10 +15,10 @@
 // under the License.
 
 //
-// Change request detail (edit, request approval, approve/reject). Unlike
+// Change request detail (request approval, approve/reject). Unlike
 // change-request-creation.spec.ts (which only ever submits once, tagged, and
 // asserts nothing beyond "it landed on its own detail page"), these specs
-// need a live CR to edit / advance through approval — but there's still no
+// need a live CR to advance through approval — but there's still no
 // delete endpoint, so we never touch a pre-existing record. Each test
 // self-provisions its own tagged CR via ChangeRequestCreatePage first, reads
 // its id back off the post-create URL, and only then drives
@@ -28,17 +28,15 @@
 // test self-skips rather than failing whenever the button isn't there or the
 // call is rejected (same rule as the documented timecard-approval 403).
 //
-// "edit fields" and "request approval" below self-skip on any non-2xx from
-// the underlying `PATCH /change-requests/:id`, rather than failing or
-// blindly retrying. Confirmed live (2026-07-26) this isn't SN
-// write-propagation lag: a single-field body (e.g. `{isCustomerApproved:
-// true}` or `{requestApproval:true}`) always 500s ("Failed to update change
-// request."), and the two-field body the Edit dialog actually sends
-// (`{isCustomerApproved,isCustomerReviewed}`) always 400s ("Invalid request
-// payload.") — reproduced with curl against both a CR created seconds
-// earlier and one from over an hour earlier, so it isn't timing-dependent;
-// it's a standing backend/API-contract issue on this endpoint, not fixable
-// from FE-only test code.
+// "request approval" below self-skips on any non-2xx from the underlying
+// `PATCH /change-requests/:id`, rather than failing or blindly retrying.
+// Confirmed live (2026-07-26) a single-field `{requestApproval:true}` body
+// always 500s ("Failed to update change request.") against the real
+// backend — a standing backend/API-contract issue on this endpoint, not
+// fixable from FE-only test code. (The Edit dialog's former
+// `{isCustomerApproved,isCustomerReviewed}` write path always 400s the same
+// way; that coverage was removed along with the toggle itself — see
+// EditChangeRequestDialog.tsx's doc comment for why the toggle was pulled.)
 //
 
 import { test, expect, withRole } from "../../fixtures/test";
@@ -66,50 +64,6 @@ async function provisionChangeRequest(
   if (!match) return undefined;
   return { id: match[1], subject };
 }
-
-test.describe("change request detail — edit fields", () => {
-  test("toggles Customer approved/reviewed and reflects on the detail page", async ({ page }) => {
-    test.setTimeout(60_000);
-
-    const provisioned = await provisionChangeRequest(page, "e2e change request detail edit");
-    test.skip(!provisioned, "change request provisioning did not reach the detail page");
-    const { id } = provisioned!;
-
-    const detail = new ChangeRequestDetailPage(page);
-    await detail.goto(id);
-
-    await detail.openEditDialog();
-    const wasApproved = await detail.customerApprovedSwitch().isChecked();
-    const wasReviewed = await detail.customerReviewedSwitch().isChecked();
-    await detail.setCustomerApproved(!wasApproved);
-    await detail.setCustomerReviewed(!wasReviewed);
-
-    // See the file-level note above: the real backend's PATCH endpoint
-    // rejects this update outright (400/500), not something a retry can
-    // paper over — self-skip rather than fail on a non-2xx.
-    const response = await Promise.all([
-      page
-        .waitForResponse((r) => new RegExp(`/change-requests/${id}$`).test(r.url()) && r.request().method() === "PATCH", {
-          timeout: 15_000,
-        })
-        .catch(() => undefined),
-      detail.saveEdit(),
-    ]).then(([r]) => r);
-
-    test.skip(
-      !!response && !response.ok(),
-      `backend rejected the edit PATCH (${response?.status()}) — standing backend issue, not a bug in this spec`,
-    );
-
-    // The edit dialog closes on a successful save — reopening it and reading
-    // the switches back is the strongest available confirmation the save
-    // actually persisted (rather than just optimistically closing).
-    await expect(detail.editDialog()).toBeHidden({ timeout: 15_000 });
-    await detail.openEditDialog();
-    await expect(detail.customerApprovedSwitch()).toHaveJSProperty("checked", !wasApproved);
-    await expect(detail.customerReviewedSwitch()).toHaveJSProperty("checked", !wasReviewed);
-  });
-});
 
 test.describe("change request detail — request approval", () => {
   test("transitions the approval section to a requested/pending state", async ({ page }) => {


### PR DESCRIPTION
## Purpose
Three known issues in the CSM portal's Change Request feature, tracked in this session's planning notes (not linked here since they live in a private planning repo — see the functional description below instead):

1. The Create Change Request form exposes `Service`, `Service offering`, `Configuration item`, and `Risk` inputs, plus an editable `Category` dropdown — none of these exist on the live ServiceNow CR form, and `Category` is left at its default value on 99.9% of real production change requests.
2. The Edit Change Request dialog exposes direct "Customer approved"/"Customer reviewed" toggles that, when traced end to end into the backing scripted API, turn out to drive a real one-way state transition (not a boolean field edit) with a destructive "off" direction (cancel / rollback).
3. The Change Request detail page's "Details" tab doesn't read as a coherent SRE change-review packet — it's relabelled and reordered here.

## Goals
- Stop the create form from sending fields that don't exist on the real ServiceNow CR form, without changing the backend contract (additive-only elsewhere).
- Remove a UI affordance that can silently cancel or roll back a change request when a CS engineer intends only to record an approval flag.
- Make the CR detail page's plan tab read in the order an SRE actually works through a change review.

## Approach
- **Create Change Request** (`CreateChangeRequestPage.tsx`): removed the `Service`/`Service offering`/`Configuration item` `AsyncEntitySelect`s and the `Risk` dropdown entirely; removed the `Category` dropdown's editable UI affordance (the field is still legitimately backend-writable for parity, just never surfaced as a control). `BeCreateChangeRequestPayload` (webapp-only type) no longer declares these fields; the Go entity-service/BFF contract is untouched, so nothing breaks if it still accepts them.
- **Edit Change Request** (`EditChangeRequestDialog.tsx`): removed the "Customer approved"/"Customer reviewed" switches and their mutual-exclusion logic. Traced the write path: webapp → BFF → Go entity-service (passthrough) → the ServiceNow scripted API's dedicated `patchCustomerApproved`/`patchCustomerReviewed` handlers. Both are gated (only accepted while the CR is already in the "Customer Approval"/"Customer Review" state) but the handler itself sets `state`, not the boolean field — `isCustomerApproved:false` moves the CR to Cancelled, `isCustomerReviewed:false` moves it to Rollback (a terminal dead end with no reason capture). Neither state has a manual UI action in ServiceNow itself either. A switch labelled "Customer approved" strongly implies a record-keeping boolean, not a one-way cancel action, so this is exactly the "inventing a capability the source system doesn't expose" pattern to avoid. Backend/Go plumbing (`isCustomerApproved`/`isCustomerReviewed` on the patch contract) is left in place — nothing else depends on removing it, and it touches a shared-adjacent layer unnecessarily.
- **Change Request detail** (`CsmChangeRequestDetailPage.tsx`): renamed the "Details" tab to "Plan" and reordered its (same seven, no new) fields to `description → justification → impactDescription → rollbackPlan → testPlan → serviceOutage → communicationPlan`.
- Updated the in-app `/help` topic (`operations.md`) and the affected unit/e2e tests and page objects to match.

No screenshots included — this is a field-removal/relabel change with no new visual layout beyond fewer inputs and a renamed tab.

## User stories
As a CS engineer, I only see Change Request fields that exist on the real system I'm updating, and I can't accidentally cancel or roll back a change request while trying to record a customer-approval flag.

## Release note
Removed non-existent fields (Service, Service offering, Configuration item, Risk, editable Category) from the Change Request creation form; removed the Edit dialog's customer-approved/reviewed toggles (they drove an unintended cancel/rollback transition); renamed and reordered the Change Request detail page's "Details" tab to "Plan".

## Documentation
N/A — in-app `/help` topic (`apps/csm-portal/webapp/src/features/help/content/operations.md`) updated as part of this PR; no external product documentation covers this yet.

## Training
N/A — no training content repo changes needed for this internal-tool fix.

## Certification
N/A — no certification exam impact for internal CSM-portal tooling.

## Marketing
N/A — internal tooling change, not customer/marketing facing.

## Automation tests
 - Unit tests
   All CR-related and full webapp unit suites pass locally (`npx vitest run` → 197 files / 1991 tests passed). Updated `EditChangeRequestDialog.test.tsx` (removed toggle-mutual-exclusion tests, added a "toggles are not rendered" test, re-pointed unrelated "make the form dirty" helpers at the rollback-plan field) and `CreateChangeRequestPage.test.tsx` (updated the clone-gap-message assertion).
 - Integration tests
   Removed the one e2e test (`change-request-detail.spec.ts`) that exercised the now-removed Edit-dialog toggles, and the corresponding page-object methods in `ChangeRequestDetailPage.ts`; the file-level comment documenting the backend's standing 400/500 on that write path was preserved and updated. Remaining CR e2e specs (creation, request-approval, approve/reject) are unaffected.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — TypeScript/React frontend change, not a Java component
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
None

## Migrations (if applicable)
N/A — no schema/data migration; this is a frontend-only field/UI removal. The backend contract fields these inputs used to populate remain accepted (just unused) so no backend change is required or included.

## Test environment
Verified locally: Node/pnpm toolchain in this repo's `apps/csm-portal/webapp` (pnpm 11.1.2), `tsc -b` (clean), `eslint .` (0 errors, 2 pre-existing unrelated warnings), `vitest run` (1991/1991 passing), `vite build` (succeeds).

## Learning
Traced the customer-approval toggle's write path from the CSM webapp down through the Go entity-service into the ServiceNow scripted API's dedicated approval handlers (`patchCustomerApproved`/`patchCustomerReviewed`) rather than assuming "dedicated handler" implied "safe boolean write" — the handler turned out to drive a real state transition with a destructive "off" branch, which only became clear from reading the actual handler logic.
