### PR TITLE
[CSM Portal] add Request update action for cases awaiting customer input

### DIFF
--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -139,6 +139,8 @@ func main() {
 	mux.HandleFunc("GET /cases/{id}", caseHandler.GetCase)
 	mux.HandleFunc("PATCH /cases/{id}", caseHandler.PatchCase)
 	mux.HandleFunc("POST /cases/{id}/comments", caseHandler.CreateCaseComment)
+	mux.HandleFunc("POST /cases/{id}/request-update", caseHandler.RequestCaseUpdate)
+	mux.HandleFunc("GET /case-update-request-templates", caseHandler.GetCaseUpdateRequestTemplates)
 	mux.HandleFunc("POST /cases/{id}/comments/search", caseHandler.SearchCaseComments)
 	mux.HandleFunc("POST /cases/{id}/activities/search", caseHandler.SearchCaseActivities)
 	mux.HandleFunc("POST /attachments", caseHandler.CreateCaseAttachment)

--- a/apps/csm-portal/backend/internal/handler/case_update_requests.go
+++ b/apps/csm-portal/backend/internal/handler/case_update_requests.go
@@ -98,8 +98,8 @@ func (h *CaseHandler) RequestCaseUpdate(w http.ResponseWriter, r *http.Request) 
 	}
 
 	caseID := r.PathValue("id")
-	if caseID == "" {
-		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+	if caseID == "" || !uuidRe.MatchString(caseID) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}
 

--- a/apps/csm-portal/backend/internal/handler/case_update_requests.go
+++ b/apps/csm-portal/backend/internal/handler/case_update_requests.go
@@ -65,12 +65,6 @@ var requestUpdateTemplates = map[requestUpdateCategory]map[requestUpdateStage]st
 	},
 }
 
-// maxRequestUpdateBodyBytes caps the "request update" request body. The body
-// is just {stage, customContent?} — a small JSON object, not a rich-text
-// comment — so it gets a much smaller cap than maxCommentBodyBytes (10 MiB,
-// sized for base64 inline images).
-const maxRequestUpdateBodyBytes = 32 << 10
-
 // requestUpdateRequest is the body of POST /cases/{id}/request-update.
 type requestUpdateRequest struct {
 	Stage         requestUpdateStage `json:"stage"`
@@ -103,7 +97,7 @@ func (h *CaseHandler) RequestCaseUpdate(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	r.Body = http.MaxBytesReader(w, r.Body, maxRequestUpdateBodyBytes)
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		if _, ok := err.(*http.MaxBytesError); ok {

--- a/apps/csm-portal/backend/internal/handler/case_update_requests.go
+++ b/apps/csm-portal/backend/internal/handler/case_update_requests.go
@@ -1,0 +1,236 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/wso2-open-operations/cs-tools/apps/csm-portal/backend/internal/middleware"
+)
+
+// requestUpdateCategory identifies which fixed-message set a "request update"
+// nudge is drawn from. It is always server-determined from the case's own
+// type/engagementType — the caller never supplies it — because the wording is
+// specific to the kind of work the case represents (a generic case vs. a
+// migration engagement) and must not be spoofable from the request body.
+type requestUpdateCategory string
+
+const (
+	requestUpdateCategoryGeneric   requestUpdateCategory = "generic"
+	requestUpdateCategoryMigration requestUpdateCategory = "migration"
+)
+
+// requestUpdateStage identifies which of the three fixed reminder stages (or
+// a caller-supplied custom message) to post.
+type requestUpdateStage string
+
+const (
+	requestUpdateStageFirst  requestUpdateStage = "first"
+	requestUpdateStageSecond requestUpdateStage = "second"
+	requestUpdateStageFinal  requestUpdateStage = "final"
+	requestUpdateStageCustom requestUpdateStage = "custom"
+)
+
+// requestUpdateTemplates holds the fixed HTML message for every
+// (category, stage) pair. Content is reviewed copy: do not paraphrase or
+// reformat it.
+var requestUpdateTemplates = map[requestUpdateCategory]map[requestUpdateStage]string{
+	requestUpdateCategoryGeneric: {
+		requestUpdateStageFirst:  `<p>Hi Team,</p><p>Please let us know if you need further assistance regarding this.</p><p>Thanks and Regards,<br>WSO2 Team.</p>`,
+		requestUpdateStageSecond: `<p>Hi Team,</p><p>Please let us know if you need further assistance regarding this or if this case is good to close.</p><p>Thanks and Regards,<br>WSO2 Team.</p>`,
+		requestUpdateStageFinal:  `<p>Hi Team,</p><p>As we haven't received a response to our previous follow-ups, we will proceed with placing this case on hold.</p><p>The Technical Owner and Account Manager have been informed.</p><p>Thanks &amp; Regards,<br>WSO2 Team.</p>`,
+	},
+	requestUpdateCategoryMigration: {
+		requestUpdateStageFirst:  `<p>Hi Team,</p><p>Kindly share a progress update on the migration process.</p><p>Thanks &amp; Regards,<br>WSO2 Team</p>`,
+		requestUpdateStageSecond: `<p>Hi Team,</p><p>Kindly share a progress update on the migration process.</p><p>If you are currently facing any blockers, delays, or technical issues please do not hesitate to contact us.</p><p>Thanks &amp; Regards,<br>WSO2 Team</p>`,
+		requestUpdateStageFinal:  `<p>Hi Team,</p><p>As we haven't received a response to our previous follow-ups, we will proceed with placing this migration ticket on hold.</p><p>If you plan to resume the migration, please open a related case and reference this ticket so we can continue from there.</p><p>The Technical Owner and Account Manager have been informed.</p><p>Thanks &amp; Regards,<br>WSO2 Team</p>`,
+	},
+}
+
+// maxRequestUpdateBodyBytes caps the "request update" request body. The body
+// is just {stage, customContent?} — a small JSON object, not a rich-text
+// comment — so it gets a much smaller cap than maxCommentBodyBytes (10 MiB,
+// sized for base64 inline images).
+const maxRequestUpdateBodyBytes = 32 << 10
+
+// requestUpdateRequest is the body of POST /cases/{id}/request-update.
+type requestUpdateRequest struct {
+	Stage         requestUpdateStage `json:"stage"`
+	CustomContent string             `json:"customContent"`
+}
+
+// requestUpdateTemplateResponse is the response shape of
+// GET /case-update-request-templates: both categories' full stage->content maps.
+type requestUpdateTemplateResponse struct {
+	Generic   map[requestUpdateStage]string `json:"generic"`
+	Migration map[requestUpdateStage]string `json:"migration"`
+}
+
+// RequestCaseUpdate handles POST /cases/{id}/request-update. It posts a
+// customer-visible comment nudging the customer for a response, using one of
+// three fixed reminder templates (first/second/final) or a caller-supplied
+// custom message. Only available while the case is in awaiting_info or
+// solution_proposed — the states where the ball is meant to be in the
+// customer's court.
+func (h *CaseHandler) RequestCaseUpdate(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	caseID := r.PathValue("id")
+	if caseID == "" {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestUpdateBodyBytes)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		if _, ok := err.(*http.MaxBytesError); ok {
+			writeError(w, http.StatusRequestEntityTooLarge, ErrMsgTooLarge)
+			return
+		}
+		writeError(w, http.StatusBadRequest, errMsgReadBody)
+		return
+	}
+
+	var req requestUpdateRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	var content string
+	switch req.Stage {
+	case requestUpdateStageFirst, requestUpdateStageSecond, requestUpdateStageFinal:
+		if req.CustomContent != "" {
+			writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+			return
+		}
+	case requestUpdateStageCustom:
+		if strings.TrimSpace(req.CustomContent) == "" {
+			writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+			return
+		}
+		content = req.CustomContent
+	default:
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	current, err := h.entity.GetCase(r.Context(), caseID)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity GetCase failed during request-update guard", "userID", user.UserID, "caseID", caseID, "err", err)
+		mapUpstreamErrorGeneric(w, err, "Failed to request an update.")
+		return
+	}
+	var currentCase struct {
+		State            string `json:"state"`
+		Type             string `json:"type"`
+		EngagementType   string `json:"engagementType"`
+		AssignedEngineer *struct {
+			ID *string `json:"id"`
+		} `json:"assignedEngineer"`
+	}
+	if err := json.Unmarshal(current, &currentCase); err != nil {
+		slog.ErrorContext(r.Context(), "failed to parse case state for request-update guard", "userID", user.UserID, "caseID", caseID, "err", err)
+		writeError(w, http.StatusInternalServerError, ErrMsgInternal)
+		return
+	}
+
+	if currentCase.State != caseStateAwaitingInfo && currentCase.State != caseStateSolutionProposed {
+		writeError(w, http.StatusConflict, ErrMsgRequestUpdateNotAllowed)
+		return
+	}
+
+	// Ownership check, mirroring CreateCaseComment's guard for a public
+	// (non-work_note) comment: this endpoint always posts a customer-visible
+	// comment, so only the case's assigned engineer may trigger it. Resolved
+	// here, after the state gate, so the extra lookup is only paid on a
+	// request that would otherwise be accepted.
+	currentUserID := h.resolveCurrentUserID(r, user)
+	if currentUserID == "" {
+		// The caller's identity could not be established, so ownership cannot
+		// be decided either way: fail closed, but as a server-side failure
+		// rather than a misleading "you are not the assignee".
+		writeError(w, http.StatusInternalServerError, ErrMsgInternal)
+		return
+	}
+	if currentCase.AssignedEngineer == nil || currentCase.AssignedEngineer.ID == nil || *currentCase.AssignedEngineer.ID != currentUserID {
+		writeError(w, http.StatusForbidden, ErrMsgCommentNotOwnCase)
+		return
+	}
+
+	// engagementType is compared case-insensitively because it is NOT
+	// normalized before reaching this layer: entity-service's CaseView.EngagementType
+	// carries ServiceNow's raw choice-field display label unmodified (e.g.
+	// literally "Migration", capitalized) — unlike State/WorkState, which go
+	// through explicit lowering functions before reaching the domain layer. A
+	// strict-case compare would silently misclassify every real migration
+	// case as generic, so case-insensitive is required here, not just safer.
+	category := requestUpdateCategoryGeneric
+	if currentCase.Type == "engagement" && strings.EqualFold(currentCase.EngagementType, "migration") {
+		category = requestUpdateCategoryMigration
+	}
+
+	if req.Stage != requestUpdateStageCustom {
+		content = requestUpdateTemplates[category][req.Stage]
+	}
+
+	commentBody, err := json.Marshal(map[string]string{
+		"type":    "comment",
+		"content": content,
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, ErrMsgInternal)
+		return
+	}
+
+	result, err := h.entity.CreateCaseComment(r.Context(), caseID, commentBody)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity CreateCaseComment failed during request-update", "userID", user.UserID, "caseID", caseID, "err", err)
+		mapUpstreamErrorGeneric(w, err, "Failed to request an update.")
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, result)
+}
+
+// GetCaseUpdateRequestTemplates handles GET /case-update-request-templates.
+// Returns the fixed reminder message catalogue for both categories, with no
+// case-specific logic or upstream call — the caller picks a stage from
+// whichever category applies once RequestCaseUpdate has told it which case
+// the case falls into (or the frontend infers it from the case it already has
+// loaded).
+func (h *CaseHandler) GetCaseUpdateRequestTemplates(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	writeJSONValue(w, http.StatusOK, requestUpdateTemplateResponse{
+		Generic:   requestUpdateTemplates[requestUpdateCategoryGeneric],
+		Migration: requestUpdateTemplates[requestUpdateCategoryMigration],
+	})
+}

