### PR TITLE
[CSM] Decode case duration and escalation state

### DIFF
--- a/apps/customer-portal/backend-v2/internal/dto/case.go
+++ b/apps/customer-portal/backend-v2/internal/dto/case.go
@@ -371,6 +371,14 @@ type CaseDetails struct {
 	EngagementStartDate *string   `json:"engagementStartDate,omitempty"`
 	EngagementEndDate   *string   `json:"engagementEndDate,omitempty"`
 	Tags                []CaseTag `json:"tags,omitempty"`
+	// Duration is the upstream's humanised elapsed time, rendered as-is.
+	Duration *string `json:"duration,omitempty"`
+	// EscalationLevel is an {id, label} ref because that is what the frontend
+	// reads (CaseDetailsContent: data?.escalationLevel?.id). entity-service
+	// exposes only the level id, per its no-{id,label} response convention, so
+	// the label is built here — the same split as case status and severity.
+	EscalationLevel *IDLabelRef `json:"escalationLevel,omitempty"`
+	IsEscalated     *bool       `json:"isEscalated,omitempty"`
 }
 
 // MapCaseDetails builds the portal response from entity-service's CaseView.
@@ -465,6 +473,9 @@ func MapCaseDetails(c entity.CaseView) CaseDetails {
 		EngagementStartDate:   c.EngagementStartDate,
 		EngagementEndDate:     c.EngagementEndDate,
 		Tags:                  tags,
+		Duration:              c.Duration,
+		EscalationLevel:       caseEscalationLevelRef(c.EscalationLevel),
+		IsEscalated:           c.IsEscalated,
 	}
 }
 

--- a/apps/customer-portal/backend-v2/internal/dto/case_enum_mapping.go
+++ b/apps/customer-portal/backend-v2/internal/dto/case_enum_mapping.go
@@ -308,3 +308,39 @@ func caseTypeRef(caseType string) *IDLabelRef {
 	}
 	return &IDLabelRef{ID: id, Label: label}
 }
+
+// caseEscalationLevelIDs maps entity-service's escalation-level id to the label
+// the portal displays. Mirrors validEscalationLevel in entity-service's
+// sn_case_service.go, which accepts exactly "0".."5".
+//
+// entity-service returns the id alone, per its convention of never emitting
+// {id, label} objects; the frontend reads escalationLevel.id and renders the
+// label, so the pair is assembled here — the same split already used for case
+// status and severity.
+var caseEscalationLevelIDs = map[string]string{
+	"0": "EL0",
+	"1": "EL1",
+	"2": "EL2",
+	"3": "EL3",
+	"4": "EL4",
+	"5": "EL5",
+}
+
+// caseEscalationLevelRef builds the {id, label} escalation-level reference.
+//
+// An unrecognised id passes through as its own label rather than blanking the
+// field, the same tolerance caseStatusRef and caseSeverityRef apply.
+func caseEscalationLevelRef(id *string) *IDLabelRef {
+	if id == nil {
+		return nil
+	}
+	trimmed := strings.TrimSpace(*id)
+	if trimmed == "" {
+		return nil
+	}
+	label, ok := caseEscalationLevelIDs[trimmed]
+	if !ok {
+		label = trimmed
+	}
+	return &IDLabelRef{ID: trimmed, Label: label}
+}

