### PR TITLE
[Entity Service] Case SLA-breach/account-escalation filters + incident madeSla filter

### DIFF
--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -3549,6 +3549,13 @@ type SearchIncidentsFilters struct {
 	//     case search's own "createdOn" filter.
 	//   - "slaViolated" (op eq): a single boolean value; restricts to
 	//     incidents with (or without) at least one breached SLA record.
+	//   - "madeSla" (op eq): a single boolean value; restricts to incidents
+	//     matching ServiceNow's raw `made_sla` field. Deliberately kept
+	//     separate from "slaViolated" above: "slaViolated" is derived from
+	//     task_sla.has_breached and is the reliable signal; "madeSla" is
+	//     ServiceNow's own less-reliable raw field, kept only for exact
+	//     parity with SN's native incident dashboards. Prefer "slaViolated"
+	//     unless dashboard parity is the explicit goal.
 	//   - "productName" (op in): one or more product names, matched as a
 	//     union against the incident's backing business_service name.
 	// See service.ParseIncidentFieldFilters.

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -1448,6 +1448,22 @@ type ParsedCaseFilters struct {
 	// escalation, from the "escalation" filter field's isEmpty/isNotEmpty op
 	// (optional; nil means no filter on this field).
 	HasActiveEscalation *bool
+	// HasBreachedSLA filters cases to those with a currently-breached SLA
+	// against the 10 named SLA definitions, from the "slaBreached" filter
+	// field's eq value (optional; nil means no filter on this field). Wire
+	// field on the SN payload: "slaBreached". Requires ServiceNow data source.
+	HasBreachedSLA *bool
+	// HasActiveAccountEscalation filters cases to those whose parent ACCOUNT
+	// has an active escalation (active_account_escalation.state IN 100,101),
+	// from the "accountEscalationActive" filter field's eq value (optional;
+	// nil means no filter on this field). Wire field on the SN payload:
+	// "accountEscalationActive". Requires ServiceNow data source.
+	//
+	// Distinct from HasActiveEscalation above: HasActiveEscalation filters by
+	// whether the CASE ITSELF carries an active escalation; this field
+	// filters by whether the case's parent ACCOUNT has one, regardless of
+	// whether this specific case is escalated.
+	HasActiveAccountEscalation *bool
 	// OrGroups: see SearchCasesFilters.AnyOf doc comment. Each entry is one
 	// parsed, ANDed branch; branches are OR'd together by the SN adapter.
 	OrGroups []CaseFilterGroup

--- a/entity-service/internal/service/case_filters.go
+++ b/entity-service/internal/service/case_filters.go
@@ -45,7 +45,7 @@ var caseFilterFieldSet = map[string]bool{
 	"projectOnboardingStatus": true, "projectType": true, "creTeam": true, "sreTeam": true,
 	"resolutionNotes": true, "parentId": true, "taskSLABusinessElapsedPercent": true,
 	"escalationLevel": true, "escalation": true, "number": true, "internalId": true,
-	"accountId": true,
+	"accountId": true, "slaBreached": true, "accountEscalationActive": true,
 }
 
 // caseFilterOpSet is the exact set of CaseFieldFilter.Op values accepted by
@@ -621,6 +621,38 @@ func ParseCaseFieldFilters(filters []domain.CaseFieldFilter, callerEmail string,
 			default:
 				return domain.ParsedCaseFilters{}, badCaseFilterCombo(f)
 			}
+
+		case "slaBreached":
+			if f.Op != "eq" {
+				return domain.ParsedCaseFilters{}, badCaseFilterCombo(f)
+			}
+			if err := requireCaseFilterValues(f); err != nil {
+				return domain.ParsedCaseFilters{}, err
+			}
+			if len(f.Values) != 1 {
+				return domain.ParsedCaseFilters{}, &apierror.ValidationError{Msg: "filters: slaBreached eq requires exactly one value"}
+			}
+			b, err := parseCaseFilterBool(f, f.Values[0])
+			if err != nil {
+				return domain.ParsedCaseFilters{}, err
+			}
+			p.HasBreachedSLA = &b
+
+		case "accountEscalationActive":
+			if f.Op != "eq" {
+				return domain.ParsedCaseFilters{}, badCaseFilterCombo(f)
+			}
+			if err := requireCaseFilterValues(f); err != nil {
+				return domain.ParsedCaseFilters{}, err
+			}
+			if len(f.Values) != 1 {
+				return domain.ParsedCaseFilters{}, &apierror.ValidationError{Msg: "filters: accountEscalationActive eq requires exactly one value"}
+			}
+			b, err := parseCaseFilterBool(f, f.Values[0])
+			if err != nil {
+				return domain.ParsedCaseFilters{}, err
+			}
+			p.HasActiveAccountEscalation = &b
 		}
 	}
 
