### PR TITLE
[CSM Portal] make activity-feed author names and entry cards more prominent

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActivitiesFeed.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActivitiesFeed.tsx
@@ -301,7 +301,7 @@ export default function CaseActivitiesFeed({
             : "Nothing to show — enable more categories in the Filter menu."}
         </Typography>
       ) : (
-        <Box sx={{ display: "flex", flexDirection: "column", gap: 1.25 }}>
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 1.75 }}>
           {entries.map((e) => {
             if (e.kind === "comment") {
               return (
@@ -355,8 +355,12 @@ export default function CaseActivitiesFeed({
                       display: "flex",
                       flexDirection: "column",
                       gap: 0.75,
-                      backgroundColor: isBreach ? "error.50" : undefined,
-                      borderColor: isBreach ? "error.main" : undefined,
+                      // Same base card-separation fix as the comment bubble
+                      // (explicit elevated surface + stronger theme-derived
+                      // border) for the non-breach case; the breach styling
+                      // itself is untouched.
+                      backgroundColor: isBreach ? "error.50" : "background.paper",
+                      borderColor: isBreach ? "error.main" : "action.disabled",
                     }}
                   >
                     {/* Header mirrors the comment bubble: actor + time up top,
@@ -370,7 +374,7 @@ export default function CaseActivitiesFeed({
                         flexWrap: "wrap",
                       }}
                     >
-                      <Typography variant="subtitle2">
+                      <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
                         <UserRefLink
                           name={e.entry.actor}
                           email={e.entry.actorUser?.email}
@@ -448,6 +452,9 @@ export default function CaseActivitiesFeed({
                     display: "flex",
                     flexDirection: "column",
                     gap: 0.75,
+                    // Same base card-separation fix as the comment bubble.
+                    bgcolor: "background.paper",
+                    borderColor: "action.disabled",
                   }}
                 >
                   <Box
@@ -458,7 +465,7 @@ export default function CaseActivitiesFeed({
                       flexWrap: "wrap",
                     }}
                   >
-                    <Typography variant="subtitle2">
+                    <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
                       <UserRefLink
                         name={e.attachment.uploadedBy}
                         email={

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentBubble.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentBubble.tsx
@@ -339,6 +339,11 @@ export default function CsmCaseCommentBubble({
           display: "flex",
           flexDirection: "column",
           gap: 0.75,
+          // The default outlined-Paper divider is near-invisible against the
+          // page background in some theme presets; an elevated surface +
+          // stronger border keeps entries visually distinct in both themes.
+          bgcolor: "background.paper",
+          borderColor: "action.disabled",
           ...(isInternal && {
             bgcolor: "action.hover",
             borderColor: "divider",
@@ -348,7 +353,7 @@ export default function CsmCaseCommentBubble({
         }}
       >
         <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
-          <Typography variant="subtitle2">
+          <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
             {compact && "Commented by "}
             <UserRefLink
               name={comment.authorName}


### PR DESCRIPTION
## Purpose
Comment author names in a case's Activities timeline rendered at the same visual weight as surrounding chip/timestamp text, and individual activity entries (comments, lifecycle changes, attachments) had a near-invisible border/background against the page, so they read as one continuous block rather than distinct entries. Reported directly by a CS engineer reviewing the timeline.

## Goals
Make the author name clearly stand out on each activity entry, and make each entry read as a visually distinct card, in both light and dark theme, without touching the already-correct internal-note and SLA-breach styling.

## Approach
- Bumped the author-name `Typography` to `fontWeight: 600` (matches the existing bold-name convention used elsewhere in this codebase, e.g. `UserProfilePage.tsx`) on the comment bubble, the lifecycle/audit entry, and the attachment entry.
- Moved each entry's `Paper` onto the theme's `background.paper` elevated-surface token with an `action.disabled` border, replacing the near-invisible default outlined-Paper divider, in `CsmCaseCommentBubble.tsx` and `CaseActivitiesFeed.tsx`. `isInternal`/`isBreach` conditional styling is untouched.
- Slightly increased the gap between timeline entries (1.25 → 1.75) for a bit more breathing room.

Root-caused via live inspection: the affected `Paper variant="outlined"` computed to a border of `rgba(255,255,255,0.086)` against a `rgb(0,0,0)` page background, and the name `Typography` computed to `font-weight: 400`, indistinguishable from adjacent text.

Verified visually against staging data in both dark ("Acrylic Orange") and light theme.

## User stories
As a CS engineer reviewing a case's activity history, I can quickly tell who said what and where one entry ends and the next begins.

## Release note
Activity timeline entries on a case (comments, state changes, attachments) now have clearer visual separation, and the author's name is bolded for readability.

## Documentation
N/A — visual polish only, no new user-facing concept or workflow to document.

## Training
N/A — no training content covers this level of UI detail.

## Certification
N/A — not exam-relevant.

## Marketing
N/A — internal visual fix, not a marketable feature.

## Automation tests
- Unit tests
  Existing `CaseActivitiesFeed.test.tsx` (17 tests) and `CsmCaseCommentBubble.test.tsx` (20 tests) pass unmodified — none assert on the specific `sx` values changed here.
- Integration tests
  N/A — pure styling change, no behavior/data-flow change to integration-test.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — TypeScript/React change, not Java; `eslint` ran clean (0 errors, 2 pre-existing unrelated warnings in untouched files)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
None

## Migrations (if applicable)
N/A — no schema/data change

## Test environment
Verified via `pnpm run lint` and `pnpm exec vitest run` locally, and visually via the webapp running locally against the staging backend (real case data), Chrome, both light and dark theme presets.

## Learning
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved spacing and visual separation between case activity entries.
  * Updated activity and comment cards with consistent themed backgrounds and clearer borders.
  * Enhanced author and actor name typography with semi-bold styling.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->