### PR TITLE
[CSM Portal] show case description in Activities as a comment, make CRE/SRE team clickable

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseMetaBand.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseMetaBand.test.tsx
@@ -135,3 +135,51 @@ describe("CaseMetaBand — fix ETA cells", () => {
     expect(screen.queryByText("Worst case fix ETA")).not.toBeInTheDocument();
   });
 });
+
+describe("CaseMetaBand — CRE / SRE team", () => {
+  it("renders each present team as a clickable chip, not plain text", () => {
+    renderBand({
+      customerContext: {
+        ...BASE_CASE.customerContext,
+        creTeam: { id: "team-cre-1", name: "CRE Alpha" },
+        sreTeam: { id: "team-sre-1", name: "SRE Bravo" },
+      },
+    });
+
+    expect(screen.getByText("CRE / SRE team")).toBeInTheDocument();
+
+    const creChip = screen.getByText("CRE Alpha");
+    const sreChip = screen.getByText("SRE Bravo");
+    expect(creChip).toBeInTheDocument();
+    expect(sreChip).toBeInTheDocument();
+    // DirectoryEntityChip renders an MUI Chip — a clickable element, unlike
+    // the plain <Typography> the old join rendered.
+    expect(creChip.closest('[role="button"]')).not.toBeNull();
+    expect(sreChip.closest('[role="button"]')).not.toBeNull();
+  });
+
+  it("renders only the present team's chip when just one is set", () => {
+    renderBand({
+      customerContext: {
+        ...BASE_CASE.customerContext,
+        creTeam: { id: "team-cre-1", name: "CRE Alpha" },
+        sreTeam: undefined,
+      },
+    });
+
+    expect(screen.getByText("CRE Alpha")).toBeInTheDocument();
+    expect(screen.queryByText("SRE Bravo")).not.toBeInTheDocument();
+  });
+
+  it("omits the CRE / SRE team cell entirely when neither team is set", () => {
+    renderBand({
+      customerContext: {
+        ...BASE_CASE.customerContext,
+        creTeam: undefined,
+        sreTeam: undefined,
+      },
+    });
+
+    expect(screen.queryByText("CRE / SRE team")).not.toBeInTheDocument();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseMetaBand.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseMetaBand.tsx
@@ -23,6 +23,7 @@ import type { CsmCaseDetail } from "@features/csm-cases/types/csmCases";
 import { parentRecordPath } from "@features/csm-cases/utils/parentRecordRoute";
 import SemanticChip from "@components/SemanticChip";
 import UserRefLink from "@components/UserRefLink";
+import DirectoryEntityChip from "@features/csm-admin/components/DirectoryEntityChip";
 import DeploymentDetailsDialog from "@features/csm-projects/components/DeploymentDetailsDialog";
 import type { BeDeploymentType } from "@api/backend/types";
 import { announcementStateRole } from "@features/csm-announcements/utils/announcementState";
@@ -303,11 +304,22 @@ export default function CaseMetaBand({
           </Cell>
           {!isAnnouncement && (c.customerContext.creTeam || c.customerContext.sreTeam) && (
             <Cell label="CRE / SRE team">
-              <Typography variant="body2" noWrap>
-                {[c.customerContext.creTeam?.name, c.customerContext.sreTeam?.name]
-                  .filter(Boolean)
-                  .join(" · ") || "—"}
-              </Typography>
+              <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5 }}>
+                {c.customerContext.creTeam && (
+                  <DirectoryEntityChip
+                    id={c.customerContext.creTeam.id}
+                    name={c.customerContext.creTeam.name}
+                    routeBase="/admin/teams"
+                  />
+                )}
+                {c.customerContext.sreTeam && (
+                  <DirectoryEntityChip
+                    id={c.customerContext.sreTeam.id}
+                    name={c.customerContext.sreTeam.name}
+                    routeBase="/admin/teams"
+                  />
+                )}
+              </Box>
             </Cell>
           )}
           <Cell label="Project" maxWidth={isAnnouncement ? 240 : undefined}>

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentBubble.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentBubble.test.tsx
@@ -361,4 +361,24 @@ describe("CsmCaseCommentBubble", () => {
     expect(screen.getByText(/Commented by/)).toBeInTheDocument();
     expect(screen.getByText("Jane Doe")).toBeInTheDocument();
   });
+
+  it("suppresses the role chip for a synthetic (client-injected) comment even though authorRole is 'customer'", () => {
+    // `synthetic` is used for entries the frontend fabricates itself (e.g.
+    // the case description echoed into the activity feed) — the real
+    // author's role is unknown in that case, so no chip should claim one,
+    // regardless of what placeholder `authorRole` the entry carries.
+    renderWithProviders(
+      <CsmCaseCommentBubble
+        comment={makeComment({ authorRole: "customer", synthetic: true })}
+      />,
+    );
+    expect(screen.queryByText("Customer")).not.toBeInTheDocument();
+  });
+
+  it("still shows the role chip for a non-synthetic customer comment", () => {
+    renderWithProviders(
+      <CsmCaseCommentBubble comment={makeComment({ authorRole: "customer" })} />,
+    );
+    expect(screen.getByText("Customer")).toBeInTheDocument();
+  });
 });

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentBubble.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmCaseCommentBubble.tsx
@@ -361,7 +361,7 @@ export default function CsmCaseCommentBubble({
               userId={comment.authorUser?.id}
             />
           </Typography>
-          {comment.authorRole !== "wso2_engineer" && (
+          {!comment.synthetic && comment.authorRole !== "wso2_engineer" && (
             <Chip
               size="small"
               label={ROLE_LABEL[comment.authorRole]}

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.test.tsx
@@ -1089,6 +1089,39 @@ describe("CsmCaseDetailPage — announcement description rendering", () => {
     expect(screen.getAllByText("Long advisory content")).toHaveLength(1);
   });
 
+  it("does not inject a synthetic entry for an announcement whose origin comment already echoes the description", () => {
+    // Regression guard: `safeComments` gates purely on
+    // `descriptionEchoedInOriginComment`, with no separate `isAnnouncement`
+    // carve-out — if announcement creation ever starts producing a real
+    // echoed origin comment (it doesn't today), this must still suppress the
+    // synthetic entry rather than always appending it for announcements.
+    useGetCsmCaseCommentsMock.mockImplementation(() => ({
+      data: [
+        {
+          id: "comment-1",
+          caseId: "case-1",
+          authorName: "Jane Doe",
+          authorRole: "customer",
+          bodyHtml: "<p>Long advisory content</p>",
+          createdAt: "2026-01-01T00:00:00Z",
+        },
+      ],
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+      isFetching: false,
+    }));
+
+    renderCaseDetailPage(
+      "/announcements/case-1",
+      "/announcements/:caseId",
+      "announcement",
+      "<p>Long advisory content</p>",
+    );
+
+    expect(screen.getAllByText("Long advisory content")).toHaveLength(1);
+  });
+
   it("renders nothing when an announcement has a blank description", () => {
     renderCaseDetailPage(
       "/announcements/case-1",

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.test.tsx
@@ -1005,11 +1005,40 @@ describe("CsmCaseDetailPage — announcement description rendering", () => {
     ).toBeTruthy();
   });
 
-  it("does not render the announcement-only description card for a non-announcement case", () => {
-    // This card is gated on isAnnouncement specifically — a plain case never
-    // gets it here regardless of the Details-tab dedupe fallback (covered in
-    // its own describe block below), since it stays on the default
-    // Activities tab in this render.
+  it("also renders the fallback card on the Activities tab for a non-announcement case whose description isn't echoed anywhere", () => {
+    // A plain case reaches the same card via `descriptionEchoedInOriginComment`
+    // rather than the isAnnouncement carve-out — with no comments loaded
+    // (the default mock), there's no origin comment to echo the description,
+    // so the fallback must still show it here instead of leaving it
+    // findable only on the Details tab.
+    renderCaseDetailPage(
+      "/cases/case-1",
+      "/cases/:caseId",
+      "case",
+      "<p>Long advisory content</p>",
+    );
+
+    expect(screen.getByText("Long advisory content")).toBeInTheDocument();
+  });
+
+  it("hides the fallback card on the Activities tab for a non-announcement case whose origin comment already echoes the description", () => {
+    useGetCsmCaseCommentsMock.mockImplementation(() => ({
+      data: [
+        {
+          id: "comment-1",
+          caseId: "case-1",
+          authorName: "Jane Doe",
+          authorRole: "customer",
+          bodyHtml: "<p>Long advisory content</p>",
+          createdAt: "2026-01-01T00:00:00Z",
+        },
+      ],
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+      isFetching: false,
+    }));
+
     renderCaseDetailPage(
       "/cases/case-1",
       "/cases/:caseId",

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.test.tsx
@@ -405,8 +405,35 @@ vi.mock("@features/csm-cases/components/LinkedChangeRequestsWidget", () => ({
 vi.mock("@features/csm-cases/components/CreateGithubIssueDialog", () => ({
   CreateGithubIssueDialog: () => null,
 }));
+// Probe, not `null`: several tests below assert on the comments the page
+// hands this feed (including the synthetic description entry — see
+// `safeComments` in CsmCaseDetailPage), which needs the passed-through
+// author name / body / role-chip-suppression to actually render. The feed's
+// own layout/filtering/sorting is covered in CaseActivitiesFeed.test.tsx.
 vi.mock("@features/csm-cases/components/CaseActivitiesFeed", () => ({
-  default: () => null,
+  default: ({
+    comments,
+  }: {
+    comments: Array<{
+      id: string;
+      authorName: string;
+      authorRole: string;
+      bodyHtml: string;
+      synthetic?: boolean;
+    }>;
+  }) => (
+    <div data-testid="case-activities-feed-probe">
+      {comments.map((c) => (
+        <div key={c.id} data-testid={`comment-${c.id}`}>
+          <span>{c.authorName}</span>
+          {!c.synthetic && c.authorRole !== "wso2_engineer" && (
+            <span>{c.authorRole === "customer" ? "Customer" : c.authorRole}</span>
+          )}
+          <span dangerouslySetInnerHTML={{ __html: c.bodyHtml }} />
+        </div>
+      ))}
+    </div>
+  ),
 }));
 vi.mock("@features/csm-cases/components/CaseMetaBand", () => ({
   default: () => null,
@@ -986,7 +1013,7 @@ function renderCaseDetailPage(
 }
 
 describe("CsmCaseDetailPage — announcement description rendering", () => {
-  it("renders the case description below the activity timeline for an announcement", () => {
+  it("renders the case description inline in the activity timeline for an announcement, attributed to the creator with no role chip", () => {
     renderCaseDetailPage(
       "/announcements/case-1",
       "/announcements/:caseId",
@@ -995,22 +1022,31 @@ describe("CsmCaseDetailPage — announcement description rendering", () => {
     );
 
     expect(screen.getByText("Long advisory content")).toBeInTheDocument();
-    // Not just presence — the description card must render below the
-    // Activity timeline, not above or interleaved with it.
+    // Not just presence — the synthetic entry must render below the
+    // Activity timeline heading, not above or interleaved with it.
     expect(
       screen
         .getByText("Activity timeline")
         .compareDocumentPosition(screen.getByText("Long advisory content")) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
+    // Rendered as a comment-like bubble attributed to the case creator
+    // (falls back to the customer context's primary contact in this
+    // fixture), not a visually distinct "Description" card.
+    expect(screen.getByText("Jane Doe")).toBeInTheDocument();
+    expect(screen.queryByText("Description")).not.toBeInTheDocument();
+    // The synthetic entry carries `authorRole: "customer"` only to pick the
+    // neutral avatar styling — the real role is unknown, so no role chip
+    // ("Customer"/"WSO2"/etc.) should render for it.
+    expect(screen.queryByText("Customer")).not.toBeInTheDocument();
   });
 
-  it("also renders the fallback card on the Activities tab for a non-announcement case whose description isn't echoed anywhere", () => {
-    // A plain case reaches the same card via `descriptionEchoedInOriginComment`
-    // rather than the isAnnouncement carve-out — with no comments loaded
-    // (the default mock), there's no origin comment to echo the description,
-    // so the fallback must still show it here instead of leaving it
-    // findable only on the Details tab.
+  it("also injects the description as a synthetic comment entry on the Activities tab for a non-announcement case whose description isn't echoed anywhere", () => {
+    // A plain case reaches the same synthetic entry via
+    // `descriptionEchoedInOriginComment` rather than the isAnnouncement
+    // carve-out — with no comments loaded (the default mock), there's no
+    // origin comment to echo the description, so it must still show up here
+    // instead of leaving it findable only on the Details tab.
     renderCaseDetailPage(
       "/cases/case-1",
       "/cases/:caseId",
@@ -1019,9 +1055,10 @@ describe("CsmCaseDetailPage — announcement description rendering", () => {
     );
 
     expect(screen.getByText("Long advisory content")).toBeInTheDocument();
+    expect(screen.queryByText("Description")).not.toBeInTheDocument();
   });
 
-  it("hides the fallback card on the Activities tab for a non-announcement case whose origin comment already echoes the description", () => {
+  it("does not inject a synthetic entry on the Activities tab for a non-announcement case whose origin comment already echoes the description", () => {
     useGetCsmCaseCommentsMock.mockImplementation(() => ({
       data: [
         {
@@ -1046,7 +1083,9 @@ describe("CsmCaseDetailPage — announcement description rendering", () => {
       "<p>Long advisory content</p>",
     );
 
-    expect(screen.queryByText("Long advisory content")).not.toBeInTheDocument();
+    // Only the real comment's copy of the content renders, not a second
+    // (synthetic) copy — the real comment already covers it.
+    expect(screen.getAllByText("Long advisory content")).toHaveLength(1);
   });
 
   it("renders nothing when an announcement has a blank description", () => {

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.test.tsx
@@ -31,6 +31,7 @@ import "@testing-library/jest-dom/vitest";
 import type { CsmCaseDetail } from "@features/csm-cases/types/csmCases";
 import type { CsmTimeCard } from "@features/csm-timecards/types/timeCards";
 import type { BeCaseState, BeCaseType } from "@api/backend/types";
+import { sanitizeDescriptionHtml } from "@utils/sanitizeHtml";
 
 // `@api/backend/client` -> `useAuthApiClient` -> `@config/apiConfig`, which
 // throws at module load when `window.config` isn't set — not present under
@@ -429,7 +430,7 @@ vi.mock("@features/csm-cases/components/CaseActivitiesFeed", () => ({
           {!c.synthetic && c.authorRole !== "wso2_engineer" && (
             <span>{c.authorRole === "customer" ? "Customer" : c.authorRole}</span>
           )}
-          <span dangerouslySetInnerHTML={{ __html: c.bodyHtml }} />
+          <span dangerouslySetInnerHTML={{ __html: sanitizeDescriptionHtml(c.bodyHtml) }} />
         </div>
       ))}
     </div>

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -175,6 +175,7 @@ import type {
   CreateIncidentFromCaseNavState,
   CreateRelatedCaseNavState,
   CreateServiceRequestFromCaseNavState,
+  CsmCaseComment,
 } from "@features/csm-cases/types/csmCases";
 import type { CaseState } from "@features/csm-dashboard/types/abtDashboard";
 import { useNavTransition } from "@hooks/useNavTransition";
@@ -1674,6 +1675,45 @@ export default function CsmCaseDetailPage(): JSX.Element {
     originComment?.bodyHtml,
   );
 
+  // The case description usually arrives as the opening comment too, so the
+  // real comment already carries it and no extra entry is needed. When it
+  // doesn't (see `descriptionEchoedInOriginComment` above — content-based,
+  // covers cases created by internal automation and cases with no origin
+  // comment at all) a synthetic comment-shaped entry is appended here so the
+  // Activities tab always shows the description inline in the timeline,
+  // attributed to the case creator, rather than as a visually distinct card.
+  // It carries `synthetic: true` so `CsmCaseCommentBubble` suppresses the
+  // author-role chip — the creator's real role isn't known on the frontend
+  // (see the field's doc comment), so nothing is claimed about it. This is
+  // folded into `safeComments` itself (not a separate prop) so the "N
+  // entries" count and the feed's own chronological sort both pick it up
+  // naturally. The Details tab keeps its own separate, pre-existing fallback
+  // card for the same content — unrelated to this and left untouched.
+  const safeComments = useMemo(() => {
+    if (
+      isBlankHtml(data?.description ?? "") ||
+      (!isAnnouncement && descriptionEchoedInOriginComment)
+    ) {
+      return mergedComments;
+    }
+    const synthetic: CsmCaseComment = {
+      id: `case-description-${data?.id}`,
+      caseId: data?.id ?? "",
+      authorName: data?.createdBy ?? data?.customerContext?.primaryContact ?? "—",
+      authorEmail: data?.createdByEmail,
+      authorUser: data?.createdByUser,
+      // Not a claim that the creator is actually a customer — "customer" is
+      // simply the enum value that renders the neutral grey avatar with no
+      // engineer styling, and the real role is unknowable here.
+      authorRole: "customer",
+      bodyHtml: data?.description ?? "",
+      createdAt: data?.createdAt ?? "",
+      internal: false,
+      synthetic: true,
+    };
+    return [...mergedComments, synthetic];
+  }, [data, isAnnouncement, descriptionEchoedInOriginComment, mergedComments]);
+
   const onUploadAttachment = useCallback(
     (file: File) => {
       if (!caseId) return;
@@ -1834,14 +1874,6 @@ export default function CsmCaseDetailPage(): JSX.Element {
   const closeBlockedReason = hasOpenTask
     ? "This case has an open task. Closing may be rejected until it's resolved or closed."
     : undefined;
-  // The case description usually arrives as the opening comment too, so the
-  // stream renders that directly rather than injecting a synthetic entry —
-  // but not always (see `descriptionEchoedInOriginComment` above): the
-  // Details tab below carries a fallback card for whenever it doesn't. The
-  // linked chat transcript (if any) is appended; the feed sorts
-  // chronologically, so the chat — being oldest — sinks below the case
-  // comments in the default newest-first view.
-  const safeComments = mergedComments;
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 2.5 }}>
@@ -2255,43 +2287,6 @@ export default function CsmCaseDetailPage(): JSX.Element {
               </>
             )}
           </Card>
-
-          {/* An announcement's own body is never echoed as the feed's opening
-              comment the way it is for every other case type (see the note
-              near `safeComments`) — only replies posted via the composer
-              above show up there, so the card below is unconditional for
-              announcements. Every other case type reaches the same card via
-              `descriptionEchoedInOriginComment`, which is content-based
-              rather than "did comments fail to load" — it's false whenever
-              the origin comment doesn't actually reproduce the description
-              (common for cases created by internal automation, and for
-              cases with no origin comment at all), so the description isn't
-              silently missing from this tab in that case either. */}
-          {!isBlankHtml(c.description) &&
-            (isAnnouncement || !descriptionEchoedInOriginComment) && (
-              <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 1.5 }}>
-                <Typography variant="subtitle2">Description</Typography>
-                <Box
-                  sx={{
-                    typography: "body2",
-                    color: "text.primary",
-                    minWidth: 0,
-                    maxWidth: "100%",
-                    contain: "inline-size",
-                    overflowX: "auto",
-                    "& p": { mb: 0.5 },
-                    "& p:last-child": { mb: 0 },
-                  }}
-                  dangerouslySetInnerHTML={{
-                    __html: sanitizeDescriptionHtml(
-                      isDarkMode
-                        ? stripLightModeInlineStyles(c.description)
-                        : c.description,
-                    ),
-                  }}
-                />
-              </Card>
-            )}
         </Box>
       )}
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -1679,21 +1679,25 @@ export default function CsmCaseDetailPage(): JSX.Element {
   // real comment already carries it and no extra entry is needed. When it
   // doesn't (see `descriptionEchoedInOriginComment` above — content-based,
   // covers cases created by internal automation and cases with no origin
-  // comment at all) a synthetic comment-shaped entry is appended here so the
+  // comment at all, and today always covers announcements too since their
+  // description is submitted through a path that never creates an origin
+  // comment) a synthetic comment-shaped entry is appended here so the
   // Activities tab always shows the description inline in the timeline,
   // attributed to the case creator, rather than as a visually distinct card.
-  // It carries `synthetic: true` so `CsmCaseCommentBubble` suppresses the
-  // author-role chip — the creator's real role isn't known on the frontend
-  // (see the field's doc comment), so nothing is claimed about it. This is
-  // folded into `safeComments` itself (not a separate prop) so the "N
-  // entries" count and the feed's own chronological sort both pick it up
-  // naturally. The Details tab keeps its own separate, pre-existing fallback
-  // card for the same content — unrelated to this and left untouched.
+  // Deliberately just `descriptionEchoedInOriginComment` — not `isAnnouncement
+  // || !descriptionEchoedInOriginComment` — so this stays correct even if
+  // announcement creation ever starts producing a real echoed origin comment;
+  // an unconditional carve-out would silently start double-rendering the
+  // description at that point instead of adapting. It carries `synthetic:
+  // true` so `CsmCaseCommentBubble` suppresses the author-role chip — the
+  // creator's real role isn't known on the frontend (see the field's doc
+  // comment), so nothing is claimed about it. This is folded into
+  // `safeComments` itself (not a separate prop) so the "N entries" count and
+  // the feed's own chronological sort both pick it up naturally. The Details
+  // tab keeps its own separate, pre-existing fallback card for the same
+  // content — unrelated to this and left untouched.
   const safeComments = useMemo(() => {
-    if (
-      isBlankHtml(data?.description ?? "") ||
-      (!isAnnouncement && descriptionEchoedInOriginComment)
-    ) {
+    if (isBlankHtml(data?.description ?? "") || descriptionEchoedInOriginComment) {
       return mergedComments;
     }
     const synthetic: CsmCaseComment = {
@@ -1712,7 +1716,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
       synthetic: true,
     };
     return [...mergedComments, synthetic];
-  }, [data, isAnnouncement, descriptionEchoedInOriginComment, mergedComments]);
+  }, [data, descriptionEchoedInOriginComment, mergedComments]);
 
   const onUploadAttachment = useCallback(
     (file: File) => {

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -2259,33 +2259,39 @@ export default function CsmCaseDetailPage(): JSX.Element {
           {/* An announcement's own body is never echoed as the feed's opening
               comment the way it is for every other case type (see the note
               near `safeComments`) — only replies posted via the composer
-              above show up there. Render the body directly below the
-              timeline instead — the only place an announcement's actual
-              content is shown. */}
-          {isAnnouncement && !isBlankHtml(c.description) && (
-            <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 1.5 }}>
-              <Typography variant="subtitle2">Description</Typography>
-              <Box
-                sx={{
-                  typography: "body2",
-                  color: "text.primary",
-                  minWidth: 0,
-                  maxWidth: "100%",
-                  contain: "inline-size",
-                  overflowX: "auto",
-                  "& p": { mb: 0.5 },
-                  "& p:last-child": { mb: 0 },
-                }}
-                dangerouslySetInnerHTML={{
-                  __html: sanitizeDescriptionHtml(
-                    isDarkMode
-                      ? stripLightModeInlineStyles(c.description)
-                      : c.description,
-                  ),
-                }}
-              />
-            </Card>
-          )}
+              above show up there, so the card below is unconditional for
+              announcements. Every other case type reaches the same card via
+              `descriptionEchoedInOriginComment`, which is content-based
+              rather than "did comments fail to load" — it's false whenever
+              the origin comment doesn't actually reproduce the description
+              (common for cases created by internal automation, and for
+              cases with no origin comment at all), so the description isn't
+              silently missing from this tab in that case either. */}
+          {!isBlankHtml(c.description) &&
+            (isAnnouncement || !descriptionEchoedInOriginComment) && (
+              <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 1.5 }}>
+                <Typography variant="subtitle2">Description</Typography>
+                <Box
+                  sx={{
+                    typography: "body2",
+                    color: "text.primary",
+                    minWidth: 0,
+                    maxWidth: "100%",
+                    contain: "inline-size",
+                    overflowX: "auto",
+                    "& p": { mb: 0.5 },
+                    "& p:last-child": { mb: 0 },
+                  }}
+                  dangerouslySetInnerHTML={{
+                    __html: sanitizeDescriptionHtml(
+                      isDarkMode
+                        ? stripLightModeInlineStyles(c.description)
+                        : c.description,
+                    ),
+                  }}
+                />
+              </Card>
+            )}
         </Box>
       )}
 
@@ -2340,18 +2346,13 @@ export default function CsmCaseDetailPage(): JSX.Element {
               </MetaCell>
             </Box>
           </Card>
-          {/* The case description usually doesn't need its own card — it
-              already renders as the opening entry in the Activities tab's
-              feed (see the note near `safeComments` above), and editing it is
-              still available via the action bar's "Edit case details…" item
-              (EditCaseDetailsDialog).
-
-              But that's only true when the origin comment actually
-              reproduces the description. It often doesn't for cases created
-              by internal automation — sometimes there's no origin comment at
-              all — so `descriptionEchoedInOriginComment` (content-based, not
-              just "did comments/search error") decides here rather than
-              assuming the feed already covered it. */}
+          {/* Duplicates the fallback card also rendered on the Activities
+              tab (below the timeline) whenever the description isn't
+              genuinely present elsewhere — see `descriptionEchoedInOriginComment`
+              and the note next to that card. Kept here too, next to the
+              action bar's "Edit case details…" item (EditCaseDetailsDialog),
+              so the description is visible while editing without switching
+              tabs. */}
           {!isBlankHtml(c.description) && !descriptionEchoedInOriginComment && (
             <Card sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 1.5 }}>
               <Typography variant="subtitle2">Description</Typography>

--- a/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
@@ -142,6 +142,12 @@ export interface CsmCaseComment {
    * `sn_customerservice_case.work_notes` vs `comments` distinction.
    */
   internal?: boolean;
+  /** True for a client-synthesized entry (e.g. the case description echoed
+   * into the feed when the backing data source never actually created a
+   * comment for it). Suppresses the author-role chip in the rendered bubble —
+   * the real creator's role isn't known on the frontend, so nothing should be
+   * claimed about it. */
+  synthetic?: boolean;
 }
 
 export interface CaseAttachment {


### PR DESCRIPTION
## Purpose
On the CSM portal's case detail page, the case description is supposed to also appear as the opening entry in the Activities tab's comment stream — but the backing data source doesn't always echo it there (common for cases created without a customer-composed opening comment). When that happened, the description was nowhere to be found on the Activities tab. Separately, the "CRE / SRE team" field on the case detail page showed plain text with no way to see who's on those teams.

## Goals
- Always show the case description somewhere on the Activities tab, styled as a real comment from the case creator, whether or not the backing data source's own comment stream happened to include it.
- Make the CRE / SRE team names on the case detail page clickable, linking to that team's member list — matching a pattern already used elsewhere in this app for the same data.

## Approach
- Added a content-based check (`descriptionEchoedInOriginComment`, pre-existing) to detect when the case's origin comment doesn't actually reproduce the description. When that's true (or for announcements, which never echo at all), a synthetic `CsmCaseComment` is appended to the case's comment list — attributed to the case creator, timestamped at case creation — so it renders in the Activities timeline exactly like a real comment (same avatar, name, timestamp) rather than as a separate card. A new `synthetic` flag on the comment type suppresses the author-role chip on this entry, since the creator's real role (customer vs. internal) isn't known on the frontend and nothing should be claimed about it.
- Swapped the plain-text CRE/SRE team display on the case meta band for the same clickable `DirectoryEntityChip` component already used elsewhere in this app for the identical data, linking to `/admin/teams/:id`. No backend change was needed — that route already resolves the id form CRE/SRE teams use.

## User stories
As a CS engineer viewing a case, I can always see the reported description in the activity timeline, and I can click a case's CRE/SRE team name to see who's on that team.

## Release note
Fixed: the case description could be missing from the Activities tab when it wasn't echoed as an opening comment — it now always appears there, attributed to the case creator. Added: CRE/SRE team names on the case detail page are now clickable, linking to that team's member list.

## Documentation
N/A — internal UI behavior change, no documented user-facing workflow changes.

## Training
N/A — not training content.

## Certification
N/A — no certification exam impact.

## Marketing
N/A — internal tooling fix, not a marketed feature.

## Automation tests
 - Unit tests
   - Added/updated Vitest coverage: `CsmCaseDetailPage.test.tsx` (synthetic comment renders when not echoed, doesn't duplicate when already echoed), `CsmCaseCommentBubble.test.tsx` (role chip suppressed for `synthetic` comments), `CaseMetaBand.test.tsx` (CRE/SRE team renders as clickable chips, one-team-only, neither-team cases). All passing (`pnpm exec vitest run` on the affected files).
 - Integration tests
   - Manually verified against real ServiceNow DEV data via the staging-backed local webapp: confirmed a real case with a non-echoed description now shows it as a comment from the creator, and confirmed clicking a CRE/SRE team chip navigates to and correctly resolves the team's member page.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — frontend TypeScript change, no Java/Go code; `pnpm run lint` (eslint) and `tsc -b --noEmit` ran clean instead.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
None

## Migrations (if applicable)
N/A — no schema or data migration involved.

## Test environment
Verified with `pnpm exec vitest`, `tsc -b --noEmit`, and `pnpm run lint` (Node/pnpm toolchain per repo `.nvmrc`/`package.json`), plus manual verification in Chrome against the deployed staging backend and real ServiceNow DEV data.

## Learning
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Case descriptions now appear in the activity timeline when not already represented by a comment.
  * Support and engineering teams are displayed as clickable directory-linked chips.
* **Bug Fixes**
  * Synthetic comments no longer display misleading customer role labels.
  * Duplicate case descriptions are prevented in the activity timeline.
* **Tests**
  * Added coverage for team chips, synthetic comments, role labels, and description handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->