@@ -761,6 +793,10 @@ func rejectUnsupportedOrGroupFields(parsed domain.ParsedCaseFilters) error {
 		return &apierror.ValidationError{Msg: "anyOf: field \"taskSLABusinessElapsedPercent\" is not supported inside an OR group"}
 	case parsed.HasActiveEscalation != nil:
 		return &apierror.ValidationError{Msg: "anyOf: field \"escalation\" is not supported inside an OR group"}
+	case parsed.HasBreachedSLA != nil:
+		return &apierror.ValidationError{Msg: "anyOf: field \"slaBreached\" is not supported inside an OR group"}
+	case parsed.HasActiveAccountEscalation != nil:
+		return &apierror.ValidationError{Msg: "anyOf: field \"accountEscalationActive\" is not supported inside an OR group"}
 	}
 	return nil
 }
@@ -777,6 +813,24 @@ func parseCaseFilterPercent(f domain.CaseFieldFilter, value string) (int, error)
 		return 0, &apierror.ValidationError{Msg: fmt.Sprintf("filters: field %q op %q value %q must be a non-negative integer", f.Field, f.Op, value)}
 	}
 	return n, nil
+}
+
+// parseCaseFilterBool mirrors incident_filters.go's parseIncidentFilterBool
+// for case search's own plain-boolean eq fields (slaBreached,
+// accountEscalationActive) -- unlike "escalation" (a reference-field
+// isEmpty/isNotEmpty presence check), these are true booleans with an
+// explicit true/false value on the wire, the same shape as the incident
+// side's slaViolated. Only the exact lowercase "true"/"false" the OpenAPI
+// contract documents are accepted.
+func parseCaseFilterBool(f domain.CaseFieldFilter, value string) (bool, error) {
+	switch value {
+	case "true":
+		return true, nil
+	case "false":
+		return false, nil
+	default:
+		return false, &apierror.ValidationError{Msg: fmt.Sprintf("filters: field %q op %q value %q must be a boolean", f.Field, f.Op, value)}
+	}
 }
 
 // resolveCaseFilterCallerEmail resolves the authenticated caller's email from

