### PR TITLE
[CSM Portal] align deployments section with customer portal (update-history, attachments, cores/tps fix)

### DIFF
--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -147,6 +147,8 @@ func main() {
 	mux.HandleFunc("POST /attachments/search", caseHandler.SearchCaseAttachments)
 	mux.HandleFunc("GET /attachments/{id}/content", caseHandler.GetCaseAttachmentContent)
 	mux.HandleFunc("DELETE /attachments/{id}", caseHandler.DeleteCaseAttachment)
+	mux.HandleFunc("GET /attachments/{id}", caseHandler.GetAttachment)
+	mux.HandleFunc("PATCH /attachments/{id}", caseHandler.UpdateAttachment)
 	mux.HandleFunc("POST /cases/{id}/call-requests", caseHandler.CreateCallRequest)
 	mux.HandleFunc("POST /cases/{id}/call-requests/search", caseHandler.SearchCallRequests)
 	mux.HandleFunc("POST /call-requests/search", caseHandler.SearchAllCallRequests)

--- a/apps/csm-portal/backend/internal/entity/customer.go
+++ b/apps/csm-portal/backend/internal/entity/customer.go
@@ -384,6 +384,18 @@ func (c *CustomerEntityClient) DeleteCaseAttachment(ctx context.Context, attachm
 	return c.do(ctx, http.MethodDelete, fmt.Sprintf("/attachments/%s", url.PathEscape(attachmentID)), nil)
 }
 
+// GetAttachment calls GET /attachments/{attachmentId} on the entity service.
+// Response is returned as raw JSON.
+func (c *CustomerEntityClient) GetAttachment(ctx context.Context, attachmentID string) ([]byte, error) {
+	return c.do(ctx, http.MethodGet, fmt.Sprintf("/attachments/%s", url.PathEscape(attachmentID)), nil)
+}
+
+// UpdateAttachment calls PATCH /attachments/{attachmentId} on the entity service.
+// Response is returned as raw JSON.
+func (c *CustomerEntityClient) UpdateAttachment(ctx context.Context, attachmentID string, body []byte) ([]byte, error) {
+	return c.do(ctx, http.MethodPatch, fmt.Sprintf("/attachments/%s", url.PathEscape(attachmentID)), body)
+}
+
 // SearchCatalogs calls POST /catalogs/search on the entity service.
 // Response is returned as raw JSON.
 func (c *CustomerEntityClient) SearchCatalogs(ctx context.Context, body []byte) ([]byte, error) {

--- a/apps/csm-portal/backend/internal/handler/cases.go
+++ b/apps/csm-portal/backend/internal/handler/cases.go
@@ -17,6 +17,7 @@
 package handler
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -729,7 +730,9 @@ func validateUpdateAttachmentBody(body []byte) bool {
 	}
 
 	var req updateAttachmentRequest
-	if err := json.Unmarshal(body, &req); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(body))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&req); err != nil {
 		return false
 	}
 	if req.ReferenceID == "" || !uuidRe.MatchString(req.ReferenceID) {

--- a/apps/csm-portal/backend/internal/handler/cases.go
+++ b/apps/csm-portal/backend/internal/handler/cases.go
@@ -692,10 +692,61 @@ func (h *CaseHandler) GetAttachment(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, result)
 }
 
+// validAttachmentReferenceTypes mirrors the entity service's own
+// validReferenceTypes allowlist for attachment operations (sn_case_service.go),
+// so an obviously invalid referenceType is rejected at this boundary instead
+// of reaching the entity service.
+var validAttachmentReferenceTypes = map[string]bool{
+	"case":           true,
+	"conversation":   true,
+	"change_request": true,
+	"deployment":     true,
+	"incident":       true,
+}
+
+// updateAttachmentRequest mirrors the entity service's domain.UpdateAttachmentRequest
+// shape. Description uses json.RawMessage (rather than *string) so an explicit
+// JSON null (clear the description) can be distinguished from an absent field,
+// matching the entity service's own tri-state semantics for this field.
+type updateAttachmentRequest struct {
+	ReferenceID   string          `json:"referenceId"`
+	ReferenceType string          `json:"referenceType"`
+	Name          *string         `json:"name,omitempty"`
+	Description   json.RawMessage `json:"description,omitempty"`
+}
+
+// validateUpdateAttachmentBody rejects a non-object body (including null and
+// arrays), a missing/invalid referenceId, an invalid referenceType, and a body
+// where neither name nor description is present, so obviously invalid requests
+// are rejected before reaching the entity service.
+func validateUpdateAttachmentBody(body []byte) bool {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(body, &fields); err != nil {
+		return false
+	}
+	if len(fields) == 0 {
+		return false
+	}
+
+	var req updateAttachmentRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return false
+	}
+	if req.ReferenceID == "" || !uuidRe.MatchString(req.ReferenceID) {
+		return false
+	}
+	if !validAttachmentReferenceTypes[req.ReferenceType] {
+		return false
+	}
+	if req.Name == nil && len(req.Description) == 0 {
+		return false
+	}
+	return true
+}
+
 // UpdateAttachment handles PATCH /attachments/{id}.
 // Accepts referenceId, referenceType, and optionally name/description; the body
-// is forwarded verbatim, since the requirement that at least one of
-// name/description is present is validated upstream by the entity service.
+// is forwarded verbatim once validated.
 func (h *CaseHandler) UpdateAttachment(w http.ResponseWriter, r *http.Request) {
 	user := middleware.UserInfoFromContext(r.Context())
 	if user == nil {
@@ -725,10 +776,15 @@ func (h *CaseHandler) UpdateAttachment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if !validateUpdateAttachmentBody(body) {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
 	result, err := h.entity.UpdateAttachment(r.Context(), attachmentID, body)
 	if err != nil {
 		slog.ErrorContext(r.Context(), "entity UpdateAttachment failed", "userID", user.UserID, "attachmentID", attachmentID, "err", err)
-		mapUpstreamError(w, err, "Failed to update attachment.")
+		mapUpstreamErrorGeneric(w, err, "Failed to update attachment.")
 		return
 	}
 

--- a/apps/csm-portal/backend/internal/handler/cases.go
+++ b/apps/csm-portal/backend/internal/handler/cases.go
@@ -82,6 +82,8 @@ type entityCaseClient interface {
 	SearchCaseAttachments(ctx context.Context, body []byte) ([]byte, error)
 	GetCaseAttachmentContent(ctx context.Context, attachmentID string) ([]byte, string, error)
 	DeleteCaseAttachment(ctx context.Context, attachmentID string) ([]byte, error)
+	GetAttachment(ctx context.Context, attachmentID string) ([]byte, error)
+	UpdateAttachment(ctx context.Context, attachmentID string, body []byte) ([]byte, error)
 	CreateCallRequest(ctx context.Context, body []byte) ([]byte, error)
 	SearchCallRequests(ctx context.Context, body []byte) ([]byte, error)
 	SearchAllCallRequests(ctx context.Context, body []byte) ([]byte, error)
@@ -658,6 +660,75 @@ func (h *CaseHandler) DeleteCaseAttachment(w http.ResponseWriter, r *http.Reques
 	if err != nil {
 		slog.ErrorContext(r.Context(), "entity DeleteCaseAttachment failed", "userID", user.UserID, "attachmentID", attachmentID, "err", err)
 		mapUpstreamErrorGeneric(w, err, "Failed to delete case attachment.")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, result)
+}
+
+// GetAttachment handles GET /attachments/{id}.
+// Returns the attachment's metadata as JSON; for the binary file contents, see
+// GetCaseAttachmentContent (GET /attachments/{id}/content).
+func (h *CaseHandler) GetAttachment(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	attachmentID := r.PathValue("id")
+	if attachmentID == "" || !uuidRe.MatchString(attachmentID) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	result, err := h.entity.GetAttachment(r.Context(), attachmentID)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity GetAttachment failed", "userID", user.UserID, "attachmentID", attachmentID, "err", err)
+		mapUpstreamErrorGeneric(w, err, "Failed to retrieve attachment.")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, result)
+}
+
+// UpdateAttachment handles PATCH /attachments/{id}.
+// Accepts referenceId, referenceType, and optionally name/description; the body
+// is forwarded verbatim, since the requirement that at least one of
+// name/description is present is validated upstream by the entity service.
+func (h *CaseHandler) UpdateAttachment(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	attachmentID := r.PathValue("id")
+	if attachmentID == "" || !uuidRe.MatchString(attachmentID) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		if _, ok := err.(*http.MaxBytesError); ok {
+			writeError(w, http.StatusRequestEntityTooLarge, ErrMsgTooLarge)
+			return
+		}
+		writeError(w, http.StatusBadRequest, errMsgReadBody)
+		return
+	}
+
+	if !json.Valid(body) {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.UpdateAttachment(r.Context(), attachmentID, body)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity UpdateAttachment failed", "userID", user.UserID, "attachmentID", attachmentID, "err", err)
+		mapUpstreamError(w, err, "Failed to update attachment.")
 		return
 	}
 

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -1957,6 +1957,202 @@ func TestGetCaseAttachmentContent(t *testing.T) {
 	})
 }
 
+// ----- GetAttachment -----
+
+func TestGetAttachment(t *testing.T) {
+	const testAttachmentID = "22222222-2222-2222-2222-222222222222"
+
+	t.Run("requires authenticated user", func(t *testing.T) {
+		h := NewCaseHandler(&mockEntityCaseClient{})
+		r := httptest.NewRequest(http.MethodGet, "/attachments/"+testAttachmentID, nil)
+		r.SetPathValue("id", testAttachmentID)
+		w := httptest.NewRecorder()
+		h.GetAttachment(w, r)
+		assertStatus(t, w, http.StatusUnauthorized)
+		assertErrorMessage(t, w, ErrMsgUnauthorized)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects empty attachment ID", func(t *testing.T) {
+		h := NewCaseHandler(&mockEntityCaseClient{})
+		r := withUser(httptest.NewRequest(http.MethodGet, "/attachments/", nil))
+		w := httptest.NewRecorder()
+		h.GetAttachment(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgInvalidUUID)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects non-UUID attachment ID", func(t *testing.T) {
+		h := NewCaseHandler(&mockEntityCaseClient{})
+		r := withUser(httptest.NewRequest(http.MethodGet, "/attachments/not-a-uuid", nil))
+		r.SetPathValue("id", "not-a-uuid")
+		w := httptest.NewRecorder()
+		h.GetAttachment(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgInvalidUUID)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("forwards attachment ID and returns upstream metadata", func(t *testing.T) {
+		const upstreamResp = `{"id":"` + testAttachmentID + `","name":"screenshot.png","description":"a screenshot"}`
+		var capturedID string
+		client := &mockEntityCaseClient{
+			getAttachmentFn: func(_ context.Context, attachmentID string) ([]byte, error) {
+				capturedID = attachmentID
+				return []byte(upstreamResp), nil
+			},
+		}
+		h := NewCaseHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodGet, "/attachments/"+testAttachmentID, nil))
+		r.SetPathValue("id", testAttachmentID)
+		w := httptest.NewRecorder()
+		h.GetAttachment(w, r)
+
+		assertStatus(t, w, http.StatusOK)
+		assertContentType(t, w, "application/json")
+		if capturedID != testAttachmentID {
+			t.Errorf("upstream received attachmentID %q, want %q", capturedID, testAttachmentID)
+		}
+		if w.Body.String() != upstreamResp {
+			t.Errorf("body = %q, want %q", w.Body.String(), upstreamResp)
+		}
+	})
+
+	t.Run("maps upstream errors", func(t *testing.T) {
+		for _, tc := range upstreamErrorsGeneric("Failed to retrieve attachment.") {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				client := &mockEntityCaseClient{
+					getAttachmentFn: func(_ context.Context, _ string) ([]byte, error) {
+						return nil, tc.err
+					},
+				}
+				h := NewCaseHandler(client)
+				r := withUser(httptest.NewRequest(http.MethodGet, "/attachments/"+testAttachmentID, nil))
+				r.SetPathValue("id", testAttachmentID)
+				w := httptest.NewRecorder()
+				h.GetAttachment(w, r)
+				assertStatus(t, w, tc.wantCode)
+				assertErrorMessage(t, w, tc.wantMsg)
+				assertContentType(t, w, "application/json")
+			})
+		}
+	})
+}
+
+// ----- UpdateAttachment -----
+
+func TestUpdateAttachment(t *testing.T) {
+	const testAttachmentID = "22222222-2222-2222-2222-222222222222"
+	const validPayload = `{"referenceId":"11111111-1111-1111-1111-111111111111","referenceType":"case","name":"renamed.png"}`
+
+	t.Run("requires authenticated user", func(t *testing.T) {
+		h := NewCaseHandler(&mockEntityCaseClient{})
+		r := httptest.NewRequest(http.MethodPatch, "/attachments/"+testAttachmentID, strings.NewReader(validPayload))
+		r.SetPathValue("id", testAttachmentID)
+		w := httptest.NewRecorder()
+		h.UpdateAttachment(w, r)
+		assertStatus(t, w, http.StatusUnauthorized)
+		assertErrorMessage(t, w, ErrMsgUnauthorized)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects empty attachment ID", func(t *testing.T) {
+		h := NewCaseHandler(&mockEntityCaseClient{})
+		r := withUser(httptest.NewRequest(http.MethodPatch, "/attachments/", strings.NewReader(validPayload)))
+		w := httptest.NewRecorder()
+		h.UpdateAttachment(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgInvalidUUID)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects non-UUID attachment ID", func(t *testing.T) {
+		h := NewCaseHandler(&mockEntityCaseClient{})
+		r := withUser(httptest.NewRequest(http.MethodPatch, "/attachments/not-a-uuid", strings.NewReader(validPayload)))
+		r.SetPathValue("id", "not-a-uuid")
+		w := httptest.NewRecorder()
+		h.UpdateAttachment(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgInvalidUUID)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects body exceeding 1 MiB", func(t *testing.T) {
+		h := NewCaseHandler(&mockEntityCaseClient{})
+		r := withUser(httptest.NewRequest(http.MethodPatch, "/attachments/"+testAttachmentID, strings.NewReader(strings.Repeat("x", maxRequestBodyBytes+1))))
+		r.SetPathValue("id", testAttachmentID)
+		w := httptest.NewRecorder()
+		h.UpdateAttachment(w, r)
+		assertStatus(t, w, http.StatusRequestEntityTooLarge)
+		assertErrorMessage(t, w, ErrMsgTooLarge)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects invalid JSON body", func(t *testing.T) {
+		h := NewCaseHandler(&mockEntityCaseClient{})
+		r := withUser(httptest.NewRequest(http.MethodPatch, "/attachments/"+testAttachmentID, strings.NewReader(`not-json`)))
+		r.SetPathValue("id", testAttachmentID)
+		w := httptest.NewRecorder()
+		h.UpdateAttachment(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("forwards attachment ID and body, returns 200 with upstream response", func(t *testing.T) {
+		var capturedID string
+		var capturedBody []byte
+		const upstreamResp = `{"id":"` + testAttachmentID + `","name":"renamed.png"}`
+		client := &mockEntityCaseClient{
+			updateAttachmentFn: func(_ context.Context, attachmentID string, body []byte) ([]byte, error) {
+				capturedID = attachmentID
+				capturedBody = body
+				return []byte(upstreamResp), nil
+			},
+		}
+		h := NewCaseHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPatch, "/attachments/"+testAttachmentID, strings.NewReader(validPayload)))
+		r.SetPathValue("id", testAttachmentID)
+		w := httptest.NewRecorder()
+		h.UpdateAttachment(w, r)
+
+		assertStatus(t, w, http.StatusOK)
+		assertContentType(t, w, "application/json")
+		if capturedID != testAttachmentID {
+			t.Errorf("upstream received attachmentID %q, want %q", capturedID, testAttachmentID)
+		}
+		if string(capturedBody) != validPayload {
+			t.Errorf("upstream received body %q, want %q", capturedBody, validPayload)
+		}
+		if w.Body.String() != upstreamResp {
+			t.Errorf("body = %q, want %q", w.Body.String(), upstreamResp)
+		}
+	})
+
+	t.Run("maps upstream errors", func(t *testing.T) {
+		for _, tc := range upstreamErrors("Failed to update attachment.") {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				client := &mockEntityCaseClient{
+					updateAttachmentFn: func(_ context.Context, _ string, _ []byte) ([]byte, error) {
+						return nil, tc.err
+					},
+				}
+				h := NewCaseHandler(client)
+				r := withUser(httptest.NewRequest(http.MethodPatch, "/attachments/"+testAttachmentID, strings.NewReader(validPayload)))
+				r.SetPathValue("id", testAttachmentID)
+				w := httptest.NewRecorder()
+				h.UpdateAttachment(w, r)
+				assertStatus(t, w, tc.wantCode)
+				assertErrorMessage(t, w, tc.wantMsg)
+				assertContentType(t, w, "application/json")
+			})
+		}
+	})
+}
+
 func TestCreateCaseGithubIssue(t *testing.T) {
 	const caseID = "11111111-1111-1111-1111-111111111111"
 

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -2101,6 +2101,46 @@ func TestUpdateAttachment(t *testing.T) {
 		assertContentType(t, w, "application/json")
 	})
 
