### PR TITLE
[Entity-Service] restrict internal note notifications to wso2.com watchers only

### DIFF
--- a/entity-service/CLAUDE.md
+++ b/entity-service/CLAUDE.md
@@ -136,7 +136,14 @@ there is no Postgres-backed equivalent for any of them):
   unlikely ordering edge case), publishing is skipped rather than sending an
   event with an empty or fabricated author name — same "skip rather than
   send something `events.Validate` would reject" precedent as an empty
-  `Recipients` list.
+  `Recipients` list. When `req.Type` is `domain.CommentTypeWorkNote` (an
+  internal note — never meant for a customer to see), `Recipients` is
+  filtered down to `wso2EmailDomain` (`@wso2.com`) addresses only via
+  `filterWso2Emails`, regardless of who else is on the case's watch list —
+  a case's watch list can include customer watchers, and an internal note
+  must never notify them just because they happen to be watching the case.
+  `wso2EmailDomain` mirrors `apps/csm-portal/backend`'s own constant of the
+  same name.
 
 `publishCaseCreated`, `publishCommentAdded`, `publishStatusChanged`, and
 `publishCaseAssigned` — every `case.*` publisher above, not

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -74,6 +74,28 @@ func watchListEmails(watchList []domain.WatchListUser) []string {
 	return recipients
 }
 