--- a/entity-service/internal/service/case_filters_test.go
+++ b/entity-service/internal/service/case_filters_test.go
@@ -238,6 +238,48 @@ func TestParseCaseFieldFilters_NamedFieldTranslations(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "slaBreached eq true maps to HasBreachedSLA",
+			in:   []domain.CaseFieldFilter{{Field: "slaBreached", Op: "eq", Values: []string{"true"}}},
+			check: func(t *testing.T, p domain.ParsedCaseFilters) {
+				if p.HasBreachedSLA == nil || !*p.HasBreachedSLA {
+					t.Fatalf("HasBreachedSLA = %v, want pointer to true", p.HasBreachedSLA)
+				}
+			},
+		},
+		{
+			name: "slaBreached eq false maps to HasBreachedSLA",
+			in:   []domain.CaseFieldFilter{{Field: "slaBreached", Op: "eq", Values: []string{"false"}}},
+			check: func(t *testing.T, p domain.ParsedCaseFilters) {
+				if p.HasBreachedSLA == nil || *p.HasBreachedSLA {
+					t.Fatalf("HasBreachedSLA = %v, want pointer to false", p.HasBreachedSLA)
+				}
+			},
+		},
+		{
+			name: "accountEscalationActive eq true maps to HasActiveAccountEscalation",
+			in:   []domain.CaseFieldFilter{{Field: "accountEscalationActive", Op: "eq", Values: []string{"true"}}},
+			check: func(t *testing.T, p domain.ParsedCaseFilters) {
+				if p.HasActiveAccountEscalation == nil || !*p.HasActiveAccountEscalation {
+					t.Fatalf("HasActiveAccountEscalation = %v, want pointer to true", p.HasActiveAccountEscalation)
+				}
+				// Distinct from the case-level escalation filter: setting
+				// accountEscalationActive must not also populate
+				// HasActiveEscalation.
+				if p.HasActiveEscalation != nil {
+					t.Fatalf("HasActiveEscalation = %v, want nil (accountEscalationActive is a distinct field)", p.HasActiveEscalation)
+				}
+			},
+		},
+		{
+			name: "accountEscalationActive eq false maps to HasActiveAccountEscalation",
+			in:   []domain.CaseFieldFilter{{Field: "accountEscalationActive", Op: "eq", Values: []string{"false"}}},
+			check: func(t *testing.T, p domain.ParsedCaseFilters) {
+				if p.HasActiveAccountEscalation == nil || *p.HasActiveAccountEscalation {
+					t.Fatalf("HasActiveAccountEscalation = %v, want pointer to false", p.HasActiveAccountEscalation)
+				}
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -268,6 +310,12 @@ func TestParseCaseFieldFilters_Rejections(t *testing.T) {
 		{name: "internalId in unsupported", in: []domain.CaseFieldFilter{{Field: "internalId", Op: "in", Values: []string{"12345"}}}},
 		{name: "projectOnboardingStatus eq unsupported", in: []domain.CaseFieldFilter{{Field: "projectOnboardingStatus", Op: "eq", Values: []string{"Completed"}}}},
 		{name: "accountId malformed UUID", in: []domain.CaseFieldFilter{{Field: "accountId", Op: "in", Values: []string{"not-a-uuid"}}}},
+		{name: "slaBreached with unsupported op", in: []domain.CaseFieldFilter{{Field: "slaBreached", Op: "in", Values: []string{"true"}}}},
+		{name: "slaBreached with non-boolean value", in: []domain.CaseFieldFilter{{Field: "slaBreached", Op: "eq", Values: []string{"yes"}}}},
+		{name: "slaBreached with more than one value", in: []domain.CaseFieldFilter{{Field: "slaBreached", Op: "eq", Values: []string{"true", "false"}}}},
+		{name: "accountEscalationActive with unsupported op", in: []domain.CaseFieldFilter{{Field: "accountEscalationActive", Op: "isNotEmpty"}}},
+		{name: "accountEscalationActive with non-boolean value", in: []domain.CaseFieldFilter{{Field: "accountEscalationActive", Op: "eq", Values: []string{"yes"}}}},
+		{name: "accountEscalationActive with more than one value", in: []domain.CaseFieldFilter{{Field: "accountEscalationActive", Op: "eq", Values: []string{"true", "false"}}}},
 	}
 
 	for _, tc := range cases {
@@ -501,6 +549,43 @@ func TestParseCaseFieldFilterGroups_RejectsStateNotIn(t *testing.T) {
 	const want = `anyOf: field "state" (notIn) is not supported inside an OR group`
 	if ve.Msg != want {
 		t.Errorf("Msg = %q, want %q", ve.Msg, want)
+	}
+}
+
+// TestParseCaseFieldFilterGroups_RejectsSLAAndAccountEscalationFilters proves
+// slaBreached and accountEscalationActive -- like the pre-existing escalation
+// filter -- are rejected inside an OR-group branch: CaseFilterGroup does not
+// model either field, so silently accepting them inside a branch would drop
+// the predicate rather than apply it.
+func TestParseCaseFieldFilterGroups_RejectsSLAAndAccountEscalationFilters(t *testing.T) {
+	cases := []struct {
+		name   string
+		branch domain.CaseFilterBranch
+		want   string
+	}{
+		{
+			name:   "slaBreached",
+			branch: domain.CaseFilterBranch{Filters: []domain.CaseFieldFilter{{Field: "slaBreached", Op: "eq", Values: []string{"true"}}}},
+			want:   `anyOf: field "slaBreached" is not supported inside an OR group`,
+		},
+		{
+			name:   "accountEscalationActive",
+			branch: domain.CaseFilterBranch{Filters: []domain.CaseFieldFilter{{Field: "accountEscalationActive", Op: "eq", Values: []string{"true"}}}},
+			want:   `anyOf: field "accountEscalationActive" is not supported inside an OR group`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParseCaseFieldFilterGroups([]domain.CaseFilterBranch{tc.branch})
+			var ve *apierror.ValidationError
+			if !errors.As(err, &ve) {
+				t.Fatalf("err = %v (%T), want *apierror.ValidationError", err, err)
+			}
+			if ve.Msg != tc.want {
+				t.Errorf("Msg = %q, want %q", ve.Msg, tc.want)
+			}
+		})
 	}
 }
 

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -509,6 +509,12 @@ func (s *caseService) SearchCases(ctx context.Context, req domain.SearchCasesReq
 	if parsed.HasActiveEscalation != nil {
 		return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: `field "escalation" is not supported by this data source`}
 	}
+	if parsed.HasBreachedSLA != nil {
+		return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: `field "slaBreached" is not supported by this data source`}
+	}
+	if parsed.HasActiveAccountEscalation != nil {
+		return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: `field "accountEscalationActive" is not supported by this data source`}
+	}
 	if len(req.Filters.AnyOf) > 0 {
 		return domain.SearchCasesResponse{}, &apierror.ValidationError{Msg: "anyOf is not supported by this data source"}
 	}

