### PR TITLE
[Customer Portal v2] Validate date filters at the portal boundary

### DIFF
--- a/apps/customer-portal/backend-v2/internal/dto/date_validation.go
+++ b/apps/customer-portal/backend-v2/internal/dto/date_validation.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dto
+
+import "regexp"
+
+// dateOnlyRe mirrors the upstream DateString constraint verbatim:
+//
+//	@constraint:String {
+//	    pattern: re `^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$`
+//	}
+//
+// Copied rather than loosened on purpose — anything the upstream accepts must be
+// accepted here, and nothing more. Note it requires zero-padded month and day,
+// so "2026-6-16" is rejected while "2026-06-16" passes.
+var dateOnlyRe = regexp.MustCompile(`^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$`)
+
+// IsValidDateOnly reports whether s is a plain YYYY-MM-DD date the upstream will
+// accept.
+//
+// Validating at the portal boundary matters because a malformed date otherwise
+// travels all the way to the Choreo integration service, which rejects it with
+// its own schema language:
+//
+//	Failed to bind request payload to the expected schema: payload validation
+//	failed: Validation failed for '$.filters.startDate:pattern' constraint(s).
+//
+// That reaches the customer verbatim and names neither the offending value nor
+// the expected format. Rejecting it here produces an actionable message and
+// saves a pointless upstream round trip.
+func IsValidDateOnly(s string) bool {
+	return dateOnlyRe.MatchString(s)
+}

--- a/apps/customer-portal/backend-v2/internal/dto/date_validation_test.go
+++ b/apps/customer-portal/backend-v2/internal/dto/date_validation_test.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dto
+
+import "testing"
+
+// TestIsValidDateOnly_MatchesTheUpstreamConstraint pins this check against the
+// upstream DateString pattern it copies. Accepting anything the upstream rejects
+// would leak a Choreo schema error to the customer; rejecting anything it accepts
+// would break a working filter, so the two must agree exactly.
+func TestIsValidDateOnly_MatchesTheUpstreamConstraint(t *testing.T) {
+	valid := []string{
+		"2026-06-16",
+		"2026-01-01",
+		"2026-12-31",
+		"1999-02-28",
+		"2026-02-30", // pattern-valid; the upstream owns real calendar validation
+	}
+	for _, s := range valid {
+		if !IsValidDateOnly(s) {
+			t.Errorf("IsValidDateOnly(%q) = false, want true — the upstream accepts this", s)
+		}
+	}
+
+	invalid := map[string]string{
+		"unpadded month":    "2026-6-16",
+		"unpadded day":      "2026-06-6",
+		"month 00":          "2026-00-16",
+		"month 13":          "2026-13-16",
+		"day 00":            "2026-06-00",
+		"day 32":            "2026-06-32",
+		"RFC3339":           "2026-06-16T00:00:00Z",
+		"with time":         "2026-06-16 00:00:00",
+		"slashes":           "2026/06/16",
+		"year and month":    "2026-06",
+		"trailing space":    "2026-06-16 ",
+		"leading space":     " 2026-06-16",
+		"two-digit year":    "26-06-16",
+		"empty":             "",
+		"not a date at all": "yyyy-mm-dd",
+	}
+	for name, s := range invalid {
+		if IsValidDateOnly(s) {
+			t.Errorf("%s: IsValidDateOnly(%q) = true, want false — the upstream rejects this", name, s)
+		}
+	}
+}

--- a/apps/customer-portal/backend-v2/internal/dto/time_card_enum_mapping.go
+++ b/apps/customer-portal/backend-v2/internal/dto/time_card_enum_mapping.go
@@ -46,6 +46,7 @@ var timeCardStateToEnum = map[string]string{
 	"approved":  "approved",
 	"rejected":  "rejected",
 	"processed": "processed",
+	"recalled":  "recalled",
 }
 
 // timeCardStatesToEnums translates the portal's time-card state filter values

