### PR TITLE
[CSM Portal] revert case-feedback endpoint paths to singular

### DIFF
--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -164,8 +164,8 @@ func main() {
 	mux.HandleFunc("GET /tags/search", caseHandler.SearchTagsQuery)
 	mux.HandleFunc("POST /cases/search", caseHandler.SearchCases)
 	mux.HandleFunc("POST /cases/aggregate", caseHandler.AggregateCases)
-	mux.HandleFunc("POST /cases/feedbacks/search", caseHandler.SearchFeedback)
-	mux.HandleFunc("POST /cases/feedbacks/aggregate", caseHandler.AggregateFeedback)
+	mux.HandleFunc("POST /cases/feedback/search", caseHandler.SearchFeedback)
+	mux.HandleFunc("POST /cases/feedback/aggregate", caseHandler.AggregateFeedback)
 	mux.HandleFunc("GET /dashboards", dashboardHandler.GetDashboards)
 	// Registered before the {dashboardId} wildcard purely for readability —
 	// net/http's ServeMux resolves by specificity, not registration order,

--- a/apps/csm-portal/backend/internal/dashboard/registry.go
+++ b/apps/csm-portal/backend/internal/dashboard/registry.go
@@ -655,7 +655,7 @@ var validWidgetShapes = map[Shape]bool{
 }
 
 // validGroupByBuckets are the legal values of GroupByConfig.Bucket -- the
-// same "day"/"week"/"month" enum POST /cases/feedbacks/aggregate documents on
+// same "day"/"week"/"month" enum POST /cases/feedback/aggregate documents on
 // the entity-service side (see AggregateFeedbackRequest.bucket in
 // openapi.yaml). Kept here rather than derived from that spec because this
 // layer never calls that endpoint; it only validates widget config shape.

--- a/apps/csm-portal/backend/internal/dashboard/widgets.go
+++ b/apps/csm-portal/backend/internal/dashboard/widgets.go
@@ -67,7 +67,7 @@ const (
 	// other ResourceType, this layer only validates that the value is a known
 	// enum member -- it does not know, and does not need to know, that a
 	// "bar"+GroupBy.Bucket widget with this resourceType resolves via the
-	// webapp's own hook calling POST /cases/feedbacks/aggregate (see
+	// webapp's own hook calling POST /cases/feedback/aggregate (see
 	// GroupByConfig.Bucket's doc comment). There is no
 	// resourceType->endpoint mapping anywhere server-side; the frontend picks
 	// the endpoint from resourceType entirely on its own, same as every other
@@ -106,7 +106,7 @@ type GroupByConfig struct {
 	// grouping -- "day", "week", or "month" (enforced at directory-load
 	// time). Mutually exclusive with Field. This is the shape a case-feedback
 	// trend widget uses (ResourceCaseFeedback, Shape "bar"): the frontend's
-	// own hook calls POST /cases/feedbacks/aggregate with this bucket value
+	// own hook calls POST /cases/feedback/aggregate with this bucket value
 	// and maps its date-bucketed response into the same per-slice shape
 	// Slices/field-grouping already produce, same client-side-resolution
 	// philosophy as the rest of this type -- this layer never calls that

--- a/apps/csm-portal/backend/internal/entity/customer.go
+++ b/apps/csm-portal/backend/internal/entity/customer.go
@@ -44,20 +44,20 @@ func (c *CustomerEntityClient) AggregateCases(ctx context.Context, body []byte) 
 	return c.do(ctx, http.MethodPost, "/cases/aggregate", body)
 }
 
-// SearchFeedback calls POST /cases/feedbacks/search on the entity service:
+// SearchFeedback calls POST /cases/feedback/search on the entity service:
 // search of case-feedback (satisfaction rating) records across cases,
 // filterable by case, accounts, and submission date range. Response is
 // returned as raw JSON; typed response structs are deferred.
 func (c *CustomerEntityClient) SearchFeedback(ctx context.Context, body []byte) ([]byte, error) {
-	return c.do(ctx, http.MethodPost, "/cases/feedbacks/search", body)
+	return c.do(ctx, http.MethodPost, "/cases/feedback/search", body)
 }
 
-// AggregateFeedback calls POST /cases/feedbacks/aggregate on the entity
+// AggregateFeedback calls POST /cases/feedback/aggregate on the entity
 // service: date-bucketed rating aggregation of case-feedback records across
 // cases. Response is returned as raw JSON; typed response structs are
 // deferred.
 func (c *CustomerEntityClient) AggregateFeedback(ctx context.Context, body []byte) ([]byte, error) {
-	return c.do(ctx, http.MethodPost, "/cases/feedbacks/aggregate", body)
+	return c.do(ctx, http.MethodPost, "/cases/feedback/aggregate", body)
 }
 
 // GetCase calls GET /cases/{id} on the entity service.

--- a/apps/csm-portal/backend/internal/handler/cases.go
+++ b/apps/csm-portal/backend/internal/handler/cases.go
@@ -519,7 +519,7 @@ func (h *CaseHandler) AggregateCases(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, result)
 }
 
-// SearchFeedback handles POST /cases/feedbacks/search.
+// SearchFeedback handles POST /cases/feedback/search.
 // Search of case-feedback (satisfaction rating) records across cases,
 // filterable by case, accounts, and submission date range. Backs the
 // case-feedback dashboard's list view. This is a plain forward-and-return
@@ -558,7 +558,7 @@ func (h *CaseHandler) SearchFeedback(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, result)
 }
 