+	invalidBodies := []struct {
+		name string
+		body string
+	}{
+		{"null body", `null`},
+		{"array body", `[]`},
+		{"empty object", `{}`},
+		{"missing referenceId", `{"referenceType":"case","name":"renamed.png"}`},
+		{"invalid referenceId", `{"referenceId":"not-a-uuid","referenceType":"case","name":"renamed.png"}`},
+		{"invalid referenceType", `{"referenceId":"11111111-1111-1111-1111-111111111111","referenceType":"bogus","name":"renamed.png"}`},
+		{"neither name nor description", `{"referenceId":"11111111-1111-1111-1111-111111111111","referenceType":"case"}`},
+	}
+	for _, tc := range invalidBodies {
+		t.Run("rejects "+tc.name, func(t *testing.T) {
+			h := NewCaseHandler(&mockEntityCaseClient{})
+			r := withUser(httptest.NewRequest(http.MethodPatch, "/attachments/"+testAttachmentID, strings.NewReader(tc.body)))
+			r.SetPathValue("id", testAttachmentID)
+			w := httptest.NewRecorder()
+			h.UpdateAttachment(w, r)
+			assertStatus(t, w, http.StatusBadRequest)
+			assertErrorMessage(t, w, ErrMsgBadRequest)
+			assertContentType(t, w, "application/json")
+		})
+	}
+
+	t.Run("accepts description-only update with explicit null (clear)", func(t *testing.T) {
+		const payload = `{"referenceId":"11111111-1111-1111-1111-111111111111","referenceType":"deployment","description":null}`
+		client := &mockEntityCaseClient{
+			updateAttachmentFn: func(_ context.Context, _ string, _ []byte) ([]byte, error) {
+				return []byte(`{}`), nil
+			},
+		}
+		h := NewCaseHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPatch, "/attachments/"+testAttachmentID, strings.NewReader(payload)))
+		r.SetPathValue("id", testAttachmentID)
+		w := httptest.NewRecorder()
+		h.UpdateAttachment(w, r)
+		assertStatus(t, w, http.StatusOK)
+	})
+
 	t.Run("forwards attachment ID and body, returns 200 with upstream response", func(t *testing.T) {
 		var capturedID string
 		var capturedBody []byte
@@ -2132,7 +2172,7 @@ func TestUpdateAttachment(t *testing.T) {
 	})
 
 	t.Run("maps upstream errors", func(t *testing.T) {
-		for _, tc := range upstreamErrors("Failed to update attachment.") {
+		for _, tc := range upstreamErrorsGeneric("Failed to update attachment.") {
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 				client := &mockEntityCaseClient{

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -2112,6 +2112,7 @@ func TestUpdateAttachment(t *testing.T) {
 		{"invalid referenceId", `{"referenceId":"not-a-uuid","referenceType":"case","name":"renamed.png"}`},
 		{"invalid referenceType", `{"referenceId":"11111111-1111-1111-1111-111111111111","referenceType":"bogus","name":"renamed.png"}`},
 		{"neither name nor description", `{"referenceId":"11111111-1111-1111-1111-111111111111","referenceType":"case"}`},
+		{"unknown field", `{"referenceId":"11111111-1111-1111-1111-111111111111","referenceType":"case","name":"renamed.png","extra":"nope"}`},
 	}
 	for _, tc := range invalidBodies {
 		t.Run("rejects "+tc.name, func(t *testing.T) {

--- a/apps/csm-portal/backend/internal/handler/helpers_test.go
+++ b/apps/csm-portal/backend/internal/handler/helpers_test.go
@@ -107,6 +107,8 @@ type mockEntityCaseClient struct {
 	searchCaseAttachmentsFn    func(ctx context.Context, body []byte) ([]byte, error)
 	getCaseAttachmentContentFn func(ctx context.Context, attachmentID string) ([]byte, string, error)
 	deleteCaseAttachmentFn     func(ctx context.Context, attachmentID string) ([]byte, error)
+	getAttachmentFn            func(ctx context.Context, attachmentID string) ([]byte, error)
+	updateAttachmentFn         func(ctx context.Context, attachmentID string, body []byte) ([]byte, error)
 	createCallRequestFn        func(ctx context.Context, body []byte) ([]byte, error)
 	searchCallRequestsFn       func(ctx context.Context, body []byte) ([]byte, error)
 	searchAllCallRequestsFn    func(ctx context.Context, body []byte) ([]byte, error)
@@ -210,6 +212,20 @@ func (m *mockEntityCaseClient) DeleteCaseAttachment(ctx context.Context, attachm
 		return m.deleteCaseAttachmentFn(ctx, attachmentID)
 	}
 	return []byte(`{"message":"Attachment deleted successfully."}`), nil
+}
+
+func (m *mockEntityCaseClient) GetAttachment(ctx context.Context, attachmentID string) ([]byte, error) {
+	if m.getAttachmentFn != nil {
+		return m.getAttachmentFn(ctx, attachmentID)
+	}
+	return []byte(`{}`), nil
+}
+
+func (m *mockEntityCaseClient) UpdateAttachment(ctx context.Context, attachmentID string, body []byte) ([]byte, error) {
+	if m.updateAttachmentFn != nil {
+		return m.updateAttachmentFn(ctx, attachmentID, body)
+	}
+	return []byte(`{}`), nil
 }
 
 func (m *mockEntityCaseClient) CreateCallRequest(ctx context.Context, body []byte) ([]byte, error) {

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -6347,6 +6347,8 @@ components:
             - taskSLABusinessElapsedPercent
             - escalationLevel
             - escalation
+            - slaBreached
+            - accountEscalationActive
             - number
             - internalId
         op:
@@ -6444,6 +6446,16 @@ components:
         - **escalation** (isEmpty / isNotEmpty): values ignored; isEmpty
           matches cases with no active escalation, isNotEmpty matches cases
           with an active escalation.
+        - **slaBreached** (eq): "true"/"false". Matches cases with a
+          currently-breached SLA against ServiceNow's own named SLA
+          definition set (task_sla.has_breached + stage=in_progress). Only
+          applied by the ServiceNow data source.
+        - **accountEscalationActive** (eq): "true"/"false". Matches cases
+          whose ACCOUNT currently has an active escalation
+          (active_account_escalation.state in Requested/Escalated) --
+          distinct from **escalation** above, which is a case-level flag.
+          The two are independent and may both be queried. Only applied by
+          the ServiceNow data source.
         - **number** (eq): a single case number (e.g. "CS0441174"); matches
           exactly. Routed as a first-class filter rather than through the
           free-text searchQuery scan.
@@ -10779,6 +10791,41 @@ components:
                 A single incident number (e.g. "INC0010001"); matches
                 exactly. Routed as a first-class filter rather than through
                 the free-text searchQuery scan.
+            state:
+              type: array
+              items:
+                type: string
+              description: >-
+                Incident state keys (e.g. "NEW", "IN_PROGRESS", "CLOSED",
+                "CANCELLED"). Already accepted by the entity-service today;
+                documented here to catch this schema up to what the code
+                actually accepts.
+            businessServiceId:
+              type: array
+              items:
+                type: string
+                format: uuid
+              description: >-
+                Business-service UUIDs. Already accepted by the
+                entity-service today; documented here to catch this schema
+                up to what the code actually accepts.
+            slaViolated:
+              type: boolean
+              description: >-
+                Whether the incident has a breached SLA, derived from
+                task_sla.has_breached (a related-list join), not from
+                ServiceNow's raw made_sla field -- deliberately more
+                reliable than made_sla, which catches only a small fraction
+                of actually-breached incidents on this instance. Prefer
+                this field for correctness-sensitive SLA-breach filtering.
+            madeSla:
+              type: boolean
+              description: >-
+                ServiceNow's raw made_sla field on the incident. Different
+                from, and less reliable than, slaViolated above -- kept
+                only for exact parity with ServiceNow dashboards/reports
+                that filter on this raw field directly. Do not use this for
+                general SLA-breach filtering; use slaViolated instead.
         sortBy:
           type: object
           properties:

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -956,6 +956,115 @@ paths:
                 $ref: '#/components/schemas/ErrorPayload'
 
   /attachments/{id}:
+    get:
+      summary: Get a case attachment's metadata.
+      operationId: getAttachment
+      parameters:
+        - name: id
+          in: path
+          description: UUID of the attachment.
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Attachment'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: NotFound
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+    patch:
+      summary: Update a case attachment's name and/or description.
+      operationId: updateAttachment
+      requestBody:
+        description: At least one of name or description must be provided (enforced upstream by the entity service).
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AttachmentUpdatePayload'
+      parameters:
+        - name: id
+          in: path
+          description: UUID of the attachment.
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Attachment'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: NotFound
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "409":
+          description: Conflict — upstream rejected the update (e.g. neither name nor description provided).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
     delete:
       summary: Delete a case attachment (ServiceNow data source only).
       operationId: deleteCaseAttachment
@@ -9177,6 +9286,24 @@ components:
         - change_request
         - deployment
         - incident
+
+    AttachmentUpdatePayload:
+      type: object
+      required: [referenceId, referenceType]
+      properties:
+        referenceId:
+          type: string
+          format: uuid
+          description: UUID of the reference entity (case, change request, etc.)
+        referenceType:
+          $ref: '#/components/schemas/ReferenceType'
+        name:
+          type: string
+          description: New file name. At least one of name or description is required.
+        description:
+          type: string
+          nullable: true
+          description: New description. At least one of name or description is required.
 
     AttachmentSearchPayload:
       type: object

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -1028,7 +1028,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Attachment'
+                $ref: '#/components/schemas/AttachmentUpdateResponse'
         "400":
           description: BadRequest
           content:
@@ -9316,6 +9316,23 @@ components:
           type: string
           nullable: true
           description: New description. At least one of name or description is required.
+
+    AttachmentUpdateResponse:
+      type: object
+      properties:
+        message:
+          type: string
+        attachment:
+          type: object
+          properties:
+            id:
+              type: string
+              format: uuid
+            updatedOn:
+              type: string
+              format: date-time
+            updatedBy:
+              type: string
 
     AttachmentSearchPayload:
       type: object

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -1558,7 +1558,11 @@ export type BeDeploymentType =
 
 export interface BeDeployment {
   id: string;
+  /** @deprecated The search/get response carries `project` (an id+name ref), not this
+   * field — it is never populated by the backend. Kept only so any external caller
+   * still typing against the old (wrong) shape doesn't break; use `project.id` instead. */
   projectId?: string;
+  project?: BeEntityRef;
   name?: string;
   type?: BeDeploymentType;
   description?: string;

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -1340,6 +1340,28 @@ export interface BeDeleteAttachmentResponse {
   message?: string;
 }
 
+/**
+ * Detail-field update for `PATCH /attachments/{id}`. `referenceId` +
+ * `referenceType` re-identify the owning entity (the BE requires both on the
+ * write, same as search/create); at least one of `name`/`description` is
+ * also required.
+ */
+export interface BeAttachmentUpdatePayload {
+  referenceId: string;
+  referenceType: BeReferenceType;
+  name?: string;
+  description?: string | null;
+}
+
+export interface BeAttachmentUpdateResponse {
+  message?: string;
+  attachment?: {
+    id: string;
+    updatedOn: string;
+    updatedBy: string;
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Users
 // ---------------------------------------------------------------------------
@@ -1677,16 +1699,26 @@ export interface BeDeployedProductVersion {
   supportEoLDate?: string | null;
 }
 
+/** A single update-level entry in a deployed product's update history. */
+export interface BeProductUpdate {
+  updateLevel: number;
+  date: string;
+  details?: string | null;
+}
+
 export interface BeDeployedProduct {
   id: string;
   deployment?: BeEntityRef;
   product?: BeEntityRef;
   version?: BeDeployedProductVersion | null;
-  // SN-only sizing fields; the entity service returns them as strings (and
+  // SN-only sizing fields; the entity service returns them as numbers (and
   // always null for the Postgres data source).
-  cores?: string | null;
-  tps?: string | null;
+  cores?: number | null;
+  tps?: number | null;
   category?: string | null;
+  /** Update-level history for this deployed product, oldest/newest order as
+   * returned by the BE. Absent when the BE omits the field entirely. */
+  updates?: BeProductUpdate[];
   createdOn?: string;
   updatedOn?: string;
 }
@@ -1730,6 +1762,13 @@ export interface BeDeployedProductDetailUpdatePayload {
   cores?: number | null;
   tps?: number | null;
   description?: string | null;
+  /**
+   * Whole-array replace: to add/edit/delete one update-history entry, read
+   * the current full array (`BeDeployedProduct.updates`), mutate it
+   * client-side, and send the complete resulting array back. There is no
+   * per-entry endpoint.
+   */
+  updates?: BeProductUpdate[] | null;
   active?: never;
 }
 
@@ -1739,6 +1778,7 @@ export interface BeDeployedProductDeactivatePayload {
   cores?: never;
   tps?: never;
   description?: never;
+  updates?: never;
 }
 
 export type BeDeployedProductUpdatePayload =

--- a/apps/csm-portal/webapp/src/features/csm-projects/api/useCreateDeploymentAttachment.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/api/useCreateDeploymentAttachment.test.tsx
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+import {
+  MAX_DEPLOYMENT_ATTACHMENT_SIZE_BYTES,
+  useCreateDeploymentAttachment,
+} from "@features/csm-projects/api/useCreateDeploymentAttachment";
+import type { BackendApi } from "@api/backend/client";
+
+const postMock = vi.fn();
+
+vi.mock("@api/backend/client", () => ({
+  useBackendApi: (): Partial<BackendApi> => ({ post: postMock }),
+}));
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+function makeFile(name: string, sizeBytes: number, type = "application/pdf"): File {
+  return new File([new Uint8Array(sizeBytes)], name, { type });
+}
+
+describe("useCreateDeploymentAttachment", () => {
+  beforeEach(() => {
+    postMock.mockClear();
+  });
+
+  it("uploads with referenceType=deployment as a base64 data URI", async () => {
+    postMock.mockResolvedValue({ message: "ok" });
+    const { result } = renderHook(() => useCreateDeploymentAttachment(), { wrapper });
+
+    result.current.mutate({ deploymentId: "dep-1", file: makeFile("a.txt", 4, "text/plain") });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(postMock).toHaveBeenCalledWith(
+      "/attachments",
+      expect.objectContaining({
+        referenceId: "dep-1",
+        referenceType: "deployment",
+        name: "a.txt",
+        type: "text/plain",
+      }),
+    );
+    const body = postMock.mock.calls[0][1];
+    expect(body.file).toMatch(/^data:text\/plain;base64,/);
+  });
+
+  it("rejects a file over the size cap without calling the API", async () => {
+    const { result } = renderHook(() => useCreateDeploymentAttachment(), { wrapper });
+
+    result.current.mutate({
+      deploymentId: "dep-1",
+      file: makeFile("big.bin", MAX_DEPLOYMENT_ATTACHMENT_SIZE_BYTES + 1),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(postMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-projects/api/useCreateDeploymentAttachment.ts
+++ b/apps/csm-portal/webapp/src/features/csm-projects/api/useCreateDeploymentAttachment.ts
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  useMutation,
+  useQueryClient,
+  type UseMutationResult,
+} from "@tanstack/react-query";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import { useBackendApi } from "@api/backend/client";
+import type {
+  BeAttachmentCreatePayload,
+  BeAttachmentCreateResponse,
+} from "@api/backend/types";
+
+/** Max upload size in bytes — the BE caps the decoded file at 10 MB. */
+export const MAX_DEPLOYMENT_ATTACHMENT_SIZE_BYTES = 10 * 1024 * 1024;
+
+/** Read a File as a base64 data URI (`data:<mime>;base64,...`). */
+function readFileAsDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (typeof reader.result === "string") resolve(reader.result);
+      else reject(new Error("Failed to read the file."));
+    };
+    reader.onerror = () =>
+      reject(reader.error ?? new Error("Failed to read the file."));
+    reader.readAsDataURL(file);
+  });
+}
+
+export interface CreateDeploymentAttachmentInput {
+  deploymentId: string;
+  file: File;
+  /** Display name for the attachment; defaults to the file's own name. */
+  name?: string;
+  /** Optional free-text note stored with the attachment. */
+  description?: string;
+}
+
+/**
+ * Upload a file to a deployment via `POST /attachments`
+ * (`referenceType: "deployment"`). The create response is a thin ack, so the
+ * list is invalidated on success to hydrate the new entry from search.
+ */
+export function useCreateDeploymentAttachment(): UseMutationResult<
+  BeAttachmentCreateResponse,
+  Error,
+  CreateDeploymentAttachmentInput
+> {
+  const api = useBackendApi();
+  const queryClient = useQueryClient();
+
+  return useMutation<
+    BeAttachmentCreateResponse,
+    Error,
+    CreateDeploymentAttachmentInput
+  >({
+    mutationFn: async (input): Promise<BeAttachmentCreateResponse> => {
+      if (input.file.size > MAX_DEPLOYMENT_ATTACHMENT_SIZE_BYTES) {
+        throw new Error(
+          `"${input.file.name}" is too large. The maximum attachment size is ${
+            MAX_DEPLOYMENT_ATTACHMENT_SIZE_BYTES / (1024 * 1024)
+          } MB.`,
+        );
+      }
+
+      const dataUri = await readFileAsDataUrl(input.file);
+      const payload: BeAttachmentCreatePayload = {
+        referenceId: input.deploymentId,
+        referenceType: "deployment",
+        name: input.name?.trim() || input.file.name,
+        type: input.file.type || "application/octet-stream",
+        file: dataUri,
+        description: input.description?.trim() || null,
+      };
+      return api.post<BeAttachmentCreatePayload, BeAttachmentCreateResponse>(
+        "/attachments",
+        payload,
+      );
+    },
+    onSuccess: (_created, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: [ApiQueryKeys.DEPLOYMENT_ATTACHMENTS, variables.deploymentId],
+      });
+    },
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-projects/api/useDeleteDeploymentAttachment.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/api/useDeleteDeploymentAttachment.test.tsx
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+import { useDeleteDeploymentAttachment } from "@features/csm-projects/api/useDeleteDeploymentAttachment";
+import type { BackendApi } from "@api/backend/client";
+
+const delMock = vi.fn();
+
+vi.mock("@api/backend/client", () => ({
+  useBackendApi: (): Partial<BackendApi> => ({ del: delMock }),
+}));
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+describe("useDeleteDeploymentAttachment", () => {
+  it("DELETEs by attachment id", async () => {
+    delMock.mockResolvedValue({ message: "ok" });
+    const { result } = renderHook(() => useDeleteDeploymentAttachment(), { wrapper });
+
+    result.current.mutate({ deploymentId: "dep-1", attachmentId: "att-1" });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(delMock).toHaveBeenCalledWith("/attachments/att-1");
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-projects/api/useDeleteDeploymentAttachment.ts
+++ b/apps/csm-portal/webapp/src/features/csm-projects/api/useDeleteDeploymentAttachment.ts
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  useMutation,
+  useQueryClient,
+  type UseMutationResult,
+} from "@tanstack/react-query";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import { useBackendApi } from "@api/backend/client";
+import type { BeDeleteAttachmentResponse } from "@api/backend/types";
+
+export interface DeleteDeploymentAttachmentInput {
+  /** Owning deployment id; used only to invalidate the right attachment list. */
+  deploymentId: string;
+  attachmentId: string;
+}
+
+/**
+ * Delete an attachment via `DELETE /attachments/{id}` (ServiceNow data source
+ * only). On success the deployment's attachment list is invalidated so the
+ * row drops.
+ */
+export function useDeleteDeploymentAttachment(): UseMutationResult<
+  void,
+  Error,
+  DeleteDeploymentAttachmentInput
+> {
+  const api = useBackendApi();
+  const queryClient = useQueryClient();
+
+  return useMutation<void, Error, DeleteDeploymentAttachmentInput>({
+    mutationFn: async (input): Promise<void> => {
+      await api.del<BeDeleteAttachmentResponse>(
+        `/attachments/${encodeURIComponent(input.attachmentId)}`,
+      );
+    },
+    onSuccess: (_void, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: [ApiQueryKeys.DEPLOYMENT_ATTACHMENTS, variables.deploymentId],
+      });
+    },
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-projects/api/useDownloadDeploymentAttachment.ts
+++ b/apps/csm-portal/webapp/src/features/csm-projects/api/useDownloadDeploymentAttachment.ts
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useCallback } from "react";
+import { useBackendApi } from "@api/backend/client";
+import { saveBlob } from "@utils/saveBlob";
+import { isSafeAttachmentContentType } from "@features/csm-cases/utils/attachmentPreview";
+import type { DeploymentAttachment } from "@features/csm-projects/types/csmProjects";
+
+/**
+ * Returns a function that fetches a deployment attachment's raw bytes via
+ * `GET /attachments/{id}/content`. Streams behind auth as a `Blob` — see
+ * {@link isSafeAttachmentContentType} for why the fetched blob is only
+ * re-labeled with the list metadata's (uploader-controlled) content type
+ * when that type is itself in the backend's safe allowlist.
+ */
+export function useDownloadDeploymentAttachment(): (
+  attachment: DeploymentAttachment,
+) => Promise<void> {
+  const api = useBackendApi();
+
+  return useCallback(
+    async (attachment: DeploymentAttachment): Promise<void> => {
+      const blob = await api.getBlob(
+        `/attachments/${encodeURIComponent(attachment.id)}/content`,
+      );
+      const toSave =
+        isSafeAttachmentContentType(attachment.contentType) &&
+        blob.type !== attachment.contentType
+          ? blob.slice(0, blob.size, attachment.contentType)
+          : blob;
+      saveBlob(toSave, attachment.name);
+    },
+    [api],
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-projects/api/useSearchDeploymentAttachments.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/api/useSearchDeploymentAttachments.test.tsx
@@ -1,0 +1,87 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+import { useSearchDeploymentAttachments } from "@features/csm-projects/api/useSearchDeploymentAttachments";
+import type { BackendApi } from "@api/backend/client";
+import type { BeAttachmentSearchResponse } from "@api/backend/types";
+
+const postMock = vi.fn();
+
+vi.mock("@api/backend/client", () => ({
+  useBackendApi: (): Partial<BackendApi> => ({ post: postMock }),
+}));
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+describe("useSearchDeploymentAttachments", () => {
+  it("is disabled until a deploymentId is provided", () => {
+    const { result } = renderHook(() => useSearchDeploymentAttachments(undefined), { wrapper });
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(postMock).not.toHaveBeenCalled();
+  });
+
+  it("searches referenceType=deployment and maps the response", async () => {
+    const response: BeAttachmentSearchResponse = {
+      attachments: [
+        {
+          id: "att-1",
+          referenceId: "dep-1",
+          referenceType: "deployment",
+          name: "runbook.pdf",
+          type: "application/pdf",
+          sizeBytes: 2048,
+          description: "Runbook",
+          createdBy: { id: "u-1", email: "jane.doe@example.com", name: "Jane Doe" },
+          createdOn: "2026-01-01T00:00:00Z",
+          downloadUrl: null,
+        },
+      ],
+      total: 1,
+      limit: 50,
+      offset: 0,
+      hasMore: false,
+    };
+    postMock.mockResolvedValue(response);
+
+    const { result } = renderHook(() => useSearchDeploymentAttachments("dep-1"), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(postMock).toHaveBeenCalledWith("/attachments/search", {
+      referenceId: "dep-1",
+      referenceType: "deployment",
+      pagination: { offset: 0, limit: 50 },
+    });
+    expect(result.current.data).toEqual([
+      {
+        id: "att-1",
+        name: "runbook.pdf",
+        contentType: "application/pdf",
+        sizeBytes: 2048,
+        description: "Runbook",
+        uploadedBy: "Jane Doe",
+        uploadedOn: "2026-01-01T00:00:00Z",
+        downloadUrl: null,
+      },
+    ]);
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-projects/api/useSearchDeploymentAttachments.ts
+++ b/apps/csm-portal/webapp/src/features/csm-projects/api/useSearchDeploymentAttachments.ts
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { ApiQueryKeys, BE_MAX_PAGE_LIMIT } from "@constants/apiConstants";
+import { useBackendApi } from "@api/backend/client";
+import type {
+  BeAttachment,
+  BeAttachmentSearchPayload,
+  BeAttachmentSearchResponse,
+} from "@api/backend/types";
+import type { DeploymentAttachment } from "@features/csm-projects/types/csmProjects";
+
+const PAGE_LIMIT = BE_MAX_PAGE_LIMIT;
+
+/** Maps a `BeAttachment` (reference-generic) to the deployment-scoped UI shape. */
+export function deploymentAttachmentFromBe(att: BeAttachment): DeploymentAttachment {
+  return {
+    id: att.id,
+    name: att.name,
+    contentType: att.type,
+    sizeBytes: att.sizeBytes,
+    description: att.description ?? null,
+    uploadedBy:
+      att.createdBy?.name?.trim() || att.createdBy?.email?.trim() || "Unknown",
+    uploadedOn: att.createdOn,
+    downloadUrl: att.downloadUrl ?? null,
+  };
+}
+
+/**
+ * All attachments on a deployment, via `POST /attachments/search` scoped to
+ * `referenceType: "deployment"`. The query is disabled until a deployment id
+ * is provided.
+ */
+export function useSearchDeploymentAttachments(
+  deploymentId: string | undefined,
+): UseQueryResult<DeploymentAttachment[], Error> {
+  const api = useBackendApi();
+
+  return useQuery<DeploymentAttachment[], Error>({
+    queryKey: [ApiQueryKeys.DEPLOYMENT_ATTACHMENTS, deploymentId ?? ""],
+    queryFn: async (): Promise<DeploymentAttachment[]> => {
+      const all: DeploymentAttachment[] = [];
+      for (let offset = 0; ; offset += PAGE_LIMIT) {
+        const payload: BeAttachmentSearchPayload = {
+          referenceId: deploymentId as string,
+          referenceType: "deployment",
+          pagination: { offset, limit: PAGE_LIMIT },
+        };
+        const res = await api.post<
+          BeAttachmentSearchPayload,
+          BeAttachmentSearchResponse
+        >("/attachments/search", payload);
+        const page = res.attachments ?? [];
+        all.push(...page.map(deploymentAttachmentFromBe));
+        if (page.length < PAGE_LIMIT) break;
+      }
+      return all;
+    },
+    enabled: !!deploymentId,
+    staleTime: 30_000,
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-projects/api/useUpdateDeploymentAttachment.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/api/useUpdateDeploymentAttachment.test.tsx
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+import { useUpdateDeploymentAttachment } from "@features/csm-projects/api/useUpdateDeploymentAttachment";
+import type { BackendApi } from "@api/backend/client";
+
+const patchMock = vi.fn();
+
+vi.mock("@api/backend/client", () => ({
+  useBackendApi: (): Partial<BackendApi> => ({ patch: patchMock }),
+}));
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+describe("useUpdateDeploymentAttachment", () => {
+  it("PATCHes only the provided fields, with referenceType=deployment", async () => {
+    patchMock.mockResolvedValue({ message: "ok" });
+    const { result } = renderHook(() => useUpdateDeploymentAttachment(), { wrapper });
+
+    result.current.mutate({ deploymentId: "dep-1", attachmentId: "att-1", name: "new-name.pdf" });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(patchMock).toHaveBeenCalledWith("/attachments/att-1", {
+      referenceId: "dep-1",
+      referenceType: "deployment",
+      name: "new-name.pdf",
+    });
+  });
+
+  it("sends description: null to clear it", async () => {
+    patchMock.mockResolvedValue({ message: "ok" });
+    const { result } = renderHook(() => useUpdateDeploymentAttachment(), { wrapper });
+
+    result.current.mutate({ deploymentId: "dep-1", attachmentId: "att-1", description: null });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(patchMock).toHaveBeenCalledWith("/attachments/att-1", {
+      referenceId: "dep-1",
+      referenceType: "deployment",
+      description: null,
+    });
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-projects/api/useUpdateDeploymentAttachment.ts
+++ b/apps/csm-portal/webapp/src/features/csm-projects/api/useUpdateDeploymentAttachment.ts
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  useMutation,
+  useQueryClient,
+  type UseMutationResult,
+} from "@tanstack/react-query";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import { useBackendApi } from "@api/backend/client";
+import type {
+  BeAttachmentUpdatePayload,
+  BeAttachmentUpdateResponse,
+} from "@api/backend/types";
+
+export interface UpdateDeploymentAttachmentInput {
+  deploymentId: string;
+  attachmentId: string;
+  /** At least one of `name`/`description` is required by the BE. */
+  name?: string;
+  description?: string | null;
+}
+
+/**
+ * Update an attachment's name/description via `PATCH /attachments/{id}`
+ * (`referenceType: "deployment"`). On success, invalidates the deployment's
+ * attachment list so the row refreshes.
+ */
+export function useUpdateDeploymentAttachment(): UseMutationResult<
+  BeAttachmentUpdateResponse,
+  Error,
+  UpdateDeploymentAttachmentInput
+> {
+  const api = useBackendApi();
+  const queryClient = useQueryClient();
+
+  return useMutation<
+    BeAttachmentUpdateResponse,
+    Error,
+    UpdateDeploymentAttachmentInput
+  >({
+    mutationFn: ({
+      deploymentId,
+      attachmentId,
+      name,
+      description,
+    }): Promise<BeAttachmentUpdateResponse> => {
+      const payload: BeAttachmentUpdatePayload = {
+        referenceId: deploymentId,
+        referenceType: "deployment",
+      };
+      if (name !== undefined) payload.name = name;
+      if (description !== undefined) payload.description = description;
+      return api.patch<BeAttachmentUpdatePayload, BeAttachmentUpdateResponse>(
+        `/attachments/${encodeURIComponent(attachmentId)}`,
+        payload,
+      );
+    },
+    onSuccess: (_res, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: [ApiQueryKeys.DEPLOYMENT_ATTACHMENTS, variables.deploymentId],
+      });
+    },
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/DeployedProductsPanel.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/DeployedProductsPanel.tsx
@@ -68,9 +68,9 @@ interface Feedback {
   severity: "success" | "error";
 }
 
-/** SN sizing fields arrive as strings; treat null/blank uniformly as "—". */
-function sizingValue(value?: string | null): string {
-  return value?.trim() ? value : "—";
+/** SN sizing fields are numeric; null/undefined render as "—". */
+function sizingValue(value?: number | null): string {
+  return value === null || value === undefined ? "—" : String(value);
 }
 
 /**

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/DeployedProductsPanel.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/DeployedProductsPanel.tsx
@@ -47,6 +47,7 @@ import type {
   BeDeployedProduct,
   BeDeployedProductCreatePayload,
   BeDeployedProductDetailUpdatePayload,
+  BeProductUpdate,
 } from "@api/backend/types";
 import CreateDeployedProductDialog from "@features/csm-projects/components/CreateDeployedProductDialog";
 import EditDeployedProductDialog from "@features/csm-projects/components/EditDeployedProductDialog";
@@ -56,8 +57,8 @@ interface DeployedProductsPanelProps {
   /**
    * The project this deployment belongs to. Required for the create payload
    * (POST /deployments/{id}/products needs projectId). Derived from
-   * BeDeployment.projectId in the parent dialog. When absent (e.g. opened
-   * from a case context where projectId is not populated), the Add button is
+   * BeDeployment.project.id in the parent dialog. When absent (e.g. opened
+   * from a case context where project is not populated), the Add button is
    * hidden.
    */
   projectId?: string;
@@ -90,11 +91,17 @@ export default function DeployedProductsPanel({
   const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
   const [menuTarget, setMenuTarget] = useState<BeDeployedProduct | null>(null);
   const [creating, setCreating] = useState(false);
-  const [editing, setEditing] = useState<BeDeployedProduct | null>(null);
+  // Store only the id, not the whole record: the Update History tab's saves
+  // refetch `products` (via the mutation's cache invalidation) without
+  // closing the dialog, so we re-derive the live record from the refreshed
+  // list below rather than freezing a stale snapshot at the time the menu
+  // was opened.
+  const [editingId, setEditingId] = useState<string | null>(null);
   const [deactivating, setDeactivating] = useState<BeDeployedProduct | null>(null);
   const [feedback, setFeedback] = useState<Feedback | null>(null);
 
   const products = data ?? [];
+  const editing = editingId ? (products.find((p) => p.id === editingId) ?? null) : null;
 
   const openMenu = (e: React.MouseEvent<HTMLElement>, p: BeDeployedProduct): void => {
     e.stopPropagation();
@@ -122,18 +129,18 @@ export default function DeployedProductsPanel({
     });
   };
 
-  const handleSaveEdit = (payload: BeDeployedProductDetailUpdatePayload): void => {
+  const handleSaveDetails = (payload: BeDeployedProductDetailUpdatePayload): void => {
     if (!editing) return;
     const productName = editing.product?.name ?? "this product";
     updateDeployedProduct.mutate(
       { deployedProductId: editing.id, payload },
       {
         onSuccess: () => {
-          setEditing(null);
+          setEditingId(null);
           setFeedback({ message: "Updated " + productName + ".", severity: "success" });
         },
         onError: (err) => {
-          setEditing(null);
+          setEditingId(null);
           setFeedback({
             message: "Could not update " + productName + ": " + err.message,
             severity: "error",
@@ -141,6 +148,20 @@ export default function DeployedProductsPanel({
         },
       },
     );
+  };
+
+  /**
+   * Update-history save: PATCHes the whole array immediately and, unlike
+   * {@link handleSaveDetails}, never closes the dialog either way — the
+   * caller ({@link UpdateHistoryPanel} via {@link EditDeployedProductDialog})
+   * shows its own inline success/error feedback and awaits this promise to
+   * drive its per-action "Adding…/Saving…/Deleting…" state.
+   */
+  const handleSaveHistory = (updates: BeProductUpdate[]): Promise<void> => {
+    if (!editing) return Promise.reject(new Error("No product selected."));
+    return updateDeployedProduct
+      .mutateAsync({ deployedProductId: editing.id, payload: { updates } })
+      .then(() => undefined);
   };
 
   const handleDeactivate = (): void => {
@@ -271,7 +292,7 @@ export default function DeployedProductsPanel({
       <Menu anchorEl={menuAnchor} open={!!menuAnchor} onClose={closeMenu}>
         <MenuItem
           onClick={() => {
-            setEditing(menuTarget);
+            setEditingId(menuTarget?.id ?? null);
             closeMenu();
           }}
         >
@@ -303,8 +324,9 @@ export default function DeployedProductsPanel({
         <EditDeployedProductDialog
           deployedProduct={editing}
           isSaving={updateDeployedProduct.isPending}
-          onClose={() => setEditing(null)}
-          onSave={handleSaveEdit}
+          onClose={() => setEditingId(null)}
+          onSaveDetails={handleSaveDetails}
+          onSaveHistory={handleSaveHistory}
         />
       )}
 

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/DeploymentAttachmentsPanel.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/DeploymentAttachmentsPanel.test.tsx
@@ -1,0 +1,144 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import type { UseQueryResult } from "@tanstack/react-query";
+import type { DeploymentAttachment } from "@features/csm-projects/types/csmProjects";
+
+const useSearchDeploymentAttachmentsMock = vi.fn();
+const createMutateAsync = vi.fn();
+const updateMutate = vi.fn();
+const deleteMutate = vi.fn();
+const downloadMock = vi.fn();
+
+vi.mock("@features/csm-projects/api/useSearchDeploymentAttachments", () => ({
+  useSearchDeploymentAttachments: () => useSearchDeploymentAttachmentsMock(),
+}));
+vi.mock("@features/csm-projects/api/useCreateDeploymentAttachment", () => ({
+  useCreateDeploymentAttachment: () => ({
+    mutateAsync: createMutateAsync,
+    isPending: false,
+  }),
+}));
+vi.mock("@features/csm-projects/api/useUpdateDeploymentAttachment", () => ({
+  useUpdateDeploymentAttachment: () => ({ mutate: updateMutate, isPending: false }),
+}));
+vi.mock("@features/csm-projects/api/useDeleteDeploymentAttachment", () => ({
+  useDeleteDeploymentAttachment: () => ({ mutate: deleteMutate, isPending: false }),
+}));
+vi.mock("@features/csm-projects/api/useDownloadDeploymentAttachment", () => ({
+  useDownloadDeploymentAttachment: () => downloadMock,
+}));
+// `AttachmentsField` pulls `MAX_ATTACHMENT_SIZE_BYTES` from the case
+// attachments module, which reads runtime config (`CSM_PORTAL_BACKEND_BASE_URL`)
+// at module load via `@api/backend/client` — not present under vitest. Stub
+// the module so the import chain doesn't throw (same approach as
+// ProjectContactsTab.test.tsx / CsmChangeRequestDetailPage.test.tsx).
+vi.mock("@api/backend/client", () => ({
+  BackendApiError: class BackendApiError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+      super(message);
+      this.status = status;
+    }
+  },
+  useBackendApi: () => ({}),
+}));
+
+import DeploymentAttachmentsPanel from "@features/csm-projects/components/DeploymentAttachmentsPanel";
+
+const ATTACHMENT: DeploymentAttachment = {
+  id: "att-1",
+  name: "runbook.pdf",
+  contentType: "application/pdf",
+  sizeBytes: 2048,
+  description: "Deployment runbook",
+  uploadedBy: "Jane Doe",
+  uploadedOn: "2026-01-01T00:00:00Z",
+  downloadUrl: null,
+};
+
+function mockList(overrides: Partial<UseQueryResult<DeploymentAttachment[], Error>>): void {
+  useSearchDeploymentAttachmentsMock.mockReturnValue({
+    data: [],
+    isLoading: false,
+    isError: false,
+    error: null,
+    ...overrides,
+  });
+}
+
+describe("DeploymentAttachmentsPanel", () => {
+  it("shows an empty state when there are no attachments", () => {
+    mockList({ data: [] });
+    render(<DeploymentAttachmentsPanel deploymentId="dep-1" />);
+    expect(screen.getByText(/no attachments on this deployment/i)).toBeInTheDocument();
+  });
+
+  it("lists existing attachments with size, uploader, and description", () => {
+    mockList({ data: [ATTACHMENT] });
+    render(<DeploymentAttachmentsPanel deploymentId="dep-1" />);
+    expect(screen.getByText("runbook.pdf")).toBeInTheDocument();
+    expect(screen.getByText("Deployment runbook")).toBeInTheDocument();
+    expect(screen.getByText(/jane doe/i)).toBeInTheDocument();
+  });
+
+  it("opens the edit dialog and saves a changed name", async () => {
+    mockList({ data: [ATTACHMENT] });
+    render(<DeploymentAttachmentsPanel deploymentId="dep-1" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /edit runbook\.pdf/i }));
+    const nameField = screen.getByLabelText(/^name$/i);
+    fireEvent.change(nameField, { target: { value: "runbook-v2.pdf" } });
+    fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
+
+    expect(updateMutate).toHaveBeenCalledWith(
+      { deploymentId: "dep-1", attachmentId: "att-1", name: "runbook-v2.pdf" },
+      expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) }),
+    );
+  });
+
+  it("confirms and deletes an attachment", () => {
+    mockList({ data: [ATTACHMENT] });
+    render(<DeploymentAttachmentsPanel deploymentId="dep-1" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /delete runbook\.pdf/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^delete$/i }));
+
+    expect(deleteMutate).toHaveBeenCalledWith(
+      { deploymentId: "dep-1", attachmentId: "att-1" },
+      expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) }),
+    );
+  });
+
+  it("downloads an attachment", async () => {
+    downloadMock.mockResolvedValue(undefined);
+    mockList({ data: [ATTACHMENT] });
+    render(<DeploymentAttachmentsPanel deploymentId="dep-1" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /download runbook\.pdf/i }));
+
+    await waitFor(() => expect(downloadMock).toHaveBeenCalledWith(ATTACHMENT));
+  });
+
+  it("shows a load error via QueryErrorState", () => {
+    mockList({ data: undefined, isError: true, error: new Error("network down") });
+    render(<DeploymentAttachmentsPanel deploymentId="dep-1" />);
+    expect(screen.getByText(/network down/i)).toBeInTheDocument();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/DeploymentAttachmentsPanel.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/DeploymentAttachmentsPanel.tsx
@@ -1,0 +1,379 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  IconButton,
+  TextField,
+  Tooltip,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { Download, Pencil, Trash2 } from "@wso2/oxygen-ui-icons-react";
+import { useState, type JSX } from "react";
+import AttachmentsField from "@components/attachments/AttachmentsField";
+import {
+  POST_CREATE_ATTACHMENTS_MAX_ENCODED_BYTES,
+  type EncodedAttachment,
+} from "@components/attachments/encodeAttachment";
+import QueryErrorState from "@components/QueryErrorState";
+import { formatBytes } from "@utils/formatBytes";
+import { useSearchDeploymentAttachments } from "@features/csm-projects/api/useSearchDeploymentAttachments";
+import { useCreateDeploymentAttachment } from "@features/csm-projects/api/useCreateDeploymentAttachment";
+import { useUpdateDeploymentAttachment } from "@features/csm-projects/api/useUpdateDeploymentAttachment";
+import { useDeleteDeploymentAttachment } from "@features/csm-projects/api/useDeleteDeploymentAttachment";
+import { useDownloadDeploymentAttachment } from "@features/csm-projects/api/useDownloadDeploymentAttachment";
+import type { DeploymentAttachment } from "@features/csm-projects/types/csmProjects";
+
+interface DeploymentAttachmentsPanelProps {
+  deploymentId: string;
+}
+
+interface Feedback {
+  message: string;
+  severity: "success" | "error";
+}
+
+function formatUploadedOn(iso: string): string {
+  const d = new Date(iso);
+  return isNaN(d.getTime()) ? iso : d.toLocaleString();
+}
+
+/**
+ * Deployment-level attachments: upload, list, edit (name/description), and
+ * delete files against the shared reference-generic `/attachments*`
+ * endpoints scoped to `referenceType: "deployment"`.
+ *
+ * New files are staged locally via {@link AttachmentsField} (the shared
+ * multi-file picker), then uploaded one at a time on "Upload" — matching the
+ * BE's one-file-per-request `POST /attachments` contract.
+ */
+export default function DeploymentAttachmentsPanel({
+  deploymentId,
+}: DeploymentAttachmentsPanelProps): JSX.Element {
+  const { data, isLoading, isError, error } = useSearchDeploymentAttachments(deploymentId);
+  const createAttachment = useCreateDeploymentAttachment();
+  const updateAttachment = useUpdateDeploymentAttachment();
+  const deleteAttachment = useDeleteDeploymentAttachment();
+  const downloadAttachment = useDownloadDeploymentAttachment();
+
+  const [pending, setPending] = useState<EncodedAttachment[]>([]);
+  const [uploading, setUploading] = useState(false);
+  const [downloadingId, setDownloadingId] = useState<string | null>(null);
+  const [editing, setEditing] = useState<DeploymentAttachment | null>(null);
+  const [editName, setEditName] = useState("");
+  const [editDescription, setEditDescription] = useState("");
+  const [deleting, setDeleting] = useState<DeploymentAttachment | null>(null);
+  const [feedback, setFeedback] = useState<Feedback | null>(null);
+
+  const attachments = data ?? [];
+
+  const handleUploadPending = async (): Promise<void> => {
+    if (pending.length === 0) return;
+    setUploading(true);
+    let failed = 0;
+    for (const p of pending) {
+      try {
+        await createAttachment.mutateAsync({ deploymentId, file: p.raw, name: p.name });
+      } catch {
+        failed += 1;
+      }
+    }
+    setUploading(false);
+    setPending([]);
+    if (failed > 0) {
+      setFeedback({
+        message: `${failed} of ${pending.length} file(s) failed to upload.`,
+        severity: "error",
+      });
+    } else {
+      setFeedback({ message: "Attachment(s) uploaded.", severity: "success" });
+    }
+  };
+
+  const openEdit = (a: DeploymentAttachment): void => {
+    setEditing(a);
+    setEditName(a.name);
+    setEditDescription(a.description ?? "");
+  };
+
+  const handleSaveEdit = (): void => {
+    if (!editing) return;
+    const nameChanged = editName.trim() !== editing.name;
+    const descriptionChanged = editDescription.trim() !== (editing.description ?? "");
+    if (!nameChanged && !descriptionChanged) {
+      setEditing(null);
+      return;
+    }
+    updateAttachment.mutate(
+      {
+        deploymentId,
+        attachmentId: editing.id,
+        ...(nameChanged ? { name: editName.trim() } : {}),
+        ...(descriptionChanged
+          ? { description: editDescription.trim() ? editDescription.trim() : null }
+          : {}),
+      },
+      {
+        onSuccess: () => {
+          setEditing(null);
+          setFeedback({ message: "Attachment updated.", severity: "success" });
+        },
+        onError: (err) => {
+          setEditing(null);
+          setFeedback({
+            message: `Could not update the attachment: ${err.message}`,
+            severity: "error",
+          });
+        },
+      },
+    );
+  };
+
+  const handleConfirmDelete = (): void => {
+    if (!deleting) return;
+    const target = deleting;
+    deleteAttachment.mutate(
+      { deploymentId, attachmentId: target.id },
+      {
+        onSuccess: () => {
+          setDeleting(null);
+          setFeedback({ message: `Deleted ${target.name}.`, severity: "success" });
+        },
+        onError: (err) => {
+          setDeleting(null);
+          setFeedback({
+            message: `Could not delete ${target.name}: ${err.message}`,
+            severity: "error",
+          });
+        },
+      },
+    );
+  };
+
+  const handleDownload = async (a: DeploymentAttachment): Promise<void> => {
+    setDownloadingId(a.id);
+    try {
+      await downloadAttachment(a);
+    } catch (err) {
+      setFeedback({
+        message: `Could not download ${a.name}: ${err instanceof Error ? err.message : String(err)}`,
+        severity: "error",
+      });
+    } finally {
+      setDownloadingId(null);
+    }
+  };
+
+  return (
+    <Box sx={{ py: 1 }}>
+      {feedback && (
+        <Alert severity={feedback.severity} onClose={() => setFeedback(null)} sx={{ mb: 1 }}>
+          {feedback.message}
+        </Alert>
+      )}
+
+      <Typography
+        variant="caption"
+        color="text.secondary"
+        sx={{ textTransform: "uppercase", letterSpacing: 0.4, display: "block", px: 1, mb: 0.5 }}
+      >
+        Attachments
+      </Typography>
+
+      <Box sx={{ px: 1, display: "flex", flexDirection: "column", gap: 1 }}>
+        <AttachmentsField
+          attachments={pending}
+          onChange={setPending}
+          onError={(message) => setFeedback({ message, severity: "error" })}
+          maxEncodedBytes={POST_CREATE_ATTACHMENTS_MAX_ENCODED_BYTES}
+          disabled={uploading}
+        />
+        {pending.length > 0 && (
+          <Box>
+            <Button
+              size="small"
+              variant="contained"
+              onClick={() => void handleUploadPending()}
+              disabled={uploading}
+              startIcon={uploading ? <CircularProgress size={14} color="inherit" /> : undefined}
+            >
+              {uploading ? "Uploading…" : `Upload ${pending.length} file(s)`}
+            </Button>
+          </Box>
+        )}
+      </Box>
+
+      {isLoading ? (
+        <Box sx={{ display: "flex", justifyContent: "center", py: 3 }}>
+          <CircularProgress size={20} />
+        </Box>
+      ) : isError ? (
+        <QueryErrorState
+          message={
+            error instanceof Error && error.message.trim()
+              ? error.message
+              : "Failed to load attachments."
+          }
+          error={error}
+        />
+      ) : attachments.length === 0 ? (
+        <Typography variant="body2" color="text.secondary" sx={{ py: 1, px: 1 }}>
+          No attachments on this deployment.
+        </Typography>
+      ) : (
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 1, mt: 1, px: 1 }}>
+          {attachments.map((a) => (
+            <Box
+              key={a.id}
+              sx={{
+                display: "flex",
+                alignItems: "flex-start",
+                justifyContent: "space-between",
+                gap: 1,
+                border: 1,
+                borderColor: "divider",
+                borderRadius: 1,
+                px: 1.5,
+                py: 1,
+              }}
+            >
+              <Box sx={{ minWidth: 0, flex: 1 }}>
+                <Typography variant="body2" sx={{ fontWeight: 500 }} noWrap title={a.name}>
+                  {a.name}
+                </Typography>
+                <Typography variant="caption" color="text.secondary">
+                  {formatBytes(a.sizeBytes)} · {a.uploadedBy} · {formatUploadedOn(a.uploadedOn)}
+                </Typography>
+                {a.description && (
+                  <Typography
+                    variant="body2"
+                    color="text.secondary"
+                    sx={{ mt: 0.5, whiteSpace: "pre-wrap", wordBreak: "break-word" }}
+                  >
+                    {a.description}
+                  </Typography>
+                )}
+              </Box>
+              <Box sx={{ display: "flex", gap: 0.25, flexShrink: 0 }}>
+                <Tooltip title="Edit">
+                  <IconButton size="small" aria-label={`Edit ${a.name}`} onClick={() => openEdit(a)}>
+                    <Pencil size={14} />
+                  </IconButton>
+                </Tooltip>
+                <Tooltip title="Delete">
+                  <IconButton
+                    size="small"
+                    aria-label={`Delete ${a.name}`}
+                    onClick={() => setDeleting(a)}
+                  >
+                    <Trash2 size={14} />
+                  </IconButton>
+                </Tooltip>
+                <Tooltip title="Download">
+                  <IconButton
+                    size="small"
+                    aria-label={`Download ${a.name}`}
+                    disabled={downloadingId === a.id}
+                    onClick={() => void handleDownload(a)}
+                  >
+                    {downloadingId === a.id ? (
+                      <CircularProgress size={14} />
+                    ) : (
+                      <Download size={14} />
+                    )}
+                  </IconButton>
+                </Tooltip>
+              </Box>
+            </Box>
+          ))}
+        </Box>
+      )}
+
+      {editing && (
+        <Dialog open onClose={() => setEditing(null)} maxWidth="sm" fullWidth>
+          <DialogTitle>Edit attachment</DialogTitle>
+          <DialogContent dividers>
+            <Box sx={{ display: "flex", flexDirection: "column", gap: 2, pt: 0.5 }}>
+              <TextField
+                label="Name"
+                value={editName}
+                onChange={(e) => setEditName(e.target.value)}
+                size="small"
+                fullWidth
+                autoFocus
+              />
+              <TextField
+                label="Description"
+                value={editDescription}
+                onChange={(e) => setEditDescription(e.target.value)}
+                size="small"
+                fullWidth
+                multiline
+                minRows={2}
+              />
+            </Box>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={() => setEditing(null)} disabled={updateAttachment.isPending}>
+              Cancel
+            </Button>
+            <Button
+              variant="contained"
+              disabled={updateAttachment.isPending || editName.trim() === ""}
+              onClick={handleSaveEdit}
+            >
+              Save changes
+            </Button>
+          </DialogActions>
+        </Dialog>
+      )}
+
+      <Dialog open={!!deleting} onClose={() => setDeleting(null)} maxWidth="xs" fullWidth>
+        <DialogTitle>Delete attachment</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            Delete{" "}
+            <Box component="span" sx={{ fontWeight: 600, color: "text.primary" }}>
+              {deleting?.name ?? "this attachment"}
+            </Box>
+            ? This cannot be undone.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeleting(null)} disabled={deleteAttachment.isPending}>
+            Cancel
+          </Button>
+          <Button
+            color="error"
+            variant="contained"
+            onClick={handleConfirmDelete}
+            disabled={deleteAttachment.isPending}
+          >
+            Delete
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/DeploymentDetailsDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/DeploymentDetailsDialog.tsx
@@ -30,6 +30,7 @@ import {
   formatDeploymentDate,
 } from "@features/csm-projects/utils/deployments";
 import DeployedProductsPanel from "@features/csm-projects/components/DeployedProductsPanel";
+import DeploymentAttachmentsPanel from "@features/csm-projects/components/DeploymentAttachmentsPanel";
 
 interface DeploymentDetailsDialogProps {
   deployment: BeDeployment;
@@ -135,6 +136,10 @@ export default function DeploymentDetailsDialog({
           )}
 
           <DeployedProductsPanel deploymentId={deployment.id} projectId={deployment.projectId} />
+
+          <Divider />
+
+          <DeploymentAttachmentsPanel deploymentId={deployment.id} />
         </Box>
         <Divider />
         <Box sx={{ display: "flex", justifyContent: "flex-end", p: 2 }}>

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/DeploymentDetailsDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/DeploymentDetailsDialog.tsx
@@ -135,7 +135,7 @@ export default function DeploymentDetailsDialog({
             </Box>
           )}
 
-          <DeployedProductsPanel deploymentId={deployment.id} projectId={deployment.projectId} />
+          <DeployedProductsPanel deploymentId={deployment.id} projectId={deployment.project?.id} />
 
           <Divider />
 

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/EditDeployedProductDialog.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/EditDeployedProductDialog.test.tsx
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 import EditDeployedProductDialog from "@features/csm-projects/components/EditDeployedProductDialog";
@@ -29,26 +29,32 @@ const DEPLOYED_PRODUCT: BeDeployedProduct = {
 };
 
 function renderDialog(overrides?: Partial<BeDeployedProduct>) {
-  const onSave = vi.fn();
+  const onSaveDetails = vi.fn();
+  const onSaveHistory = vi.fn().mockResolvedValue(undefined);
   const onClose = vi.fn();
   render(
     <EditDeployedProductDialog
       deployedProduct={{ ...DEPLOYED_PRODUCT, ...overrides }}
       isSaving={false}
       onClose={onClose}
-      onSave={onSave}
+      onSaveDetails={onSaveDetails}
+      onSaveHistory={onSaveHistory}
     />,
   );
-  return { onSave, onClose };
+  return { onSaveDetails, onSaveHistory, onClose };
 }
 
-const saveButton = (): HTMLElement =>
+const saveDetailsButton = (): HTMLElement =>
   screen.getByRole("button", { name: /save changes/i });
 
-describe("EditDeployedProductDialog", () => {
+const switchToHistoryTab = (): void => {
+  fireEvent.click(screen.getByRole("tab", { name: /update history/i }));
+};
+
+describe("EditDeployedProductDialog — Details tab", () => {
   it("disables Save until a field changes", () => {
     renderDialog();
-    expect(saveButton()).toBeDisabled();
+    expect(saveDetailsButton()).toBeDisabled();
   });
 
   it("renders numeric cores/tps directly (no re-parse of strings)", () => {
@@ -57,50 +63,106 @@ describe("EditDeployedProductDialog", () => {
     expect(screen.getByLabelText(/tps/i)).toHaveValue(100);
   });
 
-  it("sends only the changed cores as a number", () => {
-    const { onSave } = renderDialog();
+  it("sends only the changed cores as a number, and does not touch updates", () => {
+    const { onSaveDetails, onSaveHistory } = renderDialog();
     fireEvent.change(screen.getByLabelText(/cores/i), { target: { value: "8" } });
-    fireEvent.click(saveButton());
-    expect(onSave).toHaveBeenCalledWith({ cores: 8 });
+    fireEvent.click(saveDetailsButton());
+    expect(onSaveDetails).toHaveBeenCalledWith({ cores: 8 });
+    expect(onSaveHistory).not.toHaveBeenCalled();
   });
 
   it("sends null when cores is cleared", () => {
-    const { onSave } = renderDialog();
+    const { onSaveDetails } = renderDialog();
     fireEvent.change(screen.getByLabelText(/cores/i), { target: { value: "" } });
-    fireEvent.click(saveButton());
-    expect(onSave).toHaveBeenCalledWith({ cores: null });
+    fireEvent.click(saveDetailsButton());
+    expect(onSaveDetails).toHaveBeenCalledWith({ cores: null });
   });
 
+  it("calling onSaveDetails is the only way the dialog would close (parent decides, not asserted here)", () => {
+    // The dialog itself never calls onClose from a save — DeployedProductsPanel
+    // decides to close on the Details-save success callback. Confirm no
+    // automatic onClose call happens as a side effect of clicking Save.
+    const { onClose } = renderDialog();
+    fireEvent.change(screen.getByLabelText(/cores/i), { target: { value: "8" } });
+    fireEvent.click(saveDetailsButton());
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});
+
+describe("EditDeployedProductDialog — Update History tab", () => {
   it("switches to the Update History tab and lists existing entries", () => {
     renderDialog();
-    fireEvent.click(screen.getByRole("tab", { name: /update history/i }));
+    switchToHistoryTab();
     expect(screen.getByText("Initial rollout")).toBeInTheDocument();
-    expect(screen.getByText("2026-01-01")).toBeInTheDocument();
+    expect(screen.getByText(/date: 2026-01-01/i)).toBeInTheDocument();
   });
 
-  it("adds a new update-history row and saves the whole array on Save changes", () => {
-    const { onSave } = renderDialog();
-    fireEvent.click(screen.getByRole("tab", { name: /update history/i }));
+  it("shows the footer 'Add update' button only on the Update History tab", () => {
+    renderDialog();
+    expect(screen.queryByRole("button", { name: /^add update$/i })).not.toBeInTheDocument();
+    switchToHistoryTab();
+    expect(screen.getByRole("button", { name: /^add update$/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /save changes/i })).not.toBeInTheDocument();
+  });
+
+  it("adds a new update-history entry immediately via the footer button, without closing the dialog", async () => {
+    const { onSaveHistory, onClose } = renderDialog();
+    switchToHistoryTab();
 
     fireEvent.change(screen.getByLabelText(/^update level$/i), { target: { value: "2" } });
     fireEvent.change(screen.getByLabelText(/^date$/i), { target: { value: "2026-02-01" } });
-    fireEvent.click(screen.getByRole("button", { name: /^add$/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^add update$/i }));
 
-    fireEvent.click(saveButton());
-    expect(onSave).toHaveBeenCalledWith({
-      updates: [
+    await waitFor(() =>
+      expect(onSaveHistory).toHaveBeenCalledWith([
         { updateLevel: 1, date: "2026-01-01", details: "Initial rollout" },
         { updateLevel: 2, date: "2026-02-01", details: undefined },
-      ],
-    });
+      ]),
+    );
+    expect(onClose).not.toHaveBeenCalled();
   });
 
-  it("deletes an update-history row and saves the shrunk array", () => {
-    const { onSave } = renderDialog();
-    fireEvent.click(screen.getByRole("tab", { name: /update history/i }));
+  it("deletes an update-history entry immediately, without a confirm step, and without closing", async () => {
+    const { onSaveHistory, onClose } = renderDialog();
+    switchToHistoryTab();
 
     fireEvent.click(screen.getByRole("button", { name: /delete update level 1/i }));
-    fireEvent.click(saveButton());
-    expect(onSave).toHaveBeenCalledWith({ updates: [] });
+
+    await waitFor(() => expect(onSaveHistory).toHaveBeenCalledWith([]));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("only the latest (highest updateLevel) entry is editable", () => {
+    renderDialog({
+      updates: [
+        { updateLevel: 1, date: "2026-01-01", details: "Initial rollout" },
+        { updateLevel: 2, date: "2026-02-01", details: "Second update" },
+      ],
+    });
+    switchToHistoryTab();
+
+    expect(screen.getByRole("button", { name: /edit update level 2/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /edit update level 1/i })).not.toBeInTheDocument();
+  });
+
+  it("edits the latest entry in place and PATCHes the replaced array via the footer button", async () => {
+    const { onSaveHistory, onClose } = renderDialog();
+    switchToHistoryTab();
+
+    fireEvent.click(screen.getByRole("button", { name: /edit update level 1/i }));
+    // Both the in-place edit form and the always-present "Add an update"
+    // form section render a "Details" field; the edit form's timeline card
+    // appears first in DOM order.
+    fireEvent.change(screen.getAllByLabelText(/^details$/i)[0], {
+      target: { value: "Revised notes" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+
+    await waitFor(() =>
+      expect(onSaveHistory).toHaveBeenCalledWith([
+        { updateLevel: 1, date: "2026-01-01", details: "Revised notes" },
+      ]),
+    );
+    expect(onClose).not.toHaveBeenCalled();
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/EditDeployedProductDialog.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/EditDeployedProductDialog.test.tsx
@@ -1,0 +1,106 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import EditDeployedProductDialog from "@features/csm-projects/components/EditDeployedProductDialog";
+import type { BeDeployedProduct } from "@api/backend/types";
+
+const DEPLOYED_PRODUCT: BeDeployedProduct = {
+  id: "dp-1",
+  product: { id: "prod-1", name: "API Manager" },
+  cores: 4,
+  tps: 100,
+  updates: [{ updateLevel: 1, date: "2026-01-01", details: "Initial rollout" }],
+};
+
+function renderDialog(overrides?: Partial<BeDeployedProduct>) {
+  const onSave = vi.fn();
+  const onClose = vi.fn();
+  render(
+    <EditDeployedProductDialog
+      deployedProduct={{ ...DEPLOYED_PRODUCT, ...overrides }}
+      isSaving={false}
+      onClose={onClose}
+      onSave={onSave}
+    />,
+  );
+  return { onSave, onClose };
+}
+
+const saveButton = (): HTMLElement =>
+  screen.getByRole("button", { name: /save changes/i });
+
+describe("EditDeployedProductDialog", () => {
+  it("disables Save until a field changes", () => {
+    renderDialog();
+    expect(saveButton()).toBeDisabled();
+  });
+
+  it("renders numeric cores/tps directly (no re-parse of strings)", () => {
+    renderDialog();
+    expect(screen.getByLabelText(/cores/i)).toHaveValue(4);
+    expect(screen.getByLabelText(/tps/i)).toHaveValue(100);
+  });
+
+  it("sends only the changed cores as a number", () => {
+    const { onSave } = renderDialog();
+    fireEvent.change(screen.getByLabelText(/cores/i), { target: { value: "8" } });
+    fireEvent.click(saveButton());
+    expect(onSave).toHaveBeenCalledWith({ cores: 8 });
+  });
+
+  it("sends null when cores is cleared", () => {
+    const { onSave } = renderDialog();
+    fireEvent.change(screen.getByLabelText(/cores/i), { target: { value: "" } });
+    fireEvent.click(saveButton());
+    expect(onSave).toHaveBeenCalledWith({ cores: null });
+  });
+
+  it("switches to the Update History tab and lists existing entries", () => {
+    renderDialog();
+    fireEvent.click(screen.getByRole("tab", { name: /update history/i }));
+    expect(screen.getByText("Initial rollout")).toBeInTheDocument();
+    expect(screen.getByText("2026-01-01")).toBeInTheDocument();
+  });
+
+  it("adds a new update-history row and saves the whole array on Save changes", () => {
+    const { onSave } = renderDialog();
+    fireEvent.click(screen.getByRole("tab", { name: /update history/i }));
+
+    fireEvent.change(screen.getByLabelText(/^update level$/i), { target: { value: "2" } });
+    fireEvent.change(screen.getByLabelText(/^date$/i), { target: { value: "2026-02-01" } });
+    fireEvent.click(screen.getByRole("button", { name: /^add$/i }));
+
+    fireEvent.click(saveButton());
+    expect(onSave).toHaveBeenCalledWith({
+      updates: [
+        { updateLevel: 1, date: "2026-01-01", details: "Initial rollout" },
+        { updateLevel: 2, date: "2026-02-01", details: undefined },
+      ],
+    });
+  });
+
+  it("deletes an update-history row and saves the shrunk array", () => {
+    const { onSave } = renderDialog();
+    fireEvent.click(screen.getByRole("tab", { name: /update history/i }));
+
+    fireEvent.click(screen.getByRole("button", { name: /delete update level 1/i }));
+    fireEvent.click(saveButton());
+    expect(onSave).toHaveBeenCalledWith({ updates: [] });
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/EditDeployedProductDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/EditDeployedProductDialog.tsx
@@ -21,12 +21,23 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
+  IconButton,
+  Tab,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Tabs,
   TextField,
+  Typography,
 } from "@wso2/oxygen-ui";
+import { Pencil, Plus, Trash2 } from "@wso2/oxygen-ui-icons-react";
 import { useMemo, useState, type JSX } from "react";
 import type {
   BeDeployedProduct,
   BeDeployedProductDetailUpdatePayload,
+  BeProductUpdate,
 } from "@api/backend/types";
 
 interface EditDeployedProductDialogProps {
@@ -40,13 +51,21 @@ interface EditDeployedProductDialogProps {
 
 const DESCRIPTION_MAX = 4000;
 
+/** Deep-enough equality for the update-history array (small, plain objects). */
+function updatesEqual(a: BeProductUpdate[], b: BeProductUpdate[]): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
 /**
- * Edit a deployed product's cores, tps, and description
- * (`PATCH /deployments/{deploymentId}/products/{productId}` detail variant).
+ * Edit a deployed product: its cores/tps/description (Details tab) and its
+ * update-level history (Update History tab), both via
+ * `PATCH /deployments/{deploymentId}/products/{productId}` (detail variant).
  *
- * Only changed fields are sent — the BE requires minProperties 1 for this
- * variant, so Save is disabled until at least one field differs. Clearing a
- * field sends `null` to explicitly remove the value.
+ * Only changed fields are sent — the BE requires minProperties 1, so Save is
+ * disabled until at least one field differs across either tab. The Update
+ * History tab is a client-side array editor: add/edit/delete a row locally,
+ * then Save PATCHes the *whole* resulting array (there is no per-entry
+ * endpoint) alongside any changed detail fields.
  *
  * Deactivation is a separate concern handled via a confirm dialog in
  * {@link DeployedProductsPanel}, not here — keeping the two BE shapes distinct
@@ -60,16 +79,17 @@ export default function EditDeployedProductDialog({
   onClose,
   onSave,
 }: EditDeployedProductDialogProps): JSX.Element {
-  // Existing SN cores/tps arrive as strings (or null). Parse to number for the
-  // input; the payload sends numbers per the openapi spec.
+  const [tab, setTab] = useState(0);
+
+  // --- Details tab state -----------------------------------------------
   // `description` is not in the read schema (DeployedProduct in openapi.yaml
   // does not carry it back) — initialize as empty so we can only set/clear it.
-  const originalCoresStr = deployedProduct.cores?.trim() ?? "";
-  const originalTpsStr = deployedProduct.tps?.trim() ?? "";
+  const originalCores = deployedProduct.cores ?? null;
+  const originalTps = deployedProduct.tps ?? null;
   const originalDescription = "";
 
-  const [cores, setCores] = useState(originalCoresStr);
-  const [tps, setTps] = useState(originalTpsStr);
+  const [cores, setCores] = useState(originalCores === null ? "" : String(originalCores));
+  const [tps, setTps] = useState(originalTps === null ? "" : String(originalTps));
   const [description, setDescription] = useState(originalDescription);
 
   const coresNum = cores.trim() === "" ? null : Number(cores);
@@ -81,10 +101,65 @@ export default function EditDeployedProductDialog({
     tps.trim() !== "" &&
     (isNaN(tpsNum as number) || (tpsNum as number) < 0);
 
-  const coresChanged = cores.trim() !== originalCoresStr;
-  const tpsChanged = tps.trim() !== originalTpsStr;
+  const coresChanged = coresNum !== originalCores;
+  const tpsChanged = tpsNum !== originalTps;
   const descriptionChanged = description.trim() !== originalDescription;
 
+  // --- Update History tab state -----------------------------------------
+  const originalUpdates = useMemo<BeProductUpdate[]>(
+    () => deployedProduct.updates ?? [],
+    [deployedProduct.updates],
+  );
+  const [updates, setUpdates] = useState<BeProductUpdate[]>(originalUpdates);
+  const [editingIndex, setEditingIndex] = useState<number | null>(null);
+  const [rowLevel, setRowLevel] = useState("");
+  const [rowDate, setRowDate] = useState("");
+  const [rowDetails, setRowDetails] = useState("");
+
+  const updatesChanged = !updatesEqual(updates, originalUpdates);
+
+  const rowLevelNum = rowLevel.trim() === "" ? null : Number(rowLevel);
+  const rowLevelError =
+    rowLevel.trim() !== "" && (!Number.isInteger(rowLevelNum) || (rowLevelNum as number) < 0);
+  const canAddOrSaveRow =
+    rowLevel.trim() !== "" && !rowLevelError && rowDate.trim() !== "";
+
+  const resetRowForm = (): void => {
+    setEditingIndex(null);
+    setRowLevel("");
+    setRowDate("");
+    setRowDetails("");
+  };
+
+  const handleAddOrSaveRow = (): void => {
+    if (!canAddOrSaveRow) return;
+    const entry: BeProductUpdate = {
+      updateLevel: rowLevelNum as number,
+      date: rowDate,
+      details: rowDetails.trim() ? rowDetails.trim() : undefined,
+    };
+    if (editingIndex === null) {
+      setUpdates((prev) => [...prev, entry]);
+    } else {
+      setUpdates((prev) => prev.map((u, i) => (i === editingIndex ? entry : u)));
+    }
+    resetRowForm();
+  };
+
+  const handleEditRow = (index: number): void => {
+    const u = updates[index];
+    setEditingIndex(index);
+    setRowLevel(String(u.updateLevel));
+    setRowDate(u.date);
+    setRowDetails(u.details ?? "");
+  };
+
+  const handleDeleteRow = (index: number): void => {
+    setUpdates((prev) => prev.filter((_, i) => i !== index));
+    if (editingIndex === index) resetRowForm();
+  };
+
+  // --- Combined save ------------------------------------------------------
   const payload = useMemo<BeDeployedProductDetailUpdatePayload>(() => {
     const next: Record<string, unknown> = {};
     if (coresChanged) next.cores = coresNum;
@@ -92,56 +167,187 @@ export default function EditDeployedProductDialog({
     if (descriptionChanged) {
       next.description = description.trim().length > 0 ? description.trim() : null;
     }
+    if (updatesChanged) next.updates = updates;
     return next as BeDeployedProductDetailUpdatePayload;
-  }, [coresChanged, tpsChanged, descriptionChanged, coresNum, tpsNum, description]);
+  }, [
+    coresChanged,
+    tpsChanged,
+    descriptionChanged,
+    coresNum,
+    tpsNum,
+    description,
+    updatesChanged,
+    updates,
+  ]);
 
   const canSave =
     !isSaving &&
     !coresError &&
     !tpsError &&
-    (coresChanged || tpsChanged || descriptionChanged);
+    (coresChanged || tpsChanged || descriptionChanged || updatesChanged);
 
   return (
     <Dialog open onClose={onClose} maxWidth="sm" fullWidth>
       <DialogTitle>Edit deployed product</DialogTitle>
+      <Tabs value={tab} onChange={(_e, v: number) => setTab(v)} sx={{ px: 3, minHeight: 36 }}>
+        <Tab label="Details" id="edit-deployed-product-tab-details" />
+        <Tab label="Update History" id="edit-deployed-product-tab-history" />
+      </Tabs>
       <DialogContent dividers>
-        <Box sx={{ display: "flex", flexDirection: "column", gap: 2, pt: 0.5 }}>
-          <TextField
-            label="Cores"
-            value={cores}
-            onChange={(e) => setCores(e.target.value)}
-            size="small"
-            fullWidth
-            type="number"
-            autoFocus
-            slotProps={{ htmlInput: { min: 0, step: 1 } }}
-            error={coresError}
-            helperText={coresError ? "Must be a non-negative integer." : " "}
-          />
+        {tab === 0 && (
+          <Box sx={{ display: "flex", flexDirection: "column", gap: 2, pt: 0.5 }}>
+            <TextField
+              label="Cores"
+              value={cores}
+              onChange={(e) => setCores(e.target.value)}
+              size="small"
+              fullWidth
+              type="number"
+              autoFocus
+              slotProps={{ htmlInput: { min: 0, step: 1 } }}
+              error={coresError}
+              helperText={coresError ? "Must be a non-negative integer." : " "}
+            />
 
-          <TextField
-            label="TPS"
-            value={tps}
-            onChange={(e) => setTps(e.target.value)}
-            size="small"
-            fullWidth
-            type="number"
-            slotProps={{ htmlInput: { min: 0, step: 0.1 } }}
-            error={tpsError}
-            helperText={tpsError ? "Must be a non-negative number." : " "}
-          />
+            <TextField
+              label="TPS"
+              value={tps}
+              onChange={(e) => setTps(e.target.value)}
+              size="small"
+              fullWidth
+              type="number"
+              slotProps={{ htmlInput: { min: 0, step: 0.1 } }}
+              error={tpsError}
+              helperText={tpsError ? "Must be a non-negative number." : " "}
+            />
 
-          <TextField
-            label="Description"
-            value={description}
-            onChange={(e) => setDescription(e.target.value)}
-            size="small"
-            fullWidth
-            multiline
-            minRows={2}
-            slotProps={{ htmlInput: { maxLength: DESCRIPTION_MAX } }}
-          />
-        </Box>
+            <TextField
+              label="Description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              size="small"
+              fullWidth
+              multiline
+              minRows={2}
+              slotProps={{ htmlInput: { maxLength: DESCRIPTION_MAX } }}
+            />
+          </Box>
+        )}
+
+        {tab === 1 && (
+          <Box sx={{ display: "flex", flexDirection: "column", gap: 2, pt: 0.5 }}>
+            {updates.length === 0 ? (
+              <Typography variant="body2" color="text.secondary">
+                No update history recorded.
+              </Typography>
+            ) : (
+              <Table size="small">
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Level</TableCell>
+                    <TableCell>Date</TableCell>
+                    <TableCell>Details</TableCell>
+                    <TableCell align="right">Actions</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {updates.map((u, i) => (
+                    <TableRow key={i}>
+                      <TableCell>{u.updateLevel}</TableCell>
+                      <TableCell>{u.date}</TableCell>
+                      <TableCell sx={{ maxWidth: 160 }}>
+                        <Typography variant="body2" noWrap title={u.details ?? undefined}>
+                          {u.details || "—"}
+                        </Typography>
+                      </TableCell>
+                      <TableCell align="right">
+                        <IconButton
+                          size="small"
+                          aria-label={`Edit update level ${u.updateLevel}`}
+                          onClick={() => handleEditRow(i)}
+                          disabled={isSaving}
+                        >
+                          <Pencil size={14} />
+                        </IconButton>
+                        <IconButton
+                          size="small"
+                          aria-label={`Delete update level ${u.updateLevel}`}
+                          onClick={() => handleDeleteRow(i)}
+                          disabled={isSaving}
+                        >
+                          <Trash2 size={14} />
+                        </IconButton>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            )}
+
+            <Box
+              sx={{
+                display: "flex",
+                flexDirection: "column",
+                gap: 1.5,
+                border: 1,
+                borderColor: "divider",
+                borderRadius: 1,
+                p: 1.5,
+              }}
+            >
+              <Typography variant="caption" color="text.secondary">
+                {editingIndex === null ? "Add an update" : "Edit update"}
+              </Typography>
+              <Box sx={{ display: "flex", gap: 1.5, flexWrap: "wrap" }}>
+                <TextField
+                  label="Update level"
+                  value={rowLevel}
+                  onChange={(e) => setRowLevel(e.target.value)}
+                  size="small"
+                  type="number"
+                  slotProps={{ htmlInput: { min: 0, step: 1 } }}
+                  error={rowLevelError}
+                  helperText={rowLevelError ? "Must be a non-negative integer." : " "}
+                  sx={{ flex: 1, minWidth: 120 }}
+                />
+                <TextField
+                  label="Date"
+                  value={rowDate}
+                  onChange={(e) => setRowDate(e.target.value)}
+                  size="small"
+                  type="date"
+                  slotProps={{ inputLabel: { shrink: true } }}
+                  sx={{ flex: 1, minWidth: 160 }}
+                />
+              </Box>
+              <TextField
+                label="Details"
+                value={rowDetails}
+                onChange={(e) => setRowDetails(e.target.value)}
+                size="small"
+                fullWidth
+                multiline
+                minRows={2}
+              />
+              <Box sx={{ display: "flex", gap: 1, justifyContent: "flex-end" }}>
+                {editingIndex !== null && (
+                  <Button size="small" onClick={resetRowForm} disabled={isSaving}>
+                    Cancel
+                  </Button>
+                )}
+                <Button
+                  size="small"
+                  variant="outlined"
+                  startIcon={<Plus size={14} />}
+                  onClick={handleAddOrSaveRow}
+                  disabled={!canAddOrSaveRow || isSaving}
+                >
+                  {editingIndex === null ? "Add" : "Save row"}
+                </Button>
+              </Box>
+            </Box>
+          </Box>
+        )}
       </DialogContent>
       <DialogActions>
         <Button onClick={onClose} disabled={isSaving}>

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/EditDeployedProductDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/EditDeployedProductDialog.tsx
@@ -21,51 +21,68 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
-  IconButton,
   Tab,
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableRow,
   Tabs,
   TextField,
-  Typography,
 } from "@wso2/oxygen-ui";
-import { Pencil, Plus, Trash2 } from "@wso2/oxygen-ui-icons-react";
-import { useMemo, useState, type JSX } from "react";
+import { useState, type JSX } from "react";
 import type {
   BeDeployedProduct,
   BeDeployedProductDetailUpdatePayload,
   BeProductUpdate,
 } from "@api/backend/types";
+import UpdateHistoryPanel, {
+  type UpdateHistoryFormState,
+} from "@features/csm-projects/components/UpdateHistoryPanel";
 
 interface EditDeployedProductDialogProps {
   deployedProduct: BeDeployedProduct;
-  /** True while the PATCH is in flight; disables actions. */
+  /** True while the Details-tab PATCH is in flight; disables Details fields/Save. */
   isSaving: boolean;
   onClose: () => void;
-  /** Persist the changed detail fields (only changed fields are sent). */
-  onSave: (payload: BeDeployedProductDetailUpdatePayload) => void;
+  /** Persist the changed detail fields only (only changed fields are sent). */
+  onSaveDetails: (payload: BeDeployedProductDetailUpdatePayload) => void;
+  /**
+   * Persist the whole update-history array immediately. Independent of
+   * {@link onSaveDetails} — does not close the dialog either way; the caller
+   * resolves/rejects based on the PATCH result so the history panel can show
+   * inline feedback.
+   */
+  onSaveHistory: (updates: BeProductUpdate[]) => Promise<void>;
 }
 
 const DESCRIPTION_MAX = 4000;
 
-/** Deep-enough equality for the update-history array (small, plain objects). */
-function updatesEqual(a: BeProductUpdate[], b: BeProductUpdate[]): boolean {
-  return JSON.stringify(a) === JSON.stringify(b);
+function updateHistoryFooterLabel(action: UpdateHistoryFormState["saveAction"]): string {
+  switch (action) {
+    case "delete":
+      return "Deleting Update...";
+    case "edit":
+      return "Saving Update...";
+    default:
+      return "Adding...";
+  }
 }
 
 /**
  * Edit a deployed product: its cores/tps/description (Details tab) and its
- * update-level history (Update History tab), both via
+ * update-level history (Update History tab), via
  * `PATCH /deployments/{deploymentId}/products/{productId}` (detail variant).
  *
- * Only changed fields are sent — the BE requires minProperties 1, so Save is
- * disabled until at least one field differs across either tab. The Update
- * History tab is a client-side array editor: add/edit/delete a row locally,
- * then Save PATCHes the *whole* resulting array (there is no per-entry
- * endpoint) alongside any changed detail fields.
+ * The two tabs are independent saves, matching customer-portal's
+ * `ManageProductModal`/`UpdateHistoryTab` interaction:
+ *  - Details tab: only changed fields are sent (BE requires minProperties 1);
+ *    Save is disabled until at least one field differs. On success the
+ *    dialog closes.
+ *  - Update History tab: add/edit/delete each PATCH the whole resulting
+ *    array immediately (there is no per-entry endpoint) via
+ *    {@link UpdateHistoryPanel}; the dialog stays open either way, showing
+ *    inline feedback in the panel itself.
+ *
+ * The footer's action button switches with the active tab: "Save changes"
+ * on Details, "Add update" (label reflecting the in-flight action) on Update
+ * History — the latter is bound to the history panel's own add-form submit
+ * via state the panel lifts up through {@link onFormStateChange}.
  *
  * Deactivation is a separate concern handled via a confirm dialog in
  * {@link DeployedProductsPanel}, not here — keeping the two BE shapes distinct
@@ -77,7 +94,8 @@ export default function EditDeployedProductDialog({
   deployedProduct,
   isSaving,
   onClose,
-  onSave,
+  onSaveDetails,
+  onSaveHistory,
 }: EditDeployedProductDialogProps): JSX.Element {
   const [tab, setTab] = useState(0);
 
@@ -105,86 +123,24 @@ export default function EditDeployedProductDialog({
   const tpsChanged = tpsNum !== originalTps;
   const descriptionChanged = description.trim() !== originalDescription;
 
-  // --- Update History tab state -----------------------------------------
-  const originalUpdates = useMemo<BeProductUpdate[]>(
-    () => deployedProduct.updates ?? [],
-    [deployedProduct.updates],
-  );
-  const [updates, setUpdates] = useState<BeProductUpdate[]>(originalUpdates);
-  const [editingIndex, setEditingIndex] = useState<number | null>(null);
-  const [rowLevel, setRowLevel] = useState("");
-  const [rowDate, setRowDate] = useState("");
-  const [rowDetails, setRowDetails] = useState("");
+  const detailsPayload: BeDeployedProductDetailUpdatePayload = {};
+  if (coresChanged) detailsPayload.cores = coresNum;
+  if (tpsChanged) detailsPayload.tps = tpsNum;
+  if (descriptionChanged) {
+    detailsPayload.description = description.trim().length > 0 ? description.trim() : null;
+  }
 
-  const updatesChanged = !updatesEqual(updates, originalUpdates);
-
-  const rowLevelNum = rowLevel.trim() === "" ? null : Number(rowLevel);
-  const rowLevelError =
-    rowLevel.trim() !== "" && (!Number.isInteger(rowLevelNum) || (rowLevelNum as number) < 0);
-  const canAddOrSaveRow =
-    rowLevel.trim() !== "" && !rowLevelError && rowDate.trim() !== "";
-
-  const resetRowForm = (): void => {
-    setEditingIndex(null);
-    setRowLevel("");
-    setRowDate("");
-    setRowDetails("");
-  };
-
-  const handleAddOrSaveRow = (): void => {
-    if (!canAddOrSaveRow) return;
-    const entry: BeProductUpdate = {
-      updateLevel: rowLevelNum as number,
-      date: rowDate,
-      details: rowDetails.trim() ? rowDetails.trim() : undefined,
-    };
-    if (editingIndex === null) {
-      setUpdates((prev) => [...prev, entry]);
-    } else {
-      setUpdates((prev) => prev.map((u, i) => (i === editingIndex ? entry : u)));
-    }
-    resetRowForm();
-  };
-
-  const handleEditRow = (index: number): void => {
-    const u = updates[index];
-    setEditingIndex(index);
-    setRowLevel(String(u.updateLevel));
-    setRowDate(u.date);
-    setRowDetails(u.details ?? "");
-  };
-
-  const handleDeleteRow = (index: number): void => {
-    setUpdates((prev) => prev.filter((_, i) => i !== index));
-    if (editingIndex === index) resetRowForm();
-  };
-
-  // --- Combined save ------------------------------------------------------
-  const payload = useMemo<BeDeployedProductDetailUpdatePayload>(() => {
-    const next: Record<string, unknown> = {};
-    if (coresChanged) next.cores = coresNum;
-    if (tpsChanged) next.tps = tpsNum;
-    if (descriptionChanged) {
-      next.description = description.trim().length > 0 ? description.trim() : null;
-    }
-    if (updatesChanged) next.updates = updates;
-    return next as BeDeployedProductDetailUpdatePayload;
-  }, [
-    coresChanged,
-    tpsChanged,
-    descriptionChanged,
-    coresNum,
-    tpsNum,
-    description,
-    updatesChanged,
-    updates,
-  ]);
-
-  const canSave =
+  const canSaveDetails =
     !isSaving &&
     !coresError &&
     !tpsError &&
-    (coresChanged || tpsChanged || descriptionChanged || updatesChanged);
+    (coresChanged || tpsChanged || descriptionChanged);
+
+  // --- Update History tab state -----------------------------------------
+  const updates = deployedProduct.updates ?? [];
+  const [historyFormState, setHistoryFormState] = useState<UpdateHistoryFormState | null>(null);
+
+  const anySaving = isSaving || (historyFormState?.isSaving ?? false);
 
   return (
     <Dialog open onClose={onClose} maxWidth="sm" fullWidth>
@@ -207,6 +163,7 @@ export default function EditDeployedProductDialog({
               slotProps={{ htmlInput: { min: 0, step: 1 } }}
               error={coresError}
               helperText={coresError ? "Must be a non-negative integer." : " "}
+              disabled={isSaving}
             />
 
             <TextField
@@ -219,6 +176,7 @@ export default function EditDeployedProductDialog({
               slotProps={{ htmlInput: { min: 0, step: 0.1 } }}
               error={tpsError}
               helperText={tpsError ? "Must be a non-negative number." : " "}
+              disabled={isSaving}
             />
 
             <TextField
@@ -230,132 +188,43 @@ export default function EditDeployedProductDialog({
               multiline
               minRows={2}
               slotProps={{ htmlInput: { maxLength: DESCRIPTION_MAX } }}
+              disabled={isSaving}
             />
           </Box>
         )}
 
         {tab === 1 && (
-          <Box sx={{ display: "flex", flexDirection: "column", gap: 2, pt: 0.5 }}>
-            {updates.length === 0 ? (
-              <Typography variant="body2" color="text.secondary">
-                No update history recorded.
-              </Typography>
-            ) : (
-              <Table size="small">
-                <TableHead>
-                  <TableRow>
-                    <TableCell>Level</TableCell>
-                    <TableCell>Date</TableCell>
-                    <TableCell>Details</TableCell>
-                    <TableCell align="right">Actions</TableCell>
-                  </TableRow>
-                </TableHead>
-                <TableBody>
-                  {updates.map((u, i) => (
-                    <TableRow key={i}>
-                      <TableCell>{u.updateLevel}</TableCell>
-                      <TableCell>{u.date}</TableCell>
-                      <TableCell sx={{ maxWidth: 160 }}>
-                        <Typography variant="body2" noWrap title={u.details ?? undefined}>
-                          {u.details || "—"}
-                        </Typography>
-                      </TableCell>
-                      <TableCell align="right">
-                        <IconButton
-                          size="small"
-                          aria-label={`Edit update level ${u.updateLevel}`}
-                          onClick={() => handleEditRow(i)}
-                          disabled={isSaving}
-                        >
-                          <Pencil size={14} />
-                        </IconButton>
-                        <IconButton
-                          size="small"
-                          aria-label={`Delete update level ${u.updateLevel}`}
-                          onClick={() => handleDeleteRow(i)}
-                          disabled={isSaving}
-                        >
-                          <Trash2 size={14} />
-                        </IconButton>
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            )}
-
-            <Box
-              sx={{
-                display: "flex",
-                flexDirection: "column",
-                gap: 1.5,
-                border: 1,
-                borderColor: "divider",
-                borderRadius: 1,
-                p: 1.5,
-              }}
-            >
-              <Typography variant="caption" color="text.secondary">
-                {editingIndex === null ? "Add an update" : "Edit update"}
-              </Typography>
-              <Box sx={{ display: "flex", gap: 1.5, flexWrap: "wrap" }}>
-                <TextField
-                  label="Update level"
-                  value={rowLevel}
-                  onChange={(e) => setRowLevel(e.target.value)}
-                  size="small"
-                  type="number"
-                  slotProps={{ htmlInput: { min: 0, step: 1 } }}
-                  error={rowLevelError}
-                  helperText={rowLevelError ? "Must be a non-negative integer." : " "}
-                  sx={{ flex: 1, minWidth: 120 }}
-                />
-                <TextField
-                  label="Date"
-                  value={rowDate}
-                  onChange={(e) => setRowDate(e.target.value)}
-                  size="small"
-                  type="date"
-                  slotProps={{ inputLabel: { shrink: true } }}
-                  sx={{ flex: 1, minWidth: 160 }}
-                />
-              </Box>
-              <TextField
-                label="Details"
-                value={rowDetails}
-                onChange={(e) => setRowDetails(e.target.value)}
-                size="small"
-                fullWidth
-                multiline
-                minRows={2}
-              />
-              <Box sx={{ display: "flex", gap: 1, justifyContent: "flex-end" }}>
-                {editingIndex !== null && (
-                  <Button size="small" onClick={resetRowForm} disabled={isSaving}>
-                    Cancel
-                  </Button>
-                )}
-                <Button
-                  size="small"
-                  variant="outlined"
-                  startIcon={<Plus size={14} />}
-                  onClick={handleAddOrSaveRow}
-                  disabled={!canAddOrSaveRow || isSaving}
-                >
-                  {editingIndex === null ? "Add" : "Save row"}
-                </Button>
-              </Box>
-            </Box>
-          </Box>
+          <UpdateHistoryPanel
+            updates={updates}
+            onSaveUpdates={onSaveHistory}
+            onFormStateChange={setHistoryFormState}
+          />
         )}
       </DialogContent>
       <DialogActions>
-        <Button onClick={onClose} disabled={isSaving}>
+        <Button onClick={onClose} disabled={anySaving}>
           Cancel
         </Button>
-        <Button variant="contained" disabled={!canSave} onClick={() => onSave(payload)}>
-          Save changes
-        </Button>
+        {tab === 0 && (
+          <Button
+            variant="contained"
+            disabled={!canSaveDetails}
+            onClick={() => onSaveDetails(detailsPayload)}
+          >
+            Save changes
+          </Button>
+        )}
+        {tab === 1 && historyFormState && (
+          <Button
+            variant="contained"
+            disabled={!historyFormState.canAdd}
+            onClick={historyFormState.handleAdd}
+          >
+            {historyFormState.isSaving
+              ? updateHistoryFooterLabel(historyFormState.saveAction)
+              : "Add update"}
+          </Button>
+        )}
       </DialogActions>
     </Dialog>
   );

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/UpdateHistoryPanel.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/UpdateHistoryPanel.tsx
@@ -1,0 +1,438 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Alert, Box, Button, IconButton, TextField, Typography, alpha } from "@wso2/oxygen-ui";
+import { SquarePen, Trash2 } from "@wso2/oxygen-ui-icons-react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type JSX,
+} from "react";
+import type { BeProductUpdate } from "@api/backend/types";
+
+/** Which action currently owns the in-flight PATCH, for the footer button label. */
+export type UpdateHistorySaveAction = "add" | "edit" | "delete";
+
+/**
+ * State the panel lifts up to {@link EditDeployedProductDialog} so its footer
+ * "Add update" button can trigger (and reflect) the panel's own add-form
+ * submit — mirrors customer-portal's `onFormStateChange` contract.
+ */
+export interface UpdateHistoryFormState {
+  canAdd: boolean;
+  isSaving: boolean;
+  saveAction: UpdateHistorySaveAction | null;
+  handleAdd: () => void;
+}
+
+interface Feedback {
+  message: string;
+  severity: "success" | "error";
+}
+
+interface UpdateHistoryPanelProps {
+  updates: BeProductUpdate[];
+  /**
+   * Persist the whole resulting array immediately (add/edit/delete each call
+   * this independently — there is no per-entry endpoint, see
+   * {@link BeDeployedProductDetailUpdatePayload}). Rejects on failure so the
+   * panel can show an inline error and keep the in-flight form open.
+   */
+  onSaveUpdates: (updates: BeProductUpdate[]) => Promise<void>;
+  /** Lifts the add-form's submit affordance up to the dialog's footer button. */
+  onFormStateChange: (state: UpdateHistoryFormState | null) => void;
+}
+
+const EMPTY_FORM = { updateLevel: "", date: "", details: "" };
+
+function errorMessage(err: unknown, fallback: string): string {
+  return err instanceof Error && err.message.trim() ? err.message : fallback;
+}
+
+/**
+ * Update-history tab of {@link EditDeployedProductDialog}: a vertical timeline
+ * of `BeProductUpdate` entries with add/edit/delete, each saving immediately
+ * via {@link onSaveUpdates} — independent of the dialog's Details tab. Only
+ * the latest (highest `updateLevel`) entry is editable in place; delete has
+ * no confirm step, matching customer-portal's `UpdateHistoryTab`.
+ *
+ * csm-portal has no recommended-update-levels lookup (unlike customer-portal),
+ * so update level is a plain number field here rather than a dropdown.
+ */
+export default function UpdateHistoryPanel({
+  updates,
+  onSaveUpdates,
+  onFormStateChange,
+}: UpdateHistoryPanelProps): JSX.Element {
+  const [form, setForm] = useState(EMPTY_FORM);
+  const [editingIndex, setEditingIndex] = useState<number | null>(null);
+  const [editForm, setEditForm] = useState(EMPTY_FORM);
+  const [saveInFlight, setSaveInFlight] = useState<UpdateHistorySaveAction | null>(null);
+  const [feedback, setFeedback] = useState<Feedback | null>(null);
+
+  const isSaving = saveInFlight !== null;
+
+  const sortedUpdates = useMemo(
+    () =>
+      updates
+        .map((u, originalIndex) => ({ u, originalIndex }))
+        .sort((a, b) => b.u.updateLevel - a.u.updateLevel),
+    [updates],
+  );
+
+  const currentUpdateLevel = sortedUpdates.length > 0 ? sortedUpdates[0].u.updateLevel : null;
+
+  const formLevelNum = form.updateLevel.trim() === "" ? null : Number(form.updateLevel);
+  const formLevelError =
+    form.updateLevel.trim() !== "" &&
+    (!Number.isInteger(formLevelNum) || (formLevelNum as number) < 0);
+  const isFormValid = form.updateLevel.trim() !== "" && !formLevelError && form.date.trim() !== "";
+
+  const handleAddUpdate = useCallback(async () => {
+    if (!isFormValid) return;
+    const newUpdate: BeProductUpdate = {
+      updateLevel: formLevelNum as number,
+      date: form.date,
+      details: form.details.trim() ? form.details.trim() : undefined,
+    };
+    setSaveInFlight("add");
+    try {
+      await onSaveUpdates([...updates, newUpdate]);
+      setForm(EMPTY_FORM);
+      setFeedback({ message: "Update history entry added.", severity: "success" });
+    } catch (err) {
+      setFeedback({ message: errorMessage(err, "Could not add the update."), severity: "error" });
+    } finally {
+      setSaveInFlight(null);
+    }
+  }, [isFormValid, formLevelNum, form.date, form.details, updates, onSaveUpdates]);
+
+  // Keep a stable ref so the lifted `handleAdd` always calls the latest closure.
+  const handleAddUpdateRef = useRef(handleAddUpdate);
+  handleAddUpdateRef.current = handleAddUpdate;
+
+  useEffect(() => {
+    onFormStateChange({
+      canAdd: isFormValid && !isSaving,
+      isSaving,
+      saveAction: saveInFlight,
+      handleAdd: () => void handleAddUpdateRef.current(),
+    });
+  }, [isFormValid, isSaving, saveInFlight, onFormStateChange]);
+
+  // Clear the lifted state on unmount only (tab switch away / dialog close).
+  useEffect(() => {
+    return () => onFormStateChange(null);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const startEdit = (originalIndex: number): void => {
+    const u = updates[originalIndex];
+    setEditingIndex(originalIndex);
+    setEditForm({ updateLevel: String(u.updateLevel), date: u.date, details: u.details ?? "" });
+  };
+
+  const cancelEdit = (): void => {
+    setEditingIndex(null);
+    setEditForm(EMPTY_FORM);
+  };
+
+  const editLevelNum = editForm.updateLevel.trim() === "" ? null : Number(editForm.updateLevel);
+  const editLevelError =
+    editForm.updateLevel.trim() !== "" &&
+    (!Number.isInteger(editLevelNum) || (editLevelNum as number) < 0);
+  const isEditFormValid =
+    editForm.updateLevel.trim() !== "" && !editLevelError && editForm.date.trim() !== "";
+
+  const handleSaveEdit = useCallback(async () => {
+    if (editingIndex === null || !isEditFormValid) return;
+    const edited: BeProductUpdate = {
+      updateLevel: editLevelNum as number,
+      date: editForm.date,
+      details: editForm.details.trim() ? editForm.details.trim() : undefined,
+    };
+    const next = updates.map((u, i) => (i === editingIndex ? edited : u));
+    setSaveInFlight("edit");
+    try {
+      await onSaveUpdates(next);
+      setEditingIndex(null);
+      setEditForm(EMPTY_FORM);
+      setFeedback({ message: "Update history entry saved.", severity: "success" });
+    } catch (err) {
+      setFeedback({ message: errorMessage(err, "Could not save the update."), severity: "error" });
+    } finally {
+      setSaveInFlight(null);
+    }
+  }, [editingIndex, isEditFormValid, editLevelNum, editForm.date, editForm.details, updates, onSaveUpdates]);
+
+  const handleDelete = useCallback(
+    async (index: number) => {
+      const next = updates.filter((_, i) => i !== index);
+      setSaveInFlight("delete");
+      try {
+        await onSaveUpdates(next);
+        if (editingIndex === index) cancelEdit();
+        setFeedback({ message: "Update history entry deleted.", severity: "success" });
+      } catch (err) {
+        setFeedback({
+          message: errorMessage(err, "Could not delete the update."),
+          severity: "error",
+        });
+      } finally {
+        setSaveInFlight(null);
+      }
+    },
+    [updates, onSaveUpdates, editingIndex],
+  );
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 2, pt: 0.5 }}>
+      {feedback && (
+        <Alert severity={feedback.severity} onClose={() => setFeedback(null)}>
+          {feedback.message}
+        </Alert>
+      )}
+
+      {currentUpdateLevel !== null && (
+        <Box
+          sx={{
+            bgcolor: (theme) => alpha(theme.palette.primary.main, 0.08),
+            border: 1,
+            borderRadius: 1,
+            borderColor: (theme) => alpha(theme.palette.primary.main, 0.3),
+            p: 1.5,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+          }}
+        >
+          <Typography variant="body2" sx={{ fontWeight: 500 }}>
+            Current Update Level:
+          </Typography>
+          <Typography variant="subtitle1" sx={{ fontWeight: 600, color: "primary.main" }}>
+            U{currentUpdateLevel}
+          </Typography>
+        </Box>
+      )}
+
+      {sortedUpdates.length === 0 ? (
+        <Typography variant="body2" color="text.secondary">
+          No update history recorded.
+        </Typography>
+      ) : (
+        <Box sx={{ position: "relative" }}>
+          <Box
+            sx={{
+              position: "absolute",
+              left: 13,
+              top: 0,
+              bottom: 0,
+              width: "2px",
+              bgcolor: "divider",
+            }}
+          />
+          <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+            {sortedUpdates.map(({ u, originalIndex }) => {
+              const isLatest = u.updateLevel === currentUpdateLevel;
+              const isEditingThis = editingIndex === originalIndex;
+              return (
+                <Box key={`${u.updateLevel}-${u.date}`} sx={{ position: "relative", display: "flex", gap: 2 }}>
+                  <Box sx={{ position: "relative", zIndex: 1, flexShrink: 0 }}>
+                    <Box
+                      sx={{
+                        width: 28,
+                        height: 28,
+                        bgcolor: "primary.main",
+                        border: 4,
+                        borderColor: "background.paper",
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        borderRadius: "50%",
+                      }}
+                    >
+                      <Box sx={{ width: 8, height: 8, bgcolor: "background.paper", borderRadius: "50%" }} />
+                    </Box>
+                  </Box>
+                  <Box
+                    sx={{
+                      flex: 1,
+                      border: 1,
+                      borderColor: "divider",
+                      borderRadius: 1,
+                      p: 1.5,
+                    }}
+                  >
+                    {isEditingThis ? (
+                      <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+                        <Box sx={{ display: "flex", gap: 1.5, flexWrap: "wrap" }}>
+                          <TextField
+                            label="Update level"
+                            value={editForm.updateLevel}
+                            onChange={(e) =>
+                              setEditForm((prev) => ({ ...prev, updateLevel: e.target.value }))
+                            }
+                            size="small"
+                            type="number"
+                            slotProps={{ htmlInput: { min: 0, step: 1 } }}
+                            error={editLevelError}
+                            helperText={editLevelError ? "Must be a non-negative integer." : " "}
+                            disabled={isSaving}
+                            sx={{ flex: 1, minWidth: 120 }}
+                          />
+                          <TextField
+                            label="Date"
+                            value={editForm.date}
+                            onChange={(e) => setEditForm((prev) => ({ ...prev, date: e.target.value }))}
+                            size="small"
+                            type="date"
+                            slotProps={{ inputLabel: { shrink: true } }}
+                            disabled={isSaving}
+                            sx={{ flex: 1, minWidth: 160 }}
+                          />
+                        </Box>
+                        <TextField
+                          label="Details"
+                          value={editForm.details}
+                          onChange={(e) => setEditForm((prev) => ({ ...prev, details: e.target.value }))}
+                          size="small"
+                          fullWidth
+                          multiline
+                          minRows={2}
+                          disabled={isSaving}
+                        />
+                        <Box sx={{ display: "flex", gap: 1, justifyContent: "flex-end" }}>
+                          <Button size="small" onClick={cancelEdit} disabled={isSaving}>
+                            Cancel
+                          </Button>
+                          <Button
+                            size="small"
+                            variant="contained"
+                            onClick={() => void handleSaveEdit()}
+                            disabled={!isEditFormValid || isSaving}
+                          >
+                            {saveInFlight === "edit" ? "Saving Update..." : "Save"}
+                          </Button>
+                        </Box>
+                      </Box>
+                    ) : (
+                      <>
+                        <Box
+                          sx={{
+                            display: "flex",
+                            alignItems: "flex-start",
+                            justifyContent: "space-between",
+                          }}
+                        >
+                          <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                            <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+                              U{u.updateLevel}
+                            </Typography>
+                            {isLatest && (
+                              <IconButton
+                                size="small"
+                                aria-label={`Edit update level ${u.updateLevel}`}
+                                onClick={() => startEdit(originalIndex)}
+                                disabled={isSaving}
+                              >
+                                <SquarePen size={14} />
+                              </IconButton>
+                            )}
+                          </Box>
+                          <IconButton
+                            size="small"
+                            aria-label={`Delete update level ${u.updateLevel}`}
+                            onClick={() => void handleDelete(originalIndex)}
+                            disabled={isSaving}
+                          >
+                            <Trash2 size={14} />
+                          </IconButton>
+                        </Box>
+                        <Typography variant="body2" color="text.secondary">
+                          Date: {u.date}
+                        </Typography>
+                        {u.details && (
+                          <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+                            {u.details}
+                          </Typography>
+                        )}
+                      </>
+                    )}
+                  </Box>
+                </Box>
+              );
+            })}
+          </Box>
+        </Box>
+      )}
+
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          gap: 1.5,
+          borderTop: 1,
+          borderColor: "divider",
+          pt: 2,
+        }}
+      >
+        <Typography variant="caption" color="text.secondary">
+          Add an update
+        </Typography>
+        <Box sx={{ display: "flex", gap: 1.5, flexWrap: "wrap" }}>
+          <TextField
+            label="Update level"
+            value={form.updateLevel}
+            onChange={(e) => setForm((prev) => ({ ...prev, updateLevel: e.target.value }))}
+            size="small"
+            type="number"
+            slotProps={{ htmlInput: { min: 0, step: 1 } }}
+            error={formLevelError}
+            helperText={formLevelError ? "Must be a non-negative integer." : " "}
+            disabled={isSaving}
+            sx={{ flex: 1, minWidth: 120 }}
+          />
+          <TextField
+            label="Date"
+            value={form.date}
+            onChange={(e) => setForm((prev) => ({ ...prev, date: e.target.value }))}
+            size="small"
+            type="date"
+            slotProps={{ inputLabel: { shrink: true } }}
+            disabled={isSaving}
+            sx={{ flex: 1, minWidth: 160 }}
+          />
+        </Box>
+        <TextField
+          label="Details"
+          value={form.details}
+          onChange={(e: ChangeEvent<HTMLInputElement>) =>
+            setForm((prev) => ({ ...prev, details: e.target.value }))
+          }
+          size="small"
+          fullWidth
+          multiline
+          minRows={2}
+          disabled={isSaving}
+        />
+      </Box>
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/UpdateHistoryPanel.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/UpdateHistoryPanel.tsx
@@ -98,6 +98,7 @@ export default function UpdateHistoryPanel({
   );
 
   const currentUpdateLevel = sortedUpdates.length > 0 ? sortedUpdates[0].u.updateLevel : null;
+  const latestOriginalIndex = sortedUpdates.length > 0 ? sortedUpdates[0].originalIndex : null;
 
   const formLevelNum = form.updateLevel.trim() === "" ? null : Number(form.updateLevel);
   const formLevelError =
@@ -250,10 +251,10 @@ export default function UpdateHistoryPanel({
           />
           <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
             {sortedUpdates.map(({ u, originalIndex }) => {
-              const isLatest = u.updateLevel === currentUpdateLevel;
+              const isLatest = originalIndex === latestOriginalIndex;
               const isEditingThis = editingIndex === originalIndex;
               return (
-                <Box key={`${u.updateLevel}-${u.date}`} sx={{ position: "relative", display: "flex", gap: 2 }}>
+                <Box key={originalIndex} sx={{ position: "relative", display: "flex", gap: 2 }}>
                   <Box sx={{ position: "relative", zIndex: 1, flexShrink: 0 }}>
                     <Box
                       sx={{

--- a/apps/csm-portal/webapp/src/features/csm-projects/types/csmProjects.ts
+++ b/apps/csm-portal/webapp/src/features/csm-projects/types/csmProjects.ts
@@ -111,3 +111,20 @@ export interface SearchProjectsResponse {
   offset: number;
   hasMore: boolean;
 }
+
+/**
+ * A file attached to a deployment (`referenceType: "deployment"` on the
+ * shared, reference-generic `/attachments*` endpoints — see
+ * `BeAttachment` in `@api/backend/types`).
+ */
+export interface DeploymentAttachment {
+  id: string;
+  name: string;
+  /** MIME type (e.g. image/png, application/pdf). */
+  contentType: string;
+  sizeBytes: number;
+  description?: string | null;
+  uploadedBy: string;
+  uploadedOn: string;
+  downloadUrl?: string | null;
+}

--- a/apps/csm-portal/webapp/src/features/help/content/customers.md
+++ b/apps/csm-portal/webapp/src/features/help/content/customers.md
@@ -47,10 +47,10 @@ deactivate it. Deactivating a deployment marks it inactive rather than deleting 
 Opening a deployment shows its deployed products and attachments:
 
 - **Deployed products**: create, edit, or deactivate a product deployed to that
-  environment. Editing a deployed product has two tabs — **Details** (cores, TPS,
-  description) and **Update History**, where you can add, edit, or remove a version-update
-  entry (update level, date, and optional details). Both tabs save together with a single
-  **Save changes** action.
+  environment. Editing a deployed product has two tabs, each saving independently:
+  **Details** (cores, TPS, description), saved with a **Save changes** action, and
+  **Update History**, where each add, edit (of the latest entry), or delete of a
+  version-update entry (update level, date, and optional details) saves immediately.
 - **Attachments**: upload, list, edit the name/description of, download, or delete
   documents attached to the deployment.
 

--- a/apps/csm-portal/webapp/src/features/help/content/customers.md
+++ b/apps/csm-portal/webapp/src/features/help/content/customers.md
@@ -44,6 +44,16 @@ environment), each with its own type, description, and the products deployed to 
 Deployments tab lists a project's deployments and lets you create one, edit its details, or
 deactivate it. Deactivating a deployment marks it inactive rather than deleting it.
 
+Opening a deployment shows its deployed products and attachments:
+
+- **Deployed products**: create, edit, or deactivate a product deployed to that
+  environment. Editing a deployed product has two tabs — **Details** (cores, TPS,
+  description) and **Update History**, where you can add, edit, or remove a version-update
+  entry (update level, date, and optional details). Both tabs save together with a single
+  **Save changes** action.
+- **Attachments**: upload, list, edit the name/description of, download, or delete
+  documents attached to the deployment.
+
 ### Project contacts
 
 The Project contacts tab lists the people registered on a project (name, email, roles, and

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -815,17 +815,31 @@ type DeployedProductVersionRef struct {
 
 // DeployedProductView is the enriched search result for a deployed product.
 // It embeds deployment, product, and version as named refs and uses createdOn/updatedOn naming.
-// Cores, TPS, and Category are SN-only fields; they are always null for the Postgres path.
+// Cores, TPS, Category, and Updates are SN-only fields; they are always null/empty for the
+// Postgres path.
 type DeployedProductView struct {
 	ID         string                     `json:"id"`
 	Deployment EntityRef                  `json:"deployment"`
 	Product    EntityRef                  `json:"product"`
 	Version    *DeployedProductVersionRef `json:"version"`
-	Cores      *string                    `json:"cores"`
-	TPS        *string                    `json:"tps"`
+	Cores      *int                       `json:"cores"`
+	TPS        *float64                   `json:"tps"`
 	Category   *string                    `json:"category"`
-	CreatedOn  time.Time                  `json:"createdOn"`
-	UpdatedOn  time.Time                  `json:"updatedOn"`
+	// Updates is the deployed product's update-level history, most-recent-first as
+	// returned by the backing data source. Nil/empty when none have been recorded.
+	Updates   []ProductUpdateEntry `json:"updates"`
+	CreatedOn time.Time            `json:"createdOn"`
+	UpdatedOn time.Time            `json:"updatedOn"`
+}
+
+// ProductUpdateEntry records a single update-level change applied to a deployed product
+// (e.g. a patch or upgrade applied to the running instance).
+type ProductUpdateEntry struct {
+	UpdateLevel int `json:"updateLevel"`
+	// Date is a date-only "YYYY-MM-DD" string, matching the backing data source's wire format.
+	Date string `json:"date"`
+	// Details is optional free-text describing the update.
+	Details *string `json:"details"`
 }
 
 // SearchDeployedProductsRequest is the input for a deployed-product search operation.
@@ -871,17 +885,22 @@ type CreatedDeployedProduct struct {
 }
 
 // UpdateDeployedProductRequest is the input for PATCH /deployed-products/{id}.
-// Either detail fields (Cores, TPS, Description) or Active=false must be provided, but not both.
+// Either detail fields (Cores, TPS, Description, Updates) or Active=false must be provided,
+// but not both.
 // Description uses json.RawMessage to preserve three states: nil/empty = omit, "null" = clear, `"value"` = set.
 // DeploymentID, when provided, scopes the update: the deployed product must belong to that
 // deployment or the operation returns a NotFoundError.
+// Updates, when non-nil, replaces the deployed product's entire update-history array (the
+// backing data source has whole-array replace semantics: the caller fetches the current
+// array, mutates it client-side, and PATCHes the full array back).
 type UpdateDeployedProductRequest struct {
-	ID           string          `json:"-"`
-	DeploymentID *string         `json:"deploymentId,omitempty"`
-	Cores        *int            `json:"cores"`
-	TPS          *float64        `json:"tps"`
-	Description  json.RawMessage `json:"description,omitempty"`
-	Active       *bool           `json:"active"`
+	ID           string               `json:"-"`
+	DeploymentID *string              `json:"deploymentId,omitempty"`
+	Cores        *int                 `json:"cores"`
+	TPS          *float64             `json:"tps"`
+	Description  json.RawMessage      `json:"description,omitempty"`
+	Updates      []ProductUpdateEntry `json:"updates,omitempty"`
+	Active       *bool                `json:"active"`
 }
 
 // UpdateDeployedProductResponse is the response for PATCH /deployed-products/{id}.
@@ -895,6 +914,10 @@ type UpdatedDeployedProduct struct {
 	ID        string    `json:"id"`
 	UpdatedOn time.Time `json:"updatedOn"`
 	UpdatedBy string    `json:"updatedBy"`
+	// Updates echoes back the deployed product's update-history array as it stands
+	// after the write, when the backing data source returns it. Nil when the write
+	// did not touch Updates and the data source omits it from the response.
+	Updates []ProductUpdateEntry `json:"updates,omitempty"`
 }
 
 // CaseIssueType classifies the nature of a support case.
@@ -2251,6 +2274,31 @@ type DeleteAttachmentRequest struct {
 // DeleteAttachmentResponse is the output for DELETE /cases/{id}/attachments/{attachmentId}.
 type DeleteAttachmentResponse struct {
 	Message string `json:"message"`
+}
+
+// UpdateAttachmentRequest is the input for PATCH /attachments/{attachmentId}.
+// ReferenceID and ReferenceType scope the update the same way SearchAttachmentsRequest does
+// (an IDOR guard: the caller asserts which entity it believes the attachment belongs to).
+// At least one of Name or Description must be provided.
+type UpdateAttachmentRequest struct {
+	AttachmentID  string        `json:"-"`
+	ReferenceID   string        `json:"referenceId"`
+	ReferenceType ReferenceType `json:"referenceType"`
+	Name          *string       `json:"name,omitempty"`
+	Description   *string       `json:"description,omitempty"`
+}
+
+// UpdateAttachmentResponse is the response for PATCH /attachments/{attachmentId}.
+type UpdateAttachmentResponse struct {
+	Message    string            `json:"message"`
+	Attachment UpdatedAttachment `json:"attachment"`
+}
+
+// UpdatedAttachment carries the fields that may change after an attachment update.
+type UpdatedAttachment struct {
+	ID        string    `json:"id"`
+	UpdatedOn time.Time `json:"updatedOn"`
+	UpdatedBy string    `json:"updatedBy"`
 }
 
 // ChangeRequestType classifies the change request type.

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -2280,12 +2280,15 @@ type DeleteAttachmentResponse struct {
 // ReferenceID and ReferenceType scope the update the same way SearchAttachmentsRequest does
 // (an IDOR guard: the caller asserts which entity it believes the attachment belongs to).
 // At least one of Name or Description must be provided.
+// Description uses json.RawMessage to preserve three states: nil/empty = omit, "null" = clear,
+// `"value"` = set -- mirroring UpdateDeployedProductRequest.Description, since a plain *string
+// cannot tell an omitted field apart from an explicit null.
 type UpdateAttachmentRequest struct {
-	AttachmentID  string        `json:"-"`
-	ReferenceID   string        `json:"referenceId"`
-	ReferenceType ReferenceType `json:"referenceType"`
-	Name          *string       `json:"name,omitempty"`
-	Description   *string       `json:"description,omitempty"`
+	AttachmentID  string          `json:"-"`
+	ReferenceID   string          `json:"referenceId"`
+	ReferenceType ReferenceType   `json:"referenceType"`
+	Name          *string         `json:"name,omitempty"`
+	Description   json.RawMessage `json:"description,omitempty"`
 }
 
 // UpdateAttachmentResponse is the response for PATCH /attachments/{attachmentId}.

--- a/entity-service/internal/handler/case_handler.go
+++ b/entity-service/internal/handler/case_handler.go
@@ -262,6 +262,34 @@ func (h *CaseHandler) DeleteCaseAttachment(w http.ResponseWriter, r *http.Reques
 	_ = json.NewEncoder(w).Encode(resp)
 }
 
+// GetAttachment handles GET /attachments/{id}.
+func (h *CaseHandler) GetAttachment(w http.ResponseWriter, r *http.Request) {
+	attachmentID := r.PathValue("id")
+	resp, err := h.svc.GetAttachment(r.Context(), attachmentID)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// UpdateAttachment handles PATCH /attachments/{id}.
+func (h *CaseHandler) UpdateAttachment(w http.ResponseWriter, r *http.Request) {
+	var req domain.UpdateAttachmentRequest
+	if !decodeRequest(w, r, &req) {
+		return
+	}
+	req.AttachmentID = r.PathValue("id")
+	resp, err := h.svc.UpdateAttachment(r.Context(), req)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
 // AddCaseTag handles POST /cases/{id}/tags.
 func (h *CaseHandler) AddCaseTag(w http.ResponseWriter, r *http.Request) {
 	caseID := r.PathValue("id")

--- a/entity-service/internal/handler/case_handler_test.go
+++ b/entity-service/internal/handler/case_handler_test.go
@@ -43,6 +43,28 @@ type stubCaseService struct {
 	searchTagsReq    domain.SearchTagsRequest
 	searchTagsTags   []domain.Tag
 	searchTagsErr    error
+
+	getAttachmentCalled bool
+	getAttachmentID     string
+	getAttachmentResp   domain.Attachment
+	getAttachmentErr    error
+
+	updateAttachmentCalled bool
+	updateAttachmentReq    domain.UpdateAttachmentRequest
+	updateAttachmentResp   domain.UpdateAttachmentResponse
+	updateAttachmentErr    error
+}
+
+func (s *stubCaseService) GetAttachment(_ context.Context, attachmentID string) (domain.Attachment, error) {
+	s.getAttachmentCalled = true
+	s.getAttachmentID = attachmentID
+	return s.getAttachmentResp, s.getAttachmentErr
+}
+
+func (s *stubCaseService) UpdateAttachment(_ context.Context, req domain.UpdateAttachmentRequest) (domain.UpdateAttachmentResponse, error) {
+	s.updateAttachmentCalled = true
+	s.updateAttachmentReq = req
+	return s.updateAttachmentResp, s.updateAttachmentErr
 }
 
 func (s *stubCaseService) CreateCaseAttachment(_ context.Context, _ domain.CreateAttachmentRequest) (domain.CreateAttachmentResponse, error) {
@@ -295,6 +317,92 @@ func TestSearchTagsQuery_NoParams(t *testing.T) {
 	}
 	if (stub.searchTagsReq != domain.SearchTagsRequest{}) {
 		t.Fatalf("expected a zero request, got %#v", stub.searchTagsReq)
+	}
+}
+
+// TestGetAttachment_PassesPathIDToService pins the GET /attachments/{id} handler's
+// wiring: the path value must reach the service layer as-is (the service layer
+// owns UUID validation), and the response body must round-trip the service result.
+func TestGetAttachment_PassesPathIDToService(t *testing.T) {
+	const attachmentID = "11111111-1111-1111-1111-111111111111"
+	stub := &stubCaseService{getAttachmentResp: domain.Attachment{ID: attachmentID, Name: "logs.txt"}}
+	h := NewCaseHandler(stub)
+
+	req := httptest.NewRequest(http.MethodGet, "/attachments/"+attachmentID, nil)
+	req.SetPathValue("id", attachmentID)
+	rec := httptest.NewRecorder()
+
+	h.GetAttachment(rec, req)
+
+	if !stub.getAttachmentCalled {
+		t.Fatalf("expected GetAttachment to reach the service layer")
+	}
+	if stub.getAttachmentID != attachmentID {
+		t.Fatalf("service saw id %q, want %q", stub.getAttachmentID, attachmentID)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "logs.txt") {
+		t.Fatalf("expected response body to contain the attachment name, got: %s", rec.Body.String())
+	}
+}
+
+// TestUpdateAttachment_DecodesBodyAndPathID pins the PATCH /attachments/{id}
+// handler's wiring: the path id populates req.AttachmentID (the request body has
+// no id field of its own -- see domain.UpdateAttachmentRequest's `json:"-"` tag),
+// and the JSON body fields decode into the rest of the request.
+func TestUpdateAttachment_DecodesBodyAndPathID(t *testing.T) {
+	const attachmentID = "11111111-1111-1111-1111-111111111111"
+	stub := &stubCaseService{
+		updateAttachmentResp: domain.UpdateAttachmentResponse{Message: "updated"},
+	}
+	h := NewCaseHandler(stub)
+
+	body := `{"referenceId":"22222222-2222-2222-2222-222222222222","referenceType":"deployment","name":"renamed.txt"}`
+	req := httptest.NewRequest(http.MethodPatch, "/attachments/"+attachmentID, strings.NewReader(body))
+	req.SetPathValue("id", attachmentID)
+	rec := httptest.NewRecorder()
+
+	h.UpdateAttachment(rec, req)
+
+	if !stub.updateAttachmentCalled {
+		t.Fatalf("expected UpdateAttachment to reach the service layer, got status %d body %q", rec.Code, rec.Body.String())
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if stub.updateAttachmentReq.AttachmentID != attachmentID {
+		t.Fatalf("AttachmentID = %q, want %q (from the URL path, not the body)", stub.updateAttachmentReq.AttachmentID, attachmentID)
+	}
+	if stub.updateAttachmentReq.ReferenceID != "22222222-2222-2222-2222-222222222222" {
+		t.Fatalf("ReferenceID = %q, want the decoded body value", stub.updateAttachmentReq.ReferenceID)
+	}
+	if stub.updateAttachmentReq.ReferenceType != domain.ReferenceTypeDeployment {
+		t.Fatalf("ReferenceType = %q, want %q", stub.updateAttachmentReq.ReferenceType, domain.ReferenceTypeDeployment)
+	}
+	if stub.updateAttachmentReq.Name == nil || *stub.updateAttachmentReq.Name != "renamed.txt" {
+		t.Fatalf("Name = %v, want renamed.txt", stub.updateAttachmentReq.Name)
+	}
+}
+
+// TestUpdateAttachment_RejectsMalformedBody proves a body the decoder cannot
+// parse is rejected before the service layer runs.
+func TestUpdateAttachment_RejectsMalformedBody(t *testing.T) {
+	stub := &stubCaseService{}
+	h := NewCaseHandler(stub)
+
+	req := httptest.NewRequest(http.MethodPatch, "/attachments/x", strings.NewReader(`{"name":`))
+	req.SetPathValue("id", "11111111-1111-1111-1111-111111111111")
+	rec := httptest.NewRecorder()
+
+	h.UpdateAttachment(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if stub.updateAttachmentCalled {
+		t.Fatalf("expected the request to be rejected before the service layer")
 	}
 }
 

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -291,6 +291,8 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 	mux.HandleFunc("POST /attachments", caseHandler.CreateCaseAttachment)
 	mux.HandleFunc("POST /attachments/search", caseHandler.SearchCaseAttachments)
 	mux.HandleFunc("GET /attachments/{id}/content", caseHandler.GetCaseAttachmentContent)
+	mux.HandleFunc("GET /attachments/{id}", caseHandler.GetAttachment)
+	mux.HandleFunc("PATCH /attachments/{id}", caseHandler.UpdateAttachment)
 	mux.HandleFunc("DELETE /attachments/{id}", caseHandler.DeleteCaseAttachment)
 	mux.HandleFunc("POST /cases/{id}/tags", caseHandler.AddCaseTag)
 	mux.HandleFunc("DELETE /cases/{id}/tags/{tagId}", caseHandler.RemoveCaseTag)

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -584,6 +584,14 @@ func (s *caseService) DeleteCaseAttachment(_ context.Context, _ domain.DeleteAtt
 	return domain.DeleteAttachmentResponse{}, &apierror.ServiceUnavailableError{Msg: "attachments are only supported for the ServiceNow data source"}
 }
 
+func (s *caseService) GetAttachment(_ context.Context, _ string) (domain.Attachment, error) {
+	return domain.Attachment{}, &apierror.ServiceUnavailableError{Msg: "attachments are only supported for the ServiceNow data source"}
+}
+
+func (s *caseService) UpdateAttachment(_ context.Context, _ domain.UpdateAttachmentRequest) (domain.UpdateAttachmentResponse, error) {
+	return domain.UpdateAttachmentResponse{}, &apierror.ServiceUnavailableError{Msg: "attachments are only supported for the ServiceNow data source"}
+}
+
 func (s *caseService) AddCaseTag(_ context.Context, _, _ string) (domain.Tag, error) {
 	return domain.Tag{}, &apierror.ServiceUnavailableError{Msg: "case tags are only supported for the ServiceNow data source"}
 }

--- a/entity-service/internal/service/case_service_test.go
+++ b/entity-service/internal/service/case_service_test.go
@@ -18,6 +18,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
@@ -306,5 +307,34 @@ func TestCaseService_UpdateCase_RejectsTypeTransferFields(t *testing.T) {
 				t.Fatalf("expected *apierror.ValidationError, got %T: %v", err, err)
 			}
 		})
+	}
+}
+
+// TestCaseService_GetAttachment_ServiceUnavailable and
+// TestCaseService_UpdateAttachment_ServiceUnavailable prove the Postgres data
+// source reports the documented 503 for attachment reads/writes -- there is no
+// Postgres-backed attachment store, so the route must not silently succeed or
+// 404, it must say the operation is unsupported on this data source.
+func TestCaseService_GetAttachment_ServiceUnavailable(t *testing.T) {
+	svc := NewCaseService(&stubCaseRepo{}, stubUserRepo{})
+
+	_, err := svc.GetAttachment(context.Background(), "11111111-1111-1111-1111-111111111111")
+	var sue *apierror.ServiceUnavailableError
+	if !errors.As(err, &sue) {
+		t.Fatalf("GetAttachment error = %v (%T), want *apierror.ServiceUnavailableError", err, err)
+	}
+}
+
+func TestCaseService_UpdateAttachment_ServiceUnavailable(t *testing.T) {
+	svc := NewCaseService(&stubCaseRepo{}, stubUserRepo{})
+
+	_, err := svc.UpdateAttachment(context.Background(), domain.UpdateAttachmentRequest{
+		AttachmentID:  "11111111-1111-1111-1111-111111111111",
+		ReferenceID:   "22222222-2222-2222-2222-222222222222",
+		ReferenceType: domain.ReferenceTypeDeployment,
+	})
+	var sue *apierror.ServiceUnavailableError
+	if !errors.As(err, &sue) {
+		t.Fatalf("UpdateAttachment error = %v (%T), want *apierror.ServiceUnavailableError", err, err)
 	}
 }

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -224,6 +224,11 @@ type CaseService interface {
 	DeleteCaseAttachment(ctx context.Context, req domain.DeleteAttachmentRequest) (domain.DeleteAttachmentResponse, error)
 	// GetAttachment returns the metadata for the attachment identified by attachmentID,
 	// regardless of which reference type (case, deployment, ...) it is linked to.
+	// The backing ServiceNow response for a single attachment fetch does not carry
+	// referenceType (unlike the search response, which echoes back the caller's
+	// request filter), so the returned domain.Attachment's ReferenceType field is
+	// always the zero value; callers that need it already know it from context
+	// (e.g. the request that led them to the attachment id).
 	// A NotFoundError is returned if the attachment does not exist.
 	GetAttachment(ctx context.Context, attachmentID string) (domain.Attachment, error)
 	// UpdateAttachment updates the name and/or description of the attachment identified by

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -165,8 +165,9 @@ type DeployedProductService interface {
 	// CreateDeployedProduct creates a new deployed product in ServiceNow.
 	// Supported by the ServiceNow data source only.
 	CreateDeployedProduct(ctx context.Context, req domain.CreateDeployedProductRequest) (domain.CreateDeployedProductResponse, error)
-	// UpdateDeployedProduct updates a deployed product's cores, tps, description, or deactivates it.
-	// Either detail fields or Active=false must be provided, but not both.
+	// UpdateDeployedProduct updates a deployed product's cores, tps, description, update-level
+	// history, or deactivates it. Either detail fields (which now include Updates, a whole-array
+	// replace of the update-level history) or Active=false must be provided, but not both.
 	// Supported by the ServiceNow data source only.
 	UpdateDeployedProduct(ctx context.Context, req domain.UpdateDeployedProductRequest) (domain.UpdateDeployedProductResponse, error)
 }
@@ -221,6 +222,15 @@ type CaseService interface {
 	// DeleteCaseAttachment removes the attachment identified by req.AttachmentID from the case.
 	// A NotFoundError is returned if the attachment does not exist.
 	DeleteCaseAttachment(ctx context.Context, req domain.DeleteAttachmentRequest) (domain.DeleteAttachmentResponse, error)
+	// GetAttachment returns the metadata for the attachment identified by attachmentID,
+	// regardless of which reference type (case, deployment, ...) it is linked to.
+	// A NotFoundError is returned if the attachment does not exist.
+	GetAttachment(ctx context.Context, attachmentID string) (domain.Attachment, error)
+	// UpdateAttachment updates the name and/or description of the attachment identified by
+	// req.AttachmentID, regardless of which reference type it is linked to. At least one of
+	// Name or Description must be provided. A NotFoundError is returned if the attachment
+	// does not exist.
+	UpdateAttachment(ctx context.Context, req domain.UpdateAttachmentRequest) (domain.UpdateAttachmentResponse, error)
 	// AddCaseTag attaches a free-text label to the case identified by caseID.
 	// A ValidationError is returned for invalid input (e.g. malformed UUID, empty label).
 	AddCaseTag(ctx context.Context, caseID, label string) (domain.Tag, error)

--- a/entity-service/internal/service/sn_attachment_get_update_test.go
+++ b/entity-service/internal/service/sn_attachment_get_update_test.go
@@ -1,0 +1,273 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package service
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+)
+
+var (
+	testAttachmentSysid    = sysid32('a')
+	testAttachmentRefSysid = sysid32('b')
+)
+
+// TestSNCaseService_GetAttachment_HappyPath proves a well-formed SN attachment
+// response decodes into domain.Attachment, including the reference id sysid->uuid
+// mapping and the download/preview URLs.
+func TestSNCaseService_GetAttachment_HappyPath(t *testing.T) {
+	attachmentUUID := sysidToUUID(testAttachmentSysid)
+	description := "Diagnostic logs"
+	downloadURL := "https://example.com/download/1"
+	previewURL := "https://example.com/preview/1"
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/attachments/"+testAttachmentSysid, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", r.Method)
+		}
+		_, _ = w.Write([]byte(`{
+			"id": "` + testAttachmentSysid + `",
+			"referenceId": "` + testAttachmentRefSysid + `",
+			"name": "logs.txt",
+			"type": "text/plain",
+			"sizeBytes": 1024,
+			"description": "Diagnostic logs",
+			"createdBy": "jane.doe@example.com",
+			"createdByFullName": "Jane Doe",
+			"createdByUser": null,
+			"createdOn": "2026-01-01 00:00:00",
+			"downloadUrl": "https://example.com/download/1",
+			"previewUrl": "https://example.com/preview/1"
+		}`))
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowCaseService(client, nil)
+
+	got, err := svc.GetAttachment(contextWithUserIDToken("token"), attachmentUUID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got.ID != attachmentUUID {
+		t.Errorf("ID = %q, want %q", got.ID, attachmentUUID)
+	}
+	if got.ReferenceID != sysidToUUID(testAttachmentRefSysid) {
+		t.Errorf("ReferenceID = %q, want %q", got.ReferenceID, sysidToUUID(testAttachmentRefSysid))
+	}
+	if got.Name != "logs.txt" {
+		t.Errorf("Name = %q, want logs.txt", got.Name)
+	}
+	if got.Type != "text/plain" {
+		t.Errorf("Type = %q, want text/plain", got.Type)
+	}
+	if got.SizeBytes != 1024 {
+		t.Errorf("SizeBytes = %d, want 1024", got.SizeBytes)
+	}
+	if got.Description == nil || *got.Description != description {
+		t.Errorf("Description = %v, want %q", got.Description, description)
+	}
+	if got.CreatedBy == nil || got.CreatedBy.Email != "jane.doe@example.com" {
+		t.Errorf("CreatedBy = %+v, want email jane.doe@example.com", got.CreatedBy)
+	}
+	if got.DownloadURL == nil || *got.DownloadURL != downloadURL {
+		t.Errorf("DownloadURL = %v, want %q", got.DownloadURL, downloadURL)
+	}
+	if got.PreviewURL == nil || *got.PreviewURL != previewURL {
+		t.Errorf("PreviewURL = %v, want %q", got.PreviewURL, previewURL)
+	}
+	// GetAttachment's response shape has no referenceType; the zero value must
+	// surface as-is rather than being guessed at.
+	if got.ReferenceType != "" {
+		t.Errorf("ReferenceType = %q, want empty (not carried by the GET response)", got.ReferenceType)
+	}
+}
+
+// TestSNCaseService_GetAttachment_NotFound verifies a 404 from the backing service
+// surfaces as a NotFoundError.
+func TestSNCaseService_GetAttachment_NotFound(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/attachments/"+testAttachmentSysid, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":{"message":"attachment not found"},"status":"failure"}`))
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowCaseService(client, nil)
+
+	_, err := svc.GetAttachment(contextWithUserIDToken("token"), sysidToUUID(testAttachmentSysid))
+	var notFound *apierror.NotFoundError
+	if !errors.As(err, &notFound) {
+		t.Fatalf("GetAttachment error = %v (%T), want NotFoundError", err, err)
+	}
+}
+
+// TestSNCaseService_GetAttachment_RejectsInvalidUUID proves the attachment id is
+// validated before any request reaches the backing service.
+func TestSNCaseService_GetAttachment_RejectsInvalidUUID(t *testing.T) {
+	client := newTestSNClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("unexpected call to backing service for an invalid attachment id")
+	}))
+	svc := NewServiceNowCaseService(client, nil)
+
+	_, err := svc.GetAttachment(contextWithUserIDToken("token"), "not-a-uuid")
+	var ve *apierror.ValidationError
+	if !asValidationError(err, &ve) {
+		t.Fatalf("GetAttachment error = %v (%T), want ValidationError", err, err)
+	}
+}
+
+// TestSNCaseService_UpdateAttachment_HappyPath proves a valid update request is
+// forwarded to SN and the mocked response is parsed back into
+// domain.UpdateAttachmentResponse.
+func TestSNCaseService_UpdateAttachment_HappyPath(t *testing.T) {
+	attachmentUUID := sysidToUUID(testAttachmentSysid)
+	refUUID := sysidToUUID(testAttachmentRefSysid)
+	newName := "renamed.txt"
+	newDescription := "Updated description"
+
+	var gotBody map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/attachments/"+testAttachmentSysid, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Fatalf("expected PATCH, got %s", r.Method)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		_, _ = w.Write([]byte(`{
+			"message": "updated",
+			"attachment": {
+				"id": "` + testAttachmentSysid + `",
+				"updatedOn": "2026-02-01 00:00:00",
+				"updatedBy": "jane.doe@example.com"
+			}
+		}`))
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowCaseService(client, nil)
+
+	req := domain.UpdateAttachmentRequest{
+		AttachmentID:  attachmentUUID,
+		ReferenceID:   refUUID,
+		ReferenceType: domain.ReferenceTypeDeployment,
+		Name:          &newName,
+		Description:   &newDescription,
+	}
+
+	resp, err := svc.UpdateAttachment(contextWithUserIDToken("token"), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if gotBody["referenceId"] != testAttachmentRefSysid {
+		t.Errorf("outbound referenceId = %v, want %q", gotBody["referenceId"], testAttachmentRefSysid)
+	}
+	if gotBody["referenceType"] != string(domain.ReferenceTypeDeployment) {
+		t.Errorf("outbound referenceType = %v, want %q", gotBody["referenceType"], domain.ReferenceTypeDeployment)
+	}
+	if gotBody["name"] != newName {
+		t.Errorf("outbound name = %v, want %q", gotBody["name"], newName)
+	}
+	if gotBody["description"] != newDescription {
+		t.Errorf("outbound description = %v, want %q", gotBody["description"], newDescription)
+	}
+
+	if resp.Message != "updated" {
+		t.Errorf("Message = %q, want updated", resp.Message)
+	}
+	if resp.Attachment.ID != attachmentUUID {
+		t.Errorf("Attachment.ID = %q, want %q", resp.Attachment.ID, attachmentUUID)
+	}
+	if resp.Attachment.UpdatedBy != "jane.doe@example.com" {
+		t.Errorf("Attachment.UpdatedBy = %q, want jane.doe@example.com", resp.Attachment.UpdatedBy)
+	}
+}
+
+// TestSNCaseService_UpdateAttachment_ValidationErrors covers the three validation
+// failures UpdateAttachment must catch before ever reaching the backing service:
+// an invalid attachment id, an invalid referenceId, an invalid referenceType, and
+// a request providing neither name nor description.
+func TestSNCaseService_UpdateAttachment_ValidationErrors(t *testing.T) {
+	validAttachmentUUID := sysidToUUID(testAttachmentSysid)
+	validRefUUID := sysidToUUID(testAttachmentRefSysid)
+	name := "renamed.txt"
+
+	client := newTestSNClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("unexpected call to backing service for an invalid request")
+	}))
+	svc := NewServiceNowCaseService(client, nil)
+
+	cases := []struct {
+		name string
+		req  domain.UpdateAttachmentRequest
+	}{
+		{
+			name: "invalid attachment id",
+			req: domain.UpdateAttachmentRequest{
+				AttachmentID:  "not-a-uuid",
+				ReferenceID:   validRefUUID,
+				ReferenceType: domain.ReferenceTypeDeployment,
+				Name:          &name,
+			},
+		},
+		{
+			name: "invalid reference id",
+			req: domain.UpdateAttachmentRequest{
+				AttachmentID:  validAttachmentUUID,
+				ReferenceID:   "not-a-uuid",
+				ReferenceType: domain.ReferenceTypeDeployment,
+				Name:          &name,
+			},
+		},
+		{
+			name: "invalid reference type",
+			req: domain.UpdateAttachmentRequest{
+				AttachmentID:  validAttachmentUUID,
+				ReferenceID:   validRefUUID,
+				ReferenceType: domain.ReferenceType("not_a_type"),
+				Name:          &name,
+			},
+		},
+		{
+			name: "neither name nor description provided",
+			req: domain.UpdateAttachmentRequest{
+				AttachmentID:  validAttachmentUUID,
+				ReferenceID:   validRefUUID,
+				ReferenceType: domain.ReferenceTypeDeployment,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := svc.UpdateAttachment(contextWithUserIDToken("token"), tc.req)
+			var ve *apierror.ValidationError
+			if !asValidationError(err, &ve) {
+				t.Fatalf("error = %v (%T), want ValidationError", err, err)
+			}
+		})
+	}
+}

--- a/entity-service/internal/service/sn_attachment_get_update_test.go
+++ b/entity-service/internal/service/sn_attachment_get_update_test.go
@@ -174,7 +174,7 @@ func TestSNCaseService_UpdateAttachment_HappyPath(t *testing.T) {
 		ReferenceID:   refUUID,
 		ReferenceType: domain.ReferenceTypeDeployment,
 		Name:          &newName,
-		Description:   &newDescription,
+		Description:   json.RawMessage(`"` + newDescription + `"`),
 	}
 
 	resp, err := svc.UpdateAttachment(contextWithUserIDToken("token"), req)
@@ -203,6 +203,92 @@ func TestSNCaseService_UpdateAttachment_HappyPath(t *testing.T) {
 	}
 	if resp.Attachment.UpdatedBy != "jane.doe@example.com" {
 		t.Errorf("Attachment.UpdatedBy = %q, want jane.doe@example.com", resp.Attachment.UpdatedBy)
+	}
+}
+
+// TestSNCaseService_UpdateAttachment_DescriptionThreeStates proves the three states a
+// caller can express for description are preserved onto the outbound payload: omitted
+// (field absent, name alone satisfies "at least one field"), explicit null (clears it),
+// and a value (sets it). Before this fix, description was a plain *string, so omitted
+// and explicit-null were indistinguishable.
+func TestSNCaseService_UpdateAttachment_DescriptionThreeStates(t *testing.T) {
+	attachmentUUID := sysidToUUID(testAttachmentSysid)
+	refUUID := sysidToUUID(testAttachmentRefSysid)
+	name := "renamed.txt"
+
+	cases := []struct {
+		name           string
+		req            domain.UpdateAttachmentRequest
+		wantHasBodyKey bool
+		wantBodyValue  any
+	}{
+		{
+			name: "description omitted",
+			req: domain.UpdateAttachmentRequest{
+				AttachmentID:  attachmentUUID,
+				ReferenceID:   refUUID,
+				ReferenceType: domain.ReferenceTypeDeployment,
+				Name:          &name,
+			},
+			wantHasBodyKey: false,
+		},
+		{
+			name: "description explicit null",
+			req: domain.UpdateAttachmentRequest{
+				AttachmentID:  attachmentUUID,
+				ReferenceID:   refUUID,
+				ReferenceType: domain.ReferenceTypeDeployment,
+				Description:   json.RawMessage(`null`),
+			},
+			wantHasBodyKey: true,
+			wantBodyValue:  nil,
+		},
+		{
+			name: "description set to a value",
+			req: domain.UpdateAttachmentRequest{
+				AttachmentID:  attachmentUUID,
+				ReferenceID:   refUUID,
+				ReferenceType: domain.ReferenceTypeDeployment,
+				Description:   json.RawMessage(`"Updated description"`),
+			},
+			wantHasBodyKey: true,
+			wantBodyValue:  "Updated description",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotBody map[string]any
+			mux := http.NewServeMux()
+			mux.HandleFunc("/attachments/"+testAttachmentSysid, func(w http.ResponseWriter, r *http.Request) {
+				if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+					t.Fatalf("decode request body: %v", err)
+				}
+				_, _ = w.Write([]byte(`{
+					"message": "updated",
+					"attachment": {
+						"id": "` + testAttachmentSysid + `",
+						"updatedOn": "2026-02-01 00:00:00",
+						"updatedBy": "jane.doe@example.com"
+					}
+				}`))
+			})
+
+			client := newTestSNClient(t, mux)
+			svc := NewServiceNowCaseService(client, nil)
+
+			if _, err := svc.UpdateAttachment(contextWithUserIDToken("token"), tc.req); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			gotValue, gotHasKey := gotBody["description"]
+			if gotHasKey != tc.wantHasBodyKey {
+				t.Fatalf("outbound body has %q key = %v, want %v (body: %v)", "description", gotHasKey, tc.wantHasBodyKey, gotBody)
+			}
+			if gotHasKey && gotValue != tc.wantBodyValue {
+				t.Errorf("outbound description = %v, want %v", gotValue, tc.wantBodyValue)
+			}
+		})
 	}
 }
 

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -2284,6 +2284,115 @@ func (s *snCaseService) DeleteCaseAttachment(ctx context.Context, req domain.Del
 	return domain.DeleteAttachmentResponse{Message: snResp.Message}, nil
 }
 
+// GetAttachment implements CaseService.GetAttachment for the ServiceNow data source.
+// The GET /attachments/{id} response does not carry referenceType (mirroring the
+// /attachments/search response's snAttachment shape), so the returned domain.Attachment's
+// ReferenceType is left as the zero value -- callers that need it already know it from
+// context (e.g. the request that led them to the attachment id).
+func (s *snCaseService) GetAttachment(ctx context.Context, attachmentID string) (domain.Attachment, error) {
+	if err := validateUUIDs("id", []string{attachmentID}); err != nil {
+		return domain.Attachment{}, err
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+
+	raw, err := s.client.Get(ctx, "/attachments/"+uuidToSysid(attachmentID), token)
+	if err != nil {
+		return domain.Attachment{}, err
+	}
+
+	var a snAttachment
+	if err := json.Unmarshal(raw, &a); err != nil {
+		return domain.Attachment{}, fmt.Errorf("sn get attachment: parse response: %w", err)
+	}
+
+	createdOn, err := time.Parse(snCreatedOnLayout, a.CreatedOn)
+	if err != nil {
+		return domain.Attachment{}, fmt.Errorf("sn get attachment: parse createdOn %q: %w", a.CreatedOn, err)
+	}
+
+	return domain.Attachment{
+		ID:          sysidToUUID(a.ID),
+		ReferenceID: sysidToUUID(a.ReferenceID),
+		Name:        a.Name,
+		Type:        a.Type,
+		SizeBytes:   a.SizeBytes,
+		Description: a.Description,
+		CreatedBy:   snUserReference(a.CreatedByUser, a.CreatedBy, a.CreatedByFullName),
+		CreatedOn:   createdOn,
+		DownloadURL: a.DownloadURL,
+		PreviewURL:  a.PreviewURL,
+	}, nil
+}
+
+// snUpdateAttachmentPayload is the Choreo PATCH /attachments/{id} request body.
+// referenceType "deployment" requires at least one of name/description; referenceType "case"
+// requires name and forbids description -- both enforced upstream, not re-validated here.
+type snUpdateAttachmentPayload struct {
+	ReferenceID   string  `json:"referenceId"`
+	ReferenceType string  `json:"referenceType"`
+	Name          *string `json:"name,omitempty"`
+	Description   *string `json:"description,omitempty"`
+}
+
+type snUpdateAttachmentResponse struct {
+	Message    string `json:"message"`
+	Attachment struct {
+		ID        string `json:"id"`
+		UpdatedOn string `json:"updatedOn"`
+		UpdatedBy string `json:"updatedBy"`
+	} `json:"attachment"`
+}
+
+// UpdateAttachment implements CaseService.UpdateAttachment for the ServiceNow data source.
+func (s *snCaseService) UpdateAttachment(ctx context.Context, req domain.UpdateAttachmentRequest) (domain.UpdateAttachmentResponse, error) {
+	if err := validateUUIDs("id", []string{req.AttachmentID}); err != nil {
+		return domain.UpdateAttachmentResponse{}, err
+	}
+	if err := validateUUIDs("referenceId", []string{req.ReferenceID}); err != nil {
+		return domain.UpdateAttachmentResponse{}, err
+	}
+	if _, ok := validReferenceTypes[req.ReferenceType]; !ok {
+		return domain.UpdateAttachmentResponse{}, &apierror.ValidationError{Msg: "referenceType is invalid: " + string(req.ReferenceType)}
+	}
+	if req.Name == nil && req.Description == nil {
+		return domain.UpdateAttachmentResponse{}, &apierror.ValidationError{Msg: "at least one of name or description must be provided"}
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+
+	payload := snUpdateAttachmentPayload{
+		ReferenceID:   uuidToSysid(req.ReferenceID),
+		ReferenceType: string(req.ReferenceType),
+		Name:          req.Name,
+		Description:   req.Description,
+	}
+
+	raw, err := s.client.Patch(ctx, "/attachments/"+uuidToSysid(req.AttachmentID), token, payload)
+	if err != nil {
+		return domain.UpdateAttachmentResponse{}, err
+	}
+
+	var snResp snUpdateAttachmentResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.UpdateAttachmentResponse{}, fmt.Errorf("sn update attachment: parse response: %w", err)
+	}
+
+	updatedOn, err := time.Parse(snCreatedOnLayout, snResp.Attachment.UpdatedOn)
+	if err != nil {
+		return domain.UpdateAttachmentResponse{}, fmt.Errorf("sn update attachment: parse updatedOn %q: %w", snResp.Attachment.UpdatedOn, err)
+	}
+
+	return domain.UpdateAttachmentResponse{
+		Message: snResp.Message,
+		Attachment: domain.UpdatedAttachment{
+			ID:        sysidToUUID(snResp.Attachment.ID),
+			UpdatedOn: updatedOn,
+			UpdatedBy: snResp.Attachment.UpdatedBy,
+		},
+	}, nil
+}
+
 // validateOrGroupEnums validates one AnyOf branch's enum-valued fields
 // against the same validXxx maps the top-level (AND-only) filters use,
 // mirroring that validation exactly (unrecognized values would otherwise be

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -2328,11 +2328,12 @@ func (s *snCaseService) GetAttachment(ctx context.Context, attachmentID string) 
 // snUpdateAttachmentPayload is the Choreo PATCH /attachments/{id} request body.
 // referenceType "deployment" requires at least one of name/description; referenceType "case"
 // requires name and forbids description -- both enforced upstream, not re-validated here.
+// Description is json.RawMessage so an explicit null can be distinguished from an omitted field.
 type snUpdateAttachmentPayload struct {
-	ReferenceID   string  `json:"referenceId"`
-	ReferenceType string  `json:"referenceType"`
-	Name          *string `json:"name,omitempty"`
-	Description   *string `json:"description,omitempty"`
+	ReferenceID   string          `json:"referenceId"`
+	ReferenceType string          `json:"referenceType"`
+	Name          *string         `json:"name,omitempty"`
+	Description   json.RawMessage `json:"description,omitempty"`
 }
 
 type snUpdateAttachmentResponse struct {
@@ -2355,7 +2356,7 @@ func (s *snCaseService) UpdateAttachment(ctx context.Context, req domain.UpdateA
 	if _, ok := validReferenceTypes[req.ReferenceType]; !ok {
 		return domain.UpdateAttachmentResponse{}, &apierror.ValidationError{Msg: "referenceType is invalid: " + string(req.ReferenceType)}
 	}
-	if req.Name == nil && req.Description == nil {
+	if req.Name == nil && len(req.Description) == 0 {
 		return domain.UpdateAttachmentResponse{}, &apierror.ValidationError{Msg: "at least one of name or description must be provided"}
 	}
 
@@ -2365,7 +2366,9 @@ func (s *snCaseService) UpdateAttachment(ctx context.Context, req domain.UpdateA
 		ReferenceID:   uuidToSysid(req.ReferenceID),
 		ReferenceType: string(req.ReferenceType),
 		Name:          req.Name,
-		Description:   req.Description,
+	}
+	if len(req.Description) > 0 {
+		payload.Description = req.Description
 	}
 
 	raw, err := s.client.Patch(ctx, "/attachments/"+uuidToSysid(req.AttachmentID), token, payload)

--- a/entity-service/internal/service/sn_deployed_product_service.go
+++ b/entity-service/internal/service/sn_deployed_product_service.go
@@ -44,8 +44,43 @@ type snDeployedProduct struct {
 	Cores      *int                      `json:"cores"`
 	TPS        *float64                  `json:"tps"` // Ballerina decimal? serialises as 100.0
 	Category   *snDeployedProductRef     `json:"category"`
+	Updates    []snProductUpdate         `json:"updates"`
 	CreatedOn  string                    `json:"createdOn"`
 	UpdatedOn  string                    `json:"updatedOn"`
+}
+
+// snProductUpdate is the wire shape of a single deployed-product update-history entry,
+// matching Ballerina's ProductUpdate record.
+type snProductUpdate struct {
+	UpdateLevel int     `json:"updateLevel"`
+	Date        string  `json:"date"`
+	Details     *string `json:"details"`
+}
+
+// toSNProductUpdates converts the domain update-history array to its wire shape.
+// Returns nil for a nil input so an absent Updates field stays omitted (omitempty) on the
+// wire, and a non-nil empty slice for an explicit empty array so a caller can clear history.
+func toSNProductUpdates(updates []domain.ProductUpdateEntry) []snProductUpdate {
+	if updates == nil {
+		return nil
+	}
+	out := make([]snProductUpdate, 0, len(updates))
+	for _, u := range updates {
+		out = append(out, snProductUpdate{UpdateLevel: u.UpdateLevel, Date: u.Date, Details: u.Details})
+	}
+	return out
+}
+
+// fromSNProductUpdates converts the wire update-history array to its domain shape.
+func fromSNProductUpdates(updates []snProductUpdate) []domain.ProductUpdateEntry {
+	if updates == nil {
+		return nil
+	}
+	out := make([]domain.ProductUpdateEntry, 0, len(updates))
+	for _, u := range updates {
+		out = append(out, domain.ProductUpdateEntry{UpdateLevel: u.UpdateLevel, Date: u.Date, Details: u.Details})
+	}
+	return out
 }
 
 type snDeployedProductRef struct {
@@ -101,19 +136,22 @@ type snCreateDeployedProductResponse struct {
 
 // snUpdateDeployedProductPayload is the Choreo PATCH /deployed-products/{id} request body.
 // Description is json.RawMessage so an explicit null can be distinguished from an omitted field.
+// Updates, when present, whole-array-replaces the deployed product's update-level history.
 type snUpdateDeployedProductPayload struct {
-	Cores       *int            `json:"cores,omitempty"`
-	TPS         *float64        `json:"tps,omitempty"` // Ballerina decimal?
-	Description json.RawMessage `json:"description,omitempty"`
-	Active      *bool           `json:"active,omitempty"`
+	Cores       *int              `json:"cores,omitempty"`
+	TPS         *float64          `json:"tps,omitempty"` // Ballerina decimal?
+	Description json.RawMessage   `json:"description,omitempty"`
+	Updates     []snProductUpdate `json:"updates,omitempty"`
+	Active      *bool             `json:"active,omitempty"`
 }
 
 type snUpdateDeployedProductResponse struct {
 	Message         string `json:"message"`
 	DeployedProduct struct {
-		ID        string `json:"id"`
-		UpdatedOn string `json:"updatedOn"`
-		UpdatedBy string `json:"updatedBy"`
+		ID        string            `json:"id"`
+		UpdatedOn string            `json:"updatedOn"`
+		UpdatedBy string            `json:"updatedBy"`
+		Updates   []snProductUpdate `json:"updates"`
 	} `json:"deployedProduct"`
 }
 
@@ -180,7 +218,7 @@ func (s *snDeployedProductService) UpdateDeployedProduct(ctx context.Context, re
 		}
 	}
 
-	hasDetailFields := req.Cores != nil || req.TPS != nil || len(req.Description) > 0
+	hasDetailFields := req.Cores != nil || req.TPS != nil || len(req.Description) > 0 || req.Updates != nil
 	if !hasDetailFields && req.Active == nil {
 		return domain.UpdateDeployedProductResponse{}, &apierror.ValidationError{Msg: "at least one of cores, tps, or description must be provided, or active must be set to false"}
 	}
@@ -238,6 +276,9 @@ func (s *snDeployedProductService) UpdateDeployedProduct(ctx context.Context, re
 	if len(req.Description) > 0 {
 		payload.Description = req.Description
 	}
+	if req.Updates != nil {
+		payload.Updates = toSNProductUpdates(req.Updates)
+	}
 
 	raw, err := s.client.Patch(ctx, "/deployed-products/"+uuidToSysid(req.ID), token, payload)
 	if err != nil {
@@ -260,6 +301,7 @@ func (s *snDeployedProductService) UpdateDeployedProduct(ctx context.Context, re
 			ID:        sysidToUUID(snResp.DeployedProduct.ID),
 			UpdatedOn: updatedOn,
 			UpdatedBy: snResp.DeployedProduct.UpdatedBy,
+			Updates:   fromSNProductUpdates(snResp.DeployedProduct.Updates),
 		},
 	}, nil
 }
@@ -322,16 +364,6 @@ func (s *snDeployedProductService) SearchDeployedProducts(ctx context.Context, r
 			}
 		}
 
-		var cores, tps *string
-		if dp.Cores != nil {
-			s := fmt.Sprintf("%d", *dp.Cores)
-			cores = &s
-		}
-		if dp.TPS != nil {
-			s := fmt.Sprintf("%g", *dp.TPS)
-			tps = &s
-		}
-
 		var category *string
 		if dp.Category != nil {
 			category = &dp.Category.Name
@@ -342,9 +374,10 @@ func (s *snDeployedProductService) SearchDeployedProducts(ctx context.Context, r
 			Deployment: domain.EntityRef{ID: sysidToUUID(dp.Deployment.ID), Name: dp.Deployment.Name},
 			Product:    domain.EntityRef{ID: sysidToUUID(dp.Product.ID), Name: dp.Product.Name},
 			Version:    versionRef,
-			Cores:      cores,
-			TPS:        tps,
+			Cores:      dp.Cores,
+			TPS:        dp.TPS,
 			Category:   category,
+			Updates:    fromSNProductUpdates(dp.Updates),
 			CreatedOn:  createdOn,
 			UpdatedOn:  updatedOn,
 		})

--- a/entity-service/internal/service/sn_deployed_product_service.go
+++ b/entity-service/internal/service/sn_deployed_product_service.go
@@ -71,6 +71,22 @@ func toSNProductUpdates(updates []domain.ProductUpdateEntry) []snProductUpdate {
 	return out
 }
 
+// validateProductUpdates rejects an update-history array containing a negative
+// updateLevel or a malformed date before it is ever forwarded to the backing data
+// source. It stops at (and reports) the first invalid entry rather than partially
+// processing the array. A nil or empty Updates is valid (nothing to check).
+func validateProductUpdates(updates []domain.ProductUpdateEntry) error {
+	for i, u := range updates {
+		if u.UpdateLevel < 0 {
+			return &apierror.ValidationError{Msg: fmt.Sprintf("updates[%d].updateLevel must not be negative", i)}
+		}
+		if err := validateDateOnly(fmt.Sprintf("updates[%d].date", i), u.Date); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // fromSNProductUpdates converts the wire update-history array to its domain shape.
 func fromSNProductUpdates(updates []snProductUpdate) []domain.ProductUpdateEntry {
 	if updates == nil {
@@ -137,12 +153,16 @@ type snCreateDeployedProductResponse struct {
 // snUpdateDeployedProductPayload is the Choreo PATCH /deployed-products/{id} request body.
 // Description is json.RawMessage so an explicit null can be distinguished from an omitted field.
 // Updates, when present, whole-array-replaces the deployed product's update-level history.
+// Updates is a pointer so that a caller-supplied empty array (clear all history) can be told
+// apart from an absent field: encoding/json's omitempty treats a zero-length slice the same as
+// nil regardless of nil-ness, so only a non-nil *pointer* to an empty slice serialises as "[]"
+// on the wire instead of being dropped.
 type snUpdateDeployedProductPayload struct {
-	Cores       *int              `json:"cores,omitempty"`
-	TPS         *float64          `json:"tps,omitempty"` // Ballerina decimal?
-	Description json.RawMessage   `json:"description,omitempty"`
-	Updates     []snProductUpdate `json:"updates,omitempty"`
-	Active      *bool             `json:"active,omitempty"`
+	Cores       *int               `json:"cores,omitempty"`
+	TPS         *float64           `json:"tps,omitempty"` // Ballerina decimal?
+	Description json.RawMessage    `json:"description,omitempty"`
+	Updates     *[]snProductUpdate `json:"updates,omitempty"`
+	Active      *bool              `json:"active,omitempty"`
 }
 
 type snUpdateDeployedProductResponse struct {
@@ -228,6 +248,9 @@ func (s *snDeployedProductService) UpdateDeployedProduct(ctx context.Context, re
 	if req.Active != nil && hasDetailFields {
 		return domain.UpdateDeployedProductResponse{}, &apierror.ValidationError{Msg: "cores, tps, and description must not be provided when deactivating"}
 	}
+	if err := validateProductUpdates(req.Updates); err != nil {
+		return domain.UpdateDeployedProductResponse{}, err
+	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
 
@@ -277,7 +300,8 @@ func (s *snDeployedProductService) UpdateDeployedProduct(ctx context.Context, re
 		payload.Description = req.Description
 	}
 	if req.Updates != nil {
-		payload.Updates = toSNProductUpdates(req.Updates)
+		updates := toSNProductUpdates(req.Updates)
+		payload.Updates = &updates
 	}
 
 	raw, err := s.client.Patch(ctx, "/deployed-products/"+uuidToSysid(req.ID), token, payload)

--- a/entity-service/internal/service/sn_deployed_product_service_test.go
+++ b/entity-service/internal/service/sn_deployed_product_service_test.go
@@ -107,3 +107,197 @@ func TestSNDeployedProductService_SearchDeployedProducts_NilCategoryStaysNil(t *
 		t.Fatalf("expected nil category, got %v", *resp.DeployedProducts[0].Category)
 	}
 }
+
+// TestSNDeployedProductService_SearchDeployedProducts_CoresTPSNumericAndUpdatesPopulated
+// guards the removal of the old fmt.Sprintf-based cores/tps stringification: SN's wire
+// type decodes them as numeric (*int / *float64) already, so SearchDeployedProducts must
+// pass them straight through instead of re-stringifying, and the updates array must be
+// mapped from the SN response into domain.ProductUpdateEntry.
+func TestSNDeployedProductService_SearchDeployedProducts_CoresTPSNumericAndUpdatesPopulated(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/deployed-products/search", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"deployedProducts": []map[string]any{
+				{
+					"id":         testDeployedProductSysid,
+					"deployment": map[string]any{"id": testDeployedProductDeploySysid, "name": "Production"},
+					"product":    map[string]any{"id": testDeployedProductProdSysid, "name": "API Manager"},
+					"cores":      4,
+					"tps":        100.5,
+					"category":   nil,
+					"updates": []map[string]any{
+						{"updateLevel": 3, "date": "2026-02-01", "details": "Applied patch level 3"},
+						{"updateLevel": 2, "date": "2026-01-01", "details": nil},
+					},
+					"createdOn": "2026-01-01 00:00:00",
+					"updatedOn": "2026-01-02 00:00:00",
+				},
+			},
+			"totalRecords": 1, "offset": 0, "limit": 20,
+		})
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowDeployedProductService(client)
+
+	resp, err := svc.SearchDeployedProducts(contextWithUserIDToken("token"), domain.SearchDeployedProductsRequest{
+		Pagination: domain.Pagination{Limit: 20, Offset: 0},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.DeployedProducts) != 1 {
+		t.Fatalf("expected 1 deployed product, got %d", len(resp.DeployedProducts))
+	}
+	got := resp.DeployedProducts[0]
+
+	if got.Cores == nil || *got.Cores != 4 {
+		t.Fatalf("Cores = %v, want *int(4)", got.Cores)
+	}
+	if got.TPS == nil || *got.TPS != 100.5 {
+		t.Fatalf("TPS = %v, want *float64(100.5)", got.TPS)
+	}
+
+	if len(got.Updates) != 2 {
+		t.Fatalf("expected 2 update-history entries, got %d", len(got.Updates))
+	}
+	if got.Updates[0].UpdateLevel != 3 || got.Updates[0].Date != "2026-02-01" {
+		t.Fatalf("Updates[0] = %+v, want {UpdateLevel:3 Date:2026-02-01 ...}", got.Updates[0])
+	}
+	if got.Updates[0].Details == nil || *got.Updates[0].Details != "Applied patch level 3" {
+		t.Fatalf("Updates[0].Details = %v, want non-nil %q", got.Updates[0].Details, "Applied patch level 3")
+	}
+	if got.Updates[1].UpdateLevel != 2 || got.Updates[1].Details != nil {
+		t.Fatalf("Updates[1] = %+v, want {UpdateLevel:2 Details:nil}", got.Updates[1])
+	}
+}
+
+// TestSNDeployedProductService_SearchDeployedProducts_NilUpdatesStaysNil confirms an
+// absent "updates" field on the wire produces a nil (not empty-non-nil) domain slice.
+func TestSNDeployedProductService_SearchDeployedProducts_NilUpdatesStaysNil(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/deployed-products/search", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"deployedProducts": []map[string]any{
+				{
+					"id":         testDeployedProductSysid,
+					"deployment": map[string]any{"id": testDeployedProductDeploySysid, "name": "Production"},
+					"product":    map[string]any{"id": testDeployedProductProdSysid, "name": "API Manager"},
+					"createdOn":  "2026-01-01 00:00:00",
+					"updatedOn":  "2026-01-02 00:00:00",
+				},
+			},
+			"totalRecords": 1, "offset": 0, "limit": 20,
+		})
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowDeployedProductService(client)
+
+	resp, err := svc.SearchDeployedProducts(contextWithUserIDToken("token"), domain.SearchDeployedProductsRequest{
+		Pagination: domain.Pagination{Limit: 20, Offset: 0},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.DeployedProducts[0].Updates != nil {
+		t.Fatalf("expected nil Updates, got %+v", resp.DeployedProducts[0].Updates)
+	}
+}
+
+// TestSNDeployedProductService_UpdateDeployedProduct_UpdatesRoundTrip proves a request
+// carrying a non-empty Updates array is forwarded to SN as the whole-array-replace payload,
+// and the mocked SN response's echoed "updates" array comes back through in the domain
+// response.
+func TestSNDeployedProductService_UpdateDeployedProduct_UpdatesRoundTrip(t *testing.T) {
+	productUUID := sysidToUUID(testDeployedProductSysid)
+	details := "Applied patch level 5"
+
+	var gotBody map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/deployed-products/"+testDeployedProductSysid, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Fatalf("expected PATCH, got %s", r.Method)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"message": "updated",
+			"deployedProduct": map[string]any{
+				"id":        testDeployedProductSysid,
+				"updatedOn": "2026-02-01 00:00:00",
+				"updatedBy": "jane.doe@example.com",
+				"updates": []map[string]any{
+					{"updateLevel": 5, "date": "2026-02-01", "details": details},
+				},
+			},
+		})
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowDeployedProductService(client)
+
+	req := domain.UpdateDeployedProductRequest{
+		ID: productUUID,
+		Updates: []domain.ProductUpdateEntry{
+			{UpdateLevel: 4, Date: "2026-01-01", Details: nil},
+			{UpdateLevel: 5, Date: "2026-02-01", Details: &details},
+		},
+	}
+
+	resp, err := svc.UpdateDeployedProduct(contextWithUserIDToken("token"), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Assert the outbound payload carried the full Updates array, not just a delta.
+	rawUpdates, ok := gotBody["updates"].([]any)
+	if !ok || len(rawUpdates) != 2 {
+		t.Fatalf("outbound payload updates = %v, want a 2-element array", gotBody["updates"])
+	}
+	first, _ := rawUpdates[0].(map[string]any)
+	if first["updateLevel"] != float64(4) || first["date"] != "2026-01-01" {
+		t.Fatalf("outbound payload updates[0] = %v, want {updateLevel:4 date:2026-01-01}", first)
+	}
+
+	if len(resp.DeployedProduct.Updates) != 1 {
+		t.Fatalf("expected 1 echoed update entry, got %d", len(resp.DeployedProduct.Updates))
+	}
+	if resp.DeployedProduct.Updates[0].UpdateLevel != 5 {
+		t.Fatalf("echoed Updates[0].UpdateLevel = %d, want 5", resp.DeployedProduct.Updates[0].UpdateLevel)
+	}
+	if resp.DeployedProduct.Updates[0].Details == nil || *resp.DeployedProduct.Updates[0].Details != details {
+		t.Fatalf("echoed Updates[0].Details = %v, want %q", resp.DeployedProduct.Updates[0].Details, details)
+	}
+}
+
+// TestSNDeployedProductService_UpdateDeployedProduct_UpdatesAloneSatisfiesDetailFields
+// proves a request carrying only Updates (no cores/tps/description) is accepted as a
+// valid "detail fields" update rather than rejected as an empty request.
+func TestSNDeployedProductService_UpdateDeployedProduct_UpdatesAloneSatisfiesDetailFields(t *testing.T) {
+	productUUID := sysidToUUID(testDeployedProductSysid)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/deployed-products/"+testDeployedProductSysid, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"message": "updated",
+			"deployedProduct": map[string]any{
+				"id":        testDeployedProductSysid,
+				"updatedOn": "2026-02-01 00:00:00",
+				"updatedBy": "jane.doe@example.com",
+			},
+		})
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowDeployedProductService(client)
+
+	req := domain.UpdateDeployedProductRequest{
+		ID:      productUUID,
+		Updates: []domain.ProductUpdateEntry{{UpdateLevel: 1, Date: "2026-01-01"}},
+	}
+	if _, err := svc.UpdateDeployedProduct(contextWithUserIDToken("token"), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/entity-service/internal/service/sn_deployed_product_service_test.go
+++ b/entity-service/internal/service/sn_deployed_product_service_test.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
 )
 
@@ -299,5 +300,113 @@ func TestSNDeployedProductService_UpdateDeployedProduct_UpdatesAloneSatisfiesDet
 	}
 	if _, err := svc.UpdateDeployedProduct(contextWithUserIDToken("token"), req); err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestSNDeployedProductService_UpdateDeployedProduct_EmptyUpdatesArrayClearsHistory proves
+// a request carrying Updates set to a non-nil empty slice (the caller's way of clearing all
+// update history) actually serialises as "updates":[] on the wire. Before this fix, the wire
+// field's plain (non-pointer) slice type meant encoding/json's omitempty dropped an empty
+// slice from the outgoing JSON regardless of nil-ness, so an explicit clear silently no-opped.
+func TestSNDeployedProductService_UpdateDeployedProduct_EmptyUpdatesArrayClearsHistory(t *testing.T) {
+	productUUID := sysidToUUID(testDeployedProductSysid)
+
+	var gotBody map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/deployed-products/"+testDeployedProductSysid, func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"message": "updated",
+			"deployedProduct": map[string]any{
+				"id":        testDeployedProductSysid,
+				"updatedOn": "2026-02-01 00:00:00",
+				"updatedBy": "jane.doe@example.com",
+			},
+		})
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowDeployedProductService(client)
+
+	req := domain.UpdateDeployedProductRequest{
+		ID:      productUUID,
+		Updates: []domain.ProductUpdateEntry{},
+	}
+	if _, err := svc.UpdateDeployedProduct(contextWithUserIDToken("token"), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	gotUpdates, hasKey := gotBody["updates"]
+	if !hasKey {
+		t.Fatalf("outbound payload has no %q key, want an explicit empty array (body: %v)", "updates", gotBody)
+	}
+	arr, ok := gotUpdates.([]any)
+	if !ok || len(arr) != 0 {
+		t.Fatalf("outbound payload updates = %v (%T), want []", gotUpdates, gotUpdates)
+	}
+}
+
+// TestSNDeployedProductService_UpdateDeployedProduct_ValidatesUpdateEntries proves each
+// entry in Updates is validated before the request ever reaches the backing service: a
+// negative updateLevel and a malformed date are both rejected, and a well-formed array
+// passes through untouched.
+func TestSNDeployedProductService_UpdateDeployedProduct_ValidatesUpdateEntries(t *testing.T) {
+	productUUID := sysidToUUID(testDeployedProductSysid)
+
+	cases := []struct {
+		name      string
+		updates   []domain.ProductUpdateEntry
+		wantValid bool
+	}{
+		{
+			name:      "negative updateLevel rejected",
+			updates:   []domain.ProductUpdateEntry{{UpdateLevel: -1, Date: "2026-01-01"}},
+			wantValid: false,
+		},
+		{
+			name:      "malformed date rejected",
+			updates:   []domain.ProductUpdateEntry{{UpdateLevel: 1, Date: "01/01/2026"}},
+			wantValid: false,
+		},
+		{
+			name:      "valid entries pass through unchanged",
+			updates:   []domain.ProductUpdateEntry{{UpdateLevel: 1, Date: "2026-01-01"}},
+			wantValid: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := newTestSNClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if !tc.wantValid {
+					t.Fatalf("unexpected call to backing service for an invalid request")
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"message": "updated",
+					"deployedProduct": map[string]any{
+						"id":        testDeployedProductSysid,
+						"updatedOn": "2026-02-01 00:00:00",
+						"updatedBy": "jane.doe@example.com",
+					},
+				})
+			}))
+			svc := NewServiceNowDeployedProductService(client)
+
+			req := domain.UpdateDeployedProductRequest{ID: productUUID, Updates: tc.updates}
+			_, err := svc.UpdateDeployedProduct(contextWithUserIDToken("token"), req)
+
+			if tc.wantValid {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			var ve *apierror.ValidationError
+			if !asValidationError(err, &ve) {
+				t.Fatalf("error = %v (%T), want ValidationError", err, err)
+			}
+		})
 	}
 }

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -6661,7 +6661,8 @@ components:
       required: [referenceId, referenceType]
       description: >-
         At least one of name or description must be provided. referenceId/referenceType scope
-        the update the same way SearchAttachmentsRequest does.
+        the update the same way SearchAttachmentsRequest does. description is nullable: an
+        explicit null clears it, distinct from an omitted field (which leaves it unchanged).
       properties:
         referenceId:
           type: string
@@ -6672,6 +6673,10 @@ components:
           type: string
         description:
           type: string
+          nullable: true
+      anyOf:
+        - required: [name]
+        - required: [description]
 
     UpdatedAttachment:
       type: object

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -1362,6 +1362,90 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
 
   /attachments/{id}:
+    get:
+      summary: Get an attachment's metadata by id.
+      operationId: getAttachment
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Attachment UUID.
+      responses:
+        "200":
+          description: Attachment metadata.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Attachment'
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: Attachment not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    patch:
+      summary: Update an attachment's name and/or description (ServiceNow data source only).
+      operationId: updateAttachment
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Attachment UUID.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateAttachmentRequest'
+      responses:
+        "200":
+          description: Attachment updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UpdateAttachmentResponse'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: Attachment not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
     delete:
       summary: Delete a case attachment (ServiceNow data source only).
       operationId: deleteCaseAttachment
@@ -4735,20 +4819,39 @@ components:
           allOf:
             - $ref: '#/components/schemas/DeployedProductVersionRef'
         cores:
-          type: string
+          type: integer
           nullable: true
         tps:
-          type: string
+          type: number
           nullable: true
         category:
           type: string
           nullable: true
+        updates:
+          type: array
+          nullable: true
+          items:
+            $ref: '#/components/schemas/ProductUpdateEntry'
+          description: Update-level history recorded against this deployed product.
         createdOn:
           type: string
           format: date-time
         updatedOn:
           type: string
           format: date-time
+
+    ProductUpdateEntry:
+      type: object
+      required: [updateLevel, date]
+      properties:
+        updateLevel:
+          type: integer
+        date:
+          type: string
+          format: date
+        details:
+          type: string
+          nullable: true
 
     SearchDeployedProductsResponse:
       type: object
@@ -4818,7 +4921,7 @@ components:
 
     UpdateDeployedProductRequest:
       oneOf:
-        - description: Update deployed product detail fields. At least one of cores, tps, or description must be provided.
+        - description: Update deployed product detail fields. At least one of cores, tps, description, or updates must be provided.
           type: object
           minProperties: 1
           additionalProperties: false
@@ -4839,6 +4942,13 @@ components:
               type: string
               nullable: true
               description: Description of the deployed product.
+            updates:
+              type: array
+              items:
+                $ref: '#/components/schemas/ProductUpdateEntry'
+              description: >-
+                Whole-array replace of the deployed product's update-level history: fetch the
+                current array, mutate it client-side, and PATCH the full array back.
         - description: Deactivate the deployed product. active must be false; no other fields may be present.
           type: object
           required: [active]
@@ -4873,6 +4983,12 @@ components:
           format: date-time
         updatedBy:
           type: string
+        updates:
+          type: array
+          nullable: true
+          items:
+            $ref: '#/components/schemas/ProductUpdateEntry'
+          description: The deployed product's update-history array as it stands after the write.
 
     UpdateCaseRequest:
       type: object
@@ -6539,6 +6655,44 @@ components:
       properties:
         message:
           type: string
+
+    UpdateAttachmentRequest:
+      type: object
+      required: [referenceId, referenceType]
+      description: >-
+        At least one of name or description must be provided. referenceId/referenceType scope
+        the update the same way SearchAttachmentsRequest does.
+      properties:
+        referenceId:
+          type: string
+          format: uuid
+        referenceType:
+          $ref: '#/components/schemas/ReferenceType'
+        name:
+          type: string
+        description:
+          type: string
+
+    UpdatedAttachment:
+      type: object
+      required: [id, updatedOn, updatedBy]
+      properties:
+        id:
+          type: string
+          format: uuid
+        updatedOn:
+          type: string
+          format: date-time
+        updatedBy:
+          type: string
+
+    UpdateAttachmentResponse:
+      type: object
+      properties:
+        message:
+          type: string
+        attachment:
+          $ref: '#/components/schemas/UpdatedAttachment'
 
     ChangeRequestFieldFilter:
       type: object


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

We are aligning the CSM portal's Deployments section with the existing customer portal capability: adding deployed-product update-history, deployment attachments, and a numeric cores/tps fix. This is a single PR spanning all three layers it touches (entity-service, CSM backend/BFF, CSM webapp).

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

- Entity-service: `PATCH /deployed-products/{id}` accepts a whole-array-replace `updates` field (update-level history entries), search/read responses include it, `cores`/`tps` are now returned as proper numbers instead of strings, and the previously-missing `GET /attachments/{id}` / `PATCH /attachments/{id}` operations are added (reference-type-generic, already worked for `deployment` as a reference type).
- CSM backend (BFF): thin passthrough routes for the two new attachment operations; no change needed for `updates` since the existing deployed-product PATCH route already forwards the request body untouched.
- CSM webapp: an "Update History" tab on the deployed-product edit dialog — add/edit(latest entry only)/delete a version-update entry, each saving immediately (whole-array PATCH) independent of the Details tab's own save-and-close action, matching customer portal's interaction model — a new deployment-attachments panel (upload/list/edit/delete/download), and the client-side cores/tps re-parse workaround removed now that the backend returns them numeric. `/help` docs updated to describe both new capabilities.
- Also fixed a pre-existing bug surfaced during live verification: `BeDeployment` never carried a populated project reference (the backend's response shape was `project: {id, name}`, but the frontend type only declared a `projectId` string that was never sent), which silently hid the "Add product" button in the Deployments tab. Added a proper `project` field and updated the one call site.

## Approach
> Describe how you are implementing the solutions.

Additive changes only across all three layers — no changes to the upstream ServiceNow scripted APIs or the Ballerina entity-service, which already support all of this (confirmed by direct inspection before starting). Full data flow: webapp → CSM backend (thin passthrough) → entity-service (new fields/endpoints) → existing ServiceNow-backed Ballerina API.

## User stories
> Summary of user stories addressed by this change

As a CS engineer, I can view and edit a deployed product's update-level history and attach/edit documents on a deployment, matching what's already available in the customer portal.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Added deployed-product update-history and deployment-attachment support to the CSM portal (entity-service, backend, and webapp); fixed cores/tps to return as numbers instead of strings.

## Documentation
> Link(s) to product documentation

Updated the in-app CSM portal `/help` topic (Deployments section) to describe the new Update History tab and attachments panel.

## Automation tests
 - Unit tests
   > Entity-service: new/extended tests cover Updates round-trip, numeric cores/tps, GetAttachment/UpdateAttachment happy-path + validation errors, Postgres-path stubs — `go test ./...` all pass. CSM backend: new tests for the two passthrough routes — `go test ./...` all pass (one pre-existing unrelated `-race` flake in `internal/entity`, confirmed present on a clean base-branch checkout). CSM webapp: 218 test files / 2177 tests pass (`vitest run`), typecheck and lint clean apart from 2 pre-existing unrelated issues.
 - Integration tests
   > Not run against live ServiceNow/local stack in this PR; covered by mocked/unit tests only.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A for Go/TS — ran `gosec -fmt=text ./...` on both Go components instead: entity-service 0 issues; CSM backend 4 findings, all pre-existing `G304`s in `internal/dashboard/{registry,sections}.go` already carrying an inline `//nolint:gosec` justification, none in files this PR touches. `eslint` clean on the webapp changes.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A — single PR covering all three layers. Note: this branch also picked up one unrelated
documentation-only commit (`15e7a47aa`, openapi.yaml filter docs) from a concurrent session
sharing this fork — merged in rather than force-pushed over, no code behavior change.

## Migrations (if applicable)
N/A — additive fields only, no schema/migration changes.

## Test environment
Go 1.25 (toolchain auto-switched to 1.26 for gosec) for both Go components; Node/Vite/Vitest toolchain for the webapp. All commands run locally.

## Learning
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deployment attachment management: upload, view, edit names and descriptions, download, and delete files.
  * Added attachment metadata retrieval and updates.
  * Added deployed-product update history with add, edit, and delete support.
  * Added case and incident search filters, including SLA and escalation fields.
  * Deployment product sizing now uses numeric core and TPS values.

* **Documentation**
  * Updated deployment guidance for product history and attachments.

* **Tests**
  * Added coverage for attachment workflows, validation, errors, and product history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->