### PR TITLE
[CSM Portal] Case Feedback: activity-stream lane, dashboard identity fields, rating/reasons charts, click-through

### DIFF
--- a/apps/csm-portal/backend/internal/dashboard/registry.go
+++ b/apps/csm-portal/backend/internal/dashboard/registry.go
@@ -655,11 +655,15 @@ var validWidgetShapes = map[Shape]bool{
 }
 
 // validGroupByBuckets are the legal values of GroupByConfig.Bucket -- the
-// same "day"/"week"/"month" enum POST /cases/feedback/aggregate documents on
-// the entity-service side (see AggregateFeedbackRequest.bucket in
-// openapi.yaml). Kept here rather than derived from that spec because this
-// layer never calls that endpoint; it only validates widget config shape.
-var validGroupByBuckets = map[string]bool{"day": true, "week": true, "month": true}
+// same enum POST /cases/feedback/aggregate documents on the entity-service
+// side (see AggregateFeedbackRequest.bucket in openapi.yaml). Kept here
+// rather than derived from that spec because this layer never calls that
+// endpoint; it only validates widget config shape.
+var validGroupByBuckets = map[string]bool{
+	"day": true, "week": true, "month": true, "rating": true,
+	"reasons_very_dissatisfied": true, "reasons_dissatisfied": true, "reasons_neutral": true,
+	"reasons_satisfied": true, "reasons_very_satisfied": true,
+}
 
 // validateWidgets applies the loader's own fail-loud rationale one level down.
 // Dashboard-level fields were already rejected by filename; a widget with a

--- a/apps/csm-portal/backend/internal/dashboard/registry.go
+++ b/apps/csm-portal/backend/internal/dashboard/registry.go
@@ -725,7 +725,7 @@ func validateWidgets(d Dashboard, source string) error {
 				return fmt.Errorf("dashboard definitions: %s (id %q): widget %q: \"groupBy.field\" is empty",
 					source, d.ID, w.ID)
 			case hasBucket && !validGroupByBuckets[w.GroupBy.Bucket]:
-				return fmt.Errorf("dashboard definitions: %s (id %q): widget %q: unknown \"groupBy.bucket\" %q; expected one of \"day\", \"week\", \"month\"",
+				return fmt.Errorf("dashboard definitions: %s (id %q): widget %q: unknown \"groupBy.bucket\" %q; expected one of \"day\", \"week\", \"month\" (time buckets), \"rating\", \"reasons_very_dissatisfied\", \"reasons_dissatisfied\", \"reasons_neutral\", \"reasons_satisfied\", \"reasons_very_satisfied\" (categorical buckets)",
 					source, d.ID, w.ID, w.GroupBy.Bucket)
 			}
 		}

