### PR TITLE
[CSM Portal] dashboard assignee column, anyOf drill-through fix + entity-service SLA/escalation filters

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetListConfig.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetListConfig.test.tsx
@@ -206,6 +206,34 @@ describe("widgetListConfig — quick-preview icon per resourceType", () => {
     expect(screen.queryByTestId("location-probe")).not.toBeInTheDocument();
   });
 
+  it("case: renders an Assignee column, falling back to Unassigned when no engineer is assigned", () => {
+    const Renderer = WIDGET_LIST_RENDERERS.case;
+    renderRenderer(
+      <Renderer
+        items={[
+          {
+            id: "case-1",
+            caseNumber: "CS0000001",
+            subject: "Cluster degraded",
+            assignedEngineer: { id: "u-1", email: "jane.doe@example.com", name: "Jane Doe" },
+          },
+          {
+            id: "case-2",
+            caseNumber: "CS0000002",
+            subject: "Login failing",
+            assignedEngineer: null,
+          },
+        ]}
+        isLoading={false}
+      />,
+      "/cases/:id",
+    );
+
+    expect(screen.getByText("Assignee")).toBeInTheDocument();
+    expect(screen.getByText("Jane Doe")).toBeInTheDocument();
+    expect(screen.getByText("Unassigned")).toBeInTheDocument();
+  });
+
   it("call_request: renders the preview icon, opens the existing detail modal without navigating the owning case", () => {
     const Renderer = WIDGET_LIST_RENDERERS.call_request;
     renderRenderer(

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetListConfig.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetListConfig.tsx
@@ -143,12 +143,25 @@ const PREVIEW_COLUMN = { label: "Preview", width: "auto" };
 /** Case: reuses `CasesList` (the Cases tab's own table) verbatim, via the
  * same `mapCaseSearchViewToRow` mapper the tab itself uses — real reuse, not
  * a lookalike. `currentUserEmail` is omitted (only affects the "assigned to
- * me" highlight, not relevant to a dashboard preview). */
+ * me" highlight, not relevant to a dashboard preview). `optionalColumns` adds
+ * Assignee to this widget's default set (`CasesList`'s own long-standing
+ * default of product/type/severity omits it) -- a dashboard reviewer scanning
+ * a list of cases needs to see who owns each one without opening it. This
+ * renderer is shared by every `resourceType` whose rows are case rows
+ * (`service_request`/`security_report_analysis`/`announcement`/`engagement`
+ * — see `WIDGET_LIST_RENDERERS` below), so they all get the same column. */
 function CaseWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.Element {
   const cases = items.map((item) =>
     mapCaseSearchViewToRow(item as unknown as BeCaseSearchView, undefined),
   );
-  return <CasesList cases={cases} isLoading={isLoading} skeletonCount={4} />;
+  return (
+    <CasesList
+      cases={cases}
+      isLoading={isLoading}
+      skeletonCount={4}
+      optionalColumns={["product", "type", "severity", "assignee"]}
+    />
+  );
 }
 
 /** Time card: reuses `TimeCardsTable` verbatim via the tab's own `mapTimeCard`

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.test.ts
@@ -410,6 +410,58 @@ describe("WIDGET_RESOURCE_CONFIG — case-table resourceTypes beyond `case`", ()
     expect(params.get("n")).toBe("My Incident Tasks");
   });
 
+  // Regression (digiops-cs#2880): a widget's `anyOf` cross-field OR branches
+  // have no representation in `CasesFilters` (an AND-only model), so
+  // `translateCaseDashboardFilters` used to silently drop them -- a tile
+  // reading a count restricted by `anyOf` landed its "View all" click on a
+  // broader, unfiltered-by-`anyOf` cases list than what it actually counted.
+  // Each case-family type must route to the widget preview page instead
+  // (mirroring `incident_task` above) whenever `anyOf` is present, carrying
+  // the widget context and round-tripping the OR branches through the URL
+  // rather than dropping them.
+  describe("anyOf routes to the widget preview page instead of a lossy CasesFilters translation", () => {
+    const anyOfFilters = {
+      filters: [{ field: "state", op: "in", values: ["open"] }],
+      anyOf: [
+        { filters: [{ field: "severity", op: "in", values: ["catastrophic", "critical"] }] },
+        { filters: [{ field: "type", op: "in", values: ["security_report_analysis"] }] },
+      ],
+    };
+    const ctx = { widgetId: "widget-99", displayName: "WOW P0/P1" };
+
+    it("case", () => {
+      const href = WIDGET_RESOURCE_CONFIG.case.buildHref(anyOfFilters, ctx);
+      expect(href.startsWith("/dashboard/preview/cases?")).toBe(true);
+      const params = hrefParams(href);
+      expect(params.get("w")).toBe("widget-99");
+      expect(params.get("n")).toBe("WOW P0/P1");
+      expect(params.has("_anyOf")).toBe(true);
+    });
+
+    it("service_request", () => {
+      const href = WIDGET_RESOURCE_CONFIG.service_request.buildHref(anyOfFilters, ctx);
+      expect(href.startsWith("/dashboard/preview/service-requests?")).toBe(true);
+    });
+
+    it("security_report_analysis", () => {
+      const href = WIDGET_RESOURCE_CONFIG.security_report_analysis.buildHref(anyOfFilters, ctx);
+      expect(href.startsWith("/dashboard/preview/security-reports?")).toBe(true);
+    });
+
+    it("engagement", () => {
+      const href = WIDGET_RESOURCE_CONFIG.engagement.buildHref(anyOfFilters, ctx);
+      expect(href.startsWith("/dashboard/preview/engagements?")).toBe(true);
+    });
+
+    it("a case-family widget with no anyOf still lands on its own list page, unaffected", () => {
+      const href = WIDGET_RESOURCE_CONFIG.case.buildHref(
+        { filters: [{ field: "state", op: "in", values: ["open"] }] },
+        ctx,
+      );
+      expect(href.startsWith("/cases?")).toBe(true);
+    });
+  });
+
   it("each of the four has its own distinct icon from `case` and from each other", () => {
     const icons = [
       WIDGET_RESOURCE_CONFIG.case.icon,

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.ts
@@ -608,11 +608,14 @@ export const WIDGET_RESOURCE_CONFIG: Record<
     secondaryLabel: stateSecondaryLabel,
     // CsmAnnouncementsPage keeps its own filters in local component state,
     // not the URL (unlike /cases, /operations, /engagements) — there is no
-    // query-param scheme to land a filtered click-through on yet, so this
-    // stays unfiltered, same as `problem` above (including any `anyOf` a
-    // widget sets — no `caseFamilyBuildHref` wrapper here, since there's no
-    // filtered destination for it to fall back to in the first place).
-    buildHref: () => "/announcements",
+    // query-param scheme to land a filtered click-through on for the plain
+    // case, so the fallback stays the unfiltered list, same as `problem`
+    // above. An `anyOf` filter still routes through `caseFamilyBuildHref` to
+    // the generic dashboard-widget preview page, though: that page resolves
+    // `resourceType` from `previewSlug` generically and posts raw filters
+    // straight to the search endpoint, so it needs no announcement-specific
+    // filtered route of its own to render this widget's exact result set.
+    buildHref: (filters, ctx) => caseFamilyBuildHref("announcements", filters, ctx, () => "/announcements"),
     icon: Megaphone,
     iconColor: "success",
     previewSlug: "announcements",

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.ts
@@ -57,7 +57,10 @@ import {
 import { writeChangeRequestFiltersToUrl } from "@features/csm-operations/utils/changeRequestsFiltersUrl";
 import { taskStateLabel } from "@features/csm-cases/utils/taskState";
 import type { BeTaskState } from "@api/backend/types";
-import { buildWidgetPreviewHref } from "@features/csm-dashboard/utils/widgetPreviewUrl";
+import {
+  buildWidgetPreviewHref,
+  isAnyOfBranchArray,
+} from "@features/csm-dashboard/utils/widgetPreviewUrl";
 
 /** A resolved search-result row, typed loosely since its real shape depends
  * on `resourceType` — the label extractors below narrow what they read. */
@@ -200,10 +203,17 @@ function caseFilterEntry(
  * `projectType`, and the `createdOn`/`updatedOn`/`closedOn` date ranges,
  * which was the root cause of the click-through data-loss bug this function
  * exists to fix (a tile reading a filtered count landed on the org-wide
- * cases list because its filters had nowhere to go). Only `anyOf`,
- * `parentId`, and `resolutionNotes` remain genuinely dropped: no dashboard
- * widget uses them today, and `CasesFilters` has no equivalent to invent one
- * for without guessing at a UI treatment.
+ * cases list because its filters had nowhere to go). `parentId` and
+ * `resolutionNotes` remain genuinely dropped: no dashboard widget uses them
+ * today, and `CasesFilters` has no equivalent to invent one for without
+ * guessing at a UI treatment. `anyOf` (cross-field OR) is dropped here too —
+ * `CasesFilters` is an AND-only model with nothing to translate it into — but
+ * a widget carrying `anyOf` never reaches this function's output at all (see
+ * `caseFamilyBuildHref` below, and `DashboardWidgetPreviewPage.tsx`'s own
+ * `anyOf` routing check): its click-through routes to the generic,
+ * filter-faithful dashboard-widget preview page instead, the same fallback
+ * `incident_task` uses for a resourceType with no representable destination
+ * in its own list page.
  *
  * `assignedUserId` carries the current user's own UUID (every widget that
  * sets it does so via the current-user placeholder), and
@@ -423,6 +433,36 @@ function caseTypeListHref(basePath: string, filters: Record<string, unknown>): s
   return qs ? `${basePath}?${qs}` : basePath;
 }
 
+/**
+ * Shared `buildHref` wrapper for every case-family resourceType (`case`,
+ * `service_request`, `security_report_analysis`, `engagement` —
+ * `announcement` is excluded, see its own `buildHref` comment): a widget's
+ * `anyOf` cross-field-OR branches have no representation in `CasesFilters`
+ * (an AND-only model), so `fallback()` — which goes through
+ * `translateCaseDashboardFilters` one way or another — would silently drop
+ * them and land on a broader, unfiltered-by-`anyOf` list than what the tile
+ * actually counted (the bug this wrapper exists to close). Route through the
+ * generic, filter-faithful dashboard-widget preview page instead whenever
+ * `anyOf` is present, exactly mirroring `incident_task`'s own fallback for a
+ * resourceType with no representable destination of its own.
+ */
+function caseFamilyBuildHref(
+  previewSlug: string,
+  filters: Record<string, unknown>,
+  ctx: { widgetId: string; displayName: string } | undefined,
+  fallback: () => string,
+): string {
+  if (isAnyOfBranchArray(filters.anyOf)) {
+    return buildWidgetPreviewHref({
+      previewSlug,
+      widgetId: ctx?.widgetId ?? "",
+      displayName: ctx?.displayName ?? "",
+      filters,
+    });
+  }
+  return fallback();
+}
+
 /** Dashboard incident filters already use the real `BeIncidentPriority`
  * wire values (`CRITICAL`/`HIGH`/...), same as `IncidentFilters.priorities` —
  * no translation table needed, only a type narrowing. */
@@ -496,7 +536,10 @@ export const WIDGET_RESOURCE_CONFIG: Record<
     itemsKey: "cases",
     primaryLabel: numberSubjectLabel,
     secondaryLabel: stateSecondaryLabel,
-    buildHref: (filters) => casesHref(translateCaseDashboardFilters(filters)),
+    buildHref: (filters, ctx) =>
+      caseFamilyBuildHref("cases", filters, ctx, () =>
+        casesHref(translateCaseDashboardFilters(filters)),
+      ),
     icon: Briefcase,
     iconColor: "primary",
     previewSlug: "cases",
@@ -521,13 +564,15 @@ export const WIDGET_RESOURCE_CONFIG: Record<
     detailHref: caseDetailHref,
     primaryLabel: numberSubjectLabel,
     secondaryLabel: stateSecondaryLabel,
