### PR TITLE
[Entity-Service] publish case.assigned on assignee change

### DIFF
--- a/entity-service/CLAUDE.md
+++ b/entity-service/CLAUDE.md
@@ -83,7 +83,7 @@ the constructed `EventPublisherService` (nil if unconfigured) alongside the
 threaded through `server.New` to `cmd/api/main.go`, which calls `Close()` on
 it during shutdown, after `srv.Shutdown`.
 
-Four call sites publish today, all ServiceNow-data-source-only (`DATA_SOURCE=servicenow`;
+Five call sites publish today, all ServiceNow-data-source-only (`DATA_SOURCE=servicenow`;
 there is no Postgres-backed equivalent for any of them):
 
 - **`snCaseService.CreateCase`** publishes `case.created` via a private
@@ -138,19 +138,21 @@ there is no Postgres-backed equivalent for any of them):
   send something `events.Validate` would reject" precedent as an empty
   `Recipients` list.
 
-`publishCaseCreated`, `publishCommentAdded`, and `publishStatusChanged` —
-every `case.*` publisher above, not `snIncidentService.CreateIncident` —
-also set `CaseNumber` (`cv.Number`/`before.Number`, the case's
-human-readable ServiceNow reference, e.g. `"CS0023001"`) and `WSO2CaseID`
-(`cv.InternalID`/`before.InternalID`, ServiceNow's `u_wso2_case_id` custom
-field — the CSM portal's own case identifier, e.g. `"WSO2-1000"`, distinct
-from `CaseNumber`) alongside `CaseID` (the UUID) — `csm-notification-service`
+`publishCaseCreated`, `publishCommentAdded`, `publishStatusChanged`, and
+`publishCaseAssigned` — every `case.*` publisher above, not
+`snIncidentService.CreateIncident` — also set `CaseNumber`
+(`cv.Number`/`before.Number`, the case's human-readable ServiceNow
+reference, e.g. `"CS0023001"`) and `WSO2CaseID` (`cv.InternalID`/
+`before.InternalID`, ServiceNow's `u_wso2_case_id` custom field — the CSM
+portal's own case identifier, e.g. `"WSO2-1000"`, distinct from
+`CaseNumber`) alongside `CaseID` (the UUID) — `csm-notification-service`
 displays `WSO2CaseID`/`CaseNumber` in every subject line and template slot
 instead of the UUID, which is meaningless to an end user (a real, reported
 bug before these fields existed at all); `CaseID` is unchanged for anything
