### PR TITLE
[CSM Portal] fix invalid subscriptionType literal in AsyncProjectSelect test

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncProjectSelect.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncProjectSelect.test.tsx
@@ -34,7 +34,7 @@ afterEach(() => {
 const MANAGED_CLOUD_PROJECT: BeProject = {
   id: "proj-managed",
   name: "Managed Cloud Co",
-  subscriptionType: "managed_cloud",
+  subscriptionType: "managed_cloud_subscription",
 };
 const SUBSCRIPTION_PROJECT: BeProject = {
   id: "proj-subscription",
@@ -43,7 +43,7 @@ const SUBSCRIPTION_PROJECT: BeProject = {
 };
 
 const isManagedCloudProject = (p: BeProject): boolean =>
-  p.subscriptionType === "managed_cloud";
+  p.subscriptionType === "managed_cloud_subscription";
 
 describe("AsyncProjectSelect — filterProject pagination", () => {
   it("keeps loading pages when the current page's matches are all filtered out", async () => {


### PR DESCRIPTION
## Purpose
`pnpm run build` fails on `main` because `AsyncProjectSelect.test.tsx` (added in a prior PR
addressing CodeRabbit findings) uses the string literal `"managed_cloud"` as a
`BeSubscriptionType` value. That type has no `"managed_cloud"` member; the actual member is
`"managed_cloud_subscription"`. `tsc -b` fails with TS2322/TS2367, breaking the build.

## Goals
Restore a clean `pnpm run build` by correcting the test fixture literal to a value that
actually exists on `BeSubscriptionType`.

## Approach
Replaced the 3 occurrences of `"managed_cloud"` with `"managed_cloud_subscription"` in
`apps/csm-portal/webapp/src/features/csm-cases/components/AsyncProjectSelect.test.tsx`:
the `MANAGED_CLOUD_PROJECT` fixture's `subscriptionType` field and both sides of the
`isManagedCloudProject` predicate's comparison. This is a pure test-fixture typo fix; the
component under test, `AsyncProjectSelect.tsx`, never reads `subscriptionType`. No other
logic, assertions, or test names changed.

## User stories
N/A — internal build fix, no user-facing behavior change.

## Release note
Fixed a TypeScript build failure caused by an invalid `subscriptionType` literal in a test
fixture.

## Documentation
N/A — no product behavior change, no doc impact.

## Training
N/A — no training content impact.

## Certification
N/A — no certification exam impact.

## Marketing
N/A — internal test-fixture fix, not a feature.

## Automation tests
- Unit tests
  > Ran the full webapp vitest suite (`218` files / `2186` tests) after the fix: all pass.
  > `AsyncProjectSelect.test.tsx`'s 3 tests specifically verified green.
- Integration tests
  > N/A — no integration test suite covers this component; not applicable to this fix.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? N/A — test-only, no runtime code path changed
- Ran FindSecurityBugs plugin and verified report? N/A — TypeScript/React project, this tool doesn't apply
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no sample impact.

## Related PRs
None.

## Migrations (if applicable)
N/A — no schema or data migration involved.

## Test environment
Node/pnpm workspace at `apps/csm-portal/webapp`; verified with `pnpm run build`
(`tsc -b && vite build`, exit code 0) and `vitest run` locally on macOS.

## Learning
N/A — straightforward literal correction against the existing `BeSubscriptionType` union in
`src/api/backend/types.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test coverage to use the current managed cloud subscription type value.
  * Existing test behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->