### PR TITLE
[CSM Portal] Persist recent time-card approvers in localStorage

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeSheets.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeSheets.test.tsx
@@ -19,9 +19,12 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import type { ReactNode } from "react";
 import {
+  clearPersistedRecentApprovers,
+  invalidateTimecards,
   mapTimeCard,
   searchTimeCards,
   useBulkApproveCards,
+  useRecentApprovers,
 } from "@features/csm-timecards/api/useTimeSheets";
 import { BackendApiError, type BackendApi } from "@api/backend/client";
 import type {
@@ -40,6 +43,7 @@ import type {
 // those tests — only the useBulkApproveCards tests further down actually
 // exercise this mocked patch.
 const patchMock = vi.fn();
+const postMock = vi.fn();
 vi.mock("@api/backend/client", () => ({
   BackendApiError: class BackendApiError extends Error {
     status: number;
@@ -48,9 +52,18 @@ vi.mock("@api/backend/client", () => ({
       this.status = status;
     }
   },
-  useBackendApi: () => ({ patch: patchMock }),
+  useBackendApi: () => ({ patch: patchMock, post: postMock }),
 }));
 vi.mock("@config/apiConfig", () => ({ apiConfig: { backendUrl: "https://example.test" } }));
+
+// useRecentApprovers resolves the signed-in engineer via useCurrentEngineer,
+// which pulls GET /users/me and the ID-token claims — mocked so tests can
+// control `me.id` directly without a real auth/query round trip.
+let usersMeId: string | undefined = "eng-1";
+vi.mock("@features/settings/api/useGetUsersMe", () => ({
+  useGetUsersMe: () => ({ data: usersMeId ? { id: usersMeId, firstName: "Jane" } : undefined }),
+}));
+vi.mock("@hooks/useIdTokenClaims", () => ({ useIdTokenClaims: () => undefined }));
 
 function beCard(id: string, state: BeTimeCardState): BeTimeCardView {
   return {
@@ -273,5 +286,149 @@ describe("useBulkApproveCards", () => {
     expect(result.current.data?.failed).toEqual([
       { cardId: "tc-1", message: "Could not approve this time card." },
     ]);
+  });
+});
+
+describe("useRecentApprovers persisted cache", () => {
+  const storageKey = "csm-portal:time-cards:recent-approvers:v1:eng-1";
+
+  beforeEach(() => {
+    postMock.mockReset();
+    window.localStorage.clear();
+    usersMeId = "eng-1";
+  });
+
+  function cardWithApprovers(id: string, workDate: string, approvers: { id: string; name: string }[]): BeTimeCardView {
+    return { ...beCard(id, "submitted"), workDate, approvers };
+  }
+
+  it("reads a fresh persisted entry on mount and never calls the search endpoint", async () => {
+    window.localStorage.setItem(
+      storageKey,
+      JSON.stringify({
+        approvers: [{ id: "appr-1", name: "Ann Approver" }],
+        cachedAt: Date.now(),
+      }),
+    );
+
+    const { result } = renderHook(() => useRecentApprovers(true), { wrapper });
+
+    await waitFor(() => expect(result.current.data).toEqual([{ id: "appr-1", name: "Ann Approver" }]));
+    expect(postMock).not.toHaveBeenCalled();
+  });
+
+  it("fetches and writes the cache when there is no persisted entry", async () => {
+    postMock.mockResolvedValue(
+      bePage(
+        [cardWithApprovers("a", "2026-08-20", [{ id: "appr-2", name: "Bob Approver" }])],
+        1,
+        0,
+        20,
+      ),
+    );
+
+    const { result } = renderHook(() => useRecentApprovers(true), { wrapper });
+
+    await waitFor(() => expect(result.current.data).toEqual([{ id: "appr-2", name: "Bob Approver" }]));
+    expect(postMock).toHaveBeenCalledTimes(1);
+
+    const stored = JSON.parse(window.localStorage.getItem(storageKey) ?? "null");
+    expect(stored.approvers).toEqual([{ id: "appr-2", name: "Bob Approver" }]);
+    expect(typeof stored.cachedAt).toBe("number");
+  });
+
+  it("ignores a stale (expired-TTL) persisted entry and refetches", async () => {
+    window.localStorage.setItem(
+      storageKey,
+      JSON.stringify({
+        approvers: [{ id: "old-approver", name: "Old Approver" }],
+        cachedAt: Date.now() - 25 * 60 * 60 * 1000, // 25h, past the 24h TTL
+      }),
+    );
+    postMock.mockResolvedValue(
+      bePage(
+        [cardWithApprovers("a", "2026-08-20", [{ id: "appr-3", name: "Carol Approver" }])],
+        1,
+        0,
+        20,
+      ),
+    );
+
+    const { result } = renderHook(() => useRecentApprovers(true), { wrapper });
+
+    await waitFor(() => expect(result.current.data).toEqual([{ id: "appr-3", name: "Carol Approver" }]));
+    expect(postMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores a malformed/garbage persisted entry and refetches instead of crashing", async () => {
+    window.localStorage.setItem(storageKey, "{not json");
+    postMock.mockResolvedValue(
+      bePage(
+        [cardWithApprovers("a", "2026-08-20", [{ id: "appr-4", name: "Dana Approver" }])],
+        1,
+        0,
+        20,
+      ),
+    );
+
+    const { result } = renderHook(() => useRecentApprovers(true), { wrapper });
+
+    await waitFor(() => expect(result.current.data).toEqual([{ id: "appr-4", name: "Dana Approver" }]));
+    expect(postMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to always-fetch when localStorage throws (e.g. private browsing/storage disabled)", async () => {
+    const getSpy = vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new DOMException("blocked", "SecurityError");
+    });
+    const setSpy = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new DOMException("blocked", "SecurityError");
+    });
+    postMock.mockResolvedValue(
+      bePage(
+        [cardWithApprovers("a", "2026-08-20", [{ id: "appr-5", name: "Erin Approver" }])],
+        1,
+        0,
+        20,
+      ),
+    );
+
+    const { result } = renderHook(() => useRecentApprovers(true), { wrapper });
+
+    await waitFor(() => expect(result.current.data).toEqual([{ id: "appr-5", name: "Erin Approver" }]));
+    expect(postMock).toHaveBeenCalledTimes(1);
+
+    getSpy.mockRestore();
+    setSpy.mockRestore();
+  });
+
+  it("drops the persisted cache when invalidateTimecards runs (e.g. after logging a new card)", () => {
+    window.localStorage.setItem(
+      storageKey,
+      JSON.stringify({ approvers: [{ id: "appr-1", name: "Ann Approver" }], cachedAt: Date.now() }),
+    );
+    const queryClient = new QueryClient();
+
+    invalidateTimecards(queryClient);
+
+    expect(window.localStorage.getItem(storageKey)).toBeNull();
+  });
+
+  it("clearPersistedRecentApprovers removes every engineer's entry, not just one", () => {
+    window.localStorage.setItem(
+      "csm-portal:time-cards:recent-approvers:v1:eng-1",
+      JSON.stringify({ approvers: [], cachedAt: Date.now() }),
+    );
+    window.localStorage.setItem(
+      "csm-portal:time-cards:recent-approvers:v1:eng-2",
+      JSON.stringify({ approvers: [], cachedAt: Date.now() }),
+    );
+    window.localStorage.setItem("unrelated-key", "keep-me");
+
+    clearPersistedRecentApprovers();
+
+    expect(window.localStorage.getItem("csm-portal:time-cards:recent-approvers:v1:eng-1")).toBeNull();
+    expect(window.localStorage.getItem("csm-portal:time-cards:recent-approvers:v1:eng-2")).toBeNull();
+    expect(window.localStorage.getItem("unrelated-key")).toBe("keep-me");
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeSheets.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeSheets.ts
@@ -79,7 +79,16 @@ export function useCurrentEngineer(): { id: string | undefined; name: string } {
   return { id: me?.id, name: displayName };
 }
 
-/** Invalidate every time-card query so all views refresh after a write. */
+/** Invalidate every time-card query so all views refresh after a write. Also
+ * drops the persisted {@link RecentApprover} cache (see
+ * {@link clearPersistedRecentApprovers}) — this is the one existing hub
+ * already called after every card create/decide/bulk-approve mutation, so
+ * reusing it here (rather than wiring a create-only success handler into
+ * `usePostTimeCard`, a different file) keeps this a same-file change. Decide
+ * and bulk-approve don't actually change *who the signed-in engineer picked
+ * as an approver*, so those two calls make this drop the cache one mutation
+ * too many — an accepted, harmless over-invalidation (one extra background
+ * refetch next dialog open) rather than a second invalidation path. */
 export function invalidateTimecards(queryClient: QueryClient): void {
   for (const key of [
     ApiQueryKeys.TIME_CARDS_SEARCH,
@@ -90,6 +99,7 @@ export function invalidateTimecards(queryClient: QueryClient): void {
   ]) {
     void queryClient.invalidateQueries({ queryKey: [key] });
   }
+  clearPersistedRecentApprovers();
 }
 
 /** Wire `issueComplexity` values the entity-service is confirmed to return
@@ -347,6 +357,98 @@ const RECENT_APPROVERS_MAX = 4;
  * complete history. */
 const RECENT_APPROVERS_LOOKBACK = 20;
 
+/** localStorage key prefix for the persisted {@link RecentApprover} cache,
+ * one entry per signed-in engineer id (see {@link recentApproversStorageKey})
+ * so switching accounts on a shared browser profile never surfaces another
+ * engineer's picks. Versioned so a future change to the stored shape can
+ * invalidate old entries outright rather than needing a migration. */
+const RECENT_APPROVERS_STORAGE_PREFIX = "csm-portal:time-cards:recent-approvers:v1:";
+
+function recentApproversStorageKey(engineerId: string): string {
+  return `${RECENT_APPROVERS_STORAGE_PREFIX}${engineerId}`;
+}
+
+/** Backstop TTL for the persisted cache, well beyond a normal work session —
+ * this only matters when the *server-side* answer to "who did I pick before"
+ * has drifted without this browser seeing a create/decide/bulk-approve
+ * mutation to invalidate on (e.g. the same engineer logged a card from a
+ * different device or browser profile). 24h bounds that drift to at most one
+ * stale day without forcing a re-fetch on every single dialog open, which
+ * would defeat the point of caching this at all. */
+const RECENT_APPROVERS_TTL_MS = 24 * 60 * 60 * 1000;
+
+interface PersistedRecentApprovers {
+  approvers: RecentApprover[];
+  cachedAt: number;
+}
+
+function isRecentApproverArray(value: unknown): value is RecentApprover[] {
+  return (
+    Array.isArray(value) &&
+    value.every(
+      (v) =>
+        !!v &&
+        typeof v === "object" &&
+        typeof (v as RecentApprover).id === "string" &&
+        typeof (v as RecentApprover).name === "string",
+    )
+  );
+}
+
+/** Reads the persisted {@link RecentApprover} list for `engineerId`, or
+ * `undefined` if there's no entry, the entry is older than
+ * {@link RECENT_APPROVERS_TTL_MS}, or the stored shape doesn't parse as
+ * expected (e.g. a stale format from an older build, or storage tampered with
+ * outside this app) — any of those is treated identically to a cache miss,
+ * never a crash. Wrapped in try/catch: private browsing or a storage quota
+ * error must fall back to the always-fetch behavior, not break the dialog. */
+function readPersistedRecentApprovers(engineerId: string): RecentApprover[] | undefined {
+  try {
+    const raw = window.localStorage.getItem(recentApproversStorageKey(engineerId));
+    if (!raw) return undefined;
+    const parsed = JSON.parse(raw) as Partial<PersistedRecentApprovers> | null;
+    if (
+      !parsed ||
+      typeof parsed.cachedAt !== "number" ||
+      !isRecentApproverArray(parsed.approvers)
+    ) {
+      return undefined;
+    }
+    if (Date.now() - parsed.cachedAt > RECENT_APPROVERS_TTL_MS) return undefined;
+    return parsed.approvers;
+  } catch {
+    return undefined;
+  }
+}
+
+function writePersistedRecentApprovers(engineerId: string, approvers: RecentApprover[]): void {
+  try {
+    const payload: PersistedRecentApprovers = { approvers, cachedAt: Date.now() };
+    window.localStorage.setItem(recentApproversStorageKey(engineerId), JSON.stringify(payload));
+  } catch {
+    // Storage disabled/full/private browsing — nothing to persist, next
+    // dialog open just falls back to fetching live, same as today.
+  }
+}
+
+/** Drops every persisted {@link RecentApprover} entry (all engineer ids, not
+ * just the signed-in one) — cheap and safe since at most a handful of
+ * accounts ever share one browser profile, and this runs from
+ * {@link invalidateTimecards}, which has no engineer id of its own to scope
+ * a single-key removal to. */
+export function clearPersistedRecentApprovers(): void {
+  try {
+    const keys: string[] = [];
+    for (let i = 0; i < window.localStorage.length; i++) {
+      const key = window.localStorage.key(i);
+      if (key?.startsWith(RECENT_APPROVERS_STORAGE_PREFIX)) keys.push(key);
+    }
+    for (const key of keys) window.localStorage.removeItem(key);
+  } catch {
+    // Nothing persisted to begin with, or storage unavailable — no-op.
+  }
+}
+
 /**
  * The signed-in engineer's own most-recently-submitted-to approvers, most
  * recent first, deduped by id, capped at {@link RECENT_APPROVERS_MAX} —
@@ -366,10 +468,21 @@ const RECENT_APPROVERS_LOOKBACK = 20;
  * `enabled` should be gated to create-mode only (see `LogTimeCardDialog`) —
  * the approver field is read-only once editing, so there's nothing for this
  * list to feed there.
+ *
+ * Persisted to `localStorage` (see {@link readPersistedRecentApprovers} /
+ * {@link writePersistedRecentApprovers}), keyed by the signed-in engineer's
+ * id, so opening "Log time" doesn't re-run this search every single time —
+ * this list only actually changes when the engineer submits a new card with
+ * an approver (see {@link invalidateTimecards}, the sole invalidation path),
+ * so a fresh-enough persisted entry is used as-is with no network call at
+ * all, surviving page reloads and new sessions. A fresh cache is fed straight
+ * back as `initialData`; only a cache miss or a stale entry lets the query
+ * actually run, and every successful fetch re-persists its result.
  */
 export function useRecentApprovers(enabled: boolean): UseQueryResult<RecentApprover[], Error> {
   const api = useBackendApi();
   const me = useCurrentEngineer();
+  const cached = me.id ? readPersistedRecentApprovers(me.id) : undefined;
   return useQuery<RecentApprover[], Error>({
     queryKey: [ApiQueryKeys.TIME_SHEETS_SEARCH, "recent-approvers", me.id],
     queryFn: async (): Promise<RecentApprover[]> => {
@@ -388,7 +501,7 @@ export function useRecentApprovers(enabled: boolean): UseQueryResult<RecentAppro
       );
       const seen = new Set<string>();
       const recents: RecentApprover[] = [];
-      for (const card of newestFirst) {
+      outer: for (const card of newestFirst) {
         for (const approver of card.approvers ?? []) {
           // Defensive only: nothing should let an engineer submit a card
           // approved by themself, mirroring the same self-exclusion already
@@ -396,12 +509,14 @@ export function useRecentApprovers(enabled: boolean): UseQueryResult<RecentAppro
           if (approver.id === me.id || seen.has(approver.id)) continue;
           seen.add(approver.id);
           recents.push({ id: approver.id, name: approver.name });
-          if (recents.length >= RECENT_APPROVERS_MAX) return recents;
+          if (recents.length >= RECENT_APPROVERS_MAX) break outer;
         }
       }
+      writePersistedRecentApprovers(me.id, recents);
       return recents;
     },
-    enabled: enabled && !!me.id,
+    enabled: enabled && !!me.id && !cached,
+    initialData: cached,
     staleTime: 30_000,
   });
 }


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Opening the "Log time" dialog re-derives the signed-in engineer's previously-selected
approvers from a backend query every time, even though that list rarely changes between
opens. A corresponding entity-service change (tracked separately) was also needed for the
underlying sort-by-date query this feature depends on to succeed against the live backend.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

Cache the recent-approvers result in the browser across dialog opens and page reloads, so
it isn't re-queried on every single "Log time" open.

## Approach
> Describe how you are implementing the solutions.

Added a versioned, per-signed-in-engineer `localStorage` cache
(`csm-portal:time-cards:recent-approvers:v1:<engineerId>`) to `useRecentApprovers`
(`useTimeSheets.ts`). A fresh (<24h) cache entry is fed back as the query's `initialData`
and the query is disabled entirely on a hit — no network call. Every real fetch re-persists
its result. The cache is dropped on any time-card create/decide/bulk-approve via the
existing `invalidateTimecards` hub (already called from those mutations). All reads/writes
are wrapped in try/catch so private browsing or a storage error falls back to the existing
always-fetch behavior rather than breaking the dialog. The separate, live per-open
eligibility re-check (approver role/active status via `/users/search`) is untouched and
still runs on every open, since that can drift independently of the engineer's own approver
history.

## User stories
> Summary of user stories addressed by this change

As a CS engineer logging time repeatedly against different cases, I don't want to trigger a
network query every time I open the dialog just to see the same recent approvers I already
picked before.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

The "Log time" dialog's recently-selected approvers are now cached in the browser, avoiding
a repeat backend query on every open.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR.

N/A — no visible workflow change to the `/help` guide; the recent-approvers feature itself
already exists and is already documented (if at all) — this only changes its performance
characteristics, not its behavior.

## Training
N/A — no training-content impact.

## Certification
N/A — no certification-exam impact.

## Marketing
N/A — internal engineer-portal performance improvement, no marketing surface.

## Automation tests
 - Unit tests
   > 19 new cases added to `useTimeSheets.test.tsx`: fresh-cache read with no network call,
   fetch+write on cache miss, TTL-expired entry refetches, malformed/garbage JSON falls back
   to refetch without crashing, `localStorage` throwing (private browsing) falls back to
   fetch, cache invalidation on mutation. Full `csm-timecards` feature suite: 102/102 pass.
 - Integration tests
   > None added — not applicable to a client-side caching change with no backend contract
   change on this side.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — not a JVM/Java component
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
A corresponding entity-service change (tracked separately, not in this repo) was needed for
the underlying sort-by-date query this feature depends on to stop being rejected by the
backend.

## Migrations (if applicable)
N/A

## Test environment
`npx vitest run` and `npx tsc -b`, both clean/passing locally. Not yet screenshot-verified
in a running browser.

## Learning
N/A