-link-related. `publishStatusChanged` additionally sets `CaseTitle`
-(`before.Subject`) — `case.status_changed` didn't originally carry one at
-all, needed once `csm-notification-service` started requiring every
+link-related. `publishStatusChanged`/`publishCaseAssigned` additionally set
+`CaseTitle` (`before.Subject`) — neither `case.status_changed` nor
+`case.assigned` originally carried one at all, needed once
+`csm-notification-service` started requiring every
 `case.*` email's subject to follow one explicit standard format,
 `"[WSO2 Support] (<wso2 case id>/<case number>) <title>"` (see that
 service's own `CLAUDE.md`, `dispatch.subjectLine`).
@@ -170,24 +172,30 @@ service's own `CLAUDE.md`, `dispatch.subjectLine`).
   `snUpdateCaseResponse`'s own `WatchList` has emails but no project
   reference at all.
 
-`case.assigned` is **not published anywhere yet** — `events.CaseAssignedPayload`
-doesn't even exist in this service's `internal/events/events.go` (unlike
-`csm-notification-service`'s own copy, which already has it). The blocker
-isn't wiring — `UpdateCase`'s `req.AssigneeEmail` path is right there, in
-the same function `publishStatusChanged` hooks into — it's data:
-`csm-notification-service`'s `CaseAssignedPayload` requires a non-empty
-`AssignerName`/`AssignerEmail` (the person who *performed* the assignment,
-not the new assignee — see that service's `RenderCaseAssignedEmail`, which
-renders `assignerEmail` as a `mailto:` link), and this service has no way to
-resolve that today: it has no inbound-auth/identity layer at all (the
-`x-user-id-token` header `middleware.UserIDTokenFromContext` forwards is
-opaque, just a pass-through to ServiceNow, not a decodable identity), and
-`snUpdateCaseResponse.Case.UpdatedBy` is a bare string with no accompanying
-email. Publishing something with a fabricated or missing assigner would be
-actively misleading in the notification email, not just an incomplete
-event, so this needs its own decision (e.g. resolving the caller's identity
-some other way) before it can be added — flagging here rather than
-guessing.
+- **`snCaseService.UpdateCase`** also publishes `case.assigned` via
+  `publishCaseAssigned`, called only when `req.AssigneeEmail` was set (the
+  mirror image of the `case.status_changed` path above — `State`/
+  `AssigneeEmail` are mutually exclusive per request, so a single
+  `UpdateCase` call is never both). This was blocked for a while on
+  identity: `csm-notification-service`'s `CaseAssignedPayload` used to
+  require a non-empty `AssignerName`/`AssignerEmail` — the person who
+  *performed* the assignment — and this service has no inbound-auth/
+  identity layer able to resolve that (the `x-user-id-token` header
+  `middleware.UserIDTokenFromContext` forwards is opaque, just a
+  pass-through to ServiceNow, not a decodable identity). The actual
+  unblock was realizing that's the wrong question: `req.AssigneeEmail` (the
+  new assignee, not the assigner) is directly on the update request with
+  no resolution needed at all, and `csm-notification-service`'s payload was
+  renamed `AssigneeName`/`AssigneeEmail` to match — see that service's own
+  `CLAUDE.md`. `publishCaseAssigned`'s `AssigneeName` comes from
+  `snResp.Case.AssignedTo.Name` (ServiceNow's own resolved display name
+  from the PATCH response), falling back to the email if that's empty;
+  `AssigneeEmail` is `*req.AssigneeEmail` verbatim — guaranteed correct
+  since it's exactly what the caller requested. Same pre-PATCH
+  `GetCaseByID` no-op guard as `case.status_changed`: a caller re-PATCHing
+  the case's own current assignee must not send every watcher a false
+  "case assigned" email — compares `cv.AssignedEngineer.Email` against
+  `*req.AssigneeEmail` before the PATCH, same as `cv.State` there.
 
 Every helper above runs **synchronously** (not detached/async the way
 `apps/csm-portal/backend`'s own `internal/handler/cases.go` `publishAsync`

--- a/entity-service/internal/events/events.go
+++ b/entity-service/internal/events/events.go
@@ -93,6 +93,26 @@ type StatusChangedPayload struct {
 	Recipients []string `json:"recipients"`
 }
 
+// CaseAssignedPayload is the Payload shape for TypeCaseAssigned — mirrors
+// csm-notification-service's own CaseAssignedPayload, same reasoning as
+// CommentAddedPayload above. AssigneeName/AssigneeEmail identify who the
+// case is now assigned *to*, not who performed the assignment: this
+// service has no inbound identity layer able to resolve the latter (see
+// snCaseService.publishCaseAssigned's own doc comment), but the new
+// assignee's email is directly available on the update request with no
+// extra lookup needed.
+type CaseAssignedPayload struct {
+	AssigneeName  string `json:"assigneeName"`
+	AssigneeEmail string `json:"assigneeEmail"`
+	ProjectID     string `json:"projectId"`
+	CaseID        string `json:"caseId"`
+	CaseNumber    string `json:"caseNumber,omitempty"`
+	// WSO2CaseID — see CommentAddedPayload's own doc comment.
+	WSO2CaseID string   `json:"wso2CaseId,omitempty"`
+	CaseTitle  string   `json:"caseTitle,omitempty"`
+	Recipients []string `json:"recipients"`
+}
+
 // CaseCreatedPayload is the Payload shape for TypeCaseCreated — mirrors
 // csm-notification-service's own CaseCreatedPayload (its internal/events/
 // validate.go is the schema authority; keep this in sync by hand the same

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -54,6 +54,11 @@ const publishCommentAddedTimeout = 5 * time.Second
 // Publish call afterward.
 const publishStatusChangedTimeout = 5 * time.Second
 
+// publishCaseAssignedTimeout bounds the same two things as
+// publishStatusChangedTimeout, for UpdateCase's assigneeEmail path instead
+// of its state path.
+const publishCaseAssignedTimeout = 5 * time.Second
+
 // watchListEmails extracts the non-empty emails from a case's watch list —
 // Recipients for every case.* event this file publishes is the case's
 // WatchList emails only (an explicit, deliberate decision — this service
@@ -1116,6 +1121,62 @@ func (s *snCaseService) publishStatusChanged(ctx context.Context, caseID, newSta
 	}
 }
 
+// publishCaseAssigned best-effort publishes a case.assigned event after
+// UpdateCase changes a case's assignee. assigneeName/assigneeEmail
+// identify who the case is now assigned *to* — not who performed the
+// assignment: this service has no inbound identity layer (the
+// x-user-id-token header it forwards is opaque, not decodable), so it has
+// no way to resolve who made the request; the new assignee's own
+// email is directly available on req.AssigneeEmail with no extra lookup,
+// and assigneeName is ServiceNow's own resolved display name for that
+// assignee from the PATCH response, falling back to the email if
+// ServiceNow's response didn't carry one.
+//
+// before is the case as it was fetched by UpdateCase *before* issuing the
+// PATCH — same reuse-the-enrichment reasoning as publishStatusChanged's
+// own doc comment (the caller has already used it to confirm the assignee
+// actually changed).
+//
+// Recipients is the case's WatchList emails only — see publishCaseCreated's
+// own doc comment for why, and why an empty list silently skips
+// publishing.
+//
+// Runs synchronously, bounded by publishCaseAssignedTimeout — see
+// publishCaseCreated's own doc comment for why (same reasoning).
+func (s *snCaseService) publishCaseAssigned(ctx context.Context, caseID, assigneeName, assigneeEmail string, before domain.CaseView) {
+	if s.publisher == nil || assigneeEmail == "" {
+		return
+	}
+	ctx, cancel := context.WithTimeout(ctx, publishCaseAssignedTimeout)
+	defer cancel()
+
+	recipients := watchListEmails(before.WatchList)
+	if len(recipients) == 0 {
+		slog.InfoContext(ctx, "sn update case: case.assigned not published, case has no watchers to email", "caseId", caseID)
+		return
+	}
+
+	payload, err := json.Marshal(events.CaseAssignedPayload{
+		AssigneeName:  assigneeName,
+		AssigneeEmail: assigneeEmail,
+		ProjectID:     before.ProjectDetails.ID,
+		CaseID:        caseID,
+		CaseNumber:    before.Number,
+		WSO2CaseID:    before.InternalID,
+		CaseTitle:     before.Subject,
+		Recipients:    recipients,
+	})
+	if err != nil {
+		slog.ErrorContext(ctx, "sn update case: encode case.assigned payload failed", "caseId", caseID, "error", err)
+		return
+	}
+	if err := s.publisher.Publish(ctx, events.TypeCaseAssigned, caseID, payload); err != nil {
+		// Not logging err itself — see publishCaseCreated's matching log
+		// line for why.
+		slog.ErrorContext(ctx, "sn update case: publish case.assigned failed", "caseId", caseID)
+	}
+}
+
 func (s *snCaseService) GetCaseByID(ctx context.Context, id string) (domain.CaseView, error) {
 	token := middleware.UserIDTokenFromContext(ctx)
 
@@ -2015,6 +2076,30 @@ func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReq
 		}
 	}
 