--- a/apps/customer-portal/backend-v2/internal/dto/case_escalation_test.go
+++ b/apps/customer-portal/backend-v2/internal/dto/case_escalation_test.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dto
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+)
+
+// TestCaseEscalationLevelRef_BuildsTheIDLabelPair covers the translation the
+// frontend depends on: it reads escalationLevel.id, while entity-service exposes
+// only the bare level id per its no-{id,label} response convention.
+func TestCaseEscalationLevelRef_BuildsTheIDLabelPair(t *testing.T) {
+	for id, want := range map[string]string{
+		"0": "EL0", "1": "EL1", "2": "EL2", "3": "EL3", "4": "EL4", "5": "EL5",
+	} {
+		v := id
+		got := caseEscalationLevelRef(&v)
+		if got == nil {
+			t.Errorf("caseEscalationLevelRef(%q) = nil", id)
+			continue
+		}
+		if got.ID != id || got.Label != want {
+			t.Errorf("caseEscalationLevelRef(%q) = {%s, %s}, want {%s, %s}", id, got.ID, got.Label, id, want)
+		}
+	}
+}
+
+// TestCaseEscalationLevelRef_EdgeCases keeps an absent value absent and lets an
+// unrecognised id through as its own label, matching caseStatusRef/caseSeverityRef.
+func TestCaseEscalationLevelRef_EdgeCases(t *testing.T) {
+	if got := caseEscalationLevelRef(nil); got != nil {
+		t.Errorf("nil id: got %+v, want nil", got)
+	}
+	blank := "   "
+	if got := caseEscalationLevelRef(&blank); got != nil {
+		t.Errorf("blank id: got %+v, want nil", got)
+	}
+	future := "9"
+	got := caseEscalationLevelRef(&future)
+	if got == nil || got.ID != "9" || got.Label != "9" {
+		t.Errorf("unknown id: got %+v, want it passed through as its own label", got)
+	}
+	padded := " 2 "
+	if got := caseEscalationLevelRef(&padded); got == nil || got.ID != "2" || got.Label != "EL2" {
+		t.Errorf("padded id: got %+v, want {2, EL2}", got)
+	}
+}
+
+// TestMapCaseDetails_EmitsEscalationAndDuration is the regression guard: all
+// three fields were declared on no Go struct anywhere in the chain — not the
+// Choreo decode, not the domain view, not the mirror, not the DTO — so
+// encoding/json dropped them silently while Ballerina's Case record returns all
+// three and the portal reads them.
+func TestMapCaseDetails_EmitsEscalationAndDuration(t *testing.T) {
+	level := "0"
+	dur := "247 Days 4 Hours 31 Minutes"
+	esc := false
+
+	b, err := json.Marshal(MapCaseDetails(entity.CaseView{
+		ID:              "9fe85754-3ba2-cb10-3e1e-088aa4e45aae",
+		Number:          "CS0441080",
+		Duration:        &dur,
+		EscalationLevel: &level,
+		IsEscalated:     &esc,
+	}))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out struct {
+		Duration        *string `json:"duration"`
+		EscalationLevel *struct {
+			ID    string `json:"id"`
+			Label string `json:"label"`
+		} `json:"escalationLevel"`
+		IsEscalated *bool `json:"isEscalated"`
+	}
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Duration == nil || *out.Duration != dur {
+		t.Errorf("duration = %v, want %q", out.Duration, dur)
+	}
+	if out.EscalationLevel == nil {
+		t.Fatal("escalationLevel absent; CaseDetailsContent reads escalationLevel.id")
+	}
+	if out.EscalationLevel.ID != "0" || out.EscalationLevel.Label != "EL0" {
+		t.Errorf("escalationLevel = %+v, want {0, EL0}", out.EscalationLevel)
+	}
+	// A false isEscalated must survive rather than being omitted as a zero value:
+	// "not escalated" is a real answer, distinct from "unknown".
+	if out.IsEscalated == nil {
+		t.Error("isEscalated absent for an explicit false; it must be sent")
+	} else if *out.IsEscalated {
+		t.Error("isEscalated = true, want false")
+	}
+}
+
+// TestMapCaseDetails_OmitsAbsentEscalationFields keeps an unknown state absent
+// rather than fabricating a default.
+func TestMapCaseDetails_OmitsAbsentEscalationFields(t *testing.T) {
+	b, err := json.Marshal(MapCaseDetails(entity.CaseView{ID: "x", Number: "CS1"}))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var probe map[string]any
+	if err := json.Unmarshal(b, &probe); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, key := range []string{"duration", "escalationLevel", "isEscalated"} {
+		if _, present := probe[key]; present {
+			t.Errorf("%s present when absent upstream; want it omitted", key)
+		}
+	}
+}

