### PR TITLE
[CSM Portal Microapp] Fix empty time-card approver search

### DIFF
--- a/apps/csm-portal/microapp/src/components/case-detail/LinkCaseDialog.tsx
+++ b/apps/csm-portal/microapp/src/components/case-detail/LinkCaseDialog.tsx
@@ -77,10 +77,11 @@ export function LinkCaseDialog({ currentCaseId, isLinking, onClose, onLink }: Li
             backgroundImage: "none",
             backgroundColor: "background.default",
             // Same explicit cap as LogTimeCardDialog — keeps the search results scrollable within
-            // the dialog instead of letting the paper grow past the viewport.
+            // the dialog instead of letting the paper grow past the viewport. `dvh`, not `vh` — see
+            // that file's comment for why.
             display: "flex",
             flexDirection: "column",
-            maxHeight: "85vh",
+            maxHeight: "85dvh",
           },
         },
       }}

--- a/apps/csm-portal/microapp/src/components/case-detail/LogTimeCardDialog.tsx
+++ b/apps/csm-portal/microapp/src/components/case-detail/LogTimeCardDialog.tsx
@@ -250,10 +250,13 @@ export function LogTimeCardDialog({
             // Explicit cap (rather than relying on the default `calc(100% - 64px)`) so the dialog
             // never grows taller than the visible viewport in the microapp's WebView — without it,
             // the last field(s) and the action buttons can end up clipped below the fold with no
-            // way to scroll to them.
+            // way to scroll to them. `dvh`, not `vh` — `vh` resolves against the layout viewport,
+            // which in a mobile WebView (or a desktop browser with devtools docked, shrinking the
+            // available frame) can be taller than what's actually visible, letting the cap sit
+            // below the real fold anyway. Matches AttachmentPreviewDialog's use of `100dvh`.
             display: "flex",
             flexDirection: "column",
-            maxHeight: "85vh",
+            maxHeight: "85dvh",
           },
         },
       }}
@@ -329,14 +332,14 @@ export function LogTimeCardDialog({
             ))}
           </Stack>
 
-          <Stack direction="row" alignItems="center" justifyContent="space-between" flexWrap="wrap" gap={1}>
+          <Stack direction="row" alignItems="center" justifyContent="space-between" gap={1}>
             <TextField
               select
               label="Issue complexity"
               size="small"
               value={issueComplexity}
               onChange={(e) => setIssueComplexity(e.target.value as IssueComplexity)}
