### PR TITLE
[CSM Portal] fix SreGroupID issue and add Case Feedback dashboard

### DIFF
--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -164,6 +164,8 @@ func main() {
 	mux.HandleFunc("GET /tags/search", caseHandler.SearchTagsQuery)
 	mux.HandleFunc("POST /cases/search", caseHandler.SearchCases)
 	mux.HandleFunc("POST /cases/aggregate", caseHandler.AggregateCases)
+	mux.HandleFunc("POST /cases/feedback/search", caseHandler.SearchFeedback)
+	mux.HandleFunc("POST /cases/feedback/aggregate", caseHandler.AggregateFeedback)
 	mux.HandleFunc("GET /dashboards", dashboardHandler.GetDashboards)
 	// Registered before the {dashboardId} wildcard purely for readability —
 	// net/http's ServeMux resolves by specificity, not registration order,

--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -164,8 +164,8 @@ func main() {
 	mux.HandleFunc("GET /tags/search", caseHandler.SearchTagsQuery)
 	mux.HandleFunc("POST /cases/search", caseHandler.SearchCases)
 	mux.HandleFunc("POST /cases/aggregate", caseHandler.AggregateCases)
-	mux.HandleFunc("POST /cases/feedback/search", caseHandler.SearchFeedback)
-	mux.HandleFunc("POST /cases/feedback/aggregate", caseHandler.AggregateFeedback)
+	mux.HandleFunc("POST /cases/feedbacks/search", caseHandler.SearchFeedback)
+	mux.HandleFunc("POST /cases/feedbacks/aggregate", caseHandler.AggregateFeedback)
 	mux.HandleFunc("GET /dashboards", dashboardHandler.GetDashboards)
 	// Registered before the {dashboardId} wildcard purely for readability —
 	// net/http's ServeMux resolves by specificity, not registration order,

--- a/apps/csm-portal/backend/internal/dashboard/registry.go
+++ b/apps/csm-portal/backend/internal/dashboard/registry.go
@@ -647,11 +647,19 @@ var validWidgetResourceTypes = map[ResourceType]bool{
 	// injectImpliedTypeFilters).
 	ResourceServiceRequest: true, ResourceSecurityReportAnalysis: true,
 	ResourceAnnouncement: true, ResourceEngagement: true,
+	ResourceCaseFeedback: true,
 }
 
 var validWidgetShapes = map[Shape]bool{
 	ShapeCount: true, ShapeList: true, ShapePie: true, ShapeBar: true,
 }
+
+// validGroupByBuckets are the legal values of GroupByConfig.Bucket -- the
+// same "day"/"week"/"month" enum POST /cases/feedback/aggregate documents on
+// the entity-service side (see AggregateFeedbackRequest.bucket in
+// openapi.yaml). Kept here rather than derived from that spec because this
+// layer never calls that endpoint; it only validates widget config shape.
+var validGroupByBuckets = map[string]bool{"day": true, "week": true, "month": true}
 
 // validateWidgets applies the loader's own fail-loud rationale one level down.
 // Dashboard-level fields were already rejected by filename; a widget with a
@@ -702,9 +710,20 @@ func validateWidgets(d Dashboard, source string) error {
 			return fmt.Errorf("dashboard definitions: %s (id %q): widget %q: shape %q needs either \"slices\" or \"groupBy\"",
 				source, d.ID, w.ID, w.Shape)
 		}
-		if w.GroupBy != nil && strings.TrimSpace(w.GroupBy.Field) == "" {
-			return fmt.Errorf("dashboard definitions: %s (id %q): widget %q: \"groupBy.field\" is empty",
-				source, d.ID, w.ID)
+		if w.GroupBy != nil {
+			hasField := strings.TrimSpace(w.GroupBy.Field) != ""
+			hasBucket := strings.TrimSpace(w.GroupBy.Bucket) != ""
+			switch {
+			case hasField && hasBucket:
+				return fmt.Errorf("dashboard definitions: %s (id %q): widget %q: \"groupBy\" carries both \"field\" and \"bucket\"; a groupBy widget must use exactly one",
+					source, d.ID, w.ID)
+			case !hasField && !hasBucket:
+				return fmt.Errorf("dashboard definitions: %s (id %q): widget %q: \"groupBy.field\" is empty",
+					source, d.ID, w.ID)
+			case hasBucket && !validGroupByBuckets[w.GroupBy.Bucket]:
+				return fmt.Errorf("dashboard definitions: %s (id %q): widget %q: unknown \"groupBy.bucket\" %q; expected one of \"day\", \"week\", \"month\"",
+					source, d.ID, w.ID, w.GroupBy.Bucket)
+			}
 		}
 	}
 

--- a/apps/csm-portal/backend/internal/dashboard/registry.go
+++ b/apps/csm-portal/backend/internal/dashboard/registry.go
@@ -655,7 +655,7 @@ var validWidgetShapes = map[Shape]bool{
 }
 
 // validGroupByBuckets are the legal values of GroupByConfig.Bucket -- the
-// same "day"/"week"/"month" enum POST /cases/feedback/aggregate documents on
+// same "day"/"week"/"month" enum POST /cases/feedbacks/aggregate documents on
 // the entity-service side (see AggregateFeedbackRequest.bucket in
 // openapi.yaml). Kept here rather than derived from that spec because this
 // layer never calls that endpoint; it only validates widget config shape.

--- a/apps/csm-portal/backend/internal/dashboard/registry_test.go
+++ b/apps/csm-portal/backend/internal/dashboard/registry_test.go
@@ -833,6 +833,24 @@ func TestLoadDir_RejectsInvalidWidgets(t *testing.T) {
 			 "query": {}, "groupBy": {"field": ""}}`,
 			want: `widget "w": "groupBy.field" is empty`,
 		},
+		{
+			name: "bar widget groupBy with both field and bucket",
+			widgets: `{"id": "w", "displayName": "W", "resourceType": "case_feedback", "shape": "bar", "gridWidth": 3,
+			 "query": {}, "groupBy": {"field": "account", "bucket": "day"}}`,
+			want: `widget "w": "groupBy" carries both "field" and "bucket"`,
+		},
+		{
+			name: "bar widget groupBy with an unknown bucket",
+			widgets: `{"id": "w", "displayName": "W", "resourceType": "case_feedback", "shape": "bar", "gridWidth": 3,
+			 "query": {}, "groupBy": {"bucket": "quarter"}}`,
+			want: `widget "w": unknown "groupBy.bucket" "quarter"`,
+		},
+		{
+			name: "bar widget with neither slices nor groupBy",
+			widgets: `{"id": "w", "displayName": "W", "resourceType": "case_feedback", "shape": "bar", "gridWidth": 3,
+			 "query": {}}`,
+			want: `widget "w": shape "bar" needs either "slices" or "groupBy"`,
+		},
 	}
 
 	for _, tc := range cases {
@@ -854,6 +872,42 @@ func TestLoadDir_RejectsInvalidWidgets(t *testing.T) {
 				t.Errorf("err = %q, want it to name the offending file", err.Error())
 			}
 		})
+	}
+}
+
+// A "bar" widget grouped by date bucket (case-feedback trend) loads clean,
+// same as a field-grouped pie/bar widget always has -- the new
+// GroupByConfig.Bucket branch is additive, not a narrowing of what already
+// loaded.
+func TestLoadDir_AcceptsBarWidgetWithBucketGroupBy(t *testing.T) {
+	dir := t.TempDir()
+	writeDefinition(t, dir, "d.json", `{
+	  "id": "d", "displayName": "D", "type": "cs",
+	  "widgets": [
+	    {"id": "feedback-trend", "displayName": "Feedback Trend", "resourceType": "case_feedback", "shape": "bar", "gridWidth": 6,
+	     "query": {}, "groupBy": {"bucket": "week"}}
+	  ]
+	}`)
+
+	dashboards, err := LoadDir(dir)
+	if err != nil {
+		t.Fatalf("LoadDir returned error: %v", err)
+	}
+	if len(dashboards) != 1 || len(dashboards[0].Widgets) != 1 {
+		t.Fatalf("unexpected loaded dashboards: %+v", dashboards)
+	}
+	w := dashboards[0].Widgets[0]
+	if w.ResourceType != ResourceCaseFeedback {
+		t.Errorf("resourceType = %q, want %q", w.ResourceType, ResourceCaseFeedback)
+	}
+	if w.Shape != ShapeBar {
+		t.Errorf("shape = %q, want %q", w.Shape, ShapeBar)
+	}
+	if w.GroupBy == nil || w.GroupBy.Bucket != "day" && w.GroupBy.Bucket != "week" && w.GroupBy.Bucket != "month" {
+		t.Fatalf("groupBy = %+v, want a valid bucket", w.GroupBy)
+	}
+	if w.GroupBy.Field != "" {
+		t.Errorf("groupBy.field = %q, want empty for a bucket-mode groupBy", w.GroupBy.Field)
 	}
 }
 

--- a/apps/csm-portal/backend/internal/dashboard/widgets.go
+++ b/apps/csm-portal/backend/internal/dashboard/widgets.go
@@ -62,6 +62,17 @@ const (
 	ResourceSecurityReportAnalysis ResourceType = "security_report_analysis"
 	ResourceAnnouncement           ResourceType = "announcement"
 	ResourceEngagement             ResourceType = "engagement"
+	// ResourceCaseFeedback identifies a widget whose data is case-feedback
+	// (satisfaction rating) records rather than cases themselves. Like every
+	// other ResourceType, this layer only validates that the value is a known
+	// enum member -- it does not know, and does not need to know, that a
+	// "bar"+GroupBy.Bucket widget with this resourceType resolves via the
+	// webapp's own hook calling POST /cases/feedback/aggregate (see
+	// GroupByConfig.Bucket's doc comment). There is no
+	// resourceType->endpoint mapping anywhere server-side; the frontend picks
+	// the endpoint from resourceType entirely on its own, same as every other
+	// ResourceType here.
+	ResourceCaseFeedback ResourceType = "case_feedback"
 )
 
 // Shape is how a widget's resolved data should be rendered.
@@ -88,14 +99,27 @@ type GroupByConfig struct {
 	// Field is which field to group by. Each ResourceType enforces its own
 	// small allowlist server-side (see the corresponding SN Utils script
 	// include's group{X}By method) -- an unsupported value is rejected by
-	// that call with a 400, not caught here.
-	Field string `json:"field"`
+	// that call with a 400, not caught here. Mutually exclusive with Bucket
+	// (enforced at directory-load time): a widget sets exactly one.
+	Field string `json:"field,omitempty"`
+	// Bucket configures date-bucketed grouping instead of field-value
+	// grouping -- "day", "week", or "month" (enforced at directory-load
+	// time). Mutually exclusive with Field. This is the shape a case-feedback
+	// trend widget uses (ResourceCaseFeedback, Shape "bar"): the frontend's
+	// own hook calls POST /cases/feedback/aggregate with this bucket value
+	// and maps its date-bucketed response into the same per-slice shape
+	// Slices/field-grouping already produce, same client-side-resolution
+	// philosophy as the rest of this type -- this layer never calls that
+	// endpoint itself, it only validates and forwards the config.
+	Bucket string `json:"bucket,omitempty"`
 	// MaxGroups is the top-N cutoff by count, descending; the remainder is
 	// summed into one "Others" bucket. Omitted/zero defers to the backing
-	// group-by endpoint's own default (12).
+	// group-by endpoint's own default (12). Meaningless when Bucket is set --
+	// a date-bucketed aggregation has no "Others" folding.
 	MaxGroups int `json:"maxGroups,omitempty"`
 	// OthersLabel overrides the default "Others" label for the summed
-	// remainder bucket. Omitted uses "Others".
+	// remainder bucket. Omitted uses "Others". Meaningless when Bucket is
+	// set, same as MaxGroups.
 	OthersLabel string `json:"othersLabel,omitempty"`
 }
 

--- a/apps/csm-portal/backend/internal/dashboard/widgets.go
+++ b/apps/csm-portal/backend/internal/dashboard/widgets.go
@@ -67,7 +67,7 @@ const (
 	// other ResourceType, this layer only validates that the value is a known
 	// enum member -- it does not know, and does not need to know, that a
 	// "bar"+GroupBy.Bucket widget with this resourceType resolves via the
-	// webapp's own hook calling POST /cases/feedback/aggregate (see
+	// webapp's own hook calling POST /cases/feedbacks/aggregate (see
 	// GroupByConfig.Bucket's doc comment). There is no
 	// resourceType->endpoint mapping anywhere server-side; the frontend picks
 	// the endpoint from resourceType entirely on its own, same as every other
@@ -106,7 +106,7 @@ type GroupByConfig struct {
 	// grouping -- "day", "week", or "month" (enforced at directory-load
 	// time). Mutually exclusive with Field. This is the shape a case-feedback
 	// trend widget uses (ResourceCaseFeedback, Shape "bar"): the frontend's
-	// own hook calls POST /cases/feedback/aggregate with this bucket value
+	// own hook calls POST /cases/feedbacks/aggregate with this bucket value
 	// and maps its date-bucketed response into the same per-slice shape
 	// Slices/field-grouping already produce, same client-side-resolution
 	// philosophy as the rest of this type -- this layer never calls that

--- a/apps/csm-portal/backend/internal/directory/directory.go
+++ b/apps/csm-portal/backend/internal/directory/directory.go
@@ -31,8 +31,8 @@ import (
 //   - teams sorted for stable paging, with each team's backing group ids already
 //     converted to this platform's UUID form (Team.CreGroupID -> Result.CreGroupID,
 //     Team.SreGroupID -> Result.SreGroupID),
-//   - key -> team, group-name -> team, and resolved-CRE-group-UUID -> team lookups
-//     as maps,
+//   - key -> team, group-name -> team, resolved-CRE-group-UUID -> team, and
+//     resolved-SRE-group-UUID -> team lookups as maps,
 //   - the group-name list a membership query needs,
 //   - the role catalogue with its display names, and the role membership set.
 //
@@ -47,6 +47,7 @@ type Directory struct {
 	byKey        map[string]Team
 	byGroupName  map[string]Team
 	byCreGroupID map[string]Team
+	bySreGroupID map[string]Team
 	groupNames   []string
 
 	roleResults []RoleResult
@@ -60,7 +61,8 @@ type Directory struct {
 // A duplicate resolved group-id UUID is the same class of mistake -- two rows
 // configured with the same backing CreGroupID would shadow each other in
 // byCreGroupID exactly as a duplicate key would in byKey -- so it fails
-// startup too. Callers are expected to treat any error here as fatal at
+// startup too, and the same is true of a duplicate SreGroupID in
+// bySreGroupID. Callers are expected to treat any error here as fatal at
 // startup -- a half-resolved directory would mis-route dashboards rather than
 // fail visibly.
 func New(teams []Team, roles []string) (*Directory, error) {
@@ -70,6 +72,7 @@ func New(teams []Team, roles []string) (*Directory, error) {
 		byKey:        make(map[string]Team, len(teams)),
 		byGroupName:  make(map[string]Team, len(teams)),
 		byCreGroupID: make(map[string]Team, len(teams)),
+		bySreGroupID: make(map[string]Team, len(teams)),
 		groupNames:   make([]string, 0, len(teams)),
 		roleResults:  make([]RoleResult, 0, len(roles)),
 		roleSet:      make(map[string]bool, len(roles)),
@@ -92,10 +95,20 @@ func New(teams []Team, roles []string) (*Directory, error) {
 			if _, dup := d.byCreGroupID[result.CreGroupID]; dup {
 				return nil, fmt.Errorf("team registry: creGroupId %q (team %q) is configured more than once", t.CreGroupID, t.Key)
 			}
+			if _, dup := d.bySreGroupID[result.CreGroupID]; dup {
+				return nil, fmt.Errorf("team registry: creGroupId %q (team %q) collides with another team's sreGroupId", t.CreGroupID, t.Key)
+			}
 			d.byCreGroupID[result.CreGroupID] = t
 		}
 		if t.SreGroupID != "" {
 			result.SreGroupID = sourceIDToUUID(t.SreGroupID)
+			if _, dup := d.bySreGroupID[result.SreGroupID]; dup {
+				return nil, fmt.Errorf("team registry: sreGroupId %q (team %q) is configured more than once", t.SreGroupID, t.Key)
+			}
+			if _, dup := d.byCreGroupID[result.SreGroupID]; dup {
+				return nil, fmt.Errorf("team registry: sreGroupId %q (team %q) collides with another team's creGroupId", t.SreGroupID, t.Key)
+			}
+			d.bySreGroupID[result.SreGroupID] = t
 		}
 		d.teamResults = append(d.teamResults, result)
 	}
@@ -136,18 +149,27 @@ func (d *Directory) TeamByGroupName(name string) (Team, bool) {
 	return t, ok
 }
 
-// TeamByUUID looks a team up by this platform's canonical UUID form of its
-// backing CRE group id -- the same form Team.CreGroupID is converted to for
-// TeamResult.CreGroupID and for accounts.creTeam.id elsewhere. ok is false if
-// uuid does not match any configured team's resolved CRE group id, including
-// for a team that has no CreGroupID configured at all: such a team has no
-// UUID to be looked up by. It does not look up by SreGroupID -- no caller
-// needs that yet.
+// TeamByUUID looks a team up by this platform's canonical UUID form of
+// either its backing CRE group id or its backing SRE group id -- the same
+// form Team.CreGroupID/Team.SreGroupID are converted to for
+// TeamResult.CreGroupID/TeamResult.SreGroupID and for accounts.creTeam.id /
+// accounts.sreTeam.id elsewhere. It checks the CRE-group map first, then
+// falls back to the SRE-group map, because the caller (a case's creTeam.id
+// or sreTeam.id, followed through as a generic team-detail path segment) has
+// no way to say which kind of id it is looking at -- the webapp renders both
+// a case's CRE and SRE team as the same clickable chip, both hitting the
+// same GET /teams/{id} route. ok is false if uuid does not match any
+// configured team's resolved CRE or SRE group id, including for a team that
+// has neither configured at all: such a team has no UUID to be looked up by.
 //
 // uuid is lowercased before lookup, matching sourceIDToUUID's canonical
 // lowercase form, so a caller-supplied uppercase UUID still resolves.
 func (d *Directory) TeamByUUID(uuid string) (Team, bool) {
-	t, ok := d.byCreGroupID[strings.ToLower(uuid)]
+	uuid = strings.ToLower(uuid)
+	if t, ok := d.byCreGroupID[uuid]; ok {
+		return t, true
+	}
+	t, ok := d.bySreGroupID[uuid]
 	return t, ok
 }
 

--- a/apps/csm-portal/backend/internal/directory/directory_test.go
+++ b/apps/csm-portal/backend/internal/directory/directory_test.go
@@ -188,6 +188,15 @@ func TestNew_RejectsDuplicates(t *testing.T) {
 	if _, err := New(dupGroupID, DefaultRoles); err == nil {
 		t.Error("duplicate creGroupId was accepted")
 	}
+	// Same reasoning, for the parallel SreGroupID/bySreGroupID map. The
+	// 5-field form (key|name|family||sreGroupId) is needed to land the id in
+	// SreGroupID's slot rather than CreGroupID's.
+	dupSreGroupID, _ := ParseTeamRegistry(
+		"alpha|Alpha Team|||bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb," +
+			"beta|Beta Team|||bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+	if _, err := New(dupSreGroupID, DefaultRoles); err == nil {
+		t.Error("duplicate sreGroupId was accepted")
+	}
 }
 
 // An unconfigured registry is legal: the deployment still has to start.
@@ -355,6 +364,29 @@ func TestTeamByUUID_ResolvesTheConfiguredTeam(t *testing.T) {
 	// unintended fallback.
 	if _, ok := dir.TeamByUUID(""); ok {
 		t.Error("TeamByUUID matched the empty string against an unconfigured group id")
+	}
+}
+
+// An SRE-only team -- no CreGroupID configured at all, e.g. a real SRE ABT
+// like Apollo -- must still resolve through TeamByUUID via its SreGroupID.
+// Before bySreGroupID existed, TeamByUUID only ever checked byCreGroupID, so
+// such a team's UUID could never be found regardless of how correctly its
+// SreGroupID was configured -- this is the regression this test guards.
+func TestTeamByUUID_ResolvesSreOnlyTeam(t *testing.T) {
+	dir := mustDirectory(t, "delta|Delta Team|sre-abt||bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "")
+
+	team, ok := dir.TeamByUUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+	if !ok {
+		t.Fatal("TeamByUUID missed the SRE-only delta team")
+	}
+	if team.Key != "delta" {
+		t.Fatalf("TeamByUUID resolved %+v, want the delta row", team)
+	}
+
+	// A well-formed UUID that matches no configured team's group id, CRE or
+	// SRE.
+	if _, ok := dir.TeamByUUID("ffffffff-ffff-ffff-ffff-ffffffffffff"); ok {
+		t.Error("TeamByUUID matched a UUID no team is configured with")
 	}
 }
 

--- a/apps/csm-portal/backend/internal/entity/customer.go
+++ b/apps/csm-portal/backend/internal/entity/customer.go
@@ -44,20 +44,20 @@ func (c *CustomerEntityClient) AggregateCases(ctx context.Context, body []byte) 
 	return c.do(ctx, http.MethodPost, "/cases/aggregate", body)
 }
 
-// SearchFeedback calls POST /cases/feedback/search on the entity service:
+// SearchFeedback calls POST /cases/feedbacks/search on the entity service:
 // search of case-feedback (satisfaction rating) records across cases,
 // filterable by case, accounts, and submission date range. Response is
 // returned as raw JSON; typed response structs are deferred.
 func (c *CustomerEntityClient) SearchFeedback(ctx context.Context, body []byte) ([]byte, error) {
-	return c.do(ctx, http.MethodPost, "/cases/feedback/search", body)
+	return c.do(ctx, http.MethodPost, "/cases/feedbacks/search", body)
 }
 
-// AggregateFeedback calls POST /cases/feedback/aggregate on the entity
+// AggregateFeedback calls POST /cases/feedbacks/aggregate on the entity
 // service: date-bucketed rating aggregation of case-feedback records across
 // cases. Response is returned as raw JSON; typed response structs are
 // deferred.
 func (c *CustomerEntityClient) AggregateFeedback(ctx context.Context, body []byte) ([]byte, error) {
-	return c.do(ctx, http.MethodPost, "/cases/feedback/aggregate", body)
+	return c.do(ctx, http.MethodPost, "/cases/feedbacks/aggregate", body)
 }
 
 // GetCase calls GET /cases/{id} on the entity service.

--- a/apps/csm-portal/backend/internal/entity/customer.go
+++ b/apps/csm-portal/backend/internal/entity/customer.go
@@ -44,6 +44,22 @@ func (c *CustomerEntityClient) AggregateCases(ctx context.Context, body []byte) 
 	return c.do(ctx, http.MethodPost, "/cases/aggregate", body)
 }
 
+// SearchFeedback calls POST /cases/feedback/search on the entity service:
+// search of case-feedback (satisfaction rating) records across cases,
+// filterable by case, accounts, and submission date range. Response is
+// returned as raw JSON; typed response structs are deferred.
+func (c *CustomerEntityClient) SearchFeedback(ctx context.Context, body []byte) ([]byte, error) {
+	return c.do(ctx, http.MethodPost, "/cases/feedback/search", body)
+}
+
+// AggregateFeedback calls POST /cases/feedback/aggregate on the entity
+// service: date-bucketed rating aggregation of case-feedback records across
+// cases. Response is returned as raw JSON; typed response structs are
+// deferred.
+func (c *CustomerEntityClient) AggregateFeedback(ctx context.Context, body []byte) ([]byte, error) {
+	return c.do(ctx, http.MethodPost, "/cases/feedback/aggregate", body)
+}
+
 // GetCase calls GET /cases/{id} on the entity service.
 // Response is returned as raw JSON; typed response structs are deferred.
 func (c *CustomerEntityClient) GetCase(ctx context.Context, caseID string) ([]byte, error) {

--- a/apps/csm-portal/backend/internal/handler/cases.go
+++ b/apps/csm-portal/backend/internal/handler/cases.go
@@ -78,6 +78,8 @@ type entityCaseClient interface {
 	SearchCaseActivities(ctx context.Context, caseID string, body []byte) ([]byte, error)
 	SearchCases(ctx context.Context, body []byte) ([]byte, error)
 	AggregateCases(ctx context.Context, body []byte) ([]byte, error)
+	SearchFeedback(ctx context.Context, body []byte) ([]byte, error)
+	AggregateFeedback(ctx context.Context, body []byte) ([]byte, error)
 	GetCase(ctx context.Context, caseID string) ([]byte, error)
 	CreateCaseAttachment(ctx context.Context, body []byte) ([]byte, error)
 	SearchCaseAttachments(ctx context.Context, body []byte) ([]byte, error)
@@ -511,6 +513,83 @@ func (h *CaseHandler) AggregateCases(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		slog.ErrorContext(r.Context(), "entity AggregateCases failed", "userID", user.UserID, "err", err)
 		mapUpstreamErrorGeneric(w, err, "Failed to aggregate cases.")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, result)
+}
+
+// SearchFeedback handles POST /cases/feedback/search.
+// Search of case-feedback (satisfaction rating) records across cases,
+// filterable by case, accounts, and submission date range. Backs the
+// case-feedback dashboard's list view. This is a plain forward-and-return
+// proxy: filters/pagination validation is the entity service's job, this
+// layer only enforces auth, a body size cap, and valid JSON.
+func (h *CaseHandler) SearchFeedback(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		if _, ok := err.(*http.MaxBytesError); ok {
+			writeError(w, http.StatusRequestEntityTooLarge, ErrMsgTooLarge)
+			return
+		}
+		writeError(w, http.StatusBadRequest, errMsgReadBody)
+		return
+	}
+
+	if !json.Valid(body) {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.SearchFeedback(r.Context(), body)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity SearchFeedback failed", "userID", user.UserID, "err", err)
+		mapUpstreamErrorGeneric(w, err, "Failed to search case feedback.")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, result)
+}
+
+// AggregateFeedback handles POST /cases/feedback/aggregate.
+// Date-bucketed rating aggregation of case-feedback records across cases.
+// Backs the case-feedback dashboard's rating-trend chart. Same
+// forward-and-return proxy contract as SearchFeedback: the bucket enum and
+// filters are validated upstream by the entity service.
+func (h *CaseHandler) AggregateFeedback(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		if _, ok := err.(*http.MaxBytesError); ok {
+			writeError(w, http.StatusRequestEntityTooLarge, ErrMsgTooLarge)
+			return
+		}
+		writeError(w, http.StatusBadRequest, errMsgReadBody)
+		return
+	}
+
+	if !json.Valid(body) {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	result, err := h.entity.AggregateFeedback(r.Context(), body)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity AggregateFeedback failed", "userID", user.UserID, "err", err)
+		mapUpstreamErrorGeneric(w, err, "Failed to aggregate case feedback.")
 		return
 	}
 

--- a/apps/csm-portal/backend/internal/handler/cases.go
+++ b/apps/csm-portal/backend/internal/handler/cases.go
@@ -519,7 +519,7 @@ func (h *CaseHandler) AggregateCases(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, result)
 }
 
-// SearchFeedback handles POST /cases/feedback/search.
+// SearchFeedback handles POST /cases/feedbacks/search.
 // Search of case-feedback (satisfaction rating) records across cases,
 // filterable by case, accounts, and submission date range. Backs the
 // case-feedback dashboard's list view. This is a plain forward-and-return
@@ -558,7 +558,7 @@ func (h *CaseHandler) SearchFeedback(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, result)
 }
 
-// AggregateFeedback handles POST /cases/feedback/aggregate.
+// AggregateFeedback handles POST /cases/feedbacks/aggregate.
 // Date-bucketed rating aggregation of case-feedback records across cases.
 // Backs the case-feedback dashboard's rating-trend chart. Same
 // forward-and-return proxy contract as SearchFeedback: the bucket enum and

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -3053,7 +3053,7 @@ func TestAggregateCases(t *testing.T) {
 func TestSearchFeedback(t *testing.T) {
 	t.Run("requires authenticated user", func(t *testing.T) {
 		h := NewCaseHandler(&mockEntityCaseClient{})
-		r := httptest.NewRequest(http.MethodPost, "/cases/feedback/search", strings.NewReader(`{}`))
+		r := httptest.NewRequest(http.MethodPost, "/cases/feedbacks/search", strings.NewReader(`{}`))
 		w := httptest.NewRecorder()
 		h.SearchFeedback(w, r)
 		assertStatus(t, w, http.StatusUnauthorized)
@@ -3063,7 +3063,7 @@ func TestSearchFeedback(t *testing.T) {
 
 	t.Run("rejects body exceeding 1 MiB", func(t *testing.T) {
 		h := NewCaseHandler(&mockEntityCaseClient{})
-		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/feedback/search", strings.NewReader(strings.Repeat("x", maxRequestBodyBytes+1))))
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/feedbacks/search", strings.NewReader(strings.Repeat("x", maxRequestBodyBytes+1))))
 		w := httptest.NewRecorder()
 		h.SearchFeedback(w, r)
 		assertStatus(t, w, http.StatusRequestEntityTooLarge)
@@ -3073,7 +3073,7 @@ func TestSearchFeedback(t *testing.T) {
 
 	t.Run("rejects invalid JSON body", func(t *testing.T) {
 		h := NewCaseHandler(&mockEntityCaseClient{})
-		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/feedback/search", strings.NewReader(`not-json`)))
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/feedbacks/search", strings.NewReader(`not-json`)))
 		w := httptest.NewRecorder()
 		h.SearchFeedback(w, r)
 		assertStatus(t, w, http.StatusBadRequest)
@@ -3091,7 +3091,7 @@ func TestSearchFeedback(t *testing.T) {
 			},
 		}
 		h := NewCaseHandler(client)
-		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/feedback/search", strings.NewReader(reqPayload)))
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/feedbacks/search", strings.NewReader(reqPayload)))
 		w := httptest.NewRecorder()
 		h.SearchFeedback(w, r)
 
@@ -3116,7 +3116,7 @@ func TestSearchFeedback(t *testing.T) {
 					},
 				}
 				h := NewCaseHandler(client)
-				r := withUser(httptest.NewRequest(http.MethodPost, "/cases/feedback/search", strings.NewReader(`{}`)))
+				r := withUser(httptest.NewRequest(http.MethodPost, "/cases/feedbacks/search", strings.NewReader(`{}`)))
 				w := httptest.NewRecorder()
 				h.SearchFeedback(w, r)
 				assertStatus(t, w, tc.wantCode)
@@ -3130,7 +3130,7 @@ func TestSearchFeedback(t *testing.T) {
 func TestAggregateFeedback(t *testing.T) {
 	t.Run("requires authenticated user", func(t *testing.T) {
 		h := NewCaseHandler(&mockEntityCaseClient{})
-		r := httptest.NewRequest(http.MethodPost, "/cases/feedback/aggregate", strings.NewReader(`{}`))
+		r := httptest.NewRequest(http.MethodPost, "/cases/feedbacks/aggregate", strings.NewReader(`{}`))
 		w := httptest.NewRecorder()
 		h.AggregateFeedback(w, r)
 		assertStatus(t, w, http.StatusUnauthorized)
@@ -3140,7 +3140,7 @@ func TestAggregateFeedback(t *testing.T) {
 
 	t.Run("rejects body exceeding 1 MiB", func(t *testing.T) {
 		h := NewCaseHandler(&mockEntityCaseClient{})
-		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/feedback/aggregate", strings.NewReader(strings.Repeat("x", maxRequestBodyBytes+1))))
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/feedbacks/aggregate", strings.NewReader(strings.Repeat("x", maxRequestBodyBytes+1))))
 		w := httptest.NewRecorder()
 		h.AggregateFeedback(w, r)
 		assertStatus(t, w, http.StatusRequestEntityTooLarge)
@@ -3150,7 +3150,7 @@ func TestAggregateFeedback(t *testing.T) {
 
 	t.Run("rejects invalid JSON body", func(t *testing.T) {
 		h := NewCaseHandler(&mockEntityCaseClient{})
-		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/feedback/aggregate", strings.NewReader(`not-json`)))
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/feedbacks/aggregate", strings.NewReader(`not-json`)))
 		w := httptest.NewRecorder()
 		h.AggregateFeedback(w, r)
 		assertStatus(t, w, http.StatusBadRequest)
@@ -3168,7 +3168,7 @@ func TestAggregateFeedback(t *testing.T) {
 			},
 		}
 		h := NewCaseHandler(client)
-		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/feedback/aggregate", strings.NewReader(reqPayload)))
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/feedbacks/aggregate", strings.NewReader(reqPayload)))
 		w := httptest.NewRecorder()
 		h.AggregateFeedback(w, r)
 
@@ -3193,7 +3193,7 @@ func TestAggregateFeedback(t *testing.T) {
 					},
 				}
 				h := NewCaseHandler(client)
-				r := withUser(httptest.NewRequest(http.MethodPost, "/cases/feedback/aggregate", strings.NewReader(`{}`)))
+				r := withUser(httptest.NewRequest(http.MethodPost, "/cases/feedbacks/aggregate", strings.NewReader(`{}`)))
 				w := httptest.NewRecorder()
 				h.AggregateFeedback(w, r)
 				assertStatus(t, w, tc.wantCode)

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -3049,3 +3049,157 @@ func TestAggregateCases(t *testing.T) {
 		}
 	})
 }
+
+func TestSearchFeedback(t *testing.T) {
+	t.Run("requires authenticated user", func(t *testing.T) {
+		h := NewCaseHandler(&mockEntityCaseClient{})
+		r := httptest.NewRequest(http.MethodPost, "/cases/feedback/search", strings.NewReader(`{}`))
+		w := httptest.NewRecorder()
+		h.SearchFeedback(w, r)
+		assertStatus(t, w, http.StatusUnauthorized)
+		assertErrorMessage(t, w, ErrMsgUnauthorized)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects body exceeding 1 MiB", func(t *testing.T) {
+		h := NewCaseHandler(&mockEntityCaseClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/feedback/search", strings.NewReader(strings.Repeat("x", maxRequestBodyBytes+1))))
+		w := httptest.NewRecorder()
+		h.SearchFeedback(w, r)
+		assertStatus(t, w, http.StatusRequestEntityTooLarge)
+		assertErrorMessage(t, w, ErrMsgTooLarge)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects invalid JSON body", func(t *testing.T) {
+		h := NewCaseHandler(&mockEntityCaseClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/feedback/search", strings.NewReader(`not-json`)))
+		w := httptest.NewRecorder()
+		h.SearchFeedback(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("forwards body to upstream and returns 200", func(t *testing.T) {
+		reqPayload := `{"filters":{"accountIds":["acc-1"],"dateFrom":"2026-01-01","dateTo":"2026-02-01"},"page":1,"pageSize":20}`
+		var capturedBody []byte
+		client := &mockEntityCaseClient{
+			searchFeedbackFn: func(_ context.Context, body []byte) ([]byte, error) {
+				capturedBody = body
+				return []byte(`{"results":[{"instanceId":"fb-1","caseId":"case-1","rating":5,"ratingLabel":"Satisfied","comment":null,"submittedAt":"2026-01-15T00:00:00Z"}],"totalRecords":1}`), nil
+			},
+		}
+		h := NewCaseHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/feedback/search", strings.NewReader(reqPayload)))
+		w := httptest.NewRecorder()
+		h.SearchFeedback(w, r)
+
+		assertStatus(t, w, http.StatusOK)
+		assertContentType(t, w, "application/json")
+		if string(capturedBody) != reqPayload {
+			t.Errorf("upstream received body %q, want %q", capturedBody, reqPayload)
+		}
+		resp := decodeJSON[map[string]any](t, w)
+		if resp["totalRecords"] != float64(1) {
+			t.Errorf("totalRecords = %v, want 1", resp["totalRecords"])
+		}
+	})
+
+	t.Run("upstream errors are mapped correctly", func(t *testing.T) {
+		for _, tc := range upstreamErrorsGeneric("Failed to search case feedback.") {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				client := &mockEntityCaseClient{
+					searchFeedbackFn: func(_ context.Context, _ []byte) ([]byte, error) {
+						return nil, tc.err
+					},
+				}
+				h := NewCaseHandler(client)
+				r := withUser(httptest.NewRequest(http.MethodPost, "/cases/feedback/search", strings.NewReader(`{}`)))
+				w := httptest.NewRecorder()
+				h.SearchFeedback(w, r)
+				assertStatus(t, w, tc.wantCode)
+				assertErrorMessage(t, w, tc.wantMsg)
+				assertContentType(t, w, "application/json")
+			})
+		}
+	})
+}
+
+func TestAggregateFeedback(t *testing.T) {
+	t.Run("requires authenticated user", func(t *testing.T) {
+		h := NewCaseHandler(&mockEntityCaseClient{})
+		r := httptest.NewRequest(http.MethodPost, "/cases/feedback/aggregate", strings.NewReader(`{}`))
+		w := httptest.NewRecorder()
+		h.AggregateFeedback(w, r)
+		assertStatus(t, w, http.StatusUnauthorized)
+		assertErrorMessage(t, w, ErrMsgUnauthorized)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects body exceeding 1 MiB", func(t *testing.T) {
+		h := NewCaseHandler(&mockEntityCaseClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/feedback/aggregate", strings.NewReader(strings.Repeat("x", maxRequestBodyBytes+1))))
+		w := httptest.NewRecorder()
+		h.AggregateFeedback(w, r)
+		assertStatus(t, w, http.StatusRequestEntityTooLarge)
+		assertErrorMessage(t, w, ErrMsgTooLarge)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("rejects invalid JSON body", func(t *testing.T) {
+		h := NewCaseHandler(&mockEntityCaseClient{})
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/feedback/aggregate", strings.NewReader(`not-json`)))
+		w := httptest.NewRecorder()
+		h.AggregateFeedback(w, r)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertErrorMessage(t, w, ErrMsgBadRequest)
+		assertContentType(t, w, "application/json")
+	})
+
+	t.Run("forwards body to upstream and returns 200", func(t *testing.T) {
+		reqPayload := `{"filters":{"accountIds":["acc-1"]},"bucket":"week"}`
+		var capturedBody []byte
+		client := &mockEntityCaseClient{
+			aggregateFeedbackFn: func(_ context.Context, body []byte) ([]byte, error) {
+				capturedBody = body
+				return []byte(`{"buckets":[{"bucketStart":"2026-01-05","avgRating":4.2,"count":3}],"totalRecords":3}`), nil
+			},
+		}
+		h := NewCaseHandler(client)
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/feedback/aggregate", strings.NewReader(reqPayload)))
+		w := httptest.NewRecorder()
+		h.AggregateFeedback(w, r)
+
+		assertStatus(t, w, http.StatusOK)
+		assertContentType(t, w, "application/json")
+		if string(capturedBody) != reqPayload {
+			t.Errorf("upstream received body %q, want %q", capturedBody, reqPayload)
+		}
+		resp := decodeJSON[map[string]any](t, w)
+		if resp["totalRecords"] != float64(3) {
+			t.Errorf("totalRecords = %v, want 3", resp["totalRecords"])
+		}
+	})
+
+	t.Run("upstream errors are mapped correctly", func(t *testing.T) {
+		for _, tc := range upstreamErrorsGeneric("Failed to aggregate case feedback.") {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				client := &mockEntityCaseClient{
+					aggregateFeedbackFn: func(_ context.Context, _ []byte) ([]byte, error) {
+						return nil, tc.err
+					},
+				}
+				h := NewCaseHandler(client)
+				r := withUser(httptest.NewRequest(http.MethodPost, "/cases/feedback/aggregate", strings.NewReader(`{}`)))
+				w := httptest.NewRecorder()
+				h.AggregateFeedback(w, r)
+				assertStatus(t, w, tc.wantCode)
+				assertErrorMessage(t, w, tc.wantMsg)
+				assertContentType(t, w, "application/json")
+			})
+		}
+	})
+}

--- a/apps/csm-portal/backend/internal/handler/helpers_test.go
+++ b/apps/csm-portal/backend/internal/handler/helpers_test.go
@@ -102,6 +102,8 @@ type mockEntityCaseClient struct {
 	searchCaseActivitiesFn     func(ctx context.Context, caseID string, body []byte) ([]byte, error)
 	searchCasesFn              func(ctx context.Context, body []byte) ([]byte, error)
 	aggregateCasesFn           func(ctx context.Context, body []byte) ([]byte, error)
+	searchFeedbackFn           func(ctx context.Context, body []byte) ([]byte, error)
+	aggregateFeedbackFn        func(ctx context.Context, body []byte) ([]byte, error)
 	getCaseFn                  func(ctx context.Context, caseID string) ([]byte, error)
 	createCaseAttachmentFn     func(ctx context.Context, body []byte) ([]byte, error)
 	searchCaseAttachmentsFn    func(ctx context.Context, body []byte) ([]byte, error)
@@ -177,6 +179,20 @@ func (m *mockEntityCaseClient) AggregateCases(ctx context.Context, body []byte) 
 		return m.aggregateCasesFn(ctx, body)
 	}
 	return []byte(`{"groups":[],"othersCount":0,"totalRecords":0}`), nil
+}
+
+func (m *mockEntityCaseClient) SearchFeedback(ctx context.Context, body []byte) ([]byte, error) {
+	if m.searchFeedbackFn != nil {
+		return m.searchFeedbackFn(ctx, body)
+	}
+	return []byte(`{"results":[],"totalRecords":0}`), nil
+}
+
+func (m *mockEntityCaseClient) AggregateFeedback(ctx context.Context, body []byte) ([]byte, error) {
+	if m.aggregateFeedbackFn != nil {
+		return m.aggregateFeedbackFn(ctx, body)
+	}
+	return []byte(`{"buckets":[],"totalRecords":0}`), nil
 }
 
 func (m *mockEntityCaseClient) GetCase(ctx context.Context, caseID string) ([]byte, error) {

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -1972,15 +1972,15 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
-  /cases/feedback/search:
+  /cases/feedbacks/search:
     post:
       summary: Search case-feedback (satisfaction rating) records across cases.
       description: >-
         Plain forward-and-return proxy to the entity service's own POST
-        /cases/feedback/search: filterable by case, accounts, and submission
+        /cases/feedbacks/search: filterable by case, accounts, and submission
         date range, and paginated. Backs the case-feedback dashboard's list
         view. Distinct from any single-case feedback lookup.
-      operationId: postCasesFeedbackSearch
+      operationId: postCasesFeedbacksSearch
       requestBody:
         description: Case-feedback search payload
         content:
@@ -2038,20 +2038,20 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
-  /cases/feedback/aggregate:
+  /cases/feedbacks/aggregate:
     post:
       summary: >-
         Date-bucketed rating aggregation of case-feedback records across
         cases.
       description: >-
         Plain forward-and-return proxy to the entity service's own POST
-        /cases/feedback/aggregate. Backs the case-feedback dashboard's
+        /cases/feedbacks/aggregate. Backs the case-feedback dashboard's
         rating-trend chart (a shape "bar" widget with resourceType
         "case_feedback" and a "groupBy.bucket" — see DashboardWidget). This
         is the many-cases trend endpoint, not scoped to one case, so
         filters.caseId is not accepted here (unlike
-        /cases/feedback/search).
-      operationId: postCasesFeedbackAggregate
+        /cases/feedbacks/search).
+      operationId: postCasesFeedbacksAggregate
       requestBody:
         description: Case-feedback aggregate payload
         content:
@@ -6880,7 +6880,7 @@ components:
             POST /cases/search. case_feedback is case-feedback (satisfaction
             rating) records, not cases themselves — a shape "bar" widget with
             this resourceType and a "groupBy.bucket" (see below) is resolved
-            by the caller against POST /cases/feedback/aggregate instead;
+            by the caller against POST /cases/feedbacks/aggregate instead;
             there is no server-side resourceType-to-endpoint mapping, the
             caller picks the endpoint from resourceType on its own, same as
             every other value here.
@@ -6943,7 +6943,7 @@ components:
               description: >
                 Date-bucket granularity instead of field-value grouping.
                 This is the mode a case_feedback trend widget uses: the
-                caller resolves it by calling POST /cases/feedback/aggregate
+                caller resolves it by calling POST /cases/feedbacks/aggregate
                 with this value as that endpoint's own "bucket" (see
                 AggregateFeedbackRequest), not the generic
                 POST /{resourceType}/aggregate this groupBy block otherwise

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -1972,6 +1972,131 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
+  /cases/feedback/search:
+    post:
+      summary: Search case-feedback (satisfaction rating) records across cases.
+      description: >-
+        Plain forward-and-return proxy to the entity service's own POST
+        /cases/feedback/search: filterable by case, accounts, and submission
+        date range, and paginated. Backs the case-feedback dashboard's list
+        view. Distinct from any single-case feedback lookup.
+      operationId: postCasesFeedbackSearch
+      requestBody:
+        description: Case-feedback search payload
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CaseFeedbackSearchPayload'
+        required: true
+      responses:
+        "200":
+          description: Case-feedback records matching the filters.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CaseFeedbackSearchResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: NotFound
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
+  /cases/feedback/aggregate:
+    post:
+      summary: >-
+        Date-bucketed rating aggregation of case-feedback records across
+        cases.
+      description: >-
+        Plain forward-and-return proxy to the entity service's own POST
+        /cases/feedback/aggregate. Backs the case-feedback dashboard's
+        rating-trend chart (a shape "bar" widget with resourceType
+        "case_feedback" and a "groupBy.bucket" — see DashboardWidget). This
+        is the many-cases trend endpoint, not scoped to one case, so
+        filters.caseId is not accepted here (unlike
+        /cases/feedback/search).
+      operationId: postCasesFeedbackAggregate
+      requestBody:
+        description: Case-feedback aggregate payload
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CaseFeedbackAggregatePayload'
+        required: true
+      responses:
+        "200":
+          description: Feedback ratings aggregated into date buckets.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CaseFeedbackAggregateResponse'
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "404":
+          description: NotFound
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "413":
+          description: RequestEntityTooLarge
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+
   /dashboards:
     get:
       summary: List available dashboards.
@@ -6573,6 +6698,135 @@ components:
         totalRecords:
           type: integer
 
+    CaseFeedback:
+      type: object
+      description: A single case-feedback (satisfaction rating) record.
+      properties:
+        instanceId:
+          type: string
+          format: uuid
+          description: Unique id of the feedback record.
+        caseId:
+          type: string
+          format: uuid
+          description: UUID of the case the feedback belongs to.
+        rating:
+          type: integer
+          description: Numeric rating value.
+        ratingLabel:
+          type: string
+          description: Human-readable label for rating (e.g. "Satisfied").
+        comment:
+          type: string
+          nullable: true
+          description: >-
+            Free-text comment submitted with the feedback. Null for feedback
+            submitted without a comment.
+        submittedAt:
+          type: string
+          description: Timestamp when the feedback was submitted.
+
+    CaseFeedbackSearchFilters:
+      type: object
+      properties:
+        caseId:
+          type: string
+          format: uuid
+          description: Restrict results to a single case.
+        accountIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+          description: Restrict results to feedback on cases under these accounts.
+        dateFrom:
+          type: string
+          description: Start of the feedback submission date range (inclusive).
+        dateTo:
+          type: string
+          description: End of the feedback submission date range (inclusive).
+
+    CaseFeedbackSearchPayload:
+      type: object
+      nullable: true
+      properties:
+        filters:
+          $ref: '#/components/schemas/CaseFeedbackSearchFilters'
+        page:
+          type: integer
+          description: Page number for pagination. Optional; the backing data source applies a default when omitted.
+        pageSize:
+          type: integer
+          description: Number of records per page. Optional; the backing data source applies a default when omitted.
+
+    CaseFeedbackSearchResponse:
+      type: object
+      properties:
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/CaseFeedback'
+        totalRecords:
+          type: integer
+          description: Total number of matching records across all pages.
+
+    CaseFeedbackAggregateFilters:
+      type: object
+      description: >-
+        Deliberately narrower than CaseFeedbackSearchFilters -- this is the
+        many-cases trend endpoint, not scoped to a single case, so caseId is
+        not accepted here.
+      properties:
+        accountIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+          description: Restrict results to feedback on cases under these accounts.
+        dateFrom:
+          type: string
+          description: Start of the feedback submission date range (inclusive).
+        dateTo:
+          type: string
+          description: End of the feedback submission date range (inclusive).
+
+    CaseFeedbackAggregatePayload:
+      type: object
+      required: [bucket]
+      properties:
+        filters:
+          $ref: '#/components/schemas/CaseFeedbackAggregateFilters'
+        bucket:
+          type: string
+          enum: [day, week, month]
+          description: Time bucket granularity to group results by.
+
+    FeedbackBucket:
+      type: object
+      description: One aggregated time bucket in a case-feedback aggregate result.
+      properties:
+        bucketStart:
+          type: string
+          description: Start of this bucket's time range.
+        avgRating:
+          type: number
+          description: Average rating across feedback records in this bucket.
+        count:
+          type: integer
+          description: Number of feedback records in this bucket.
+
+    CaseFeedbackAggregateResponse:
+      type: object
+      properties:
+        buckets:
+          type: array
+          items:
+            $ref: '#/components/schemas/FeedbackBucket'
+          description: Time buckets, in chronological order.
+        totalRecords:
+          type: integer
+          description: Total number of feedback records across every bucket.
+
     DashboardWidget:
       type: object
       properties:
@@ -6604,13 +6858,20 @@ components:
             - security_report_analysis
             - announcement
             - engagement
+            - case_feedback
           description: >
             Which resource's /search endpoint this widget's filters target.
             service_request, security_report_analysis, announcement and
             engagement are additional values of the case-search "type" field
             (see Case's own type enum) exposed as their own widget
             resourceType alongside case itself — all five route to the same
-            POST /cases/search.
+            POST /cases/search. case_feedback is case-feedback (satisfaction
+            rating) records, not cases themselves — a shape "bar" widget with
+            this resourceType and a "groupBy.bucket" (see below) is resolved
+            by the caller against POST /cases/feedback/aggregate instead;
+            there is no server-side resourceType-to-endpoint mapping, the
+            caller picks the endpoint from resourceType on its own, same as
+            every other value here.
         shape:
           type: string
           enum:
@@ -6653,7 +6914,9 @@ components:
             caller issues one POST /{resourceType}/aggregate request (filters
             = this widget's own query) and maps the response's groups/
             othersCount into the same per-slice shape "slices" already
-            produces.
+            produces. Carries exactly one of "field" (value grouping) or
+            "bucket" (date grouping) — both set, or neither set, is rejected
+            at dashboard-load time.
           properties:
             field:
               type: string
@@ -6661,19 +6924,32 @@ components:
                 Which field to group by. Each resourceType enforces its own
                 small allowlist server-side; an unsupported value is
                 rejected by the aggregate call itself with a 400, not caught
-                here.
+                here. Mutually exclusive with "bucket".
+            bucket:
+              type: string
+              enum: [day, week, month]
+              description: >
+                Date-bucket granularity instead of field-value grouping.
+                This is the mode a case_feedback trend widget uses: the
+                caller resolves it by calling POST /cases/feedback/aggregate
+                with this value as that endpoint's own "bucket" (see
+                AggregateFeedbackRequest), not the generic
+                POST /{resourceType}/aggregate this groupBy block otherwise
+                implies. Mutually exclusive with "field".
             maxGroups:
               type: integer
               description: >
                 Top-N cutoff by count, descending; the remainder is summed
                 into one "Others" bucket. Omitted/zero defers to the
-                aggregate endpoint's own default (12).
+                aggregate endpoint's own default (12). Meaningless when
+                "bucket" is set — a date-bucketed aggregation has no
+                "Others" folding.
             othersLabel:
               type: string
               description: >
                 Overrides the default "Others" label for the summed
-                remainder bucket.
-          required: [field]
+                remainder bucket. Meaningless when "bucket" is set, same as
+                "maxGroups".
         listLimit:
           type: integer
           description: Only meaningful for shape list; how many records to show

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -2031,6 +2031,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
+        "503":
+          description: Upstream service unavailable.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
 
   /cases/feedback/aggregate:
     post:
@@ -2092,6 +2098,12 @@ paths:
                 $ref: '#/components/schemas/ErrorPayload'
         "500":
           description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorPayload'
+        "503":
+          description: Upstream service unavailable.
           content:
             application/json:
               schema:

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -3245,7 +3245,8 @@ export type BeWidgetResourceType =
   | "security_report_analysis"
   | "announcement"
   | "engagement"
-  | "incident_task";
+  | "incident_task"
+  | "case_feedback";
 
 /**
  * How a widget's resolved data should be rendered. `pie` and `bar` both
@@ -3290,13 +3291,27 @@ export interface BeDashboardPieSlice {
  * the backend enforces exactly one of the two at config-load time. */
 export interface BeDashboardGroupByConfig {
   /** The field to aggregate on — forwarded verbatim as that request's
-   * `groupBy` key. */
-  field: string;
+   * `groupBy` key. Mutually exclusive with `bucket` (backend-enforced at
+   * config-load time): a widget sets exactly one. Optional (rather than
+   * required) only because of that mutual exclusivity — a `bucket`-configured
+   * widget carries no `field` at all. */
+  field?: string;
+  /** Date-bucketed grouping instead of field-value grouping — the shape a
+   * `case_feedback` trend widget uses (`shape: "bar"`). Mutually exclusive
+   * with `field`. Resolved by `useCaseFeedbackTrendData`, a dedicated hook
+   * (not `useWidgetGroupByData`, whose `POST {resourceType}/aggregate`
+   * request/response shape this doesn't match) that calls `POST
+   * /cases/feedback/aggregate` with this value and maps its date-bucketed
+   * response into the same per-slice `PieSliceResult[]` shape every other
+   * pie/bar widget already renders. */
+  bucket?: "day" | "week" | "month";
   /** Caps the number of returned buckets; anything beyond that rolls up
-   * into the response's `othersCount`. */
+   * into the response's `othersCount`. Meaningless when `bucket` is set — a
+   * date-bucketed aggregation has no "Others" folding. */
   maxGroups?: number;
   /** Label for the synthetic "everything else" bucket built from
-   * `othersCount`. Defaults to `"Others"` when omitted. */
+   * `othersCount`. Defaults to `"Others"` when omitted. Meaningless when
+   * `bucket` is set, same as `maxGroups`. */
   othersLabel?: string;
 }
 
@@ -3313,6 +3328,71 @@ export interface BeGroupByBucket {
 export interface BeGroupByResponse {
   groups: BeGroupByBucket[];
   othersCount: number;
+  totalRecords: number;
+}
+
+/**
+ * A single case-feedback (satisfaction rating) record, as returned by both
+ * `POST /cases/feedback/search`'s `results` array and, opaquely, read by the
+ * `case_feedback` widget resourceType's `columns`-driven list renderer (see
+ * `widgetResourceConfig.ts`'s `case_feedback` entry). Distinct id space from
+ * `BeCaseSearchView` — `caseId` is the only link back to a real case (there
+ * is no `number`/`subject` on this view; the entity service does not join
+ * the owning case's own fields into this response).
+ */
+export interface BeCaseFeedback {
+  instanceId: string;
+  caseId: string;
+  rating: number;
+  ratingLabel: string;
+  /** `null` for feedback submitted without a comment. */
+  comment: string | null;
+  submittedAt: string;
+}
+
+/** Body of `POST /cases/feedback/search` — deliberately NOT the
+ * `{ pagination: { offset, limit } }` shape every other resourceType's
+ * search endpoint takes (see `BeDashboardWidget.query`'s sibling contracts);
+ * this one takes flat `page`/`pageSize` instead, mirrored on `WidgetResourceConfig`'s
+ * `case_feedback` entry via `buildSearchRequestBody`. */
+export interface BeCaseFeedbackSearchFilters {
+  /** Restrict results to a single case. Not accepted by
+   * `/cases/feedback/aggregate` — see {@link BeCaseFeedbackAggregateFilters}. */
+  caseId?: string;
+  accountIds?: string[];
+  dateFrom?: string;
+  dateTo?: string;
+}
+
+export interface BeCaseFeedbackSearchResponse {
+  results: BeCaseFeedback[];
+  totalRecords: number;
+}
+
+/** Narrower than {@link BeCaseFeedbackSearchFilters} — `/cases/feedback/
+ * aggregate` is the many-cases trend endpoint, not scoped to a single case,
+ * so `caseId` is not accepted here. */
+export interface BeCaseFeedbackAggregateFilters {
+  accountIds?: string[];
+  dateFrom?: string;
+  dateTo?: string;
+}
+
+export interface BeCaseFeedbackAggregatePayload {
+  filters?: BeCaseFeedbackAggregateFilters;
+  bucket: "day" | "week" | "month";
+}
+
+/** One aggregated time bucket in a `POST /cases/feedback/aggregate`
+ * response. */
+export interface BeFeedbackBucket {
+  bucketStart: string;
+  avgRating: number;
+  count: number;
+}
+
+export interface BeCaseFeedbackAggregateResponse {
+  buckets: BeFeedbackBucket[];
   totalRecords: number;
 }
 

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -3301,7 +3301,7 @@ export interface BeDashboardGroupByConfig {
    * with `field`. Resolved by `useCaseFeedbackTrendData`, a dedicated hook
    * (not `useWidgetGroupByData`, whose `POST {resourceType}/aggregate`
    * request/response shape this doesn't match) that calls `POST
-   * /cases/feedback/aggregate` with this value and maps its date-bucketed
+   * /cases/feedbacks/aggregate` with this value and maps its date-bucketed
    * response into the same per-slice `PieSliceResult[]` shape every other
    * pie/bar widget already renders. */
   bucket?: "day" | "week" | "month";
@@ -3333,7 +3333,7 @@ export interface BeGroupByResponse {
 
 /**
  * A single case-feedback (satisfaction rating) record, as returned by both
- * `POST /cases/feedback/search`'s `results` array and, opaquely, read by the
+ * `POST /cases/feedbacks/search`'s `results` array and, opaquely, read by the
  * `case_feedback` widget resourceType's `columns`-driven list renderer (see
  * `widgetResourceConfig.ts`'s `case_feedback` entry). Distinct id space from
  * `BeCaseSearchView` — `caseId` is the only link back to a real case (there
@@ -3350,14 +3350,14 @@ export interface BeCaseFeedback {
   submittedAt: string;
 }
 
-/** Body of `POST /cases/feedback/search` — deliberately NOT the
+/** Body of `POST /cases/feedbacks/search` — deliberately NOT the
  * `{ pagination: { offset, limit } }` shape every other resourceType's
  * search endpoint takes (see `BeDashboardWidget.query`'s sibling contracts);
  * this one takes flat `page`/`pageSize` instead, mirrored on `WidgetResourceConfig`'s
  * `case_feedback` entry via `buildSearchRequestBody`. */
 export interface BeCaseFeedbackSearchFilters {
   /** Restrict results to a single case. Not accepted by
-   * `/cases/feedback/aggregate` — see {@link BeCaseFeedbackAggregateFilters}. */
+   * `/cases/feedbacks/aggregate` — see {@link BeCaseFeedbackAggregateFilters}. */
   caseId?: string;
   accountIds?: string[];
   dateFrom?: string;
@@ -3369,7 +3369,7 @@ export interface BeCaseFeedbackSearchResponse {
   totalRecords: number;
 }
 
-/** Narrower than {@link BeCaseFeedbackSearchFilters} — `/cases/feedback/
+/** Narrower than {@link BeCaseFeedbackSearchFilters} — `/cases/feedbacks/
  * aggregate` is the many-cases trend endpoint, not scoped to a single case,
  * so `caseId` is not accepted here. */
 export interface BeCaseFeedbackAggregateFilters {
@@ -3383,7 +3383,7 @@ export interface BeCaseFeedbackAggregatePayload {
   bucket: "day" | "week" | "month";
 }
 
-/** One aggregated time bucket in a `POST /cases/feedback/aggregate`
+/** One aggregated time bucket in a `POST /cases/feedbacks/aggregate`
  * response. */
 export interface BeFeedbackBucket {
   bucketStart: string;

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useCaseFeedbackTrendData.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useCaseFeedbackTrendData.test.tsx
@@ -58,7 +58,7 @@ describe("useCaseFeedbackTrendData", () => {
 
     expect(postMock).toHaveBeenCalledTimes(1);
     expect(postMock).toHaveBeenCalledWith(
-      "/cases/feedback/aggregate",
+      "/cases/feedbacks/aggregate",
       { filters: { accountIds: ["acc-1"] }, bucket: "month" },
       { signal: expect.any(AbortSignal) },
     );

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useCaseFeedbackTrendData.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useCaseFeedbackTrendData.test.tsx
@@ -1,0 +1,134 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { ReactNode } from "react";
+
+const postMock = vi.fn();
+
+vi.mock("@api/backend/client", () => ({
+  useBackendApi: () => ({ post: postMock }),
+}));
+
+import { useCaseFeedbackTrendData } from "@features/csm-dashboard/api/useCaseFeedbackTrendData";
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+describe("useCaseFeedbackTrendData", () => {
+  beforeEach(() => {
+    postMock.mockReset();
+  });
+
+  it("issues a single date-bucketed aggregate request and maps buckets into non-navigable avg-rating slices", async () => {
+    postMock.mockResolvedValue({
+      buckets: [
+        { bucketStart: "2026-07-01", avgRating: 4.2, count: 30 },
+        { bucketStart: "2026-08-01", avgRating: 3.8, count: 15 },
+      ],
+      totalRecords: 45,
+    });
+
+    const { result } = renderHook(
+      () =>
+        useCaseFeedbackTrendData("feedback_trend", { accountIds: ["acc-1"] }, { bucket: "month" }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(postMock).toHaveBeenCalledTimes(1);
+    expect(postMock).toHaveBeenCalledWith(
+      "/cases/feedback/aggregate",
+      { filters: { accountIds: ["acc-1"] }, bucket: "month" },
+      { signal: expect.any(AbortSignal) },
+    );
+
+    expect(result.current.slices).toEqual([
+      { label: "Jul 2026", query: {}, navigable: false, value: 4.2 },
+      { label: "Aug 2026", query: {}, navigable: false, value: 3.8 },
+    ]);
+    expect(result.current.total).toBe(45);
+  });
+
+  it("formats day/week buckets without a year", async () => {
+    postMock.mockResolvedValue({
+      buckets: [{ bucketStart: "2026-08-03", avgRating: 5, count: 2 }],
+      totalRecords: 2,
+    });
+
+    const { result } = renderHook(
+      () => useCaseFeedbackTrendData("feedback_trend", {}, { bucket: "day" }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.slices).toEqual([
+      { label: "Aug 3", query: {}, navigable: false, value: 5 },
+    ]);
+  });
+
+  it("fires no query and returns a zero result when groupBy is undefined", () => {
+    const { result } = renderHook(
+      () => useCaseFeedbackTrendData("feedback_trend", {}, undefined),
+      { wrapper },
+    );
+
+    expect(postMock).not.toHaveBeenCalled();
+    expect(result.current.slices).toEqual([]);
+    expect(result.current.total).toBe(0);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isError).toBe(false);
+  });
+
+  it("fires no query when groupBy carries field instead of bucket", () => {
+    const { result } = renderHook(
+      () => useCaseFeedbackTrendData("feedback_trend", {}, { field: "severity" }),
+      { wrapper },
+    );
+
+    expect(postMock).not.toHaveBeenCalled();
+    expect(result.current.slices).toEqual([]);
+  });
+
+  it("does not fire while enabled is false", () => {
+    const { result } = renderHook(
+      () => useCaseFeedbackTrendData("feedback_trend", {}, { bucket: "month" }, false),
+      { wrapper },
+    );
+
+    expect(postMock).not.toHaveBeenCalled();
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it("surfaces isError when the aggregate request fails", async () => {
+    postMock.mockRejectedValue(new Error("boom"));
+
+    const { result } = renderHook(
+      () => useCaseFeedbackTrendData("feedback_trend", {}, { bucket: "month" }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useCaseFeedbackTrendData.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useCaseFeedbackTrendData.ts
@@ -57,7 +57,7 @@ function formatBucketLabel(bucketStart: string, bucket: "day" | "week" | "month"
 
 /**
  * Resolves a `shape: "bar"` `case_feedback` widget's date-bucketed rating
- * trend via a single `POST /cases/feedback/aggregate` call — the
+ * trend via a single `POST /cases/feedbacks/aggregate` call — the
  * `groupBy.bucket` counterpart of `useWidgetGroupByData`'s `groupBy.field`
  * (see that field's own doc comment on `BeDashboardGroupByConfig` for why
  * this is a dedicated hook rather than a branch inside that one: the

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useCaseFeedbackTrendData.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useCaseFeedbackTrendData.ts
@@ -1,0 +1,166 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useQuery } from "@tanstack/react-query";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import { useBackendApi } from "@api/backend/client";
+import type { BeCaseFeedbackAggregateResponse, BeDashboardGroupByConfig } from "@api/backend/types";
+import { WIDGET_RESOURCE_CONFIG } from "@features/csm-dashboard/config/widgetResourceConfig";
+import { resolveRelativeDateFilters } from "@features/csm-dashboard/utils/resolveRelativeDateFilters";
+import {
+  shouldRetryWidgetFetch,
+  withWidgetFetchSlot,
+} from "@features/csm-dashboard/utils/widgetFetchConcurrency";
+import type { PieSliceResult, WidgetPieData } from "@features/csm-dashboard/api/useWidgetPieData";
+
+/** Formats one bucket's own `bucketStart` for the x-axis label, at the
+ * granularity implied by `bucket` — "month" reads as "Aug 2026" (the day is
+ * meaningless at that granularity), "week"/"day" as "Aug 1" (the year is
+ * omitted; a trend chart spans at most a handful of months in practice, and
+ * dropping it keeps the label short enough not to overlap its neighbors).
+ * Falls back to the raw string for anything `Date` can't parse, rather than
+ * rendering "Invalid Date" — the entity service is the source of this value,
+ * not something validated client-side.
+ *
+ * Formatted in `timeZone: "UTC"`, deliberately NOT the viewer's own local
+ * time (unlike `resolveRelativeDateFilters`, which is intentionally
+ * local-time for a different reason — see that module's own doc comment): a
+ * date-only `bucketStart` like `"2026-08-01"` parses as UTC midnight, and
+ * reading it back in a negative-UTC-offset timezone (most of the Americas)
+ * without pinning the formatter to UTC would roll it back to the previous
+ * day/month on the label — e.g. "Jul 2026" for a bucket the response itself
+ * calls August. Pinning to UTC makes the label match the bucket's own wire
+ * value everywhere, regardless of the viewer's timezone. */
+function formatBucketLabel(bucketStart: string, bucket: "day" | "week" | "month"): string {
+  const date = new Date(bucketStart);
+  if (Number.isNaN(date.getTime())) return bucketStart;
+  return new Intl.DateTimeFormat("en-US", {
+    timeZone: "UTC",
+    month: "short",
+    year: bucket === "month" ? "numeric" : undefined,
+    day: bucket === "month" ? undefined : "numeric",
+  }).format(date);
+}
+
+/**
+ * Resolves a `shape: "bar"` `case_feedback` widget's date-bucketed rating
+ * trend via a single `POST /cases/feedback/aggregate` call — the
+ * `groupBy.bucket` counterpart of `useWidgetGroupByData`'s `groupBy.field`
+ * (see that field's own doc comment on `BeDashboardGroupByConfig` for why
+ * this is a dedicated hook rather than a branch inside that one: the
+ * request body (`{filters, bucket}`, no `groupBy`/`maxGroups`) and response
+ * shape (`{buckets: [{bucketStart, avgRating, count}], totalRecords}`, no
+ * `groups`/`othersCount`) are both unrelated to `BeGroupByResponse`).
+ *
+ * Renders **average rating per bucket** as the primary metric (this task's
+ * own stated default) rather than a count-by-rating-bucket breakdown — every
+ * returned slice's `value` is `avgRating` (1-5), not `count`. `count` is
+ * still read off the response (as `WidgetPieData.total`, the bar tile's own
+ * header badge — see `DashboardWidgetTile`), just not per-bucket.
+ *
+ * Every bucket slice is marked `navigable: false`: unlike a field-based
+ * groupBy bucket (which resolves to a real filtered case-list query — see
+ * `useWidgetGroupByData`'s `bucketQuery`), a case-feedback bucket has no
+ * dedicated list page or click-through target of its own to scope a filtered
+ * result set to (see `WIDGET_RESOURCE_CONFIG.case_feedback.buildHref`) — a
+ * navigable-but-nowhere-useful click was judged worse than none.
+ *
+ * `groupBy` of `undefined`, or one carrying no `bucket` (a field-based
+ * `groupBy` reaching this hook by mistake — never true in practice, since
+ * `DashboardWidgetTile` only calls this hook when `groupBy.bucket` is set),
+ * fires no query and returns an empty/zero result, mirroring
+ * `useWidgetGroupByData`'s own behavior for an undefined `groupBy`.
+ */
+export function useCaseFeedbackTrendData(
+  widgetId: string,
+  /** This widget's own base filters (`CaseFeedbackAggregateFilters` —
+   * `accountIds`/`dateFrom`/`dateTo`; NOT the case-search DSL). Already
+   * resolved for the `__dateRangeFrom__`/`__dateRangeTo__` placeholder by
+   * the caller (`DashboardWidgetGrid`'s `renderTile` — see
+   * `dateRangeFilterPlaceholder.ts`), the single merge point shared with the
+   * `shape: "list"` grid widget that reads its own filters off the exact
+   * same `widget.query`, so this hook only ever sees concrete values (or
+   * none). Only `resolveRelativeDateFilters` runs here — a fail-open no-op
+   * for this resourceType's own flat `dateFrom`/`dateTo` shape (it only
+   * resolves the case-search DSL's `{filters: [...]}`  shape), kept for
+   * parity with every other widget hook and as a forward-compatible no-op
+   * should a relative-date placeholder ever be supported here too. */
+  baseFilters: Record<string, unknown>,
+  groupBy: BeDashboardGroupByConfig | undefined,
+  enabled = true,
+): WidgetPieData {
+  const api = useBackendApi();
+  const config = WIDGET_RESOURCE_CONFIG.case_feedback;
+  const bucket = groupBy?.bucket;
+
+  const resolvedFilters = resolveRelativeDateFilters(baseFilters);
+
+  const query = useQuery({
+    queryKey: [
+      ApiQueryKeys.CSM_DASHBOARD_WIDGET_DATA,
+      "feedback-trend",
+      widgetId,
+      resolvedFilters,
+      bucket,
+    ],
+    queryFn: async (): Promise<BeCaseFeedbackAggregateResponse> => {
+      if (!bucket) {
+        return { buckets: [], totalRecords: 0 };
+      }
+      if (!config?.groupByEndpoint) {
+        throw new Error("case_feedback resourceType has no groupByEndpoint configured");
+      }
+      // Same shared concurrency slot (and timeout) every other widget fetch
+      // uses — see useWidgetGroupByData's own comment. This resourceType has
+      // no team concept at all (see the retry option's own comment below), so
+      // a constant `teamKey` ("case_feedback") is passed — it never drops
+      // this fetch from the shared FIFO queue.
+      return withWidgetFetchSlot(async (signal) => {
+        return api.post<
+          { filters: Record<string, unknown>; bucket: "day" | "week" | "month" },
+          BeCaseFeedbackAggregateResponse
+        >(
+          config.groupByEndpoint as string,
+          { filters: resolvedFilters, bucket },
+          { signal },
+        );
+      }, "case_feedback");
+    },
+    enabled: enabled && !!bucket,
+    // This dashboard carries no team/current-user placeholder at all (see
+    // `dateRangeFilterPlaceholder.ts` — case_feedback's own filters shape has
+    // no team-scoped field), so every fetch here is "team-independent" in
+    // `shouldRetryWidgetFetch`'s own sense — always eligible for the
+    // queue-drop retry it applies to a widget whose own filters can't change
+    // out from under an in-flight fetch.
+    retry: (failureCount, error) => shouldRetryWidgetFetch(failureCount, error, true),
+    staleTime: 60_000,
+  });
+
+  const isLoading = !enabled || (!!bucket && query.isLoading);
+  const isError = !!bucket && query.isError;
+
+  const buckets = query.data?.buckets ?? [];
+  const slices: PieSliceResult[] = buckets.map((b) => ({
+    label: bucket ? formatBucketLabel(b.bucketStart, bucket) : b.bucketStart,
+    query: {},
+    navigable: false,
+    value: b.avgRating,
+  }));
+  const total = query.data?.totalRecords ?? 0;
+
+  return { slices, total, isLoading, isError };
+}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetData.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetData.ts
@@ -157,22 +157,35 @@ export function useWidgetData(
       // actually abort this specific in-flight request, not just start a
       // timer nothing observes.
       return withWidgetFetchSlot(async (signal) => {
-        const res = await api.post<
-          {
-            filters: Record<string, unknown>;
-            pagination: { offset: number; limit: number };
-            sortBy?: Record<string, unknown>;
-          },
-          Record<string, unknown>
-        >(
+        // Most resourceTypes' own search contract takes
+        // `{filters, pagination:{offset,limit}, sortBy?}` and returns
+        // `{total, [itemsKey]: [...]}` — `config.buildSearchRequestBody`/
+        // `config.parseSearchResponse` exist only for the resourceType(s)
+        // whose real contract diverges from that (today: `case_feedback`'s
+        // flat `page`/`pageSize` request and `totalRecords`/`results`
+        // response — see `WidgetResourceConfig`'s own doc comments). Both
+        // are omitted for every other resourceType, so this stays the exact
+        // request/response shape it always was for them.
+        const body = config.buildSearchRequestBody
+          ? config.buildSearchRequestBody({
+              filters: resolvedFilters,
+              offset: effectiveOffset,
+              limit,
+              sortBy: effectiveSortBy,
+            })
+          : {
+              filters: resolvedFilters,
+              pagination: { offset: effectiveOffset, limit },
+              ...(effectiveSortBy ? { sortBy: effectiveSortBy } : {}),
+            };
+        const res = await api.post<Record<string, unknown>, Record<string, unknown>>(
           config.searchEndpoint,
-          {
-            filters: resolvedFilters,
-            pagination: { offset: effectiveOffset, limit },
-            ...(effectiveSortBy ? { sortBy: effectiveSortBy } : {}),
-          },
+          body,
           { signal },
         );
+        if (config.parseSearchResponse) {
+          return config.parseSearchResponse(res);
+        }
         const total = typeof res.total === "number" ? res.total : 0;
         const rawItems = res[config.itemsKey];
         const items = Array.isArray(rawItems)

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetGroupByData.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetGroupByData.ts
@@ -125,7 +125,7 @@ export function useWidgetGroupByData(
       // `groupBy.bucket` widget (date-bucketed grouping; see that field's own
       // doc comment on `BeDashboardGroupByConfig`) never reaches this hook at
       // all: `DashboardWidgetTile` calls `useCaseFeedbackTrendData` instead,
-      // whose own `POST /cases/feedback/aggregate` request/response shape
+      // whose own `POST /cases/feedbacks/aggregate` request/response shape
       // this hook's `groupBy`/`BeGroupByResponse` types don't match. This
       // check is therefore normally dead — it exists only so a
       // misconfigured/future caller that reaches here with a bucket-only

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetGroupByData.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetGroupByData.ts
@@ -121,6 +121,22 @@ export function useWidgetGroupByData(
       if (!config?.groupByEndpoint) {
         throw new Error(`Unsupported group-by widget resourceType: ${resourceType}`);
       }
+      // `groupBy.field` is only set for field-based grouping — a
+      // `groupBy.bucket` widget (date-bucketed grouping; see that field's own
+      // doc comment on `BeDashboardGroupByConfig`) never reaches this hook at
+      // all: `DashboardWidgetTile` calls `useCaseFeedbackTrendData` instead,
+      // whose own `POST /cases/feedback/aggregate` request/response shape
+      // this hook's `groupBy`/`BeGroupByResponse` types don't match. This
+      // check is therefore normally dead — it exists only so a
+      // misconfigured/future caller that reaches here with a bucket-only
+      // `groupBy` fails loudly instead of posting `groupBy: undefined`
+      // silently.
+      if (!groupBy.field) {
+        throw new Error(
+          `useWidgetGroupByData: groupBy carries no "field" (bucket-based grouping belongs to useCaseFeedbackTrendData, not this hook) for widget "${widgetId}"`,
+        );
+      }
+      const field = groupBy.field;
       // Same shared concurrency slot (and timeout) useWidgetPieData's own
       // slice fetches use — a groupBy widget fires one call on top of every
       // other widget's own call, so it needs both at least as much.
@@ -132,7 +148,7 @@ export function useWidgetGroupByData(
           config.groupByEndpoint as string,
           {
             filters: resolvedFilters,
-            groupBy: groupBy.field,
+            groupBy: field,
             maxGroups: groupBy.maxGroups,
           },
           { signal },
@@ -164,7 +180,7 @@ export function useWidgetGroupByData(
     // `bucketQuery`'s own doc comment) — an empty `query` here would merge
     // to the widget's unfiltered base result set instead of this bucket's,
     // since `mergeWidgetFilters({...}, {})` is a no-op.
-    query: groupBy ? bucketQuery(resourceType, groupBy.field, bucket.key) : {},
+    query: groupBy?.field ? bucketQuery(resourceType, groupBy.field, bucket.key) : {},
     value: bucket.count,
   }));
   if (othersCount > 0) {

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/AgentsLandingPagePilot.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/AgentsLandingPagePilot.tsx
@@ -15,11 +15,15 @@
 // under the License.
 
 import { Box, Card, Skeleton, Typography } from "@wso2/oxygen-ui";
-import type { JSX } from "react";
+import { useMemo, useState, type JSX } from "react";
 import { useDashboard } from "@features/csm-dashboard/api/useDashboard";
 import DashboardWidgetGrid from "@features/csm-dashboard/components/DashboardWidgetGrid";
+import DateRangeFilter, {
+  type DateRangeFilterValue,
+} from "@features/csm-dashboard/components/DateRangeFilter";
 import SectionCard from "@features/csm-dashboard/components/SectionCard";
 import { WIDGET_GRID_SX } from "@features/csm-dashboard/utils/dashboardWidgetGridLayout";
+import { hasDateRangeFilterPlaceholder } from "@features/csm-dashboard/utils/dateRangeFilterPlaceholder";
 
 /** Placeholder tile count while the dashboard detail is in flight. */
 const PILOT_TILE_COUNT = 3;
@@ -69,6 +73,32 @@ export default function AgentsLandingPagePilot({
 }: AgentsLandingPagePilotProps): JSX.Element {
   const { data, isLoading, isError } = useDashboard(dashboardId);
 
+  // Whether ANY widget on this loaded dashboard actually uses the
+  // date-range placeholder (see `dateRangeFilterPlaceholder.ts`) — derived
+  // purely from the loaded widget list, not a dashboard-level config flag:
+  // no such flag exists (or is needed), the same "derive from what's
+  // actually configured" approach the chart-vs-list-tile grouping above
+  // already uses. Checks both a widget's own `query` (every shape) and, for
+  // a `groupBy`-configured pie/bar widget, `groupBy` itself carries no
+  // filters of its own to check — its base filters are `query`, same as
+  // every other shape (see `BeDashboardWidget.query`'s own doc comment) — so
+  // `query` alone is the complete check. Defaults to `false` (no control
+  // rendered) while the dashboard is still loading/erroring, same as
+  // rendering no grid at all in those states below.
+  const showDateRangeFilter = useMemo(
+    () => (data?.widgets ?? []).some((w) => hasDateRangeFilterPlaceholder(w.query ?? {})),
+    [data?.widgets],
+  );
+  // Page-local UI state, not URL/query-param-backed: unlike the team
+  // picker (a real selection that should survive a refresh/share — see
+  // `CsmDashboardPage`), a date range here is closer to an in-page filter
+  // tweak. `undefined`/`undefined` (both fields) is "no range selected",
+  // which `resolveDateRangeFilterPlaceholder` treats as "drop the filter
+  // entirely" — i.e. all time, matching this dashboard's own real
+  // unfiltered totals (961 feedback records, 229 in the last ~22 months) as
+  // the default view rather than an arbitrary pre-selected window.
+  const [dateRange, setDateRange] = useState<DateRangeFilterValue>({});
+
   return (
     <SectionCard>
       {isError ? (
@@ -84,12 +114,21 @@ export default function AgentsLandingPagePilot({
           ))}
         </Box>
       ) : (
-        <DashboardWidgetGrid
-          widgets={data?.widgets ?? []}
-          selectedTeamCreGroupId={selectedTeamCreGroupId}
-          selectedTeamSreGroupId={selectedTeamSreGroupId}
-          selectedTeamLabel={selectedTeamLabel}
-        />
+        <>
+          {showDateRangeFilter && (
+            <Box sx={{ mb: 2 }}>
+              <DateRangeFilter value={dateRange} onChange={setDateRange} />
+            </Box>
+          )}
+          <DashboardWidgetGrid
+            widgets={data?.widgets ?? []}
+            selectedTeamCreGroupId={selectedTeamCreGroupId}
+            selectedTeamSreGroupId={selectedTeamSreGroupId}
+            selectedTeamLabel={selectedTeamLabel}
+            dateRangeFrom={dateRange.from}
+            dateRangeTo={dateRange.to}
+          />
+        </>
       )}
     </SectionCard>
   );

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetGrid.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetGrid.tsx
@@ -26,6 +26,7 @@ import {
   WIDGET_GRID_SX,
   groupWidgetsBySection,
 } from "@features/csm-dashboard/utils/dashboardWidgetGridLayout";
+import { resolveDateRangeFilterPlaceholder } from "@features/csm-dashboard/utils/dateRangeFilterPlaceholder";
 
 // Hides the section refresh button + its "Last refreshed" label by default
 // and reveals both together on hover/focus of an ancestor carrying this sx
@@ -116,6 +117,20 @@ export interface DashboardWidgetGridProps {
    * "Add section" entry point, or an empty section shell that has no
    * widgets in it yet. */
   trailingContent?: ReactNode;
+  /** The dashboard's own currently-selected date range (see
+   * `DateRangeFilter`, owned by `AgentsLandingPagePilot`), resolved into
+   * every widget's own `query`/base filters here — the single merge point
+   * both a `shape: "list"` grid widget and a `shape: "bar"` trend widget
+   * share, since both read their own base filters off the same
+   * `widget.query` (see `renderTile`'s `filters` prop below). `undefined`
+   * for "no range selected" (all time) or a dashboard with no widget that
+   * references the placeholder at all (see `hasDateRangeFilterPlaceholder`),
+   * in which case this is a no-op — every existing dashboard's widgets carry
+   * no `__dateRangeFrom__`/`__dateRangeTo__` value, so nothing about them
+   * changes. See `dateRangeFilterPlaceholder.ts`. */
+  dateRangeFrom?: string;
+  /** The `to` half of {@link dateRangeFrom}. */
+  dateRangeTo?: string;
 }
 
 /**
@@ -136,6 +151,8 @@ export default function DashboardWidgetGrid({
   renderWidgetAction,
   renderSectionActions,
   trailingContent,
+  dateRangeFrom,
+  dateRangeTo,
 }: DashboardWidgetGridProps): JSX.Element {
   const queryClient = useQueryClient();
   // Per-section refresh tracks its own in-flight state, keyed by section.
@@ -177,7 +194,11 @@ export default function DashboardWidgetGrid({
           // widget (see `BeDashboardWidget.query`'s doc comment) — default
           // to `{}` here too, at the source, on top of `mergeWidgetFilters`
           // and `useWidgetData`/`useWidgetPieData` already tolerating it.
-          filters={widget.query ?? {}}
+          // `resolveDateRangeFilterPlaceholder` is a no-op for every widget
+          // that doesn't carry `__dateRangeFrom__`/`__dateRangeTo__` (every
+          // widget today except `case_feedback`'s own two) — see that
+          // function's own doc comment.
+          filters={resolveDateRangeFilterPlaceholder(widget.query ?? {}, dateRangeFrom, dateRangeTo)}
           listLimit={widget.listLimit}
           slices={widget.slices}
           groupBy={widget.groupBy}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
@@ -370,7 +370,7 @@ export default function DashboardWidgetTile({
   // `groupBy.bucket` (date-bucketed grouping — only `case_feedback`'s own
   // trend widget uses this today) resolves via `useCaseFeedbackTrendData`
   // instead of `useWidgetGroupByData`: its request/response contract (`POST
-  // /cases/feedback/aggregate`) is unrelated to `BeGroupByResponse` (see
+  // /cases/feedbacks/aggregate`) is unrelated to `BeGroupByResponse` (see
   // `BeDashboardGroupByConfig.bucket`'s own doc comment) — passing a
   // `bucket`-configured `groupBy` into `useWidgetGroupByData` would throw
   // (see that hook's own field-presence guard), so it's withheld here

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
@@ -34,6 +34,7 @@ import { useCurrentUser } from "@context/current-user/CurrentUserContext";
 import { useWidgetData } from "@features/csm-dashboard/api/useWidgetData";
 import { useWidgetPieData, type PieSliceResult } from "@features/csm-dashboard/api/useWidgetPieData";
 import { useWidgetGroupByData } from "@features/csm-dashboard/api/useWidgetGroupByData";
+import { useCaseFeedbackTrendData } from "@features/csm-dashboard/api/useCaseFeedbackTrendData";
 import { WIDGET_RESOURCE_CONFIG } from "@features/csm-dashboard/config/widgetResourceConfig";
 import { WIDGET_LIST_RENDERERS } from "@features/csm-dashboard/config/widgetListConfig";
 import GenericColumnList from "@features/csm-dashboard/components/GenericColumnList";
@@ -360,21 +361,38 @@ export default function DashboardWidgetTile({
   );
   // groupBy is the alternative to slices for shapes "pie"/"bar" — mutually
   // exclusive, backend-enforced (never both, never neither for those
-  // shapes). Both hooks are called unconditionally (rules of hooks; a
-  // widget's shape/config never changes across this component's lifetime)
-  // and only one of them ever actually fires a request, gated by its own
-  // `groupBy`/`slices` argument being empty/undefined.
+  // shapes). Every one of these three hooks is called unconditionally
+  // (rules of hooks; a widget's shape/config never changes across this
+  // component's lifetime) and only one of them ever actually fires a
+  // request, gated by its own `groupBy`/`slices` argument being
+  // empty/undefined.
+  //
+  // `groupBy.bucket` (date-bucketed grouping — only `case_feedback`'s own
+  // trend widget uses this today) resolves via `useCaseFeedbackTrendData`
+  // instead of `useWidgetGroupByData`: its request/response contract (`POST
+  // /cases/feedback/aggregate`) is unrelated to `BeGroupByResponse` (see
+  // `BeDashboardGroupByConfig.bucket`'s own doc comment) — passing a
+  // `bucket`-configured `groupBy` into `useWidgetGroupByData` would throw
+  // (see that hook's own field-presence guard), so it's withheld here
+  // exactly the way `groupBy` itself is withheld from `useWidgetGroupByData`
+  // for a `shape` that isn't "pie"/"bar" at all.
   const groupByData = useWidgetGroupByData(
     widgetId,
     resourceType,
     filters,
-    shape === "pie" || shape === "bar" ? groupBy : undefined,
+    shape === "pie" || shape === "bar" ? (groupBy?.bucket ? undefined : groupBy) : undefined,
     selectedTeamCreGroupId,
     selectedTeamSreGroupId,
     currentUserId,
     isVisible,
   );
-  const pieData = groupBy ? groupByData : sliceData;
+  const feedbackTrendData = useCaseFeedbackTrendData(
+    widgetId,
+    filters,
+    shape === "bar" && groupBy?.bucket ? groupBy : undefined,
+    isVisible,
+  );
+  const pieData = groupBy?.bucket ? feedbackTrendData : groupBy ? groupByData : sliceData;
   // True while this widget carries a `__current_user__` filter and the
   // signed-in user's profile hasn't loaded yet. `useWidgetData`/
   // `useWidgetPieData` hold their requests in that window (see

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DateRangeFilter.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DateRangeFilter.test.tsx
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import DateRangeFilter from "@features/csm-dashboard/components/DateRangeFilter";
+
+// MUI's sectioned DatePicker renders each date as separate Month/Day/Year
+// spinbutton spans PLUS a mirrored `aria-hidden` plain `<input>` carrying the
+// same accessible name ("From"/"To") for form-submission purposes — two
+// elements sharing one label, which is why `getByLabelText` (a single-match
+// query) can't be used to assert the resolved value here. Reading the
+// hidden input directly (in DOM order: "From" first, "To" second, matching
+// this component's own render order) is the reliable way to assert the
+// resolved MM/DD/YYYY text without coupling the test to MUI's internal
+// section markup.
+function hiddenDateInputs(container: HTMLElement): HTMLInputElement[] {
+  return Array.from(container.querySelectorAll('input[aria-hidden="true"]'));
+}
+
+describe("DateRangeFilter", () => {
+  it("renders From/To fields, empty, when value carries neither bound", () => {
+    const { container } = render(<DateRangeFilter value={{}} onChange={vi.fn()} />);
+    const [from, to] = hiddenDateInputs(container);
+    expect(from).toHaveValue("");
+    expect(to).toHaveValue("");
+  });
+
+  it("displays the given from/to values formatted as MM/DD/YYYY", () => {
+    const { container } = render(
+      <DateRangeFilter value={{ from: "2026-07-01", to: "2026-08-15" }} onChange={vi.fn()} />,
+    );
+    const [from, to] = hiddenDateInputs(container);
+    expect(from).toHaveValue("07/01/2026");
+    expect(to).toHaveValue("08/15/2026");
+  });
+
+  it("gives the From and To fields distinct accessible names", () => {
+    render(<DateRangeFilter value={{}} onChange={vi.fn()} />);
+    expect(screen.getAllByLabelText("From")).toHaveLength(2);
+    expect(screen.getAllByLabelText("To")).toHaveLength(2);
+  });
+
+  it("renders the default label when none is given", () => {
+    render(<DateRangeFilter value={{}} onChange={vi.fn()} />);
+    expect(screen.getByText("Date range")).toBeInTheDocument();
+  });
+
+  it("renders a caller-supplied label instead of the default", () => {
+    render(<DateRangeFilter value={{}} onChange={vi.fn()} label="Feedback submitted" />);
+    expect(screen.getByText("Feedback submitted")).toBeInTheDocument();
+    expect(screen.queryByText("Date range")).not.toBeInTheDocument();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DateRangeFilter.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DateRangeFilter.tsx
@@ -1,0 +1,132 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { AdapterDateFns, Box, DatePickers, Typography } from "@wso2/oxygen-ui";
+import type { JSX } from "react";
+
+const { DatePicker, LocalizationProvider } = DatePickers;
+
+/** "YYYY-MM-DD" to a local-midnight Date (avoids the UTC-parse day-shift
+ * `new Date(dateString)` can cause depending on the viewer's timezone) —
+ * same helper `ChangeRequestsFilterBar` keeps locally for its own date-only
+ * fields; duplicated here (rather than imported from that feature) since
+ * this component lives in `csm-dashboard`, a lower-level feature than
+ * `csm-operations` shouldn't depend on. */
+function parseDateOnly(value: string | undefined): Date | null {
+  if (!value) return null;
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) return null;
+  const date = new Date(Number(match[1]), Number(match[2]) - 1, Number(match[3]));
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+/** Local-midnight Date back to "YYYY-MM-DD". */
+function formatDateOnly(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+export interface DateRangeFilterValue {
+  /** "YYYY-MM-DD", inclusive. `undefined` means no lower bound. */
+  from?: string;
+  /** "YYYY-MM-DD", inclusive. `undefined` means no upper bound. */
+  to?: string;
+}
+
+export interface DateRangeFilterProps {
+  value: DateRangeFilterValue;
+  onChange: (next: DateRangeFilterValue) => void;
+  /** Shown above the two date fields. Defaults to a generic label — callers
+   * with a more specific scope (e.g. "Feedback submitted") should override
+   * it rather than leaving the generic one, which says nothing about WHAT
+   * is being date-filtered. */
+  label?: string;
+}
+
+/**
+ * Reusable "from"/"to" date-range control, controlled by the caller (no
+ * internal state) — the same pair-of-`DatePicker`s idiom every existing
+ * filter bar in this app already hand-rolls per-feature (see
+ * `ChangeRequestsFilterBar`'s own `closedStartDate`/`closedEndDate` fields),
+ * extracted here as a real shared component because this is the first place
+ * TWO different widget shapes (a list-shape grid and a bar-shape trend
+ * chart — see `AgentsLandingPagePilot`) need the exact same date-range value
+ * to drive two independent data fetches at once, rather than one filter bar
+ * owning one table's own query.
+ *
+ * Each field clamps the OTHER field's own bound (`from`'s `maxDate` is
+ * `to`, `to`'s `minDate` is `from`), same UX as every other date-range
+ * picker pair in this app — this can't express an inverted range through
+ * the UI at all, rather than accepting one and leaving a broader-than-
+ * intended filter to be caught (or silently misread) downstream.
+ */
+export default function DateRangeFilter({
+  value,
+  onChange,
+  label = "Date range",
+}: DateRangeFilterProps): JSX.Element {
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+      <Typography variant="caption" color="text.secondary">
+        {label}
+      </Typography>
+      <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
+        <LocalizationProvider dateAdapter={AdapterDateFns}>
+          <DatePicker
+            label="From"
+            value={parseDateOnly(value.from)}
+            maxDate={parseDateOnly(value.to) ?? undefined}
+            onChange={(date) =>
+              onChange({
+                ...value,
+                from:
+                  date instanceof Date && !Number.isNaN(date.getTime())
+                    ? formatDateOnly(date)
+                    : undefined,
+              })
+            }
+            slotProps={{
+              textField: { size: "small" },
+              field: { clearable: true },
+            }}
+          />
+        </LocalizationProvider>
+        <LocalizationProvider dateAdapter={AdapterDateFns}>
+          <DatePicker
+            label="To"
+            value={parseDateOnly(value.to)}
+            minDate={parseDateOnly(value.from) ?? undefined}
+            onChange={(date) =>
+              onChange({
+                ...value,
+                to:
+                  date instanceof Date && !Number.isNaN(date.getTime())
+                    ? formatDateOnly(date)
+                    : undefined,
+              })
+            }
+            slotProps={{
+              textField: { size: "small" },
+              field: { clearable: true },
+            }}
+          />
+        </LocalizationProvider>
+      </Box>
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetListConfig.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetListConfig.tsx
@@ -742,6 +742,65 @@ function CallRequestWidgetList({ items, isLoading }: WidgetListRendererProps): J
   );
 }
 
+/**
+ * Hardcoded renderer for `case_feedback` — the fallback for a
+ * `case_feedback` widget with no `columns` configured (see
+ * `DashboardWidgetTile`'s `hasColumns` branch). The real `case-feedback.json`
+ * dashboard's own list widget sets `columns` (rating/comment/case/submitted
+ * — matching ServiceNow's own "Case Feedback" scorecard page), so this path
+ * is a fallback rather than the primary renderer, same relationship
+ * `columns` has to every other hardcoded renderer here — but it still has to
+ * exist and render something reasonable, since `WIDGET_LIST_RENDERERS` is
+ * exhaustive over every `BeWidgetResourceType` (see that Record's own doc
+ * comment) and `DashboardWidgetTile` falls back to it whenever `columns` is
+ * absent/empty.
+ */
+function CaseFeedbackWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.Element {
+  const feedback = items as unknown as {
+    instanceId?: string;
+    caseId?: string;
+    rating?: number;
+    ratingLabel?: string;
+    comment?: string | null;
+    submittedAt?: string;
+  }[];
+  const dashboardReturnState = useDashboardReturnState();
+  const navigate = useNavTransition();
+  return (
+    <DashboardMiniTable
+      isLoading={isLoading}
+      emptyMessage="No feedback records match this widget's filters."
+      columns={[
+        { label: "Rating", width: "minmax(90px, 0.6fr)" },
+        { label: "Comment", width: "minmax(200px, 3fr)" },
+        { label: "Case", width: "minmax(90px, 0.8fr)" },
+        { label: "Submitted", width: "minmax(90px, 1fr)" },
+      ]}
+      rows={feedback.map((f, i) => {
+        const href = f.caseId ? `/cases/${f.caseId}` : undefined;
+        return {
+          key: f.instanceId ?? `feedback-${i}`,
+          onClick: href ? () => navigate(href, { state: dashboardReturnState }) : undefined,
+          cells: [
+            <Typography key="rating" variant="body2" noWrap>
+              {f.ratingLabel || "—"}
+            </Typography>,
+            <Typography key="comment" variant="body2" noWrap title={f.comment ?? undefined}>
+              {f.comment || "—"}
+            </Typography>,
+            <Typography key="case" variant="body2" noWrap>
+              {f.caseId ?? "—"}
+            </Typography>,
+            <Typography key="submitted" variant="caption" color="text.secondary" noWrap>
+              {formatDate(f.submittedAt)}
+            </Typography>,
+          ],
+        };
+      })}
+    />
+  );
+}
+
 /** Per-resourceType renderer for a `shape: "list"` dashboard widget. Every
  * resource type is covered — `WIDGET_RESOURCE_CONFIG` (in
  * `widgetResourceConfig.ts`) is keyed the same way, so a missing entry here
@@ -770,4 +829,5 @@ export const WIDGET_LIST_RENDERERS: Record<
   product_vulnerability: ProductVulnerabilityWidgetList,
   task: TaskWidgetList,
   call_request: CallRequestWidgetList,
+  case_feedback: CaseFeedbackWidgetList,
 };

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.ts
@@ -121,7 +121,7 @@ export interface WidgetResourceConfig {
   /** Only meaningful for shape "list". Overrides the default request body
    * `useWidgetData` POSTs to `searchEndpoint` (`{ filters, pagination: {
    * offset, limit }, sortBy? }`) — every resourceType's own search contract
-   * uses that shape EXCEPT `case_feedback`'s `POST /cases/feedback/search`,
+   * uses that shape EXCEPT `case_feedback`'s `POST /cases/feedbacks/search`,
    * which takes flat `page`/`pageSize` instead of `pagination.offset/limit`
    * (see that entry's own comment for why). Omitted (every other
    * resourceType) keeps `useWidgetData`'s existing request shape untouched. */
@@ -878,7 +878,7 @@ export const WIDGET_RESOURCE_CONFIG: Record<
     },
   },
   // Satisfaction-rating survey responses across cases (`POST
-  // /cases/feedback/search` / `POST /cases/feedback/aggregate`) — its own
+  // /cases/feedbacks/search` / `POST /cases/feedbacks/aggregate`) — its own
   // resourceType, not a case `type` variant like `service_request` etc.
   // above, because a feedback record isn't a case row at all (no
   // `number`/`subject`/`state`; see `BeCaseFeedback`). Its own two-endpoint
@@ -892,8 +892,8 @@ export const WIDGET_RESOURCE_CONFIG: Record<
   // `buildHref`/`previewSlug` have nowhere real to land — same situation
   // `task` is in above, same fallback.
   case_feedback: {
-    searchEndpoint: "/cases/feedback/search",
-    groupByEndpoint: "/cases/feedback/aggregate",
+    searchEndpoint: "/cases/feedbacks/search",
+    groupByEndpoint: "/cases/feedbacks/aggregate",
     itemsKey: "results",
     buildSearchRequestBody: ({ filters, offset, limit }) => {
       // `case_feedback` has no sortable columns exposed by its own search

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.ts
@@ -28,6 +28,7 @@ import {
   Megaphone,
   Shield,
   ShieldAlert,
+  Star,
   Users,
   ListChecks,
   type LucideIcon,
@@ -117,6 +118,28 @@ export interface WidgetResourceConfig {
    * case instead, handled the same way the hardcoded `CallRequestWidgetList`
    * does) or when the item carries no usable id. */
   detailHref?: (item: WidgetItem) => string | undefined;
+  /** Only meaningful for shape "list". Overrides the default request body
+   * `useWidgetData` POSTs to `searchEndpoint` (`{ filters, pagination: {
+   * offset, limit }, sortBy? }`) — every resourceType's own search contract
+   * uses that shape EXCEPT `case_feedback`'s `POST /cases/feedback/search`,
+   * which takes flat `page`/`pageSize` instead of `pagination.offset/limit`
+   * (see that entry's own comment for why). Omitted (every other
+   * resourceType) keeps `useWidgetData`'s existing request shape untouched. */
+  buildSearchRequestBody?: (args: {
+    filters: Record<string, unknown>;
+    offset: number;
+    limit: number;
+    sortBy?: Record<string, unknown>;
+  }) => Record<string, unknown>;
+  /** Only meaningful for shape "list"/"count". Overrides how `useWidgetData`
+   * reads `total`/the item page off `searchEndpoint`'s own response (default:
+   * `res.total`, `res[itemsKey]`) — only `case_feedback`'s response diverges
+   * (`totalRecords`/`results`, not `total`/`itemsKey`). Omitted keeps the
+   * default reading untouched. */
+  parseSearchResponse?: (res: Record<string, unknown>) => {
+    total: number;
+    items: Record<string, unknown>[];
+  };
 }
 
 function asString(v: unknown): string | undefined {
@@ -851,6 +874,73 @@ export const WIDGET_RESOURCE_CONFIG: Record<
     // standalone detail page of its own, so rows link to the owning case.
     detailHref: (item) => {
       const caseId = nestedID(item.case);
+      return caseId ? `/cases/${caseId}` : undefined;
+    },
+  },
+  // Satisfaction-rating survey responses across cases (`POST
+  // /cases/feedback/search` / `POST /cases/feedback/aggregate`) — its own
+  // resourceType, not a case `type` variant like `service_request` etc.
+  // above, because a feedback record isn't a case row at all (no
+  // `number`/`subject`/`state`; see `BeCaseFeedback`). Its own two-endpoint
+  // request/response contract diverges from every other resourceType's
+  // shared `{pagination:{offset,limit}} -> {total, itemsKey}` shape
+  // (`page`/`pageSize` -> `totalRecords`/`results`, no `total` field at
+  // all), which is exactly what `buildSearchRequestBody`/
+  // `parseSearchResponse` exist to adapt — see those fields' own doc
+  // comments on `WidgetResourceConfig`. There is no standalone list page for
+  // feedback records (only the dashboard's own list-shape widget), so
+  // `buildHref`/`previewSlug` have nowhere real to land — same situation
+  // `task` is in above, same fallback.
+  case_feedback: {
+    searchEndpoint: "/cases/feedback/search",
+    groupByEndpoint: "/cases/feedback/aggregate",
+    itemsKey: "results",
+    buildSearchRequestBody: ({ filters, offset, limit }) => {
+      // `case_feedback` has no sortable columns exposed by its own search
+      // contract (no `sortBy` field on `CaseFeedbackSearchPayload`) — a
+      // `sortBy` passed down from a `shape: "list"` widget config is
+      // silently dropped rather than sent, the same "config is responsible
+      // for a field valid for that resourceType's own contract" convention
+      // `useWidgetData`'s own `sortBy` doc comment already documents for
+      // every other resourceType (an invalid field there gets rejected by
+      // the search endpoint itself; here there's no such endpoint-side
+      // rejection to fall back on, since the field would just be ignored by
+      // this request body entirely).
+      //
+      // `page` is 1-based (see openapi.yaml's CaseFeedbackSearchPayload) —
+      // `offset`/`limit` (0-based, from `useWidgetData`) convert via
+      // `Math.floor(offset / limit) + 1`, matching only the offsets
+      // `useWidgetData` itself ever actually requests (page-aligned:
+      // `offset` is always a multiple of `limit`, either 0 for a tile or
+      // `listLimit * pageIndex` for the preview page's own pager).
+      const page = limit > 0 ? Math.floor(offset / limit) + 1 : 1;
+      return { filters, page, pageSize: limit };
+    },
+    parseSearchResponse: (res) => {
+      const total = typeof res.totalRecords === "number" ? res.totalRecords : 0;
+      const rawItems = res.results;
+      const items = Array.isArray(rawItems) ? (rawItems as Record<string, unknown>[]) : [];
+      return { total, items };
+    },
+    primaryLabel: (item) => {
+      const ratingLabel = asString(item.ratingLabel);
+      const submittedAt = asString(item.submittedAt);
+      return [ratingLabel, submittedAt].filter(Boolean).join(" — ") || "—";
+    },
+    secondaryLabel: (item) => asString(item.comment) ?? undefined,
+    // No standalone case-feedback list page exists (only this dashboard's
+    // own widgets) — same situation as `task`/`call_request`'s own tile-level
+    // click-through above.
+    buildHref: () => "/dashboard",
+    icon: Star,
+    iconColor: "warning",
+    previewSlug: "case-feedback",
+    // The one link this resourceType's rows DO have: back to the owning
+    // case. `caseId` is a platform UUID already (see `BeCaseFeedback`), not
+    // a nested reference to resolve via `nestedID` the way `call_request`'s
+    // `item.case` is.
+    detailHref: (item) => {
+      const caseId = asString(item.caseId);
       return caseId ? `/cases/${caseId}` : undefined;
     },
   },

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/utils/dateRangeFilterPlaceholder.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/utils/dateRangeFilterPlaceholder.test.ts
@@ -1,0 +1,91 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { describe, expect, it } from "vitest";
+import {
+  DATE_RANGE_FROM_PLACEHOLDER,
+  DATE_RANGE_TO_PLACEHOLDER,
+  hasDateRangeFilterPlaceholder,
+  resolveDateRangeFilterPlaceholder,
+} from "@features/csm-dashboard/utils/dateRangeFilterPlaceholder";
+
+describe("resolveDateRangeFilterPlaceholder", () => {
+  it("substitutes both placeholders with the selected range", () => {
+    const result = resolveDateRangeFilterPlaceholder(
+      { dateFrom: DATE_RANGE_FROM_PLACEHOLDER, dateTo: DATE_RANGE_TO_PLACEHOLDER, accountIds: ["a"] },
+      "2026-07-01",
+      "2026-08-01",
+    );
+    expect(result).toEqual({ dateFrom: "2026-07-01", dateTo: "2026-08-01", accountIds: ["a"] });
+  });
+
+  it("drops dateFrom entirely when no range is selected, rather than sending the literal placeholder", () => {
+    const result = resolveDateRangeFilterPlaceholder(
+      { dateFrom: DATE_RANGE_FROM_PLACEHOLDER },
+      undefined,
+      undefined,
+    );
+    expect(result).toEqual({});
+    expect("dateFrom" in result).toBe(false);
+  });
+
+  it("drops dateTo entirely when no range is selected", () => {
+    const result = resolveDateRangeFilterPlaceholder(
+      { dateTo: DATE_RANGE_TO_PLACEHOLDER },
+      undefined,
+      undefined,
+    );
+    expect(result).toEqual({});
+  });
+
+  it("resolves dateFrom and drops dateTo independently", () => {
+    const result = resolveDateRangeFilterPlaceholder(
+      { dateFrom: DATE_RANGE_FROM_PLACEHOLDER, dateTo: DATE_RANGE_TO_PLACEHOLDER },
+      "2026-07-01",
+      undefined,
+    );
+    expect(result).toEqual({ dateFrom: "2026-07-01" });
+  });
+
+  it("leaves a literal dateFrom/dateTo untouched (not the placeholder)", () => {
+    const result = resolveDateRangeFilterPlaceholder(
+      { dateFrom: "2025-01-01", dateTo: "2025-12-31" },
+      "2026-07-01",
+      "2026-08-01",
+    );
+    expect(result).toEqual({ dateFrom: "2025-01-01", dateTo: "2025-12-31" });
+  });
+
+  it("passes through filters with neither key unchanged", () => {
+    const filters = { accountIds: ["a"] };
+    expect(resolveDateRangeFilterPlaceholder(filters, "2026-07-01", "2026-08-01")).toEqual(filters);
+  });
+});
+
+describe("hasDateRangeFilterPlaceholder", () => {
+  it("detects the from placeholder", () => {
+    expect(hasDateRangeFilterPlaceholder({ dateFrom: DATE_RANGE_FROM_PLACEHOLDER })).toBe(true);
+  });
+
+  it("detects the to placeholder", () => {
+    expect(hasDateRangeFilterPlaceholder({ dateTo: DATE_RANGE_TO_PLACEHOLDER })).toBe(true);
+  });
+
+  it("returns false for filters carrying neither placeholder", () => {
+    expect(hasDateRangeFilterPlaceholder({ dateFrom: "2025-01-01", accountIds: ["a"] })).toBe(false);
+    expect(hasDateRangeFilterPlaceholder({})).toBe(false);
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/utils/dateRangeFilterPlaceholder.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/utils/dateRangeFilterPlaceholder.ts
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+ * Placeholder values a widget's own flat `dateFrom`/`dateTo` filter (the
+ * `case_feedback` resourceType's own shape — `CaseFeedbackSearchFilters`/
+ * `CaseFeedbackAggregateFilters`, never the case-search DSL) may carry to
+ * mean "the dashboard's own currently-selected date range" — the
+ * `case_feedback`-dashboard-scoped counterpart of `__current_team__`
+ * (`teamFilterPlaceholder.ts`), resolved entirely CLIENT-SIDE the same way.
+ *
+ * There is no per-dashboard interactive filter control anywhere else in this
+ * widget framework today — every other widget's `query`/`groupBy` is fully
+ * static, resolved only through the team/current-user/relative-date
+ * placeholder pipelines. This is the first widget-level control a viewer can
+ * actually change at runtime (see `DateRangeFilter`), which is why it needs
+ * its own placeholder pair rather than reusing an existing one: it stands for
+ * page-local UI state, not identity (`__current_user__`) or dashboard
+ * scoping (`__current_team__`).
+ */
+export const DATE_RANGE_FROM_PLACEHOLDER = "__dateRangeFrom__";
+export const DATE_RANGE_TO_PLACEHOLDER = "__dateRangeTo__";
+
+/**
+ * Substitutes {@link DATE_RANGE_FROM_PLACEHOLDER}/{@link DATE_RANGE_TO_PLACEHOLDER}
+ * wherever they appear as the literal value of a widget's own flat
+ * `dateFrom`/`dateTo` filter keys with the dashboard's own currently-selected
+ * range (see `DateRangeFilter`) — mirrors `resolveTeamPlaceholder`'s flat-field
+ * resolution (`assignmentTeamIds`), not its case-DSL one: `case_feedback`'s
+ * filters are always the flat `{caseId?, accountIds?, dateFrom?, dateTo?}`
+ * shape, never `{filters: BeCaseFieldFilter[]}`.
+ *
+ * `dateRangeFrom`/`dateRangeTo` of `undefined` (no range selected — "all
+ * time", the default) DROPS the corresponding key from the returned filters
+ * object entirely, rather than sending the literal placeholder string (which
+ * the entity service would either reject as an invalid date or, worse,
+ * silently fail to parse as a filter bound) — same fail-safe "widen back to
+ * unfiltered" policy `resolveTeamPlaceholder` documents for its own
+ * placeholder, and for the same reason: a chart/list that's too broad is
+ * visibly wrong and gets noticed; a request that 400s or silently matches
+ * nothing does not read as "no filter applied" to the viewer.
+ *
+ * A literal `dateFrom`/`dateTo` value already present (i.e. not this
+ * placeholder) is left alone — this only ever substitutes the placeholder
+ * itself, never overrides a widget's own hardcoded date bound.
+ */
+export function resolveDateRangeFilterPlaceholder(
+  filters: Record<string, unknown>,
+  dateRangeFrom: string | undefined,
+  dateRangeTo: string | undefined,
+): Record<string, unknown> {
+  let result = filters;
+  if (result.dateFrom === DATE_RANGE_FROM_PLACEHOLDER) {
+    if (dateRangeFrom === undefined) {
+      const { dateFrom: _dropped, ...rest } = result;
+      result = rest;
+    } else {
+      result = { ...result, dateFrom: dateRangeFrom };
+    }
+  }
+  if (result.dateTo === DATE_RANGE_TO_PLACEHOLDER) {
+    if (dateRangeTo === undefined) {
+      const { dateTo: _dropped, ...rest } = result;
+      result = rest;
+    } else {
+      result = { ...result, dateTo: dateRangeTo };
+    }
+  }
+  return result;
+}
+
+/**
+ * Whether `filters` carries either placeholder anywhere
+ * {@link resolveDateRangeFilterPlaceholder} would actually resolve it — used
+ * by `AgentsLandingPagePilot` to decide, purely from the loaded dashboard's
+ * own widget list, whether to render the `DateRangeFilter` control at all
+ * (no dashboard-level config flag exists or is needed: any dashboard whose
+ * widgets reference this placeholder opts in automatically, the same
+ * "derive from what's actually there" approach already used for chart vs.
+ * list grouping).
+ */
+export function hasDateRangeFilterPlaceholder(filters: Record<string, unknown>): boolean {
+  return filters.dateFrom === DATE_RANGE_FROM_PLACEHOLDER || filters.dateTo === DATE_RANGE_TO_PLACEHOLDER;
+}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/utils/invalidateWidgetQueries.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/utils/invalidateWidgetQueries.test.ts
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { describe, expect, it } from "vitest";
+import { QueryClient } from "@tanstack/react-query";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import { invalidateWidgetQueries } from "./invalidateWidgetQueries";
+
+const KEY = ApiQueryKeys.CSM_DASHBOARD_WIDGET_DATA;
+
+function seedQuery(queryClient: QueryClient, queryKey: unknown[]) {
+  queryClient.setQueryData(queryKey, { seeded: true });
+}
+
+describe("invalidateWidgetQueries", () => {
+  it("invalidates every widget-data query-key shape for a matching widget id", async () => {
+    const queryClient = new QueryClient();
+    const targetId = "widget-1";
+
+    seedQuery(queryClient, [KEY, targetId]); // count/list shape
+    seedQuery(queryClient, [KEY, "pie-slice", targetId, "slice-a"]);
+    seedQuery(queryClient, [KEY, "group-by", targetId, "field"]);
+    seedQuery(queryClient, [KEY, "feedback-trend", targetId, "month"]);
+    seedQuery(queryClient, [KEY, "unrelated-widget"]); // not targeted
+
+    await invalidateWidgetQueries(queryClient, new Set([targetId]));
+
+    const states = queryClient.getQueryCache().getAll();
+    const isStale = (queryKey: unknown[]) =>
+      states.find((q) => JSON.stringify(q.queryKey) === JSON.stringify(queryKey))?.isStale();
+
+    expect(isStale([KEY, targetId])).toBe(true);
+    expect(isStale([KEY, "pie-slice", targetId, "slice-a"])).toBe(true);
+    expect(isStale([KEY, "group-by", targetId, "field"])).toBe(true);
+    expect(isStale([KEY, "feedback-trend", targetId, "month"])).toBe(true);
+    expect(isStale([KEY, "unrelated-widget"])).toBe(false);
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/utils/invalidateWidgetQueries.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/utils/invalidateWidgetQueries.ts
@@ -23,7 +23,9 @@ import { ApiQueryKeys } from "@constants/apiConstants";
  * `[KEY, widgetId, ...]` for count/list (see `useWidgetData`),
  * `[KEY, "pie-slice", widgetId, ...]` for pie/bar via `slices` (see
  * `useWidgetPieData`), `[KEY, "group-by", widgetId, ...]` for pie/bar via
- * `groupBy` (see `useWidgetGroupByData`).
+ * `groupBy` (see `useWidgetGroupByData`), `[KEY, "feedback-trend", widgetId,
+ * ...]` for the case-feedback bar/date-bucket trend (see
+ * `useCaseFeedbackTrendData`).
  *
  * Shared between `DashboardWidgetGrid` (a whole section's worth of widget
  * ids at once) and `DashboardWidgetTile` (its own single widget id) so this
@@ -37,7 +39,10 @@ export function invalidateWidgetQueries(
     predicate: (query) => {
       const key = query.queryKey;
       if (key[0] !== ApiQueryKeys.CSM_DASHBOARD_WIDGET_DATA) return false;
-      const widgetId = key[1] === "pie-slice" || key[1] === "group-by" ? key[2] : key[1];
+      const widgetId =
+        key[1] === "pie-slice" || key[1] === "group-by" || key[1] === "feedback-trend"
+          ? key[2]
+          : key[1];
       return typeof widgetId === "string" && widgetIds.has(widgetId);
     },
   });

--- a/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeSheets.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeSheets.test.tsx
@@ -19,9 +19,12 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import type { ReactNode } from "react";
 import {
+  clearPersistedRecentApprovers,
+  invalidateTimecards,
   mapTimeCard,
   searchTimeCards,
   useBulkApproveCards,
+  useRecentApprovers,
 } from "@features/csm-timecards/api/useTimeSheets";
 import { BackendApiError, type BackendApi } from "@api/backend/client";
 import type {
@@ -40,6 +43,7 @@ import type {
 // those tests — only the useBulkApproveCards tests further down actually
 // exercise this mocked patch.
 const patchMock = vi.fn();
+const postMock = vi.fn();
 vi.mock("@api/backend/client", () => ({
   BackendApiError: class BackendApiError extends Error {
     status: number;
@@ -48,9 +52,18 @@ vi.mock("@api/backend/client", () => ({
       this.status = status;
     }
   },
-  useBackendApi: () => ({ patch: patchMock }),
+  useBackendApi: () => ({ patch: patchMock, post: postMock }),
 }));
 vi.mock("@config/apiConfig", () => ({ apiConfig: { backendUrl: "https://example.test" } }));
+
+// useRecentApprovers resolves the signed-in engineer via useCurrentEngineer,
+// which pulls GET /users/me and the ID-token claims — mocked so tests can
+// control `me.id` directly without a real auth/query round trip.
+let usersMeId: string | undefined = "eng-1";
+vi.mock("@features/settings/api/useGetUsersMe", () => ({
+  useGetUsersMe: () => ({ data: usersMeId ? { id: usersMeId, firstName: "Jane" } : undefined }),
+}));
+vi.mock("@hooks/useIdTokenClaims", () => ({ useIdTokenClaims: () => undefined }));
 
 function beCard(id: string, state: BeTimeCardState): BeTimeCardView {
   return {
@@ -273,5 +286,149 @@ describe("useBulkApproveCards", () => {
     expect(result.current.data?.failed).toEqual([
       { cardId: "tc-1", message: "Could not approve this time card." },
     ]);
+  });
+});
+
+describe("useRecentApprovers persisted cache", () => {
+  const storageKey = "csm-portal:time-cards:recent-approvers:v1:eng-1";
+
+  beforeEach(() => {
+    postMock.mockReset();
+    window.localStorage.clear();
+    usersMeId = "eng-1";
+  });
+
+  function cardWithApprovers(id: string, workDate: string, approvers: { id: string; name: string }[]): BeTimeCardView {
+    return { ...beCard(id, "submitted"), workDate, approvers };
+  }
+
+  it("reads a fresh persisted entry on mount and never calls the search endpoint", async () => {
+    window.localStorage.setItem(
+      storageKey,
+      JSON.stringify({
+        approvers: [{ id: "appr-1", name: "Ann Approver" }],
+        cachedAt: Date.now(),
+      }),
+    );
+
+    const { result } = renderHook(() => useRecentApprovers(true), { wrapper });
+
+    await waitFor(() => expect(result.current.data).toEqual([{ id: "appr-1", name: "Ann Approver" }]));
+    expect(postMock).not.toHaveBeenCalled();
+  });
+
+  it("fetches and writes the cache when there is no persisted entry", async () => {
+    postMock.mockResolvedValue(
+      bePage(
+        [cardWithApprovers("a", "2026-08-20", [{ id: "appr-2", name: "Bob Approver" }])],
+        1,
+        0,
+        20,
+      ),
+    );
+
+    const { result } = renderHook(() => useRecentApprovers(true), { wrapper });
+
+    await waitFor(() => expect(result.current.data).toEqual([{ id: "appr-2", name: "Bob Approver" }]));
+    expect(postMock).toHaveBeenCalledTimes(1);
+
+    const stored = JSON.parse(window.localStorage.getItem(storageKey) ?? "null");
+    expect(stored.approvers).toEqual([{ id: "appr-2", name: "Bob Approver" }]);
+    expect(typeof stored.cachedAt).toBe("number");
+  });
+
+  it("ignores a stale (expired-TTL) persisted entry and refetches", async () => {
+    window.localStorage.setItem(
+      storageKey,
+      JSON.stringify({
+        approvers: [{ id: "old-approver", name: "Old Approver" }],
+        cachedAt: Date.now() - 25 * 60 * 60 * 1000, // 25h, past the 24h TTL
+      }),
+    );
+    postMock.mockResolvedValue(
+      bePage(
+        [cardWithApprovers("a", "2026-08-20", [{ id: "appr-3", name: "Carol Approver" }])],
+        1,
+        0,
+        20,
+      ),
+    );
+
+    const { result } = renderHook(() => useRecentApprovers(true), { wrapper });
+
+    await waitFor(() => expect(result.current.data).toEqual([{ id: "appr-3", name: "Carol Approver" }]));
+    expect(postMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores a malformed/garbage persisted entry and refetches instead of crashing", async () => {
+    window.localStorage.setItem(storageKey, "{not json");
+    postMock.mockResolvedValue(
+      bePage(
+        [cardWithApprovers("a", "2026-08-20", [{ id: "appr-4", name: "Dana Approver" }])],
+        1,
+        0,
+        20,
+      ),
+    );
+
+    const { result } = renderHook(() => useRecentApprovers(true), { wrapper });
+
+    await waitFor(() => expect(result.current.data).toEqual([{ id: "appr-4", name: "Dana Approver" }]));
+    expect(postMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to always-fetch when localStorage throws (e.g. private browsing/storage disabled)", async () => {
+    const getSpy = vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new DOMException("blocked", "SecurityError");
+    });
+    const setSpy = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new DOMException("blocked", "SecurityError");
+    });
+    postMock.mockResolvedValue(
+      bePage(
+        [cardWithApprovers("a", "2026-08-20", [{ id: "appr-5", name: "Erin Approver" }])],
+        1,
+        0,
+        20,
+      ),
+    );
+
+    const { result } = renderHook(() => useRecentApprovers(true), { wrapper });
+
+    await waitFor(() => expect(result.current.data).toEqual([{ id: "appr-5", name: "Erin Approver" }]));
+    expect(postMock).toHaveBeenCalledTimes(1);
+
+    getSpy.mockRestore();
+    setSpy.mockRestore();
+  });
+
+  it("drops the persisted cache when invalidateTimecards runs (e.g. after logging a new card)", () => {
+    window.localStorage.setItem(
+      storageKey,
+      JSON.stringify({ approvers: [{ id: "appr-1", name: "Ann Approver" }], cachedAt: Date.now() }),
+    );
+    const queryClient = new QueryClient();
+
+    invalidateTimecards(queryClient);
+
+    expect(window.localStorage.getItem(storageKey)).toBeNull();
+  });
+
+  it("clearPersistedRecentApprovers removes every engineer's entry, not just one", () => {
+    window.localStorage.setItem(
+      "csm-portal:time-cards:recent-approvers:v1:eng-1",
+      JSON.stringify({ approvers: [], cachedAt: Date.now() }),
+    );
+    window.localStorage.setItem(
+      "csm-portal:time-cards:recent-approvers:v1:eng-2",
+      JSON.stringify({ approvers: [], cachedAt: Date.now() }),
+    );
+    window.localStorage.setItem("unrelated-key", "keep-me");
+
+    clearPersistedRecentApprovers();
+
+    expect(window.localStorage.getItem("csm-portal:time-cards:recent-approvers:v1:eng-1")).toBeNull();
+    expect(window.localStorage.getItem("csm-portal:time-cards:recent-approvers:v1:eng-2")).toBeNull();
+    expect(window.localStorage.getItem("unrelated-key")).toBe("keep-me");
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeSheets.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeSheets.test.tsx
@@ -360,6 +360,29 @@ describe("useRecentApprovers persisted cache", () => {
     expect(postMock).toHaveBeenCalledTimes(1);
   });
 
+  it("ignores a persisted entry with a future cachedAt and refetches", async () => {
+    window.localStorage.setItem(
+      storageKey,
+      JSON.stringify({
+        approvers: [{ id: "old-approver", name: "Old Approver" }],
+        cachedAt: Date.now() + 60 * 60 * 1000, // 1h in the future
+      }),
+    );
+    postMock.mockResolvedValue(
+      bePage(
+        [cardWithApprovers("a", "2026-08-20", [{ id: "appr-5", name: "Eve Approver" }])],
+        1,
+        0,
+        20,
+      ),
+    );
+
+    const { result } = renderHook(() => useRecentApprovers(true), { wrapper });
+
+    await waitFor(() => expect(result.current.data).toEqual([{ id: "appr-5", name: "Eve Approver" }]));
+    expect(postMock).toHaveBeenCalledTimes(1);
+  });
+
   it("ignores a malformed/garbage persisted entry and refetches instead of crashing", async () => {
     window.localStorage.setItem(storageKey, "{not json");
     postMock.mockResolvedValue(

--- a/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeSheets.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeSheets.ts
@@ -79,7 +79,16 @@ export function useCurrentEngineer(): { id: string | undefined; name: string } {
   return { id: me?.id, name: displayName };
 }
 
-/** Invalidate every time-card query so all views refresh after a write. */
+/** Invalidate every time-card query so all views refresh after a write. Also
+ * drops the persisted {@link RecentApprover} cache (see
+ * {@link clearPersistedRecentApprovers}) — this is the one existing hub
+ * already called after every card create/decide/bulk-approve mutation, so
+ * reusing it here (rather than wiring a create-only success handler into
+ * `usePostTimeCard`, a different file) keeps this a same-file change. Decide
+ * and bulk-approve don't actually change *who the signed-in engineer picked
+ * as an approver*, so those two calls make this drop the cache one mutation
+ * too many — an accepted, harmless over-invalidation (one extra background
+ * refetch next dialog open) rather than a second invalidation path. */
 export function invalidateTimecards(queryClient: QueryClient): void {
   for (const key of [
     ApiQueryKeys.TIME_CARDS_SEARCH,
@@ -90,6 +99,7 @@ export function invalidateTimecards(queryClient: QueryClient): void {
   ]) {
     void queryClient.invalidateQueries({ queryKey: [key] });
   }
+  clearPersistedRecentApprovers();
 }
 
 /** Wire `issueComplexity` values the entity-service is confirmed to return
@@ -347,6 +357,98 @@ const RECENT_APPROVERS_MAX = 4;
  * complete history. */
 const RECENT_APPROVERS_LOOKBACK = 20;
 
+/** localStorage key prefix for the persisted {@link RecentApprover} cache,
+ * one entry per signed-in engineer id (see {@link recentApproversStorageKey})
+ * so switching accounts on a shared browser profile never surfaces another
+ * engineer's picks. Versioned so a future change to the stored shape can
+ * invalidate old entries outright rather than needing a migration. */
+const RECENT_APPROVERS_STORAGE_PREFIX = "csm-portal:time-cards:recent-approvers:v1:";
+
+function recentApproversStorageKey(engineerId: string): string {
+  return `${RECENT_APPROVERS_STORAGE_PREFIX}${engineerId}`;
+}
+
+/** Backstop TTL for the persisted cache, well beyond a normal work session —
+ * this only matters when the *server-side* answer to "who did I pick before"
+ * has drifted without this browser seeing a create/decide/bulk-approve
+ * mutation to invalidate on (e.g. the same engineer logged a card from a
+ * different device or browser profile). 24h bounds that drift to at most one
+ * stale day without forcing a re-fetch on every single dialog open, which
+ * would defeat the point of caching this at all. */
+const RECENT_APPROVERS_TTL_MS = 24 * 60 * 60 * 1000;
+
+interface PersistedRecentApprovers {
+  approvers: RecentApprover[];
+  cachedAt: number;
+}
+
+function isRecentApproverArray(value: unknown): value is RecentApprover[] {
+  return (
+    Array.isArray(value) &&
+    value.every(
+      (v) =>
+        !!v &&
+        typeof v === "object" &&
+        typeof (v as RecentApprover).id === "string" &&
+        typeof (v as RecentApprover).name === "string",
+    )
+  );
+}
+
+/** Reads the persisted {@link RecentApprover} list for `engineerId`, or
+ * `undefined` if there's no entry, the entry is older than
+ * {@link RECENT_APPROVERS_TTL_MS}, or the stored shape doesn't parse as
+ * expected (e.g. a stale format from an older build, or storage tampered with
+ * outside this app) — any of those is treated identically to a cache miss,
+ * never a crash. Wrapped in try/catch: private browsing or a storage quota
+ * error must fall back to the always-fetch behavior, not break the dialog. */
+function readPersistedRecentApprovers(engineerId: string): RecentApprover[] | undefined {
+  try {
+    const raw = window.localStorage.getItem(recentApproversStorageKey(engineerId));
+    if (!raw) return undefined;
+    const parsed = JSON.parse(raw) as Partial<PersistedRecentApprovers> | null;
+    if (
+      !parsed ||
+      typeof parsed.cachedAt !== "number" ||
+      !isRecentApproverArray(parsed.approvers)
+    ) {
+      return undefined;
+    }
+    if (Date.now() - parsed.cachedAt > RECENT_APPROVERS_TTL_MS) return undefined;
+    return parsed.approvers;
+  } catch {
+    return undefined;
+  }
+}
+
+function writePersistedRecentApprovers(engineerId: string, approvers: RecentApprover[]): void {
+  try {
+    const payload: PersistedRecentApprovers = { approvers, cachedAt: Date.now() };
+    window.localStorage.setItem(recentApproversStorageKey(engineerId), JSON.stringify(payload));
+  } catch {
+    // Storage disabled/full/private browsing — nothing to persist, next
+    // dialog open just falls back to fetching live, same as today.
+  }
+}
+
+/** Drops every persisted {@link RecentApprover} entry (all engineer ids, not
+ * just the signed-in one) — cheap and safe since at most a handful of
+ * accounts ever share one browser profile, and this runs from
+ * {@link invalidateTimecards}, which has no engineer id of its own to scope
+ * a single-key removal to. */
+export function clearPersistedRecentApprovers(): void {
+  try {
+    const keys: string[] = [];
+    for (let i = 0; i < window.localStorage.length; i++) {
+      const key = window.localStorage.key(i);
+      if (key?.startsWith(RECENT_APPROVERS_STORAGE_PREFIX)) keys.push(key);
+    }
+    for (const key of keys) window.localStorage.removeItem(key);
+  } catch {
+    // Nothing persisted to begin with, or storage unavailable — no-op.
+  }
+}
+
 /**
  * The signed-in engineer's own most-recently-submitted-to approvers, most
  * recent first, deduped by id, capped at {@link RECENT_APPROVERS_MAX} —
@@ -366,10 +468,21 @@ const RECENT_APPROVERS_LOOKBACK = 20;
  * `enabled` should be gated to create-mode only (see `LogTimeCardDialog`) —
  * the approver field is read-only once editing, so there's nothing for this
  * list to feed there.
+ *
+ * Persisted to `localStorage` (see {@link readPersistedRecentApprovers} /
+ * {@link writePersistedRecentApprovers}), keyed by the signed-in engineer's
+ * id, so opening "Log time" doesn't re-run this search every single time —
+ * this list only actually changes when the engineer submits a new card with
+ * an approver (see {@link invalidateTimecards}, the sole invalidation path),
+ * so a fresh-enough persisted entry is used as-is with no network call at
+ * all, surviving page reloads and new sessions. A fresh cache is fed straight
+ * back as `initialData`; only a cache miss or a stale entry lets the query
+ * actually run, and every successful fetch re-persists its result.
  */
 export function useRecentApprovers(enabled: boolean): UseQueryResult<RecentApprover[], Error> {
   const api = useBackendApi();
   const me = useCurrentEngineer();
+  const cached = me.id ? readPersistedRecentApprovers(me.id) : undefined;
   return useQuery<RecentApprover[], Error>({
     queryKey: [ApiQueryKeys.TIME_SHEETS_SEARCH, "recent-approvers", me.id],
     queryFn: async (): Promise<RecentApprover[]> => {
@@ -388,7 +501,7 @@ export function useRecentApprovers(enabled: boolean): UseQueryResult<RecentAppro
       );
       const seen = new Set<string>();
       const recents: RecentApprover[] = [];
-      for (const card of newestFirst) {
+      outer: for (const card of newestFirst) {
         for (const approver of card.approvers ?? []) {
           // Defensive only: nothing should let an engineer submit a card
           // approved by themself, mirroring the same self-exclusion already
@@ -396,12 +509,14 @@ export function useRecentApprovers(enabled: boolean): UseQueryResult<RecentAppro
           if (approver.id === me.id || seen.has(approver.id)) continue;
           seen.add(approver.id);
           recents.push({ id: approver.id, name: approver.name });
-          if (recents.length >= RECENT_APPROVERS_MAX) return recents;
+          if (recents.length >= RECENT_APPROVERS_MAX) break outer;
         }
       }
+      writePersistedRecentApprovers(me.id, recents);
       return recents;
     },
-    enabled: enabled && !!me.id,
+    enabled: enabled && !!me.id && !cached,
+    initialData: cached,
     staleTime: 30_000,
   });
 }

--- a/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeSheets.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeSheets.ts
@@ -414,7 +414,14 @@ function readPersistedRecentApprovers(engineerId: string): RecentApprover[] | un
     ) {
       return undefined;
     }
-    if (Date.now() - parsed.cachedAt > RECENT_APPROVERS_TTL_MS) return undefined;
+    const now = Date.now();
+    if (
+      !Number.isFinite(parsed.cachedAt) ||
+      parsed.cachedAt > now ||
+      now - parsed.cachedAt > RECENT_APPROVERS_TTL_MS
+    ) {
+      return undefined;
+    }
     return parsed.approvers;
   } catch {
     return undefined;

--- a/entity-service/internal/domain/feedback.go
+++ b/entity-service/internal/domain/feedback.go
@@ -38,7 +38,7 @@ type SearchFeedbackFilters struct {
 	DateTo     string   `json:"dateTo,omitempty"`
 }
 
-// SearchFeedbackRequest is the input for POST /cases/feedback/search.
+// SearchFeedbackRequest is the input for POST /cases/feedbacks/search.
 // Page and PageSize are 1-based/optional; omitted values let the backing
 // data source apply its own defaults.
 type SearchFeedbackRequest struct {
@@ -54,7 +54,7 @@ type SearchFeedbackResponse struct {
 }
 
 // FeedbackBucket is the enum of supported date-bucket granularities for
-// POST /cases/feedback/aggregate.
+// POST /cases/feedbacks/aggregate.
 type FeedbackBucket string
 
 const (
@@ -72,7 +72,7 @@ type AggregateFeedbackFilters struct {
 	DateTo     string   `json:"dateTo,omitempty"`
 }
 
-// AggregateFeedbackRequest is the input for POST /cases/feedback/aggregate.
+// AggregateFeedbackRequest is the input for POST /cases/feedbacks/aggregate.
 type AggregateFeedbackRequest struct {
 	Filters AggregateFeedbackFilters `json:"filters"`
 	// Bucket selects the date-bucket granularity. Required; one of "day", "week", "month".

--- a/entity-service/internal/domain/feedback.go
+++ b/entity-service/internal/domain/feedback.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package domain
+
+// CaseFeedback is a single case-feedback (satisfaction rating) record.
+type CaseFeedback struct {
+	InstanceID string `json:"instanceId"`
+	CaseID     string `json:"caseId"`
+	Rating     int    `json:"rating"`
+	// RatingLabel is the human-readable label for Rating (e.g. "Satisfied"),
+	// as supplied by the backing data source.
+	RatingLabel string `json:"ratingLabel"`
+	// Comment is nullable: feedback submitted without free-text comment
+	// carries a null comment upstream, not an empty string.
+	Comment     *string `json:"comment"`
+	SubmittedAt string  `json:"submittedAt"`
+}
+
+// SearchFeedbackFilters holds the optional filter criteria for a case-feedback search.
+type SearchFeedbackFilters struct {
+	CaseID     string   `json:"caseId,omitempty"`
+	AccountIDs []string `json:"accountIds,omitempty"`
+	DateFrom   string   `json:"dateFrom,omitempty"`
+	DateTo     string   `json:"dateTo,omitempty"`
+}
+
+// SearchFeedbackRequest is the input for POST /cases/feedback/search.
+// Page and PageSize are 1-based/optional; omitted values let the backing
+// data source apply its own defaults.
+type SearchFeedbackRequest struct {
+	Filters  SearchFeedbackFilters `json:"filters"`
+	Page     int                   `json:"page,omitempty"`
+	PageSize int                   `json:"pageSize,omitempty"`
+}
+
+// SearchFeedbackResponse is the result of a case-feedback search.
+type SearchFeedbackResponse struct {
+	Results      []CaseFeedback `json:"results"`
+	TotalRecords int            `json:"totalRecords"`
+}
+
+// FeedbackBucket is the enum of supported date-bucket granularities for
+// POST /cases/feedback/aggregate.
+type FeedbackBucket string
+
+const (
+	FeedbackBucketDay   FeedbackBucket = "day"
+	FeedbackBucketWeek  FeedbackBucket = "week"
+	FeedbackBucketMonth FeedbackBucket = "month"
+)
+
+// AggregateFeedbackFilters holds the optional filter criteria for a
+// date-bucketed feedback aggregation. Unlike SearchFeedbackFilters, this has
+// no CaseID: aggregation is the many-cases trend endpoint, not scoped to one case.
+type AggregateFeedbackFilters struct {
+	AccountIDs []string `json:"accountIds,omitempty"`
+	DateFrom   string   `json:"dateFrom,omitempty"`
+	DateTo     string   `json:"dateTo,omitempty"`
+}
+
+// AggregateFeedbackRequest is the input for POST /cases/feedback/aggregate.
+type AggregateFeedbackRequest struct {
+	Filters AggregateFeedbackFilters `json:"filters"`
+	// Bucket selects the date-bucket granularity. Required; one of "day", "week", "month".
+	Bucket FeedbackBucket `json:"bucket"`
+}
+
+// FeedbackBucketResult is one date bucket in an aggregated feedback result.
+type FeedbackBucketResult struct {
+	BucketStart string  `json:"bucketStart"`
+	AvgRating   float64 `json:"avgRating"`
+	Count       int     `json:"count"`
+}
+
+// AggregateFeedbackResponse is the result of a date-bucketed feedback aggregation.
+type AggregateFeedbackResponse struct {
+	Buckets      []FeedbackBucketResult `json:"buckets"`
+	TotalRecords int                    `json:"totalRecords"`
+}

--- a/entity-service/internal/handler/feedback_handler.go
+++ b/entity-service/internal/handler/feedback_handler.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/service"
+)
+
+// FeedbackHandler handles HTTP requests for the case-feedback resource.
+type FeedbackHandler struct {
+	svc service.FeedbackService
+}
+
+// NewFeedbackHandler constructs a FeedbackHandler with the given service.
+func NewFeedbackHandler(svc service.FeedbackService) *FeedbackHandler {
+	return &FeedbackHandler{svc: svc}
+}
+
+// SearchFeedback handles POST /cases/feedback/search.
+func (h *FeedbackHandler) SearchFeedback(w http.ResponseWriter, r *http.Request) {
+	var req domain.SearchFeedbackRequest
+	if !decodeRequest(w, r, &req) {
+		return
+	}
+	resp, err := h.svc.SearchFeedback(r.Context(), req)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// AggregateFeedback handles POST /cases/feedback/aggregate.
+func (h *FeedbackHandler) AggregateFeedback(w http.ResponseWriter, r *http.Request) {
+	var req domain.AggregateFeedbackRequest
+	if !decodeRequest(w, r, &req) {
+		return
+	}
+	resp, err := h.svc.AggregateFeedback(r.Context(), req)
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}

--- a/entity-service/internal/handler/feedback_handler.go
+++ b/entity-service/internal/handler/feedback_handler.go
@@ -34,7 +34,7 @@ func NewFeedbackHandler(svc service.FeedbackService) *FeedbackHandler {
 	return &FeedbackHandler{svc: svc}
 }
 
-// SearchFeedback handles POST /cases/feedback/search.
+// SearchFeedback handles POST /cases/feedbacks/search.
 func (h *FeedbackHandler) SearchFeedback(w http.ResponseWriter, r *http.Request) {
 	var req domain.SearchFeedbackRequest
 	if !decodeRequest(w, r, &req) {
@@ -49,7 +49,7 @@ func (h *FeedbackHandler) SearchFeedback(w http.ResponseWriter, r *http.Request)
 	_ = json.NewEncoder(w).Encode(resp)
 }
 
-// AggregateFeedback handles POST /cases/feedback/aggregate.
+// AggregateFeedback handles POST /cases/feedbacks/aggregate.
 func (h *FeedbackHandler) AggregateFeedback(w http.ResponseWriter, r *http.Request) {
 	var req domain.AggregateFeedbackRequest
 	if !decodeRequest(w, r, &req) {

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -292,8 +292,8 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 	mux.HandleFunc("POST /cases/search", caseHandler.SearchCases)
 	mux.HandleFunc("POST /cases/aggregate", caseHandler.AggregateCases)
 	if feedbackHandler != nil {
-		mux.HandleFunc("POST /cases/feedback/search", feedbackHandler.SearchFeedback)
-		mux.HandleFunc("POST /cases/feedback/aggregate", feedbackHandler.AggregateFeedback)
+		mux.HandleFunc("POST /cases/feedbacks/search", feedbackHandler.SearchFeedback)
+		mux.HandleFunc("POST /cases/feedbacks/aggregate", feedbackHandler.AggregateFeedback)
 	}
 	mux.HandleFunc("POST /cases/{id}/comments", caseHandler.CreateCaseComment)
 	mux.HandleFunc("POST /cases/{id}/activities/search", caseHandler.SearchCaseActivities)

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -152,6 +152,11 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 		catalogHandler = handler.NewCatalogHandler(service.NewServiceNowCatalogService(serviceNowIntegrationServiceClient))
 	}
 
+	var feedbackHandler *handler.FeedbackHandler
+	if cfg.DataSource == config.DataSourceServiceNow {
+		feedbackHandler = handler.NewFeedbackHandler(service.NewServiceNowFeedbackService(serviceNowIntegrationServiceClient))
+	}
+
 	var productVulnerabilityHandler *handler.ProductVulnerabilityHandler
 	if cfg.DataSource == config.DataSourceServiceNow {
 		productVulnerabilityHandler = handler.NewProductVulnerabilityHandler(service.NewServiceNowProductVulnerabilityService(serviceNowIntegrationServiceClient))
@@ -286,6 +291,10 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 	mux.HandleFunc("POST /cases", caseHandler.CreateCase)
 	mux.HandleFunc("POST /cases/search", caseHandler.SearchCases)
 	mux.HandleFunc("POST /cases/aggregate", caseHandler.AggregateCases)
+	if feedbackHandler != nil {
+		mux.HandleFunc("POST /cases/feedback/search", feedbackHandler.SearchFeedback)
+		mux.HandleFunc("POST /cases/feedback/aggregate", feedbackHandler.AggregateFeedback)
+	}
 	mux.HandleFunc("POST /cases/{id}/comments", caseHandler.CreateCaseComment)
 	mux.HandleFunc("POST /cases/{id}/activities/search", caseHandler.SearchCaseActivities)
 	mux.HandleFunc("POST /attachments", caseHandler.CreateCaseAttachment)

--- a/entity-service/internal/service/feedback_service.go
+++ b/entity-service/internal/service/feedback_service.go
@@ -1,0 +1,212 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/middleware"
+	integrationservice "github.com/wso2-open-operations/cs-tools/entity-service/internal/servicenow-integration-service"
+)
+
+// validFeedbackBuckets is the closed set of bucket granularities the backing
+// data source accepts for POST /cases/feedback/aggregate.
+var validFeedbackBuckets = map[domain.FeedbackBucket]bool{
+	domain.FeedbackBucketDay:   true,
+	domain.FeedbackBucketWeek:  true,
+	domain.FeedbackBucketMonth: true,
+}
+
+// snFeedbackFilters mirrors the "filters" object accepted by the Choreo
+// POST /cases/feedback/search and POST /cases/feedback/aggregate endpoints.
+// The aggregate endpoint's closed-record binding rejects a caseId field, so
+// this struct -- shared by both outbound payloads -- deliberately never sets
+// CaseID for an aggregate call (see snAggregateFeedbackPayload).
+type snFeedbackFilters struct {
+	CaseID     string   `json:"caseId,omitempty"`
+	AccountIDs []string `json:"accountIds,omitempty"`
+	DateFrom   string   `json:"dateFrom,omitempty"`
+	DateTo     string   `json:"dateTo,omitempty"`
+}
+
+// snSearchFeedbackPayload is the Choreo POST /cases/feedback/search request body.
+type snSearchFeedbackPayload struct {
+	Filters  snFeedbackFilters `json:"filters"`
+	Page     int               `json:"page,omitempty"`
+	PageSize int               `json:"pageSize,omitempty"`
+}
+
+// snFeedbackRow mirrors a single row in the Choreo feedback-search response.
+type snFeedbackRow struct {
+	InstanceID  string  `json:"instanceId"`
+	CaseID      string  `json:"caseId"`
+	Rating      int     `json:"rating"`
+	RatingLabel string  `json:"ratingLabel"`
+	Comment     *string `json:"comment"`
+	SubmittedAt string  `json:"submittedAt"`
+}
+
+// snSearchFeedbackResponse mirrors the Choreo POST /cases/feedback/search response.
+type snSearchFeedbackResponse struct {
+	Results      []snFeedbackRow `json:"results"`
+	TotalRecords int             `json:"totalRecords"`
+}
+
+// snAggregateFeedbackPayload is the Choreo POST /cases/feedback/aggregate request
+// body. Filters never carries CaseID: the aggregate endpoint's closed-record
+// binding rejects it with a 400 (it is the many-cases trend endpoint, not
+// scoped to one case).
+type snAggregateFeedbackPayload struct {
+	Filters snFeedbackFilters     `json:"filters"`
+	Bucket  domain.FeedbackBucket `json:"bucket"`
+}
+
+// snFeedbackBucketRow mirrors a single bucket in the Choreo feedback-aggregate response.
+type snFeedbackBucketRow struct {
+	BucketStart string  `json:"bucketStart"`
+	AvgRating   float64 `json:"avgRating"`
+	Count       int     `json:"count"`
+}
+
+// snAggregateFeedbackResponse mirrors the Choreo POST /cases/feedback/aggregate response.
+type snAggregateFeedbackResponse struct {
+	Buckets      []snFeedbackBucketRow `json:"buckets"`
+	TotalRecords int                   `json:"totalRecords"`
+}
+
+type snFeedbackService struct {
+	client *integrationservice.Client
+}
+
+// NewServiceNowFeedbackService constructs a FeedbackService backed by the Choreo API.
+func NewServiceNowFeedbackService(client *integrationservice.Client) FeedbackService {
+	return &snFeedbackService{client: client}
+}
+
+// SearchFeedback implements FeedbackService by calling the Choreo
+// POST /cases/feedback/search endpoint.
+func (s *snFeedbackService) SearchFeedback(ctx context.Context, req domain.SearchFeedbackRequest) (domain.SearchFeedbackResponse, error) {
+	if req.Page < 0 {
+		return domain.SearchFeedbackResponse{}, &apierror.ValidationError{Msg: "page must not be negative"}
+	}
+	if req.PageSize < 0 {
+		return domain.SearchFeedbackResponse{}, &apierror.ValidationError{Msg: "pageSize must not be negative"}
+	}
+	if err := validateUUIDs("accountIds", req.Filters.AccountIDs); err != nil {
+		return domain.SearchFeedbackResponse{}, err
+	}
+	if req.Filters.CaseID != "" {
+		if err := validateUUIDs("caseId", []string{req.Filters.CaseID}); err != nil {
+			return domain.SearchFeedbackResponse{}, err
+		}
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+
+	// AccountIDs/CaseID are UUIDs at this service's own public boundary, like
+	// every other ID this entity-service exposes; converted to ServiceNow
+	// sysids here to match the sysid<->UUID boundary convention used by every
+	// other SN-backed filter in this package (see sn_id.go). Both conversion
+	// helpers are safe no-ops on input that isn't already sysid/UUID shaped.
+	payload := snSearchFeedbackPayload{
+		Filters: snFeedbackFilters{
+			CaseID:     uuidToSysid(req.Filters.CaseID),
+			AccountIDs: uuidsToSysids(req.Filters.AccountIDs),
+			DateFrom:   req.Filters.DateFrom,
+			DateTo:     req.Filters.DateTo,
+		},
+		Page:     req.Page,
+		PageSize: req.PageSize,
+	}
+
+	raw, err := s.client.Post(ctx, "/cases/feedback/search", token, payload)
+	if err != nil {
+		return domain.SearchFeedbackResponse{}, err
+	}
+
+	var snResp snSearchFeedbackResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.SearchFeedbackResponse{}, fmt.Errorf("sn search feedback: parse response: %w", err)
+	}
+
+	results := make([]domain.CaseFeedback, 0, len(snResp.Results))
+	for _, row := range snResp.Results {
+		results = append(results, domain.CaseFeedback{
+			InstanceID:  sysidToUUID(row.InstanceID),
+			CaseID:      sysidToUUID(row.CaseID),
+			Rating:      row.Rating,
+			RatingLabel: row.RatingLabel,
+			Comment:     row.Comment,
+			SubmittedAt: row.SubmittedAt,
+		})
+	}
+
+	return domain.SearchFeedbackResponse{
+		Results:      results,
+		TotalRecords: snResp.TotalRecords,
+	}, nil
+}
+
+// AggregateFeedback implements FeedbackService by calling the Choreo
+// POST /cases/feedback/aggregate endpoint.
+func (s *snFeedbackService) AggregateFeedback(ctx context.Context, req domain.AggregateFeedbackRequest) (domain.AggregateFeedbackResponse, error) {
+	if !validFeedbackBuckets[req.Bucket] {
+		return domain.AggregateFeedbackResponse{}, &apierror.ValidationError{Msg: "bucket must be one of: day, week, month"}
+	}
+	if err := validateUUIDs("accountIds", req.Filters.AccountIDs); err != nil {
+		return domain.AggregateFeedbackResponse{}, err
+	}
+
+	token := middleware.UserIDTokenFromContext(ctx)
+
+	payload := snAggregateFeedbackPayload{
+		Filters: snFeedbackFilters{
+			AccountIDs: uuidsToSysids(req.Filters.AccountIDs),
+			DateFrom:   req.Filters.DateFrom,
+			DateTo:     req.Filters.DateTo,
+		},
+		Bucket: req.Bucket,
+	}
+
+	raw, err := s.client.Post(ctx, "/cases/feedback/aggregate", token, payload)
+	if err != nil {
+		return domain.AggregateFeedbackResponse{}, err
+	}
+
+	var snResp snAggregateFeedbackResponse
+	if err := json.Unmarshal(raw, &snResp); err != nil {
+		return domain.AggregateFeedbackResponse{}, fmt.Errorf("sn aggregate feedback: parse response: %w", err)
+	}
+
+	buckets := make([]domain.FeedbackBucketResult, 0, len(snResp.Buckets))
+	for _, b := range snResp.Buckets {
+		buckets = append(buckets, domain.FeedbackBucketResult{
+			BucketStart: b.BucketStart,
+			AvgRating:   b.AvgRating,
+			Count:       b.Count,
+		})
+	}
+
+	return domain.AggregateFeedbackResponse{
+		Buckets:      buckets,
+		TotalRecords: snResp.TotalRecords,
+	}, nil
+}

--- a/entity-service/internal/service/feedback_service.go
+++ b/entity-service/internal/service/feedback_service.go
@@ -28,7 +28,7 @@ import (
 )
 
 // validFeedbackBuckets is the closed set of bucket granularities the backing
-// data source accepts for POST /cases/feedback/aggregate.
+// data source accepts for POST /cases/feedbacks/aggregate.
 var validFeedbackBuckets = map[domain.FeedbackBucket]bool{
 	domain.FeedbackBucketDay:   true,
 	domain.FeedbackBucketWeek:  true,
@@ -36,7 +36,7 @@ var validFeedbackBuckets = map[domain.FeedbackBucket]bool{
 }
 
 // snFeedbackFilters mirrors the "filters" object accepted by the Choreo
-// POST /cases/feedback/search and POST /cases/feedback/aggregate endpoints.
+// POST /cases/feedbacks/search and POST /cases/feedbacks/aggregate endpoints.
 // The aggregate endpoint's closed-record binding rejects a caseId field, so
 // this struct -- shared by both outbound payloads -- deliberately never sets
 // CaseID for an aggregate call (see snAggregateFeedbackPayload).
@@ -47,7 +47,7 @@ type snFeedbackFilters struct {
 	DateTo     string   `json:"dateTo,omitempty"`
 }
 
-// snSearchFeedbackPayload is the Choreo POST /cases/feedback/search request body.
+// snSearchFeedbackPayload is the Choreo POST /cases/feedbacks/search request body.
 type snSearchFeedbackPayload struct {
 	Filters  snFeedbackFilters `json:"filters"`
 	Page     int               `json:"page,omitempty"`
@@ -64,13 +64,13 @@ type snFeedbackRow struct {
 	SubmittedAt string  `json:"submittedAt"`
 }
 
-// snSearchFeedbackResponse mirrors the Choreo POST /cases/feedback/search response.
+// snSearchFeedbackResponse mirrors the Choreo POST /cases/feedbacks/search response.
 type snSearchFeedbackResponse struct {
 	Results      []snFeedbackRow `json:"results"`
 	TotalRecords int             `json:"totalRecords"`
 }
 
-// snAggregateFeedbackPayload is the Choreo POST /cases/feedback/aggregate request
+// snAggregateFeedbackPayload is the Choreo POST /cases/feedbacks/aggregate request
 // body. Filters never carries CaseID: the aggregate endpoint's closed-record
 // binding rejects it with a 400 (it is the many-cases trend endpoint, not
 // scoped to one case).
@@ -86,7 +86,7 @@ type snFeedbackBucketRow struct {
 	Count       int     `json:"count"`
 }
 
-// snAggregateFeedbackResponse mirrors the Choreo POST /cases/feedback/aggregate response.
+// snAggregateFeedbackResponse mirrors the Choreo POST /cases/feedbacks/aggregate response.
 type snAggregateFeedbackResponse struct {
 	Buckets      []snFeedbackBucketRow `json:"buckets"`
 	TotalRecords int                   `json:"totalRecords"`
@@ -102,7 +102,7 @@ func NewServiceNowFeedbackService(client *integrationservice.Client) FeedbackSer
 }
 
 // SearchFeedback implements FeedbackService by calling the Choreo
-// POST /cases/feedback/search endpoint.
+// POST /cases/feedbacks/search endpoint.
 func (s *snFeedbackService) SearchFeedback(ctx context.Context, req domain.SearchFeedbackRequest) (domain.SearchFeedbackResponse, error) {
 	if req.Page < 0 {
 		return domain.SearchFeedbackResponse{}, &apierror.ValidationError{Msg: "page must not be negative"}
@@ -137,7 +137,7 @@ func (s *snFeedbackService) SearchFeedback(ctx context.Context, req domain.Searc
 		PageSize: req.PageSize,
 	}
 
-	raw, err := s.client.Post(ctx, "/cases/feedback/search", token, payload)
+	raw, err := s.client.Post(ctx, "/cases/feedbacks/search", token, payload)
 	if err != nil {
 		return domain.SearchFeedbackResponse{}, err
 	}
@@ -166,7 +166,7 @@ func (s *snFeedbackService) SearchFeedback(ctx context.Context, req domain.Searc
 }
 
 // AggregateFeedback implements FeedbackService by calling the Choreo
-// POST /cases/feedback/aggregate endpoint.
+// POST /cases/feedbacks/aggregate endpoint.
 func (s *snFeedbackService) AggregateFeedback(ctx context.Context, req domain.AggregateFeedbackRequest) (domain.AggregateFeedbackResponse, error) {
 	if !validFeedbackBuckets[req.Bucket] {
 		return domain.AggregateFeedbackResponse{}, &apierror.ValidationError{Msg: "bucket must be one of: day, week, month"}
@@ -186,7 +186,7 @@ func (s *snFeedbackService) AggregateFeedback(ctx context.Context, req domain.Ag
 		Bucket: req.Bucket,
 	}
 
-	raw, err := s.client.Post(ctx, "/cases/feedback/aggregate", token, payload)
+	raw, err := s.client.Post(ctx, "/cases/feedbacks/aggregate", token, payload)
 	if err != nil {
 		return domain.AggregateFeedbackResponse{}, err
 	}

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -269,6 +269,20 @@ type CatalogService interface {
 	GetCatalogItemVariables(ctx context.Context, catalogID, catalogItemID string) (domain.GetCatalogItemVariablesResponse, error)
 }
 
+// FeedbackService defines the operations available on the case-feedback (satisfaction
+// rating) entity, for the case-feedback dashboard's list and rating-trend views.
+// All methods require the ServiceNow data source; there is no Postgres fallback.
+type FeedbackService interface {
+	// SearchFeedback returns a paginated list of case-feedback records, optionally
+	// filtered by case, accounts, and submission date range. A ValidationError is
+	// returned for invalid input.
+	SearchFeedback(ctx context.Context, req domain.SearchFeedbackRequest) (domain.SearchFeedbackResponse, error)
+	// AggregateFeedback returns date-bucketed average-rating aggregates across cases,
+	// optionally filtered by accounts and submission date range. Bucket is required.
+	// A ValidationError is returned for invalid input.
+	AggregateFeedback(ctx context.Context, req domain.AggregateFeedbackRequest) (domain.AggregateFeedbackResponse, error)
+}
+
 // CallRequestService defines the operations available on the call_requests entity.
 // All methods require the ServiceNow data source; there is no Postgres fallback.
 type CallRequestService interface {

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -870,7 +870,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
-  /cases/feedback/search:
+  /cases/feedbacks/search:
     post:
       summary: >-
         Search case-feedback (satisfaction rating) records across cases
@@ -879,7 +879,7 @@ paths:
         Backs the case-feedback dashboard's list view. Distinct from any
         single-case feedback lookup: this is filterable by case, accounts,
         and submission date range, and is paginated.
-      operationId: searchCaseFeedback
+      operationId: searchCaseFeedbacks
       requestBody:
         required: true
         content:
@@ -924,7 +924,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
-  /cases/feedback/aggregate:
+  /cases/feedbacks/aggregate:
     post:
       summary: >-
         Date-bucketed rating aggregation of case-feedback records across
@@ -932,8 +932,8 @@ paths:
       description: >-
         Backs the case-feedback dashboard's rating-trend chart. This is the
         many-cases trend endpoint, not scoped to one case, so filters.caseId
-        is not accepted here (unlike POST /cases/feedback/search).
-      operationId: aggregateCaseFeedback
+        is not accepted here (unlike POST /cases/feedbacks/search).
+      operationId: aggregateCaseFeedbacks
       requestBody:
         required: true
         content:

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -870,6 +870,108 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /cases/feedback/search:
+    post:
+      summary: >-
+        Search case-feedback (satisfaction rating) records across cases
+        (ServiceNow data source only).
+      description: >-
+        Backs the case-feedback dashboard's list view. Distinct from any
+        single-case feedback lookup: this is filterable by case, accounts,
+        and submission date range, and is paginated.
+      operationId: searchCaseFeedback
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SearchFeedbackRequest'
+      responses:
+        "200":
+          description: Case-feedback records matching the filters.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchFeedbackResponse'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: Not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "413":
+          description: Request body too large.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "503":
+          description: Downstream service unavailable.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /cases/feedback/aggregate:
+    post:
+      summary: >-
+        Date-bucketed rating aggregation of case-feedback records across
+        cases (ServiceNow data source only).
+      description: >-
+        Backs the case-feedback dashboard's rating-trend chart. This is the
+        many-cases trend endpoint, not scoped to one case, so filters.caseId
+        is not accepted here (unlike POST /cases/feedback/search).
+      operationId: aggregateCaseFeedback
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AggregateFeedbackRequest'
+      responses:
+        "200":
+          description: Feedback ratings aggregated into date buckets.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AggregateFeedbackResponse'
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "413":
+          description: Request body too large.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "503":
+          description: Downstream service unavailable.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /cases/{id}/comments:
     post:
       summary: Create a comment on a support case.
@@ -7106,6 +7208,138 @@ components:
           type: integer
         offset:
           type: integer
+
+    CaseFeedback:
+      type: object
+      required: [instanceId, caseId, rating, ratingLabel, comment, submittedAt]
+      description: A single case-feedback (satisfaction rating) record.
+      properties:
+        instanceId:
+          type: string
+          format: uuid
+          description: Unique id of the feedback record.
+        caseId:
+          type: string
+          format: uuid
+          description: UUID of the case the feedback belongs to.
+        rating:
+          type: integer
+          description: Numeric rating value.
+        ratingLabel:
+          type: string
+          description: Human-readable label for rating (e.g. "Satisfied").
+        comment:
+          type: string
+          nullable: true
+          description: >-
+            Free-text comment submitted with the feedback. Null for feedback
+            submitted without a comment.
+        submittedAt:
+          type: string
+          description: Timestamp when the feedback was submitted.
+
+    SearchFeedbackFilters:
+      type: object
+      properties:
+        caseId:
+          type: string
+          format: uuid
+          description: Restrict results to a single case.
+        accountIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+          description: Restrict results to feedback on cases under these accounts.
+        dateFrom:
+          type: string
+          description: Start of the feedback submission date range (inclusive).
+        dateTo:
+          type: string
+          description: End of the feedback submission date range (inclusive).
+
+    SearchFeedbackRequest:
+      type: object
+      properties:
+        filters:
+          $ref: '#/components/schemas/SearchFeedbackFilters'
+        page:
+          type: integer
+          description: Page number for pagination. Optional; the backing data source applies a default when omitted.
+        pageSize:
+          type: integer
+          description: Number of records per page. Optional; the backing data source applies a default when omitted.
+
+    SearchFeedbackResponse:
+      type: object
+      required: [results, totalRecords]
+      properties:
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/CaseFeedback'
+        totalRecords:
+          type: integer
+          description: Total number of matching records across all pages.
+
+    AggregateFeedbackFilters:
+      type: object
+      description: >-
+        Deliberately narrower than SearchFeedbackFilters -- this is the
+        many-cases trend endpoint, not scoped to a single case, so caseId is
+        not accepted here.
+      properties:
+        accountIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+          description: Restrict results to feedback on cases under these accounts.
+        dateFrom:
+          type: string
+          description: Start of the feedback submission date range (inclusive).
+        dateTo:
+          type: string
+          description: End of the feedback submission date range (inclusive).
+
+    AggregateFeedbackRequest:
+      type: object
+      required: [bucket]
+      properties:
+        filters:
+          $ref: '#/components/schemas/AggregateFeedbackFilters'
+        bucket:
+          type: string
+          enum: [day, week, month]
+          description: Time bucket granularity to group results by.
+
+    FeedbackBucketResult:
+      type: object
+      required: [bucketStart, avgRating, count]
+      description: One aggregated time bucket in a case-feedback aggregate result.
+      properties:
+        bucketStart:
+          type: string
+          description: Start of this bucket's time range.
+        avgRating:
+          type: number
+          description: Average rating across feedback records in this bucket.
+        count:
+          type: integer
+          description: Number of feedback records in this bucket.
+
+    AggregateFeedbackResponse:
+      type: object
+      required: [buckets, totalRecords]
+      properties:
+        buckets:
+          type: array
+          items:
+            $ref: '#/components/schemas/FeedbackBucketResult'
+          description: Time buckets, in chronological order.
+        totalRecords:
+          type: integer
+          description: Total number of feedback records across every bucket.
 
     CaseVariable:
       type: object


### PR DESCRIPTION
**This PR bundles three changes** 

1. The `Directory.TeamByUUID` SRE-group-id fix described below.
2. `[CSM Portal] Persist recent time-card approvers in localStorage` — caches
   `useRecentApprovers`'s result (`apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeSheets.ts`)
   in a per-engineer, TTL'd `localStorage` entry so the "Log time" dialog's recent-approvers
   query isn't re-run on every open; invalidated on time-card create/decide/bulk-approve.
   19 new tests in `useTimeSheets.test.tsx`; full `csm-timecards` suite 102/102 pass;
   `tsc -b` clean. Depends on a corresponding entity-service change (tracked separately,
   not in this repo) for the underlying sort-by-date query to succeed against the live
   backend.
3. **Case Feedback dashboard** — new read-only reporting surface across the Go
   entity-service and CSM BFF/webapp, backed by a corresponding entity-service (Ballerina)
   change (tracked separately, not in this repo) reading ServiceNow's existing "Case
   Feedback" CSAT survey data (1-5 rating scale). Adds:
   - Entity-service: `POST /cases/feedback/search` and `POST /cases/feedback/aggregate`
     (date-bucketed by day/week/month), forwarding to the corresponding entity-service
     endpoints. `caseId`/`instanceId` converted sysid↔UUID at this boundary, matching every
     other SN-backed resource in this service.
   - CSM BFF: matching proxy routes, plus a new `bar` dashboard-widget shape and a
     date-bucketed `groupBy.bucket` mode (distinct from the existing field-based
     `groupBy.field`) — config passthrough only; widget data is still resolved
     client-side by the webapp, per this codebase's existing pie/bar architecture.
   - CSM webapp: a `case_feedback` dashboard resourceType, a `useCaseFeedbackTrendData`
     hook (avg rating per bucket), `bar`-shape chart rendering, and a new reusable
     `DateRangeFilter` component (the dashboard framework previously had no interactive
     date-range filtering — this is a genuinely new capability, not case-feedback-specific).
   - Live-verified end-to-end against real ServiceNow DEV data at every backend layer
     (961 real feedback rows; 229 rows across 13 real monthly buckets, Oct 2024–Aug 2026)
     through this PR's own entity-service and BFF layers. The webapp layer is verified by
     `tsc -b`/`lint`/`build`/`vitest` (2221/2221 passing on this merged branch) plus
     load-time validation of the new dashboard config against the real BFF loader; live
     browser verification against a running stack was not performed as part of this bundle.

---

## Purpose
Clicking a case's "CRE / SRE team" chip on the case detail page routes to `/admin/teams/{id}` to show that team's members (shipped in cs-tools#1577). For a team that is SRE-only -- has an `sreGroupId` configured but no `creGroupId` at all, e.g. a real SRE ABT like "Apollo SRE Group" -- that click always failed with `teamIds contains unknown team: <uuid>`, even after the team registry was given the correct, verified group id. Resolves a live production report.

## Goals
Make `Directory.TeamByUUID` resolve a team by either its CRE group id or its SRE group id, so any correctly-configured team -- CRE-only, SRE-only, or both -- can be found via the case detail page's team chip.

## Approach
`Directory` only ever built `byCreGroupID`; `TeamByUUID` looked up that map alone (its own doc comment said "no caller needs [SreGroupID] yet"). That assumption broke once the case detail page started routing both a case's `creTeam.id` and `sreTeam.id` through the exact same generic `GET /teams/{id}` chip, with no way for the backend to tell which kind of id it's looking at. A team with only an `sreGroupId` (no `creGroupId` at all) could therefore never be found, regardless of how the registry was configured -- confirmed live: the registry fix landed with the real, verified group id and the error persisted, because `byCreGroupID` has nothing to find for a team with no `CreGroupID`.

Fix: added a parallel `bySreGroupID` map, populated identically to `byCreGroupID` (including a duplicate-at-startup check, plus a new cross-map collision check between the two, since a CRE group id colliding with a different team's SRE group id would silently shadow one of them). `TeamByUUID` now checks `byCreGroupID` first, then falls back to `bySreGroupID`. Doc comments updated to explain why both are checked.

## User stories
As a CS engineer, clicking any case's CRE or SRE team name shows that team's member list, including for a team that only has an SRE group configured.

## Release note
Fixed: clicking an SRE-only team's name on the case detail page (e.g. "Apollo SRE Group") incorrectly showed "unknown team" -- it now correctly opens that team's member list.

## Documentation
N/A -- internal backend fix, no documented behavior change beyond making an already-shipped feature work for a case it silently didn't cover.

## Training
N/A

## Certification
N/A -- no certification exam impact.

## Marketing
N/A

## Automation tests
 - Unit tests
   - Added `TestTeamByUUID_ResolvesSreOnlyTeam` (an SRE-only team resolves via its SRE group's UUID; an unrelated UUID still misses) and extended `TestNew_RejectsDuplicates` with a duplicate-`sreGroupId` case. `go test ./...` passes (all packages).
 - Integration tests
   - N/A -- no upstream/integration surface changed; covered by the unit tests above plus manual confirmation the reported production case's group id round-trips once the team registry carries it.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A -- Go backend; ran `gosec -fmt=text ./internal/directory/...` instead: 0 issues. `govulncheck ./...`: no vulnerabilities found.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
Builds on cs-tools#1577 (CRE/SRE team chip click-through). Pairs with a `config/csm-team-registry.txt` data fix in the planning repo (not part of this repo) that fills in the real `sreGroupId` for `apollo_sre_group`/`artemis_sre_group` -- both this code fix and that registry/env-var update are needed together for the reported case to actually resolve in production.

## Migrations (if applicable)
N/A -- no schema or data migration.

## Test environment
Verified with `go build ./...`, `go vet ./...`, `go test ./...`, `gosec -fmt=text ./internal/directory/...`, `govulncheck ./...` (Go toolchain per `go.mod`).

## Learning
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added case-feedback search and aggregation with day, week, and month rating trends.
  - Added case-feedback dashboard widgets with filtering, navigation, and date-range controls.
  - Teams can be found using either CRE or SRE group UUIDs, regardless of letter casing.
  - Recent approvers are cached locally for up to 24 hours.

- **Bug Fixes**
  - Prevented duplicate or conflicting CRE and SRE group identifiers.
  - Cleared cached approvers when timecard changes invalidate the data.
  - Improved validation for dashboard grouping configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


