### PR TITLE
[Entity Service] Change-request approval filter + BFF openapi filter-array docs

### DIFF
--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -9385,6 +9385,38 @@ components:
                 A single change request number (e.g. "CHG0010001"); matches
                 exactly. Routed as a first-class filter rather than through
                 the free-text searchQuery scan.
+            filters:
+              type: array
+              items:
+                type: object
+                required: [field, op]
+                properties:
+                  field:
+                    type: string
+                    enum: [createdOn, assignmentGroupId, approval]
+                  op:
+                    type: string
+                    enum: [gte, lte, in, eq]
+                  values:
+                    type: array
+                    items:
+                      type: string
+              description: >-
+                Generic field/op/values filter predicates, additive to the
+                named fields above. Passed through as-is to the entity
+                service. Supported fields:
+
+                - **createdOn** (gte / lte): a single RFC3339 timestamp,
+                  YYYY-MM-DD date, or relative-date placeholder (e.g.
+                  "__daysAgo:90__") bounding the change request's created
+                  timestamp.
+                - **assignmentGroupId** (in): sys_user_group UUIDs.
+                - **approval** (eq): ServiceNow's raw task.approval rollup on
+                  the change request. Exactly one value, one of
+                  "not requested", "requested", "approved", "rejected".
+                  Distinct from the approvedBy/approvedOn fields on a change
+                  request's detail view, which come from a narrower
+                  Customer-Approval-stage record, not this CR-wide field.
         sortBy:
           type: object
           properties:

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -2421,6 +2421,11 @@ type SearchChangeRequestsFilters struct {
 	//     inclusive "on or after", lte is inclusive "on or before". A lte
 	//     bound earlier than its own gte bound is rejected.
 	//   - "assignmentGroupId" (op in): sys_user_group UUIDs.
+	//   - "approval" (op eq): ServiceNow's raw task.approval rollup on the
+	//     change request. One of "not requested", "requested", "approved",
+	//     "rejected". Distinct from approvedBy/approvedOn on
+	//     ChangeRequestDetail, which are derived from a narrower
+	//     Customer-Approval-stage record, not this CR-wide field.
 	// See service.ParseChangeRequestFieldFilters.
 	Filters []ChangeRequestFieldFilter `json:"filters,omitempty"`
 }

--- a/entity-service/internal/service/change_request_filters.go
+++ b/entity-service/internal/service/change_request_filters.go
@@ -30,7 +30,7 @@ import (
 // (states/impacts/closedOn/projectIds/number/searchQuery), which stay outside
 // this array.
 var changeRequestFilterFieldSet = map[string]bool{
-	"createdOn": true, "assignmentGroupId": true,
+	"createdOn": true, "assignmentGroupId": true, "approval": true,
 }
 
 // changeRequestFilterOpSet is the exact set of ChangeRequestFieldFilter.Op
@@ -38,7 +38,15 @@ var changeRequestFilterFieldSet = map[string]bool{
 // Field/op compatibility is enforced separately in
 // ParseChangeRequestFieldFilters.
 var changeRequestFilterOpSet = map[string]bool{
-	"gte": true, "lte": true, "in": true,
+	"gte": true, "lte": true, "in": true, "eq": true,
+}
+
+// changeRequestApprovalValueSet is the exact set of values ServiceNow's raw
+// task.approval field can hold on a change_request record. Confirmed live
+// and meaningful on the production instance (distinct from phase_state,
+// which is structurally dead there).
+var changeRequestApprovalValueSet = map[string]bool{
+	"not requested": true, "requested": true, "approved": true, "rejected": true,
 }
 
 // requireChangeRequestFilterValues rejects a filter entry whose op needs a
@@ -92,6 +100,10 @@ type parsedChangeRequestFilters struct {
 	// sysids -- that conversion happens where the outbound payload is built,
 	// same as before).
 	AssignmentGroupIDs []string
+	// Approval is ServiceNow's raw task.approval value on the change
+	// request ("not requested" / "requested" / "approved" / "rejected"),
+	// passed straight through to SN as filters.approval.
+	Approval *string
 }
 
 // ParseChangeRequestFieldFilters translates the change-request-search wire
@@ -144,6 +156,22 @@ func ParseChangeRequestFieldFilters(filters []domain.ChangeRequestFieldFilter, n
 				return parsedChangeRequestFilters{}, err
 			}
 			p.AssignmentGroupIDs = append(p.AssignmentGroupIDs, f.Values...)
+
+		case "approval":
+			if f.Op != "eq" {
+				return parsedChangeRequestFilters{}, badChangeRequestFilterCombo(f)
+			}
+			if err := requireChangeRequestFilterValues(f); err != nil {
+				return parsedChangeRequestFilters{}, err
+			}
+			if len(f.Values) != 1 {
+				return parsedChangeRequestFilters{}, &apierror.ValidationError{Msg: "filters: field \"approval\" accepts exactly one value"}
+			}
+			if !changeRequestApprovalValueSet[f.Values[0]] {
+				return parsedChangeRequestFilters{}, &apierror.ValidationError{Msg: "filters: field \"approval\" value must be one of \"not requested\", \"requested\", \"approved\", \"rejected\""}
+			}
+			v := f.Values[0]
+			p.Approval = &v
 		}
 	}
 

