### PR TITLE
[CSM Portal] fix: dashboard preview "View more" ignores tag exclusion filters

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-dashboard/pages/DashboardWidgetPreviewPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/pages/DashboardWidgetPreviewPage.test.tsx
@@ -462,12 +462,17 @@ describe("DashboardWidgetPreviewPage — case-family widgets get the real, edita
     expect(lastCall?.[1]).toMatchObject({ filters: { searchQuery: "disk" } });
   });
 
-  // The core regression: a tag has no small, fixed universe of values (see
-  // `CaseFamilyWidgetPreview`'s own doc comment), so a widget's
-  // `tag notIn ["s_dip"]` can't be represented by a real `excludeTags`
-  // control (there isn't one here) -- it's seeded into the single "Tags"
-  // control as the complement over the currently-known tag catalog instead.
-  it("seeds the single 'Tags' control with the complement of the tag catalog for a tag notIn widget filter", async () => {
+  // The core regression (this is the fix under test): a tag has no small,
+  // fixed universe of values (see `CaseFamilyWidgetPreview`'s own doc
+  // comment), so a widget's `tag notIn ["s_dip"]` can't be represented by a
+  // real `excludeTags` control on `CasesFilterBar` (there isn't one here) --
+  // it's *shown* in the single "Tags" control as the complement over the
+  // currently-known tag catalog. But what's actually sent to
+  // `/cases/search` must stay the real `notIn` blacklist (`apiFilters`),
+  // never that catalog-derived approximation, or a case with no tags at all
+  // would be wrongly excluded and the preview page would disagree with the
+  // dashboard tile it was reached from.
+  it("queries /cases/search with the real tag notIn blacklist, even though the 'Tags' control displays the catalog complement", async () => {
     mockPost({
       tags: { tags: [{ id: "t1", label: "s_dip" }, { id: "t2", label: "other-tag" }] },
       cases: { cases: [], total: 0, limit: 10, offset: 0 },
@@ -486,6 +491,13 @@ describe("DashboardWidgetPreviewPage — case-family widgets get the real, edita
       expect(postMock).toHaveBeenCalledWith("/tags/search", expect.anything()),
     );
 
+    // The displayed "Tags" control shows the complement (checked "other-tag").
+    await waitFor(() => {
+      expect(screen.getByText("other-tag")).toBeInTheDocument();
+    });
+
+    // But the query itself carries the real `notIn` blacklist, not an `in`
+    // whitelist derived from the (necessarily incomplete) tag catalog.
     await waitFor(() => {
       const lastCasesCall = postMock.mock.calls
         .filter((c) => c[0] === "/cases/search")
@@ -494,24 +506,75 @@ describe("DashboardWidgetPreviewPage — case-family widgets get the real, edita
       expect(lastCasesCall?.[1]).toMatchObject({
         filters: {
           filters: expect.arrayContaining([
-            { field: "tag", op: "in", values: ["other-tag"] },
+            { field: "tag", op: "notIn", values: ["s_dip"] },
           ]),
         },
       });
     });
 
-    // The excluded tag itself never appears as a selected/included value.
     const lastCasesCall = postMock.mock.calls.filter((c) => c[0] === "/cases/search").at(-1);
-    const tagEntry = (
-      lastCasesCall?.[1] as { filters: { filters: { field: string; values: string[] }[] } }
-    ).filters.filters.find((f) => f.field === "tag");
-    expect(tagEntry?.values).not.toContain("s_dip");
+    const tagEntries = (
+      lastCasesCall?.[1] as { filters: { filters: { field: string; op: string }[] } }
+    ).filters.filters.filter((f) => f.field === "tag");
+    // No complement-derived `in` entry ever reaches the API call.
+    expect(tagEntries.some((f) => f.op === "in")).toBe(false);
+  });
+
+  // Once the viewer edits the filter bar themselves, displayed and queried
+  // filters must collapse to the same value -- they're now consciously
+  // picking specific tags to include, so the approximation/blacklist
+  // divergence no longer applies.
+  it("queries exactly what's displayed once the viewer edits the filter bar themselves", async () => {
+    mockPost({
+      tags: { tags: [{ id: "t1", label: "s_dip" }, { id: "t2", label: "other-tag" }] },
+      cases: { cases: [], total: 0, limit: 10, offset: 0 },
+    });
+
+    renderAt(
+      buildWidgetPreviewHref({
+        previewSlug: "cases",
+        widgetId: "excl_tag_widget",
+        displayName: "Discussions on Going",
+        filters: { filters: [{ field: "tag", op: "notIn", values: ["s_dip"] }] },
+      }),
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole("combobox", { name: "Tags" })).toBeInTheDocument(),
+    );
+    const callsBefore = postMock.mock.calls.filter((c) => c[0] === "/cases/search").length;
+
+    fireEvent.change(screen.getByPlaceholderText(/search by case #/i), {
+      target: { value: "disk" },
+    });
+
+    await waitFor(() => {
+      const callsAfter = postMock.mock.calls.filter((c) => c[0] === "/cases/search").length;
+      expect(callsAfter).toBeGreaterThan(callsBefore);
+    });
+    const lastCasesCall = postMock.mock.calls.filter((c) => c[0] === "/cases/search").at(-1);
+    // The complement-derived `tag in [other-tag]` the bar still displays now
+    // matches what's queried -- no more real `notIn` sent underneath it.
+    expect(lastCasesCall?.[1]).toMatchObject({
+      filters: expect.objectContaining({
+        searchQuery: "disk",
+        filters: expect.arrayContaining([
+          { field: "tag", op: "in", values: ["other-tag"] },
+        ]),
+      }),
+    });
+    const tagEntries = (
+      lastCasesCall?.[1] as { filters: { filters: { field: string; op: string }[] } }
+    ).filters.filters.filter((f) => f.field === "tag");
+    expect(tagEntries.some((f) => f.op === "notIn")).toBe(false);
   });
 
   // CodeRabbit finding: overwriting `tags` with the complement would
   // silently drop a widget's own "must have one of these tags" requirement
-  // when it also excludes a tag. Intersecting instead preserves both.
-  it("intersects an existing tag-in list with the complement, rather than overwriting it, when a widget has both tag in and tag notIn", async () => {
+  // when it also excludes a tag. Intersecting instead preserves both -- this
+  // still governs what's *displayed*; the query itself uses the real,
+  // un-intersected `tag in`/`tag notIn` pair straight from the widget.
+  it("intersects an existing tag-in list with the complement for display, while the query keeps the widget's real tag in/notIn pair", async () => {
     mockPost({
       tags: {
         tags: [
@@ -538,6 +601,10 @@ describe("DashboardWidgetPreviewPage — case-family widgets get the real, edita
     );
 
     await waitFor(() => {
+      expect(screen.getByText("required-tag")).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
       const lastCasesCall = postMock.mock.calls
         .filter((c) => c[0] === "/cases/search")
         .at(-1);
@@ -546,6 +613,7 @@ describe("DashboardWidgetPreviewPage — case-family widgets get the real, edita
         filters: {
           filters: expect.arrayContaining([
             { field: "tag", op: "in", values: ["required-tag"] },
+            { field: "tag", op: "notIn", values: ["s_dip"] },
           ]),
         },
       });

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/pages/DashboardWidgetPreviewPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/pages/DashboardWidgetPreviewPage.tsx
@@ -214,6 +214,18 @@ interface CaseFamilyWidgetPreviewProps {
  * tag-catalog fetch falls back to the widget's raw, un-complemented
  * `excludeTags` (still correctly scoped, just not shown as checked items)
  * rather than silently dropping the exclusion and broadening the search.
+ *
+ * That approximation is *display-only*, though. What actually gets sent to
+ * `/cases/search` is a second, independent piece of state (`apiFilters`),
+ * seeded straight from `rawTranslated` -- the real `excludeTags` blacklist,
+ * never the catalog-derived complement -- so a fresh load or a Reset queries
+ * exactly what the dashboard tile itself queries (a case with no tags at
+ * all correctly passes a `notIn` filter here, unlike the whitelist shown in
+ * the Tags control). The two stay in sync from the moment the viewer makes
+ * their first edit through `CasesFilterBar` onward: once they're
+ * consciously picking specific tags to include, "what's displayed" and
+ * "what's queried" collapse into the same value, and stay collapsed even
+ * across a later Reset back to this baseline (see `handleReset`).
  */
 function CaseFamilyWidgetPreview({
   displayName,
@@ -290,12 +302,36 @@ function CaseFamilyWidgetPreview({
     setCasesFilters(resetBaseline);
   }
 
+  // What actually gets queried -- the widget's real `excludeTags` blacklist,
+  // never the catalog-derived complement `casesFilters` shows as checked
+  // "Tags". Seeded eagerly from `rawTranslated` alone, so it's correct from
+  // the very first render regardless of whether/when the tag catalog
+  // resolves. Stays this way until the viewer edits the filter bar
+  // themselves (`handleFiltersChange`), at which point the displayed value
+  // becomes the source of truth for both.
+  const [apiFilters, setApiFilters] = useState<CasesFilters>(() => ({
+    ...DEFAULT_CASES_FILTERS,
+    ...rawTranslated,
+  }));
+
   const [isFiltersOpen, setIsFiltersOpen] = useState(true);
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_ROWS_PER_PAGE);
 
   const handleFiltersChange = (next: CasesFilters): void => {
     setCasesFilters(next);
+    setApiFilters(next);
+    setPage(0);
+  };
+
+  // Distinct from `handleFiltersChange`: a Reset must restore the *original*
+  // divergence (display shows the complement baseline, the query goes back
+  // to the widget's real blacklist) rather than collapsing them the way a
+  // manual edit does -- otherwise a single Reset after any edit would lock
+  // `apiFilters` to the complement approximation forever.
+  const handleReset = (): void => {
+    setCasesFilters(resetBaseline ?? DEFAULT_CASES_FILTERS);
+    setApiFilters({ ...DEFAULT_CASES_FILTERS, ...rawTranslated });
     setPage(0);
   };
 
@@ -305,7 +341,7 @@ function CaseFamilyWidgetPreview({
   };
 
   const { data, isLoading, isError, isFetching, refetch, dataUpdatedAt } = useGetCsmCases(
-    casesFilters ?? DEFAULT_CASES_FILTERS,
+    apiFilters,
     page,
     rowsPerPage,
     casesFilters !== null,
@@ -345,7 +381,7 @@ function CaseFamilyWidgetPreview({
       <CasesFilterBar
         filters={casesFilters}
         onChange={handleFiltersChange}
-        onReset={() => handleFiltersChange(resetBaseline ?? DEFAULT_CASES_FILTERS)}
+        onReset={handleReset}
         isFiltersOpen={isFiltersOpen}
         onFiltersToggle={() => setIsFiltersOpen((prev) => !prev)}
         availableAssigneeUsers={[]}


### PR DESCRIPTION
## Purpose
The case-family dashboard widget "View more" preview page returns a different, incorrect result set than the corresponding dashboard tile for widgets with a tag exclusion filter (e.g. `tag notIn [s_dip, patch]`).

## Goals
Make the preview page's cases-search query use the widget's real tag exclusion filter, so it matches the dashboard tile's result set for the same widget.

## Approach
`CaseFamilyWidgetPreview` (`DashboardWidgetPreviewPage.tsx`) approximates a widget's tag exclusion filter as an inclusion whitelist for display, since its `CasesFilterBar` has only one "Tags" control and no separate "exclude" control. That whitelist is computed as the complement of the excluded tags against a tag catalog that only covers recently/commonly used tags -- an incomplete universe -- and a case with no tags at all can never match a whitelist "in" condition either way.

The bug: that same approximated whitelist was also being sent to `useGetCsmCases` for the actual API call, instead of only being used for display.

The fix decouples the two: a new `apiFilters` state, seeded from the widget's real (un-complemented) filters, drives the actual `/cases/search` query; the existing `casesFilters` state continues to drive what's shown as checked items in the Tags control, unchanged. The two stay independent until the viewer manually edits tags through the filter bar, at which point what's displayed and what's queried converge (they're now consciously picking an inclusion list) -- including across a later Reset, which restores the original divergence rather than locking the query to the approximation.

The UX of how tag exclusion is presented in the Tags control is unchanged by this PR; that's a separate, deferred decision.

## User stories
As a CS engineer, when I click "View more" on a dashboard widget that excludes certain tags (e.g. "On Going Cases" excluding `s_dip`/`patch`), I see the same case list the dashboard tile itself is built from.

## Release note
Fixed: the dashboard widget "View more" preview page could show an incorrect case list for widgets that exclude specific tags, differing from the dashboard tile's own result.

## Documentation
N/A -- internal bug fix, no user-facing behavior/doc change (the preview page's visible Tags control is unchanged).

## Training
N/A -- not training content.

## Certification
N/A -- no certification content impact.

## Marketing
N/A -- internal bug fix.

## Automation tests
- Unit tests
  > Rewrote 2 existing `DashboardWidgetPreviewPage.test.tsx` tests that asserted the old (buggy) complement-based API payload to assert the real exclusion filter is sent instead; added a new test covering that a manual filter-bar edit collapses the query to exactly what's displayed. Full suite: `npx vitest run src/features/csm-dashboard` -> 31 files, 352/352 passed.
- Integration tests
  > N/A -- no integration test suite covers this page; verified via the unit tests above plus `npx tsc -b` and `npx eslint` on the changed files, both clean.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A -- TypeScript/React change, not Java; `npx eslint` ran clean on the changed files instead
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A -- no sample code affected.

## Related PRs
None.

## Migrations (if applicable)
N/A -- no data or schema migration.

## Test environment
Verified with `npx vitest`, `npx eslint`, `npx tsc -b` in the webapp workspace (Node toolchain per repo `package.json`). No live dev-server/browser verification was performed against the reported URL in this pass.

## Learning
N/A.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected case-family widget filtering so excluded tags are sent accurately to case searches.
  - Updated the displayed tag filter to show the appropriate complementary tags.
  - Ensured editing or resetting filters keeps the displayed criteria and search query synchronized.
  - Improved combined tag filtering to apply both included and excluded tags correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->