+	// Same reasoning as the state-change block above, applied to
+	// assigneeEmail instead: a caller re-PATCHing the case's current
+	// assignee (a no-op as far as ServiceNow is concerned) must not send
+	// every watcher a false "case assigned" notification. req.State and
+	// req.AssigneeEmail are mutually exclusive per request (see
+	// exclusiveCount above), so this and the block above never both fire
+	// for the same call.
+	var caseBeforeAssign domain.CaseView
+	publishCaseAssign := false
+	if req.AssigneeEmail != nil && s.publisher != nil {
+		enrichCtx, cancel := context.WithTimeout(ctx, publishCaseAssignedTimeout)
+		cv, err := s.GetCaseByID(enrichCtx, req.ID)
+		cancel()
+		switch {
+		case err != nil:
+			slog.ErrorContext(ctx, "sn update case: enrich case for case.assigned publish failed", "caseId", req.ID)
+		case cv.AssignedEngineer != nil && strings.EqualFold(cv.AssignedEngineer.Email, *req.AssigneeEmail):
+			slog.InfoContext(ctx, "sn update case: case.assigned not published, assignee is unchanged", "caseId", req.ID)
+		default:
+			caseBeforeAssign = cv
+			publishCaseAssign = true
+		}
+	}
+
 	raw, err := s.client.Patch(ctx, "/cases/"+uuidToSysid(req.ID), token, payload)
 	if err != nil {
 		return domain.UpdateCaseResponse{}, err
@@ -2121,6 +2206,13 @@ func (s *snCaseService) UpdateCase(ctx context.Context, req domain.UpdateCaseReq
 
 	if publishStatusChange && snResp.Case.State != nil {
 		s.publishStatusChanged(ctx, req.ID, snResp.Case.State.Label, caseBeforeUpdate)
+	}
+	if publishCaseAssign {
+		assigneeName := *req.AssigneeEmail
+		if snResp.Case.AssignedTo != nil && snResp.Case.AssignedTo.Name != "" {
+			assigneeName = snResp.Case.AssignedTo.Name
+		}
+		s.publishCaseAssigned(ctx, req.ID, assigneeName, *req.AssigneeEmail, caseBeforeAssign)
 	}
 
 	return resp, nil

--- a/entity-service/internal/service/sn_case_service_publish_test.go
+++ b/entity-service/internal/service/sn_case_service_publish_test.go
@@ -702,7 +702,11 @@ func TestSNCaseService_UpdateCase_SkipsPublishWhenStateUnchanged(t *testing.T) {
 // TestSNCaseService_UpdateCase_DoesNotPublishStatusChangedForOtherFields
 // verifies that a PATCH not touching State (e.g. assigneeEmail) never
 // triggers publishStatusChanged at all — status_changed is specifically a
-// State-change event, not a catch-all "case updated" one.
+// State-change event, not a catch-all "case updated" one. This fixture's
+// case has no watchList, so its own case.assigned publish (see the
+// dedicated tests below) is skipped too, but for an unrelated reason —
+// not proof status_changed and case.assigned are mutually exclusive in
+// general, just that this particular assigneeEmail PATCH triggers neither.
 func TestSNCaseService_UpdateCase_DoesNotPublishStatusChangedForOtherFields(t *testing.T) {
 	caseSysid := sysid32('a')
 	projectSysid := sysid32('b')
@@ -740,5 +744,179 @@ func TestSNCaseService_UpdateCase_DoesNotPublishStatusChangedForOtherFields(t *t
 	}
 	if len(publisher.calls) != 0 {
 		t.Fatalf("expected no publish call for a non-State update, got %d", len(publisher.calls))
+	}
+}
+
+// TestSNCaseService_UpdateCase_PublishesCaseAssigned verifies the happy
+// path: an AssigneeEmail-only PATCH publishes case.assigned with the new
+// assignee's own name (resolved by ServiceNow in the PATCH response) and
+// email (the exact value the caller requested — see publishCaseAssigned's
+// own doc comment for why this service has no way to resolve who
+// performed the assignment instead), the enriched case's project id, and
+// the watch list's emails as Recipients.
+func TestSNCaseService_UpdateCase_PublishesCaseAssigned(t *testing.T) {
+	caseSysid := sysid32('a')
+	projectSysid := sysid32('b')
+	watcherSysid := sysid32('c')
+	assigneeSysid := sysid32('e')
+	caseID := sysidToUUID(caseSysid)
+
+	getCaseBody := `{
+		"id": "` + caseSysid + `",
+		"internalId": "WSO2-027",
+		"number": "CS0027001",
+		"title": "Assignee change test",
+		"description": "d",
+		"createdOn": "2026-01-02 10:00:00",
+		"createdBy": "jane.doe@example.com",
+		"createdByFullName": "Jane Doe",
+		"project": {"id": "` + projectSysid + `", "name": "Project Zeta"},
+		"deployment": {"id": "", "name": ""},
+		"deployedProduct": {"id": "", "name": "", "version": ""},
+		"state": {"id": 1, "label": "Open"},
+		"watchList": [
+			{"id": "` + watcherSysid + `", "userName": "jroe", "name": "John Roe", "email": "john.roe@example.com"}
+		]
+	}`
+	updateCaseBody := `{
+		"message": "Case updated successfully",
+		"case": {"id": "` + caseSysid + `", "updatedOn": "2026-01-02 12:00:00", "updatedBy": "jane.doe", "assignedTo": {"id": "` + assigneeSysid + `", "name": "Alex Assignee"}}
+	}`
+
+	client := newTestUpdateCaseClient(t, getCaseBody, updateCaseBody)
+	publisher := &mockEventPublisher{}
+	svc := NewServiceNowCaseService(client, nil, publisher)
+
+	assigneeEmail := "alex@example.com"
+	req := domain.UpdateCaseRequest{ID: caseID, AssigneeEmail: &assigneeEmail}
+
+	if _, err := svc.UpdateCase(contextWithUserIDToken("token"), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(publisher.calls) != 1 {
+		t.Fatalf("expected 1 publish call, got %d", len(publisher.calls))
+	}
+	call := publisher.calls[0]
+	if call.eventType != events.TypeCaseAssigned {
+		t.Errorf("eventType = %q, want %q", call.eventType, events.TypeCaseAssigned)
+	}
+	if call.entityID != caseID {
+		t.Errorf("entityID = %q, want %q", call.entityID, caseID)
+	}
+
+	var payload events.CaseAssignedPayload
+	if err := json.Unmarshal(call.payload, &payload); err != nil {
+		t.Fatalf("decode published payload: %v", err)
+	}
+	if payload.AssigneeName != "Alex Assignee" {
+		t.Errorf("assigneeName = %q, want %q", payload.AssigneeName, "Alex Assignee")
+	}
+	if payload.AssigneeEmail != assigneeEmail {
+		t.Errorf("assigneeEmail = %q, want %q", payload.AssigneeEmail, assigneeEmail)
+	}
+	wantProjectID := sysidToUUID(projectSysid)
+	if payload.ProjectID != wantProjectID {
+		t.Errorf("projectId = %q, want %q", payload.ProjectID, wantProjectID)
+	}
+	if payload.CaseID != caseID {
+		t.Errorf("caseId = %q, want %q", payload.CaseID, caseID)
+	}
+	if len(payload.Recipients) != 1 || payload.Recipients[0] != "john.roe@example.com" {
+		t.Errorf("recipients = %v, want [john.roe@example.com]", payload.Recipients)
+	}
+}
+
+// TestSNCaseService_UpdateCase_SkipsPublishCaseAssignedWhenNoWatchers
+// mirrors TestSNCaseService_UpdateCase_SkipsPublishWhenNoWatchers for
+// case.assigned.
+func TestSNCaseService_UpdateCase_SkipsPublishCaseAssignedWhenNoWatchers(t *testing.T) {
+	caseSysid := sysid32('a')
+	projectSysid := sysid32('b')
+	assigneeSysid := sysid32('e')
+	caseID := sysidToUUID(caseSysid)
+
+	getCaseBody := `{
+		"id": "` + caseSysid + `",
+		"internalId": "WSO2-028",
+		"number": "CS0028001",
+		"title": "No watchers here",
+		"description": "d",
+		"createdOn": "2026-01-02 10:00:00",
+		"createdBy": "jane.doe@example.com",
+		"createdByFullName": "Jane Doe",
+		"project": {"id": "` + projectSysid + `", "name": "Project Zeta"},
+		"deployment": {"id": "", "name": ""},
+		"deployedProduct": {"id": "", "name": "", "version": ""},
+		"state": {"id": 1, "label": "Open"}
+	}`
+	updateCaseBody := `{
+		"message": "Case updated successfully",
+		"case": {"id": "` + caseSysid + `", "updatedOn": "2026-01-02 12:00:00", "updatedBy": "jane.doe", "assignedTo": {"id": "` + assigneeSysid + `", "name": "Alex Assignee"}}
+	}`
+
+	client := newTestUpdateCaseClient(t, getCaseBody, updateCaseBody)
+	publisher := &mockEventPublisher{}
+	svc := NewServiceNowCaseService(client, nil, publisher)
+
+	assigneeEmail := "alex@example.com"
+	req := domain.UpdateCaseRequest{ID: caseID, AssigneeEmail: &assigneeEmail}
+
+	if _, err := svc.UpdateCase(contextWithUserIDToken("token"), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(publisher.calls) != 0 {
+		t.Fatalf("expected no publish call for a case with no watchers, got %d", len(publisher.calls))
+	}
+}
+
+// TestSNCaseService_UpdateCase_SkipsPublishCaseAssignedWhenAssigneeUnchanged
+// is the assigneeEmail-path mirror of
+// TestSNCaseService_UpdateCase_SkipsPublishWhenStateUnchanged: a PATCH
+// re-sending the case's own current assignee must not send every watcher a
+// false "case assigned" email. UpdateCase itself must still succeed — only
+// the publish is skipped.
+func TestSNCaseService_UpdateCase_SkipsPublishCaseAssignedWhenAssigneeUnchanged(t *testing.T) {
+	caseSysid := sysid32('a')
+	projectSysid := sysid32('b')
+	watcherSysid := sysid32('c')
+	assigneeSysid := sysid32('e')
+	caseID := sysidToUUID(caseSysid)
+
+	getCaseBody := `{
+		"id": "` + caseSysid + `",
+		"internalId": "WSO2-029",
+		"number": "CS0029001",
+		"title": "Same assignee re-PATCH",
+		"description": "d",
+		"createdOn": "2026-01-02 10:00:00",
+		"createdBy": "jane.doe@example.com",
+		"createdByFullName": "Jane Doe",
+		"project": {"id": "` + projectSysid + `", "name": "Project Zeta"},
+		"deployment": {"id": "", "name": ""},
+		"deployedProduct": {"id": "", "name": "", "version": ""},
+		"state": {"id": 1, "label": "Open"},
+		"assignedEngineer": {"id": "` + assigneeSysid + `", "name": "Alex Assignee", "email": "alex@example.com"},
+		"watchList": [
+			{"id": "` + watcherSysid + `", "userName": "jroe", "name": "John Roe", "email": "john.roe@example.com"}
+		]
+	}`
+	updateCaseBody := `{
+		"message": "Case updated successfully",
+		"case": {"id": "` + caseSysid + `", "updatedOn": "2026-01-02 12:00:00", "updatedBy": "jane.doe", "assignedTo": {"id": "` + assigneeSysid + `", "name": "Alex Assignee"}}
+	}`
+
+	client := newTestUpdateCaseClient(t, getCaseBody, updateCaseBody)
+	publisher := &mockEventPublisher{}
+	svc := NewServiceNowCaseService(client, nil, publisher)
+
+	assigneeEmail := "alex@example.com"
+	req := domain.UpdateCaseRequest{ID: caseID, AssigneeEmail: &assigneeEmail}
+
+	if _, err := svc.UpdateCase(contextWithUserIDToken("token"), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(publisher.calls) != 0 {
+		t.Fatalf("expected no publish call when the assignee didn't actually change, got %d", len(publisher.calls))
 	}
 }


### PR DESCRIPTION
## Summary
- `UpdateCase` now publishes `case.assigned` when `req.AssigneeEmail` is set and the assignee actually changes (same pre-PATCH `GetCaseByID` no-op guard as `case.status_changed`'s state comparison, to avoid a false notification on a re-PATCH of the current assignee).
- Unblocks a feature that was previously documented here as blocked on identity resolution ("who performed the assignment") — that was the wrong question: the new assignee's own email is already on the update request (`req.AssigneeEmail`), and ServiceNow's PATCH response resolves their display name (`assignedTo.name`), so no extra identity/auth work is needed.
- Matches `csm-notification-service`'s companion PR renaming `CaseAssignedPayload.AssignerName/AssignerEmail` → `AssigneeName/AssigneeEmail` to reflect what's actually being published.

## Test plan
- [x] `go build`/`go vet`/`gofmt -l` clean
- [x] `go test ./...` clean — 3 new tests: happy path, no-watchers skip, unchanged-assignee skip
- [x] `gosec` (via `GOTOOLCHAIN=auto`, per this repo's own convention) — 0 issues, 112 files scanned
- [x] `govulncheck ./...` — 0 vulnerabilities