--- a/apps/csm-portal/backend/internal/dashboard/widgets.go
+++ b/apps/csm-portal/backend/internal/dashboard/widgets.go
@@ -103,8 +103,12 @@ type GroupByConfig struct {
 	// (enforced at directory-load time): a widget sets exactly one.
 	Field string `json:"field,omitempty"`
 	// Bucket configures date-bucketed grouping instead of field-value
-	// grouping -- "day", "week", "month", or "rating" (enforced at
-	// directory-load time). Mutually exclusive with Field. This is the shape
+	// grouping -- "day", "week", "month" (temporal buckets, a real time
+	// range in ascending chronological order), or one of the categorical
+	// buckets "rating", "reasons_very_dissatisfied", "reasons_dissatisfied",
+	// "reasons_neutral", "reasons_satisfied", "reasons_very_satisfied" (no
+	// ordering guarantee) -- enforced at directory-load time. Mutually
+	// exclusive with Field. This is the shape
 	// a case-feedback trend/distribution widget uses (ResourceCaseFeedback,
 	// Shape "bar" or "pie"): the frontend's own hook calls POST
 	// /cases/feedback/aggregate with this bucket value and maps its bucketed

--- a/apps/csm-portal/backend/internal/dashboard/widgets.go
+++ b/apps/csm-portal/backend/internal/dashboard/widgets.go
@@ -103,14 +103,15 @@ type GroupByConfig struct {
 	// (enforced at directory-load time): a widget sets exactly one.
 	Field string `json:"field,omitempty"`
 	// Bucket configures date-bucketed grouping instead of field-value
-	// grouping -- "day", "week", or "month" (enforced at directory-load
-	// time). Mutually exclusive with Field. This is the shape a case-feedback
-	// trend widget uses (ResourceCaseFeedback, Shape "bar"): the frontend's
-	// own hook calls POST /cases/feedback/aggregate with this bucket value
-	// and maps its date-bucketed response into the same per-slice shape
-	// Slices/field-grouping already produce, same client-side-resolution
-	// philosophy as the rest of this type -- this layer never calls that
-	// endpoint itself, it only validates and forwards the config.
+	// grouping -- "day", "week", "month", or "rating" (enforced at
+	// directory-load time). Mutually exclusive with Field. This is the shape
+	// a case-feedback trend/distribution widget uses (ResourceCaseFeedback,
+	// Shape "bar" or "pie"): the frontend's own hook calls POST
+	// /cases/feedback/aggregate with this bucket value and maps its bucketed
+	// response into the same per-slice shape Slices/field-grouping already
+	// produce, same client-side-resolution philosophy as the rest of this
+	// type -- this layer never calls that endpoint itself, it only
+	// validates and forwards the config.
 	Bucket string `json:"bucket,omitempty"`
 	// MaxGroups is the top-N cutoff by count, descending; the remainder is
 	// summed into one "Others" bucket. Omitted/zero defers to the backing

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -6722,6 +6722,12 @@ components:
           type: string
           format: uuid
           description: UUID of the case the feedback belongs to.
+        caseNumber:
+          type: string
+          nullable: true
+          description: >-
+            Human-readable case number (e.g. "CS0441331"). Null if the case
+            record could not be resolved.
         rating:
           type: integer
           description: Numeric rating value.
@@ -6737,6 +6743,16 @@ components:
         submittedAt:
           type: string
           description: Timestamp when the feedback was submitted.
+        submitterName:
+          type: string
+          nullable: true
+          description: >-
+            Display name of the customer contact who submitted the feedback.
+            Null if the submitting user record could not be resolved.
+        submitterEmail:
+          type: string
+          nullable: true
+          description: Email of the submitting contact. Null, same as submitterName.
 
     CaseFeedbackSearchFilters:
       type: object

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -6728,6 +6728,12 @@ components:
           description: >-
             Human-readable case number (e.g. "CS0441331"). Null if the case
             record could not be resolved.
+        caseInternalId:
+          type: string
+          nullable: true
+          description: >-
+            WSO2 internal case id (e.g. "SCTPSUB-88") for caseId. Null if the
+            case record could not be resolved or has no internal id assigned.
         rating:
           type: integer
           description: Numeric rating value.
@@ -6767,6 +6773,11 @@ components:
             type: string
             format: uuid
           description: Restrict results to feedback on cases under these accounts.
+        rating:
+          type: integer
+          minimum: 1
+          maximum: 5
+          description: Restrict results to feedback with this exact rating value.
         dateFrom:
           type: string
           description: Start of the feedback submission date range (inclusive).
@@ -6826,8 +6837,25 @@ components:
           $ref: '#/components/schemas/CaseFeedbackAggregateFilters'
         bucket:
           type: string
-          enum: [day, week, month]
-          description: Time bucket granularity to group results by.
+          enum:
+            - day
+            - week
+            - month
+            - rating
+            - reasons_very_dissatisfied
+            - reasons_dissatisfied
+            - reasons_neutral
+            - reasons_satisfied
+            - reasons_very_satisfied
+          description: >-
+            Aggregation granularity to group results by. "day"/"week"/"month"
+            bucket by submission date; "rating" groups by rating value
+            instead of time (each bucket's bucketStart then carries the
+            rating's own label, e.g. "Very Satisfied", rather than a date);
+            each "reasons_*" value groups by which free-text reason was
+            selected for that specific rating level (each bucket's
+            bucketStart then carries the reason's own label, e.g. "Unhelpful
+            support").
 
     FeedbackBucket:
       type: object
@@ -6955,10 +6983,22 @@ components:
                 here. Mutually exclusive with "bucket".
             bucket:
               type: string
-              enum: [day, week, month]
+              enum:
+                - day
+                - week
+                - month
+                - rating
+                - reasons_very_dissatisfied
+                - reasons_dissatisfied
+                - reasons_neutral
+                - reasons_satisfied
+                - reasons_very_satisfied
               description: >
-                Date-bucket granularity instead of field-value grouping.
-                This is the mode a case_feedback trend widget uses: the
+                Date-bucket granularity instead of field-value grouping,
+                "rating" to group by rating value instead of time, or a
+                "reasons_*" value to group by which reason was selected for
+                that specific rating level. This is the mode a
+                case_feedback trend/distribution widget uses: the
                 caller resolves it by calling POST /cases/feedback/aggregate
                 with this value as that endpoint's own "bucket" (see
                 AggregateFeedbackRequest), not the generic

--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -6849,24 +6849,41 @@ components:
             - reasons_very_satisfied
           description: >-
             Aggregation granularity to group results by. "day"/"week"/"month"
-            bucket by submission date; "rating" groups by rating value
-            instead of time (each bucket's bucketStart then carries the
-            rating's own label, e.g. "Very Satisfied", rather than a date);
-            each "reasons_*" value groups by which free-text reason was
-            selected for that specific rating level (each bucket's
-            bucketStart then carries the reason's own label, e.g. "Unhelpful
-            support").
+            are temporal buckets by submission date. "rating" and every
+            "reasons_*" value are categorical buckets, not time ranges:
+            "rating" groups by rating value instead of time (each bucket's
+            bucketStart then carries the rating's own label, e.g. "Very
+            Satisfied", rather than a date); each "reasons_*" value groups by
+            which free-text reason was selected for that specific rating
+            level (each bucket's bucketStart then carries the reason's own
+            label, e.g. "Unhelpful support"). See FeedbackBucket for what
+            each bucket shape carries, and note categorical buckets carry no
+            ordering guarantee.
 
     FeedbackBucket:
       type: object
-      description: One aggregated time bucket in a case-feedback aggregate result.
+      description: >-
+        One bucket in a case-feedback aggregate result. Shape depends on the
+        request's "bucket" granularity: for "day"/"week"/"month" (temporal
+        buckets) this represents a time range, in ascending chronological
+        order; for "rating"/"reasons_*" (categorical buckets) it represents
+        one category instead, with no ordering guarantee across buckets.
       properties:
         bucketStart:
           type: string
-          description: Start of this bucket's time range.
+          description: >-
+            For a temporal bucket, the start of this bucket's time range
+            (e.g. "2026-08-01"). For a categorical bucket, the category's own
+            label instead (e.g. "Very Satisfied" for "rating", "Unhelpful
+            support" for a "reasons_*" bucket) — not a date.
         avgRating:
           type: number
-          description: Average rating across feedback records in this bucket.
+          description: >-
+            For a temporal or "rating" bucket, the average rating across
+            feedback records in this bucket. Meaningless for a "reasons_*"
+            bucket (every row is a categorical chip selection, not a
+            rating) — present on the wire for shape consistency but not a
+            useful value there.
         count:
           type: integer
           description: Number of feedback records in this bucket.
@@ -6994,16 +7011,19 @@ components:
                 - reasons_satisfied
                 - reasons_very_satisfied
               description: >
-                Date-bucket granularity instead of field-value grouping,
-                "rating" to group by rating value instead of time, or a
-                "reasons_*" value to group by which reason was selected for
-                that specific rating level. This is the mode a
-                case_feedback trend/distribution widget uses: the
-                caller resolves it by calling POST /cases/feedback/aggregate
-                with this value as that endpoint's own "bucket" (see
-                AggregateFeedbackRequest), not the generic
-                POST /{resourceType}/aggregate this groupBy block otherwise
-                implies. Mutually exclusive with "field".
+                Date-bucket granularity instead of field-value grouping
+                ("day"/"week"/"month", temporal — a real time range, in
+                ascending chronological order), or a categorical bucket
+                instead: "rating" groups by rating value, or a "reasons_*"
+                value groups by which reason was selected for that specific
+                rating level — categorical buckets carry no ordering
+                guarantee. This is the mode a case_feedback
+                trend/distribution widget uses: the caller resolves it by
+                calling POST /cases/feedback/aggregate with this value as
+                that endpoint's own "bucket" (see AggregateFeedbackRequest,
+                and FeedbackBucket for what each bucket shape carries), not
+                the generic POST /{resourceType}/aggregate this groupBy
+                block otherwise implies. Mutually exclusive with "field".
             maxGroups:
               type: integer
               description: >

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -3285,6 +3285,26 @@ export interface BeDashboardPieSlice {
   query: Record<string, unknown> | null;
 }
 
+/** Aggregation granularity for a `case_feedback` trend/distribution widget's
+ * `groupBy.bucket` and the matching `POST /cases/feedback/aggregate`
+ * `bucket` request field. `"day"`/`"week"`/`"month"` bucket by submission
+ * date; `"rating"` groups by rating value instead of time (each bucket's
+ * `bucketStart` then carries the rating's own label, e.g. "Very Satisfied",
+ * rather than a date); each `"reasons_*"` value groups by which free-text
+ * reason was selected for that specific rating level (each bucket's
+ * `bucketStart` then carries the reason's own label, e.g. "Unhelpful
+ * support"). */
+export type BeCaseFeedbackBucket =
+  | "day"
+  | "week"
+  | "month"
+  | "rating"
+  | "reasons_very_dissatisfied"
+  | "reasons_dissatisfied"
+  | "reasons_neutral"
+  | "reasons_satisfied"
+  | "reasons_very_satisfied";
+
 /** Alternative to {@link BeDashboardPieSlice}[] for shapes "pie"/"bar":
  * one server-side `POST /{resourceType}/aggregate` call instead of one
  * `search` per hand-authored slice. Mutually exclusive with `slices` —
@@ -3297,14 +3317,15 @@ export interface BeDashboardGroupByConfig {
    * widget carries no `field` at all. */
   field?: string;
   /** Date-bucketed grouping instead of field-value grouping — the shape a
-   * `case_feedback` trend widget uses (`shape: "bar"`). Mutually exclusive
-   * with `field`. Resolved by `useCaseFeedbackTrendData`, a dedicated hook
-   * (not `useWidgetGroupByData`, whose `POST {resourceType}/aggregate`
-   * request/response shape this doesn't match) that calls `POST
-   * /cases/feedback/aggregate` with this value and maps its date-bucketed
-   * response into the same per-slice `PieSliceResult[]` shape every other
-   * pie/bar widget already renders. */
-  bucket?: "day" | "week" | "month";
+   * `case_feedback` trend/distribution widget uses (`shape: "bar"` or
+   * `"pie"`). Mutually exclusive with `field`. Resolved by
+   * `useCaseFeedbackTrendData`, a dedicated hook (not `useWidgetGroupByData`,
+   * whose `POST {resourceType}/aggregate` request/response shape this
+   * doesn't match) that calls `POST /cases/feedback/aggregate` with this
+   * value and maps its bucketed response into the same per-slice
+   * `PieSliceResult[]` shape every other pie/bar widget already renders. See
+   * {@link BeCaseFeedbackBucket} for what each value means. */
+  bucket?: BeCaseFeedbackBucket;
   /** Caps the number of returned buckets; anything beyond that rolls up
    * into the response's `othersCount`. Meaningless when `bucket` is set — a
    * date-bucketed aggregation has no "Others" folding. */
@@ -3345,6 +3366,9 @@ export interface BeCaseFeedback {
   caseId: string;
   /** `null` if the case record could not be resolved. */
   caseNumber: string | null;
+  /** WSO2 internal case id (e.g. "SCTPSUB-88") for caseId. `null` if the case
+   * record could not be resolved or has no internal id assigned. */
+  caseInternalId: string | null;
   rating: number;
   ratingLabel: string;
   /** `null` for feedback submitted without a comment. */
@@ -3366,6 +3390,8 @@ export interface BeCaseFeedbackSearchFilters {
    * `/cases/feedback/aggregate` — see {@link BeCaseFeedbackAggregateFilters}. */
   caseId?: string;
   accountIds?: string[];
+  /** Restrict results to feedback with this exact rating value (1-5). */
+  rating?: number;
   dateFrom?: string;
   dateTo?: string;
 }
@@ -3386,7 +3412,7 @@ export interface BeCaseFeedbackAggregateFilters {
 
 export interface BeCaseFeedbackAggregatePayload {
   filters?: BeCaseFeedbackAggregateFilters;
-  bucket: "day" | "week" | "month";
+  bucket: BeCaseFeedbackBucket;
 }
 
 /** One aggregated time bucket in a `POST /cases/feedback/aggregate`

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -3343,11 +3343,17 @@ export interface BeGroupByResponse {
 export interface BeCaseFeedback {
   instanceId: string;
   caseId: string;
+  /** `null` if the case record could not be resolved. */
+  caseNumber: string | null;
   rating: number;
   ratingLabel: string;
   /** `null` for feedback submitted without a comment. */
   comment: string | null;
   submittedAt: string;
+  /** `null` if the submitting user record could not be resolved. */
+  submitterName: string | null;
+  /** `null`, same as submitterName. */
+  submitterEmail: string | null;
 }
 
 /** Body of `POST /cases/feedback/search` — deliberately NOT the

--- a/apps/csm-portal/webapp/src/constants/apiConstants.ts
+++ b/apps/csm-portal/webapp/src/constants/apiConstants.ts
@@ -120,6 +120,7 @@ export const ApiQueryKeys = {
   CSM_CASE_COMMENTS: "csm-case-comments",
   CSM_CASE_ATTACHMENTS: "csm-case-attachments",
   CSM_CASE_ACTIVITIES: "csm-case-activities",
+  CSM_CASE_FEEDBACK: "csm-case-feedback",
   CSM_CASE_SLAS: "csm-case-slas",
   CSM_CASE_CHILDREN: "csm-case-children",
   CSM_CASE_SEARCH_BY_QUERY: "csm-case-search-by-query",

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useCsmCaseFeedback.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useCsmCaseFeedback.ts
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import { useBackendApi } from "@api/backend/client";
+import type {
+  BeCaseFeedback,
+  BeCaseFeedbackSearchFilters,
+  BeCaseFeedbackSearchResponse,
+} from "@api/backend/types";
+import { WIDGET_RESOURCE_CONFIG } from "@features/csm-dashboard/config/widgetResourceConfig";
+import type { CaseFeedbackEntry } from "@features/csm-cases/types/csmCases";
+
+function feedbackEntryFromBe(f: BeCaseFeedback): CaseFeedbackEntry {
+  return {
+    id: f.instanceId,
+    rating: f.rating,
+    ratingLabel: f.ratingLabel,
+    comment: f.comment,
+    submittedAt: f.submittedAt,
+  };
+}
+
+/**
+ * Loads any Case Feedback survey submissions for a single case, for the case
+ * detail page's activity feed. Case Feedback is a CSAT survey submitted by
+ * the customer, typically only once a case is closed — an open case will
+ * almost always resolve to an empty list, which is expected, not an error.
+ *
+ * Reuses `WIDGET_RESOURCE_CONFIG.case_feedback`'s endpoint rather than
+ * hardcoding the path, so this stays in sync with that config's own source
+ * of truth for the endpoint name.
+ */
+export function useGetCsmCaseFeedback(
+  caseId: string | undefined,
+): UseQueryResult<CaseFeedbackEntry[], Error> {
+  const api = useBackendApi();
+
+  return useQuery<CaseFeedbackEntry[], Error>({
+    queryKey: [ApiQueryKeys.CSM_CASE_FEEDBACK, caseId ?? ""],
+    queryFn: async (): Promise<CaseFeedbackEntry[]> => {
+      if (!caseId) return [];
+
+      const payload = {
+        filters: { caseId } satisfies BeCaseFeedbackSearchFilters,
+        page: 1,
+        pageSize: 20,
+      };
+      const response = await api.post<
+        typeof payload,
+        BeCaseFeedbackSearchResponse
+      >(WIDGET_RESOURCE_CONFIG.case_feedback.searchEndpoint, payload);
+      return (response.results ?? []).map(feedbackEntryFromBe);
+    },
+    enabled: !!caseId,
+    staleTime: 10_000,
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useCsmCaseFeedback.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useCsmCaseFeedback.ts
@@ -24,6 +24,7 @@ import type {
 } from "@api/backend/types";
 import { WIDGET_RESOURCE_CONFIG } from "@features/csm-dashboard/config/widgetResourceConfig";
 import type { CaseFeedbackEntry } from "@features/csm-cases/types/csmCases";
+import { normalizeBackendTimestamp } from "@utils/dateTime";
 
 function feedbackEntryFromBe(f: BeCaseFeedback): CaseFeedbackEntry {
   return {
@@ -31,7 +32,17 @@ function feedbackEntryFromBe(f: BeCaseFeedback): CaseFeedbackEntry {
     rating: f.rating,
     ratingLabel: f.ratingLabel,
     comment: f.comment,
-    submittedAt: f.submittedAt,
+    // ServiceNow returns submittedAt as a raw space-separated timestamp
+    // ("2026-08-17 06:17:56"), not ISO 8601 like every other activity-feed
+    // entry's own timestamp. CaseActivitiesFeed's compareFeedEntries sorts by
+    // a plain string compare of each entry's `at` — a raw space-separated
+    // string sorts BEFORE a same-day ISO "T"-separated one purely because
+    // " " < "T" in ASCII, regardless of actual time-of-day, which put real
+    // feedback entries out of chronological order in the feed. Normalize to
+    // ISO 8601 UTC here, at the API boundary, same as every other entry.
+    submittedAt: normalizeBackendTimestamp(f.submittedAt) ?? f.submittedAt,
+    submitterName: f.submitterName,
+    submitterEmail: f.submitterEmail,
   };
 }
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActivitiesFeed.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActivitiesFeed.test.tsx
@@ -93,13 +93,15 @@ function CaseActivitiesFeedHarness({
 }
 
 describe("CaseActivitiesFeed — feedback lane", () => {
-  it("renders a Case Feedback entry with rating and comment", () => {
+  it("renders a Case Feedback entry with rating, comment, and submitter", () => {
     const feedback: CaseFeedbackEntry = {
       id: "fb-1",
       rating: 5,
       ratingLabel: "Very Satisfied",
       comment: "Great support, thank you!",
       submittedAt: "2026-08-17T06:17:56Z",
+      submitterName: "Jane Customer",
+      submitterEmail: "jane.customer@example.com",
     };
 
     renderWithRouter(
@@ -114,6 +116,30 @@ describe("CaseActivitiesFeed — feedback lane", () => {
     expect(screen.getByText("Case Feedback")).toBeInTheDocument();
     expect(screen.getByText("Very Satisfied (5/5)")).toBeInTheDocument();
     expect(screen.getByText("Great support, thank you!")).toBeInTheDocument();
+    expect(screen.getByText("Jane Customer")).toBeInTheDocument();
+  });
+
+  it("falls back to 'Customer' when the submitter could not be resolved", () => {
+    const feedback: CaseFeedbackEntry = {
+      id: "fb-3",
+      rating: 4,
+      ratingLabel: "Satisfied",
+      comment: null,
+      submittedAt: "2026-08-17T06:17:56Z",
+      submitterName: null,
+      submitterEmail: null,
+    };
+
+    renderWithRouter(
+      <CaseActivitiesFeed
+        comments={[]}
+        audit={[]}
+        attachments={[]}
+        feedback={[feedback]}
+      />,
+    );
+
+    expect(screen.getByText("Customer")).toBeInTheDocument();
   });
 
   it("renders no comment line when feedback has none", () => {

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActivitiesFeed.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActivitiesFeed.test.tsx
@@ -38,6 +38,7 @@ import { useGetAlert, useGetSmartAlert } from "@features/csm-cases/api/useSnLink
 import type {
   CaseAttachment,
   CaseAuditEntry,
+  CaseFeedbackEntry,
   CsmCaseComment,
 } from "@features/csm-cases/types/csmCases";
 
@@ -90,6 +91,62 @@ function CaseActivitiesFeedHarness({
     />
   );
 }
+
+describe("CaseActivitiesFeed — feedback lane", () => {
+  it("renders a Case Feedback entry with rating and comment", () => {
+    const feedback: CaseFeedbackEntry = {
+      id: "fb-1",
+      rating: 5,
+      ratingLabel: "Very Satisfied",
+      comment: "Great support, thank you!",
+      submittedAt: "2026-08-17T06:17:56Z",
+    };
+
+    renderWithRouter(
+      <CaseActivitiesFeed
+        comments={[]}
+        audit={[]}
+        attachments={[]}
+        feedback={[feedback]}
+      />,
+    );
+
+    expect(screen.getByText("Case Feedback")).toBeInTheDocument();
+    expect(screen.getByText("Very Satisfied (5/5)")).toBeInTheDocument();
+    expect(screen.getByText("Great support, thank you!")).toBeInTheDocument();
+  });
+
+  it("renders no comment line when feedback has none", () => {
+    const feedback: CaseFeedbackEntry = {
+      id: "fb-2",
+      rating: 3,
+      ratingLabel: "Neutral",
+      comment: null,
+      submittedAt: "2026-08-17T06:17:56Z",
+    };
+
+    renderWithRouter(
+      <CaseActivitiesFeed
+        comments={[]}
+        audit={[]}
+        attachments={[]}
+        feedback={[feedback]}
+      />,
+    );
+
+    expect(screen.getByText("Neutral (3/5)")).toBeInTheDocument();
+  });
+
+  it("shows no feedback lane and no filter option when feedback is empty", () => {
+    renderWithRouter(
+      <CaseActivitiesFeed comments={[]} audit={[]} attachments={[]} feedback={[]} />,
+    );
+
+    expect(screen.queryByText("Case Feedback")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByText("Filter"));
+    expect(screen.queryByText(/^Feedback \(/)).not.toBeInTheDocument();
+  });
+});
 
 describe("CaseActivitiesFeed", () => {
   it("renders a field_change entry with old/new values", () => {

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActivitiesFeed.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActivitiesFeed.tsx
@@ -491,8 +491,12 @@ export default function CaseActivitiesFeed({
                       }}
                     >
                       <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
-                        Case Feedback
+                        <UserRefLink
+                          name={e.feedback.submitterName || "Customer"}
+                          email={e.feedback.submitterEmail ?? undefined}
+                        />
                       </Typography>
+                      <Chip size="small" variant="outlined" label="Case Feedback" />
                       <Chip
                         size="small"
                         variant="outlined"

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActivitiesFeed.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActivitiesFeed.tsx
@@ -38,6 +38,7 @@ import {
   ListFilter,
   Paperclip,
   Plus,
+  Star,
   TriangleAlert,
   User,
   Users,
@@ -63,6 +64,7 @@ import type { SnLinkType } from "@features/csm-cases/utils/snLinkRegistry";
 import type {
   CaseAttachment,
   CaseAuditEntry,
+  CaseFeedbackEntry,
   CsmCaseComment,
 } from "@features/csm-cases/types/csmCases";
 
@@ -70,6 +72,10 @@ interface CaseActivitiesFeedProps {
   comments: CsmCaseComment[];
   audit: CaseAuditEntry[];
   attachments: CaseAttachment[];
+  /** Case Feedback (CSAT survey) submissions for this case, if any — typically
+   * only present once a case is closed and the customer has responded to the
+   * survey. Defaults to an empty array (no feedback lane shown). */
+  feedback?: CaseFeedbackEntry[];
   /**
    * Call requests already fetched for this case (e.g. by the page's Call
    * Requests tab query) — reused here, never re-fetched, to resolve a
@@ -160,6 +166,7 @@ export default function CaseActivitiesFeed({
   comments,
   audit,
   attachments,
+  feedback = [],
   callRequests = [],
   onDownloadAttachment,
   preview,
@@ -167,6 +174,7 @@ export default function CaseActivitiesFeed({
   const [showWorkNotes, setShowWorkNotes] = useState(true);
   const [showLifecycle, setShowLifecycle] = useState(true);
   const [showAttachments, setShowAttachments] = useState(true);
+  const [showFeedback, setShowFeedback] = useState(true);
   const [newestFirst, setNewestFirst] = useState(true);
   const [filterAnchor, setFilterAnchor] = useState<HTMLElement | null>(null);
   const [fullscreenImageSrc, setFullscreenImageSrc] = useState<string | null>(null);
@@ -193,6 +201,11 @@ export default function CaseActivitiesFeed({
         out.push({ kind: "attachment", at: a.uploadedAt, attachment: a });
       }
     }
+    if (showFeedback) {
+      for (const f of feedback) {
+        out.push({ kind: "feedback", at: f.submittedAt, feedback: f });
+      }
+    }
     out.sort((a, b) =>
       newestFirst ? -compareFeedEntries(a, b) : compareFeedEntries(a, b),
     );
@@ -201,9 +214,11 @@ export default function CaseActivitiesFeed({
     comments,
     audit,
     attachments,
+    feedback,
     showWorkNotes,
     showLifecycle,
     showAttachments,
+    showFeedback,
     newestFirst,
   ]);
 
@@ -212,6 +227,7 @@ export default function CaseActivitiesFeed({
     workNotes: comments.filter((c) => c.internal).length,
     lifecycle: audit.length,
     attachments: attachments.length,
+    feedback: feedback.length,
   };
 
   // Filters live in a dropdown so the timeline reads as content, not a row of
@@ -237,6 +253,17 @@ export default function CaseActivitiesFeed({
       checked: showAttachments,
       toggle: () => setShowAttachments((v) => !v),
     },
+    // Only offered when this case actually has feedback — a lane with
+    // nothing to hide would just be dead-weight in the filter menu.
+    ...(counts.feedback > 0
+      ? [
+          {
+            label: `Feedback (${counts.feedback})`,
+            checked: showFeedback,
+            toggle: () => setShowFeedback((v) => !v),
+          },
+        ]
+      : []),
   ];
   const activeFilters = filterOptions.filter((o) => o.checked).length;
   const filterLabel =
@@ -416,6 +443,78 @@ export default function CaseActivitiesFeed({
                         </Typography>
                       )}
                     </Box>
+                  </Paper>
+                </Box>
+              );
+            }
+            if (e.kind === "feedback") {
+              return (
+                <Box
+                  id={e.feedback.id}
+                  key={`fb-${e.feedback.id}`}
+                  sx={{
+                    display: "flex",
+                    gap: 1.5,
+                    alignItems: "flex-start",
+                    scrollMarginTop: 96,
+                  }}
+                >
+                  <Avatar
+                    sx={{
+                      width: 32,
+                      height: 32,
+                      bgcolor: "warning.light",
+                      color: "warning.contrastText",
+                    }}
+                  >
+                    <Star size={16} />
+                  </Avatar>
+                  <Paper
+                    variant="outlined"
+                    sx={{
+                      p: 1.5,
+                      flex: 1,
+                      minWidth: 0,
+                      display: "flex",
+                      flexDirection: "column",
+                      gap: 0.75,
+                      backgroundColor: "background.paper",
+                      borderColor: "action.disabled",
+                    }}
+                  >
+                    <Box
+                      sx={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 1,
+                        flexWrap: "wrap",
+                      }}
+                    >
+                      <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+                        Case Feedback
+                      </Typography>
+                      <Chip
+                        size="small"
+                        variant="outlined"
+                        icon={<Star size={14} />}
+                        label={`${e.feedback.ratingLabel} (${e.feedback.rating}/5)`}
+                        color="warning"
+                      />
+                      <Typography variant="caption" color="text.secondary">
+                        <RelativeTime
+                          iso={e.feedback.submittedAt}
+                          href={`#${e.feedback.id}`}
+                        />
+                      </Typography>
+                    </Box>
+                    {e.feedback.comment && (
+                      <Typography
+                        variant="body2"
+                        sx={{ overflowWrap: "anywhere" }}
+                      >
+                        {e.feedback.comment}
+                      </Typography>
+                    )}
                   </Paper>
                 </Box>
               );

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.test.tsx
@@ -221,6 +221,15 @@ vi.mock("@features/csm-cases/api/useCsmCaseActivities", () => ({
     isFetching: false,
   }),
 }));
+vi.mock("@features/csm-cases/api/useCsmCaseFeedback", () => ({
+  useGetCsmCaseFeedback: () => ({
+    data: undefined,
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+    isFetching: false,
+  }),
+}));
 vi.mock("@features/csm-cases/api/useCsmCaseAttachments", () => ({
   useGetCsmCaseAttachments: () => ({
     data: undefined,

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -74,6 +74,7 @@ import {
 } from "@features/csm-cases/api/useCsmCaseComments";
 import { useGetCsmConversationMessages } from "@features/csm-cases/api/useCsmConversationMessages";
 import { useGetCsmCaseActivities } from "@features/csm-cases/api/useCsmCaseActivities";
+import { useGetCsmCaseFeedback } from "@features/csm-cases/api/useCsmCaseFeedback";
 import {
   useGetCsmCaseAttachments,
   usePostCsmCaseAttachment,
@@ -446,6 +447,10 @@ export default function CsmCaseDetailPage(): JSX.Element {
     refetch: refetchActivities,
     isFetching: isFetchingActivities,
   } = useGetCsmCaseActivities(caseId);
+  // Case Feedback (CSAT survey) submissions for this case, if any — almost
+  // always empty for an open case (the survey goes out after closure), which
+  // is expected and renders no feedback lane rather than an error.
+  const { data: caseFeedback } = useGetCsmCaseFeedback(caseId);
   // The chat transcript the case was spawned from, when linked. Loaded lazily
   // off the case's conversation id and merged into the comment stream below so
   // it renders as the earliest activity entries — mirrors the customer portal.
@@ -2233,7 +2238,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
                   <Chip
                     size="small"
                     variant="outlined"
-                    label={`${safeComments.length + (activityAudit?.length ?? 0) + attachmentList.length} entries`}
+                    label={`${safeComments.length + (activityAudit?.length ?? 0) + attachmentList.length + (caseFeedback?.length ?? 0)} entries`}
                   />
                 )}
               </Box>
@@ -2280,6 +2285,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
                   comments={safeComments}
                   audit={activityAudit ?? []}
                   attachments={attachmentList}
+                  feedback={caseFeedback ?? []}
                   callRequests={callRequests ?? []}
                   onDownloadAttachment={onDownloadAttachment}
                   preview={{

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -450,7 +450,13 @@ export default function CsmCaseDetailPage(): JSX.Element {
   // Case Feedback (CSAT survey) submissions for this case, if any — almost
   // always empty for an open case (the survey goes out after closure), which
   // is expected and renders no feedback lane rather than an error.
-  const { data: caseFeedback } = useGetCsmCaseFeedback(caseId);
+  const {
+    data: caseFeedback,
+    isLoading: isFeedbackLoading,
+    isError: isFeedbackError,
+    refetch: refetchFeedback,
+    isFetching: isFetchingFeedback,
+  } = useGetCsmCaseFeedback(caseId);
   // The chat transcript the case was spawned from, when linked. Loaded lazily
   // off the case's conversation id and merged into the comment stream below so
   // it renders as the earliest activity entries — mirrors the customer portal.
@@ -698,7 +704,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
   // already-open tab this race has usually already settled by the time a
   // fragment link is followed, which is why the bug reads as "new tab only."
   const activitiesFeedReady =
-    !isCommentsLoading && !isChatLoading && !isActivityLoading;
+    !isCommentsLoading && !isChatLoading && !isActivityLoading && !isFeedbackLoading;
   // Forces the Activities tab exactly once per permalink — on the case or the
   // fragment actually changing, tracked by this ref rather than `activeTab`
   // itself (which would re-force every time the *effect* below re-ran, e.g.
@@ -764,13 +770,15 @@ export default function CsmCaseDetailPage(): JSX.Element {
     isFetchingActivities ||
     isFetchingChat ||
     isFetchingAttachments ||
-    isFetchingCallRequests;
+    isFetchingCallRequests ||
+    isFetchingFeedback;
   const refreshActivitiesTab = (): void => {
     void refetchComments();
     void refetchActivities();
     void refetchChat();
     void refetchAttachments();
     void refetchCallRequests();
+    void refetchFeedback();
   };
 
   // Re-runs every source the Details tab renders: the case itself plus the
@@ -2249,10 +2257,11 @@ export default function CsmCaseDetailPage(): JSX.Element {
               />
             </Box>
 
-            {isCommentsLoading || isChatLoading || isActivityLoading ? (
-              // Wait for the comments, linked chat transcript, and activity
-              // audit so nothing pops into an already-rendered timeline.
-              // isChatLoading is false for chat-less cases (query disabled).
+            {isCommentsLoading || isChatLoading || isActivityLoading || isFeedbackLoading ? (
+              // Wait for the comments, linked chat transcript, activity
+              // audit, and Case Feedback so nothing pops into an
+              // already-rendered timeline. isChatLoading is false for
+              // chat-less cases (query disabled).
               <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
                 {[0, 1, 2].map((i) => (
                   <Skeleton key={i} variant="rounded" height={56} />
@@ -2272,6 +2281,12 @@ export default function CsmCaseDetailPage(): JSX.Element {
                 {isChatError && (
                   <Typography variant="body2" color="error">
                     Could not load the chat conversation. Showing the rest of the
+                    activity — reload to try again.
+                  </Typography>
+                )}
+                {isFeedbackError && (
+                  <Typography variant="body2" color="error">
+                    Could not load Case Feedback. Showing the rest of the
                     activity — reload to try again.
                   </Typography>
                 )}

--- a/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
@@ -338,6 +338,10 @@ export interface CaseFeedbackEntry {
   /** `null`/absent for feedback submitted without a comment. */
   comment?: string | null;
   submittedAt: string;
+  /** `null`/absent if the submitting user record could not be resolved. */
+  submitterName?: string | null;
+  /** `null`/absent, same as submitterName. */
+  submitterEmail?: string | null;
 }
 
 export interface CaseAuditEntry {

--- a/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
@@ -330,6 +330,16 @@ export interface CaseAuditFieldChange {
   newValue?: string;
 }
 
+/** One Case Feedback survey submission for a case, shown in its activity feed. */
+export interface CaseFeedbackEntry {
+  id: string;
+  rating: number;
+  ratingLabel: string;
+  /** `null`/absent for feedback submitted without a comment. */
+  comment?: string | null;
+  submittedAt: string;
+}
+
 export interface CaseAuditEntry {
   id: string;
   kind: CaseAuditKind;

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/caseActivityFeed.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/caseActivityFeed.ts
@@ -17,6 +17,7 @@
 import type {
   CaseAttachment,
   CaseAuditEntry,
+  CaseFeedbackEntry,
   CsmCaseComment,
 } from "@features/csm-cases/types/csmCases";
 
@@ -24,12 +25,14 @@ import type {
 export type FeedEntry =
   | { kind: "comment"; at: string; comment: CsmCaseComment }
   | { kind: "audit"; at: string; entry: CaseAuditEntry }
-  | { kind: "attachment"; at: string; attachment: CaseAttachment };
+  | { kind: "attachment"; at: string; attachment: CaseAttachment }
+  | { kind: "feedback"; at: string; feedback: CaseFeedbackEntry };
 
 export function feedEntryId(e: FeedEntry): string {
   if (e.kind === "comment") return e.comment.id;
   if (e.kind === "audit") return e.entry.id;
-  return e.attachment.id;
+  if (e.kind === "attachment") return e.attachment.id;
+  return e.feedback.id;
 }
 
 /**

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useCaseFeedbackTrendData.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useCaseFeedbackTrendData.test.tsx
@@ -39,7 +39,7 @@ describe("useCaseFeedbackTrendData", () => {
     postMock.mockReset();
   });
 
-  it("issues a single date-bucketed aggregate request and maps buckets into non-navigable avg-rating slices", async () => {
+  it("issues a single date-bucketed aggregate request and maps buckets into navigable avg-rating slices", async () => {
     postMock.mockResolvedValue({
       buckets: [
         { bucketStart: "2026-07-01", avgRating: 4.2, count: 30 },
@@ -64,8 +64,20 @@ describe("useCaseFeedbackTrendData", () => {
     );
 
     expect(result.current.slices).toEqual([
-      { label: "Jul 2026", query: {}, navigable: false, value: 4.2 },
-      { label: "Aug 2026", query: {}, navigable: false, value: 3.8 },
+      {
+        label: "Jul 2026",
+        query: { dateFrom: "2026-07-01", dateTo: "2026-07-31" },
+        navigable: true,
+        value: 4.2,
+        color: "success",
+      },
+      {
+        label: "Aug 2026",
+        query: { dateFrom: "2026-08-01", dateTo: "2026-08-31" },
+        navigable: true,
+        value: 3.8,
+        color: "warning",
+      },
     ]);
     expect(result.current.total).toBe(45);
   });
@@ -84,7 +96,165 @@ describe("useCaseFeedbackTrendData", () => {
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
     expect(result.current.slices).toEqual([
-      { label: "Aug 3", query: {}, navigable: false, value: 5 },
+      {
+        label: "Aug 3",
+        query: { dateFrom: "2026-08-03", dateTo: "2026-08-03" },
+        navigable: true,
+        value: 5,
+        color: "success",
+      },
+    ]);
+  });
+
+  it("colors each bucket by its own avgRating (error < 3, warning < 4, success >= 4), not a rotating palette", async () => {
+    postMock.mockResolvedValue({
+      buckets: [
+        { bucketStart: "2026-06-01", avgRating: 2.4, count: 5 },
+        { bucketStart: "2026-07-01", avgRating: 3.5, count: 10 },
+        { bucketStart: "2026-08-01", avgRating: 4.9, count: 20 },
+      ],
+      totalRecords: 35,
+    });
+
+    const { result } = renderHook(
+      () => useCaseFeedbackTrendData("feedback_trend", {}, { bucket: "month" }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.slices.map((s) => s.color)).toEqual(["error", "warning", "success"]);
+  });
+
+  it("switches the default month bucket to week when the selected range spans 3 months or less", async () => {
+    postMock.mockResolvedValue({
+      buckets: [{ bucketStart: "2026-06-01", avgRating: 4, count: 5 }],
+      totalRecords: 5,
+    });
+
+    const { result } = renderHook(
+      () =>
+        useCaseFeedbackTrendData(
+          "feedback_trend",
+          { dateFrom: "2026-06-01", dateTo: "2026-08-01" },
+          { bucket: "month" },
+        ),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(postMock).toHaveBeenCalledWith(
+      "/cases/feedback/aggregate",
+      { filters: { dateFrom: "2026-06-01", dateTo: "2026-08-01" }, bucket: "week" },
+      { signal: expect.any(AbortSignal) },
+    );
+  });
+
+  it("keeps the month bucket when the selected range spans more than 3 months", async () => {
+    postMock.mockResolvedValue({ buckets: [], totalRecords: 0 });
+
+    renderHook(
+      () =>
+        useCaseFeedbackTrendData(
+          "feedback_trend",
+          { dateFrom: "2026-01-01", dateTo: "2026-08-01" },
+          { bucket: "month" },
+        ),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(postMock).toHaveBeenCalled());
+
+    expect(postMock).toHaveBeenCalledWith(
+      "/cases/feedback/aggregate",
+      { filters: { dateFrom: "2026-01-01", dateTo: "2026-08-01" }, bucket: "month" },
+      { signal: expect.any(AbortSignal) },
+    );
+  });
+
+  it("keeps the month bucket when the date range is unbounded (no dateFrom/dateTo)", async () => {
+    postMock.mockResolvedValue({ buckets: [], totalRecords: 0 });
+
+    renderHook(() => useCaseFeedbackTrendData("feedback_trend", {}, { bucket: "month" }), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(postMock).toHaveBeenCalled());
+
+    expect(postMock).toHaveBeenCalledWith(
+      "/cases/feedback/aggregate",
+      { filters: {}, bucket: "month" },
+      { signal: expect.any(AbortSignal) },
+    );
+  });
+
+  it("resolves a rating-value distribution: labels are the rating names, values are counts, colored by rating", async () => {
+    postMock.mockResolvedValue({
+      buckets: [
+        { bucketStart: "Very Dissatisfied", avgRating: 1, count: 57 },
+        { bucketStart: "Very Satisfied", avgRating: 5, count: 76 },
+      ],
+      totalRecords: 229,
+    });
+
+    const { result } = renderHook(
+      () => useCaseFeedbackTrendData("feedback_rating_distribution", {}, { bucket: "rating" }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(postMock).toHaveBeenCalledWith(
+      "/cases/feedback/aggregate",
+      { filters: {}, bucket: "rating" },
+      { signal: expect.any(AbortSignal) },
+    );
+    expect(result.current.slices).toEqual([
+      {
+        label: "Very Dissatisfied",
+        query: { rating: 1 },
+        navigable: true,
+        value: 57,
+        color: "error",
+      },
+      {
+        label: "Very Satisfied",
+        query: { rating: 5 },
+        navigable: true,
+        value: 76,
+        color: "success",
+      },
+    ]);
+  });
+
+  it("resolves a reasons_* distribution: labels are the reason names, values are counts, no rating-based color", async () => {
+    postMock.mockResolvedValue({
+      buckets: [
+        { bucketStart: "Friendly support", avgRating: 1, count: 16 },
+        { bucketStart: "Quick resolution", avgRating: 1, count: 20 },
+      ],
+      totalRecords: 71,
+    });
+
+    const { result } = renderHook(
+      () =>
+        useCaseFeedbackTrendData("feedback_reasons_very_satisfied", {}, {
+          bucket: "reasons_very_satisfied",
+        }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(postMock).toHaveBeenCalledWith(
+      "/cases/feedback/aggregate",
+      { filters: {}, bucket: "reasons_very_satisfied" },
+      { signal: expect.any(AbortSignal) },
+    );
+    expect(result.current.slices).toEqual([
+      { label: "Friendly support", query: {}, navigable: false, value: 16, color: undefined },
+      { label: "Quick resolution", query: {}, navigable: false, value: 20, color: undefined },
     ]);
   });
 

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/api/useCaseFeedbackTrendData.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/api/useCaseFeedbackTrendData.ts
@@ -17,7 +17,12 @@
 import { useQuery } from "@tanstack/react-query";
 import { ApiQueryKeys } from "@constants/apiConstants";
 import { useBackendApi } from "@api/backend/client";
-import type { BeCaseFeedbackAggregateResponse, BeDashboardGroupByConfig } from "@api/backend/types";
+import type {
+  BeCaseFeedbackAggregateResponse,
+  BeCaseFeedbackBucket,
+  BeDashboardGroupByConfig,
+  BeWidgetPaletteColor,
+} from "@api/backend/types";
 import { WIDGET_RESOURCE_CONFIG } from "@features/csm-dashboard/config/widgetResourceConfig";
 import { resolveRelativeDateFilters } from "@features/csm-dashboard/utils/resolveRelativeDateFilters";
 import {
@@ -25,6 +30,68 @@ import {
   withWidgetFetchSlot,
 } from "@features/csm-dashboard/utils/widgetFetchConcurrency";
 import type { PieSliceResult, WidgetPieData } from "@features/csm-dashboard/api/useWidgetPieData";
+
+const THREE_MONTHS_DAYS = 92;
+
+/** Switches the trend widget's default "month" bucket to "week" when the
+ * selected date range spans 3 months or less — a monthly bucket over a
+ * short range collapses to just 1-3 bars, too coarse to be useful, while a
+ * weekly bucket over a long range would produce far too many. Any other
+ * bucket (an explicit "week"/"day", or a "rating"/"reasons_*" distribution)
+ * is left untouched — this override only applies to the trend widget's own
+ * default. An unbounded or partially-bounded range (either side missing)
+ * also leaves "month" as-is, since the span can't be measured. */
+function resolveEffectiveBucket(
+  bucket: BeCaseFeedbackBucket | undefined,
+  filters: Record<string, unknown>,
+): BeCaseFeedbackBucket | undefined {
+  if (bucket !== "month") return bucket;
+  const dateFrom = filters.dateFrom;
+  const dateTo = filters.dateTo;
+  if (typeof dateFrom !== "string" || typeof dateTo !== "string") return bucket;
+  const from = new Date(dateFrom);
+  const to = new Date(dateTo);
+  if (Number.isNaN(from.getTime()) || Number.isNaN(to.getTime())) return bucket;
+  const spanDays = (to.getTime() - from.getTime()) / 86_400_000;
+  if (spanDays >= 0 && spanDays <= THREE_MONTHS_DAYS) return "week";
+  return bucket;
+}
+
+/** Computes the `[dateFrom, dateTo]` (YYYY-MM-DD) range a date-bucket slice
+ * covers, for click-through into the feedback list filtered to just that
+ * bucket — the same date-only format the list widget's own date-range
+ * filter already sends. `bucketStart` is UTC-midnight per
+ * `_computeBucketStart`'s own contract (see `formatBucketLabel`'s doc
+ * comment), so every date built here uses `Date.UTC`/`getUTCDate` to stay
+ * on the same calendar day the bucket itself represents. */
+function bucketDateRange(bucketStart: string, bucket: "day" | "week" | "month"): [string, string] {
+  const start = new Date(bucketStart);
+  if (Number.isNaN(start.getTime())) return [bucketStart, bucketStart];
+  const toISODate = (d: Date): string => d.toISOString().slice(0, 10);
+  if (bucket === "day") return [bucketStart, bucketStart];
+  if (bucket === "week") {
+    const end = new Date(start);
+    end.setUTCDate(end.getUTCDate() + 6);
+    return [bucketStart, toISODate(end)];
+  }
+  // "month": bucketStart is always the 1st (see _computeBucketStart) —
+  // the last day of that month is the day before the 1st of the next one.
+  const end = new Date(Date.UTC(start.getUTCFullYear(), start.getUTCMonth() + 1, 0));
+  return [bucketStart, toISODate(end)];
+}
+
+/** Maps a bucket's average rating (1-5 scale) to a fixed red/amber/green
+ * palette color instead of the bar chart's default per-index color
+ * rotation — a rating trend has an inherent "better/worse" direction that a
+ * rotating rainbow of unrelated palette colors doesn't communicate, and
+ * would misleadingly suggest each bucket is a distinct unrelated category.
+ * Thresholds mirror the underlying CSAT labels (1-2 = Dissatisfied/Very
+ * Dissatisfied, 3 = Neutral, 4-5 = Satisfied/Very Satisfied). */
+function colorForAvgRating(avgRating: number): BeWidgetPaletteColor {
+  if (avgRating < 3) return "error";
+  if (avgRating < 4) return "warning";
+  return "success";
+}
 
 /** Formats one bucket's own `bucketStart` for the x-axis label, at the
  * granularity implied by `bucket` — "month" reads as "Aug 2026" (the day is
@@ -44,7 +111,11 @@ import type { PieSliceResult, WidgetPieData } from "@features/csm-dashboard/api/
  * day/month on the label — e.g. "Jul 2026" for a bucket the response itself
  * calls August. Pinning to UTC makes the label match the bucket's own wire
  * value everywhere, regardless of the viewer's timezone. */
-function formatBucketLabel(bucketStart: string, bucket: "day" | "week" | "month"): string {
+function formatBucketLabel(bucketStart: string, bucket: BeCaseFeedbackBucket): string {
+  // "rating"/"reasons_*" modes group by a fixed label (rating name or reason
+  // chip) instead of time: bucketStart is already that label, not a date to
+  // parse.
+  if (bucket === "rating" || bucket.startsWith("reasons_")) return bucketStart;
   const date = new Date(bucketStart);
   if (Number.isNaN(date.getTime())) return bucketStart;
   return new Intl.DateTimeFormat("en-US", {
@@ -56,27 +127,29 @@ function formatBucketLabel(bucketStart: string, bucket: "day" | "week" | "month"
 }
 
 /**
- * Resolves a `shape: "bar"` `case_feedback` widget's date-bucketed rating
- * trend via a single `POST /cases/feedback/aggregate` call — the
- * `groupBy.bucket` counterpart of `useWidgetGroupByData`'s `groupBy.field`
- * (see that field's own doc comment on `BeDashboardGroupByConfig` for why
- * this is a dedicated hook rather than a branch inside that one: the
- * request body (`{filters, bucket}`, no `groupBy`/`maxGroups`) and response
- * shape (`{buckets: [{bucketStart, avgRating, count}], totalRecords}`, no
- * `groups`/`othersCount`) are both unrelated to `BeGroupByResponse`).
+ * Resolves a `shape: "bar"`/`"pie"` `case_feedback` widget's bucketed data
+ * via a single `POST /cases/feedback/aggregate` call — the `groupBy.bucket`
+ * counterpart of `useWidgetGroupByData`'s `groupBy.field` (see that field's
+ * own doc comment on `BeDashboardGroupByConfig` for why this is a dedicated
+ * hook rather than a branch inside that one: the request body (`{filters,
+ * bucket}`, no `groupBy`/`maxGroups`) and response shape (`{buckets:
+ * [{bucketStart, avgRating, count}], totalRecords}`, no `groups`/
+ * `othersCount`) are both unrelated to `BeGroupByResponse`).
  *
- * Renders **average rating per bucket** as the primary metric (this task's
- * own stated default) rather than a count-by-rating-bucket breakdown — every
- * returned slice's `value` is `avgRating` (1-5), not `count`. `count` is
- * still read off the response (as `WidgetPieData.total`, the bar tile's own
- * header badge — see `DashboardWidgetTile`), just not per-bucket.
+ * Renders **average rating per bucket** as the primary metric for date
+ * buckets (this task's own stated default) — every returned slice's `value`
+ * is `avgRating` (1-5), not `count`, in that mode. `count` is still read off
+ * the response (as `WidgetPieData.total`, the tile's own header badge — see
+ * `DashboardWidgetTile`), just not per-bucket. For "rating"/"reasons_*"
+ * modes, `value` is `count` instead — see the slice-building code below.
  *
- * Every bucket slice is marked `navigable: false`: unlike a field-based
- * groupBy bucket (which resolves to a real filtered case-list query — see
- * `useWidgetGroupByData`'s `bucketQuery`), a case-feedback bucket has no
- * dedicated list page or click-through target of its own to scope a filtered
- * result set to (see `WIDGET_RESOURCE_CONFIG.case_feedback.buildHref`) — a
- * navigable-but-nowhere-useful click was judged worse than none.
+ * A date-bucket (day/week/month) or "rating" slice is click-through
+ * navigable — into the feedback list's own dashboard-widget preview page
+ * (`WIDGET_RESOURCE_CONFIG.case_feedback.buildHref`), filtered to that
+ * bucket's own date range or rating value respectively. A "reasons_*" slice
+ * stays `navigable: false`: which chip a customer picked isn't a field the
+ * feedback list's search can filter by, so there's no safe selector to
+ * scope to — see the slice-building code below for the full reasoning.
  *
  * `groupBy` of `undefined`, or one carrying no `bucket` (a field-based
  * `groupBy` reaching this hook by mistake — never true in practice, since
@@ -104,9 +177,9 @@ export function useCaseFeedbackTrendData(
 ): WidgetPieData {
   const api = useBackendApi();
   const config = WIDGET_RESOURCE_CONFIG.case_feedback;
-  const bucket = groupBy?.bucket;
 
   const resolvedFilters = resolveRelativeDateFilters(baseFilters);
+  const bucket = resolveEffectiveBucket(groupBy?.bucket, resolvedFilters);
 
   const query = useQuery({
     queryKey: [
@@ -130,7 +203,7 @@ export function useCaseFeedbackTrendData(
       // this fetch from the shared FIFO queue.
       return withWidgetFetchSlot(async (signal) => {
         return api.post<
-          { filters: Record<string, unknown>; bucket: "day" | "week" | "month" },
+          { filters: Record<string, unknown>; bucket: BeCaseFeedbackBucket },
           BeCaseFeedbackAggregateResponse
         >(
           config.groupByEndpoint as string,
@@ -153,13 +226,51 @@ export function useCaseFeedbackTrendData(
   const isLoading = !enabled || (!!bucket && query.isLoading);
   const isError = !!bucket && query.isError;
 
+  // "rating"/"reasons_*" modes group by a fixed label instead of time, so
+  // the meaningful per-slice metric is how many responses fell into that
+  // group (count), not avgRating — which for "rating" is always just the
+  // rating value itself (a constant, not a useful slice size), and for
+  // "reasons_*" carries no meaningful average at all (each row is a
+  // categorical chip selection, not a rating).
+  const isCountBased = bucket === "rating" || !!bucket?.startsWith("reasons_");
+  // Red/amber/green by value only makes sense for the rating dimension
+  // itself — a "reasons_*" bucket's slices are categorical chip choices
+  // within a single, already-fixed rating level, with no better/worse
+  // ordering of their own, so they keep the bar/pie chart's own default
+  // per-index color rotation instead (color left undefined).
+  const isRatingColored = bucket === "rating" || (!!bucket && !bucket.startsWith("reasons_"));
   const buckets = query.data?.buckets ?? [];
-  const slices: PieSliceResult[] = buckets.map((b) => ({
-    label: bucket ? formatBucketLabel(b.bucketStart, bucket) : b.bucketStart,
-    query: {},
-    navigable: false,
-    value: b.avgRating,
-  }));
+  const slices: PieSliceResult[] = buckets.map((b) => {
+    // Click-through target, by bucket kind:
+    // - date buckets (day/week/month): the exact date range that bucket
+    //   covers, filtering the feedback list to just those submissions.
+    // - "rating": the exact rating value, via the new rating filter —
+    //   avgRating in this mode is always just the rating value itself
+    //   (every row in the bucket shares it), so it's a safe round-trip.
+    // - "reasons_*": no click-through — a reason chip isn't a field the
+    //   feedback list's own search can filter by (it's a separate
+    //   asmt_metric_result row, not a column on the feedback record
+    //   itself), so there's no safe selector to scope to, same reasoning
+    //   `useWidgetGroupByData`'s synthetic "Others" bucket uses for its
+    //   own `navigable: false`.
+    let sliceQuery: Record<string, unknown> = {};
+    let navigable = false;
+    if (bucket === "day" || bucket === "week" || bucket === "month") {
+      const [dateFrom, dateTo] = bucketDateRange(b.bucketStart, bucket);
+      sliceQuery = { dateFrom, dateTo };
+      navigable = true;
+    } else if (bucket === "rating") {
+      sliceQuery = { rating: Math.round(b.avgRating) };
+      navigable = true;
+    }
+    return {
+      label: bucket ? formatBucketLabel(b.bucketStart, bucket) : b.bucketStart,
+      query: sliceQuery,
+      navigable,
+      value: isCountBased ? b.count : b.avgRating,
+      color: isRatingColored ? colorForAvgRating(b.avgRating) : undefined,
+    };
+  });
   const total = query.data?.totalRecords ?? 0;
 
   return { slices, total, isLoading, isError };

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/components/DashboardWidgetTile.tsx
@@ -367,9 +367,10 @@ export default function DashboardWidgetTile({
   // request, gated by its own `groupBy`/`slices` argument being
   // empty/undefined.
   //
-  // `groupBy.bucket` (date-bucketed grouping — only `case_feedback`'s own
-  // trend widget uses this today) resolves via `useCaseFeedbackTrendData`
-  // instead of `useWidgetGroupByData`: its request/response contract (`POST
+  // `groupBy.bucket` (date- or rating-bucketed grouping — only
+  // `case_feedback`'s own trend/distribution widgets use this today)
+  // resolves via `useCaseFeedbackTrendData` instead of `useWidgetGroupByData`:
+  // its request/response contract (`POST
   // /cases/feedback/aggregate`) is unrelated to `BeGroupByResponse` (see
   // `BeDashboardGroupByConfig.bucket`'s own doc comment) — passing a
   // `bucket`-configured `groupBy` into `useWidgetGroupByData` would throw
@@ -389,7 +390,7 @@ export default function DashboardWidgetTile({
   const feedbackTrendData = useCaseFeedbackTrendData(
     widgetId,
     filters,
-    shape === "bar" && groupBy?.bucket ? groupBy : undefined,
+    (shape === "bar" || shape === "pie") && groupBy?.bucket ? groupBy : undefined,
     isVisible,
   );
   const pieData = groupBy?.bucket ? feedbackTrendData : groupBy ? groupByData : sliceData;

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetListConfig.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetListConfig.test.tsx
@@ -234,6 +234,46 @@ describe("widgetListConfig — quick-preview icon per resourceType", () => {
     expect(screen.getByText("Unassigned")).toBeInTheDocument();
   });
 
+  it("case_feedback: renders both the internal case id and the case number, falling back to the raw caseId when neither resolved", () => {
+    const Renderer = WIDGET_LIST_RENDERERS.case_feedback;
+    renderRenderer(
+      <Renderer
+        items={[
+          {
+            instanceId: "fb-1",
+            caseId: "case-1",
+            caseNumber: "CS0440709",
+            caseInternalId: "SCTPSUB-88",
+            rating: 4,
+            ratingLabel: "Satisfied",
+            comment: null,
+            submittedAt: "2026-08-03T04:37:50Z",
+            submitterName: "Jane Customer",
+          },
+          {
+            instanceId: "fb-2",
+            caseId: "case-2",
+            caseNumber: null,
+            caseInternalId: null,
+            rating: 5,
+            ratingLabel: "Very Satisfied",
+            comment: null,
+            submittedAt: "2026-08-17T06:17:56Z",
+            submitterName: null,
+          },
+        ]}
+        isLoading={false}
+      />,
+      "/cases/:id",
+    );
+
+    expect(screen.getByText("SCTPSUB-88")).toBeInTheDocument();
+    expect(screen.getByText("CS0440709")).toBeInTheDocument();
+    expect(screen.getByText("case-2")).toBeInTheDocument();
+    expect(screen.getByText("Jane Customer")).toBeInTheDocument();
+    expect(screen.getByText("Customer")).toBeInTheDocument();
+  });
+
   it("call_request: renders the preview icon, opens the existing detail modal without navigating the owning case", () => {
     const Renderer = WIDGET_LIST_RENDERERS.call_request;
     renderRenderer(

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetListConfig.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetListConfig.tsx
@@ -21,6 +21,7 @@ import { Eye } from "@wso2/oxygen-ui-icons-react";
 import { useState, type JSX } from "react";
 import { useLocation } from "react-router";
 import type {
+  BeCaseFeedback,
   BeCaseSearchView,
   BeIncident,
   BeChangeRequestSearchView,
@@ -752,17 +753,7 @@ function CallRequestWidgetList({ items, isLoading }: WidgetListRendererProps): J
  * renderer here). Renders rating/comment/case/submitted-by/submitted.
  */
 function CaseFeedbackWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.Element {
-  const feedback = items as unknown as {
-    instanceId?: string;
-    caseId?: string;
-    caseNumber?: string | null;
-    caseInternalId?: string | null;
-    rating?: number;
-    ratingLabel?: string;
-    comment?: string | null;
-    submittedAt?: string;
-    submitterName?: string | null;
-  }[];
+  const feedback = items as unknown as BeCaseFeedback[];
   const dashboardReturnState = useDashboardReturnState();
   const navigate = useNavTransition();
   return (

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetListConfig.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetListConfig.tsx
@@ -759,6 +759,7 @@ function CaseFeedbackWidgetList({ items, isLoading }: WidgetListRendererProps): 
   const feedback = items as unknown as {
     instanceId?: string;
     caseId?: string;
+    caseNumber?: string | null;
     rating?: number;
     ratingLabel?: string;
     comment?: string | null;
@@ -789,7 +790,7 @@ function CaseFeedbackWidgetList({ items, isLoading }: WidgetListRendererProps): 
               {f.comment || "—"}
             </Typography>,
             <Typography key="case" variant="body2" noWrap>
-              {f.caseId ?? "—"}
+              {f.caseNumber || f.caseId || "—"}
             </Typography>,
             <Typography key="submitted" variant="caption" color="text.secondary" noWrap>
               {formatDate(f.submittedAt)}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetListConfig.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetListConfig.tsx
@@ -16,7 +16,7 @@
 
 /* eslint-disable react-refresh/only-export-components -- this is a config module of per-resourceType render helpers (like widgetResourceConfig.ts), not a component module; none of the individual XxxWidgetList functions are exported (fast-refresh DX only) */
 
-import { Chip, IconButton, Tooltip, Typography } from "@wso2/oxygen-ui";
+import { Box, Chip, IconButton, Tooltip, Typography } from "@wso2/oxygen-ui";
 import { Eye } from "@wso2/oxygen-ui-icons-react";
 import { useState, type JSX } from "react";
 import { useLocation } from "react-router";
@@ -743,27 +743,25 @@ function CallRequestWidgetList({ items, isLoading }: WidgetListRendererProps): J
 }
 
 /**
- * Hardcoded renderer for `case_feedback` — the fallback for a
- * `case_feedback` widget with no `columns` configured (see
- * `DashboardWidgetTile`'s `hasColumns` branch). The real `case-feedback.json`
- * dashboard's own list widget sets `columns` (rating/comment/case/submitted
- * — matching ServiceNow's own "Case Feedback" scorecard page), so this path
- * is a fallback rather than the primary renderer, same relationship
- * `columns` has to every other hardcoded renderer here — but it still has to
- * exist and render something reasonable, since `WIDGET_LIST_RENDERERS` is
- * exhaustive over every `BeWidgetResourceType` (see that Record's own doc
- * comment) and `DashboardWidgetTile` falls back to it whenever `columns` is
- * absent/empty.
+ * Hardcoded renderer for `case_feedback` — the primary renderer for this
+ * resourceType's `shape: "list"` widget (the `case-feedback.json` dashboard's
+ * own list widget sets no `columns`, so `DashboardWidgetTile`'s
+ * `hasColumns` branch always dispatches here rather than to the generic
+ * `GenericColumnList` — a widget that *does* set `columns` would use that
+ * path instead, same relationship `columns` has to every other hardcoded
+ * renderer here). Renders rating/comment/case/submitted-by/submitted.
  */
 function CaseFeedbackWidgetList({ items, isLoading }: WidgetListRendererProps): JSX.Element {
   const feedback = items as unknown as {
     instanceId?: string;
     caseId?: string;
     caseNumber?: string | null;
+    caseInternalId?: string | null;
     rating?: number;
     ratingLabel?: string;
     comment?: string | null;
     submittedAt?: string;
+    submitterName?: string | null;
   }[];
   const dashboardReturnState = useDashboardReturnState();
   const navigate = useNavTransition();
@@ -774,7 +772,8 @@ function CaseFeedbackWidgetList({ items, isLoading }: WidgetListRendererProps): 
       columns={[
         { label: "Rating", width: "minmax(90px, 0.6fr)" },
         { label: "Comment", width: "minmax(200px, 3fr)" },
-        { label: "Case", width: "minmax(90px, 0.8fr)" },
+        { label: "Case", width: "minmax(140px, 1fr)" },
+        { label: "Submitted by", width: "minmax(140px, 1.5fr)" },
         { label: "Submitted", width: "minmax(90px, 1fr)" },
       ]}
       rows={feedback.map((f, i) => {
@@ -789,8 +788,28 @@ function CaseFeedbackWidgetList({ items, isLoading }: WidgetListRendererProps): 
             <Typography key="comment" variant="body2" noWrap title={f.comment ?? undefined}>
               {f.comment || "—"}
             </Typography>,
-            <Typography key="case" variant="body2" noWrap>
-              {f.caseNumber || f.caseId || "—"}
+            <Box key="case" sx={{ minWidth: 0 }}>
+              {f.caseInternalId && (
+                <Typography
+                  variant="body2"
+                  noWrap
+                  title={f.caseInternalId}
+                  sx={{ fontFamily: "monospace", fontWeight: 600 }}
+                >
+                  {f.caseInternalId}
+                </Typography>
+              )}
+              <Typography
+                variant={f.caseInternalId ? "caption" : "body2"}
+                color={f.caseInternalId ? "text.secondary" : undefined}
+                noWrap
+                sx={{ fontFamily: "monospace", display: "block" }}
+              >
+                {f.caseNumber || f.caseId || "—"}
+              </Typography>
+            </Box>,
+            <Typography key="submitter" variant="body2" noWrap title={f.submitterName ?? undefined}>
+              {f.submitterName || "Customer"}
             </Typography>,
             <Typography key="submitted" variant="caption" color="text.secondary" noWrap>
               {formatDate(f.submittedAt)}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.test.ts
@@ -473,3 +473,32 @@ describe("WIDGET_RESOURCE_CONFIG — case-table resourceTypes beyond `case`", ()
     expect(new Set(icons).size).toBe(icons.length);
   });
 });
+
+describe("WIDGET_RESOURCE_CONFIG.case_feedback.buildSearchRequestBody", () => {
+  // The dashboard-widget preview page's URL round-trip (parseWidgetPreviewFilters)
+  // decodes every query param as a comma-split string array — the shape every
+  // other resourceType's filters use, but not case_feedback's own flat scalar
+  // contract (dateFrom/dateTo/caseId/rating). A trend-bar or rating-pie slice's
+  // click-through arrives here exactly as that parser produces it.
+  const build = WIDGET_RESOURCE_CONFIG.case_feedback.buildSearchRequestBody!;
+
+  it("unwraps array-wrapped dateFrom/dateTo/rating back to scalars", () => {
+    const body = build({
+      filters: { dateFrom: ["2026-08-01"], dateTo: ["2026-08-31"], rating: ["5"] },
+      offset: 0,
+      limit: 10,
+    }) as { filters: Record<string, unknown> };
+
+    expect(body.filters).toEqual({ dateFrom: "2026-08-01", dateTo: "2026-08-31", rating: 5 });
+  });
+
+  it("leaves already-scalar filters untouched (a tile-level fetch, no URL round trip)", () => {
+    const body = build({
+      filters: { dateFrom: "2026-08-01", rating: 5 },
+      offset: 0,
+      limit: 10,
+    }) as { filters: Record<string, unknown> };
+
+    expect(body.filters).toEqual({ dateFrom: "2026-08-01", rating: 5 });
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.ts
@@ -914,7 +914,31 @@ export const WIDGET_RESOURCE_CONFIG: Record<
       // `offset` is always a multiple of `limit`, either 0 for a tile or
       // `listLimit * pageIndex` for the preview page's own pager).
       const page = limit > 0 ? Math.floor(offset / limit) + 1 : 1;
-      return { filters, page, pageSize: limit };
+      // The dashboard-widget preview page's own URL round-trip
+      // (`parseWidgetPreviewFilters`) decodes every query param as a
+      // comma-split string array — the shape every other resourceType's own
+      // filters actually use (case-search-DSL field values). `case_feedback`
+      // is one of the few resourceTypes whose filters are a flat scalar
+      // object instead (`dateFrom`/`dateTo`/`caseId`/`rating`, not arrays),
+      // so a preview-page click-through (e.g. a trend-bar bucket's date
+      // range, or the rating pie's `rating` slice) arrives here as
+      // `{dateFrom: ["2026-07-01"], rating: ["5"]}` rather than the scalar
+      // values this endpoint's own contract expects — sent as-is, the
+      // backing data source rejects the array shape outright. Unwrap known
+      // scalar fields back to their real type before forwarding; a
+      // tile-level fetch (whose filters
+      // never went through that round-trip) already has scalars here and is
+      // a no-op through this same unwrap.
+      const scalarFilters = { ...filters };
+      for (const key of ["caseId", "dateFrom", "dateTo"] as const) {
+        const v = scalarFilters[key];
+        if (Array.isArray(v)) scalarFilters[key] = v[0];
+      }
+      if (Array.isArray(scalarFilters.rating)) {
+        const parsed = Number(scalarFilters.rating[0]);
+        scalarFilters.rating = Number.isNaN(parsed) ? undefined : parsed;
+      }
+      return { filters: scalarFilters, page, pageSize: limit };
     },
     parseSearchResponse: (res) => {
       const total = typeof res.totalRecords === "number" ? res.totalRecords : 0;
@@ -929,9 +953,17 @@ export const WIDGET_RESOURCE_CONFIG: Record<
     },
     secondaryLabel: (item) => asString(item.comment) ?? undefined,
     // No standalone case-feedback list page exists (only this dashboard's
-    // own widgets) — same situation as `task`/`call_request`'s own tile-level
-    // click-through above.
-    buildHref: () => "/dashboard",
+    // own widgets), so — like `incident_task` above — every click routes
+    // through the generic dashboard-widget preview page, the only
+    // destination that can render this resourceType's own filtered result
+    // set.
+    buildHref: (filters, ctx) =>
+      buildWidgetPreviewHref({
+        previewSlug: "case-feedback",
+        widgetId: ctx?.widgetId ?? "",
+        displayName: ctx?.displayName ?? "",
+        filters,
+      }),
     icon: Star,
     iconColor: "warning",
     previewSlug: "case-feedback",

--- a/apps/csm-portal/webapp/src/features/help/content/support.md
+++ b/apps/csm-portal/webapp/src/features/help/content/support.md
@@ -49,6 +49,11 @@ A few things worth knowing:
 Opening a case shows its full detail: overview fields, the comment/activity timeline,
 attachments, and any linked service requests.
 
+If a customer submits Case Feedback (a CSAT survey, typically sent once a case closes), it
+appears in the activity timeline alongside comments and status changes, in its correct
+chronological position — showing the submitter, star rating, and any free-text comment they
+left.
+
 **Linked service requests** appear in their own widget on the case, listing each linked
 request's number, name, state, and current assignee. Clicking a row navigates to that
 request's own case page (with a "back" link that returns you here). You can start a new

--- a/entity-service/internal/domain/feedback.go
+++ b/entity-service/internal/domain/feedback.go
@@ -23,7 +23,11 @@ type CaseFeedback struct {
 	// CaseNumber is the human-readable case number (e.g. "CS0441331").
 	// Nullable -- absent if the case record could not be resolved.
 	CaseNumber *string `json:"caseNumber"`
-	Rating     int     `json:"rating"`
+	// CaseInternalID is the WSO2 internal case id (e.g. "SCTPSUB-88") for CaseID.
+	// Nullable -- absent if the case record could not be resolved upstream or has
+	// no internal id assigned.
+	CaseInternalID *string `json:"caseInternalId"`
+	Rating         int     `json:"rating"`
 	// RatingLabel is the human-readable label for Rating (e.g. "Satisfied"),
 	// as supplied by the backing data source.
 	RatingLabel string `json:"ratingLabel"`
@@ -44,8 +48,11 @@ type CaseFeedback struct {
 type SearchFeedbackFilters struct {
 	CaseID     string   `json:"caseId,omitempty"`
 	AccountIDs []string `json:"accountIds,omitempty"`
-	DateFrom   string   `json:"dateFrom,omitempty"`
-	DateTo     string   `json:"dateTo,omitempty"`
+	// Rating is an exact-match filter (1-5). Nil means unset; the valid
+	// range never includes 0, so a plain *int (not 0-as-sentinel) is used.
+	Rating   *int   `json:"rating,omitempty"`
+	DateFrom string `json:"dateFrom,omitempty"`
+	DateTo   string `json:"dateTo,omitempty"`
 }
 
 // SearchFeedbackRequest is the input for POST /cases/feedback/search.
@@ -63,14 +70,25 @@ type SearchFeedbackResponse struct {
 	TotalRecords int            `json:"totalRecords"`
 }
 
-// FeedbackBucket is the enum of supported date-bucket granularities for
-// POST /cases/feedback/aggregate.
+// FeedbackBucket is the enum of supported aggregation granularities for
+// POST /cases/feedback/aggregate: "day"/"week"/"month" bucket by submission
+// date, "rating" groups by rating value instead of time (each bucket's
+// BucketStart then carries the rating's own label, e.g. "Very Satisfied",
+// rather than a date), and the 5 "reasons_*" values group by which free-text
+// reason was selected for that specific rating level (each bucket's
+// BucketStart then carries the reason's own label, e.g. "Unhelpful support").
 type FeedbackBucket string
 
 const (
-	FeedbackBucketDay   FeedbackBucket = "day"
-	FeedbackBucketWeek  FeedbackBucket = "week"
-	FeedbackBucketMonth FeedbackBucket = "month"
+	FeedbackBucketDay                     FeedbackBucket = "day"
+	FeedbackBucketWeek                    FeedbackBucket = "week"
+	FeedbackBucketMonth                   FeedbackBucket = "month"
+	FeedbackBucketRating                  FeedbackBucket = "rating"
+	FeedbackBucketReasonsVeryDissatisfied FeedbackBucket = "reasons_very_dissatisfied"
+	FeedbackBucketReasonsDissatisfied     FeedbackBucket = "reasons_dissatisfied"
+	FeedbackBucketReasonsNeutral          FeedbackBucket = "reasons_neutral"
+	FeedbackBucketReasonsSatisfied        FeedbackBucket = "reasons_satisfied"
+	FeedbackBucketReasonsVerySatisfied    FeedbackBucket = "reasons_very_satisfied"
 )
 
 // AggregateFeedbackFilters holds the optional filter criteria for a
@@ -85,7 +103,7 @@ type AggregateFeedbackFilters struct {
 // AggregateFeedbackRequest is the input for POST /cases/feedback/aggregate.
 type AggregateFeedbackRequest struct {
 	Filters AggregateFeedbackFilters `json:"filters"`
-	// Bucket selects the date-bucket granularity. Required; one of "day", "week", "month".
+	// Bucket selects the aggregation granularity. Required; see FeedbackBucket.
 	Bucket FeedbackBucket `json:"bucket"`
 }
 

--- a/entity-service/internal/domain/feedback.go
+++ b/entity-service/internal/domain/feedback.go
@@ -20,7 +20,10 @@ package domain
 type CaseFeedback struct {
 	InstanceID string `json:"instanceId"`
 	CaseID     string `json:"caseId"`
-	Rating     int    `json:"rating"`
+	// CaseNumber is the human-readable case number (e.g. "CS0441331").
+	// Nullable -- absent if the case record could not be resolved.
+	CaseNumber *string `json:"caseNumber"`
+	Rating     int     `json:"rating"`
 	// RatingLabel is the human-readable label for Rating (e.g. "Satisfied"),
 	// as supplied by the backing data source.
 	RatingLabel string `json:"ratingLabel"`
@@ -28,6 +31,13 @@ type CaseFeedback struct {
 	// carries a null comment upstream, not an empty string.
 	Comment     *string `json:"comment"`
 	SubmittedAt string  `json:"submittedAt"`
+	// SubmitterName is the display name of the customer contact who
+	// submitted the feedback. Nullable -- absent if the submitting user
+	// record could not be resolved.
+	SubmitterName *string `json:"submitterName"`
+	// SubmitterEmail is the email of the submitting contact. Nullable, same
+	// as SubmitterName.
+	SubmitterEmail *string `json:"submitterEmail"`
 }
 
 // SearchFeedbackFilters holds the optional filter criteria for a case-feedback search.

--- a/entity-service/internal/service/feedback_service.go
+++ b/entity-service/internal/service/feedback_service.go
@@ -56,12 +56,15 @@ type snSearchFeedbackPayload struct {
 
 // snFeedbackRow mirrors a single row in the Choreo feedback-search response.
 type snFeedbackRow struct {
-	InstanceID  string  `json:"instanceId"`
-	CaseID      string  `json:"caseId"`
-	Rating      int     `json:"rating"`
-	RatingLabel string  `json:"ratingLabel"`
-	Comment     *string `json:"comment"`
-	SubmittedAt string  `json:"submittedAt"`
+	InstanceID     string  `json:"instanceId"`
+	CaseID         string  `json:"caseId"`
+	CaseNumber     *string `json:"caseNumber"`
+	Rating         int     `json:"rating"`
+	RatingLabel    string  `json:"ratingLabel"`
+	Comment        *string `json:"comment"`
+	SubmittedAt    string  `json:"submittedAt"`
+	SubmitterName  *string `json:"submitterName"`
+	SubmitterEmail *string `json:"submitterEmail"`
 }
 
 // snSearchFeedbackResponse mirrors the Choreo POST /cases/feedback/search response.
@@ -150,12 +153,15 @@ func (s *snFeedbackService) SearchFeedback(ctx context.Context, req domain.Searc
 	results := make([]domain.CaseFeedback, 0, len(snResp.Results))
 	for _, row := range snResp.Results {
 		results = append(results, domain.CaseFeedback{
-			InstanceID:  sysidToUUID(row.InstanceID),
-			CaseID:      sysidToUUID(row.CaseID),
-			Rating:      row.Rating,
-			RatingLabel: row.RatingLabel,
-			Comment:     row.Comment,
-			SubmittedAt: row.SubmittedAt,
+			InstanceID:     sysidToUUID(row.InstanceID),
+			CaseID:         sysidToUUID(row.CaseID),
+			CaseNumber:     row.CaseNumber,
+			Rating:         row.Rating,
+			RatingLabel:    row.RatingLabel,
+			Comment:        row.Comment,
+			SubmittedAt:    row.SubmittedAt,
+			SubmitterName:  row.SubmitterName,
+			SubmitterEmail: row.SubmitterEmail,
 		})
 	}
 

--- a/entity-service/internal/service/feedback_service.go
+++ b/entity-service/internal/service/feedback_service.go
@@ -188,7 +188,7 @@ func (s *snFeedbackService) SearchFeedback(ctx context.Context, req domain.Searc
 // POST /cases/feedback/aggregate endpoint.
 func (s *snFeedbackService) AggregateFeedback(ctx context.Context, req domain.AggregateFeedbackRequest) (domain.AggregateFeedbackResponse, error) {
 	if !validFeedbackBuckets[req.Bucket] {
-		return domain.AggregateFeedbackResponse{}, &apierror.ValidationError{Msg: "bucket must be one of: day, week, month"}
+		return domain.AggregateFeedbackResponse{}, &apierror.ValidationError{Msg: "bucket must be one of: day, week, month, rating, reasons_very_dissatisfied, reasons_dissatisfied, reasons_neutral, reasons_satisfied, reasons_very_satisfied"}
 	}
 	if err := validateUUIDs("accountIds", req.Filters.AccountIDs); err != nil {
 		return domain.AggregateFeedbackResponse{}, err

--- a/entity-service/internal/service/feedback_service.go
+++ b/entity-service/internal/service/feedback_service.go
@@ -30,9 +30,15 @@ import (
 // validFeedbackBuckets is the closed set of bucket granularities the backing
 // data source accepts for POST /cases/feedback/aggregate.
 var validFeedbackBuckets = map[domain.FeedbackBucket]bool{
-	domain.FeedbackBucketDay:   true,
-	domain.FeedbackBucketWeek:  true,
-	domain.FeedbackBucketMonth: true,
+	domain.FeedbackBucketDay:                     true,
+	domain.FeedbackBucketWeek:                    true,
+	domain.FeedbackBucketMonth:                   true,
+	domain.FeedbackBucketRating:                  true,
+	domain.FeedbackBucketReasonsVeryDissatisfied: true,
+	domain.FeedbackBucketReasonsDissatisfied:     true,
+	domain.FeedbackBucketReasonsNeutral:          true,
+	domain.FeedbackBucketReasonsSatisfied:        true,
+	domain.FeedbackBucketReasonsVerySatisfied:    true,
 }
 
 // snFeedbackFilters mirrors the "filters" object accepted by the Choreo
@@ -43,6 +49,7 @@ var validFeedbackBuckets = map[domain.FeedbackBucket]bool{
 type snFeedbackFilters struct {
 	CaseID     string   `json:"caseId,omitempty"`
 	AccountIDs []string `json:"accountIds,omitempty"`
+	Rating     *int     `json:"rating,omitempty"`
 	DateFrom   string   `json:"dateFrom,omitempty"`
 	DateTo     string   `json:"dateTo,omitempty"`
 }
@@ -59,6 +66,7 @@ type snFeedbackRow struct {
 	InstanceID     string  `json:"instanceId"`
 	CaseID         string  `json:"caseId"`
 	CaseNumber     *string `json:"caseNumber"`
+	CaseInternalID *string `json:"caseInternalId"`
 	Rating         int     `json:"rating"`
 	RatingLabel    string  `json:"ratingLabel"`
 	Comment        *string `json:"comment"`
@@ -121,6 +129,9 @@ func (s *snFeedbackService) SearchFeedback(ctx context.Context, req domain.Searc
 			return domain.SearchFeedbackResponse{}, err
 		}
 	}
+	if req.Filters.Rating != nil && (*req.Filters.Rating < 1 || *req.Filters.Rating > 5) {
+		return domain.SearchFeedbackResponse{}, &apierror.ValidationError{Msg: "rating must be between 1 and 5"}
+	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
 
@@ -133,6 +144,7 @@ func (s *snFeedbackService) SearchFeedback(ctx context.Context, req domain.Searc
 		Filters: snFeedbackFilters{
 			CaseID:     uuidToSysid(req.Filters.CaseID),
 			AccountIDs: uuidsToSysids(req.Filters.AccountIDs),
+			Rating:     req.Filters.Rating,
 			DateFrom:   req.Filters.DateFrom,
 			DateTo:     req.Filters.DateTo,
 		},
@@ -156,6 +168,7 @@ func (s *snFeedbackService) SearchFeedback(ctx context.Context, req domain.Searc
 			InstanceID:     sysidToUUID(row.InstanceID),
 			CaseID:         sysidToUUID(row.CaseID),
 			CaseNumber:     row.CaseNumber,
+			CaseInternalID: row.CaseInternalID,
 			Rating:         row.Rating,
 			RatingLabel:    row.RatingLabel,
 			Comment:        row.Comment,

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -7222,6 +7222,12 @@ components:
           type: string
           format: uuid
           description: UUID of the case the feedback belongs to.
+        caseNumber:
+          type: string
+          nullable: true
+          description: >-
+            Human-readable case number (e.g. "CS0441331"). Null if the case
+            record could not be resolved.
         rating:
           type: integer
           description: Numeric rating value.
@@ -7237,6 +7243,16 @@ components:
         submittedAt:
           type: string
           description: Timestamp when the feedback was submitted.
+        submitterName:
+          type: string
+          nullable: true
+          description: >-
+            Display name of the customer contact who submitted the feedback.
+            Null if the submitting user record could not be resolved.
+        submitterEmail:
+          type: string
+          nullable: true
+          description: Email of the submitting contact. Null, same as submitterName.
 
     SearchFeedbackFilters:
       type: object

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -7349,25 +7349,42 @@ components:
             - reasons_very_satisfied
           description: >-
             Aggregation granularity to group results by. "day"/"week"/"month"
-            bucket by submission date; "rating" groups by rating value
-            instead of time (each bucket's bucketStart then carries the
-            rating's own label, e.g. "Very Satisfied", rather than a date);
-            each "reasons_*" value groups by which free-text reason was
-            selected for that specific rating level (each bucket's
-            bucketStart then carries the reason's own label, e.g. "Unhelpful
-            support").
+            are temporal buckets by submission date. "rating" and every
+            "reasons_*" value are categorical buckets, not time ranges:
+            "rating" groups by rating value instead of time (each bucket's
+            bucketStart then carries the rating's own label, e.g. "Very
+            Satisfied", rather than a date); each "reasons_*" value groups by
+            which free-text reason was selected for that specific rating
+            level (each bucket's bucketStart then carries the reason's own
+            label, e.g. "Unhelpful support"). See FeedbackBucketResult for
+            what each bucket shape carries, and note categorical buckets
+            carry no ordering guarantee.
 
     FeedbackBucketResult:
       type: object
       required: [bucketStart, avgRating, count]
-      description: One aggregated time bucket in a case-feedback aggregate result.
+      description: >-
+        One bucket in a case-feedback aggregate result. Shape depends on the
+        request's "bucket" granularity: for "day"/"week"/"month" (temporal
+        buckets) this represents a time range, in ascending chronological
+        order; for "rating"/"reasons_*" (categorical buckets) it represents
+        one category instead, with no ordering guarantee across buckets.
       properties:
         bucketStart:
           type: string
-          description: Start of this bucket's time range.
+          description: >-
+            For a temporal bucket, the start of this bucket's time range
+            (e.g. "2026-08-01"). For a categorical bucket, the category's own
+            label instead (e.g. "Very Satisfied" for "rating", "Unhelpful
+            support" for a "reasons_*" bucket) — not a date.
         avgRating:
           type: number
-          description: Average rating across feedback records in this bucket.
+          description: >-
+            For a temporal or "rating" bucket, the average rating across
+            feedback records in this bucket. Meaningless for a "reasons_*"
+            bucket (every row is a categorical chip selection, not a
+            rating) — present on the wire for shape consistency but not a
+            useful value there.
         count:
           type: integer
           description: Number of feedback records in this bucket.

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -7228,6 +7228,12 @@ components:
           description: >-
             Human-readable case number (e.g. "CS0441331"). Null if the case
             record could not be resolved.
+        caseInternalId:
+          type: string
+          nullable: true
+          description: >-
+            WSO2 internal case id (e.g. "SCTPSUB-88") for caseId. Null if the
+            case record could not be resolved or has no internal id assigned.
         rating:
           type: integer
           description: Numeric rating value.
@@ -7267,6 +7273,11 @@ components:
             type: string
             format: uuid
           description: Restrict results to feedback on cases under these accounts.
+        rating:
+          type: integer
+          minimum: 1
+          maximum: 5
+          description: Restrict results to feedback with this exact rating value.
         dateFrom:
           type: string
           description: Start of the feedback submission date range (inclusive).
@@ -7326,8 +7337,25 @@ components:
           $ref: '#/components/schemas/AggregateFeedbackFilters'
         bucket:
           type: string
-          enum: [day, week, month]
-          description: Time bucket granularity to group results by.
+          enum:
+            - day
+            - week
+            - month
+            - rating
+            - reasons_very_dissatisfied
+            - reasons_dissatisfied
+            - reasons_neutral
+            - reasons_satisfied
+            - reasons_very_satisfied
+          description: >-
+            Aggregation granularity to group results by. "day"/"week"/"month"
+            bucket by submission date; "rating" groups by rating value
+            instead of time (each bucket's bucketStart then carries the
+            rating's own label, e.g. "Very Satisfied", rather than a date);
+            each "reasons_*" value groups by which free-text reason was
+            selected for that specific rating level (each bucket's
+            bucketStart then carries the reason's own label, e.g. "Unhelpful
+            support").
 
     FeedbackBucketResult:
       type: object


### PR DESCRIPTION
## Purpose
`[CSM Portal]` A closed case's Case Feedback (CSAT survey) submission wasn't visible
anywhere on the case detail page — an engineer had to know it existed and go find it
elsewhere. Surface it directly in the case's own activity stream, where every other
signal about the case's lifecycle already lives. Also adds the feedback submitter's
identity, the case number and internal case id instead of a raw UUID in the dashboard
grid, a real chronological-ordering fix, and a set of dashboard chart additions
(rating distribution, per-rating reason breakdowns, colored trend, click-through)
requested after reviewing the initial build.

## Goals
When viewing a case, if it has any Case Feedback submitted, show it as an entry in the
unified activity feed: who submitted it, rating (1-5, with its label), the free-text
comment if the customer left one, and the real submission timestamp — positioned
chronologically alongside comments, lifecycle changes, and attachments, the same as every
other lane. The Case Feedback dashboard shows the real case number/internal case id
instead of a raw UUID, a rating-distribution pie and per-rating "reasons" pies alongside
the existing trend chart, and every chart's slices/bars click through to the underlying
feedback list, filtered accordingly.

## Approach
- New `useGetCsmCaseFeedback(caseId)` hook (`features/csm-cases/api/useCsmCaseFeedback.ts`)
  — calls the existing `POST /cases/feedback/search` endpoint scoped to `filters.caseId`,
  mapping `BeCaseFeedback` onto a new `CaseFeedbackEntry` type. Reuses
  `WIDGET_RESOURCE_CONFIG.case_feedback.searchEndpoint` rather than hardcoding the path,
  so it stays in sync with that config's own source of truth.
- New `"feedback"` variant on the unified `FeedEntry` union
  (`features/csm-cases/utils/caseActivityFeed.ts`) — sorts into the feed by its real
  `submittedAt` timestamp using the feed's existing chronological ordering, no special
  casing needed.
- `CaseActivitiesFeed.tsx` renders a feedback entry the same visual way as every other
  lane (avatar + card), showing the submitter via the existing `UserRefLink` component
  (falls back to "Customer" when unresolved), a "Case Feedback" chip, and a rating chip;
  the comment line only renders when the customer actually left one. A "Feedback (N)"
  toggle appears in the Filter menu **only when the case has at least one submission**.
- `CsmCaseDetailPage.tsx` wires the new hook in alongside the existing
  comments/activities/attachments hooks and passes the result through.
- Entity-service and the CSM backend now carry `caseNumber`/`caseInternalId`/
  `submitterName`/`submitterEmail` (all nullable) on the `CaseFeedback` record, resolved
  upstream from the backing data source and passed through unchanged.
- `widgetListConfig.tsx`'s `CaseFeedbackWidgetList` (the dashboard's Feedback Records
  grid) now renders the internal case id and case number instead of always showing the
  raw UUID, plus a submitter column, instead of always showing the raw UUID for Case.
- **Ordering fix**: the backing data source returns `submittedAt` as a raw space-separated
  timestamp, not ISO 8601 like every other activity-feed entry's own timestamp. The feed's
  sort does a plain string compare, so an unnormalized feedback timestamp sorted *before*
  a same-day ISO timestamp purely because `" " < "T"` in ASCII, independent of actual
  time-of-day — found by reviewing a real case where a feedback submission rendered 3rd
  instead of 1st. Fixed by normalizing `submittedAt` through the existing
  `normalizeBackendTimestamp` util at the API boundary, same place every other entry's
  timestamp is already normalized.
- **New "rating" and 5 "reasons_*" aggregate bucket modes** alongside the existing
  `day`/`week`/`month` date buckets: `"rating"` groups feedback by rating value (backing a
  new Rating Distribution pie widget); each `"reasons_*"` value groups by which free-text
  reason a customer selected for that specific rating level (backing 5 new per-rating
  "Reasons" pie widgets). Both reuse the exact same `useCaseFeedbackTrendData` hook and
  `{bucketStart, avgRating, count}` response shape the date buckets already use — no new
  contract, just new enum values.
- **New `rating` search filter** (1-5, exact match) on `POST /cases/feedback/search`,
  needed for the Rating Distribution pie's click-through into the feedback list.
- **Colored trend bar chart**: bars are now colored red/amber/green by their own average
  rating (thresholds mirror the underlying CSAT labels) instead of the bar chart's default
  rotating palette, which read as an arbitrary rainbow with no meaning for a rating trend.
- **Automatic weekly bucket for short ranges**: the trend widget's default "month" bucket
  switches to "week" when the selected date range spans 3 months or less, since a monthly
  bucket over a short range collapses to just 1-3 bars.
- **Click-through**: a trend-bar bucket or Rating Distribution slice now navigates into the
  feedback list's own dashboard-widget preview page, filtered to that bucket's date range
  or rating value respectively (`buildHref` now routes through `buildWidgetPreviewHref`
  instead of a dead `/dashboard` link). Reasons-pie slices stay non-navigable — which chip
  a customer picked isn't a field the feedback list's search can filter by, so there's no
  safe selector to scope to. **Real bug found and fixed while verifying this**: the
  dashboard-widget preview page's own URL round-trip decodes every query param as a
  comma-split string array (the shape every other resourceType's own filters use), but
  `case_feedback`'s filters are a flat scalar object (`dateFrom`/`dateTo`/`rating`, not
  arrays) — a click-through arrived at the search endpoint as `{dateFrom: ["2026-08-01"]}`
  and was rejected outright. Fixed by unwrapping known scalar fields back to their real
  type at the request-body boundary (`buildSearchRequestBody`).
- `/help` guide updated: `support.md`'s "Case detail" section now mentions the Case
  Feedback lane in the activity timeline.

## User stories
As a CS engineer viewing a closed case, I can see who submitted feedback, their CSAT
rating, and any comment they left, correctly positioned in the case's activity timeline
without navigating elsewhere. As a CS engineer viewing the Case Feedback dashboard, I can
identify which case a feedback row belongs to by its case number/internal id, see the
overall rating distribution and why customers picked each rating, and click through any
chart to see the underlying records.

## Release note
Added: a closed case's Case Feedback (CSAT survey) submission, when present, now appears
in the case's own activity timeline, including who submitted it. The Case Feedback
dashboard now shows the case number/internal case id instead of a raw case id, adds a
rating-distribution chart and per-rating "why" breakdowns, colors the trend chart by
rating, and lets you click through any chart to the underlying records. Fixed a bug where
feedback entries could appear out of chronological order in the activity timeline.

## Documentation
N/A — internal CS-engineer-facing UI addition; the in-app `/help` Cases topic was updated
directly as part of this PR.

## Training
N/A

## Certification
N/A — no certification exam impact.

## Marketing
N/A — internal CS portal feature.

## Automation tests
 - Unit tests
   - `CaseActivitiesFeed.test.tsx`: renders a feedback entry with rating, comment, and
     submitter; renders no comment line when the feedback has none; falls back to
     "Customer" when the submitter could not be resolved; shows no feedback lane or filter
     toggle when the case has no feedback at all.
   - `useCaseFeedbackTrendData.test.tsx`: date-bucket slices are navigable with the correct
     date-range query; bars are colored by their own avgRating; the month→week bucket
     switch fires only for ranges ≤3 months and only when both dates are set; rating and
     reasons_* distributions resolve to the correct label/value/color/navigability.
   - `widgetListConfig.test.tsx`: the dashboard grid renders the internal case id, case
     number, and submitter correctly, with sane fallbacks.
   - `widgetResourceConfig.test.ts`: the preview-page URL round-trip's array-wrapped
     filters are correctly unwrapped back to scalars before being sent.
   - Existing `CsmCaseDetailPage.test.tsx` suite updated with a matching hook mock.
   - Full webapp suite: 222 files / 2235 tests passing, 0 failures.
 - Integration tests
   - Live-verified locally against a real running stack (Ballerina → Go entity-service →
     CSM BFF → webapp) pointed at real backing-data-source DEV data: opened a real closed
     case with a real "Very Satisfied (5/5)" Case Feedback submission and confirmed it
     renders correctly, showing the real submitter's name, positioned by its real
     timestamp.
   - Confirmed the dashboard's Feedback Records grid shows real case numbers/internal ids
     instead of UUIDs, and the Rating Distribution/Reasons pies match the exact real counts
     from the backing data source.
   - Confirmed a case whose feedback was submitted after other activities now sorts that
     feedback entry to the top of the activity timeline.
   - Confirmed a trend-bar click and a Rating Distribution slice click both land on the
     feedback list preview page pre-filtered correctly, with counts matching the chart.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — TypeScript/React frontend, and Go changes are additive nullable fields/filters on an existing read-only response
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
Builds on the Case Feedback dashboard feature (`cs-tools#1580`, `digiops-cs#2916` —
merged, `cs-tools#1585`) — reuses its existing `/cases/feedback/search` endpoint.

## Migrations (if applicable)
N/A — no schema or data migration.

## Test environment
`pnpm build`/`pnpm lint`/`pnpm test` (Node/pnpm per this repo's `package.json`), Go
`build`/`vet`/`test` on entity-service and the CSM backend; live manual verification via a
local full-stack preview against real backing-data-source DEV data with a real identity
provider login.

## Learning
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Case activity timelines now include customer feedback with star ratings, comments, submitter details, and submission times.
  * Case feedback lists display case identifiers and submitter information, with sensible fallbacks when details are unavailable.
  * Added exact rating filtering for feedback searches.
  * Dashboard widgets now support rating and satisfaction-reason distributions, including pie charts and interactive date-based views.
* **Documentation**
  * Updated help content to explain how customer feedback appears in case timelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->