+// wso2EmailDomain is WSO2's own corporate domain — mirrors
+// apps/csm-portal/backend's own wso2EmailDomain constant (see that
+// package's user_external_account.go).
+const wso2EmailDomain = "@wso2.com"
+
+// filterWso2Emails returns only the emails in emails on wso2EmailDomain,
+// preserving order. Used for CommentTypeWorkNote (an internal note, never
+// meant for a customer's eyes) — a case's watch list can contain both
+// internal and customer emails, so publishing an internal note's
+// case.comment_added event with the full, unfiltered watch list would
+// notify customer watchers about a note that was never meant for them,
+// regardless of how that watch list was populated.
+func filterWso2Emails(emails []string) []string {
+	filtered := make([]string, 0, len(emails))
+	for _, e := range emails {
+		if strings.HasSuffix(strings.ToLower(e), wso2EmailDomain) {
+			filtered = append(filtered, e)
+		}
+	}
+	return filtered
+}
+
 // snCasesResponse mirrors the Choreo POST /cases/search response.
 type snCasesResponse struct {
 	Cases        []snCase `json:"cases"`
@@ -1002,7 +1024,11 @@ func (s *snCaseService) resolveCommentAuthorName(ctx context.Context, caseID, co
 // after a new comment is created. Recipients is the case's WatchList
 // emails only — see publishCaseCreated's own doc comment for why, and why
 // an empty list silently skips publishing rather than sending a payload
-// csm-notification-service's events.Validate would reject anyway.
+// csm-notification-service's events.Validate would reject anyway. When
+// req.Type is CommentTypeWorkNote (an internal note — never meant for a
+// customer to see), Recipients is filtered down to wso2.com addresses
+// only via filterWso2Emails, regardless of who else is on the case's
+// watch list.
 //
 // events.CommentAddedPayload.Name requires the comment author's resolved
 // display name, which snCreateCommentResponse doesn't carry (only a raw
@@ -1032,6 +1058,9 @@ func (s *snCaseService) publishCommentAdded(ctx context.Context, req domain.Crea
 	}
 
 	recipients := watchListEmails(cv.WatchList)
+	if req.Type == domain.CommentTypeWorkNote {
+		recipients = filterWso2Emails(recipients)
+	}
 	if len(recipients) == 0 {
 		slog.InfoContext(ctx, "sn create comment: case.comment_added not published, case has no watchers to email", "caseId", req.CaseID)
 		return

--- a/entity-service/internal/service/sn_case_service_publish_test.go
+++ b/entity-service/internal/service/sn_case_service_publish_test.go
@@ -424,6 +424,134 @@ func TestSNCaseService_CreateCaseComment_PublishesCommentAdded(t *testing.T) {
 	}
 }
 
+// TestSNCaseService_CreateCaseComment_WorkNote_FiltersRecipientsToWso2Domain
+// verifies that an internal note (CommentTypeWorkNote — never meant for a
+// customer's eyes) only notifies watchers on WSO2's own domain, even when
+// the case's watch list also has non-wso2.com watchers.
+func TestSNCaseService_CreateCaseComment_WorkNote_FiltersRecipientsToWso2Domain(t *testing.T) {
+	caseSysid := sysid32('a')
+	projectSysid := sysid32('b')
+	internalWatcherSysid := sysid32('c')
+	customerWatcherSysid := sysid32('f')
+	commentSysid := sysid32('d')
+	caseID := sysidToUUID(caseSysid)
+	commentID := sysidToUUID(commentSysid)
+
+	getCaseBody := `{
+		"id": "` + caseSysid + `",
+		"internalId": "WSO2-030",
+		"number": "CS0030001",
+		"title": "Login is broken",
+		"description": "d",
+		"createdOn": "2026-01-02 10:00:00",
+		"createdBy": "jane.doe@example.com",
+		"createdByFullName": "Jane Doe",
+		"project": {"id": "` + projectSysid + `", "name": "Project Zeta"},
+		"deployment": {"id": "", "name": ""},
+		"deployedProduct": {"id": "", "name": "", "version": ""},
+		"state": {"id": 1, "label": "Open"},
+		"watchList": [
+			{"id": "` + internalWatcherSysid + `", "userName": "jroe", "name": "John Roe", "email": "john.roe@wso2.com"},
+			{"id": "` + customerWatcherSysid + `", "userName": "csmith", "name": "Cara Smith", "email": "cara.smith@acme.com"}
+		]
+	}`
+	createCommentBody := `{
+		"message": "Comment created successfully",
+		"comment": {"id": "` + commentSysid + `", "createdOn": "2026-01-02 11:00:00", "createdBy": "agent.smith"}
+	}`
+	searchCommentsBody := `{
+		"comments": [
+			{"id": "` + commentSysid + `", "referenceId": "` + caseSysid + `", "content": "Internal only", "type": "work_notes", "createdOn": "2026-01-02 11:00:00", "createdBy": "agent.smith", "createdByFullName": "Agent Smith"}
+		],
+		"offset": 0, "limit": 20, "totalRecords": 1
+	}`
+
+	client := newTestCommentClient(t, getCaseBody, createCommentBody, searchCommentsBody)
+	publisher := &mockEventPublisher{}
+	svc := NewServiceNowCaseService(client, nil, publisher)
+
+	req := domain.CreateCaseCommentRequest{
+		CaseID:  caseID,
+		Type:    domain.CommentTypeWorkNote,
+		Content: "Internal only",
+	}
+
+	if _, err := svc.CreateCaseComment(contextWithUserIDToken("token"), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(publisher.calls) != 1 {
+		t.Fatalf("expected 1 publish call, got %d", len(publisher.calls))
+	}
+	var payload events.CommentAddedPayload
+	if err := json.Unmarshal(publisher.calls[0].payload, &payload); err != nil {
+		t.Fatalf("decode published payload: %v", err)
+	}
+	if payload.CommentID != commentID {
+		t.Errorf("commentId = %q, want %q", payload.CommentID, commentID)
+	}
+	if len(payload.Recipients) != 1 || payload.Recipients[0] != "john.roe@wso2.com" {
+		t.Errorf("recipients = %v, want only [john.roe@wso2.com] — the customer watcher must not be notified of an internal note", payload.Recipients)
+	}
+}
+
+// TestSNCaseService_CreateCaseComment_WorkNote_SkipsPublishWhenNoWso2Watchers
+// verifies that an internal note with no wso2.com watchers on the case
+// skips publishing entirely, rather than notifying customer watchers as a
+// fallback.
+func TestSNCaseService_CreateCaseComment_WorkNote_SkipsPublishWhenNoWso2Watchers(t *testing.T) {
+	caseSysid := sysid32('a')
+	projectSysid := sysid32('b')
+	customerWatcherSysid := sysid32('f')
+	commentSysid := sysid32('d')
+	caseID := sysidToUUID(caseSysid)
+
+	getCaseBody := `{
+		"id": "` + caseSysid + `",
+		"internalId": "WSO2-031",
+		"number": "CS0031001",
+		"title": "Login is broken",
+		"description": "d",
+		"createdOn": "2026-01-02 10:00:00",
+		"createdBy": "jane.doe@example.com",
+		"createdByFullName": "Jane Doe",
+		"project": {"id": "` + projectSysid + `", "name": "Project Zeta"},
+		"deployment": {"id": "", "name": ""},
+		"deployedProduct": {"id": "", "name": "", "version": ""},
+		"state": {"id": 1, "label": "Open"},
+		"watchList": [
+			{"id": "` + customerWatcherSysid + `", "userName": "csmith", "name": "Cara Smith", "email": "cara.smith@acme.com"}
+		]
+	}`
+	createCommentBody := `{
+		"message": "Comment created successfully",
+		"comment": {"id": "` + commentSysid + `", "createdOn": "2026-01-02 11:00:00", "createdBy": "agent.smith"}
+	}`
+	searchCommentsBody := `{
+		"comments": [
+			{"id": "` + commentSysid + `", "referenceId": "` + caseSysid + `", "content": "Internal only", "type": "work_notes", "createdOn": "2026-01-02 11:00:00", "createdBy": "agent.smith", "createdByFullName": "Agent Smith"}
+		],
+		"offset": 0, "limit": 20, "totalRecords": 1
+	}`
+
+	client := newTestCommentClient(t, getCaseBody, createCommentBody, searchCommentsBody)
+	publisher := &mockEventPublisher{}
+	svc := NewServiceNowCaseService(client, nil, publisher)
+
+	req := domain.CreateCaseCommentRequest{
+		CaseID:  caseID,
+		Type:    domain.CommentTypeWorkNote,
+		Content: "Internal only",
+	}
+
+	if _, err := svc.CreateCaseComment(contextWithUserIDToken("token"), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(publisher.calls) != 0 {
+		t.Fatalf("expected no publish call when no wso2.com watcher is on the case, got %d", len(publisher.calls))
+	}
+}
+
 // TestSNCaseService_CreateCaseComment_SkipsPublishWhenNoWatchers mirrors
 // TestSNCaseService_CreateCase_SkipsPublishWhenNoWatchers for
 // case.comment_added.


### PR DESCRIPTION
## Summary
- When a case comment is an internal note (`domain.CommentTypeWorkNote`), `publishCommentAdded` now filters `case.comment_added`'s `Recipients` down to `@wso2.com` addresses only, regardless of who else is on the case's watch list. A watch list can include customer watchers alongside internal ones; an internal note must never notify them just because they're watching the case.
- Customer-visible comments (`domain.CommentTypeComment`) are unaffected — full watch list, same as before.
- `filterWso2Emails`/`wso2EmailDomain` mirror the existing `wso2EmailDomain` constant already used the same way in `apps/csm-portal/backend`.

## Test plan
- [x] `go build`/`go vet`/`gofmt -l` clean
- [x] `go test ./...` clean — 2 new tests: mixed watch list filters to wso2.com only, all-customer watch list skips publishing entirely
- [x] `gosec` (via `GOTOOLCHAIN=auto`) — 0 issues, 112 files scanned
- [x] `govulncheck ./...` — 0 vulnerabilities

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated internal work-note notifications so they are sent only to authorized `@wso2.com` watchers.
  - Customer watchers are no longer notified when internal work notes are added.
  - If no eligible watchers are present, no notification is sent, while the comment is still created successfully.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->