### PR TITLE
[Customer Portal v2] Decode entity-service's canonical person reference

### DIFF
--- a/apps/customer-portal/backend-v2/internal/dto/ai_chat.go
+++ b/apps/customer-portal/backend-v2/internal/dto/ai_chat.go
@@ -247,7 +247,7 @@ func MapSearchConversations(r entity.SearchConversationsResponse) SearchConversa
 			Case:         entityRefToIDLabel(c.Case),
 			State:        conversationStateRef(c.State),
 			CreatedOn:    c.CreatedOn,
-			CreatedBy:    c.CreatedBy,
+			CreatedBy:    userRefIdentity(c.CreatedBy),
 		}
 		if c.ID != nil {
 			summary.ID = *c.ID

--- a/apps/customer-portal/backend-v2/internal/dto/case.go
+++ b/apps/customer-portal/backend-v2/internal/dto/case.go
@@ -129,7 +129,7 @@ func MapSearchCases(r entity.SearchCasesResponse) SearchCasesResponse {
 			CaseTypes:        caseTypeRef(c.Type),
 			CreatedOn:        c.CreatedOn,
 			UpdatedOn:        c.UpdatedOn,
-			CreatedBy:        c.CreatedBy,
+			CreatedBy:        userRefIdentity(c.CreatedBy),
 		})
 	}
 	return SearchCasesResponse{
@@ -803,14 +803,20 @@ func MapSearchCaseActivities(r entity.SearchCaseActivitiesResponse) SearchCaseAc
 		}
 
 		items = append(items, CaseActivity{
-			ID:                 a.ID,
-			Type:               string(a.Type),
-			Content:            a.Content,
-			CreatedOn:          a.CreatedOn,
-			CreatedBy:          a.CreatedByFullName,
+			ID:        a.ID,
+			Type:      string(a.Type),
+			Content:   a.Content,
+			CreatedOn: a.CreatedOn,
+			// Both carry the display name, which is what this mapper did before
+			// entity-service replaced its string createdBy plus separate
+			// createdByFullName with one UserReference. Keeping createdBy as the
+			// name preserves the portal's existing output rather than quietly
+			// switching it to an email; CommentBubble falls back to createdBy
+			// when createdByFullName is empty, so both must resolve the same way.
+			CreatedBy:          userRefDisplayName(a.CreatedBy),
 			CreatedByFirstName: a.CreatedByFirstName,
 			CreatedByLastName:  a.CreatedByLastName,
-			CreatedByFullName:  a.CreatedByFullName,
+			CreatedByFullName:  userRefDisplayName(a.CreatedBy),
 			CommentType:        commentType,
 			FileName:           a.FileName,
 			ContentType:        a.ContentType,

--- a/apps/customer-portal/backend-v2/internal/dto/case_test.go
+++ b/apps/customer-portal/backend-v2/internal/dto/case_test.go
@@ -189,7 +189,7 @@ func TestMapSearchCases_MatchesFrontendCaseListItemShape(t *testing.T) {
 				Number:           "CS0440883",
 				CreatedOn:        "2026-07-27 08:39:48",
 				UpdatedOn:        "2026-08-01 10:00:00",
-				CreatedBy:        "customer@example.com",
+				CreatedBy:        &entity.UserReference{Email: "customer@example.com", Name: "A Customer"},
 				Subject:          &subject,
 				Description:      &description,
 				State:            "Work In Progress",

--- a/apps/customer-portal/backend-v2/internal/dto/user_reference.go
+++ b/apps/customer-portal/backend-v2/internal/dto/user_reference.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dto
+
+import (
+	"strings"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+)
+
+// userRefIdentity flattens entity-service's person reference to the identity
+// string the portal contract exposes as createdBy.
+//
+// Email, not name: the frontend treats createdBy as an identity, not a label —
+// isNoveraOrBotSender compares it against "novera" to decide whether a comment
+// came from the assistant, and the Ballerina backend sent the email here too
+// ("anuradhab@wso2.com", "system"). Using the display name would silently break
+// bot attribution.
+//
+// Falls back to the name only when there is no email, so an unresolved author
+// still renders as something rather than vanishing.
+func userRefIdentity(u *entity.UserReference) string {
+	if u == nil {
+		return ""
+	}
+	if e := strings.TrimSpace(u.Email); e != "" {
+		return e
+	}
+	return strings.TrimSpace(u.Name)
+}
+
+// userRefDisplayName flattens the same reference to a human-readable name, for
+// the portal's createdByFullName.
+//
+// entity-service used to send createdByFullName as its own field and removed it
+// in the same change that made createdBy an object, so the name now has to come
+// from the reference. Returns "" when the upstream could not resolve the person,
+// which keeps the field omitted rather than showing an email where a name belongs.
+func userRefDisplayName(u *entity.UserReference) string {
+	if u == nil {
+		return ""
+	}
+	return strings.TrimSpace(u.Name)
+}

--- a/apps/customer-portal/backend-v2/internal/dto/user_reference_test.go
+++ b/apps/customer-portal/backend-v2/internal/dto/user_reference_test.go
@@ -1,0 +1,145 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dto
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+)
+
+// entitySearchCasesPayload is a verbatim-shaped entity-service response, with
+// createdBy as the object it became in the "one canonical person reference per
+// response field" change. Decoding this against a string field is what produced
+// "Failed to search cases." on every case search.
+const entitySearchCasesPayload = `{
+  "cases": [
+    {
+      "id": "9fe85754-3ba2-cb10-3e1e-088aa4e45aae",
+      "internalId": "CUPRSUB-1015",
+      "number": "CS0441080",
+      "createdOn": "2026-08-03 06:15:31",
+      "updatedOn": "2026-08-03 07:02:30",
+      "createdBy": {"id": "u-1", "email": "anuradhab@wso2.com", "name": "Anuradha B"},
+      "subject": "test",
+      "state": "Open",
+      "type": "announcement",
+      "project": {"id": "6fa0b42d-1bfa-a694-a002-c9d3604bcb77", "name": "Customer 3 Project"}
+    }
+  ],
+  "total": 1, "limit": 10, "offset": 0
+}`
+
+// TestSearchCases_DecodesObjectCreatedBy is the regression guard for
+// "Failed to search cases." — a 500 produced entirely inside backend-v2 while
+// entity-service returned a valid 200.
+func TestSearchCases_DecodesObjectCreatedBy(t *testing.T) {
+	var resp entity.SearchCasesResponse
+	if err := json.Unmarshal([]byte(entitySearchCasesPayload), &resp); err != nil {
+		t.Fatalf("decoding entity-service's real payload failed: %v", err)
+	}
+	if len(resp.Cases) != 1 {
+		t.Fatalf("decoded %d cases, want 1", len(resp.Cases))
+	}
+	if resp.Cases[0].CreatedBy == nil || resp.Cases[0].CreatedBy.Email != "anuradhab@wso2.com" {
+		t.Fatalf("createdBy = %+v, want the email decoded from the object", resp.Cases[0].CreatedBy)
+	}
+
+	// The portal contract stays a plain identity string.
+	b, err := json.Marshal(MapSearchCases(resp))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out struct {
+		Cases []map[string]json.RawMessage `json:"cases"`
+	}
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	var identity string
+	if err := json.Unmarshal(out.Cases[0]["createdBy"], &identity); err != nil {
+		t.Fatalf("createdBy is not a JSON string (%s); the frontend reads it as one", out.Cases[0]["createdBy"])
+	}
+	if identity != "anuradhab@wso2.com" {
+		t.Errorf("createdBy = %q, want the email — isNoveraOrBotSender treats this as an identity", identity)
+	}
+}
+
+// TestUserRefIdentity_PrefersEmail pins the identity choice. The frontend
+// compares createdBy against "novera" for bot attribution and the Ballerina
+// backend sent the email here, so the display name must not win.
+func TestUserRefIdentity_PrefersEmail(t *testing.T) {
+	both := &entity.UserReference{Email: "a@wso2.com", Name: "A Person"}
+	if got := userRefIdentity(both); got != "a@wso2.com" {
+		t.Errorf("userRefIdentity = %q, want the email", got)
+	}
+	nameOnly := &entity.UserReference{Name: "A Person"}
+	if got := userRefIdentity(nameOnly); got != "A Person" {
+		t.Errorf("no email: got %q, want the name as a fallback rather than empty", got)
+	}
+	if got := userRefIdentity(nil); got != "" {
+		t.Errorf("nil: got %q, want empty", got)
+	}
+}
+
+// TestUserRefDisplayName_IsNameOnly keeps an email out of a field that renders as
+// a person's name — showing "a@wso2.com" where a name belongs is worse than
+// showing nothing, because CommentBubble falls back to createdBy when this is
+// empty.
+func TestUserRefDisplayName_IsNameOnly(t *testing.T) {
+	if got := userRefDisplayName(&entity.UserReference{Email: "a@wso2.com"}); got != "" {
+		t.Errorf("email-only reference: got %q, want empty", got)
+	}
+	if got := userRefDisplayName(&entity.UserReference{Email: "a@wso2.com", Name: "A Person"}); got != "A Person" {
+		t.Errorf("got %q, want the name", got)
+	}
+	if got := userRefDisplayName(nil); got != "" {
+		t.Errorf("nil: got %q, want empty", got)
+	}
+}
+
+// TestCaseActivities_DecodeObjectCreatedBy covers the second broken endpoint,
+// POST /cases/{id}/activities/search, and the field entity-service removed:
+// createdByFullName no longer arrives, so the display name has to come from the
+// reference or every comment renders as "Unknown".
+func TestCaseActivities_DecodeObjectCreatedBy(t *testing.T) {
+	payload := `{"activity":[{
+	  "id":"a1","type":"comment","content":"hello","createdOn":"2026-08-03T06:15:31Z",
+	  "createdBy":{"id":"u-1","email":"anuradhab@wso2.com","name":"Anuradha B"},
+	  "createdByFirstName":"Anuradha","createdByLastName":"B"
+	}],"total":1,"limit":10,"offset":0}`
+
+	var resp entity.SearchCaseActivitiesResponse
+	if err := json.Unmarshal([]byte(payload), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	mapped := MapSearchCaseActivities(resp)
+	if len(mapped.Activities) != 1 {
+		t.Fatalf("got %d activities, want 1", len(mapped.Activities))
+	}
+	a := mapped.Activities[0]
+	if a.CreatedByFullName != "Anuradha B" {
+		t.Errorf("createdByFullName = %q, want the name from the reference", a.CreatedByFullName)
+	}
+	if a.CreatedBy != "Anuradha B" {
+		t.Errorf("createdBy = %q, want the same display name this mapper produced before the upstream change", a.CreatedBy)
+	}
+	if a.CreatedByFirstName != "Anuradha" || a.CreatedByLastName != "B" {
+		t.Errorf("first/last name lost: %q %q", a.CreatedByFirstName, a.CreatedByLastName)
+	}
+}

--- a/apps/customer-portal/backend-v2/internal/entity/types.go
+++ b/apps/customer-portal/backend-v2/internal/entity/types.go
@@ -514,6 +514,18 @@ type DeployedProductRef struct {
 }
 
 // UserRef is a reference to a user with key display fields.
+// UserReference is entity-service's canonical person reference. It replaced the
+// former string createdBy plus sibling createdByUser/assignedEngineerUser fields
+// (see its "one canonical person reference per response field" change), so every
+// mirrored response field named createdBy is now an object. Declaring it as a
+// string made json.Unmarshal fail with "cannot unmarshal object into Go value of
+// type string", aborting the whole decode.
+type UserReference struct {
+	ID    *string `json:"id"`
+	Email string  `json:"email"`
+	Name  string  `json:"name"`
+}
+
 type UserRef struct {
 	ID     string `json:"id,omitempty"`
 	Name   string `json:"name,omitempty"`
@@ -535,7 +547,7 @@ type SearchCaseView struct {
 	Number           string               `json:"number"`
 	CreatedOn        string               `json:"createdOn"`
 	UpdatedOn        string               `json:"updatedOn"`
-	CreatedBy        string               `json:"createdBy"`
+	CreatedBy        *UserReference       `json:"createdBy"`
 	Subject          *string              `json:"subject"`
 	Description      *string              `json:"description"`
 	IssueType        *string              `json:"issueType"`
@@ -1073,20 +1085,19 @@ type FieldChange struct {
 // field changes). Field types/omitempty here mirror entity-service's struct
 // exactly (see its doc comment) — do not change to pointers.
 type CaseActivity struct {
-	ID                 string        `json:"id"`
-	Type               ActivityType  `json:"type"`
-	Content            string        `json:"content"`
-	CreatedOn          time.Time     `json:"createdOn"`
-	CreatedBy          string        `json:"createdBy"`
-	CreatedByFirstName string        `json:"createdByFirstName"`
-	CreatedByLastName  string        `json:"createdByLastName"`
-	CreatedByFullName  string        `json:"createdByFullName"`
-	CommentType        *CommentType  `json:"commentType,omitempty"`
-	FileName           string        `json:"fileName,omitempty"`
-	ContentType        string        `json:"contentType,omitempty"`
-	SizeBytes          int           `json:"sizeBytes,omitempty"`
-	DownloadURL        string        `json:"downloadUrl,omitempty"`
-	Changes            []FieldChange `json:"changes,omitempty"`
+	ID                 string         `json:"id"`
+	Type               ActivityType   `json:"type"`
+	Content            string         `json:"content"`
+	CreatedOn          time.Time      `json:"createdOn"`
+	CreatedBy          *UserReference `json:"createdBy"`
+	CreatedByFirstName string         `json:"createdByFirstName"`
+	CreatedByLastName  string         `json:"createdByLastName"`
+	CommentType        *CommentType   `json:"commentType,omitempty"`
+	FileName           string         `json:"fileName,omitempty"`
+	ContentType        string         `json:"contentType,omitempty"`
+	SizeBytes          int            `json:"sizeBytes,omitempty"`
+	DownloadURL        string         `json:"downloadUrl,omitempty"`
+	Changes            []FieldChange  `json:"changes,omitempty"`
 }
 
 // SearchCaseActivitiesRequest is the input for POST /cases/{id}/activities/search.
@@ -1456,15 +1467,15 @@ type SearchConversationsRequest struct {
 
 // SearchConversationView is the conversation representation returned in search results.
 type SearchConversationView struct {
-	ID             *string    `json:"id"`
-	Number         *string    `json:"number"`
-	InitialMessage *string    `json:"initialMessage"`
-	MessageCount   int        `json:"messageCount"`
-	Project        *EntityRef `json:"project"`
-	Case           *EntityRef `json:"case"`
-	State          *string    `json:"state"`
-	CreatedOn      string     `json:"createdOn"`
-	CreatedBy      string     `json:"createdBy"`
+	ID             *string        `json:"id"`
+	Number         *string        `json:"number"`
+	InitialMessage *string        `json:"initialMessage"`
+	MessageCount   int            `json:"messageCount"`
+	Project        *EntityRef     `json:"project"`
+	Case           *EntityRef     `json:"case"`
+	State          *string        `json:"state"`
+	CreatedOn      string         `json:"createdOn"`
+	CreatedBy      *UserReference `json:"createdBy"`
 }
 
 // SearchConversationsResponse is entity-service's response for POST /conversations/search.


### PR DESCRIPTION
Fixes `{"message":"Failed to search cases."}` — and **two more list endpoints** broken the same way that had not been reported yet.

## Cause

entity-service consolidated its person fields in **`4cf093dd3` "one canonical person reference per response field"**:

```go
// before                                  // after
CreatedBy     string          →            CreatedBy *UserReference
CreatedByUser *UserReference  →            (removed)
AssignedEngineerUser          →            AssignedEngineer *UserReference
CreatedByFullName             →            (removed)
```

That reached `dev-app-csm-portal` through the main merge. backend-v2's mirrors still declared `createdBy` as a **string**, so `json.Unmarshal` failed with `cannot unmarshal object into Go value of type string` and aborted the whole decode. A valid 200 became a 500, which `mapUpstreamError` renders as its generic fallback — which is why the message named no field.

## Blast radius: three endpoints

| Mirror | Endpoint |
|---|---|
| `SearchCaseView` | `POST /projects/{id}/cases/search` ← the reported one |
| `CaseActivity` | `POST /cases/{id}/activities/search` |
| `SearchConversationView` | `POST /projects/{id}/conversations/search` |

**Only these three.** I swept all **211** shared struct names between the two services for scalar-vs-object mismatches. The many named string types (`CaseSeverity`, `DeploymentType`, sort fields) decode into `string` fine and are not a problem — worth stating, because a naive type-name diff flags ~50 of them.

## The portal contract is unchanged

`createdBy` stays a plain string. **Which** string differs per endpoint, and both choices preserve existing behaviour rather than tidying it:

- **Cases and conversations** keep the **email** — the frontend treats `createdBy` as an identity (`isNoveraOrBotSender` compares it), and that is what the field already carried. The pre-existing `case_test.go` fixture asserting `customer@example.com` still passes unchanged, which confirms it.
- **Activities** keep the **display name** — that mapper already sourced *both* `createdBy` and `createdByFullName` from the now-removed `createdByFullName`. `CommentBubble` falls back to `createdBy` when `createdByFullName` is empty, so both must resolve the same way or every comment renders as "Unknown".

The mirror's now-unsent `createdByFullName` is removed rather than left to deserialise as a permanent empty string.

## Note on the announcements symptom

This is very likely what you were seeing: the announcements page uses `POST /projects/{id}/cases/search`, so with that endpoint 500-ing, no announcements could render regardless of the filter. The filter path itself checks out (`caseTypes: ["announcement"]` → `validCaseType` → `snCaseTypeMap`, all with proper `ok` checks), so I expect this to be the fix — but the same 500 would have hidden any *other* problem on that page, so worth re-checking the page after deploy rather than assuming.

## Testing

- `gofmt -l`, `go build`, `go vet`, `go test -race ./...` — all pass
- `gosec -fmt=text ./...` — **0 issues** (108 files)
- Tests decode **verbatim-shaped** entity-service payloads for the case and activity paths, assert the emitted `createdBy` is still a JSON *string*, and pin the email-vs-name choice per endpoint

## Deployment

**backend-v2 only** — entity-service already has the change; this catches the mirror up to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed case, activity, and conversation data loading when creator information is provided as a structured person reference.
  * Creator identities now consistently display email addresses when available, with names used as a fallback.
  * Activity creator names are derived correctly, improving displayed attribution details.
  * Added regression coverage for creator identity and display-name handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->