### PR TITLE
[CSM Portal] case-feedback: submitter identity, case number, activity-feed ordering fix

### DIFF
--- a/apps/csm-portal/backend/openapi.yaml
+++ b/apps/csm-portal/backend/openapi.yaml
@@ -6722,6 +6722,12 @@ components:
           type: string
           format: uuid
           description: UUID of the case the feedback belongs to.
+        caseNumber:
+          type: string
+          nullable: true
+          description: >-
+            Human-readable case number (e.g. "CS0441331"). Null if the case
+            record could not be resolved.
         rating:
           type: integer
           description: Numeric rating value.
@@ -6737,6 +6743,16 @@ components:
         submittedAt:
           type: string
           description: Timestamp when the feedback was submitted.
+        submitterName:
+          type: string
+          nullable: true
+          description: >-
+            Display name of the customer contact who submitted the feedback.
+            Null if the submitting user record could not be resolved.
+        submitterEmail:
+          type: string
+          nullable: true
+          description: Email of the submitting contact. Null, same as submitterName.
 
     CaseFeedbackSearchFilters:
       type: object

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -3343,11 +3343,17 @@ export interface BeGroupByResponse {
 export interface BeCaseFeedback {
   instanceId: string;
   caseId: string;
+  /** `null` if the case record could not be resolved. */
+  caseNumber: string | null;
   rating: number;
   ratingLabel: string;
   /** `null` for feedback submitted without a comment. */
   comment: string | null;
   submittedAt: string;
+  /** `null` if the submitting user record could not be resolved. */
+  submitterName: string | null;
+  /** `null`, same as submitterName. */
+  submitterEmail: string | null;
 }
 
 /** Body of `POST /cases/feedback/search` — deliberately NOT the

--- a/apps/csm-portal/webapp/src/constants/apiConstants.ts
+++ b/apps/csm-portal/webapp/src/constants/apiConstants.ts
@@ -120,6 +120,7 @@ export const ApiQueryKeys = {
   CSM_CASE_COMMENTS: "csm-case-comments",
   CSM_CASE_ATTACHMENTS: "csm-case-attachments",
   CSM_CASE_ACTIVITIES: "csm-case-activities",
+  CSM_CASE_FEEDBACK: "csm-case-feedback",
   CSM_CASE_SLAS: "csm-case-slas",
   CSM_CASE_CHILDREN: "csm-case-children",
   CSM_CASE_SEARCH_BY_QUERY: "csm-case-search-by-query",

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useCsmCaseFeedback.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useCsmCaseFeedback.ts
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { ApiQueryKeys } from "@constants/apiConstants";
+import { useBackendApi } from "@api/backend/client";
+import type {
+  BeCaseFeedback,
+  BeCaseFeedbackSearchFilters,
+  BeCaseFeedbackSearchResponse,
+} from "@api/backend/types";
+import { WIDGET_RESOURCE_CONFIG } from "@features/csm-dashboard/config/widgetResourceConfig";
+import type { CaseFeedbackEntry } from "@features/csm-cases/types/csmCases";
+
+function feedbackEntryFromBe(f: BeCaseFeedback): CaseFeedbackEntry {
+  return {
+    id: f.instanceId,
+    rating: f.rating,
+    ratingLabel: f.ratingLabel,
+    comment: f.comment,
+    submittedAt: f.submittedAt,
+  };
+}
+
+/**
+ * Loads any Case Feedback survey submissions for a single case, for the case
+ * detail page's activity feed. Case Feedback is a CSAT survey submitted by
+ * the customer, typically only once a case is closed — an open case will
+ * almost always resolve to an empty list, which is expected, not an error.
+ *
+ * Reuses `WIDGET_RESOURCE_CONFIG.case_feedback`'s endpoint rather than
+ * hardcoding the path, so this stays in sync with that config's own source
+ * of truth for the endpoint name.
+ */
+export function useGetCsmCaseFeedback(
+  caseId: string | undefined,
+): UseQueryResult<CaseFeedbackEntry[], Error> {
+  const api = useBackendApi();
+
+  return useQuery<CaseFeedbackEntry[], Error>({
+    queryKey: [ApiQueryKeys.CSM_CASE_FEEDBACK, caseId ?? ""],
+    queryFn: async (): Promise<CaseFeedbackEntry[]> => {
+      if (!caseId) return [];
+
+      const payload = {
+        filters: { caseId } satisfies BeCaseFeedbackSearchFilters,
+        page: 1,
+        pageSize: 20,
+      };
+      const response = await api.post<
+        typeof payload,
+        BeCaseFeedbackSearchResponse
+      >(WIDGET_RESOURCE_CONFIG.case_feedback.searchEndpoint, payload);
+      return (response.results ?? []).map(feedbackEntryFromBe);
+    },
+    enabled: !!caseId,
+    staleTime: 10_000,
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useCsmCaseFeedback.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useCsmCaseFeedback.ts
@@ -24,6 +24,7 @@ import type {
 } from "@api/backend/types";
 import { WIDGET_RESOURCE_CONFIG } from "@features/csm-dashboard/config/widgetResourceConfig";
 import type { CaseFeedbackEntry } from "@features/csm-cases/types/csmCases";
+import { normalizeBackendTimestamp } from "@utils/dateTime";
 
 function feedbackEntryFromBe(f: BeCaseFeedback): CaseFeedbackEntry {
   return {
@@ -31,7 +32,17 @@ function feedbackEntryFromBe(f: BeCaseFeedback): CaseFeedbackEntry {
     rating: f.rating,
     ratingLabel: f.ratingLabel,
     comment: f.comment,
-    submittedAt: f.submittedAt,
+    // ServiceNow returns submittedAt as a raw space-separated timestamp
+    // ("2026-08-17 06:17:56"), not ISO 8601 like every other activity-feed
+    // entry's own timestamp. CaseActivitiesFeed's compareFeedEntries sorts by
+    // a plain string compare of each entry's `at` — a raw space-separated
+    // string sorts BEFORE a same-day ISO "T"-separated one purely because
+    // " " < "T" in ASCII, regardless of actual time-of-day, which put real
+    // feedback entries out of chronological order in the feed. Normalize to
+    // ISO 8601 UTC here, at the API boundary, same as every other entry.
+    submittedAt: normalizeBackendTimestamp(f.submittedAt) ?? f.submittedAt,
+    submitterName: f.submitterName,
+    submitterEmail: f.submitterEmail,
   };
 }
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActivitiesFeed.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActivitiesFeed.test.tsx
@@ -93,13 +93,15 @@ function CaseActivitiesFeedHarness({
 }
 
 describe("CaseActivitiesFeed — feedback lane", () => {
-  it("renders a Case Feedback entry with rating and comment", () => {
+  it("renders a Case Feedback entry with rating, comment, and submitter", () => {
     const feedback: CaseFeedbackEntry = {
       id: "fb-1",
       rating: 5,
       ratingLabel: "Very Satisfied",
       comment: "Great support, thank you!",
       submittedAt: "2026-08-17T06:17:56Z",
+      submitterName: "Jane Customer",
+      submitterEmail: "jane.customer@example.com",
     };
 
     renderWithRouter(
@@ -114,6 +116,30 @@ describe("CaseActivitiesFeed — feedback lane", () => {
     expect(screen.getByText("Case Feedback")).toBeInTheDocument();
     expect(screen.getByText("Very Satisfied (5/5)")).toBeInTheDocument();
     expect(screen.getByText("Great support, thank you!")).toBeInTheDocument();
+    expect(screen.getByText("Jane Customer")).toBeInTheDocument();
+  });
+
+  it("falls back to 'Customer' when the submitter could not be resolved", () => {
+    const feedback: CaseFeedbackEntry = {
+      id: "fb-3",
+      rating: 4,
+      ratingLabel: "Satisfied",
+      comment: null,
+      submittedAt: "2026-08-17T06:17:56Z",
+      submitterName: null,
+      submitterEmail: null,
+    };
+
+    renderWithRouter(
+      <CaseActivitiesFeed
+        comments={[]}
+        audit={[]}
+        attachments={[]}
+        feedback={[feedback]}
+      />,
+    );
+
+    expect(screen.getByText("Customer")).toBeInTheDocument();
   });
 
   it("renders no comment line when feedback has none", () => {

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActivitiesFeed.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActivitiesFeed.test.tsx
@@ -38,6 +38,7 @@ import { useGetAlert, useGetSmartAlert } from "@features/csm-cases/api/useSnLink
 import type {
   CaseAttachment,
   CaseAuditEntry,
+  CaseFeedbackEntry,
   CsmCaseComment,
 } from "@features/csm-cases/types/csmCases";
 
@@ -90,6 +91,62 @@ function CaseActivitiesFeedHarness({
     />
   );
 }
+
+describe("CaseActivitiesFeed — feedback lane", () => {
+  it("renders a Case Feedback entry with rating and comment", () => {
+    const feedback: CaseFeedbackEntry = {
+      id: "fb-1",
+      rating: 5,
+      ratingLabel: "Very Satisfied",
+      comment: "Great support, thank you!",
+      submittedAt: "2026-08-17T06:17:56Z",
+    };
+
+    renderWithRouter(
+      <CaseActivitiesFeed
+        comments={[]}
+        audit={[]}
+        attachments={[]}
+        feedback={[feedback]}
+      />,
+    );
+
+    expect(screen.getByText("Case Feedback")).toBeInTheDocument();
+    expect(screen.getByText("Very Satisfied (5/5)")).toBeInTheDocument();
+    expect(screen.getByText("Great support, thank you!")).toBeInTheDocument();
+  });
+
+  it("renders no comment line when feedback has none", () => {
+    const feedback: CaseFeedbackEntry = {
+      id: "fb-2",
+      rating: 3,
+      ratingLabel: "Neutral",
+      comment: null,
+      submittedAt: "2026-08-17T06:17:56Z",
+    };
+
+    renderWithRouter(
+      <CaseActivitiesFeed
+        comments={[]}
+        audit={[]}
+        attachments={[]}
+        feedback={[feedback]}
+      />,
+    );
+
+    expect(screen.getByText("Neutral (3/5)")).toBeInTheDocument();
+  });
+
+  it("shows no feedback lane and no filter option when feedback is empty", () => {
+    renderWithRouter(
+      <CaseActivitiesFeed comments={[]} audit={[]} attachments={[]} feedback={[]} />,
+    );
+
+    expect(screen.queryByText("Case Feedback")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByText("Filter"));
+    expect(screen.queryByText(/^Feedback \(/)).not.toBeInTheDocument();
+  });
+});
 
 describe("CaseActivitiesFeed", () => {
   it("renders a field_change entry with old/new values", () => {

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActivitiesFeed.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActivitiesFeed.tsx
@@ -491,8 +491,12 @@ export default function CaseActivitiesFeed({
                       }}
                     >
                       <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
-                        Case Feedback
+                        <UserRefLink
+                          name={e.feedback.submitterName || "Customer"}
+                          email={e.feedback.submitterEmail ?? undefined}
+                        />
                       </Typography>
+                      <Chip size="small" variant="outlined" label="Case Feedback" />
                       <Chip
                         size="small"
                         variant="outlined"

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActivitiesFeed.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseActivitiesFeed.tsx
@@ -38,6 +38,7 @@ import {
   ListFilter,
   Paperclip,
   Plus,
+  Star,
   TriangleAlert,
   User,
   Users,
@@ -63,6 +64,7 @@ import type { SnLinkType } from "@features/csm-cases/utils/snLinkRegistry";
 import type {
   CaseAttachment,
   CaseAuditEntry,
+  CaseFeedbackEntry,
   CsmCaseComment,
 } from "@features/csm-cases/types/csmCases";
 
@@ -70,6 +72,10 @@ interface CaseActivitiesFeedProps {
   comments: CsmCaseComment[];
   audit: CaseAuditEntry[];
   attachments: CaseAttachment[];
+  /** Case Feedback (CSAT survey) submissions for this case, if any — typically
+   * only present once a case is closed and the customer has responded to the
+   * survey. Defaults to an empty array (no feedback lane shown). */
+  feedback?: CaseFeedbackEntry[];
   /**
    * Call requests already fetched for this case (e.g. by the page's Call
    * Requests tab query) — reused here, never re-fetched, to resolve a
@@ -160,6 +166,7 @@ export default function CaseActivitiesFeed({
   comments,
   audit,
   attachments,
+  feedback = [],
   callRequests = [],
   onDownloadAttachment,
   preview,
@@ -167,6 +174,7 @@ export default function CaseActivitiesFeed({
   const [showWorkNotes, setShowWorkNotes] = useState(true);
   const [showLifecycle, setShowLifecycle] = useState(true);
   const [showAttachments, setShowAttachments] = useState(true);
+  const [showFeedback, setShowFeedback] = useState(true);
   const [newestFirst, setNewestFirst] = useState(true);
   const [filterAnchor, setFilterAnchor] = useState<HTMLElement | null>(null);
   const [fullscreenImageSrc, setFullscreenImageSrc] = useState<string | null>(null);
@@ -193,6 +201,11 @@ export default function CaseActivitiesFeed({
         out.push({ kind: "attachment", at: a.uploadedAt, attachment: a });
       }
     }
+    if (showFeedback) {
+      for (const f of feedback) {
+        out.push({ kind: "feedback", at: f.submittedAt, feedback: f });
+      }
+    }
     out.sort((a, b) =>
       newestFirst ? -compareFeedEntries(a, b) : compareFeedEntries(a, b),
     );
@@ -201,9 +214,11 @@ export default function CaseActivitiesFeed({
     comments,
     audit,
     attachments,
+    feedback,
     showWorkNotes,
     showLifecycle,
     showAttachments,
+    showFeedback,
     newestFirst,
   ]);
 
@@ -212,6 +227,7 @@ export default function CaseActivitiesFeed({
     workNotes: comments.filter((c) => c.internal).length,
     lifecycle: audit.length,
     attachments: attachments.length,
+    feedback: feedback.length,
   };
 
   // Filters live in a dropdown so the timeline reads as content, not a row of
@@ -237,6 +253,17 @@ export default function CaseActivitiesFeed({
       checked: showAttachments,
       toggle: () => setShowAttachments((v) => !v),
     },
+    // Only offered when this case actually has feedback — a lane with
+    // nothing to hide would just be dead-weight in the filter menu.
+    ...(counts.feedback > 0
+      ? [
+          {
+            label: `Feedback (${counts.feedback})`,
+            checked: showFeedback,
+            toggle: () => setShowFeedback((v) => !v),
+          },
+        ]
+      : []),
   ];
   const activeFilters = filterOptions.filter((o) => o.checked).length;
   const filterLabel =
@@ -416,6 +443,78 @@ export default function CaseActivitiesFeed({
                         </Typography>
                       )}
                     </Box>
+                  </Paper>
+                </Box>
+              );
+            }
+            if (e.kind === "feedback") {
+              return (
+                <Box
+                  id={e.feedback.id}
+                  key={`fb-${e.feedback.id}`}
+                  sx={{
+                    display: "flex",
+                    gap: 1.5,
+                    alignItems: "flex-start",
+                    scrollMarginTop: 96,
+                  }}
+                >
+                  <Avatar
+                    sx={{
+                      width: 32,
+                      height: 32,
+                      bgcolor: "warning.light",
+                      color: "warning.contrastText",
+                    }}
+                  >
+                    <Star size={16} />
+                  </Avatar>
+                  <Paper
+                    variant="outlined"
+                    sx={{
+                      p: 1.5,
+                      flex: 1,
+                      minWidth: 0,
+                      display: "flex",
+                      flexDirection: "column",
+                      gap: 0.75,
+                      backgroundColor: "background.paper",
+                      borderColor: "action.disabled",
+                    }}
+                  >
+                    <Box
+                      sx={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 1,
+                        flexWrap: "wrap",
+                      }}
+                    >
+                      <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+                        Case Feedback
+                      </Typography>
+                      <Chip
+                        size="small"
+                        variant="outlined"
+                        icon={<Star size={14} />}
+                        label={`${e.feedback.ratingLabel} (${e.feedback.rating}/5)`}
+                        color="warning"
+                      />
+                      <Typography variant="caption" color="text.secondary">
+                        <RelativeTime
+                          iso={e.feedback.submittedAt}
+                          href={`#${e.feedback.id}`}
+                        />
+                      </Typography>
+                    </Box>
+                    {e.feedback.comment && (
+                      <Typography
+                        variant="body2"
+                        sx={{ overflowWrap: "anywhere" }}
+                      >
+                        {e.feedback.comment}
+                      </Typography>
+                    )}
                   </Paper>
                 </Box>
               );

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.test.tsx
@@ -221,6 +221,15 @@ vi.mock("@features/csm-cases/api/useCsmCaseActivities", () => ({
     isFetching: false,
   }),
 }));
+vi.mock("@features/csm-cases/api/useCsmCaseFeedback", () => ({
+  useGetCsmCaseFeedback: () => ({
+    data: undefined,
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+    isFetching: false,
+  }),
+}));
 vi.mock("@features/csm-cases/api/useCsmCaseAttachments", () => ({
   useGetCsmCaseAttachments: () => ({
     data: undefined,

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -74,6 +74,7 @@ import {
 } from "@features/csm-cases/api/useCsmCaseComments";
 import { useGetCsmConversationMessages } from "@features/csm-cases/api/useCsmConversationMessages";
 import { useGetCsmCaseActivities } from "@features/csm-cases/api/useCsmCaseActivities";
+import { useGetCsmCaseFeedback } from "@features/csm-cases/api/useCsmCaseFeedback";
 import {
   useGetCsmCaseAttachments,
   usePostCsmCaseAttachment,
@@ -446,6 +447,10 @@ export default function CsmCaseDetailPage(): JSX.Element {
     refetch: refetchActivities,
     isFetching: isFetchingActivities,
   } = useGetCsmCaseActivities(caseId);
+  // Case Feedback (CSAT survey) submissions for this case, if any — almost
+  // always empty for an open case (the survey goes out after closure), which
+  // is expected and renders no feedback lane rather than an error.
+  const { data: caseFeedback } = useGetCsmCaseFeedback(caseId);
   // The chat transcript the case was spawned from, when linked. Loaded lazily
   // off the case's conversation id and merged into the comment stream below so
   // it renders as the earliest activity entries — mirrors the customer portal.
@@ -2233,7 +2238,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
                   <Chip
                     size="small"
                     variant="outlined"
-                    label={`${safeComments.length + (activityAudit?.length ?? 0) + attachmentList.length} entries`}
+                    label={`${safeComments.length + (activityAudit?.length ?? 0) + attachmentList.length + (caseFeedback?.length ?? 0)} entries`}
                   />
                 )}
               </Box>
@@ -2280,6 +2285,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
                   comments={safeComments}
                   audit={activityAudit ?? []}
                   attachments={attachmentList}
+                  feedback={caseFeedback ?? []}
                   callRequests={callRequests ?? []}
                   onDownloadAttachment={onDownloadAttachment}
                   preview={{

--- a/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
@@ -338,6 +338,10 @@ export interface CaseFeedbackEntry {
   /** `null`/absent for feedback submitted without a comment. */
   comment?: string | null;
   submittedAt: string;
+  /** `null`/absent if the submitting user record could not be resolved. */
+  submitterName?: string | null;
+  /** `null`/absent, same as submitterName. */
+  submitterEmail?: string | null;
 }
 
 export interface CaseAuditEntry {

--- a/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/types/csmCases.ts
@@ -330,6 +330,16 @@ export interface CaseAuditFieldChange {
   newValue?: string;
 }
 
+/** One Case Feedback survey submission for a case, shown in its activity feed. */
+export interface CaseFeedbackEntry {
+  id: string;
+  rating: number;
+  ratingLabel: string;
+  /** `null`/absent for feedback submitted without a comment. */
+  comment?: string | null;
+  submittedAt: string;
+}
+
 export interface CaseAuditEntry {
   id: string;
   kind: CaseAuditKind;

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/caseActivityFeed.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/caseActivityFeed.ts
@@ -17,6 +17,7 @@
 import type {
   CaseAttachment,
   CaseAuditEntry,
+  CaseFeedbackEntry,
   CsmCaseComment,
 } from "@features/csm-cases/types/csmCases";
 
@@ -24,12 +25,14 @@ import type {
 export type FeedEntry =
   | { kind: "comment"; at: string; comment: CsmCaseComment }
   | { kind: "audit"; at: string; entry: CaseAuditEntry }
-  | { kind: "attachment"; at: string; attachment: CaseAttachment };
+  | { kind: "attachment"; at: string; attachment: CaseAttachment }
+  | { kind: "feedback"; at: string; feedback: CaseFeedbackEntry };
 
 export function feedEntryId(e: FeedEntry): string {
   if (e.kind === "comment") return e.comment.id;
   if (e.kind === "audit") return e.entry.id;
-  return e.attachment.id;
+  if (e.kind === "attachment") return e.attachment.id;
+  return e.feedback.id;
 }
 
 /**

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetListConfig.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetListConfig.tsx
@@ -759,6 +759,7 @@ function CaseFeedbackWidgetList({ items, isLoading }: WidgetListRendererProps): 
   const feedback = items as unknown as {
     instanceId?: string;
     caseId?: string;
+    caseNumber?: string | null;
     rating?: number;
     ratingLabel?: string;
     comment?: string | null;
@@ -789,7 +790,7 @@ function CaseFeedbackWidgetList({ items, isLoading }: WidgetListRendererProps): 
               {f.comment || "—"}
             </Typography>,
             <Typography key="case" variant="body2" noWrap>
-              {f.caseId ?? "—"}
+              {f.caseNumber || f.caseId || "—"}
             </Typography>,
             <Typography key="submitted" variant="caption" color="text.secondary" noWrap>
               {formatDate(f.submittedAt)}

--- a/apps/csm-portal/webapp/src/features/help/content/support.md
+++ b/apps/csm-portal/webapp/src/features/help/content/support.md
@@ -49,6 +49,11 @@ A few things worth knowing:
 Opening a case shows its full detail: overview fields, the comment/activity timeline,
 attachments, and any linked service requests.
 
+If a customer submits Case Feedback (a CSAT survey, typically sent once a case closes), it
+appears in the activity timeline alongside comments and status changes, in its correct
+chronological position — showing the submitter, star rating, and any free-text comment they
+left.
+
 **Linked service requests** appear in their own widget on the case, listing each linked
 request's number, name, state, and current assignee. Clicking a row navigates to that
 request's own case page (with a "back" link that returns you here). You can start a new

--- a/entity-service/internal/domain/feedback.go
+++ b/entity-service/internal/domain/feedback.go
@@ -20,7 +20,10 @@ package domain
 type CaseFeedback struct {
 	InstanceID string `json:"instanceId"`
 	CaseID     string `json:"caseId"`
-	Rating     int    `json:"rating"`
+	// CaseNumber is the human-readable case number (e.g. "CS0441331").
+	// Nullable -- absent if the case record could not be resolved.
+	CaseNumber *string `json:"caseNumber"`
+	Rating     int     `json:"rating"`
 	// RatingLabel is the human-readable label for Rating (e.g. "Satisfied"),
 	// as supplied by the backing data source.
 	RatingLabel string `json:"ratingLabel"`
@@ -28,6 +31,13 @@ type CaseFeedback struct {
 	// carries a null comment upstream, not an empty string.
 	Comment     *string `json:"comment"`
 	SubmittedAt string  `json:"submittedAt"`
+	// SubmitterName is the display name of the customer contact who
+	// submitted the feedback. Nullable -- absent if the submitting user
+	// record could not be resolved.
+	SubmitterName *string `json:"submitterName"`
+	// SubmitterEmail is the email of the submitting contact. Nullable, same
+	// as SubmitterName.
+	SubmitterEmail *string `json:"submitterEmail"`
 }
 
 // SearchFeedbackFilters holds the optional filter criteria for a case-feedback search.

--- a/entity-service/internal/service/feedback_service.go
+++ b/entity-service/internal/service/feedback_service.go
@@ -56,12 +56,15 @@ type snSearchFeedbackPayload struct {
 
 // snFeedbackRow mirrors a single row in the Choreo feedback-search response.
 type snFeedbackRow struct {
-	InstanceID  string  `json:"instanceId"`
-	CaseID      string  `json:"caseId"`
-	Rating      int     `json:"rating"`
-	RatingLabel string  `json:"ratingLabel"`
-	Comment     *string `json:"comment"`
-	SubmittedAt string  `json:"submittedAt"`
+	InstanceID     string  `json:"instanceId"`
+	CaseID         string  `json:"caseId"`
+	CaseNumber     *string `json:"caseNumber"`
+	Rating         int     `json:"rating"`
+	RatingLabel    string  `json:"ratingLabel"`
+	Comment        *string `json:"comment"`
+	SubmittedAt    string  `json:"submittedAt"`
+	SubmitterName  *string `json:"submitterName"`
+	SubmitterEmail *string `json:"submitterEmail"`
 }
 
 // snSearchFeedbackResponse mirrors the Choreo POST /cases/feedback/search response.
@@ -150,12 +153,15 @@ func (s *snFeedbackService) SearchFeedback(ctx context.Context, req domain.Searc
 	results := make([]domain.CaseFeedback, 0, len(snResp.Results))
 	for _, row := range snResp.Results {
 		results = append(results, domain.CaseFeedback{
-			InstanceID:  sysidToUUID(row.InstanceID),
-			CaseID:      sysidToUUID(row.CaseID),
-			Rating:      row.Rating,
-			RatingLabel: row.RatingLabel,
-			Comment:     row.Comment,
-			SubmittedAt: row.SubmittedAt,
+			InstanceID:     sysidToUUID(row.InstanceID),
+			CaseID:         sysidToUUID(row.CaseID),
+			CaseNumber:     row.CaseNumber,
+			Rating:         row.Rating,
+			RatingLabel:    row.RatingLabel,
+			Comment:        row.Comment,
+			SubmittedAt:    row.SubmittedAt,
+			SubmitterName:  row.SubmitterName,
+			SubmitterEmail: row.SubmitterEmail,
 		})
 	}
 

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -7222,6 +7222,12 @@ components:
           type: string
           format: uuid
           description: UUID of the case the feedback belongs to.
+        caseNumber:
+          type: string
+          nullable: true
+          description: >-
+            Human-readable case number (e.g. "CS0441331"). Null if the case
+            record could not be resolved.
         rating:
           type: integer
           description: Numeric rating value.
@@ -7237,6 +7243,16 @@ components:
         submittedAt:
           type: string
           description: Timestamp when the feedback was submitted.
+        submitterName:
+          type: string
+          nullable: true
+          description: >-
+            Display name of the customer contact who submitted the feedback.
+            Null if the submitting user record could not be resolved.
+        submitterEmail:
+          type: string
+          nullable: true
+          description: Email of the submitting contact. Null, same as submitterName.
 
     SearchFeedbackFilters:
       type: object


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Follow-up on the case-feedback dashboard/activity-stream work (#1580, #1585, #1587). Two issues found while reviewing the local preview:
1. The dashboard's Feedback Records grid and the case-detail activity stream showed no indication of who submitted the feedback.
2. The dashboard's "Case" column showed a raw case UUID instead of a human-readable case number.

Also fixes a real bug found while verifying the above: a Case Feedback entry submitted after other activities was rendering out of chronological order in the case's activity stream.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

- Surface the feedback submitter's name/email in both the activity-stream entry and the dashboard grid.
- Show the case number instead of the raw UUID in the dashboard grid.
- Fix the activity-stream chronological ordering for feedback entries.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

Entity-service and CSM backend now carry `caseNumber`/`submitterName`/`submitterEmail` (all nullable) on the `CaseFeedback` record — resolved upstream from ServiceNow and passed through unchanged (no transform at these layers, matching the corresponding backend/Ballerina change tracked separately).

Frontend:
- `CaseActivitiesFeed.tsx`'s feedback entry now shows the submitter via the existing `UserRefLink` component, falling back to "Customer" when unresolved.
- `widgetListConfig.tsx`'s `CaseFeedbackWidgetList` now renders `caseNumber || caseId || "—"` for the Case column.
- `useCsmCaseFeedback.ts` now normalizes `submittedAt` through the existing `normalizeBackendTimestamp` util — ServiceNow returns a raw space-separated timestamp, not ISO 8601 like every other activity-feed entry, and the feed's sort does a plain string compare, so unnormalized feedback timestamps sorted before same-day ISO timestamps purely due to `" " < "T"` in ASCII, independent of actual time-of-day.

## User stories
> Summary of user stories addressed by this change>

As a CS engineer, I want to see who submitted case feedback and the case's real number in the dashboard, and I want the case activity stream to show feedback in the correct chronological position.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Case Feedback dashboard and case activity stream now show the feedback submitter's identity and the case number; fixed a chronological-ordering bug for feedback entries in the case activity stream.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter âN/Aâ plus brief explanation of why thereâs no doc impact

N/A — no new nav/flow surface, just additional fields on an existing surface (#1587).

## Training
N/A

## Certification
N/A — no exam-relevant change.

## Marketing
N/A

## Automation tests
 - Unit tests
   > Code coverage information

   Added a submitter-identity test and a submitter-fallback test to `CaseActivitiesFeed.test.tsx`. Full suite: 222 files / 2226 tests passing.
 - Integration tests
   > Details about the test cases and coverage

   Live-verified against real ServiceNow DEV data through the full local stack: dashboard grid shows real case numbers, activity stream shows the real submitter name, and the reported out-of-order case now shows its feedback entry correctly sorted as the top-most activity.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — no new attack surface, additive nullable fields on an existing read-only response
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
#1580, #1585, #1587 — this PR builds on #1587's branch.

## Migrations (if applicable)
N/A

## Test environment
Local full stack (webapp, CSM backend, Go entity-service, Ballerina entity-service) against real ServiceNow DEV, verified in Chrome via the repo's local-preview tooling.

## Learning
N/A
