### PR TITLE
[CSM Portal] Allow CS engineers to comment on and create announcements

### DIFF
--- a/apps/csm-portal/backend/internal/handler/cases.go
+++ b/apps/csm-portal/backend/internal/handler/cases.go
@@ -269,6 +269,7 @@ func (h *CaseHandler) CreateCaseComment(w http.ResponseWriter, r *http.Request) 
 			return
 		}
 		var currentCase struct {
+			Type             string  `json:"type"`
 			State            string  `json:"state"`
 			WorkState        *string `json:"workState"`
 			AssignedEngineer *struct {
@@ -280,26 +281,38 @@ func (h *CaseHandler) CreateCaseComment(w http.ResponseWriter, r *http.Request) 
 			writeError(w, http.StatusInternalServerError, ErrMsgInternal)
 			return
 		}
-		if currentCase.State != "work_in_progress" || currentCase.WorkState == nil || *currentCase.WorkState != "ongoing" {
-			writeError(w, http.StatusConflict, ErrMsgCommentNotAllowed)
-			return
-		}
-		// Ownership check. assignedEngineer.id is a platform user record id, so
-		// it can only be compared against the caller's own platform id — never
-		// against the identity provider's user id on the JWT. Resolved here,
-		// after the state gate, so the extra lookup is only paid on a request
-		// that would otherwise be accepted.
-		currentUserID := h.resolveCurrentUserID(r, user)
-		if currentUserID == "" {
-			// The caller's identity could not be established, so ownership
-			// cannot be decided either way: fail closed, but as a server-side
-			// failure rather than a misleading "you are not the assignee".
-			writeError(w, http.StatusInternalServerError, ErrMsgInternal)
-			return
-		}
-		if currentCase.AssignedEngineer == nil || currentCase.AssignedEngineer.ID == nil || *currentCase.AssignedEngineer.ID != currentUserID {
-			writeError(w, http.StatusForbidden, ErrMsgCommentNotOwnCase)
-			return
+		if currentCase.Type == caseTypeAnnouncement {
+			// Announcement cases publish immediately and have no
+			// work_in_progress/ongoing workflow, and may carry no assigned
+			// engineer at all — the state and ownership gates below don't
+			// apply. They still block new comments once closed, like every
+			// other case type.
+			if currentCase.State == caseStateClosed {
+				writeError(w, http.StatusConflict, ErrMsgCommentOnClosedCase)
+				return
+			}
+		} else {
+			if currentCase.State != caseStateWorkInProgress || currentCase.WorkState == nil || *currentCase.WorkState != "ongoing" {
+				writeError(w, http.StatusConflict, ErrMsgCommentNotAllowed)
+				return
+			}
+			// Ownership check. assignedEngineer.id is a platform user record id, so
+			// it can only be compared against the caller's own platform id — never
+			// against the identity provider's user id on the JWT. Resolved here,
+			// after the state gate, so the extra lookup is only paid on a request
+			// that would otherwise be accepted.
+			currentUserID := h.resolveCurrentUserID(r, user)
+			if currentUserID == "" {
+				// The caller's identity could not be established, so ownership
+				// cannot be decided either way: fail closed, but as a server-side
+				// failure rather than a misleading "you are not the assignee".
+				writeError(w, http.StatusInternalServerError, ErrMsgInternal)
+				return
+			}
+			if currentCase.AssignedEngineer == nil || currentCase.AssignedEngineer.ID == nil || *currentCase.AssignedEngineer.ID != currentUserID {
+				writeError(w, http.StatusForbidden, ErrMsgCommentNotOwnCase)
+				return
+			}
 		}
 	}
 

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -509,6 +509,61 @@ func TestCreateCaseComment(t *testing.T) {
 		assertErrorMessage(t, w, ErrMsgWorkNoteOnClosedCase)
 	})
 
