### PR TITLE
[CSM Portal] approver recency in time log + case/CR display and SR project filter fixes

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncProjectSelect.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncProjectSelect.tsx
@@ -19,6 +19,7 @@ import { useMemo, useState, type JSX } from "react";
 import type * as React from "react";
 import { useDebouncedValue } from "@hooks/useDebouncedValue";
 import { useInfiniteProjectSearch } from "@features/csm-cases/api/useProjectSearch";
+import type { BeProject } from "@api/backend/types";
 
 interface ProjectOption {
   id: string;
@@ -33,6 +34,14 @@ interface AsyncProjectSelectProps {
   onChange: (next: string) => void;
   required?: boolean;
   disabled?: boolean;
+  /**
+   * Restricts the searchable/selectable options to projects matching this
+   * predicate (e.g. by `subscriptionType`) — the backend search endpoint has
+   * no such filter, so this narrows the already-fetched page client-side.
+   * Absent means "no restriction" (the default, used by the case/security
+   * report/engagement creation flows).
+   */
+  filterProject?: (project: BeProject) => boolean;
 }
 
 /**
@@ -49,6 +58,7 @@ export default function AsyncProjectSelect({
   onChange,
   required,
   disabled,
+  filterProject,
 }: AsyncProjectSelectProps): JSX.Element {
   // Search term tracked separately from the displayed input value (which MUI
   // manages and shows the selected project's name) so the type-ahead works.
@@ -93,14 +103,17 @@ export default function AsyncProjectSelect({
   }, [value, picked, projects]);
 
   // Pool = the current selection (so it can render) + the search results,
-  // de-duplicated by id.
+  // de-duplicated by id. `filterProject` (when given) is applied to the
+  // search results only — the current selection always stays shown so an
+  // already-picked project never disappears out from under the field.
   const options = useMemo<ProjectOption[]>(() => {
-    const results = projects.map((p) => ({ id: p.id, name: p.name || p.id }));
+    const filtered = filterProject ? projects.filter(filterProject) : projects;
+    const results = filtered.map((p) => ({ id: p.id, name: p.name || p.id }));
     if (selectedOption && !results.some((o) => o.id === selectedOption.id)) {
       return [selectedOption, ...results];
     }
     return results;
-  }, [projects, selectedOption]);
+  }, [projects, selectedOption, filterProject]);
 
   return (
     <Autocomplete<ProjectOption>

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/ProjectSelectionField.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/ProjectSelectionField.tsx
@@ -28,6 +28,7 @@ import { CheckCircle, Lock } from "@wso2/oxygen-ui-icons-react";
 import { useState, type JSX } from "react";
 import AsyncProjectSelect from "@features/csm-cases/components/AsyncProjectSelect";
 import { useGetProject } from "@features/csm-projects/api/useGetProject";
+import type { BeProject } from "@api/backend/types";
 
 export interface ProjectSelectionFieldProps {
   /** Selected project id ("" when none picked yet). */
@@ -40,6 +41,12 @@ export interface ProjectSelectionFieldProps {
    */
   lockedProjectId?: string;
   required?: boolean;
+  /**
+   * Restricts the searchable picker to projects matching this predicate
+   * (see {@link AsyncProjectSelect}'s `filterProject`). Not applied to the
+   * locked-project display — a project arriving locked is trusted as-is.
+   */
+  filterProject?: (project: BeProject) => boolean;
 }
 
 /**
@@ -60,6 +67,7 @@ export default function ProjectSelectionField({
   onChange,
   lockedProjectId,
   required,
+  filterProject,
 }: ProjectSelectionFieldProps): JSX.Element {
   const isLocked = !!lockedProjectId;
   // Picked from the Autocomplete but not yet confirmed in the dialog below —
@@ -117,6 +125,7 @@ export default function ProjectSelectionField({
             if (next) setPendingProjectId(next);
           }}
           required={required}
+          filterProject={filterProject}
         />
         {/*
           A plain `Modal` + `Paper` rather than `Dialog` — `Dialog`'s paper is

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.test.tsx
@@ -398,7 +398,9 @@ vi.mock("@features/csm-cases/components/LinkedServiceRequestsWidget", () => ({
   LinkedServiceRequestsWidget: () => null,
 }));
 vi.mock("@features/csm-cases/components/LinkedChangeRequestsWidget", () => ({
-  LinkedChangeRequestsWidget: () => null,
+  LinkedChangeRequestsWidget: () => (
+    <div data-testid="linked-change-requests-widget-probe" />
+  ),
 }));
 vi.mock("@features/csm-cases/components/CreateGithubIssueDialog", () => ({
   CreateGithubIssueDialog: () => null,
@@ -1339,5 +1341,62 @@ describe("CsmCaseDetailPage — change case type", () => {
       { severity: "high" },
       expect.anything(),
     );
+  });
+});
+
+describe("CsmCaseDetailPage — Linked change requests widget only shows on service requests", () => {
+  it("does not render LinkedChangeRequestsWidget for a plain case, even one carrying stale linkedChangeRequests data", () => {
+    // A plain case should never carry `linkedChangeRequests` per the field's
+    // own doc comment (SR-only), but the guard must not rely on that alone —
+    // this proves the render gate itself, not just the data shape, keeps the
+    // widget off a plain case.
+    useGetCsmCaseDetailMock.mockImplementation((id: string | undefined) => ({
+      data: id
+        ? {
+            ...buildCase(id),
+            caseType: "incident",
+            linkedChangeRequests: [{ id: "cr-1", number: "CR-1", name: "Stale link" }],
+          }
+        : undefined,
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+      isFetching: false,
+      dataUpdatedAt: 0,
+    }));
+
+    renderPage();
+    fireEvent.click(screen.getByRole("tab", { name: /linked items/i }));
+
+    expect(
+      screen.queryByTestId("linked-change-requests-widget-probe"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders LinkedChangeRequestsWidget for a service request", () => {
+    useGetCsmCaseDetailMock.mockImplementation((id: string | undefined) => ({
+      data: id ? { ...buildCase(id), caseType: "service_request" } : undefined,
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+      isFetching: false,
+      dataUpdatedAt: 0,
+    }));
+
+    // A service request's canonical route is /operations/service-requests/:id
+    // (see CASE_ROUTE_MOUNTS above) — mounting it on the plain /cases/:id
+    // route instead would trip the canonical-redirect skeleton rather than
+    // rendering the tabs.
+    renderPageAt(
+      "/operations/service-requests/case-1",
+      "/operations/service-requests/:caseId",
+    );
+    fireEvent.click(screen.getByRole("tab", { name: /linked items/i }));
+
+    expect(
+      screen.getByTestId("linked-change-requests-widget-probe"),
+    ).toBeInTheDocument();
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -2468,11 +2468,13 @@ export default function CsmCaseDetailPage(): JSX.Element {
               onLinkIncident={() => setLinkIncidentOpen(true)}
               linkDisabled={isClosed}
             />
-            {/* Content-relevance, not a data-source gate: shown whenever this is
-                a service request (the only case type that carries the link) or
-                the list already has entries — never checks the record's data
-                source. */}
-            {(isServiceRequest || (c.linkedChangeRequests?.length ?? 0) > 0) && (
+            {/* Change requests are only ever raised from a service request,
+                never directly from a plain case — gate solely on
+                `isServiceRequest` rather than falling back to
+                `linkedChangeRequests` having entries, which a plain case
+                should never carry anyway (see `linkedChangeRequests` doc
+                comment on the case-detail type). Not a data-source gate. */}
+            {isServiceRequest && (
               <LinkedChangeRequestsWidget changeRequests={c.linkedChangeRequests} />
             )}
             <LinkedServiceRequestsWidget

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateServiceRequestPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateServiceRequestPage.tsx
@@ -33,6 +33,7 @@ import { useMemo, useState, type JSX } from "react";
 import { useLocation, useSearchParams } from "react-router";
 
 import { BackendApiError } from "@api/backend/client";
+import type { BeProject } from "@api/backend/types";
 import AttachmentsField from "@components/attachments/AttachmentsField";
 import {
   POST_CREATE_ATTACHMENTS_MAX_ENCODED_BYTES,
@@ -59,6 +60,14 @@ import {
   isAttachmentField,
 } from "@features/csm-operations/utils/catalogVariables";
 import type { CreateServiceRequestFromCaseNavState } from "@features/csm-cases/types/csmCases";
+
+// Service requests are a managed-cloud-only artefact — the underlying
+// catalog/deployment flow only makes sense for a managed-cloud subscription's
+// project. Module-level (not per-render) so `ProjectSelectionField`'s
+// `filterProject` prop keeps a stable identity across re-renders.
+function isManagedCloudProject(project: BeProject): boolean {
+  return project.subscriptionType === "managed_cloud_subscription";
+}
 
 export default function CreateServiceRequestPage(): JSX.Element {
   const navigate = useNavTransition();
@@ -345,6 +354,7 @@ export default function CreateServiceRequestPage(): JSX.Element {
               onChange={onProjectChange}
               lockedProjectId={lockedProjectId}
               required
+              filterProject={isManagedCloudProject}
             />
           </Grid>
 

--- a/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeSheets.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeSheets.ts
@@ -319,6 +319,81 @@ export function useAllTimeCards(
   });
 }
 
+/** A previously-selected approver, reduced from the signed-in engineer's own
+ * recent time-card submissions (see {@link useRecentApprovers}) — deliberately
+ * the same `{ id, name }` shape as {@link TimeCardApprover} since it feeds the
+ * exact same approver-picker candidate rendering in `LogTimeCardDialog`. */
+export interface RecentApprover {
+  id: string;
+  name: string;
+}
+
+/** How many distinct recent approvers {@link useRecentApprovers} surfaces —
+ * enough to cover an engineer's usual handful of team leads without turning
+ * the "before you type" list into a full roster. */
+const RECENT_APPROVERS_MAX = 4;
+
+/** How many of the signed-in engineer's own most-recent cards to look at when
+ * deriving {@link RecentApprover}s — a small page is enough since the same
+ * few approvers repeat constantly; this is "who did I pick before", not a
+ * complete history. */
+const RECENT_APPROVERS_LOOKBACK = 20;
+
+/**
+ * The signed-in engineer's own most-recently-submitted-to approvers, most
+ * recent first, deduped by id, capped at {@link RECENT_APPROVERS_MAX} —
+ * powers "Log time"'s approver picker showing previously-picked approvers
+ * before the engineer types anything (digiops-cs#2839), instead of requiring
+ * the same search every time.
+ *
+ * Derived entirely from the existing `POST /time-cards/search` endpoint
+ * (`userId`-scoped to the signed-in engineer, no `states` filter — an
+ * approved, rejected, or still-`submitted` card all equally answer "who did I
+ * pick before") rather than a new backend endpoint or local storage: no state
+ * restriction is needed here, this is about the approver pick, not the
+ * outcome. `/time-cards/search`'s own default ordering isn't documented, so
+ * results are explicitly re-sorted here by `workDate` descending rather than
+ * assumed to already be newest-first.
+ *
+ * `enabled` should be gated to create-mode only (see `LogTimeCardDialog`) —
+ * the approver field is read-only once editing, so there's nothing for this
+ * list to feed there.
+ */
+export function useRecentApprovers(enabled: boolean): UseQueryResult<RecentApprover[], Error> {
+  const api = useBackendApi();
+  const me = useCurrentEngineer();
+  return useQuery<RecentApprover[], Error>({
+    queryKey: [ApiQueryKeys.TIME_SHEETS_SEARCH, "recent-approvers", me.id],
+    queryFn: async (): Promise<RecentApprover[]> => {
+      if (!me.id) return [];
+      const { cards } = await searchTimeCards(
+        api,
+        { userId: me.id },
+        { page: 0, rowsPerPage: RECENT_APPROVERS_LOOKBACK },
+      );
+      const newestFirst = [...cards].sort((a, b) =>
+        (b.workDate || "").localeCompare(a.workDate || ""),
+      );
+      const seen = new Set<string>();
+      const recents: RecentApprover[] = [];
+      for (const card of newestFirst) {
+        for (const approver of card.approvers ?? []) {
+          // Defensive only: nothing should let an engineer submit a card
+          // approved by themself, mirroring the same self-exclusion already
+          // applied to live search candidates in LogTimeCardDialog.
+          if (approver.id === me.id || seen.has(approver.id)) continue;
+          seen.add(approver.id);
+          recents.push({ id: approver.id, name: approver.name });
+          if (recents.length >= RECENT_APPROVERS_MAX) return recents;
+        }
+      }
+      return recents;
+    },
+    enabled: enabled && !!me.id,
+    staleTime: 30_000,
+  });
+}
+
 /** Approve or reject a single card. */
 export function useDecideCard(): UseMutationResult<
   CsmTimeCard,

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/LogTimeCardDialog.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/LogTimeCardDialog.test.tsx
@@ -15,10 +15,11 @@
 // under the License.
 
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 import LogTimeCardDialog from "@features/csm-timecards/components/LogTimeCardDialog";
 import { useSearchUsers } from "@features/csm-users/api/useSearchUsers";
+import { useRecentApprovers } from "@features/csm-timecards/api/useTimeSheets";
 import type { CsmTimeCard } from "@features/csm-timecards/types/timeCards";
 
 // Not under test here — stubbed to a plain textarea, same technique used by
@@ -44,11 +45,38 @@ vi.mock("@hooks/useIdTokenClaims", () => ({
 vi.mock("@features/csm-users/api/useSearchUsers", () => ({
   useSearchUsers: vi.fn(),
 }));
+// Only `useRecentApprovers` is used by the component from this module; the
+// rest of it reaches the runtime-config-reading backend client at import
+// time, which isn't present under vitest (same approach as
+// ChangeRequestApprovals.test.tsx's `@api/backend/client` stub).
+vi.mock("@features/csm-timecards/api/useTimeSheets", () => ({
+  useRecentApprovers: vi.fn(),
+}));
 
 const mockedUseSearchUsers = vi.mocked(useSearchUsers);
 mockedUseSearchUsers.mockReturnValue({
   data: { users: [] },
 } as unknown as ReturnType<typeof useSearchUsers>);
+
+const mockedUseRecentApprovers = vi.mocked(useRecentApprovers);
+mockedUseRecentApprovers.mockReturnValue({
+  data: [],
+} as unknown as ReturnType<typeof useRecentApprovers>);
+
+// Tests below override these with `mockReturnValue` (not `mockReturnValueOnce`
+// — the dialog re-renders more than once per interaction, e.g. on every
+// keystroke into the approver search box, so a one-shot mock would only
+// satisfy the first render and silently fall back to the empty default on
+// the next) — reset back to the shared empty defaults afterwards so later
+// tests aren't affected by an earlier test's override.
+afterEach(() => {
+  mockedUseSearchUsers.mockReturnValue({
+    data: { users: [] },
+  } as unknown as ReturnType<typeof useSearchUsers>);
+  mockedUseRecentApprovers.mockReturnValue({
+    data: [],
+  } as unknown as ReturnType<typeof useRecentApprovers>);
+});
 
 const EDITING_CARD: CsmTimeCard = {
   id: "card-1",
@@ -94,6 +122,101 @@ describe("LogTimeCardDialog — create mode", () => {
     expect(
       screen.getByPlaceholderText("Search engineers by name or email…"),
     ).toBeInTheDocument();
+  });
+
+  it("shows previously-selected approvers before the engineer types anything", () => {
+    mockedUseRecentApprovers.mockReturnValue({
+      data: [
+        { id: "lead-1", name: "Priya Lead" },
+        { id: "lead-2", name: "Sam Approver" },
+      ],
+    } as unknown as ReturnType<typeof useRecentApprovers>);
+
+    render(
+      <LogTimeCardDialog
+        caseId="case-1"
+        caseNumber="CS0000001"
+        caseSeverity="S3"
+        projectId="proj-1"
+        projectName="Acme"
+        isSubmitting={false}
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Recently selected")).toBeInTheDocument();
+    // textContent includes the avatar's initials fallback ahead of the name
+    // (e.g. "PLPriya Lead") since the Avatar and name share one button —
+    // asserting via the visible name text alone is enough to confirm order.
+    expect(screen.getByText("Priya Lead")).toBeInTheDocument();
+    expect(screen.getByText("Sam Approver")).toBeInTheDocument();
+    const shown = screen.getAllByTestId("approver-candidate").map((el) => el.textContent);
+    expect(shown).toEqual(["PLPriya Lead", "SASam Approver"]);
+    expect(
+      screen.queryByText("Start typing to search for an approver."),
+    ).not.toBeInTheDocument();
+  });
+
+  it("prioritizes a matching recent approver ahead of live search results when typing", () => {
+    mockedUseRecentApprovers.mockReturnValue({
+      data: [{ id: "lead-1", name: "Priya Lead" }],
+    } as unknown as ReturnType<typeof useRecentApprovers>);
+    mockedUseSearchUsers.mockReturnValue({
+      data: {
+        users: [
+          { id: "lead-3", name: "Other Lead", userName: "other.lead", email: "other.lead@example.test" },
+          { id: "lead-1", name: "Priya Lead", userName: "priya.lead", email: "priya.lead@example.test" },
+        ],
+      },
+    } as unknown as ReturnType<typeof useSearchUsers>);
+
+    render(
+      <LogTimeCardDialog
+        caseId="case-1"
+        caseNumber="CS0000001"
+        caseSeverity="S3"
+        projectId="proj-1"
+        projectName="Acme"
+        isSubmitting={false}
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByPlaceholderText("Search engineers by name or email…"), {
+      target: { value: "lead" },
+    });
+
+    const shown = screen.getAllByTestId("approver-candidate").map((el) => el.textContent);
+    // "Priya Lead" appears once (deduped), and first (prioritized as a
+    // recent) — textContent also carries the avatar initials fallback and,
+    // for the live-search-only result, its email.
+    expect(shown).toEqual(["PLPriya Lead", "OLOther Leadother.lead@example.test"]);
+  });
+
+  it("falls back to the ordinary empty-search prompt when there is no recent history", () => {
+    mockedUseRecentApprovers.mockReturnValueOnce({
+      data: [],
+    } as unknown as ReturnType<typeof useRecentApprovers>);
+
+    render(
+      <LogTimeCardDialog
+        caseId="case-1"
+        caseNumber="CS0000001"
+        caseSeverity="S3"
+        projectId="proj-1"
+        projectName="Acme"
+        isSubmitting={false}
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByText("Start typing to search for an approver."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Recently selected")).not.toBeInTheDocument();
   });
 });
 

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/LogTimeCardDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/LogTimeCardDialog.tsx
@@ -47,6 +47,7 @@ import { useIdTokenClaims } from "@hooks/useIdTokenClaims";
 import { initialsOf, resolveUserInfo } from "@utils/userClaims";
 import { useSearchUsers } from "@features/csm-users/api/useSearchUsers";
 import type { NormalizedUser } from "@features/csm-users/types/csmUsers";
+import { useRecentApprovers } from "@features/csm-timecards/api/useTimeSheets";
 import TimeCardStatusChip from "@features/csm-timecards/components/TimeCardStatusChip";
 import type { SeverityOrUnset } from "@features/csm-dashboard/types/abtDashboard";
 import {
@@ -123,6 +124,52 @@ interface ApproverOption {
 
 function fullName(u: NormalizedUser): string {
   return u.name.trim() || u.userName;
+}
+
+/** One clickable approver candidate — shared between the "recently selected"
+ * list (shown before typing) and the live search results (shown once typed),
+ * so the two never drift into rendering the row differently. */
+function ApproverCandidateButton({
+  option,
+  onSelect,
+}: {
+  option: ApproverOption;
+  onSelect: (option: ApproverOption) => void;
+}): JSX.Element {
+  return (
+    <Button
+      data-testid="approver-candidate"
+      variant="text"
+      color="inherit"
+      onClick={() => onSelect(option)}
+      sx={{
+        justifyContent: "flex-start",
+        textTransform: "none",
+        px: 1,
+        py: 0.5,
+        gap: 1,
+      }}
+    >
+      <Avatar sx={{ width: 24, height: 24, fontSize: "0.7rem" }}>
+        {initialsOf(option.name)}
+      </Avatar>
+      <Box sx={{ minWidth: 0, textAlign: "left" }}>
+        <Typography variant="body2" noWrap>
+          {option.name}
+        </Typography>
+        {option.email && (
+          <Typography
+            variant="caption"
+            color="text.secondary"
+            noWrap
+            sx={{ display: "block" }}
+          >
+            {option.email}
+          </Typography>
+        )}
+      </Box>
+    </Button>
+  );
 }
 
 /** One activity row: a labelled whole-minutes input plus a proportion bar
@@ -278,6 +325,32 @@ export default function LogTimeCardDialog({
       )
       .map((u) => ({ id: u.id, name: fullName(u), email: u.email }));
   }, [data, hasApproverInput, me.email]);
+
+  // Previously-selected approvers (digiops-cs#2839) — surfaced before the
+  // engineer types anything, and prioritized within the typed results, so
+  // picking the same team lead again doesn't require retyping the same
+  // search every time. Only fetched in create mode: the approver field is
+  // read-only once editing, so there's nothing for this list to feed there.
+  const { data: recentApprovers = [] } = useRecentApprovers(!isEditMode);
+  // Merges recents matching the current query ahead of the live search's own
+  // candidates, deduped by id — a recent approver who still matches what was
+  // typed should stay at the top rather than getting buried in whatever order
+  // useSearchUsers's page happens to return. Not cross-referenced against
+  // `data?.users` for live eligibility: that list is itself scoped to the
+  // current (possibly empty) query and page-limited to 6, so filtering
+  // recents against it would risk dropping a genuinely still-eligible
+  // approver who simply isn't on that particular page — this is a minor UX
+  // nicety, not a security boundary, and the create action itself still
+  // validates the approver server-side either way.
+  const approverCandidates: ApproverOption[] = useMemo(() => {
+    if (!hasApproverInput) return recentApprovers;
+    const typed = approverInput.trim().toLowerCase();
+    const recentMatches = recentApprovers.filter((a) =>
+      a.name.toLowerCase().includes(typed),
+    );
+    const recentIds = new Set(recentMatches.map((a) => a.id));
+    return [...recentMatches, ...candidates.filter((c) => !recentIds.has(c.id))];
+  }, [approverInput, candidates, hasApproverInput, recentApprovers]);
 
   const setActivity = (key: ActivityKey, next: number): void =>
     setBreakdown((prev) => ({ ...prev, [key]: next }));
@@ -578,14 +651,36 @@ export default function LogTimeCardDialog({
                   }}
                 >
                   {!hasApproverInput ? (
-                    <Typography
-                      variant="caption"
-                      color="text.secondary"
-                      sx={{ p: 1 }}
-                    >
-                      Start typing to search for an approver.
-                    </Typography>
-                  ) : candidates.length === 0 ? (
+                    approverCandidates.length === 0 ? (
+                      <Typography
+                        variant="caption"
+                        color="text.secondary"
+                        sx={{ p: 1 }}
+                      >
+                        Start typing to search for an approver.
+                      </Typography>
+                    ) : (
+                      <>
+                        <Typography
+                          variant="caption"
+                          color="text.secondary"
+                          sx={{ px: 1, pt: 1 }}
+                        >
+                          Recently selected
+                        </Typography>
+                        {approverCandidates.map((u) => (
+                          <ApproverCandidateButton
+                            key={u.id}
+                            option={u}
+                            onSelect={(picked) => {
+                              setApprover({ id: picked.id, name: picked.name });
+                              setApproverInput("");
+                            }}
+                          />
+                        ))}
+                      </>
+                    )
+                  ) : approverCandidates.length === 0 ? (
                     <Typography
                       variant="caption"
                       color="text.secondary"
@@ -594,43 +689,15 @@ export default function LogTimeCardDialog({
                       No matching engineers.
                     </Typography>
                   ) : (
-                    candidates.map((u) => (
-                      <Button
+                    approverCandidates.map((u) => (
+                      <ApproverCandidateButton
                         key={u.id}
-                        data-testid="approver-candidate"
-                        variant="text"
-                        color="inherit"
-                        onClick={() => {
-                          setApprover({ id: u.id, name: u.name });
+                        option={u}
+                        onSelect={(picked) => {
+                          setApprover({ id: picked.id, name: picked.name });
                           setApproverInput("");
                         }}
-                        sx={{
-                          justifyContent: "flex-start",
-                          textTransform: "none",
-                          px: 1,
-                          py: 0.5,
-                          gap: 1,
-                        }}
-                      >
-                        <Avatar sx={{ width: 24, height: 24, fontSize: "0.7rem" }}>
-                          {initialsOf(u.name)}
-                        </Avatar>
-                        <Box sx={{ minWidth: 0, textAlign: "left" }}>
-                          <Typography variant="body2" noWrap>
-                            {u.name}
-                          </Typography>
-                          {u.email && (
-                            <Typography
-                              variant="caption"
-                              color="text.secondary"
-                              noWrap
-                              sx={{ display: "block" }}
-                            >
-                              {u.email}
-                            </Typography>
-                          )}
-                        </Box>
-                      </Button>
+                      />
                     ))
                   )}
                 </Box>


### PR DESCRIPTION
## Purpose
Two small CSM Portal improvements bundled in one PR:
1. Engineers logging time have to retype the same approver search every time, even though
   in practice the same few approvers are reused repeatedly.
2. A plain case's detail page could show a "linked change requests" widget even though
   change requests are only ever created from a service request, never directly from a
   case — and the direct service-request creation flow's project picker listed every
   project, including ones that aren't eligible for service requests.

## Goals
- Surface the signed-in engineer's previously selected approver(s) first in the time-log
  Approver search, before they type anything, and prioritize them while typing.
- Stop rendering the linked-change-requests widget on a plain case's detail page.
- Restrict the direct service-request creation page's project picker to managed-cloud
  subscription projects, matching the same restriction already applied on case creation.

## Approach
- Added a `useRecentApprovers` hook that derives recency from the engineer's own past
  time-card submissions (`POST /time-cards/search` scoped to their own user id) — no new
  backend endpoint, no local storage, works across devices since it's server-derived.
  Wired into the Log Time dialog's approver picker: recents shown before typing, prioritized
  ahead of live search results while typing, falls back to today's behavior when there's no
  history.
- Fixed the case detail page's render guard for the linked-change-requests widget to gate
  solely on the case being a service request, rather than also rendering whenever stale
  `linkedChangeRequests` data happened to be present on a plain case.
- Added an opt-in `filterProject` predicate to the shared project-selection components, used
  only by the service-request creation page (other creation flows using the same components
  don't want this restriction), filtering to managed-cloud-subscription projects client-side.

## User stories
As a CS engineer logging time, I want my previously used approvers suggested first so I
don't have to retype the same search every time.
As a CS engineer viewing a case, I want the linked-change-requests section to only appear
where it's actually applicable (service requests), not on every case.
As a CS engineer creating a service request, I want the project picker to only show projects
eligible for service requests.

## Release note
- Time logging: the Approver search now shows your previously selected approvers first.
- Case detail: linked change requests are now only shown on service requests.
- Service request creation: the project picker now only lists managed-cloud projects.

## Documentation
N/A — no new user-facing concept, just refined existing behavior; the in-app help topics
for time logging and service request creation don't need updates for this change.

## Automation tests
- Unit tests
  - `LogTimeCardDialog.test.tsx`: 3 new cases covering recents shown before typing, recents
    prioritized when typing matches, and fallback to the original empty-state when there's
    no history. 9/9 pass.
  - `CsmCaseDetailPage.test.tsx`: 2 new cases covering a plain case with stale
    `linkedChangeRequests` data never rendering the widget, and a service request still
    rendering it. 17/17 pass.
- Integration tests
  N/A — no integration test suite covers these UI flows; covered by the unit tests above and
  manual verification against the local stack.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — TypeScript/React change, not Java; `npx tsc -b` ran clean and no new dependencies were introduced
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no new samples applicable to this change.

## Related PRs
None.

## Migrations (if applicable)
N/A — no data migration involved.

## Test environment
Verified via `npx vitest run` and `npx tsc -b` in the CSM portal webapp workspace (Node/pnpm
toolchain as pinned in the repo).

## Learning
N/A — no new library, pattern, or external research introduced; both changes reuse existing
data-fetching and component patterns already established elsewhere in the codebase.