--- a/entity-service/internal/service/change_request_filters_test.go
+++ b/entity-service/internal/service/change_request_filters_test.go
@@ -54,3 +54,51 @@ func TestParseChangeRequestFieldFilters_CreatedOnAbsoluteDateStillWorks(t *testi
 		t.Fatal("CreatedEndDate = nil, want a resolved time")
 	}
 }
+
+// TestParseChangeRequestFieldFilters_ApprovalAccepted verifies each of
+// ServiceNow's four raw task.approval values is accepted via the "approval"
+// field / "eq" op and passed through into parsedChangeRequestFilters.Approval
+// unchanged.
+func TestParseChangeRequestFieldFilters_ApprovalAccepted(t *testing.T) {
+	now := time.Now().UTC()
+
+	for _, value := range []string{"not requested", "requested", "approved", "rejected"} {
+		parsed, err := ParseChangeRequestFieldFilters([]domain.ChangeRequestFieldFilter{
+			{Field: "approval", Op: "eq", Values: []string{value}},
+		}, now)
+		if err != nil {
+			t.Fatalf("value %q: unexpected error: %v", value, err)
+		}
+		if parsed.Approval == nil || *parsed.Approval != value {
+			t.Fatalf("value %q: Approval = %v, want %q", value, parsed.Approval, value)
+		}
+	}
+}
+
+// TestParseChangeRequestFieldFilters_ApprovalInvalidValueRejected verifies a
+// value outside ServiceNow's four-value task.approval set is rejected rather
+// than passed through as free text.
+func TestParseChangeRequestFieldFilters_ApprovalInvalidValueRejected(t *testing.T) {
+	now := time.Now().UTC()
+
+	_, err := ParseChangeRequestFieldFilters([]domain.ChangeRequestFieldFilter{
+		{Field: "approval", Op: "eq", Values: []string{"maybe"}},
+	}, now)
+	if err == nil {
+		t.Fatal("expected an error for an invalid approval value, got nil")
+	}
+}
+
+// TestParseChangeRequestFieldFilters_ApprovalWrongOpRejected verifies
+// "approval" only accepts op "eq" -- gte/lte/in (valid ops for other fields)
+// are rejected for this field.
+func TestParseChangeRequestFieldFilters_ApprovalWrongOpRejected(t *testing.T) {
+	now := time.Now().UTC()
+
+	_, err := ParseChangeRequestFieldFilters([]domain.ChangeRequestFieldFilter{
+		{Field: "approval", Op: "in", Values: []string{"approved"}},
+	}, now)
+	if err == nil {
+		t.Fatal("expected an error for op \"in\" on field \"approval\", got nil")
+	}
+}

--- a/entity-service/internal/service/sn_change_request_service.go
+++ b/entity-service/internal/service/sn_change_request_service.go
@@ -98,6 +98,10 @@ type snChangeRequestFilters struct {
 	CreatedEndDate   string `json:"createdEndDate,omitempty"`
 	// AssignmentGroupIDs: sys_user_group sys_ids (converted from UUIDs).
 	AssignmentGroupIDs []string `json:"assignmentGroupIds,omitempty"`
+	// Approval: see domain.SearchChangeRequestsFilters.Filters doc comment
+	// ("approval" field). ServiceNow's raw task.approval value, passed
+	// through as-is -- not a key/enum mapping.
+	Approval string `json:"approval,omitempty"`
 }
 
 // snCRTypeIDMap maps domain ChangeRequestType enums to SN numeric type IDs.
@@ -322,6 +326,7 @@ func (s *snChangeRequestService) SearchChangeRequests(ctx context.Context, req d
 			CreatedStartDate:   formatSNDateTimeUTC(parsedFilters.CreatedStartDate),
 			CreatedEndDate:     formatSNDateTimeUTC(parsedFilters.CreatedEndDate),
 			AssignmentGroupIDs: uuidsToSysids(parsedFilters.AssignmentGroupIDs),
+			Approval:           stringPtrValue(parsedFilters.Approval),
 		},
 		SortBy:     snSortBy,
 		Pagination: snProjectPagination{Limit: req.Pagination.Limit, Offset: req.Pagination.Offset},