-              sx={{ minWidth: 140 }}
+              sx={{ minWidth: 120, flexShrink: 0 }}
               slotProps={{ select: { MenuProps: { slotProps: { paper: OPAQUE_POPUP } } } }}
             >
               {ISSUE_COMPLEXITY_OPTIONS.map((o) => (
@@ -345,7 +348,10 @@ export function LogTimeCardDialog({
                 </MenuItem>
               ))}
             </TextField>
-            <Stack alignItems="flex-end" gap={0.25}>
+            {/* Bounded so the caption below wraps onto its own line(s) instead of growing this
+                column wide enough to push the row into flex-wrap, which put the toggle on its own
+                line under Issue complexity. */}
+            <Stack alignItems="flex-end" gap={0.25} sx={{ maxWidth: 150 }}>
               <FormControlLabel
                 control={
                   <Switch
@@ -359,7 +365,7 @@ export function LogTimeCardDialog({
                 sx={{ ml: 0 }}
               />
               {isAlwaysNonBillable && (
-                <Typography variant="caption" color="text.secondary">
+                <Typography variant="caption" color="text.secondary" sx={{ textAlign: "right" }}>
                   Always non-billable{caseSeverity ? ` for ${SEVERITY_LABELS[caseSeverity]} cases` : ""}.
                 </Typography>
               )}

--- a/apps/csm-portal/microapp/src/components/case-detail/LogTimeCardDialog.tsx
+++ b/apps/csm-portal/microapp/src/components/case-detail/LogTimeCardDialog.tsx
@@ -332,7 +332,7 @@ export function LogTimeCardDialog({
             ))}
           </Stack>
 
-          <Stack direction="row" alignItems="center" justifyContent="space-between" gap={1}>
+          <Stack direction="row" alignItems="center" justifyContent="space-between" flexWrap="wrap" gap={1}>
             <TextField
               select
               label="Issue complexity"
@@ -349,8 +349,11 @@ export function LogTimeCardDialog({
               ))}
             </TextField>
             {/* Bounded so the caption below wraps onto its own line(s) instead of growing this
-                column wide enough to push the row into flex-wrap, which put the toggle on its own
-                line under Issue complexity. */}
+                column wide enough to push the row into flex-wrap at normal dialog widths, which
+                is what put the toggle on its own line under Issue complexity. flexWrap stays on
+                the row itself (rather than switching to nowrap) as a fallback for genuinely
+                narrow viewports where even 120px (Issue complexity) + 150px (this column) can't
+                both fit — there it still wraps instead of clipping. */}
             <Stack alignItems="flex-end" gap={0.25} sx={{ maxWidth: 150 }}>
               <FormControlLabel
                 control={

--- a/apps/csm-portal/microapp/src/pages/UpdatesPage.tsx
+++ b/apps/csm-portal/microapp/src/pages/UpdatesPage.tsx
@@ -458,7 +458,8 @@ function DialogPaperWrapper({ children, onClose }: { children: ReactNode; onClos
       onClose={onClose}
       slots={{ paper: DialogPaper }}
       slotProps={{
-        paper: { sx: { bgcolor: "background.default", p: 2, gap: 2, m: 2, maxHeight: "85vh", overflowY: "auto" } },
+        // `dvh`, not `vh` — see LogTimeCardDialog's comment for why.
+        paper: { sx: { bgcolor: "background.default", p: 2, gap: 2, m: 2, maxHeight: "85dvh", overflowY: "auto" } },
       }}
     >
       {children}

--- a/apps/csm-portal/microapp/src/services/adminUsers.ts
+++ b/apps/csm-portal/microapp/src/services/adminUsers.ts
@@ -16,7 +16,7 @@
 
 import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query";
 import { USERS_SEARCH_ENDPOINT } from "@config/endpoints";
-import type { AdminUserRole, UserSearchFiltersDto, UserSearchPayloadDto, UserSearchResponseDto } from "@src/types";
+import type { UserSearchFiltersDto, UserSearchPayloadDto, UserSearchResponseDto } from "@src/types";
 import { toAdminUser, type AdminUser } from "@src/types";
 import apiClient from "./apiClient";
 
@@ -39,9 +39,13 @@ const searchUsers = async (payload: UserSearchPayloadDto = {}): Promise<AdminUse
 
 const ADMIN_USERS_PAGE_LIMIT = 20;
 
-// Eligible time-card approvers — mirrors the webapp's INTERNAL_USER_ROLES
-// (csmUsers.ts). A customer account can't approve internal time cards.
-const APPROVER_ROLES: AdminUserRole[] = ["internal", "agent", "admin"];
+// Eligible time-card approvers must hold this dedicated permission group — mirrors the webapp's
+// TIMECARD_APPROVER_GROUP (csm-timecards/constants/timeCardConstants.ts). Filtering on the
+// generic internal-user roles ("internal"/"agent"/"admin") instead — the webapp's own past bug,
+// since fixed there — let a submitter pick literally anyone at the company; here it did the
+// opposite, since none of the ServiceNow accounts actually eligible to approve carry those
+// generic role tags, so the search always came back empty (digiops-cs#2805).
+const TIMECARD_APPROVER_GROUP = "timecard_approver";
 const APPROVER_SEARCH_LIMIT = 6;
 
 export const adminUsers = {
@@ -62,13 +66,13 @@ export const adminUsers = {
 
   // One-shot type-ahead search for a single-pick field (LogTimeCardDialog's
   // approver picker) — mirrors projects.ts's `search`, not the paged `infinite`
-  // list above. Scoped to internal accounts only.
+  // list above. Scoped to timecard approvers only.
   search: (searchQuery: string) =>
     queryOptions({
       queryKey: ["admin-users", "search", searchQuery],
       queryFn: () =>
         searchUsers({
-          filters: { searchQuery, roleIds: APPROVER_ROLES, active: true },
+          filters: { searchQuery, roleIds: [TIMECARD_APPROVER_GROUP], active: true },
           pagination: { offset: 0, limit: APPROVER_SEARCH_LIMIT },
         }),
       enabled: searchQuery.trim().length > 0,

--- a/apps/csm-portal/microapp/src/types/adminUser.dto.ts
+++ b/apps/csm-portal/microapp/src/types/adminUser.dto.ts
@@ -64,9 +64,11 @@ export interface SnUserDto {
 export interface UserSearchFiltersDto {
   searchQuery?: string;
   /** ServiceNow data source only. Named `roleIds` (not `roles`) to match the backend contract —
-   * a role's "id" is its key (e.g. "agent"), not a separate numeric identifier. Mirrors the
-   * webapp's UserSearchFilters.roleIds. */
-  roleIds?: AdminUserRole[];
+   * a role's "id" is its key (e.g. "agent"), not a separate numeric identifier. Plain `string[]`
+   * rather than `AdminUserRole[]` because this also carries permission-group ids (e.g.
+   * "timecard_approver" — see adminUsers.ts's approver search) that aren't part of the
+   * `AdminUserRole` enum. Mirrors the webapp's UserSearchFilters.roleIds. */
+  roleIds?: string[];
   /** ServiceNow data source only. */
   active?: boolean;
 }


### PR DESCRIPTION
## Purpose
Users can't submit time cards on the CSM portal mobile application — the Approver search never returns any candidates.

## Goals
- Approver search in the Log time dialog returns real matches.
- Two related dialog layout bugs, found while verifying the fix on device, fixed alongside it.

## Approach
- `adminUsers.ts` filtered approver candidates by the generic internal-user roles (`internal`/`agent`/`admin`) instead of the dedicated `timecard_approver` permission group, so the search always came back empty — none of the accounts actually eligible to approve carry those generic role tags. The webapp had this exact bug once and already fixed it (`csm-timecards/constants/timeCardConstants.ts`'s `TIMECARD_APPROVER_GROUP`); this ports that fix to the microapp. Widened `UserSearchFiltersDto.roleIds` from `AdminUserRole[]` to `string[]`, since `timecard_approver` is a permission group, not a user role, matching how the webapp types the equivalent field.
- `LogTimeCardDialog`/`LinkCaseDialog`/`UpdatesPage`: all capped their dialog at `maxHeight: 85vh`, which can sit below the actually-visible viewport (mobile WebView chrome, or a desktop browser with devtools docked) and clip the last field(s)/action buttons with no way to scroll to them. Switched to `dvh`, matching `AttachmentPreviewDialog`'s existing use of `100dvh`.
- `LogTimeCardDialog`'s Issue complexity / Billable row: the caption under the toggle could grow wide enough to push the row into flex-wrap, dropping the toggle onto its own line. Bounded that column's width so the caption wraps internally instead.

## User stories
As a CSM engineer, I can search for and select a real approver when logging time on my case, and the Log time dialog stays fully usable on screen.

## Release note
Fixed the time-card approver search returning no results on the CSM portal mobile app, plus two dialog layout clipping bugs found while verifying the fix.

## Documentation
N/A — internal CSM portal UI, no external doc surface affected.

## Automation tests
- No test runner wired up in the microapp yet (pre-existing).
- Verified locally against the staging backend: searching by name/email in the Approver field now returns matches; Log time, Link case, and the Updates dialog all stay scrollable to their action buttons.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (frontend-only change)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
- `npm run lint`, `npm run build` passing locally (Node 20, macOS).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved dialog sizing on mobile and desktop by adapting to the visible screen area.
  - Adjusted time-entry controls to prevent cramped layouts and improve readability.
  - Refined the “Always non-billable” label alignment.
  - Approver searches now return eligible time-card approvers more accurately.
- **Documentation**
  - Updated search filter documentation to support permission-group identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->