-    buildHref: (filters) =>
-      operationsHref(
-        "service_requests",
-        writeCasesFiltersToUrl({
-          ...DEFAULT_CASES_FILTERS,
-          ...translateCaseDashboardFilters(filters),
-        }),
+    buildHref: (filters, ctx) =>
+      caseFamilyBuildHref("service-requests", filters, ctx, () =>
+        operationsHref(
+          "service_requests",
+          writeCasesFiltersToUrl({
+            ...DEFAULT_CASES_FILTERS,
+            ...translateCaseDashboardFilters(filters),
+          }),
+        ),
       ),
     icon: Cog,
     iconColor: "info",
@@ -540,13 +585,15 @@ export const WIDGET_RESOURCE_CONFIG: Record<
     detailHref: caseDetailHref,
     primaryLabel: numberSubjectLabel,
     secondaryLabel: stateSecondaryLabel,
-    buildHref: (filters) =>
-      securityCenterHref(
-        "security_reports",
-        writeCasesFiltersToUrl({
-          ...DEFAULT_CASES_FILTERS,
-          ...translateCaseDashboardFilters(filters),
-        }),
+    buildHref: (filters, ctx) =>
+      caseFamilyBuildHref("security-reports", filters, ctx, () =>
+        securityCenterHref(
+          "security_reports",
+          writeCasesFiltersToUrl({
+            ...DEFAULT_CASES_FILTERS,
+            ...translateCaseDashboardFilters(filters),
+          }),
+        ),
       ),
     icon: Shield,
     iconColor: "warning",
@@ -562,7 +609,9 @@ export const WIDGET_RESOURCE_CONFIG: Record<
     // CsmAnnouncementsPage keeps its own filters in local component state,
     // not the URL (unlike /cases, /operations, /engagements) — there is no
     // query-param scheme to land a filtered click-through on yet, so this
-    // stays unfiltered, same as `problem` above.
+    // stays unfiltered, same as `problem` above (including any `anyOf` a
+    // widget sets — no `caseFamilyBuildHref` wrapper here, since there's no
+    // filtered destination for it to fall back to in the first place).
     buildHref: () => "/announcements",
     icon: Megaphone,
     iconColor: "success",
@@ -575,7 +624,8 @@ export const WIDGET_RESOURCE_CONFIG: Record<
     detailHref: caseDetailHref,
     primaryLabel: numberSubjectLabel,
     secondaryLabel: stateSecondaryLabel,
-    buildHref: (filters) => caseTypeListHref("/engagements", filters),
+    buildHref: (filters, ctx) =>
+      caseFamilyBuildHref("engagements", filters, ctx, () => caseTypeListHref("/engagements", filters)),
     icon: Handshake,
     iconColor: "secondary",
     previewSlug: "engagements",

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/pages/DashboardWidgetPreviewPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/pages/DashboardWidgetPreviewPage.test.tsx
@@ -320,6 +320,64 @@ describe("DashboardWidgetPreviewPage — generic resourceTypes keep the read-onl
 });
 
 /**
+ * Regression (digiops-cs#2880): a case-family widget carrying `anyOf`
+ * (cross-field OR branches) must NOT fall into `CaseFamilyWidgetPreview` —
+ * `CasesFilters`/`CasesFilterBar` have no OR construct, so seeding them from
+ * `translateCaseDashboardFilters` would silently drop `anyOf` and land on a
+ * broader, unfiltered-by-`anyOf` result set than the tile it was reached
+ * from actually counted. It falls through to the generic, filter-faithful
+ * `useWidgetData`-backed content instead (same path `resourceType: "incident"`
+ * always used), which posts the widget's raw filters — `anyOf` included —
+ * straight to `/cases/search`.
+ */
+describe("DashboardWidgetPreviewPage — a case-family widget with anyOf skips the editable filter bar", () => {
+  beforeEach(() => {
+    postMock.mockReset();
+  });
+
+  it("posts the widget's anyOf branches verbatim to /cases/search instead of seeding CasesFilterBar", async () => {
+    postMock.mockResolvedValue({
+      cases: [{ id: "c1", number: "CS-1", subject: "Disk full", state: "open" }],
+      total: 1,
+      limit: 10,
+      offset: 0,
+    });
+
+    const anyOf = [
+      { filters: [{ field: "severity", op: "in", values: ["catastrophic", "critical"] }] },
+      { filters: [{ field: "type", op: "in", values: ["security_report_analysis"] }] },
+    ];
+
+    renderAt(
+      buildWidgetPreviewHref({
+        previewSlug: "cases",
+        widgetId: "wow_p0p1",
+        displayName: "WOW P0/P1",
+        filters: {
+          filters: [{ field: "state", op: "in", values: ["open"] }],
+          anyOf,
+        },
+      }),
+    );
+
+    await waitFor(() => expect(screen.getByText("CS-1")).toBeInTheDocument());
+    // The real, editable Cases filter bar never mounts for this widget.
+    expect(screen.queryByRole("combobox", { name: "Severity" })).not.toBeInTheDocument();
+
+    expect(postMock).toHaveBeenCalledWith(
+      "/cases/search",
+      expect.objectContaining({
+        filters: expect.objectContaining({
+          filters: [{ field: "state", op: "in", values: ["open"] }],
+          anyOf,
+        }),
+      }),
+      { signal: expect.any(AbortSignal) },
+    );
+  });
+});
+
+/**
  * Reported live: a case-family widget's "View more" landed on a static
  * "Filtered by:" chip summary, unlike every other list page in the app,
  * which has a real, editable filter bar. `CaseFamilyWidgetPreview` (in

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/pages/DashboardWidgetPreviewPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/pages/DashboardWidgetPreviewPage.tsx
@@ -31,6 +31,7 @@ import {
 } from "@features/csm-dashboard/config/widgetResourceConfig";
 import {
   describeWidgetFilters,
+  isAnyOfBranchArray,
   parseWidgetPreviewFilters,
   resolveCurrentUserSentinels,
 } from "@features/csm-dashboard/utils/widgetPreviewUrl";
@@ -57,6 +58,19 @@ const SEARCH_DEBOUNCE_MS = 300;
  * `CasesFilterBar` + `useGetCsmCases` + `CasesList`, the same trio the Cases
  * tab itself uses, seeded from the widget's own filters via
  * `translateCaseDashboardFilters` and then fully editable from there.
+ *
+ * Exception: a widget carrying `anyOf` (cross-field OR — see
+ * `isAnyOfBranchArray`) skips this editable path entirely and falls through
+ * to the plain `DashboardWidgetPreviewContent` below instead (see the
+ * `!isAnyOfBranchArray(...)` check at the call site) — `CasesFilters` has no
+ * OR construct to seed `CasesFilterBar` with, so `translateCaseDashboardFilters`
+ * would have to silently drop `anyOf` the same way `casesHref`'s own
+ * click-through used to (the bug `caseFamilyBuildHref` in
+ * `widgetResourceConfig.ts` exists to close). `DashboardWidgetPreviewContent`
+ * posts the widget's raw, un-translated filters straight to `/cases/search`
+ * via `useWidgetData` — the same request shape the tile's own count used —
+ * so its result set is guaranteed to match, at the cost of a plain search box
+ * instead of a fully editable filter bar for just this one case.
  */
 const CASE_FAMILY_RESOURCE_TYPES = new Set<BeWidgetResourceType>([
   "case",
@@ -140,7 +154,7 @@ export default function DashboardWidgetPreviewPage(): JSX.Element {
 
   const filters = resolveCurrentUserSentinels(rawFilters, user?.id);
 
-  if (CASE_FAMILY_RESOURCE_TYPES.has(resourceType)) {
+  if (CASE_FAMILY_RESOURCE_TYPES.has(resourceType) && !isAnyOfBranchArray(filters.anyOf)) {
     return (
       <CaseFamilyWidgetPreview
         displayName={displayName}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/utils/widgetPreviewUrl.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/utils/widgetPreviewUrl.test.ts
@@ -207,6 +207,84 @@ describe("widget preview URL — filter op round-trip", () => {
   });
 });
 
+/**
+ * Regression (digiops-cs#2880): `anyOf` (cross-field OR branches) used to be
+ * silently dropped entirely by this file -- neither serialized into the
+ * preview URL nor read back out of it -- so a widget's "View more" click
+ * (and, separately, `WIDGET_RESOURCE_CONFIG`'s own count-tile `buildHref`)
+ * landed on a broader, unfiltered-by-`anyOf` result set than what the tile
+ * itself had counted.
+ */
+describe("widget preview URL — anyOf round-trip", () => {
+  const anyOf = [
+    { filters: [{ field: "severity", op: "in", values: ["catastrophic", "critical"] }] },
+    { filters: [{ field: "type", op: "in", values: ["security_report_analysis"] }] },
+  ];
+
+  it("round-trips anyOf branches through build + parse, alongside a flat filters object", () => {
+    const href = buildWidgetPreviewHref({
+      previewSlug: "cases",
+      widgetId: "w1",
+      displayName: "WOW P0/P1",
+      filters: { severities: ["critical"], anyOf },
+    });
+
+    const searchParams = new URLSearchParams(href.split("?")[1]);
+    const { filters } = parseWidgetPreviewFilters(searchParams);
+    expect(filters.severities).toEqual(["critical"]);
+    expect(filters.anyOf).toEqual(anyOf);
+  });
+
+  it("round-trips anyOf branches alongside the nested case field/op/values filter shape", () => {
+    const href = buildWidgetPreviewHref({
+      previewSlug: "cases",
+      widgetId: "w1",
+      displayName: "WOW P0/P1",
+      filters: {
+        filters: [{ field: "state", op: "in", values: ["open"] }],
+        anyOf,
+      },
+    });
+
+    const searchParams = new URLSearchParams(href.split("?")[1]);
+    const { filters } = parseWidgetPreviewFilters(searchParams);
+    expect(filters.filters).toEqual([{ field: "state", op: "in", values: ["open"] }]);
+    expect(filters.anyOf).toEqual(anyOf);
+  });
+
+  it("masks the current user's own id inside an anyOf branch, and resolveCurrentUserSentinels restores it", () => {
+    const href = buildWidgetPreviewHref({
+      previewSlug: "cases",
+      widgetId: "w1",
+      displayName: "My anyOf widget",
+      filters: {
+        anyOf: [{ filters: [{ field: "assignedUserId", op: "in", values: [CURRENT_USER_ID] }] }],
+      },
+      currentUserId: CURRENT_USER_ID,
+    });
+
+    expect(href).not.toContain(CURRENT_USER_ID);
+    const searchParams = new URLSearchParams(href.split("?")[1]);
+    const { filters, needsCurrentUser } = parseWidgetPreviewFilters(searchParams);
+    expect(needsCurrentUser).toBe(true);
+    expect(filters.anyOf).toEqual([
+      { filters: [{ field: "assignedUserId", op: "in", values: ["@me"] }] },
+    ]);
+
+    const resolved = resolveCurrentUserSentinels(filters, CURRENT_USER_ID);
+    expect(resolved.anyOf).toEqual([
+      { filters: [{ field: "assignedUserId", op: "in", values: [CURRENT_USER_ID] }] },
+    ]);
+  });
+
+  it("drops a malformed anyOf param rather than throwing", () => {
+    const searchParams = new URLSearchParams({ w: "id", n: "Name", _anyOf: "not json{{{" });
+    expect(() => parseWidgetPreviewFilters(searchParams)).not.toThrow();
+    const { filters } = parseWidgetPreviewFilters(searchParams);
+    expect(filters.anyOf).toBeUndefined();
+  });
+});
+
 describe("describeWidgetFilters", () => {
   it("flattens the flat resourceType filter shape into readable field: value entries", () => {
     expect(

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/utils/widgetPreviewUrl.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/utils/widgetPreviewUrl.ts
@@ -20,7 +20,17 @@
  * reconstruct `{ filters: [...] }` rather than a flat key→values record. */
 const CASE_FILTER_MARKER = "_cf";
 
-const RESERVED_PARAMS = new Set(["w", "n", CASE_FILTER_MARKER]);
+/** Carries a case widget's `anyOf` cross-field-OR branches (see
+ * `isAnyOfBranchArray`) as one JSON blob, round-tripped by
+ * `buildWidgetPreviewHref`/`parseWidgetPreviewFilters` below. Unlike every
+ * other filter field here, an `anyOf` branch can filter on any field and
+ * there can be several branches, so there's no natural one-field-one-param
+ * encoding the way `severities=critical` works for a flat AND'd field —
+ * this is the one deliberate exception to this file's "no opaque JSON blob"
+ * approach, scoped to just this one nested construct. */
+const ANY_OF_PARAM = "_anyOf";
+
+const RESERVED_PARAMS = new Set(["w", "n", CASE_FILTER_MARKER, ANY_OF_PARAM]);
 
 /** Placeholder swapped in for the signed-in user's own id wherever a
  * widget's (opaque, backend-resolved) filters carry it — e.g. "My Cases"
@@ -78,6 +88,29 @@ export function isCaseFieldFilterArray(value: unknown): value is WidgetCaseField
   );
 }
 
+/** One `anyOf` branch: its own predicate array, ANDed within the branch, OR'd
+ * against every other branch — matches the backend's `CaseFilterBranch` and
+ * `widgetFilterMerge.ts`'s own (independently duplicated, not imported here
+ * to avoid a circular import — `widgetFilterMerge.ts` already imports from
+ * this file) structural check of the identical shape. */
+export interface WidgetAnyOfBranch {
+  filters: WidgetCaseFieldFilterLike[];
+}
+
+function isAnyOfBranch(value: unknown): value is WidgetAnyOfBranch {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    Array.isArray((value as { filters?: unknown }).filters)
+  );
+}
+
+/** True when `value` is a case widget's `anyOf` cross-field-OR branch array
+ * (`{filters: BeCaseFieldFilter[]}[]`, at least one branch). */
+export function isAnyOfBranchArray(value: unknown): value is WidgetAnyOfBranch[] {
+  return Array.isArray(value) && value.length > 0 && value.every(isAnyOfBranch);
+}
+
 /**
  * Builds the URL a dashboard widget tile's "View more" link points at — a
  * real, bookmarkable/shareable/refresh-safe URL (no router state): the
@@ -128,6 +161,24 @@ export function buildWidgetPreviewHref(params: {
         // inverted `notIn` -- a tag EXCLUSION became a tag filter).
         q.set(op === "in" ? entry.field : `${entry.field}${OP_SEPARATOR}${op}`, masked.join(","));
       }
+      continue;
+    }
+    if (key === "anyOf" && isAnyOfBranchArray(value)) {
+      // No natural per-field flat encoding exists for a cross-field OR (a
+      // branch can filter on any field, and there can be several branches),
+      // so this round-trips as one JSON blob (see `ANY_OF_PARAM`'s doc
+      // comment) rather than being silently skipped the way it was before —
+      // that silent drop is exactly what let a "View more" click-through
+      // land on a broader, unfiltered-by-`anyOf` result set than the tile
+      // it was clicked from had counted.
+      const masked = value.map((branch) => ({
+        ...branch,
+        filters: branch.filters.map((f) => ({
+          ...f,
+          values: f.values?.map((v) => (v === params.currentUserId ? CURRENT_USER_SENTINEL : v)),
+        })),
+      }));
+      q.set(ANY_OF_PARAM, JSON.stringify(masked));
       continue;
     }
     if (isStringArray(value)) {
@@ -224,6 +275,28 @@ export function parseWidgetPreviewFilters(
 ): ParsedWidgetPreviewFilters {
   let needsCurrentUser = false;
 
+  // `anyOf` round-trips as its own single JSON param regardless of which of
+  // the two shapes below applies — a case-family widget with `anyOf` branches
+  // still carries the flat `filters.filters` array (or a flat field record,
+  // for a non-case-family resourceType) alongside it, so this is read once,
+  // up front, and merged into whichever `filters` object gets built below.
+  let anyOf: WidgetAnyOfBranch[] | undefined;
+  const anyOfRaw = searchParams.get(ANY_OF_PARAM);
+  if (anyOfRaw) {
+    try {
+      const parsed: unknown = JSON.parse(anyOfRaw);
+      if (isAnyOfBranchArray(parsed)) {
+        anyOf = parsed;
+        if (parsed.some((b) => b.filters.some((f) => f.values?.includes(CURRENT_USER_SENTINEL)))) {
+          needsCurrentUser = true;
+        }
+      }
+    } catch {
+      // A malformed/hand-edited URL drops just `anyOf` rather than throwing —
+      // every other filter param still parses and queries normally.
+    }
+  }
+
   if (searchParams.get(CASE_FILTER_MARKER) === "1") {
     const fieldFilters: WidgetCaseFieldFilterLike[] = [];
     for (const [key, raw] of searchParams.entries()) {
@@ -236,7 +309,10 @@ export function parseWidgetPreviewFilters(
       if (values.includes(CURRENT_USER_SENTINEL)) needsCurrentUser = true;
       fieldFilters.push({ field, op, values });
     }
-    return { filters: { filters: fieldFilters }, needsCurrentUser };
+    return {
+      filters: anyOf ? { filters: fieldFilters, anyOf } : { filters: fieldFilters },
+      needsCurrentUser,
+    };
   }
 
   const filters: Record<string, unknown> = {};
@@ -247,6 +323,7 @@ export function parseWidgetPreviewFilters(
     if (values.includes(CURRENT_USER_SENTINEL)) needsCurrentUser = true;
     filters[key] = values;
   }
+  if (anyOf) filters.anyOf = anyOf;
 
   return { filters, needsCurrentUser };
 }
@@ -268,6 +345,21 @@ export function resolveCurrentUserSentinels(
         values: entry.values?.map((v) =>
           v === CURRENT_USER_SENTINEL ? currentUserId : v,
         ),
+      }));
+      continue;
+    }
+    if (key === "anyOf" && isAnyOfBranchArray(value)) {
+      // Same nested-substitution as `filters` above -- the generic
+      // `Array.isArray` branch below only replaces a sentinel that is itself
+      // one of the array's own elements, which would leave `@me` unresolved
+      // inside a branch's own `filters` entries (branch objects, not bare
+      // sentinel strings).
+      resolved[key] = value.map((branch) => ({
+        ...branch,
+        filters: branch.filters.map((f) => ({
+          ...f,
+          values: f.values?.map((v) => (v === CURRENT_USER_SENTINEL ? currentUserId : v)),
+        })),
       }));
       continue;
     }

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestLifecycleStepper.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestLifecycleStepper.test.tsx
@@ -74,4 +74,19 @@ describe("ChangeRequestLifecycleStepper", () => {
     render(<ChangeRequestLifecycleStepper state="scheduled" />);
     expect(screen.queryByText(/diverted from the standard path/i)).not.toBeInTheDocument();
   });
+
+  it("shows a current-state note for a state that is neither a forward state nor a recognized off-ramp", () => {
+    render(<ChangeRequestLifecycleStepper state="some_future_state" />);
+    expect(screen.getByText(/current state:/i)).toBeInTheDocument();
+    expect(screen.getByText("some future state")).toBeInTheDocument();
+    // No forward-line marker claims to be current, and none render complete.
+    expect(document.querySelector('[aria-current="step"]')).toBeNull();
+    expect(screen.queryByText(/diverted from the standard path/i)).not.toBeInTheDocument();
+  });
+
+  it("shows no current-state note when the CR has no state yet", () => {
+    render(<ChangeRequestLifecycleStepper state={null} />);
+    expect(screen.queryByText(/current state:/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/diverted from the standard path/i)).not.toBeInTheDocument();
+  });
 });

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestLifecycleStepper.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestLifecycleStepper.test.tsx
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import ChangeRequestLifecycleStepper from "@features/csm-operations/components/ChangeRequestLifecycleStepper";
+
+describe("ChangeRequestLifecycleStepper", () => {
+  it("renders all 9 forward states as list items", () => {
+    render(<ChangeRequestLifecycleStepper state="new" />);
+    expect(screen.getAllByRole("listitem")).toHaveLength(9);
+  });
+
+  it("marks the CR's current state with aria-current='step'", () => {
+    render(<ChangeRequestLifecycleStepper state="implement" />);
+    const current = screen.getByText("Implement").closest('[aria-current="step"]');
+    expect(current).not.toBeNull();
+  });
+
+  it("marks every state before the current one as complete, and none after", () => {
+    render(<ChangeRequestLifecycleStepper state="implement" />);
+    const list = screen.getByRole("list", { name: /change request lifecycle/i });
+
+    // Prior states (New, Assess, Authorize, Customer Approval, Scheduled) each
+    // render a check icon (svg) inside their step marker.
+    ["New", "Assess", "Authorize", "Customer Approval", "Scheduled"].forEach((label) => {
+      const item = within(list).getByText(label).closest('[role="listitem"]')!;
+      expect((item as HTMLElement).querySelector("svg")).not.toBeNull();
+    });
+
+    // The current step itself carries aria-current, states after it don't
+    // and have no check icon.
+    const review = within(list).getByText("Review").closest('[role="listitem"]')!;
+    expect(review).not.toHaveAttribute("aria-current");
+    expect((review as HTMLElement).querySelector("svg")).toBeNull();
+  });
+
+  it("does not plot rollback/canceled on the forward line", () => {
+    render(<ChangeRequestLifecycleStepper state="implement" />);
+    expect(screen.queryByText("Rollback")).not.toBeInTheDocument();
+    expect(screen.queryByText("Canceled")).not.toBeInTheDocument();
+  });
+
+  it("shows a separate off-ramp note instead of a forward-path highlight when canceled", () => {
+    render(<ChangeRequestLifecycleStepper state="canceled" />);
+    expect(screen.getByText(/diverted from the standard path/i)).toBeInTheDocument();
+    // The label appears in the off-ramp note itself.
+    expect(screen.getByText("Canceled")).toBeInTheDocument();
+    // Nothing on the forward line claims to be the current step.
+    expect(document.querySelector('[aria-current="step"]')).toBeNull();
+  });
+
+  it("shows the off-ramp note for rollback too", () => {
+    render(<ChangeRequestLifecycleStepper state="rollback" />);
+    expect(screen.getByText(/diverted from the standard path/i)).toBeInTheDocument();
+    expect(screen.getByText("Rollback")).toBeInTheDocument();
+  });
+
+  it("renders no off-ramp note for a normal forward state", () => {
+    render(<ChangeRequestLifecycleStepper state="scheduled" />);
+    expect(screen.queryByText(/diverted from the standard path/i)).not.toBeInTheDocument();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestLifecycleStepper.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestLifecycleStepper.tsx
@@ -113,13 +113,20 @@ export default function ChangeRequestLifecycleStepper({
     ? -1
     : CHANGE_REQUEST_FORWARD_STATES.indexOf(state as (typeof CHANGE_REQUEST_FORWARD_STATES)[number]);
   const lastIndex = CHANGE_REQUEST_FORWARD_STATES.length - 1;
+  // A state the backend could start sending that isn't yet one of the 9
+  // forward states or a recognized off-ramp — distinct from "no state at
+  // all" (`!state`), which is just a CR still being created and gets no
+  // note. Without this, `currentIndex` is -1 the same as an off-ramp but
+  // `offRamp` is false, so every marker would render pending with no
+  // indication anywhere of what the CR's real state actually is.
+  const unrecognizedState = !offRamp && currentIndex < 0 && !!state;
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
       <Box
         role="list"
         aria-label="Change request lifecycle"
-        sx={{ display: "flex", alignItems: "flex-start", opacity: offRamp ? 0.45 : 1 }}
+        sx={{ display: "flex", alignItems: "flex-start", opacity: offRamp || unrecognizedState ? 0.45 : 1 }}
       >
         {CHANGE_REQUEST_FORWARD_STATES.map((s, index) => {
           const isCurrent = index === currentIndex;
@@ -185,6 +192,14 @@ export default function ChangeRequestLifecycleStepper({
             Diverted from the standard path:
           </Typography>
           <Chip size="small" color="error" label={changeRequestStateLabel(state)} />
+        </Box>
+      )}
+      {unrecognizedState && (
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+          <Typography variant="caption" color="text.secondary">
+            Current state:
+          </Typography>
+          <Chip size="small" color="default" label={changeRequestStateLabel(state)} />
         </Box>
       )}
     </Box>

--- a/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestLifecycleStepper.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/components/ChangeRequestLifecycleStepper.tsx
@@ -1,0 +1,192 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Box, Chip, Typography } from "@wso2/oxygen-ui";
+import { Check } from "@wso2/oxygen-ui-icons-react";
+import type { JSX } from "react";
+import {
+  CHANGE_REQUEST_FORWARD_STATES,
+  changeRequestStateLabel,
+  isChangeRequestOffRampState,
+} from "@features/csm-operations/utils/changeRequests";
+
+const NODE_SIZE = 22;
+
+/**
+ * One step marker: a filled circle for done/current, an outlined circle for
+ * not-yet-reached. The current step additionally gets a soft halo (a larger,
+ * low-opacity ring behind it) so it reads as "you are here" at a glance
+ * rather than just "a slightly different colour than its neighbours".
+ *
+ * Current uses `info` rather than `primary`: `primary` is this app's brand
+ * accent, already used everywhere (buttons, the active tab underline, links)
+ * — reusing it here would blend the stepper into that noise instead of
+ * standing out as its own "you are here" signal. `info` reads as
+ * in-progress/informational and doesn't compete with any nearby primary CTA.
+ */
+function StepNode({ done, current }: { done: boolean; current: boolean }): JSX.Element {
+  return (
+    <Box sx={{ position: "relative", display: "flex", alignItems: "center", justifyContent: "center" }}>
+      {current && (
+        <Box
+          aria-hidden
+          sx={{
+            position: "absolute",
+            width: NODE_SIZE + 12,
+            height: NODE_SIZE + 12,
+            borderRadius: "50%",
+            bgcolor: "info.main",
+            opacity: 0.15,
+          }}
+        />
+      )}
+      <Box
+        sx={{
+          position: "relative",
+          width: NODE_SIZE,
+          height: NODE_SIZE,
+          borderRadius: "50%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          flexShrink: 0,
+          transition: "background-color 0.15s, border-color 0.15s",
+          ...(done
+            ? { bgcolor: "success.main", color: "success.contrastText" }
+            : current
+              ? { bgcolor: "info.main", color: "info.contrastText" }
+              : {
+                  bgcolor: "transparent",
+                  border: "2px solid",
+                  borderColor: "divider",
+                }),
+        }}
+      >
+        {done ? (
+          <Check size={13} strokeWidth={3} />
+        ) : current ? (
+          <Box sx={{ width: 7, height: 7, borderRadius: "50%", bgcolor: "info.contrastText" }} />
+        ) : null}
+      </Box>
+    </Box>
+  );
+}
+
+/**
+ * Horizontal lifecycle indicator for a change request's 9-state forward path
+ * (`CHANGE_REQUEST_FORWARD_STATES`): a connected line of step markers — solid
+ * and checked for every state already passed, a highlighted "current
+ * position" marker for the CR's actual state, and a faint outline for what's
+ * still ahead — with the connecting line itself filling in step by step. The
+ * row stretches to the card's full width (each segment is an equal flex
+ * share) rather than clumping to one side.
+ *
+ * `rollback` and `canceled` are deliberately never plotted on this line: both
+ * are destructive off-ramps reachable from several different points in the
+ * forward path (see `DESTRUCTIVE_TRANSITIONS`), not a 10th/11th sequential
+ * step, so forcing either into the line would misrepresent it as "the step
+ * after review". When the CR is currently in one of them, the forward line
+ * renders dimmed with nothing marked current or complete — the record
+ * carries no history of which forward state it was in before the off-ramp —
+ * and a distinct tag below names the actual state.
+ */
+export default function ChangeRequestLifecycleStepper({
+  state,
+}: {
+  state?: string | null;
+}): JSX.Element {
+  const offRamp = isChangeRequestOffRampState(state);
+  const currentIndex = offRamp
+    ? -1
+    : CHANGE_REQUEST_FORWARD_STATES.indexOf(state as (typeof CHANGE_REQUEST_FORWARD_STATES)[number]);
+  const lastIndex = CHANGE_REQUEST_FORWARD_STATES.length - 1;
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+      <Box
+        role="list"
+        aria-label="Change request lifecycle"
+        sx={{ display: "flex", alignItems: "flex-start", opacity: offRamp ? 0.45 : 1 }}
+      >
+        {CHANGE_REQUEST_FORWARD_STATES.map((s, index) => {
+          const isCurrent = index === currentIndex;
+          const isDone = currentIndex > index;
+          // The connector to the LEFT of this node is "filled" once this node
+          // itself has been reached (done or current) — so the line completes
+          // in step with the marker it leads into, not the one it leads out of.
+          const incomingFilled = isDone || isCurrent;
+          return (
+            <Box
+              key={s}
+              role="listitem"
+              aria-current={isCurrent ? "step" : undefined}
+              sx={{
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                flex: index === 0 || index === lastIndex ? "0 0 auto" : 1,
+                minWidth: 0,
+              }}
+            >
+              <Box sx={{ display: "flex", alignItems: "center", width: "100%" }}>
+                <Box
+                  aria-hidden
+                  sx={{
+                    flex: 1,
+                    height: 2,
+                    visibility: index === 0 ? "hidden" : "visible",
+                    bgcolor: incomingFilled ? "success.main" : "divider",
+                  }}
+                />
+                <StepNode done={isDone} current={isCurrent} />
+                <Box
+                  aria-hidden
+                  sx={{
+                    flex: 1,
+                    height: 2,
+                    visibility: index === lastIndex ? "hidden" : "visible",
+                    bgcolor: isDone ? "success.main" : "divider",
+                  }}
+                />
+              </Box>
+              <Typography
+                variant="caption"
+                align="center"
+                sx={{
+                  mt: 0.75,
+                  maxWidth: 88,
+                  lineHeight: 1.25,
+                  fontWeight: isCurrent ? 700 : 400,
+                  color: isCurrent ? "info.main" : isDone ? "text.primary" : "text.secondary",
+                }}
+              >
+                {changeRequestStateLabel(s)}
+              </Typography>
+            </Box>
+          );
+        })}
+      </Box>
+      {offRamp && (
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+          <Typography variant="caption" color="text.secondary">
+            Diverted from the standard path:
+          </Typography>
+          <Chip size="small" color="error" label={changeRequestStateLabel(state)} />
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.test.tsx
@@ -59,6 +59,10 @@ vi.mock("@context/error-banner/ErrorBannerContext", () => ({
 vi.mock("@features/csm-operations/api/useGetChangeRequest", () => ({
   useGetChangeRequest: () => useGetChangeRequestMock(),
 }));
+const useGetChangeRequestApprovalsMock = vi.fn();
+vi.mock("@features/csm-operations/api/useGetChangeRequestApprovals", () => ({
+  useGetChangeRequestApprovals: () => useGetChangeRequestApprovalsMock(),
+}));
 vi.mock("@features/csm-operations/api/usePatchChangeRequest", () => ({
   usePatchChangeRequest: () => ({
     mutate: patchMutateMock,
@@ -139,6 +143,12 @@ beforeEach(() => {
   patchMutateAsyncMock.mockResolvedValue({ id: "chg-1" });
   postCommentMutateAsyncMock.mockReset();
   postCommentMutateAsyncMock.mockResolvedValue({ id: "comment-1" });
+  useGetChangeRequestApprovalsMock.mockReturnValue({
+    data: null,
+    isLoading: false,
+    isError: false,
+    error: null,
+  });
 });
 
 /** Surfaces the router's current search string, for the `?tab=` sync tests
@@ -197,6 +207,116 @@ describe("CsmChangeRequestDetailPage", () => {
     renderPage();
     const linkedCaseCell = screen.getByText("Linked case").parentElement!;
     expect(within(linkedCaseCell).getByText("—")).toBeInTheDocument();
+  });
+
+  it("shows the Impact meta cell in the Overview grid, alongside the header chip", () => {
+    mockQueryResult({ data: { ...BASE_CR, impact: "high" } });
+    renderPage();
+    const impactCell = screen.getByText("Impact").parentElement!;
+    expect(within(impactCell).getByText("High")).toBeInTheDocument();
+  });
+
+  it("shows a dash for Impact in the Overview grid when unset", () => {
+    mockQueryResult({ data: { ...BASE_CR, impact: undefined } });
+    renderPage();
+    const impactCell = screen.getByText("Impact").parentElement!;
+    expect(within(impactCell).getByText("—")).toBeInTheDocument();
+  });
+
+  it("renders the lifecycle stepper for this CR's state", () => {
+    mockQueryResult({ data: { ...BASE_CR, state: "implement" } });
+    renderPage();
+    expect(screen.getByRole("list", { name: /change request lifecycle/i })).toBeInTheDocument();
+  });
+});
+
+describe("CsmChangeRequestDetailPage — blocking-reason header note", () => {
+  it("shows 'Awaiting <stage> approval' when a stage is pending or requested", () => {
+    mockQueryResult({ data: { ...BASE_CR, state: "assess" } });
+    useGetChangeRequestApprovalsMock.mockReturnValue({
+      data: {
+        approvals: [
+          {
+            stage: "Assess",
+            approverType: "STATIC_GROUP",
+            approverName: null,
+            status: "REQUESTED",
+            approvers: [],
+          },
+        ],
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+    renderPage();
+    expect(screen.getByText("Awaiting Assess approval")).toBeInTheDocument();
+  });
+
+  it("names the approver group when the stage carries one", () => {
+    mockQueryResult({ data: { ...BASE_CR, state: "authorize" } });
+    useGetChangeRequestApprovalsMock.mockReturnValue({
+      data: {
+        approvals: [
+          {
+            stage: "Authorize",
+            approverType: "STATIC_GROUP",
+            approverName: "Devops Approval",
+            status: "PENDING",
+            approvers: [],
+          },
+        ],
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+    renderPage();
+    expect(screen.getByText("Awaiting Devops Approval")).toBeInTheDocument();
+  });
+
+  it("shows no blocking-reason note when no stage is pending/requested", () => {
+    mockQueryResult({ data: { ...BASE_CR, state: "authorize" } });
+    useGetChangeRequestApprovalsMock.mockReturnValue({
+      data: {
+        approvals: [
+          {
+            stage: "Assess",
+            approverType: "STATIC_GROUP",
+            approverName: null,
+            status: "APPROVED",
+            approvers: [],
+          },
+        ],
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+    renderPage();
+    expect(screen.queryByText(/awaiting/i)).not.toBeInTheDocument();
+  });
+
+  it("suppresses the blocking-reason note once the CR is closed, even with stale pending approval data", () => {
+    mockQueryResult({ data: { ...BASE_CR, state: "closed" } });
+    useGetChangeRequestApprovalsMock.mockReturnValue({
+      data: {
+        approvals: [
+          {
+            stage: "Assess",
+            approverType: "STATIC_GROUP",
+            approverName: null,
+            status: "REQUESTED",
+            approvers: [],
+          },
+        ],
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+    renderPage();
+    expect(screen.queryByText(/awaiting/i)).not.toBeInTheDocument();
   });
 });
 

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CsmChangeRequestDetailPage.tsx
@@ -27,6 +27,7 @@ import {
 import {
   ArrowLeft,
   Check,
+  Clock,
   ClipboardCheck,
   CopyPlus,
   FileText,
@@ -52,6 +53,7 @@ import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
 import { useEngineerDisplayName } from "@hooks/useEngineerDisplayName";
 import { useRecordRecentView } from "@features/csm-recent/hooks/useRecentViews";
 import { useGetChangeRequest } from "@features/csm-operations/api/useGetChangeRequest";
+import { useGetChangeRequestApprovals } from "@features/csm-operations/api/useGetChangeRequestApprovals";
 import { usePatchChangeRequest } from "@features/csm-operations/api/usePatchChangeRequest";
 import {
   useGetCsmChangeRequestComments,
@@ -59,11 +61,13 @@ import {
 } from "@features/csm-operations/api/useCsmChangeRequestComments";
 import ChangeRequestActionBar from "@features/csm-operations/components/ChangeRequestActionBar";
 import ChangeRequestApprovals from "@features/csm-operations/components/ChangeRequestApprovals";
+import ChangeRequestLifecycleStepper from "@features/csm-operations/components/ChangeRequestLifecycleStepper";
 import ChangeRequestTransitionReasonDialog from "@features/csm-operations/components/ChangeRequestTransitionReasonDialog";
 import EditChangeRequestDialog from "@features/csm-operations/components/EditChangeRequestDialog";
 import EntityRefLink from "@features/csm-operations/components/EntityRefLink";
 import {
   buildCloneChangeRequestNavState,
+  changeRequestBlockingReason,
   changeRequestCommentGateReason,
   changeRequestTransitionRequiresReason,
   changeRequestImpactColor,
@@ -218,6 +222,12 @@ export default function CsmChangeRequestDetailPage(): JSX.Element {
   const backState = useLocation().state as { from?: string } | undefined;
   const backTarget = backState?.from ?? OPERATIONS_CR_PATH;
   const { data, isLoading, isError } = useGetChangeRequest(id);
+  // Fetched here (not just inside the Approval tab's `ChangeRequestApprovals`)
+  // so the header's blocking-reason note has data on first render, even when
+  // the engineer lands on a different tab. Both call sites share the same
+  // query key, so react-query dedupes this into a single request rather than
+  // fetching twice.
+  const { data: approvalsData } = useGetChangeRequestApprovals(id);
   const { showError } = useErrorBanner();
   const patchCr = usePatchChangeRequest();
   const [editOpen, setEditOpen] = useState(false);
@@ -330,6 +340,13 @@ export default function CsmChangeRequestDetailPage(): JSX.Element {
   }
 
   const cr = data;
+  // Only meaningful while the CR is actively moving through approval —
+  // closed/canceled/rollback are terminal or off-ramp states where "awaiting
+  // approval" no longer describes what's happening.
+  const blockingReason =
+    cr.state === "closed" || cr.state === "canceled" || cr.state === "rollback"
+      ? null
+      : changeRequestBlockingReason(approvalsData?.approvals);
   // A transition is in flight whenever either half of a destructive
   // transition (the reason comment, then the patch) or a plain patch is
   // running, so the bar stays disabled across both and a double-click can't
@@ -483,8 +500,17 @@ export default function CsmChangeRequestDetailPage(): JSX.Element {
                 label={`${changeRequestImpactLabel(cr.impact)} impact`}
               />
             )}
+            {blockingReason && (
+              <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                <Clock size={14} />
+                <Typography variant="body2" color="text.secondary">
+                  {blockingReason}
+                </Typography>
+              </Box>
+            )}
           </Box>
           <Typography variant="h5">{cr.subject || "Change request"}</Typography>
+          <ChangeRequestLifecycleStepper state={cr.state} />
         </Box>
         <Box sx={{ flexShrink: 0, alignSelf: { xs: "stretch", md: "flex-start" } }}>
           <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
@@ -539,6 +565,18 @@ export default function CsmChangeRequestDetailPage(): JSX.Element {
             <Typography variant="body2">{cr.type || "—"}</Typography>
           </MetaCell>
           <MetaCell label="Linked case"><EntityRefLink value={cr.case} routeBase="/cases" /></MetaCell>
+          <MetaCell label="Impact">
+            {cr.impact ? (
+              <Chip
+                size="small"
+                variant="outlined"
+                color={changeRequestImpactColor(cr.impact)}
+                label={changeRequestImpactLabel(cr.impact)}
+              />
+            ) : (
+              <Typography variant="body2">—</Typography>
+            )}
+          </MetaCell>
           <MetaCell label="Deployment"><RefText value={cr.deployment} /></MetaCell>
           <MetaCell label="Deployed product"><RefText value={cr.deployedProduct} /></MetaCell>
           <MetaCell label="Product"><RefText value={cr.product} /></MetaCell>
@@ -596,30 +634,59 @@ export default function CsmChangeRequestDetailPage(): JSX.Element {
       </Box>
 
       {activeTab === "approval" && (
-        <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
-          <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 2 }}>
-            <Typography variant="subtitle2">Approval</Typography>
-            <Box
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
+          <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+            <Typography
+              variant="overline"
+              color="text.secondary"
+              sx={{ letterSpacing: 0.6 }}
+            >
+              Customer approval
+            </Typography>
+            <Card
               sx={{
-                display: "grid",
+                p: 2.5,
+                display: "flex",
+                flexDirection: "column",
                 gap: 2,
-                gridTemplateColumns: {
-                  xs: "1fr",
-                  sm: "repeat(2, minmax(0, 1fr))",
-                  md: "repeat(3, minmax(0, 1fr))",
-                },
+                borderLeft: 3,
+                borderColor: "info.main",
               }}
             >
-              <MetaCell label="Customer approved"><YesNo value={cr.hasCustomerApproved} /></MetaCell>
-              <MetaCell label="Customer reviewed"><YesNo value={cr.hasCustomerReviewed} /></MetaCell>
-              <MetaCell label="Approved by"><RefText value={cr.approvedBy} /></MetaCell>
-              <MetaCell label="Approved on">
-                <Typography variant="body2">{formatDateTime(cr.approvedOn)}</Typography>
-              </MetaCell>
-            </Box>
-          </Card>
+              <Typography variant="body2" color="text.secondary">
+                What the customer has confirmed on this change.
+              </Typography>
+              <Box
+                sx={{
+                  display: "grid",
+                  gap: 2,
+                  gridTemplateColumns: {
+                    xs: "1fr",
+                    sm: "repeat(2, minmax(0, 1fr))",
+                    md: "repeat(3, minmax(0, 1fr))",
+                  },
+                }}
+              >
+                <MetaCell label="Customer approved"><YesNo value={cr.hasCustomerApproved} /></MetaCell>
+                <MetaCell label="Customer reviewed"><YesNo value={cr.hasCustomerReviewed} /></MetaCell>
+                <MetaCell label="Approved by"><RefText value={cr.approvedBy} /></MetaCell>
+                <MetaCell label="Approved on">
+                  <Typography variant="body2">{formatDateTime(cr.approvedOn)}</Typography>
+                </MetaCell>
+              </Box>
+            </Card>
+          </Box>
 
-          <ChangeRequestApprovals id={cr.id} />
+          <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+            <Typography
+              variant="overline"
+              color="text.secondary"
+              sx={{ letterSpacing: 0.6 }}
+            >
+              Internal approval workflow
+            </Typography>
+            <ChangeRequestApprovals id={cr.id} />
+          </Box>
         </Box>
       )}
 

--- a/apps/csm-portal/webapp/src/features/csm-operations/utils/__tests__/changeRequests.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/utils/__tests__/changeRequests.test.ts
@@ -15,8 +15,11 @@
 // under the License.
 
 import { describe, expect, it } from "vitest";
-import { buildCloneChangeRequestNavState } from "@features/csm-operations/utils/changeRequests";
-import type { BeChangeRequestDetail } from "@api/backend/types";
+import {
+  buildCloneChangeRequestNavState,
+  changeRequestBlockingReason,
+} from "@features/csm-operations/utils/changeRequests";
+import type { BeChangeRequestApproval, BeChangeRequestDetail } from "@api/backend/types";
 
 const FULL_CR: BeChangeRequestDetail = {
   id: "chg-1",
@@ -144,5 +147,76 @@ describe("buildCloneChangeRequestNavState", () => {
     });
     expect(state.description).not.toContain("<script>");
     expect(state.description).toContain("Safe");
+  });
+});
+
+describe("changeRequestBlockingReason", () => {
+  function approval(overrides: Partial<BeChangeRequestApproval>): BeChangeRequestApproval {
+    return {
+      stage: "Assess",
+      approverType: "STATIC_GROUP",
+      approverName: null,
+      status: "APPROVED",
+      approvers: [],
+      ...overrides,
+    };
+  }
+
+  it("returns null when there are no approval stages yet", () => {
+    expect(changeRequestBlockingReason(undefined)).toBeNull();
+    expect(changeRequestBlockingReason([])).toBeNull();
+  });
+
+  it("returns null when every stage is settled (approved/rejected/not required)", () => {
+    expect(
+      changeRequestBlockingReason([
+        approval({ status: "APPROVED" }),
+        approval({ stage: "Authorize", status: "NOT_REQUIRED" }),
+      ]),
+    ).toBeNull();
+  });
+
+  it("names the stage when a stage is REQUESTED and has no named approver group", () => {
+    expect(
+      changeRequestBlockingReason([approval({ stage: "Authorize", status: "REQUESTED" })]),
+    ).toBe("Awaiting Authorize approval");
+  });
+
+  it("treats PENDING the same as REQUESTED", () => {
+    expect(
+      changeRequestBlockingReason([approval({ stage: "Assess", status: "PENDING" })]),
+    ).toBe("Awaiting Assess approval");
+  });
+
+  it("names the approver group instead of the stage when one is present", () => {
+    expect(
+      changeRequestBlockingReason([
+        approval({ stage: "Authorize", status: "REQUESTED", approverName: "Devops Approval" }),
+      ]),
+    ).toBe("Awaiting Devops Approval");
+  });
+
+  it("does not double the word 'approval' when the approver name already carries it", () => {
+    const reason = changeRequestBlockingReason([
+      approval({ status: "REQUESTED", approverName: "Security Approval Board" }),
+    ]);
+    expect(reason).toBe("Awaiting Security Approval Board");
+    expect(reason?.match(/approval/gi)).toHaveLength(1);
+  });
+
+  it("returns the first waiting stage, in stage order, when several are unsettled", () => {
+    expect(
+      changeRequestBlockingReason([
+        approval({ stage: "Assess", status: "APPROVED" }),
+        approval({ stage: "Authorize", status: "REQUESTED" }),
+        approval({ stage: "Customer Approval", status: "PENDING" }),
+      ]),
+    ).toBe("Awaiting Authorize approval");
+  });
+
+  it("is case-insensitive on the status value", () => {
+    expect(
+      changeRequestBlockingReason([approval({ stage: "Assess", status: "requested" })]),
+    ).toBe("Awaiting Assess approval");
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-operations/utils/changeRequests.ts
+++ b/apps/csm-portal/webapp/src/features/csm-operations/utils/changeRequests.ts
@@ -15,6 +15,7 @@
 // under the License.
 
 import type {
+  BeChangeRequestApproval,
   BeChangeRequestDetail,
   BeChangeRequestImpact,
   BeChangeRequestState,
@@ -68,6 +69,23 @@ const IMPACT_COLOR: Record<BeChangeRequestImpact, ChipColor> = {
 
 /** All CR states, for a filter control. */
 export const CHANGE_REQUEST_STATES = Object.keys(STATE_LABEL) as BeChangeRequestState[];
+
+/**
+ * The 9 states that make up the CR's linear forward path, in order —
+ * `CHANGE_REQUEST_STATES` minus `rollback`/`canceled`. Those two are
+ * destructive off-ramps reachable from several points in the path (see
+ * `DESTRUCTIVE_TRANSITIONS` below), not sequential steps in it, so a lifecycle
+ * step indicator built from this array should render them separately rather
+ * than forcing them into the same line.
+ */
+export const CHANGE_REQUEST_FORWARD_STATES = CHANGE_REQUEST_STATES.filter(
+  (s) => s !== "rollback" && s !== "canceled",
+);
+
+/** True for `rollback`/`canceled`: an off-ramp from the linear forward path, not a step in it. */
+export function isChangeRequestOffRampState(state?: string | null): boolean {
+  return state === "rollback" || state === "canceled";
+}
 
 /** All CR impact levels, for a filter control. */
 export const CHANGE_REQUEST_IMPACTS = Object.keys(IMPACT_LABEL) as BeChangeRequestImpact[];
@@ -141,6 +159,30 @@ export function approvalStatusLabel(status?: string | null): string {
 export function approvalStatusColor(status?: string | null): ChipColor {
   if (!status) return "default";
   return APPROVAL_STATUS_COLOR[status.toUpperCase()] ?? "default";
+}
+
+/** Stage-level statuses that mean the stage is actively waiting on someone. */
+const WAITING_APPROVAL_STATUSES = new Set(["PENDING", "REQUESTED"]);
+
+/**
+ * Plain-language reason a change request isn't moving on its own right now,
+ * derived from its approval stages (`GET /change-requests/{id}/approvals`) —
+ * the same data `ChangeRequestApprovals` renders. Names the first stage still
+ * waiting on someone (in stage order, not necessarily severity order): e.g.
+ * "Awaiting Authorize approval" or, when the stage carries a named approver
+ * group, "Awaiting Devops Approval". Returns `null` when nothing is currently
+ * blocking on approval — no waiting stage, or the approvals haven't loaded
+ * yet — so callers should treat `null` as "no reason to show", not an error.
+ */
+export function changeRequestBlockingReason(
+  approvals: BeChangeRequestApproval[] | undefined,
+): string | null {
+  const waiting = approvals?.find((a) => WAITING_APPROVAL_STATUSES.has(a.status.trim().toUpperCase()));
+  if (!waiting) return null;
+  const who = waiting.approverName?.trim() || waiting.stage;
+  // Approver-group names sometimes already say "Approval" ("Devops
+  // Approval"); avoid a doubled "approval approval" in that case.
+  return /approval/i.test(who) ? `Awaiting ${who}` : `Awaiting ${who} approval`;
 }
 
 // ---------------------------------------------------------------------------

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -1448,6 +1448,22 @@ type ParsedCaseFilters struct {
 	// escalation, from the "escalation" filter field's isEmpty/isNotEmpty op
 	// (optional; nil means no filter on this field).
 	HasActiveEscalation *bool
+	// HasBreachedSLA filters cases to those with a currently-breached SLA
+	// against the 10 named SLA definitions, from the "slaBreached" filter
+	// field's eq value (optional; nil means no filter on this field). Wire
+	// field on the SN payload: "slaBreached". Requires ServiceNow data source.
+	HasBreachedSLA *bool
+	// HasActiveAccountEscalation filters cases to those whose parent ACCOUNT
+	// has an active escalation (active_account_escalation.state IN 100,101),
+	// from the "accountEscalationActive" filter field's eq value (optional;
+	// nil means no filter on this field). Wire field on the SN payload:
+	// "accountEscalationActive". Requires ServiceNow data source.
+	//
+	// Distinct from HasActiveEscalation above: HasActiveEscalation filters by
+	// whether the CASE ITSELF carries an active escalation; this field
+	// filters by whether the case's parent ACCOUNT has one, regardless of
+	// whether this specific case is escalated.
+	HasActiveAccountEscalation *bool
 	// OrGroups: see SearchCasesFilters.AnyOf doc comment. Each entry is one
 	// parsed, ANDed branch; branches are OR'd together by the SN adapter.
 	OrGroups []CaseFilterGroup

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -3548,6 +3548,13 @@ type SearchIncidentsFilters struct {
 	//     case search's own "createdOn" filter.
 	//   - "slaViolated" (op eq): a single boolean value; restricts to
 	//     incidents with (or without) at least one breached SLA record.
+	//   - "madeSla" (op eq): a single boolean value; restricts to incidents
+	//     matching ServiceNow's raw `made_sla` field. Deliberately kept
+	//     separate from "slaViolated" above: "slaViolated" is derived from
+	//     task_sla.has_breached and is the reliable signal; "madeSla" is
+	//     ServiceNow's own less-reliable raw field, kept only for exact
+	//     parity with SN's native incident dashboards. Prefer "slaViolated"
+	//     unless dashboard parity is the explicit goal.
 	//   - "productName" (op in): one or more product names, matched as a
 	//     union against the incident's backing business_service name.
 	// See service.ParseIncidentFieldFilters.

--- a/entity-service/internal/service/case_filters.go
+++ b/entity-service/internal/service/case_filters.go
@@ -45,7 +45,7 @@ var caseFilterFieldSet = map[string]bool{
 	"projectOnboardingStatus": true, "projectType": true, "creTeam": true, "sreTeam": true,
 	"resolutionNotes": true, "parentId": true, "taskSLABusinessElapsedPercent": true,
 	"escalationLevel": true, "escalation": true, "number": true, "internalId": true,
-	"accountId": true,
+	"accountId": true, "slaBreached": true, "accountEscalationActive": true,
 }
 
 // caseFilterOpSet is the exact set of CaseFieldFilter.Op values accepted by
@@ -621,6 +621,38 @@ func ParseCaseFieldFilters(filters []domain.CaseFieldFilter, callerEmail string,
 			default:
 				return domain.ParsedCaseFilters{}, badCaseFilterCombo(f)
 			}
+
+		case "slaBreached":
+			if f.Op != "eq" {
+				return domain.ParsedCaseFilters{}, badCaseFilterCombo(f)
+			}
+			if err := requireCaseFilterValues(f); err != nil {
+				return domain.ParsedCaseFilters{}, err
+			}
+			if len(f.Values) != 1 {
+				return domain.ParsedCaseFilters{}, &apierror.ValidationError{Msg: "filters: slaBreached eq requires exactly one value"}
+			}
+			b, err := parseCaseFilterBool(f, f.Values[0])
+			if err != nil {
+				return domain.ParsedCaseFilters{}, err
+			}
+			p.HasBreachedSLA = &b
+
+		case "accountEscalationActive":
+			if f.Op != "eq" {
+				return domain.ParsedCaseFilters{}, badCaseFilterCombo(f)
+			}
+			if err := requireCaseFilterValues(f); err != nil {
+				return domain.ParsedCaseFilters{}, err
+			}
+			if len(f.Values) != 1 {
+				return domain.ParsedCaseFilters{}, &apierror.ValidationError{Msg: "filters: accountEscalationActive eq requires exactly one value"}
+			}
+			b, err := parseCaseFilterBool(f, f.Values[0])
+			if err != nil {
+				return domain.ParsedCaseFilters{}, err
+			}
+			p.HasActiveAccountEscalation = &b
 		}
 	}
 
@@ -761,6 +793,10 @@ func rejectUnsupportedOrGroupFields(parsed domain.ParsedCaseFilters) error {
 		return &apierror.ValidationError{Msg: "anyOf: field \"taskSLABusinessElapsedPercent\" is not supported inside an OR group"}
 	case parsed.HasActiveEscalation != nil:
 		return &apierror.ValidationError{Msg: "anyOf: field \"escalation\" is not supported inside an OR group"}
+	case parsed.HasBreachedSLA != nil:
+		return &apierror.ValidationError{Msg: "anyOf: field \"slaBreached\" is not supported inside an OR group"}
+	case parsed.HasActiveAccountEscalation != nil:
+		return &apierror.ValidationError{Msg: "anyOf: field \"accountEscalationActive\" is not supported inside an OR group"}
 	}
 	return nil
 }
@@ -777,6 +813,24 @@ func parseCaseFilterPercent(f domain.CaseFieldFilter, value string) (int, error)
 		return 0, &apierror.ValidationError{Msg: fmt.Sprintf("filters: field %q op %q value %q must be a non-negative integer", f.Field, f.Op, value)}
 	}
 	return n, nil
+}
+
+// parseCaseFilterBool mirrors incident_filters.go's parseIncidentFilterBool
+// for case search's own plain-boolean eq fields (slaBreached,
+// accountEscalationActive) -- unlike "escalation" (a reference-field
+// isEmpty/isNotEmpty presence check), these are true booleans with an
+// explicit true/false value on the wire, the same shape as the incident
+// side's slaViolated. Only the exact lowercase "true"/"false" the OpenAPI
+// contract documents are accepted.
+func parseCaseFilterBool(f domain.CaseFieldFilter, value string) (bool, error) {
+	switch value {
+	case "true":
+		return true, nil
+	case "false":
+		return false, nil
+	default:
+		return false, &apierror.ValidationError{Msg: fmt.Sprintf("filters: field %q op %q value %q must be a boolean", f.Field, f.Op, value)}
+	}
 }
 
 // resolveCaseFilterCallerEmail resolves the authenticated caller's email from

--- a/entity-service/internal/service/case_filters_test.go
+++ b/entity-service/internal/service/case_filters_test.go
@@ -238,6 +238,48 @@ func TestParseCaseFieldFilters_NamedFieldTranslations(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "slaBreached eq true maps to HasBreachedSLA",
+			in:   []domain.CaseFieldFilter{{Field: "slaBreached", Op: "eq", Values: []string{"true"}}},
+			check: func(t *testing.T, p domain.ParsedCaseFilters) {
+				if p.HasBreachedSLA == nil || !*p.HasBreachedSLA {
+					t.Fatalf("HasBreachedSLA = %v, want pointer to true", p.HasBreachedSLA)
+				}
+			},
+		},
+		{
+			name: "slaBreached eq false maps to HasBreachedSLA",
+			in:   []domain.CaseFieldFilter{{Field: "slaBreached", Op: "eq", Values: []string{"false"}}},
+			check: func(t *testing.T, p domain.ParsedCaseFilters) {
+				if p.HasBreachedSLA == nil || *p.HasBreachedSLA {
+					t.Fatalf("HasBreachedSLA = %v, want pointer to false", p.HasBreachedSLA)
+				}
+			},
+		},
+		{
+			name: "accountEscalationActive eq true maps to HasActiveAccountEscalation",
+			in:   []domain.CaseFieldFilter{{Field: "accountEscalationActive", Op: "eq", Values: []string{"true"}}},
+			check: func(t *testing.T, p domain.ParsedCaseFilters) {
+				if p.HasActiveAccountEscalation == nil || !*p.HasActiveAccountEscalation {
+					t.Fatalf("HasActiveAccountEscalation = %v, want pointer to true", p.HasActiveAccountEscalation)
+				}
+				// Distinct from the case-level escalation filter: setting
+				// accountEscalationActive must not also populate
+				// HasActiveEscalation.
+				if p.HasActiveEscalation != nil {
+					t.Fatalf("HasActiveEscalation = %v, want nil (accountEscalationActive is a distinct field)", p.HasActiveEscalation)
+				}
+			},
+		},
+		{
+			name: "accountEscalationActive eq false maps to HasActiveAccountEscalation",
+			in:   []domain.CaseFieldFilter{{Field: "accountEscalationActive", Op: "eq", Values: []string{"false"}}},
+			check: func(t *testing.T, p domain.ParsedCaseFilters) {
+				if p.HasActiveAccountEscalation == nil || *p.HasActiveAccountEscalation {
+					t.Fatalf("HasActiveAccountEscalation = %v, want pointer to false", p.HasActiveAccountEscalation)
+				}
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -268,6 +310,12 @@ func TestParseCaseFieldFilters_Rejections(t *testing.T) {
 		{name: "internalId in unsupported", in: []domain.CaseFieldFilter{{Field: "internalId", Op: "in", Values: []string{"12345"}}}},
 		{name: "projectOnboardingStatus eq unsupported", in: []domain.CaseFieldFilter{{Field: "projectOnboardingStatus", Op: "eq", Values: []string{"Completed"}}}},
 		{name: "accountId malformed UUID", in: []domain.CaseFieldFilter{{Field: "accountId", Op: "in", Values: []string{"not-a-uuid"}}}},
+		{name: "slaBreached with unsupported op", in: []domain.CaseFieldFilter{{Field: "slaBreached", Op: "in", Values: []string{"true"}}}},
+		{name: "slaBreached with non-boolean value", in: []domain.CaseFieldFilter{{Field: "slaBreached", Op: "eq", Values: []string{"yes"}}}},
+		{name: "slaBreached with more than one value", in: []domain.CaseFieldFilter{{Field: "slaBreached", Op: "eq", Values: []string{"true", "false"}}}},
+		{name: "accountEscalationActive with unsupported op", in: []domain.CaseFieldFilter{{Field: "accountEscalationActive", Op: "isNotEmpty"}}},
+		{name: "accountEscalationActive with non-boolean value", in: []domain.CaseFieldFilter{{Field: "accountEscalationActive", Op: "eq", Values: []string{"yes"}}}},
+		{name: "accountEscalationActive with more than one value", in: []domain.CaseFieldFilter{{Field: "accountEscalationActive", Op: "eq", Values: []string{"true", "false"}}}},
 	}
 
 	for _, tc := range cases {
@@ -501,6 +549,43 @@ func TestParseCaseFieldFilterGroups_RejectsStateNotIn(t *testing.T) {
 	const want = `anyOf: field "state" (notIn) is not supported inside an OR group`
 	if ve.Msg != want {
 		t.Errorf("Msg = %q, want %q", ve.Msg, want)
+	}
+}
+
+// TestParseCaseFieldFilterGroups_RejectsSLAAndAccountEscalationFilters proves
+// slaBreached and accountEscalationActive -- like the pre-existing escalation
+// filter -- are rejected inside an OR-group branch: CaseFilterGroup does not
+// model either field, so silently accepting them inside a branch would drop
+// the predicate rather than apply it.
+func TestParseCaseFieldFilterGroups_RejectsSLAAndAccountEscalationFilters(t *testing.T) {
+	cases := []struct {
+		name   string
+		branch domain.CaseFilterBranch
+		want   string
+	}{
+		{
+			name:   "slaBreached",
+			branch: domain.CaseFilterBranch{Filters: []domain.CaseFieldFilter{{Field: "slaBreached", Op: "eq", Values: []string{"true"}}}},
+			want:   `anyOf: field "slaBreached" is not supported inside an OR group`,
+		},
+		{
+			name:   "accountEscalationActive",
+			branch: domain.CaseFilterBranch{Filters: []domain.CaseFieldFilter{{Field: "accountEscalationActive", Op: "eq", Values: []string{"true"}}}},
+			want:   `anyOf: field "accountEscalationActive" is not supported inside an OR group`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParseCaseFieldFilterGroups([]domain.CaseFilterBranch{tc.branch})
+			var ve *apierror.ValidationError
+			if !errors.As(err, &ve) {
+				t.Fatalf("err = %v (%T), want *apierror.ValidationError", err, err)
+			}
+			if ve.Msg != tc.want {
+				t.Errorf("Msg = %q, want %q", ve.Msg, tc.want)
+			}
+		})
 	}
 }
 

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -509,6 +509,12 @@ func (s *caseService) SearchCases(ctx context.Context, req domain.SearchCasesReq
 	if parsed.HasActiveEscalation != nil {
 		return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: `field "escalation" is not supported by this data source`}
 	}
+	if parsed.HasBreachedSLA != nil {
+		return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: `field "slaBreached" is not supported by this data source`}
+	}
+	if parsed.HasActiveAccountEscalation != nil {
+		return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: `field "accountEscalationActive" is not supported by this data source`}
+	}
 	if len(req.Filters.AnyOf) > 0 {
 		return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: "anyOf is not supported by this data source"}
 	}

--- a/entity-service/internal/service/case_service_test.go
+++ b/entity-service/internal/service/case_service_test.go
@@ -201,6 +201,20 @@ func TestCaseService_SearchCases_RejectsServiceNowOnlyOptions(t *testing.T) {
 			wantMsg: `field "escalation" is not supported by this data source`,
 		},
 		{
+			name: "slaBreached",
+			req: domain.SearchCasesRequest{Filters: domain.SearchCasesFilters{
+				Filters: []domain.CaseFieldFilter{{Field: "slaBreached", Op: "eq", Values: []string{"true"}}},
+			}},
+			wantMsg: `field "slaBreached" is not supported by this data source`,
+		},
+		{
+			name: "accountEscalationActive",
+			req: domain.SearchCasesRequest{Filters: domain.SearchCasesFilters{
+				Filters: []domain.CaseFieldFilter{{Field: "accountEscalationActive", Op: "eq", Values: []string{"true"}}},
+			}},
+			wantMsg: `field "accountEscalationActive" is not supported by this data source`,
+		},
+		{
 			name: "resolvedOn gte",
 			req: domain.SearchCasesRequest{Filters: domain.SearchCasesFilters{
 				Filters: []domain.CaseFieldFilter{{Field: "resolvedOn", Op: "gte", Values: []string{"2026-01-01"}}},

--- a/entity-service/internal/service/incident_filters.go
+++ b/entity-service/internal/service/incident_filters.go
@@ -28,7 +28,7 @@ import (
 // accepted by incident search. Anything else is rejected outright.
 var incidentFilterFieldSet = map[string]bool{
 	"state": true, "assignmentGroupId": true, "businessServiceId": true,
-	"createdOn": true, "slaViolated": true, "productName": true,
+	"createdOn": true, "slaViolated": true, "madeSla": true, "productName": true,
 }
 
 // incidentFilterOpSet is the exact set of IncidentFieldFilter.Op values
@@ -37,8 +37,8 @@ var incidentFilterFieldSet = map[string]bool{
 // assignmentGroupId/businessServiceId/productName, "gte"/"lte" cover
 // createdOn (mirrors case_filters.go's "createdOn" handling exactly,
 // including its relative-date placeholder support, e.g. "__daysAgo:90__"),
-// and "eq" covers slaViolated (single boolean value, mirroring case search's
-// "number"/"internalId" single-value eq fields).
+// and "eq" covers slaViolated/madeSla (single boolean value, mirroring case
+// search's "number"/"internalId" single-value eq fields).
 var incidentFilterOpSet = map[string]bool{
 	"in": true, "gte": true, "lte": true, "eq": true,
 }
@@ -119,6 +119,13 @@ type parsedIncidentFilters struct {
 	// to incidents with/without at least one breached SLA record; nil means
 	// the filter was not supplied.
 	SlaViolated *bool
+	// MadeSla is set from a "madeSla" "eq" filter: true/false restricts to
+	// incidents matching ServiceNow's raw `made_sla` field; nil means the
+	// filter was not supplied. Deliberately kept separate from SlaViolated
+	// above -- see domain.SearchIncidentsFilters Filters "madeSla" doc
+	// comment: this is SN's own less-reliable raw signal, kept only for
+	// exact parity with SN's native incident dashboards.
+	MadeSla *bool
 	// ProductNames are the values of a "productName" "in" filter, matched as a
 	// union against the incident's backing business_service name.
 	ProductNames []string
@@ -211,6 +218,22 @@ func ParseIncidentFieldFilters(filters []domain.IncidentFieldFilter, now time.Ti
 				return parsedIncidentFilters{}, err
 			}
 			p.SlaViolated = &b
+
+		case "madeSla":
+			if f.Op != "eq" {
+				return parsedIncidentFilters{}, badIncidentFilterCombo(f)
+			}
+			if err := requireIncidentFilterValues(f); err != nil {
+				return parsedIncidentFilters{}, err
+			}
+			if len(f.Values) != 1 {
+				return parsedIncidentFilters{}, &apierror.ValidationError{Msg: "filters: madeSla eq requires exactly one value"}
+			}
+			b, err := parseIncidentFilterBool(f, f.Values[0])
+			if err != nil {
+				return parsedIncidentFilters{}, err
+			}
+			p.MadeSla = &b
 
 		case "productName":
 			if f.Op != "in" {

--- a/entity-service/internal/service/incident_filters_test.go
+++ b/entity-service/internal/service/incident_filters_test.go
@@ -86,6 +86,28 @@ func TestParseIncidentFieldFilters_SlaViolated(t *testing.T) {
 	}
 }
 
+func TestParseIncidentFieldFilters_MadeSla(t *testing.T) {
+	parsed, err := ParseIncidentFieldFilters([]domain.IncidentFieldFilter{
+		{Field: "madeSla", Op: "eq", Values: []string{"true"}},
+	}, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if parsed.MadeSla == nil || !*parsed.MadeSla {
+		t.Fatalf("MadeSla = %v, want pointer to true", parsed.MadeSla)
+	}
+
+	parsed, err = ParseIncidentFieldFilters([]domain.IncidentFieldFilter{
+		{Field: "madeSla", Op: "eq", Values: []string{"false"}},
+	}, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if parsed.MadeSla == nil || *parsed.MadeSla {
+		t.Fatalf("MadeSla = %v, want pointer to false", parsed.MadeSla)
+	}
+}
+
 func TestParseIncidentFieldFilters_ProductName(t *testing.T) {
 	parsed, err := ParseIncidentFieldFilters([]domain.IncidentFieldFilter{
 		{Field: "productName", Op: "in", Values: []string{"API Manager", "Choreo"}},
@@ -149,6 +171,18 @@ func TestParseIncidentFieldFilters_Rejections(t *testing.T) {
 		{
 			name:    "slaViolated with more than one value",
 			filters: []domain.IncidentFieldFilter{{Field: "slaViolated", Op: "eq", Values: []string{"true", "false"}}},
+		},
+		{
+			name:    "madeSla with unsupported op",
+			filters: []domain.IncidentFieldFilter{{Field: "madeSla", Op: "in", Values: []string{"true"}}},
+		},
+		{
+			name:    "madeSla with non-boolean value",
+			filters: []domain.IncidentFieldFilter{{Field: "madeSla", Op: "eq", Values: []string{"yes"}}},
+		},
+		{
+			name:    "madeSla with more than one value",
+			filters: []domain.IncidentFieldFilter{{Field: "madeSla", Op: "eq", Values: []string{"true", "false"}}},
 		},
 		{
 			name:    "productName with unsupported op",

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -441,6 +441,13 @@ type snCaseFilters struct {
 	// IsEscalated: a *bool (not bool) so that an explicit false is still sent on
 	// the wire -- omitempty on a pointer only drops a nil, not a false value.
 	IsEscalated *bool `json:"isEscalated,omitempty"`
+	// SlaBreached: see domain.ParsedCaseFilters.HasBreachedSLA doc comment. A
+	// *bool for the same reason as IsEscalated above -- an explicit false must
+	// still reach ServiceNow, not be silently dropped.
+	SlaBreached *bool `json:"slaBreached,omitempty"`
+	// AccountEscalationActive: see domain.ParsedCaseFilters.HasActiveAccountEscalation
+	// doc comment. A *bool for the same reason as IsEscalated above.
+	AccountEscalationActive *bool `json:"accountEscalationActive,omitempty"`
 	// OrGroups is the ServiceNow wire field name, deliberately unchanged:
 	// ServiceNow's CaseUtils Script Include reads "orGroups" and silently
 	// ignores JSON keys it does not recognise (returning an unfiltered count
@@ -2400,6 +2407,8 @@ func buildSNCaseFilters(parsed domain.ParsedCaseFilters, searchQuery string) snC
 		TaskSLAFilter:                    buildSNTaskSLAFilter(parsed.TaskSLAFilter),
 		EscalationLevels:                 parsed.EscalationLevels,
 		IsEscalated:                      parsed.HasActiveEscalation,
+		SlaBreached:                      parsed.HasBreachedSLA,
+		AccountEscalationActive:          parsed.HasActiveAccountEscalation,
 		OrGroups:                         buildSNCaseFilterGroups(parsed.OrGroups),
 	}
 }

--- a/entity-service/internal/service/sn_case_service_test.go
+++ b/entity-service/internal/service/sn_case_service_test.go
@@ -1501,6 +1501,8 @@ func TestSNCaseService_SearchCases_GenericFiltersTranslateToSNPayload(t *testing
 				{Field: "resolutionNotes", Op: "isEmpty"},
 				{Field: "createdBy", Op: "eq", Values: []string{currentUserFilterPlaceholder}},
 				{Field: "projectType", Op: "in", Values: []string{"Subscription", "Free Trial"}},
+				{Field: "slaBreached", Op: "eq", Values: []string{"true"}},
+				{Field: "accountEscalationActive", Op: "eq", Values: []string{"true"}},
 			},
 		},
 	}
@@ -1534,6 +1536,70 @@ func TestSNCaseService_SearchCases_GenericFiltersTranslateToSNPayload(t *testing
 		gotBody.Filters.ProjectTypeNames[0] != "Subscription" ||
 		gotBody.Filters.ProjectTypeNames[1] != "Free Trial" {
 		t.Fatalf("ProjectTypeNames = %v, want [Subscription, Free Trial] passed through unchanged", gotBody.Filters.ProjectTypeNames)
+	}
+	if gotBody.Filters.SlaBreached == nil || !*gotBody.Filters.SlaBreached {
+		t.Fatalf("SlaBreached = %v, want pointer to true", gotBody.Filters.SlaBreached)
+	}
+	if gotBody.Filters.AccountEscalationActive == nil || !*gotBody.Filters.AccountEscalationActive {
+		t.Fatalf("AccountEscalationActive = %v, want pointer to true", gotBody.Filters.AccountEscalationActive)
+	}
+}
+
+// TestSNCaseService_SearchCases_SLABreachedAndAccountEscalationTravelOnTheirOwnWireKeys
+// pins the exact JSON wire keys for the two new plain-boolean filters --
+// "slaBreached" and "accountEscalationActive" -- distinct from the existing
+// case-level "isEscalated" key, and proves an explicit false is still sent on
+// the wire (not dropped by omitempty, since both fields are *bool).
+func TestSNCaseService_SearchCases_SLABreachedAndAccountEscalationTravelOnTheirOwnWireKeys(t *testing.T) {
+	var rawBody []byte
+	mux := http.NewServeMux()
+	mux.HandleFunc("/cases/search", func(w http.ResponseWriter, r *http.Request) {
+		b, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read request body: %v", err)
+		}
+		rawBody = b
+		_ = json.NewEncoder(w).Encode(map[string]any{"cases": []map[string]any{}, "total": 0, "offset": 0, "limit": 20})
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowCaseService(client, nil)
+
+	req := domain.SearchCasesRequest{
+		Filters: domain.SearchCasesFilters{
+			Filters: []domain.CaseFieldFilter{
+				{Field: "slaBreached", Op: "eq", Values: []string{"false"}},
+				{Field: "accountEscalationActive", Op: "eq", Values: []string{"false"}},
+			},
+		},
+	}
+	ctx := contextWithUserIDToken(fakeJWTWithEmail(t, "jane.doe@example.com"))
+	if _, err := svc.SearchCases(ctx, req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var envelope struct {
+		Filters map[string]json.RawMessage `json:"filters"`
+	}
+	if err := json.Unmarshal(rawBody, &envelope); err != nil {
+		t.Fatalf("unmarshal request body: %v", err)
+	}
+	slaBreachedRaw, ok := envelope.Filters["slaBreached"]
+	if !ok {
+		t.Fatalf("expected \"slaBreached\" key on the wire even for an explicit false, filters = %v", envelope.Filters)
+	}
+	if string(slaBreachedRaw) != "false" {
+		t.Fatalf("slaBreached = %s, want false", slaBreachedRaw)
+	}
+	accountEscalationRaw, ok := envelope.Filters["accountEscalationActive"]
+	if !ok {
+		t.Fatalf("expected \"accountEscalationActive\" key on the wire even for an explicit false, filters = %v", envelope.Filters)
+	}
+	if string(accountEscalationRaw) != "false" {
+		t.Fatalf("accountEscalationActive = %s, want false", accountEscalationRaw)
+	}
+	if _, ok := envelope.Filters["isEscalated"]; ok {
+		t.Fatalf("expected no \"isEscalated\" key: accountEscalationActive must not be conflated with the case-level escalation filter")
 	}
 }
 

--- a/entity-service/internal/service/sn_incident_service.go
+++ b/entity-service/internal/service/sn_incident_service.go
@@ -105,6 +105,12 @@ type snIncidentFilters struct {
 	// SlaViolated: see domain.SearchIncidentsFilters Filters "slaViolated" doc
 	// comment. nil (omitted) means the filter was not supplied.
 	SlaViolated *bool `json:"slaViolated,omitempty"`
+	// MadeSla: see domain.SearchIncidentsFilters Filters "madeSla" doc
+	// comment. nil (omitted) means the filter was not supplied. Deliberately
+	// kept separate from SlaViolated above -- this is ServiceNow's own raw,
+	// less-reliable `made_sla` field, carried through only for exact parity
+	// with SN's native incident dashboards; prefer SlaViolated otherwise.
+	MadeSla *bool `json:"madeSla,omitempty"`
 	// ProductNames: see domain.SearchIncidentsFilters Filters "productName"
 	// doc comment. Matched as a union against the incident's backing
 	// business_service name.
@@ -252,6 +258,7 @@ func (s *snIncidentService) SearchIncidents(ctx context.Context, req domain.Sear
 			StartCreatedDate:   formatSNDateTimeUTC(parsedFilters.StartCreatedDate),
 			EndCreatedDate:     formatSNDateTimeUTC(parsedFilters.EndCreatedDate),
 			SlaViolated:        parsedFilters.SlaViolated,
+			MadeSla:            parsedFilters.MadeSla,
 			ProductNames:       parsedFilters.ProductNames,
 		},
 		SortBy:     snSortBy,
@@ -396,6 +403,7 @@ func (s *snIncidentService) AggregateIncidents(ctx context.Context, req domain.A
 			StartCreatedDate:   formatSNDateTimeUTC(parsedFilters.StartCreatedDate),
 			EndCreatedDate:     formatSNDateTimeUTC(parsedFilters.EndCreatedDate),
 			SlaViolated:        parsedFilters.SlaViolated,
+			MadeSla:            parsedFilters.MadeSla,
 			ProductNames:       parsedFilters.ProductNames,
 		},
 		GroupBy:   req.GroupBy,

--- a/entity-service/internal/service/sn_incident_service_test.go
+++ b/entity-service/internal/service/sn_incident_service_test.go
@@ -337,6 +337,72 @@ func TestSNIncidentService_SearchIncidents_SlaViolatedInvalidValue(t *testing.T)
 	}
 }
 
+// TestSNIncidentService_SearchIncidents_MadeSlaPassedThrough verifies the
+// generic filters array's madeSla predicate reaches the outgoing payload
+// under the exact wire name Ballerina accepts, as a sibling to (and
+// independent of) slaViolated -- see domain.SearchIncidentsFilters Filters
+// "madeSla" doc comment for why the two are kept distinct.
+func TestSNIncidentService_SearchIncidents_MadeSlaPassedThrough(t *testing.T) {
+	var gotBody map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/incidents/search", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", r.Method)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"incidents": [], "totalRecords": 0, "offset": 0, "limit": 20}`))
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowIncidentService(client)
+
+	req := domain.SearchIncidentsRequest{
+		Filters: domain.SearchIncidentsFilters{
+			Filters: []domain.IncidentFieldFilter{
+				{Field: "madeSla", Op: "eq", Values: []string{"false"}},
+			},
+		},
+	}
+	if _, err := svc.SearchIncidents(contextWithUserIDToken("token"), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	gotFilters, ok := gotBody["filters"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected filters object in payload, got %+v", gotBody["filters"])
+	}
+
+	if gotFilters["madeSla"] != false {
+		t.Fatalf("filters.madeSla: got %v, want false", gotFilters["madeSla"])
+	}
+	if _, present := gotFilters["slaViolated"]; present {
+		t.Fatalf("filters.slaViolated: got present with value %v, want omitted since it was not requested", gotFilters["slaViolated"])
+	}
+}
+
+// TestSNIncidentService_SearchIncidents_MadeSlaInvalidValue verifies a
+// non-boolean madeSla filter value is rejected with a clean validation error
+// before any SN call.
+func TestSNIncidentService_SearchIncidents_MadeSlaInvalidValue(t *testing.T) {
+	// client is intentionally nil: validation must fail before touching it.
+	svc := NewServiceNowIncidentService(nil)
+
+	req := domain.SearchIncidentsRequest{
+		Filters: domain.SearchIncidentsFilters{
+			Filters: []domain.IncidentFieldFilter{
+				{Field: "madeSla", Op: "eq", Values: []string{"not-a-bool"}},
+			},
+		},
+	}
+	_, err := svc.SearchIncidents(contextWithUserIDToken("token"), req)
+	if _, ok := err.(*apierror.ValidationError); !ok {
+		t.Fatalf("expected *apierror.ValidationError, got %T: %v", err, err)
+	}
+}
+
 // TestSNIncidentService_SearchIncidents_InvalidStateValue verifies an
 // unrecognized state filter value is rejected with a clean validation error
 // before any SN call.

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -8673,6 +8673,7 @@ components:
             - businessServiceId
             - createdOn
             - slaViolated
+            - madeSla
             - productName
         op:
           type: string
@@ -8700,6 +8701,13 @@ components:
         - **slaViolated** (eq): a single boolean value ("true"/"false").
           Restricts to incidents with (or without) at least one breached SLA
           record.
+        - **madeSla** (eq): a single boolean value ("true"/"false").
+          Restricts to incidents matching ServiceNow's raw `made_sla` field.
+          Deliberately separate from **slaViolated** above: slaViolated is
+          derived from task_sla.has_breached and is the reliable signal;
+          madeSla is ServiceNow's own less-reliable raw field, kept only for
+          exact parity with SN's native incident dashboards. Prefer
+          slaViolated unless dashboard parity is the explicit goal.
         - **productName** (in): one or more product names to match as a
           union (an incident matching any one of them is returned). Only a
           minority of incidents carry a product association, so this filter

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -5403,6 +5403,8 @@ components:
             - escalation
             - number
             - internalId
+            - slaBreached
+            - accountEscalationActive
         op:
           type: string
           enum: [eq, in, notIn, isEmpty, isNotEmpty, gte, lte]
@@ -5519,6 +5521,15 @@ components:
         - **internalId** (eq): a single WSO2 case id; matches exactly. Routed
           as a first-class filter rather than through the free-text
           searchQuery scan.
+        - **slaBreached** (eq): a single boolean value ("true"/"false").
+          Matches cases with a currently-breached SLA against the platform's
+          10 named SLA definitions. Only applied by the ServiceNow data
+          source.
+        - **accountEscalationActive** (eq): a single boolean value
+          ("true"/"false"). Matches cases whose parent ACCOUNT has an active
+          escalation (state IN 100,101) — distinct from **escalation** above,
+          which matches on the case's own escalation state, not its parent
+          account's. Only applied by the ServiceNow data source.
 
     CaseFilterBranch:
       type: object


### PR DESCRIPTION
## Purpose
Four independent CSM Portal fixes/improvements, bundled in one PR since they're the same overall effort landed in the same session:

1. The dashboard's hardcoded list-shape widgets for case-family resource types (cases, service requests, security reports, engagements) didn't show who a case was assigned to, so a reviewer scanning a widget had to open each row to find out.
2. A dashboard count-tile widget configured with a cross-field OR filter (`anyOf`) had its "View all" click-through silently drop that OR condition, since the cases list's own filter model has no OR construct to translate it into — the destination showed a broader set of cases than what the tile itself had counted.
3. **(Bundled 2026-08-24)** A CSM dashboard rebuild needs to numerically match a live ServiceNow reference dashboard. Two case-search tiles ("SLA Violations", "Escalated Cases") and one incident-search tile currently use approximate signals that diverge from what the ServiceNow tiles actually count; the ServiceNow and Ballerina entity-service layers now expose the exact underlying signals, but this Go entity-service did not yet surface them. See "Bundled change" section near the end.
4. **(Bundled 2026-08-24)** The change-request detail page gave no sense of where a CR sits in its lifecycle (only a single state chip) and buried why it wasn't progressing one tab-click into Approval. Compared against ServiceNow's own change-request form for reference, two things it does better were worth borrowing; everything else about that form (no related lists, no activity stream) was not.

## Goals
- Add an "Assignee" column to every dashboard list widget backed by case rows.
- Make a case-family widget's "View all"/count-tile click-through faithfully reflect an `anyOf` filter instead of silently dropping it.
- (Bundled) Expose `slaBreached`/`accountEscalationActive` (case search) and `madeSla` (incident search) as new entity-service filter fields.
- (Bundled) Give the change-request detail page a lifecycle stepper, an inline blocking-reason note, a clearer customer-vs-internal approval split, and the Impact field in its Overview grid.

## Approach
1. **Assignee column**: `CaseWidgetList` (the shared renderer for case/service_request/security_report_analysis/announcement/engagement dashboard widgets) now passes `optionalColumns` to `CasesList` including `assignee`, reusing the exact same column definition and "Unassigned" fallback the Cases tab's own configurable-columns feature already established. No new UI concept — the column already existed, it just wasn't turned on for these widgets.
2. **`anyOf` drill-through**: `CasesFilters` (the cases list's own URL filter model) is AND-only and has no way to represent a cross-field OR, so extending it would be a much larger UI change than this fix warrants. Instead, a case-family widget carrying `anyOf` now routes its click-through to the existing generic, filter-faithful dashboard-widget preview page (the same fallback already used by `incident_task`, a resourceType with no representable destination of its own) rather than translating through the lossy AND-only model. That preview page posts the widget's raw filters straight to the search endpoint, so its result set is guaranteed to match what the tile counted. This required teaching the widget-preview URL encoding (`widgetPreviewUrl.ts`) to round-trip `anyOf` at all — it was previously neither serialized into nor read back from that URL, so even the widgets that already went through the generic preview page for other reasons would have silently lost `anyOf` on that URL round trip.
4. **(Bundled) Change-request detail page**: a new `ChangeRequestLifecycleStepper` renders the 9-state forward path (`CHANGE_REQUEST_FORWARD_STATES`) as connected step markers — filled + checked for done, a highlighted node for the CR's current state, outlined for what's ahead. `rollback`/`canceled` are off-ramps reachable from several points in the path, not a 10th/11th sequential step, so they're deliberately excluded from the line and shown instead as a separate note naming the actual state. A new `changeRequestBlockingReason` util derives a plain-language line ("Awaiting Devops Approval") from the same approval-stage data `ChangeRequestApprovals` already fetches (query lifted to page level; react-query dedupes, no extra request). The Approval tab's existing customer-approval fields and internal approval-stage list are now two visually distinct, labeled sections instead of two identically-styled stacked cards. `impact` (already shown as a header chip) is also added to the Overview grid. No backend change; `priority`/`risk` remain out of scope (write-only on the entity service today) and `urgency` has no equivalent in this platform's CR model at all.

All four items above are scoped to `apps/csm-portal/webapp` and (items 3) `entity-service`; no other app, and no customer-portal-facing API contract, changed by them.

## User stories
As a CS engineer reviewing a dashboard widget's case list, I can see each case's assignee without opening it. As a CS engineer clicking "View all" on a widget whose count reflects an OR condition, the list I land on matches what was counted. (Bundled) As a CSM dashboard widget, I can filter cases by SLA-breach and account-escalation status, and incidents by ServiceNow's raw SLA-met signal, matching a reference ServiceNow dashboard exactly. (Bundled) As a CS engineer viewing a change request, I can see at a glance where it sits in its lifecycle and why it isn't moving, without digging into a tab.

## Release note
CSM Portal: dashboard case widgets now show an Assignee column, and a dashboard tile's "View all" link for a widget using an OR filter condition now shows the correct, matching set of records. Entity service: new case-search filters `slaBreached`/`accountEscalationActive`; new incident-search filter `madeSla`. Change-request detail page: adds a lifecycle stepper, an inline reason when a CR isn't progressing, a clearer customer-vs-internal approval layout, and an Impact field in the Overview section.

## Documentation
N/A for items 1–2 and 4 — no user-facing workflow changed, just a widget's own column set, the correctness of an existing drill-through link, and a detail page's own layout/information density. Item 3: `entity-service/openapi.yaml` updated with the three new filter fields and their descriptions.

## Training
N/A — no training content references dashboard widget internals or entity-service filter fields.

## Certification
N/A — no certification content covers this surface.

## Marketing
N/A — internal correctness/UX fix and internal API surface, not a marketable feature.

## Automation tests
- Unit tests
  - `widgetListConfig.test.tsx`: new case renderer test asserting the Assignee column renders, including the "Unassigned" fallback.
  - `widgetResourceConfig.test.ts`: new `anyOf` regression suite asserting each case-family `buildHref` routes to the widget preview page (with widget context) instead of the lossy `CasesFilters` translation.
  - `widgetPreviewUrl.test.ts`: new round-trip tests for `anyOf` through `buildWidgetPreviewHref`/`parseWidgetPreviewFilters`/`resolveCurrentUserSentinels`, including current-user-sentinel masking inside a branch and a malformed-URL fallback.
  - `DashboardWidgetPreviewPage.test.tsx`: new test asserting a case-family widget with `anyOf` skips the editable Cases filter bar and posts its raw filters (branches included) to the search endpoint.
  - Full webapp suite: `pnpm run test -- --run` → 210 files, 2139 tests passed (includes new `ChangeRequestLifecycleStepper.test.tsx`, `changeRequests.test.ts` additions for `changeRequestBlockingReason`, and updated `CsmChangeRequestDetailPage.test.tsx` coverage for the stepper, blocking-reason line, and Impact cell).
  - (Bundled) `entity-service`: case-side field translation (true/false, non-leakage between the two escalation concepts), 6 rejection cases, an `anyOf`-filter-group rejection test, a Postgres-path rejection test, a wire-level test pinning the exact JSON keys and proving explicit `false` isn't dropped; incident-side parse tests (true/false + 3 rejections) and a passthrough test proving `madeSla`/`slaViolated` are independent. `go build ./...`, `go vet ./...`, `go test ./...` all pass clean from the `entity-service` module root after combining both commits onto this branch.
- Integration tests
  - N/A for items 1–2 — no backend/API contract change; covered by the above component/unit tests plus `pnpm run build` (tsc + vite build) succeeding.
  - (Bundled) No automated integration suite covers the entity-service paths (consistent with this service's existing convention). A real end-to-end run against ServiceNow DEV was not performed: the corresponding Ballerina entity-service change (a separate PR, not yet merged) is a prerequisite for a genuine round-trip test, and a peer development session was concurrently holding this environment's local-stack ports during this work. Disclosed honestly rather than overstated; a live smoke test against DEV is recommended once the Ballerina PR merges.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — items 1–2 are frontend-only TypeScript/React (no Go/Java touched; `pnpm run lint` ran clean, 0 errors, 2 pre-existing unrelated warnings). Item 3 touches Go: `gosec` was not available in this environment for this PR; no security-sensitive surface is added (three new boolean filter fields following existing patterns), but this should still be run before merge per this service's normal convention.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no new sample/example content.

## Related PRs
A corresponding ServiceNow scripted-API change and a corresponding Ballerina entity-service change (for the bundled item 3) are tracked separately, not in this repo.

## Migrations (if applicable)
N/A — no schema or data migration involved.

## Test environment
Verified with `pnpm run lint`, `pnpm run build` (tsc -b && vite build), and `pnpm run test -- --run` (Vitest, jsdom) in `apps/csm-portal/webapp`; `go build`/`go vet`/`go test` in `entity-service`. macOS/Darwin, Node/Go via the repo's pinned toolchains.

## Learning
Reused two existing patterns rather than inventing new ones: the Cases tab's already-shipped configurable-columns `assignee` column, and the `incident_task` widget's existing precedent of routing to the generic dashboard-widget preview page when its own list route can't represent its filters. For the bundled entity-service change: two of the three new fields don't fit either of this service's existing boolean-filter idioms cleanly, so a small `parseCaseFilterBool` helper was added mirroring the incident side's existing equivalent, rather than forcing a mismatched pattern. For the bundled change-request page: read the entity-service's own request/response structs (not just the frontend types) before proposing a field, which caught that `priority`/`risk` are write-only on the read path and `urgency` doesn't exist at all — better to scope those out than build UI for data that can't be shown.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added lifecycle visualization, impact details, approval sections, and blocking-approval notices to change request details.
  * Improved dashboard case widgets with explicit product, type, severity, and assignee columns.
  * Preserved cross-field OR filters in dashboard preview URLs and routing.
  * Added case filters for SLA breaches and active account escalations.
  * Added incident filtering for ServiceNow SLA status.

* **Bug Fixes**
  * Dashboard previews now retain complex filters instead of losing or misapplying them.
  * Unsupported filters now return clear validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->