@@ -466,6 +471,7 @@ func (s *snChangeRequestService) AggregateChangeRequests(ctx context.Context, re
 			CreatedStartDate:   formatSNDateTimeUTC(parsedFilters.CreatedStartDate),
 			CreatedEndDate:     formatSNDateTimeUTC(parsedFilters.CreatedEndDate),
 			AssignmentGroupIDs: uuidsToSysids(parsedFilters.AssignmentGroupIDs),
+			Approval:           stringPtrValue(parsedFilters.Approval),
 		},
 		GroupBy:   req.GroupBy,
 		MaxGroups: req.MaxGroups,

--- a/entity-service/internal/service/sn_change_request_service_test.go
+++ b/entity-service/internal/service/sn_change_request_service_test.go
@@ -261,6 +261,64 @@ func TestSNChangeRequestService_SearchChangeRequests_NewFiltersPassedThrough(t *
 	}
 }
 
+// TestSNChangeRequestService_SearchChangeRequests_ApprovalFilterPassedThrough
+// verifies the generic filters array's "approval" predicate translates into
+// filters.approval on the outgoing payload under the exact raw ServiceNow
+// task.approval value, unchanged (no key/enum mapping).
+func TestSNChangeRequestService_SearchChangeRequests_ApprovalFilterPassedThrough(t *testing.T) {
+	var gotBody map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/change-requests/search", func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"changeRequests": [], "totalRecords": 0, "offset": 0, "limit": 20}`))
+	})
+
+	client := newTestSNClient(t, mux)
+	svc := NewServiceNowChangeRequestService(client)
+
+	req := domain.SearchChangeRequestsRequest{
+		Filters: domain.SearchChangeRequestsFilters{
+			Filters: []domain.ChangeRequestFieldFilter{
+				{Field: "approval", Op: "eq", Values: []string{"approved"}},
+			},
+		},
+	}
+	if _, err := svc.SearchChangeRequests(contextWithUserIDToken("token"), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	gotFilters, ok := gotBody["filters"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected filters object in payload, got %+v", gotBody["filters"])
+	}
+	if gotFilters["approval"] != "approved" {
+		t.Fatalf("filters.approval: got %v, want %q", gotFilters["approval"], "approved")
+	}
+}
+
+// TestSNChangeRequestService_SearchChangeRequests_ApprovalInvalidValueRejected
+// verifies a malformed approval filter value is rejected with a clean
+// validation error before any SN call.
+func TestSNChangeRequestService_SearchChangeRequests_ApprovalInvalidValueRejected(t *testing.T) {
+	// client is intentionally nil: validation must fail before touching it.
+	svc := NewServiceNowChangeRequestService(nil)
+
+	req := domain.SearchChangeRequestsRequest{
+		Filters: domain.SearchChangeRequestsFilters{
+			Filters: []domain.ChangeRequestFieldFilter{
+				{Field: "approval", Op: "eq", Values: []string{"maybe"}},
+			},
+		},
+	}
+	_, err := svc.SearchChangeRequests(contextWithUserIDToken("token"), req)
+	if _, ok := err.(*apierror.ValidationError); !ok {
+		t.Fatalf("expected *apierror.ValidationError, got %T: %v", err, err)
+	}
+}
+
 // TestSNChangeRequestService_SearchChangeRequests_CreatedEndDateBeforeStart verifies
 // a createdOn lte predicate earlier than its own gte predicate is rejected,
 // mirroring the existing closedEndDate/closedStartDate ordering check.

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -6549,9 +6549,10 @@ components:
           enum:
             - createdOn
             - assignmentGroupId
+            - approval
         op:
           type: string
-          enum: [gte, lte, in]
+          enum: [gte, lte, in, eq]
         values:
           type: array
           items:
@@ -6570,6 +6571,12 @@ components:
           its own gte bound is rejected with a validation error.
         - **assignmentGroupId** (in): sys_user_group UUIDs to filter the
           assignment group by.
+        - **approval** (eq): ServiceNow's raw `task.approval` rollup on the
+          change request. Exactly one value, one of `"not requested"`,
+          `"requested"`, `"approved"`, `"rejected"`. Distinct from
+          `approvedBy`/`approvedOn` on ChangeRequestDetail, which are derived
+          from a narrower Customer-Approval-stage record, not this CR-wide
+          field.
 
     SearchChangeRequestsRequest:
       type: object


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Two commits, one PR: (1) the Go entity-service filter itself, (2) a pure-documentation follow-up to the BFF openapi.yaml catching up its generic change-request filter array to what the code already accepts. Both are the same overall change (exposing approval), so kept together rather than split.