-// AggregateFeedback handles POST /cases/feedbacks/aggregate.
+// AggregateFeedback handles POST /cases/feedback/aggregate.
 // Date-bucketed rating aggregation of case-feedback records across cases.
 // Backs the case-feedback dashboard's rating-trend chart. Same
 // forward-and-return proxy contract as SearchFeedback: the bucket enum and

--- a/apps/csm-portal/backend/internal/handler/cases_test.go
+++ b/apps/csm-portal/backend/internal/handler/cases_test.go
@@ -3053,7 +3053,7 @@ func TestAggregateCases(t *testing.T) {
 func TestSearchFeedback(t *testing.T) {
 	t.Run("requires authenticated user", func(t *testing.T) {
 		h := NewCaseHandler(&mockEntityCaseClient{})
-		r := httptest.NewRequest(http.MethodPost, "/cases/feedbacks/search", strings.NewReader(`{}`))
+		r := httptest.NewRequest(http.MethodPost, "/cases/feedback/search", strings.NewReader(`{}`))
 		w := httptest.NewRecorder()
 		h.SearchFeedback(w, r)
 		assertStatus(t, w, http.StatusUnauthorized)
@@ -3063,7 +3063,7 @@ func TestSearchFeedback(t *testing.T) {
 
 	t.Run("rejects body exceeding 1 MiB", func(t *testing.T) {
 		h := NewCaseHandler(&mockEntityCaseClient{})
-		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/feedbacks/search", strings.NewReader(strings.Repeat("x", maxRequestBodyBytes+1))))
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/feedback/search", strings.NewReader(strings.Repeat("x", maxRequestBodyBytes+1))))
 		w := httptest.NewRecorder()
 		h.SearchFeedback(w, r)
 		assertStatus(t, w, http.StatusRequestEntityTooLarge)
@@ -3073,7 +3073,7 @@ func TestSearchFeedback(t *testing.T) {
 
 	t.Run("rejects invalid JSON body", func(t *testing.T) {
 		h := NewCaseHandler(&mockEntityCaseClient{})
-		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/feedbacks/search", strings.NewReader(`not-json`)))
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/feedback/search", strings.NewReader(`not-json`)))
 		w := httptest.NewRecorder()
 		h.SearchFeedback(w, r)
 		assertStatus(t, w, http.StatusBadRequest)
@@ -3091,7 +3091,7 @@ func TestSearchFeedback(t *testing.T) {
 			},
 		}
 		h := NewCaseHandler(client)
-		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/feedbacks/search", strings.NewReader(reqPayload)))
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/feedback/search", strings.NewReader(reqPayload)))
 		w := httptest.NewRecorder()
 		h.SearchFeedback(w, r)
 
@@ -3116,7 +3116,7 @@ func TestSearchFeedback(t *testing.T) {
 					},
 				}
 				h := NewCaseHandler(client)
-				r := withUser(httptest.NewRequest(http.MethodPost, "/cases/feedbacks/search", strings.NewReader(`{}`)))
+				r := withUser(httptest.NewRequest(http.MethodPost, "/cases/feedback/search", strings.NewReader(`{}`)))
 				w := httptest.NewRecorder()
 				h.SearchFeedback(w, r)
 				assertStatus(t, w, tc.wantCode)
@@ -3130,7 +3130,7 @@ func TestSearchFeedback(t *testing.T) {
 func TestAggregateFeedback(t *testing.T) {
 	t.Run("requires authenticated user", func(t *testing.T) {
 		h := NewCaseHandler(&mockEntityCaseClient{})
-		r := httptest.NewRequest(http.MethodPost, "/cases/feedbacks/aggregate", strings.NewReader(`{}`))
+		r := httptest.NewRequest(http.MethodPost, "/cases/feedback/aggregate", strings.NewReader(`{}`))
 		w := httptest.NewRecorder()
 		h.AggregateFeedback(w, r)
 		assertStatus(t, w, http.StatusUnauthorized)
@@ -3140,7 +3140,7 @@ func TestAggregateFeedback(t *testing.T) {
 
 	t.Run("rejects body exceeding 1 MiB", func(t *testing.T) {
 		h := NewCaseHandler(&mockEntityCaseClient{})
-		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/feedbacks/aggregate", strings.NewReader(strings.Repeat("x", maxRequestBodyBytes+1))))
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/feedback/aggregate", strings.NewReader(strings.Repeat("x", maxRequestBodyBytes+1))))
 		w := httptest.NewRecorder()
 		h.AggregateFeedback(w, r)
 		assertStatus(t, w, http.StatusRequestEntityTooLarge)
@@ -3150,7 +3150,7 @@ func TestAggregateFeedback(t *testing.T) {
 
 	t.Run("rejects invalid JSON body", func(t *testing.T) {
 		h := NewCaseHandler(&mockEntityCaseClient{})
-		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/feedbacks/aggregate", strings.NewReader(`not-json`)))
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/feedback/aggregate", strings.NewReader(`not-json`)))
 		w := httptest.NewRecorder()
 		h.AggregateFeedback(w, r)
 		assertStatus(t, w, http.StatusBadRequest)
@@ -3168,7 +3168,7 @@ func TestAggregateFeedback(t *testing.T) {
 			},
 		}
 		h := NewCaseHandler(client)
-		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/feedbacks/aggregate", strings.NewReader(reqPayload)))
+		r := withUser(httptest.NewRequest(http.MethodPost, "/cases/feedback/aggregate", strings.NewReader(reqPayload)))
 		w := httptest.NewRecorder()
 		h.AggregateFeedback(w, r)
 
@@ -3193,7 +3193,7 @@ func TestAggregateFeedback(t *testing.T) {
 					},
 				}
 				h := NewCaseHandler(client)
-				r := withUser(httptest.NewRequest(http.MethodPost, "/cases/feedbacks/aggregate", strings.NewReader(`{}`)))
+				r := withUser(httptest.NewRequest(http.MethodPost, "/cases/feedback/aggregate", strings.NewReader(`{}`)))
 				w := httptest.NewRecorder()
 				h.AggregateFeedback(w, r)
 				assertStatus(t, w, tc.wantCode)

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -1972,15 +1972,15 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
-  /cases/feedbacks/search:
+  /cases/feedback/search:
     post:
       summary: Search case-feedback (satisfaction rating) records across cases.
       description: >-
         Plain forward-and-return proxy to the entity service's own POST
-        /cases/feedbacks/search: filterable by case, accounts, and submission
+        /cases/feedback/search: filterable by case, accounts, and submission
         date range, and paginated. Backs the case-feedback dashboard's list
         view. Distinct from any single-case feedback lookup.
-      operationId: postCasesFeedbacksSearch
+      operationId: postCasesFeedbackSearch
       requestBody:
         description: Case-feedback search payload
         content:
@@ -2038,20 +2038,20 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 
-  /cases/feedbacks/aggregate:
+  /cases/feedback/aggregate:
     post:
       summary: >-
         Date-bucketed rating aggregation of case-feedback records across
         cases.
       description: >-
         Plain forward-and-return proxy to the entity service's own POST
-        /cases/feedbacks/aggregate. Backs the case-feedback dashboard's
+        /cases/feedback/aggregate. Backs the case-feedback dashboard's
         rating-trend chart (a shape "bar" widget with resourceType
         "case_feedback" and a "groupBy.bucket" — see DashboardWidget). This
         is the many-cases trend endpoint, not scoped to one case, so
         filters.caseId is not accepted here (unlike
-        /cases/feedbacks/search).
-      operationId: postCasesFeedbacksAggregate
+        /cases/feedback/search).
+      operationId: postCasesFeedbackAggregate
       requestBody:
         description: Case-feedback aggregate payload
         content:
@@ -6880,7 +6880,7 @@ components:
             POST /cases/search. case_feedback is case-feedback (satisfaction
             rating) records, not cases themselves — a shape "bar" widget with
             this resourceType and a "groupBy.bucket" (see below) is resolved
-            by the caller against POST /cases/feedbacks/aggregate instead;
+            by the caller against POST /cases/feedback/aggregate instead;
             there is no server-side resourceType-to-endpoint mapping, the
             caller picks the endpoint from resourceType on its own, same as
             every other value here.
@@ -6943,7 +6943,7 @@ components:
               description: >
                 Date-bucket granularity instead of field-value grouping.
                 This is the mode a case_feedback trend widget uses: the
-                caller resolves it by calling POST /cases/feedbacks/aggregate
+                caller resolves it by calling POST /cases/feedback/aggregate
                 with this value as that endpoint's own "bucket" (see
                 AggregateFeedbackRequest), not the generic
                 POST /{resourceType}/aggregate this groupBy block otherwise

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -3301,7 +3301,7 @@ export interface BeDashboardGroupByConfig {
    * with `field`. Resolved by `useCaseFeedbackTrendData`, a dedicated hook
    * (not `useWidgetGroupByData`, whose `POST {resourceType}/aggregate`
    * request/response shape this doesn't match) that calls `POST
-   * /cases/feedbacks/aggregate` with this value and maps its date-bucketed
+   * /cases/feedback/aggregate` with this value and maps its date-bucketed
    * response into the same per-slice `PieSliceResult[]` shape every other
    * pie/bar widget already renders. */
   bucket?: "day" | "week" | "month";
@@ -3333,7 +3333,7 @@ export interface BeGroupByResponse {
 
 /**
  * A single case-feedback (satisfaction rating) record, as returned by both
- * `POST /cases/feedbacks/search`'s `results` array and, opaquely, read by the
+ * `POST /cases/feedback/search`'s `results` array and, opaquely, read by the
  * `case_feedback` widget resourceType's `columns`-driven list renderer (see
  * `widgetResourceConfig.ts`'s `case_feedback` entry). Distinct id space from
  * `BeCaseSearchView` — `caseId` is the only link back to a real case (there
@@ -3350,14 +3350,14 @@ export interface BeCaseFeedback {
   submittedAt: string;
 }
 
-/** Body of `POST /cases/feedbacks/search` — deliberately NOT the
+/** Body of `POST /cases/feedback/search` — deliberately NOT the
  * `{ pagination: { offset, limit } }` shape every other resourceType's
  * search endpoint takes (see `BeDashboardWidget.query`'s sibling contracts);
  * this one takes flat `page`/`pageSize` instead, mirrored on `WidgetResourceConfig`'s
  * `case_feedback` entry via `buildSearchRequestBody`. */
 export interface BeCaseFeedbackSearchFilters {
   /** Restrict results to a single case. Not accepted by
-   * `/cases/feedbacks/aggregate` — see {@link BeCaseFeedbackAggregateFilters}. */
+   * `/cases/feedback/aggregate` — see {@link BeCaseFeedbackAggregateFilters}. */
   caseId?: string;
   accountIds?: string[];
   dateFrom?: string;
@@ -3369,7 +3369,7 @@ export interface BeCaseFeedbackSearchResponse {
   totalRecords: number;
 }
 
-/** Narrower than {@link BeCaseFeedbackSearchFilters} — `/cases/feedbacks/
+/** Narrower than {@link BeCaseFeedbackSearchFilters} — `/cases/feedback/
  * aggregate` is the many-cases trend endpoint, not scoped to a single case,
  * so `caseId` is not accepted here. */
 export interface BeCaseFeedbackAggregateFilters {
@@ -3383,7 +3383,7 @@ export interface BeCaseFeedbackAggregatePayload {
   bucket: "day" | "week" | "month";
 }
 
-/** One aggregated time bucket in a `POST /cases/feedbacks/aggregate`
+/** One aggregated time bucket in a `POST /cases/feedback/aggregate`
  * response. */
 export interface BeFeedbackBucket {
   bucketStart: string;

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useCaseFeedbackTrendData.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useCaseFeedbackTrendData.test.tsx
@@ -58,7 +58,7 @@ describe("useCaseFeedbackTrendData", () => {
 
     expect(postMock).toHaveBeenCalledTimes(1);
     expect(postMock).toHaveBeenCalledWith(
-      "/cases/feedbacks/aggregate",
+      "/cases/feedback/aggregate",
       { filters: { accountIds: ["acc-1"] }, bucket: "month" },
       { signal: expect.any(AbortSignal) },
     );

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useCaseFeedbackTrendData.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useCaseFeedbackTrendData.ts
@@ -57,7 +57,7 @@ function formatBucketLabel(bucketStart: string, bucket: "day" | "week" | "month"
 
 /**
  * Resolves a `shape: "bar"` `case_feedback` widget's date-bucketed rating
- * trend via a single `POST /cases/feedbacks/aggregate` call — the
+ * trend via a single `POST /cases/feedback/aggregate` call — the
  * `groupBy.bucket` counterpart of `useWidgetGroupByData`'s `groupBy.field`
  * (see that field's own doc comment on `BeDashboardGroupByConfig` for why
  * this is a dedicated hook rather than a branch inside that one: the

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetGroupByData.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useWidgetGroupByData.ts
@@ -125,7 +125,7 @@ export function useWidgetGroupByData(
       // `groupBy.bucket` widget (date-bucketed grouping; see that field's own
       // doc comment on `BeDashboardGroupByConfig`) never reaches this hook at
       // all: `DashboardWidgetTile` calls `useCaseFeedbackTrendData` instead,
-      // whose own `POST /cases/feedbacks/aggregate` request/response shape
+      // whose own `POST /cases/feedback/aggregate` request/response shape
       // this hook's `groupBy`/`BeGroupByResponse` types don't match. This
       // check is therefore normally dead — it exists only so a
       // misconfigured/future caller that reaches here with a bucket-only

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
@@ -370,7 +370,7 @@ export default function DashboardWidgetTile({
   // `groupBy.bucket` (date-bucketed grouping — only `case_feedback`'s own
   // trend widget uses this today) resolves via `useCaseFeedbackTrendData`
   // instead of `useWidgetGroupByData`: its request/response contract (`POST
-  // /cases/feedbacks/aggregate`) is unrelated to `BeGroupByResponse` (see
+  // /cases/feedback/aggregate`) is unrelated to `BeGroupByResponse` (see
   // `BeDashboardGroupByConfig.bucket`'s own doc comment) — passing a
   // `bucket`-configured `groupBy` into `useWidgetGroupByData` would throw
   // (see that hook's own field-presence guard), so it's withheld here

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.ts
@@ -121,7 +121,7 @@ export interface WidgetResourceConfig {
   /** Only meaningful for shape "list". Overrides the default request body
    * `useWidgetData` POSTs to `searchEndpoint` (`{ filters, pagination: {
    * offset, limit }, sortBy? }`) — every resourceType's own search contract
-   * uses that shape EXCEPT `case_feedback`'s `POST /cases/feedbacks/search`,
+   * uses that shape EXCEPT `case_feedback`'s `POST /cases/feedback/search`,
    * which takes flat `page`/`pageSize` instead of `pagination.offset/limit`
    * (see that entry's own comment for why). Omitted (every other
    * resourceType) keeps `useWidgetData`'s existing request shape untouched. */
@@ -878,7 +878,7 @@ export const WIDGET_RESOURCE_CONFIG: Record<
     },
   },
   // Satisfaction-rating survey responses across cases (`POST
-  // /cases/feedbacks/search` / `POST /cases/feedbacks/aggregate`) — its own
+  // /cases/feedback/search` / `POST /cases/feedback/aggregate`) — its own
   // resourceType, not a case `type` variant like `service_request` etc.
   // above, because a feedback record isn't a case row at all (no
   // `number`/`subject`/`state`; see `BeCaseFeedback`). Its own two-endpoint
@@ -892,8 +892,8 @@ export const WIDGET_RESOURCE_CONFIG: Record<
   // `buildHref`/`previewSlug` have nowhere real to land — same situation
   // `task` is in above, same fallback.
   case_feedback: {
-    searchEndpoint: "/cases/feedbacks/search",
-    groupByEndpoint: "/cases/feedbacks/aggregate",
+    searchEndpoint: "/cases/feedback/search",
+    groupByEndpoint: "/cases/feedback/aggregate",
     itemsKey: "results",
     buildSearchRequestBody: ({ filters, offset, limit }) => {
       // `case_feedback` has no sortable columns exposed by its own search

--- a/entity-service/internal/domain/feedback.go
+++ b/entity-service/internal/domain/feedback.go
@@ -38,7 +38,7 @@ type SearchFeedbackFilters struct {
 	DateTo     string   `json:"dateTo,omitempty"`
 }
 
-// SearchFeedbackRequest is the input for POST /cases/feedbacks/search.
+// SearchFeedbackRequest is the input for POST /cases/feedback/search.
 // Page and PageSize are 1-based/optional; omitted values let the backing
 // data source apply its own defaults.
 type SearchFeedbackRequest struct {
@@ -54,7 +54,7 @@ type SearchFeedbackResponse struct {
 }
 
 // FeedbackBucket is the enum of supported date-bucket granularities for
-// POST /cases/feedbacks/aggregate.
+// POST /cases/feedback/aggregate.
 type FeedbackBucket string
 
 const (
@@ -72,7 +72,7 @@ type AggregateFeedbackFilters struct {
 	DateTo     string   `json:"dateTo,omitempty"`
 }
 
-// AggregateFeedbackRequest is the input for POST /cases/feedbacks/aggregate.
+// AggregateFeedbackRequest is the input for POST /cases/feedback/aggregate.
 type AggregateFeedbackRequest struct {
 	Filters AggregateFeedbackFilters `json:"filters"`
 	// Bucket selects the date-bucket granularity. Required; one of "day", "week", "month".

--- a/entity-service/internal/handler/feedback_handler.go
+++ b/entity-service/internal/handler/feedback_handler.go
@@ -34,7 +34,7 @@ func NewFeedbackHandler(svc service.FeedbackService) *FeedbackHandler {
 	return &FeedbackHandler{svc: svc}
 }
 
-// SearchFeedback handles POST /cases/feedbacks/search.
+// SearchFeedback handles POST /cases/feedback/search.
 func (h *FeedbackHandler) SearchFeedback(w http.ResponseWriter, r *http.Request) {
 	var req domain.SearchFeedbackRequest
 	if !decodeRequest(w, r, &req) {
@@ -49,7 +49,7 @@ func (h *FeedbackHandler) SearchFeedback(w http.ResponseWriter, r *http.Request)
 	_ = json.NewEncoder(w).Encode(resp)
 }
 
-// AggregateFeedback handles POST /cases/feedbacks/aggregate.
+// AggregateFeedback handles POST /cases/feedback/aggregate.
 func (h *FeedbackHandler) AggregateFeedback(w http.ResponseWriter, r *http.Request) {
 	var req domain.AggregateFeedbackRequest
 	if !decodeRequest(w, r, &req) {

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -292,8 +292,8 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) http.Handler {
 	mux.HandleFunc("POST /cases/search", caseHandler.SearchCases)
 	mux.HandleFunc("POST /cases/aggregate", caseHandler.AggregateCases)
 	if feedbackHandler != nil {
-		mux.HandleFunc("POST /cases/feedbacks/search", feedbackHandler.SearchFeedback)
-		mux.HandleFunc("POST /cases/feedbacks/aggregate", feedbackHandler.AggregateFeedback)
+		mux.HandleFunc("POST /cases/feedback/search", feedbackHandler.SearchFeedback)
+		mux.HandleFunc("POST /cases/feedback/aggregate", feedbackHandler.AggregateFeedback)
 	}
 	mux.HandleFunc("POST /cases/{id}/comments", caseHandler.CreateCaseComment)
 	mux.HandleFunc("POST /cases/{id}/activities/search", caseHandler.SearchCaseActivities)

--- a/entity-service/internal/service/feedback_service.go
+++ b/entity-service/internal/service/feedback_service.go
@@ -28,7 +28,7 @@ import (
 )
 
 // validFeedbackBuckets is the closed set of bucket granularities the backing
-// data source accepts for POST /cases/feedbacks/aggregate.
+// data source accepts for POST /cases/feedback/aggregate.
 var validFeedbackBuckets = map[domain.FeedbackBucket]bool{
 	domain.FeedbackBucketDay:   true,
 	domain.FeedbackBucketWeek:  true,
@@ -36,7 +36,7 @@ var validFeedbackBuckets = map[domain.FeedbackBucket]bool{
 }
 
 // snFeedbackFilters mirrors the "filters" object accepted by the Choreo
-// POST /cases/feedbacks/search and POST /cases/feedbacks/aggregate endpoints.
+// POST /cases/feedback/search and POST /cases/feedback/aggregate endpoints.
 // The aggregate endpoint's closed-record binding rejects a caseId field, so
 // this struct -- shared by both outbound payloads -- deliberately never sets
 // CaseID for an aggregate call (see snAggregateFeedbackPayload).
@@ -47,7 +47,7 @@ type snFeedbackFilters struct {
 	DateTo     string   `json:"dateTo,omitempty"`
 }
 
-// snSearchFeedbackPayload is the Choreo POST /cases/feedbacks/search request body.
+// snSearchFeedbackPayload is the Choreo POST /cases/feedback/search request body.
 type snSearchFeedbackPayload struct {
 	Filters  snFeedbackFilters `json:"filters"`
 	Page     int               `json:"page,omitempty"`
@@ -64,13 +64,13 @@ type snFeedbackRow struct {
 	SubmittedAt string  `json:"submittedAt"`
 }
 
-// snSearchFeedbackResponse mirrors the Choreo POST /cases/feedbacks/search response.
+// snSearchFeedbackResponse mirrors the Choreo POST /cases/feedback/search response.
 type snSearchFeedbackResponse struct {
 	Results      []snFeedbackRow `json:"results"`
 	TotalRecords int             `json:"totalRecords"`
 }
 
-// snAggregateFeedbackPayload is the Choreo POST /cases/feedbacks/aggregate request
+// snAggregateFeedbackPayload is the Choreo POST /cases/feedback/aggregate request
 // body. Filters never carries CaseID: the aggregate endpoint's closed-record
 // binding rejects it with a 400 (it is the many-cases trend endpoint, not
 // scoped to one case).
@@ -86,7 +86,7 @@ type snFeedbackBucketRow struct {
 	Count       int     `json:"count"`
 }
 
-// snAggregateFeedbackResponse mirrors the Choreo POST /cases/feedbacks/aggregate response.
+// snAggregateFeedbackResponse mirrors the Choreo POST /cases/feedback/aggregate response.
 type snAggregateFeedbackResponse struct {
 	Buckets      []snFeedbackBucketRow `json:"buckets"`
 	TotalRecords int                   `json:"totalRecords"`
@@ -102,7 +102,7 @@ func NewServiceNowFeedbackService(client *integrationservice.Client) FeedbackSer
 }
 
 // SearchFeedback implements FeedbackService by calling the Choreo
-// POST /cases/feedbacks/search endpoint.
+// POST /cases/feedback/search endpoint.
 func (s *snFeedbackService) SearchFeedback(ctx context.Context, req domain.SearchFeedbackRequest) (domain.SearchFeedbackResponse, error) {
 	if req.Page < 0 {
 		return domain.SearchFeedbackResponse{}, &apierror.ValidationError{Msg: "page must not be negative"}
@@ -137,7 +137,7 @@ func (s *snFeedbackService) SearchFeedback(ctx context.Context, req domain.Searc
 		PageSize: req.PageSize,
 	}
 
-	raw, err := s.client.Post(ctx, "/cases/feedbacks/search", token, payload)
+	raw, err := s.client.Post(ctx, "/cases/feedback/search", token, payload)
 	if err != nil {
 		return domain.SearchFeedbackResponse{}, err
 	}
@@ -166,7 +166,7 @@ func (s *snFeedbackService) SearchFeedback(ctx context.Context, req domain.Searc
 }
 
 // AggregateFeedback implements FeedbackService by calling the Choreo
-// POST /cases/feedbacks/aggregate endpoint.
+// POST /cases/feedback/aggregate endpoint.
 func (s *snFeedbackService) AggregateFeedback(ctx context.Context, req domain.AggregateFeedbackRequest) (domain.AggregateFeedbackResponse, error) {
 	if !validFeedbackBuckets[req.Bucket] {
 		return domain.AggregateFeedbackResponse{}, &apierror.ValidationError{Msg: "bucket must be one of: day, week, month"}
@@ -186,7 +186,7 @@ func (s *snFeedbackService) AggregateFeedback(ctx context.Context, req domain.Ag
 		Bucket: req.Bucket,
 	}
 
-	raw, err := s.client.Post(ctx, "/cases/feedbacks/aggregate", token, payload)
+	raw, err := s.client.Post(ctx, "/cases/feedback/aggregate", token, payload)
 	if err != nil {
 		return domain.AggregateFeedbackResponse{}, err
 	}

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -870,7 +870,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
-  /cases/feedbacks/search:
+  /cases/feedback/search:
     post:
       summary: >-
         Search case-feedback (satisfaction rating) records across cases
@@ -879,7 +879,7 @@ paths:
         Backs the case-feedback dashboard's list view. Distinct from any
         single-case feedback lookup: this is filterable by case, accounts,
         and submission date range, and is paginated.
-      operationId: searchCaseFeedbacks
+      operationId: searchCaseFeedback
       requestBody:
         required: true
         content:
@@ -924,7 +924,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
-  /cases/feedbacks/aggregate:
+  /cases/feedback/aggregate:
     post:
       summary: >-
         Date-bucketed rating aggregation of case-feedback records across
@@ -932,8 +932,8 @@ paths:
       description: >-
         Backs the case-feedback dashboard's rating-trend chart. This is the
         many-cases trend endpoint, not scoped to one case, so filters.caseId
-        is not accepted here (unlike POST /cases/feedbacks/search).
-      operationId: aggregateCaseFeedbacks
+        is not accepted here (unlike POST /cases/feedback/search).
+      operationId: aggregateCaseFeedback
       requestBody:
         required: true
         content:


### PR DESCRIPTION
## Purpose
`[CSM Portal]` Companion PR to `digiops-cs#2916`: the Ballerina entity-service's own
exposed path for the Case Feedback dashboard's endpoints was renamed from
`/cases/feedback/{search,aggregate}` to `/cases/feedbacks/{search,aggregate}` earlier
(per a different reviewer's collection-naming-convention comment), then reverted back
to singular by a human reviewer (`Rashmika998`) on `digiops-cs#2916` — "feedback" is
uncountable, "feedbacks" isn't standard usage. That revert only touched Ballerina's own
exposed resource path; the outbound call to ServiceNow (still `/cases/feedbacks/*`) and
everything above Ballerina — this repo's Go entity-service, CSM BFF, and CSM webapp —
were still on the plural path, which would 404 against the now-singular Ballerina layer.

## Goals
Revert `/cases/feedbacks/{search,aggregate}` back to `/cases/feedback/{search,aggregate}`
across the Go entity-service, CSM BFF, and CSM webapp, matching Ballerina's reverted
exposed path. ServiceNow's own REST resources and Ballerina's outbound call to them stay
on the plural path — only the segment between Ballerina and the webapp changes.

## Approach
Mechanical, symmetric rename of the literal `feedbacks`/`Feedbacks` string wherever it
encoded a URL path segment or an identifier derived from one (`operationId`s, function/
handler names). Left the `CaseFeedback`-prefixed Go/TS type names and the `case_feedback`
dashboard resourceType value untouched — neither is a URL path segment. 18 files, all
`Feedbacks`→`Feedback` / `feedbacks`→`feedback`, no other changes.

## User stories
N/A — internal API path correction, no user-facing behavior change (same data, same UI).

## Release note
N/A — internal path naming fix, not yet in any release.

## Documentation
N/A — internal API contract only (openapi.yaml updated in this PR), no product docs affected.

## Training
N/A

## Certification
N/A — no certification exam impact.

## Marketing
N/A — internal path naming fix.

## Automation tests
 - Unit tests
   - No new tests — pure rename, existing coverage (`go test ./...` both components,
     `vitest run` webapp) re-verified passing at the new path names: entity-service and
     CSM BFF Go suites all `ok`; webapp 222 files / 2222 tests passing.
 - Integration tests
   - N/A — the underlying endpoints were already live-verified end-to-end against real
     ServiceNow DEV data under this exact naming in an earlier pass of the same feature;
     this PR is a pure identifier rename with no logic change.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — Go backend; not applicable
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
Companion to a corresponding entity-service (Ballerina) change in a private repo, tracked
separately, which reverted the equivalent path naming at that layer.

## Migrations (if applicable)
N/A — no schema or data migration; the underlying feature was not yet released.

## Test environment
`go build`/`go vet`/`go test` on both `entity-service` and `apps/csm-portal/backend`
(Go toolchain per `go.mod`, `GOTOOLCHAIN=auto`); `pnpm build`/`pnpm lint`/`pnpm test` on
`apps/csm-portal/webapp`; both `openapi.yaml` files re-validated with
`openapi-spec-validator`.

## Learning
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **API Changes**
  * Renamed case feedback search and aggregation endpoints to use the singular `/cases/feedback/...` path.
  * Updated API documentation and endpoint references across the portal and feedback services.
* **Bug Fixes**
  * Synchronized clients, dashboard widgets, and service routes with the corrected endpoint paths.
* **Tests**
  * Updated endpoint tests and expectations to validate the new routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->