### PR TITLE
[Customer Portal v2] Emit project dates as calendar dates, not timestamps

### DIFF
--- a/apps/customer-portal/backend-v2/internal/dto/date_only.go
+++ b/apps/customer-portal/backend-v2/internal/dto/date_only.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dto
+
+import "time"
+
+// dateOnlyLayout is the wire format for a calendar date with no time component,
+// matching the upstream DateString type the portal was built against.
+const dateOnlyLayout = "2006-01-02"
+
+// DateOnly renders a timestamp as a bare calendar date, or nil when there is no
+// date to render.
+//
+// Calendar dates must not reach the portal as RFC3339 timestamps. Ballerina types
+// these fields as DateString (constrained to ^\d{4}-\d{2}-\d{2}$) and the frontend
+// treats the value as opaque text it can hand straight back as a filter — the
+// time-tracking page defaults its startDate filter to project.startDate verbatim.
+// Emitting "2026-06-16T00:00:00Z" there produced
+// "startDate=2026-06-16T00:00:00Z", which the upstream rejects on its own date
+// pattern while the locally-formatted endDate beside it was accepted.
+//
+// A zero time is treated as absent rather than rendered as "0001-01-01": these
+// fields are nullable upstream, and a fabricated date is worse than a missing one.
+func DateOnly(t *time.Time) *string {
+	if t == nil || t.IsZero() {
+		return nil
+	}
+	s := t.Format(dateOnlyLayout)
+	return &s
+}
+
+// DateOnlyValue is DateOnly for a non-pointer timestamp, for fields entity-service
+// models as always-present but which the portal still exposes as nullable —
+// entity-service returns a zero time when the upstream omitted the date.
+func DateOnlyValue(t time.Time) *string {
+	return DateOnly(&t)
+}

--- a/apps/customer-portal/backend-v2/internal/dto/date_only_test.go
+++ b/apps/customer-portal/backend-v2/internal/dto/date_only_test.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dto
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+)
+
+// TestDateOnly_RendersBareCalendarDates covers the helper directly, including the
+// zero-time case: a fabricated "0001-01-01" is worse than an absent field.
+func TestDateOnly_RendersBareCalendarDates(t *testing.T) {
+	ts := time.Date(2026, 6, 16, 13, 45, 7, 0, time.UTC)
+	if got := DateOnly(&ts); got == nil || *got != "2026-06-16" {
+		t.Errorf("DateOnly = %v, want 2026-06-16 (time component dropped)", got)
+	}
+	if got := DateOnly(nil); got != nil {
+		t.Errorf("DateOnly(nil) = %v, want nil", got)
+	}
+	var zero time.Time
+	if got := DateOnly(&zero); got != nil {
+		t.Errorf("DateOnly(zero) = %v, want nil rather than a fabricated date", got)
+	}
+	if got := DateOnlyValue(zero); got != nil {
+		t.Errorf("DateOnlyValue(zero) = %v, want nil", got)
+	}
+}
+
+// TestProjectDates_AreDateOnlyNotTimestamps is the regression guard for the
+// time-tracking filter failure.
+//
+// The time-tracking page defaults its startDate filter to project.startDate
+// verbatim (ProjectTimeTracking.tsx: setStartDate(project.startDate)). While this
+// backend emitted an RFC3339 timestamp, that produced
+// startDate=2026-06-16T00:00:00Z, which the upstream rejects on its own date
+// pattern — while the locally-formatted endDate beside it was accepted. Ballerina
+// types every one of these as DateString, so date-only is the contract.
+func TestProjectDates_AreDateOnlyNotTimestamps(t *testing.T) {
+	d := func(y int, m time.Month, day int) *time.Time {
+		v := time.Date(y, m, day, 0, 0, 0, 0, time.UTC)
+		return &v
+	}
+
+	b, err := json.Marshal(MapProjectDetails(entity.ProjectDetailsView{
+		ID:        "6fa0b42d-1bfa-a694-a002-c9d3604bcb77",
+		StartDate: *d(2026, 6, 16),
+		EndDate:   *d(2027, 6, 15),
+	}))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for key, want := range map[string]string{
+		"startDate": "2026-06-16",
+		"endDate":   "2027-06-15",
+	} {
+		got, _ := out[key].(string)
+		if got != want {
+			t.Errorf("%s = %q, want %q — a timestamp here breaks the time-tracking filter", key, got, want)
+		}
+	}
+}
+
+// TestSearchProjects_DatesAreDateOnly covers the search item, which the page's
+// project lookup also reads.
+func TestSearchProjects_DatesAreDateOnly(t *testing.T) {
+	start := time.Date(2026, 6, 16, 9, 30, 0, 0, time.UTC)
+	end := time.Date(2027, 1, 5, 0, 0, 0, 0, time.UTC)
+	b, err := json.Marshal(MapSearchProjects(entity.SearchProjectsResponse{
+		Projects: []entity.ProjectView{{ID: "a", StartDate: &start, EndDate: &end}},
+	}))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out struct {
+		Projects []map[string]any `json:"projects"`
+	}
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got, _ := out.Projects[0]["startDate"].(string); got != "2026-06-16" {
+		t.Errorf("startDate = %q, want 2026-06-16", got)
+	}
+	if got, _ := out.Projects[0]["endDate"].(string); got != "2027-01-05" {
+		t.Errorf("endDate = %q, want 2027-01-05", got)
+	}
+}
+
+// TestProjectDates_RoundTripThroughTheDateFilterValidator ties the two halves
+// together: whatever this backend emits for a project date must be accepted by
+// its own date-filter validation, because the frontend feeds one straight into
+// the other.
+func TestProjectDates_RoundTripThroughTheDateFilterValidator(t *testing.T) {
+	ts := time.Date(2026, 6, 16, 23, 59, 59, 0, time.UTC)
+	emitted := DateOnly(&ts)
+	if emitted == nil {
+		t.Fatal("DateOnly returned nil for a valid timestamp")
+	}
+	if !IsValidDateOnly(*emitted) {
+		t.Errorf("this backend emits %q for a project date, but its own filter validation rejects it", *emitted)
+	}
+}

