### PR TITLE
[CSM Portal] Align operations detail headers + Problem-update Go/BFF passthrough + webapp UI

### DIFF
--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -233,6 +233,7 @@ func main() {
 	mux.HandleFunc("POST /change-requests/{id}/comments/search", changeRequestHandler.SearchChangeRequestComments)
 	mux.HandleFunc("POST /problems", problemHandler.CreateProblem)
 	mux.HandleFunc("GET /problems/{id}", problemHandler.GetProblem)
+	mux.HandleFunc("PATCH /problems/{id}", problemHandler.PatchProblem)
 	mux.HandleFunc("POST /problems/search", problemHandler.SearchProblems)
 	mux.HandleFunc("POST /problems/aggregate", problemHandler.AggregateProblems)
 	mux.HandleFunc("GET /incident-tasks/{id}", incidentTaskHandler.GetIncidentTask)

--- a/apps/csm-portal/backend/internal/entity/customer.go
+++ b/apps/csm-portal/backend/internal/entity/customer.go
@@ -233,6 +233,12 @@ func (c *CustomerEntityClient) GetProblem(ctx context.Context, id string) ([]byt
 	return c.do(ctx, http.MethodGet, fmt.Sprintf("/problems/%s", url.PathEscape(id)), nil)
 }
 
+// UpdateProblem calls PATCH /problems/{id} on the entity service to partially update a problem.
+// Response is returned as raw JSON; typed response structs are deferred.
+func (c *CustomerEntityClient) UpdateProblem(ctx context.Context, id string, body []byte) ([]byte, error) {
+	return c.do(ctx, http.MethodPatch, fmt.Sprintf("/problems/%s", url.PathEscape(id)), body)
+}
+
 // SearchIncidentTasks calls POST /incident-tasks/search on the entity service.
 // Response is returned as raw JSON; field filtering to the portal shape is deferred.
 func (c *CustomerEntityClient) SearchIncidentTasks(ctx context.Context, body []byte) ([]byte, error) {

--- a/apps/csm-portal/backend/internal/handler/helpers_test.go
+++ b/apps/csm-portal/backend/internal/handler/helpers_test.go
@@ -557,6 +557,7 @@ type mockEntityProblemClient struct {
 	aggregateProblemsFn func(ctx context.Context, body []byte) ([]byte, error)
 	getProblemFn        func(ctx context.Context, id string) ([]byte, error)
 	createProblemFn     func(ctx context.Context, body []byte) ([]byte, error)
+	updateProblemFn     func(ctx context.Context, id string, body []byte) ([]byte, error)
 }
 
 func (m *mockEntityProblemClient) SearchProblems(ctx context.Context, body []byte) ([]byte, error) {
@@ -583,6 +584,13 @@ func (m *mockEntityProblemClient) GetProblem(ctx context.Context, id string) ([]
 func (m *mockEntityProblemClient) CreateProblem(ctx context.Context, body []byte) ([]byte, error) {
 	if m.createProblemFn != nil {
 		return m.createProblemFn(ctx, body)
+	}
+	return []byte(`{}`), nil
+}
+
+func (m *mockEntityProblemClient) UpdateProblem(ctx context.Context, id string, body []byte) ([]byte, error) {
+	if m.updateProblemFn != nil {
+		return m.updateProblemFn(ctx, id, body)
 	}
 	return []byte(`{}`), nil
 }

--- a/apps/csm-portal/backend/internal/handler/problems.go
+++ b/apps/csm-portal/backend/internal/handler/problems.go
@@ -35,6 +35,7 @@ type entityProblemClient interface {
 	AggregateProblems(ctx context.Context, body []byte) ([]byte, error)
 	GetProblem(ctx context.Context, id string) ([]byte, error)
 	CreateProblem(ctx context.Context, body []byte) ([]byte, error)
+	UpdateProblem(ctx context.Context, id string, body []byte) ([]byte, error)
 }
 
 // createProblemRequest mirrors the enum/format-constrained fields of the documented
@@ -69,6 +70,61 @@ func validateCreateProblemBody(body []byte) bool {
 		return false
 	}
 	if req.PrimaryIncidentID != "" && !uuidRe.MatchString(req.PrimaryIncidentID) {
+		return false
+	}
+	return true
+}
+
+// updateProblemRequest mirrors the format-constrained fields of the documented
+// UpdateProblemPayload schema. It is decoded only to validate those fields at the
+// boundary; the original raw body is still forwarded to the entity service unchanged.
+//
+// Transition is deliberately not represented here as a typed/validated field: it is one
+// of "assess"/"confirm"/"fix"/"resolve"/"close" per ServiceNow's own server-side
+// validation, but every layer below this one (ServiceNow, the Ballerina entity-service,
+// the Go entity-service) ships it as a plain unvalidated string on purpose. A closed-enum
+// check here would swallow ServiceNow's own actionable error message ("Invalid
+// transition: ...") behind a generic validation error instead. Do not add one.
+type updateProblemRequest struct {
+	AssignedToID      string `json:"assignedToId"`
+	AssignmentGroupID string `json:"assignmentGroupId"`
+}
+
+// validateUpdateProblemBody rejects an empty JSON object (matching the "at least one
+// field required" contract of UpdateProblemPayload), and checks the UUID-formatted
+// fields (assignedToId, assignmentGroupId) when present and non-empty. transition is
+// intentionally left unconstrained beyond decoding as a string (see updateProblemRequest
+// doc comment) — an absent, null, or non-string value for it is handled by the type
+// decode itself (json.Unmarshal fails for a non-string transition), not by a semantic
+// check here.
+func validateUpdateProblemBody(body []byte) bool {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(body, &fields); err != nil {
+		return false
+	}
+	if len(fields) == 0 {
+		return false
+	}
+
+	// Decoding transition here (as *string) only confirms it is a JSON string (or
+	// null/absent) without constraining its value, matching the "no closed-enum
+	// validation" requirement while still rejecting an invalid JSON type such as
+	// "transition": 5.
+	var transition struct {
+		Transition *string `json:"transition"`
+	}
+	if err := json.Unmarshal(body, &transition); err != nil {
+		return false
+	}
+
+	var req updateProblemRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return false
+	}
+	if req.AssignedToID != "" && !uuidRe.MatchString(req.AssignedToID) {
+		return false
+	}
+	if req.AssignmentGroupID != "" && !uuidRe.MatchString(req.AssignmentGroupID) {
 		return false
 	}
 	return true
@@ -218,6 +274,52 @@ func (h *ProblemHandler) GetProblem(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		slog.ErrorContext(r.Context(), "entity GetProblem failed", "userID", user.UserID, "id", id, "err", err)
 		mapUpstreamErrorGeneric(w, err, "Failed to retrieve problem.")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, result)
+}
+
+// PatchProblem handles PATCH /problems/{id}.
+func (h *ProblemHandler) PatchProblem(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	id := r.PathValue("id")
+	if id == "" || !uuidRe.MatchString(id) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			writeError(w, http.StatusRequestEntityTooLarge, ErrMsgTooLarge)
+			return
+		}
+		writeError(w, http.StatusBadRequest, errMsgReadBody)
+		return
+	}
+
+	if !json.Valid(body) {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	if !validateUpdateProblemBody(body) {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.UpdateProblem(r.Context(), id, body)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity UpdateProblem failed", "userID", user.UserID, "id", id, "err", err)
+		mapUpstreamError(w, err, "Failed to update problem.")
 		return
 	}
 

--- a/apps/csm-portal/backend/internal/handler/problems_test.go
+++ b/apps/csm-portal/backend/internal/handler/problems_test.go
@@ -22,6 +22,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/wso2-open-operations/cs-tools/apps/csm-portal/backend/internal/apierror"
 )
 
 const testProblemID = "aaaaaaaa-bbbb-cccc-dddd-ffffffffffff"
@@ -176,6 +178,182 @@ func TestGetProblem(t *testing.T) {
 				r.SetPathValue("id", testProblemID)
 				w := httptest.NewRecorder()
 				h.GetProblem(w, r)
+				assertStatus(t, w, tc.wantCode)
+				assertErrorMessage(t, w, tc.wantMsg)
+				assertContentType(t, w, "application/json")
+			})
+		}
+	})
+}
+
+func TestUpdateProblem(t *testing.T) {
+	t.Run("requires authenticated user", func(t *testing.T) {
+		h := NewProblemHandler(&mockEntityProblemClient{})
+		r := httptest.NewRequest(http.MethodPatch, "/problems/"+testProblemID, strings.NewReader(`{"transition":"assess"}`))
+		r.SetPathValue("id", testProblemID)
+		w := httptest.NewRecorder()
+		h.PatchProblem(w, r)
+		assertStatus(t, w, http.StatusUnauthorized)
+		assertErrorMessage(t, w, ErrMsgUnauthorized)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects invalid UUID in path", func(t *testing.T) {
+		h := NewProblemHandler(&mockEntityProblemClient{})
+		r := withUser(httptest.NewRequest(http.MethodPatch, "/problems/not-a-uuid", strings.NewReader(`{"transition":"assess"}`)))
+		r.SetPathValue("id", "not-a-uuid")
+		w := httptest.NewRecorder()
+		h.PatchProblem(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgInvalidUUID)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects body exceeding 1 MiB", func(t *testing.T) {
+		h := NewProblemHandler(&mockEntityProblemClient{})
+		r := withUser(httptest.NewRequest(http.MethodPatch, "/problems/"+testProblemID, strings.NewReader(strings.Repeat("x", maxRequestBodyBytes+1))))
+		r.SetPathValue("id", testProblemID)
+		w := httptest.NewRecorder()
+		h.PatchProblem(w, r)
+		assertStatus(t, w, http.StatusRequestEntityTooLarge)
+		assertErrorMessage(t, w, ErrMsgTooLarge)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects invalid JSON body", func(t *testing.T) {
+		h := NewProblemHandler(&mockEntityProblemClient{})
+		r := withUser(httptest.NewRequest(http.MethodPatch, "/problems/"+testProblemID, strings.NewReader(`not-json`)))
+		r.SetPathValue("id", testProblemID)
+		w := httptest.NewRecorder()
+		h.PatchProblem(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects empty body", func(t *testing.T) {
+		h := NewProblemHandler(&mockEntityProblemClient{})
+		r := withUser(httptest.NewRequest(http.MethodPatch, "/problems/"+testProblemID, strings.NewReader(`{}`)))
+		r.SetPathValue("id", testProblemID)
+		w := httptest.NewRecorder()
+		h.PatchProblem(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects non-UUID assignedToId", func(t *testing.T) {
+		h := NewProblemHandler(&mockEntityProblemClient{})
+		r := withUser(httptest.NewRequest(http.MethodPatch, "/problems/"+testProblemID, strings.NewReader(`{"assignedToId":"not-a-uuid"}`)))
+		r.SetPathValue("id", testProblemID)
+		w := httptest.NewRecorder()
+		h.PatchProblem(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects non-UUID assignmentGroupId", func(t *testing.T) {
+		h := NewProblemHandler(&mockEntityProblemClient{})
+		r := withUser(httptest.NewRequest(http.MethodPatch, "/problems/"+testProblemID, strings.NewReader(`{"assignmentGroupId":"not-a-uuid"}`)))
+		r.SetPathValue("id", testProblemID)
+		w := httptest.NewRecorder()
+		h.PatchProblem(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects non-string transition value", func(t *testing.T) {
+		h := NewProblemHandler(&mockEntityProblemClient{})
+		r := withUser(httptest.NewRequest(http.MethodPatch, "/problems/"+testProblemID, strings.NewReader(`{"transition":5}`)))
+		r.SetPathValue("id", testProblemID)
+		w := httptest.NewRecorder()
+		h.PatchProblem(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("accepts any non-empty transition string without enum validation", func(t *testing.T) {
+		client := &mockEntityProblemClient{
+			updateProblemFn: func(_ context.Context, _ string, _ []byte) ([]byte, error) {
+				return []byte(`{"message":"problem updated","problem":{"id":"` + testProblemID + `","state":"in_review"}}`), nil
+			},
+		}
+		h := NewProblemHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPatch, "/problems/"+testProblemID, strings.NewReader(`{"transition":"not-a-real-transition"}`)))
+		r.SetPathValue("id", testProblemID)
+		w := httptest.NewRecorder()
+		h.PatchProblem(w, r)
+		assertStatus(t, w, http.StatusOK)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("forwards body to upstream and returns 200 with response", func(t *testing.T) {
+		const reqPayload = `{"transition":"assess","causeNotes":"Root cause under investigation."}`
+		var capturedID string
+		var capturedBody []byte
+		client := &mockEntityProblemClient{
+			updateProblemFn: func(_ context.Context, id string, body []byte) ([]byte, error) {
+				capturedID = id
+				capturedBody = body
+				return []byte(`{"message":"problem updated","problem":{"id":"` + testProblemID + `","state":"assess"}}`), nil
+			},
+		}
+		h := NewProblemHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPatch, "/problems/"+testProblemID, strings.NewReader(reqPayload)))
+		r.SetPathValue("id", testProblemID)
+		w := httptest.NewRecorder()
+		h.PatchProblem(w, r)
+
+		assertStatus(t, w, http.StatusOK)
+		assertContentType(t, w, "application/json")
+		if capturedID != testProblemID {
+			t.Errorf("upstream received id %q, want %q", capturedID, testProblemID)
+		}
+		if string(capturedBody) != reqPayload {
+			t.Errorf("upstream received body %q, want %q", capturedBody, reqPayload)
+		}
+		resp := decodeJSON[map[string]any](t, w)
+		if resp["message"] != "problem updated" {
+			t.Errorf("message = %v, want %q", resp["message"], "problem updated")
+		}
+	})
+
+	t.Run("surfaces upstream 409 transition rejection message", func(t *testing.T) {
+		client := &mockEntityProblemClient{
+			updateProblemFn: func(_ context.Context, _ string, _ []byte) ([]byte, error) {
+				return nil, &apierror.Error{
+					StatusCode: http.StatusConflict,
+					Body:       `Invalid transition: bogus. Must be one of: assess, confirm, fix, resolve, close`,
+				}
+			},
+		}
+		h := NewProblemHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPatch, "/problems/"+testProblemID, strings.NewReader(`{"transition":"bogus"}`)))
+		r.SetPathValue("id", testProblemID)
+		w := httptest.NewRecorder()
+		h.PatchProblem(w, r)
+		assertStatus(t, w, http.StatusConflict)
+		assertErrorMessage(t, w, "Invalid transition: bogus. Must be one of: assess, confirm, fix, resolve, close")
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("upstream errors are mapped correctly", func(t *testing.T) {
+		for _, tc := range upstreamErrors("Failed to update problem.") {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				client := &mockEntityProblemClient{
+					updateProblemFn: func(_ context.Context, _ string, _ []byte) ([]byte, error) {
+						return nil, tc.err
+					},
+				}
+				h := NewProblemHandler(client)
+				r := withUser(httptest.NewRequest(http.MethodPatch, "/problems/"+testProblemID, strings.NewReader(`{"transition":"assess"}`)))
+				r.SetPathValue("id", testProblemID)
+				w := httptest.NewRecorder()
+				h.PatchProblem(w, r)
 				assertStatus(t, w, tc.wantCode)
 				assertErrorMessage(t, w, tc.wantMsg)
 				assertContentType(t, w, "application/json")

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -4937,6 +4937,62 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
+    patch:
+      summary: Partially update a problem (ServiceNow data source only).
+      operationId: patchProblemById
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: UUID of the problem.
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        description: Problem update payload. All fields are optional, but at least one must be provided.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateProblemPayload'
+        required: true
+      responses:
+        "200":
+          description: Problem updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UpdateProblemResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: Problem not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
   /problems/search:
     post:
       summary: Search problems (ServiceNow data source only).
@@ -10901,6 +10957,64 @@ components:
           type: string
         incident:
           $ref: '#/components/schemas/IncidentDetail'
+
+    UpdateProblemPayload:
+      type: object
+      description: All fields are optional, but at least one must be provided.
+      minProperties: 1
+      properties:
+        transition:
+          type: string
+          description: >-
+            One of assess, confirm, fix, resolve, close per the data source's own
+            server-side validation. Deliberately typed as a plain string, not a closed
+            enum: an invalid value is rejected upstream with an actionable error naming
+            the valid values, and validating it here would hide that message behind a
+            generic one instead.
+        assignedToId:
+          type: string
+          format: uuid
+        assignmentGroupId:
+          type: string
+          format: uuid
+        causeNotes:
+          type: string
+        fixNotes:
+          type: string
+        workaround:
+          type: string
+        targetResolutionDate:
+          type: string
+
+    UpdateProblemResponse:
+      type: object
+      properties:
+        message:
+          type: string
+        problem:
+          $ref: '#/components/schemas/UpdateProblemView'
+
+    UpdateProblemView:
+      type: object
+      description: >-
+        Deliberately narrower than ProblemDetail: only the fields the update response
+        actually carries.
+      properties:
+        id:
+          type: string
+          format: uuid
+        updatedOn:
+          type: string
+        updatedBy:
+          type: string
+        state:
+          type: string
+        resolutionCode:
+          type: string
+        assignedTo:
+          $ref: '#/components/schemas/EntityRef'
+        assignmentGroup:
+          $ref: '#/components/schemas/EntityRef'
 
     ProblemSearchPayload:
       type: object

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -2752,6 +2752,77 @@ export interface BeProblemDetail {
 }
 
 /**
+ * `PATCH /problems/{id}` body (ServiceNow data source only, `minProperties:
+ * 1`). Two mutually-non-exclusive shapes in one payload: a `transition`
+ * request may also carry any of the plain-field keys in the same call (this
+ * is in fact required for `assess` on a bare New problem with no prior
+ * owner — see `transition`'s own doc comment).
+ */
+export interface BeUpdateProblemPayload {
+  /**
+   * One of `assess` | `confirm` | `fix` | `resolve` | `close`, matching the
+   * live 6-state forward chain `New -> Assess -> Root Cause Analysis -> Fix
+   * in Progress -> Resolved -> Closed`. Deliberately typed as a plain
+   * string, not a closed union, mirroring every layer below this one
+   * (ServiceNow, Ballerina, Go entity-service, CSM BFF): a closed-enum
+   * check here would swallow ServiceNow's own actionable "Invalid
+   * transition: ...must be one of: ..." error behind a generic one. Do not
+   * add client-side value validation beyond the state-machine-driven
+   * button set already in `getNextProblemTransition`.
+   *
+   * A bare `assess` on a New problem with no existing owner 409s (a real
+   * ServiceNow precondition: Problem Management requires an owner before
+   * any state move) — pair it with `assignedToId` in the same request,
+   * which is also enough on its own to trigger `assess` as a side effect
+   * (see `assignedToId` below).
+   */
+  transition?: string;
+  /**
+   * Setting this on a New problem with no prior owner auto-promotes it to
+   * Assess as a ServiceNow business-rule side effect, even with no
+   * `transition` key present — the response (and the refetched detail)
+   * always reflects the real resulting state, never the caller's
+   * assumption.
+   */
+  assignedToId?: string | null;
+  assignmentGroupId?: string | null;
+  /** Free text; closest real field to "root cause". */
+  causeNotes?: string;
+  /** Free text; closest real field to a permanent-fix description. */
+  fixNotes?: string;
+  workaround?: string;
+  /**
+   * `YYYY-MM-DD HH:mm:ss`. Backed by the generic `task.due_date` column —
+   * confirmed writable and persistent, but **not on the native ServiceNow
+   * Problem form at all**, so a value set here won't be visible to an SRE
+   * looking at the record in ServiceNow directly.
+   */
+  targetResolutionDate?: string;
+}
+
+/**
+ * `PATCH /problems/{id}` response. Deliberately narrower than
+ * `BeProblemDetail` — only the fields the update response actually
+ * carries (`causeNotes`/`fixNotes`/`workaround`/`targetResolutionDate` are
+ * not echoed back; refetch `GET /problems/{id}` to see them, which
+ * `usePatchProblem` does automatically).
+ */
+export interface BeProblemUpdateView {
+  id: string;
+  updatedOn?: string;
+  updatedBy?: string;
+  state?: BeProblemState;
+  resolutionCode?: string | null;
+  assignedTo?: BeEntityRef | null;
+  assignmentGroup?: BeEntityRef | null;
+}
+
+export interface BePatchProblemResponse {
+  message: string;
+  problem: BeProblemUpdateView;
+}
+
+/**
  * List-item shape for `POST /incident-tasks/search`. No dedicated detail
  * page exists for incident tasks in this app (unlike problem/incident), so
  * there is no separate `BeIncidentTaskDetail` type yet — `description`,

--- a/apps/csm-portal/webapp/src/features/csm-operations/api/usePatchProblem.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/api/usePatchProblem.test.tsx
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { ReactNode } from "react";
+
+const patchMock = vi.fn();
+const invalidateQueriesMock = vi.fn();
+
+// The real client reads runtime config at module load, which isn't present
+// under vitest; stub it (same approach as usePatchChangeRequest.test.tsx).
+vi.mock("@api/backend/client", () => ({
+  BackendApiError: class BackendApiError extends Error {},
+  useBackendApi: () => ({ patch: patchMock }),
+}));
+
+import { usePatchProblem } from "@features/csm-operations/api/usePatchProblem";
+
+/**
+ * Query-client wrapper for `renderHook`, with `invalidateQueries` swapped for
+ * a spy — these tests assert the mutation invalidates cached detail/list data
+ * on settle (success *and* error), so the call itself is the thing under
+ * test. Retries are off so an error case settles on the first rejection.
+ */
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  queryClient.invalidateQueries = invalidateQueriesMock.mockImplementation(
+    () => Promise.resolve(),
+  );
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe("usePatchProblem", () => {
+  beforeEach(() => {
+    patchMock.mockReset();
+    invalidateQueriesMock.mockReset();
+  });
+
+  it("PATCHes /problems/{id} with the given patch", async () => {
+    patchMock.mockResolvedValue({
+      message: "Problem updated successfully",
+      problem: { id: "prb-1", state: "ASSESS" },
+    });
+    const { result } = renderHook(() => usePatchProblem(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ id: "prb-1", patch: { transition: "assess", assignedToId: "user-1" } });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(patchMock).toHaveBeenCalledWith("/problems/prb-1", {
+      transition: "assess",
+      assignedToId: "user-1",
+    });
+  });
+
+  it("invalidates the problem's detail and the list on success", async () => {
+    patchMock.mockResolvedValue({
+      message: "ok",
+      problem: { id: "prb-1", state: "ASSESS" },
+    });
+    const { result } = renderHook(() => usePatchProblem(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ id: "prb-1", patch: { transition: "assess" } });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(invalidateQueriesMock).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ["problem-details", "prb-1"] }),
+    );
+    expect(invalidateQueriesMock).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ["problems"] }),
+    );
+  });
+
+  // A live ServiceNow business rule can revert/reject a transition after a
+  // 200 (or the request can otherwise fail) — see
+  // CHANGES-problem-update.md §2. Trusting a stale cached "unchanged" state
+  // after such a failure would make an already-attempted transition button
+  // look available again; invalidating on error too keeps the next read
+  // honest regardless of which side of that ambiguity a given failure falls
+  // on. Same lesson `usePatchChangeRequest` already applied.
+  it("also invalidates the problem's detail and the list on error", async () => {
+    const upstreamError = new Error("State transition rejected");
+    patchMock.mockRejectedValue(upstreamError);
+    const { result } = renderHook(() => usePatchProblem(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ id: "prb-1", patch: { transition: "assess" } });
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toBe(upstreamError);
+    expect(invalidateQueriesMock).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ["problem-details", "prb-1"] }),
+    );
+    expect(invalidateQueriesMock).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ["problems"] }),
+    );
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-operations/api/usePatchProblem.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/api/usePatchProblem.ts
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  useMutation,
+  useQueryClient,
+  type UseMutationResult,
+} from "@tanstack/react-query";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import { useBackendApi } from "@api/backend/client";
+import type {
+  BePatchProblemResponse,
+  BeUpdateProblemPayload,
+} from "@api/backend/types";
+
+export interface PatchProblemInput {
+  id: string;
+  patch: BeUpdateProblemPayload;
+}
+
+/**
+ * Update a problem via `PATCH /problems/{id}` (ServiceNow data source only).
+ * The BE requires at least one field in `patch`.
+ *
+ * The detail and the problems list are invalidated on both success *and*
+ * error (`onSettled`, not just `onSuccess`) — same reasoning as
+ * `usePatchChangeRequest`: a state transition can be rejected/reverted by a
+ * live ServiceNow business rule (the response's `state` always reflects the
+ * real post-write value, per `CHANGES-problem-update.md` §2), so trusting a
+ * stale cached state after a failed attempt would make an already-attempted
+ * transition button look available again. Refetching after every attempt
+ * keeps the next render honest regardless of which side of that ambiguity a
+ * given failure falls on.
+ *
+ * The response itself (`BeProblemUpdateView`) is intentionally narrower than
+ * the full problem detail — it doesn't echo `causeNotes`/`fixNotes`/
+ * `workaround`/`targetResolutionDate` back — so the invalidation, not the
+ * mutation's own return value, is what makes those show up on screen.
+ */
+export function usePatchProblem(): UseMutationResult<
+  BePatchProblemResponse,
+  Error,
+  PatchProblemInput
+> {
+  const api = useBackendApi();
+  const queryClient = useQueryClient();
+
+  return useMutation<BePatchProblemResponse, Error, PatchProblemInput>({
+    mutationFn: (input): Promise<BePatchProblemResponse> =>
+      api.patch<BeUpdateProblemPayload, BePatchProblemResponse>(
+        `/problems/${encodeURIComponent(input.id)}`,
+        input.patch,
+      ),
+    onSettled: (_data, _error, variables) => {
+      void queryClient.invalidateQueries({
+        queryKey: [ApiQueryKeys.PROBLEM_DETAILS, variables.id],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: [ApiQueryKeys.PROBLEMS],
+      });
+    },
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/EditProblemDialog.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/EditProblemDialog.test.tsx
@@ -1,0 +1,98 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import type { BeProblemDetail } from "@api/backend/types";
+
+// The dialog's async reference pickers (Assigned to, Assignment group) go
+// through `useSearch*` hooks that hit the backend client via react-query.
+// Stub them out — same approach as EditIncidentDialog.test.tsx.
+const useSearchUsersByNameMock = vi.fn(() => ({ data: [], isFetching: false, isError: false }));
+const useSearchGroupsMock = vi.fn(() => ({ data: [], isFetching: false, isError: false }));
+
+vi.mock("@api/useSearchUsersByName", () => ({
+  useSearchUsersByName: (...args: unknown[]) => useSearchUsersByNameMock(...(args as [])),
+}));
+vi.mock("@api/useSearchGroups", () => ({
+  useSearchGroups: (...args: unknown[]) => useSearchGroupsMock(...(args as [])),
+}));
+
+import EditProblemDialog from "@features/csm-operations/components/EditProblemDialog";
+
+const BASE_PROBLEM: BeProblemDetail = {
+  id: "prb-1",
+  number: "PRB0040157",
+  subject: "Intermittent 502s",
+  state: "NEW",
+  assignedTo: { id: "user-1", name: "Jane Doe" },
+  workaround: "Restart the pod.",
+};
+
+describe("EditProblemDialog", () => {
+  it("disables Save when nothing has changed", () => {
+    render(<EditProblemDialog problem={BASE_PROBLEM} isSaving={false} onClose={vi.fn()} onSave={vi.fn()} />);
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+  });
+
+  it("enables Save and submits only the changed workaround", () => {
+    const onSave = vi.fn();
+    render(<EditProblemDialog problem={BASE_PROBLEM} isSaving={false} onClose={vi.fn()} onSave={onSave} />);
+    fireEvent.change(screen.getByLabelText("Workaround"), {
+      target: { value: "Restart the pod, then clear the cache." },
+    });
+    const saveBtn = screen.getByRole("button", { name: "Save" });
+    expect(saveBtn).not.toBeDisabled();
+    fireEvent.click(saveBtn);
+    expect(onSave).toHaveBeenCalledWith({ workaround: "Restart the pod, then clear the cache." });
+  });
+
+  it("does not pre-fill assignmentGroupId or targetResolutionDate (not returned by GET)", () => {
+    render(<EditProblemDialog problem={BASE_PROBLEM} isSaving={false} onClose={vi.fn()} onSave={vi.fn()} />);
+    expect(
+      screen.getByText(
+        "Not shown pre-filled — the portal can't yet read a problem's current assignment group back.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the passed-in save error", () => {
+    render(
+      <EditProblemDialog
+        problem={BASE_PROBLEM}
+        isSaving={false}
+        saveError="Could not update the problem."
+        onClose={vi.fn()}
+        onSave={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Could not update the problem.")).toBeInTheDocument();
+  });
+
+  it("disables actions while saving", () => {
+    render(<EditProblemDialog problem={BASE_PROBLEM} isSaving onClose={vi.fn()} onSave={vi.fn()} />);
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Saving…" })).toBeDisabled();
+  });
+
+  it("calls onClose when Cancel is clicked", () => {
+    const onClose = vi.fn();
+    render(<EditProblemDialog problem={BASE_PROBLEM} isSaving={false} onClose={onClose} onSave={vi.fn()} />);
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/EditProblemDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/EditProblemDialog.tsx
@@ -1,0 +1,195 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  AdapterDateFns,
+  Alert,
+  Box,
+  Button,
+  DatePickers,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Typography,
+  TextField,
+} from "@wso2/oxygen-ui";
+import { useMemo, useState, type JSX } from "react";
+import { useSearchGroups } from "@api/useSearchGroups";
+import { useSearchUsersByName } from "@api/useSearchUsersByName";
+import AsyncEntitySelect from "@components/AsyncEntitySelect";
+import { userLabel } from "@features/csm-operations/utils/incidentFormOptions";
+import { formatDateTimeLocal, parseDateTimeLocal } from "@utils/dateTime";
+import type { BeGroup, BeProblemDetail, BeUpdateProblemPayload, BeUser } from "@api/backend/types";
+
+const { DateTimePicker, LocalizationProvider } = DatePickers;
+
+interface EditProblemDialogProps {
+  problem: BeProblemDetail;
+  /** True while the PATCH is in flight; disables the actions. */
+  isSaving: boolean;
+  /** User-facing message for the most recent failed save, if any. */
+  saveError?: string | null;
+  onClose: () => void;
+  /** Submit only the changed/filled-in fields (`PATCH /problems/{id}`). */
+  onSave: (patch: BeUpdateProblemPayload) => void;
+}
+
+/** Convert a backend timestamp (`YYYY-MM-DD HH:MM:SS`) to `YYYY-MM-DDTHH:MM`. */
+function toDateTimeLocal(raw?: string | null): string {
+  const m = /^(\d{4}-\d{2}-\d{2})[ T](\d{2}:\d{2})/.exec(raw?.trim() ?? "");
+  return m ? `${m[1]}T${m[2]}` : "";
+}
+
+/** Convert a `datetime-local` value back to the BE's `YYYY-MM-DD HH:MM:SS`. */
+function toBackendDateTime(local: string): string {
+  return `${local.replace("T", " ")}:00`;
+}
+
+/**
+ * Assignment/tracking edit dialog for a problem: `assignedToId`,
+ * `assignmentGroupId`, `workaround`, and `targetResolutionDate`. Deliberately
+ * narrower than `EditIncidentDialog`/`EditChangeRequestDialog` — no
+ * classification fields (category/subcategory/priority aren't
+ * Update-writable per `CHANGES-problem-update.md` §3) and no state field
+ * (state moves only through `ProblemActionBar`'s modeled forward
+ * transitions, never an arbitrary jump here).
+ *
+ * `assignmentGroupId` and `targetResolutionDate` start blank on every open,
+ * not prefilled from `problem` — `GET /problems/{id}` doesn't return either
+ * field today (confirmed only via a direct ServiceNow table read-back, not
+ * through the Problem-detail response shape; see `BeProblemDetail`'s own
+ * scope). Leaving a value in place across dialog opens would risk a false
+ * "already set to X" impression the portal can't actually verify.
+ */
+export default function EditProblemDialog({
+  problem,
+  isSaving,
+  saveError,
+  onClose,
+  onSave,
+}: EditProblemDialogProps): JSX.Element {
+  const [assignedToId, setAssignedToId] = useState(problem.assignedTo?.id ?? "");
+  const [assignmentGroupId, setAssignmentGroupId] = useState("");
+  const [workaround, setWorkaround] = useState(problem.workaround ?? "");
+  const [targetResolutionDate, setTargetResolutionDate] = useState("");
+
+  const initialAssignedToId = problem.assignedTo?.id ?? "";
+  const initialWorkaround = problem.workaround ?? "";
+
+  const dateValue = useMemo(() => parseDateTimeLocal(toDateTimeLocal(targetResolutionDate)), [
+    targetResolutionDate,
+  ]);
+
+  const patch = useMemo(() => {
+    const next: BeUpdateProblemPayload = {};
+    if (assignedToId !== initialAssignedToId) next.assignedToId = assignedToId || null;
+    if (assignmentGroupId) next.assignmentGroupId = assignmentGroupId;
+    if (workaround !== initialWorkaround) next.workaround = workaround;
+    if (targetResolutionDate) next.targetResolutionDate = targetResolutionDate;
+    return next;
+  }, [assignedToId, initialAssignedToId, assignmentGroupId, workaround, initialWorkaround, targetResolutionDate]);
+
+  const hasChanges = Object.keys(patch).length > 0;
+
+  return (
+    <Dialog open onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Edit problem</DialogTitle>
+      <DialogContent dividers>
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 2, pt: 0.5 }}>
+          {saveError && <Alert severity="error">{saveError}</Alert>}
+
+          <Typography variant="subtitle2">Assignment</Typography>
+          <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
+            <Box sx={{ flex: "1 1 220px" }}>
+              <AsyncEntitySelect<BeUser>
+                id="edit-problem-assigned-to"
+                label="Assigned to"
+                placeholder="Search people…"
+                value={assignedToId}
+                onChange={setAssignedToId}
+                disabled={isSaving}
+                useSearch={useSearchUsersByName}
+                getId={(u) => u.id!}
+                getLabel={userLabel}
+                knownLabel={problem.assignedTo?.name}
+                helperText="Setting this on a New problem with no existing owner moves it to Assess automatically (a ServiceNow business rule)."
+              />
+            </Box>
+            <Box sx={{ flex: "1 1 220px" }}>
+              <AsyncEntitySelect<BeGroup>
+                id="edit-problem-assignment-group"
+                label="Assignment group"
+                placeholder="Search groups…"
+                value={assignmentGroupId}
+                onChange={setAssignmentGroupId}
+                disabled={isSaving}
+                useSearch={useSearchGroups}
+                getId={(g) => g.id}
+                getLabel={(g) => g.name}
+                helperText="Not shown pre-filled — the portal can't yet read a problem's current assignment group back."
+              />
+            </Box>
+          </Box>
+
+          <Typography variant="subtitle2">Tracking</Typography>
+          <TextField
+            label="Workaround"
+            value={workaround}
+            onChange={(e) => setWorkaround(e.target.value)}
+            disabled={isSaving}
+            multiline
+            minRows={2}
+            fullWidth
+          />
+          <LocalizationProvider dateAdapter={AdapterDateFns}>
+            <DateTimePicker
+              label="Target resolution date"
+              value={dateValue}
+              onChange={(next) =>
+                setTargetResolutionDate(
+                  next instanceof Date && !Number.isNaN(next.getTime())
+                    ? toBackendDateTime(formatDateTimeLocal(next))
+                    : "",
+                )
+              }
+              slotProps={{
+                textField: {
+                  size: "small",
+                  fullWidth: true,
+                  helperText:
+                    "Not on the native ServiceNow Problem form — this is a generic due-date column exposed here for internal tracking only. Not shown pre-filled for the same reason as Assignment group.",
+                },
+              }}
+            />
+          </LocalizationProvider>
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button color="inherit" onClick={onClose} disabled={isSaving}>
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          onClick={() => onSave(patch)}
+          disabled={isSaving || !hasChanges}
+        >
+          {isSaving ? "Saving…" : "Save"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ProblemActionBar.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ProblemActionBar.test.tsx
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import ProblemActionBar from "@features/csm-operations/components/ProblemActionBar";
+import type { BeProblemDetail, BeProblemState } from "@api/backend/types";
+
+function problem(state: BeProblemState): BeProblemDetail {
+  return { id: "prb-1", number: "PRB0040000", state };
+}
+
+describe("ProblemActionBar", () => {
+  it.each([
+    ["NEW", "assess", "Move to Assess"],
+    ["ASSESS", "confirm", "Move to Root Cause Analysis"],
+    ["ROOT_CAUSE_ANALYSIS", "fix", "Move to Fix In Progress"],
+    ["FIX_IN_PROGRESS", "resolve", "Move to Resolved"],
+    ["RESOLVED", "close", "Move to Closed"],
+  ] as const)(
+    "renders the single legal forward transition from %s and dispatches transition=%s on click",
+    (state, transition, label) => {
+      const onAction = vi.fn();
+      render(<ProblemActionBar problem={problem(state)} isPending={false} onAction={onAction} />);
+      const btn = screen.getByRole("button", { name: label });
+      fireEvent.click(btn);
+      expect(onAction).toHaveBeenCalledWith(transition);
+    },
+  );
+
+  it("renders nothing for a Closed (terminal) problem", () => {
+    const { container } = render(
+      <ProblemActionBar problem={problem("CLOSED")} isPending={false} onAction={vi.fn()} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when the problem has no state", () => {
+    const { container } = render(
+      <ProblemActionBar problem={{ id: "prb-1" }} isPending={false} onAction={vi.fn()} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("disables the button while a transition is pending", () => {
+    render(<ProblemActionBar problem={problem("NEW")} isPending onAction={vi.fn()} />);
+    expect(screen.getByRole("button", { name: "Move to Assess" })).toBeDisabled();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ProblemActionBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ProblemActionBar.tsx
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Button } from "@wso2/oxygen-ui";
+import { ArrowRight, CheckCircle } from "@wso2/oxygen-ui-icons-react";
+import type { JSX } from "react";
+import { getNextProblemTransition, problemStateLabel } from "@features/csm-operations/utils/problems";
+import type { BeProblemDetail } from "@api/backend/types";
+
+interface ProblemActionBarProps {
+  problem: BeProblemDetail;
+  /** True while a `PATCH /problems/{id}` transition is in flight. */
+  isPending: boolean;
+  /**
+   * Fired with the `transition` key (`assess`/`confirm`/`fix`/`resolve`/
+   * `close`) the engineer picked. The caller decides how to apply it — a
+   * direct `PATCH { transition }` for most, or (for `fix`) opening a dialog
+   * to optionally collect `causeNotes`/`fixNotes` first — this bar has no
+   * opinion on that, same split of responsibility as `IncidentActionBar` +
+   * `CsmIncidentDetailPage.onIncidentAction`.
+   */
+  onAction: (transition: string) => void;
+}
+
+/**
+ * Lifecycle action bar for the problem detail page. Unlike
+ * `IncidentActionBar`/`ChangeRequestActionBar`, a problem's live state
+ * machine is a strictly linear forward chain (`New -> Assess -> Root Cause
+ * Analysis -> Fix in Progress -> Resolved -> Closed`, one legal next step at
+ * a time — see `getNextProblemTransition`), so there's never more than one
+ * button and no dropdown menu is needed. Renders nothing once the problem is
+ * `Closed` (terminal) or in a state with no modeled forward transition.
+ */
+export default function ProblemActionBar({
+  problem,
+  isPending,
+  onAction,
+}: ProblemActionBarProps): JSX.Element | null {
+  const next = getNextProblemTransition(problem.state);
+  if (!next) return null;
+
+  const isTerminalTarget = next.target === "CLOSED" || next.target === "RESOLVED";
+
+  return (
+    <Button
+      size="small"
+      variant="contained"
+      color={isTerminalTarget ? "success" : "primary"}
+      startIcon={isTerminalTarget ? <CheckCircle size={16} /> : <ArrowRight size={16} />}
+      disabled={isPending}
+      onClick={() => onAction(next.transition)}
+    >
+      Move to {problemStateLabel(next.target)}
+    </Button>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ProblemFixNotesDialog.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ProblemFixNotesDialog.test.tsx
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import ProblemFixNotesDialog from "@features/csm-operations/components/ProblemFixNotesDialog";
+
+describe("ProblemFixNotesDialog", () => {
+  it("confirms with empty causeNotes/fixNotes when the engineer skips them", () => {
+    const onConfirm = vi.fn();
+    render(<ProblemFixNotesDialog isSubmitting={false} onClose={vi.fn()} onConfirm={onConfirm} />);
+    fireEvent.click(screen.getByRole("button", { name: "Move to Fix In Progress" }));
+    expect(onConfirm).toHaveBeenCalledWith({ causeNotes: "", fixNotes: "" });
+  });
+
+  it("confirms with the filled-in notes, trimmed", () => {
+    const onConfirm = vi.fn();
+    render(<ProblemFixNotesDialog isSubmitting={false} onClose={vi.fn()} onConfirm={onConfirm} />);
+    fireEvent.change(screen.getByLabelText("Cause notes"), {
+      target: { value: "  bad config push  " },
+    });
+    fireEvent.change(screen.getByLabelText("Fix notes"), {
+      target: { value: "rolled back" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Move to Fix In Progress" }));
+    expect(onConfirm).toHaveBeenCalledWith({ causeNotes: "bad config push", fixNotes: "rolled back" });
+  });
+
+  it("shows the passed-in error message", () => {
+    render(
+      <ProblemFixNotesDialog
+        isSubmitting={false}
+        error="State transition rejected"
+        onClose={vi.fn()}
+        onConfirm={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("State transition rejected")).toBeInTheDocument();
+  });
+
+  it("disables Cancel and Confirm while submitting", () => {
+    render(<ProblemFixNotesDialog isSubmitting onClose={vi.fn()} onConfirm={vi.fn()} />);
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Move to Fix In Progress" })).toBeDisabled();
+  });
+
+  it("calls onClose when Cancel is clicked and not submitting", () => {
+    const onClose = vi.fn();
+    render(<ProblemFixNotesDialog isSubmitting={false} onClose={onClose} onConfirm={vi.fn()} />);
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ProblemFixNotesDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ProblemFixNotesDialog.tsx
@@ -1,0 +1,114 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Alert,
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  TextField,
+} from "@wso2/oxygen-ui";
+import { useState, type JSX } from "react";
+
+interface ProblemFixNotesDialogProps {
+  isSubmitting: boolean;
+  /** User-facing message for the most recent failed attempt, if any. */
+  error?: string | null;
+  onClose: () => void;
+  onConfirm: (fields: { causeNotes: string; fixNotes: string }) => void;
+}
+
+/**
+ * Optional-notes dialog for the `fix` transition (Root Cause Analysis ->
+ * Fix in Progress). Unlike `IncidentResolutionDialog`'s `resolutionCode`/
+ * `resolutionNotes` (ServiceNow-required, confirmed live: those 500 without
+ * it), `causeNotes`/`fixNotes` are genuinely optional on this transition per
+ * `CHANGES-problem-update.md` §3 — so this dialog can be skipped rather than
+ * blocking the transition on empty fields, same "confirm without forcing
+ * input" shape as `ChangeRequestTransitionReasonDialog` but without the
+ * required-field gate that dialog has for its two destructive transitions.
+ */
+export default function ProblemFixNotesDialog({
+  isSubmitting,
+  error,
+  onClose,
+  onConfirm,
+}: ProblemFixNotesDialogProps): JSX.Element {
+  const [causeNotes, setCauseNotes] = useState("");
+  const [fixNotes, setFixNotes] = useState("");
+
+  return (
+    <Dialog
+      open
+      onClose={() => {
+        if (!isSubmitting) onClose();
+      }}
+      maxWidth="xs"
+      fullWidth
+      aria-labelledby="problem-fix-notes-title"
+    >
+      <DialogTitle id="problem-fix-notes-title">Move to Fix In Progress</DialogTitle>
+      <DialogContent dividers>
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 2, pt: 0.5 }}>
+          {error && <Alert severity="error">{error}</Alert>}
+          <DialogContentText variant="body2">
+            Cause and fix notes are optional here — you can add them now or
+            edit them later from the problem's overview.
+          </DialogContentText>
+          <TextField
+            label="Cause notes"
+            multiline
+            minRows={2}
+            fullWidth
+            size="small"
+            value={causeNotes}
+            disabled={isSubmitting}
+            onChange={(e) => setCauseNotes(e.target.value)}
+            helperText="Root cause / detailed RCA."
+          />
+          <TextField
+            label="Fix notes"
+            multiline
+            minRows={2}
+            fullWidth
+            size="small"
+            value={fixNotes}
+            disabled={isSubmitting}
+            onChange={(e) => setFixNotes(e.target.value)}
+            helperText="Description of the permanent fix being applied."
+          />
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button color="inherit" onClick={onClose} disabled={isSubmitting}>
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          onClick={() => onConfirm({ causeNotes: causeNotes.trim(), fixNotes: fixNotes.trim() })}
+          disabled={isSubmitting}
+          loading={isSubmitting}
+        >
+          Move to Fix In Progress
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.tsx
@@ -438,33 +438,56 @@ export default function CsmChangeRequestDetailPage(): JSX.Element {
     <Box sx={{ display: "flex", flexDirection: "column", gap: 2.5 }}>
       {BackButton}
 
-      <Box sx={{ display: "flex", flexDirection: "column", gap: 1, minWidth: 0 }}>
-        <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, flexWrap: "wrap" }}>
-          <Typography variant="h5">{cr.subject || cr.number || "Change request"}</Typography>
-          {cr.state && (
-            <Chip
-              size="small"
-              color={changeRequestStateColor(cr.state)}
-              label={changeRequestStateLabel(cr.state)}
-            />
-          )}
-          {cr.impact && (
-            <Chip
-              size="small"
-              variant="outlined"
-              color={changeRequestImpactColor(cr.impact)}
-              label={`${changeRequestImpactLabel(cr.impact)} impact`}
-            />
-          )}
-          <Box
+      <Box
+        sx={{
+          display: "flex",
+          gap: 2,
+          alignItems: "flex-start",
+          flexWrap: { xs: "wrap", md: "nowrap" },
+          justifyContent: "space-between",
+        }}
+      >
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 1,
+            flex: 1,
+            minWidth: 0,
+          }}
+        >
+          <Typography
+            variant="h6"
             sx={{
-              ml: "auto",
-              display: "flex",
-              alignItems: "center",
-              gap: 1,
-              flexShrink: 0,
+              fontFamily: "monospace",
+              fontWeight: 700,
+              letterSpacing: 0.2,
+              lineHeight: 1.2,
             }}
           >
+            {cr.number || cr.id}
+          </Typography>
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
+            {cr.state && (
+              <Chip
+                size="small"
+                color={changeRequestStateColor(cr.state)}
+                label={changeRequestStateLabel(cr.state)}
+              />
+            )}
+            {cr.impact && (
+              <Chip
+                size="small"
+                variant="outlined"
+                color={changeRequestImpactColor(cr.impact)}
+                label={`${changeRequestImpactLabel(cr.impact)} impact`}
+              />
+            )}
+          </Box>
+          <Typography variant="h5">{cr.subject || cr.number || "Change request"}</Typography>
+        </Box>
+        <Box sx={{ flexShrink: 0, alignSelf: { xs: "stretch", md: "flex-start" } }}>
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
             <ChangeRequestActionBar
               cr={cr}
               isPending={transitionPending}
@@ -496,9 +519,6 @@ export default function CsmChangeRequestDetailPage(): JSX.Element {
             </Button>
           </Box>
         </Box>
-        <Typography variant="body2" color="text.secondary" sx={{ fontFamily: "monospace" }}>
-          {cr.number || cr.id}
-        </Typography>
       </Box>
 
       <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 2 }}>

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.tsx
@@ -484,7 +484,7 @@ export default function CsmChangeRequestDetailPage(): JSX.Element {
               />
             )}
           </Box>
-          <Typography variant="h5">{cr.subject || cr.number || "Change request"}</Typography>
+          <Typography variant="h5">{cr.subject || "Change request"}</Typography>
         </Box>
         <Box sx={{ flexShrink: 0, alignSelf: { xs: "stretch", md: "flex-start" } }}>
           <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmIncidentDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmIncidentDetailPage.tsx
@@ -383,25 +383,56 @@ export default function CsmIncidentDetailPage(): JSX.Element {
     <Box sx={{ display: "flex", flexDirection: "column", gap: 2.5 }}>
       {BackButton}
 
-      <Box sx={{ display: "flex", flexDirection: "column", gap: 1, minWidth: 0 }}>
-        <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, flexWrap: "wrap" }}>
+      <Box
+        sx={{
+          display: "flex",
+          gap: 2,
+          alignItems: "flex-start",
+          flexWrap: { xs: "wrap", md: "nowrap" },
+          justifyContent: "space-between",
+        }}
+      >
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 1,
+            flex: 1,
+            minWidth: 0,
+          }}
+        >
+          <Typography
+            variant="h6"
+            sx={{
+              fontFamily: "monospace",
+              fontWeight: 700,
+              letterSpacing: 0.2,
+              lineHeight: 1.2,
+            }}
+          >
+            {incident.number || incident.id}
+          </Typography>
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
+            {incident.state && (
+              <Chip
+                size="small"
+                color={incidentStateColor(incident.state)}
+                label={incidentStateLabel(incident.state)}
+              />
+            )}
+            {incident.priority && (
+              <Chip
+                size="small"
+                variant="outlined"
+                color={incidentPriorityColor(incident.priority)}
+                label={incidentPriorityLabel(incident.priority)}
+              />
+            )}
+          </Box>
           <Typography variant="h5">{incident.subject || incident.number || "Incident"}</Typography>
-          {incident.state && (
-            <Chip
-              size="small"
-              color={incidentStateColor(incident.state)}
-              label={incidentStateLabel(incident.state)}
-            />
-          )}
-          {incident.priority && (
-            <Chip
-              size="small"
-              variant="outlined"
-              color={incidentPriorityColor(incident.priority)}
-              label={incidentPriorityLabel(incident.priority)}
-            />
-          )}
-          <Box sx={{ display: "flex", alignItems: "center", gap: 1, ml: "auto", flexShrink: 0 }}>
+        </Box>
+        <Box sx={{ flexShrink: 0, alignSelf: { xs: "stretch", md: "flex-start" } }}>
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
             <IncidentActionBar
               incident={incident}
               isPending={patchIncident.isPending}
@@ -417,9 +448,6 @@ export default function CsmIncidentDetailPage(): JSX.Element {
             </Button>
           </Box>
         </Box>
-        <Typography variant="body2" color="text.secondary" sx={{ fontFamily: "monospace" }}>
-          {incident.number || incident.id}
-        </Typography>
       </Box>
 
       <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 2 }}>

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmIncidentDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmIncidentDetailPage.tsx
@@ -429,7 +429,7 @@ export default function CsmIncidentDetailPage(): JSX.Element {
               />
             )}
           </Box>
-          <Typography variant="h5">{incident.subject || incident.number || "Incident"}</Typography>
+          <Typography variant="h5">{incident.subject || "Incident"}</Typography>
         </Box>
         <Box sx={{ flexShrink: 0, alignSelf: { xs: "stretch", md: "flex-start" } }}>
           <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/ProblemDetailPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/ProblemDetailPage.test.tsx
@@ -14,8 +14,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
 import "@testing-library/jest-dom/vitest";
 import type { UseQueryResult } from "@tanstack/react-query";
 import type { BeProblemDetail } from "@api/backend/types";
@@ -23,6 +23,25 @@ import type { BeProblemDetail } from "@api/backend/types";
 const navigateMock = vi.fn();
 const useGetProblemMock = vi.fn();
 const useLocationMock = vi.fn<() => { state: { from?: string } | null }>(() => ({ state: null }));
+const patchMutateMock = vi.fn();
+const showErrorMock = vi.fn();
+const editProblemDialogMock = vi.fn();
+const problemFixNotesDialogMock = vi.fn();
+let patchIsPending = false;
+
+// The backend client reads runtime config at module load, which isn't
+// present under vitest. The page imports `BackendApiError` from it directly,
+// so stub the module with a real class (so `instanceof` still works) — same
+// approach as CsmIncidentDetailPage.test.tsx / CsmChangeRequestDetailPage.test.tsx.
+vi.mock("@api/backend/client", () => ({
+  BackendApiError: class BackendApiError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+      super(message);
+      this.status = status;
+    }
+  },
+}));
 
 vi.mock("react-router", () => ({
   useParams: () => ({ id: "prb-1" }),
@@ -31,8 +50,33 @@ vi.mock("react-router", () => ({
 vi.mock("@hooks/useNavTransition", () => ({
   useNavTransition: () => navigateMock,
 }));
+vi.mock("@context/error-banner/ErrorBannerContext", () => ({
+  useErrorBanner: () => ({ showError: showErrorMock }),
+}));
 vi.mock("@features/csm-operations/api/useGetProblem", () => ({
   useGetProblem: () => useGetProblemMock(),
+}));
+vi.mock("@features/csm-operations/api/usePatchProblem", () => ({
+  usePatchProblem: () => ({
+    mutate: patchMutateMock,
+    isPending: patchIsPending,
+    isError: false,
+    error: null,
+  }),
+}));
+// Exercised in isolation by their own test files; here we only assert this
+// page opens them and wires the expected props.
+vi.mock("@features/csm-operations/components/EditProblemDialog", () => ({
+  default: (props: unknown) => {
+    editProblemDialogMock(props);
+    return null;
+  },
+}));
+vi.mock("@features/csm-operations/components/ProblemFixNotesDialog", () => ({
+  default: (props: unknown) => {
+    problemFixNotesDialogMock(props);
+    return null;
+  },
 }));
 
 // Imported after the mocks above so the module picks them up.
@@ -77,6 +121,14 @@ function mockQueryResult(
 }
 
 describe("ProblemDetailPage", () => {
+  beforeEach(() => {
+    patchMutateMock.mockReset();
+    showErrorMock.mockReset();
+    editProblemDialogMock.mockReset();
+    problemFixNotesDialogMock.mockReset();
+    patchIsPending = false;
+  });
+
   it("renders a loading skeleton while the query is pending", () => {
     mockQueryResult({ isLoading: true });
     const { container } = render(<ProblemDetailPage />);
@@ -174,5 +226,50 @@ describe("ProblemDetailPage", () => {
     render(<ProblemDetailPage />);
     screen.getByRole("button", { name: "Back" }).click();
     expect(navigateMock).toHaveBeenCalledWith("/operations?tab=problems&state=closed");
+  });
+
+  it("shows a transition action button for a New problem (assess) and PATCHes with { transition } on click", () => {
+    mockQueryResult({ data: { ...BASE_PROBLEM, state: "NEW" } });
+    render(<ProblemDetailPage />);
+    const btn = screen.getByRole("button", { name: /Move to Assess/i });
+    fireEvent.click(btn);
+    expect(patchMutateMock).toHaveBeenCalledWith(
+      { id: "prb-1", patch: { transition: "assess" } },
+      expect.objectContaining({ onError: expect.any(Function) }),
+    );
+  });
+
+  it("opens the optional fix-notes dialog instead of PATCHing directly for the fix transition", () => {
+    mockQueryResult({ data: { ...BASE_PROBLEM, state: "ROOT_CAUSE_ANALYSIS" } });
+    render(<ProblemDetailPage />);
+    fireEvent.click(screen.getByRole("button", { name: /Move to Fix In Progress/i }));
+    expect(patchMutateMock).not.toHaveBeenCalled();
+    expect(problemFixNotesDialogMock).toHaveBeenCalled();
+  });
+
+  it("renders no transition action button for a Closed (terminal) problem", () => {
+    mockQueryResult({ data: { ...BASE_PROBLEM, state: "CLOSED" } });
+    render(<ProblemDetailPage />);
+    expect(screen.queryByRole("button", { name: /Move to/i })).not.toBeInTheDocument();
+  });
+
+  it("opens EditProblemDialog with the current problem when Edit is clicked", () => {
+    mockQueryResult({ data: BASE_PROBLEM });
+    render(<ProblemDetailPage />);
+    expect(editProblemDialogMock).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+    expect(editProblemDialogMock).toHaveBeenCalledWith(
+      expect.objectContaining({ problem: BASE_PROBLEM, isSaving: false }),
+    );
+  });
+
+  it("shows an error banner message when a transition PATCH fails with a caller-actionable status", () => {
+    mockQueryResult({ data: { ...BASE_PROBLEM, state: "NEW" } });
+    patchMutateMock.mockImplementation((_input, opts) => {
+      opts?.onError?.(new Error("State transition rejected"));
+    });
+    render(<ProblemDetailPage />);
+    fireEvent.click(screen.getByRole("button", { name: /Move to Assess/i }));
+    expect(showErrorMock).toHaveBeenCalled();
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/ProblemDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/ProblemDetailPage.tsx
@@ -188,9 +188,26 @@ export default function ProblemDetailPage(): JSX.Element {
     <Box sx={{ display: "flex", flexDirection: "column", gap: 2.5 }}>
       {BackButton}
 
-      <Box sx={{ display: "flex", flexDirection: "column", gap: 1, minWidth: 0 }}>
-        <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, flexWrap: "wrap" }}>
-          <Typography variant="h5">{problem.subject || problem.number || "Problem"}</Typography>
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          gap: 1,
+          minWidth: 0,
+        }}
+      >
+        <Typography
+          variant="h6"
+          sx={{
+            fontFamily: "monospace",
+            fontWeight: 700,
+            letterSpacing: 0.2,
+            lineHeight: 1.2,
+          }}
+        >
+          {problem.number || problem.id}
+        </Typography>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
           {problem.state && (
             <Chip
               size="small"
@@ -199,9 +216,7 @@ export default function ProblemDetailPage(): JSX.Element {
             />
           )}
         </Box>
-        <Typography variant="body2" color="text.secondary" sx={{ fontFamily: "monospace" }}>
-          {problem.number || problem.id}
-        </Typography>
+        <Typography variant="h5">{problem.subject || problem.number || "Problem"}</Typography>
       </Box>
 
       <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 2 }}>

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/ProblemDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/ProblemDetailPage.tsx
@@ -15,13 +15,19 @@
 // under the License.
 
 import { Box, Button, Card, Chip, Skeleton, Typography } from "@wso2/oxygen-ui";
-import { ArrowLeft, Link as LinkIcon } from "@wso2/oxygen-ui-icons-react";
-import { type JSX, type ReactNode, useEffect } from "react";
+import { ArrowLeft, Link as LinkIcon, Pencil } from "@wso2/oxygen-ui-icons-react";
+import { type JSX, type ReactNode, useCallback, useEffect, useState } from "react";
 import { useLocation } from "react-router";
 import { formatBackendTimestampForDisplay } from "@utils/dateTime";
+import { BackendApiError } from "@api/backend/client";
+import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 import { useGetProblem } from "@features/csm-operations/api/useGetProblem";
+import { usePatchProblem } from "@features/csm-operations/api/usePatchProblem";
+import EditProblemDialog from "@features/csm-operations/components/EditProblemDialog";
+import ProblemActionBar from "@features/csm-operations/components/ProblemActionBar";
+import ProblemFixNotesDialog from "@features/csm-operations/components/ProblemFixNotesDialog";
 import { problemStateColor, problemStateLabel } from "@features/csm-operations/utils/problems";
-import type { BeEntityRef, BeProblemRef } from "@api/backend/types";
+import type { BeEntityRef, BeProblemRef, BeUpdateProblemPayload } from "@api/backend/types";
 import { useNavTransition } from "@hooks/useNavTransition";
 import { useNormalizedIdParam } from "@hooks/useNormalizedIdParam";
 import { useRecordRecentView } from "@features/csm-recent/hooks/useRecentViews";
@@ -90,10 +96,18 @@ function ProblemRefItem({
 }
 
 /**
- * Read-only detail for a single problem (`GET /problems/{id}`): its overview
- * fields, linked records, and resolution/fix notes. There is no Edit dialog
- * — problems are SRE-owned and the portal doesn't yet expose a mutation
- * endpoint for them (unlike change requests/incidents).
+ * Detail for a single problem (`GET /problems/{id}`): its overview fields,
+ * linked records, and resolution/fix notes. State transitions (`PATCH
+ * /problems/{id} { transition }`) go through `ProblemActionBar` — the live
+ * ServiceNow Problem Management engine is a strictly linear forward chain
+ * (`New -> Assess -> Root Cause Analysis -> Fix in Progress -> Resolved ->
+ * Closed`, see `getNextProblemTransition`), so there's only ever one legal
+ * next button, unlike Incident/CR. The `fix` transition routes through
+ * `ProblemFixNotesDialog` first to optionally collect `causeNotes`/
+ * `fixNotes` (unlike Incident's `RESOLVED`/`CLOSED`, these are genuinely
+ * optional, not ServiceNow-required — the dialog is skippable). A separate
+ * `EditProblemDialog` covers `assignedToId`/`assignmentGroupId`/
+ * `workaround`/`targetResolutionDate`, independent of any transition.
  */
 export default function ProblemDetailPage(): JSX.Element {
   const id = useNormalizedIdParam("id");
@@ -104,6 +118,13 @@ export default function ProblemDetailPage(): JSX.Element {
   const backState = useLocation().state as { from?: string } | undefined;
   const backTarget = backState?.from ?? OPERATIONS_PROBLEMS_PATH;
   const { data, isLoading, isError } = useGetProblem(id);
+  const { showError } = useErrorBanner();
+  const patchProblem = usePatchProblem();
+  const [editOpen, setEditOpen] = useState(false);
+  // Set only while the `fix` transition's optional-notes dialog is open;
+  // `null` otherwise. Every other transition dispatches directly with no
+  // intermediate dialog.
+  const [fixNotesOpen, setFixNotesOpen] = useState(false);
 
   const recordView = useRecordRecentView();
   useEffect(() => {
@@ -118,6 +139,58 @@ export default function ProblemDetailPage(): JSX.Element {
       href: `/operations/problems/${data.id}`,
     });
   }, [data, recordView]);
+
+  /**
+   * Dispatch a transition from `ProblemActionBar`. `fix` opens the optional
+   * notes dialog first; every other transition PATCHes directly, same split
+   * of responsibility as `IncidentActionBar` +
+   * `CsmIncidentDetailPage.onIncidentAction`.
+   */
+  const onProblemAction = useCallback(
+    (transition: string) => {
+      if (!id) return;
+      if (transition === "fix") {
+        setFixNotesOpen(true);
+        return;
+      }
+      patchProblem.mutate(
+        { id, patch: { transition } },
+        {
+          onError: (err) => {
+            const msg =
+              err instanceof BackendApiError && err.status < 500 && err.message
+                ? err.message
+                : "Could not update the problem's state. Please try again.";
+            showError(msg, err);
+          },
+        },
+      );
+    },
+    [id, patchProblem, showError],
+  );
+
+  const onFixNotesSubmit = useCallback(
+    (fields: { causeNotes: string; fixNotes: string }) => {
+      if (!id) return;
+      const patch: BeUpdateProblemPayload = { transition: "fix" };
+      if (fields.causeNotes) patch.causeNotes = fields.causeNotes;
+      if (fields.fixNotes) patch.fixNotes = fields.fixNotes;
+      patchProblem.mutate(
+        { id, patch },
+        {
+          onSuccess: () => setFixNotesOpen(false),
+          onError: (err) => {
+            const msg =
+              err instanceof BackendApiError && err.status < 500 && err.message
+                ? err.message
+                : "Could not update the problem's state. Please try again.";
+            showError(msg, err);
+          },
+        },
+      );
+    },
+    [id, patchProblem, showError],
+  );
 
   const back = (): void => {
     navigate(backTarget);
@@ -191,32 +264,60 @@ export default function ProblemDetailPage(): JSX.Element {
       <Box
         sx={{
           display: "flex",
-          flexDirection: "column",
-          gap: 1,
-          minWidth: 0,
+          gap: 2,
+          alignItems: "flex-start",
+          flexWrap: { xs: "wrap", md: "nowrap" },
+          justifyContent: "space-between",
         }}
       >
-        <Typography
-          variant="h6"
+        <Box
           sx={{
-            fontFamily: "monospace",
-            fontWeight: 700,
-            letterSpacing: 0.2,
-            lineHeight: 1.2,
+            display: "flex",
+            flexDirection: "column",
+            gap: 1,
+            flex: 1,
+            minWidth: 0,
           }}
         >
-          {problem.number || problem.id}
-        </Typography>
-        <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
-          {problem.state && (
-            <Chip
-              size="small"
-              color={problemStateColor(problem.state)}
-              label={problemStateLabel(problem.state)}
-            />
-          )}
+          <Typography
+            variant="h6"
+            sx={{
+              fontFamily: "monospace",
+              fontWeight: 700,
+              letterSpacing: 0.2,
+              lineHeight: 1.2,
+            }}
+          >
+            {problem.number || problem.id}
+          </Typography>
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
+            {problem.state && (
+              <Chip
+                size="small"
+                color={problemStateColor(problem.state)}
+                label={problemStateLabel(problem.state)}
+              />
+            )}
+          </Box>
+          <Typography variant="h5">{problem.subject || problem.number || "Problem"}</Typography>
         </Box>
-        <Typography variant="h5">{problem.subject || problem.number || "Problem"}</Typography>
+        <Box sx={{ flexShrink: 0, alignSelf: { xs: "stretch", md: "flex-start" } }}>
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+            <ProblemActionBar
+              problem={problem}
+              isPending={patchProblem.isPending}
+              onAction={onProblemAction}
+            />
+            <Button
+              variant="outlined"
+              size="small"
+              startIcon={<Pencil size={14} />}
+              onClick={() => setEditOpen(true)}
+            >
+              Edit
+            </Button>
+          </Box>
+        </Box>
       </Box>
 
       <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 2 }}>
@@ -355,6 +456,48 @@ export default function ProblemDetailPage(): JSX.Element {
             </Box>
           )}
         </Card>
+      )}
+
+      {editOpen && (
+        <EditProblemDialog
+          problem={problem}
+          isSaving={patchProblem.isPending}
+          saveError={
+            patchProblem.isError
+              ? (patchProblem.error instanceof BackendApiError && patchProblem.error.message
+                  ? patchProblem.error.message
+                  : "Could not update the problem. Please try again.")
+              : null
+          }
+          onClose={() => {
+            if (!patchProblem.isPending) setEditOpen(false);
+          }}
+          onSave={(patch) =>
+            patchProblem.mutate(
+              { id: problem.id, patch },
+              {
+                onSuccess: () => setEditOpen(false),
+                onError: (err) => {
+                  const msg =
+                    err instanceof BackendApiError && err.status < 500 && err.message
+                      ? err.message
+                      : "Could not update the problem. Please try again.";
+                  showError(msg, err);
+                },
+              },
+            )
+          }
+        />
+      )}
+
+      {fixNotesOpen && (
+        <ProblemFixNotesDialog
+          isSubmitting={patchProblem.isPending}
+          onClose={() => {
+            if (!patchProblem.isPending) setFixNotesOpen(false);
+          }}
+          onConfirm={onFixNotesSubmit}
+        />
       )}
     </Box>
   );

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/ProblemDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/ProblemDetailPage.tsx
@@ -299,7 +299,7 @@ export default function ProblemDetailPage(): JSX.Element {
               />
             )}
           </Box>
-          <Typography variant="h5">{problem.subject || problem.number || "Problem"}</Typography>
+          <Typography variant="h5">{problem.subject || "Problem"}</Typography>
         </Box>
         <Box sx={{ flexShrink: 0, alignSelf: { xs: "stretch", md: "flex-start" } }}>
           <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>

--- a/apps/csm-portal/webapp/src/features/csm-operations/utils/problems.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/utils/problems.ts
@@ -55,6 +55,44 @@ export function problemStateColor(state?: string | null): ChipColor {
 }
 
 /**
+ * The single forward transition legal from a given state, per the live
+ * 6-state ServiceNow Problem Management engine (`CHANGES-problem-update.md`
+ * §1/§3) — a strictly linear chain, unlike Incident/Change Request, which
+ * both allow multiple legal next states from a given point. `null` once the
+ * problem is `CLOSED` (terminal) or in a state this CSM-platform doesn't
+ * expose a forward action for. `Mark Duplicate`/`Cancel`/`Re-Analyze` are
+ * deliberately not modeled here — see the contract doc's "Not built" note.
+ */
+const PROBLEM_TRANSITIONS: Partial<
+  Record<BeProblemState, { transition: string; target: BeProblemState }>
+> = {
+  NEW: { transition: "assess", target: "ASSESS" },
+  ASSESS: { transition: "confirm", target: "ROOT_CAUSE_ANALYSIS" },
+  ROOT_CAUSE_ANALYSIS: { transition: "fix", target: "FIX_IN_PROGRESS" },
+  FIX_IN_PROGRESS: { transition: "resolve", target: "RESOLVED" },
+  RESOLVED: { transition: "close", target: "CLOSED" },
+};
+
+export interface ProblemNextTransition {
+  /** The `transition` key to send in the `PATCH /problems/{id}` body. */
+  transition: string;
+  /** The state this transition moves the problem into, for the button label. */
+  target: BeProblemState;
+}
+
+/**
+ * The one legal forward transition from `current`, or `null` if there isn't
+ * one (terminal state, or an unrecognized value from a future backend
+ * state this CSM-platform guardrail doesn't know about yet).
+ */
+export function getNextProblemTransition(
+  current?: BeProblemState | null,
+): ProblemNextTransition | null {
+  if (!current) return null;
+  return PROBLEM_TRANSITIONS[current] ?? null;
+}
+
+/**
  * Filters for the problems list. Deliberately just search + state — see the
  * caveat on `BeProblemSearchFilters.states` in `api/backend/types.ts` (not yet
  * confirmed live against the backend).

--- a/apps/csm-portal/webapp/src/features/help/content/operations.md
+++ b/apps/csm-portal/webapp/src/features/help/content/operations.md
@@ -105,9 +105,26 @@ incident, linked change request, and linked incidents), and, once resolved,
 a resolution section with resolution code, resolved-by, resolved-on, cause
 notes, fix notes, and workaround.
 
-Problem management is read-only in the portal today: there is no Edit dialog
-and no state-changing action bar. Problems are owned by the SRE team, and the
-portal doesn't yet expose a mutation endpoint for them the way it does for
-change requests and incidents. A **Create problem** button on the list opens
-a form to raise a new problem, but nothing on the detail page can be changed
-from here afterward.
+A **Create problem** button on the list opens a form to raise a new problem.
+
+The detail page's action bar moves a problem through ServiceNow's own
+Problem Management lifecycle, one step at a time: **New → Assess → Root
+Cause Analysis → Fix In Progress → Resolved → Closed**. Only one transition
+is ever available at once (the next step in the chain); once a problem is
+Closed there is nothing further to do. Moving to Fix In Progress opens a
+small dialog offering to record cause notes and fix notes — both optional,
+and can be added or edited later — before the state changes.
+
+An **Edit** button on the detail page opens a separate dialog for fields
+that don't require a lifecycle transition: assigned engineer, assignment
+group, workaround, and target resolution date. Two caveats:
+
+- Assigning an engineer to a problem that has no owner yet automatically
+  moves it to Assess, even without using the action bar — this is a
+  ServiceNow business rule, not a portal quirk.
+- Assignment group and target resolution date always start blank in the
+  Edit dialog, even if a value was set previously — the portal can't read
+  either one back from ServiceNow yet, so it doesn't guess. Target
+  resolution date in particular is not shown anywhere on ServiceNow's own
+  Problem form; it's a generic tracking field exposed here for the portal's
+  own use.

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -3924,6 +3924,48 @@ type CreateProblemRequest struct {
 	PrimaryIncidentID *string `json:"primaryIncidentId,omitempty"`
 }
 
+// UpdateProblemRequest is the input for PATCH /problems/{id}. All fields are optional, but
+// at least one must be provided. A Transition request may also carry any of the plain-field
+// keys in the same body (e.g. attaching an owner and requesting "assess" together).
+//
+// Transition is a plain, unvalidated passthrough string -- one of "assess", "confirm", "fix",
+// "resolve", "close" per the data source's own server-side validation -- rather than a closed
+// enum. Do not add strict validation against this list here: the data source's own "Invalid
+// transition" error names the valid values, and a Go-side closed check would swallow that
+// message with a generic one instead, the same mistake the Ballerina layer made and reverted
+// (see CHANGES-problem-update.md).
+type UpdateProblemRequest struct {
+	ID                   string  `json:"-"`
+	Transition           *string `json:"transition,omitempty"`
+	AssignedToID         *string `json:"assignedToId,omitempty"`
+	AssignmentGroupID    *string `json:"assignmentGroupId,omitempty"`
+	CauseNotes           *string `json:"causeNotes,omitempty"`
+	FixNotes             *string `json:"fixNotes,omitempty"`
+	Workaround           *string `json:"workaround,omitempty"`
+	TargetResolutionDate *string `json:"targetResolutionDate,omitempty"`
+}
+
+// UpdateProblemResponse is the output for PATCH /problems/{id}.
+type UpdateProblemResponse struct {
+	Message string            `json:"message"`
+	Problem UpdateProblemView `json:"problem"`
+}
+
+// UpdateProblemView is the problem representation returned by the update (PATCH) operation --
+// deliberately narrower than ProblemDetail: only the fields the update response actually
+// carries. State and ResolutionCode always reflect the real post-write state, not the caller's
+// requested transition -- the data source's own business rules can force- or fail-promote the
+// state as a side effect (see CHANGES-problem-update.md).
+type UpdateProblemView struct {
+	ID              *string    `json:"id"`
+	UpdatedOn       *string    `json:"updatedOn"`
+	UpdatedBy       *string    `json:"updatedBy"`
+	State           *string    `json:"state"`
+	ResolutionCode  *string    `json:"resolutionCode"`
+	AssignedTo      *EntityRef `json:"assignedTo"`
+	AssignmentGroup *EntityRef `json:"assignmentGroup"`
+}
+
 // IncidentTaskFieldFilter is a single predicate in an incident-task search's
 // generic filter expression array: "field op values", mirroring
 // ProblemFieldFilter's contract. See service.ParseIncidentTaskFieldFilters

--- a/entity-service/internal/handler/problem_handler.go
+++ b/entity-service/internal/handler/problem_handler.go
@@ -93,3 +93,20 @@ func (h *ProblemHandler) CreateProblem(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusCreated)
 	_ = json.NewEncoder(w).Encode(resp)
 }
+
+// PatchProblem handles PATCH /problems/{id}.
+func (h *ProblemHandler) PatchProblem(w http.ResponseWriter, r *http.Request) {
+	var req domain.UpdateProblemRequest
+	if !decodeRequest(w, r, &req) {
+		return
+	}
+	req.ID = r.PathValue("id")
+	resp, err := h.svc.UpdateProblem(r.Context(), req)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(resp)
+}

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -387,6 +387,7 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 		mux.HandleFunc("POST /problems/search", problemHandler.SearchProblems)
 		mux.HandleFunc("POST /problems/aggregate", problemHandler.AggregateProblems)
 		mux.HandleFunc("GET /problems/{id}", problemHandler.GetProblem)
+		mux.HandleFunc("PATCH /problems/{id}", problemHandler.PatchProblem)
 	}
 
 	if incidentTaskHandler != nil {

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -475,6 +475,13 @@ type ProblemService interface {
 	// CreateProblem creates a new problem. Subject is required; OriginCaseID is optional.
 	// Supported by the ServiceNow data source only.
 	CreateProblem(ctx context.Context, req domain.CreateProblemRequest) (domain.ProblemDetail, error)
+
+	// UpdateProblem partially updates an existing problem -- a forward state transition
+	// (assess/confirm/fix/resolve/close), plain-field updates, or both in the same request. At
+	// least one field must be provided. Transition is validated by the data source, not here.
+	// A NotFoundError is returned if the problem does not exist; a ConflictError if the data
+	// source rejects or reverts the requested transition.
+	UpdateProblem(ctx context.Context, req domain.UpdateProblemRequest) (domain.UpdateProblemResponse, error)
 }
 
 // IncidentTaskService defines the operations available on the incident_task entity.

--- a/entity-service/internal/service/sn_problem_service.go
+++ b/entity-service/internal/service/sn_problem_service.go
@@ -399,3 +399,112 @@ func mapSNProblemDetailToView(p snProblemDetailResponse) domain.ProblemDetail {
 
 	return view
 }
+
+// snUpdateProblemPayload is the Choreo PATCH /problems/{id} request body.
+type snUpdateProblemPayload struct {
+	Transition           *string `json:"transition,omitempty"`
+	AssignedToID         *string `json:"assignedToId,omitempty"`
+	AssignmentGroupID    *string `json:"assignmentGroupId,omitempty"`
+	CauseNotes           *string `json:"causeNotes,omitempty"`
+	FixNotes             *string `json:"fixNotes,omitempty"`
+	Workaround           *string `json:"workaround,omitempty"`
+	TargetResolutionDate *string `json:"targetResolutionDate,omitempty"`
+}
+
+// snUpdateProblemResult mirrors the Choreo PATCH /problems/{id} response's "problem" object --
+// deliberately narrower than snProblemDetailResponse, matching what that endpoint actually
+// returns.
+type snUpdateProblemResult struct {
+	ID              string            `json:"id"`
+	UpdatedOn       string            `json:"updatedOn"`
+	UpdatedBy       string            `json:"updatedBy"`
+	State           *string           `json:"state"`
+	ResolutionCode  *string           `json:"resolutionCode"`
+	AssignedTo      *snProblemUserRef `json:"assignedTo"`
+	AssignmentGroup *snProblemUserRef `json:"assignmentGroup"`
+}
+
+// snUpdateProblemResponse mirrors the Choreo PATCH /problems/{id} response.
+type snUpdateProblemResponse struct {
+	Message string                `json:"message"`
+	Problem snUpdateProblemResult `json:"problem"`
+}
+
+// UpdateProblem implements ProblemService for the ServiceNow data source. It is a thin
+// passthrough: Transition is forwarded unvalidated (see domain.UpdateProblemRequest doc
+// comment), and the response always reflects the data source's real post-write state.
+func (s *snProblemService) UpdateProblem(ctx context.Context, req domain.UpdateProblemRequest) (domain.UpdateProblemResponse, error) {
+	if err := validateUUIDs("id", []string{req.ID}); err != nil {
+		return domain.UpdateProblemResponse{}, err
+	}
+
+	hasUpdate := req.Transition != nil || req.AssignedToID != nil || req.AssignmentGroupID != nil ||
+		req.CauseNotes != nil || req.FixNotes != nil || req.Workaround != nil || req.TargetResolutionDate != nil
+	if !hasUpdate {
+		return domain.UpdateProblemResponse{}, &apierror.ValidationError{Msg: "at least one field must be provided"}
+	}
+
+	optionalUUIDs := map[string]*string{
+		"assignedToId":      req.AssignedToID,
+		"assignmentGroupId": req.AssignmentGroupID,
+	}
+	for field, val := range optionalUUIDs {
+		if val != nil {
+			if err := validateUUIDs(field, []string{*val}); err != nil {
+				return domain.UpdateProblemResponse{}, err
+			}
+		}
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+
+	payload := snUpdateProblemPayload{
+		Transition:           req.Transition,
+		CauseNotes:           req.CauseNotes,
+		FixNotes:             req.FixNotes,
+		Workaround:           req.Workaround,
+		TargetResolutionDate: req.TargetResolutionDate,
+	}
+	if req.AssignedToID != nil {
+		v := uuidToSysid(*req.AssignedToID)
+		payload.AssignedToID = &v
+	}
+	if req.AssignmentGroupID != nil {
+		v := uuidToSysid(*req.AssignmentGroupID)
+		payload.AssignmentGroupID = &v
+	}
+
+	raw, err := s.client.Patch(ctx, "/problems/"+uuidToSysid(req.ID), token, payload)
+	if err != nil {
+		return domain.UpdateProblemResponse{}, err
+	}
+
+	var snResp snUpdateProblemResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.UpdateProblemResponse{}, fmt.Errorf("sn update problem: parse response: %w", err)
+	}
+
+	updatedOn := snResp.Problem.UpdatedOn
+	updatedBy := snResp.Problem.UpdatedBy
+	view := domain.UpdateProblemView{
+		UpdatedOn:      &updatedOn,
+		UpdatedBy:      &updatedBy,
+		State:          snResp.Problem.State,
+		ResolutionCode: snResp.Problem.ResolutionCode,
+	}
+	if snResp.Problem.ID != "" {
+		id := sysidToUUID(snResp.Problem.ID)
+		view.ID = &id
+	}
+	if snResp.Problem.AssignedTo != nil {
+		view.AssignedTo = &domain.EntityRef{ID: sysidToUUID(snResp.Problem.AssignedTo.ID), Name: snResp.Problem.AssignedTo.Name}
+	}
+	if snResp.Problem.AssignmentGroup != nil {
+		view.AssignmentGroup = &domain.EntityRef{ID: sysidToUUID(snResp.Problem.AssignmentGroup.ID), Name: snResp.Problem.AssignmentGroup.Name}
+	}
+
+	return domain.UpdateProblemResponse{
+		Message: snResp.Message,
+		Problem: view,
+	}, nil
+}

--- a/entity-service/internal/service/sn_problem_service_test.go
+++ b/entity-service/internal/service/sn_problem_service_test.go
@@ -18,6 +18,7 @@ package service
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strings"
 	"testing"
@@ -94,5 +95,129 @@ func TestSNProblemService_SearchProblems_RejectsOverlongNumber(t *testing.T) {
 	}
 	if called {
 		t.Fatal("ServiceNow client was called despite the invalid filter")
+	}
+}
+
+const (
+	testProblemUUID  = "77777777-7777-7777-7777-777777777777"
+	testProblemSysid = "77777777777777777777777777777777"
+)
+
+// TestSNProblemService_UpdateProblem_TransitionPassedThroughUnvalidated verifies a
+// transition value reaches the outgoing PATCH payload verbatim -- this layer must
+// never re-validate it as a closed enum, so an invalid value's actionable error from
+// the data source reaches the caller unchanged instead of being swallowed here.
+func TestSNProblemService_UpdateProblem_TransitionPassedThroughUnvalidated(t *testing.T) {
+	var gotBody map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/problems/"+testProblemSysid, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Fatalf("expected PATCH, got %s", r.Method)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"message": "Problem updated successfully",
+			"problem": {
+				"id": "` + testProblemSysid + `",
+				"updatedOn": "2026-08-23 00:00:00",
+				"updatedBy": "engineer@example.com",
+				"state": "ASSESS",
+				"resolutionCode": null,
+				"assignedTo": {"id": "` + testProblemSysid + `", "name": "Jane Doe"},
+				"assignmentGroup": null
+			}
+		}`))
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowProblemService(client)
+
+	resp, err := svc.UpdateProblem(contextWithUserIDToken("token"), domain.UpdateProblemRequest{
+		ID:           testProblemUUID,
+		Transition:   strPtr("teleport"), // deliberately invalid -- must still be forwarded as-is
+		AssignedToID: strPtr(testProblemUUID),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if gotBody["transition"] != "teleport" {
+		t.Fatalf("transition: got %v, want %q (unvalidated passthrough)", gotBody["transition"], "teleport")
+	}
+	if gotBody["assignedToId"] != testProblemSysid {
+		t.Fatalf("assignedToId: got %v, want %q (UUID must be converted to sysid)", gotBody["assignedToId"], testProblemSysid)
+	}
+	if resp.Problem.State == nil || *resp.Problem.State != "ASSESS" {
+		t.Fatalf("response state: got %v, want ASSESS (the real post-write state)", resp.Problem.State)
+	}
+	if resp.Problem.AssignedTo == nil || resp.Problem.AssignedTo.ID != testProblemUUID {
+		t.Fatalf("response assignedTo: got %+v, want id %q (sysid converted back to UUID)", resp.Problem.AssignedTo, testProblemUUID)
+	}
+}
+
+// TestSNProblemService_UpdateProblem_RequiresAtLeastOneField verifies an empty
+// request is rejected as a *apierror.ValidationError before the client is called.
+func TestSNProblemService_UpdateProblem_RequiresAtLeastOneField(t *testing.T) {
+	called := false
+	mux := http.NewServeMux()
+	mux.HandleFunc("/problems/"+testProblemSysid, func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowProblemService(client)
+
+	_, err := svc.UpdateProblem(contextWithUserIDToken("token"), domain.UpdateProblemRequest{ID: testProblemUUID})
+
+	var valErr *apierror.ValidationError
+	if !asValidationError(err, &valErr) {
+		t.Fatalf("expected *apierror.ValidationError, got %T: %v", err, err)
+	}
+	if called {
+		t.Fatal("ServiceNow client was called despite an empty update request")
+	}
+}
+
+// TestSNProblemService_UpdateProblem_InvalidAssignedToID verifies a malformed
+// assignedToId is rejected as a validation error before the client is called.
+func TestSNProblemService_UpdateProblem_InvalidAssignedToID(t *testing.T) {
+	// client is intentionally nil: validation must fail before touching it.
+	svc := NewServiceNowProblemService(nil)
+
+	_, err := svc.UpdateProblem(contextWithUserIDToken("token"), domain.UpdateProblemRequest{
+		ID:           testProblemUUID,
+		AssignedToID: strPtr("not-a-uuid"),
+	})
+
+	var valErr *apierror.ValidationError
+	if !asValidationError(err, &valErr) {
+		t.Fatalf("expected *apierror.ValidationError, got %T: %v", err, err)
+	}
+}
+
+// TestSNProblemService_UpdateProblem_ConflictMapped verifies a 409 from the data
+// source (a rejected/reverted state transition) surfaces as a *apierror.ConflictError.
+func TestSNProblemService_UpdateProblem_ConflictMapped(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/problems/"+testProblemSysid, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"code": 409, "message": "State transition rejected"}`))
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowProblemService(client)
+
+	_, err := svc.UpdateProblem(contextWithUserIDToken("token"), domain.UpdateProblemRequest{
+		ID:         testProblemUUID,
+		Transition: strPtr("assess"),
+	})
+
+	var confErr *apierror.ConflictError
+	if !errors.As(err, &confErr) {
+		t.Fatalf("expected *apierror.ConflictError, got %T: %v", err, err)
 	}
 }

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -3315,6 +3315,62 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+    patch:
+      summary: >-
+        Update a problem -- a forward state transition, plain-field updates, or both
+        (ServiceNow data source only).
+      operationId: updateProblem
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateProblemRequest'
+      responses:
+        "200":
+          description: Problem updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UpdateProblemResponse'
+        "400":
+          description: Missing fields, invalid transition, or invalid state transition.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: Problem, assignedToId, or assignmentGroupId not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "409":
+          description: State transition rejected by the data source.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /incident-tasks/search:
     post:
       summary: Search incident tasks (ServiceNow data source only). Search and get only -- no create/update.
@@ -9245,6 +9301,89 @@ components:
         primaryIncidentId:
           type: string
           format: uuid
+          nullable: true
+
+    UpdateProblemRequest:
+      type: object
+      description: >-
+        All fields are optional, but at least one must be provided. A transition request may
+        also carry any of the plain-field keys in the same body (e.g. attaching an owner and
+        requesting "assess" together).
+      minProperties: 1
+      properties:
+        transition:
+          type: string
+          description: >-
+            Forward state transition to request: one of "assess", "confirm", "fix", "resolve",
+            "close". Left as an open string (validated server-side by the data source, not a
+            closed enum here) so an invalid value's actionable error message reaches the
+            caller unchanged.
+        assignedToId:
+          type: string
+          format: uuid
+          nullable: true
+          description: >-
+            404 if not a real user. Setting this on a brand-new problem with no prior assignee
+            can auto-promote it to Assess as a data-source side effect -- the response always
+            reflects the real resulting state, never the caller's assumption.
+        assignmentGroupId:
+          type: string
+          format: uuid
+          nullable: true
+          description: 404 if not a real group.
+        causeNotes:
+          type: string
+          nullable: true
+        fixNotes:
+          type: string
+          nullable: true
+        workaround:
+          type: string
+          nullable: true
+        targetResolutionDate:
+          type: string
+          nullable: true
+          description: >-
+            Format: YYYY-MM-DD HH:mm:ss. Not surfaced on the native Problem form in the
+            backing data source.
+
+    UpdateProblemResponse:
+      type: object
+      properties:
+        message:
+          type: string
+        problem:
+          $ref: '#/components/schemas/UpdateProblemView'
+
+    UpdateProblemView:
+      type: object
+      description: >-
+        Deliberately narrower than ProblemDetail: only the fields the update response
+        actually carries.
+      properties:
+        id:
+          type: string
+          nullable: true
+        updatedOn:
+          type: string
+          nullable: true
+        updatedBy:
+          type: string
+          nullable: true
+        state:
+          type: string
+          nullable: true
+          description: >-
+            Always the real post-write state, not the caller's requested transition --
+            the data source's business rules can force- or fail-promote it.
+        resolutionCode:
+          type: string
+          nullable: true
+        assignedTo:
+          $ref: '#/components/schemas/EntityRef'
+          nullable: true
+        assignmentGroup:
+          $ref: '#/components/schemas/EntityRef'
           nullable: true
 
     ProblemFieldFilter:


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

**1. Header alignment.** The Incident, Change Request, and Problem detail pages laid out their
header the opposite way from the Case detail page: subject + chips + the action bar all crammed
onto one line, with the record number reduced to a small line underneath. This made the three
operations pages visually inconsistent with Case, the page CS engineers use most.

**2. Problem-update Go passthrough.** Problem management had Create/Get/Search/Aggregate but no
Update — the one confirmed real gap in Problem CRUD. The ServiceNow and Ballerina
entity-service layers for the new `PATCH /problems/{id}` are done; this PR adds the matching
Go entity-service passthrough so the operation is reachable one layer further up the stack.

**3. CSM BFF passthrough.** The Go entity-service now exposes `PATCH /problems/{id}`, but the
CSM portal BFF (the layer the webapp actually talks to) had no matching route. This PR adds it,
closing the last backend gap before a webapp update flow for Problems can be built.

**4. Problem update webapp UI.** All backend layers for `PATCH /problems/{id}` were done, but
`ProblemDetailPage.tsx` had no UI wired to them — problems were still read-only from the CS
engineer's point of view, with no way to move a problem through its lifecycle, assign it, or
record a workaround/target resolution date from the portal.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

**1. Header alignment.** Make the Incident, Change Request, and Problem detail-page headers
match the Case detail page's structure exactly: record number first (prominent, monospace),
then the status chip row, then the subject — with the action bar (state/clone/edit controls)
moved out of the chip row into its own box to the right of that column.

**2. Problem-update Go passthrough.** Add `PATCH /problems/{id}` to the Go entity-service as a
thin, additive passthrough to the backing data source's new Update Problem resource, matching
the existing Get/Search/Create/Aggregate Problem and `PATCH /incidents/{id}` conventions
exactly. No existing Problem operation's behavior or response shape is touched.

**3. CSM BFF passthrough.** Add `PATCH /problems/{id}` to the CSM portal BFF, forwarding to the
entity-service passthrough above, matching this BFF's own existing `PATCH /incidents/{id}`
handler conventions exactly (auth check, body-size cap, JSON validation, at-least-one-field
validation, `mapUpstreamError` for upstream-reason passthrough on 4xx). No existing Problem
BFF operation's behavior or response shape is touched.

**4. Problem update webapp UI.** Add a lifecycle action bar and a separate assignment/tracking
edit dialog to `ProblemDetailPage.tsx`, following the same `*ActionBar` + `Edit*Dialog` split
already established for Incident/Change Request, adapted to Problem's own state machine (a
strictly linear forward chain, unlike Incident/CR's multi-target transitions) and its own
optional-vs-required field rules for the `fix` transition.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

**1. Header alignment.** Layout-only change, no chip content/logic touched:
- `CsmIncidentDetailPage.tsx`: reordered to number (h6, monospace) → state +
  priority chips → subject (h5); `IncidentActionBar` + Edit moved to a
  sibling box (`flexShrink:0, alignSelf:{xs:stretch, md:flex-start}`),
  matching Case's outer flex structure (`flex:1, minWidth:0` text column +
  sibling actions box, `flexWrap:{xs:wrap, md:nowrap}`).
- `CsmChangeRequestDetailPage.tsx`: same reorder (number → state + impact
  chips → subject); `ChangeRequestActionBar` + Clone + Edit moved to the
  sibling actions box.
- `ProblemDetailPage.tsx`: same reorder (number → state chip → subject).
  Problems have no mutation endpoint yet, so there's no action bar to move —
  this file only fixes the text-column ordering.

Verified against real staging data (screenshots taken locally, not attached
here since they show internal case/incident content):
- All four detail pages (Case as reference, Incident, Change Request,
  Problem) show the same number → chips → subject ordering in both light
  and dark theme.
- The action bar sits to the right of the text column, not inline in the
  chip row, on Incident and Change Request.
- At narrow width the action box wraps below the text column exactly like
  Case's does (verified by testing with the exact same `sx` values Case
  uses — this is inherent to the shared flex structure, not a
  page-specific behavior).

**2. Problem-update Go passthrough.** In `entity-service/`:
- `internal/domain/entity.go`: new `UpdateProblemRequest` (`transition`, `assignedToId`,
  `assignmentGroupId`, `causeNotes`, `fixNotes`, `workaround`, `targetResolutionDate`, all
  optional, at least one required), `UpdateProblemResponse`/`UpdateProblemView` (a narrower
  view than `ProblemDetail`, matching what the update response actually returns).
- `internal/service/interfaces.go` + `sn_problem_service.go`: `UpdateProblem` on
  `ProblemService`, calling the backing client's `Patch` the same way
  `sn_incident_service.go`'s `UpdateIncident` calls it — uuid↔sysid conversion,
  `apierror.ConflictError` surfaced for a 409 (state transition rejected by the data source).
  `transition` is forwarded as a plain, unvalidated string rather than a closed enum: a
  Go-side allow-list would swallow the data source's own actionable "must be one of: ..."
  error behind a generic type-mismatch message instead of letting it reach the caller.
- `internal/handler/problem_handler.go` + `internal/server/routes.go`: `PatchProblem` handler,
  registered as `PATCH /problems/{id}`.
- `openapi.yaml`: documented the new operation and the `UpdateProblemRequest`/
  `UpdateProblemResponse`/`UpdateProblemView` schemas — required for
  `TestEveryRegisteredRouteIsPublished`, which failed until this was added.

**3. CSM BFF passthrough.** In `apps/csm-portal/backend/`:
- `internal/handler/problems.go`: new `PatchProblem` handler for `PATCH /problems/{id}`,
  matching `PatchIncident`'s structure in `incidents.go` exactly — UUID path validation,
  `MaxBytesReader` + body read, `json.Valid`, then a new `validateUpdateProblemBody` that
  rejects an empty JSON object and validates the UUID-formatted `assignedToId`/
  `assignmentGroupId` fields when present. `transition` is decoded only far enough to confirm
  it is a JSON string (or absent/null) — its value is never checked against the
  assess/confirm/fix/resolve/close list, continuing the same reasoning as layers 2 and
  ServiceNow: a closed-enum check here would hide the data source's own actionable
  "Invalid transition" error behind a generic one. Uses `mapUpstreamError` (not
  `mapUpstreamErrorGeneric`), matching `PatchIncident`'s choice, so a rejected transition's
  upstream reason (e.g. a 409 from ServiceNow) reaches the caller.
- `internal/entity/customer.go`: `UpdateProblem` on `CustomerEntityClient`, a one-line
  `PATCH /problems/{id}` call mirroring `PatchIncident`'s.
- `cmd/server/main.go`: registers `PATCH /problems/{id}` next to the other `/problems` routes.
- `internal/handler/helpers_test.go` / `problems_test.go`: extends `mockEntityProblemClient`
  with `UpdateProblem`, and adds `TestUpdateProblem` following `TestCreateProblem`'s/
  `TestPatchIncident`'s structure — auth, body-size, invalid-JSON, invalid-UUID, empty-body,
  non-UUID reference fields, non-string `transition`, an unconstrained-`transition`-value
  pass-through case, a happy-path forward-and-return-200 case, an explicit upstream-409
  transition-rejection passthrough case, and the full `upstreamErrors` table (the PATCH
  variant, since this handler uses `mapUpstreamError`).
- `openapi.yaml`: documented `patch: /problems/{id}` and the `UpdateProblemPayload`/
  `UpdateProblemResponse`/`UpdateProblemView` schemas, mirroring the Incident PATCH
  documentation shape (this repo has no automated route-publish check for the BFF, unlike
  `entity-service/`, so this is for documentation completeness rather than a build gate).

**4. Problem update webapp UI.** In `apps/csm-portal/webapp/`:
- `api/backend/types.ts`: `BeUpdateProblemPayload` (mirrors `UpdateProblemPayload` exactly —
  `transition` stays a plain, undocumented-as-enum string here too, for the same reason as
  every layer below) and `BeProblemUpdateView`/`BePatchProblemResponse` (mirrors
  `UpdateProblemView`/`UpdateProblemResponse` — deliberately narrower than `BeProblemDetail`,
  since the PATCH response doesn't echo `causeNotes`/`fixNotes`/`workaround`/
  `targetResolutionDate` back).
- `features/csm-operations/api/usePatchProblem.ts`: `PATCH /problems/{id}` mutation hook,
  matching `usePatchChangeRequest`'s `onSettled` (not just `onSuccess`) invalidation —
  necessary here too, since a Problem transition can be rejected/reverted by a live ServiceNow
  business rule after the request is sent, and a stale cached state would make an
  already-attempted transition button look available again.
- `features/csm-operations/utils/problems.ts`: `getNextProblemTransition`, a small
  state-machine lookup (`New -> Assess -> Root Cause Analysis -> Fix in Progress -> Resolved ->
  Closed`) returning at most one legal next transition — Problem's live ServiceNow lifecycle is
  strictly linear, unlike Incident/CR, which both allow branching to multiple next states.
- `features/csm-operations/components/ProblemActionBar.tsx`: renders the single next-transition
  button (or nothing, once Closed), dispatching the bare `transition` key.
- `features/csm-operations/components/ProblemFixNotesDialog.tsx`: optional `causeNotes`/
  `fixNotes` collection before the `fix` transition — skippable, since (unlike Incident's
  `RESOLVED`/`CLOSED`) ServiceNow doesn't require these fields for this transition.
- `features/csm-operations/components/EditProblemDialog.tsx`: `assignedToId` (async user
  picker, pre-filled from the read model), `assignmentGroupId` (async group picker),
  `workaround` (pre-filled), and `targetResolutionDate` (date-time picker). The latter two of
  those four intentionally start blank on every open rather than pre-filled —
  `GET /problems/{id}` doesn't return `assignmentGroup` or `targetResolutionDate` today (per
  the backing contract note, `targetResolutionDate` was only ever confirmed persisted via a
  direct ServiceNow table read-back, not through the Problem-detail response shape) — with
  inline helper text explaining why, plus that `targetResolutionDate` isn't on ServiceNow's
  native Problem form at all.
- `features/csm-operations/pages/ProblemDetailPage.tsx`: wires the action bar into the header's
  sibling actions box (matching the layout `1.` established for Incident/CR), an `Edit` button
  opening `EditProblemDialog`, and the `fix`-transition branch into
  `ProblemFixNotesDialog`. Purely additive to the existing Overview/Linked-records/Resolution
  card rendering — none of that changed. Updated the file's own doc comment, which was stale
  ("there is no Edit dialog").
- `features/help/content/operations.md`: replaced the stale "read-only in the portal today"
  paragraph with a description of the new action bar, the `fix` transition's optional-notes
  dialog, and the Edit dialog's two caveats (owner-assignment auto-promotes a New problem to
  Assess; assignment group / target resolution date aren't pre-filled).

## User stories
> Summary of user stories addressed by this change

**1. Header alignment.** As a CS engineer, when I open an Incident, Change Request, or Problem,
the header reads the same way it does on a Case, so I don't have to reorient myself to a
different layout for each entity type.

**2. Problem-update Go passthrough.** No end-user-visible change yet (no BFF or webapp surface
in this PR) — this is infrastructure for a future "update a Problem" flow.

**3. CSM BFF passthrough.** No end-user-visible change yet (no webapp surface in this PR) — the
backend is now fully wired end-to-end for a future "update a Problem" flow; only the webapp UI
remains.

**4. Problem update webapp UI.** As a CS engineer, I can move a problem through Assess / Root
Cause Analysis / Fix in Progress / Resolved / Closed directly from its detail page, optionally
record cause/fix notes when moving to Fix in Progress, and assign an owner/group, a workaround,
or a target resolution date — all without leaving the portal.

## Release note
Incident, Change Request, and Problem detail pages now show the record number, status, and
subject in the same order as the Case detail page. Problems can now be updated from the CSM
portal: an action bar moves a problem through its lifecycle (Assess → Root Cause Analysis →
Fix in Progress → Resolved → Closed), and an Edit dialog covers assignment, workaround, and
target resolution date.

## Documentation
**1. Header alignment.** N/A — layout-only change, no new field, flow, or behavior to document.
The in-app help guide's operations topics don't describe header layout, only what
fields/actions exist, so no update needed there.

**2. Problem-update Go passthrough.** N/A — no user-facing surface yet; the in-app help guide's
Problem topic describes fields/actions, not backend API shape, and gets no update until the
BFF/webapp layers ship.

**3. CSM BFF passthrough.** N/A — no user-facing surface yet. The in-app help guide's
Problem-management topic still correctly states there is no mutation endpoint reachable from
the portal UI (the webapp has no Edit dialog or action bar wired to this endpoint); it becomes
stale, and will need updating, only once that webapp layer ships.

**4. Problem update webapp UI.** Updated `features/help/content/operations.md`'s Problem
management topic (see Approach) — it previously stated the portal had no mutation endpoint for
problems at all, which was true until this PR and is now stale without the update.

## Training
N/A — no training content references either change.

## Certification
N/A — no certification content covers either change.

## Marketing
N/A — internal CS-engineer tooling, no marketing surface.

## Automation tests
 - Unit tests
   > Header alignment: `CsmIncidentDetailPage.test.tsx` (19), `CsmChangeRequestDetailPage.test.tsx` (35), and
   > `ProblemDetailPage.test.tsx` (12) all pass unchanged against the new layout — 66/66 —
   > confirming the reorder didn't break any existing assertions on header content.
   >
   > Problem-update Go passthrough: added `TestSNProblemService_UpdateProblem_*` covering the
   > unvalidated-transition passthrough contract (request/response marshaling round-trip against
   > the documented contract), at-least-one-field validation, invalid-UUID rejection, and 409
   > conflict mapping. `go build ./...` and `go test ./...` both clean in `entity-service/`
   > (existing suite unaffected, new tests passing).
   >
   > CSM BFF passthrough: added `TestUpdateProblem` in `apps/csm-portal/backend/internal/handler/problems_test.go`
   > covering auth, body-size cap, invalid JSON, invalid path UUID, empty body, non-UUID
   > `assignedToId`/`assignmentGroupId`, a non-string `transition` value, an
   > any-non-empty-string-`transition`-accepted case, the happy-path forward/200 case, an
   > explicit upstream-409 transition-rejection-message passthrough case, and the full
   > PATCH-handler `upstreamErrors` table. `go build ./...`, `go vet ./...`, `gofmt -l .`
   > (empty), and `go test ./...` all clean in `apps/csm-portal/backend/` (existing suite
   > unaffected, new tests passing).
   >
   > Problem update webapp UI: added `ProblemActionBar.test.tsx` (8 cases — one per legal
   > transition plus terminal/no-state/pending states), `ProblemFixNotesDialog.test.tsx` (5),
   > `EditProblemDialog.test.tsx` (6), and `usePatchProblem.test.tsx` (3, including the
   > `onSettled`-invalidates-on-error case). Extended `ProblemDetailPage.test.tsx` with 7 new
   > cases covering the action bar dispatch, the `fix`-transition dialog branch, the terminal
   > (no-button) state, the Edit affordance, and the error-banner path. Full
   > `src/features/csm-operations` suite: 335/335 passing (up from 296 before this change), no
   > regressions. `npx tsc -b` and `npx eslint` clean on every changed/added file.
 - Integration tests
   > Header alignment: none added; this is a pure JSX reorder with no new interactive behavior.
   > Manually verified via a real staging-backed local build (see Approach) across both themes
   > and a narrow viewport.
   >
   > Problem-update Go passthrough: none added. A full live round-trip would need the
   > not-yet-merged backing Ballerina PR deployed somewhere reachable, which wasn't practical
   > here — verification is build + unit tests (mocked HTTP layer matching the documented
   > contract) only, not a live call through to a real backend.
   >
   > CSM BFF passthrough: none added, same limitation as above — no running entity-service to
   > hit in this environment (its own backing Ballerina layer is unmerged). Verification is
   > build + unit tests against a mocked entity client only.
   >
   > Problem update webapp UI: none added, same limitation as above one layer further —
   > standing up a real Ballerina + Go entity-service + CSM BFF chain against a live ServiceNow
   > DEV Problem record wasn't practical in this environment. Verification is `tsc -b` +
   > `eslint` + the RTL suite above (all mocked at the `usePatchProblem`/`useGetProblem`
   > boundary) plus a reasoned static review of the JSX against the documented
   > `PATCH /problems/{id}` contract — not a live screenshot pass.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A for the header-alignment and webapp-UI changes (TypeScript/React, no Go/Java touched; `eslint` and `tsc -b` ran clean on the changed files). The Go entity-service and CSM BFF changes were each verified with `go vet ./...` (both clean) instead — no new external input parsing beyond the existing decode-request path shared with every other PATCH handler in each service.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no sample code affected.

## Related PRs
None referenceable here — a corresponding Ballerina entity-service change for the backing
`PATCH /problems/{id}` resource exists but is tracked in a separate, private repository.

## Migrations (if applicable)
N/A — no data or schema migration involved.

## Test environment
Header alignment: verified with a local Vite dev server (Node 24, pnpm) serving this branch's
code against the deployed staging backend, real Asgardeo-authenticated session, in Chrome.

Problem-update Go passthrough: `go build ./...` / `go test ./...` from `entity-service/` on
this branch. No live backend round-trip (see Automation tests).

CSM BFF passthrough: `go build ./...` / `go vet ./...` / `gofmt -l .` / `go test ./...` from
`apps/csm-portal/backend/` on this branch. No live backend round-trip (see Automation tests) —
the Ballerina layer this eventually reaches is unmerged and there is no running entity-service
in this environment.

Problem update webapp UI: `npx tsc -b`, `npx eslint <changed files>`, and
`npx vitest run src/features/csm-operations` from `apps/csm-portal/webapp/` on this branch —
all clean (335/335 tests passing). No live/staging round-trip and no screenshots — see
Integration tests above for why.

## Learning
N/A.