--- a/apps/customer-portal/backend-v2/internal/entity/types.go
+++ b/apps/customer-portal/backend-v2/internal/entity/types.go
@@ -771,6 +771,11 @@ type CaseView struct {
 	AcknowledgedBy        *EntityRef `json:"acknowledgedBy"`
 	EngagementPaymentType *string    `json:"engagementPaymentType"`
 	Tags                  []Tag      `json:"tags"`
+	// Duration is upstream display text; EscalationLevel is the level id
+	// ("0".."5") that entity-service exposes rather than the "EL0" label.
+	Duration        *string `json:"duration"`
+	EscalationLevel *string `json:"escalationLevel"`
+	IsEscalated     *bool   `json:"isEscalated"`
 }
 
 // --- deployments ---

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -1493,6 +1493,15 @@ type CaseView struct {
 	EngagementStartDate   *string    `json:"engagementStartDate"`
 	EngagementEndDate     *string    `json:"engagementEndDate"`
 	EngagementPaymentType *string    `json:"engagementPaymentType"`
+	// Duration is the upstream's own humanised elapsed-time string
+	// (e.g. "247 Days 4 Hours 31 Minutes"), passed through rather than parsed —
+	// it is display text, not a computable interval.
+	Duration *string `json:"duration"`
+	// EscalationLevel is the level id ("0".."5"), the same vocabulary the
+	// escalationLevel request filter accepts, so the value round-trips. Rendering
+	// it as a label is the caller's concern.
+	EscalationLevel *string `json:"escalationLevel"`
+	IsEscalated     *bool   `json:"isEscalated"`
 }
 
 // Tag is a free-text label attached to a case via ServiceNow's generic

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -145,6 +145,15 @@ type snCase struct {
 	EngagementStartDate   *string          `json:"engagementStartDate"`
 	EngagementEndDate     *string          `json:"engagementEndDate"`
 	EngagementPaymentType *snCaseLabel     `json:"engagementPaymentType"`
+	// Duration/EscalationLevel/IsEscalated are response fields Choreo already
+	// sends. Note escalationLevel appears twice in this file for different
+	// purposes: as a []string request filter on the search payload, and as this
+	// single choice-list value on the response. Only the filter was declared, so
+	// encoding/json discarded all three on the way back and the portal had no
+	// escalation state or duration to render.
+	Duration        *string                `json:"duration"`
+	EscalationLevel *snCaseEscalationLevel `json:"escalationLevel"`
+	IsEscalated     *bool                  `json:"isEscalated"`
 }
 
 // snWatchListUser mirrors the watch-list user shape ServiceNow/Ballerina returns on both
@@ -222,6 +231,16 @@ type snCaseLabel struct {
 	Label string `json:"label"`
 }
 
