### PR TITLE
[Customer Portal v2] Fail loudly on an untranslatable time-card state

### DIFF
--- a/apps/customer-portal/backend-v2/internal/dto/time_card_enum_mapping.go
+++ b/apps/customer-portal/backend-v2/internal/dto/time_card_enum_mapping.go
@@ -51,25 +51,44 @@ var timeCardStateToEnum = map[string]string{
 // timeCardStatesToEnums translates the portal's time-card state filter values
 // into entity-service's enum vocabulary.
 //
-// An unrecognised value is dropped rather than forwarded, matching the
-// request-side convention for search filters described in this backend's
-// CLAUDE.md ("an unrecognized id is silently dropped (search)"). Note the
-// consequence: if every value is dropped the filter goes away entirely and
-// entity-service returns time cards in all states. That is the documented
-// behaviour for search filters, but it means a future choice-list label absent
-// from the table above shows unfiltered data rather than failing loudly — add
-// the label here when the choice list gains one.
+// Unrecognised values are dropped **only when at least one value translated**,
+// which is a deliberate departure from the "silently drop unknown filter ids"
+// convention this backend applies to case search. That convention is safe there
+// because dropping one of several status ids still leaves a filter in place. It
+// is not safe here: dropping the *only* value removes the state filter entirely,
+// and entity-service then returns time cards in every state — so the page would
+// quietly show unapproved cards as though they were approved, which is worse
+// than an error.
 //
-// Returns nil for no usable values so the field is omitted from the upstream
-// request instead of being sent as an empty array.
+// So when nothing translates, the original values are passed through unchanged
+// and entity-service's own validation rejects them with a 400. A wrong filter
+// fails loudly instead of showing wrong data. The ids come from ServiceNow via
+// GET /projects/{id}/filters and snFlexibleID accepts numbers as well as
+// strings, so an environment whose choice list uses numeric ids is a real
+// possibility, not a hypothetical.
+//
+// Returns nil for genuinely empty input so the field is omitted from the
+// upstream request rather than sent as an empty array.
 func timeCardStatesToEnums(states []string) []string {
 	if len(states) == 0 {
 		return nil
 	}
-	out := make([]string, 0, len(states))
-	seen := make(map[string]struct{}, len(states))
+	// Blank entries carry no intent, so they neither translate nor get forwarded
+	// as a bogus filter — a states array of only blanks means "no filter".
+	supplied := make([]string, 0, len(states))
 	for _, s := range states {
-		enum, ok := timeCardStateToEnum[strings.ToLower(strings.TrimSpace(s))]
+		if t := strings.TrimSpace(s); t != "" {
+			supplied = append(supplied, t)
+		}
+	}
+	if len(supplied) == 0 {
+		return nil
+	}
+
+	out := make([]string, 0, len(supplied))
+	seen := make(map[string]struct{}, len(supplied))
+	for _, s := range supplied {
+		enum, ok := timeCardStateToEnum[strings.ToLower(s)]
 		if !ok {
 			continue
 		}
@@ -80,7 +99,9 @@ func timeCardStatesToEnums(states []string) []string {
 		out = append(out, enum)
 	}
 	if len(out) == 0 {
-		return nil
+		// Nothing recognised. Forward as-is so the request fails visibly rather
+		// than silently widening to every state.
+		return supplied
 	}
 	return out
 }

--- a/apps/customer-portal/backend-v2/internal/dto/time_card_enum_mapping_test.go
+++ b/apps/customer-portal/backend-v2/internal/dto/time_card_enum_mapping_test.go
@@ -46,19 +46,41 @@ func TestTimeCardStatesToEnums_TranslatesServiceNowLabels(t *testing.T) {
 	}
 }
 
-// TestTimeCardStatesToEnums_OmitsWhenNothingUsable checks the field is omitted
-// rather than sent as an empty array. entity-service treats an absent filter as
-// "no state restriction"; an empty array would be a different, pointless
-// request shape.
-func TestTimeCardStatesToEnums_OmitsWhenNothingUsable(t *testing.T) {
+// TestTimeCardStatesToEnums_OmitsWhenNoIntent checks the field is omitted rather
+// than sent as an empty array when the caller supplied nothing meaningful.
+// entity-service treats an absent filter as "no state restriction"; an empty
+// array would be a different, pointless request shape.
+func TestTimeCardStatesToEnums_OmitsWhenNoIntent(t *testing.T) {
 	for name, in := range map[string][]string{
 		"nil":           nil,
 		"empty":         {},
-		"all unknown":   {"Draft", "In Review"},
-		"empty strings": {"", "   "},
+		"blank strings": {"", "   "},
+		"blanks only":   {"\t"},
 	} {
 		if got := timeCardStatesToEnums(in); got != nil {
 			t.Errorf("%s: got %v, want nil so the field is omitted upstream", name, got)
+		}
+	}
+}
+
+// TestTimeCardStatesToEnums_UnknownOnlyFailsLoudly is the deliberate departure
+// from the "silently drop unknown filter ids" convention used for case search.
+//
+// Dropping one of several case status ids still leaves a filter in place.
+// Dropping the *only* time-card state removes the filter entirely, and
+// entity-service then returns cards in every state — the page would quietly show
+// unapproved cards as approved. Forwarding the unrecognised value instead makes
+// entity-service reject it with a 400, so a wrong filter fails visibly rather
+// than displaying wrong data. ServiceNow choice ids can be numeric
+// (snFlexibleID accepts numbers), so this path is reachable in practice.
+func TestTimeCardStatesToEnums_UnknownOnlyFailsLoudly(t *testing.T) {
+	for name, in := range map[string][]string{
+		"unknown labels": {"Draft", "In Review"},
+		"numeric ids":    {"3"},
+	} {
+		got := timeCardStatesToEnums(in)
+		if len(got) == 0 {
+			t.Errorf("%s: got %v — dropping every value silently widens the search to all states", name, got)
 		}
 	}
 }


### PR DESCRIPTION
Follow-up to #1553. Not a new bug — a correction to a choice I made in that PR.

## What I got wrong

#1553 dropped unrecognised state values, following the "silently drop unknown filter ids" convention this backend applies to case search. Checking that against what the data can actually be, the convention does not transfer to this filter.

Dropping one of several case status ids still leaves a filter in place. Dropping the **only** time-card state removes the filter entirely — and entity-service then returns time cards in *every* state. The page would quietly show unapproved cards as though they were approved.

Silently wrong data is worse than an error, especially on a page about billable hours.

## Change

Unrecognised values are dropped only when **at least one value translated**. When nothing translates, the originals are forwarded and entity-service's own validation rejects them with a 400, so a broken filter fails visibly instead of widening the result set.

Blank entries are handled separately: they carry no intent, so an array of only blanks still omits the filter rather than forwarding a bogus value.

## This path is reachable, not hypothetical

The ids come from ServiceNow's choice list via `GET /projects/{id}/filters`, and `snFlexibleID` accepts **numbers as well as strings**:

```go
type snFlexibleID string
func (f *snFlexibleID) UnmarshalJSON(data []byte) error { /* string, else json.Number */ }
```

So an environment whose time-card choice list uses numeric ids would send `states: ["3"]` and hit exactly this path. Under #1553 that would have returned every state with no error.

## Worth raising separately

The underlying inconsistency is in **entity-service**, not the portal or the frontend: it serves `"Approved"` as a valid choice-list id from `/filters`, then rejects `"Approved"` as an invalid state on search. Its response vocabulary and its request vocabulary disagree, so the value does not round-trip. The BFF absorbing that is the documented convention, but the cleaner long-term fix is for entity-service to either serve enum values as choice ids or accept its own ids on search (the alias pattern its CLAUDE.md already documents for `caseTypeAliases`).

To be explicit: this is **not** a frontend bug. The frontend correctly sends the `id` that `/filters` handed it.

## Testing

- `gofmt -l`, `go build`, `go vet`, `go test -race ./...` — all pass
- `gosec -fmt=text ./...` — **0 issues** (105 files)
- New test asserts unknown-only input is forwarded rather than dropped, covering both unknown labels and numeric ids; the omit-when-no-intent test now covers blanks specifically

> Validation ran on a local Go 1.27 toolchain and a locally installed gosec — Docker Desktop is not running in this environment. Same checks, different runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved time card state filtering by ignoring blank values while preserving valid translated states.
  * Unknown state values are now rejected with a validation error instead of silently removing the filter.
  * Empty or whitespace-only state filters continue to be omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->