### PR TITLE
[CSM Portal] fix comment composer paste spacing and code block duplication

### DIFF
--- a/apps/csm-portal/webapp/src/components/rich-text-editor/Editor.tsx
+++ b/apps/csm-portal/webapp/src/components/rich-text-editor/Editor.tsx
@@ -37,6 +37,7 @@ import {
   INSERT_IMAGE_COMMAND,
   tokenizePlainTextPaste,
   unwrapNestedPreCodeElements,
+  collapseEmptyParagraphElements,
 } from "@components/rich-text-editor/richTextEditor";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { type ReactNode, useEffect, useState, useCallback, useMemo, useRef } from "react";
@@ -289,6 +290,14 @@ const ClipboardImagePlugin = ({ onPasteError }: { onPasteError?: () => void }): 
  *   Notion's standard code block markup): flattens the nested `<code>`
  *   before conversion so it doesn't produce a duplicated, nested CodeNode.
  *   See `unwrapNestedPreCodeElements` in richTextEditor.tsx.
+ * - HTML paste containing an empty `<p>`/`<div>` between two real paragraphs
+ *   (how Google Docs, Gmail, Gemini, Claude, Notion, Word, and a manual
+ *   text-selection copy from ChatGPT's rendered page all represent a blank
+ *   line in their clipboard HTML): removes the empty block before
+ *   conversion, the same "extra space between paragraphs" fix the plain-text
+ *   path gets from `tokenizePlainTextPaste`, generalized to any source that
+ *   puts `text/html` on the clipboard. See `collapseEmptyParagraphElements`
+ *   in richTextEditor.tsx.
  */
 const PasteNormalizationPlugin = (): null => {
   const [editor] = useLexicalComposerContext();
@@ -306,7 +315,9 @@ const PasteNormalizationPlugin = (): null => {
 
         if (html.trim()) {
           const dom = new DOMParser().parseFromString(html, "text/html");
-          if (!unwrapNestedPreCodeElements(dom)) return false;
+          const unwrappedPreCode = unwrapNestedPreCodeElements(dom);
+          const collapsedEmptyParagraphs = collapseEmptyParagraphElements(dom);
+          if (!unwrappedPreCode && !collapsedEmptyParagraphs) return false;
 
           event.preventDefault();
           editor.update(
@@ -545,6 +556,13 @@ const Editor = ({
               "& p": {
                 margin: 0,
                 padding: 0,
+              },
+              // Mirrors CsmCaseCommentBubble's read-view rule (`"& p + p": { mt: 0.75 }`)
+              // so a real paragraph-to-paragraph adjacency shows the same visible gap
+              // while composing as it will once posted -- otherwise distinct paragraphs
+              // look identical to a soft line break during composition.
+              "& p + p": {
+                marginTop: 0.75,
               },
               "& > p:only-child > br:only-child": {
                 display: "none",

--- a/apps/csm-portal/webapp/src/components/rich-text-editor/Editor.tsx
+++ b/apps/csm-portal/webapp/src/components/rich-text-editor/Editor.tsx
@@ -35,6 +35,8 @@ import {
   getFileIcon,
   scrollElement,
   INSERT_IMAGE_COMMAND,
+  tokenizePlainTextPaste,
+  unwrapNestedPreCodeElements,
 } from "@components/rich-text-editor/richTextEditor";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { type ReactNode, useEffect, useState, useCallback, useMemo, useRef } from "react";
@@ -61,6 +63,9 @@ import {
   $getSelection,
   $isRangeSelection,
   INSERT_PARAGRAPH_COMMAND,
+  PASTE_COMMAND,
+  PASTE_TAG,
+  $createTabNode,
 } from "lexical";
 import { $isListItemNode } from "@lexical/list";
 import { $findMatchingParent } from "@lexical/utils";
@@ -261,6 +266,89 @@ const ClipboardImagePlugin = ({ onPasteError }: { onPasteError?: () => void }): 
         prevRootElement?.removeEventListener("paste", handlePaste);
         rootElement?.addEventListener("paste", handlePaste);
       },
+    );
+  }, [editor]);
+
+  return null;
+};
+
+/**
+ * Normalizes two paste-import gaps in Lexical's default paste handling
+ * before it runs (registered at COMMAND_PRIORITY_HIGH, above the default
+ * rich-text paste handler's COMMAND_PRIORITY_EDITOR, so it can intercept
+ * first). Falls through (returns false) whenever neither fix applies, so
+ * every other paste shape is handled exactly as before.
+ *
+ * - Plain-text paste (clipboard has text/plain but no text/html -- exactly
+ *   ChatGPT's own clipboard format): replays the same tokenization Lexical's
+ *   default handler uses, but collapsing blank lines into ordinary paragraph
+ *   breaks instead of standalone empty paragraphs. See
+ *   `tokenizePlainTextPaste` in richTextEditor.tsx for why the default
+ *   causes the reported "extra space between paragraphs".
+ * - HTML paste containing `<pre><code>...</code></pre>` (ChatGPT/GitHub/
+ *   Notion's standard code block markup): flattens the nested `<code>`
+ *   before conversion so it doesn't produce a duplicated, nested CodeNode.
+ *   See `unwrapNestedPreCodeElements` in richTextEditor.tsx.
+ */
+const PasteNormalizationPlugin = (): null => {
+  const [editor] = useLexicalComposerContext();
+
+  useEffect(() => {
+    return editor.registerCommand(
+      PASTE_COMMAND,
+      (event) => {
+        if (!(event instanceof ClipboardEvent)) return false;
+        const clipboardData = event.clipboardData;
+        if (!clipboardData) return false;
+
+        const html = clipboardData.getData("text/html");
+        const text = clipboardData.getData("text/plain");
+
+        if (html.trim()) {
+          const dom = new DOMParser().parseFromString(html, "text/html");
+          if (!unwrapNestedPreCodeElements(dom)) return false;
+
+          event.preventDefault();
+          editor.update(
+            () => {
+              const selection = $getSelection();
+              if (!$isRangeSelection(selection)) return;
+              const nodes = $generateNodesFromDOM(editor, dom);
+              selection.insertNodes(nodes);
+            },
+            { tag: PASTE_TAG },
+          );
+          return true;
+        }
+
+        if (text) {
+          const tokens = tokenizePlainTextPaste(text);
+          if (tokens.length === 0) return false;
+
+          event.preventDefault();
+          editor.update(
+            () => {
+              for (const token of tokens) {
+                const currentSelection = $getSelection();
+                if (!$isRangeSelection(currentSelection)) continue;
+
+                if (token.type === "paragraph") {
+                  currentSelection.insertParagraph();
+                } else if (token.type === "tab") {
+                  currentSelection.insertNodes([$createTabNode()]);
+                } else {
+                  currentSelection.insertText(token.value);
+                }
+              }
+            },
+            { tag: PASTE_TAG },
+          );
+          return true;
+        }
+
+        return false;
+      },
+      COMMAND_PRIORITY_HIGH,
     );
   }, [editor]);
 
@@ -529,6 +617,7 @@ const Editor = ({
           <ListPlugin />
           <ImagesPlugin />
           <ClipboardImagePlugin onPasteError={onPasteError} />
+          <PasteNormalizationPlugin />
           <LinkPlugin />
           <ClickableLinkPlugin />
           <InitialValuePlugin initialHtml={value} />

--- a/apps/csm-portal/webapp/src/components/rich-text-editor/pasteNormalization.test.ts
+++ b/apps/csm-portal/webapp/src/components/rich-text-editor/pasteNormalization.test.ts
@@ -218,4 +218,26 @@ describe("collapseEmptyParagraphElements", () => {
     expect(changed).toBe(false);
     expect(dom.querySelectorAll("p").length).toBe(2);
   });
+
+  it("collapses a nested empty wrapper (<div><div><br></div></div>) entirely", () => {
+    const dom = parse("<p>Para1</p><div><div><br></div></div><p>Para2</p>");
+
+    const changed = collapseEmptyParagraphElements(dom);
+
+    expect(changed).toBe(true);
+    expect(dom.querySelector("div")).toBeNull();
+    expect(dom.body.textContent).toBe("Para1Para2");
+  });
+
+  it("collapses a three-level nested empty wrapper", () => {
+    const dom = parse(
+      "<p>Para1</p><div><div><div><br></div></div></div><p>Para2</p>",
+    );
+
+    const changed = collapseEmptyParagraphElements(dom);
+
+    expect(changed).toBe(true);
+    expect(dom.querySelector("div")).toBeNull();
+    expect(dom.body.textContent).toBe("Para1Para2");
+  });
 });

--- a/apps/csm-portal/webapp/src/components/rich-text-editor/pasteNormalization.test.ts
+++ b/apps/csm-portal/webapp/src/components/rich-text-editor/pasteNormalization.test.ts
@@ -18,6 +18,7 @@ import { describe, expect, it } from "vitest";
 import {
   tokenizePlainTextPaste,
   unwrapNestedPreCodeElements,
+  collapseEmptyParagraphElements,
 } from "./richTextEditor";
 
 describe("tokenizePlainTextPaste", () => {
@@ -147,5 +148,74 @@ describe("unwrapNestedPreCodeElements", () => {
 
     expect(changed).toBe(false);
     expect(dom.querySelector("code")).not.toBeNull();
+  });
+});
+
+describe("collapseEmptyParagraphElements", () => {
+  const parse = (html: string) =>
+    new DOMParser().parseFromString(html, "text/html");
+
+  it("removes an empty <p>&nbsp;</p> sitting between two real paragraphs", () => {
+    const dom = parse("<p>Para1</p><p>&nbsp;</p><p>Para2</p>");
+
+    const changed = collapseEmptyParagraphElements(dom);
+
+    expect(changed).toBe(true);
+    expect(
+      Array.from(dom.querySelectorAll("p")).map((p) => p.textContent),
+    ).toEqual(["Para1", "Para2"]);
+  });
+
+  it("removes an empty <p><br></p> sitting between two real paragraphs", () => {
+    const dom = parse("<p>Para1</p><p><br></p><p>Para2</p>");
+
+    const changed = collapseEmptyParagraphElements(dom);
+
+    expect(changed).toBe(true);
+    expect(dom.querySelectorAll("p").length).toBe(2);
+    expect(dom.body.textContent).toBe("Para1Para2");
+  });
+
+  it("removes an empty <div><br></div> sitting between two real paragraphs", () => {
+    const dom = parse("<p>Para1</p><div><br></div><p>Para2</p>");
+
+    const changed = collapseEmptyParagraphElements(dom);
+
+    expect(changed).toBe(true);
+    expect(dom.querySelector("div")).toBeNull();
+    expect(dom.body.textContent).toBe("Para1Para2");
+  });
+
+  it("collapses multiple consecutive empty blocks between two real paragraphs", () => {
+    const dom = parse(
+      "<p>Para1</p><p><br></p><p>&nbsp;</p><div><br></div><p>Para2</p>",
+    );
+
+    const changed = collapseEmptyParagraphElements(dom);
+
+    expect(changed).toBe(true);
+    expect(
+      Array.from(dom.querySelectorAll("p")).map((p) => p.textContent),
+    ).toEqual(["Para1", "Para2"]);
+  });
+
+  it("does not remove a paragraph or div that carries real content", () => {
+    const dom = parse(
+      '<p>Para1</p><div><img src="x.png" alt="x" /></div><p>Para2</p>',
+    );
+
+    const changed = collapseEmptyParagraphElements(dom);
+
+    expect(changed).toBe(false);
+    expect(dom.querySelector("img")).not.toBeNull();
+  });
+
+  it("returns false and leaves the DOM untouched when there are no empty blocks", () => {
+    const dom = parse("<p>Para1</p><p>Para2</p>");
+
+    const changed = collapseEmptyParagraphElements(dom);
+
+    expect(changed).toBe(false);
+    expect(dom.querySelectorAll("p").length).toBe(2);
   });
 });

--- a/apps/csm-portal/webapp/src/components/rich-text-editor/pasteNormalization.test.ts
+++ b/apps/csm-portal/webapp/src/components/rich-text-editor/pasteNormalization.test.ts
@@ -1,0 +1,151 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { describe, expect, it } from "vitest";
+import {
+  tokenizePlainTextPaste,
+  unwrapNestedPreCodeElements,
+} from "./richTextEditor";
+
+describe("tokenizePlainTextPaste", () => {
+  it("does not emit a standalone empty paragraph between blank-line-separated paragraphs", () => {
+    const tokens = tokenizePlainTextPaste("Para1\n\nPara2\n\nPara3");
+
+    expect(tokens).toEqual([
+      { type: "text", value: "Para1" },
+      { type: "paragraph" },
+      { type: "text", value: "Para2" },
+      { type: "paragraph" },
+      { type: "text", value: "Para3" },
+    ]);
+  });
+
+  it("collapses multiple consecutive blank lines into a single paragraph break", () => {
+    const tokens = tokenizePlainTextPaste("Para1\n\n\n\nPara2");
+
+    expect(tokens).toEqual([
+      { type: "text", value: "Para1" },
+      { type: "paragraph" },
+      { type: "text", value: "Para2" },
+    ]);
+  });
+
+  it("still starts a new paragraph for a single, non-blank-separated newline", () => {
+    const tokens = tokenizePlainTextPaste("Line1\nLine2");
+
+    expect(tokens).toEqual([
+      { type: "text", value: "Line1" },
+      { type: "paragraph" },
+      { type: "text", value: "Line2" },
+    ]);
+  });
+
+  it("inserts single-line text inline, without a leading/trailing paragraph break", () => {
+    const tokens = tokenizePlainTextPaste("Hello world");
+
+    expect(tokens).toEqual([{ type: "text", value: "Hello world" }]);
+  });
+
+  it("handles tabs within a line", () => {
+    const tokens = tokenizePlainTextPaste("a\tb");
+
+    expect(tokens).toEqual([
+      { type: "text", value: "a" },
+      { type: "tab" },
+      { type: "text", value: "b" },
+    ]);
+  });
+
+  it("collapses a leading blank line to a single paragraph break", () => {
+    const tokens = tokenizePlainTextPaste("\n\nPara1");
+
+    expect(tokens).toEqual([
+      { type: "paragraph" },
+      { type: "text", value: "Para1" },
+    ]);
+  });
+
+  it("normalizes CRLF the same way as LF", () => {
+    const tokens = tokenizePlainTextPaste("Para1\r\n\r\nPara2");
+
+    expect(tokens).toEqual([
+      { type: "text", value: "Para1" },
+      { type: "paragraph" },
+      { type: "text", value: "Para2" },
+    ]);
+  });
+});
+
+describe("unwrapNestedPreCodeElements", () => {
+  const parse = (html: string) =>
+    new DOMParser().parseFromString(html, "text/html");
+
+  it("flattens a <pre><code> pair into a single-level <pre> and reports a change", () => {
+    const dom = parse(
+      '<pre><code class="language-javascript">line1\nline2</code></pre>',
+    );
+
+    const changed = unwrapNestedPreCodeElements(dom);
+
+    expect(changed).toBe(true);
+    const pre = dom.querySelector("pre");
+    expect(pre).not.toBeNull();
+    expect(pre?.querySelector("code")).toBeNull();
+    expect(pre?.textContent).toBe("line1\nline2");
+  });
+
+  it("carries the language hint from <code class=\"language-xxx\"> onto <pre data-language>", () => {
+    const dom = parse(
+      '<pre><code class="language-python">print(1)</code></pre>',
+    );
+
+    unwrapNestedPreCodeElements(dom);
+
+    expect(dom.querySelector("pre")?.getAttribute("data-language")).toBe(
+      "python",
+    );
+  });
+
+  it("does not overwrite an existing data-language on <pre>", () => {
+    const dom = parse(
+      '<pre data-language="go"><code class="language-python">print(1)</code></pre>',
+    );
+
+    unwrapNestedPreCodeElements(dom);
+
+    expect(dom.querySelector("pre")?.getAttribute("data-language")).toBe(
+      "go",
+    );
+  });
+
+  it("leaves a standalone <pre> without a nested <code> untouched", () => {
+    const dom = parse("<pre>line1\nline2</pre>");
+
+    const changed = unwrapNestedPreCodeElements(dom);
+
+    expect(changed).toBe(false);
+    expect(dom.querySelector("pre")?.textContent).toBe("line1\nline2");
+  });
+
+  it("leaves a standalone multi-line <code> not inside a <pre> untouched", () => {
+    const dom = parse('<p><code class="language-js">a\nb</code></p>');
+
+    const changed = unwrapNestedPreCodeElements(dom);
+
+    expect(changed).toBe(false);
+    expect(dom.querySelector("code")).not.toBeNull();
+  });
+});

--- a/apps/csm-portal/webapp/src/components/rich-text-editor/richTextEditor.tsx
+++ b/apps/csm-portal/webapp/src/components/rich-text-editor/richTextEditor.tsx
@@ -308,8 +308,14 @@ export function collapseEmptyParagraphElements(dom: Document): boolean {
     return true;
   };
 
+  // querySelectorAll returns elements in document order (ancestors before
+  // descendants). Reversing processes descendants first, so an outer wrapper
+  // whose only child is itself an empty block (e.g. `<div><div><br></div></div>`)
+  // is re-evaluated as empty once its inner child has already been removed,
+  // instead of being skipped because it "contained an element" at the time it
+  // was checked.
   let changed = false;
-  for (const el of Array.from(body.querySelectorAll("p, div"))) {
+  for (const el of Array.from(body.querySelectorAll("p, div")).reverse()) {
     if (isEffectivelyEmptyBlock(el)) {
       el.remove();
       changed = true;

--- a/apps/csm-portal/webapp/src/components/rich-text-editor/richTextEditor.tsx
+++ b/apps/csm-portal/webapp/src/components/rich-text-editor/richTextEditor.tsx
@@ -267,3 +267,54 @@ export function unwrapNestedPreCodeElements(dom: Document): boolean {
 
   return changed;
 }
+
+/**
+ * Removes paragraph-like elements (`<p>` or `<div>`) that carry no real
+ * content -- empty, or containing only whitespace, `&nbsp;`, and/or `<br>` --
+ * from pasted HTML. Mutates `dom` in place; returns whether anything was
+ * removed.
+ *
+ * Rich clipboard sources (Google Docs, Gmail, Gemini, Claude, Notion, Word,
+ * and even a manual text-selection copy from ChatGPT's rendered page --
+ * anything that puts `text/html` on the clipboard) commonly represent a
+ * blank line between paragraphs as an empty `<p>&nbsp;</p>`, `<p><br></p>`,
+ * or an empty `<div><br></div>` in their clipboard HTML. Left in place, each
+ * one becomes its own empty ParagraphNode once converted, which reproduces
+ * the same "extra space between paragraphs" bug in the read view that
+ * `tokenizePlainTextPaste` above fixes for plain-text paste -- the read
+ * view's `"& p + p": { mt: 0.75 }` adjacency rule fires around the empty
+ * paragraph too, and the empty paragraph contributes its own line height on
+ * top.
+ *
+ * Only `<p>`/`<div>` elements whose only children are whitespace text nodes
+ * and/or `<br>` elements are removed, so a block that carries real content
+ * (text, an image, a link, a nested list, etc.) is always left untouched.
+ */
+export function collapseEmptyParagraphElements(dom: Document): boolean {
+  const body = dom.body;
+  if (!body) return false;
+
+  const isEffectivelyEmptyBlock = (el: Element): boolean => {
+    if (el.tagName !== "P" && el.tagName !== "DIV") return false;
+    for (const child of Array.from(el.childNodes)) {
+      if (child.nodeType === Node.TEXT_NODE) {
+        const text = (child.textContent ?? "").replace(/\u00a0/g, " ").trim();
+        if (text !== "") return false;
+      } else if (child.nodeType === Node.ELEMENT_NODE) {
+        if ((child as Element).tagName !== "BR") return false;
+      }
+      // Other node types (comments, etc.) carry no visible content.
+    }
+    return true;
+  };
+
+  let changed = false;
+  for (const el of Array.from(body.querySelectorAll("p, div"))) {
+    if (isEffectivelyEmptyBlock(el)) {
+      el.remove();
+      changed = true;
+    }
+  }
+
+  return changed;
+}

--- a/apps/csm-portal/webapp/src/components/rich-text-editor/richTextEditor.tsx
+++ b/apps/csm-portal/webapp/src/components/rich-text-editor/richTextEditor.tsx
@@ -155,3 +155,115 @@ export const scrollElement = (
 export const INSERT_IMAGE_COMMAND: LexicalCommand<
   string | InsertImagePayload
 > = createCommand();
+
+/** A single step used to replay a plain-text clipboard paste into the editor. */
+export type PlainTextPasteToken =
+  | { type: "text"; value: string }
+  | { type: "tab" }
+  | { type: "paragraph" };
+
+/**
+ * Tokenizes plain-text clipboard content (used whenever the clipboard has
+ * text/plain but no text/html -- exactly ChatGPT's own clipboard format) the
+ * same way Lexical's default `$insertDataTransferForPlainText` does
+ * (`@lexical/clipboard`): split on newlines/tabs, one "paragraph" token per
+ * newline, one "text" token per run of plain text, one "tab" token per tab.
+ *
+ * The one deliberate difference: Lexical's default tokenizer emits a
+ * "paragraph" token for every newline unconditionally, so a blank line
+ * ("Para1\n\nPara2", which is exactly ChatGPT's blank-line-separated
+ * paragraph format) produces two back-to-back paragraph breaks with nothing
+ * typed in between -- i.e. a standalone empty paragraph -- instead of a
+ * single paragraph break. This tokenizer drops a "paragraph" token when it
+ * would immediately follow another one with no text/tab token in between, so
+ * one or more consecutive blank lines collapse to a single paragraph break.
+ * A lone newline inside real content still starts a new paragraph, same as
+ * before -- only the redundant, content-free break is removed.
+ */
+export function tokenizePlainTextPaste(text: string): PlainTextPasteToken[] {
+  const parts = text.split(/(\r?\n|\t)/);
+  if (parts[parts.length - 1] === "") {
+    parts.pop();
+  }
+
+  const tokens: PlainTextPasteToken[] = [];
+  let sawContentSinceLastBreak = false;
+
+  for (const part of parts) {
+    if (part === "\n" || part === "\r\n") {
+      if (!sawContentSinceLastBreak && tokens.length > 0) {
+        // Back-to-back paragraph break with nothing typed in between (a
+        // blank line) -- drop it instead of emitting an empty paragraph.
+        continue;
+      }
+      tokens.push({ type: "paragraph" });
+      sawContentSinceLastBreak = false;
+    } else if (part === "\t") {
+      tokens.push({ type: "tab" });
+      sawContentSinceLastBreak = true;
+    } else if (part !== "") {
+      tokens.push({ type: "text", value: part });
+      sawContentSinceLastBreak = true;
+    }
+    // part === "" is the empty segment between two consecutive delimiters;
+    // it carries no content of its own and is otherwise skipped.
+  }
+
+  return tokens;
+}
+
+/**
+ * Unwraps a `<code>` element that is a direct child of a `<pre>`, moving the
+ * `<code>`'s children up to be the `<pre>`'s own children and removing the
+ * now-empty `<code>` wrapper. Mutates `dom` in place; returns whether any
+ * unwrapping happened.
+ *
+ * `<pre><code class="language-xxx">...</code></pre>` is the standard shape
+ * emitted by ChatGPT, GitHub, and Notion for a fenced code block. Lexical's
+ * `@lexical/code` CodeNode.importDOM() registers independent DOM converters
+ * for both the `pre` tag and any multi-line `code` tag: converting the
+ * `<pre>` creates a CodeNode and then recurses into its children as usual,
+ * so the nested multi-line `<code>` gets converted a second time,
+ * independently creating a second CodeNode nested inside the first --
+ * producing a duplicated `<code class="editor-code"><code
+ * class="editor-code">` wrapper instead of a single code block. Flattening
+ * the DOM before conversion removes the nested `<code>` element entirely, so
+ * only the `<pre>` converter fires.
+ *
+ * Also carries the language hint from the removed `<code>`'s
+ * `class="language-xxx"` onto the `<pre>` as `data-language` (what
+ * `$convertPreElement` reads), when the `<pre>` doesn't already have one, so
+ * the resulting single CodeNode keeps its language.
+ *
+ * Leaves standalone `<pre>` (no nested `<code>`) and standalone multi-line
+ * `<code>` (not inside a `<pre>`) untouched -- both already convert to
+ * exactly one CodeNode today.
+ */
+export function unwrapNestedPreCodeElements(dom: Document): boolean {
+  let changed = false;
+
+  for (const pre of Array.from(dom.querySelectorAll("pre"))) {
+    const codeChildren = Array.from(pre.children).filter(
+      (child): child is HTMLElement => child.tagName === "CODE",
+    );
+
+    for (const code of codeChildren) {
+      if (!pre.hasAttribute("data-language")) {
+        const languageMatch = code
+          .getAttribute("class")
+          ?.match(/language-([\w-]+)/i);
+        if (languageMatch) {
+          pre.setAttribute("data-language", languageMatch[1]);
+        }
+      }
+
+      while (code.firstChild) {
+        pre.insertBefore(code.firstChild, code);
+      }
+      pre.removeChild(code);
+      changed = true;
+    }
+  }
+
+  return changed;
+}


### PR DESCRIPTION
## Purpose
The CSM Portal comment composer mis-formats content pasted from external rich-text sources (ChatGPT, Google Docs, Gmail, Gemini, Claude, etc.). Three related symptoms, all traced to two root causes:
1. Pasting multi-paragraph plain text or HTML with blank-line paragraph separators inserted an extra empty paragraph for every blank line.
2. Pasting a standard fenced code block (`<pre><code>...</code></pre>`, the markup used by most AI assistants and GitHub) produced a duplicated, nested code-block wrapper instead of a single clean one.
3. The composer's live-editing view zeroed all paragraph margins, so a single Enter between paragraphs showed no visible gap while typing — which drove users to manually press Enter twice to "see" separation, and *that* extra blank paragraph then rendered with real, doubled spacing once posted (the read view correctly gives one gap per paragraph adjacency, so an empty paragraph in between gets counted twice).


## Goals
- A blank line between two pasted paragraphs (from any rich-text source, not just one clipboard MIME type) produces exactly one paragraph break, never a standalone empty paragraph.
- A pasted `<pre><code>` block converts to exactly one code block, with its language preserved.
- The composer's live view matches what will actually render once posted (WYSIWYG for paragraph spacing), so a single Enter is enough to see a real paragraph break — no more need to double-Enter to "get" spacing.
- A user who deliberately presses Enter twice to insert an intentional blank line still gets that blank line, both while composing and once posted — this is different from an unwanted paste artifact and is explicitly preserved.
- Every other paste shape (already-clean HTML, single-line plain text, etc.) is unaffected.

## Approach
Two root causes, fixed independently:

**1. Lexical's default paste-import behavior** has two gaps for these specific input shapes — verified by reading `@lexical/code`'s `CodeNode.importDOM()` (registers independent DOM converters for `<pre>` and any multi-line `<code>`, so a `<code>` nested inside a `<pre>` gets converted twice) and by testing Lexical's default plain-text/HTML paste tokenization directly (blank lines become standalone empty paragraphs).

A `PasteNormalizationPlugin` is registered on Lexical's `PASTE_COMMAND` at a priority above the default rich-text paste handler:
- For HTML paste: flattens a `<code>` element that is a direct child of a `<pre>` before conversion (carrying the language hint onto the `<pre>`), and collapses any content-empty `<p>`/`<div>` blank-line marker (covers Google Docs/Gmail/Notion/Word's shapes, e.g. `<p>&nbsp;</p>`, `<p><br></p>`, `<div><br></div>`, not just ChatGPT's). Falls through to the default handler unchanged when neither applies.
- For plain-text-only paste (no `text/html` on the clipboard): replays Lexical's own tokenization but drops a redundant paragraph-break token when it immediately follows another one with nothing typed in between.

**2. The composer's own CSS mismatched the read view.** `Editor.tsx` zeroed all `<p>` margins unconditionally; the comment view (`CsmCaseCommentBubble.tsx`) uses a `p + p` adjacent-sibling rule that gives exactly one gap per real paragraph adjacency. Changed the composer to the same `p + p` rule, so what you see while typing is what gets posted — for both a single Enter (now shows the real gap immediately) and a deliberate double Enter (now shows the real, larger gap immediately, instead of looking identical to a single Enter until you post it).

The paste plugin only intercepts `PASTE_COMMAND`; manually typed Enter presses go through Lexical's `INSERT_PARAGRAPH_COMMAND` and are untouched by design — a deliberate double-Enter is a user choice, not a paste artifact, and keeps its extra space.

## User stories
As a CS engineer, when I paste a multi-paragraph answer or a code snippet from an external source into a case/CR comment, the formatting should look the way it looked at the source, without extra blank lines or broken code blocks — and when I'm typing my own reply, pressing Enter once should visibly separate paragraphs the same way it will look once posted.

## Release note
Fixed: pasting multi-paragraph text or a fenced code block into the CSM Portal comment composer (from ChatGPT, Google Docs, Gmail, or similar sources) no longer adds extra blank lines between paragraphs or duplicates the code block. The composer's paragraph spacing while typing now matches the posted comment.

## Documentation
N/A — internal editor behavior fix, no user-facing documentation describes paste/spacing behavior today.

## Training
N/A — not training content.

## Certification
N/A — no certification impact.

## Marketing
N/A — not a marketing-facing feature.

## Automation tests
- Unit tests
  > `pasteNormalization.test.ts`: 18 cases covering blank-line collapsing (plain text and HTML shapes — `<p>&nbsp;</p>`, `<p><br></p>`, `<div><br></div>`), `<pre><code>` flattening (with/without language class), and confirming typed-content node lists are untouched (paste-path only). Full suite (2125 tests) passes; `tsc -b`, `eslint`, and `pnpm build` all clean.
- Integration tests
  > Manually verified end-to-end in a real browser via Chrome DevTools Protocol against `csm-stg` (mode 1, staging backend): (a) the real clipboard payload captured from a live ChatGPT response — pasted, composed, and **posted as an actual work note** — renders with correct paragraph/list/code-block formatting, single non-nested code block, language preserved; (b) typed a single Enter between two paragraphs — now shows a visible gap while composing, posts and renders correctly; (c) typed a deliberate double Enter — now shows a visibly larger gap while composing (matching what double-Enter always rendered as), posted and confirmed the extra blank line survives intact in the activity timeline, distinct from and not collapsed with the single-Enter case.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — TypeScript/React change, not Java; `eslint` ran clean (0 errors) as the applicable static-analysis check.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no new sample apps or code samples introduced.

## Related PRs
None.

## Migrations (if applicable)
N/A — no schema, data, or config migration involved.

## Test environment
Local: Node.js via pnpm workspace, Vitest 4.0.18, Chrome (latest, via DevTools Protocol) against `csm-stg` (staging backend) on macOS. No database involved on the frontend side of this change.

## Learning
Root-caused the code-block duplication by reading `@lexical/code`'s `CodeNode.importDOM()` source directly, confirming it as an upstream default-behavior gap rather than something introduced by this codebase. The paragraph-spacing bug turned out to be two compounding causes rather than one: a paste-time empty-paragraph artifact, and a composer/read-view CSS mismatch that was independently causing users to work around the first bug by doubling their Enter presses — fixing only the paste side without the CSS parity fix would have left the underlying WYSIWYG mismatch in place.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plain-text pasting by preserving tabs, handling line endings consistently, and converting blank lines into clear paragraph breaks.
  * Prevented duplicated nested code blocks when pasting formatted code.
  * Preserved programming-language metadata when pasting code content.
  * Removed unnecessary empty paragraphs from pasted content while preserving meaningful text.
  * Added consistent spacing between adjacent paragraphs in the editor.
* **Tests**
  * Added coverage for plain-text formatting, whitespace, line endings, code-block handling, and empty paragraph cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->