--- a/apps/customer-portal/backend-v2/internal/dto/project.go
+++ b/apps/customer-portal/backend-v2/internal/dto/project.go
@@ -36,8 +36,8 @@ type ProjectSummary struct {
 	// Type is what the frontend actually reads (project.type.label); see
 	// projectTypeRef. subscriptionType is kept for existing consumers.
 	Type         *IDLabelRef `json:"type,omitempty"`
-	StartDate    *time.Time  `json:"startDate,omitempty"`
-	EndDate      *time.Time  `json:"endDate,omitempty"`
+	StartDate    *string     `json:"startDate,omitempty"`
+	EndDate      *string     `json:"endDate,omitempty"`
 	CreatedOn    time.Time   `json:"createdOn"`
 	ClosureState *string     `json:"closureState,omitempty"`
 	// No omitempty: the frontend's ProjectListItem types activeCasesCount as a
@@ -66,8 +66,8 @@ func MapSearchProjects(r entity.SearchProjectsResponse) SearchProjectsResponse {
 			Key:              p.Key,
 			SubscriptionType: p.SubscriptionType,
 			Type:             projectTypeRef(p.SubscriptionType),
-			StartDate:        p.StartDate,
-			EndDate:          p.EndDate,
+			StartDate:        DateOnly(p.StartDate),
+			EndDate:          DateOnly(p.EndDate),
 			CreatedOn:        p.CreatedOn,
 			ClosureState:     p.ClosureState,
 			ActiveCasesCount: p.ActiveCasesCount,
@@ -113,18 +113,18 @@ func BuildEntitySearchProjectsRequest(req SearchProjectsRequest) entity.SearchPr
 // project.account?.hasAgent) — not actually internal-only despite this
 // struct's earlier doc comment claiming so.
 type ProjectAccount struct {
-	ID              string     `json:"id"`
-	Name            string     `json:"name"`
-	SupportTier     string     `json:"supportTier"`
-	Region          *string    `json:"region,omitempty"`
-	HasAgent        bool       `json:"hasAgent"`
-	HasKbReferences bool       `json:"hasKbReferences"`
-	ActivationDate  *time.Time `json:"activationDate,omitempty"`
+	ID              string  `json:"id"`
+	Name            string  `json:"name"`
+	SupportTier     string  `json:"supportTier"`
+	Region          *string `json:"region,omitempty"`
+	HasAgent        bool    `json:"hasAgent"`
+	HasKbReferences bool    `json:"hasKbReferences"`
+	ActivationDate  *string `json:"activationDate,omitempty"`
 	// The owning and technical contacts belong to the account, matching the
 	// frontend's ProjectDetailsAccount type.
-	DeactivationDate    *time.Time `json:"deactivationDate,omitempty"`
-	OwnerEmail          *string    `json:"ownerEmail,omitempty"`
-	TechnicalOwnerEmail *string    `json:"technicalOwnerEmail,omitempty"`
+	DeactivationDate    *string `json:"deactivationDate,omitempty"`
+	OwnerEmail          *string `json:"ownerEmail,omitempty"`
+	TechnicalOwnerEmail *string `json:"technicalOwnerEmail,omitempty"`
 }
 
 // ProjectDetails is the portal's response for GET /projects/{id}.
@@ -141,8 +141,8 @@ type ProjectDetails struct {
 	// Type is what the frontend actually reads (project.type.label); see
 	// projectTypeRef. subscriptionType is kept for existing consumers.
 	Type         *IDLabelRef `json:"type,omitempty"`
-	StartDate    time.Time   `json:"startDate"`
-	EndDate      time.Time   `json:"endDate"`
+	StartDate    *string     `json:"startDate,omitempty"`
+	EndDate      *string     `json:"endDate,omitempty"`
 	CreatedOn    time.Time   `json:"createdOn"`
 	UpdatedOn    time.Time   `json:"updatedOn"`
 	ClosureState *string     `json:"closureState,omitempty"`
@@ -156,16 +156,16 @@ type ProjectDetails struct {
 	// omitempty on a pointer omits only nil, so a genuine zero balance still
 	// serialises: "tracked, none remaining" stays distinguishable from
 	// "not tracked".
-	TotalQueryHours          *float64   `json:"totalQueryHours,omitempty"`
-	ConsumedQueryHours       *float64   `json:"consumedQueryHours,omitempty"`
-	RemainingQueryHours      *float64   `json:"remainingQueryHours,omitempty"`
-	TotalOnboardingHours     *float64   `json:"totalOnboardingHours,omitempty"`
-	ConsumedOnboardingHours  *float64   `json:"consumedOnboardingHours,omitempty"`
-	RemainingOnboardingHours *float64   `json:"remainingOnboardingHours,omitempty"`
-	GoLiveDate               *time.Time `json:"goLiveDate,omitempty"`
-	GoLivePlanDate           *time.Time `json:"goLivePlanDate,omitempty"`
-	OnboardingExpiryDate     *time.Time `json:"onboardingExpiryDate,omitempty"`
-	OnboardingStatus         *string    `json:"onboardingStatus,omitempty"`
+	TotalQueryHours          *float64 `json:"totalQueryHours,omitempty"`
+	ConsumedQueryHours       *float64 `json:"consumedQueryHours,omitempty"`
+	RemainingQueryHours      *float64 `json:"remainingQueryHours,omitempty"`
+	TotalOnboardingHours     *float64 `json:"totalOnboardingHours,omitempty"`
+	ConsumedOnboardingHours  *float64 `json:"consumedOnboardingHours,omitempty"`
+	RemainingOnboardingHours *float64 `json:"remainingOnboardingHours,omitempty"`
+	GoLiveDate               *string  `json:"goLiveDate,omitempty"`
+	GoLivePlanDate           *string  `json:"goLivePlanDate,omitempty"`
+	OnboardingExpiryDate     *string  `json:"onboardingExpiryDate,omitempty"`
+	OnboardingStatus         *string  `json:"onboardingStatus,omitempty"`
 }
 
 // MapProjectDetails builds the portal response from entity-service's ProjectDetailsView.
@@ -179,9 +179,9 @@ func MapProjectDetails(p entity.ProjectDetailsView) ProjectDetails {
 			Region:          p.Account.Region,
 			HasAgent:        p.Account.AgentEnabled,
 			HasKbReferences: p.Account.KbReferencesEnabled,
-			ActivationDate:  p.Account.ActivationDate,
+			ActivationDate:  DateOnly(p.Account.ActivationDate),
 
-			DeactivationDate:    p.Account.DeactivationDate,
+			DeactivationDate:    DateOnly(p.Account.DeactivationDate),
 			OwnerEmail:          p.Account.OwnerEmail,
 			TechnicalOwnerEmail: p.Account.TechnicalOwnerEmail,
 		},
@@ -189,8 +189,8 @@ func MapProjectDetails(p entity.ProjectDetailsView) ProjectDetails {
 		Key:              p.Key,
 		SubscriptionType: p.SubscriptionType,
 		Type:             projectTypeRef(p.SubscriptionType),
-		StartDate:        p.StartDate,
-		EndDate:          p.EndDate,
+		StartDate:        DateOnlyValue(p.StartDate),
+		EndDate:          DateOnlyValue(p.EndDate),
 		CreatedOn:        p.CreatedOn,
 		UpdatedOn:        p.UpdatedOn,
 		ClosureState:     p.ClosureState,
@@ -201,9 +201,9 @@ func MapProjectDetails(p entity.ProjectDetailsView) ProjectDetails {
 		TotalOnboardingHours:     p.TotalOnboardingHours,
 		ConsumedOnboardingHours:  p.ConsumedOnboardingHours,
 		RemainingOnboardingHours: p.RemainingOnboardingHours,
-		GoLiveDate:               p.GoLiveDate,
-		GoLivePlanDate:           p.GoLivePlanDate,
-		OnboardingExpiryDate:     p.OnboardingExpiryDate,
+		GoLiveDate:               DateOnly(p.GoLiveDate),
+		GoLivePlanDate:           DateOnly(p.GoLivePlanDate),
+		OnboardingExpiryDate:     DateOnly(p.OnboardingExpiryDate),
 		OnboardingStatus:         p.OnboardingStatus,
 	}
 }

--- a/apps/customer-portal/backend-v2/openapi.yaml
+++ b/apps/customer-portal/backend-v2/openapi.yaml
@@ -6383,7 +6383,7 @@ components:
           description: Email of the account technical owner.
         deactivationDate:
           type: string
-          format: date-time
+          format: date
           description: Date the account was deactivated.
         id:
           type: string
@@ -6423,15 +6423,15 @@ components:
           description: Onboarding hours remaining. Omitted when not tracked; 0 means none remaining.
         goLiveDate:
           type: string
-          format: date-time
+          format: date
           description: Actual go-live date.
         goLivePlanDate:
           type: string
-          format: date-time
+          format: date
           description: Planned go-live date.
         onboardingExpiryDate:
           type: string
-          format: date-time
+          format: date
           description: Date the onboarding entitlement expires.
         onboardingStatus:
           type: string


### PR DESCRIPTION
This is the **cause** behind the date-format rejections on the time-tracking page. The validation added in #1566 was right to reject the input — it just named the symptom.

## The evidence

The page built this request itself:

```
?startDate=2026-06-16T00%3A00%3A00Z&endDate=2026-08-25
```

The asymmetry is the whole story. `ProjectTimeTracking.tsx` defaults the filter with:

```js
setStartDate(project.startDate);                // copied verbatim from the API
setEndDate(format(new Date(), "yyyy-MM-dd"));   // formatted locally
```

`startDate` is whatever this backend emitted for the project; `endDate` is formatted in the browser. Ballerina types every one of these as `DateString` (constrained to `^\d{4}-\d{2}-\d{2}$`), so copying it verbatim into a date filter has always worked there. This backend typed them `time.Time`, which marshals as RFC3339 — so the page fed a timestamp into a field the upstream constrains to a bare date.

## Scope: nine fields, three response types

| Field | Where | Origin |
|---|---|---|
| `startDate`, `endDate` | project summary **and** detail | predates this work |
| `goLiveDate`, `goLivePlanDate`, `onboardingExpiryDate` | detail | **introduced by me** in the project/onboarding field work |
| `activationDate`, `deactivationDate` | account | predates this work |

So three of them are mine, from #1511. The reported failure was only `startDate`, but every one of these is copied into the UI as opaque text and would misbehave the same way.

## Behaviour

`dto.DateOnly` renders a bare calendar date and treats a **zero time as absent** rather than emitting `"0001-01-01"` — these are nullable upstream, and a fabricated date is worse than a missing one. That also makes the detail's `startDate`/`endDate` omittable, matching Ballerina's `DateString?` rather than always sending a value.

A test asserts the round trip that was broken:

> whatever this backend emits for a project date must pass its own date-filter validation, because the frontend feeds one straight into the other

That is the invariant whose absence caused this, and it now fails the build if it regresses.

## Testing

- `gofmt -l`, `go build`, `go vet`, `go test -race ./...` — all pass
- `gosec -fmt=text ./...` — **0 issues** (108 files)
- Tests cover the helper (including nil and zero-time), the detail and search payloads, and the emit→validate round trip
- `openapi.yaml`: `format: date-time` → `format: date` on the affected fields; spec parses

> Validation ran on a local Go 1.27 toolchain with locally installed gosec — Docker Desktop is not running in this environment.

## Deployment

**backend-v2 only** — no entity-service change, so no ordering constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Project and account dates are now displayed as date-only values in `YYYY-MM-DD` format.
  - Empty or unspecified dates remain blank instead of showing invalid timestamps.
  - Updated API date formats for deactivation, go-live, planned go-live, and onboarding expiry fields.
- **Bug Fixes**
  - Prevented time and timezone information from appearing in date-only fields.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->