--- a/apps/csm-portal/backend/internal/handler/case_update_requests.go
+++ b/apps/csm-portal/backend/internal/handler/case_update_requests.go
@@ -92,7 +92,11 @@ func (h *CaseHandler) RequestCaseUpdate(w http.ResponseWriter, r *http.Request) 
 	}
 
 	caseID := r.PathValue("id")
-	if caseID == "" || !uuidRe.MatchString(caseID) {
+	if caseID == "" {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+	if !uuidRe.MatchString(caseID) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
 		return
 	}

--- a/apps/csm-portal/backend/internal/handler/case_update_requests_test.go
+++ b/apps/csm-portal/backend/internal/handler/case_update_requests_test.go
@@ -45,7 +45,7 @@ func TestRequestCaseUpdate(t *testing.T) {
 		w := httptest.NewRecorder()
 		h.RequestCaseUpdate(w, r)
 		assertStatus(t, w, http.StatusBadRequest)
-		assertErrorMessage(t, w, ErrMsgInvalidUUID)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
 	})
 
 	t.Run("rejects malformed UUID", func(t *testing.T) {

--- a/apps/csm-portal/backend/internal/handler/case_update_requests_test.go
+++ b/apps/csm-portal/backend/internal/handler/case_update_requests_test.go
@@ -1,0 +1,402 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+const testUpdateRequestCaseID = "11111111-1111-1111-1111-111111111111"
+
+func TestRequestCaseUpdate(t *testing.T) {
+	t.Run("requires authenticated user", func(t *testing.T) {
+		h := NewCaseHandler(&mockEntityCaseClient{})
+		r := httptest.NewRequest(http.MethodPost, "/cases/"+testUpdateRequestCaseID+"/request-update", strings.NewReader(`{"stage":"first"}`))
+		r.SetPathValue("id", testUpdateRequestCaseID)
+		w := httptest.NewRecorder()
+		h.RequestCaseUpdate(w, r)
+		assertStatus(t, w, http.StatusUnauthorized)
+		assertErrorMessage(t, w, ErrMsgUnauthorized)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects empty case ID", func(t *testing.T) {
+		h := NewCaseHandler(&mockEntityCaseClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases//request-update", strings.NewReader(`{"stage":"first"}`)))
+		w := httptest.NewRecorder()
+		h.RequestCaseUpdate(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+	})
+
+	t.Run("rejects body exceeding the size cap", func(t *testing.T) {
+		h := NewCaseHandler(&mockEntityCaseClient{})
+		body := `{"stage":"custom","customContent":"` + strings.Repeat("x", maxRequestUpdateBodyBytes) + `"}`
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/"+testUpdateRequestCaseID+"/request-update", strings.NewReader(body)))
+		r.SetPathValue("id", testUpdateRequestCaseID)
+		w := httptest.NewRecorder()
+		h.RequestCaseUpdate(w, r)
+		assertStatus(t, w, http.StatusRequestEntityTooLarge)
+		assertErrorMessage(t, w, ErrMsgTooLarge)
+	})
+
+	t.Run("rejects invalid JSON body", func(t *testing.T) {
+		h := NewCaseHandler(&mockEntityCaseClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/"+testUpdateRequestCaseID+"/request-update", strings.NewReader(`not-json`)))
+		r.SetPathValue("id", testUpdateRequestCaseID)
+		w := httptest.NewRecorder()
+		h.RequestCaseUpdate(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+	})
+
+	t.Run("rejects an unrecognized stage", func(t *testing.T) {
+		h := NewCaseHandler(&mockEntityCaseClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/"+testUpdateRequestCaseID+"/request-update", strings.NewReader(`{"stage":"third"}`)))
+		r.SetPathValue("id", testUpdateRequestCaseID)
+		w := httptest.NewRecorder()
+		h.RequestCaseUpdate(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+	})
+
+	t.Run("rejects empty customContent when stage is custom", func(t *testing.T) {
+		for _, body := range []string{
+			`{"stage":"custom"}`,
+			`{"stage":"custom","customContent":""}`,
+			`{"stage":"custom","customContent":"   "}`,
+		} {
+			body := body
+			t.Run(body, func(t *testing.T) {
+				h := NewCaseHandler(&mockEntityCaseClient{})
+				r := withUser(httptest.NewRequest(http.MethodPost, "/cases/"+testUpdateRequestCaseID+"/request-update", strings.NewReader(body)))
+				r.SetPathValue("id", testUpdateRequestCaseID)
+				w := httptest.NewRecorder()
+				h.RequestCaseUpdate(w, r)
+				assertStatus(t, w, http.StatusBadRequest)
+				assertErrorMessage(t, w, ErrMsgBadRequest)
+			})
+		}
+	})
+
+	t.Run("rejects a fixed-template stage carrying customContent", func(t *testing.T) {
+		for _, stage := range []string{"first", "second", "final"} {
+			stage := stage
+			t.Run(stage, func(t *testing.T) {
+				h := NewCaseHandler(&mockEntityCaseClient{})
+				body := `{"stage":"` + stage + `","customContent":"not allowed here"}`
+				r := withUser(httptest.NewRequest(http.MethodPost, "/cases/"+testUpdateRequestCaseID+"/request-update", strings.NewReader(body)))
+				r.SetPathValue("id", testUpdateRequestCaseID)
+				w := httptest.NewRecorder()
+				h.RequestCaseUpdate(w, r)
+				assertStatus(t, w, http.StatusBadRequest)
+				assertErrorMessage(t, w, ErrMsgBadRequest)
+			})
+		}
+	})
+
+	t.Run("rejects when case state is not awaiting_info or solution_proposed", func(t *testing.T) {
+		for _, state := range []string{"open", "work_in_progress", "waiting_on_wso2", "reopened", "closed"} {
+			state := state
+			t.Run(state, func(t *testing.T) {
+				client := &mockEntityCaseClient{
+					getCaseFn: func(_ context.Context, _ string) ([]byte, error) {
+						return []byte(`{"state":"` + state + `","type":"case"}`), nil
+					},
+				}
+				h := NewCaseHandler(client)
+				r := withUser(httptest.NewRequest(http.MethodPost, "/cases/"+testUpdateRequestCaseID+"/request-update", strings.NewReader(`{"stage":"first"}`)))
+				r.SetPathValue("id", testUpdateRequestCaseID)
+				w := httptest.NewRecorder()
+				h.RequestCaseUpdate(w, r)
+				assertStatus(t, w, http.StatusConflict)
+				assertErrorMessage(t, w, ErrMsgRequestUpdateNotAllowed)
+			})
+		}
+	})
+
+	t.Run("rejects when the caller is not the case's assigned engineer", func(t *testing.T) {
+		client := &mockEntityCaseClient{
+			getCaseFn: func(_ context.Context, _ string) ([]byte, error) {
+				return []byte(`{"state":"awaiting_info","type":"case","assignedEngineer":{"id":"someone-else"}}`), nil
+			},
+		}
+		h := NewCaseHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/"+testUpdateRequestCaseID+"/request-update", strings.NewReader(`{"stage":"first"}`)))
+		r.SetPathValue("id", testUpdateRequestCaseID)
+		w := httptest.NewRecorder()
+		h.RequestCaseUpdate(w, r)
+		assertStatus(t, w, http.StatusForbidden)
+		assertErrorMessage(t, w, ErrMsgCommentNotOwnCase)
+	})
+
+	t.Run("rejects when the case has no assigned engineer", func(t *testing.T) {
+		client := &mockEntityCaseClient{
+			getCaseFn: func(_ context.Context, _ string) ([]byte, error) {
+				return []byte(`{"state":"awaiting_info","type":"case"}`), nil
+			},
+		}
+		h := NewCaseHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/"+testUpdateRequestCaseID+"/request-update", strings.NewReader(`{"stage":"first"}`)))
+		r.SetPathValue("id", testUpdateRequestCaseID)
+		w := httptest.NewRecorder()
+		h.RequestCaseUpdate(w, r)
+		assertStatus(t, w, http.StatusForbidden)
+		assertErrorMessage(t, w, ErrMsgCommentNotOwnCase)
+	})
+
+	t.Run("fails closed when the caller's own id cannot be resolved", func(t *testing.T) {
+		var commentCreated bool
+		client := &mockEntityCaseClient{
+			getCaseFn: func(_ context.Context, _ string) ([]byte, error) {
+				return []byte(`{"state":"awaiting_info","type":"case","assignedEngineer":{"id":"` + testPlatformUserID + `"}}`), nil
+			},
+			getUserMeFn: func(context.Context) ([]byte, error) {
+				return []byte(`{"id":""}`), nil
+			},
+			createCaseCommentFn: func(_ context.Context, _ string, _ []byte) ([]byte, error) {
+				commentCreated = true
+				return []byte(`{"id":"comment-1"}`), nil
+			},
+		}
+		h := NewCaseHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/"+testUpdateRequestCaseID+"/request-update", strings.NewReader(`{"stage":"first"}`)))
+		r.SetPathValue("id", testUpdateRequestCaseID)
+		w := httptest.NewRecorder()
+		h.RequestCaseUpdate(w, r)
+		assertStatus(t, w, http.StatusInternalServerError)
+		assertErrorMessage(t, w, ErrMsgInternal)
+		if commentCreated {
+			t.Error("comment was created despite the caller's identity being unresolvable")
+		}
+	})
+
+	t.Run("does not resolve the caller's id when the state gate already rejects", func(t *testing.T) {
+		client := &mockEntityCaseClient{
+			getCaseFn: func(_ context.Context, _ string) ([]byte, error) {
+				return []byte(`{"state":"open","type":"case","assignedEngineer":{"id":"` + testPlatformUserID + `"}}`), nil
+			},
+			getUserMeFn: func(context.Context) ([]byte, error) {
+				t.Error("GetUserMe must not be called once the state gate has rejected the request")
+				return nil, nil
+			},
+		}
+		h := NewCaseHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/"+testUpdateRequestCaseID+"/request-update", strings.NewReader(`{"stage":"first"}`)))
+		r.SetPathValue("id", testUpdateRequestCaseID)
+		w := httptest.NewRecorder()
+		h.RequestCaseUpdate(w, r)
+		assertStatus(t, w, http.StatusConflict)
+		assertErrorMessage(t, w, ErrMsgRequestUpdateNotAllowed)
+	})
+
+	t.Run("posts the generic template for a non-migration case in each allowed state", func(t *testing.T) {
+		for _, state := range []string{"awaiting_info", "solution_proposed"} {
+			for _, stage := range []struct {
+				name    string
+				content string
+			}{
+				{"first", requestUpdateTemplates[requestUpdateCategoryGeneric][requestUpdateStageFirst]},
+				{"second", requestUpdateTemplates[requestUpdateCategoryGeneric][requestUpdateStageSecond]},
+				{"final", requestUpdateTemplates[requestUpdateCategoryGeneric][requestUpdateStageFinal]},
+			} {
+				state, stage := state, stage
+				t.Run(state+"/"+stage.name, func(t *testing.T) {
+					var posted map[string]string
+					client := &mockEntityCaseClient{
+						getCaseFn: func(_ context.Context, _ string) ([]byte, error) {
+							return []byte(`{"state":"` + state + `","type":"case","assignedEngineer":{"id":"` + testPlatformUserID + `"}}`), nil
+						},
+						createCaseCommentFn: func(_ context.Context, _ string, body []byte) ([]byte, error) {
+							if err := json.Unmarshal(body, &posted); err != nil {
+								t.Fatalf("unmarshal posted comment body: %v", err)
+							}
+							return []byte(`{"id":"comment-1"}`), nil
+						},
+					}
+					h := NewCaseHandler(client)
+					r := withUser(httptest.NewRequest(http.MethodPost, "/cases/"+testUpdateRequestCaseID+"/request-update", strings.NewReader(`{"stage":"`+stage.name+`"}`)))
+					r.SetPathValue("id", testUpdateRequestCaseID)
+					w := httptest.NewRecorder()
+					h.RequestCaseUpdate(w, r)
+					assertStatus(t, w, http.StatusCreated)
+					if posted["type"] != "comment" {
+						t.Errorf("posted type = %q, want %q", posted["type"], "comment")
+					}
+					if posted["content"] != stage.content {
+						t.Errorf("posted content = %q, want %q", posted["content"], stage.content)
+					}
+				})
+			}
+		}
+	})
+
+	t.Run("posts the migration template for an engagement case with engagementType migration", func(t *testing.T) {
+		for _, stage := range []struct {
+			name    string
+			content string
+		}{
+			{"first", requestUpdateTemplates[requestUpdateCategoryMigration][requestUpdateStageFirst]},
+			{"second", requestUpdateTemplates[requestUpdateCategoryMigration][requestUpdateStageSecond]},
+			{"final", requestUpdateTemplates[requestUpdateCategoryMigration][requestUpdateStageFinal]},
+		} {
+			stage := stage
+			t.Run(stage.name, func(t *testing.T) {
+				var posted map[string]string
+				client := &mockEntityCaseClient{
+					getCaseFn: func(_ context.Context, _ string) ([]byte, error) {
+						return []byte(`{"state":"awaiting_info","type":"engagement","engagementType":"Migration","assignedEngineer":{"id":"` + testPlatformUserID + `"}}`), nil
+					},
+					createCaseCommentFn: func(_ context.Context, _ string, body []byte) ([]byte, error) {
+						if err := json.Unmarshal(body, &posted); err != nil {
+							t.Fatalf("unmarshal posted comment body: %v", err)
+						}
+						return []byte(`{"id":"comment-1"}`), nil
+					},
+				}
+				h := NewCaseHandler(client)
+				r := withUser(httptest.NewRequest(http.MethodPost, "/cases/"+testUpdateRequestCaseID+"/request-update", strings.NewReader(`{"stage":"`+stage.name+`"}`)))
+				r.SetPathValue("id", testUpdateRequestCaseID)
+				w := httptest.NewRecorder()
+				h.RequestCaseUpdate(w, r)
+				assertStatus(t, w, http.StatusCreated)
+				if posted["content"] != stage.content {
+					t.Errorf("posted content = %q, want %q (migration template, capitalized engagementType from upstream)", posted["content"], stage.content)
+				}
+			})
+		}
+	})
+
+	t.Run("treats a non-migration engagement as generic", func(t *testing.T) {
+		var posted map[string]string
+		client := &mockEntityCaseClient{
+			getCaseFn: func(_ context.Context, _ string) ([]byte, error) {
+				return []byte(`{"state":"awaiting_info","type":"engagement","engagementType":"onboarding","assignedEngineer":{"id":"` + testPlatformUserID + `"}}`), nil
+			},
+			createCaseCommentFn: func(_ context.Context, _ string, body []byte) ([]byte, error) {
+				_ = json.Unmarshal(body, &posted)
+				return []byte(`{"id":"comment-1"}`), nil
+			},
+		}
+		h := NewCaseHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/"+testUpdateRequestCaseID+"/request-update", strings.NewReader(`{"stage":"first"}`)))
+		r.SetPathValue("id", testUpdateRequestCaseID)
+		w := httptest.NewRecorder()
+		h.RequestCaseUpdate(w, r)
+		assertStatus(t, w, http.StatusCreated)
+		want := requestUpdateTemplates[requestUpdateCategoryGeneric][requestUpdateStageFirst]
+		if posted["content"] != want {
+			t.Errorf("posted content = %q, want the generic template %q", posted["content"], want)
+		}
+	})
+
+	t.Run("posts the caller-supplied custom message verbatim", func(t *testing.T) {
+		var posted map[string]string
+		client := &mockEntityCaseClient{
+			getCaseFn: func(_ context.Context, _ string) ([]byte, error) {
+				return []byte(`{"state":"solution_proposed","type":"case","assignedEngineer":{"id":"` + testPlatformUserID + `"}}`), nil
+			},
+			createCaseCommentFn: func(_ context.Context, _ string, body []byte) ([]byte, error) {
+				_ = json.Unmarshal(body, &posted)
+				return []byte(`{"id":"comment-1"}`), nil
+			},
+		}
+		h := NewCaseHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/"+testUpdateRequestCaseID+"/request-update", strings.NewReader(`{"stage":"custom","customContent":"Please confirm you received our fix."}`)))
+		r.SetPathValue("id", testUpdateRequestCaseID)
+		w := httptest.NewRecorder()
+		h.RequestCaseUpdate(w, r)
+		assertStatus(t, w, http.StatusCreated)
+		if posted["content"] != "Please confirm you received our fix." {
+			t.Errorf("posted content = %q, want the custom message verbatim", posted["content"])
+		}
+	})
+
+	t.Run("maps a GetCase upstream error via mapUpstreamErrorGeneric", func(t *testing.T) {
+		for _, tc := range upstreamErrorsGeneric("Failed to request an update.") {
+			tc := tc
+			t.Run(tc.name, func(t *testing.T) {
+				client := &mockEntityCaseClient{
+					getCaseFn: func(_ context.Context, _ string) ([]byte, error) {
+						return nil, tc.err
+					},
+				}
+				h := NewCaseHandler(client)
+				r := withUser(httptest.NewRequest(http.MethodPost, "/cases/"+testUpdateRequestCaseID+"/request-update", strings.NewReader(`{"stage":"first"}`)))
+				r.SetPathValue("id", testUpdateRequestCaseID)
+				w := httptest.NewRecorder()
+				h.RequestCaseUpdate(w, r)
+				assertStatus(t, w, tc.wantCode)
+				assertErrorMessage(t, w, tc.wantMsg)
+			})
+		}
+	})
+}
+
+func TestGetCaseUpdateRequestTemplates(t *testing.T) {
+	t.Run("requires authenticated user", func(t *testing.T) {
+		h := NewCaseHandler(&mockEntityCaseClient{})
+		r := httptest.NewRequest(http.MethodGet, "/case-update-request-templates", nil)
+		w := httptest.NewRecorder()
+		h.GetCaseUpdateRequestTemplates(w, r)
+		assertStatus(t, w, http.StatusUnauthorized)
+		assertErrorMessage(t, w, ErrMsgUnauthorized)
+	})
+
+	t.Run("returns both categories with all three fixed stages and no custom key", func(t *testing.T) {
+		h := NewCaseHandler(&mockEntityCaseClient{})
+		r := withUser(httptest.NewRequest(http.MethodGet, "/case-update-request-templates", nil))
+		w := httptest.NewRecorder()
+		h.GetCaseUpdateRequestTemplates(w, r)
+		assertStatus(t, w, http.StatusOK)
+		assertContentType(t, w, "application/json")
+
+		got := decodeJSON[requestUpdateTemplateResponse](t, w)
+
+		for _, cat := range []struct {
+			name string
+			m    map[requestUpdateStage]string
+		}{
+			{"generic", got.Generic},
+			{"migration", got.Migration},
+		} {
+			if len(cat.m) != 3 {
+				t.Errorf("%s: got %d stages, want 3: %v", cat.name, len(cat.m), cat.m)
+			}
+			for _, stage := range []requestUpdateStage{requestUpdateStageFirst, requestUpdateStageSecond, requestUpdateStageFinal} {
+				if cat.m[stage] == "" {
+					t.Errorf("%s: missing content for stage %q", cat.name, stage)
+				}
+			}
+			if _, ok := cat.m[requestUpdateStageCustom]; ok {
+				t.Errorf("%s: unexpectedly contains a %q entry", cat.name, requestUpdateStageCustom)
+			}
+		}
+
+		if got.Generic[requestUpdateStageFirst] != requestUpdateTemplates[requestUpdateCategoryGeneric][requestUpdateStageFirst] {
+			t.Error("generic/first content does not match the source template")
+		}
+		if got.Migration[requestUpdateStageFinal] != requestUpdateTemplates[requestUpdateCategoryMigration][requestUpdateStageFinal] {
+			t.Error("migration/final content does not match the source template")
+		}
+	})
+}

--- a/apps/csm-portal/backend/internal/handler/case_update_requests_test.go
+++ b/apps/csm-portal/backend/internal/handler/case_update_requests_test.go
@@ -60,7 +60,7 @@ func TestRequestCaseUpdate(t *testing.T) {
 
 	t.Run("rejects body exceeding the size cap", func(t *testing.T) {
 		h := NewCaseHandler(&mockEntityCaseClient{})
-		body := `{"stage":"custom","customContent":"` + strings.Repeat("x", maxRequestUpdateBodyBytes) + `"}`
+		body := `{"stage":"custom","customContent":"` + strings.Repeat("x", maxRequestBodyBytes) + `"}`
 		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/"+testUpdateRequestCaseID+"/request-update", strings.NewReader(body)))
 		r.SetPathValue("id", testUpdateRequestCaseID)
 		w := httptest.NewRecorder()

--- a/apps/csm-portal/backend/internal/handler/case_update_requests_test.go
+++ b/apps/csm-portal/backend/internal/handler/case_update_requests_test.go
@@ -45,7 +45,17 @@ func TestRequestCaseUpdate(t *testing.T) {
 		w := httptest.NewRecorder()
 		h.RequestCaseUpdate(w, r)
 		assertStatus(t, w, http.StatusBadRequest)
-		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertErrorMessage(t, w, ErrMsgInvalidUUID)
+	})
+
+	t.Run("rejects malformed UUID", func(t *testing.T) {
+		h := NewCaseHandler(&mockEntityCaseClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/not-a-uuid/request-update", strings.NewReader(`{"stage":"first"}`)))
+		r.SetPathValue("id", "not-a-uuid")
+		w := httptest.NewRecorder()
+		h.RequestCaseUpdate(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgInvalidUUID)
 	})
 
 	t.Run("rejects body exceeding the size cap", func(t *testing.T) {

--- a/apps/csm-portal/backend/internal/handler/response.go
+++ b/apps/csm-portal/backend/internal/handler/response.go
@@ -27,20 +27,21 @@ import (
 
 // Error message constants matching the customer-portal error vocabulary.
 const (
-	ErrMsgUnauthorized           = "You are not authorized to perform this action. Please try again."
-	ErrMsgForbidden              = "Access to the requested resource is forbidden!"
-	ErrMsgNotFound               = "The requested resource was not found!"
-	ErrMsgBadRequest             = "Invalid request payload."
-	ErrMsgTooLarge               = "Request body too large."
-	ErrMsgInternal               = "An internal server error occurred. Please try again later."
-	ErrMsgInvalidTransition      = "Invalid state transition."
-	ErrMsgWorkStateNotAllowed    = "Work state can only be updated when the case is in progress."
-	ErrMsgCommentNotAllowed      = "Comments can only be added when the case is in progress and the work state is ongoing."
-	ErrMsgCommentNotOwnCase      = "Only the assigned engineer can add a public comment on this case."
-	ErrMsgWorkNoteOnClosedCase   = "Work notes cannot be added to a closed case."
-	ErrMsgAttachmentOnClosedCase = "Attachments cannot be added to a closed case."
-	ErrMsgInvalidUUID            = "Invalid UUID format."
-	errMsgReadBody               = "Failed to read request body."
+	ErrMsgUnauthorized            = "You are not authorized to perform this action. Please try again."
+	ErrMsgForbidden               = "Access to the requested resource is forbidden!"
+	ErrMsgNotFound                = "The requested resource was not found!"
+	ErrMsgBadRequest              = "Invalid request payload."
+	ErrMsgTooLarge                = "Request body too large."
+	ErrMsgInternal                = "An internal server error occurred. Please try again later."
+	ErrMsgInvalidTransition       = "Invalid state transition."
+	ErrMsgWorkStateNotAllowed     = "Work state can only be updated when the case is in progress."
+	ErrMsgCommentNotAllowed       = "Comments can only be added when the case is in progress and the work state is ongoing."
+	ErrMsgCommentNotOwnCase       = "Only the assigned engineer can add a public comment on this case."
+	ErrMsgWorkNoteOnClosedCase    = "Work notes cannot be added to a closed case."
+	ErrMsgAttachmentOnClosedCase  = "Attachments cannot be added to a closed case."
+	ErrMsgRequestUpdateNotAllowed = "An update can only be requested while the case is awaiting info or has a proposed solution."
+	ErrMsgInvalidUUID             = "Invalid UUID format."
+	errMsgReadBody                = "Failed to read request body."
 )
 
 // errorBody is the JSON error payload format matching the customer-portal pattern.

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -274,6 +274,117 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
+  /cases/{id}/request-update:
+    post:
+      summary: >
+        Post a customer-visible "request update" nudge comment on a case. Only
+        the case's assigned engineer may call this, and only while the case is
+        awaiting_info or solution_proposed. The message is one of three fixed
+        reminder templates (first/second/final), automatically drawn from a
+        generic or migration wording set depending on the case's own
+        type/engagementType, or a caller-supplied custom message. The
+        category is always server-determined; it is never accepted from the
+        caller.
+      operationId: postCasesIdRequestUpdate
+      parameters:
+        - name: id
+          in: path
+          description: UUID of the case.
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        description: Request-update payload.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RequestCaseUpdatePayload'
+        required: true
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CaseComment'
+        "400":
+          description: BadRequest — malformed body, an unrecognized stage, missing customContent for stage=custom, or customContent supplied alongside a fixed-template stage.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden — the caller is not the case's assigned engineer.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: NotFound
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "409":
+          description: Conflict — an update can only be requested while the case is awaiting_info or solution_proposed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /case-update-request-templates:
+    get:
+      summary: >
+        List the fixed "request update" reminder message templates, by
+        category (generic, migration) and stage (first, second, final). No
+        case-specific logic; a category has no "custom" entry since that
+        content is supplied by the caller of POST /cases/{id}/request-update.
+      operationId: getCaseUpdateRequestTemplates
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CaseUpdateRequestTemplates'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
   /cases/{id}/comments/search:
     post:
       summary: Search comments on a case.
@@ -8649,6 +8760,49 @@ components:
         content:
           type: string
           description: Comment text
+
+    RequestCaseUpdatePayload:
+      type: object
+      required:
+        - stage
+      description: >
+        The category (generic vs. migration) is never accepted here — it is
+        always resolved server-side from the case's own type/engagementType.
+      properties:
+        stage:
+          type: string
+          enum: [first, second, final, custom]
+          description: >
+            One of the three fixed reminder templates, or "custom" to supply
+            customContent instead.
+        customContent:
+          type: string
+          description: >
+            Required and non-empty when stage is "custom"; rejected (must be
+            absent) for every other stage.
+
+    CaseUpdateRequestTemplates:
+      type: object
+      description: >
+        Both categories' full stage->message maps. Neither category includes
+        a "custom" entry.
+      properties:
+        generic:
+          type: object
+          additionalProperties:
+            type: string
+          example:
+            first: "<p>Hi Team,</p>..."
+            second: "<p>Hi Team,</p>..."
+            final: "<p>Hi Team,</p>..."
+        migration:
+          type: object
+          additionalProperties:
+            type: string
+          example:
+            first: "<p>Hi Team,</p>..."
+            second: "<p>Hi Team,</p>..."
+            final: "<p>Hi Team,</p>..."
 
     SnCommentCreatePayload:
       type: object

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -1091,6 +1091,38 @@ export interface BeCommentSearchResponse extends BeSearchResponseBase {
 }
 
 // ---------------------------------------------------------------------------
+// "Request update" nudges — POST /cases/{id}/request-update,
+// GET /case-update-request-templates
+// ---------------------------------------------------------------------------
+
+/**
+ * Which fixed reminder stage (or a caller-supplied custom message) to post.
+ * The category (generic vs. migration) is never part of the request — the
+ * backend derives it itself from the case's own `type`/`engagementType`.
+ */
+export type BeCaseUpdateRequestStage = "first" | "second" | "final" | "custom";
+
+/** Body of `POST /cases/{id}/request-update`. */
+export interface BeCaseUpdateRequestPayload {
+  stage: BeCaseUpdateRequestStage;
+  /** Required (non-empty) iff `stage` is `"custom"`; omitted/rejected otherwise. */
+  customContent?: string;
+}
+
+/** One category's fixed HTML message for each of the three reminder stages. */
+export interface BeCaseUpdateRequestTemplateSet {
+  first: string;
+  second: string;
+  final: string;
+}
+
+/** `GET /case-update-request-templates` response — both categories' full sets. */
+export interface BeCaseUpdateRequestTemplates {
+  generic: BeCaseUpdateRequestTemplateSet;
+  migration: BeCaseUpdateRequestTemplateSet;
+}
+
+// ---------------------------------------------------------------------------
 // Conversations (Novera chat sessions)
 // ---------------------------------------------------------------------------
 

--- a/apps/csm-portal/webapp/src/constants/apiConstants.ts
+++ b/apps/csm-portal/webapp/src/constants/apiConstants.ts
@@ -123,6 +123,7 @@ export const ApiQueryKeys = {
   CSM_CASE_SLAS: "csm-case-slas",
   CSM_CASE_CHILDREN: "csm-case-children",
   CSM_CASE_SEARCH_BY_QUERY: "csm-case-search-by-query",
+  CSM_CASE_UPDATE_REQUEST_TEMPLATES: "csm-case-update-request-templates",
   CSM_PROJECTS: "csm-projects",
   CSM_PROJECT_DETAIL: "csm-project-detail",
   CSM_ACCOUNTS: "csm-accounts",

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCaseDetail.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCaseDetail.ts
@@ -74,6 +74,7 @@ function detailFromBeCase(
     wso2CaseId: c.internalId,
     subject: c.subject ?? "(no subject)",
     caseType: c.type ?? undefined,
+    engagementType: c.engagementType ?? undefined,
     customer,
     accountId: account?.id ?? "",
     projectId: c.project?.id ?? "",

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useRequestCaseUpdate.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useRequestCaseUpdate.ts
@@ -1,0 +1,105 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type UseMutationResult,
+  type UseQueryResult,
+} from "@tanstack/react-query";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import { useBackendApi } from "@api/backend/client";
+import type {
+  BeCaseUpdateRequestPayload,
+  BeCaseUpdateRequestStage,
+  BeCaseUpdateRequestTemplates,
+  BeComment,
+} from "@api/backend/types";
+import { uiCommentFromBe } from "@api/backend/mappers";
+import type { CsmCaseComment } from "@features/csm-cases/types/csmCases";
+
+/**
+ * Load the fixed reminder-message catalogue (both categories, all three
+ * stages). Static content — same response every request, no case-specific
+ * data — so it's cached for the life of the session rather than refetched.
+ */
+export function useGetCaseUpdateRequestTemplates(): UseQueryResult<
+  BeCaseUpdateRequestTemplates,
+  Error
+> {
+  const api = useBackendApi();
+
+  return useQuery<BeCaseUpdateRequestTemplates, Error>({
+    queryKey: [ApiQueryKeys.CSM_CASE_UPDATE_REQUEST_TEMPLATES],
+    queryFn: async (): Promise<BeCaseUpdateRequestTemplates> => {
+      const res = await api.get<BeCaseUpdateRequestTemplates>(
+        "/case-update-request-templates",
+      );
+      // The endpoint is static/always-200 in normal operation; a null (404)
+      // response would mean the route itself is missing, which is a real
+      // failure to surface rather than paper over with empty templates.
+      if (!res) throw new Error("Update request templates are unavailable.");
+      return res;
+    },
+    staleTime: Infinity,
+    gcTime: Infinity,
+  });
+}
+
+export interface RequestCaseUpdateInput {
+  caseId: string;
+  stage: BeCaseUpdateRequestStage;
+  /** Required (non-empty) iff `stage` is `"custom"`. */
+  customContent?: string;
+}
+
+/**
+ * Post a "request update" nudge: `POST /cases/{id}/request-update`. Creates a
+ * customer-visible comment on the case (same response shape as
+ * `POST /cases/{id}/comments`), so the comments list is invalidated on
+ * success exactly like `usePostCsmCaseComment` — the new entry then appears
+ * in the activity feed without a manual refetch.
+ */
+export function useRequestCaseUpdate(): UseMutationResult<
+  CsmCaseComment,
+  Error,
+  RequestCaseUpdateInput
+> {
+  const api = useBackendApi();
+  const queryClient = useQueryClient();
+
+  return useMutation<CsmCaseComment, Error, RequestCaseUpdateInput>({
+    mutationFn: async (input): Promise<CsmCaseComment> => {
+      const payload: BeCaseUpdateRequestPayload = {
+        stage: input.stage,
+        ...(input.stage === "custom" && input.customContent
+          ? { customContent: input.customContent }
+          : {}),
+      };
+      const created = await api.post<BeCaseUpdateRequestPayload, BeComment>(
+        `/cases/${encodeURIComponent(input.caseId)}/request-update`,
+        payload,
+      );
+      return uiCommentFromBe(created, { context: "case" });
+    },
+    onSuccess: (_newComment, variables) => {
+      void queryClient.invalidateQueries({
+        queryKey: [ApiQueryKeys.CSM_CASE_COMMENTS, variables.caseId],
+      });
+    },
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.test.tsx
@@ -610,6 +610,24 @@ describe("CaseActionBar — Request update (enabled only in Awaiting info / Solu
       expect(onAction).not.toHaveBeenCalled();
     },
   );
+
+  it("disables request_update in an eligible state when the caller isn't the assigned engineer", () => {
+    const onAction = vi.fn();
+    render(
+      <CaseActionBar
+        caseDetail={{
+          ...caseInState("awaiting_info", ["waiting_on_wso2"]),
+          assigneeIsMe: false,
+        }}
+        onAction={onAction}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /more/i }));
+    const item = screen.getByRole("menuitem", { name: /request update/i });
+    expect(item).toHaveAttribute("aria-disabled", "true");
+    fireEvent.click(item);
+    expect(onAction).not.toHaveBeenCalled();
+  });
 });
 
 describe("CaseActionBar — advisory close-gate (open task)", () => {

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.test.tsx
@@ -565,6 +565,53 @@ describe("CaseActionBar — Set fix ETA", () => {
   });
 });
 
+describe("CaseActionBar — Request update (enabled only in Awaiting info / Solution proposed)", () => {
+  it("dispatches request_update when the case is awaiting info", () => {
+    const onAction = vi.fn();
+    render(
+      <CaseActionBar
+        caseDetail={caseInState("awaiting_info", ["waiting_on_wso2"])}
+        onAction={onAction}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /more/i }));
+    const item = screen.getByRole("menuitem", { name: /request update/i });
+    expect(item).not.toHaveAttribute("aria-disabled", "true");
+    fireEvent.click(item);
+    expect(onAction).toHaveBeenCalledWith({ secondary: "request_update" });
+  });
+
+  it("dispatches request_update when the case has a proposed solution", () => {
+    const onAction = vi.fn();
+    render(
+      <CaseActionBar
+        caseDetail={caseInState("solution_proposed", ["closed"])}
+        onAction={onAction}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /more/i }));
+    const item = screen.getByRole("menuitem", { name: /request update/i });
+    expect(item).not.toHaveAttribute("aria-disabled", "true");
+    fireEvent.click(item);
+    expect(onAction).toHaveBeenCalledWith({ secondary: "request_update" });
+  });
+
+  it.each<CaseState>(["work_in_progress", "waiting_on_wso2", "open", "closed"])(
+    "disables request_update while the case is %s, with an explanatory tooltip",
+    (state) => {
+      const onAction = vi.fn();
+      render(
+        <CaseActionBar caseDetail={caseInState(state, [])} onAction={onAction} />,
+      );
+      fireEvent.click(screen.getByRole("button", { name: /more/i }));
+      const item = screen.getByRole("menuitem", { name: /request update/i });
+      expect(item).toHaveAttribute("aria-disabled", "true");
+      fireEvent.click(item);
+      expect(onAction).not.toHaveBeenCalled();
+    },
+  );
+});
+
 describe("CaseActionBar — advisory close-gate (open task)", () => {
   it("disables the single-button Close transition with a tooltip when closeBlockedReason is set", () => {
     const onAction = vi.fn();

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
@@ -37,6 +37,7 @@ import {
   GitPullRequest,
   Inbox,
   Link as LinkIcon,
+  MessageCircleQuestion,
   PauseCircle,
   Pencil,
   Play,
@@ -48,6 +49,7 @@ import type {
   CaseLifecycleAction,
   CsmCaseDetail,
 } from "@features/csm-cases/types/csmCases";
+import { canRequestCaseUpdate } from "@features/csm-cases/utils/caseUpdateRequests";
 import type {
   CaseState,
   SeverityOrUnset,
@@ -221,6 +223,11 @@ interface SecondaryItem {
  *   - Link to incident               → ISSU-021 (PATCH /cases/{id} { parentId }, see
  *                                       LinkIncidentDialog.tsx)
  *   - Raise Git issue                → ISSU-020
+ *   - Request update…                → nudge the customer for a response using a fixed
+ *                                       reminder template or a custom message. Only offered
+ *                                       while the case is Awaiting info or Solution proposed
+ *                                       — see `POST /cases/{id}/request-update` and
+ *                                       RequestUpdateDialog.tsx.
  *   - Create change request          → service-request-only. Navigates to the change-request
  *                                       create form pre-filled with this service request as the
  *                                       "Originating service request" (POST /change-requests, then
@@ -309,6 +316,12 @@ function buildSecondaryItems(caseDetail: CsmCaseDetail): SecondaryItem[] {
     caseDetail.state,
   );
 
+  // Opposite shape to the git-issue gate above: "Request update" is only
+  // meaningful while the ball is meant to be in the customer's court, so it's
+  // enabled ONLY in those two states rather than blocked in a few — mirrors
+  // the backend's own gate in `RequestCaseUpdate` (409 outside these states).
+  const requestUpdateAllowed = canRequestCaseUpdate(caseDetail);
+
   // Only a service request can be the "Originating service request" a change
   // request links back to (see the create form's picker), so the action is
   // offered only there — mirrors the same `caseType === "service_request"`
@@ -336,6 +349,16 @@ function buildSecondaryItems(caseDetail: CsmCaseDetail): SecondaryItem[] {
         : gitIssueStateBlocked
           ? "Git issues can only be raised while the case is Open, Work in progress, Waiting on WSO2, or Reopened."
           : undefined,
+    },
+    {
+      key: "request_update",
+      label: "Request update…",
+      icon: <MessageCircleQuestion size={16} />,
+      divider: true,
+      disabled: !requestUpdateAllowed,
+      tooltip: !requestUpdateAllowed
+        ? "Requesting an update is only available while the case is Awaiting info or has a proposed solution."
+        : undefined,
     },
     {
       key: "reassign_engineer",

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActionBar.tsx
@@ -319,8 +319,14 @@ function buildSecondaryItems(caseDetail: CsmCaseDetail): SecondaryItem[] {
   // Opposite shape to the git-issue gate above: "Request update" is only
   // meaningful while the ball is meant to be in the customer's court, so it's
   // enabled ONLY in those two states rather than blocked in a few — mirrors
-  // the backend's own gate in `RequestCaseUpdate` (409 outside these states).
-  const requestUpdateAllowed = canRequestCaseUpdate(caseDetail);
+  // the backend's own state gate in `RequestCaseUpdate` (409 outside these
+  // states). Also requires `assigneeIsMe`: the backend separately rejects a
+  // non-assignee with 403 (same ownership rule `CreateCaseComment` already
+  // enforces for public comments), so gating on state alone would let anyone
+  // open the dialog and fill it in only to hit a confusing 403 on submit.
+  const requestUpdateStateAllowed = canRequestCaseUpdate(caseDetail);
+  const requestUpdateAllowed =
+    requestUpdateStateAllowed && caseDetail.assigneeIsMe;
 
   // Only a service request can be the "Originating service request" a change
   // request links back to (see the create form's picker), so the action is
@@ -356,9 +362,11 @@ function buildSecondaryItems(caseDetail: CsmCaseDetail): SecondaryItem[] {
       icon: <MessageCircleQuestion size={16} />,
       divider: true,
       disabled: !requestUpdateAllowed,
-      tooltip: !requestUpdateAllowed
+      tooltip: !requestUpdateStateAllowed
         ? "Requesting an update is only available while the case is Awaiting info or has a proposed solution."
-        : undefined,
+        : !requestUpdateAllowed
+          ? "Only the assigned engineer can request an update on this case."
+          : undefined,
     },
     {
       key: "reassign_engineer",

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/RequestUpdateDialog.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/RequestUpdateDialog.test.tsx
@@ -1,0 +1,238 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import RequestUpdateDialog from "@features/csm-cases/components/RequestUpdateDialog";
+import { useGetCaseUpdateRequestTemplates } from "@features/csm-cases/api/useRequestCaseUpdate";
+import type { BeCaseUpdateRequestTemplates } from "@api/backend/types";
+
+vi.mock("@features/csm-cases/api/useRequestCaseUpdate", () => ({
+  useGetCaseUpdateRequestTemplates: vi.fn(),
+}));
+
+const mockedUseGetTemplates = vi.mocked(useGetCaseUpdateRequestTemplates);
+
+const TEMPLATES: BeCaseUpdateRequestTemplates = {
+  generic: {
+    first: "<p>Hi Team,</p><p>Generic first reminder.</p>",
+    second: "<p>Hi Team,</p><p>Generic second reminder.</p>",
+    final: "<p>Hi Team,</p><p>Generic final notice.</p>",
+  },
+  migration: {
+    first: "<p>Hi Team,</p><p>Migration first reminder.</p>",
+    second: "<p>Hi Team,</p><p>Migration second reminder.</p>",
+    final: "<p>Hi Team,</p><p>Migration final notice.</p>",
+  },
+};
+
+function mockTemplatesLoaded(
+  templates: BeCaseUpdateRequestTemplates = TEMPLATES,
+): void {
+  mockedUseGetTemplates.mockReturnValue({
+    data: templates,
+    isLoading: false,
+    isError: false,
+  } as ReturnType<typeof useGetCaseUpdateRequestTemplates>);
+}
+
+function selectStage(label: RegExp): void {
+  fireEvent.mouseDown(screen.getByRole("combobox", { name: /message/i }));
+  fireEvent.click(within(screen.getByRole("listbox")).getByText(label));
+}
+
+describe("RequestUpdateDialog", () => {
+  it("defaults to the first reminder and previews the generic template", () => {
+    mockTemplatesLoaded();
+    render(
+      <RequestUpdateDialog
+        category="generic"
+        isSaving={false}
+        onClose={() => {}}
+        onSave={() => {}}
+      />,
+    );
+    expect(screen.getByTestId("request-update-preview").innerHTML).toContain(
+      "Generic first reminder.",
+    );
+  });
+
+  it("previews the migration template set when category is migration", () => {
+    mockTemplatesLoaded();
+    render(
+      <RequestUpdateDialog
+        category="migration"
+        isSaving={false}
+        onClose={() => {}}
+        onSave={() => {}}
+      />,
+    );
+    expect(screen.getByTestId("request-update-preview").innerHTML).toContain(
+      "Migration first reminder.",
+    );
+  });
+
+  it("switches the preview when a different stage is selected", () => {
+    mockTemplatesLoaded();
+    render(
+      <RequestUpdateDialog
+        category="generic"
+        isSaving={false}
+        onClose={() => {}}
+        onSave={() => {}}
+      />,
+    );
+    selectStage(/second reminder/i);
+    expect(screen.getByTestId("request-update-preview").innerHTML).toContain(
+      "Generic second reminder.",
+    );
+  });
+
+  it("calls onSave with just the stage for a fixed reminder", () => {
+    mockTemplatesLoaded();
+    const onSave = vi.fn();
+    render(
+      <RequestUpdateDialog
+        category="generic"
+        isSaving={false}
+        onClose={() => {}}
+        onSave={onSave}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /^send$/i }));
+    expect(onSave).toHaveBeenCalledWith({ stage: "first" });
+  });
+
+  it("shows a text field instead of a preview for a custom message, and blocks Send until non-empty", () => {
+    mockTemplatesLoaded();
+    render(
+      <RequestUpdateDialog
+        category="generic"
+        isSaving={false}
+        onClose={() => {}}
+        onSave={() => {}}
+      />,
+    );
+    selectStage(/custom message/i);
+    expect(screen.queryByTestId("request-update-preview")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^send$/i })).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText(/custom message/i), {
+      target: { value: "Any update on your side?" },
+    });
+    expect(screen.getByRole("button", { name: /^send$/i })).toBeEnabled();
+  });
+
+  it("wraps the custom message in an escaped paragraph before saving", () => {
+    mockTemplatesLoaded();
+    const onSave = vi.fn();
+    render(
+      <RequestUpdateDialog
+        category="generic"
+        isSaving={false}
+        onClose={() => {}}
+        onSave={onSave}
+      />,
+    );
+    selectStage(/custom message/i);
+    fireEvent.change(screen.getByLabelText(/custom message/i), {
+      target: { value: "Any update <on> your side?" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^send$/i }));
+    expect(onSave).toHaveBeenCalledWith({
+      stage: "custom",
+      customContent: "<p>Any update &lt;on&gt; your side?</p>",
+    });
+  });
+
+  it("disables Send while templates are loading", () => {
+    mockedUseGetTemplates.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+    } as ReturnType<typeof useGetCaseUpdateRequestTemplates>);
+    render(
+      <RequestUpdateDialog
+        category="generic"
+        isSaving={false}
+        onClose={() => {}}
+        onSave={() => {}}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /^send$/i })).toBeDisabled();
+  });
+
+  it("shows an error state when templates fail to load, but still allows a custom message", () => {
+    mockedUseGetTemplates.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    } as ReturnType<typeof useGetCaseUpdateRequestTemplates>);
+    const onSave = vi.fn();
+    render(
+      <RequestUpdateDialog
+        category="generic"
+        isSaving={false}
+        onClose={() => {}}
+        onSave={onSave}
+      />,
+    );
+    expect(screen.getByText(/couldn't load the reminder message templates/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^send$/i })).toBeDisabled();
+
+    selectStage(/custom message/i);
+    fireEvent.change(screen.getByLabelText(/custom message/i), {
+      target: { value: "Checking in." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^send$/i }));
+    expect(onSave).toHaveBeenCalledWith({
+      stage: "custom",
+      customContent: "<p>Checking in.</p>",
+    });
+  });
+
+  it("shows a loading state and disables actions while isSaving", () => {
+    mockTemplatesLoaded();
+    render(
+      <RequestUpdateDialog
+        category="generic"
+        isSaving
+        onClose={() => {}}
+        onSave={() => {}}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /^send$/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /^close$/i })).toBeDisabled();
+  });
+
+  it("calls onClose on Close without calling onSave", () => {
+    mockTemplatesLoaded();
+    const onSave = vi.fn();
+    const onClose = vi.fn();
+    render(
+      <RequestUpdateDialog
+        category="generic"
+        isSaving={false}
+        onClose={onClose}
+        onSave={onSave}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /^close$/i }));
+    expect(onClose).toHaveBeenCalled();
+    expect(onSave).not.toHaveBeenCalled();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/RequestUpdateDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/RequestUpdateDialog.tsx
@@ -1,0 +1,199 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Alert,
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Skeleton,
+  TextField,
+  Typography,
+  type SelectChangeEvent,
+} from "@wso2/oxygen-ui";
+import { useMemo, useState, type JSX } from "react";
+import { escapeHtml, sanitizeRichTextHtml } from "@utils/sanitizeHtml";
+import { useGetCaseUpdateRequestTemplates } from "@features/csm-cases/api/useRequestCaseUpdate";
+import {
+  REQUEST_UPDATE_STAGE_LABEL,
+  type CaseUpdateRequestCategory,
+} from "@features/csm-cases/utils/caseUpdateRequests";
+import type { BeCaseUpdateRequestStage } from "@api/backend/types";
+
+/** Payload this dialog produces on confirm — mirrors `RequestCaseUpdateInput` minus `caseId`. */
+export interface RequestUpdateSavePayload {
+  stage: BeCaseUpdateRequestStage;
+  customContent?: string;
+}
+
+interface RequestUpdateDialogProps {
+  /** Which fixed reminder-message set to preview — see `deriveCaseUpdateRequestCategory`. */
+  category: CaseUpdateRequestCategory;
+  /** True while the `POST /cases/{id}/request-update` call is in flight. */
+  isSaving: boolean;
+  onClose: () => void;
+  onSave: (payload: RequestUpdateSavePayload) => void;
+}
+
+const STAGE_ORDER: BeCaseUpdateRequestStage[] = ["first", "second", "final", "custom"];
+
+/**
+ * "Request update" dialog: nudge the customer for a response using one of
+ * three fixed reminder templates (previewed read-only, exactly as they'll be
+ * posted) or a custom message. Adapted from ServiceNow's equivalent "Add
+ * Comment Options" modal for this case's own dedicated backend endpoint —
+ * see `POST /cases/{id}/request-update` / `GET /case-update-request-templates`.
+ */
+export default function RequestUpdateDialog({
+  category,
+  isSaving,
+  onClose,
+  onSave,
+}: RequestUpdateDialogProps): JSX.Element {
+  const { data: templates, isLoading, isError } =
+    useGetCaseUpdateRequestTemplates();
+  const [stage, setStage] = useState<BeCaseUpdateRequestStage>("first");
+  const [customMessage, setCustomMessage] = useState("");
+
+  const previewHtml = useMemo(() => {
+    if (stage === "custom" || !templates) return "";
+    return sanitizeRichTextHtml(templates[category][stage]);
+  }, [templates, category, stage]);
+
+  const trimmedCustomMessage = customMessage.trim();
+  // A custom message needs no template — it's still sendable even if the
+  // template fetch failed or is still loading; only the three fixed stages
+  // depend on the templates query having actually resolved.
+  const canSubmit =
+    stage === "custom"
+      ? trimmedCustomMessage.length > 0
+      : !isLoading && !isError && !!templates?.[category]?.[stage];
+
+  const handleSave = (): void => {
+    if (!canSubmit) return;
+    if (stage === "custom") {
+      // The backend accepts any string as `customContent`, but every stored
+      // comment is rendered as HTML on read (see CsmCaseCommentBubble), so
+      // wrap the plain-text input in escaped paragraphs rather than sending
+      // it unescaped — a literal "<" in the engineer's message must not be
+      // interpreted as markup once it comes back through the feed.
+      const html = trimmedCustomMessage
+        .split(/\n+/)
+        .filter((line) => line.trim().length > 0)
+        .map((line) => `<p>${escapeHtml(line.trim())}</p>`)
+        .join("");
+      onSave({ stage, customContent: html });
+      return;
+    }
+    onSave({ stage });
+  };
+
+  return (
+    <Dialog open onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Request update</DialogTitle>
+      <DialogContent>
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 2, pt: 0.5 }}>
+          <Typography variant="body2" color="text.secondary">
+            Post a customer-visible comment nudging the customer for a
+            response. Pick one of the fixed reminder messages below, or write
+            your own.
+          </Typography>
+
+          <FormControl fullWidth size="small">
+            <InputLabel id="request-update-stage-label">Message</InputLabel>
+            <Select
+              labelId="request-update-stage-label"
+              label="Message"
+              value={stage}
+              disabled={isSaving}
+              onChange={(e: SelectChangeEvent<string>) =>
+                setStage(e.target.value as BeCaseUpdateRequestStage)
+              }
+            >
+              {STAGE_ORDER.map((s) => (
+                <MenuItem key={s} value={s}>
+                  {s === "custom" ? "Custom message" : REQUEST_UPDATE_STAGE_LABEL[s]}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+
+          {isError && (
+            <Alert severity="error">
+              Couldn't load the reminder message templates. You can still send
+              a custom message, or close and try again.
+            </Alert>
+          )}
+
+          {stage === "custom" ? (
+            <TextField
+              label="Custom message"
+              placeholder="Write the message to post on this case…"
+              multiline
+              minRows={4}
+              fullWidth
+              size="small"
+              value={customMessage}
+              onChange={(e) => setCustomMessage(e.target.value)}
+              disabled={isSaving}
+            />
+          ) : isLoading ? (
+            <Skeleton variant="rounded" width="100%" height={100} />
+          ) : (
+            !isError && (
+              <Box
+                sx={{
+                  border: 1,
+                  borderColor: "divider",
+                  borderRadius: 1,
+                  p: 1.5,
+                  bgcolor: "action.hover",
+                  "& p": { m: 0 },
+                  "& p + p": { mt: 0.75 },
+                }}
+                data-testid="request-update-preview"
+                // Fixed templates are server-provided rich text, sanitized
+                // above — same safe-render approach the comment feed itself
+                // uses (`sanitizeRichTextHtml` + `dangerouslySetInnerHTML`).
+                dangerouslySetInnerHTML={{ __html: previewHtml }}
+              />
+            )
+          )}
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={isSaving}>
+          Close
+        </Button>
+        <Button
+          variant="contained"
+          disabled={!canSubmit || isSaving}
+          loading={isSaving}
+          onClick={handleSave}
+        >
+          Send
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.test.tsx
@@ -270,6 +270,9 @@ vi.mock("@features/csm-cases/api/useCaseTags", () => ({
 vi.mock("@features/csm-cases/api/useCsmCaseGithubIssue", () => ({
   usePostCaseGithubIssue: () => ({ mutate: vi.fn(), isPending: false }),
 }));
+vi.mock("@features/csm-cases/api/useRequestCaseUpdate", () => ({
+  useRequestCaseUpdate: () => ({ mutate: vi.fn(), isPending: false }),
+}));
 vi.mock("@features/csm-timecards/api/useTimeCards", () => ({
   usePostTimeCard: () => ({ mutate: vi.fn(), isPending: false }),
   useUpdateTimeCard: () => ({ mutate: vi.fn(), isPending: false }),
@@ -350,6 +353,9 @@ vi.mock("@features/csm-cases/components/CreateTaskDialog", () => ({
   default: () => null,
 }));
 vi.mock("@features/csm-cases/components/AddTagDialog", () => ({
+  default: () => null,
+}));
+vi.mock("@features/csm-cases/components/RequestUpdateDialog", () => ({
   default: () => null,
 }));
 vi.mock("@features/csm-cases/components/ChildCasesWidget", () => ({

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.test.tsx
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { JSX } from "react";
 import {
@@ -138,6 +138,14 @@ const useGetCsmCaseDetailMock = vi.fn();
 vi.mock("@features/csm-cases/api/useGetCsmCaseDetail", () => ({
   useGetCsmCaseDetail: (id: string | undefined) => useGetCsmCaseDetailMock(id),
 }));
+
+// A real (non-vi.fn-per-render) mock so a test can capture the onSuccess/
+// onError options passed to `.mutate()` and invoke them later, simulating a
+// response that arrives after the page has navigated elsewhere.
+const requestCaseUpdateMutateMock = vi.fn();
+afterEach(() => {
+  requestCaseUpdateMutateMock.mockClear();
+});
 function defaultCaseDetailImpl(id: string | undefined): unknown {
   return {
     data: id ? buildCase(id) : undefined,
@@ -271,7 +279,10 @@ vi.mock("@features/csm-cases/api/useCsmCaseGithubIssue", () => ({
   usePostCaseGithubIssue: () => ({ mutate: vi.fn(), isPending: false }),
 }));
 vi.mock("@features/csm-cases/api/useRequestCaseUpdate", () => ({
-  useRequestCaseUpdate: () => ({ mutate: vi.fn(), isPending: false }),
+  useRequestCaseUpdate: () => ({
+    mutate: requestCaseUpdateMutateMock,
+    isPending: false,
+  }),
 }));
 vi.mock("@features/csm-timecards/api/useTimeCards", () => ({
   usePostTimeCard: () => ({ mutate: vi.fn(), isPending: false }),
@@ -282,15 +293,20 @@ vi.mock("@features/csm-timecards/api/useTimeCards", () => ({
 vi.mock("@features/csm-cases/components/CsmCaseCommentInput", () => ({
   default: () => null,
 }));
-// Probe, not `null`: the change_case_type test below needs a way to open
-// ChangeCaseTypeDialog the same way a real user would (via the action bar's
-// menu). CaseActionBar's own rendering/gating is covered in
+// Probe, not `null`: the change_case_type and request_update tests below
+// need a way to open their dialogs the same way a real user would (via the
+// action bar's menu). CaseActionBar's own rendering/gating is covered in
 // CaseActionBar.test.tsx.
 vi.mock("@features/csm-cases/components/CaseActionBar", () => ({
   default: ({ onAction }: { onAction: (action: { secondary: string }) => void }) => (
-    <button type="button" onClick={() => onAction({ secondary: "change_case_type" })}>
-      stub open change case type
-    </button>
+    <>
+      <button type="button" onClick={() => onAction({ secondary: "change_case_type" })}>
+        stub open change case type
+      </button>
+      <button type="button" onClick={() => onAction({ secondary: "request_update" })}>
+        stub open request update
+      </button>
+    </>
   ),
   canAcknowledge: () => false,
 }));
@@ -355,8 +371,15 @@ vi.mock("@features/csm-cases/components/CreateTaskDialog", () => ({
 vi.mock("@features/csm-cases/components/AddTagDialog", () => ({
   default: () => null,
 }));
+// Probe, not `null`: the stale-callback regression test below needs a way to
+// submit the dialog the same way a real user would (its own template-preview/
+// custom-message UI is covered in RequestUpdateDialog.test.tsx).
 vi.mock("@features/csm-cases/components/RequestUpdateDialog", () => ({
-  default: () => null,
+  default: ({ onSave }: { onSave: (payload: { stage: string }) => void }) => (
+    <button type="button" onClick={() => onSave({ stage: "first" })}>
+      stub save request update
+    </button>
+  ),
 }));
 vi.mock("@features/csm-cases/components/ChildCasesWidget", () => ({
   ChildCasesWidget: () => null,
@@ -841,6 +864,78 @@ describe("CsmCaseDetailPage — time-card edit dialog reset on case change", () 
     // page has already moved on to case-2.
     expect(
       screen.queryByTestId("log-time-card-dialog-probe"),
+    ).not.toBeInTheDocument();
+  });
+});
+
+// Fires real navigate() calls between case-1 and case-2, both directions —
+// the A -> B -> A regression below needs a return trip, unlike
+// NavigateToCaseTwoButton (one-way, used by the simpler dialog-reset tests).
+function NavigateBetweenCasesButtons(): JSX.Element {
+  const navigate = useNavigate();
+  return (
+    <>
+      <button type="button" onClick={() => navigate("/cases/case-2")}>
+        Go to case 2
+      </button>
+      <button type="button" onClick={() => navigate("/cases/case-1")}>
+        Go to case 1
+      </button>
+    </>
+  );
+}
+
+describe("CsmCaseDetailPage — request-update stale-callback guard", () => {
+  it("ignores a request-update response that arrives after navigating away and back to the same case", () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={["/cases/case-1"]}>
+          <NavigateBetweenCasesButtons />
+          <LocationProbe />
+          <Routes>
+            <Route path="/cases/:caseId" element={<CsmCaseDetailPage />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // Open the dialog and submit while still on case-1; capture the mutate
+    // options instead of letting the mock resolve immediately, so the
+    // response can be replayed later — simulating a slow network response.
+    fireEvent.click(screen.getByRole("button", { name: /stub open request update/i }));
+    fireEvent.click(screen.getByRole("button", { name: /stub save request update/i }));
+    expect(requestCaseUpdateMutateMock).toHaveBeenCalledTimes(1);
+    const [, mutateOptions] = requestCaseUpdateMutateMock.mock.calls[0] as [
+      unknown,
+      { onSuccess: () => void },
+    ];
+
+    // Navigate away and back to case-1 — a real round trip, not a no-op:
+    // caseId is identical before and after, which is exactly what a plain
+    // caseId comparison in the mutation guard can't tell apart from "never
+    // left". The view token (bumped on every transition, including this
+    // return trip) is what makes the guard correctly treat the pending
+    // request as stale here.
+    fireEvent.click(screen.getByRole("button", { name: /go to case 2/i }));
+    fireEvent.click(screen.getByRole("button", { name: /go to case 1/i }));
+    expect(screen.getByTestId("location-probe")).toHaveTextContent(
+      "/cases/case-1",
+    );
+
+    // The delayed response for the *original* case-1 visit arrives now.
+    act(() => {
+      mutateOptions.onSuccess();
+    });
+
+    // A caseId-only guard would treat this as still current (case-1 ==
+    // case-1) and show the success toast; the view-token guard correctly
+    // drops it since this is a different visit to case-1 than the one that
+    // submitted the request.
+    expect(
+      screen.queryByText(/update request posted/i),
     ).not.toBeInTheDocument();
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -610,6 +610,12 @@ export default function CsmCaseDetailPage(): JSX.Element {
   // during render (React's recommended pattern for resetting state when a
   // prop changes) rather than in an effect, to avoid an extra render pass.
   const [prevCaseId, setPrevCaseId] = useState(caseId);
+  // Distinguishes this render's view of the page from every prior one, even
+  // a return visit to the same caseId (A -> B -> A) — a plain caseId
+  // comparison can't tell those apart, which is exactly what let a stale
+  // mutation callback from the first visit to A slip through on the second.
+  // Bumped inside the reset block below, once per genuine transition.
+  const caseViewTokenRef = useRef(0);
   if (caseId !== prevCaseId) {
     setPrevCaseId(caseId);
     setFeedback(null);
@@ -637,6 +643,10 @@ export default function CsmCaseDetailPage(): JSX.Element {
     setFixEtaOpen(false);
     setRequestUpdateOpen(false);
     setAddTagOpen(false);
+    // A new view of the page, distinct from every prior one even if it's a
+    // return visit to the same caseId (A -> B -> A) — see caseViewTokenRef
+    // below, which onRequestUpdate compares against instead of caseId itself.
+    caseViewTokenRef.current += 1;
     // The permalink-fragment-triggered force to Activities (for both this
     // case-change and a same-case fragment change) lives in one effect below
     // — see `permalinkForceRef` — rather than here, since `setActiveTab` now
@@ -1567,22 +1577,21 @@ export default function CsmCaseDetailPage(): JSX.Element {
     [patchCase, showError],
   );
 
-  // `caseId` at mutate-time, captured per-call so a slow response for a
-  // since-navigated-away-from case can't close the dialog or show feedback
-  // for whatever case the page has moved on to (CsmCaseDetailPage stays
-  // mounted across a caseId change — see the `prevCaseId` reset block above).
-  const activeCaseIdRef = useRef(caseId);
-  activeCaseIdRef.current = caseId;
-
   const onRequestUpdate = useCallback(
     (payload: RequestUpdateSavePayload) => {
       if (!caseId) return;
-      const submittedCaseId = caseId;
+      // Compared against caseViewTokenRef in the callbacks below, not caseId
+      // itself: a plain caseId comparison can't tell a still-pending request
+      // from *this* view of the case apart from one left over from an
+      // earlier visit to the same case (A -> B -> A), since the id is
+      // identical in both. The token bumps on every transition, including a
+      // return to a previously-visited case, so it can.
+      const submittedViewToken = caseViewTokenRef.current;
       requestCaseUpdate.mutate(
         { caseId, ...payload },
         {
           onSuccess: () => {
-            if (activeCaseIdRef.current !== submittedCaseId) return;
+            if (caseViewTokenRef.current !== submittedViewToken) return;
             setRequestUpdateOpen(false);
             setFeedback({
               message: "Update request posted.",
@@ -1591,7 +1600,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
             });
           },
           onError: (err) => {
-            if (activeCaseIdRef.current !== submittedCaseId) return;
+            if (caseViewTokenRef.current !== submittedViewToken) return;
             // 403 (not the assigned engineer) / 409 (case moved out of the
             // eligible state since the dialog opened) both carry an
             // actionable, specific backend message — surface it instead of a

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -103,6 +103,11 @@ import LinkCaseDialog, {
 import SetFixEtaDialog, {
   type FixEtaSavePayload,
 } from "@features/csm-cases/components/SetFixEtaDialog";
+import RequestUpdateDialog, {
+  type RequestUpdateSavePayload,
+} from "@features/csm-cases/components/RequestUpdateDialog";
+import { useRequestCaseUpdate } from "@features/csm-cases/api/useRequestCaseUpdate";
+import { deriveCaseUpdateRequestCategory } from "@features/csm-cases/utils/caseUpdateRequests";
 import CreateTaskDialog from "@features/csm-cases/components/CreateTaskDialog";
 import AddTagDialog from "@features/csm-cases/components/AddTagDialog";
 import { useCreateCaseTask } from "@features/csm-cases/api/useCreateCaseTask";
@@ -509,6 +514,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
   const createTask = useCreateCaseTask(caseId);
   const addTag = useAddCaseTag(caseId);
   const removeTag = useRemoveCaseTag(caseId);
+  const requestCaseUpdate = useRequestCaseUpdate();
   const findMyOngoingCases = useFindMyOngoingCases();
   const recordView = useRecordRecentView();
   const claims = useIdTokenClaims();
@@ -555,6 +561,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
   const [editDetailsOpen, setEditDetailsOpen] = useState(false);
   const [createTaskOpen, setCreateTaskOpen] = useState(false);
   const [fixEtaOpen, setFixEtaOpen] = useState(false);
+  const [requestUpdateOpen, setRequestUpdateOpen] = useState(false);
   const [addTagOpen, setAddTagOpen] = useState(false);
   // ISSU-026: closing or proposing a solution opens this instead of PATCHing
   // immediately — it collects the Post Resolution Activity and doubles as
@@ -1127,6 +1134,13 @@ export default function CsmCaseDetailPage(): JSX.Element {
         return;
       }
 
+      // Request update opens the reminder-template dialog; the POST happens
+      // in onRequestUpdate once a stage (or custom message) is confirmed.
+      if (action.secondary === "request_update") {
+        setRequestUpdateOpen(true);
+        return;
+      }
+
       // Pause / resume the work sub-state via PATCH { workState }. Only for an
       // in-progress case assigned to the current user. Pausing is a direct
       // single-field patch. Resuming sets this case `ongoing`, so it runs the
@@ -1550,6 +1564,37 @@ export default function CsmCaseDetailPage(): JSX.Element {
       });
     },
     [patchCase, showError],
+  );
+
+  const onRequestUpdate = useCallback(
+    (payload: RequestUpdateSavePayload) => {
+      if (!caseId) return;
+      requestCaseUpdate.mutate(
+        { caseId, ...payload },
+        {
+          onSuccess: () => {
+            setRequestUpdateOpen(false);
+            setFeedback({
+              message: "Update request posted.",
+              severity: "success",
+              sticky: false,
+            });
+          },
+          onError: (err) => {
+            // 403 (not the assigned engineer) / 409 (case moved out of the
+            // eligible state since the dialog opened) both carry an
+            // actionable, specific backend message — surface it instead of a
+            // generic fallback, same treatment as every other 4xx on this page.
+            const msg =
+              err instanceof BackendApiError && err.status < 500 && err.message
+                ? err.message
+                : "Could not post the update request.";
+            showError(msg, err);
+          },
+        },
+      );
+    },
+    [caseId, requestCaseUpdate, showError],
   );
 
   const onAddTag = useCallback(
@@ -2615,6 +2660,15 @@ export default function CsmCaseDetailPage(): JSX.Element {
           isSaving={patchCase.isPending}
           onClose={() => setFixEtaOpen(false)}
           onSave={onSetFixEta}
+        />
+      )}
+
+      {requestUpdateOpen && (
+        <RequestUpdateDialog
+          category={deriveCaseUpdateRequestCategory(c)}
+          isSaving={requestCaseUpdate.isPending}
+          onClose={() => setRequestUpdateOpen(false)}
+          onSave={onRequestUpdate}
         />
       )}
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -635,6 +635,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
     setEditDetailsOpen(false);
     setCreateTaskOpen(false);
     setFixEtaOpen(false);
+    setRequestUpdateOpen(false);
     setAddTagOpen(false);
     // The permalink-fragment-triggered force to Activities (for both this
     // case-change and a same-case fragment change) lives in one effect below

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -1567,13 +1567,22 @@ export default function CsmCaseDetailPage(): JSX.Element {
     [patchCase, showError],
   );
 
+  // `caseId` at mutate-time, captured per-call so a slow response for a
+  // since-navigated-away-from case can't close the dialog or show feedback
+  // for whatever case the page has moved on to (CsmCaseDetailPage stays
+  // mounted across a caseId change — see the `prevCaseId` reset block above).
+  const activeCaseIdRef = useRef(caseId);
+  activeCaseIdRef.current = caseId;
+
   const onRequestUpdate = useCallback(
     (payload: RequestUpdateSavePayload) => {
       if (!caseId) return;
+      const submittedCaseId = caseId;
       requestCaseUpdate.mutate(
         { caseId, ...payload },
         {
           onSuccess: () => {
+            if (activeCaseIdRef.current !== submittedCaseId) return;
             setRequestUpdateOpen(false);
             setFeedback({
               message: "Update request posted.",
@@ -1582,6 +1591,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
             });
           },
           onError: (err) => {
+            if (activeCaseIdRef.current !== submittedCaseId) return;
             // 403 (not the assigned engineer) / 409 (case moved out of the
             // eligible state since the dialog opened) both carry an
             // actionable, specific backend message — surface it instead of a

--- a/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
@@ -71,6 +71,15 @@ export interface CsmCaseRow {
    */
   caseType?: BeCaseType;
   /**
+   * Engagement type (e.g. "Migration"), only meaningful when `caseType` is
+   * `"engagement"`. Carried through unmodified from the backend's raw display
+   * label (not normalized/lowercased) — see `detailFromBeCase` in
+   * `useGetCsmCaseDetail.ts`. Consumers that need to test for "is this a
+   * migration engagement" must compare case-insensitively, matching the
+   * backend's own `strings.EqualFold` check in `RequestCaseUpdate`.
+   */
+  engagementType?: string;
+  /**
    * Work sub-state of an in-progress case (`ongoing` / `paused`); `null` when
    * the case is not `work_in_progress`. Drives the comment gate and the paused
    * indicator. See {@link commentGateReason}.

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/caseUpdateRequests.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/caseUpdateRequests.test.ts
@@ -1,0 +1,87 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { describe, expect, it } from "vitest";
+import {
+  canRequestCaseUpdate,
+  deriveCaseUpdateRequestCategory,
+} from "@features/csm-cases/utils/caseUpdateRequests";
+import type { CsmCaseDetail } from "@features/csm-cases/types/csmCases";
+import type { CaseState } from "@features/csm-dashboard/types/abtDashboard";
+
+describe("canRequestCaseUpdate", () => {
+  it.each<CaseState>(["awaiting_info", "solution_proposed"])(
+    "is true while the case is %s",
+    (state) => {
+      expect(canRequestCaseUpdate({ state } as CsmCaseDetail)).toBe(true);
+    },
+  );
+
+  it.each<CaseState>(["open", "work_in_progress", "waiting_on_wso2", "closed"])(
+    "is false while the case is %s",
+    (state) => {
+      expect(canRequestCaseUpdate({ state } as CsmCaseDetail)).toBe(false);
+    },
+  );
+});
+
+describe("deriveCaseUpdateRequestCategory", () => {
+  it("is migration only for an engagement case with engagementType migration", () => {
+    expect(
+      deriveCaseUpdateRequestCategory({
+        caseType: "engagement",
+        engagementType: "Migration",
+      }),
+    ).toBe("migration");
+  });
+
+  it("is case-insensitive on engagementType, mirroring the backend's strings.EqualFold check", () => {
+    expect(
+      deriveCaseUpdateRequestCategory({
+        caseType: "engagement",
+        engagementType: "MIGRATION",
+      }),
+    ).toBe("migration");
+    expect(
+      deriveCaseUpdateRequestCategory({
+        caseType: "engagement",
+        engagementType: "migration",
+      }),
+    ).toBe("migration");
+  });
+
+  it("is generic for a non-migration engagement type", () => {
+    expect(
+      deriveCaseUpdateRequestCategory({
+        caseType: "engagement",
+        engagementType: "onboarding",
+      }),
+    ).toBe("generic");
+  });
+
+  it("is generic for a non-engagement case even when engagementType is somehow set", () => {
+    expect(
+      deriveCaseUpdateRequestCategory({
+        caseType: "case",
+        engagementType: "Migration",
+      }),
+    ).toBe("generic");
+  });
+
+  it("is generic when caseType/engagementType are both absent", () => {
+    expect(deriveCaseUpdateRequestCategory({})).toBe("generic");
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/caseUpdateRequests.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/caseUpdateRequests.ts
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { BeCaseUpdateRequestStage } from "@api/backend/types";
+import type { CsmCaseDetail } from "@features/csm-cases/types/csmCases";
+
+/** The two fixed reminder-message sets `case-update-request-templates` returns. */
+export type CaseUpdateRequestCategory = "generic" | "migration";
+
+/**
+ * States in which "Request update" is offered — the case must actually be
+ * waiting on the customer for the nudge to make sense. Mirrors the backend's
+ * own gate in `RequestCaseUpdate` (`ErrMsgRequestUpdateNotAllowed` on any
+ * other state), so the FE never offers an action the backend would 409 on.
+ */
+export function canRequestCaseUpdate(caseDetail: CsmCaseDetail): boolean {
+  return (
+    caseDetail.state === "awaiting_info" ||
+    caseDetail.state === "solution_proposed"
+  );
+}
+
+/**
+ * Which fixed reminder-message set applies to this case. Replicates the
+ * backend's own derivation in `RequestCaseUpdate` exactly — case-insensitive,
+ * because `engagementType` is carried through unmodified from the data
+ * source's raw display label (e.g. literally "Migration") rather than
+ * normalized before it reaches either layer — so the dialog's preview always
+ * matches what the backend will actually post.
+ */
+export function deriveCaseUpdateRequestCategory(
+  caseDetail: Pick<CsmCaseDetail, "caseType" | "engagementType">,
+): CaseUpdateRequestCategory {
+  return caseDetail.caseType === "engagement" &&
+    !!caseDetail.engagementType &&
+    caseDetail.engagementType.toLowerCase() === "migration"
+    ? "migration"
+    : "generic";
+}
+
+/** Display labels for the fixed reminder stages, in menu/selector order. */
+export const REQUEST_UPDATE_STAGE_LABEL: Record<
+  Exclude<BeCaseUpdateRequestStage, "custom">,
+  string
+> = {
+  first: "First reminder",
+  second: "Second reminder",
+  final: "Final notice",
+};

--- a/apps/csm-portal/webapp/src/features/help/content/support.md
+++ b/apps/csm-portal/webapp/src/features/help/content/support.md
@@ -81,6 +81,12 @@ Comments in the timeline are color/role-tagged (Customer, WSO2, System, AI Agent
 scan who said what at a glance, and each has a permalink (click the timestamp) for referencing
 a specific comment.
 
+**Request update…**, in the case's **More** menu, posts a customer-visible comment nudging the
+customer for a response — pick a first, second, or final reminder (each shown as a read-only
+preview of the exact wording that will be posted) or write a custom message instead. It's only
+offered while the case is **Awaiting info** or has a **Solution proposed**, since those are the
+states where a reply from the customer is actually expected.
+
 ## Attachments
 
 Click an image or PDF attachment to preview it: images open inline in a dialog; PDFs open in a


### PR DESCRIPTION
## Purpose
CS engineers currently have no built-in action to nudge a customer for a response while a case sits in Awaiting info or Solution proposed state — the only options are an ad hoc email or a generic comment. This PR adds a dedicated "Request update" action for that.

## Goals
- A backend action, gated to the two applicable case states, that posts a customer-visible nudge comment using a fixed reminder template or a custom message.
- Two reminder-template categories (generic and migration-engagement), matched automatically to the case rather than left to the engineer to pick.
- A case-detail action bar entry point with a preview of the exact wording before it's sent.

## Approach
Backend (`apps/csm-portal/backend`):
- `POST /cases/{id}/request-update` — body `{stage: "first"|"second"|"final"|"custom", customContent?}`. Validates the case is in `awaiting_info` or `solution_proposed`, that the caller is the case's assigned engineer (same ownership rule as the existing comment endpoint), resolves the template category from the case's own type, and posts through the existing comment-creation path so the current customer-notification pipeline is unchanged.
- `GET /case-update-request-templates` — static, returns both template categories so the frontend can preview the exact wording before sending.
- No entity-service change: built entirely on the existing `GetCase`/`CreateCaseComment` client methods.

Frontend (`apps/csm-portal/webapp`):
- A "Request update…" item in the case detail action bar's More menu (`CaseActionBar.tsx`), enabled only in the two applicable states, disabled with an explanatory tooltip otherwise.
- A dedicated dialog (`RequestUpdateDialog.tsx`) showing a read-only, sanitized preview of the applicable template (category derived client-side the same way the backend derives it) for the three fixed stages, or a plain-text field for a custom message.
- Updated the in-app help guide's case-actions topic.

Kept in **draft** for a final look before marking ready.

## User stories
As a CS engineer, when a case is Awaiting info or has a proposed solution, I want to nudge the customer for a response using a standard or custom message, so the case doesn't stall silently.

## Release note
Added a "Request update" action for cases in Awaiting info or Solution proposed state, letting a CS engineer send a customer-visible reminder using a fixed template or a custom message.

## Documentation
N/A — no external product documentation for this contract yet; the CSM portal in-app help topic (`features/help/content/support.md`) was updated as part of this PR.

## Training
N/A — no training content impact.

## Certification
N/A — no certification exam impact.

## Marketing
N/A — internal CS-tooling feature, no marketing content.

## Automation tests
- Unit tests
  Backend: 20+ new subtests in `internal/handler/case_update_requests_test.go` covering auth, body validation, the state gate, the ownership check, category selection (generic/migration), custom-message handling, and upstream error mapping. `go test -race ./internal/handler/...` passes clean.
  Frontend: `RequestUpdateDialog.test.tsx` (10 tests), `caseUpdateRequests.test.ts` (11 tests), plus updated `CaseActionBar.test.tsx` and `CsmCaseDetailPage.test.tsx`. Full `csm-cases` suite: 51 files / 549 tests passing. Full webapp suite: 205 files / 2077 tests passing. `tsc -b` and `eslint` both clean (2 pre-existing, unrelated warnings).
- Integration tests
  None — no live-service test harness for this app; all tests run against mocked upstream/API clients.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A for Go/TS — ran `gosec -fmt=text ./...` and `govulncheck ./...` on the backend (both clean when scoped to the changed packages; pre-existing findings elsewhere are untouched and already annotated) and `eslint`/`tsc` on the frontend
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
None

## Migrations (if applicable)
N/A — no schema change; this data source is ServiceNow, no local database involved in this code path.

## Test environment
Go 1.26 / Node with pnpm, local `go test`/`gosec`/`govulncheck` and `pnpm vitest`/`tsc`/`eslint` runs. No live ServiceNow calls made anywhere — all tests run against mocked clients.

## Learning
Ported the reminder-template concept from ServiceNow's own equivalent (a `sys_ui_action` "Add Comment Options" dialog gated to the same two case states), generalizing its migration-only 3-stage template ladder to a proper category split available for both generic and migration cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Request update…** action for assigned engineers handling cases in **Awaiting info** or **Solution proposed** states.
  * Supports first, second, and final reminder templates, plus custom messages with previews.
  * Posts customer-visible update requests and provides success or error feedback.
  * Added category-specific templates for generic and migration cases.
* **Documentation**
  * Documented the case update request workflow, message options, and availability restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->