A CSM dashboard widget needs to count "Approved" change requests. ServiceNow's raw OOB `task.approval` field (inherited onto `change_request`) is the correct, live, meaningful signal for this (confirmed: 4,105 of 8,714 production change requests are `approved`) -- distinct from `phase_state` (a different field on this instance, proven structurally dead: 0 of 8,701 change requests have ever had it set to anything but its default) and from the existing `approvedBy`/`approvedOn` fields (derived from the narrower Customer-Approval-stage approver record, not this CR-wide rollup). The corresponding ServiceNow and Ballerina entity-service layers now expose it; this Go entity-service did not yet surface it.

Resolves: N/A -- tracked internally.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

- Expose `approval` as a change-request search filter field, matching ServiceNow's four real choice values exactly.
- Document the field in this repo's BFF `openapi.yaml`.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

**Added to the change-request search's existing generic filter array, not as a new named struct field.** Change-request filters are otherwise either closed enums (`states`, `impacts`) already served by named fields, or additive/less-common predicates already served by the generic `ChangeRequestFieldFilter{field, op, values}` array (`createdOn`, `assignmentGroupId`). `approval`'s four fixed values fit that array cleanly with a new `op: "eq"` (single-value equality -- previously only `gte`/`lte`/`in` existed on this array) rather than adding a fifth named field for something the extensible mechanism already covers.

`internal/domain/entity.go`'s filter doc comment documents the distinction from `approvedBy`/`approvedOn` explicitly, so a future reader doesn't conflate this CR-wide rollup with that narrower stage-specific pair. `internal/service/change_request_filters.go` adds the field to the allowed-field/op sets, a value allow-list (the 4 real SN choices), and a parse branch requiring `eq` + exactly one value. `internal/service/sn_change_request_service.go` wires the parsed value into the outbound SN payload for both search and aggregate.

Second commit is doc-only: this BFF's `openapi.yaml` had never documented the change-request search's generic `filters` array at all (missing `createdOn`/`assignmentGroupId` too, not just the new `approval`) -- backfilled all three in one pass since they were found together, called out explicitly so it isn't mistaken for scope creep. No BFF Go code change was needed: `SearchChangeRequests`/`AggregateChangeRequests` are pure `[]byte` passthrough handlers with no request typing.

## User stories
> Summary of user stories addressed by this change

- As a CSM dashboard widget, I can filter change requests by ServiceNow's real approval status, matching a reference ServiceNow dashboard's "Approved CR" tile.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Entity service: new change-request search filter `approval` (not requested/requested/approved/rejected).

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter "N/A" plus brief explanation of why there's no doc impact

`entity-service/openapi.yaml` and `apps/csm-portal/backend/openapi.yaml` both updated with the new filter field and its description.

## Training
N/A -- no training content covers this internal service.

## Certification
N/A -- no certification exam covers this internal service.

## Marketing
N/A -- internal infrastructure.

## Automation tests
 - Unit tests
   > Code coverage information

`go build ./...`, `go vet ./...`, `go test ./...` all pass clean from the `entity-service` module root. New tests: `change_request_filters_test.go` (all 4 valid values accepted, an invalid value rejected, a wrong op rejected) and `sn_change_request_service_test.go` (end-to-end payload pass-through asserting `filters.approval == "approved"` reaches the wire, and invalid-value rejection before any SN call) -- mirroring the existing `createdOn`/`assignmentGroupId` test coverage patterns.

 - Integration tests
   > Details about the test cases and coverage

No automated integration suite covers these paths. A real end-to-end request against ServiceNow DEV was not performed for this PR: ports 8080/8081 (this service's default local ports) were already held by another concurrent development session's running stack, and standing up a second instance risked contention/interference with that session's in-flight work. This is disclosed honestly rather than overstated. The corresponding ServiceNow-layer change has already been verified live against 3 real change requests in both directions (a known-`approved` CR correctly included; known-`requested`/`not requested` CRs correctly excluded) -- a live smoke test through this Go layer specifically is recommended before/at merge.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A -- `gosec` was not available in this environment for this PR; no security-sensitive surface is added (one new string filter field following an existing extensible pattern), but this should still be run before merge per this service's normal convention.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
> List any other related PRs

A corresponding ServiceNow scripted-API change (live on DEV) and a corresponding Ballerina entity-service change are tracked separately, not in this repo.

## Migrations (if applicable)
N/A -- no schema/data migration involved.

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested

Go entity-service, macOS, local build/test only (see Automation tests above for the honest scope of verification).

## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

Confirmed this repo's convention of reaching for the generic filter array (`ChangeRequestFieldFilter`) for additive, less-common predicates rather than adding a new named struct field for every new filterable attribute -- `approval` is a clean fit for that existing mechanism, not a reason to grow the named-field surface.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added approval-status filtering for change requests.
  * Supports filtering by approval status, assignment group, and creation date using flexible field/operator/value criteria.
  * Approval filters support statuses including not requested, requested, approved, and rejected.

* **Bug Fixes**
  * Invalid approval values and unsupported operators are now rejected with validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->