### PR TITLE
[CSM Portal] require engagement payment type on case-type transfer to engagement

### DIFF
--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -663,6 +663,7 @@ interface BeCaseUpdateNever {
   severity?: never;
   type?: never;
   engagementType?: never;
+  engagementPaymentType?: never;
   workState?: never;
   assigneeEmail?: never;
   watchList?: never;
@@ -684,8 +685,8 @@ interface BeCaseUpdateNever {
 
 /**
  * Request body for `PATCH /cases/{id}` (mirrors the entity `UpdateCaseRequest`).
- * **Exactly one** of `state` / `severity` / `type` (+ `engagementType` when
- * `type` is `"engagement"`) / `workState` / `assigneeEmail` / `watchList` /
+ * **Exactly one** of `state` / `severity` / `type` (+ `engagementType` and
+ * `engagementPaymentType` when `type` is `"engagement"`) / `workState` / `assigneeEmail` / `watchList` /
  * `parentId` / `subject` / `description` / `deploymentId` /
  * `deployedProductId` / `relatedCaseId` / `autocloseHoldUntil` / the combined
  * fix-ETA variant (below) is sent per call — the backend rejects zero or more
@@ -719,14 +720,16 @@ export type BeCaseUpdatePayload =
       severity: BeCaseSeverity;
       issueType: BeCaseIssueType;
     })
-  /** Case type transfer into `engagement` — `engagementType` is required
-   * alongside `type` in the same call, mirroring the create payload's own
-   * requirement for this type (same `BeEngagementType` string enum as
-   * {@link BeEngagementCreatePayload}, not a raw ServiceNow choice-list
-   * integer — that translation is a backend concern). */
-  | (Omit<BeCaseUpdateNever, "type" | "engagementType"> & {
+  /** Case type transfer into `engagement` — `engagementType` and
+   * `engagementPaymentType` are both required alongside `type` in the same
+   * call, mirroring the create payload's own requirement for this type (same
+   * `BeEngagementType` / `BeEngagementPaymentType` string enums as
+   * {@link BeEngagementCreatePayload}, not raw ServiceNow choice-list
+   * integers — that translation is a backend concern). */
+  | (Omit<BeCaseUpdateNever, "type" | "engagementType" | "engagementPaymentType"> & {
       type: "engagement";
       engagementType: BeEngagementType;
+      engagementPaymentType: BeEngagementPaymentType;
     })
   /** Case type transfer into `service_request` — the target catalog item and a
    * non-empty set of answers to its questions are required in the same call.

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/ChangeCaseTypeDialog.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/ChangeCaseTypeDialog.test.tsx
@@ -219,6 +219,8 @@ describe("ChangeCaseTypeDialog — step 2: retained attributes carry over disabl
     expect(screen.queryByRole("combobox", { name: /^severity$/i })).not.toBeInTheDocument();
     fireEvent.mouseDown(screen.getByRole("combobox", { name: /engagement type/i }));
     fireEvent.click(screen.getByRole("option", { name: /consultancy/i }));
+    fireEvent.mouseDown(screen.getByRole("combobox", { name: /engagement payment type/i }));
+    fireEvent.click(screen.getByRole("option", { name: /^foc$/i }));
     advanceToReview();
     expect(screen.getByText(/no longer applies/i)).toBeInTheDocument();
     expect(screen.getByText("Severity")).toBeInTheDocument();
@@ -255,6 +257,8 @@ describe("ChangeCaseTypeDialog — step 2 -> 3: transfer into engagement", () =>
     pickTargetAndAdvanceToFields(/^engagement$/i);
     fireEvent.mouseDown(screen.getByRole("combobox", { name: /engagement type/i }));
     fireEvent.click(screen.getByRole("option", { name: /consultancy/i }));
+    fireEvent.mouseDown(screen.getByRole("combobox", { name: /engagement payment type/i }));
+    fireEvent.click(screen.getByRole("option", { name: /^foc$/i }));
     advanceToReview();
     expect(screen.getByText(/step 3 of 3/i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /transfer to engagement/i })).toBeEnabled();
@@ -273,7 +277,7 @@ describe("ChangeCaseTypeDialog — step 2 -> 3: transfer into engagement", () =>
     );
     pickTargetAndAdvanceToFields(/^engagement$/i);
     expect(screen.getByRole("button", { name: /^next$/i })).toBeDisabled();
-    expect(screen.getByText(/required to continue/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/required to continue/i).length).toBeGreaterThan(0);
   });
 
   it("submits type and engagementType together", () => {
@@ -291,13 +295,34 @@ describe("ChangeCaseTypeDialog — step 2 -> 3: transfer into engagement", () =>
     pickTargetAndAdvanceToFields(/^engagement$/i);
     fireEvent.mouseDown(screen.getByRole("combobox", { name: /engagement type/i }));
     fireEvent.click(screen.getByRole("option", { name: /migration/i }));
+    fireEvent.mouseDown(screen.getByRole("combobox", { name: /engagement payment type/i }));
+    fireEvent.click(screen.getByRole("option", { name: /^paid$/i }));
     advanceToReview();
     fireEvent.click(screen.getByRole("button", { name: /transfer to engagement/i }));
 
     expect(onSubmit).toHaveBeenCalledWith({
       targetType: "engagement",
       engagementType: "migration",
+      engagementPaymentType: "paid",
     });
+  });
+
+  it("blocks confirm until engagement payment type is also picked", () => {
+    render(
+      <ChangeCaseTypeDialog
+        currentType="case"
+        currentSeverity="S2"
+        hasAttachments
+        isSubmitting={false}
+        onClose={() => {}}
+        onSubmit={() => {}}
+      />,
+    );
+    pickTargetAndAdvanceToFields(/^engagement$/i);
+    fireEvent.mouseDown(screen.getByRole("combobox", { name: /engagement type/i }));
+    fireEvent.click(screen.getByRole("option", { name: /migration/i }));
+    expect(screen.getByRole("button", { name: /^next$/i })).toBeDisabled();
+    expect(screen.getAllByText(/required to continue/i).length).toBeGreaterThan(0);
   });
 
   it("lists the source type's lost fields on the review step", () => {
@@ -314,6 +339,8 @@ describe("ChangeCaseTypeDialog — step 2 -> 3: transfer into engagement", () =>
     pickTargetAndAdvanceToFields(/^engagement$/i);
     fireEvent.mouseDown(screen.getByRole("combobox", { name: /engagement type/i }));
     fireEvent.click(screen.getByRole("option", { name: /migration/i }));
+    fireEvent.mouseDown(screen.getByRole("combobox", { name: /engagement payment type/i }));
+    fireEvent.click(screen.getByRole("option", { name: /^paid$/i }));
     advanceToReview();
     expect(screen.getByText(/no longer applies/i)).toBeInTheDocument();
     expect(screen.getByText("Severity")).toBeInTheDocument();
@@ -351,6 +378,8 @@ describe("ChangeCaseTypeDialog — step 2 -> 3: transfer into engagement", () =>
     pickTargetAndAdvanceToFields(/^engagement$/i);
     fireEvent.mouseDown(screen.getByRole("combobox", { name: /engagement type/i }));
     fireEvent.click(screen.getByRole("option", { name: /migration/i }));
+    fireEvent.mouseDown(screen.getByRole("combobox", { name: /engagement payment type/i }));
+    fireEvent.click(screen.getByRole("option", { name: /^paid$/i }));
     advanceToReview();
     fireEvent.click(screen.getByRole("button", { name: /^back$/i }));
     expect(screen.getByText(/step 2 of 3/i)).toBeInTheDocument();

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/ChangeCaseTypeDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/ChangeCaseTypeDialog.tsx
@@ -35,7 +35,12 @@ import {
 } from "@wso2/oxygen-ui";
 import { Check, Upload } from "@wso2/oxygen-ui-icons-react";
 import { useMemo, useRef, useState, type ChangeEvent, type JSX } from "react";
-import type { BeCaseIssueType, BeCaseType, BeEngagementType } from "@api/backend/types";
+import type {
+  BeCaseIssueType,
+  BeCaseType,
+  BeEngagementPaymentType,
+  BeEngagementType,
+} from "@api/backend/types";
 import type { Severity, SeverityOrUnset } from "@features/csm-dashboard/types/abtDashboard";
 import { SEVERITY_LABEL } from "@features/csm-dashboard/utils/abtDashboard";
 import { useSearchCatalogs } from "@features/csm-operations/api/useSearchCatalogs";
@@ -74,6 +79,11 @@ const ENGAGEMENT_TYPES: { value: BeEngagementType; label: string }[] = [
   { value: "onboarding", label: "Onboarding" },
 ];
 
+const ENGAGEMENT_PAYMENT_TYPES: { value: BeEngagementPaymentType; label: string }[] = [
+  { value: "paid", label: "Paid" },
+  { value: "foc", label: "FOC" },
+];
+
 type Step = "pick" | "fields" | "review";
 const STEP_NUMBER: Record<Step, number> = { pick: 1, fields: 2, review: 3 };
 
@@ -81,7 +91,11 @@ const STEP_NUMBER: Record<Step, number> = { pick: 1, fields: 2, review: 3 };
  * each target's mandatory companions are compiler-enforced rather than relying on
  * runtime guards. Mirrors the backend's own per-target requirements. */
 export type CaseTypeTransferSubmission =
-  | { targetType: "engagement"; engagementType: BeEngagementType }
+  | {
+      targetType: "engagement";
+      engagementType: BeEngagementType;
+      engagementPaymentType: BeEngagementPaymentType;
+    }
   | {
       targetType: "case";
       /** Both are mandatory for this target: the backend selects the concrete case
@@ -163,6 +177,9 @@ export default function ChangeCaseTypeDialog({
     TRANSFERABLE_CASE_TYPES.find((t) => t !== currentType) ?? TRANSFERABLE_CASE_TYPES[0],
   );
   const [engagementType, setEngagementType] = useState<BeEngagementType | "">("");
+  const [engagementPaymentType, setEngagementPaymentType] = useState<
+    BeEngagementPaymentType | ""
+  >("");
   const [severity, setSeverity] = useState<Severity | "">(
     currentSeverity === "unset" ? "" : currentSeverity,
   );
@@ -175,6 +192,8 @@ export default function ChangeCaseTypeDialog({
   const preview = computeTransferPreview(currentType, targetType, hasAttachments);
   const isSupportedTarget = SUPPORTED_TRANSFER_TARGETS.includes(targetType);
   const engagementTypeMissing = targetType === "engagement" && engagementType === "";
+  const engagementPaymentTypeMissing =
+    targetType === "engagement" && engagementPaymentType === "";
   // severity and issueType are both required by the backend for a transfer to `case`;
   // submitting without them is a guaranteed 400, so gate the button instead.
   const severityMissing = targetType === "case" && severity === "";
@@ -206,7 +225,7 @@ export default function ChangeCaseTypeDialog({
 
   const fieldsStepValid =
     targetType === "engagement"
-      ? !engagementTypeMissing
+      ? !engagementTypeMissing && !engagementPaymentTypeMissing
       : targetType === "security_report_analysis"
         ? hasAttachments
         : targetType === "service_request"
@@ -219,6 +238,7 @@ export default function ChangeCaseTypeDialog({
   const canSubmit =
     isSupportedTarget &&
     !engagementTypeMissing &&
+    !engagementPaymentTypeMissing &&
     !caseFieldsMissing &&
     fieldsStepValid &&
     !isSubmitting;
@@ -226,6 +246,7 @@ export default function ChangeCaseTypeDialog({
   const handleTargetChange = (next: BeCaseType): void => {
     setTargetType(next);
     setEngagementType("");
+    setEngagementPaymentType("");
     setCatalogId("");
     setCatalogItemId("");
     setAnswers({});
@@ -242,7 +263,11 @@ export default function ChangeCaseTypeDialog({
   const handleConfirm = (): void => {
     if (!canSubmit) return;
     if (targetType === "engagement") {
-      onSubmit({ targetType: "engagement", engagementType: engagementType as BeEngagementType });
+      onSubmit({
+        targetType: "engagement",
+        engagementType: engagementType as BeEngagementType,
+        engagementPaymentType: engagementPaymentType as BeEngagementPaymentType,
+      });
     } else if (targetType === "security_report_analysis") {
       onSubmit({ targetType: "security_report_analysis" });
     } else if (targetType === "service_request") {
@@ -436,6 +461,32 @@ export default function ChangeCaseTypeDialog({
                   ))}
                 </Select>
                 {engagementTypeMissing && (
+                  <FormHelperText error>Required to continue.</FormHelperText>
+                )}
+              </FormControl>
+            )}
+
+            {targetType === "engagement" && (
+              <FormControl fullWidth size="small" required error={engagementPaymentTypeMissing}>
+                <InputLabel id="transfer-engagement-payment-type-label">
+                  Engagement payment type
+                </InputLabel>
+                <Select
+                  labelId="transfer-engagement-payment-type-label"
+                  label="Engagement payment type"
+                  value={engagementPaymentType}
+                  onChange={(e) =>
+                    setEngagementPaymentType(e.target.value as BeEngagementPaymentType)
+                  }
+                  disabled={isSubmitting}
+                >
+                  {ENGAGEMENT_PAYMENT_TYPES.map((ept) => (
+                    <MenuItem key={ept.value} value={ept.value}>
+                      {ept.label}
+                    </MenuItem>
+                  ))}
+                </Select>
+                {engagementPaymentTypeMissing && (
                   <FormHelperText error>Required to continue.</FormHelperText>
                 )}
               </FormControl>

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.test.tsx
@@ -309,14 +309,20 @@ vi.mock("@features/csm-cases/components/ChangeCaseTypeDialog", () => ({
   }: {
     onSubmit: (
       submission:
-        | { targetType: "engagement"; engagementType: string }
+        | { targetType: "engagement"; engagementType: string; engagementPaymentType: string }
         | { targetType: "case"; severity: string; issueType: string },
     ) => void;
   }) => (
     <>
       <button
         type="button"
-        onClick={() => onSubmit({ targetType: "engagement", engagementType: "migration" })}
+        onClick={() =>
+          onSubmit({
+            targetType: "engagement",
+            engagementType: "migration",
+            engagementPaymentType: "paid",
+          })
+        }
       >
         stub transfer to engagement
       </button>
@@ -1151,13 +1157,13 @@ describe("CsmCaseDetailPage — Watchers tab", () => {
 });
 
 describe("CsmCaseDetailPage — change case type", () => {
-  it("PATCHes type and engagementType together for an engagement transfer", () => {
+  it("PATCHes type, engagementType, and engagementPaymentType together for an engagement transfer", () => {
     renderPage();
     fireEvent.click(screen.getByRole("button", { name: /stub open change case type/i }));
     fireEvent.click(screen.getByRole("button", { name: /stub transfer to engagement/i }));
 
     expect(patchCaseMutateMock).toHaveBeenCalledWith(
-      { type: "engagement", engagementType: "migration" },
+      { type: "engagement", engagementType: "migration", engagementPaymentType: "paid" },
       expect.anything(),
     );
   });

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -1326,8 +1326,9 @@ export default function CsmCaseDetailPage(): JSX.Element {
   );
 
   // Changes the case's type. The type change itself is one
-  // PATCH ({type} alone, or {type, engagementType} together for a transfer
-  // into engagement — the backend requires them combined there). Severity is
+  // PATCH ({type} alone, or {type, engagementType, engagementPaymentType}
+  // together for a transfer into engagement — the backend requires them
+  // combined there). Severity is
   // a separate, optional follow-up PATCH when transferring into `case`: it's
   // a data-completeness extra, not required to complete the transfer (see
   // caseTypeTransfer.ts), so its failure is reported but doesn't roll back
@@ -1342,7 +1343,11 @@ export default function CsmCaseDetailPage(): JSX.Element {
       // standalone severity patch is rejected outright on a case of any other type.
       patchCase.mutate(
         submission.targetType === "engagement"
-          ? { type: "engagement", engagementType: submission.engagementType }
+          ? {
+              type: "engagement",
+              engagementType: submission.engagementType,
+              engagementPaymentType: submission.engagementPaymentType,
+            }
           : submission.targetType === "security_report_analysis"
             ? { type: "security_report_analysis" }
             : submission.targetType === "service_request"

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -1647,13 +1647,14 @@ type UpdateCaseRequest struct {
 	// Type transfers the case to another type. One of
 	// "case" / "engagement" / "security_report_analysis" / "service_request" —
 	// "announcement" and the hosting_* types are system-managed and are never
-	// transfer targets. EngagementType is required alongside Type when
-	// transferring into "engagement"; CatalogID/CatalogItemID (and optionally
-	// Variables) are required alongside Type when transferring into
+	// transfer targets. EngagementType and EngagementPaymentType are both required
+	// alongside Type when transferring into "engagement"; CatalogID/CatalogItemID
+	// (and optionally Variables) are required alongside Type when transferring into
 	// "service_request". Neither combination is meaningful for any other Type
 	// value and both are rejected if supplied otherwise.
-	Type           *string         `json:"type"`
-	EngagementType *EngagementType `json:"engagementType"`
+	Type                  *string                `json:"type"`
+	EngagementType        *EngagementType        `json:"engagementType"`
+	EngagementPaymentType *EngagementPaymentType `json:"engagementPaymentType"`
 	// IssueType classifies the case when transferring to type "case". Required in that
 	// transfer and rejected for every other target type: the backing data source stores
 	// issue type only on Incident/Query records.

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -1224,16 +1224,17 @@ type snUpdateCasePayload struct {
 	WorkStateKey *int `json:"workStateKey,omitempty"`
 	// Type transfers the case to another type --
 	// same string values as the create payload's own Type field (see
-	// snCaseTypeMap). EngagementType (int key, only meaningful with
-	// Type "engagement") and CatalogID/CatalogItemID/Variables (only
-	// meaningful with Type "service_request") are its companions, mirroring
+	// snCaseTypeMap). EngagementType/EngagementPaymentType (int keys, only
+	// meaningful with Type "engagement") and CatalogID/CatalogItemID/Variables
+	// (only meaningful with Type "service_request") are its companions, mirroring
 	// snCreateCasePayload's own field set for those two type-specific shapes.
-	Type           *string          `json:"type,omitempty"`
-	EngagementType *int             `json:"engagementType,omitempty"`
-	IssueTypeKey   *int             `json:"issueTypeKey,omitempty"`
-	CatalogID      *string          `json:"catalogId,omitempty"`
-	CatalogItemID  *string          `json:"catalogItemId,omitempty"`
-	Variables      []snCaseVariable `json:"variables,omitempty"`
+	Type                  *string          `json:"type,omitempty"`
+	EngagementType        *int             `json:"engagementType,omitempty"`
+	EngagementPaymentType *int             `json:"engagementPaymentType,omitempty"`
+	IssueTypeKey          *int             `json:"issueTypeKey,omitempty"`
+	CatalogID             *string          `json:"catalogId,omitempty"`
+	CatalogItemID         *string          `json:"catalogItemId,omitempty"`
+	Variables             []snCaseVariable `json:"variables,omitempty"`
 	// WatchList replaces the whole list, so an explicitly empty list must still be
 	// sent to clear it rather than be omitted -- hence the pointer.
 	WatchList     *[]string `json:"watchList,omitempty"`
@@ -1521,8 +1522,8 @@ func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReq
 	if hasResolutionFields && req.State == nil {
 		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "resolutionCode, cause, and closeNotes are only allowed when state is also provided"}
 	}
-	if req.Type == nil && (req.EngagementType != nil || req.CatalogID != nil || req.CatalogItemID != nil || len(req.Variables) > 0 || req.IssueType != nil) {
-		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "engagementType, issueType, catalogId, catalogItemId, and variables are only allowed when type is also provided"}
+	if req.Type == nil && (req.EngagementType != nil || req.EngagementPaymentType != nil || req.CatalogID != nil || req.CatalogItemID != nil || len(req.Variables) > 0 || req.IssueType != nil) {
+		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "engagementType, engagementPaymentType, issueType, catalogId, catalogItemId, and variables are only allowed when type is also provided"}
 	}
 	if req.AddPublicComment == nil && (req.Product != nil || req.PublicTicket != nil) {
 		return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "product and publicTicket are only allowed when addPublicComment is also provided"}
@@ -1584,6 +1585,9 @@ func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReq
 			if req.EngagementType == nil {
 				return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "engagementType is required when type is \"engagement\""}
 			}
+			if req.EngagementPaymentType == nil {
+				return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "engagementPaymentType is required when type is \"engagement\""}
+			}
 			if req.CatalogID != nil || req.CatalogItemID != nil || len(req.Variables) > 0 {
 				return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "catalogId, catalogItemId, and variables are only accepted when type is \"service_request\""}
 			}
@@ -1596,8 +1600,13 @@ func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReq
 			if !validEngagementType[*req.EngagementType] {
 				return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "engagementType contains invalid value: " + string(*req.EngagementType)}
 			}
+			if !validEngagementPaymentType[*req.EngagementPaymentType] {
+				return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "engagementPaymentType contains invalid value: " + string(*req.EngagementPaymentType)}
+			}
 			id := snEngagementTypeIDMap[*req.EngagementType]
 			payload.EngagementType = &id
+			paymentID := snEngagementPaymentTypeIDMap[*req.EngagementPaymentType]
+			payload.EngagementPaymentType = &paymentID
 		case "service_request":
 			if req.CatalogID == nil || req.CatalogItemID == nil {
 				return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "catalogId and catalogItemId are required when type is \"service_request\""}
@@ -1608,8 +1617,8 @@ func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReq
 			if len(req.Variables) == 0 {
 				return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "variables must contain at least one entry when type is \"service_request\""}
 			}
-			if req.EngagementType != nil {
-				return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "engagementType is only accepted when type is \"engagement\""}
+			if req.EngagementType != nil || req.EngagementPaymentType != nil {
+				return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "engagementType and engagementPaymentType are only accepted when type is \"engagement\""}
 			}
 			if req.Severity != nil {
 				return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "severity may only accompany type when type is \"case\""}
@@ -1635,8 +1644,8 @@ func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReq
 				payload.Variables = vars
 			}
 		case "case":
-			if req.EngagementType != nil || req.CatalogID != nil || req.CatalogItemID != nil || len(req.Variables) > 0 {
-				return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "engagementType is only accepted when type is \"engagement\"; catalogId, catalogItemId, and variables are only accepted when type is \"service_request\""}
+			if req.EngagementType != nil || req.EngagementPaymentType != nil || req.CatalogID != nil || req.CatalogItemID != nil || len(req.Variables) > 0 {
+				return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "engagementType and engagementPaymentType are only accepted when type is \"engagement\"; catalogId, catalogItemId, and variables are only accepted when type is \"service_request\""}
 			}
 			// Both are mandatory at the backing data source: severity selects Incident vs Query,
 			// and issue type is the classification those records carry.
@@ -1655,8 +1664,8 @@ func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReq
 			}
 			payload.IssueTypeKey = &issueTypeID
 		default:
-			if req.EngagementType != nil || req.CatalogID != nil || req.CatalogItemID != nil || len(req.Variables) > 0 {
-				return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "engagementType is only accepted when type is \"engagement\"; catalogId, catalogItemId, and variables are only accepted when type is \"service_request\""}
+			if req.EngagementType != nil || req.EngagementPaymentType != nil || req.CatalogID != nil || req.CatalogItemID != nil || len(req.Variables) > 0 {
+				return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "engagementType and engagementPaymentType are only accepted when type is \"engagement\"; catalogId, catalogItemId, and variables are only accepted when type is \"service_request\""}
 			}
 			if req.IssueType != nil {
 				return domain.UpdateCaseResponse{}, &apierror.ValidationError{Msg: "issueType is only accepted when type is \"case\""}

--- a/entity-service/internal/service/sn_case_service_test.go
+++ b/entity-service/internal/service/sn_case_service_test.go
@@ -603,6 +603,7 @@ func TestSNCaseService_UpdateCase_NewSingleFieldVariants(t *testing.T) {
 func TestSNCaseService_UpdateCase_TypeTransfer_ValidationErrors(t *testing.T) {
 	strPtr := func(s string) *string { return &s }
 	engagement := domain.EngagementTypeMigration
+	paymentType := domain.EngagementPaymentTypePaid
 	severity := domain.CaseSeverityHigh
 
 	tests := []struct {
@@ -618,12 +619,22 @@ func TestSNCaseService_UpdateCase_TypeTransfer_ValidationErrors(t *testing.T) {
 			req:  domain.UpdateCaseRequest{ID: testDeploymentUUID, Type: strPtr("engagement")},
 		},
 		{
+			name: "engagement without engagementPaymentType",
+			req: domain.UpdateCaseRequest{
+				ID: testDeploymentUUID, Type: strPtr("engagement"), EngagementType: &engagement,
+			},
+		},
+		{
 			name: "service_request without catalogId/catalogItemId",
 			req:  domain.UpdateCaseRequest{ID: testDeploymentUUID, Type: strPtr("service_request")},
 		},
 		{
 			name: "engagementType supplied without type",
 			req:  domain.UpdateCaseRequest{ID: testDeploymentUUID, EngagementType: &engagement},
+		},
+		{
+			name: "engagementPaymentType supplied without type",
+			req:  domain.UpdateCaseRequest{ID: testDeploymentUUID, EngagementPaymentType: &paymentType},
 		},
 		{
 			name: "catalogId supplied without type",
@@ -636,16 +647,30 @@ func TestSNCaseService_UpdateCase_TypeTransfer_ValidationErrors(t *testing.T) {
 			},
 		},
 		{
+			name: "engagementPaymentType supplied with type \"case\"",
+			req: domain.UpdateCaseRequest{
+				ID: testDeploymentUUID, Type: strPtr("case"), EngagementPaymentType: &paymentType,
+			},
+		},
+		{
 			name: "catalogId supplied with type \"engagement\"",
 			req: domain.UpdateCaseRequest{
 				ID: testDeploymentUUID, Type: strPtr("engagement"), EngagementType: &engagement,
-				CatalogID: strPtr(testDeploymentUUID),
+				EngagementPaymentType: &paymentType,
+				CatalogID:             strPtr(testDeploymentUUID),
 			},
 		},
 		{
 			name: "engagementType supplied with type \"service_request\"",
 			req: domain.UpdateCaseRequest{
 				ID: testDeploymentUUID, Type: strPtr("service_request"), EngagementType: &engagement,
+				CatalogID: strPtr(testDeploymentUUID), CatalogItemID: strPtr(testDeploymentUUID),
+			},
+		},
+		{
+			name: "engagementPaymentType supplied with type \"service_request\"",
+			req: domain.UpdateCaseRequest{
+				ID: testDeploymentUUID, Type: strPtr("service_request"), EngagementPaymentType: &paymentType,
 				CatalogID: strPtr(testDeploymentUUID), CatalogItemID: strPtr(testDeploymentUUID),
 			},
 		},
@@ -729,7 +754,7 @@ func TestSNCaseService_UpdateCase_TypeTransfer_Case(t *testing.T) {
 	if _, ok := gotBody["severityKey"]; !ok {
 		t.Fatalf("expected severityKey to be sent alongside type: %+v", gotBody)
 	}
-	for _, field := range []string{"engagementType", "catalogId", "catalogItemId", "variables"} {
+	for _, field := range []string{"engagementType", "engagementPaymentType", "catalogId", "catalogItemId", "variables"} {
 		if _, ok := gotBody[field]; ok {
 			t.Fatalf("unexpected extra field %q present in a type: \"case\" payload: %+v", field, gotBody)
 		}
@@ -799,6 +824,7 @@ func TestSNCaseService_UpdateCase_IssueTypeWithoutTypeRejected(t *testing.T) {
 func TestSNCaseService_UpdateCase_TypeTransfer_Engagement(t *testing.T) {
 	typ := "engagement"
 	engagement := domain.EngagementTypeMigration
+	paymentType := domain.EngagementPaymentTypePaid
 	var gotBody map[string]any
 	client := newTestCaseClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
@@ -813,7 +839,7 @@ func TestSNCaseService_UpdateCase_TypeTransfer_Engagement(t *testing.T) {
 
 	svc := NewServiceNowCaseService(client, nil)
 	_, err := svc.UpdateCase(contextWithUserIDToken("token"), domain.UpdateCaseRequest{
-		ID: testDeploymentUUID, Type: &typ, EngagementType: &engagement,
+		ID: testDeploymentUUID, Type: &typ, EngagementType: &engagement, EngagementPaymentType: &paymentType,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -823,6 +849,9 @@ func TestSNCaseService_UpdateCase_TypeTransfer_Engagement(t *testing.T) {
 	}
 	if got, ok := gotBody["engagementType"]; !ok || !jsonEqual(got, float64(1)) {
 		t.Fatalf("expected engagementType 1 (migration), got %v (body: %+v)", got, gotBody)
+	}
+	if got, ok := gotBody["engagementPaymentType"]; !ok || !jsonEqual(got, float64(1)) {
+		t.Fatalf("expected engagementPaymentType 1 (paid), got %v (body: %+v)", got, gotBody)
 	}
 }
 
@@ -928,6 +957,7 @@ func TestSNCaseService_UpdateCase_TypeTransfer_ServiceRequestRequiresVariables(t
 func TestSNCaseService_UpdateCase_TypeTransfer_SeverityRejectedForOtherTargets(t *testing.T) {
 	sev := domain.CaseSeverityHigh
 	engagement := domain.EngagementTypeMigration
+	paymentType := domain.EngagementPaymentTypePaid
 	catalogUUID := "44444444-4444-4444-4444-444444444444"
 	catalogItemUUID := "55555555-5555-5555-5555-555555555555"
 	variableUUID := "66666666-6666-6666-6666-666666666666"
@@ -944,7 +974,8 @@ func TestSNCaseService_UpdateCase_TypeTransfer_SeverityRejectedForOtherTargets(t
 		{
 			name: "engagement",
 			req: domain.UpdateCaseRequest{
-				ID: testDeploymentUUID, Type: strPtr("engagement"), EngagementType: &engagement, Severity: &sev,
+				ID: testDeploymentUUID, Type: strPtr("engagement"), EngagementType: &engagement,
+				EngagementPaymentType: &paymentType, Severity: &sev,
 			},
 		},
 		{

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -4831,9 +4831,10 @@ components:
         `state` when the state is `closed` or `solution_proposed`.
         `type` transfers the case to another type and is supported only for the ServiceNow
         data source. Its companion fields carry the target type's mandatory data:
-        `severity` and `issueType` alongside `type: case`; `engagementType` alongside
-        `type: engagement`; `catalogId`, `catalogItemId` and a non-empty `variables`
-        alongside `type: service_request`; none for `type: security_report_analysis`.
+        `severity` and `issueType` alongside `type: case`; `engagementType` and
+        `engagementPaymentType` alongside `type: engagement`; `catalogId`, `catalogItemId`
+        and a non-empty `variables` alongside `type: service_request`; none for
+        `type: security_report_analysis`.
         A companion is rejected when sent without `type`, or with a `type` it does not
         belong to. `severity` is the one field that may be combined with `type`.
       oneOf:
@@ -4866,6 +4867,11 @@ components:
           type: string
           enum: [migration, consultancy, new_feature_improvement, follow_up, onboarding]
           description: "Required alongside `type: engagement`."
+        engagementPaymentType:
+          type: string
+          enum: [paid, foc]
+          description: >
+            Required alongside `type: engagement`. `foc` means "free of charge".
         issueType:
           type: string
           enum: [total_outage, partial_outage, performance_degradation, question, security_or_compliance, error]


### PR DESCRIPTION
## Purpose
The case-type-transfer action added the ability to move a case into `engagement`, collecting `engagementType` as the target's mandatory data. It did not yet collect `engagementPaymentType`, so a case transferred into `engagement` this way ends up without that field set on the backing record. This PR adds it, matching how it's already required on engagement *creation*.

## Goals
- On a case-type transfer to `engagement`, require and forward `engagementPaymentType` alongside `engagementType`, mirroring the existing create-time requirement.
- Surface the corresponding field in the CSM webapp's "Change case type" dialog when the target is `engagement`.

## Approach
Backend (`entity-service`):
- `domain.UpdateCaseRequest` gains `EngagementPaymentType`.
- `UpdateCase`'s `"engagement"` branch now requires it (same validation shape as the existing `engagementType` check), forwards it via the existing `snEngagementPaymentTypeIDMap`, and the sibling case/service_request/default branches reject it on the wrong target, symmetric with `engagementType`.
- `openapi.yaml` documents the new field on `UpdateCaseRequest`.

Frontend (`apps/csm-portal/webapp`):
- `ChangeCaseTypeDialog.tsx` gets a second required field, "Engagement payment type", shown only when transferring to `engagement`, mirroring the existing Engagement Type field (hardcoded Paid/FOC options, same as the create-engagement page).
- Threaded through `CsmCaseDetailPage.tsx` into the `PATCH /cases/{id}` body and the `BeCaseUpdatePayload` discriminated union in `src/api/backend/types.ts`.

## User stories
As a CS engineer transferring an existing case into an engagement, I want to be asked for the payment type at transfer time (not left to fix it later), so the transferred record is complete from the start.

## Release note
The "Change case type" dialog now also asks for Engagement payment type when transferring a case to Engagement.

## Documentation
N/A — no external product documentation for this contract yet.

## Training
N/A — internal CS-engineer tooling, no training content impact.

## Certification
N/A — no certification exam impact.

## Marketing
N/A — internal CS-tooling fix, no marketing content.

## Automation tests
- Unit tests
  Backend: extended `sn_case_service_test.go` with new validation subtests (missing/misplaced `engagementPaymentType`) and updated the engagement-transfer fixtures to include it. `go test ./...` passes (all 4 packages).
  Frontend: `ChangeCaseTypeDialog.test.tsx` (21/21 passing, including a new "blocks confirm until payment type is also picked" case) and `CsmCaseDetailPage.test.tsx` (29/29 passing, updated PATCH-body assertion). `tsc -b` and `eslint` both clean (one pre-existing, unrelated warning).
- Integration tests
  Live end-to-end test via CDP against the mode-2 local stack (real ServiceNow DEV + real Asgardeo), driving the actual "Change case type" dialog: (1) confirmed the dialog blocks proceeding with either field empty and only enables once both are filled; (2) transferred a real DEV case to Engagement with Engagement type = Migration, Engagement payment type = Paid — `PATCH` returned 200 and the case detail immediately showed type Engagement; (3) hard-reloaded the case detail page (fresh `GET`, not a cached render) — 200, fully rendered; (4) transferred the same case back to `case` to confirm the new field doesn't leak into other transfer targets — fields step showed only Severity/Issue type as before, `PATCH` returned 200, and the record was restored to its original type.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A for Go/TS — ran `gosec -fmt=text ./...` on the backend (0 issues) and `eslint`/`tsc` on the frontend (clean)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
None

## Migrations (if applicable)
N/A — no schema change; this data source is the platform's existing case-type-transfer contract, no local database involved in this code path.

## Test environment
Go 1.26 / Node with pnpm, local `go build`/`go vet`/`go test`/`gosec` and `pnpm vitest`/`tsc`/`eslint` runs, plus a live end-to-end pass against the local full stack (real backing data source DEV tenant + real IdP).

## Learning
N/A — direct extension of the existing engagement-creation pattern to the type-transfer path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Case transfers to **Engagement** now require selecting an engagement payment type.
  - Added payment options for **Paid** and **FOC**.
  - Transfers now validate and submit both engagement type and payment type together.

- **Bug Fixes**
  - Prevented invalid payment-type combinations for non-Engagement case transfers.
  - Updated case transfer API validation and documentation to reflect the required fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->