--- a/entity-service/internal/service/case_service_test.go
+++ b/entity-service/internal/service/case_service_test.go
@@ -201,6 +201,20 @@ func TestCaseService_SearchCases_RejectsServiceNowOnlyOptions(t *testing.T) {
 			wantMsg: `field "escalation" is not supported by this data source`,
 		},
 		{
+			name: "slaBreached",
+			req: domain.SearchCasesRequest{Filters: domain.SearchCasesFilters{
+				Filters: []domain.CaseFieldFilter{{Field: "slaBreached", Op: "eq", Values: []string{"true"}}},
+			}},
+			wantMsg: `field "slaBreached" is not supported by this data source`,
+		},
+		{
+			name: "accountEscalationActive",
+			req: domain.SearchCasesRequest{Filters: domain.SearchCasesFilters{
+				Filters: []domain.CaseFieldFilter{{Field: "accountEscalationActive", Op: "eq", Values: []string{"true"}}},
+			}},
+			wantMsg: `field "accountEscalationActive" is not supported by this data source`,
+		},
+		{
 			name: "resolvedOn gte",
 			req: domain.SearchCasesRequest{Filters: domain.SearchCasesFilters{
 				Filters: []domain.CaseFieldFilter{{Field: "resolvedOn", Op: "gte", Values: []string{"2026-01-01"}}},

--- a/entity-service/internal/service/incident_filters.go
+++ b/entity-service/internal/service/incident_filters.go
@@ -28,7 +28,7 @@ import (
 // accepted by incident search. Anything else is rejected outright.
 var incidentFilterFieldSet = map[string]bool{
 	"state": true, "assignmentGroupId": true, "businessServiceId": true,
-	"createdOn": true, "slaViolated": true, "productName": true,
+	"createdOn": true, "slaViolated": true, "madeSla": true, "productName": true,
 }
 
 // incidentFilterOpSet is the exact set of IncidentFieldFilter.Op values
@@ -37,8 +37,8 @@ var incidentFilterFieldSet = map[string]bool{
 // assignmentGroupId/businessServiceId/productName, "gte"/"lte" cover
 // createdOn (mirrors case_filters.go's "createdOn" handling exactly,
 // including its relative-date placeholder support, e.g. "__daysAgo:90__"),
-// and "eq" covers slaViolated (single boolean value, mirroring case search's
-// "number"/"internalId" single-value eq fields).
+// and "eq" covers slaViolated/madeSla (single boolean value, mirroring case
+// search's "number"/"internalId" single-value eq fields).
 var incidentFilterOpSet = map[string]bool{
 	"in": true, "gte": true, "lte": true, "eq": true,
 }
@@ -119,6 +119,13 @@ type parsedIncidentFilters struct {
 	// to incidents with/without at least one breached SLA record; nil means
 	// the filter was not supplied.
 	SlaViolated *bool
+	// MadeSla is set from a "madeSla" "eq" filter: true/false restricts to
+	// incidents matching ServiceNow's raw `made_sla` field; nil means the
+	// filter was not supplied. Deliberately kept separate from SlaViolated
+	// above -- see domain.SearchIncidentsFilters Filters "madeSla" doc
+	// comment: this is SN's own less-reliable raw signal, kept only for
+	// exact parity with SN's native incident dashboards.
+	MadeSla *bool
 	// ProductNames are the values of a "productName" "in" filter, matched as a
 	// union against the incident's backing business_service name.
 	ProductNames []string
@@ -211,6 +218,22 @@ func ParseIncidentFieldFilters(filters []domain.IncidentFieldFilter, now time.Ti
 				return parsedIncidentFilters{}, err
 			}
 			p.SlaViolated = &b
+
+		case "madeSla":
+			if f.Op != "eq" {
+				return parsedIncidentFilters{}, badIncidentFilterCombo(f)
+			}
+			if err := requireIncidentFilterValues(f); err != nil {
+				return parsedIncidentFilters{}, err
+			}
+			if len(f.Values) != 1 {
+				return parsedIncidentFilters{}, &apierror.ValidationError{Msg: "filters: madeSla eq requires exactly one value"}
+			}
+			b, err := parseIncidentFilterBool(f, f.Values[0])
+			if err != nil {
+				return parsedIncidentFilters{}, err
+			}
+			p.MadeSla = &b
 
 		case "productName":
 			if f.Op != "in" {

--- a/entity-service/internal/service/incident_filters_test.go
+++ b/entity-service/internal/service/incident_filters_test.go
@@ -86,6 +86,28 @@ func TestParseIncidentFieldFilters_SlaViolated(t *testing.T) {
 	}
 }
 
+func TestParseIncidentFieldFilters_MadeSla(t *testing.T) {
+	parsed, err := ParseIncidentFieldFilters([]domain.IncidentFieldFilter{
+		{Field: "madeSla", Op: "eq", Values: []string{"true"}},
+	}, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if parsed.MadeSla == nil || !*parsed.MadeSla {
+		t.Fatalf("MadeSla = %v, want pointer to true", parsed.MadeSla)
+	}
+
+	parsed, err = ParseIncidentFieldFilters([]domain.IncidentFieldFilter{
+		{Field: "madeSla", Op: "eq", Values: []string{"false"}},
+	}, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if parsed.MadeSla == nil || *parsed.MadeSla {
+		t.Fatalf("MadeSla = %v, want pointer to false", parsed.MadeSla)
+	}
+}
+
 func TestParseIncidentFieldFilters_ProductName(t *testing.T) {
 	parsed, err := ParseIncidentFieldFilters([]domain.IncidentFieldFilter{
 		{Field: "productName", Op: "in", Values: []string{"API Manager", "Choreo"}},
@@ -149,6 +171,18 @@ func TestParseIncidentFieldFilters_Rejections(t *testing.T) {
 		{
 			name:    "slaViolated with more than one value",
 			filters: []domain.IncidentFieldFilter{{Field: "slaViolated", Op: "eq", Values: []string{"true", "false"}}},
+		},
+		{
+			name:    "madeSla with unsupported op",
+			filters: []domain.IncidentFieldFilter{{Field: "madeSla", Op: "in", Values: []string{"true"}}},
+		},
+		{
+			name:    "madeSla with non-boolean value",
+			filters: []domain.IncidentFieldFilter{{Field: "madeSla", Op: "eq", Values: []string{"yes"}}},
+		},
+		{
+			name:    "madeSla with more than one value",
+			filters: []domain.IncidentFieldFilter{{Field: "madeSla", Op: "eq", Values: []string{"true", "false"}}},
 		},
 		{
 			name:    "productName with unsupported op",

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -441,6 +441,13 @@ type snCaseFilters struct {
 	// IsEscalated: a *bool (not bool) so that an explicit false is still sent on
 	// the wire -- omitempty on a pointer only drops a nil, not a false value.
 	IsEscalated *bool `json:"isEscalated,omitempty"`
+	// SlaBreached: see domain.ParsedCaseFilters.HasBreachedSLA doc comment. A
+	// *bool for the same reason as IsEscalated above -- an explicit false must
+	// still reach ServiceNow, not be silently dropped.
+	SlaBreached *bool `json:"slaBreached,omitempty"`
+	// AccountEscalationActive: see domain.ParsedCaseFilters.HasActiveAccountEscalation
+	// doc comment. A *bool for the same reason as IsEscalated above.
+	AccountEscalationActive *bool `json:"accountEscalationActive,omitempty"`
 	// OrGroups is the ServiceNow wire field name, deliberately unchanged:
 	// ServiceNow's CaseUtils Script Include reads "orGroups" and silently
 	// ignores JSON keys it does not recognise (returning an unfiltered count
@@ -2409,6 +2416,8 @@ func buildSNCaseFilters(parsed domain.ParsedCaseFilters, searchQuery string) snC
 		TaskSLAFilter:                    buildSNTaskSLAFilter(parsed.TaskSLAFilter),
 		EscalationLevels:                 parsed.EscalationLevels,
 		IsEscalated:                      parsed.HasActiveEscalation,
+		SlaBreached:                      parsed.HasBreachedSLA,
+		AccountEscalationActive:          parsed.HasActiveAccountEscalation,
 		OrGroups:                         buildSNCaseFilterGroups(parsed.OrGroups),
 	}
 }

--- a/entity-service/internal/service/sn_case_service_test.go
+++ b/entity-service/internal/service/sn_case_service_test.go
@@ -1532,6 +1532,8 @@ func TestSNCaseService_SearchCases_GenericFiltersTranslateToSNPayload(t *testing
 				{Field: "resolutionNotes", Op: "isEmpty"},
 				{Field: "createdBy", Op: "eq", Values: []string{currentUserFilterPlaceholder}},
 				{Field: "projectType", Op: "in", Values: []string{"Subscription", "Free Trial"}},
+				{Field: "slaBreached", Op: "eq", Values: []string{"true"}},
+				{Field: "accountEscalationActive", Op: "eq", Values: []string{"true"}},
 			},
 		},
 	}
@@ -1565,6 +1567,70 @@ func TestSNCaseService_SearchCases_GenericFiltersTranslateToSNPayload(t *testing
 		gotBody.Filters.ProjectTypeNames[0] != "Subscription" ||
 		gotBody.Filters.ProjectTypeNames[1] != "Free Trial" {
 		t.Fatalf("ProjectTypeNames = %v, want [Subscription, Free Trial] passed through unchanged", gotBody.Filters.ProjectTypeNames)
+	}
+	if gotBody.Filters.SlaBreached == nil || !*gotBody.Filters.SlaBreached {
+		t.Fatalf("SlaBreached = %v, want pointer to true", gotBody.Filters.SlaBreached)
+	}
+	if gotBody.Filters.AccountEscalationActive == nil || !*gotBody.Filters.AccountEscalationActive {
+		t.Fatalf("AccountEscalationActive = %v, want pointer to true", gotBody.Filters.AccountEscalationActive)
+	}
+}
+
+// TestSNCaseService_SearchCases_SLABreachedAndAccountEscalationTravelOnTheirOwnWireKeys
+// pins the exact JSON wire keys for the two new plain-boolean filters --
+// "slaBreached" and "accountEscalationActive" -- distinct from the existing
+// case-level "isEscalated" key, and proves an explicit false is still sent on
+// the wire (not dropped by omitempty, since both fields are *bool).
+func TestSNCaseService_SearchCases_SLABreachedAndAccountEscalationTravelOnTheirOwnWireKeys(t *testing.T) {
+	var rawBody []byte
+	mux := http.NewServeMux()
+	mux.HandleFunc("/cases/search", func(w http.ResponseWriter, r *http.Request) {
+		b, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read request body: %v", err)
+		}
+		rawBody = b
+		_ = json.NewEncoder(w).Encode(map[string]any{"cases": []map[string]any{}, "total": 0, "offset": 0, "limit": 20})
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowCaseService(client, nil)
+
+	req := domain.SearchCasesRequest{
+		Filters: domain.SearchCasesFilters{
+			Filters: []domain.CaseFieldFilter{
+				{Field: "slaBreached", Op: "eq", Values: []string{"false"}},
+				{Field: "accountEscalationActive", Op: "eq", Values: []string{"false"}},
+			},
+		},
+	}
+	ctx := contextWithUserIDToken(fakeJWTWithEmail(t, "jane.doe@example.com"))
+	if _, err := svc.SearchCases(ctx, req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var envelope struct {
+		Filters map[string]json.RawMessage `json:"filters"`
+	}
+	if err := json.Unmarshal(rawBody, &envelope); err != nil {
+		t.Fatalf("unmarshal request body: %v", err)
+	}
+	slaBreachedRaw, ok := envelope.Filters["slaBreached"]
+	if !ok {
+		t.Fatalf("expected \"slaBreached\" key on the wire even for an explicit false, filters = %v", envelope.Filters)
+	}
+	if string(slaBreachedRaw) != "false" {
+		t.Fatalf("slaBreached = %s, want false", slaBreachedRaw)
+	}
+	accountEscalationRaw, ok := envelope.Filters["accountEscalationActive"]
+	if !ok {
+		t.Fatalf("expected \"accountEscalationActive\" key on the wire even for an explicit false, filters = %v", envelope.Filters)
+	}
+	if string(accountEscalationRaw) != "false" {
+		t.Fatalf("accountEscalationActive = %s, want false", accountEscalationRaw)
+	}
+	if _, ok := envelope.Filters["isEscalated"]; ok {
+		t.Fatalf("expected no \"isEscalated\" key: accountEscalationActive must not be conflated with the case-level escalation filter")
 	}
 }
 

--- a/entity-service/internal/service/sn_incident_service.go
+++ b/entity-service/internal/service/sn_incident_service.go
@@ -105,6 +105,12 @@ type snIncidentFilters struct {
 	// SlaViolated: see domain.SearchIncidentsFilters Filters "slaViolated" doc
 	// comment. nil (omitted) means the filter was not supplied.
 	SlaViolated *bool `json:"slaViolated,omitempty"`
+	// MadeSla: see domain.SearchIncidentsFilters Filters "madeSla" doc
+	// comment. nil (omitted) means the filter was not supplied. Deliberately
+	// kept separate from SlaViolated above -- this is ServiceNow's own raw,
+	// less-reliable `made_sla` field, carried through only for exact parity
+	// with SN's native incident dashboards; prefer SlaViolated otherwise.
+	MadeSla *bool `json:"madeSla,omitempty"`
 	// ProductNames: see domain.SearchIncidentsFilters Filters "productName"
 	// doc comment. Matched as a union against the incident's backing
 	// business_service name.
@@ -252,6 +258,7 @@ func (s *snIncidentService) SearchIncidents(ctx context.Context, req domain.Sear
 			StartCreatedDate:   formatSNDateTimeUTC(parsedFilters.StartCreatedDate),
 			EndCreatedDate:     formatSNDateTimeUTC(parsedFilters.EndCreatedDate),
 			SlaViolated:        parsedFilters.SlaViolated,
+			MadeSla:            parsedFilters.MadeSla,
 			ProductNames:       parsedFilters.ProductNames,
 		},
 		SortBy:     snSortBy,
@@ -396,6 +403,7 @@ func (s *snIncidentService) AggregateIncidents(ctx context.Context, req domain.A
 			StartCreatedDate:   formatSNDateTimeUTC(parsedFilters.StartCreatedDate),
 			EndCreatedDate:     formatSNDateTimeUTC(parsedFilters.EndCreatedDate),
 			SlaViolated:        parsedFilters.SlaViolated,
+			MadeSla:            parsedFilters.MadeSla,
 			ProductNames:       parsedFilters.ProductNames,
 		},
 		GroupBy:   req.GroupBy,

--- a/entity-service/internal/service/sn_incident_service_test.go
+++ b/entity-service/internal/service/sn_incident_service_test.go
@@ -337,6 +337,72 @@ func TestSNIncidentService_SearchIncidents_SlaViolatedInvalidValue(t *testing.T)
 	}
 }
 
+// TestSNIncidentService_SearchIncidents_MadeSlaPassedThrough verifies the
+// generic filters array's madeSla predicate reaches the outgoing payload
+// under the exact wire name Ballerina accepts, as a sibling to (and
+// independent of) slaViolated -- see domain.SearchIncidentsFilters Filters
+// "madeSla" doc comment for why the two are kept distinct.
+func TestSNIncidentService_SearchIncidents_MadeSlaPassedThrough(t *testing.T) {
+	var gotBody map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/incidents/search", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", r.Method)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"incidents": [], "totalRecords": 0, "offset": 0, "limit": 20}`))
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowIncidentService(client)
+
+	req := domain.SearchIncidentsRequest{
+		Filters: domain.SearchIncidentsFilters{
+			Filters: []domain.IncidentFieldFilter{
+				{Field: "madeSla", Op: "eq", Values: []string{"false"}},
+			},
+		},
+	}
+	if _, err := svc.SearchIncidents(contextWithUserIDToken("token"), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	gotFilters, ok := gotBody["filters"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected filters object in payload, got %+v", gotBody["filters"])
+	}
+
+	if gotFilters["madeSla"] != false {
+		t.Fatalf("filters.madeSla: got %v, want false", gotFilters["madeSla"])
+	}
+	if _, present := gotFilters["slaViolated"]; present {
+		t.Fatalf("filters.slaViolated: got present with value %v, want omitted since it was not requested", gotFilters["slaViolated"])
+	}
+}
+
+// TestSNIncidentService_SearchIncidents_MadeSlaInvalidValue verifies a
+// non-boolean madeSla filter value is rejected with a clean validation error
+// before any SN call.
+func TestSNIncidentService_SearchIncidents_MadeSlaInvalidValue(t *testing.T) {
+	// client is intentionally nil: validation must fail before touching it.
+	svc := NewServiceNowIncidentService(nil)
+
+	req := domain.SearchIncidentsRequest{
+		Filters: domain.SearchIncidentsFilters{
+			Filters: []domain.IncidentFieldFilter{
+				{Field: "madeSla", Op: "eq", Values: []string{"not-a-bool"}},
+			},
+		},
+	}
+	_, err := svc.SearchIncidents(contextWithUserIDToken("token"), req)
+	if _, ok := err.(*apierror.ValidationError); !ok {
+		t.Fatalf("expected *apierror.ValidationError, got %T: %v", err, err)
+	}
+}
+
 // TestSNIncidentService_SearchIncidents_InvalidStateValue verifies an
 // unrecognized state filter value is rejected with a clean validation error
 // before any SN call.

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -5409,6 +5409,8 @@ components:
             - escalation
             - number
             - internalId
+            - slaBreached
+            - accountEscalationActive
         op:
           type: string
           enum: [eq, in, notIn, isEmpty, isNotEmpty, gte, lte]
@@ -5525,6 +5527,15 @@ components:
         - **internalId** (eq): a single WSO2 case id; matches exactly. Routed
           as a first-class filter rather than through the free-text
           searchQuery scan.
+        - **slaBreached** (eq): a single boolean value ("true"/"false").
+          Matches cases with a currently-breached SLA against the platform's
+          10 named SLA definitions. Only applied by the ServiceNow data
+          source.
+        - **accountEscalationActive** (eq): a single boolean value
+          ("true"/"false"). Matches cases whose parent ACCOUNT has an active
+          escalation (state IN 100,101) — distinct from **escalation** above,
+          which matches on the case's own escalation state, not its parent
+          account's. Only applied by the ServiceNow data source.
 
     CaseFilterBranch:
       type: object


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

A CSM dashboard rebuild effort needs to numerically match a live ServiceNow reference dashboard. Two of its tiles ("SLA Violations", "Escalated Cases" on the case side, and an SRE incident-SLA tile) currently use approximate signals that diverge from what the SN tiles actually count. The corresponding ServiceNow and Ballerina entity-service layers now expose the exact underlying signals; this service does not yet surface them.

Resolves: N/A -- tracked internally.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

- Expose `slaBreached` (case search): whether a case has a currently-breached SLA against a specific named-SLA-definition set.
- Expose `accountEscalationActive` (case search): whether the case's account currently has an active escalation record -- a different, account-level mechanism from the existing case-level `escalation`/`isEscalated` filter.
- Expose `madeSla` (incident search): ServiceNow's raw `made_sla` field, kept deliberately separate from the existing, more reliable `slaViolated` filter.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

**Two independent, additive filters, bundled into one PR (same effort, landed same session).**

**`slaBreached` / `accountEscalationActive`** -- added as `*bool` fields on the case-search filter domain type, mirroring the existing `escalation`/`isEscalated` field's shape. Neither fits the existing isEmpty/isNotEmpty reference-presence pattern `escalation` uses, so a new `parseCaseFilterBool` helper was added (mirroring the incident side's equivalent, for consistency across resource types). Both are explicitly rejected on the Postgres-backed path and inside `anyOf` filter groups, matching the existing pattern for other ServiceNow-only case filters (`escalation`, `taskSLABusinessElapsedPercent`) -- these are ServiceNow-only capabilities and are not silently allowed to leak into paths that can't support them. `accountEscalationActive`'s doc comment explicitly distinguishes it from the case-level `escalation` field so a future reader doesn't conflate the two different mechanisms. Wire payload uses `*bool` (not plain `bool`) so an explicit `false` still reaches ServiceNow, matching the existing `IsEscalated` precedent.

**`madeSla`** -- added as a direct `*bool` sibling of the existing `SlaViolated` field at all three of its call sites (domain filter struct, allowed-field parser, outbound ServiceNow payload builder for both search and aggregate). Doc comment explicitly cross-references `slaViolated` and states `madeSla` is the less-reliable raw signal, kept only for exact ServiceNow-dashboard-parity purposes -- so nobody mistakes it for a newer/better version of `slaViolated`.

`openapi.yaml` updated for both.

## User stories
> Summary of user stories addressed by this change

- As a CSM dashboard widget, I can filter cases by whether they have a breached SLA against the same named-SLA-definition set ServiceNow's own dashboard uses.
- As a CSM dashboard widget, I can filter cases by account-level escalation state, distinct from case-level escalation.
- As a CSM dashboard widget, I can filter incidents by ServiceNow's raw SLA-met field for exact dashboard parity, without disturbing the existing, more reliable `slaViolated` filter.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Entity service: new case-search filters `slaBreached` and `accountEscalationActive`; new incident-search filter `madeSla`.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter "N/A" plus brief explanation of why there's no doc impact

`openapi.yaml` updated with all three new filter fields and their descriptions, including the distinguishing notes vs. their similarly-named siblings.

## Training
N/A -- no training content covers this internal service.

## Certification
N/A -- no certification exam covers this internal service.

## Marketing
N/A -- internal infrastructure.

## Automation tests
 - Unit tests
   > Code coverage information

`go build ./...`, `go vet ./...`, `go test ./...` all pass clean from the `entity-service` module root. New tests: case-side field translation (true/false, and a check that `accountEscalationActive` doesn't leak into the existing `escalation`/`HasActiveEscalation` field), 6 new rejection cases (bad op / non-boolean / multi-value, one pair per new field), an `anyOf`-group rejection test, a Postgres-path rejection test, and a wire-level test pinning the exact JSON keys and proving an explicit `false` is transmitted rather than dropped. Incident-side: parse tests (true/false + 3 rejection cases) and a passthrough test proving `madeSla`/`slaViolated` are independent.

 - Integration tests
   > Details about the test cases and coverage

No automated integration suite covers these paths (consistent with this service's existing convention). A real end-to-end run against ServiceNow DEV was not performed for this PR: the corresponding Ballerina entity-service change (a separate PR, not yet merged) is a prerequisite for a genuine round-trip test, and a peer development session was concurrently holding this environment's local-stack ports during this work. This is disclosed here rather than overstated; a live smoke test against DEV is recommended once the Ballerina PR merges, before this is considered fully proven end-to-end.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A -- `gosec` was not available in this environment for this PR; no security-sensitive surface is touched (three new boolean filter fields following existing patterns), but this should still be run before merge per this service's normal convention.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
> List any other related PRs

A corresponding ServiceNow scripted-API change and a corresponding Ballerina entity-service change are tracked separately (not in this repo / a separate PR in the private entity-service repo).

## Migrations (if applicable)
N/A -- no schema/data migration involved.

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested

Go entity-service, macOS, local build/test only (see Automation tests above for the honest scope of verification).

## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

Two of the three new fields don't fit either of this service's existing boolean-filter idioms cleanly (isEmpty/isNotEmpty for reference-presence checks like `escalation`) -- rather than force a mismatched pattern, a small `parseCaseFilterBool` helper was added, mirroring the incident side's existing equivalent, so plain-boolean filters have one consistent idiom across resource types.
