### PR TITLE
[CSM] Decode the case audit fields on case time-card rollups

### DIFF
--- a/apps/customer-portal/backend-v2/internal/dto/case_time_cards.go
+++ b/apps/customer-portal/backend-v2/internal/dto/case_time_cards.go
@@ -55,6 +55,13 @@ type CaseTimeCardCaseRef struct {
 	Name      string         `json:"name"`
 	UpdatedOn string         `json:"updatedOn"`
 	Project   *ReferenceItem `json:"project"`
+	// CreatedBy is what the time-tracking card renders as
+	// "Created by <email>" (TimeTrackingCard.tsx); without it the card showed
+	// only the case number and title. createdOn/updatedBy come from the same
+	// upstream object and complete the audit set the Ballerina response carried.
+	CreatedOn *string `json:"createdOn,omitempty"`
+	CreatedBy *string `json:"createdBy,omitempty"`
+	UpdatedBy *string `json:"updatedBy,omitempty"`
 }
 
 // CaseTimeCardBillingInfo is a billable/non-billable time breakdown.
@@ -97,6 +104,9 @@ func MapCaseTimeCardSearchResponse(r entity.SearchCaseTimeCardsResponse) CaseTim
 				Number:    c.Case.Number,
 				Name:      c.Case.Name,
 				UpdatedOn: c.Case.UpdatedOn,
+				CreatedOn: c.Case.CreatedOn,
+				CreatedBy: c.Case.CreatedBy,
+				UpdatedBy: c.Case.UpdatedBy,
 			},
 			TotalTime:   c.TotalTime,
 			TotalCount:  c.TotalCount,

--- a/apps/customer-portal/backend-v2/internal/dto/case_time_cards_audit_test.go
+++ b/apps/customer-portal/backend-v2/internal/dto/case_time_cards_audit_test.go
@@ -1,0 +1,120 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dto
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+)
+
+func sp(v string) *string { return &v }
+
+// TestMapCaseTimeCardSearchResponse_EmitsCaseAuditFields is the regression guard
+// for the time-tracking card rendering without its author.
+//
+// TimeTrackingCard.tsx renders "Created by <email>" from case.createdBy. The
+// field was declared on no Go struct — not in entity-service's decode, not in
+// its domain view, not in backend-v2's mirror — so encoding/json discarded it
+// silently at the first hop and the card showed only a number and a title.
+func TestMapCaseTimeCardSearchResponse_EmitsCaseAuditFields(t *testing.T) {
+	out := MapCaseTimeCardSearchResponse(entity.SearchCaseTimeCardsResponse{
+		Cases: []entity.CaseTimeCardSummary{{
+			Case: entity.CaseTimeCardCaseRef{
+				ID:        "70d63bca-3bd2-0310-9140-4c6aa5e45a37",
+				Number:    "CS0440883",
+				Name:      "Combined-field PATCH test case title",
+				UpdatedOn: "2026-08-06 17:26:23",
+				CreatedOn: sp("2026-07-27 08:39:48"),
+				CreatedBy: sp("rashmika@wso2.com"),
+				UpdatedBy: sp("sajithe@wso2.com"),
+			},
+			TotalTime:  450,
+			TotalCount: 1,
+			Billable:   entity.CaseTimeCardBillingInfo{TotalTime: 450, Count: 1},
+		}},
+		Total: 1,
+	})
+
+	b, err := json.Marshal(out)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var probe struct {
+		CaseTimeCards []struct {
+			Case struct {
+				CreatedBy *string `json:"createdBy"`
+				CreatedOn *string `json:"createdOn"`
+				UpdatedBy *string `json:"updatedBy"`
+			} `json:"case"`
+			Billable struct {
+				Count int `json:"count"`
+			} `json:"billable"`
+		} `json:"caseTimeCards"`
+	}
+	if err := json.Unmarshal(b, &probe); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(probe.CaseTimeCards) != 1 {
+		t.Fatalf("got %d cards, want 1", len(probe.CaseTimeCards))
+	}
+	c := probe.CaseTimeCards[0]
+
+	if c.Case.CreatedBy == nil || *c.Case.CreatedBy != "rashmika@wso2.com" {
+		t.Errorf("case.createdBy = %v, want rashmika@wso2.com — the card renders \"Created by\" from this", c.Case.CreatedBy)
+	}
+	if c.Case.CreatedOn == nil || *c.Case.CreatedOn != "2026-07-27 08:39:48" {
+		t.Errorf("case.createdOn = %v", c.Case.CreatedOn)
+	}
+	if c.Case.UpdatedBy == nil || *c.Case.UpdatedBy != "sajithe@wso2.com" {
+		t.Errorf("case.updatedBy = %v", c.Case.UpdatedBy)
+	}
+	// The Billable chip is gated on (billable?.count ?? 0) > 0, so the count has
+	// to survive the mapping alongside totalTime.
+	if c.Billable.Count != 1 {
+		t.Errorf("billable.count = %d, want 1 — the Billable chip depends on it", c.Billable.Count)
+	}
+}
+
+// TestMapCaseTimeCardSearchResponse_OmitsAbsentAuditFields keeps an absent value
+// out of the payload rather than sending an empty string, so the card renders no
+// author line instead of "Created by ".
+func TestMapCaseTimeCardSearchResponse_OmitsAbsentAuditFields(t *testing.T) {
+	out := MapCaseTimeCardSearchResponse(entity.SearchCaseTimeCardsResponse{
+		Cases: []entity.CaseTimeCardSummary{{
+			Case: entity.CaseTimeCardCaseRef{ID: "x", Number: "CS1", Name: "n"},
+		}},
+	})
+	b, err := json.Marshal(out)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var probe struct {
+		CaseTimeCards []struct {
+			Case map[string]any `json:"case"`
+		} `json:"caseTimeCards"`
+	}
+	if err := json.Unmarshal(b, &probe); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, key := range []string{"createdBy", "createdOn", "updatedBy"} {
+		if _, present := probe.CaseTimeCards[0].Case[key]; present {
+			t.Errorf("%s present when absent upstream; want it omitted", key)
+		}
+	}
+}