+	t.Run("allows public comment on an announcement case with no work-in-progress state and no assigned engineer", func(t *testing.T) {
+		for _, state := range []string{"open", "published"} {
+			state := state
+			t.Run(state, func(t *testing.T) {
+				t.Parallel()
+				client := &mockEntityCaseClient{
+					getCaseFn: func(_ context.Context, _ string) ([]byte, error) {
+						return []byte(`{"type":"announcement","state":"` + state + `"}`), nil
+					},
+					createCaseCommentFn: func(_ context.Context, _ string, _ []byte) ([]byte, error) {
+						return []byte(`{"id":"comment-1"}`), nil
+					},
+				}
+				h := NewCaseHandler(client)
+				r := withUser(httptest.NewRequest(http.MethodPost, "/cases/case-1/comments", strings.NewReader(validPayload)))
+				r.SetPathValue("id", "case-1")
+				w := httptest.NewRecorder()
+				h.CreateCaseComment(w, r)
+				assertStatus(t, w, http.StatusCreated)
+			})
+		}
+	})
+
+	t.Run("blocks public comment on a closed announcement case", func(t *testing.T) {
+		client := &mockEntityCaseClient{
+			getCaseFn: func(_ context.Context, _ string) ([]byte, error) {
+				return []byte(`{"type":"announcement","state":"closed"}`), nil
+			},
+		}
+		h := NewCaseHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/case-1/comments", strings.NewReader(validPayload)))
+		r.SetPathValue("id", "case-1")
+		w := httptest.NewRecorder()
+		h.CreateCaseComment(w, r)
+		assertStatus(t, w, http.StatusConflict)
+		assertErrorMessage(t, w, ErrMsgCommentOnClosedCase)
+	})
+
+	t.Run("allows work_note on an announcement case with no assigned engineer", func(t *testing.T) {
+		client := &mockEntityCaseClient{
+			getCaseFn: func(_ context.Context, _ string) ([]byte, error) {
+				return []byte(`{"type":"announcement","state":"open"}`), nil
+			},
+			createCaseCommentFn: func(_ context.Context, _ string, _ []byte) ([]byte, error) {
+				return []byte(`{"id":"wn-1"}`), nil
+			},
+		}
+		h := NewCaseHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/case-1/comments", strings.NewReader(`{"type":"work_note","content":"internal note"}`)))
+		r.SetPathValue("id", "case-1")
+		w := httptest.NewRecorder()
+		h.CreateCaseComment(w, r)
+		assertStatus(t, w, http.StatusCreated)
+	})
+
 	t.Run("forwards body to entity and returns response", func(t *testing.T) {
 		var capturedCaseID string
 		var capturedBody []byte

--- a/apps/csm-portal/backend/internal/handler/response.go
+++ b/apps/csm-portal/backend/internal/handler/response.go
@@ -38,6 +38,7 @@ const (
 	ErrMsgCommentNotAllowed       = "Comments can only be added when the case is in progress and the work state is ongoing."
 	ErrMsgCommentNotOwnCase       = "Only the assigned engineer can add a public comment on this case."
 	ErrMsgWorkNoteOnClosedCase    = "Work notes cannot be added to a closed case."
+	ErrMsgCommentOnClosedCase     = "Comments cannot be added to a closed case."
 	ErrMsgAttachmentOnClosedCase  = "Attachments cannot be added to a closed case."
 	ErrMsgRequestUpdateNotAllowed = "An update can only be requested while the case is awaiting info or has a proposed solution."
 	ErrMsgInvalidUUID             = "Invalid UUID format."

--- a/apps/csm-portal/backend/internal/handler/state.go
+++ b/apps/csm-portal/backend/internal/handler/state.go
@@ -32,6 +32,11 @@ const relatedCaseWindow = 60 * 24 * time.Hour
 // create flows that don't accept a relatedCaseId today.
 const caseTypeCase = "case"
 
+// caseTypeAnnouncement is a case type with no work-in-progress workflow: it
+// publishes immediately and may never carry an assigned engineer. The
+// comment-creation state/ownership gate in cases.go carves this type out.
+const caseTypeAnnouncement = "announcement"
+
 const (
 	caseStateOpen             = "open"
 	caseStateWorkInProgress   = "work_in_progress"

--- a/apps/csm-portal/webapp/src/App.tsx
+++ b/apps/csm-portal/webapp/src/App.tsx
@@ -178,6 +178,9 @@ const CsmTimeCardsPage = lazy(
 const CsmAnnouncementsPage = lazy(
   () => import("@features/csm-announcements/pages/CsmAnnouncementsPage"),
 );
+const CsmAnnouncementCreatePage = lazy(
+  () => import("@features/csm-announcements/pages/CsmAnnouncementCreatePage"),
+);
 const HelpPage = lazy(() => import("@features/help/pages/HelpPage"));
 
 /**
@@ -567,6 +570,10 @@ export default function App(): JSX.Element {
                   </Route>
                   <Route path="time-cards" element={<CsmTimeCardsPage />} />
                   <Route path="announcements" element={<CsmAnnouncementsPage />} />
+                  <Route
+                    path="announcements/new"
+                    element={<CsmAnnouncementCreatePage />}
+                  />
                   <Route
                     path="announcements/:caseId"
                     element={<CsmCaseDetailPage />}

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -556,14 +556,31 @@ export interface BeEngagementCreatePayload {
 }
 
 /**
+ * Announcement (`type: "announcement"`). A broadcast, not a worked case — no
+ * severity/issueType/deployment/deployedProduct/attachments. Always created
+ * against a single project; a multi-project announcement is fanned out into
+ * one create call per project by the caller (see
+ * `CsmAnnouncementCreatePage.tsx`), not expressed as one payload with a
+ * target list.
+ */
+export interface BeAnnouncementCreatePayload {
+  type: "announcement";
+  projectId: string;
+  subject: string;
+  description: string;
+}
+
+/**
  * Any body accepted by `POST /cases`: a standard support case, a catalog
- * service request, a security report analysis, or an engagement.
+ * service request, a security report analysis, an engagement, or an
+ * announcement.
  */
 export type BeCaseCreateBody =
   | BeCaseCreatePayload
   | BeServiceRequestCreatePayload
   | BeSecurityReportCreatePayload
-  | BeEngagementCreatePayload;
+  | BeEngagementCreatePayload
+  | BeAnnouncementCreatePayload;
 
 /** The case summary embedded in the `POST /cases` success envelope. */
 export interface BeCreatedCase {

--- a/apps/csm-portal/webapp/src/features/csm-announcements/pages/CsmAnnouncementCreatePage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-announcements/pages/CsmAnnouncementCreatePage.test.tsx
@@ -1,0 +1,183 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+
+const navigateMock = vi.fn();
+const postCaseMutateAsyncMock = vi.fn();
+const showErrorMock = vi.fn();
+
+vi.mock("react-router", () => ({
+  useNavigate: () => navigateMock,
+}));
+vi.mock("@context/error-banner/ErrorBannerContext", () => ({
+  useErrorBanner: () => ({ showError: showErrorMock }),
+}));
+vi.mock("@features/csm-cases/api/usePostCsmCase", () => ({
+  usePostCsmCase: () => ({ mutateAsync: postCaseMutateAsyncMock }),
+}));
+vi.mock("@components/rich-text-editor/Editor", () => ({
+  default: ({ value, onChange }: { value: string; onChange: (v: string) => void }) => (
+    <textarea aria-label="editor" value={value} onChange={(e) => onChange(e.target.value)} />
+  ),
+}));
+// The real multi-select searches the backend as the user types; stub it with
+// a plain multi-value control so this file stays focused on the create form's
+// own required-field and fan-out-submit behavior (the picker itself has its
+// own tests via CsmAnnouncementsPage.test.tsx's filter-bar coverage).
+vi.mock("@features/csm-cases/components/AsyncProjectMultiSelect", () => ({
+  default: ({
+    values,
+    onChange,
+  }: {
+    values: string[];
+    onChange: (next: string[]) => void;
+  }) => (
+    <select
+      aria-label="Projects"
+      multiple
+      value={values}
+      onChange={(e) =>
+        onChange(Array.from(e.target.selectedOptions).map((o) => o.value))
+      }
+    >
+      <option value="proj-1">Project One</option>
+      <option value="proj-2">Project Two</option>
+    </select>
+  ),
+}));
+// CsmAnnouncementCreatePage imports BackendApiError from the real API client
+// module, which reads window.config at module load and throws outside a
+// configured runtime — mirrors CreateSecurityReportPage.test.tsx.
+vi.mock("@api/backend/client", () => ({
+  BackendApiError: class BackendApiError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+      super(message);
+      this.status = status;
+    }
+  },
+}));
+
+// Imported after the mocks above so the module picks them up.
+import CsmAnnouncementCreatePage from "@features/csm-announcements/pages/CsmAnnouncementCreatePage";
+
+function selectProjects(...values: string[]): void {
+  const select = screen.getByLabelText("Projects") as HTMLSelectElement;
+  Array.from(select.options).forEach((o) => {
+    o.selected = values.includes(o.value);
+  });
+  fireEvent.change(select);
+}
+
+function fillSubjectAndDescription(): void {
+  fireEvent.change(screen.getByLabelText(/subject/i), {
+    target: { value: "Scheduled maintenance" },
+  });
+  fireEvent.change(screen.getByLabelText("editor"), {
+    target: { value: "<p>Maintenance window details.</p>" },
+  });
+}
+
+describe("CsmAnnouncementCreatePage", () => {
+  beforeEach(() => {
+    navigateMock.mockReset();
+    postCaseMutateAsyncMock.mockReset();
+    showErrorMock.mockReset();
+  });
+
+  it("keeps Create disabled until title, description, and at least one project are filled", () => {
+    render(<CsmAnnouncementCreatePage />);
+    const submit = screen.getByRole("button", { name: /create announcement/i });
+    expect(submit).toBeDisabled();
+
+    fillSubjectAndDescription();
+    // Subject + description are filled, but no project is selected yet.
+    expect(submit).toBeDisabled();
+
+    selectProjects("proj-1");
+    expect(submit).toBeEnabled();
+  });
+
+  it("fans out one POST /cases call per selected project, with the same subject/description", async () => {
+    postCaseMutateAsyncMock.mockResolvedValue({ id: "ann-1" });
+    render(<CsmAnnouncementCreatePage />);
+
+    fillSubjectAndDescription();
+    selectProjects("proj-1", "proj-2");
+
+    fireEvent.click(screen.getByRole("button", { name: /create announcement/i }));
+    await screen.findByRole("button", { name: /creating/i });
+
+    await waitFor(() => {
+      expect(postCaseMutateAsyncMock).toHaveBeenCalledTimes(2);
+    });
+    expect(postCaseMutateAsyncMock).toHaveBeenCalledWith({
+      type: "announcement",
+      projectId: "proj-1",
+      subject: "Scheduled maintenance",
+      description: "<p>Maintenance window details.</p>",
+    });
+    expect(postCaseMutateAsyncMock).toHaveBeenCalledWith({
+      type: "announcement",
+      projectId: "proj-2",
+      subject: "Scheduled maintenance",
+      description: "<p>Maintenance window details.</p>",
+    });
+
+    await waitFor(() => {
+      expect(navigateMock).toHaveBeenCalledWith("/announcements", undefined);
+    });
+  });
+
+  it("reports which project failed on a partial failure, keeps the succeeded one, and still navigates back", async () => {
+    postCaseMutateAsyncMock.mockImplementation(({ projectId }: { projectId: string }) =>
+      projectId === "proj-1"
+        ? Promise.resolve({ id: "ann-1" })
+        : Promise.reject(new Error("network down")),
+    );
+    render(<CsmAnnouncementCreatePage />);
+
+    fillSubjectAndDescription();
+    selectProjects("proj-1", "proj-2");
+    fireEvent.click(screen.getByRole("button", { name: /create announcement/i }));
+
+    await waitFor(() => {
+      expect(showErrorMock).toHaveBeenCalledWith(
+        expect.stringContaining("proj-2"),
+      );
+    });
+    expect(navigateMock).toHaveBeenCalledWith("/announcements", undefined);
+  });
+
+  it("surfaces a single error and does not navigate when every project fails", async () => {
+    postCaseMutateAsyncMock.mockRejectedValue(new Error("network down"));
+    render(<CsmAnnouncementCreatePage />);
+
+    fillSubjectAndDescription();
+    selectProjects("proj-1");
+    fireEvent.click(screen.getByRole("button", { name: /create announcement/i }));
+
+    await waitFor(() => {
+      expect(showErrorMock).toHaveBeenCalledWith(
+        "Could not create the announcement. Please try again.",
+      );
+    });
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-announcements/pages/CsmAnnouncementCreatePage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-announcements/pages/CsmAnnouncementCreatePage.tsx
@@ -1,0 +1,193 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Box, Button, Card, Grid, TextField, Typography } from "@wso2/oxygen-ui";
+import { ArrowLeft } from "@wso2/oxygen-ui-icons-react";
+import { useMemo, useState, type JSX } from "react";
+import Editor from "@components/rich-text-editor/Editor";
+import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
+import AsyncProjectMultiSelect from "@features/csm-cases/components/AsyncProjectMultiSelect";
+import { usePostCsmCase } from "@features/csm-cases/api/usePostCsmCase";
+import { useNavTransition } from "@hooks/useNavTransition";
+
+/** The rich-text editor emits `<p></p>` when empty; check the stripped text. */
+function isEmptyHtml(html: string): boolean {
+  return html.replace(/<[^>]*>/g, "").replace(/&nbsp;/g, " ").trim().length === 0;
+}
+
+const BACK_TARGET = "/announcements";
+
+/**
+ * Create an announcement (`type: "announcement"`) against one or more
+ * projects. Unlike a standard case, this is a broadcast — no
+ * severity/issueType/deployment/deployedProduct/attachments, just a subject
+ * and description.
+ *
+ * A single announcement "record" per selected project: the backend's
+ * `POST /cases` create call takes exactly one `projectId`, so a
+ * multi-project pick here fans out into one independent create call per
+ * project (same subject/description on each), not one record with a target
+ * list. Submitting is therefore a batch: if some calls fail while others
+ * succeed, the succeeded ones stand (no auto-retry) and the failures are
+ * reported by project so the engineer can retry just those.
+ */
+export default function CsmAnnouncementCreatePage(): JSX.Element {
+  const navigate = useNavTransition();
+  const { showError } = useErrorBanner();
+
+  const [projectIds, setProjectIds] = useState<string[]>([]);
+  const [subject, setSubject] = useState("");
+  const [description, setDescription] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const postCase = usePostCsmCase();
+
+  const canSubmit = useMemo(
+    () =>
+      projectIds.length > 0 &&
+      subject.trim().length > 0 &&
+      !isEmptyHtml(description) &&
+      !submitting,
+    [projectIds, subject, description, submitting],
+  );
+
+  const handleSubmit = async (): Promise<void> => {
+    if (!canSubmit) return;
+    setSubmitting(true);
+
+    const trimmedSubject = subject.trim();
+    const results = await Promise.allSettled(
+      projectIds.map((projectId) =>
+        postCase.mutateAsync({
+          type: "announcement",
+          projectId,
+          subject: trimmedSubject,
+          description,
+        }),
+      ),
+    );
+    setSubmitting(false);
+
+    // The multi-select doesn't expose picked project names to this page (it
+    // only reports ids via onChange), so a failure is reported by id — still
+    // enough for the engineer to identify which project(s) to retry.
+    const failedProjectIds = projectIds.filter(
+      (_, i) => results[i].status === "rejected",
+    );
+
+    if (failedProjectIds.length === 0) {
+      navigate(BACK_TARGET);
+      return;
+    }
+
+    const succeededCount = projectIds.length - failedProjectIds.length;
+    if (succeededCount > 0) {
+      // Partial failure: the succeeded creates already landed and aren't
+      // retried automatically, so navigate away and surface exactly which
+      // project(s) still need a retry.
+      showError(
+        `The announcement was created for ${succeededCount} of ${projectIds.length} project${
+          projectIds.length === 1 ? "" : "s"
+        }, but failed for project${failedProjectIds.length === 1 ? "" : "s"} ${failedProjectIds.join(
+          ", ",
+        )}. Create it again for the failed project${failedProjectIds.length === 1 ? "" : "s"} only.`,
+      );
+      navigate(BACK_TARGET);
+    } else {
+      showError("Could not create the announcement. Please try again.");
+    }
+  };
+
+  return (
+    <Box sx={{ width: "100%", px: 3, py: 3 }}>
+      <Button
+        variant="text"
+        startIcon={<ArrowLeft size={16} />}
+        onClick={() => navigate(BACK_TARGET)}
+        sx={{ mb: 1 }}
+      >
+        Back
+      </Button>
+      <Typography variant="h5" sx={{ mb: 2 }}>
+        New announcement
+      </Typography>
+
+      <Card variant="outlined" sx={{ p: 3 }}>
+        <Grid container spacing={2.5}>
+          <Grid size={{ xs: 12 }}>
+            <AsyncProjectMultiSelect
+              id="announcement-create-projects"
+              label="Projects"
+              values={projectIds}
+              onChange={setProjectIds}
+            />
+          </Grid>
+
+          <Grid size={{ xs: 12 }}>
+            <TextField
+              label="Subject"
+              size="small"
+              fullWidth
+              required
+              value={subject}
+              onChange={(e) => setSubject(e.target.value.slice(0, 200))}
+              helperText={
+                subject.length >= 160 ? `${subject.length}/200` : undefined
+              }
+            />
+          </Grid>
+          <Grid size={{ xs: 12 }}>
+            <Typography
+              id="announcement-description-label"
+              component="label"
+              variant="caption"
+              color="text.secondary"
+              sx={{ display: "block", mb: 0.5 }}
+            >
+              Description
+            </Typography>
+            {/* Editor doesn't accept an `id`, so associate the label by wrapping
+                the editor in a labelled group for assistive tech. */}
+            <Box role="group" aria-labelledby="announcement-description-label">
+              <Editor
+                value={description}
+                onChange={setDescription}
+                placeholder="Describe the announcement…"
+                minHeight={180}
+                maxHeight={420}
+                toolbarVariant="full"
+                disabled={submitting}
+              />
+            </Box>
+          </Grid>
+        </Grid>
+
+        <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 1.5, mt: 2.5 }}>
+          <Button variant="outlined" onClick={() => navigate(BACK_TARGET)}>
+            Cancel
+          </Button>
+          <Button
+            variant="contained"
+            onClick={() => void handleSubmit()}
+            disabled={!canSubmit}
+          >
+            {submitting ? "Creating…" : "Create announcement"}
+          </Button>
+        </Box>
+      </Card>
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-announcements/pages/CsmAnnouncementsPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-announcements/pages/CsmAnnouncementsPage.tsx
@@ -31,9 +31,10 @@ import {
   TextField,
   Typography,
 } from "@wso2/oxygen-ui";
-import { Search, X } from "@wso2/oxygen-ui-icons-react";
+import { Plus, Search, X } from "@wso2/oxygen-ui-icons-react";
 import { useMemo, useState, type ChangeEvent, type JSX, type ReactNode } from "react";
 import { Link as RouterLink } from "react-router";
+import { useNavTransition } from "@hooks/useNavTransition";
 import ColumnCustomizerButton from "@components/column-customizer/ColumnCustomizerButton";
 import MultiSelectField from "@components/MultiSelectField";
 import QueryErrorState from "@components/QueryErrorState";
@@ -169,13 +170,14 @@ function renderAnnouncementCell(id: AnnouncementColumnId, a: CsmAnnouncementRow)
 }
 
 /**
- * Read-only announcements list. Announcements are cases of
- * `type: "announcement"` surfaced via `POST /cases/search`. Filterable by
- * state and project (all default to "show all"). Creating /
- * targeting / unpublishing needs the dedicated announcement backend,
- * tracked separately, which isn't built yet, so this page is view-only for now.
+ * Announcements list. Announcements are cases of `type: "announcement"`
+ * surfaced via `POST /cases/search`. Filterable by state and project (all
+ * default to "show all"). Creating one is handled by
+ * `CsmAnnouncementCreatePage` ("New announcement" below); unpublishing isn't
+ * built yet.
  */
 export default function CsmAnnouncementsPage(): JSX.Element {
+  const navigate = useNavTransition();
   const [filters, setFilters] = useState<AnnouncementFilters>(DEFAULT_ANNOUNCEMENT_FILTERS);
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_ROWS_PER_PAGE);
@@ -224,6 +226,15 @@ export default function CsmAnnouncementsPage(): JSX.Element {
           </Typography>
         </Box>
         <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+          <Button
+            variant="contained"
+            color="primary"
+            size="small"
+            startIcon={<Plus size={16} />}
+            onClick={() => navigate("/announcements/new")}
+          >
+            New announcement
+          </Button>
           <RefreshButton
             onRefresh={() => void refetch()}
             isFetching={isFetching}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActivitiesFeed.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActivitiesFeed.tsx
@@ -296,7 +296,9 @@ export default function CaseActivitiesFeed({
 
       {entries.length === 0 ? (
         <Typography variant="body2" color="text.secondary">
-          Nothing to show — enable more categories in the Filter menu.
+          {activeFilters === filterOptions.length
+            ? "No activity yet."
+            : "Nothing to show — enable more categories in the Filter menu."}
         </Typography>
       ) : (
         <Box sx={{ display: "flex", flexDirection: "column", gap: 1.25 }}>

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.test.tsx
@@ -30,7 +30,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import "@testing-library/jest-dom/vitest";
 import type { CsmCaseDetail } from "@features/csm-cases/types/csmCases";
 import type { CsmTimeCard } from "@features/csm-timecards/types/timeCards";
-import type { BeCaseType } from "@api/backend/types";
+import type { BeCaseState, BeCaseType } from "@api/backend/types";
 
 // `@api/backend/client` -> `useAuthApiClient` -> `@config/apiConfig`, which
 // throws at module load when `window.config` isn't set — not present under
@@ -84,7 +84,11 @@ vi.mock("@utils/useDarkMode", () => ({
 // `isLoading`/`isError`/`!data` early returns) for whichever case is active.
 function buildCase(
   id: string,
-  overrides?: { caseType?: BeCaseType; description?: string },
+  overrides?: {
+    caseType?: BeCaseType;
+    description?: string;
+    state?: BeCaseState;
+  },
 ): CsmCaseDetail {
   return {
     id,
@@ -96,7 +100,7 @@ function buildCase(
     projectName: "Acme Project",
     product: "WSO2 Identity Server",
     severity: "S2",
-    state: "open",
+    state: overrides?.state ?? "open",
     assignee: "Unassigned",
     assigneeIsMe: false,
     slaClockType: "resolution",
@@ -940,18 +944,18 @@ describe("CsmCaseDetailPage — request-update stale-callback guard", () => {
   });
 });
 
-// Announcements have no composer and no real comment thread (see the
-// isAnnouncement gate in the page), so the case description never arrives as
-// the Activities feed's opening comment the way it does for every other case
-// type — it has to be rendered directly.
+// An announcement's own body never arrives as the Activities feed's opening
+// comment the way it does for every other case type — it has to be rendered
+// directly (see the note above the description card in the page).
 function renderCaseDetailPage(
   path: string,
   routePattern: string,
   caseType: BeCaseType | undefined,
   description: string,
+  state?: BeCaseState,
 ): ReturnType<typeof render> {
   useGetCsmCaseDetailMock.mockImplementation((id: string | undefined) => ({
-    data: id ? buildCase(id, { caseType, description }) : undefined,
+    data: id ? buildCase(id, { caseType, description, state }) : undefined,
     isLoading: false,
     isError: false,
     error: null,
@@ -1017,6 +1021,55 @@ describe("CsmCaseDetailPage — announcement description rendering", () => {
     );
 
     expect(screen.queryByText("Description")).not.toBeInTheDocument();
+  });
+});
+
+// The comment/work-note composer used to be suppressed outright for
+// announcements (`isAnnouncement ? null : …`) — the entity now accepts
+// replies on an announcement the same as any other open case (see the
+// backend's announcement carve-out in CreateCaseComment), so the page must
+// show the same collapsed-until-clicked composer toggle it already shows for
+// a plain case, and only gate it on the case being closed.
+describe("CsmCaseDetailPage — announcement comment composer", () => {
+  it("shows the collapsed 'Add comment' toggle for an open announcement and reveals the composer on click", () => {
+    renderCaseDetailPage(
+      "/announcements/case-1",
+      "/announcements/:caseId",
+      "announcement",
+      "<p>Advisory content</p>",
+      "open",
+    );
+
+    const toggle = screen.getByRole("button", {
+      name: /compose a reply to the customer/i,
+    });
+    expect(toggle).toBeEnabled();
+
+    // Composer content itself is a mocked stub (see the CsmCaseCommentInput
+    // mock above) — what this page owns is the reveal chrome around it: the
+    // "Reply" header and its Cancel action only exist once composerOpen is
+    // true.
+    expect(screen.queryByText("Reply")).not.toBeInTheDocument();
+    fireEvent.click(toggle);
+    expect(screen.getByText("Reply")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /cancel/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("disables the 'Add comment' toggle for a closed announcement", () => {
+    renderCaseDetailPage(
+      "/announcements/case-1",
+      "/announcements/:caseId",
+      "announcement",
+      "<p>Advisory content</p>",
+      "closed",
+    );
+
+    const toggle = screen.getByRole("button", {
+      name: /this case is closed — comments and work notes are read-only/i,
+    });
+    expect(toggle).toBeDisabled();
   });
 });
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -1793,11 +1793,18 @@ export default function CsmCaseDetailPage(): JSX.Element {
   // disables the public-reply path in the composer — never work notes.
   // Mirrors the BFF comment guard so the engineer sees a clear reason instead
   // of a generic error.
-  const publicReplyGateReason = publicCommentGateReason(
-    c.state,
-    c.workState,
-    c.assigneeIsMe,
-  );
+  //
+  // Announcements are exempt from this whole gate on the backend (see
+  // CreateCaseComment's announcement carve-out): they publish immediately,
+  // have no work_in_progress/ongoing workflow, and may carry no assigned
+  // engineer at all. The only thing that still blocks a comment there is the
+  // case being closed, which `isClosed` above (and the composer's `disabled`
+  // prop below) already covers — so skip the state/ownership gate here rather
+  // than have it report a reason ("...actively in progress"/"...assigned
+  // engineer...") that would never resolve for an announcement.
+  const publicReplyGateReason = isAnnouncement
+    ? null
+    : publicCommentGateReason(c.state, c.workState, c.assigneeIsMe);
   // The composer's inline "Resume work" quick-fix only applies to this one
   // lock reason — the case is already work_in_progress and assigned to the
   // signed-in engineer, just paused, so resuming is the single-field PATCH
@@ -1805,11 +1812,10 @@ export default function CsmCaseDetailPage(): JSX.Element {
   // reason (not started yet) needs the full assign/start flow, which doesn't
   // belong in the composer; `assigneeIsMe` also excludes another engineer's
   // paused case, matching CaseActionBar's own gate on the same action.
-  const canResumeToUnlockPublicReply = computeCanResumeToUnlockPublicReply(
-    c.state,
-    c.workState,
-    c.assigneeIsMe,
-  );
+  // Never applicable to announcements — see publicReplyGateReason above.
+  const canResumeToUnlockPublicReply = isAnnouncement
+    ? false
+    : computeCanResumeToUnlockPublicReply(c.state, c.workState, c.assigneeIsMe);
   // FE-only, advisory close-gate: warn when the case has an open task, so the
   // engineer isn't surprised by a close rejection. Best-effort — the task
   // *list* (`POST /cases/{id}/tasks/search`) returns `BeTaskSummary`, which
@@ -2071,10 +2077,13 @@ export default function CsmCaseDetailPage(): JSX.Element {
               the thread the focal point until the engineer chooses to reply.
               The composer is always available (an internal work note can be
               added in any state); the public-reply path is gated inside it via
-              `publicReplyGateReason` when the case isn't in-progress/ongoing. */}
-          {/* Announcements are read-only broadcasts — no reply/work-note
-              composer, matching the hidden CaseActionBar (no patch ops). */}
-          {isAnnouncement ? null : composerOpen ? (
+              `publicReplyGateReason` when the case isn't in-progress/ongoing —
+              always null for an announcement, per the note on that constant
+              above. Shown for announcements too (backend now accepts both
+              comment types there), despite the hidden CaseActionBar above —
+              that hides case-lifecycle patch actions, which don't apply to an
+              announcement, not the ability to reply to one. */}
+          {composerOpen ? (
             <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 1.5 }}>
               <Box
                 sx={{
@@ -2242,12 +2251,12 @@ export default function CsmCaseDetailPage(): JSX.Element {
             )}
           </Card>
 
-          {/* Announcements have no composer and no real comment thread (see
-              the isAnnouncement gate above), so the case description never
-              arrives as the feed's opening comment the way it does for every
-              other case type (see the note near `safeComments`). Render it
-              directly below the timeline instead — the only place an
-              announcement's actual content is shown. */}
+          {/* An announcement's own body is never echoed as the feed's opening
+              comment the way it is for every other case type (see the note
+              near `safeComments`) — only replies posted via the composer
+              above show up there. Render the body directly below the
+              timeline instead — the only place an announcement's actual
+              content is shown. */}
           {isAnnouncement && !isBlankHtml(c.description) && (
             <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 1.5 }}>
               <Typography variant="subtitle2">Description</Typography>

--- a/apps/csm-portal/webapp/src/features/help/content/announcements.md
+++ b/apps/csm-portal/webapp/src/features/help/content/announcements.md
@@ -1,10 +1,9 @@
 # Announcements
 
 The Announcements section lists customer-facing announcements published across
-projects and tiers. Under the hood, an announcement is a case of type
-`announcement`, so it shows up here read-only, using the same search and
-detail infrastructure as regular cases, just trimmed down to what makes
-sense for a broadcast.
+projects. Under the hood, an announcement is a case of type `announcement`,
+so it shows up here using the same search and detail infrastructure as
+regular cases, just trimmed down to what makes sense for a broadcast.
 
 ## Viewing the list
 

--- a/apps/csm-portal/webapp/src/features/help/content/announcements.md
+++ b/apps/csm-portal/webapp/src/features/help/content/announcements.md
@@ -30,10 +30,8 @@ Selecting a row opens the announcement's detail page. It reuses the same
 case detail view as regular cases, but with the parts that don't apply to a
 broadcast hidden:
 
-- No action bar: announcements aren't assigned, acknowledged, or
-  transitioned by an engineer from this page.
-- No reply or work-note composer: announcements are read-only; there's
-  nothing to reply to.
+- No assignment, acknowledgement, or state-transition actions: an
+  announcement isn't assigned to or worked by an engineer.
 - No Related, Watchers, SLA, Time, or Call Requests tabs, since none of
   those concepts apply to an announcement.
 
@@ -41,8 +39,37 @@ The announcement's body is shown as its Description, rendered as rich text
 (the same HTML editor content used elsewhere in the portal), so formatting,
 links, and lists in the original announcement are preserved.
 
+## Commenting on an announcement
+
+Announcements aren't read-only anymore. An **Add comment** button reveals a
+composer — the same one used on regular cases — offering a choice between:
+
+- A **customer-visible comment**, which the targeted project's customers can
+  see, for clarifying whether an announcement applies to them, follow-up
+  details, etc.
+- An **internal work note**, visible only to CS engineers.
+
+A closed announcement no longer accepts new comments of either kind, same as
+any other closed case.
+
+## Creating an announcement
+
+Use **New announcement** on the list page to publish one. You provide a
+subject, a description (rich text), and one or more target projects. Picking
+several projects doesn't create one shared announcement — it creates one
+independent case per project, each with its own comment thread; if you later
+reply to "the announcement," you're replying to one specific project's copy
+of it, not all of them at once.
+
+There's no draft state: an announcement is live for its target project(s) as
+soon as you submit. If some of the selected projects fail to create (and
+others succeed), the ones that succeeded are already published; you're told
+which project(s) failed so you can retry just those.
+
 ## What you can't do yet
 
-Creating, targeting, or unpublishing announcements isn't available from the
-CSM portal yet: it depends on a dedicated announcements backend that hasn't
-been built. Until then, this section is view-only.
+- **Targeting is project-level only.** There's no way to target a tier or an
+  "Asgardeo customers only" audience yet — pick specific projects one by one,
+  or all of them.
+- **No unpublish or edit.** Once created, an announcement can't be
+  retargeted, edited, or taken down from the CSM portal.

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -50,6 +50,7 @@ var validCaseType = map[string]bool{
 	"service_request":          true,
 	"security_report_analysis": true,
 	"engagement":               true,
+	"announcement":             true,
 }
 
 var validEngagementType = map[domain.EngagementType]bool{
@@ -124,11 +125,15 @@ func validateCreateCaseRequest(req domain.CreateCaseRequest) error {
 	if req.ProjectID == "" {
 		return &apierror.ValidationError{Msg: "projectId is required"}
 	}
-	if req.DeploymentID == "" {
-		return &apierror.ValidationError{Msg: "deploymentId is required"}
-	}
-	if req.DeployedProductID == "" {
-		return &apierror.ValidationError{Msg: "deployedProductId is required"}
+	// Announcements have no deployment/deployed-product concept: these fields
+	// are deliberately omitted at the ServiceNow layer, not just optional.
+	if req.Type != "announcement" {
+		if req.DeploymentID == "" {
+			return &apierror.ValidationError{Msg: "deploymentId is required"}
+		}
+		if req.DeployedProductID == "" {
+			return &apierror.ValidationError{Msg: "deployedProductId is required"}
+		}
 	}
 
 	switch req.Type {
@@ -186,6 +191,13 @@ func validateCreateCaseRequest(req domain.CreateCaseRequest) error {
 		}
 		if !validEngagementPaymentType[req.EngagementPaymentType] {
 			return &apierror.ValidationError{Msg: "engagementPaymentType contains invalid value: " + string(req.EngagementPaymentType)}
+		}
+	case "announcement":
+		if req.Subject == "" {
+			return &apierror.ValidationError{Msg: "subject is required for announcement"}
+		}
+		if req.Description == "" {
+			return &apierror.ValidationError{Msg: "description is required for announcement"}
 		}
 	}
 

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -708,11 +708,15 @@ func (s *snCaseService) CreateCase(ctx context.Context, req domain.CreateCaseReq
 	if err := validateUUIDs("projectId", []string{req.ProjectID}); err != nil {
 		return domain.CreateCaseResponse{}, err
 	}
-	if err := validateUUIDs("deploymentId", []string{req.DeploymentID}); err != nil {
-		return domain.CreateCaseResponse{}, err
-	}
-	if err := validateUUIDs("deployedProductId", []string{req.DeployedProductID}); err != nil {
-		return domain.CreateCaseResponse{}, err
+	// Announcements have no deployment/deployed-product concept, so these
+	// fields are left empty rather than validated as UUIDs.
+	if req.Type != "announcement" {
+		if err := validateUUIDs("deploymentId", []string{req.DeploymentID}); err != nil {
+			return domain.CreateCaseResponse{}, err
+		}
+		if err := validateUUIDs("deployedProductId", []string{req.DeployedProductID}); err != nil {
+			return domain.CreateCaseResponse{}, err
+		}
 	}
 
 	payload := snCreateCasePayload{
@@ -762,6 +766,9 @@ func (s *snCaseService) CreateCase(ctx context.Context, req domain.CreateCaseReq
 		payload.Description = req.Description
 		payload.EngagementType = snEngagementTypeIDMap[req.EngagementType]
 		payload.EngagementPaymentType = snEngagementPaymentTypeIDMap[req.EngagementPaymentType]
+	case "announcement":
+		payload.Title = req.Subject
+		payload.Description = req.Description
 	}
 
 	if len(req.WatchList) > 0 {

--- a/entity-service/internal/service/sn_case_service_create_test.go
+++ b/entity-service/internal/service/sn_case_service_create_test.go
@@ -178,3 +178,92 @@ func TestSNCaseService_CreateCase_SecurityReportAnalysis_AttachmentsOptional(t *
 		t.Fatalf("expected no attachments field in payload when none provided, got %v", gotBody["attachments"])
 	}
 }
+
+// TestSNCaseService_CreateCase_AnnouncementValidation verifies that an
+// announcement CreateCaseRequest requires only subject and description --
+// announcements have no deployment/deployed-product concept, so those fields
+// must not be required for this type.
+func TestSNCaseService_CreateCase_AnnouncementValidation(t *testing.T) {
+	baseReq := domain.CreateCaseRequest{
+		Type:      "announcement",
+		ProjectID: testProjectUUID,
+	}
+
+	tests := []struct {
+		name string
+		req  domain.CreateCaseRequest
+	}{
+		{name: "missing subject", req: baseReq},
+		{name: "missing description", req: func() domain.CreateCaseRequest { r := baseReq; r.Subject = "Planned maintenance"; return r }()},
+	}
+
+	// client is intentionally nil: every case must fail validation before touching it.
+	svc := NewServiceNowCaseService(nil, nil)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := svc.CreateCase(contextWithUserIDToken("token"), tt.req)
+			if _, ok := err.(*apierror.ValidationError); !ok {
+				t.Fatalf("expected *apierror.ValidationError, got %T: %v", err, err)
+			}
+		})
+	}
+}
+
+// TestSNCaseService_CreateCase_Announcement verifies a valid announcement
+// request builds the expected snCreateCasePayload (title/description only,
+// no deploymentId/deployedProductId) and maps a successful ServiceNow
+// response back to domain.CreateCaseResponse.
+func TestSNCaseService_CreateCase_Announcement(t *testing.T) {
+	var gotBody map[string]any
+	client := newTestCaseClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", r.Method)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{
+			"message": "Case created successfully",
+			"case": {"id": "` + testWLCaseSysid + `", "number": "CS0000003", "createdBy": "engineer@example.com", "createdOn": "2026-01-02 10:00:00", "state": {"id": 1, "label": "Open"}}
+		}`))
+	})
+
+	svc := NewServiceNowCaseService(client, nil)
+	req := domain.CreateCaseRequest{
+		Type:        "announcement",
+		ProjectID:   testProjectUUID,
+		Subject:     "Planned maintenance",
+		Description: "Maintenance window this weekend",
+	}
+
+	resp, err := svc.CreateCase(contextWithUserIDToken("token"), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Case.Number != "CS0000003" {
+		t.Fatalf("unexpected case number: %s", resp.Case.Number)
+	}
+
+	if gotBody["title"] != "Planned maintenance" {
+		t.Fatalf("payload title: got %v, want %q", gotBody["title"], "Planned maintenance")
+	}
+	if gotBody["description"] != "Maintenance window this weekend" {
+		t.Fatalf("payload description: got %v, want %q", gotBody["description"], "Maintenance window this weekend")
+	}
+	if gotBody["type"] != "announcement" {
+		t.Fatalf("payload type: got %v, want %q", gotBody["type"], "announcement")
+	}
+	// deploymentId/deployedProductId are not omitempty on the payload struct,
+	// so they still serialize -- but as empty strings, since announcements
+	// have no deployment/deployed-product concept and req.DeploymentID/
+	// req.DeployedProductID are never populated for this type.
+	if v, present := gotBody["deploymentId"]; present && v != "" {
+		t.Fatalf("expected empty deploymentId in payload for announcement, got %v", v)
+	}
+	if v, present := gotBody["deployedProductId"]; present && v != "" {
+		t.Fatalf("expected empty deployedProductId in payload for announcement, got %v", v)
+	}
+}


### PR DESCRIPTION
## Purpose
CS engineers had no way to reply to an announcement or create one from the CSM portal — announcements were view-only. Interim step toward the broader announcements story; full multi-project/tier/role targeting is out of scope here.

## Goals
- Let a CS engineer post a comment (customer-visible or internal work note) on an announcement.
- Let a CS engineer create a new announcement, targeted to one or more projects.
- Stop showing a misleading "enable more categories in the Filter menu" message on an empty activity feed when nothing is actually filtered out.

## Approach
- `CaseActivitiesFeed.tsx`: only show the filter-hint empty message when a filter is actually hiding something; otherwise show a plain "No activity yet."
- `cases.go` (`CreateCaseComment`): carve announcement-type cases out of the state/assigned-engineer gate that blocks customer-visible comments on every other case type unless it's `work_in_progress`/`ongoing` — announcements never enter that workflow. A closed announcement still blocks new comments, same as any other case type.
- `CsmCaseDetailPage.tsx`: the existing reveal-on-click reply composer (with its internal-note/public toggle) was explicitly hidden for announcements; removed that exclusion and bypassed the same work-in-progress gate on the frontend side to match.
- Backing data-source and entity-service layers gained support for `announcement` as a creatable case type (title + description + one target project each; no severity/issue-type/deployment fields, which don't apply to a broadcast). Corresponding changes there are tracked separately.
- `entity-service` (Go): accept `type: "announcement"` on create, skipping the deployment/deployed-product fields that don't apply.
- New `CsmAnnouncementCreatePage.tsx` + `/announcements/new` route + a "New announcement" button on the list page. Targeting multiple projects creates one independent case per project (each with its own comment thread), not one shared record — a form submission fans out one create call per selected project and reports which ones failed, if any.
- Updated the in-app user guide's Announcements topic to match.

## User stories
As a CS engineer, I can reply to a customer-facing announcement to clarify whether it applies to them, and I can publish a new announcement to one or more projects without needing the backing data source's own admin tooling.

## Release note
CS engineers can now comment on and create announcements from the CSM portal.

## Documentation
Updated in-app: `apps/csm-portal/webapp/src/features/help/content/announcements.md` (this PR).

## Training
N/A — no training content exists for this portal yet.

## Certification
N/A — no certification exam covers this portal.

## Marketing
N/A — internal tool change, not customer-marketed.

## Automation tests
- Unit tests: new/updated tests for the comment-gate carve-out (`cases_test.go`), the composer reveal behavior (`CsmCaseDetailPage.test.tsx`), the entity-service create path (`sn_case_service_create_test.go`), the new create page (`CsmAnnouncementCreatePage.test.tsx`), and the empty-state fix — all passing alongside the full existing suites for each touched package.
- Integration tests: none added; this PR doesn't touch integration test suites.

## Security checks
- Followed secure coding standards: yes
- Ran FindSecurityBugs plugin and verified report: no — Go/TS only, not applicable to this stack
- Confirmed no keys, passwords, tokens, usernames, or other secrets committed: yes

## Samples
N/A

## Related PRs
A corresponding change to the Ballerina proxy service that talks to the backing data source is tracked separately (not in this repo).

## Migrations
N/A

## Test environment
Local dev stack; manual end-to-end verification not yet performed against a live browser session — automated tests only so far.

## Learning
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added announcement creation for one or more projects, with project selection, rich-text descriptions, validation, and partial-failure reporting.
  * Added a “New announcement” entry point and authenticated creation route.
  * Announcements now support customer comments and internal work notes until closed.
* **Bug Fixes**
  * Closed announcements correctly prevent new comments.
  * Improved activity-feed messaging when filters hide existing activity.
* **Documentation**
  * Updated announcement guidance, limitations, and publishing behavior.
* **Tests**
  * Expanded coverage for announcement creation, comments, and case states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->