### PR TITLE
[Customer Portal v2] Batch bulk product-vulnerability fetches

### DIFF
--- a/apps/customer-portal/backend-v2/internal/handler/product_vulnerabilities.go
+++ b/apps/customer-portal/backend-v2/internal/handler/product_vulnerabilities.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/dto"
 	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
@@ -37,11 +38,14 @@ type entityProductVulnerabilityClient interface {
 // ProductVulnerabilityHandler handles HTTP requests for product vulnerability operations.
 type ProductVulnerabilityHandler struct {
 	entity entityProductVulnerabilityClient
+	// bulkCache holds fully-aggregated result sets for "fetch all" requests, which
+	// have to be assembled from many upstream pages. See fetchAllVulnerabilities.
+	bulkCache *vulnerabilityBulkCache
 }
 
 // NewProductVulnerabilityHandler creates a ProductVulnerabilityHandler backed by the given entity client.
 func NewProductVulnerabilityHandler(entity entityProductVulnerabilityClient) *ProductVulnerabilityHandler {
-	return &ProductVulnerabilityHandler{entity: entity}
+	return &ProductVulnerabilityHandler{entity: entity, bulkCache: newVulnerabilityBulkCache()}
 }
 
 // SearchProductVulnerabilities handles POST /products/vulnerabilities/search.
@@ -60,6 +64,17 @@ func (h *ProductVulnerabilityHandler) SearchProductVulnerabilities(w http.Respon
 	var req dto.SearchProductVulnerabilitiesRequest
 	if err := json.Unmarshal(body, &req); err != nil {
 		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+
+	// The frontend's security page asks for the whole advisory set in one call
+	// (PRODUCT_VULNERABILITIES_ALL_FETCH_LIMIT = 5000), but entity-service rejects
+	// any limit above 50 because its own backing data source does. Forwarding that
+	// verbatim produced "limit cannot exceed 50" and an empty page. Requests above
+	// the cap are therefore assembled from batched upstream calls here, the same
+	// way the Ballerina backend does it.
+	if req.Pagination.Limit > vulnerabilityUpstreamMaxLimit {
+		h.searchAllProductVulnerabilities(w, r, user.UserID, req)
 		return
 	}
 
@@ -95,4 +110,43 @@ func (h *ProductVulnerabilityHandler) GetProductVulnerability(w http.ResponseWri
 	}
 
 	writeJSONValue(w, http.StatusOK, dto.MapProductVulnerability(result))
+}
+
+// searchAllProductVulnerabilities serves a request whose limit exceeds
+// entity-service's per-request cap by batching upstream and slicing locally.
+//
+// The response still echoes the caller's own limit and offset and reports the
+// true total, so a client that does paginate keeps working; a client that asked
+// for everything gets everything.
+func (h *ProductVulnerabilityHandler) searchAllProductVulnerabilities(
+	w http.ResponseWriter,
+	r *http.Request,
+	userID string,
+	req dto.SearchProductVulnerabilitiesRequest,
+) {
+	// Many sequential upstream calls can outlast the server's global WriteTimeout
+	// even when each one is fast, so extend this response's deadline the same way
+	// the license-provisioning flow does.
+	if rc := http.NewResponseController(w); rc != nil {
+		if err := rc.SetWriteDeadline(time.Now().Add(vulnerabilityBulkDeadline)); err != nil {
+			slog.WarnContext(r.Context(), "could not extend the write deadline for a bulk vulnerability fetch", "userID", userID, "err", summarizeErr(err))
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), vulnerabilityBulkDeadline)
+	defer cancel()
+
+	all, err := fetchAllVulnerabilities(ctx, h.entity, h.bulkCache, req, time.Now())
+	if err != nil {
+		slog.ErrorContext(ctx, "entity SearchProductVulnerabilities failed during a bulk fetch", "userID", userID, "err", summarizeErr(err))
+		mapUpstreamError(w, err, "Failed to search product vulnerabilities.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusOK, dto.SearchProductVulnerabilitiesResponse{
+		ProductVulnerabilities: sliceVulnerabilityPage(all, req.Pagination.Offset, req.Pagination.Limit),
+		TotalRecords:           len(all),
+		Limit:                  req.Pagination.Limit,
+		Offset:                 req.Pagination.Offset,
+	})
 }

--- a/apps/customer-portal/backend-v2/internal/handler/product_vulnerability_bulk.go
+++ b/apps/customer-portal/backend-v2/internal/handler/product_vulnerability_bulk.go
@@ -69,10 +69,52 @@ type vulnerabilityCacheEntry struct {
 type vulnerabilityBulkCache struct {
 	mu      sync.Mutex
 	entries map[string]vulnerabilityCacheEntry
+	// inflight coalesces concurrent cold-cache fetches for the same filter
+	// combination. Without it, N callers arriving together after a restart or a
+	// TTL expiry each run the whole batch loop — N x 26 upstream calls, which is
+	// the load this cache exists to prevent, just arriving a different way.
+	inflight map[string]*vulnerabilityFetch
+}
+
+// vulnerabilityFetch is one in-progress aggregate fetch that later arrivals wait
+// on rather than duplicating.
+type vulnerabilityFetch struct {
+	done  chan struct{}
+	items []dto.ProductVulnerability
+	err   error
 }
 
 func newVulnerabilityBulkCache() *vulnerabilityBulkCache {
-	return &vulnerabilityBulkCache{entries: make(map[string]vulnerabilityCacheEntry)}
+	return &vulnerabilityBulkCache{
+		entries:  make(map[string]vulnerabilityCacheEntry),
+		inflight: make(map[string]*vulnerabilityFetch),
+	}
+}
+
+// lead registers the caller as the fetcher for key, or returns the fetch already
+// in progress for it.
+//
+// leader is true for exactly one caller per key at a time; that caller must call
+// finish. Everyone else receives the in-flight fetch and waits on it.
+func (c *vulnerabilityBulkCache) lead(key string) (f *vulnerabilityFetch, leader bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if existing, ok := c.inflight[key]; ok {
+		return existing, false
+	}
+	f = &vulnerabilityFetch{done: make(chan struct{})}
+	c.inflight[key] = f
+	return f, true
+}
+
+// finish publishes the result to any waiters and clears the in-flight slot.
+func (c *vulnerabilityBulkCache) finish(key string, f *vulnerabilityFetch, items []dto.ProductVulnerability, err error) {
+	c.mu.Lock()
+	delete(c.inflight, key)
+	c.mu.Unlock()
+
+	f.items, f.err = items, err
+	close(f.done)
 }
 
 // get returns the cached aggregate for key, if present and unexpired.
@@ -189,6 +231,43 @@ func fetchAllVulnerabilities(
 		return cached, nil
 	}
 
+	// Only one caller per key runs the batch loop; the rest wait for its result.
+	// The count call above has already run for each of them, so authorization
+	// stays per-caller even though the fetch is shared.
+	fetch, leader := cache.lead(key)
+	if !leader {
+		select {
+		case <-fetch.done:
+			return fetch.items, fetch.err
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+
+	all, err := fetchVulnerabilityPages(ctx, client, req, total)
+	if err == nil && len(all) == total {
+		// Cache only a complete set. A short aggregate could never be read back —
+		// the guard above requires len(cached) == total — so storing one would be
+		// dead weight that also evicts a good entry from the bounded cache.
+		cache.put(key, all, now)
+	}
+	cache.finish(key, fetch, all, err)
+	return all, err
+}
+
+// fetchVulnerabilityPages walks the upstream in batches of the per-request cap
+// until it has total records.
+//
+// A page that comes back empty stops the loop: the upstream reported more records
+// than it will serve, and continuing would spin against a total that can never be
+// reached. The partial result is still returned — showing some of the set beats
+// showing none — but the caller does not cache it.
+func fetchVulnerabilityPages(
+	ctx context.Context,
+	client vulnerabilitySearcher,
+	req dto.SearchProductVulnerabilitiesRequest,
+	total int,
+) ([]dto.ProductVulnerability, error) {
 	all := make([]dto.ProductVulnerability, 0, total)
 	for offset := 0; offset < total; offset += vulnerabilityUpstreamMaxLimit {
 		if err := ctx.Err(); err != nil {
@@ -203,13 +282,9 @@ func fetchAllVulnerabilities(
 		}
 		mapped := dto.MapSearchProductVulnerabilities(page)
 		if len(mapped.ProductVulnerabilities) == 0 {
-			// The upstream returned fewer records than it claimed. Stop rather than
-			// loop forever against a total that will never be reached.
 			break
 		}
 		all = append(all, mapped.ProductVulnerabilities...)
 	}
-
-	cache.put(key, all, now)
 	return all, nil
 }

--- a/apps/customer-portal/backend-v2/internal/handler/product_vulnerability_bulk.go
+++ b/apps/customer-portal/backend-v2/internal/handler/product_vulnerability_bulk.go
@@ -244,7 +244,20 @@ func fetchAllVulnerabilities(
 		}
 	}
 
-	all, err := fetchVulnerabilityPages(ctx, client, req, total)
+	// The shared fetch runs on a context detached from the leader's own request.
+	// Otherwise one caller navigating away cancels the batch and every waiter
+	// receives that cancellation instead of the data it is still waiting for —
+	// the leader is an implementation detail of coalescing, not the owner of the
+	// work.
+	//
+	// WithoutCancel rather than a fresh context: the entity client reads the
+	// caller's ID token out of the context (entity.WithUserIDToken), so the values
+	// have to survive even though the cancellation must not. The deadline still
+	// bounds the work, so a detached fetch cannot outlive it.
+	fetchCtx, cancelFetch := context.WithTimeout(context.WithoutCancel(ctx), vulnerabilityBulkDeadline)
+	defer cancelFetch()
+
+	all, err := fetchVulnerabilityPages(fetchCtx, client, req, total)
 	if err == nil && len(all) == total {
 		// Cache only a complete set. A short aggregate could never be read back —
 		// the guard above requires len(cached) == total — so storing one would be

--- a/apps/customer-portal/backend-v2/internal/handler/product_vulnerability_bulk.go
+++ b/apps/customer-portal/backend-v2/internal/handler/product_vulnerability_bulk.go
@@ -1,0 +1,215 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/dto"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+)
+
+const (
+	// vulnerabilityUpstreamMaxLimit is entity-service's hard per-request cap. Its
+	// own comment explains the reason: the backing data source rejects anything
+	// above 50. So a caller asking for more cannot simply be forwarded, and the
+	// cap cannot be raised upstream either — the request has to be split.
+	vulnerabilityUpstreamMaxLimit = 50
+
+	// vulnerabilityCacheTTL matches the Ballerina backend's own 12 hours. The
+	// dataset is a published advisory list, not per-user state, so it does not
+	// need to be fresh by the minute.
+	vulnerabilityCacheTTL = 12 * time.Hour
+
+	// vulnerabilityCacheCapacity bounds the number of distinct filter
+	// combinations held at once, matching the Ballerina cache's capacity.
+	vulnerabilityCacheCapacity = 20
+
+	// vulnerabilityBulkDeadline is how long the batching path is given. Fetching
+	// ~1300 records is ~26 sequential upstream calls, which can plausibly exceed
+	// the server's global WriteTimeout even when no single call is slow — the same
+	// reasoning as the license-provisioning flow, which extends its deadline for
+	// the same structural reason.
+	vulnerabilityBulkDeadline = 3 * time.Minute
+)
+
+// vulnerabilityCacheEntry is one cached aggregate plus its expiry.
+type vulnerabilityCacheEntry struct {
+	items     []dto.ProductVulnerability
+	expiresAt time.Time
+}
+
+// vulnerabilityBulkCache caches fully-aggregated vulnerability sets keyed by
+// filter combination.
+//
+// Shared across users, deliberately: the vulnerability list is an org-wide
+// published advisory set, identical for every caller, so per-user copies would
+// multiply memory for no benefit. Authorization is *not* delegated to the cache —
+// see fetchAllVulnerabilities, which performs an upstream call on every request
+// before any cached data is served. That is a deliberate difference from the
+// Ballerina implementation, which returns cached results before contacting
+// entity-service at all and so cannot reject a caller who has lost access.
+type vulnerabilityBulkCache struct {
+	mu      sync.Mutex
+	entries map[string]vulnerabilityCacheEntry
+}
+
+func newVulnerabilityBulkCache() *vulnerabilityBulkCache {
+	return &vulnerabilityBulkCache{entries: make(map[string]vulnerabilityCacheEntry)}
+}
+
+// get returns the cached aggregate for key, if present and unexpired.
+func (c *vulnerabilityBulkCache) get(key string, now time.Time) ([]dto.ProductVulnerability, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e, ok := c.entries[key]
+	if !ok {
+		return nil, false
+	}
+	if now.After(e.expiresAt) {
+		delete(c.entries, key)
+		return nil, false
+	}
+	return e.items, true
+}
+
+// put stores items under key, evicting expired entries first and then the
+// soonest-to-expire if still at capacity.
+func (c *vulnerabilityBulkCache) put(key string, items []dto.ProductVulnerability, now time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for k, e := range c.entries {
+		if now.After(e.expiresAt) {
+			delete(c.entries, k)
+		}
+	}
+	if _, replacing := c.entries[key]; !replacing && len(c.entries) >= vulnerabilityCacheCapacity {
+		var oldestKey string
+		var oldest time.Time
+		for k, e := range c.entries {
+			if oldestKey == "" || e.expiresAt.Before(oldest) {
+				oldestKey, oldest = k, e.expiresAt
+			}
+		}
+		delete(c.entries, oldestKey)
+	}
+	c.entries[key] = vulnerabilityCacheEntry{items: items, expiresAt: now.Add(vulnerabilityCacheTTL)}
+}
+
+// vulnerabilityCacheKey identifies one filter combination.
+//
+// Every filter dimension has to appear, or two different queries would share an
+// entry and one would serve the other's results. Pagination is deliberately
+// excluded: the cache holds the whole set and the page is sliced from it.
+func vulnerabilityCacheKey(f *dto.SearchProductVulnerabilitiesFilters) string {
+	if f == nil {
+		return "sq=|sv=|pn=|pv="
+	}
+	severity := ""
+	if f.SeverityID != nil {
+		severity = fmt.Sprintf("%d", *f.SeverityID)
+	}
+	return fmt.Sprintf("sq=%s|sv=%s|pn=%s|pv=%s",
+		f.SearchQuery, severity, f.ProductName, f.ProductVersion)
+}
+
+// sliceVulnerabilityPage returns the [offset, offset+limit) window of items,
+// tolerating an offset past the end and a limit that overruns it.
+func sliceVulnerabilityPage(items []dto.ProductVulnerability, offset, limit int) []dto.ProductVulnerability {
+	if offset < 0 {
+		offset = 0
+	}
+	if offset >= len(items) {
+		return []dto.ProductVulnerability{}
+	}
+	end := len(items)
+	if limit > 0 && offset+limit < end {
+		end = offset + limit
+	}
+	return items[offset:end]
+}
+
+// vulnerabilitySearcher is the single upstream call the bulk path needs.
+type vulnerabilitySearcher interface {
+	SearchProductVulnerabilities(ctx context.Context, req entity.SearchProductVulnerabilitiesRequest) (entity.SearchProductVulnerabilitiesResponse, error)
+}
+
+// fetchAllVulnerabilities returns every record matching req's filters, batching
+// around entity-service's 50-record cap.
+//
+// It always issues one upstream request first, with limit 1. That call does two
+// jobs: it reports the true total so the batch loop can be sized, and — more
+// importantly — it re-checks the caller's access on every request, so a cache hit
+// can never serve data to someone entity-service would now reject. The Ballerina
+// implementation checks its cache before contacting entity-service at all, which
+// means a warm cache bypasses that check entirely; this does not.
+//
+// Returns the full aggregate; the caller slices the requested page from it.
+func fetchAllVulnerabilities(
+	ctx context.Context,
+	client vulnerabilitySearcher,
+	cache *vulnerabilityBulkCache,
+	req dto.SearchProductVulnerabilitiesRequest,
+	now time.Time,
+) ([]dto.ProductVulnerability, error) {
+	countReq := dto.BuildEntitySearchProductVulnerabilitiesRequest(req)
+	countReq.Pagination = entity.Pagination{Offset: 0, Limit: 1}
+
+	countResp, err := client.SearchProductVulnerabilities(ctx, countReq)
+	if err != nil {
+		return nil, err
+	}
+	total := countResp.Total
+	if total <= 0 {
+		return []dto.ProductVulnerability{}, nil
+	}
+
+	key := vulnerabilityCacheKey(req.Filters)
+	// Only trust the cache when it still agrees with the upstream count; a changed
+	// total means the advisory set moved and the entry is stale regardless of TTL.
+	if cached, ok := cache.get(key, now); ok && len(cached) == total {
+		return cached, nil
+	}
+
+	all := make([]dto.ProductVulnerability, 0, total)
+	for offset := 0; offset < total; offset += vulnerabilityUpstreamMaxLimit {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		pageReq := dto.BuildEntitySearchProductVulnerabilitiesRequest(req)
+		pageReq.Pagination = entity.Pagination{Offset: offset, Limit: vulnerabilityUpstreamMaxLimit}
+
+		page, pageErr := client.SearchProductVulnerabilities(ctx, pageReq)
+		if pageErr != nil {
+			return nil, pageErr
+		}
+		mapped := dto.MapSearchProductVulnerabilities(page)
+		if len(mapped.ProductVulnerabilities) == 0 {
+			// The upstream returned fewer records than it claimed. Stop rather than
+			// loop forever against a total that will never be reached.
+			break
+		}
+		all = append(all, mapped.ProductVulnerabilities...)
+	}
+
+	cache.put(key, all, now)
+	return all, nil
+}

--- a/apps/customer-portal/backend-v2/internal/handler/product_vulnerability_bulk_test.go
+++ b/apps/customer-portal/backend-v2/internal/handler/product_vulnerability_bulk_test.go
@@ -368,3 +368,88 @@ func (s *shortVulnSearcher) SearchProductVulnerabilities(_ context.Context, req 
 		Offset:                 req.Pagination.Offset,
 	}, nil
 }
+
+// TestFetchAllVulnerabilities_WaiterSurvivesLeaderCancellation is the regression
+// guard for a hazard introduced by coalescing: the leader is an implementation
+// detail, not the owner of the shared work, so its client navigating away must not
+// fail everyone waiting on the same fetch.
+func TestFetchAllVulnerabilities_WaiterSurvivesLeaderCancellation(t *testing.T) {
+	const total = 500
+	// gate holds the first page until the waiter has joined, so the cancellation
+	// lands while the shared fetch is genuinely in flight.
+	gate := make(chan struct{})
+	joined := make(chan struct{})
+	c := &gatedVulnSearcher{total: total, gate: gate, inBatch: make(chan struct{})}
+	cache := newVulnerabilityBulkCache()
+	now := time.Now()
+
+	leaderCtx, cancelLeader := context.WithCancel(context.Background())
+	leaderErr := make(chan error, 1)
+	go func() {
+		_, err := fetchAllVulnerabilities(leaderCtx, c, cache, bulkReq(5000, 0), now)
+		leaderErr <- err
+	}()
+
+	// Wait until the leader is inside the batch loop, then join as a waiter.
+	<-c.inBatch
+	waiterItems := make(chan []dto.ProductVulnerability, 1)
+	waiterErr := make(chan error, 1)
+	go func() {
+		close(joined)
+		items, err := fetchAllVulnerabilities(context.Background(), c, cache, bulkReq(5000, 0), now)
+		waiterItems <- items
+		waiterErr <- err
+	}()
+	<-joined
+	time.Sleep(20 * time.Millisecond) // let the waiter reach its select
+
+	// The leader's client goes away mid-fetch.
+	cancelLeader()
+	close(gate) // let the batch proceed
+
+	select {
+	case err := <-waiterErr:
+		if err != nil {
+			t.Fatalf("waiter got %v; it must still receive the aggregate after the leader cancelled", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("waiter blocked after the leader cancelled")
+	}
+	if got := len(<-waiterItems); got != total {
+		t.Errorf("waiter got %d records, want the complete %d", got, total)
+	}
+	<-leaderErr // drain
+}
+
+// gatedVulnSearcher blocks the first batch page until gate is closed, and signals
+// inBatch once the batch loop has started.
+type gatedVulnSearcher struct {
+	mu      sync.Mutex
+	total   int
+	gate    chan struct{}
+	inBatch chan struct{}
+	once    sync.Once
+	batched bool
+}
+
+func (s *gatedVulnSearcher) SearchProductVulnerabilities(ctx context.Context, req entity.SearchProductVulnerabilitiesRequest) (entity.SearchProductVulnerabilitiesResponse, error) {
+	// The count call (limit 1) passes straight through; the batch pages gate.
+	if req.Pagination.Limit > 1 {
+		s.once.Do(func() { close(s.inBatch) })
+		<-s.gate
+		if err := ctx.Err(); err != nil {
+			return entity.SearchProductVulnerabilitiesResponse{}, err
+		}
+	}
+
+	items := []entity.ProductVulnerabilityView{}
+	for i := req.Pagination.Offset; i < s.total && len(items) < req.Pagination.Limit; i++ {
+		items = append(items, entity.ProductVulnerabilityView{ID: fmt.Sprintf("v-%d", i)})
+	}
+	return entity.SearchProductVulnerabilitiesResponse{
+		ProductVulnerabilities: items,
+		Total:                  s.total,
+		Limit:                  req.Pagination.Limit,
+		Offset:                 req.Pagination.Offset,
+	}, nil
+}

--- a/apps/customer-portal/backend-v2/internal/handler/product_vulnerability_bulk_test.go
+++ b/apps/customer-portal/backend-v2/internal/handler/product_vulnerability_bulk_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sync"
 	"testing"
 	"time"
 
@@ -33,29 +34,42 @@ import (
 // 50-record cap so a test fails the same way production did if the batching is
 // wrong.
 type stubVulnSearcher struct {
+	mu       sync.Mutex
 	total    int
 	calls    int
 	limits   []int
 	forbidAt int // return 403 on this call number (1-based); 0 disables
+	// delay slows each call so a concurrency test can reliably overlap callers.
+	delay time.Duration
 }
 
 func (s *stubVulnSearcher) SearchProductVulnerabilities(_ context.Context, req entity.SearchProductVulnerabilitiesRequest) (entity.SearchProductVulnerabilitiesResponse, error) {
+	s.mu.Lock()
 	s.calls++
+	current := s.calls
 	s.limits = append(s.limits, req.Pagination.Limit)
-	if s.forbidAt != 0 && s.calls == s.forbidAt {
+	s.mu.Unlock()
+
+	if s.delay > 0 {
+		time.Sleep(s.delay)
+	}
+	if s.forbidAt != 0 && current == s.forbidAt {
 		return entity.SearchProductVulnerabilitiesResponse{}, apierror.NewUpstreamError(http.StatusForbidden, nil)
 	}
 	if req.Pagination.Limit > vulnerabilityUpstreamMaxLimit {
 		return entity.SearchProductVulnerabilitiesResponse{},
 			apierror.NewUpstreamError(http.StatusBadRequest, []byte(`{"message":"limit cannot exceed 50"}`))
 	}
+	s.mu.Lock()
+	total := s.total
+	s.mu.Unlock()
 	items := []entity.ProductVulnerabilityView{}
-	for i := req.Pagination.Offset; i < s.total && len(items) < req.Pagination.Limit; i++ {
+	for i := req.Pagination.Offset; i < total && len(items) < req.Pagination.Limit; i++ {
 		items = append(items, entity.ProductVulnerabilityView{ID: fmt.Sprintf("v-%d", i)})
 	}
 	return entity.SearchProductVulnerabilitiesResponse{
 		ProductVulnerabilities: items,
-		Total:                  s.total,
+		Total:                  total,
 		Limit:                  req.Pagination.Limit,
 		Offset:                 req.Pagination.Offset,
 	}, nil
@@ -80,8 +94,8 @@ func TestFetchAllVulnerabilities_BatchesAroundTheUpstreamCap(t *testing.T) {
 		t.Errorf("got %d records, want all 1265", len(all))
 	}
 	// 1 count call + ceil(1265/50) = 26 pages.
-	if c.calls != 27 {
-		t.Errorf("made %d upstream calls, want 27 (1 count + 26 pages)", c.calls)
+	if c.callCount() != 27 {
+		t.Errorf("made %d upstream calls, want 27 (1 count + 26 pages)", c.callCount())
 	}
 	for i, l := range c.limits {
 		if l > vulnerabilityUpstreamMaxLimit {
@@ -123,12 +137,12 @@ func TestFetchAllVulnerabilities_ServesFromCacheWithoutRefetching(t *testing.T) 
 	if _, err := fetchAllVulnerabilities(context.Background(), c, cache, bulkReq(5000, 0), now); err != nil {
 		t.Fatalf("first: %v", err)
 	}
-	first := c.calls
+	first := c.callCount()
 
 	if _, err := fetchAllVulnerabilities(context.Background(), c, cache, bulkReq(5000, 0), now); err != nil {
 		t.Fatalf("second: %v", err)
 	}
-	if got := c.calls - first; got != 1 {
+	if got := c.callCount() - first; got != 1 {
 		t.Errorf("second request made %d calls, want exactly 1 (the authorization/count check)", got)
 	}
 }
@@ -162,8 +176,8 @@ func TestFetchAllVulnerabilities_EmptyCorpus(t *testing.T) {
 	if len(all) != 0 {
 		t.Errorf("got %d records, want 0", len(all))
 	}
-	if c.calls != 1 {
-		t.Errorf("made %d calls, want just the count call", c.calls)
+	if c.callCount() != 1 {
+		t.Errorf("made %d calls, want just the count call", c.callCount())
 	}
 }
 
@@ -258,4 +272,99 @@ func errorsAs(err error, target any) bool {
 		return false
 	}
 	return false
+}
+
+// callCount reads the stub's call counter under its lock.
+func (s *stubVulnSearcher) callCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls
+}
+
+// TestFetchAllVulnerabilities_CoalescesConcurrentColdMisses is the regression
+// guard for the thundering herd: without coalescing, N callers arriving together
+// on a cold cache each ran the whole batch loop, which is the load the cache
+// exists to prevent.
+//
+// 10 callers over 500 records is 1 count call each (authorization stays
+// per-caller) plus exactly one shared batch of 10 pages — not 10 batches.
+func TestFetchAllVulnerabilities_CoalescesConcurrentColdMisses(t *testing.T) {
+	const callers = 10
+	c := &stubVulnSearcher{total: 500, delay: 2 * time.Millisecond}
+	cache := newVulnerabilityBulkCache()
+	now := time.Now()
+
+	var wg sync.WaitGroup
+	results := make([][]dto.ProductVulnerability, callers)
+	errs := make([]error, callers)
+	start := make(chan struct{})
+
+	for i := 0; i < callers; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			<-start
+			results[idx], errs[idx] = fetchAllVulnerabilities(context.Background(), c, cache, bulkReq(5000, 0), now)
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("caller %d: %v", i, err)
+		}
+		if len(results[i]) != 500 {
+			t.Errorf("caller %d got %d records, want 500", i, len(results[i]))
+		}
+	}
+
+	// ceil(500/50) = 10 pages, fetched once. Plus one count call per caller.
+	const wantPages = 10
+	if got := c.callCount(); got > callers+wantPages {
+		t.Errorf("made %d upstream calls; want at most %d (%d count calls + one shared batch of %d) — the batch loop ran more than once",
+			got, callers+wantPages, callers, wantPages)
+	}
+}
+
+// TestFetchAllVulnerabilities_DoesNotCacheAShortAggregate covers the other
+// finding. When the upstream reports more records than it serves, the aggregate is
+// incomplete; caching it would be dead weight, because the read guard requires
+// len(cached) == total, and it would evict a usable entry from the bounded cache.
+func TestFetchAllVulnerabilities_DoesNotCacheAShortAggregate(t *testing.T) {
+	// Claims 500 but only ever serves the first 60, so the loop stops early.
+	c := &shortVulnSearcher{claimed: 500, available: 60}
+	cache := newVulnerabilityBulkCache()
+	now := time.Now()
+
+	all, err := fetchAllVulnerabilities(context.Background(), c, cache, bulkReq(5000, 0), now)
+	if err != nil {
+		t.Fatalf("fetchAllVulnerabilities: %v", err)
+	}
+	if len(all) != 60 {
+		t.Errorf("got %d records, want the 60 actually served", len(all))
+	}
+	// The partial set is returned to the caller but must not be cached.
+	if _, cached := cache.get(vulnerabilityCacheKey(nil), now); cached {
+		t.Error("an incomplete aggregate was cached; it can never be read back and evicts good entries")
+	}
+}
+
+// shortVulnSearcher reports more records than it will serve.
+type shortVulnSearcher struct {
+	claimed   int
+	available int
+}
+
+func (s *shortVulnSearcher) SearchProductVulnerabilities(_ context.Context, req entity.SearchProductVulnerabilitiesRequest) (entity.SearchProductVulnerabilitiesResponse, error) {
+	items := []entity.ProductVulnerabilityView{}
+	for i := req.Pagination.Offset; i < s.available && len(items) < req.Pagination.Limit; i++ {
+		items = append(items, entity.ProductVulnerabilityView{ID: fmt.Sprintf("v-%d", i)})
+	}
+	return entity.SearchProductVulnerabilitiesResponse{
+		ProductVulnerabilities: items,
+		Total:                  s.claimed,
+		Limit:                  req.Pagination.Limit,
+		Offset:                 req.Pagination.Offset,
+	}, nil
 }

--- a/apps/customer-portal/backend-v2/internal/handler/product_vulnerability_bulk_test.go
+++ b/apps/customer-portal/backend-v2/internal/handler/product_vulnerability_bulk_test.go
@@ -1,0 +1,261 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/apierror"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/dto"
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+)
+
+// stubVulnSearcher serves a synthetic corpus, enforcing entity-service's real
+// 50-record cap so a test fails the same way production did if the batching is
+// wrong.
+type stubVulnSearcher struct {
+	total    int
+	calls    int
+	limits   []int
+	forbidAt int // return 403 on this call number (1-based); 0 disables
+}
+
+func (s *stubVulnSearcher) SearchProductVulnerabilities(_ context.Context, req entity.SearchProductVulnerabilitiesRequest) (entity.SearchProductVulnerabilitiesResponse, error) {
+	s.calls++
+	s.limits = append(s.limits, req.Pagination.Limit)
+	if s.forbidAt != 0 && s.calls == s.forbidAt {
+		return entity.SearchProductVulnerabilitiesResponse{}, apierror.NewUpstreamError(http.StatusForbidden, nil)
+	}
+	if req.Pagination.Limit > vulnerabilityUpstreamMaxLimit {
+		return entity.SearchProductVulnerabilitiesResponse{},
+			apierror.NewUpstreamError(http.StatusBadRequest, []byte(`{"message":"limit cannot exceed 50"}`))
+	}
+	items := []entity.ProductVulnerabilityView{}
+	for i := req.Pagination.Offset; i < s.total && len(items) < req.Pagination.Limit; i++ {
+		items = append(items, entity.ProductVulnerabilityView{ID: fmt.Sprintf("v-%d", i)})
+	}
+	return entity.SearchProductVulnerabilitiesResponse{
+		ProductVulnerabilities: items,
+		Total:                  s.total,
+		Limit:                  req.Pagination.Limit,
+		Offset:                 req.Pagination.Offset,
+	}, nil
+}
+
+func bulkReq(limit, offset int) dto.SearchProductVulnerabilitiesRequest {
+	return dto.SearchProductVulnerabilitiesRequest{
+		Pagination: entity.Pagination{Limit: limit, Offset: offset},
+	}
+}
+
+// TestFetchAllVulnerabilities_BatchesAroundTheUpstreamCap is the regression guard
+// for `{"message":"limit cannot exceed 50"}`. The frontend asks for 5000 in one
+// call; entity-service rejects anything over 50 because its own data source does.
+func TestFetchAllVulnerabilities_BatchesAroundTheUpstreamCap(t *testing.T) {
+	c := &stubVulnSearcher{total: 1265}
+	all, err := fetchAllVulnerabilities(context.Background(), c, newVulnerabilityBulkCache(), bulkReq(5000, 0), time.Now())
+	if err != nil {
+		t.Fatalf("fetchAllVulnerabilities: %v", err)
+	}
+	if len(all) != 1265 {
+		t.Errorf("got %d records, want all 1265", len(all))
+	}
+	// 1 count call + ceil(1265/50) = 26 pages.
+	if c.calls != 27 {
+		t.Errorf("made %d upstream calls, want 27 (1 count + 26 pages)", c.calls)
+	}
+	for i, l := range c.limits {
+		if l > vulnerabilityUpstreamMaxLimit {
+			t.Fatalf("call %d used limit %d, above the upstream cap — this is the bug being fixed", i+1, l)
+		}
+	}
+}
+
+// TestFetchAllVulnerabilities_AuthorizesOnEveryRequest is the deliberate
+// difference from the Ballerina implementation, which reads its shared cache
+// before contacting entity-service and therefore cannot reject a caller who has
+// lost access. Here a warm cache must still 403.
+func TestFetchAllVulnerabilities_AuthorizesOnEveryRequest(t *testing.T) {
+	cache := newVulnerabilityBulkCache()
+	warm := &stubVulnSearcher{total: 120}
+	if _, err := fetchAllVulnerabilities(context.Background(), warm, cache, bulkReq(5000, 0), time.Now()); err != nil {
+		t.Fatalf("warming: %v", err)
+	}
+
+	denied := &stubVulnSearcher{total: 120, forbidAt: 1}
+	_, err := fetchAllVulnerabilities(context.Background(), denied, cache, bulkReq(5000, 0), time.Now())
+	if err == nil {
+		t.Fatal("a cache hit served data to a caller entity-service rejected")
+	}
+	var apiErr *apierror.Error
+	if !errorsAs(err, &apiErr) || apiErr.StatusCode != http.StatusForbidden {
+		t.Errorf("err = %v, want the upstream 403 propagated", err)
+	}
+}
+
+// TestFetchAllVulnerabilities_ServesFromCacheWithoutRefetching checks the cache
+// actually saves the batch work: a second identical request should cost one call
+// (the authorization/count check) rather than 27.
+func TestFetchAllVulnerabilities_ServesFromCacheWithoutRefetching(t *testing.T) {
+	cache := newVulnerabilityBulkCache()
+	c := &stubVulnSearcher{total: 120}
+	now := time.Now()
+
+	if _, err := fetchAllVulnerabilities(context.Background(), c, cache, bulkReq(5000, 0), now); err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	first := c.calls
+
+	if _, err := fetchAllVulnerabilities(context.Background(), c, cache, bulkReq(5000, 0), now); err != nil {
+		t.Fatalf("second: %v", err)
+	}
+	if got := c.calls - first; got != 1 {
+		t.Errorf("second request made %d calls, want exactly 1 (the authorization/count check)", got)
+	}
+}
+
+// TestFetchAllVulnerabilities_StaleWhenTotalChanges checks the cache is not
+// trusted when the upstream count disagrees with it — the advisory set moved, so
+// the entry is stale regardless of TTL.
+func TestFetchAllVulnerabilities_StaleWhenTotalChanges(t *testing.T) {
+	cache := newVulnerabilityBulkCache()
+	now := time.Now()
+	if _, err := fetchAllVulnerabilities(context.Background(), &stubVulnSearcher{total: 60}, cache, bulkReq(5000, 0), now); err != nil {
+		t.Fatalf("warming: %v", err)
+	}
+	grown := &stubVulnSearcher{total: 130}
+	all, err := fetchAllVulnerabilities(context.Background(), grown, cache, bulkReq(5000, 0), now)
+	if err != nil {
+		t.Fatalf("refetch: %v", err)
+	}
+	if len(all) != 130 {
+		t.Errorf("got %d records, want 130 refetched rather than 60 from a stale entry", len(all))
+	}
+}
+
+// TestFetchAllVulnerabilities_EmptyCorpus avoids a pointless batch loop.
+func TestFetchAllVulnerabilities_EmptyCorpus(t *testing.T) {
+	c := &stubVulnSearcher{total: 0}
+	all, err := fetchAllVulnerabilities(context.Background(), c, newVulnerabilityBulkCache(), bulkReq(5000, 0), time.Now())
+	if err != nil {
+		t.Fatalf("fetchAllVulnerabilities: %v", err)
+	}
+	if len(all) != 0 {
+		t.Errorf("got %d records, want 0", len(all))
+	}
+	if c.calls != 1 {
+		t.Errorf("made %d calls, want just the count call", c.calls)
+	}
+}
+
+// TestSliceVulnerabilityPage covers the windowing, including the overruns a
+// "fetch all" caller produces (limit far beyond the corpus).
+func TestSliceVulnerabilityPage(t *testing.T) {
+	items := make([]dto.ProductVulnerability, 10)
+	for i := range items {
+		items[i] = dto.ProductVulnerability{ID: fmt.Sprintf("v-%d", i)}
+	}
+	for name, tc := range map[string]struct {
+		offset, limit, wantLen int
+		wantFirst              string
+	}{
+		"whole corpus":       {0, 5000, 10, "v-0"},
+		"exact page":         {0, 10, 10, "v-0"},
+		"second page":        {5, 5, 5, "v-5"},
+		"limit overruns end": {8, 5, 2, "v-8"},
+		"offset past end":    {10, 5, 0, ""},
+		"negative offset":    {-3, 4, 4, "v-0"},
+	} {
+		got := sliceVulnerabilityPage(items, tc.offset, tc.limit)
+		if len(got) != tc.wantLen {
+			t.Errorf("%s: got %d items, want %d", name, len(got), tc.wantLen)
+			continue
+		}
+		if tc.wantLen > 0 && got[0].ID != tc.wantFirst {
+			t.Errorf("%s: first = %s, want %s", name, got[0].ID, tc.wantFirst)
+		}
+	}
+}
+
+// TestVulnerabilityCacheKey_SeparatesFilterCombinations stops one query serving
+// another's results.
+func TestVulnerabilityCacheKey_SeparatesFilterCombinations(t *testing.T) {
+	sev1, sev2 := 1, 2
+	keys := map[string]string{
+		"empty":     vulnerabilityCacheKey(nil),
+		"query":     vulnerabilityCacheKey(&dto.SearchProductVulnerabilitiesFilters{SearchQuery: "cve"}),
+		"severity1": vulnerabilityCacheKey(&dto.SearchProductVulnerabilitiesFilters{SeverityID: &sev1}),
+		"severity2": vulnerabilityCacheKey(&dto.SearchProductVulnerabilitiesFilters{SeverityID: &sev2}),
+		"product":   vulnerabilityCacheKey(&dto.SearchProductVulnerabilitiesFilters{ProductName: "APIM"}),
+		"version":   vulnerabilityCacheKey(&dto.SearchProductVulnerabilitiesFilters{ProductVersion: "4.5.0"}),
+	}
+	seen := map[string]string{}
+	for name, k := range keys {
+		if prev, dup := seen[k]; dup {
+			t.Errorf("%s and %s share cache key %q", name, prev, k)
+		}
+		seen[k] = name
+	}
+}
+
+// TestVulnerabilityCache_ExpiresEntries checks the TTL is honoured.
+func TestVulnerabilityCache_ExpiresEntries(t *testing.T) {
+	c := newVulnerabilityBulkCache()
+	now := time.Now()
+	c.put("k", []dto.ProductVulnerability{{ID: "v-1"}}, now)
+
+	if _, ok := c.get("k", now.Add(vulnerabilityCacheTTL-time.Minute)); !ok {
+		t.Error("entry expired early")
+	}
+	if _, ok := c.get("k", now.Add(vulnerabilityCacheTTL+time.Minute)); ok {
+		t.Error("entry served past its TTL")
+	}
+}
+
+// TestVulnerabilityCache_BoundedCapacity stops unbounded growth across many
+// distinct filter combinations.
+func TestVulnerabilityCache_BoundedCapacity(t *testing.T) {
+	c := newVulnerabilityBulkCache()
+	now := time.Now()
+	for i := 0; i < vulnerabilityCacheCapacity*3; i++ {
+		c.put(fmt.Sprintf("k-%d", i), []dto.ProductVulnerability{{ID: "v"}}, now.Add(time.Duration(i)*time.Second))
+	}
+	c.mu.Lock()
+	n := len(c.entries)
+	c.mu.Unlock()
+	if n > vulnerabilityCacheCapacity {
+		t.Errorf("cache holds %d entries, want at most %d", n, vulnerabilityCacheCapacity)
+	}
+}
+
+// errorsAs is errors.As, wrapped so the assertion above reads clearly.
+func errorsAs(err error, target any) bool {
+	var t *apierror.Error
+	if p, ok := target.(**apierror.Error); ok {
+		if errors.As(err, &t) {
+			*p = t
+			return true
+		}
+		return false
+	}
+	return false
+}


### PR DESCRIPTION
Fixes `400 {"message":"limit cannot exceed 50"}` on `POST /products/vulnerabilities/search`.

## Cause

The frontend asks for the whole advisory set in one call — `PRODUCT_VULNERABILITIES_ALL_FETCH_LIMIT = 5000` — and the Ballerina backend answers it with all **1265** records:

```json
{ "limit": 5000, "offset": 0, "totalRecords": 1265, "productVulnerabilities": [ … ] }
```

entity-service rejects any limit above 50, and its own comment says why:

> `maxLimit` is 50 **because the backing data source rejects anything above 50** with an opaque validation error.

So the cap **cannot** be raised upstream, and the request cannot be forwarded as sent. It has to be split — which is exactly what the Ballerina backend already does (`service.bal:57`: *"In-memory cache for bulk product-vulnerability fetches (limit > 50)"*).

## Approach — ported from the Ballerina implementation

One count call to size the work → sequential batches of 50 → aggregate cached 12h, keyed on the filter combination → local slice to the caller's offset/limit. The response echoes the caller's own `limit`/`offset` and reports the true total, so a client that paginates keeps working while one that asked for everything gets everything.

**Requests at or below 50 pass straight through, unchanged.**

## One deliberate difference: authorization

Ballerina reads its **shared** cache *before* contacting entity-service at all. A warm cache therefore serves data without re-checking access — a caller who has since lost permission still gets results.

Here the count call runs on **every** request, before any cached data is returned. It sizes the batch loop and re-authorizes at the same time. A cache hit costs **1** upstream call instead of 27, and still 403s when it should. There is a test for precisely that:

```
TestFetchAllVulnerabilities_AuthorizesOnEveryRequest
  → warms the cache, then asserts a 403 caller is still rejected
```

The cache is shared rather than per-user because the vulnerability list is an org-wide published advisory set, identical for every caller — and with authorization no longer delegated to it, sharing is safe. It is bounded to 20 filter combinations, and an entry is discarded when the upstream total disagrees with it, since that means the set moved regardless of TTL.

## Timeout

Twenty-six sequential upstream calls can outlast the server's global `WriteTimeout` even when each is fast, so this path extends its own write deadline — the same structural reason the license-provisioning flow does.

## Testing

- `gofmt -l`, `go build`, `go vet`, `go test -race ./...` — all pass
- `gosec -fmt=text ./...` — **0 issues** (110 files)

Nine tests, including a stub that **enforces the real 50 cap** so a batching mistake fails the same way production did:

| Test | |
|---|---|
| batching | 1265 records via 1 count + 26 pages, no call above the cap |
| authorization | warm cache still 403s |
| cache hit | second request costs 1 call, not 27 |
| staleness | changed upstream total discards the entry |
| empty corpus | count call only, no batch loop |
| slicing | whole corpus, exact page, overrun, offset past end, negative offset |
| key separation, TTL expiry, capacity bound | |

> Validation ran on a local Go 1.27 toolchain with locally installed gosec — Docker Desktop is not running in this environment.

## Deployment

**backend-v2 only** — no entity-service change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded vulnerability searches beyond upstream record limits through batched retrieval.
  * Added pagination and total-result counts for large searches.
  * Improved response times for repeated searches with short-term result caching.
  * Preserved filtering and authorization across bulk searches.

* **Bug Fixes**
  * Improved handling of expired, empty, and changing vulnerability results.
  * Added safeguards for canceled requests and upstream errors.
  * Improved consistency when multiple searches request the same uncached results.
  * Added bounded caching to maintain reliable performance over time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->