--- a/apps/customer-portal/backend-v2/internal/entity/types.go
+++ b/apps/customer-portal/backend-v2/internal/entity/types.go
@@ -2219,6 +2219,9 @@ type CaseTimeCardCaseRef struct {
 	Name      string     `json:"name"`
 	UpdatedOn string     `json:"updatedOn"`
 	Project   *EntityRef `json:"project"`
+	CreatedOn *string    `json:"createdOn"`
+	CreatedBy *string    `json:"createdBy"`
+	UpdatedBy *string    `json:"updatedBy"`
 }
 
 // CaseTimeCardSummary is the time-card rollup for a single case.

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -4718,6 +4718,12 @@ type CaseTimeCardCaseRef struct {
 	Name      string     `json:"name"`
 	UpdatedOn string     `json:"updatedOn"`
 	Project   *EntityRef `json:"project"`
+	// Audit fields the upstream supplies for the case behind a time-card
+	// rollup. Nullable rather than empty-string per the optional-field
+	// convention; UpdatedOn above predates it and is left as-is.
+	CreatedOn *string `json:"createdOn"`
+	CreatedBy *string `json:"createdBy"`
+	UpdatedBy *string `json:"updatedBy"`
 }
 
 // CaseTimeCardSummary is the time-card rollup for a single case.