+// snCaseEscalationLevel is the escalation-level choice list on a case response,
+// e.g. {"id": "0", "label": "EL0"}. snCaseLabel cannot be reused because it
+// carries no id, and the id is the part that round-trips into the
+// escalationLevel request filter. json.Number because Choreo has sent choice ids
+// both quoted and bare elsewhere in this API.
+type snCaseEscalationLevel struct {
+	ID    json.Number `json:"id"`
+	Label string      `json:"label"`
+}
+
 type snCaseIssueType struct {
 	ID    json.Number `json:"id"`
 	Label string      `json:"label"`
@@ -256,6 +275,28 @@ var snCaseTypeMap = map[string]string{
 	"hosting":                  "hosting",
 	"hosting_query":            "hosting_query",
 	"hosting_task":             "hosting_task",
+}
+
+// snEscalationLevelToDomain reduces Choreo's escalation-level choice list to the
+// plain nullable string this service exposes for enum-valued fields.
+//
+// It keeps the level id ("0".."5", the same vocabulary validEscalationLevel
+// accepts on the request side) rather than the display label ("EL0"), so the
+// value round-trips: a caller can feed what it reads back into the
+// escalationLevel filter. Building the {id, label} pair the portal renders is
+// the BFF's job, not this service's.
+//
+// An id outside the known set yields nil rather than passing an unrecognised
+// value through, matching how the other snXxxToEnum helpers here behave.
+func snEscalationLevelToDomain(l *snCaseEscalationLevel) *string {
+	if l == nil {
+		return nil
+	}
+	id := strings.TrimSpace(l.ID.String())
+	if id == "" || !validEscalationLevel[id] {
+		return nil
+	}
+	return &id
 }
 
 // snCaseTypeSysidMap maps ServiceNow caseType sysids to domain case type values.
@@ -926,19 +967,22 @@ func (s *snCaseService) GetCaseByID(ctx context.Context, id string) (domain.Case
 	}
 
 	cv := domain.CaseView{
-		ID:             sysidToUUID(c.ID),
-		Number:         c.Number,
-		InternalID:     c.InternalID,
-		Subject:        c.Title,
-		Description:    c.Description,
-		Severity:       snSeverityToSeverity(c.Severity),
-		IssueType:      snIssueTypeToEnum(c.IssueType),
-		State:          state,
-		WorkState:      snWorkStateLabelToEnum(c.WorkState),
-		Type:           snCaseTypeToDomain(c.CaseType),
-		EngagementType: snLabelStr(c.EngagementType),
-		CreatedOn:      createdOn,
-		UpdatedOn:      updatedOn,
+		ID:              sysidToUUID(c.ID),
+		Number:          c.Number,
+		InternalID:      c.InternalID,
+		Subject:         c.Title,
+		Duration:        c.Duration,
+		EscalationLevel: snEscalationLevelToDomain(c.EscalationLevel),
+		IsEscalated:     c.IsEscalated,
+		Description:     c.Description,
+		Severity:        snSeverityToSeverity(c.Severity),
+		IssueType:       snIssueTypeToEnum(c.IssueType),
+		State:           state,
+		WorkState:       snWorkStateLabelToEnum(c.WorkState),
+		Type:            snCaseTypeToDomain(c.CaseType),
+		EngagementType:  snLabelStr(c.EngagementType),
+		CreatedOn:       createdOn,
+		UpdatedOn:       updatedOn,
 		// The case read carries no id for the creator, only the email and full
 		// name, so the canonical reference is emitted with a null id.
 		CreatedBy:      domain.NewUserReference("", c.CreatedBy, c.CreatedByFullName),


### PR DESCRIPTION
> [!IMPORTANT]
> Touches **both** services. Deploy **entity-service first** — backend-v2 cannot read a field entity-service is not yet emitting.

## What was missing

Ballerina's `Case` record returns `duration`, `escalationLevel` and `isEscalated`, and the portal reads all three:

| Field | Read in |
|---|---|
| `escalationLevel` | 3 components |
| `isEscalated` | 2 components |
| `duration` | 2 components |

**None** was declared on any Go struct anywhere in the chain:

| Layer | Had them? |
|---|---|
| `snCase` (Choreo decode) | ❌ |
| `domain.CaseView` | ❌ |
| backend-v2 `entity.CaseView` | ❌ |
| backend-v2 `dto.CaseDetails` | ❌ |

So `encoding/json` discarded them at the first hop and nothing failed — the same silent-drop class as `deployedProductCount` and the project/onboarding fields.

### Why `escalationLevel` was easy to miss

The name already appeared **twice** in `sn_case_service.go` — but both were **request-side filters** (a `[]string` on the search payload and another on the filter group). A grep for it looked satisfied while the response field went undeclared. Worth knowing when auditing the remaining gaps: a name being present is not evidence the response side reads it.

## Representation

entity-service exposes the **level id** (`"0".."5"`), not the `"EL0"` label, per its convention that enum-valued responses are plain nullable strings and never `{id, label}` objects. That id is the same vocabulary `validEscalationLevel` accepts on the request side, so the value **round-trips** — a caller can feed what it reads back into the `escalationLevel` filter. An id outside that set maps to `nil` rather than passing an unrecognised value through.

backend-v2 assembles the `{id, label}` pair the frontend reads (`CaseDetailsContent`: `data?.escalationLevel?.id`) — the same split already used for case status and severity. An unrecognised id passes through as its own label rather than blanking the field.

`snCaseEscalationLevel` is a new type because `snCaseLabel` carries only a label and the id is the part that matters here. Its id is `json.Number` since Choreo has sent choice ids both quoted and bare elsewhere in this API.

A test pins that an explicit `isEscalated: false` **survives** rather than being omitted as a zero value — "not escalated" is a real answer, distinct from "unknown".

## Scope note

This came out of investigating "security announcements not visible". I could **not** reproduce or confirm that symptom from the code: the announcement filter path checks out end to end in Go (`caseTypes: ["announcement"]` → `type in` filter → `validCaseType` → `snCaseTypeMap`, all with proper `ok` checks), and `title`/`description` are both emitted. These three fields are a real, separately-verified gap found while looking — not a confirmed fix for that symptom.

The remaining case-item gaps versus Ballerina (`parentCase`, `relatedCase`, `catalog`, `catalogItem`, `assignedTeam`, `product`, `conversation`) are all present on the **detail** DTO already; they are absent only from the **search** item, where no consumer was found reading them.

## Testing

Both services: `gofmt -l`, `go build`, `go vet`, `go test -race ./...` — all pass.

- `gosec` — **0 issues** (107 files backend-v2, 112 entity-service)
- `govulncheck ./...` — **no vulnerabilities**

Tests cover all six escalation levels, nil/blank/padded/unknown ids, the emitted JSON keys, the explicit-false case, and omission when absent.

> Validation ran on a local Go 1.27 toolchain with locally installed gosec/govulncheck — Docker Desktop is not running in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)