### PR TITLE
[CSM Portal] timecard approver recency, case/CR display, SR project filter, and announcement-create field fixes

### DIFF
--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -3091,6 +3091,8 @@ export interface BeSearchTimeCardsFilters {
 
 export interface BeSearchTimeCardsPayload {
   filters?: BeSearchTimeCardsFilters;
+  /** Defaults to updatedOn desc server-side when omitted. */
+  sortBy?: { field: "workDate" | "updatedOn"; order: "asc" | "desc" };
   pagination?: BePagination;
 }
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncProjectSelect.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncProjectSelect.test.tsx
@@ -1,0 +1,123 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import AsyncProjectSelect from "@features/csm-cases/components/AsyncProjectSelect";
+import { useInfiniteProjectSearch } from "@features/csm-cases/api/useProjectSearch";
+import type { BeProject } from "@api/backend/types";
+
+vi.mock("@features/csm-cases/api/useProjectSearch", () => ({
+  useInfiniteProjectSearch: vi.fn(),
+}));
+
+const mockedUseInfiniteProjectSearch = vi.mocked(useInfiniteProjectSearch);
+
+afterEach(() => {
+  mockedUseInfiniteProjectSearch.mockReset();
+});
+
+const MANAGED_CLOUD_PROJECT: BeProject = {
+  id: "proj-managed",
+  name: "Managed Cloud Co",
+  subscriptionType: "managed_cloud",
+};
+const SUBSCRIPTION_PROJECT: BeProject = {
+  id: "proj-subscription",
+  name: "Subscription Only Co",
+  subscriptionType: "subscription",
+};
+
+const isManagedCloudProject = (p: BeProject): boolean =>
+  p.subscriptionType === "managed_cloud";
+
+describe("AsyncProjectSelect — filterProject pagination", () => {
+  it("keeps loading pages when the current page's matches are all filtered out", async () => {
+    const fetchNextPage = vi.fn();
+    // First page has no managed-cloud project at all — with filterProject
+    // applied, options is empty and the listbox can never be scrolled to
+    // trigger the scroll-based fetchNextPage, so this must be driven
+    // automatically instead.
+    mockedUseInfiniteProjectSearch.mockReturnValue({
+      projects: [SUBSCRIPTION_PROJECT],
+      isFetching: false,
+      isFetchingNextPage: false,
+      hasNextPage: true,
+      isError: false,
+      fetchNextPage,
+    });
+
+    render(
+      <AsyncProjectSelect
+        value=""
+        onChange={vi.fn()}
+        filterProject={isManagedCloudProject}
+      />,
+    );
+    // The auto-continue effect only runs while the dropdown is open.
+    fireEvent.mouseDown(screen.getByRole("combobox"));
+
+    await waitFor(() => expect(fetchNextPage).toHaveBeenCalledTimes(1));
+  });
+
+  it("stops requesting more pages once a match is loaded", () => {
+    const fetchNextPage = vi.fn();
+    mockedUseInfiniteProjectSearch.mockReturnValue({
+      projects: [SUBSCRIPTION_PROJECT, MANAGED_CLOUD_PROJECT],
+      isFetching: false,
+      isFetchingNextPage: false,
+      hasNextPage: true,
+      isError: false,
+      fetchNextPage,
+    });
+
+    render(
+      <AsyncProjectSelect
+        value=""
+        onChange={vi.fn()}
+        filterProject={isManagedCloudProject}
+      />,
+    );
+    fireEvent.mouseDown(screen.getByRole("combobox"));
+
+    expect(fetchNextPage).not.toHaveBeenCalled();
+  });
+
+  it("stops requesting more pages once hasNextPage is false", () => {
+    const fetchNextPage = vi.fn();
+    mockedUseInfiniteProjectSearch.mockReturnValue({
+      projects: [SUBSCRIPTION_PROJECT],
+      isFetching: false,
+      isFetchingNextPage: false,
+      hasNextPage: false,
+      isError: false,
+      fetchNextPage,
+    });
+
+    render(
+      <AsyncProjectSelect
+        value=""
+        onChange={vi.fn()}
+        filterProject={isManagedCloudProject}
+      />,
+    );
+    fireEvent.mouseDown(screen.getByRole("combobox"));
+
+    expect(fetchNextPage).not.toHaveBeenCalled();
+    expect(screen.queryByText(/loading/i)).not.toBeInTheDocument();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncProjectSelect.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncProjectSelect.tsx
@@ -19,6 +19,7 @@ import { useMemo, useState, type JSX } from "react";
 import type * as React from "react";
 import { useDebouncedValue } from "@hooks/useDebouncedValue";
 import { useInfiniteProjectSearch } from "@features/csm-cases/api/useProjectSearch";
+import type { BeProject } from "@api/backend/types";
 
 interface ProjectOption {
   id: string;
@@ -33,6 +34,14 @@ interface AsyncProjectSelectProps {
   onChange: (next: string) => void;
   required?: boolean;
   disabled?: boolean;
+  /**
+   * Restricts the searchable/selectable options to projects matching this
+   * predicate (e.g. by `subscriptionType`) — the backend search endpoint has
+   * no such filter, so this narrows the already-fetched page client-side.
+   * Absent means "no restriction" (the default, used by the case/security
+   * report/engagement creation flows).
+   */
+  filterProject?: (project: BeProject) => boolean;
 }
 
 /**
@@ -49,6 +58,7 @@ export default function AsyncProjectSelect({
   onChange,
   required,
   disabled,
+  filterProject,
 }: AsyncProjectSelectProps): JSX.Element {
   // Search term tracked separately from the displayed input value (which MUI
   // manages and shows the selected project's name) so the type-ahead works.
@@ -93,14 +103,17 @@ export default function AsyncProjectSelect({
   }, [value, picked, projects]);
 
   // Pool = the current selection (so it can render) + the search results,
-  // de-duplicated by id.
+  // de-duplicated by id. `filterProject` (when given) is applied to the
+  // search results only — the current selection always stays shown so an
+  // already-picked project never disappears out from under the field.
   const options = useMemo<ProjectOption[]>(() => {
-    const results = projects.map((p) => ({ id: p.id, name: p.name || p.id }));
+    const filtered = filterProject ? projects.filter(filterProject) : projects;
+    const results = filtered.map((p) => ({ id: p.id, name: p.name || p.id }));
     if (selectedOption && !results.some((o) => o.id === selectedOption.id)) {
       return [selectedOption, ...results];
     }
     return results;
-  }, [projects, selectedOption]);
+  }, [projects, selectedOption, filterProject]);
 
   return (
     <Autocomplete<ProjectOption>

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncProjectSelect.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncProjectSelect.tsx
@@ -15,7 +15,7 @@
 // under the License.
 
 import { Autocomplete, TextField } from "@wso2/oxygen-ui";
-import { useMemo, useState, type JSX } from "react";
+import { useEffect, useMemo, useState, type JSX } from "react";
 import type * as React from "react";
 import { useDebouncedValue } from "@hooks/useDebouncedValue";
 import { useInfiniteProjectSearch } from "@features/csm-cases/api/useProjectSearch";
@@ -106,14 +106,44 @@ export default function AsyncProjectSelect({
   // de-duplicated by id. `filterProject` (when given) is applied to the
   // search results only — the current selection always stays shown so an
   // already-picked project never disappears out from under the field.
+  const filteredProjects = useMemo(
+    () => (filterProject ? projects.filter(filterProject) : projects),
+    [projects, filterProject],
+  );
   const options = useMemo<ProjectOption[]>(() => {
-    const filtered = filterProject ? projects.filter(filterProject) : projects;
-    const results = filtered.map((p) => ({ id: p.id, name: p.name || p.id }));
+    const results = filteredProjects.map((p) => ({ id: p.id, name: p.name || p.id }));
     if (selectedOption && !results.some((o) => o.id === selectedOption.id)) {
       return [selectedOption, ...results];
     }
     return results;
-  }, [projects, selectedOption, filterProject]);
+  }, [filteredProjects, selectedOption]);
+
+  // With `filterProject` narrowing the loaded page(s) client-side, a page can
+  // come back with zero matches even though a later page has some — and with
+  // nothing rendered, the listbox can't be scrolled to trigger
+  // handleListboxScroll's fetchNextPage. Keep loading pages automatically in
+  // that case until a match appears or hasNextPage runs out.
+  useEffect(() => {
+    if (
+      !open ||
+      !filterProject ||
+      isFetching ||
+      isFetchingNextPage ||
+      !hasNextPage ||
+      filteredProjects.length > 0
+    ) {
+      return;
+    }
+    fetchNextPage();
+  }, [
+    open,
+    filterProject,
+    isFetching,
+    isFetchingNextPage,
+    hasNextPage,
+    filteredProjects,
+    fetchNextPage,
+  ]);
 
   return (
     <Autocomplete<ProjectOption>

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/ProjectSelectionField.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/ProjectSelectionField.tsx
@@ -28,6 +28,7 @@ import { CheckCircle, Lock } from "@wso2/oxygen-ui-icons-react";
 import { useState, type JSX } from "react";
 import AsyncProjectSelect from "@features/csm-cases/components/AsyncProjectSelect";
 import { useGetProject } from "@features/csm-projects/api/useGetProject";
+import type { BeProject } from "@api/backend/types";
 
 export interface ProjectSelectionFieldProps {
   /** Selected project id ("" when none picked yet). */
@@ -40,6 +41,12 @@ export interface ProjectSelectionFieldProps {
    */
   lockedProjectId?: string;
   required?: boolean;
+  /**
+   * Restricts the searchable picker to projects matching this predicate
+   * (see {@link AsyncProjectSelect}'s `filterProject`). Not applied to the
+   * locked-project display — a project arriving locked is trusted as-is.
+   */
+  filterProject?: (project: BeProject) => boolean;
 }
 
 /**
@@ -60,6 +67,7 @@ export default function ProjectSelectionField({
   onChange,
   lockedProjectId,
   required,
+  filterProject,
 }: ProjectSelectionFieldProps): JSX.Element {
   const isLocked = !!lockedProjectId;
   // Picked from the Autocomplete but not yet confirmed in the dialog below —
@@ -117,6 +125,7 @@ export default function ProjectSelectionField({
             if (next) setPendingProjectId(next);
           }}
           required={required}
+          filterProject={filterProject}
         />
         {/*
           A plain `Modal` + `Paper` rather than `Dialog` — `Dialog`'s paper is

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.test.tsx
@@ -398,7 +398,9 @@ vi.mock("@features/csm-cases/components/LinkedServiceRequestsWidget", () => ({
   LinkedServiceRequestsWidget: () => null,
 }));
 vi.mock("@features/csm-cases/components/LinkedChangeRequestsWidget", () => ({
-  LinkedChangeRequestsWidget: () => null,
+  LinkedChangeRequestsWidget: () => (
+    <div data-testid="linked-change-requests-widget-probe" />
+  ),
 }));
 vi.mock("@features/csm-cases/components/CreateGithubIssueDialog", () => ({
   CreateGithubIssueDialog: () => null,
@@ -1339,5 +1341,62 @@ describe("CsmCaseDetailPage — change case type", () => {
       { severity: "high" },
       expect.anything(),
     );
+  });
+});
+
+describe("CsmCaseDetailPage — Linked change requests widget only shows on service requests", () => {
+  it("does not render LinkedChangeRequestsWidget for a plain case, even one carrying stale linkedChangeRequests data", () => {
+    // A plain case should never carry `linkedChangeRequests` per the field's
+    // own doc comment (SR-only), but the guard must not rely on that alone —
+    // this proves the render gate itself, not just the data shape, keeps the
+    // widget off a plain case.
+    useGetCsmCaseDetailMock.mockImplementation((id: string | undefined) => ({
+      data: id
+        ? {
+            ...buildCase(id),
+            caseType: "incident",
+            linkedChangeRequests: [{ id: "cr-1", number: "CR-1", name: "Stale link" }],
+          }
+        : undefined,
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+      isFetching: false,
+      dataUpdatedAt: 0,
+    }));
+
+    renderPage();
+    fireEvent.click(screen.getByRole("tab", { name: /linked items/i }));
+
+    expect(
+      screen.queryByTestId("linked-change-requests-widget-probe"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders LinkedChangeRequestsWidget for a service request", () => {
+    useGetCsmCaseDetailMock.mockImplementation((id: string | undefined) => ({
+      data: id ? { ...buildCase(id), caseType: "service_request" } : undefined,
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+      isFetching: false,
+      dataUpdatedAt: 0,
+    }));
+
+    // A service request's canonical route is /operations/service-requests/:id
+    // (see CASE_ROUTE_MOUNTS above) — mounting it on the plain /cases/:id
+    // route instead would trip the canonical-redirect skeleton rather than
+    // rendering the tabs.
+    renderPageAt(
+      "/operations/service-requests/case-1",
+      "/operations/service-requests/:caseId",
+    );
+    fireEvent.click(screen.getByRole("tab", { name: /linked items/i }));
+
+    expect(
+      screen.getByTestId("linked-change-requests-widget-probe"),
+    ).toBeInTheDocument();
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -2468,11 +2468,13 @@ export default function CsmCaseDetailPage(): JSX.Element {
               onLinkIncident={() => setLinkIncidentOpen(true)}
               linkDisabled={isClosed}
             />
-            {/* Content-relevance, not a data-source gate: shown whenever this is
-                a service request (the only case type that carries the link) or
-                the list already has entries — never checks the record's data
-                source. */}
-            {(isServiceRequest || (c.linkedChangeRequests?.length ?? 0) > 0) && (
+            {/* Change requests are only ever raised from a service request,
+                never directly from a plain case — gate solely on
+                `isServiceRequest` rather than falling back to
+                `linkedChangeRequests` having entries, which a plain case
+                should never carry anyway (see `linkedChangeRequests` doc
+                comment on the case-detail type). Not a data-source gate. */}
+            {isServiceRequest && (
               <LinkedChangeRequestsWidget changeRequests={c.linkedChangeRequests} />
             )}
             <LinkedServiceRequestsWidget

--- a/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateServiceRequestPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-operations/pages/CreateServiceRequestPage.tsx
@@ -33,6 +33,7 @@ import { useMemo, useState, type JSX } from "react";
 import { useLocation, useSearchParams } from "react-router";
 
 import { BackendApiError } from "@api/backend/client";
+import type { BeProject } from "@api/backend/types";
 import AttachmentsField from "@components/attachments/AttachmentsField";
 import {
   POST_CREATE_ATTACHMENTS_MAX_ENCODED_BYTES,
@@ -59,6 +60,14 @@ import {
   isAttachmentField,
 } from "@features/csm-operations/utils/catalogVariables";
 import type { CreateServiceRequestFromCaseNavState } from "@features/csm-cases/types/csmCases";
+
+// Service requests are a managed-cloud-only artefact — the underlying
+// catalog/deployment flow only makes sense for a managed-cloud subscription's
+// project. Module-level (not per-render) so `ProjectSelectionField`'s
+// `filterProject` prop keeps a stable identity across re-renders.
+function isManagedCloudProject(project: BeProject): boolean {
+  return project.subscriptionType === "managed_cloud_subscription";
+}
 
 export default function CreateServiceRequestPage(): JSX.Element {
   const navigate = useNavTransition();
@@ -345,6 +354,7 @@ export default function CreateServiceRequestPage(): JSX.Element {
               onChange={onProjectChange}
               lockedProjectId={lockedProjectId}
               required
+              filterProject={isManagedCloudProject}
             />
           </Grid>
 

--- a/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeSheets.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeSheets.ts
@@ -319,6 +319,81 @@ export function useAllTimeCards(
   });
 }
 
+/** A previously-selected approver, reduced from the signed-in engineer's own
+ * recent time-card submissions (see {@link useRecentApprovers}) — deliberately
+ * the same `{ id, name }` shape as {@link TimeCardApprover} since it feeds the
+ * exact same approver-picker candidate rendering in `LogTimeCardDialog`. */
+export interface RecentApprover {
+  id: string;
+  name: string;
+}
+
+/** How many distinct recent approvers {@link useRecentApprovers} surfaces —
+ * enough to cover an engineer's usual handful of team leads without turning
+ * the "before you type" list into a full roster. */
+const RECENT_APPROVERS_MAX = 4;
+
+/** How many of the signed-in engineer's own most-recent cards to look at when
+ * deriving {@link RecentApprover}s — a small page is enough since the same
+ * few approvers repeat constantly; this is "who did I pick before", not a
+ * complete history. */
+const RECENT_APPROVERS_LOOKBACK = 20;
+
+/**
+ * The signed-in engineer's own most-recently-submitted-to approvers, most
+ * recent first, deduped by id, capped at {@link RECENT_APPROVERS_MAX} —
+ * powers "Log time"'s approver picker showing previously-picked approvers
+ * before the engineer types anything (digiops-cs#2839), instead of requiring
+ * the same search every time.
+ *
+ * Derived entirely from the existing `POST /time-cards/search` endpoint
+ * (`userId`-scoped to the signed-in engineer, no `states` filter — an
+ * approved, rejected, or still-`submitted` card all equally answer "who did I
+ * pick before") rather than a new backend endpoint or local storage: no state
+ * restriction is needed here, this is about the approver pick, not the
+ * outcome. `/time-cards/search`'s own default ordering isn't documented, so
+ * results are explicitly re-sorted here by `workDate` descending rather than
+ * assumed to already be newest-first.
+ *
+ * `enabled` should be gated to create-mode only (see `LogTimeCardDialog`) —
+ * the approver field is read-only once editing, so there's nothing for this
+ * list to feed there.
+ */
+export function useRecentApprovers(enabled: boolean): UseQueryResult<RecentApprover[], Error> {
+  const api = useBackendApi();
+  const me = useCurrentEngineer();
+  return useQuery<RecentApprover[], Error>({
+    queryKey: [ApiQueryKeys.TIME_SHEETS_SEARCH, "recent-approvers", me.id],
+    queryFn: async (): Promise<RecentApprover[]> => {
+      if (!me.id) return [];
+      const { cards } = await searchTimeCards(
+        api,
+        { userId: me.id },
+        { page: 0, rowsPerPage: RECENT_APPROVERS_LOOKBACK },
+      );
+      const newestFirst = [...cards].sort((a, b) =>
+        (b.workDate || "").localeCompare(a.workDate || ""),
+      );
+      const seen = new Set<string>();
+      const recents: RecentApprover[] = [];
+      for (const card of newestFirst) {
+        for (const approver of card.approvers ?? []) {
+          // Defensive only: nothing should let an engineer submit a card
+          // approved by themself, mirroring the same self-exclusion already
+          // applied to live search candidates in LogTimeCardDialog.
+          if (approver.id === me.id || seen.has(approver.id)) continue;
+          seen.add(approver.id);
+          recents.push({ id: approver.id, name: approver.name });
+          if (recents.length >= RECENT_APPROVERS_MAX) return recents;
+        }
+      }
+      return recents;
+    },
+    enabled: enabled && !!me.id,
+    staleTime: 30_000,
+  });
+}
+
 /** Approve or reject a single card. */
 export function useDecideCard(): UseMutationResult<
   CsmTimeCard,

--- a/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeSheets.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeSheets.ts
@@ -197,11 +197,18 @@ export interface TimeCardSearchResult {
  * their own such walk — was slow enough to sometimes fail outright. Real,
  * caller-driven pagination replaces that: callers ask for one page at a
  * time via `pagination`, and `total` lets them drive page controls.
+ *
+ * `sortBy` is an escape hatch for callers that need the server to select
+ * (not just order) by a specific field before applying `pagination` — e.g.
+ * {@link useRecentApprovers}, where the top `RECENT_APPROVERS_LOOKBACK`
+ * cards must actually be the most recent by `workDate`, not just sorted
+ * after the fact within whatever page the default order happened to return.
  */
 export async function searchTimeCards(
   api: BackendApi,
   filters?: TimeCardSearchFilters,
   pagination?: TimeCardPagination,
+  sortBy?: BeSearchTimeCardsPayload["sortBy"],
 ): Promise<TimeCardSearchResult> {
   const limit = Math.min(pagination?.rowsPerPage ?? BE_MAX_PAGE_LIMIT, BE_MAX_PAGE_LIMIT);
   const wireFilters: BeSearchTimeCardsFilters = {
@@ -216,6 +223,7 @@ export async function searchTimeCards(
   };
   const payload: BeSearchTimeCardsPayload = {
     filters: wireFilters,
+    ...(sortBy ? { sortBy } : {}),
     pagination: { limit, offset: (pagination?.page ?? 0) * limit },
   };
   const res = await api.post<BeSearchTimeCardsPayload, BeSearchTimeCardsResponse>(
@@ -366,10 +374,14 @@ export function useRecentApprovers(enabled: boolean): UseQueryResult<RecentAppro
     queryKey: [ApiQueryKeys.TIME_SHEETS_SEARCH, "recent-approvers", me.id],
     queryFn: async (): Promise<RecentApprover[]> => {
       if (!me.id) return [];
+      // sortBy: workDate desc so the page itself is the most-recent-by-workDate
+      // cards — the server's default order (updatedOn desc) selects a
+      // different, and possibly non-overlapping, top-N.
       const { cards } = await searchTimeCards(
         api,
         { userId: me.id },
         { page: 0, rowsPerPage: RECENT_APPROVERS_LOOKBACK },
+        { field: "workDate", order: "desc" },
       );
       const newestFirst = [...cards].sort((a, b) =>
         (b.workDate || "").localeCompare(a.workDate || ""),

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/LogTimeCardDialog.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/LogTimeCardDialog.test.tsx
@@ -15,10 +15,11 @@
 // under the License.
 
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 import LogTimeCardDialog from "@features/csm-timecards/components/LogTimeCardDialog";
 import { useSearchUsers } from "@features/csm-users/api/useSearchUsers";
+import { useRecentApprovers } from "@features/csm-timecards/api/useTimeSheets";
 import type { CsmTimeCard } from "@features/csm-timecards/types/timeCards";
 
 // Not under test here — stubbed to a plain textarea, same technique used by
@@ -44,11 +45,38 @@ vi.mock("@hooks/useIdTokenClaims", () => ({
 vi.mock("@features/csm-users/api/useSearchUsers", () => ({
   useSearchUsers: vi.fn(),
 }));
+// Only `useRecentApprovers` is used by the component from this module; the
+// rest of it reaches the runtime-config-reading backend client at import
+// time, which isn't present under vitest (same approach as
+// ChangeRequestApprovals.test.tsx's `@api/backend/client` stub).
+vi.mock("@features/csm-timecards/api/useTimeSheets", () => ({
+  useRecentApprovers: vi.fn(),
+}));
 
 const mockedUseSearchUsers = vi.mocked(useSearchUsers);
 mockedUseSearchUsers.mockReturnValue({
   data: { users: [] },
 } as unknown as ReturnType<typeof useSearchUsers>);
+
+const mockedUseRecentApprovers = vi.mocked(useRecentApprovers);
+mockedUseRecentApprovers.mockReturnValue({
+  data: [],
+} as unknown as ReturnType<typeof useRecentApprovers>);
+
+// Tests below override these with `mockReturnValue` (not `mockReturnValueOnce`
+// — the dialog re-renders more than once per interaction, e.g. on every
+// keystroke into the approver search box, so a one-shot mock would only
+// satisfy the first render and silently fall back to the empty default on
+// the next) — reset back to the shared empty defaults afterwards so later
+// tests aren't affected by an earlier test's override.
+afterEach(() => {
+  mockedUseSearchUsers.mockReturnValue({
+    data: { users: [] },
+  } as unknown as ReturnType<typeof useSearchUsers>);
+  mockedUseRecentApprovers.mockReturnValue({
+    data: [],
+  } as unknown as ReturnType<typeof useRecentApprovers>);
+});
 
 const EDITING_CARD: CsmTimeCard = {
   id: "card-1",
@@ -94,6 +122,101 @@ describe("LogTimeCardDialog — create mode", () => {
     expect(
       screen.getByPlaceholderText("Search engineers by name or email…"),
     ).toBeInTheDocument();
+  });
+
+  it("shows previously-selected approvers before the engineer types anything", () => {
+    mockedUseRecentApprovers.mockReturnValue({
+      data: [
+        { id: "lead-1", name: "Priya Lead" },
+        { id: "lead-2", name: "Sam Approver" },
+      ],
+    } as unknown as ReturnType<typeof useRecentApprovers>);
+
+    render(
+      <LogTimeCardDialog
+        caseId="case-1"
+        caseNumber="CS0000001"
+        caseSeverity="S3"
+        projectId="proj-1"
+        projectName="Acme"
+        isSubmitting={false}
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Recently selected")).toBeInTheDocument();
+    // textContent includes the avatar's initials fallback ahead of the name
+    // (e.g. "PLPriya Lead") since the Avatar and name share one button —
+    // asserting via the visible name text alone is enough to confirm order.
+    expect(screen.getByText("Priya Lead")).toBeInTheDocument();
+    expect(screen.getByText("Sam Approver")).toBeInTheDocument();
+    const shown = screen.getAllByTestId("approver-candidate").map((el) => el.textContent);
+    expect(shown).toEqual(["PLPriya Lead", "SASam Approver"]);
+    expect(
+      screen.queryByText("Start typing to search for an approver."),
+    ).not.toBeInTheDocument();
+  });
+
+  it("prioritizes a matching recent approver ahead of live search results when typing", () => {
+    mockedUseRecentApprovers.mockReturnValue({
+      data: [{ id: "lead-1", name: "Priya Lead" }],
+    } as unknown as ReturnType<typeof useRecentApprovers>);
+    mockedUseSearchUsers.mockReturnValue({
+      data: {
+        users: [
+          { id: "lead-3", name: "Other Lead", userName: "other.lead", email: "other.lead@example.test" },
+          { id: "lead-1", name: "Priya Lead", userName: "priya.lead", email: "priya.lead@example.test" },
+        ],
+      },
+    } as unknown as ReturnType<typeof useSearchUsers>);
+
+    render(
+      <LogTimeCardDialog
+        caseId="case-1"
+        caseNumber="CS0000001"
+        caseSeverity="S3"
+        projectId="proj-1"
+        projectName="Acme"
+        isSubmitting={false}
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByPlaceholderText("Search engineers by name or email…"), {
+      target: { value: "lead" },
+    });
+
+    const shown = screen.getAllByTestId("approver-candidate").map((el) => el.textContent);
+    // "Priya Lead" appears once (deduped), and first (prioritized as a
+    // recent) — textContent also carries the avatar initials fallback and,
+    // for the live-search-only result, its email.
+    expect(shown).toEqual(["PLPriya Lead", "OLOther Leadother.lead@example.test"]);
+  });
+
+  it("falls back to the ordinary empty-search prompt when there is no recent history", () => {
+    mockedUseRecentApprovers.mockReturnValueOnce({
+      data: [],
+    } as unknown as ReturnType<typeof useRecentApprovers>);
+
+    render(
+      <LogTimeCardDialog
+        caseId="case-1"
+        caseNumber="CS0000001"
+        caseSeverity="S3"
+        projectId="proj-1"
+        projectName="Acme"
+        isSubmitting={false}
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByText("Start typing to search for an approver."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Recently selected")).not.toBeInTheDocument();
   });
 });
 

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/LogTimeCardDialog.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/LogTimeCardDialog.test.tsx
@@ -54,29 +54,41 @@ vi.mock("@features/csm-timecards/api/useTimeSheets", () => ({
 }));
 
 const mockedUseSearchUsers = vi.mocked(useSearchUsers);
-mockedUseSearchUsers.mockReturnValue({
-  data: { users: [] },
-} as unknown as ReturnType<typeof useSearchUsers>);
-
 const mockedUseRecentApprovers = vi.mocked(useRecentApprovers);
-mockedUseRecentApprovers.mockReturnValue({
-  data: [],
-} as unknown as ReturnType<typeof useRecentApprovers>);
 
-// Tests below override these with `mockReturnValue` (not `mockReturnValueOnce`
-// — the dialog re-renders more than once per interaction, e.g. on every
-// keystroke into the approver search box, so a one-shot mock would only
-// satisfy the first render and silently fall back to the empty default on
-// the next) — reset back to the shared empty defaults afterwards so later
-// tests aren't affected by an earlier test's override.
-afterEach(() => {
-  mockedUseSearchUsers.mockReturnValue({
-    data: { users: [] },
-  } as unknown as ReturnType<typeof useSearchUsers>);
+type MockUser = { id: string; name: string; userName: string; email: string };
+
+// The component calls `useSearchUsers` twice with different intent: once for
+// the live typed-search candidates, once (filters.userIds set) to re-check
+// recentApprovers against current eligibility. Both calls hit this same
+// mocked function, so the mock discriminates on `filters.userIds` rather than
+// call order, and each call site's data is configured independently.
+function setSearchUsersData(opts: { live?: MockUser[]; eligible?: MockUser[] }): void {
+  mockedUseSearchUsers.mockImplementation(
+    (request) =>
+      ({
+        data: {
+          users: request.filters?.userIds ? (opts.eligible ?? []) : (opts.live ?? []),
+        },
+      }) as unknown as ReturnType<typeof useSearchUsers>,
+  );
+}
+
+// Tests below override these with `mockReturnValue`/`mockImplementation` (not
+// a `*Once` variant — the dialog re-renders more than once per interaction,
+// e.g. on every keystroke into the approver search box, so a one-shot mock
+// would only satisfy the first render and silently fall back to the empty
+// default on the next) — reset back to the shared empty defaults afterwards
+// so later tests aren't affected by an earlier test's override.
+function resetMocks(): void {
+  setSearchUsersData({});
   mockedUseRecentApprovers.mockReturnValue({
     data: [],
   } as unknown as ReturnType<typeof useRecentApprovers>);
-});
+}
+
+resetMocks();
+afterEach(resetMocks);
 
 const EDITING_CARD: CsmTimeCard = {
   id: "card-1",
@@ -131,6 +143,12 @@ describe("LogTimeCardDialog — create mode", () => {
         { id: "lead-2", name: "Sam Approver" },
       ],
     } as unknown as ReturnType<typeof useRecentApprovers>);
+    setSearchUsersData({
+      eligible: [
+        { id: "lead-1", name: "Priya Lead", userName: "priya.lead", email: "priya.lead@example.test" },
+        { id: "lead-2", name: "Sam Approver", userName: "sam.approver", email: "sam.approver@example.test" },
+      ],
+    });
 
     render(
       <LogTimeCardDialog
@@ -162,14 +180,13 @@ describe("LogTimeCardDialog — create mode", () => {
     mockedUseRecentApprovers.mockReturnValue({
       data: [{ id: "lead-1", name: "Priya Lead" }],
     } as unknown as ReturnType<typeof useRecentApprovers>);
-    mockedUseSearchUsers.mockReturnValue({
-      data: {
-        users: [
-          { id: "lead-3", name: "Other Lead", userName: "other.lead", email: "other.lead@example.test" },
-          { id: "lead-1", name: "Priya Lead", userName: "priya.lead", email: "priya.lead@example.test" },
-        ],
-      },
-    } as unknown as ReturnType<typeof useSearchUsers>);
+    setSearchUsersData({
+      live: [
+        { id: "lead-3", name: "Other Lead", userName: "other.lead", email: "other.lead@example.test" },
+        { id: "lead-1", name: "Priya Lead", userName: "priya.lead", email: "priya.lead@example.test" },
+      ],
+      eligible: [{ id: "lead-1", name: "Priya Lead", userName: "priya.lead", email: "priya.lead@example.test" }],
+    });
 
     render(
       <LogTimeCardDialog
@@ -193,6 +210,37 @@ describe("LogTimeCardDialog — create mode", () => {
     // recent) — textContent also carries the avatar initials fallback and,
     // for the live-search-only result, its email.
     expect(shown).toEqual(["PLPriya Lead", "OLOther Leadother.lead@example.test"]);
+  });
+
+  it("excludes a recent approver who is no longer active/eligible", () => {
+    mockedUseRecentApprovers.mockReturnValue({
+      data: [
+        { id: "lead-1", name: "Priya Lead" },
+        { id: "lead-2", name: "Departed Lead" },
+      ],
+    } as unknown as ReturnType<typeof useRecentApprovers>);
+    // Only lead-1 comes back as still active/in the approver role — lead-2
+    // has since been deactivated or removed from TIMECARD_APPROVER_GROUP.
+    setSearchUsersData({
+      eligible: [{ id: "lead-1", name: "Priya Lead", userName: "priya.lead", email: "priya.lead@example.test" }],
+    });
+
+    render(
+      <LogTimeCardDialog
+        caseId="case-1"
+        caseNumber="CS0000001"
+        caseSeverity="S3"
+        projectId="proj-1"
+        projectName="Acme"
+        isSubmitting={false}
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Priya Lead")).toBeInTheDocument();
+    expect(screen.queryByText("Departed Lead")).not.toBeInTheDocument();
+    expect(screen.getAllByTestId("approver-candidate")).toHaveLength(1);
   });
 
   it("falls back to the ordinary empty-search prompt when there is no recent history", () => {

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/LogTimeCardDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/LogTimeCardDialog.tsx
@@ -47,6 +47,7 @@ import { useIdTokenClaims } from "@hooks/useIdTokenClaims";
 import { initialsOf, resolveUserInfo } from "@utils/userClaims";
 import { useSearchUsers } from "@features/csm-users/api/useSearchUsers";
 import type { NormalizedUser } from "@features/csm-users/types/csmUsers";
+import { useRecentApprovers } from "@features/csm-timecards/api/useTimeSheets";
 import TimeCardStatusChip from "@features/csm-timecards/components/TimeCardStatusChip";
 import type { SeverityOrUnset } from "@features/csm-dashboard/types/abtDashboard";
 import {
@@ -123,6 +124,52 @@ interface ApproverOption {
 
 function fullName(u: NormalizedUser): string {
   return u.name.trim() || u.userName;
+}
+
+/** One clickable approver candidate — shared between the "recently selected"
+ * list (shown before typing) and the live search results (shown once typed),
+ * so the two never drift into rendering the row differently. */
+function ApproverCandidateButton({
+  option,
+  onSelect,
+}: {
+  option: ApproverOption;
+  onSelect: (option: ApproverOption) => void;
+}): JSX.Element {
+  return (
+    <Button
+      data-testid="approver-candidate"
+      variant="text"
+      color="inherit"
+      onClick={() => onSelect(option)}
+      sx={{
+        justifyContent: "flex-start",
+        textTransform: "none",
+        px: 1,
+        py: 0.5,
+        gap: 1,
+      }}
+    >
+      <Avatar sx={{ width: 24, height: 24, fontSize: "0.7rem" }}>
+        {initialsOf(option.name)}
+      </Avatar>
+      <Box sx={{ minWidth: 0, textAlign: "left" }}>
+        <Typography variant="body2" noWrap>
+          {option.name}
+        </Typography>
+        {option.email && (
+          <Typography
+            variant="caption"
+            color="text.secondary"
+            noWrap
+            sx={{ display: "block" }}
+          >
+            {option.email}
+          </Typography>
+        )}
+      </Box>
+    </Button>
+  );
 }
 
 /** One activity row: a labelled whole-minutes input plus a proportion bar
@@ -278,6 +325,32 @@ export default function LogTimeCardDialog({
       )
       .map((u) => ({ id: u.id, name: fullName(u), email: u.email }));
   }, [data, hasApproverInput, me.email]);
+
+  // Previously-selected approvers (digiops-cs#2839) — surfaced before the
+  // engineer types anything, and prioritized within the typed results, so
+  // picking the same team lead again doesn't require retyping the same
+  // search every time. Only fetched in create mode: the approver field is
+  // read-only once editing, so there's nothing for this list to feed there.
+  const { data: recentApprovers = [] } = useRecentApprovers(!isEditMode);
+  // Merges recents matching the current query ahead of the live search's own
+  // candidates, deduped by id — a recent approver who still matches what was
+  // typed should stay at the top rather than getting buried in whatever order
+  // useSearchUsers's page happens to return. Not cross-referenced against
+  // `data?.users` for live eligibility: that list is itself scoped to the
+  // current (possibly empty) query and page-limited to 6, so filtering
+  // recents against it would risk dropping a genuinely still-eligible
+  // approver who simply isn't on that particular page — this is a minor UX
+  // nicety, not a security boundary, and the create action itself still
+  // validates the approver server-side either way.
+  const approverCandidates: ApproverOption[] = useMemo(() => {
+    if (!hasApproverInput) return recentApprovers;
+    const typed = approverInput.trim().toLowerCase();
+    const recentMatches = recentApprovers.filter((a) =>
+      a.name.toLowerCase().includes(typed),
+    );
+    const recentIds = new Set(recentMatches.map((a) => a.id));
+    return [...recentMatches, ...candidates.filter((c) => !recentIds.has(c.id))];
+  }, [approverInput, candidates, hasApproverInput, recentApprovers]);
 
   const setActivity = (key: ActivityKey, next: number): void =>
     setBreakdown((prev) => ({ ...prev, [key]: next }));
@@ -578,14 +651,36 @@ export default function LogTimeCardDialog({
                   }}
                 >
                   {!hasApproverInput ? (
-                    <Typography
-                      variant="caption"
-                      color="text.secondary"
-                      sx={{ p: 1 }}
-                    >
-                      Start typing to search for an approver.
-                    </Typography>
-                  ) : candidates.length === 0 ? (
+                    approverCandidates.length === 0 ? (
+                      <Typography
+                        variant="caption"
+                        color="text.secondary"
+                        sx={{ p: 1 }}
+                      >
+                        Start typing to search for an approver.
+                      </Typography>
+                    ) : (
+                      <>
+                        <Typography
+                          variant="caption"
+                          color="text.secondary"
+                          sx={{ px: 1, pt: 1 }}
+                        >
+                          Recently selected
+                        </Typography>
+                        {approverCandidates.map((u) => (
+                          <ApproverCandidateButton
+                            key={u.id}
+                            option={u}
+                            onSelect={(picked) => {
+                              setApprover({ id: picked.id, name: picked.name });
+                              setApproverInput("");
+                            }}
+                          />
+                        ))}
+                      </>
+                    )
+                  ) : approverCandidates.length === 0 ? (
                     <Typography
                       variant="caption"
                       color="text.secondary"
@@ -594,43 +689,15 @@ export default function LogTimeCardDialog({
                       No matching engineers.
                     </Typography>
                   ) : (
-                    candidates.map((u) => (
-                      <Button
+                    approverCandidates.map((u) => (
+                      <ApproverCandidateButton
                         key={u.id}
-                        data-testid="approver-candidate"
-                        variant="text"
-                        color="inherit"
-                        onClick={() => {
-                          setApprover({ id: u.id, name: u.name });
+                        option={u}
+                        onSelect={(picked) => {
+                          setApprover({ id: picked.id, name: picked.name });
                           setApproverInput("");
                         }}
-                        sx={{
-                          justifyContent: "flex-start",
-                          textTransform: "none",
-                          px: 1,
-                          py: 0.5,
-                          gap: 1,
-                        }}
-                      >
-                        <Avatar sx={{ width: 24, height: 24, fontSize: "0.7rem" }}>
-                          {initialsOf(u.name)}
-                        </Avatar>
-                        <Box sx={{ minWidth: 0, textAlign: "left" }}>
-                          <Typography variant="body2" noWrap>
-                            {u.name}
-                          </Typography>
-                          {u.email && (
-                            <Typography
-                              variant="caption"
-                              color="text.secondary"
-                              noWrap
-                              sx={{ display: "block" }}
-                            >
-                              {u.email}
-                            </Typography>
-                          )}
-                        </Box>
-                      </Button>
+                      />
                     ))
                   )}
                 </Box>

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/LogTimeCardDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/LogTimeCardDialog.tsx
@@ -331,17 +331,33 @@ export default function LogTimeCardDialog({
   // picking the same team lead again doesn't require retyping the same
   // search every time. Only fetched in create mode: the approver field is
   // read-only once editing, so there's nothing for this list to feed there.
-  const { data: recentApprovers = [] } = useRecentApprovers(!isEditMode);
+  const { data: rawRecentApprovers = [] } = useRecentApprovers(!isEditMode);
+  const recentApproverIds = useMemo(
+    () => rawRecentApprovers.map((a) => a.id),
+    [rawRecentApprovers],
+  );
+  // Re-checked against the same active/TIMECARD_APPROVER_GROUP eligibility as
+  // live search candidates: `rawRecentApprovers` is derived purely from past
+  // card submissions (see useRecentApprovers), so an approver deactivated or
+  // removed from the role since then would otherwise still show up here.
+  // Only queried once there's something to check (empty `userIds` would
+  // otherwise be an unscoped users search).
+  const { data: recentEligibility } = useSearchUsers(
+    {
+      filters: { userIds: recentApproverIds, roleIds: [TIMECARD_APPROVER_GROUP], active: true },
+      pagination: { limit: recentApproverIds.length || 1, offset: 0 },
+    },
+    recentApproverIds.length > 0,
+  );
+  const recentApprovers: ApproverOption[] = useMemo(() => {
+    if (recentApproverIds.length === 0) return [];
+    const eligibleIds = new Set((recentEligibility?.users ?? []).map((u) => u.id));
+    return rawRecentApprovers.filter((a) => eligibleIds.has(a.id));
+  }, [rawRecentApprovers, recentApproverIds, recentEligibility]);
   // Merges recents matching the current query ahead of the live search's own
   // candidates, deduped by id — a recent approver who still matches what was
   // typed should stay at the top rather than getting buried in whatever order
-  // useSearchUsers's page happens to return. Not cross-referenced against
-  // `data?.users` for live eligibility: that list is itself scoped to the
-  // current (possibly empty) query and page-limited to 6, so filtering
-  // recents against it would risk dropping a genuinely still-eligible
-  // approver who simply isn't on that particular page — this is a minor UX
-  // nicety, not a security boundary, and the create action itself still
-  // validates the approver server-side either way.
+  // useSearchUsers's page happens to return.
   const approverCandidates: ApproverOption[] = useMemo(() => {
     if (!hasApproverInput) return recentApprovers;
     const typed = approverInput.trim().toLowerCase();

--- a/apps/csm-portal/webapp/src/features/csm-users/api/useSearchUsers.ts
+++ b/apps/csm-portal/webapp/src/features/csm-users/api/useSearchUsers.ts
@@ -30,8 +30,13 @@ import {
  * (postgres `User` vs ServiceNow `SnUser`); the result is normalized into a
  * source-agnostic {@link NormalizedUserSearchResult} so callers don't branch
  * on the live data source.
+ *
+ * `enabled` (default `true`) skips the query entirely — for a caller that
+ * only wants to search once it has something to filter by (e.g. a `userIds`
+ * scope derived from another query), rather than firing against an empty or
+ * not-yet-known filter set.
  */
-export function useSearchUsers(request: SearchUsersRequest) {
+export function useSearchUsers(request: SearchUsersRequest, enabled = true) {
   const authFetch = useAuthApiClient();
 
   return useQuery<SearchUsersResponse, Error, NormalizedUserSearchResult>({
@@ -54,5 +59,6 @@ export function useSearchUsers(request: SearchUsersRequest) {
     select: normalizeUserSearchResponse,
     placeholderData: keepPreviousData,
     staleTime: 30_000,
+    enabled,
   });
 }

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -661,8 +661,8 @@ var snIssueTypeID = map[domain.CaseIssueType]int{
 type snCreateCasePayload struct {
 	Type                  string             `json:"type"`
 	ProjectID             string             `json:"projectId"`
-	DeploymentID          string             `json:"deploymentId"`
-	DeployedProductID     string             `json:"deployedProductId"`
+	DeploymentID          string             `json:"deploymentId,omitempty"`
+	DeployedProductID     string             `json:"deployedProductId,omitempty"`
 	Title                 string             `json:"title,omitempty"`
 	Description           string             `json:"description,omitempty"`
 	SeverityKey           int                `json:"severityKey,omitempty"`


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

This PR fixes the time-log dialog's approver search, case/CR relationship display, and the service-request project picker, plus an additional issue found while verifying the recently-merged announcement case-create feature against a local stack: creating an `"announcement"` case failed with a 400 because `snCreateCasePayload.DeploymentID`/`DeployedProductID` lacked `omitempty`, so the payload always sent `"deploymentId":""`/`"deployedProductId":""`, which fails the backing service's sysid pattern validation.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

- Time-log dialog: prioritize previously selected approvers.
- Case/CR relationship display and service-request project picker fixes.
- entity-service: omit `deploymentId`/`deployedProductId` from the case-create payload when empty (announcement cases have no deployment concept), instead of sending empty strings that fail upstream validation.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

Added `,omitempty` to the two JSON tags in `entity-service/internal/service/sn_case_service.go`'s `snCreateCasePayload` struct, alongside the time-log/case-display/project-picker fixes.

**Known follow-up (not in this PR):** this Go-side fix is necessary but not sufficient for announcement case creation to work end-to-end. `digiops-cs`'s `entity-service/modules/servicenow/openapi.yaml` still marks `deploymentId`/`deployedProductId` as `required` in the case-create schema for every case type, so Ballerina rejects the request with "required field 'deployedProductId' not present in JSON" even after this fix. That's a separate private-repo change, tracked separately.

## User stories
> Summary of user stories addressed by this change

N/A — internal CS-engineer-facing bug fixes.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Fixed the time-log dialog's approver search to prioritize previously selected approvers; fixed case/change-request relationship display and the service-request project picker; fixed announcement case creation sending empty deployment/deployed-product fields.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

N/A — no user-facing behavior or flow change requiring `/help` updates.

## Training
N/A

## Certification
N/A — no exam-relevant behavior change.

## Marketing
N/A

## Automation tests
 - Unit tests
   > `go test ./internal/service/...` passes with the `omitempty` change.
 - Integration tests
   > Verified live against a local stack (local Ballerina entity-service on current `digiops-cs` main → real ServiceNow DEV `wso2sndev`, real Asgardeo login): before the fix, announcement case creation returned a 400 from the sysid pattern validator; after the fix, that specific error is gone (a separate, already-tracked digiops-cs schema issue now surfaces instead).

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — Go backend; gosec run separately per repo convention, no findings on the changed file
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested

macOS, Go 1.26 toolchain, Ballerina 2201.12.7 (JDK 21.0.5), local stack against real ServiceNow DEV (`wso2sndev`) and real Asgardeo.

## Learning
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Project selectors can now filter results, including limiting service-request projects to eligible managed-cloud subscriptions.
  - Create-mode time card approval suggestions now show recent approvers first, with duplicate results removed.
- **Bug Fixes**
  - Linked change-request details now appear only for service-request cases.
  - Announcement case requests no longer send empty deployment fields.
- **Tests**
  - Added coverage for project filtering, case-specific widgets, and recent approver prioritization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->