--- a/entity-service/internal/service/sn_time_card_service.go
+++ b/entity-service/internal/service/sn_time_card_service.go
@@ -334,6 +334,13 @@ type snCaseTimeCardCaseRef struct {
 	Name      string       `json:"name"`
 	UpdatedOn string       `json:"updatedOn"`
 	Project   *snEntityRef `json:"project"`
+	// Choreo sends these three alongside updatedOn; leaving them undeclared
+	// meant encoding/json discarded them, so the portal's time-tracking card had
+	// no author to render. Pointers per this service's optional-field convention:
+	// nil serialises as null rather than an empty string.
+	CreatedOn *string `json:"createdOn"`
+	CreatedBy *string `json:"createdBy"`
+	UpdatedBy *string `json:"updatedBy"`
 }
 
 // snCaseTimeCardSummary mirrors the Choreo CaseTimeCardSummary shape.
@@ -379,6 +386,9 @@ func (s *snTimeCardService) SearchCaseTimeCards(ctx context.Context, req domain.
 				Number:    c.Case.Number,
 				Name:      c.Case.Name,
 				UpdatedOn: c.Case.UpdatedOn,
+				CreatedOn: c.Case.CreatedOn,
+				CreatedBy: c.Case.CreatedBy,
+				UpdatedBy: c.Case.UpdatedBy,
 			},
 			TotalTime:   c.TotalTime,
 			TotalCount:  c.TotalCount,


### PR DESCRIPTION
Closes wso2-enterprise/digiops-cs#2905.

> [!IMPORTANT]
> Touches **both** services. Deploy **entity-service first** — backend-v2 cannot read a field entity-service is not yet emitting.

## Symptom

The time-tracking card showed only a case number and title. The Ballerina-backed portal shows `Created by rashmika@wso2.com` on the same case.

## Cause

`TimeTrackingCard.tsx` renders that line from `case.createdBy`. The field was declared on **no Go struct anywhere in the chain**:

| Layer | Had `createdBy`? |
|---|---|
| `snCaseTimeCardCaseRef` (Choreo decode) | ❌ |
| `domain.CaseTimeCardCaseRef` | ❌ |
| backend-v2 `entity.CaseTimeCardCaseRef` | ❌ |
| backend-v2 `dto.CaseTimeCardCaseRef` | ❌ |

So `encoding/json` discarded it at the first hop and nothing failed — the same silent-drop class as `deployedProductCount` (blank Usage & Metrics) and the project/onboarding fields.

**The upstream does send it.** The Ballerina response for the same request carries `createdOn`, `createdBy` and `updatedBy` on the case object alongside `updatedOn` — which is what proves these are decodable rather than absent upstream, rather than me assuming it.

## Change

All three added across both services and mapped through, with `sysidToUUID` already correctly applied to the ids on that path (unchanged).

They are **nullable rather than plain strings**, per entity-service's optional-field convention, so an absent value is omitted and the card renders no author line instead of `"Created by "` with nothing after it. The neighbouring `UpdatedOn` predates that convention and is deliberately left as a plain string rather than changed here — that would be an unrelated behaviour change.

## Not fixed here — still open

The **`Billable` chip** is also missing in the Go UI. It is gated on `(billable?.count ?? 0) > 0`, and `count` is declared and mapped correctly at every layer, so the code path looks right. I did not want to guess at a fix: this needs the actual Go response body to confirm whether `billable.count` is arriving as `0` and why. Tracked in the issue.

Separately, the Go page showed *"Showing 8 of 8"* against Ballerina's *"3 of 3"* — that is the state filter, handled in #1553/#1555, not here.

## Testing

Both services: `gofmt -l`, `go build`, `go vet`, `go test -race ./...` — all pass.

- `gosec` — **0 issues** (105 files backend-v2, 112 entity-service)
- `govulncheck ./...` — **no vulnerabilities** (entity-service, per its CLAUDE.md)

New tests assert the emitted JSON keys on the case ref, that `billable.count` survives the mapping alongside `totalTime`, and that absent values are omitted rather than sent as empty strings.

> Validation ran on a local Go 1.27 toolchain with locally installed gosec/govulncheck — Docker Desktop is not running in this environment. Same checks, different runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)