--- a/apps/customer-portal/backend-v2/internal/dto/time_card_enum_mapping_test.go
+++ b/apps/customer-portal/backend-v2/internal/dto/time_card_enum_mapping_test.go
@@ -33,7 +33,7 @@ func TestTimeCardStatesToEnums_TranslatesServiceNowLabels(t *testing.T) {
 		want []string
 	}{
 		"the failing case":  {[]string{"Approved"}, []string{"approved"}},
-		"all five labels":   {[]string{"Pending", "Submitted", "Approved", "Rejected", "Processed"}, []string{"pending", "submitted", "approved", "rejected", "processed"}},
+		"all six labels":    {[]string{"Pending", "Submitted", "Approved", "Rejected", "Processed", "Recalled"}, []string{"pending", "submitted", "approved", "rejected", "processed", "recalled"}},
 		"already enum":      {[]string{"approved"}, []string{"approved"}},
 		"mixed case":        {[]string{"aPpRoVeD"}, []string{"approved"}},
 		"surrounding space": {[]string{"  Approved  "}, []string{"approved"}},
@@ -102,8 +102,11 @@ func TestTimeCardStatesToEnums_KeepsKnownDropsUnknown(t *testing.T) {
 // whichever filter value maps to the new state.
 func TestTimeCardStateTableCoversEntityServiceEnum(t *testing.T) {
 	// Verbatim from validTimeCardStates in
-	// entity-service/internal/service/sn_time_card_service.go.
-	entityServiceEnum := []string{"pending", "submitted", "approved", "rejected", "processed"}
+	// entity-service/internal/service/sn_time_card_service.go. "recalled" was
+	// missed on the first pass; with unknown values now forwarded rather than
+	// dropped, omitting a state entity-service actually accepts would turn a
+	// legitimate filter into a 400.
+	entityServiceEnum := []string{"pending", "submitted", "approved", "rejected", "processed", "recalled"}
 
 	for _, want := range entityServiceEnum {
 		got, ok := timeCardStateToEnum[want]

--- a/apps/customer-portal/backend-v2/internal/handler/date_params.go
+++ b/apps/customer-portal/backend-v2/internal/handler/date_params.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"net/http"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/dto"
+)
+
+// dateParam pairs a caller-facing field name with the value supplied for it, so
+// a rejection can name the field the caller actually sent.
+type dateParam struct {
+	Name  string
+	Value string
+}
+
+// validateDateParams writes a 400 and returns false when any supplied date is
+// not a plain YYYY-MM-DD value.
+//
+// An empty value is skipped rather than rejected: these are optional filters,
+// and absent means "no bound", which every affected upstream already handles.
+// Order is significant — the slice is walked in order so the message is
+// deterministic when more than one date is malformed.
+func validateDateParams(w http.ResponseWriter, params ...dateParam) bool {
+	for _, p := range params {
+		if p.Value == "" {
+			continue
+		}
+		if !dto.IsValidDateOnly(p.Value) {
+			writeError(w, http.StatusBadRequest, "Invalid "+p.Name+": expected a date in YYYY-MM-DD format.")
+			return false
+		}
+	}
+	return true
+}
+
+// derefString returns the pointed-to value, or "" when the pointer is nil, so an
+// optional filter can be fed to validateDateParams without a nil check at each
+// call site.
+func derefString(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}

--- a/apps/customer-portal/backend-v2/internal/handler/date_params_test.go
+++ b/apps/customer-portal/backend-v2/internal/handler/date_params_test.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestValidateDateParams_RejectsMalformedAndNamesTheField checks the caller gets
+// an actionable 400 naming the field and the expected format, instead of the
+// upstream's schema language leaking through:
+//
+//	Validation failed for '$.filters.startDate:pattern' constraint(s).
+func TestValidateDateParams_RejectsMalformedAndNamesTheField(t *testing.T) {
+	w := httptest.NewRecorder()
+	ok := validateDateParams(w, dateParam{"filters.startDate", "2026-6-16"})
+
+	if ok {
+		t.Fatal("validateDateParams accepted an unpadded date")
+	}
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+	var body struct{ Message string }
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !strings.Contains(body.Message, "filters.startDate") {
+		t.Errorf("message %q does not name the offending field", body.Message)
+	}
+	if !strings.Contains(body.Message, "YYYY-MM-DD") {
+		t.Errorf("message %q does not state the expected format", body.Message)
+	}
+	// The rejected value must not be echoed back — it is caller input.
+	if strings.Contains(body.Message, "2026-6-16") {
+		t.Errorf("message %q echoes the caller's value back", body.Message)
+	}
+}
+
+// TestValidateDateParams_SkipsEmptyValues keeps these filters optional: absent
+// means "no bound", which every affected upstream already handles.
+func TestValidateDateParams_SkipsEmptyValues(t *testing.T) {
+	w := httptest.NewRecorder()
+	if !validateDateParams(w, dateParam{"startDate", ""}, dateParam{"endDate", ""}) {
+		t.Error("empty dates were rejected; they must be treated as absent")
+	}
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want no response written", w.Code)
+	}
+}
+
+// TestValidateDateParams_ReportsTheFirstMalformedInOrder pins deterministic
+// messaging when more than one date is bad — the slice is walked in order.
+func TestValidateDateParams_ReportsTheFirstMalformedInOrder(t *testing.T) {
+	w := httptest.NewRecorder()
+	validateDateParams(w, dateParam{"startDate", "bad"}, dateParam{"endDate", "also-bad"})
+
+	var body struct{ Message string }
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !strings.Contains(body.Message, "startDate") || strings.Contains(body.Message, "endDate") {
+		t.Errorf("message %q should name startDate only, the first supplied", body.Message)
+	}
+}
+
+// TestValidateDateParams_AcceptsValidDates is the pass-through case.
+func TestValidateDateParams_AcceptsValidDates(t *testing.T) {
+	w := httptest.NewRecorder()
+	if !validateDateParams(w, dateParam{"startDate", "2026-06-16"}, dateParam{"endDate", "2026-08-24"}) {
+		t.Error("valid dates were rejected")
+	}
+}
+
+// TestDerefString covers the nil-pointer path used for optional filters.
+func TestDerefString(t *testing.T) {
+	if got := derefString(nil); got != "" {
+		t.Errorf("derefString(nil) = %q, want empty", got)
+	}
+	v := "2026-06-16"
+	if got := derefString(&v); got != v {
+		t.Errorf("derefString(&v) = %q, want %q", got, v)
+	}
+}

--- a/apps/customer-portal/backend-v2/internal/handler/project_stats.go
+++ b/apps/customer-portal/backend-v2/internal/handler/project_stats.go
@@ -251,7 +251,13 @@ func (h *ProjectStatsHandler) GetProjectTimeCardStats(w http.ResponseWriter, r *
 		return
 	}
 
-	result, err := h.entity.GetProjectTimeCardStats(r.Context(), id, r.URL.Query().Get("startDate"), r.URL.Query().Get("endDate"))
+	startDate := r.URL.Query().Get("startDate")
+	endDate := r.URL.Query().Get("endDate")
+	if !validateDateParams(w, dateParam{"startDate", startDate}, dateParam{"endDate", endDate}) {
+		return
+	}
+
+	result, err := h.entity.GetProjectTimeCardStats(r.Context(), id, startDate, endDate)
 	if err != nil {
 		slog.ErrorContext(r.Context(), "entity GetProjectTimeCardStats failed", "userID", user.UserID, "projectID", id, "err", summarizeErr(err))
 		mapUpstreamError(w, err, "Failed to retrieve time card statistics.")
@@ -309,6 +315,15 @@ func (h *ProjectStatsHandler) SearchProjectCaseTimeCards(w http.ResponseWriter, 
 	if err := json.Unmarshal(body, &req); err != nil {
 		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
 		return
+	}
+
+	if req.Filters != nil {
+		if !validateDateParams(w,
+			dateParam{"filters.startDate", derefString(req.Filters.StartDate)},
+			dateParam{"filters.endDate", derefString(req.Filters.EndDate)},
+		) {
+			return
+		}
 	}
 
 	result, err := h.entity.SearchCaseTimeCards(r.Context(), dto.BuildEntityCaseTimeCardSearchRequest(id, req))

--- a/apps/customer-portal/backend-v2/internal/handler/time_cards.go
+++ b/apps/customer-portal/backend-v2/internal/handler/time_cards.go
@@ -73,6 +73,13 @@ func (h *TimeCardHandler) SearchTimeCards(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	if !validateDateParams(w,
+		dateParam{"filters.startDate", derefString(req.Filters.StartDate)},
+		dateParam{"filters.endDate", derefString(req.Filters.EndDate)},
+	) {
+		return
+	}
+
 	result, err := h.entity.SearchTimeCards(r.Context(), dto.BuildEntitySearchTimeCardsRequest(projectID, req))
 	if err != nil {
 		slog.ErrorContext(r.Context(), "entity SearchTimeCards failed", "userID", user.UserID, "err", summarizeErr(err))


### PR DESCRIPTION
Two commits. The first is a **regression fix that missed the #1555 merge** and should land promptly.

## 1. `recalled` state — missed the #1555 merge

`07bd6aa5f`, cherry-picked from the #1555 branch. #1555 merged at `eddc64688`; this commit was pushed after and never landed, so `dev-app-csm-portal` currently has #1555's fail-loudly behaviour **without** the sixth state.

entity-service accepts six states — `validTimeCardStates` and `snTimeCardStateLabelToSN` both include `domain.TimeCardStateRecalled` — and the table here has five. Harmless while unknown values were dropped; **not** harmless now they are forwarded: a legitimate `"Recalled"` filter reaches entity-service untranslated and is rejected with a 400. My omission, my miss on the merge.

## 2. Date filters were never validated

Two upstream errors were reaching the customer verbatim:

```
query validation failed: Validation failed for '$:pattern' constraint(s).
Failed to bind request payload to the expected schema: payload validation failed:
Validation failed for '$.filters.startDate:pattern' constraint(s).
```

Those are Choreo data-binding messages. The upstream constrains its date type to:

```
pattern: re `^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$`
```

and this backend forwarded whatever arrived without checking — there is **no date formatting or validation anywhere** on the time-card paths, so a malformed value made the full round trip and came back as upstream schema language naming neither the offending value nor the expected format.

The pattern requires **zero-padded** parts, so `2026-6-16` is rejected while `2026-06-16` passes. That is the most likely shape of the failure, since the time-tracking date inputs accept typed text.

### Approach

`dto.IsValidDateOnly` copies the upstream pattern **verbatim** rather than approximating it — accepting anything the upstream rejects would just move the error later, and rejecting anything it accepts would break a working filter. A test pins the two together in both directions.

`handler.validateDateParams` applies it to the three time-card entry points that had none:

| Endpoint | |
|---|---|
| `GET /projects/{id}/stats/time-cards` | query params |
| `POST /projects/{id}/time-cards/search` | `filters.startDate` / `endDate` |
| `POST /projects/{id}/cases/time-cards/search` | same |

Empty values are **skipped, not rejected** — these are optional filters and absent means "no bound", which every affected upstream already handles. The rejection names the field but never echoes the value, since it is caller input (a test asserts that).

### Scope, stated plainly

Equivalent helpers already existed for deployed-product metrics (`dto.IsInvalidDateRange`, `dto.IsWithinOneYear`) but were never applied here. Other date-carrying endpoints — instances, global search — are **still unvalidated** and would benefit from the same treatment. I left them out to keep this to the paths with a reported failure, but they are the same latent issue.

## Testing

- `gofmt -l`, `go build`, `go vet`, `go test -race ./...` — all pass
- `gosec -fmt=text ./...` — **0 issues** (107 files)
- Tests cover 5 accepted and 15 rejected date shapes (unpadded, RFC3339, slashes, partial, whitespace-padded), the field-naming and no-echo requirements, empty-skip, deterministic ordering when several dates are bad, and the nil-pointer path

> Validation ran on a local Go 1.27 toolchain with locally installed gosec — Docker Desktop is not running in this environment. Same checks, different runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `recalled` time-card status.
  * Added validation for optional date filters using the required `YYYY-MM-DD` format.

* **Bug Fixes**
  * Invalid date filters now return a clear HTTP 400 error identifying the problematic field.
  * Empty date filters continue to be treated as unspecified.

* **Tests**
  * Added coverage for date validation, error handling, optional values, and recalled time-card mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->