### PR TITLE
[CSM Portal] make Created/Severity/State case-list headers sortable

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
@@ -36,6 +36,7 @@ import type {
 } from "@features/csm-cases/types/csmCases";
 import {
   DEFAULT_CASES_SORT,
+  type CasesSortField,
   type CasesSortOrder,
 } from "@features/csm-cases/utils/casesSort";
 
@@ -64,11 +65,13 @@ const EXACT_MATCH_LIMIT = 5;
  * `limit` / `offset` / `hasMore`).
  *
  * `page` is zero-based (matching MUI `TablePagination`); `pageSize` is the row
- * limit (≤ the backend's page-size cap, `BE_MAX_PAGE_LIMIT`). Cases are always sorted by `updatedOn`;
- * `sortOrder` (default `"desc"`) controls direction, so the cases page loads
- * the most recently updated cases on arrival by default but can be flipped
- * to oldest-updated-first. `enabled` is an optional escape hatch to suspend
- * the fetch.
+ * limit (≤ the backend's page-size cap, `BE_MAX_PAGE_LIMIT`). `sortField`
+ * (default `"updatedOn"`) picks which column drives the server-side sort —
+ * `createdOn`, `updatedOn`, `severity`, or `state` — and `sortOrder` (default
+ * `"desc"`) controls direction, so the cases page loads the most recently
+ * updated cases on arrival by default but can be flipped or repointed at a
+ * different column. `enabled` is an optional escape hatch to suspend the
+ * fetch.
  */
 export function useGetCsmCases(
   filters: CasesFilters,
@@ -76,6 +79,7 @@ export function useGetCsmCases(
   pageSize: number,
   enabled = true,
   sortOrder: CasesSortOrder = DEFAULT_CASES_SORT.order,
+  sortField: CasesSortField = DEFAULT_CASES_SORT.field,
 ): UseQueryResult<CsmCasesListResponse, Error> {
   const logger = useLogger();
   const api = useBackendApi();
@@ -140,6 +144,7 @@ export function useGetCsmCases(
       wantsMe ? (currentUserId ?? "") : "",
       page,
       pageSize,
+      sortField,
       sortOrder,
     ],
     queryFn: async (): Promise<CsmCasesListResponse> => {
@@ -177,7 +182,7 @@ export function useGetCsmCases(
       ): Promise<BeCaseSearchResponse> =>
         api.post<BeCaseSearchPayload, BeCaseSearchResponse>("/cases/search", {
           pagination,
-          sortBy: { field: "updatedOn", order: sortOrder },
+          sortBy: { field: sortField, order: sortOrder },
           filters: buildCaseSearchFilters(
             filters,
             search,

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.test.tsx
@@ -310,3 +310,90 @@ describe("CasesList optional columns", () => {
     expect(screen.queryByText("Created")).not.toBeInTheDocument();
   });
 });
+
+describe("CasesList sortable headers", () => {
+  function renderSortable(initialField: "createdOn" | "updatedOn" | "severity" | "state") {
+    const onSortFieldChange = vi.fn();
+    const onSortOrderChange = vi.fn();
+    renderWithProviders(
+      <Routes>
+        <Route
+          path="/cases"
+          element={
+            <CasesList
+              cases={[CASE]}
+              isLoading={false}
+              optionalColumns={["severity", "createdAt"]}
+              sortField={initialField}
+              sortOrder="desc"
+              onSortFieldChange={onSortFieldChange}
+              onSortOrderChange={onSortOrderChange}
+            />
+          }
+        />
+        <Route path="/cases/:id" element={<DetailStub />} />
+      </Routes>,
+      ["/cases"],
+    );
+    return { onSortFieldChange, onSortOrderChange };
+  }
+
+  it("activates a non-active header at desc order when clicked", () => {
+    const { onSortFieldChange, onSortOrderChange } = renderSortable("updatedOn");
+
+    fireEvent.click(screen.getByText("Created"));
+
+    expect(onSortFieldChange).toHaveBeenCalledWith("createdOn");
+    expect(onSortOrderChange).toHaveBeenCalledWith("desc");
+  });
+
+  it("toggles order when the already-active header is clicked again", () => {
+    const { onSortFieldChange, onSortOrderChange } = renderSortable("severity");
+
+    fireEvent.click(screen.getByText("Severity"));
+
+    expect(onSortFieldChange).not.toHaveBeenCalled();
+    expect(onSortOrderChange).toHaveBeenCalledWith("asc");
+  });
+
+  it("marks only the currently active column as sorted", () => {
+    renderSortable("state");
+
+    // MUI's `TableSortLabel` reflects the active column via `aria-sort` on
+    // its containing header text (rendered as a nested `<span>` here rather
+    // than a real `<th>`, so assert on the label's own active/inactive
+    // class instead of `aria-sort`).
+    const activeLabel = screen.getByText("State").closest(".MuiTableSortLabel-root");
+    const inactiveLabel = screen.getByText("Updated").closest(".MuiTableSortLabel-root");
+
+    expect(activeLabel).toHaveClass("Mui-active");
+    expect(inactiveLabel).not.toHaveClass("Mui-active");
+  });
+
+  it("renders every clickable header when sort props are wired up", () => {
+    renderSortable("updatedOn");
+
+    ["Created", "Severity", "State", "Updated"].forEach((label) => {
+      expect(screen.getByText(label).closest(".MuiTableSortLabel-root")).toBeInTheDocument();
+    });
+  });
+
+  it("keeps headers as plain text when no sort props are passed", () => {
+    renderWithProviders(
+      <Routes>
+        <Route
+          path="/cases"
+          element={
+            <CasesList cases={[CASE]} isLoading={false} optionalColumns={["severity", "createdAt"]} />
+          }
+        />
+        <Route path="/cases/:id" element={<DetailStub />} />
+      </Routes>,
+      ["/cases"],
+    );
+
+    ["Created", "Severity", "State", "Updated"].forEach((label) => {
+      expect(screen.getByText(label).closest(".MuiTableSortLabel-root")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesList.tsx
@@ -35,7 +35,10 @@ import StateChip from "@components/StateChip";
 import WorkStateChip from "@components/WorkStateChip";
 import CasePreviewDrawer from "@features/csm-cases/components/CasePreviewDrawer";
 import type { CsmCaseRow } from "@features/csm-cases/types/csmCases";
-import type { CasesSortOrder } from "@features/csm-cases/utils/casesSort";
+import type {
+  CasesSortField,
+  CasesSortOrder,
+} from "@features/csm-cases/utils/casesSort";
 import {
   CASE_TYPE_COLOR,
   CASE_TYPE_LABEL,
@@ -71,13 +74,28 @@ interface CasesListProps {
    * long-standing fixed set, gated only by `hideSeverityColumn`, exactly as
    * every other caller of `CasesList` already gets it. */
   optionalColumns?: CaseOptionalColumnId[];
-  /** Current sort order for the "Updated" column, when the caller wants it
-   * sortable. Omit both `sortOrder` and `onSortOrderChange` for a plain
-   * (non-interactive) header — the list is always server-sorted by
-   * `updatedOn`, this just lets the user flip the direction. */
+  /** Which column is currently driving the server-side sort — Updated and
+   * State are always present; Created and Severity only sort when their own
+   * optional column is visible (see `OPTIONAL_COLUMN_SORT_FIELD`). Pass all
+   * four of `sortField` / `sortOrder` / `onSortFieldChange` /
+   * `onSortOrderChange` together for sortable headers, or omit all four for
+   * plain (non-interactive) ones — a caller that only wants the legacy
+   * "Updated" toggle can still do that by wiring only the "Updated" click
+   * through, since every header's click handler always reports back through
+   * these same two callbacks. */
+  sortField?: CasesSortField;
+  onSortFieldChange?: (field: CasesSortField) => void;
   sortOrder?: CasesSortOrder;
   onSortOrderChange?: (order: CasesSortOrder) => void;
 }
+
+/** Maps the optional columns that double as sort headers to the field they
+ * sort by. Columns not listed here (Product, Type, Assignee, Customer) have
+ * no server-side sort of their own. */
+const OPTIONAL_COLUMN_SORT_FIELD: Partial<Record<CaseOptionalColumnId, CasesSortField>> = {
+  createdAt: "createdOn",
+  severity: "severity",
+};
 
 function renderOptionalCell(id: CaseOptionalColumnId, c: CsmCaseRow): JSX.Element {
   switch (id) {
@@ -151,6 +169,8 @@ export default function CasesList({
   detailBasePath,
   hideSeverityColumn = false,
   optionalColumns,
+  sortField,
+  onSortFieldChange,
   sortOrder,
   onSortOrderChange,
 }: CasesListProps): JSX.Element {
@@ -165,11 +185,65 @@ export default function CasesList({
   const effectiveOptionalColumns: CaseOptionalColumnId[] =
     optionalColumns ?? (hideSeverityColumn ? ["product"] : ["product", "type", "severity"]);
 
-  const headerCells = [
-    "Case ID",
-    "Subject",
-    ...effectiveOptionalColumns.map((id) => CASE_OPTIONAL_COLUMNS[id].label),
-    "State",
+  // Sortable headers only render as such when the caller wired up all four
+  // sort props — a caller that passes none of them (dashboard widgets, mini
+  // tables) keeps every header as plain, non-interactive text.
+  const sortInteractive =
+    sortField !== undefined &&
+    sortOrder !== undefined &&
+    onSortFieldChange !== undefined &&
+    onSortOrderChange !== undefined;
+
+  const handleSortClick = (field: CasesSortField): void => {
+    if (!onSortFieldChange || !onSortOrderChange) return;
+    if (field === sortField) {
+      onSortOrderChange(sortOrder === "desc" ? "asc" : "desc");
+    } else {
+      onSortFieldChange(field);
+      onSortOrderChange("desc");
+    }
+  };
+
+  function renderHeaderCell(label: string, field?: CasesSortField): JSX.Element {
+    if (!field || !sortInteractive) {
+      return (
+        <Typography
+          key={label}
+          variant="caption"
+          color="text.secondary"
+          sx={{ fontWeight: 600, textAlign: "left" }}
+        >
+          {label}
+        </Typography>
+      );
+    }
+    const isActive = field === sortField;
+    return (
+      <TableSortLabel
+        key={label}
+        active={isActive}
+        direction={isActive ? sortOrder : "desc"}
+        onClick={() => handleSortClick(field)}
+        sx={{
+          justifySelf: "start",
+          "& .MuiTableSortLabel-icon": { fontSize: "1rem" },
+        }}
+      >
+        <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 600 }}>
+          {label}
+        </Typography>
+      </TableSortLabel>
+    );
+  }
+
+  const headerCells: { label: string; sortableField?: CasesSortField }[] = [
+    { label: "Case ID" },
+    { label: "Subject" },
+    ...effectiveOptionalColumns.map((id) => ({
+      label: CASE_OPTIONAL_COLUMNS[id].label,
+      sortableField: OPTIONAL_COLUMN_SORT_FIELD[id],
+    })),
+    { label: "State", sortableField: "state" as CasesSortField },
   ];
   const gridTemplateColumns = [
     "auto",
@@ -216,45 +290,8 @@ export default function CasesList({
         >
           Preview
         </Typography>
-        {headerCells.map((label) => (
-          <Typography
-            key={label}
-            variant="caption"
-            color="text.secondary"
-            sx={{ fontWeight: 600, textAlign: "left" }}
-          >
-            {label}
-          </Typography>
-        ))}
-        {sortOrder && onSortOrderChange ? (
-          <TableSortLabel
-            active
-            direction={sortOrder}
-            onClick={() =>
-              onSortOrderChange(sortOrder === "desc" ? "asc" : "desc")
-            }
-            sx={{
-              justifySelf: "start",
-              "& .MuiTableSortLabel-icon": { fontSize: "1rem" },
-            }}
-          >
-            <Typography
-              variant="caption"
-              color="text.secondary"
-              sx={{ fontWeight: 600 }}
-            >
-              Updated
-            </Typography>
-          </TableSortLabel>
-        ) : (
-          <Typography
-            variant="caption"
-            color="text.secondary"
-            sx={{ fontWeight: 600, textAlign: "left" }}
-          >
-            Updated
-          </Typography>
-        )}
+        {headerCells.map((cell) => renderHeaderCell(cell.label, cell.sortableField))}
+        {renderHeaderCell("Updated", "updatedOn")}
       </Box>
 
       {/* Rows */}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmIssuesView.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmIssuesView.tsx
@@ -65,6 +65,7 @@ import {
 } from "@features/csm-cases/utils/casesFiltersUrl";
 import {
   DEFAULT_CASES_SORT,
+  type CasesSortField,
   type CasesSortOrder,
 } from "@features/csm-cases/utils/casesSort";
 import { stateLabel } from "@features/csm-dashboard/utils/abtDashboard";
@@ -206,6 +207,9 @@ export default function CsmIssuesView({
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_ROWS_PER_PAGE);
   const [isFiltersOpen, setIsFiltersOpen] = useState(true);
+  const [sortField, setSortField] = useState<CasesSortField>(
+    DEFAULT_CASES_SORT.field,
+  );
   const [sortOrder, setSortOrder] = useState<CasesSortOrder>(
     DEFAULT_CASES_SORT.order,
   );
@@ -274,7 +278,12 @@ export default function CsmIssuesView({
     error,
     refetch,
     dataUpdatedAt,
-  } = useGetCsmCases(queryFilters, page, rowsPerPage, true, sortOrder);
+  } = useGetCsmCases(queryFilters, page, rowsPerPage, true, sortOrder, sortField);
+
+  const handleSortFieldChange = (field: CasesSortField): void => {
+    setSortField(field);
+    setPage(0);
+  };
 
   const handleSortOrderChange = (order: CasesSortOrder): void => {
     setSortOrder(order);
@@ -352,14 +361,14 @@ export default function CsmIssuesView({
         "/cases/search",
         {
           pagination: { offset, limit },
-          sortBy: { field: "updatedOn", order: sortOrder },
+          sortBy: { field: sortField, order: sortOrder },
           filters: buildCaseSearchFilters(queryFilters, exportSearch, assignedUserIds),
         },
       );
       const items = (res.cases ?? []).map((c) => mapCaseSearchViewToRow(c, currentUserEmail));
       return { items, total: res.total };
     },
-    [api, queryFilters, exportSearch, sortOrder, currentUserId, currentUserEmail],
+    [api, queryFilters, exportSearch, sortField, sortOrder, currentUserId, currentUserEmail],
   );
 
   // Same gate `CasesList` is given (`hideSeverityColumn={isServiceRequestOnly
@@ -545,6 +554,8 @@ export default function CsmIssuesView({
             ? columnPrefs.visibleColumns.map((c) => c.id as CaseOptionalColumnId)
             : undefined
         }
+        sortField={sortField}
+        onSortFieldChange={handleSortFieldChange}
         sortOrder={sortOrder}
         onSortOrderChange={handleSortOrderChange}
       />

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/casesSort.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/casesSort.ts
@@ -15,12 +15,12 @@
 // under the License.
 
 /**
- * Sort fields the cases list exposes to the user via the "Updated" column
- * header. `/cases/search` also accepts `severity` / `state` (see
- * `BeCaseSortField`), but those columns already have their own filters and
- * don't need a sort toggle.
+ * Sort fields the cases list exposes to the user via a clickable column
+ * header: Created, Updated, Severity, and State. Matches `BeCaseSortField`
+ * one-for-one (see `@api/backend/types`) — every value here is already
+ * accepted end-to-end by `/cases/search`.
  */
-export type CasesSortField = "createdOn" | "updatedOn";
+export type CasesSortField = "createdOn" | "updatedOn" | "severity" | "state";
 export type CasesSortOrder = "asc" | "desc";
 
 export const DEFAULT_CASES_SORT: {


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

CS engineers can currently only flip the sort *direction* on the case list, always ordered by "Updated" — there's no way to sort by created date, severity, or state. We're adding sort-by-column support for the other attributes the backend already accepts.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

Let a user click any of the Created / Severity / State / Updated column headers to sort by that attribute, in addition to the existing direction toggle.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

`CasesList`'s single hardcoded "Updated"-only `TableSortLabel` is generalized to a `sortField`/`onSortFieldChange` prop pair (alongside the existing `sortOrder`/`onSortOrderChange`), rendered on every header that maps to a backend sort field: Created (the existing `createdAt` optional column), Severity (the existing `severity` optional column, when visible), State (always-present), and Updated. Clicking an inactive header activates it at descending order; clicking the active header toggles direction — matching today's Updated-only behavior exactly. No backend or API contract change: `/cases/search`'s `sortBy.field` already accepts `createdOn`/`updatedOn`/`severity`/`state` end-to-end.

Callers that don't wire the new props (dashboard widgets, mini tables, the preview page) are unaffected — the new props are fully optional and the header falls back to plain, non-interactive text exactly as before.

No screenshot attached (small header-interaction change, no visual layout change to the table itself — the sort icon already existed on the Updated column).

## User stories
> Summary of user stories addressed by this change

As a CS engineer, I want to sort the case list by created date, severity, or state, not just last-updated, so I can triage in the order that matters for what I'm doing.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Case list: the Created, Severity, and State column headers are now clickable to sort by that attribute, alongside the existing Updated column sort.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there's no doc impact

N/A — no in-app `/help` topic documents the case-list's sort behavior specifically (checked `features/help/content/`), so there's nothing stale to update.

## Training
N/A — no training content references case-list sort behavior.

## Certification
N/A — no certification exam content covers case-list sort behavior.

## Marketing
N/A — internal CS-tooling UX improvement, no external marketing surface.

## Automation tests
 - Unit tests
   > Code coverage information

Extended `CasesList.test.tsx` with coverage for: clicking a non-active header activates it at descending order; clicking the active header toggles order; only one column is ever marked active; all four sortable headers render as `TableSortLabel` when sort props are wired, and as plain text when they're not.

 - Integration tests
   > Details about the test cases and coverage

N/A — no integration-test layer for this webapp beyond Vitest component tests + Playwright e2e; no e2e change needed for a header-click interaction already covered at the component level.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — TypeScript/React frontend, not a Java/Go target for FindSecurityBugs; `eslint` ran clean (0 errors, 2 pre-existing warnings unrelated to this change)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no sample app impact.

## Related PRs
None.

## Migrations (if applicable)
N/A — no schema, data, or config migration; pure frontend sort-control change.

## Test environment
Verified locally: `pnpm run lint`, `pnpm run test` (full suite: 212 files / 2162 tests passed), and `tsc -b --noEmit` (typecheck clean aside from one pre-existing, unrelated failing test file confirmed to predate this change).

## Learning
N/A — straightforward extension of an existing, already-established sort-header pattern in this codebase; no new research needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added server-side sorting for case lists by Updated, State, Created, and Severity.
  * Sort selections now apply consistently to case results and CSV exports.
  * Sorting by a different field resets pagination.
* **Bug Fixes**
  * Improved sort indicators and header interactions, including active-column styling and order toggling.
  * Headers remain plain text when sorting is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->