### PR TITLE
[CSM Portal] SFTPGo-backed attachment storage (feature-flagged, off by default)

### DIFF
--- a/apps/csm-portal/backend/.env.example
+++ b/apps/csm-portal/backend/.env.example
@@ -138,6 +138,19 @@ AUTH_ISSUER=
 AUTH_AUDIENCE=                    # comma-separated; token is accepted if any listed audience is present
 AUTH_TOKEN_VALIDATOR_ENABLED=true
 
+# SFTPGo-backed attachment storage — off by default. When off (unset/false),
+# none of the vars below are read and the /cases/{id}/attachments/upload-token
+# and /attachments/{id}/share routes are not even registered; the existing
+# streaming attachment endpoints (POST /attachments, GET /attachments/{id}/content,
+# DELETE /attachments/{id}) are completely unaffected either way.
+# SFTPGO_ATTACHMENT_STORAGE_ENABLED=false
+# SFTPGo's REST API base URL. Required when SFTPGO_ATTACHMENT_STORAGE_ENABLED=true.
+# SFTPGO_BASE_URL=https://sftpgo.example.com
+# Public host for constructing share URLs (/web/client/pubshares/{id}) — set
+# this only if SFTPGo's WebClient share pages are fronted separately from its
+# REST API. Optional; defaults to SFTPGO_BASE_URL when unset.
+# SFTPGO_PUBLIC_BASE_URL=
+
 # Server
 PORT=8080
 # Comma-separated allow-list of browser Origins permitted to connect

--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -38,6 +38,7 @@ import (
 	"github.com/wso2-open-operations/cs-tools/apps/csm-portal/backend/internal/handler"
 	"github.com/wso2-open-operations/cs-tools/apps/csm-portal/backend/internal/middleware"
 	"github.com/wso2-open-operations/cs-tools/apps/csm-portal/backend/internal/scim"
+	"github.com/wso2-open-operations/cs-tools/apps/csm-portal/backend/internal/sftpgo"
 	"github.com/wso2-open-operations/cs-tools/apps/csm-portal/backend/internal/updates"
 )
 
@@ -108,6 +109,16 @@ func main() {
 	incidentHandler := handler.NewIncidentHandler(customerEntityClient)
 	problemHandler := handler.NewProblemHandler(customerEntityClient)
 
+	// SFTPGo-backed attachment storage — off by default (see loadSftpgoConfig).
+	// When disabled, no SFTPGO_* env var is read at all and neither the client
+	// nor its routes are constructed: the existing streaming attachment
+	// endpoints on caseHandler above are completely unaffected either way.
+	sftpgoAttachmentStorageEnabled, sftpgoCfg := loadSftpgoConfig()
+	var attachmentStorageHandler *handler.AttachmentStorageHandler
+	if sftpgoAttachmentStorageEnabled {
+		attachmentStorageHandler = handler.NewAttachmentStorageHandler(customerEntityClient, sftpgo.NewClient(sftpgoCfg))
+	}
+
 	updatesCfg := updates.Config{
 		BaseURL:      mustEnv("UPDATES_BASE_URL"),
 		TokenURL:     oauth2TokenURL,
@@ -150,6 +161,14 @@ func main() {
 	mux.HandleFunc("POST /attachments/search", caseHandler.SearchCaseAttachments)
 	mux.HandleFunc("GET /attachments/{id}/content", caseHandler.GetCaseAttachmentContent)
 	mux.HandleFunc("DELETE /attachments/{id}", caseHandler.DeleteCaseAttachment)
+	// The SFTPGo-backed attachment-storage routes only exist on the mux when
+	// the feature flag is on: with it off (default), these paths are not
+	// registered at all and 404, rather than existing but erroring, so
+	// shipping this dark carries zero risk to the routes above.
+	if attachmentStorageHandler != nil {
+		mux.HandleFunc("POST /cases/{id}/attachments/upload-token", attachmentStorageHandler.MintUploadToken)
+		mux.HandleFunc("POST /attachments/{id}/share", attachmentStorageHandler.CreateAttachmentShare)
+	}
 	mux.HandleFunc("POST /cases/{id}/call-requests", caseHandler.CreateCallRequest)
 	mux.HandleFunc("POST /cases/{id}/call-requests/search", caseHandler.SearchCallRequests)
 	mux.HandleFunc("POST /call-requests/search", caseHandler.SearchAllCallRequests)
@@ -428,6 +447,48 @@ func loadDirectory() *directory.Directory {
 	}
 	slog.Info("resolved reference catalogues", "teams", dir.TeamCount(), "roles", dir.RoleCount())
 	return dir
+}
+
+// loadSftpgoConfig resolves the SFTPGo-backed attachment-storage feature
+// flag and, only when it is on, the client configuration it needs:
+//
+//	SFTPGO_ATTACHMENT_STORAGE_ENABLED  Any strconv.ParseBool-true value (1, t,
+//	                                   T, TRUE, true, True). Off by default —
+//	                                   unset, empty, or any other value keeps
+//	                                   this feature dark and every other
+//	                                   env var below unread. This mirrors
+//	                                   DASHBOARDS_HOT_RELOAD's parsing: an
+//	                                   unparseable non-empty value is a
+//	                                   warning, not fatal, and defaults to off.
+//	SFTPGO_BASE_URL                    SFTPGo's REST API base URL. Required
+//	                                   when the flag is on.
+//	SFTPGO_PUBLIC_BASE_URL             Public host for constructing share
+//	                                   URLs, e.g. when SFTPGo's WebClient
+//	                                   share pages are fronted separately
+//	                                   from its REST API. Optional; defaults
+//	                                   to SFTPGO_BASE_URL when unset.
+//
+// Returns (false, zero Config) when the flag is off, so the caller never
+// touches the returned Config in that case.
+func loadSftpgoConfig() (bool, sftpgo.Config) {
+	enabled := false
+	if raw := strings.TrimSpace(os.Getenv("SFTPGO_ATTACHMENT_STORAGE_ENABLED")); raw != "" {
+		parsed, err := strconv.ParseBool(raw)
+		if err != nil {
+			slog.Warn("SFTPGO_ATTACHMENT_STORAGE_ENABLED is not a boolean; treating it as false",
+				"value", raw, "expected", "1, t, T, TRUE, true, True, 0, f, F, FALSE, false, False")
+		}
+		enabled = parsed
+	}
+	if !enabled {
+		return false, sftpgo.Config{}
+	}
+
+	slog.Info("SFTPGO_ATTACHMENT_STORAGE_ENABLED is on: the SFTPGo-backed attachment-storage endpoints are active")
+	return true, sftpgo.Config{
+		BaseURL:       mustEnv("SFTPGO_BASE_URL"),
+		PublicBaseURL: os.Getenv("SFTPGO_PUBLIC_BASE_URL"),
+	}
 }
 
 func mustEnv(key string) string {

--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -137,7 +137,7 @@ func main() {
 		Scopes:       splitComma(os.Getenv("SCIM_SCOPES")),
 	}
 	scimClient := scim.NewClient(scimCfg)
-	usersHandler := handler.NewUsersHandler(scimClient, customerEntityClient, dir)
+	usersHandler := handler.NewUsersHandler(scimClient, customerEntityClient, dir, sftpgoAttachmentStorageEnabled)
 
 	authCfg := middleware.Config{
 		JWKSEndpoint:          mustEnv("AUTH_JWKS_ENDPOINT"),

--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -508,15 +508,19 @@ func loadSftpgoConfig() (bool, sftpgo.Config) {
 // refuse to start rather than proceed with it.
 func mustHTTPSURL(key, value string) string {
 	if err := validateHTTPSURL(value); err != nil {
-		slog.Error("invalid environment variable", "key", key, "value", value, "err", err)
+		// Deliberately omit the raw value from this log line: it may carry
+		// embedded userinfo (e.g. "https://user:pass@host"), which would
+		// otherwise write a credential straight into the startup log.
+		slog.Error("invalid environment variable", "key", key, "err", err)
 		os.Exit(1)
 	}
 	return value
 }
 
 // validateHTTPSURL reports an error unless value parses as a URL with scheme
-// "https" and no embedded userinfo (e.g. "https://user:pass@host/...", which
-// could indicate a misconfigured or spoofed URL).
+// "https", a non-empty host, and no embedded userinfo (e.g.
+// "https://user:pass@host/...", which could indicate a misconfigured or
+// spoofed URL).
 func validateHTTPSURL(value string) error {
 	parsed, err := url.Parse(value)
 	if err != nil {
@@ -524,6 +528,9 @@ func validateHTTPSURL(value string) error {
 	}
 	if parsed.Scheme != "https" {
 		return fmt.Errorf("must use the https scheme, got %q", parsed.Scheme)
+	}
+	if parsed.Hostname() == "" {
+		return errors.New("must include a host (e.g. \"https://host/...\")")
 	}
 	if parsed.User != nil {
 		return errors.New("must not contain embedded userinfo (e.g. \"https://user:pass@host/...\")")

--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -20,9 +20,11 @@ import (
 	"bufio"
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
 	"strconv"
@@ -485,10 +487,48 @@ func loadSftpgoConfig() (bool, sftpgo.Config) {
 	}
 
 	slog.Info("SFTPGO_ATTACHMENT_STORAGE_ENABLED is on: the SFTPGo-backed attachment-storage endpoints are active")
-	return true, sftpgo.Config{
-		BaseURL:       mustEnv("SFTPGO_BASE_URL"),
-		PublicBaseURL: os.Getenv("SFTPGO_PUBLIC_BASE_URL"),
+	baseURL := mustHTTPSURL("SFTPGO_BASE_URL", mustEnv("SFTPGO_BASE_URL"))
+	publicBaseURL := baseURL
+	if raw := os.Getenv("SFTPGO_PUBLIC_BASE_URL"); raw != "" {
+		publicBaseURL = mustHTTPSURL("SFTPGO_PUBLIC_BASE_URL", raw)
 	}
+	return true, sftpgo.Config{
+		BaseURL:       baseURL,
+		PublicBaseURL: publicBaseURL,
+	}
+}
+
+// mustHTTPSURL validates value via validateHTTPSURL, exiting the process with
+// a logged error if it is invalid. Both SFTPGO_BASE_URL and
+// SFTPGO_PUBLIC_BASE_URL are used to build requests/URLs that carry the
+// caller's email and raw gateway JWT (see internal/sftpgo.Client.MintToken)
+// or are handed to end users as a public download link (see
+// internal/sftpgo.Client.PublicShareURL), so a non-HTTPS or spoofed-looking
+// value here is a credential-leak/MITM risk, not just a misconfiguration —
+// refuse to start rather than proceed with it.
+func mustHTTPSURL(key, value string) string {
+	if err := validateHTTPSURL(value); err != nil {
+		slog.Error("invalid environment variable", "key", key, "value", value, "err", err)
+		os.Exit(1)
+	}
+	return value
+}
+
+// validateHTTPSURL reports an error unless value parses as a URL with scheme
+// "https" and no embedded userinfo (e.g. "https://user:pass@host/...", which
+// could indicate a misconfigured or spoofed URL).
+func validateHTTPSURL(value string) error {
+	parsed, err := url.Parse(value)
+	if err != nil {
+		return fmt.Errorf("not a valid URL: %w", err)
+	}
+	if parsed.Scheme != "https" {
+		return fmt.Errorf("must use the https scheme, got %q", parsed.Scheme)
+	}
+	if parsed.User != nil {
+		return errors.New("must not contain embedded userinfo (e.g. \"https://user:pass@host/...\")")
+	}
+	return nil
 }
 
 func mustEnv(key string) string {

--- a/apps/csm-portal/backend/cmd/server/main_test.go
+++ b/apps/csm-portal/backend/cmd/server/main_test.go
@@ -41,6 +41,8 @@ func TestValidateHTTPSURL(t *testing.T) {
 		{name: "unparseable rejected", value: "https://%zz", wantErr: true},
 		{name: "embedded userinfo rejected", value: "https://user:pass@sftpgo.internal.example.com", wantErr: true},
 		{name: "embedded username only rejected", value: "https://user@sftpgo.internal.example.com", wantErr: true},
+		{name: "no host rejected", value: "https:///api", wantErr: true},
+		{name: "opaque no host rejected", value: "https:opaque", wantErr: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -79,7 +81,7 @@ func TestLoadSftpgoConfigRejectsBadURLs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cmd := exec.Command(os.Args[0], "-test.run=^TestLoadSftpgoConfigRejectsBadURLs$")
+			cmd := exec.CommandContext(t.Context(), os.Args[0], "-test.run=^TestLoadSftpgoConfigRejectsBadURLs$")
 			cmd.Env = append(os.Environ(),
 				"BE_LOAD_SFTPGO_CONFIG_SUBPROCESS=1",
 				"SFTPGO_ATTACHMENT_STORAGE_ENABLED=true",

--- a/apps/csm-portal/backend/cmd/server/main_test.go
+++ b/apps/csm-portal/backend/cmd/server/main_test.go
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+)
+
+// TestValidateHTTPSURL covers the pure validation logic behind mustHTTPSURL,
+// which gates SFTPGO_BASE_URL and SFTPGO_PUBLIC_BASE_URL: both are used to
+// build requests carrying the caller's email and raw gateway JWT (see
+// internal/sftpgo.Client.MintToken) or a public download link handed to end
+// users (see internal/sftpgo.Client.PublicShareURL), so neither may be
+// non-HTTPS or carry embedded userinfo.
+func TestValidateHTTPSURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{name: "https ok", value: "https://sftpgo.internal.example.com", wantErr: false},
+		{name: "https with path ok", value: "https://sftpgo.internal.example.com/api", wantErr: false},
+		{name: "http rejected", value: "http://sftpgo.internal.example.com", wantErr: true},
+		{name: "scheme-less rejected", value: "sftpgo.internal.example.com", wantErr: true},
+		{name: "unparseable rejected", value: "https://%zz", wantErr: true},
+		{name: "embedded userinfo rejected", value: "https://user:pass@sftpgo.internal.example.com", wantErr: true},
+		{name: "embedded username only rejected", value: "https://user@sftpgo.internal.example.com", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateHTTPSURL(tt.value)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateHTTPSURL(%q) error = %v, wantErr %v", tt.value, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestLoadSftpgoConfigRejectsBadURLs exercises the real exit path exercised
+// at server startup: loadSftpgoConfig calls os.Exit(1) via mustHTTPSURL when
+// SFTPGO_BASE_URL or SFTPGO_PUBLIC_BASE_URL is invalid while the feature flag
+// is on, so this re-execs the test binary as a subprocess (the standard Go
+// pattern for testing os.Exit call sites) and asserts on its exit status.
+func TestLoadSftpgoConfigRejectsBadURLs(t *testing.T) {
+	if os.Getenv("BE_LOAD_SFTPGO_CONFIG_SUBPROCESS") == "1" {
+		loadSftpgoConfig()
+		return
+	}
+
+	tests := []struct {
+		name            string
+		baseURL         string
+		publicBaseURL   string
+		wantExitNonZero bool
+	}{
+		{name: "valid https base URL, no public URL", baseURL: "https://sftpgo.internal.example.com", wantExitNonZero: false},
+		{name: "valid https for both", baseURL: "https://sftpgo.internal.example.com", publicBaseURL: "https://share.example.com", wantExitNonZero: false},
+		{name: "http base URL rejected", baseURL: "http://sftpgo.internal.example.com", wantExitNonZero: true},
+		{name: "http public base URL rejected", baseURL: "https://sftpgo.internal.example.com", publicBaseURL: "http://share.example.com", wantExitNonZero: true},
+		{name: "userinfo in base URL rejected", baseURL: "https://user:pass@sftpgo.internal.example.com", wantExitNonZero: true},
+		{name: "userinfo in public base URL rejected", baseURL: "https://sftpgo.internal.example.com", publicBaseURL: "https://user:pass@share.example.com", wantExitNonZero: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := exec.Command(os.Args[0], "-test.run=^TestLoadSftpgoConfigRejectsBadURLs$")
+			cmd.Env = append(os.Environ(),
+				"BE_LOAD_SFTPGO_CONFIG_SUBPROCESS=1",
+				"SFTPGO_ATTACHMENT_STORAGE_ENABLED=true",
+				"SFTPGO_BASE_URL="+tt.baseURL,
+				"SFTPGO_PUBLIC_BASE_URL="+tt.publicBaseURL,
+			)
+			out, err := cmd.CombinedOutput()
+
+			if tt.wantExitNonZero {
+				if err == nil {
+					t.Fatalf("expected loadSftpgoConfig to exit non-zero, but it exited cleanly; output:\n%s", out)
+				}
+				var exitErr *exec.ExitError
+				if !isExitError(err, &exitErr) {
+					t.Fatalf("expected an *exec.ExitError, got %T: %v; output:\n%s", err, err, out)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("expected loadSftpgoConfig to exit cleanly, got error %v; output:\n%s", err, out)
+			}
+		})
+	}
+}
+
+// isExitError reports whether err is an *exec.ExitError and, if so, assigns
+// it to *target.
+func isExitError(err error, target **exec.ExitError) bool {
+	e, ok := err.(*exec.ExitError)
+	if ok {
+		*target = e
+	}
+	return ok
+}

--- a/apps/csm-portal/backend/internal/entity/customer.go
+++ b/apps/csm-portal/backend/internal/entity/customer.go
@@ -329,6 +329,22 @@ func (c *CustomerEntityClient) DeleteCaseAttachment(ctx context.Context, attachm
 	return c.do(ctx, http.MethodDelete, fmt.Sprintf("/attachments/%s", url.PathEscape(attachmentID)), nil)
 }
 
+// GetCaseAttachment calls GET /attachments/{attachmentId} on the entity
+// service and returns a single attachment's metadata as raw JSON, including
+// (once the entity service supports it) its storageKey — the SFTPGo path the
+// attachment's file lives at.
+//
+// Assumption flagged: this single-attachment GET is not one of the entity
+// service routes this backend calls elsewhere today (only .../search and
+// .../{id}/content exist — see the other CaseAttachment methods above). It
+// is required by the SFTPGo-backed share-creation path
+// (handler.AttachmentStorageHandler.CreateAttachmentShare) to resolve an
+// attachment's storageKey, and assumes a corresponding entity-service change
+// that is out of scope for this layer/PR.
+func (c *CustomerEntityClient) GetCaseAttachment(ctx context.Context, attachmentID string) ([]byte, error) {
+	return c.do(ctx, http.MethodGet, fmt.Sprintf("/attachments/%s", url.PathEscape(attachmentID)), nil)
+}
+
 // SearchCatalogs calls POST /catalogs/search on the entity service.
 // Response is returned as raw JSON.
 func (c *CustomerEntityClient) SearchCatalogs(ctx context.Context, body []byte) ([]byte, error) {

--- a/apps/csm-portal/backend/internal/handler/attachment_storage.go
+++ b/apps/csm-portal/backend/internal/handler/attachment_storage.go
@@ -1,0 +1,265 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/wso2-open-operations/cs-tools/apps/csm-portal/backend/internal/middleware"
+	"github.com/wso2-open-operations/cs-tools/apps/csm-portal/backend/internal/sftpgo"
+)
+
+// shareTTL bounds how long a created SFTPGo share — and by extension the
+// public download/inline-image URL handed to the caller — stays valid. Kept
+// short because a share is minted fresh on every request that needs one; see
+// AttachmentStorageHandler.CreateAttachmentShare's doc comment on why shares
+// are never created eagerly.
+const shareTTL = 5 * time.Minute
+
+// jwtAssertionHeader mirrors the unexported constant of the same name in
+// internal/middleware/auth.go — that package does not export it, so it is
+// duplicated here rather than introducing a cross-package export for a
+// single literal.
+const jwtAssertionHeader = "x-jwt-assertion"
+
+// sftpgoClient abstracts the SFTPGo operations used by AttachmentStorageHandler,
+// allowing the handler to be tested without a live SFTPGo instance.
+type sftpgoClient interface {
+	MintToken(ctx context.Context, email, jwtAssertion string) (*sftpgo.Token, error)
+	CreateShare(ctx context.Context, accessToken, storageKey string, ttl time.Duration) (string, error)
+	PublicShareURL(shareID string) string
+	BaseURL() string
+}
+
+// AttachmentStorageHandler implements the SFTPGo-backed attachment-storage
+// endpoints: minting a short-lived SFTPGo access token before an upload, and
+// creating a short-lived public download share for an already-stored
+// attachment. It never touches attachment bytes itself — uploads and
+// downloads go directly between the browser and SFTPGo using the
+// credentials this handler mints; see package sftpgo's doc comment. Its
+// routes are only registered (and therefore only reachable) when
+// SFTPGO_ATTACHMENT_STORAGE_ENABLED is on — see cmd/server/main.go. The
+// existing streaming attachment endpoints on CaseHandler are completely
+// unaffected by this handler and by the flag.
+type AttachmentStorageHandler struct {
+	entity entityCaseClient
+	sftpgo sftpgoClient
+}
+
+// NewAttachmentStorageHandler creates an AttachmentStorageHandler backed by
+// the given entity and SFTPGo clients.
+func NewAttachmentStorageHandler(entity entityCaseClient, sftpgo sftpgoClient) *AttachmentStorageHandler {
+	return &AttachmentStorageHandler{entity: entity, sftpgo: sftpgo}
+}
+
+// uploadTokenResponse is the response body of
+// POST /cases/{id}/attachments/upload-token.
+type uploadTokenResponse struct {
+	SftpgoAccessToken string          `json:"sftpgoAccessToken"`
+	ExpiresAt         json.RawMessage `json:"expiresAt"`
+	SftpgoBaseURL     string          `json:"sftpgoBaseUrl"`
+}
+
+// MintUploadToken handles POST /cases/{id}/attachments/upload-token. It mints
+// a short-lived SFTPGo access token scoped to the caller's own identity (the
+// gateway-validated email claim) for the browser to use directly against
+// SFTPGo's chunked/TUS upload endpoint — this backend never sees the
+// uploaded bytes. Requires write access to the target case, checked via the
+// same guard CaseHandler.CreateCaseAttachment already applies (case exists
+// and is not closed): a token is never minted for a case the caller could
+// not otherwise attach a file to.
+func (h *AttachmentStorageHandler) MintUploadToken(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	caseID := r.PathValue("id")
+	if caseID == "" || !uuidRe.MatchString(caseID) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	if !h.canWriteCase(w, r, caseID) {
+		return
+	}
+
+	jwtAssertion := r.Header.Get(jwtAssertionHeader)
+	if jwtAssertion == "" {
+		// The Auth middleware already rejects any request without this
+		// header before it reaches here, so this is not a real caller path —
+		// fail closed rather than mint a token with an empty credential.
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	token, err := h.sftpgo.MintToken(r.Context(), user.Email, jwtAssertion)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "sftpgo MintToken failed", "userID", user.UserID, "caseID", caseID, "err", summarizeErr(err))
+		writeError(w, http.StatusBadGateway, "Failed to obtain an upload token.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusOK, uploadTokenResponse{
+		SftpgoAccessToken: token.AccessToken,
+		ExpiresAt:         token.ExpiresAt,
+		SftpgoBaseURL:     h.sftpgo.BaseURL(),
+	})
+}
+
+// attachmentMeta is the subset of the entity service's Attachment fields this
+// handler needs (see openapi.yaml's Attachment schema) plus storageKey.
+//
+// Assumption flagged: storageKey does not exist on the entity service's
+// Attachment schema today — every existing attachment is a base64 payload
+// the entity service stores itself, with no notion of an external storage
+// path. This field is assumed to be added by a corresponding entity-service
+// change (out of scope for this layer/PR) that populates it with the SFTPGo
+// path an attachment was uploaded to, only when it was created via the
+// SFTPGo-backed upload path. A missing/empty storageKey here is treated as
+// "not shareable" rather than an error — see StorageKey's nil check below —
+// so an attachment stored the old way fails cleanly instead of panicking.
+type attachmentMeta struct {
+	ReferenceID   string  `json:"referenceId"`
+	ReferenceType string  `json:"referenceType"`
+	StorageKey    *string `json:"storageKey"`
+}
+
+// shareResponse is the response body of POST /attachments/{id}/share.
+type shareResponse struct {
+	ShareURL string `json:"shareUrl"`
+}
+
+// CreateAttachmentShare handles POST /attachments/{id}/share. It creates a
+// fresh, short-lived (shareTTL) SFTPGo public share for one attachment's
+// stored file and returns its public URL.
+//
+// This must be called lazily — once per attachment id, only when that
+// specific attachment is actually opened or an inline image is actually
+// rendered — never eagerly for a whole attachment list or comment thread: a
+// share is a real SFTPGo object with its own lifecycle, and creating one for
+// every attachment on every list/search response would mint SFTPGo shares
+// nobody asked to open.
+func (h *AttachmentStorageHandler) CreateAttachmentShare(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	attachmentID := r.PathValue("id")
+	if attachmentID == "" || !uuidRe.MatchString(attachmentID) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	raw, err := h.entity.GetCaseAttachment(r.Context(), attachmentID)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity GetCaseAttachment failed", "userID", user.UserID, "attachmentID", attachmentID, "err", summarizeErr(err))
+		mapUpstreamErrorGeneric(w, err, "Failed to retrieve attachment.")
+		return
+	}
+	var meta attachmentMeta
+	if err := json.Unmarshal(raw, &meta); err != nil {
+		slog.ErrorContext(r.Context(), "failed to parse attachment metadata", "userID", user.UserID, "attachmentID", attachmentID, "err", err)
+		writeError(w, http.StatusInternalServerError, ErrMsgInternal)
+		return
+	}
+
+	// Read-access check: mirrors the (lack of) additional case-state gating
+	// on GetCaseAttachmentContent and SearchCaseAttachments today — those
+	// endpoints impose no restriction beyond the entity service's own
+	// GetCase access control (a 403/404 from upstream decides who can see
+	// what). Reused here, unchanged, for the read path.
+	if meta.ReferenceType == "case" && meta.ReferenceID != "" {
+		if !h.canReadCase(w, r, meta.ReferenceID) {
+			return
+		}
+	}
+
+	if meta.StorageKey == nil || *meta.StorageKey == "" {
+		writeError(w, http.StatusConflict, ErrMsgAttachmentNotShareable)
+		return
+	}
+
+	jwtAssertion := r.Header.Get(jwtAssertionHeader)
+	if jwtAssertion == "" {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	token, err := h.sftpgo.MintToken(r.Context(), user.Email, jwtAssertion)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "sftpgo MintToken failed", "userID", user.UserID, "attachmentID", attachmentID, "err", summarizeErr(err))
+		writeError(w, http.StatusBadGateway, "Failed to create a share for this attachment.")
+		return
+	}
+
+	shareID, err := h.sftpgo.CreateShare(r.Context(), token.AccessToken, *meta.StorageKey, shareTTL)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "sftpgo CreateShare failed", "userID", user.UserID, "attachmentID", attachmentID, "err", summarizeErr(err))
+		writeError(w, http.StatusBadGateway, "Failed to create a share for this attachment.")
+		return
+	}
+
+	writeJSONValue(w, http.StatusCreated, shareResponse{ShareURL: h.sftpgo.PublicShareURL(shareID)})
+}
+
+// canWriteCase mirrors CaseHandler.CreateCaseAttachment's closed-case guard —
+// the same check that gates whether a case may receive a new attachment
+// today — reused here so an upload token is never minted for a case an
+// upload could not proceed against anyway.
+func (h *AttachmentStorageHandler) canWriteCase(w http.ResponseWriter, r *http.Request, caseID string) bool {
+	current, err := h.entity.GetCase(r.Context(), caseID)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity GetCase failed during attachment-storage write guard", "caseID", caseID, "err", summarizeErr(err))
+		mapUpstreamErrorGeneric(w, err, "Failed to validate case access.")
+		return false
+	}
+	var currentCase struct {
+		State string `json:"state"`
+	}
+	if err := json.Unmarshal(current, &currentCase); err != nil {
+		slog.ErrorContext(r.Context(), "failed to parse case state for attachment-storage write guard", "caseID", caseID, "err", err)
+		writeError(w, http.StatusInternalServerError, ErrMsgInternal)
+		return false
+	}
+	if currentCase.State == "closed" {
+		writeError(w, http.StatusConflict, ErrMsgAttachmentOnClosedCase)
+		return false
+	}
+	return true
+}
+
+// canReadCase confirms the caller can view the target case at all — mirrors
+// the (lack of) additional gating on GetCaseAttachmentContent and
+// SearchCaseAttachments today: those endpoints impose no case-state
+// restriction and rely entirely on the entity service's own GetCase access
+// control (a 403/404 from upstream) to decide who can see what.
+func (h *AttachmentStorageHandler) canReadCase(w http.ResponseWriter, r *http.Request, caseID string) bool {
+	if _, err := h.entity.GetCase(r.Context(), caseID); err != nil {
+		slog.ErrorContext(r.Context(), "entity GetCase failed during attachment-storage read guard", "caseID", caseID, "err", summarizeErr(err))
+		mapUpstreamErrorGeneric(w, err, "Failed to validate case access.")
+		return false
+	}
+	return true
+}

--- a/apps/csm-portal/backend/internal/handler/attachment_storage.go
+++ b/apps/csm-portal/backend/internal/handler/attachment_storage.go
@@ -18,7 +18,9 @@ package handler
 
 import (
 	"context"
+	"crypto/rand"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"time"
@@ -76,6 +78,13 @@ type uploadTokenResponse struct {
 	SftpgoAccessToken string          `json:"sftpgoAccessToken"`
 	ExpiresAt         json.RawMessage `json:"expiresAt"`
 	SftpgoBaseURL     string          `json:"sftpgoBaseUrl"`
+	// StorageKey is the exact SFTPGo path the frontend must upload the file
+	// to (as the TUS/chunked-upload target) and must later send back
+	// unchanged as CreateAttachmentRequest.storageKey when it creates the
+	// attachment metadata row. Minted here, server-side, rather than left for
+	// the frontend to invent, so the id embedded in it is guaranteed to match
+	// no other attachment. See buildStorageKey for the path convention.
+	StorageKey string `json:"storageKey"`
 }
 
 // MintUploadToken handles POST /cases/{id}/attachments/upload-token. It mints
@@ -99,7 +108,8 @@ func (h *AttachmentStorageHandler) MintUploadToken(w http.ResponseWriter, r *htt
 		return
 	}
 
-	if !h.canWriteCase(w, r, caseID) {
+	projectID, ok := h.canWriteCase(w, r, caseID)
+	if !ok {
 		return
 	}
 
@@ -119,10 +129,17 @@ func (h *AttachmentStorageHandler) MintUploadToken(w http.ResponseWriter, r *htt
 		return
 	}
 
+	// Generated here, server-side, rather than left for the frontend to
+	// invent: the frontend has no way to guarantee id uniqueness or apply the
+	// storage-key convention, and both are this backend's responsibility.
+	attachmentID := newAttachmentID()
+	storageKey := buildStorageKey(projectID, caseID, attachmentID)
+
 	writeJSONValue(w, http.StatusOK, uploadTokenResponse{
 		SftpgoAccessToken: token.AccessToken,
 		ExpiresAt:         token.ExpiresAt,
 		SftpgoBaseURL:     h.sftpgo.BaseURL(),
+		StorageKey:        storageKey,
 	})
 }
 
@@ -227,27 +244,71 @@ func (h *AttachmentStorageHandler) CreateAttachmentShare(w http.ResponseWriter, 
 // canWriteCase mirrors CaseHandler.CreateCaseAttachment's closed-case guard —
 // the same check that gates whether a case may receive a new attachment
 // today — reused here so an upload token is never minted for a case an
-// upload could not proceed against anyway.
-func (h *AttachmentStorageHandler) canWriteCase(w http.ResponseWriter, r *http.Request, caseID string) bool {
+// upload could not proceed against anyway. projectID is the case's
+// projectId as reported by the entity service (see domain.Case.ProjectID),
+// used by MintUploadToken to build the storage key; it is "" when the
+// upstream response omits it, which buildStorageKey treats as "no project
+// concept for this case" rather than an error.
+func (h *AttachmentStorageHandler) canWriteCase(w http.ResponseWriter, r *http.Request, caseID string) (projectID string, ok bool) {
 	current, err := h.entity.GetCase(r.Context(), caseID)
 	if err != nil {
 		slog.ErrorContext(r.Context(), "entity GetCase failed during attachment-storage write guard", "caseID", caseID, "err", summarizeErr(err))
 		mapUpstreamErrorGeneric(w, err, "Failed to validate case access.")
-		return false
+		return "", false
 	}
 	var currentCase struct {
-		State string `json:"state"`
+		State     string `json:"state"`
+		ProjectID string `json:"projectId"`
 	}
 	if err := json.Unmarshal(current, &currentCase); err != nil {
 		slog.ErrorContext(r.Context(), "failed to parse case state for attachment-storage write guard", "caseID", caseID, "err", err)
 		writeError(w, http.StatusInternalServerError, ErrMsgInternal)
-		return false
+		return "", false
 	}
 	if currentCase.State == "closed" {
 		writeError(w, http.StatusConflict, ErrMsgAttachmentOnClosedCase)
-		return false
+		return "", false
 	}
-	return true
+	return currentCase.ProjectID, true
+}
+
+// newAttachmentID generates a random UUID v4 for a not-yet-created
+// attachment. Mirrors middleware.newCorrelationID's approach (that helper is
+// unexported in a different package, so it is duplicated here rather than
+// exporting a single-purpose helper across a package boundary for it).
+func newAttachmentID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		panic("attachment_storage: failed to read random bytes: " + err.Error())
+	}
+	b[6] = (b[6] & 0x0f) | 0x40 // version 4
+	b[8] = (b[8] & 0x3f) | 0x80 // variant bits
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:])
+}
+
+// buildStorageKey computes the SFTPGo path an attachment's bytes live under:
+// "/attachments/project-<projectId>/cases/<caseId>/<attachmentId>". SFTPGo
+// permissions are granted per project, so the project segment is
+// load-bearing whenever a project is known.
+//
+// projectID is "" when the case's own record carries no project reference.
+// Cases in this Postgres/CSM-native data source are NOT guaranteed to have a
+// project: domain.Case.ProjectID exists on the schema, but nothing in
+// entity-service enforces it is always populated for a CSM-native case
+// (unlike ServiceNow-sourced cases, which are always project-scoped). Rather
+// than block minting a token over a missing project reference, this falls
+// back to a project-less path shape,
+// "/attachments/cases/<caseId>/<attachmentId>", which still uniquely
+// identifies the file. This fallback path cannot be granted SFTPGo
+// permissions per-project the way the documented convention can; it is
+// accepted here as a deliberate, narrower scope (case-only) rather than a
+// blocker, and should be revisited if/when CSM-native cases gain a
+// guaranteed project reference.
+func buildStorageKey(projectID, caseID, attachmentID string) string {
+	if projectID == "" {
+		return fmt.Sprintf("/attachments/cases/%s/%s", caseID, attachmentID)
+	}
+	return fmt.Sprintf("/attachments/project-%s/cases/%s/%s", projectID, caseID, attachmentID)
 }
 
 // canReadCase confirms the caller can view the target case at all — mirrors

--- a/apps/csm-portal/backend/internal/handler/attachment_storage_test.go
+++ b/apps/csm-portal/backend/internal/handler/attachment_storage_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -187,6 +188,81 @@ func TestMintUploadTokenSuccess(t *testing.T) {
 	}
 	if resp.SftpgoBaseURL != "https://sftpgo.example.com" {
 		t.Errorf("SftpgoBaseURL = %q, want https://sftpgo.example.com", resp.SftpgoBaseURL)
+	}
+	// The case fixture above carries no "projectId", so this must fall back
+	// to the project-less path shape rather than emitting a malformed
+	// "project-" segment.
+	wantKey := "/attachments/cases/" + caseID + "/"
+	if !strings.HasPrefix(resp.StorageKey, wantKey) {
+		t.Errorf("StorageKey = %q, want prefix %q (no-project fallback)", resp.StorageKey, wantKey)
+	}
+	attachmentID := strings.TrimPrefix(resp.StorageKey, wantKey)
+	if !uuidRe.MatchString(attachmentID) {
+		t.Errorf("StorageKey %q does not end in a well-formed UUID, got %q", resp.StorageKey, attachmentID)
+	}
+}
+
+// TestMintUploadTokenStorageKeyIncludesProject verifies that when the case's
+// own record carries a projectId, the minted storageKey follows the
+// documented convention:
+// /attachments/project-<projectId>/cases/<caseId>/<attachmentId>.
+func TestMintUploadTokenStorageKeyIncludesProject(t *testing.T) {
+	t.Parallel()
+	const projectID = "22222222-2222-2222-2222-222222222222"
+	entity := &mockEntityCaseClient{
+		getCaseFn: func(ctx context.Context, caseID string) ([]byte, error) {
+			return []byte(`{"state":"work_in_progress","projectId":"` + projectID + `"}`), nil
+		},
+	}
+	sftpgoMock := &mockSftpgoClient{}
+	h := NewAttachmentStorageHandler(entity, sftpgoMock)
+
+	caseID := "11111111-1111-1111-1111-111111111111"
+	req := withUser(httptest.NewRequest(http.MethodPost, "/cases/"+caseID+"/attachments/upload-token", nil))
+	req.SetPathValue("id", caseID)
+	req.Header.Set("x-jwt-assertion", "raw-jwt")
+	w := httptest.NewRecorder()
+
+	h.MintUploadToken(w, req)
+
+	assertStatus(t, w, http.StatusOK)
+	resp := decodeJSON[uploadTokenResponse](t, w)
+
+	wantPrefix := "/attachments/project-" + projectID + "/cases/" + caseID + "/"
+	if !strings.HasPrefix(resp.StorageKey, wantPrefix) {
+		t.Fatalf("StorageKey = %q, want prefix %q", resp.StorageKey, wantPrefix)
+	}
+	attachmentID := strings.TrimPrefix(resp.StorageKey, wantPrefix)
+	if !uuidRe.MatchString(attachmentID) {
+		t.Errorf("StorageKey %q does not end in a well-formed UUID, got %q", resp.StorageKey, attachmentID)
+	}
+}
+
+// TestMintUploadTokenStorageKeyUniquePerCall verifies each mint generates a
+// fresh attachment id, never reusing one across calls.
+func TestMintUploadTokenStorageKeyUniquePerCall(t *testing.T) {
+	t.Parallel()
+	entity := &mockEntityCaseClient{
+		getCaseFn: func(ctx context.Context, caseID string) ([]byte, error) {
+			return []byte(`{"state":"work_in_progress"}`), nil
+		},
+	}
+	h := NewAttachmentStorageHandler(entity, &mockSftpgoClient{})
+
+	caseID := "11111111-1111-1111-1111-111111111111"
+	seen := make(map[string]bool)
+	for i := 0; i < 5; i++ {
+		req := withUser(httptest.NewRequest(http.MethodPost, "/cases/"+caseID+"/attachments/upload-token", nil))
+		req.SetPathValue("id", caseID)
+		req.Header.Set("x-jwt-assertion", "raw-jwt")
+		w := httptest.NewRecorder()
+		h.MintUploadToken(w, req)
+		assertStatus(t, w, http.StatusOK)
+		resp := decodeJSON[uploadTokenResponse](t, w)
+		if seen[resp.StorageKey] {
+			t.Fatalf("StorageKey %q was generated twice", resp.StorageKey)
+		}
+		seen[resp.StorageKey] = true
 	}
 }
 

--- a/apps/csm-portal/backend/internal/handler/attachment_storage_test.go
+++ b/apps/csm-portal/backend/internal/handler/attachment_storage_test.go
@@ -1,0 +1,383 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/wso2-open-operations/cs-tools/apps/csm-portal/backend/internal/apierror"
+	"github.com/wso2-open-operations/cs-tools/apps/csm-portal/backend/internal/sftpgo"
+)
+
+// ----- mock SFTPGo client -----
+
+type mockSftpgoClient struct {
+	mintTokenFn    func(ctx context.Context, email, jwtAssertion string) (*sftpgo.Token, error)
+	createShareFn  func(ctx context.Context, accessToken, storageKey string, ttl time.Duration) (string, error)
+	publicShareURL func(shareID string) string
+	baseURL        string
+
+	mintTokenCalls   []string // records the jwtAssertion passed on each call
+	createShareCalls []string // records the storageKey passed on each call
+}
+
+func (m *mockSftpgoClient) MintToken(ctx context.Context, email, jwtAssertion string) (*sftpgo.Token, error) {
+	m.mintTokenCalls = append(m.mintTokenCalls, jwtAssertion)
+	if m.mintTokenFn != nil {
+		return m.mintTokenFn(ctx, email, jwtAssertion)
+	}
+	return &sftpgo.Token{AccessToken: "mock-access-token", ExpiresAt: json.RawMessage(`"2026-08-27T12:00:00Z"`)}, nil
+}
+
+func (m *mockSftpgoClient) CreateShare(ctx context.Context, accessToken, storageKey string, ttl time.Duration) (string, error) {
+	m.createShareCalls = append(m.createShareCalls, storageKey)
+	if m.createShareFn != nil {
+		return m.createShareFn(ctx, accessToken, storageKey, ttl)
+	}
+	return "mock-share-id", nil
+}
+
+func (m *mockSftpgoClient) PublicShareURL(shareID string) string {
+	if m.publicShareURL != nil {
+		return m.publicShareURL(shareID)
+	}
+	return "https://share.example.com/web/client/pubshares/" + shareID + "?compress=false"
+}
+
+func (m *mockSftpgoClient) BaseURL() string {
+	if m.baseURL != "" {
+		return m.baseURL
+	}
+	return "https://sftpgo.example.com"
+}
+
+// ----- MintUploadToken -----
+
+func TestMintUploadTokenRequiresAuth(t *testing.T) {
+	t.Parallel()
+	h := NewAttachmentStorageHandler(&mockEntityCaseClient{}, &mockSftpgoClient{})
+
+	req := httptest.NewRequest(http.MethodPost, "/cases/11111111-1111-1111-1111-111111111111/attachments/upload-token", nil)
+	req.SetPathValue("id", "11111111-1111-1111-1111-111111111111")
+	w := httptest.NewRecorder()
+
+	h.MintUploadToken(w, req)
+
+	assertStatus(t, w, http.StatusUnauthorized)
+}
+
+func TestMintUploadTokenRejectsInvalidCaseID(t *testing.T) {
+	t.Parallel()
+	h := NewAttachmentStorageHandler(&mockEntityCaseClient{}, &mockSftpgoClient{})
+
+	req := withUser(httptest.NewRequest(http.MethodPost, "/cases/not-a-uuid/attachments/upload-token", nil))
+	req.SetPathValue("id", "not-a-uuid")
+	req.Header.Set("x-jwt-assertion", "raw-jwt")
+	w := httptest.NewRecorder()
+
+	h.MintUploadToken(w, req)
+
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+// TestMintUploadTokenBlocksClosedCase verifies the ACL check runs BEFORE any
+// token is minted: a closed case must produce a 409 and zero calls into the
+// SFTPGo client.
+func TestMintUploadTokenBlocksClosedCase(t *testing.T) {
+	t.Parallel()
+	entity := &mockEntityCaseClient{
+		getCaseFn: func(ctx context.Context, caseID string) ([]byte, error) {
+			return []byte(`{"state":"closed"}`), nil
+		},
+	}
+	sftpgoMock := &mockSftpgoClient{}
+	h := NewAttachmentStorageHandler(entity, sftpgoMock)
+
+	caseID := "11111111-1111-1111-1111-111111111111"
+	req := withUser(httptest.NewRequest(http.MethodPost, "/cases/"+caseID+"/attachments/upload-token", nil))
+	req.SetPathValue("id", caseID)
+	req.Header.Set("x-jwt-assertion", "raw-jwt")
+	w := httptest.NewRecorder()
+
+	h.MintUploadToken(w, req)
+
+	assertStatus(t, w, http.StatusConflict)
+	assertErrorMessage(t, w, ErrMsgAttachmentOnClosedCase)
+	if len(sftpgoMock.mintTokenCalls) != 0 {
+		t.Errorf("MintToken was called %d times; want 0 — a token must never be minted for a closed case", len(sftpgoMock.mintTokenCalls))
+	}
+}
+
+// TestMintUploadTokenRequiresJWTAssertionHeader verifies the raw
+// x-jwt-assertion header value (not some other credential) is what gets
+// forwarded as the mint password, and that a request without it never
+// reaches the SFTPGo client.
+func TestMintUploadTokenRequiresJWTAssertionHeader(t *testing.T) {
+	t.Parallel()
+	entity := &mockEntityCaseClient{
+		getCaseFn: func(ctx context.Context, caseID string) ([]byte, error) {
+			return []byte(`{"state":"work_in_progress"}`), nil
+		},
+	}
+	sftpgoMock := &mockSftpgoClient{}
+	h := NewAttachmentStorageHandler(entity, sftpgoMock)
+
+	caseID := "11111111-1111-1111-1111-111111111111"
+	req := withUser(httptest.NewRequest(http.MethodPost, "/cases/"+caseID+"/attachments/upload-token", nil))
+	req.SetPathValue("id", caseID)
+	// Deliberately no x-jwt-assertion header set.
+	w := httptest.NewRecorder()
+
+	h.MintUploadToken(w, req)
+
+	assertStatus(t, w, http.StatusUnauthorized)
+	if len(sftpgoMock.mintTokenCalls) != 0 {
+		t.Errorf("MintToken was called %d times; want 0", len(sftpgoMock.mintTokenCalls))
+	}
+}
+
+// TestMintUploadTokenSuccess verifies a successful mint on an open case
+// forwards the exact x-jwt-assertion header value and returns the expected
+// response shape.
+func TestMintUploadTokenSuccess(t *testing.T) {
+	t.Parallel()
+	entity := &mockEntityCaseClient{
+		getCaseFn: func(ctx context.Context, caseID string) ([]byte, error) {
+			return []byte(`{"state":"work_in_progress"}`), nil
+		},
+	}
+	sftpgoMock := &mockSftpgoClient{baseURL: "https://sftpgo.example.com"}
+	h := NewAttachmentStorageHandler(entity, sftpgoMock)
+
+	caseID := "11111111-1111-1111-1111-111111111111"
+	req := withUser(httptest.NewRequest(http.MethodPost, "/cases/"+caseID+"/attachments/upload-token", nil))
+	req.SetPathValue("id", caseID)
+	req.Header.Set("x-jwt-assertion", "the-raw-jwt-assertion")
+	w := httptest.NewRecorder()
+
+	h.MintUploadToken(w, req)
+
+	assertStatus(t, w, http.StatusOK)
+	if len(sftpgoMock.mintTokenCalls) != 1 || sftpgoMock.mintTokenCalls[0] != "the-raw-jwt-assertion" {
+		t.Fatalf("mintTokenCalls = %v, want exactly one call with the raw x-jwt-assertion value", sftpgoMock.mintTokenCalls)
+	}
+
+	resp := decodeJSON[uploadTokenResponse](t, w)
+	if resp.SftpgoAccessToken != "mock-access-token" {
+		t.Errorf("SftpgoAccessToken = %q, want mock-access-token", resp.SftpgoAccessToken)
+	}
+	if resp.SftpgoBaseURL != "https://sftpgo.example.com" {
+		t.Errorf("SftpgoBaseURL = %q, want https://sftpgo.example.com", resp.SftpgoBaseURL)
+	}
+}
+
+func TestMintUploadTokenPropagatesSftpgoFailure(t *testing.T) {
+	t.Parallel()
+	entity := &mockEntityCaseClient{
+		getCaseFn: func(ctx context.Context, caseID string) ([]byte, error) {
+			return []byte(`{"state":"work_in_progress"}`), nil
+		},
+	}
+	sftpgoMock := &mockSftpgoClient{
+		mintTokenFn: func(ctx context.Context, email, jwtAssertion string) (*sftpgo.Token, error) {
+			return nil, &apierror.Error{StatusCode: http.StatusUnauthorized, Body: "denied"}
+		},
+	}
+	h := NewAttachmentStorageHandler(entity, sftpgoMock)
+
+	caseID := "11111111-1111-1111-1111-111111111111"
+	req := withUser(httptest.NewRequest(http.MethodPost, "/cases/"+caseID+"/attachments/upload-token", nil))
+	req.SetPathValue("id", caseID)
+	req.Header.Set("x-jwt-assertion", "raw-jwt")
+	w := httptest.NewRecorder()
+
+	h.MintUploadToken(w, req)
+
+	assertStatus(t, w, http.StatusBadGateway)
+}
+
+// ----- CreateAttachmentShare -----
+
+func TestCreateAttachmentShareRequiresAuth(t *testing.T) {
+	t.Parallel()
+	h := NewAttachmentStorageHandler(&mockEntityCaseClient{}, &mockSftpgoClient{})
+
+	req := httptest.NewRequest(http.MethodPost, "/attachments/11111111-1111-1111-1111-111111111111/share", nil)
+	req.SetPathValue("id", "11111111-1111-1111-1111-111111111111")
+	w := httptest.NewRecorder()
+
+	h.CreateAttachmentShare(w, req)
+
+	assertStatus(t, w, http.StatusUnauthorized)
+}
+
+func TestCreateAttachmentShareRejectsInvalidAttachmentID(t *testing.T) {
+	t.Parallel()
+	h := NewAttachmentStorageHandler(&mockEntityCaseClient{}, &mockSftpgoClient{})
+
+	req := withUser(httptest.NewRequest(http.MethodPost, "/attachments/not-a-uuid/share", nil))
+	req.SetPathValue("id", "not-a-uuid")
+	w := httptest.NewRecorder()
+
+	h.CreateAttachmentShare(w, req)
+
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+// TestCreateAttachmentShareEnforcesReadAccessBeforeMinting verifies the case
+// read-access check runs, and fails, BEFORE any SFTPGo call is made.
+func TestCreateAttachmentShareEnforcesReadAccessBeforeMinting(t *testing.T) {
+	t.Parallel()
+	storageKey := "/attachments/att-1"
+	caseID := "22222222-2222-2222-2222-222222222222"
+	entity := &mockEntityCaseClient{
+		getCaseAttachmentFn: func(ctx context.Context, attachmentID string) ([]byte, error) {
+			return []byte(`{"referenceId":"` + caseID + `","referenceType":"case","storageKey":"` + storageKey + `"}`), nil
+		},
+		getCaseFn: func(ctx context.Context, id string) ([]byte, error) {
+			return nil, &apierror.Error{StatusCode: http.StatusNotFound, Body: "not found"}
+		},
+	}
+	sftpgoMock := &mockSftpgoClient{}
+	h := NewAttachmentStorageHandler(entity, sftpgoMock)
+
+	attachmentID := "11111111-1111-1111-1111-111111111111"
+	req := withUser(httptest.NewRequest(http.MethodPost, "/attachments/"+attachmentID+"/share", nil))
+	req.SetPathValue("id", attachmentID)
+	req.Header.Set("x-jwt-assertion", "raw-jwt")
+	w := httptest.NewRecorder()
+
+	h.CreateAttachmentShare(w, req)
+
+	assertStatus(t, w, http.StatusNotFound)
+	if len(sftpgoMock.mintTokenCalls) != 0 || len(sftpgoMock.createShareCalls) != 0 {
+		t.Errorf("sftpgo was called (mint=%d, share=%d); want 0 — access must be checked before minting/sharing",
+			len(sftpgoMock.mintTokenCalls), len(sftpgoMock.createShareCalls))
+	}
+}
+
+// TestCreateAttachmentShareRejectsMissingStorageKey verifies an attachment
+// with no storageKey (e.g. stored the old, non-SFTPGo way) fails cleanly
+// rather than attempting to share an empty path.
+func TestCreateAttachmentShareRejectsMissingStorageKey(t *testing.T) {
+	t.Parallel()
+	caseID := "22222222-2222-2222-2222-222222222222"
+	entity := &mockEntityCaseClient{
+		getCaseAttachmentFn: func(ctx context.Context, attachmentID string) ([]byte, error) {
+			return []byte(`{"referenceId":"` + caseID + `","referenceType":"case"}`), nil
+		},
+		getCaseFn: func(ctx context.Context, id string) ([]byte, error) {
+			return []byte(`{"state":"work_in_progress"}`), nil
+		},
+	}
+	sftpgoMock := &mockSftpgoClient{}
+	h := NewAttachmentStorageHandler(entity, sftpgoMock)
+
+	attachmentID := "11111111-1111-1111-1111-111111111111"
+	req := withUser(httptest.NewRequest(http.MethodPost, "/attachments/"+attachmentID+"/share", nil))
+	req.SetPathValue("id", attachmentID)
+	req.Header.Set("x-jwt-assertion", "raw-jwt")
+	w := httptest.NewRecorder()
+
+	h.CreateAttachmentShare(w, req)
+
+	assertStatus(t, w, http.StatusConflict)
+	assertErrorMessage(t, w, ErrMsgAttachmentNotShareable)
+	if len(sftpgoMock.mintTokenCalls) != 0 {
+		t.Errorf("MintToken was called %d times; want 0", len(sftpgoMock.mintTokenCalls))
+	}
+}
+
+// TestCreateAttachmentShareSuccess verifies the happy path: the storage key
+// is forwarded to CreateShare verbatim, and the response carries the URL
+// built from PublicShareURL(shareID) — never a hand-rolled URL.
+func TestCreateAttachmentShareSuccess(t *testing.T) {
+	t.Parallel()
+	caseID := "22222222-2222-2222-2222-222222222222"
+	storageKey := "/attachments/att-1"
+	entity := &mockEntityCaseClient{
+		getCaseAttachmentFn: func(ctx context.Context, attachmentID string) ([]byte, error) {
+			return []byte(`{"referenceId":"` + caseID + `","referenceType":"case","storageKey":"` + storageKey + `"}`), nil
+		},
+		getCaseFn: func(ctx context.Context, id string) ([]byte, error) {
+			return []byte(`{"state":"closed"}`), nil // reads are allowed even on a closed case
+		},
+	}
+	sftpgoMock := &mockSftpgoClient{
+		createShareFn: func(ctx context.Context, accessToken, gotStorageKey string, ttl time.Duration) (string, error) {
+			if ttl != shareTTL {
+				t.Errorf("ttl = %v, want %v", ttl, shareTTL)
+			}
+			return "share-xyz", nil
+		},
+	}
+	h := NewAttachmentStorageHandler(entity, sftpgoMock)
+
+	attachmentID := "11111111-1111-1111-1111-111111111111"
+	req := withUser(httptest.NewRequest(http.MethodPost, "/attachments/"+attachmentID+"/share", nil))
+	req.SetPathValue("id", attachmentID)
+	req.Header.Set("x-jwt-assertion", "raw-jwt")
+	w := httptest.NewRecorder()
+
+	h.CreateAttachmentShare(w, req)
+
+	assertStatus(t, w, http.StatusCreated)
+	if len(sftpgoMock.createShareCalls) != 1 || sftpgoMock.createShareCalls[0] != storageKey {
+		t.Fatalf("createShareCalls = %v, want exactly [%q]", sftpgoMock.createShareCalls, storageKey)
+	}
+
+	resp := decodeJSON[shareResponse](t, w)
+	want := sftpgoMock.PublicShareURL("share-xyz")
+	if resp.ShareURL != want {
+		t.Errorf("ShareURL = %q, want %q", resp.ShareURL, want)
+	}
+}
+
+func TestCreateAttachmentSharePropagatesSftpgoFailure(t *testing.T) {
+	t.Parallel()
+	caseID := "22222222-2222-2222-2222-222222222222"
+	storageKey := "/attachments/att-1"
+	entity := &mockEntityCaseClient{
+		getCaseAttachmentFn: func(ctx context.Context, attachmentID string) ([]byte, error) {
+			return []byte(`{"referenceId":"` + caseID + `","referenceType":"case","storageKey":"` + storageKey + `"}`), nil
+		},
+		getCaseFn: func(ctx context.Context, id string) ([]byte, error) {
+			return []byte(`{"state":"work_in_progress"}`), nil
+		},
+	}
+	sftpgoMock := &mockSftpgoClient{
+		createShareFn: func(ctx context.Context, accessToken, gotStorageKey string, ttl time.Duration) (string, error) {
+			return "", &apierror.Error{StatusCode: http.StatusInternalServerError, Body: "boom"}
+		},
+	}
+	h := NewAttachmentStorageHandler(entity, sftpgoMock)
+
+	attachmentID := "11111111-1111-1111-1111-111111111111"
+	req := withUser(httptest.NewRequest(http.MethodPost, "/attachments/"+attachmentID+"/share", nil))
+	req.SetPathValue("id", attachmentID)
+	req.Header.Set("x-jwt-assertion", "raw-jwt")
+	w := httptest.NewRecorder()
+
+	h.CreateAttachmentShare(w, req)
+
+	assertStatus(t, w, http.StatusBadGateway)
+}

--- a/apps/csm-portal/backend/internal/handler/cases.go
+++ b/apps/csm-portal/backend/internal/handler/cases.go
@@ -85,6 +85,9 @@ type entityCaseClient interface {
 	SearchCaseAttachments(ctx context.Context, body []byte) ([]byte, error)
 	GetCaseAttachmentContent(ctx context.Context, attachmentID string) ([]byte, string, error)
 	DeleteCaseAttachment(ctx context.Context, attachmentID string) ([]byte, error)
+	// GetCaseAttachment resolves a single attachment's metadata — used by the
+	// SFTPGo-backed share-creation path; see AttachmentStorageHandler.
+	GetCaseAttachment(ctx context.Context, attachmentID string) ([]byte, error)
 	CreateCallRequest(ctx context.Context, body []byte) ([]byte, error)
 	SearchCallRequests(ctx context.Context, body []byte) ([]byte, error)
 	SearchAllCallRequests(ctx context.Context, body []byte) ([]byte, error)

--- a/apps/csm-portal/backend/internal/handler/helpers_test.go
+++ b/apps/csm-portal/backend/internal/handler/helpers_test.go
@@ -106,6 +106,7 @@ type mockEntityCaseClient struct {
 	searchCaseAttachmentsFn    func(ctx context.Context, body []byte) ([]byte, error)
 	getCaseAttachmentContentFn func(ctx context.Context, attachmentID string) ([]byte, string, error)
 	deleteCaseAttachmentFn     func(ctx context.Context, attachmentID string) ([]byte, error)
+	getCaseAttachmentFn        func(ctx context.Context, attachmentID string) ([]byte, error)
 	createCallRequestFn        func(ctx context.Context, body []byte) ([]byte, error)
 	searchCallRequestsFn       func(ctx context.Context, body []byte) ([]byte, error)
 	searchAllCallRequestsFn    func(ctx context.Context, body []byte) ([]byte, error)
@@ -202,6 +203,13 @@ func (m *mockEntityCaseClient) DeleteCaseAttachment(ctx context.Context, attachm
 		return m.deleteCaseAttachmentFn(ctx, attachmentID)
 	}
 	return []byte(`{"message":"Attachment deleted successfully."}`), nil
+}
+
+func (m *mockEntityCaseClient) GetCaseAttachment(ctx context.Context, attachmentID string) ([]byte, error) {
+	if m.getCaseAttachmentFn != nil {
+		return m.getCaseAttachmentFn(ctx, attachmentID)
+	}
+	return []byte(`{}`), nil
 }
 
 func (m *mockEntityCaseClient) CreateCallRequest(ctx context.Context, body []byte) ([]byte, error) {

--- a/apps/csm-portal/backend/internal/handler/reference_test.go
+++ b/apps/csm-portal/backend/internal/handler/reference_test.go
@@ -150,7 +150,7 @@ func TestUsersHandler_GetUser(t *testing.T) {
 	const testUserID = "11111111-1111-1111-1111-111111111111"
 
 	t.Run("rejects an unauthenticated caller", func(t *testing.T) {
-		h := NewUsersHandler(&mockSCIMClient{}, &mockEntityUserClient{}, testDirectory(t))
+		h := NewUsersHandler(&mockSCIMClient{}, &mockEntityUserClient{}, testDirectory(t), false)
 		w := httptest.NewRecorder()
 		h.GetUser(w, httptest.NewRequest(http.MethodGet, "/users/abc", nil))
 		assertStatus(t, w, http.StatusUnauthorized)
@@ -163,7 +163,7 @@ func TestUsersHandler_GetUser(t *testing.T) {
 				gotID = id
 				return []byte(`{"id":"` + id + `","userType":"internal","groups":[],"teams":[]}`), nil
 			},
-		}, testDirectory(t))
+		}, testDirectory(t), false)
 		r := withUser(httptest.NewRequest(http.MethodGet, "/users/"+testUserID, nil))
 		r.SetPathValue("id", testUserID)
 		w := httptest.NewRecorder()
@@ -176,7 +176,7 @@ func TestUsersHandler_GetUser(t *testing.T) {
 	})
 
 	t.Run("rejects a missing id", func(t *testing.T) {
-		h := NewUsersHandler(&mockSCIMClient{}, &mockEntityUserClient{}, testDirectory(t))
+		h := NewUsersHandler(&mockSCIMClient{}, &mockEntityUserClient{}, testDirectory(t), false)
 		w := httptest.NewRecorder()
 		h.GetUser(w, withUser(httptest.NewRequest(http.MethodGet, "/users/", nil)))
 		assertStatus(t, w, http.StatusBadRequest)
@@ -192,7 +192,7 @@ func TestUsersHandler_GetUser(t *testing.T) {
 				called = true
 				return []byte(`{}`), nil
 			},
-		}, testDirectory(t))
+		}, testDirectory(t), false)
 		r := withUser(httptest.NewRequest(http.MethodGet, "/users/not-a-uuid", nil))
 		r.SetPathValue("id", "not-a-uuid")
 		w := httptest.NewRecorder()
@@ -210,7 +210,7 @@ func TestUsersHandler_GetUser(t *testing.T) {
 			getUserFn: func(_ context.Context, _ string) ([]byte, error) {
 				return nil, errors.New("not found")
 			},
-		}, testDirectory(t))
+		}, testDirectory(t), false)
 		r := withUser(httptest.NewRequest(http.MethodGet, "/users/"+testUserID, nil))
 		r.SetPathValue("id", testUserID)
 		w := httptest.NewRecorder()

--- a/apps/csm-portal/backend/internal/handler/response.go
+++ b/apps/csm-portal/backend/internal/handler/response.go
@@ -39,6 +39,7 @@ const (
 	ErrMsgCommentNotOwnCase      = "Only the assigned engineer can add a public comment on this case."
 	ErrMsgWorkNoteOnClosedCase   = "Work notes cannot be added to a closed case."
 	ErrMsgAttachmentOnClosedCase = "Attachments cannot be added to a closed case."
+	ErrMsgAttachmentNotShareable = "This attachment is not available for direct download."
 	ErrMsgInvalidUUID            = "Invalid UUID format."
 	errMsgReadBody               = "Failed to read request body."
 )

--- a/apps/csm-portal/backend/internal/handler/user_external_account_test.go
+++ b/apps/csm-portal/backend/internal/handler/user_external_account_test.go
@@ -41,7 +41,7 @@ func TestGetUser_ExternalAccountStatus_AppendedForExternalContacts(t *testing.T)
 		getUserFn: func(_ context.Context, _ string) ([]byte, error) {
 			return []byte(`{"id":"` + id + `","email":"contact@example.com","userType":"external"}`), nil
 		},
-	}, testDirectory(t))
+	}, testDirectory(t), false)
 
 	r := withUser(httptest.NewRequest(http.MethodGet, "/users/"+id, nil))
 	r.SetPathValue("id", id)
@@ -81,7 +81,7 @@ func TestGetUser_ExternalAccountStatus_SkippedForInternalStaff(t *testing.T) {
 		getUserFn: func(_ context.Context, _ string) ([]byte, error) {
 			return []byte(`{"id":"` + id + `","email":"staff@example.com","userType":"internal"}`), nil
 		},
-	}, testDirectory(t))
+	}, testDirectory(t), false)
 
 	r := withUser(httptest.NewRequest(http.MethodGet, "/users/"+id, nil))
 	r.SetPathValue("id", id)
@@ -114,7 +114,7 @@ func TestGetUser_ExternalAccountStatus_SkippedForWso2Email(t *testing.T) {
 		getUserFn: func(_ context.Context, _ string) ([]byte, error) {
 			return []byte(`{"id":"` + id + `","email":"tester@wso2.com","userType":"external"}`), nil
 		},
-	}, testDirectory(t))
+	}, testDirectory(t), false)
 
 	r := withUser(httptest.NewRequest(http.MethodGet, "/users/"+id, nil))
 	r.SetPathValue("id", id)
@@ -144,7 +144,7 @@ func TestGetUser_ExternalAccountStatus_FailureDoesNotFailTheRequest(t *testing.T
 		getUserFn: func(_ context.Context, _ string) ([]byte, error) {
 			return []byte(`{"id":"` + id + `","email":"contact@example.com","userType":"external"}`), nil
 		},
-	}, testDirectory(t))
+	}, testDirectory(t), false)
 
 	r := withUser(httptest.NewRequest(http.MethodGet, "/users/"+id, nil))
 	r.SetPathValue("id", id)

--- a/apps/csm-portal/backend/internal/handler/user_teams_test.go
+++ b/apps/csm-portal/backend/internal/handler/user_teams_test.go
@@ -36,7 +36,7 @@ func capturedSearch(t *testing.T, body string) (string, *httptest.ResponseRecord
 			captured = string(b)
 			return []byte(`{"users":[],"total":0,"limit":10,"offset":0}`), nil
 		},
-	}, testDirectory(t))
+	}, testDirectory(t), false)
 	w := httptest.NewRecorder()
 	h.SearchUsers(w, withUser(httptest.NewRequest(http.MethodPost, "/users/search", strings.NewReader(body))))
 	return captured, w
@@ -127,7 +127,7 @@ func TestSearchUsers_UnknownTeamUUIDIsRejectedWithoutCallingUpstream(t *testing.
 			called = true
 			return []byte(`{}`), nil
 		},
-	}, testDirectory(t))
+	}, testDirectory(t), false)
 	w := httptest.NewRecorder()
 	h.SearchUsers(w, withUser(httptest.NewRequest(http.MethodPost, "/users/search",
 		strings.NewReader(`{"filters":{"teamIds":["ffffffff-ffff-ffff-ffff-ffffffffffff"]}}`))))
@@ -148,7 +148,7 @@ func TestSearchUsers_UnknownTeamKeyIsRejectedWithoutCallingUpstream(t *testing.T
 			called = true
 			return []byte(`{}`), nil
 		},
-	}, testDirectory(t))
+	}, testDirectory(t), false)
 	w := httptest.NewRecorder()
 	h.SearchUsers(w, withUser(httptest.NewRequest(http.MethodPost, "/users/search",
 		strings.NewReader(`{"filters":{"teamIds":["no-such-team"]}}`))))
@@ -168,7 +168,7 @@ func TestSearchUsers_RejectsARoleOutsideTheAllowList(t *testing.T) {
 			called = true
 			return []byte(`{"users":[],"total":0}`), nil
 		},
-	}, testDirectory(t))
+	}, testDirectory(t), false)
 
 	w := httptest.NewRecorder()
 	h.SearchUsers(w, withUser(httptest.NewRequest(http.MethodPost, "/users/search",
@@ -209,7 +209,7 @@ func TestSearchUsers_TeamResolutionMakesNoEntityCalls(t *testing.T) {
 			calls++
 			return []byte(`{"users":[],"total":0}`), nil
 		},
-	}, testDirectory(t))
+	}, testDirectory(t), false)
 
 	const iterations = 20
 	for i := 0; i < iterations; i++ {
@@ -232,7 +232,7 @@ func TestGetUser_DerivesTeamsFromGroups(t *testing.T) {
 			return []byte(`{"id":"` + id + `","email":"staff@example.com","lockedOut":true,"groups":[` +
 				`{"id":"g-1","name":"ABT One"},{"id":"g-2","name":"Some Other Group"}]}`), nil
 		},
-	}, testDirectory(t))
+	}, testDirectory(t), false)
 
 	r := withUser(httptest.NewRequest(http.MethodGet, "/users/"+id, nil))
 	r.SetPathValue("id", id)
@@ -280,7 +280,7 @@ func TestGetUser_EmptyTeamsWhenNoneMatch(t *testing.T) {
 		getUserFn: func(_ context.Context, _ string) ([]byte, error) {
 			return []byte(`{"id":"` + id + `","groups":[{"id":"g-2","name":"Some Other Group"}]}`), nil
 		},
-	}, testDirectory(t))
+	}, testDirectory(t), false)
 
 	r := withUser(httptest.NewRequest(http.MethodGet, "/users/"+id, nil))
 	r.SetPathValue("id", id)

--- a/apps/csm-portal/backend/internal/handler/users.go
+++ b/apps/csm-portal/backend/internal/handler/users.go
@@ -55,12 +55,20 @@ type UsersHandler struct {
 	// registry, so it can only answer membership questions when this layer
 	// hands it the group names to ask about.
 	dir *directory.Directory
+	// sftpgoAttachmentStorageEnabled mirrors SFTPGO_ATTACHMENT_STORAGE_ENABLED
+	// (see cmd/server/main.go), surfaced on GET /users/me so the frontend can
+	// tell whether AttachmentStorageHandler's routes are reachable without
+	// probing them.
+	sftpgoAttachmentStorageEnabled bool
 }
 
 // NewUsersHandler creates a UsersHandler backed by the given SCIM and entity
-// clients and the startup-resolved directory.
-func NewUsersHandler(scim scimClient, entity entityUserClient, dir *directory.Directory) *UsersHandler {
-	return &UsersHandler{scim: scim, entity: entity, dir: dir}
+// clients and the startup-resolved directory. sftpgoAttachmentStorageEnabled
+// mirrors the same runtime flag value main.go uses to decide whether to
+// register AttachmentStorageHandler's routes (SFTPGO_ATTACHMENT_STORAGE_ENABLED),
+// so GET /users/me can tell the frontend whether those routes are reachable.
+func NewUsersHandler(scim scimClient, entity entityUserClient, dir *directory.Directory, sftpgoAttachmentStorageEnabled bool) *UsersHandler {
+	return &UsersHandler{scim: scim, entity: entity, dir: dir, sftpgoAttachmentStorageEnabled: sftpgoAttachmentStorageEnabled}
 }
 
 // userMeResponse is the GET /users/me response shape.
@@ -73,6 +81,12 @@ type userMeResponse struct {
 	Roles       []string          `json:"roles,omitempty"`
 	PhoneNumber *string           `json:"phoneNumber,omitempty"`
 	Team        *userTeamResponse `json:"team,omitempty"`
+	// SftpgoAttachmentStorageEnabled mirrors the backend's
+	// SFTPGO_ATTACHMENT_STORAGE_ENABLED runtime flag. Always present (never
+	// omitted) so the frontend can distinguish "flag is off" from "field not
+	// yet known to this backend version" only by absence on an old backend —
+	// a new field an existing caller ignores, so this is backward compatible.
+	SftpgoAttachmentStorageEnabled bool `json:"sftpgoAttachmentStorageEnabled"`
 }
 
 // userTeamResponse is the caller's resolved ABT (Account-Based Team). Nil when
@@ -132,7 +146,10 @@ func (h *UsersHandler) GetMe(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp := userMeResponse{Email: user.Email}
+	resp := userMeResponse{
+		Email:                          user.Email,
+		SftpgoAttachmentStorageEnabled: h.sftpgoAttachmentStorageEnabled,
+	}
 
 	entityRaw, err := h.entity.GetUserMe(r.Context())
 	if err != nil {

--- a/apps/csm-portal/backend/internal/handler/users_test.go
+++ b/apps/csm-portal/backend/internal/handler/users_test.go
@@ -19,6 +19,7 @@ package handler
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -31,7 +32,7 @@ import (
 
 func TestGetMe(t *testing.T) {
 	t.Run("requires authenticated user", func(t *testing.T) {
-		h := NewUsersHandler(&mockSCIMClient{}, &mockEntityUserClient{}, testDirectory(t))
+		h := NewUsersHandler(&mockSCIMClient{}, &mockEntityUserClient{}, testDirectory(t), false)
 		r := httptest.NewRequest(http.MethodGet, "/users/me", nil)
 		w := httptest.NewRecorder()
 		h.GetMe(w, r)
@@ -47,7 +48,7 @@ func TestGetMe(t *testing.T) {
 				return nil, errors.New("scim unavailable")
 			},
 		}
-		h := NewUsersHandler(scimClient, &mockEntityUserClient{}, testDirectory(t))
+		h := NewUsersHandler(scimClient, &mockEntityUserClient{}, testDirectory(t), false)
 		r := withUser(httptest.NewRequest(http.MethodGet, "/users/me", nil))
 		w := httptest.NewRecorder()
 		h.GetMe(w, r)
@@ -72,7 +73,7 @@ func TestGetMe(t *testing.T) {
 						return nil, tc.err
 					},
 				}
-				h := NewUsersHandler(&mockSCIMClient{}, entityClient, testDirectory(t))
+				h := NewUsersHandler(&mockSCIMClient{}, entityClient, testDirectory(t), false)
 				r := withUser(httptest.NewRequest(http.MethodGet, "/users/me", nil))
 				w := httptest.NewRecorder()
 				h.GetMe(w, r)
@@ -89,7 +90,7 @@ func TestGetMe(t *testing.T) {
 				return nil, nil // user not found in SCIM
 			},
 		}
-		h := NewUsersHandler(scimClient, &mockEntityUserClient{}, testDirectory(t))
+		h := NewUsersHandler(scimClient, &mockEntityUserClient{}, testDirectory(t), false)
 		r := withUser(httptest.NewRequest(http.MethodGet, "/users/me", nil))
 		w := httptest.NewRecorder()
 		h.GetMe(w, r)
@@ -111,7 +112,7 @@ func TestGetMe(t *testing.T) {
 			},
 		}
 		_ = entityCalls
-		h := NewUsersHandler(&mockSCIMClient{}, entityClient, testDirectory(t))
+		h := NewUsersHandler(&mockSCIMClient{}, entityClient, testDirectory(t), false)
 		r := withUser(httptest.NewRequest(http.MethodGet, "/users/me", nil))
 		w := httptest.NewRecorder()
 		h.GetMe(w, r)
@@ -145,7 +146,7 @@ func TestGetMe(t *testing.T) {
 					`"groups":[{"id":"g-2","name":"ABT Two"}]}`), nil
 			},
 		}
-		h := NewUsersHandler(&mockSCIMClient{}, entityClient, testDirectory(t))
+		h := NewUsersHandler(&mockSCIMClient{}, entityClient, testDirectory(t), false)
 		r := withUser(httptest.NewRequest(http.MethodGet, "/users/me", nil))
 		w := httptest.NewRecorder()
 		h.GetMe(w, r)
@@ -174,7 +175,7 @@ func TestGetMe(t *testing.T) {
 					`"groups":[{"id":"g-9","name":"Some Other Group"}]}`), nil
 			},
 		}
-		h := NewUsersHandler(&mockSCIMClient{}, entityClient, testDirectory(t))
+		h := NewUsersHandler(&mockSCIMClient{}, entityClient, testDirectory(t), false)
 		r := withUser(httptest.NewRequest(http.MethodGet, "/users/me", nil))
 		w := httptest.NewRecorder()
 		h.GetMe(w, r)
@@ -197,7 +198,7 @@ func TestGetMe(t *testing.T) {
 				}, nil
 			},
 		}
-		h := NewUsersHandler(scimClient, &mockEntityUserClient{}, testDirectory(t))
+		h := NewUsersHandler(scimClient, &mockEntityUserClient{}, testDirectory(t), false)
 		r := withUser(httptest.NewRequest(http.MethodGet, "/users/me", nil))
 		w := httptest.NewRecorder()
 		h.GetMe(w, r)
@@ -221,11 +222,35 @@ func TestGetMe(t *testing.T) {
 	})
 }
 
+// TestGetMeSftpgoAttachmentStorageEnabled verifies GET /users/me reports the
+// backend's SFTPGO_ATTACHMENT_STORAGE_ENABLED runtime flag value exactly,
+// both on and off, so the frontend can tell whether
+// AttachmentStorageHandler's routes are reachable without probing them.
+func TestGetMeSftpgoAttachmentStorageEnabled(t *testing.T) {
+	for _, enabled := range []bool{true, false} {
+		t.Run(fmt.Sprintf("flag=%v", enabled), func(t *testing.T) {
+			h := NewUsersHandler(&mockSCIMClient{}, &mockEntityUserClient{}, testDirectory(t), enabled)
+			r := withUser(httptest.NewRequest(http.MethodGet, "/users/me", nil))
+			w := httptest.NewRecorder()
+			h.GetMe(w, r)
+
+			assertStatus(t, w, http.StatusOK)
+			type getMeResp struct {
+				SftpgoAttachmentStorageEnabled bool `json:"sftpgoAttachmentStorageEnabled"`
+			}
+			resp := decodeJSON[getMeResp](t, w)
+			if resp.SftpgoAttachmentStorageEnabled != enabled {
+				t.Errorf("sftpgoAttachmentStorageEnabled = %v, want %v", resp.SftpgoAttachmentStorageEnabled, enabled)
+			}
+		})
+	}
+}
+
 // ----- PatchMe -----
 
 func TestPatchMe(t *testing.T) {
 	t.Run("requires authenticated user", func(t *testing.T) {
-		h := NewUsersHandler(&mockSCIMClient{}, &mockEntityUserClient{}, testDirectory(t))
+		h := NewUsersHandler(&mockSCIMClient{}, &mockEntityUserClient{}, testDirectory(t), false)
 		r := httptest.NewRequest(http.MethodPatch, "/users/me", strings.NewReader(`{"phoneNumber":"+1"}`))
 		w := httptest.NewRecorder()
 		h.PatchMe(w, r)
@@ -235,7 +260,7 @@ func TestPatchMe(t *testing.T) {
 	})
 
 	t.Run("rejects body exceeding 1 MiB", func(t *testing.T) {
-		h := NewUsersHandler(&mockSCIMClient{}, &mockEntityUserClient{}, testDirectory(t))
+		h := NewUsersHandler(&mockSCIMClient{}, &mockEntityUserClient{}, testDirectory(t), false)
 		r := withUser(httptest.NewRequest(http.MethodPatch, "/users/me", strings.NewReader(strings.Repeat("x", maxRequestBodyBytes+1))))
 		w := httptest.NewRecorder()
 		h.PatchMe(w, r)
@@ -244,7 +269,7 @@ func TestPatchMe(t *testing.T) {
 	})
 
 	t.Run("rejects empty body", func(t *testing.T) {
-		h := NewUsersHandler(&mockSCIMClient{}, &mockEntityUserClient{}, testDirectory(t))
+		h := NewUsersHandler(&mockSCIMClient{}, &mockEntityUserClient{}, testDirectory(t), false)
 		r := withUser(httptest.NewRequest(http.MethodPatch, "/users/me", strings.NewReader("")))
 		w := httptest.NewRecorder()
 		h.PatchMe(w, r)
@@ -253,7 +278,7 @@ func TestPatchMe(t *testing.T) {
 	})
 
 	t.Run("rejects invalid JSON", func(t *testing.T) {
-		h := NewUsersHandler(&mockSCIMClient{}, &mockEntityUserClient{}, testDirectory(t))
+		h := NewUsersHandler(&mockSCIMClient{}, &mockEntityUserClient{}, testDirectory(t), false)
 		r := withUser(httptest.NewRequest(http.MethodPatch, "/users/me", strings.NewReader(`not-json`)))
 		w := httptest.NewRecorder()
 		h.PatchMe(w, r)
@@ -262,7 +287,7 @@ func TestPatchMe(t *testing.T) {
 	})
 
 	t.Run("rejects JSON with no updateable fields", func(t *testing.T) {
-		h := NewUsersHandler(&mockSCIMClient{}, &mockEntityUserClient{}, testDirectory(t))
+		h := NewUsersHandler(&mockSCIMClient{}, &mockEntityUserClient{}, testDirectory(t), false)
 		r := withUser(httptest.NewRequest(http.MethodPatch, "/users/me", strings.NewReader(`{}`)))
 		w := httptest.NewRecorder()
 		h.PatchMe(w, r)
@@ -280,7 +305,7 @@ func TestPatchMe(t *testing.T) {
 				return &updated, nil
 			},
 		}
-		h := NewUsersHandler(scimClient, &mockEntityUserClient{}, testDirectory(t))
+		h := NewUsersHandler(scimClient, &mockEntityUserClient{}, testDirectory(t), false)
 		r := withUser(httptest.NewRequest(http.MethodPatch, "/users/me", strings.NewReader(`{"phoneNumber":"+94777654321"}`)))
 		w := httptest.NewRecorder()
 		h.PatchMe(w, r)
@@ -311,7 +336,7 @@ func TestPatchMe(t *testing.T) {
 						return nil, tc.err
 					},
 				}
-				h := NewUsersHandler(scimClient, &mockEntityUserClient{}, testDirectory(t))
+				h := NewUsersHandler(scimClient, &mockEntityUserClient{}, testDirectory(t), false)
 				r := withUser(httptest.NewRequest(http.MethodPatch, "/users/me", strings.NewReader(`{"phoneNumber":"+1"}`)))
 				w := httptest.NewRecorder()
 				h.PatchMe(w, r)
@@ -327,7 +352,7 @@ func TestPatchMe(t *testing.T) {
 
 func TestSearchUsers(t *testing.T) {
 	t.Run("requires authenticated user", func(t *testing.T) {
-		h := NewUsersHandler(&mockSCIMClient{}, &mockEntityUserClient{}, testDirectory(t))
+		h := NewUsersHandler(&mockSCIMClient{}, &mockEntityUserClient{}, testDirectory(t), false)
 		r := httptest.NewRequest(http.MethodPost, "/users/search", strings.NewReader(`{}`))
 		w := httptest.NewRecorder()
 		h.SearchUsers(w, r)
@@ -337,7 +362,7 @@ func TestSearchUsers(t *testing.T) {
 	})
 
 	t.Run("rejects body exceeding 1 MiB", func(t *testing.T) {
-		h := NewUsersHandler(&mockSCIMClient{}, &mockEntityUserClient{}, testDirectory(t))
+		h := NewUsersHandler(&mockSCIMClient{}, &mockEntityUserClient{}, testDirectory(t), false)
 		r := withUser(httptest.NewRequest(http.MethodPost, "/users/search", strings.NewReader(strings.Repeat("x", maxRequestBodyBytes+1))))
 		w := httptest.NewRecorder()
 		h.SearchUsers(w, r)
@@ -346,7 +371,7 @@ func TestSearchUsers(t *testing.T) {
 	})
 
 	t.Run("rejects invalid JSON body", func(t *testing.T) {
-		h := NewUsersHandler(&mockSCIMClient{}, &mockEntityUserClient{}, testDirectory(t))
+		h := NewUsersHandler(&mockSCIMClient{}, &mockEntityUserClient{}, testDirectory(t), false)
 		r := withUser(httptest.NewRequest(http.MethodPost, "/users/search", strings.NewReader(`not-json`)))
 		w := httptest.NewRecorder()
 		h.SearchUsers(w, r)
@@ -363,7 +388,7 @@ func TestSearchUsers(t *testing.T) {
 				return []byte(`{"users":[{"id":"u-1"}],"total":1}`), nil
 			},
 		}
-		h := NewUsersHandler(&mockSCIMClient{}, entityClient, testDirectory(t))
+		h := NewUsersHandler(&mockSCIMClient{}, entityClient, testDirectory(t), false)
 		r := withUser(httptest.NewRequest(http.MethodPost, "/users/search", strings.NewReader(reqPayload)))
 		w := httptest.NewRecorder()
 		h.SearchUsers(w, r)
@@ -388,7 +413,7 @@ func TestSearchUsers(t *testing.T) {
 						return nil, tc.err
 					},
 				}
-				h := NewUsersHandler(&mockSCIMClient{}, entityClient, testDirectory(t))
+				h := NewUsersHandler(&mockSCIMClient{}, entityClient, testDirectory(t), false)
 				r := withUser(httptest.NewRequest(http.MethodPost, "/users/search", strings.NewReader(`{}`)))
 				w := httptest.NewRecorder()
 				h.SearchUsers(w, r)

--- a/apps/csm-portal/backend/internal/sftpgo/client.go
+++ b/apps/csm-portal/backend/internal/sftpgo/client.go
@@ -1,0 +1,236 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package sftpgo is an HTTP client for the small subset of SFTPGo's REST API
+// this backend calls when the SFTPGo-backed attachment-storage feature flag
+// (SFTPGO_ATTACHMENT_STORAGE_ENABLED) is on: minting a short-lived per-user
+// access token, and creating a short-lived public download share. This
+// package never touches attachment bytes: uploads and downloads always go
+// directly between the browser and SFTPGo using the credentials it mints
+// here — see internal/handler.AttachmentStorageHandler for the call sites.
+package sftpgo
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/wso2-open-operations/cs-tools/apps/csm-portal/backend/internal/apierror"
+)
+
+// maxErrBodyBytes bounds how much of a non-2xx response body is retained on
+// an *apierror.Error, mirroring internal/entity's CustomerEntityClient.
+const maxErrBodyBytes = 256
+
+// Config holds the configuration for a SFTPGo Client.
+type Config struct {
+	// BaseURL is SFTPGo's REST API base (used for both the token-mint and
+	// share-creation calls below), and is also the host the FE is told to
+	// call directly for the chunked/TUS upload once it has a minted token —
+	// SFTPGo serves both its REST API and its upload endpoints from the same
+	// httpd listener, so one base URL covers both.
+	BaseURL string
+	// PublicBaseURL is the host used to construct the public share URL
+	// returned by CreateShare's caller (see PublicShareURL). SFTPGo commonly
+	// fronts its WebClient (share pages) on a different public host/port
+	// than its REST API, so this is a separate, optional value; when unset
+	// it defaults to BaseURL.
+	PublicBaseURL string
+}
+
+// Client is a minimal SFTPGo REST API client scoped to token-mint and
+// share-creation — the only two calls this backend ever makes to SFTPGo.
+type Client struct {
+	http          *http.Client
+	baseURL       string
+	publicBaseURL string
+}
+
+// NewClient constructs a SFTPGo Client from cfg.
+func NewClient(cfg Config) *Client {
+	publicBaseURL := cfg.PublicBaseURL
+	if publicBaseURL == "" {
+		publicBaseURL = cfg.BaseURL
+	}
+	return &Client{
+		http:          &http.Client{Timeout: 15 * time.Second},
+		baseURL:       strings.TrimRight(cfg.BaseURL, "/"),
+		publicBaseURL: strings.TrimRight(publicBaseURL, "/"),
+	}
+}
+
+// BaseURL returns the configured REST API base URL, verbatim — handed back
+// to the FE by AttachmentStorageHandler.MintUploadToken as the host it
+// should call directly for the upload itself.
+func (c *Client) BaseURL() string {
+	return c.baseURL
+}
+
+// Token is the response body of SFTPGo's GET /api/v2/user/token. ExpiresAt is
+// kept as raw JSON and passed through unmodified rather than parsed into a
+// Go time value, since its exact wire type (string vs. epoch number) was not
+// verified against a live instance for this change.
+type Token struct {
+	AccessToken string          `json:"access_token"`
+	ExpiresAt   json.RawMessage `json:"expires_at"`
+}
+
+// MintToken calls SFTPGo's GET /api/v2/user/token using HTTP Basic auth:
+// username is the caller's email claim, password is the caller's raw
+// gateway-issued JWT (the x-jwt-assertion header value this backend itself
+// already validated). SFTPGo's external_auth_hook (see
+// operations/sftpgo-authentication-service's /external-auth-hook)
+// independently re-validates that JWT against the same JWKS/issuer/audience
+// this backend trusts, so the "password" here is never a SFTPGo-native
+// credential — it is the same bearer token the caller already presented to
+// this backend.
+func (c *Client) MintToken(ctx context.Context, email, jwtAssertion string) (*Token, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/api/v2/user/token", nil)
+	if err != nil {
+		return nil, fmt.Errorf("sftpgo: build token request: %w", err)
+	}
+	req.SetBasicAuth(email, jwtAssertion)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("sftpgo: token request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("sftpgo: read token response: %w", err)
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, &apierror.Error{StatusCode: resp.StatusCode, Body: truncate(body)}
+	}
+
+	var tok Token
+	if err := json.Unmarshal(body, &tok); err != nil {
+		return nil, fmt.Errorf("sftpgo: decode token response: %w", err)
+	}
+	if tok.AccessToken == "" {
+		return nil, fmt.Errorf("sftpgo: token response carried no access_token")
+	}
+	return &tok, nil
+}
+
+// shareScopeRead is SFTPGo's Share.Scope value for a read-only (download)
+// share. Not verified against a live instance for this change — flagged
+// explicitly in the PR description alongside the other SFTPGo API-shape
+// assumptions this client makes.
+const shareScopeRead = 1
+
+// shareCreateRequest is the request body of POST /api/v2/user/shares.
+type shareCreateRequest struct {
+	Paths     []string `json:"paths"`
+	Scope     int      `json:"scope"`
+	ExpiresAt int64    `json:"expires_at"`
+}
+
+// shareCreateResponseBody is the fallback shape checked when the share id is
+// not present on the X-Object-Id response header (see CreateShare). Both
+// field names are checked since which one (if either) SFTPGo actually uses
+// here was not verified against a live instance.
+type shareCreateResponseBody struct {
+	ID      string `json:"id"`
+	ShareID string `json:"share_id"`
+}
+
+// CreateShare calls SFTPGo's POST /api/v2/user/shares, authenticated as the
+// caller via accessToken (minted by MintToken), to create a short-lived,
+// read-only public share for a single storage path. ttl controls how soon
+// the share expires; callers should keep this short since a share is created
+// fresh on every request that needs one (see
+// AttachmentStorageHandler.CreateAttachmentShare — this is a lazy,
+// per-attachment, per-request operation, never an eager batch one). Returns
+// the created share's id.
+func (c *Client) CreateShare(ctx context.Context, accessToken, storageKey string, ttl time.Duration) (string, error) {
+	reqBody, err := json.Marshal(shareCreateRequest{
+		Paths:     []string{storageKey},
+		Scope:     shareScopeRead,
+		ExpiresAt: time.Now().Add(ttl).UnixMilli(),
+	})
+	if err != nil {
+		return "", fmt.Errorf("sftpgo: encode share request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/api/v2/user/shares", bytes.NewReader(reqBody))
+	if err != nil {
+		return "", fmt.Errorf("sftpgo: build share request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("sftpgo: share request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("sftpgo: read share response: %w", err)
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return "", &apierror.Error{StatusCode: resp.StatusCode, Body: truncate(body)}
+	}
+
+	// SFTPGo has historically returned the created object's id via the
+	// X-Object-Id response header rather than the JSON body — confirmed
+	// empirically against a real instance in a prior session. The JSON body
+	// is only a fallback here and has NOT been independently re-verified for
+	// this change.
+	if id := resp.Header.Get("X-Object-Id"); id != "" {
+		return id, nil
+	}
+
+	var decoded shareCreateResponseBody
+	if err := json.Unmarshal(body, &decoded); err == nil {
+		if decoded.ID != "" {
+			return decoded.ID, nil
+		}
+		if decoded.ShareID != "" {
+			return decoded.ShareID, nil
+		}
+	}
+
+	return "", fmt.Errorf("sftpgo: share response carried no id (checked X-Object-Id header and id/share_id body fields)")
+}
+
+// PublicShareURL builds the public download URL for a share id.
+//
+// This is deliberately NOT "{publicBaseURL}/shares/{id}", despite that being
+// what SFTPGo's own OpenAPI path naming might suggest — the working path,
+// confirmed empirically against a real instance in a prior session, is
+// "/web/client/pubshares/{id}".
+func (c *Client) PublicShareURL(shareID string) string {
+	return c.publicBaseURL + "/web/client/pubshares/" + url.PathEscape(shareID) + "?compress=false"
+}
+
+// truncate bounds body to maxErrBodyBytes for inclusion on an *apierror.Error.
+func truncate(body []byte) string {
+	if len(body) > maxErrBodyBytes {
+		body = body[:maxErrBodyBytes]
+	}
+	return string(body)
+}

--- a/apps/csm-portal/backend/internal/sftpgo/client_test.go
+++ b/apps/csm-portal/backend/internal/sftpgo/client_test.go
@@ -1,0 +1,296 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package sftpgo
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/wso2-open-operations/cs-tools/apps/csm-portal/backend/internal/apierror"
+)
+
+func TestMintTokenSendsCorrectBasicAuth(t *testing.T) {
+	t.Parallel()
+
+	var gotAuthHeader, gotMethod, gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuthHeader = r.Header.Get("Authorization")
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"tok-123","expires_at":"2026-08-27T12:00:00Z"}`))
+	}))
+	defer srv.Close()
+
+	client := NewClient(Config{BaseURL: srv.URL})
+
+	tok, err := client.MintToken(context.Background(), "jane.doe@example.com", "raw-jwt-assertion")
+	if err != nil {
+		t.Fatalf("MintToken: %v", err)
+	}
+
+	if gotMethod != http.MethodGet {
+		t.Errorf("method = %q, want GET", gotMethod)
+	}
+	if gotPath != "/api/v2/user/token" {
+		t.Errorf("path = %q, want /api/v2/user/token", gotPath)
+	}
+
+	wantAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte("jane.doe@example.com:raw-jwt-assertion"))
+	if gotAuthHeader != wantAuth {
+		t.Errorf("Authorization header = %q, want %q", gotAuthHeader, wantAuth)
+	}
+
+	if tok.AccessToken != "tok-123" {
+		t.Errorf("AccessToken = %q, want tok-123", tok.AccessToken)
+	}
+	var expiresAt string
+	if err := json.Unmarshal(tok.ExpiresAt, &expiresAt); err != nil {
+		t.Fatalf("decode ExpiresAt: %v", err)
+	}
+	if expiresAt != "2026-08-27T12:00:00Z" {
+		t.Errorf("ExpiresAt = %q, want 2026-08-27T12:00:00Z", expiresAt)
+	}
+}
+
+func TestMintTokenPropagatesUpstreamError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"message":"invalid credentials"}`))
+	}))
+	defer srv.Close()
+
+	client := NewClient(Config{BaseURL: srv.URL})
+
+	_, err := client.MintToken(context.Background(), "jane.doe@example.com", "bad-jwt")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	apiErr, ok := err.(*apierror.Error)
+	if !ok {
+		t.Fatalf("error type = %T, want *apierror.Error", err)
+	}
+	if apiErr.StatusCode != http.StatusUnauthorized {
+		t.Errorf("StatusCode = %d, want 401", apiErr.StatusCode)
+	}
+}
+
+func TestMintTokenRejectsMissingAccessToken(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	client := NewClient(Config{BaseURL: srv.URL})
+
+	if _, err := client.MintToken(context.Background(), "jane.doe@example.com", "raw-jwt"); err == nil {
+		t.Fatal("expected error for a response with no access_token, got nil")
+	}
+}
+
+func TestCreateShareSendsCorrectRequestShape(t *testing.T) {
+	t.Parallel()
+
+	var gotAuthHeader, gotMethod, gotPath string
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuthHeader = r.Header.Get("Authorization")
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &gotBody)
+
+		w.Header().Set("X-Object-Id", "share-abc-123")
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	client := NewClient(Config{BaseURL: srv.URL})
+
+	before := time.Now()
+	shareID, err := client.CreateShare(context.Background(), "access-tok", "/attachments/00000000-0000-0000-0000-000000000000", 5*time.Minute)
+	if err != nil {
+		t.Fatalf("CreateShare: %v", err)
+	}
+	after := time.Now()
+
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	if gotPath != "/api/v2/user/shares" {
+		t.Errorf("path = %q, want /api/v2/user/shares", gotPath)
+	}
+	if gotAuthHeader != "Bearer access-tok" {
+		t.Errorf("Authorization header = %q, want %q", gotAuthHeader, "Bearer access-tok")
+	}
+	if shareID != "share-abc-123" {
+		t.Errorf("shareID = %q, want share-abc-123 (from X-Object-Id header)", shareID)
+	}
+
+	paths, _ := gotBody["paths"].([]any)
+	if len(paths) != 1 || paths[0] != "/attachments/00000000-0000-0000-0000-000000000000" {
+		t.Errorf("paths = %v, want a single-element array with the storage key", gotBody["paths"])
+	}
+	if scope, _ := gotBody["scope"].(float64); scope != shareScopeRead {
+		t.Errorf("scope = %v, want %d (read-only)", gotBody["scope"], shareScopeRead)
+	}
+	expiresAtMs, _ := gotBody["expires_at"].(float64)
+	wantMin := float64(before.Add(5 * time.Minute).UnixMilli())
+	wantMax := float64(after.Add(5 * time.Minute).UnixMilli())
+	if expiresAtMs < wantMin || expiresAtMs > wantMax {
+		t.Errorf("expires_at = %v, want between %v and %v (now+5m in unix ms)", expiresAtMs, wantMin, wantMax)
+	}
+}
+
+func TestCreateShareFallsBackToJSONBodyWhenHeaderMissing(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"share-from-body"}`))
+	}))
+	defer srv.Close()
+
+	client := NewClient(Config{BaseURL: srv.URL})
+
+	shareID, err := client.CreateShare(context.Background(), "access-tok", "/attachments/x", time.Minute)
+	if err != nil {
+		t.Fatalf("CreateShare: %v", err)
+	}
+	if shareID != "share-from-body" {
+		t.Errorf("shareID = %q, want share-from-body", shareID)
+	}
+}
+
+func TestCreateSharePrefersHeaderOverBody(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Object-Id", "from-header")
+		_, _ = w.Write([]byte(`{"id":"from-body"}`))
+	}))
+	defer srv.Close()
+
+	client := NewClient(Config{BaseURL: srv.URL})
+
+	shareID, err := client.CreateShare(context.Background(), "access-tok", "/attachments/x", time.Minute)
+	if err != nil {
+		t.Fatalf("CreateShare: %v", err)
+	}
+	if shareID != "from-header" {
+		t.Errorf("shareID = %q, want from-header (header takes precedence)", shareID)
+	}
+}
+
+func TestCreateShareErrorsWhenNoIDFound(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	client := NewClient(Config{BaseURL: srv.URL})
+
+	if _, err := client.CreateShare(context.Background(), "access-tok", "/attachments/x", time.Minute); err == nil {
+		t.Fatal("expected error when neither header nor body carry an id, got nil")
+	}
+}
+
+func TestCreateSharePropagatesUpstreamError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	client := NewClient(Config{BaseURL: srv.URL})
+
+	_, err := client.CreateShare(context.Background(), "access-tok", "/attachments/x", time.Minute)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	apiErr, ok := err.(*apierror.Error)
+	if !ok {
+		t.Fatalf("error type = %T, want *apierror.Error", err)
+	}
+	if apiErr.StatusCode != http.StatusForbidden {
+		t.Errorf("StatusCode = %d, want 403", apiErr.StatusCode)
+	}
+}
+
+func TestPublicShareURL(t *testing.T) {
+	t.Parallel()
+
+	t.Run("uses PublicBaseURL when set", func(t *testing.T) {
+		t.Parallel()
+		client := NewClient(Config{BaseURL: "https://sftpgo-api.internal.example.com", PublicBaseURL: "https://share.example.com"})
+		got := client.PublicShareURL("abc-123")
+		want := "https://share.example.com/web/client/pubshares/abc-123?compress=false"
+		if got != want {
+			t.Errorf("PublicShareURL = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("defaults to BaseURL when PublicBaseURL unset", func(t *testing.T) {
+		t.Parallel()
+		client := NewClient(Config{BaseURL: "https://sftpgo.example.com/"})
+		got := client.PublicShareURL("abc-123")
+		want := "https://sftpgo.example.com/web/client/pubshares/abc-123?compress=false"
+		if got != want {
+			t.Errorf("PublicShareURL = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("path-escapes the share id", func(t *testing.T) {
+		t.Parallel()
+		client := NewClient(Config{BaseURL: "https://sftpgo.example.com"})
+		got := client.PublicShareURL("abc/def")
+		if !strings.Contains(got, "abc%2Fdef") {
+			t.Errorf("PublicShareURL = %q, want the share id path-escaped", got)
+		}
+	})
+
+	t.Run("does not use the /shares/{id} path", func(t *testing.T) {
+		t.Parallel()
+		client := NewClient(Config{BaseURL: "https://sftpgo.example.com"})
+		got := client.PublicShareURL("abc-123")
+		if strings.Contains(got, "/shares/abc-123") && !strings.Contains(got, "/web/client/pubshares/abc-123") {
+			t.Errorf("PublicShareURL = %q, must use /web/client/pubshares/, not /shares/", got)
+		}
+	})
+}
+
+func TestBaseURL(t *testing.T) {
+	t.Parallel()
+	client := NewClient(Config{BaseURL: "https://sftpgo.example.com/"})
+	if got := client.BaseURL(); got != "https://sftpgo.example.com" {
+		t.Errorf("BaseURL() = %q, want trailing slash trimmed", got)
+	}
+}

--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -1166,16 +1166,58 @@ export interface BeAttachmentSearchResponse extends BeSearchResponseBase {
 
 /**
  * Upload payload for `POST /attachments`. `referenceId` + `referenceType` link
- * the file to its owning entity; `file` is a base64 data URI (e.g.
- * `data:image/png;base64,...`); the BE caps the decoded size at 10 MB.
+ * the file to its owning entity.
+ *
+ * The two data sources populate mutually exclusive fields (see
+ * entity-service openapi.yaml's `CreateAttachmentRequest`): the default path
+ * sends `file`, a base64 data URI (e.g. `data:image/png;base64,...`), and the
+ * BE caps the decoded size at 10 MB. When the SFTPGo-backed attachment
+ * storage flag is on (`sftpgoAttachmentStorageEnabled` on `GET /users/me`),
+ * the file's bytes were already uploaded directly to SFTPGo out of band, so
+ * `storageKey` + `sizeBytes` are sent instead of `file` — see
+ * `usePostCsmCaseAttachment`.
  */
 export interface BeAttachmentCreatePayload {
   referenceId: string;
   referenceType: BeReferenceType;
   name: string;
   type: string;
-  file: string;
+  file?: string;
   description?: string | null;
+  /** Set instead of `file` when the attachment's bytes were uploaded directly
+   * to SFTPGo (see `POST /cases/{id}/attachments/upload-token`). */
+  storageKey?: string;
+  /** Required alongside `storageKey`; the entity service cannot compute this
+   * itself since it never sees the file's bytes on that path. */
+  sizeBytes?: number;
+}
+
+/**
+ * Response body of `POST /cases/{id}/attachments/upload-token`. Only
+ * reachable when `sftpgoAttachmentStorageEnabled` is on. `storageKey` is the
+ * exact SFTPGo path to PATCH the file's bytes to (the TUS/chunked-upload
+ * target), and the exact value to send back unchanged as
+ * `BeAttachmentCreatePayload.storageKey` once the upload completes.
+ */
+export interface BeAttachmentUploadTokenResponse {
+  sftpgoAccessToken: string;
+  /** SFTPGo's raw `expires_at` — shape (string vs. epoch number) not relied
+   * on by the frontend; the mint call itself is what's time-boxed. */
+  expiresAt: string | number;
+  sftpgoBaseUrl: string;
+  storageKey: string;
+}
+
+/**
+ * Response body of `POST /attachments/{id}/share`. `shareUrl` is a public,
+ * short-lived (5 minute TTL) download URL for the attachment's stored file —
+ * see `AttachmentStorageHandler.CreateAttachmentShare` on the backend. Must
+ * be requested lazily (only when an inline image is actually rendered, or a
+ * specific attachment's download is actually clicked), never eagerly for a
+ * whole list.
+ */
+export interface BeAttachmentShareResponse {
+  shareUrl: string;
 }
 
 /** Thin ack returned by `POST /attachments`. */

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/attachmentStorageTus.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/attachmentStorageTus.test.ts
@@ -1,0 +1,193 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { uploadFileViaTus } from "@features/csm-cases/api/attachmentStorageTus";
+
+/** Minimal fake XMLHttpRequest that records the PATCH call and fires progress/load. */
+class FakeXhr {
+  static instances: FakeXhr[] = [];
+  method = "";
+  url = "";
+  headers: Record<string, string> = {};
+  upload = { onprogress: null as ((e: ProgressEvent) => void) | null };
+  onload: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  onabort: (() => void) | null = null;
+  status = 200;
+  sentBody: unknown = null;
+
+  constructor() {
+    FakeXhr.instances.push(this);
+  }
+  open(method: string, url: string): void {
+    this.method = method;
+    this.url = url;
+  }
+  setRequestHeader(key: string, value: string): void {
+    this.headers[key] = value;
+  }
+  send(body: unknown): void {
+    this.sentBody = body;
+    this.upload.onprogress?.({
+      lengthComputable: true,
+      loaded: 5,
+      total: 10,
+    } as ProgressEvent);
+    this.upload.onprogress?.({
+      lengthComputable: true,
+      loaded: 10,
+      total: 10,
+    } as ProgressEvent);
+    this.onload?.();
+  }
+  abort(): void {
+    this.onabort?.();
+  }
+}
+
+describe("uploadFileViaTus", () => {
+  const file = new File(["hello world"], "hello.txt", { type: "text/plain" });
+
+  beforeEach(() => {
+    FakeXhr.instances = [];
+    vi.stubGlobal(
+      "XMLHttpRequest",
+      FakeXhr as unknown as typeof XMLHttpRequest,
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("POSTs to open the upload session, then PATCHes the bytes to the returned Location", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(null, {
+        status: 201,
+        headers: { Location: "/api/v2/user/files/chunked-upload/abc123" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const onProgress = vi.fn();
+    await uploadFileViaTus({
+      sftpgoBaseUrl: "https://sftpgo.example.com",
+      sftpgoAccessToken: "tok-1",
+      storageKey: "/attachments/cases/case-1/att-1",
+      file,
+      onProgress,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [createUrl, createInit] = fetchMock.mock.calls[0];
+    expect(createUrl).toBe(
+      "https://sftpgo.example.com/api/v2/user/files/chunked-upload",
+    );
+    expect(createInit.method).toBe("POST");
+    expect(createInit.headers.Authorization).toBe("Bearer tok-1");
+    expect(createInit.headers["Upload-Length"]).toBe(String(file.size));
+    // Upload-Metadata carries the base64-encoded storage key under "path".
+    const metadata = createInit.headers["Upload-Metadata"] as string;
+    const pathEntry = metadata
+      .split(",")
+      .find((entry: string) => entry.startsWith("path "));
+    expect(pathEntry).toBeDefined();
+    const decodedPath = atob(pathEntry!.split(" ")[1]);
+    expect(decodedPath).toBe("/attachments/cases/case-1/att-1");
+
+    expect(FakeXhr.instances).toHaveLength(1);
+    const xhr = FakeXhr.instances[0];
+    expect(xhr.method).toBe("PATCH");
+    expect(xhr.url).toBe(
+      "https://sftpgo.example.com/api/v2/user/files/chunked-upload/abc123",
+    );
+    expect(xhr.headers.Authorization).toBe("Bearer tok-1");
+    expect(xhr.headers["Upload-Offset"]).toBe("0");
+    expect(xhr.headers["Content-Type"]).toBe("application/offset+octet-stream");
+    expect(xhr.sentBody).toBe(file);
+
+    expect(onProgress).toHaveBeenCalledWith(50);
+    expect(onProgress).toHaveBeenLastCalledWith(100);
+  });
+
+  it("falls back to the create endpoint when the create response has no Location header", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response(null, { status: 200 })),
+    );
+
+    await uploadFileViaTus({
+      sftpgoBaseUrl: "https://sftpgo.example.com/",
+      sftpgoAccessToken: "tok-1",
+      storageKey: "/attachments/cases/case-1/att-1",
+      file,
+    });
+
+    expect(FakeXhr.instances[0].url).toBe(
+      "https://sftpgo.example.com/api/v2/user/files/chunked-upload",
+    );
+  });
+
+  it("throws when opening the upload session fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response(null, { status: 401 })),
+    );
+
+    await expect(
+      uploadFileViaTus({
+        sftpgoBaseUrl: "https://sftpgo.example.com",
+        sftpgoAccessToken: "tok-1",
+        storageKey: "/attachments/cases/case-1/att-1",
+        file,
+      }),
+    ).rejects.toThrow(/401/);
+
+    expect(FakeXhr.instances).toHaveLength(0);
+  });
+
+  it("rejects when the PATCH itself fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(null, {
+          status: 201,
+          headers: { Location: "/api/v2/user/files/chunked-upload/abc123" },
+        }),
+      ),
+    );
+
+    class FailingXhr extends FakeXhr {
+      send(body: unknown): void {
+        this.sentBody = body;
+        this.status = 500;
+        this.onload?.();
+      }
+    }
+    vi.stubGlobal("XMLHttpRequest", FailingXhr as unknown as typeof XMLHttpRequest);
+
+    await expect(
+      uploadFileViaTus({
+        sftpgoBaseUrl: "https://sftpgo.example.com",
+        sftpgoAccessToken: "tok-1",
+        storageKey: "/attachments/cases/case-1/att-1",
+        file,
+      }),
+    ).rejects.toThrow(/500/);
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/attachmentStorageTus.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/attachmentStorageTus.test.ts
@@ -190,4 +190,71 @@ describe("uploadFileViaTus", () => {
       }),
     ).rejects.toThrow(/500/);
   });
+
+  it("rejects a non-https sftpgoBaseUrl before opening any request", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      uploadFileViaTus({
+        sftpgoBaseUrl: "http://sftpgo.example.com",
+        sftpgoAccessToken: "tok-1",
+        storageKey: "/attachments/cases/case-1/att-1",
+        file,
+      }),
+    ).rejects.toThrow(/https/i);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(FakeXhr.instances).toHaveLength(0);
+  });
+
+  it("rejects a Location header pointing at a foreign origin before the PATCH is opened", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(null, {
+          status: 201,
+          headers: { Location: "https://evil.example.com/steal-the-token" },
+        }),
+      ),
+    );
+
+    await expect(
+      uploadFileViaTus({
+        sftpgoBaseUrl: "https://sftpgo.example.com",
+        sftpgoAccessToken: "tok-1",
+        storageKey: "/attachments/cases/case-1/att-1",
+        file,
+      }),
+    ).rejects.toThrow(/untrusted origin/i);
+
+    expect(FakeXhr.instances).toHaveLength(0);
+  });
+
+  it("accepts a same-origin absolute Location header", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(null, {
+          status: 201,
+          headers: {
+            Location:
+              "https://sftpgo.example.com/api/v2/user/files/chunked-upload/abc123",
+          },
+        }),
+      ),
+    );
+
+    await uploadFileViaTus({
+      sftpgoBaseUrl: "https://sftpgo.example.com",
+      sftpgoAccessToken: "tok-1",
+      storageKey: "/attachments/cases/case-1/att-1",
+      file,
+    });
+
+    expect(FakeXhr.instances).toHaveLength(1);
+    expect(FakeXhr.instances[0].url).toBe(
+      "https://sftpgo.example.com/api/v2/user/files/chunked-upload/abc123",
+    );
+  });
 });

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/attachmentStorageTus.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/attachmentStorageTus.ts
@@ -1,0 +1,172 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+ * Uploads a file directly from the browser to SFTPGo's chunked/TUS upload
+ * endpoint, bypassing this app's own backend entirely (the backend only
+ * mints the short-lived credential — see `usePostCsmCaseAttachment`).
+ *
+ * Deliberately NOT sent through `useBackendApi`/`useAuthApiClient`: that
+ * client refuses to attach a bearer token to any origin other than this
+ * app's own backend (see `useAuthApiClient.ts`), and the SFTPGo access token
+ * minted for this upload is a different credential entirely — it must never
+ * be confused with, or sent alongside, this app's own auth tokens.
+ *
+ * Follows the TUS resumable-upload protocol (POST to open an upload, then
+ * PATCH to send the bytes): this is the wire shape SFTPGo's
+ * `chunked-upload` endpoint was specified against for this change, but has
+ * not been independently re-verified against a live SFTPGo instance — flagged
+ * here the same way the backend's own `internal/sftpgo/client.go` flags its
+ * own unverified SFTPGo API-shape assumptions (e.g. the share-scope and
+ * share-id-header assumptions there).
+ */
+
+/** Base64-encodes a UTF-8 string for a TUS `Upload-Metadata` entry. */
+function toBase64(value: string): string {
+  // btoa operates on a byte string; encode to UTF-8 bytes first so a
+  // non-ASCII file name doesn't throw.
+  const bytes = new TextEncoder().encode(value);
+  let binary = "";
+  bytes.forEach((b) => {
+    binary += String.fromCharCode(b);
+  });
+  return btoa(binary);
+}
+
+export interface UploadFileViaTusInput {
+  sftpgoBaseUrl: string;
+  sftpgoAccessToken: string;
+  /** The exact SFTPGo path minted by `POST /cases/{id}/attachments/upload-token`. */
+  storageKey: string;
+  file: File;
+  /** Called with 0-100 as the upload progresses. */
+  onProgress?: (percent: number) => void;
+  signal?: AbortSignal;
+}
+
+const TUS_RESUMABLE_VERSION = "1.0.0";
+
+/**
+ * Opens a TUS upload session (`POST`) for `storageKey`, then uploads the
+ * file's bytes in a single `PATCH` at offset 0, reporting progress via
+ * `onProgress`. Uses `XMLHttpRequest` for the `PATCH` rather than `fetch`:
+ * `fetch` has no cross-browser-reliable upload progress event, while
+ * `XMLHttpRequest.upload.onprogress` does.
+ */
+export async function uploadFileViaTus({
+  sftpgoBaseUrl,
+  sftpgoAccessToken,
+  storageKey,
+  file,
+  onProgress,
+  signal,
+}: UploadFileViaTusInput): Promise<void> {
+  const createEndpoint = `${sftpgoBaseUrl.replace(/\/+$/, "")}/api/v2/user/files/chunked-upload`;
+  const uploadMetadata = [
+    `path ${toBase64(storageKey)}`,
+    `filename ${toBase64(file.name)}`,
+  ].join(",");
+
+  const createResponse = await fetch(createEndpoint, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${sftpgoAccessToken}`,
+      "Tus-Resumable": TUS_RESUMABLE_VERSION,
+      "Upload-Length": String(file.size),
+      "Upload-Metadata": uploadMetadata,
+    },
+    signal,
+  });
+  if (!createResponse.ok) {
+    throw new Error(
+      `Failed to open the upload session (status ${createResponse.status}).`,
+    );
+  }
+
+  // The TUS spec returns the upload's URL via `Location`, which may be
+  // relative to the create endpoint's origin.
+  const location = createResponse.headers.get("Location");
+  const uploadUrl = location
+    ? new URL(location, createEndpoint).toString()
+    : createEndpoint;
+
+  await patchWithProgress({
+    url: uploadUrl,
+    accessToken: sftpgoAccessToken,
+    file,
+    onProgress,
+    signal,
+  });
+}
+
+function patchWithProgress({
+  url,
+  accessToken,
+  file,
+  onProgress,
+  signal,
+}: {
+  url: string;
+  accessToken: string;
+  file: File;
+  onProgress?: (percent: number) => void;
+  signal?: AbortSignal;
+}): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    xhr.open("PATCH", url, true);
+    xhr.setRequestHeader("Authorization", `Bearer ${accessToken}`);
+    xhr.setRequestHeader("Tus-Resumable", TUS_RESUMABLE_VERSION);
+    xhr.setRequestHeader("Upload-Offset", "0");
+    xhr.setRequestHeader("Content-Type", "application/offset+octet-stream");
+
+    const onAbort = (): void => xhr.abort();
+    if (signal) {
+      if (signal.aborted) {
+        reject(new DOMException("Aborted", "AbortError"));
+        return;
+      }
+      signal.addEventListener("abort", onAbort);
+    }
+
+    xhr.upload.onprogress = (event) => {
+      if (!onProgress || !event.lengthComputable) return;
+      onProgress(Math.round((event.loaded / event.total) * 100));
+    };
+
+    xhr.onload = () => {
+      signal?.removeEventListener("abort", onAbort);
+      if (xhr.status >= 200 && xhr.status < 300) {
+        onProgress?.(100);
+        resolve();
+      } else {
+        reject(
+          new Error(`Failed to upload the file (status ${xhr.status}).`),
+        );
+      }
+    };
+    xhr.onerror = () => {
+      signal?.removeEventListener("abort", onAbort);
+      reject(new Error("Failed to upload the file (network error)."));
+    };
+    xhr.onabort = () => {
+      signal?.removeEventListener("abort", onAbort);
+      reject(new DOMException("Aborted", "AbortError"));
+    };
+
+    xhr.send(file);
+  });
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/attachmentStorageTus.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/attachmentStorageTus.ts
@@ -74,6 +74,19 @@ export async function uploadFileViaTus({
   onProgress,
   signal,
 }: UploadFileViaTusInput): Promise<void> {
+  let parsedBaseUrl: URL;
+  try {
+    parsedBaseUrl = new URL(sftpgoBaseUrl);
+  } catch {
+    throw new Error(`sftpgoBaseUrl is not a valid URL: "${sftpgoBaseUrl}".`);
+  }
+  if (parsedBaseUrl.protocol !== "https:") {
+    throw new Error(
+      `sftpgoBaseUrl must be an https:// URL, got "${sftpgoBaseUrl}".`,
+    );
+  }
+  const trustedOrigin = parsedBaseUrl.origin;
+
   const createEndpoint = `${sftpgoBaseUrl.replace(/\/+$/, "")}/api/v2/user/files/chunked-upload`;
   const uploadMetadata = [
     `path ${toBase64(storageKey)}`,
@@ -97,11 +110,20 @@ export async function uploadFileViaTus({
   }
 
   // The TUS spec returns the upload's URL via `Location`, which may be
-  // relative to the create endpoint's origin.
+  // relative to the create endpoint's origin, or an absolute URL. Either
+  // way, the resolved URL's origin must match the configured SFTPGo
+  // origin before the bearer token is attached and sent there — otherwise
+  // a misconfigured or compromised SFTPGo instance could redirect the
+  // upload (and the token) to an attacker-controlled host.
   const location = createResponse.headers.get("Location");
   const uploadUrl = location
     ? new URL(location, createEndpoint).toString()
     : createEndpoint;
+  if (new URL(uploadUrl).origin !== trustedOrigin) {
+    throw new Error(
+      `Refusing to upload to an untrusted origin returned by the SFTPGo Location header: "${uploadUrl}".`,
+    );
+  }
 
   await patchWithProgress({
     url: uploadUrl,

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useCsmCaseAttachments.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useCsmCaseAttachments.test.tsx
@@ -1,0 +1,264 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+
+// `vi.mock` factories are hoisted above top-level `const`s, so anything a
+// factory below closes over must itself be created via `vi.hoisted`.
+const { postMock, getBlobMock, uploadFileViaTusMock, sftpgoFlag } = vi.hoisted(
+  () => ({
+    postMock: vi.fn(),
+    getBlobMock: vi.fn(),
+    uploadFileViaTusMock: vi.fn(),
+    sftpgoFlag: { enabled: false },
+  }),
+);
+
+// The real client reads runtime config at module load, which isn't present
+// under vitest (same approach as useSearchTags.test.tsx).
+vi.mock("@api/backend/client", () => ({
+  useBackendApi: () => ({ post: postMock, getBlob: getBlobMock }),
+}));
+
+vi.mock("@context/current-user/CurrentUserContext", () => ({
+  useCurrentUser: () => ({
+    user: { sftpgoAttachmentStorageEnabled: sftpgoFlag.enabled },
+    isLoading: false,
+    isError: false,
+  }),
+}));
+
+vi.mock("@features/csm-cases/api/attachmentStorageTus", () => ({
+  uploadFileViaTus: uploadFileViaTusMock,
+}));
+
+vi.mock("@utils/saveBlob", () => ({ saveBlob: vi.fn() }));
+
+import {
+  usePostCsmCaseAttachment,
+  useDownloadCsmCaseAttachment,
+} from "@features/csm-cases/api/useCsmCaseAttachments";
+import { saveBlob } from "@utils/saveBlob";
+import type { CaseAttachment } from "@features/csm-cases/types/csmCases";
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+const FILE = new File(["hello world"], "hello.txt", { type: "text/plain" });
+
+describe("usePostCsmCaseAttachment", () => {
+  beforeEach(() => {
+    postMock.mockReset();
+    getBlobMock.mockReset();
+    uploadFileViaTusMock.mockReset();
+    sftpgoFlag.enabled = false;
+  });
+
+  it("flag off: sends a single POST /attachments with a base64 file payload, unchanged", async () => {
+    postMock.mockResolvedValue({});
+    const { result } = renderHook(() => usePostCsmCaseAttachment(), {
+      wrapper,
+    });
+
+    await act(() =>
+      result.current.mutateAsync({
+        caseId: "case-1",
+        file: FILE,
+        uploadedBy: "Jane Doe",
+      }),
+    );
+
+    expect(uploadFileViaTusMock).not.toHaveBeenCalled();
+    expect(postMock).toHaveBeenCalledTimes(1);
+    const [path, payload] = postMock.mock.calls[0];
+    expect(path).toBe("/attachments");
+    expect(payload.storageKey).toBeUndefined();
+    expect(payload.sizeBytes).toBeUndefined();
+    expect(typeof payload.file).toBe("string");
+    expect(payload.file.startsWith("data:")).toBe(true);
+    expect(result.current.uploadProgress).toBeNull();
+  });
+
+  it("flag on: mints an upload token, uploads via TUS, then creates metadata with storageKey/sizeBytes and no file", async () => {
+    sftpgoFlag.enabled = true;
+    postMock.mockImplementation((path: string) => {
+      if (path.endsWith("/attachments/upload-token")) {
+        return Promise.resolve({
+          sftpgoAccessToken: "tok-1",
+          expiresAt: "2026-01-01T00:00:00Z",
+          sftpgoBaseUrl: "https://sftpgo.example.com",
+          storageKey: "/attachments/cases/case-1/att-1",
+        });
+      }
+      return Promise.resolve({});
+    });
+    uploadFileViaTusMock.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => usePostCsmCaseAttachment(), {
+      wrapper,
+    });
+
+    await act(() =>
+      result.current.mutateAsync({
+        caseId: "case-1",
+        file: FILE,
+        uploadedBy: "Jane Doe",
+      }),
+    );
+
+    // Order: mint token, then TUS upload, then metadata create.
+    expect(postMock).toHaveBeenCalledTimes(2);
+    expect(postMock.mock.calls[0][0]).toBe(
+      "/cases/case-1/attachments/upload-token",
+    );
+    expect(uploadFileViaTusMock).toHaveBeenCalledTimes(1);
+    expect(uploadFileViaTusMock.mock.calls[0][0]).toMatchObject({
+      sftpgoBaseUrl: "https://sftpgo.example.com",
+      sftpgoAccessToken: "tok-1",
+      storageKey: "/attachments/cases/case-1/att-1",
+      file: FILE,
+    });
+
+    const [metaPath, metaPayload] = postMock.mock.calls[1];
+    expect(metaPath).toBe("/attachments");
+    expect(metaPayload.storageKey).toBe("/attachments/cases/case-1/att-1");
+    expect(metaPayload.sizeBytes).toBe(FILE.size);
+    expect(metaPayload.file).toBeUndefined();
+
+    // The TUS call must have happened before the metadata create.
+    const tusCallOrder = uploadFileViaTusMock.mock.invocationCallOrder[0];
+    const metaCallOrder = postMock.mock.invocationCallOrder[1];
+    expect(tusCallOrder).toBeLessThan(metaCallOrder);
+
+    expect(result.current.uploadProgress).toBeNull();
+  });
+
+  it("flag on: exposes upload progress from the TUS callback while in flight", async () => {
+    sftpgoFlag.enabled = true;
+    postMock.mockImplementation((path: string) => {
+      if (path.endsWith("/attachments/upload-token")) {
+        return Promise.resolve({
+          sftpgoAccessToken: "tok-1",
+          expiresAt: "2026-01-01T00:00:00Z",
+          sftpgoBaseUrl: "https://sftpgo.example.com",
+          storageKey: "/attachments/cases/case-1/att-1",
+        });
+      }
+      return Promise.resolve({});
+    });
+
+    // A deferred promise the test resolves explicitly, so the upload is
+    // guaranteed to still be "in flight" while the progress assertion below
+    // runs — a `setTimeout(0)` here would race the real TUS call's resolution
+    // against `waitFor`'s own polling and could resolve before the test gets
+    // a chance to observe the in-flight percentage.
+    let resolveUpload: (() => void) | undefined;
+    let capturedOnProgress: ((percent: number) => void) | undefined;
+    uploadFileViaTusMock.mockImplementation(({ onProgress }) => {
+      capturedOnProgress = onProgress;
+      return new Promise<void>((resolve) => {
+        resolveUpload = resolve;
+      });
+    });
+
+    const { result } = renderHook(() => usePostCsmCaseAttachment(), {
+      wrapper,
+    });
+
+    let promise!: Promise<unknown>;
+    act(() => {
+      promise = result.current.mutateAsync({
+        caseId: "case-1",
+        file: FILE,
+        uploadedBy: "Jane Doe",
+      });
+    });
+
+    await waitFor(() => expect(capturedOnProgress).toBeDefined());
+    act(() => capturedOnProgress!(42));
+    await waitFor(() => expect(result.current.uploadProgress).toBe(42));
+
+    await act(async () => {
+      resolveUpload!();
+      await promise;
+    });
+    await waitFor(() => expect(result.current.uploadProgress).toBeNull());
+  });
+});
+
+describe("useDownloadCsmCaseAttachment", () => {
+  const ATTACHMENT: CaseAttachment = {
+    id: "att-1",
+    filename: "hello.txt",
+    size: 11,
+    contentType: "text/plain",
+    uploadedBy: "Jane Doe",
+    uploadedAt: "2026-01-01T00:00:00Z",
+  };
+
+  beforeEach(() => {
+    postMock.mockReset();
+    getBlobMock.mockReset();
+    sftpgoFlag.enabled = false;
+    vi.mocked(saveBlob).mockReset();
+  });
+
+  it("flag off: fetches the content blob and saves it, unchanged", async () => {
+    getBlobMock.mockResolvedValue(new Blob(["hello"], { type: "text/plain" }));
+    const { result } = renderHook(() => useDownloadCsmCaseAttachment(), {
+      wrapper,
+    });
+
+    await result.current(ATTACHMENT);
+
+    expect(postMock).not.toHaveBeenCalled();
+    expect(getBlobMock).toHaveBeenCalledWith("/attachments/att-1/content");
+    expect(saveBlob).toHaveBeenCalledTimes(1);
+  });
+
+  it("flag on: creates exactly one share for the clicked attachment and never fetches the content blob", async () => {
+    sftpgoFlag.enabled = true;
+    postMock.mockResolvedValue({
+      shareUrl: "https://sftpgo.example.com/web/client/pubshares/abc",
+    });
+    const clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => {});
+
+    const { result } = renderHook(() => useDownloadCsmCaseAttachment(), {
+      wrapper,
+    });
+
+    await result.current(ATTACHMENT);
+
+    expect(postMock).toHaveBeenCalledTimes(1);
+    expect(postMock).toHaveBeenCalledWith("/attachments/att-1/share", {});
+    expect(getBlobMock).not.toHaveBeenCalled();
+    expect(saveBlob).not.toHaveBeenCalled();
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+
+    clickSpy.mockRestore();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useCsmCaseAttachments.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useCsmCaseAttachments.ts
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import {
   useMutation,
   useQuery,
@@ -29,6 +29,8 @@ import type {
   BeAttachmentCreateResponse,
   BeAttachmentSearchPayload,
   BeAttachmentSearchResponse,
+  BeAttachmentShareResponse,
+  BeAttachmentUploadTokenResponse,
   BeDeleteAttachmentResponse,
   BeReferenceType,
 } from "@api/backend/types";
@@ -36,6 +38,8 @@ import { uiAttachmentFromBe } from "@api/backend/mappers";
 import { saveBlob } from "@utils/saveBlob";
 import type { CaseAttachment } from "@features/csm-cases/types/csmCases";
 import { isSafeAttachmentContentType } from "@features/csm-cases/utils/attachmentPreview";
+import { useCurrentUser } from "@context/current-user/CurrentUserContext";
+import { uploadFileViaTus } from "@features/csm-cases/api/attachmentStorageTus";
 
 /**
  * Page size used by the attachments list. A single wide page is enough for the
@@ -110,21 +114,48 @@ export interface PostCsmCaseAttachmentInput {
   referenceType?: BeReferenceType;
 }
 
-/**
- * Upload a file attachment to a reference entity via `POST /attachments`
- * (`referenceType` defaults to `"case"`). The file is sent as a base64 data
- * URI. The create response is a thin ack, so the list is refetched on success
- * to hydrate the new entry from search.
- */
-export function usePostCsmCaseAttachment(): UseMutationResult<
+/** Return type of {@link usePostCsmCaseAttachment}: the underlying mutation
+ * plus upload progress for the SFTPGo direct-upload path. */
+export type PostCsmCaseAttachmentResult = UseMutationResult<
   CaseAttachment | null,
   Error,
   PostCsmCaseAttachmentInput
-> {
+> & {
+  /**
+   * 0-100 while a direct-to-SFTPGo upload is in flight, `null` otherwise
+   * (including for the whole default base64-payload path, which has no
+   * granular progress). Only meaningful when
+   * `sftpgoAttachmentStorageEnabled` is on.
+   */
+  uploadProgress: number | null;
+};
+
+/**
+ * Upload a file attachment to a reference entity.
+ *
+ * Two mutually exclusive paths, gated on the signed-in user's
+ * `sftpgoAttachmentStorageEnabled` flag (`GET /users/me`):
+ *  - Off (default, unchanged): the file is sent as a base64 data URI in a
+ *    single `POST /attachments`.
+ *  - On: the file's bytes go straight from the browser to SFTPGo (mirroring
+ *    `uploadProgress`), then `POST /attachments` is called with `storageKey`
+ *    + `sizeBytes` instead of `file` — see `BeAttachmentCreatePayload`.
+ *
+ * The create response is a thin ack either way, so the list is refetched on
+ * success to hydrate the new entry from search.
+ */
+export function usePostCsmCaseAttachment(): PostCsmCaseAttachmentResult {
   const api = useBackendApi();
   const queryClient = useQueryClient();
+  const { user } = useCurrentUser();
+  const sftpgoEnabled = !!user?.sftpgoAttachmentStorageEnabled;
+  const [uploadProgress, setUploadProgress] = useState<number | null>(null);
 
-  return useMutation<CaseAttachment | null, Error, PostCsmCaseAttachmentInput>({
+  const mutation = useMutation<
+    CaseAttachment | null,
+    Error,
+    PostCsmCaseAttachmentInput
+  >({
     mutationFn: async (input): Promise<CaseAttachment | null> => {
       if (input.file.size > MAX_ATTACHMENT_SIZE_BYTES) {
         throw new Error(
@@ -134,12 +165,52 @@ export function usePostCsmCaseAttachment(): UseMutationResult<
         );
       }
 
+      const referenceType = input.referenceType ?? "case";
+      const name = input.name?.trim() || input.file.name;
+      const type = input.file.type || "application/octet-stream";
+
+      if (sftpgoEnabled) {
+        setUploadProgress(0);
+        try {
+          const tokenResponse = await api.post<
+            Record<string, never>,
+            BeAttachmentUploadTokenResponse
+          >(`/cases/${encodeURIComponent(input.caseId)}/attachments/upload-token`, {});
+
+          await uploadFileViaTus({
+            sftpgoBaseUrl: tokenResponse.sftpgoBaseUrl,
+            sftpgoAccessToken: tokenResponse.sftpgoAccessToken,
+            storageKey: tokenResponse.storageKey,
+            file: input.file,
+            onProgress: setUploadProgress,
+          });
+
+          const payload: BeAttachmentCreatePayload = {
+            referenceId: input.caseId,
+            referenceType,
+            name,
+            type,
+            storageKey: tokenResponse.storageKey,
+            sizeBytes: input.file.size,
+            description: input.description?.trim() || null,
+          };
+          await api.post<BeAttachmentCreatePayload, BeAttachmentCreateResponse>(
+            "/attachments",
+            payload,
+          );
+        } finally {
+          setUploadProgress(null);
+        }
+        // The create response is a thin ack; refetch hydrates the full entry.
+        return null;
+      }
+
       const dataUri = await readFileAsDataUrl(input.file);
       const payload: BeAttachmentCreatePayload = {
         referenceId: input.caseId,
-        referenceType: input.referenceType ?? "case",
-        name: input.name?.trim() || input.file.name,
-        type: input.file.type || "application/octet-stream",
+        referenceType,
+        name,
+        type,
         file: dataUri,
         description: input.description?.trim() || null,
       };
@@ -160,6 +231,8 @@ export function usePostCsmCaseAttachment(): UseMutationResult<
       });
     },
   });
+
+  return { ...mutation, uploadProgress };
 }
 
 /**
@@ -209,21 +282,53 @@ export function useGetCsmCaseAttachmentContent(): (
   );
 }
 
+/** Opens a URL for download in a new tab, rather than navigating the SPA away
+ * from itself. Used for the SFTPGo share URL below, which is a plain public
+ * link (not fetched as a `Blob` through this app's own auth) — a normal link
+ * click, not a `fetch`, so cross-origin/CORS is a non-issue. */
+function openForDownload(url: string): void {
+  const a = document.createElement("a");
+  a.href = url;
+  a.target = "_blank";
+  a.rel = "noopener noreferrer";
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+}
+
 /**
- * Returns a function that downloads an attachment's content and saves it to
- * disk, built on {@link useGetCsmCaseAttachmentContent}.
+ * Returns a function that downloads an attachment, built on
+ * {@link useGetCsmCaseAttachmentContent}.
+ *
+ * When `sftpgoAttachmentStorageEnabled` is on, this creates a share
+ * (`POST /attachments/{id}/share`) for exactly the one attachment being
+ * downloaded — never eagerly for a whole list, see
+ * `AttachmentStorageHandler.CreateAttachmentShare`'s doc comment on the
+ * backend — and opens the returned short-lived public URL directly, instead
+ * of fetching the content as an authenticated `Blob`.
  */
 export function useDownloadCsmCaseAttachment(): (
   attachment: CaseAttachment,
 ) => Promise<void> {
+  const api = useBackendApi();
   const getContent = useGetCsmCaseAttachmentContent();
+  const { user } = useCurrentUser();
+  const sftpgoEnabled = !!user?.sftpgoAttachmentStorageEnabled;
 
   return useCallback(
     async (attachment: CaseAttachment): Promise<void> => {
+      if (sftpgoEnabled) {
+        const { shareUrl } = await api.post<
+          Record<string, never>,
+          BeAttachmentShareResponse
+        >(`/attachments/${encodeURIComponent(attachment.id)}/share`, {});
+        openForDownload(shareUrl);
+        return;
+      }
       const blob = await getContent(attachment);
       saveBlob(blob, attachment.filename);
     },
-    [getContent],
+    [api, getContent, sftpgoEnabled],
   );
 }
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useResolvedInlineImageHtml.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useResolvedInlineImageHtml.test.tsx
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+
+const { postMock, getBlobMock, sftpgoFlag } = vi.hoisted(() => ({
+  postMock: vi.fn(),
+  getBlobMock: vi.fn(),
+  sftpgoFlag: { enabled: false },
+}));
+
+vi.mock("@api/backend/client", () => ({
+  useBackendApi: () => ({ post: postMock, getBlob: getBlobMock }),
+}));
+
+vi.mock("@context/current-user/CurrentUserContext", () => ({
+  useCurrentUser: () => ({
+    user: { sftpgoAttachmentStorageEnabled: sftpgoFlag.enabled },
+    isLoading: false,
+    isError: false,
+  }),
+}));
+
+import { useResolvedInlineImageHtml } from "@features/csm-cases/api/useResolvedInlineImageHtml";
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+const ATTACHMENT_SYSID = "0123456789abcdef0123456789abcdef";
+const HTML = `<p>see <img src="/inline/${ATTACHMENT_SYSID}.iix"></p>`;
+
+describe("useResolvedInlineImageHtml", () => {
+  beforeEach(() => {
+    postMock.mockReset();
+    getBlobMock.mockReset();
+    sftpgoFlag.enabled = false;
+  });
+
+  it("flag off: resolves via GET /attachments/{id}/content into a data: URL", async () => {
+    getBlobMock.mockResolvedValue(new Blob(["fake"], { type: "image/png" }));
+
+    const { result } = renderHook(() => useResolvedInlineImageHtml(HTML), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(postMock).not.toHaveBeenCalled();
+    expect(getBlobMock).toHaveBeenCalledTimes(1);
+    const [calledPath] = getBlobMock.mock.calls[0];
+    expect(calledPath).toContain("/content");
+    expect(result.current.resolvedHtml).toContain("data:image/png;base64,");
+  });
+
+  it("flag on: resolves via POST /attachments/{id}/share and uses shareUrl directly, without fetching content", async () => {
+    sftpgoFlag.enabled = true;
+    postMock.mockResolvedValue({
+      shareUrl: "https://sftpgo.example.com/web/client/pubshares/abc?compress=false",
+    });
+
+    const { result } = renderHook(() => useResolvedInlineImageHtml(HTML), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(getBlobMock).not.toHaveBeenCalled();
+    expect(postMock).toHaveBeenCalledTimes(1);
+    const [calledPath, calledBody] = postMock.mock.calls[0];
+    expect(calledPath).toMatch(/\/attachments\/.+\/share$/);
+    expect(calledBody).toEqual({});
+    expect(result.current.resolvedHtml).toContain(
+      "https://sftpgo.example.com/web/client/pubshares/abc?compress=false",
+    );
+    expect(result.current.resolvedHtml).not.toContain("data:");
+  });
+
+  it("does not resolve anything when the HTML has no .iix references", () => {
+    const { result } = renderHook(
+      () => useResolvedInlineImageHtml("<p>no images here</p>"),
+      { wrapper },
+    );
+
+    expect(postMock).not.toHaveBeenCalled();
+    expect(getBlobMock).not.toHaveBeenCalled();
+    expect(result.current.isLoading).toBe(false);
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useResolvedInlineImageHtml.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useResolvedInlineImageHtml.ts
@@ -18,11 +18,25 @@ import { useMemo } from "react";
 import { useQueries } from "@tanstack/react-query";
 import { useBackendApi } from "@api/backend/client";
 import { ApiQueryKeys } from "@constants/apiConstants";
+import type { BeAttachmentShareResponse } from "@api/backend/types";
+import { useCurrentUser } from "@context/current-user/CurrentUserContext";
 import {
   extractIixAttachmentIds,
   replaceInlineImageSrcs,
   sysidToUuid,
 } from "@features/csm-cases/utils/inlineImages";
+
+/**
+ * How long a resolved share URL is treated as fresh before React Query would
+ * refetch it. SFTPGo shares expire 5 minutes after creation (see the
+ * backend's `shareTTL`); this is kept comfortably under that so a stale
+ * cached URL is never handed to an `<img>` past its expiry, while still
+ * avoiding a share-creation call on every re-render/remount within the
+ * window. A fixed shorter `staleTime` is a deliberate, simple first pass —
+ * not a full "detect the 403 and mint a fresh share" retry loop, which is
+ * unnecessary complexity for an inline preview image.
+ */
+const INLINE_IMAGE_SHARE_STALE_TIME_MS = 3 * 60_000;
 
 const SAFE_IMAGE_SUBTYPES = /^(png|jpeg|jpg|gif|webp|svg\+xml|bmp|avif)$/i;
 
@@ -48,11 +62,18 @@ function blobToDataUrl(blob: Blob): Promise<string | null> {
 }
 
 /**
- * Fetches inline-image attachments referenced within comment/description HTML
- * via the authenticated `GET /attachments/{id}/content` endpoint and resolves
- * them into `data:` URLs so `<img>` tags can render them without the browser
- * making an unauthenticated request. Mirrors the customer portal's
- * `useResolvedInlineImageHtml`.
+ * Resolves inline-image attachments referenced within comment/description
+ * HTML so `<img>` tags can render them.
+ *
+ * Two mutually exclusive paths, gated on the signed-in user's
+ * `sftpgoAttachmentStorageEnabled` flag (`GET /users/me`):
+ *  - Off (default, unchanged): fetches each attachment via the authenticated
+ *    `GET /attachments/{id}/content` endpoint and resolves it into a `data:`
+ *    URL, so the browser never makes an unauthenticated request. Mirrors the
+ *    customer portal's `useResolvedInlineImageHtml`.
+ *  - On: creates a short-lived public share (`POST /attachments/{id}/share`)
+ *    for each referenced attachment and uses its `shareUrl` directly as the
+ *    `<img>` src.
  *
  * @param html - Sanitized HTML that may contain `.iix` `<img>` src references.
  */
@@ -61,26 +82,48 @@ export function useResolvedInlineImageHtml(html: string): {
   isLoading: boolean;
 } {
   const api = useBackendApi();
+  const { user } = useCurrentUser();
+  const sftpgoEnabled = !!user?.sftpgoAttachmentStorageEnabled;
   const attachmentIds = useMemo(() => extractIixAttachmentIds(html), [html]);
 
   const queries = useQueries({
     queries: attachmentIds.map((id) => ({
-      queryKey: [ApiQueryKeys.CSM_CASE_ATTACHMENTS, "inline-preview", id],
+      queryKey: [
+        ApiQueryKeys.CSM_CASE_ATTACHMENTS,
+        "inline-preview",
+        id,
+        sftpgoEnabled,
+      ],
       queryFn: async (): Promise<string | null> => {
         // The extracted id is a bare 32-char sysid; the endpoint requires the
         // canonical UUID shape (hyphens re-inserted), same as every other
         // attachment id sent to this backend.
-        const blob = await api.getBlob(
-          `/attachments/${encodeURIComponent(sysidToUuid(id))}/content`,
-        );
+        const attachmentId = encodeURIComponent(sysidToUuid(id));
+
+        if (sftpgoEnabled) {
+          // A share is a real SFTPGo object with its own lifecycle — only
+          // create one when this specific inline image is actually being
+          // resolved for render, never eagerly for a whole comment thread.
+          const { shareUrl } = await api.post<
+            Record<string, never>,
+            BeAttachmentShareResponse
+          >(`/attachments/${attachmentId}/share`, {});
+          // The share URL is a public, unauthenticated download link, so it
+          // can be set directly as the <img> src rather than fetched and
+          // re-encoded as a data URL.
+          return shareUrl;
+        }
+
+        const blob = await api.getBlob(`/attachments/${attachmentId}/content`);
         const mimeType = toSafeMimeType(blob.type);
         if (!mimeType) return null;
         return blobToDataUrl(blob);
       },
       enabled: !!id,
-      // Attachment content is immutable once uploaded, so cache it
-      // indefinitely rather than refetching on every window focus.
-      staleTime: Infinity,
+      // The default (non-SFTPGo) path resolves immutable attachment content,
+      // so it's cached indefinitely. The SFTPGo share path resolves to a
+      // URL that itself expires — see INLINE_IMAGE_SHARE_STALE_TIME_MS.
+      staleTime: sftpgoEnabled ? INLINE_IMAGE_SHARE_STALE_TIME_MS : Infinity,
       retry: 1,
     })),
   });

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.test.tsx
@@ -382,6 +382,63 @@ describe("AttachmentsWidget — preview affordance", () => {
   });
 });
 
+describe("AttachmentsWidget — upload progress", () => {
+  it("shows an indeterminate bar with no percentage when uploadProgress is not supplied", () => {
+    renderWithRouter(
+      <AttachmentsWidgetHarness
+        attachments={[]}
+        uploading
+        onUpload={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Uploading…")).toBeInTheDocument();
+    const bar = document.querySelector(".MuiLinearProgress-root");
+    expect(bar).not.toHaveAttribute("aria-valuenow");
+  });
+
+  it("shows a determinate bar with the percentage when uploadProgress is a number", () => {
+    renderWithRouter(
+      <AttachmentsWidgetHarness
+        attachments={[]}
+        uploading
+        uploadProgress={42}
+        onUpload={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Uploading… 42%")).toBeInTheDocument();
+    const bar = document.querySelector(".MuiLinearProgress-root");
+    expect(bar).toHaveAttribute("aria-valuenow", "42");
+  });
+
+  it("only calls onDownload when a specific attachment's Download button is clicked, never on render", () => {
+    const onDownload = vi.fn();
+    const attachment: CaseAttachment = {
+      id: "att-1",
+      filename: "notes.txt",
+      size: 128,
+      contentType: "text/plain",
+      uploadedBy: "Jane Doe",
+      uploadedAt: "2026-01-01T00:00:00Z",
+    };
+    renderWithRouter(
+      <AttachmentsWidgetHarness
+        attachments={[attachment]}
+        onDownload={onDownload}
+      />,
+    );
+
+    // Rendering the list alone must never trigger a download resolution
+    // (e.g. a lazily-created SFTPGo share) — only an explicit click does.
+    expect(onDownload).not.toHaveBeenCalled();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: `Download ${attachment.filename}` }),
+    );
+    expect(onDownload).toHaveBeenCalledTimes(1);
+    expect(onDownload).toHaveBeenCalledWith(attachment);
+  });
+});
+
 describe("CustomerContextWidget", () => {
   const CTX: CaseCustomerContext = {
     accountName: "Acme Corp",

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CaseDetailWidgets.tsx
@@ -743,6 +743,7 @@ export function AttachmentsWidget({
   error = false,
   onRetry,
   uploading = false,
+  uploadProgress = null,
   uploadError,
   onUpload,
   onDownloadAll,
@@ -762,6 +763,13 @@ export function AttachmentsWidget({
   onRetry?: () => void;
   /** An upload is in flight. */
   uploading?: boolean;
+  /**
+   * 0-100 while a direct-to-SFTPGo upload is in flight (see
+   * `usePostCsmCaseAttachment`'s `uploadProgress`), `null`/omitted otherwise
+   * — including for the default upload path, which has no granular
+   * progress and falls back to an indeterminate bar.
+   */
+  uploadProgress?: number | null;
   /** Message shown when the last upload failed (size, network, 413, …). */
   uploadError?: string | null;
   onUpload?: (file: File) => void;
@@ -832,7 +840,11 @@ export function AttachmentsWidget({
                 onClick={pickFile}
                 disabled={uploading}
               >
-                {uploading ? "Uploading…" : "Upload"}
+                {uploading
+                  ? uploadProgress != null
+                    ? `Uploading… ${uploadProgress}%`
+                    : "Uploading…"
+                  : "Upload"}
               </Button>
             )}
             <Button
@@ -856,7 +868,13 @@ export function AttachmentsWidget({
             aria-hidden
           />
         )}
-        {uploading && <LinearProgress sx={{ mb: 1 }} />}
+        {uploading && (
+          <LinearProgress
+            sx={{ mb: 1 }}
+            variant={uploadProgress != null ? "determinate" : "indeterminate"}
+            value={uploadProgress ?? undefined}
+          />
+        )}
         {uploadError && (
           <Typography variant="body2" color="error" sx={{ mb: 1 }}>
             {uploadError}

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.test.tsx
@@ -15,7 +15,7 @@
 // under the License.
 
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { JSX } from "react";
 import {
   MemoryRouter,
@@ -187,6 +187,19 @@ vi.mock("@features/csm-cases/api/useCsmCaseActivities", () => ({
     isFetching: false,
   }),
 }));
+// A vi.fn() (rather than a plain arrow function) so individual tests — the
+// cross-case upload-scoping regression below — can override its return value
+// per case, the same convention as `useGetCsmCaseDetailMock` above.
+const usePostCsmCaseAttachmentMock = vi.fn();
+usePostCsmCaseAttachmentMock.mockReturnValue({
+  mutate: vi.fn(),
+  mutateAsync: vi.fn(),
+  isPending: false,
+  isError: false,
+  error: null,
+  variables: undefined,
+  uploadProgress: null,
+});
 vi.mock("@features/csm-cases/api/useCsmCaseAttachments", () => ({
   useGetCsmCaseAttachments: () => ({
     data: undefined,
@@ -196,12 +209,7 @@ vi.mock("@features/csm-cases/api/useCsmCaseAttachments", () => ({
     isFetching: false,
     dataUpdatedAt: 0,
   }),
-  usePostCsmCaseAttachment: () => ({
-    mutateAsync: vi.fn(),
-    isPending: false,
-    isError: false,
-    error: null,
-  }),
+  usePostCsmCaseAttachment: () => usePostCsmCaseAttachmentMock(),
   useDownloadCsmCaseAttachment: () => vi.fn(),
   useDeleteCsmCaseAttachment: () => ({ mutate: vi.fn(), isPending: false }),
   useGetCsmCaseAttachmentContent: () => vi.fn(),
@@ -310,8 +318,21 @@ vi.mock("@features/csm-cases/components/CaseActivitiesFeed", () => ({
 vi.mock("@features/csm-cases/components/CaseMetaBand", () => ({
   default: () => null,
 }));
+// AttachmentsWidget renders as a probe (not a stub returning null) so the
+// cross-case upload-scoping regression below can assert on the actual
+// `uploading`/`uploadProgress` props this page passes down.
 vi.mock("@features/csm-cases/components/CaseDetailWidgets", () => ({
-  AttachmentsWidget: () => null,
+  AttachmentsWidget: ({
+    uploading,
+    uploadProgress,
+  }: {
+    uploading?: boolean;
+    uploadProgress?: number | null;
+  }) => (
+    <div data-testid="attachments-widget-probe">
+      {`uploading=${String(!!uploading)} uploadProgress=${String(uploadProgress ?? "null")}`}
+    </div>
+  ),
   CustomerContextWidget: () => null,
   ProductContextWidget: () => null,
   TagsWidget: () => null,
@@ -748,5 +769,62 @@ describe("CsmCaseDetailPage — time-card edit dialog reset on case change", () 
     expect(
       screen.queryByTestId("log-time-card-dialog-probe"),
     ).not.toBeInTheDocument();
+  });
+});
+
+describe("CsmCaseDetailPage — upload progress scoped to the case it belongs to", () => {
+  afterEach(() => {
+    // Restore the shared mock's default (idle) return value so later tests
+    // in this file aren't affected by an override left behind here.
+    usePostCsmCaseAttachmentMock.mockReturnValue({
+      mutate: vi.fn(),
+      mutateAsync: vi.fn(),
+      isPending: false,
+      isError: false,
+      error: null,
+      variables: undefined,
+      uploadProgress: null,
+    });
+  });
+
+  it("does not show a case-1 upload in progress once the page has navigated to case-2", () => {
+    // `postAttachment` is a single mutation object shared across renders of
+    // this page — it doesn't know or care which case's AttachmentsWidget is
+    // currently on screen. Simulate an upload still in flight for case-1
+    // by returning pending state whose `variables.caseId` is "case-1".
+    usePostCsmCaseAttachmentMock.mockReturnValue({
+      mutate: vi.fn(),
+      mutateAsync: vi.fn(),
+      isPending: true,
+      isError: false,
+      error: null,
+      variables: { caseId: "case-1", file: new File([], "x.txt") },
+      uploadProgress: 42,
+    });
+
+    renderPage();
+
+    // Switch to the Attachments tab on case-1: the in-flight upload belongs
+    // here, so the widget should show it.
+    fireEvent.click(screen.getByRole("tab", { name: /^attachments$/i }));
+    expect(screen.getByTestId("attachments-widget-probe")).toHaveTextContent(
+      "uploading=true uploadProgress=42",
+    );
+
+    // Navigate to case-2 through a real router transition (same route, only
+    // :caseId changes — this page stays mounted, and `postAttachment`'s
+    // pending state is still for case-1's upload). Re-select the
+    // Attachments tab, since the tab lives in the URL's `?tab=` and a plain
+    // `/cases/case-2` navigation (no `?tab=`) resets it to the default.
+    fireEvent.click(screen.getByRole("button", { name: /go to case 2/i }));
+    expect(screen.getByTestId("location-probe")).toHaveTextContent(
+      "/cases/case-2",
+    );
+    fireEvent.click(screen.getByRole("tab", { name: /^attachments$/i }));
+
+    // Case-1's still-pending upload must not leak into case-2's widget.
+    expect(screen.getByTestId("attachments-widget-probe")).toHaveTextContent(
+      "uploading=false uploadProgress=null",
+    );
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.test.tsx
@@ -325,12 +325,14 @@ vi.mock("@features/csm-cases/components/CaseDetailWidgets", () => ({
   AttachmentsWidget: ({
     uploading,
     uploadProgress,
+    uploadError,
   }: {
     uploading?: boolean;
     uploadProgress?: number | null;
+    uploadError?: string | null;
   }) => (
     <div data-testid="attachments-widget-probe">
-      {`uploading=${String(!!uploading)} uploadProgress=${String(uploadProgress ?? "null")}`}
+      {`uploading=${String(!!uploading)} uploadProgress=${String(uploadProgress ?? "null")} uploadError=${String(uploadError ?? "null")}`}
     </div>
   ),
   CustomerContextWidget: () => null,
@@ -808,7 +810,7 @@ describe("CsmCaseDetailPage — upload progress scoped to the case it belongs to
     // here, so the widget should show it.
     fireEvent.click(screen.getByRole("tab", { name: /^attachments$/i }));
     expect(screen.getByTestId("attachments-widget-probe")).toHaveTextContent(
-      "uploading=true uploadProgress=42",
+      "uploading=true uploadProgress=42 uploadError=null",
     );
 
     // Navigate to case-2 through a real router transition (same route, only
@@ -824,7 +826,46 @@ describe("CsmCaseDetailPage — upload progress scoped to the case it belongs to
 
     // Case-1's still-pending upload must not leak into case-2's widget.
     expect(screen.getByTestId("attachments-widget-probe")).toHaveTextContent(
-      "uploading=false uploadProgress=null",
+      "uploading=false uploadProgress=null uploadError=null",
+    );
+  });
+
+  it("does not show a case-1 upload error once the page has navigated to case-2", () => {
+    // Same shared-mutation-object hazard as above, but for a failed upload:
+    // `postAttachment.isError` stays true (React Query keeps the last
+    // mutation's error state until the next mutate call) even after the
+    // widget on screen has moved to a different case's attachments.
+    usePostCsmCaseAttachmentMock.mockReturnValue({
+      mutate: vi.fn(),
+      mutateAsync: vi.fn(),
+      isPending: false,
+      isError: true,
+      error: new Error("Could not upload the attachment."),
+      variables: { caseId: "case-1", file: new File([], "x.txt") },
+      uploadProgress: null,
+    });
+
+    renderPage();
+
+    // Switch to the Attachments tab on case-1: the failed upload belongs
+    // here, so the widget should show the error.
+    fireEvent.click(screen.getByRole("tab", { name: /^attachments$/i }));
+    expect(screen.getByTestId("attachments-widget-probe")).toHaveTextContent(
+      "uploading=false uploadProgress=null uploadError=Could not upload the attachment.",
+    );
+
+    // Navigate to case-2 through a real router transition (same route, only
+    // :caseId changes — this page stays mounted, and `postAttachment`'s
+    // error state is still for case-1's failed upload).
+    fireEvent.click(screen.getByRole("button", { name: /go to case 2/i }));
+    expect(screen.getByTestId("location-probe")).toHaveTextContent(
+      "/cases/case-2",
+    );
+    fireEvent.click(screen.getByRole("tab", { name: /^attachments$/i }));
+
+    // Case-1's stale upload error must not leak into case-2's widget.
+    expect(screen.getByTestId("attachments-widget-probe")).toHaveTextContent(
+      "uploading=false uploadProgress=null uploadError=null",
     );
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -2386,7 +2386,8 @@ export default function CsmCaseDetailPage(): JSX.Element {
             uploading={isUploadingForThisCase}
             uploadProgress={isUploadingForThisCase ? postAttachment.uploadProgress : null}
             uploadError={
-              postAttachment.isError
+              postAttachment.isError &&
+              postAttachment.variables?.caseId === caseId
                 ? (postAttachment.error?.message ??
                   "Could not upload the attachment.")
                 : null

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -2374,6 +2374,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
             isRefreshing={isFetchingAttachments}
             refreshedAt={attachmentsUpdatedAt}
             uploading={postAttachment.isPending}
+            uploadProgress={postAttachment.uploadProgress}
             uploadError={
               postAttachment.isError
                 ? (postAttachment.error?.message ??

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -1577,6 +1577,16 @@ export default function CsmCaseDetailPage(): JSX.Element {
 
   const attachmentList = useMemo(() => attachments ?? [], [attachments]);
 
+  // `postAttachment` is a single shared mutation object that stays mounted
+  // across `caseId` changes (this page doesn't remount on navigation between
+  // cases). Without this check, an upload still in flight for a previously
+  // viewed case would show its progress/disabled state on whichever case is
+  // open now. `variables` reflects whichever call is currently pending, so
+  // comparing its `caseId` to the page's current `caseId` scopes the
+  // in-flight state to the case it actually belongs to.
+  const isUploadingForThisCase =
+    postAttachment.isPending && postAttachment.variables?.caseId === caseId;
+
   // Case comments + the linked chat transcript, as one list for the activity
   // feed. Memoised so the feed's own sort doesn't rerun on every render.
   const mergedComments = useMemo(
@@ -2373,8 +2383,8 @@ export default function CsmCaseDetailPage(): JSX.Element {
             onRefresh={() => void refetchAttachments()}
             isRefreshing={isFetchingAttachments}
             refreshedAt={attachmentsUpdatedAt}
-            uploading={postAttachment.isPending}
-            uploadProgress={postAttachment.uploadProgress}
+            uploading={isUploadingForThisCase}
+            uploadProgress={isUploadingForThisCase ? postAttachment.uploadProgress : null}
             uploadError={
               postAttachment.isError
                 ? (postAttachment.error?.message ??

--- a/apps/csm-portal/webapp/src/features/settings/api/useGetUsersMe.test.tsx
+++ b/apps/csm-portal/webapp/src/features/settings/api/useGetUsersMe.test.tsx
@@ -22,7 +22,7 @@ import type { ReactNode } from "react";
 const fetchMock = vi.fn();
 
 vi.mock("@config/apiConfig", () => ({
-  apiConfig: { backendUrl: "https://backend.example.com" },
+  apiConfig: { backendUrl: "https://example.test" },
 }));
 
 vi.mock("@hooks/useAuthApiClient", () => ({

--- a/apps/csm-portal/webapp/src/features/settings/api/useGetUsersMe.test.tsx
+++ b/apps/csm-portal/webapp/src/features/settings/api/useGetUsersMe.test.tsx
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+
+const fetchMock = vi.fn();
+
+vi.mock("@config/apiConfig", () => ({
+  apiConfig: { backendUrl: "https://backend.example.com" },
+}));
+
+vi.mock("@hooks/useAuthApiClient", () => ({
+  useAuthApiClient: () => fetchMock,
+}));
+
+import { useGetUsersMe } from "@features/settings/api/useGetUsersMe";
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe("useGetUsersMe", () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+  });
+
+  it("surfaces sftpgoAttachmentStorageEnabled: true from the response body", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          email: "jane.doe@example.com",
+          sftpgoAttachmentStorageEnabled: true,
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const { result } = renderHook(() => useGetUsersMe(), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.sftpgoAttachmentStorageEnabled).toBe(true);
+  });
+
+  it("surfaces sftpgoAttachmentStorageEnabled: false from the response body", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          email: "jane.doe@example.com",
+          sftpgoAttachmentStorageEnabled: false,
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const { result } = renderHook(() => useGetUsersMe(), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.sftpgoAttachmentStorageEnabled).toBe(false);
+  });
+
+  it("treats an absent field (older backend) as undefined, not a thrown error", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ email: "jane.doe@example.com" }), {
+        status: 200,
+      }),
+    );
+
+    const { result } = renderHook(() => useGetUsersMe(), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.sftpgoAttachmentStorageEnabled).toBeUndefined();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/settings/api/useGetUsersMe.ts
+++ b/apps/csm-portal/webapp/src/features/settings/api/useGetUsersMe.ts
@@ -43,6 +43,16 @@ export interface UsersMeResponse {
     teamName: string;
     family?: string;
   };
+  /**
+   * Mirrors the backend's `SFTPGO_ATTACHMENT_STORAGE_ENABLED` runtime flag.
+   * Always present on a backend that knows this field (never omitted), so
+   * `undefined` here means either the profile hasn't loaded yet or the
+   * backend predates this field — both should be treated the same as "off".
+   * Gates the direct-to-SFTPGo upload/share attachment flows; see
+   * `usePostCsmCaseAttachment`, `useDownloadCsmCaseAttachment`, and
+   * `useResolvedInlineImageHtml`.
+   */
+  sftpgoAttachmentStorageEnabled?: boolean;
 }
 
 export function useGetUsersMe() {

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -2361,16 +2361,38 @@ type Attachment struct {
 	CreatedOn   time.Time      `json:"createdOn"`
 	DownloadURL *string        `json:"downloadUrl"`
 	PreviewURL  *string        `json:"previewUrl"`
+	// StorageKey identifies the file's location in external object storage
+	// (SFTPGo) for CSM-native (Postgres) data source attachments. Nil for
+	// ServiceNow-sourced attachments, whose bytes are held by ServiceNow itself.
+	StorageKey *string `json:"storageKey,omitempty"`
 }
 
 // CreateAttachmentRequest is the input for POST /attachments.
+//
+// The two data sources populate mutually exclusive fields: ServiceNow requires
+// File (a base64 data URI) and computes SizeBytes from the decoded bytes; the
+// CSM-native (Postgres) data source requires StorageKey (the file was already
+// uploaded to SFTPGo out of band) and SizeBytes, since this service never sees
+// the bytes themselves.
 type CreateAttachmentRequest struct {
 	ReferenceID   string        `json:"referenceId"`
 	ReferenceType ReferenceType `json:"referenceType"`
 	Name          string        `json:"name"`
 	Type          string        `json:"type"`
-	File          string        `json:"file"`
+	File          string        `json:"file,omitempty"`
 	Description   *string       `json:"description"`
+	// StorageKey references file bytes already uploaded to SFTPGo. Required
+	// for the CSM-native (Postgres) data source; ignored for ServiceNow.
+	StorageKey *string `json:"storageKey,omitempty"`
+	// SizeBytes is the file size in bytes. Required for the CSM-native
+	// (Postgres) data source (this service cannot compute it, since it never
+	// sees the file bytes); ignored for ServiceNow, which computes it from
+	// the decoded File payload.
+	SizeBytes int `json:"sizeBytes,omitempty"`
+	// CreatedBy is the resolved actor user id, wired in by the Postgres-backed
+	// service from the request's auth token before it reaches the repository.
+	// Not part of the wire contract.
+	CreatedBy string `json:"-"`
 }
 
 // AttachmentDetail holds the core fields returned after creating an attachment.
@@ -2380,6 +2402,9 @@ type AttachmentDetail struct {
 	CreatedOn   time.Time `json:"createdOn"`
 	CreatedBy   string    `json:"createdBy"`
 	DownloadURL string    `json:"downloadUrl"`
+	// StorageKey is set only for CSM-native (Postgres) data source attachments.
+	// See Attachment.StorageKey.
+	StorageKey *string `json:"storageKey,omitempty"`
 }
 
 // CreateAttachmentResponse is the response for POST /cases/{id}/attachments.
@@ -4456,7 +4481,10 @@ type CaseFeedback struct {
 	AdditionalComment *string              `json:"additionalComment"`
 }
 
-// --- attachment gaps (ServiceNow data source only) ---
+// --- attachment gaps (formerly ServiceNow data source only; the CSM-native
+// Postgres data source now implements GetAttachmentByID and UpdateAttachment
+// too, in caseService -- see its Content/StorageKey doc comments above for how
+// the two data sources differ) ---
 
 // AttachmentDetails is the response for GET /attachments/{id} — attachment
 // metadata plus its base64-encoded file content. Note ServiceNow's
@@ -4476,6 +4504,10 @@ type AttachmentDetails struct {
 	DownloadURL *string   `json:"downloadUrl"`
 	PreviewURL  *string   `json:"previewUrl"`
 	Content     string    `json:"content"`
+	// StorageKey is set only for CSM-native (Postgres) data source
+	// attachments, whose Content is always "" (this service holds no bytes
+	// for them -- see CaseService.GetCaseAttachmentContent).
+	StorageKey *string `json:"storageKey,omitempty"`
 }
 
 // UpdateAttachmentRequest is the request body for PATCH /attachments/{id}.

--- a/entity-service/internal/repository/case_repo.go
+++ b/entity-service/internal/repository/case_repo.go
@@ -56,6 +56,25 @@ type CaseRepository interface {
 	// closed_at is set to NOW() when transitioning to closed.
 	// Returns a NotFoundError if no matching row exists.
 	UpdateCase(ctx context.Context, req domain.UpdateCaseRequest) (domain.Case, error)
+	// CreateCaseAttachment inserts a new attachment metadata row for the case
+	// identified by req.ReferenceID. req.StorageKey must be non-nil: this data
+	// source stores file bytes externally in SFTPGo, never inline in Postgres.
+	// Returns a ValidationError if req.ReferenceID does not match an existing case.
+	CreateCaseAttachment(ctx context.Context, req domain.CreateAttachmentRequest) (domain.Attachment, error)
+	// SearchCaseAttachments returns a paginated slice of attachments for the given
+	// case, most recently created first, together with the total matching count.
+	SearchCaseAttachments(ctx context.Context, caseID string, pagination domain.Pagination) ([]domain.Attachment, int, error)
+	// GetCaseAttachmentByID returns the attachment identified by id.
+	// Returns a NotFoundError if no matching row exists.
+	GetCaseAttachmentByID(ctx context.Context, id string) (domain.Attachment, error)
+	// DeleteCaseAttachment permanently removes the attachment metadata row
+	// identified by id. It does not delete the backing SFTPGo file -- that
+	// remains the downstream CSM backend's responsibility.
+	// Returns a NotFoundError if no matching row exists.
+	DeleteCaseAttachment(ctx context.Context, id string) error
+	// UpdateCaseAttachmentName renames the attachment identified by id and
+	// records who did it. Returns a NotFoundError if no matching row exists.
+	UpdateCaseAttachmentName(ctx context.Context, id, name, updatedBy string) (updatedOn time.Time, err error)
 }
 
 type caseRepo struct {
@@ -339,6 +358,173 @@ func (r *caseRepo) UpdateCase(ctx context.Context, req domain.UpdateCaseRequest)
 		c.WorkState = &ws
 	}
 	return c, nil
+}
+
+// CreateCaseAttachment implements CaseRepository.
+func (r *caseRepo) CreateCaseAttachment(ctx context.Context, req domain.CreateAttachmentRequest) (domain.Attachment, error) {
+	const query = `
+		INSERT INTO case_attachments (case_id, storage_key, filename, mime_type, size_bytes, description, uploaded_by)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+		RETURNING id, case_id, storage_key, filename, mime_type, size_bytes, description, uploaded_by, created_at`
+
+	var (
+		a            domain.Attachment
+		storageKey   string
+		uploadedByID string
+	)
+	err := r.db.QueryRow(ctx, query,
+		req.ReferenceID, req.StorageKey, req.Name, req.Type, req.SizeBytes, req.Description, req.CreatedBy,
+	).Scan(
+		&a.ID, &a.ReferenceID, &storageKey, &a.Name, &a.Type, &a.SizeBytes, &a.Description,
+		&uploadedByID, &a.CreatedOn,
+	)
+	if err != nil {
+		if pgErr := (*pgconn.PgError)(nil); errors.As(err, &pgErr) {
+			switch pgErr.Code {
+			case "23503": // foreign_key_violation — case_id or uploaded_by does not exist
+				return domain.Attachment{}, &apierror.ValidationError{Msg: "one or more referenced IDs do not exist: " + pgErr.Detail}
+			case "23514": // check_violation — e.g. size_bytes <= 0
+				return domain.Attachment{}, &apierror.ValidationError{Msg: pgErr.Message}
+			}
+		}
+		return domain.Attachment{}, fmt.Errorf("create case attachment: %w", err)
+	}
+	a.ReferenceType = domain.ReferenceTypeCase
+	a.StorageKey = &storageKey
+	// The insert returns only the uploader's id; email and display name would
+	// need a further join, so the reference carries the id alone, same as
+	// CreateCaseComment above.
+	a.CreatedBy = domain.NewUserReference(uploadedByID, "", "")
+	return a, nil
+}
+
+// SearchCaseAttachments implements CaseRepository.
+func (r *caseRepo) SearchCaseAttachments(ctx context.Context, caseID string, pagination domain.Pagination) ([]domain.Attachment, int, error) {
+	const countQuery = `SELECT COUNT(*) FROM case_attachments WHERE case_id = $1`
+	const dataQuery = `
+		SELECT ca.id, ca.case_id, ca.filename, ca.mime_type, ca.size_bytes, ca.description,
+		       u.id, u.email, TRIM(u.first_name || ' ' || u.last_name) AS full_name,
+		       ca.created_at, ca.storage_key
+		FROM case_attachments ca
+		JOIN users u ON u.id = ca.uploaded_by
+		WHERE ca.case_id = $1
+		ORDER BY ca.created_at DESC, ca.id
+		LIMIT $2 OFFSET $3`
+
+	var total int
+	var attachments []domain.Attachment
+
+	eg, egCtx := errgroup.WithContext(ctx)
+
+	eg.Go(func() error {
+		if err := r.db.QueryRow(egCtx, countQuery, caseID).Scan(&total); err != nil {
+			return fmt.Errorf("count case attachments: %w", err)
+		}
+		return nil
+	})
+
+	eg.Go(func() error {
+		rows, err := r.db.Query(egCtx, dataQuery, caseID, pagination.Limit, pagination.Offset)
+		if err != nil {
+			return fmt.Errorf("query case attachments: %w", err)
+		}
+		defer rows.Close()
+
+		result := make([]domain.Attachment, 0, pagination.Limit)
+		for rows.Next() {
+			var (
+				a                         domain.Attachment
+				uploaderID, uploaderEmail string
+				uploaderName, storageKey  string
+			)
+			if err := rows.Scan(
+				&a.ID, &a.ReferenceID, &a.Name, &a.Type, &a.SizeBytes, &a.Description,
+				&uploaderID, &uploaderEmail, &uploaderName, &a.CreatedOn, &storageKey,
+			); err != nil {
+				return fmt.Errorf("scan case attachment: %w", err)
+			}
+			a.ReferenceType = domain.ReferenceTypeCase
+			a.CreatedBy = domain.NewUserReference(uploaderID, uploaderEmail, uploaderName)
+			a.StorageKey = &storageKey
+			result = append(result, a)
+		}
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("iterate case attachments: %w", err)
+		}
+		attachments = result
+		return nil
+	})
+
+	if err := eg.Wait(); err != nil {
+		return nil, 0, err
+	}
+
+	return attachments, total, nil
+}
+
+// GetCaseAttachmentByID implements CaseRepository.
+func (r *caseRepo) GetCaseAttachmentByID(ctx context.Context, id string) (domain.Attachment, error) {
+	const query = `
+		SELECT ca.id, ca.case_id, ca.filename, ca.mime_type, ca.size_bytes, ca.description,
+		       u.id, u.email, TRIM(u.first_name || ' ' || u.last_name) AS full_name,
+		       ca.created_at, ca.storage_key
+		FROM case_attachments ca
+		JOIN users u ON u.id = ca.uploaded_by
+		WHERE ca.id = $1`
+
+	var (
+		a                         domain.Attachment
+		uploaderID, uploaderEmail string
+		uploaderName, storageKey  string
+	)
+	err := r.db.QueryRow(ctx, query, id).Scan(
+		&a.ID, &a.ReferenceID, &a.Name, &a.Type, &a.SizeBytes, &a.Description,
+		&uploaderID, &uploaderEmail, &uploaderName, &a.CreatedOn, &storageKey,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return domain.Attachment{}, &apierror.NotFoundError{Msg: "attachment not found"}
+	}
+	if err != nil {
+		return domain.Attachment{}, fmt.Errorf("get case attachment by id: %w", err)
+	}
+	a.ReferenceType = domain.ReferenceTypeCase
+	a.CreatedBy = domain.NewUserReference(uploaderID, uploaderEmail, uploaderName)
+	a.StorageKey = &storageKey
+	return a, nil
+}
+
+// DeleteCaseAttachment implements CaseRepository.
+func (r *caseRepo) DeleteCaseAttachment(ctx context.Context, id string) error {
+	tag, err := r.db.Exec(ctx, `DELETE FROM case_attachments WHERE id = $1`, id)
+	if err != nil {
+		return fmt.Errorf("delete case attachment: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return &apierror.NotFoundError{Msg: "attachment not found"}
+	}
+	return nil
+}
+
+// UpdateCaseAttachmentName implements CaseRepository.
+func (r *caseRepo) UpdateCaseAttachmentName(ctx context.Context, id, name, updatedBy string) (time.Time, error) {
+	const query = `
+		UPDATE case_attachments
+		SET filename = $2, updated_at = NOW(), updated_by = $3
+		WHERE id = $1
+		RETURNING updated_at`
+
+	var updatedOn time.Time
+	err := r.db.QueryRow(ctx, query, id, name, updatedBy).Scan(&updatedOn)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return time.Time{}, &apierror.NotFoundError{Msg: "attachment not found"}
+	}
+	if err != nil {
+		if pgErr := (*pgconn.PgError)(nil); errors.As(err, &pgErr) && pgErr.Code == "23503" {
+			return time.Time{}, &apierror.ValidationError{Msg: "one or more referenced IDs do not exist: " + pgErr.Detail}
+		}
+		return time.Time{}, fmt.Errorf("update case attachment name: %w", err)
+	}
+	return updatedOn, nil
 }
 
 // pgSortColMap maps domain CaseSortField values to Postgres column expressions.

--- a/entity-service/internal/service/case_attachment_service_test.go
+++ b/entity-service/internal/service/case_attachment_service_test.go
@@ -1,0 +1,452 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
+	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
+)
+
+const testCaseID = "00000000-0000-0000-0000-0000000000c1"
+const testAttachmentID = "00000000-0000-0000-0000-0000000000a1"
+const testStorageKey = "cases/00000000-0000-0000-0000-0000000000c1/00000000-0000-0000-0000-0000000000a1"
+
+func validCreateAttachmentRequest() domain.CreateAttachmentRequest {
+	storageKey := testStorageKey
+	return domain.CreateAttachmentRequest{
+		ReferenceID:   testCaseID,
+		ReferenceType: domain.ReferenceTypeCase,
+		Name:          "diagnostics.log",
+		Type:          "text/plain",
+		StorageKey:    &storageKey,
+		SizeBytes:     2048,
+	}
+}
+
+func actorUserRepo(t *testing.T) stubUserRepo {
+	t.Helper()
+	return stubUserRepo{
+		getUserByEmail: func(_ context.Context, email string) (domain.User, error) {
+			if email != "jane.doe@example.com" {
+				t.Fatalf("unexpected email looked up: %s", email)
+			}
+			return domain.User{ID: "user-jane", Email: "jane.doe@example.com", FirstName: "Jane", LastName: "Doe"}, nil
+		},
+	}
+}
+
+// TestCaseService_CreateCaseAttachment_Succeeds proves a well-formed request
+// (storageKey + sizeBytes supplied, matching this data source's contract)
+// reaches the repository and the response carries storageKey through.
+func TestCaseService_CreateCaseAttachment_Succeeds(t *testing.T) {
+	var capturedReq domain.CreateAttachmentRequest
+	createdOn := time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
+
+	repo := &stubCaseRepo{
+		createCaseAttachment: func(_ context.Context, req domain.CreateAttachmentRequest) (domain.Attachment, error) {
+			capturedReq = req
+			return domain.Attachment{
+				ID:            testAttachmentID,
+				ReferenceID:   req.ReferenceID,
+				ReferenceType: domain.ReferenceTypeCase,
+				Name:          req.Name,
+				Type:          req.Type,
+				SizeBytes:     req.SizeBytes,
+				CreatedBy:     domain.NewUserReference(req.CreatedBy, "", ""),
+				CreatedOn:     createdOn,
+				StorageKey:    req.StorageKey,
+			}, nil
+		},
+	}
+
+	svc := NewCaseService(repo, actorUserRepo(t))
+	ctx := contextWithUserIDToken(fakeJWTWithEmail(t, "jane.doe@example.com"))
+
+	resp, err := svc.CreateCaseAttachment(ctx, validCreateAttachmentRequest())
+	if err != nil {
+		t.Fatalf("CreateCaseAttachment returned error: %v", err)
+	}
+	if capturedReq.CreatedBy != "user-jane" {
+		t.Fatalf("expected repo to receive resolved actor id, got %q", capturedReq.CreatedBy)
+	}
+	if resp.Attachment.ID != testAttachmentID {
+		t.Fatalf("expected attachment id %q, got %q", testAttachmentID, resp.Attachment.ID)
+	}
+	if resp.Attachment.StorageKey == nil || *resp.Attachment.StorageKey != testStorageKey {
+		t.Fatalf("expected storageKey %q on response, got %v", testStorageKey, resp.Attachment.StorageKey)
+	}
+	if resp.Attachment.CreatedBy != "jane.doe@example.com" {
+		t.Fatalf("expected createdBy to be the actor's email, got %q", resp.Attachment.CreatedBy)
+	}
+}
+
+// TestCaseService_CreateCaseAttachment_RequiresStorageKey proves this data
+// source rejects a create request with no storageKey rather than falling
+// back to a base64 payload -- there is no such fallback here, unlike
+// ServiceNow.
+func TestCaseService_CreateCaseAttachment_RequiresStorageKey(t *testing.T) {
+	repo := &stubCaseRepo{
+		createCaseAttachment: func(context.Context, domain.CreateAttachmentRequest) (domain.Attachment, error) {
+			t.Fatal("repository should not be reached when storageKey is missing")
+			return domain.Attachment{}, nil
+		},
+	}
+	svc := NewCaseService(repo, actorUserRepo(t))
+	ctx := contextWithUserIDToken(fakeJWTWithEmail(t, "jane.doe@example.com"))
+
+	req := validCreateAttachmentRequest()
+	req.StorageKey = nil
+
+	_, err := svc.CreateCaseAttachment(ctx, req)
+	var ve *apierror.ValidationError
+	if !asValidationError(err, &ve) {
+		t.Fatalf("expected *apierror.ValidationError, got %T: %v", err, err)
+	}
+}
+
+// TestCaseService_CreateCaseAttachment_RequiresSizeBytes proves sizeBytes
+// must be a positive value: this service cannot compute it (it never sees
+// the file bytes for this data source).
+func TestCaseService_CreateCaseAttachment_RequiresSizeBytes(t *testing.T) {
+	svc := NewCaseService(&stubCaseRepo{}, actorUserRepo(t))
+	ctx := contextWithUserIDToken(fakeJWTWithEmail(t, "jane.doe@example.com"))
+
+	req := validCreateAttachmentRequest()
+	req.SizeBytes = 0
+
+	_, err := svc.CreateCaseAttachment(ctx, req)
+	var ve *apierror.ValidationError
+	if !asValidationError(err, &ve) {
+		t.Fatalf("expected *apierror.ValidationError, got %T: %v", err, err)
+	}
+}
+
+// TestCaseService_CreateCaseAttachment_RejectsNonCaseReferenceType proves
+// this data source only models case attachments -- conversation, deployment,
+// change_request, and incident have no Postgres schema backing here.
+func TestCaseService_CreateCaseAttachment_RejectsNonCaseReferenceType(t *testing.T) {
+	svc := NewCaseService(&stubCaseRepo{}, actorUserRepo(t))
+	ctx := contextWithUserIDToken(fakeJWTWithEmail(t, "jane.doe@example.com"))
+
+	req := validCreateAttachmentRequest()
+	req.ReferenceType = domain.ReferenceTypeDeployment
+
+	_, err := svc.CreateCaseAttachment(ctx, req)
+	var ve *apierror.ValidationError
+	if !asValidationError(err, &ve) {
+		t.Fatalf("expected *apierror.ValidationError, got %T: %v", err, err)
+	}
+}
+
+// TestCaseService_CreateCaseAttachment_RejectsUnauthenticatedCaller proves
+// the same "must be a known, authenticated user" gate CreateCaseComment
+// already enforces also protects attachment creation.
+func TestCaseService_CreateCaseAttachment_RejectsUnauthenticatedCaller(t *testing.T) {
+	svc := NewCaseService(&stubCaseRepo{}, stubUserRepo{})
+	ctx := contextWithUserIDToken("") // no x-user-id-token header
+
+	_, err := svc.CreateCaseAttachment(ctx, validCreateAttachmentRequest())
+	var ue *apierror.UnauthorizedError
+	if !errorsAsUnauthorized(err, &ue) {
+		t.Fatalf("expected *apierror.UnauthorizedError, got %T: %v", err, err)
+	}
+}
+
+// TestCaseService_SearchCaseAttachments_ReturnsStorageKey proves the search
+// path surfaces storageKey for every row, not just create.
+func TestCaseService_SearchCaseAttachments_ReturnsStorageKey(t *testing.T) {
+	key := testStorageKey
+	repo := &stubCaseRepo{
+		searchCaseAttachments: func(_ context.Context, caseID string, pagination domain.Pagination) ([]domain.Attachment, int, error) {
+			if caseID != testCaseID {
+				t.Fatalf("expected caseID %q, got %q", testCaseID, caseID)
+			}
+			return []domain.Attachment{{
+				ID:            testAttachmentID,
+				ReferenceID:   caseID,
+				ReferenceType: domain.ReferenceTypeCase,
+				Name:          "diagnostics.log",
+				Type:          "text/plain",
+				SizeBytes:     2048,
+				CreatedBy:     domain.NewUserReference("user-jane", "jane.doe@example.com", "Jane Doe"),
+				CreatedOn:     time.Now(),
+				StorageKey:    &key,
+			}}, 1, nil
+		},
+	}
+
+	svc := NewCaseService(repo, stubUserRepo{})
+	resp, err := svc.SearchCaseAttachments(context.Background(), domain.SearchAttachmentsRequest{
+		ReferenceID:   testCaseID,
+		ReferenceType: domain.ReferenceTypeCase,
+	})
+	if err != nil {
+		t.Fatalf("SearchCaseAttachments returned error: %v", err)
+	}
+	if len(resp.Attachments) != 1 {
+		t.Fatalf("expected 1 attachment, got %d", len(resp.Attachments))
+	}
+	if resp.Attachments[0].StorageKey == nil || *resp.Attachments[0].StorageKey != testStorageKey {
+		t.Fatalf("expected storageKey %q, got %v", testStorageKey, resp.Attachments[0].StorageKey)
+	}
+}
+
+// TestCaseService_GetAttachmentByID_ReturnsStorageKeyNotContent proves the
+// Postgres-backed GetAttachmentByID never fabricates base64 content: Content
+// is always empty and StorageKey is populated, so a caller resolves bytes
+// externally instead.
+func TestCaseService_GetAttachmentByID_ReturnsStorageKeyNotContent(t *testing.T) {
+	key := testStorageKey
+	repo := &stubCaseRepo{
+		getCaseAttachmentByID: func(_ context.Context, id string) (domain.Attachment, error) {
+			if id != testAttachmentID {
+				t.Fatalf("expected id %q, got %q", testAttachmentID, id)
+			}
+			return domain.Attachment{
+				ID:            id,
+				ReferenceID:   testCaseID,
+				ReferenceType: domain.ReferenceTypeCase,
+				Name:          "diagnostics.log",
+				Type:          "text/plain",
+				SizeBytes:     2048,
+				CreatedBy:     domain.NewUserReference("user-jane", "jane.doe@example.com", "Jane Doe"),
+				CreatedOn:     time.Now(),
+				StorageKey:    &key,
+			}, nil
+		},
+	}
+
+	svc := NewCaseService(repo, stubUserRepo{})
+	details, err := svc.GetAttachmentByID(context.Background(), testAttachmentID)
+	if err != nil {
+		t.Fatalf("GetAttachmentByID returned error: %v", err)
+	}
+	if details.Content != "" {
+		t.Fatalf("expected empty Content for a Postgres-sourced attachment, got %q", details.Content)
+	}
+	if details.StorageKey == nil || *details.StorageKey != testStorageKey {
+		t.Fatalf("expected storageKey %q, got %v", testStorageKey, details.StorageKey)
+	}
+	if details.CreatedBy != "jane.doe@example.com" {
+		t.Fatalf("expected createdBy email, got %q", details.CreatedBy)
+	}
+}
+
+// TestCaseService_GetAttachmentByID_NotFound proves a missing attachment
+// surfaces as a NotFoundError, not a generic error.
+func TestCaseService_GetAttachmentByID_NotFound(t *testing.T) {
+	repo := &stubCaseRepo{
+		getCaseAttachmentByID: func(context.Context, string) (domain.Attachment, error) {
+			return domain.Attachment{}, &apierror.NotFoundError{Msg: "attachment not found"}
+		},
+	}
+	svc := NewCaseService(repo, stubUserRepo{})
+
+	_, err := svc.GetAttachmentByID(context.Background(), testAttachmentID)
+	var nfe *apierror.NotFoundError
+	if !errorsAsNotFound(err, &nfe) {
+		t.Fatalf("expected *apierror.NotFoundError, got %T: %v", err, err)
+	}
+}
+
+// TestCaseService_GetCaseAttachmentContent_ReturnsTypedError proves this data
+// source never attempts to serve bytes for an attachment it doesn't hold --
+// it returns an accurate, typed error instead of fabricating a response or
+// reaching out to SFTPGo itself.
+func TestCaseService_GetCaseAttachmentContent_ReturnsTypedError(t *testing.T) {
+	svc := NewCaseService(&stubCaseRepo{}, stubUserRepo{})
+
+	content, contentType, err := svc.GetCaseAttachmentContent(context.Background(), testAttachmentID)
+	if content != nil {
+		t.Fatalf("expected nil content, got %v", content)
+	}
+	if contentType != "" {
+		t.Fatalf("expected empty contentType, got %q", contentType)
+	}
+	var sue *apierror.ServiceUnavailableError
+	if !errorsAsServiceUnavailable(err, &sue) {
+		t.Fatalf("expected *apierror.ServiceUnavailableError, got %T: %v", err, err)
+	}
+}
+
+// TestCaseService_DeleteCaseAttachment_RemovesRow proves delete reaches the
+// repository with the requested id and reports success.
+func TestCaseService_DeleteCaseAttachment_RemovesRow(t *testing.T) {
+	var deletedID string
+	repo := &stubCaseRepo{
+		deleteCaseAttachment: func(_ context.Context, id string) error {
+			deletedID = id
+			return nil
+		},
+	}
+	svc := NewCaseService(repo, actorUserRepo(t))
+	ctx := contextWithUserIDToken(fakeJWTWithEmail(t, "jane.doe@example.com"))
+
+	resp, err := svc.DeleteCaseAttachment(ctx, domain.DeleteAttachmentRequest{AttachmentID: testAttachmentID})
+	if err != nil {
+		t.Fatalf("DeleteCaseAttachment returned error: %v", err)
+	}
+	if deletedID != testAttachmentID {
+		t.Fatalf("expected repo to receive id %q, got %q", testAttachmentID, deletedID)
+	}
+	if resp.Message == "" {
+		t.Fatal("expected a non-empty confirmation message")
+	}
+}
+
+// TestCaseService_DeleteCaseAttachment_RejectsUnauthenticatedCaller proves
+// deletion is gated behind the same authentication check as create.
+func TestCaseService_DeleteCaseAttachment_RejectsUnauthenticatedCaller(t *testing.T) {
+	repo := &stubCaseRepo{
+		deleteCaseAttachment: func(context.Context, string) error {
+			t.Fatal("repository should not be reached for an unauthenticated caller")
+			return nil
+		},
+	}
+	svc := NewCaseService(repo, stubUserRepo{})
+	ctx := contextWithUserIDToken("")
+
+	_, err := svc.DeleteCaseAttachment(ctx, domain.DeleteAttachmentRequest{AttachmentID: testAttachmentID})
+	var ue *apierror.UnauthorizedError
+	if !errorsAsUnauthorized(err, &ue) {
+		t.Fatalf("expected *apierror.UnauthorizedError, got %T: %v", err, err)
+	}
+}
+
+// TestCaseService_DeleteCaseAttachment_NotFound proves deleting a
+// non-existent attachment surfaces as a NotFoundError.
+func TestCaseService_DeleteCaseAttachment_NotFound(t *testing.T) {
+	repo := &stubCaseRepo{
+		deleteCaseAttachment: func(context.Context, string) error {
+			return &apierror.NotFoundError{Msg: "attachment not found"}
+		},
+	}
+	svc := NewCaseService(repo, actorUserRepo(t))
+	ctx := contextWithUserIDToken(fakeJWTWithEmail(t, "jane.doe@example.com"))
+
+	_, err := svc.DeleteCaseAttachment(ctx, domain.DeleteAttachmentRequest{AttachmentID: testAttachmentID})
+	var nfe *apierror.NotFoundError
+	if !errorsAsNotFound(err, &nfe) {
+		t.Fatalf("expected *apierror.NotFoundError, got %T: %v", err, err)
+	}
+}
+
+// TestCaseService_UpdateAttachment_RenamesFile proves the one mutation this
+// data source supports (renaming, mirroring the ServiceNow "case" reference
+// type behavior) reaches the repository and returns the actor's email.
+func TestCaseService_UpdateAttachment_RenamesFile(t *testing.T) {
+	updatedOn := time.Date(2026, 8, 27, 13, 0, 0, 0, time.UTC)
+	var gotID, gotName, gotUpdatedBy string
+	repo := &stubCaseRepo{
+		updateAttachmentName: func(_ context.Context, id, name, updatedBy string) (time.Time, error) {
+			gotID, gotName, gotUpdatedBy = id, name, updatedBy
+			return updatedOn, nil
+		},
+	}
+	svc := NewCaseService(repo, actorUserRepo(t))
+	ctx := contextWithUserIDToken(fakeJWTWithEmail(t, "jane.doe@example.com"))
+
+	name := "renamed.log"
+	resp, err := svc.UpdateAttachment(ctx, domain.UpdateAttachmentRequest{
+		ID:            testAttachmentID,
+		ReferenceID:   testCaseID,
+		ReferenceType: domain.ReferenceTypeCase,
+		Name:          &name,
+	})
+	if err != nil {
+		t.Fatalf("UpdateAttachment returned error: %v", err)
+	}
+	if gotID != testAttachmentID || gotName != "renamed.log" || gotUpdatedBy != "user-jane" {
+		t.Fatalf("unexpected repo call: id=%q name=%q updatedBy=%q", gotID, gotName, gotUpdatedBy)
+	}
+	if resp.Attachment.UpdatedBy != "jane.doe@example.com" {
+		t.Fatalf("expected updatedBy email, got %q", resp.Attachment.UpdatedBy)
+	}
+	if !resp.Attachment.UpdatedOn.Equal(updatedOn) {
+		t.Fatalf("expected updatedOn %v, got %v", updatedOn, resp.Attachment.UpdatedOn)
+	}
+}
+
+// TestCaseService_UpdateAttachment_RejectsDescriptionForCase mirrors the
+// ServiceNow path's validateAttachmentUpdate rule: description is not a
+// valid field to update for reference type "case".
+func TestCaseService_UpdateAttachment_RejectsDescriptionForCase(t *testing.T) {
+	svc := NewCaseService(&stubCaseRepo{}, actorUserRepo(t))
+	ctx := contextWithUserIDToken(fakeJWTWithEmail(t, "jane.doe@example.com"))
+
+	name := "renamed.log"
+	description := "not allowed"
+	_, err := svc.UpdateAttachment(ctx, domain.UpdateAttachmentRequest{
+		ID:            testAttachmentID,
+		ReferenceID:   testCaseID,
+		ReferenceType: domain.ReferenceTypeCase,
+		Name:          &name,
+		Description:   &description,
+	})
+	var ve *apierror.ValidationError
+	if !asValidationError(err, &ve) {
+		t.Fatalf("expected *apierror.ValidationError, got %T: %v", err, err)
+	}
+}
+
+// TestCaseService_UpdateAttachment_RejectsDeploymentReferenceType proves this
+// data source rejects the "deployment" reference type ServiceNow allows for
+// updates: deployment attachments have no Postgres schema backing here.
+func TestCaseService_UpdateAttachment_RejectsDeploymentReferenceType(t *testing.T) {
+	svc := NewCaseService(&stubCaseRepo{}, actorUserRepo(t))
+	ctx := contextWithUserIDToken(fakeJWTWithEmail(t, "jane.doe@example.com"))
+
+	name := "renamed.log"
+	_, err := svc.UpdateAttachment(ctx, domain.UpdateAttachmentRequest{
+		ID:            testAttachmentID,
+		ReferenceID:   testCaseID,
+		ReferenceType: domain.ReferenceTypeDeployment,
+		Name:          &name,
+	})
+	var ve *apierror.ValidationError
+	if !asValidationError(err, &ve) {
+		t.Fatalf("expected *apierror.ValidationError, got %T: %v", err, err)
+	}
+}
+
+func errorsAsUnauthorized(err error, target **apierror.UnauthorizedError) bool {
+	if ue, ok := err.(*apierror.UnauthorizedError); ok {
+		*target = ue
+		return true
+	}
+	return false
+}
+
+func errorsAsNotFound(err error, target **apierror.NotFoundError) bool {
+	if nfe, ok := err.(*apierror.NotFoundError); ok {
+		*target = nfe
+		return true
+	}
+	return false
+}
+
+func errorsAsServiceUnavailable(err error, target **apierror.ServiceUnavailableError) bool {
+	if sue, ok := err.(*apierror.ServiceUnavailableError); ok {
+		*target = sue
+		return true
+	}
+	return false
+}

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -20,6 +20,7 @@ package service
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
@@ -582,24 +583,133 @@ func (s *caseService) GroupCasesBy(_ context.Context, _ domain.GroupCasesByReque
 	return domain.GroupByResponse{}, &apierror.ServiceUnavailableError{Msg: "groupBy is only supported for the ServiceNow data source"}
 }
 
-func (s *caseService) CreateCaseAttachment(_ context.Context, _ domain.CreateAttachmentRequest) (domain.CreateAttachmentResponse, error) {
-	return domain.CreateAttachmentResponse{}, &apierror.ServiceUnavailableError{Msg: "attachments are only supported for the ServiceNow data source"}
+// resolveActor authenticates the caller from the x-user-id-token header
+// carried on ctx and resolves it to a platform user record. It is the same
+// authentication step CreateCaseComment above already performs -- there is no
+// finer-grained per-case ACL check in this data source's case service beyond
+// "the caller must be a known, authenticated user," so attachment mutations
+// reuse it verbatim rather than inventing a new authorization pattern.
+func (s *caseService) resolveActor(ctx context.Context) (domain.User, error) {
+	token := middleware.UserIDTokenFromContext(ctx)
+	if token == "" {
+		return domain.User{}, &apierror.UnauthorizedError{Msg: "x-user-id-token header is required"}
+	}
+	email, err := emailFromJWT(token)
+	if err != nil {
+		return domain.User{}, &apierror.ValidationError{Msg: "x-user-id-token: " + err.Error()}
+	}
+	return s.userRepo.GetUserByEmail(ctx, email)
 }
 
-func (s *caseService) SearchCaseAttachments(_ context.Context, _ domain.SearchAttachmentsRequest) (domain.SearchAttachmentsResponse, error) {
-	return domain.SearchAttachmentsResponse{}, &apierror.ServiceUnavailableError{Msg: "attachments are only supported for the ServiceNow data source"}
+// CreateCaseAttachment implements CaseService for the CSM-native (Postgres)
+// data source. Unlike ServiceNow, this data source never receives file bytes
+// directly: the caller must have already uploaded the file to SFTPGo and
+// supplies its storage_key plus the size/name/type metadata. Only
+// ReferenceTypeCase is supported -- the other ReferenceType values
+// (conversation, change_request, deployment, incident) have no Postgres
+// schema backing on this data source.
+func (s *caseService) CreateCaseAttachment(ctx context.Context, req domain.CreateAttachmentRequest) (domain.CreateAttachmentResponse, error) {
+	if err := validateUUIDs("referenceId", []string{req.ReferenceID}); err != nil {
+		return domain.CreateAttachmentResponse{}, err
+	}
+	if req.ReferenceType != domain.ReferenceTypeCase {
+		return domain.CreateAttachmentResponse{}, &apierror.ValidationError{Msg: "referenceType must be 'case' for this data source"}
+	}
+	if req.Name == "" {
+		return domain.CreateAttachmentResponse{}, &apierror.ValidationError{Msg: "name is required"}
+	}
+	if req.Type == "" {
+		return domain.CreateAttachmentResponse{}, &apierror.ValidationError{Msg: "type is required"}
+	}
+	if req.StorageKey == nil || *req.StorageKey == "" {
+		return domain.CreateAttachmentResponse{}, &apierror.ValidationError{Msg: "storageKey is required: this data source has no base64 payload alternative, the file must already be uploaded to SFTPGo"}
+	}
+	if req.SizeBytes <= 0 {
+		return domain.CreateAttachmentResponse{}, &apierror.ValidationError{Msg: "sizeBytes must be greater than zero"}
+	}
+
+	user, err := s.resolveActor(ctx)
+	if err != nil {
+		return domain.CreateAttachmentResponse{}, err
+	}
+	req.CreatedBy = user.ID
+
+	a, err := s.repo.CreateCaseAttachment(ctx, req)
+	if err != nil {
+		return domain.CreateAttachmentResponse{}, err
+	}
+
+	return domain.CreateAttachmentResponse{
+		Message: "Attachment created successfully",
+		Attachment: domain.AttachmentDetail{
+			ID:         a.ID,
+			SizeBytes:  a.SizeBytes,
+			CreatedOn:  a.CreatedOn,
+			CreatedBy:  user.Email,
+			StorageKey: a.StorageKey,
+			// No DownloadURL: this service holds no bytes for a Postgres-sourced
+			// attachment, only its storage_key. Resolving storage_key to an
+			// actual download location is the downstream CSM backend's job.
+		},
+	}, nil
+}
+
+// SearchCaseAttachments implements CaseService for the CSM-native (Postgres)
+// data source.
+func (s *caseService) SearchCaseAttachments(ctx context.Context, req domain.SearchAttachmentsRequest) (domain.SearchAttachmentsResponse, error) {
+	if err := validateUUIDs("referenceId", []string{req.ReferenceID}); err != nil {
+		return domain.SearchAttachmentsResponse{}, err
+	}
+	if req.ReferenceType != domain.ReferenceTypeCase {
+		return domain.SearchAttachmentsResponse{}, &apierror.ValidationError{Msg: "referenceType must be 'case' for this data source"}
+	}
+	if err := normalizePagination(&req.Pagination); err != nil {
+		return domain.SearchAttachmentsResponse{}, err
+	}
+
+	attachments, total, err := s.repo.SearchCaseAttachments(ctx, req.ReferenceID, req.Pagination)
+	if err != nil {
+		return domain.SearchAttachmentsResponse{}, err
+	}
+
+	return domain.SearchAttachmentsResponse{
+		Attachments: attachments,
+		Total:       total,
+		Limit:       req.Pagination.Limit,
+		Offset:      req.Pagination.Offset,
+		HasMore:     req.Pagination.Offset+len(attachments) < total,
+	}, nil
 }
 
 func (s *caseService) SearchCaseActivities(_ context.Context, _ domain.SearchCaseActivitiesRequest) (domain.SearchCaseActivitiesResponse, error) {
 	return domain.SearchCaseActivitiesResponse{}, &apierror.ServiceUnavailableError{Msg: "case activities are only supported for the ServiceNow data source"}
 }
 
+// GetCaseAttachmentContent implements CaseService for the CSM-native
+// (Postgres) data source. This service never holds the file bytes for a
+// Postgres-sourced attachment -- they live in SFTPGo, addressed by the
+// attachment's storage_key (see GetAttachmentByID / SearchCaseAttachments).
+// Callers must resolve content externally via that storage_key rather than
+// through this endpoint.
 func (s *caseService) GetCaseAttachmentContent(_ context.Context, _ string) ([]byte, string, error) {
-	return nil, "", &apierror.ServiceUnavailableError{Msg: "attachments are only supported for the ServiceNow data source"}
+	return nil, "", &apierror.ServiceUnavailableError{Msg: "this data source does not serve attachment bytes directly; resolve content via the attachment's storageKey"}
 }
 
-func (s *caseService) DeleteCaseAttachment(_ context.Context, _ domain.DeleteAttachmentRequest) (domain.DeleteAttachmentResponse, error) {
-	return domain.DeleteAttachmentResponse{}, &apierror.ServiceUnavailableError{Msg: "attachments are only supported for the ServiceNow data source"}
+// DeleteCaseAttachment implements CaseService for the CSM-native (Postgres)
+// data source. This only removes the metadata row -- it does not delete the
+// backing SFTPGo file, which is the downstream CSM backend's responsibility
+// when it also calls SFTPGo's own delete API.
+func (s *caseService) DeleteCaseAttachment(ctx context.Context, req domain.DeleteAttachmentRequest) (domain.DeleteAttachmentResponse, error) {
+	if err := validateUUIDs("attachmentId", []string{req.AttachmentID}); err != nil {
+		return domain.DeleteAttachmentResponse{}, err
+	}
+	if _, err := s.resolveActor(ctx); err != nil {
+		return domain.DeleteAttachmentResponse{}, err
+	}
+	if err := s.repo.DeleteCaseAttachment(ctx, req.AttachmentID); err != nil {
+		return domain.DeleteAttachmentResponse{}, err
+	}
+	return domain.DeleteAttachmentResponse{Message: "Attachment deleted successfully"}, nil
 }
 
 func (s *caseService) AddCaseTag(_ context.Context, _, _ string) (domain.Tag, error) {
@@ -622,10 +732,91 @@ func (s *caseService) SubmitCaseFeedback(_ context.Context, _ string, _ domain.S
 	return domain.SubmitCaseFeedbackResponse{}, &apierror.ServiceUnavailableError{Msg: "case feedback is only supported for the ServiceNow data source"}
 }
 
-func (s *caseService) GetAttachmentByID(_ context.Context, _ string) (domain.AttachmentDetails, error) {
-	return domain.AttachmentDetails{}, &apierror.ServiceUnavailableError{Msg: "attachments are only supported for the ServiceNow data source"}
+// GetAttachmentByID implements CaseService for the CSM-native (Postgres) data
+// source. Content is always "": this service holds no bytes for a
+// Postgres-sourced attachment, only its storage_key -- see
+// GetCaseAttachmentContent's doc comment for why content must be resolved
+// externally via StorageKey instead.
+func (s *caseService) GetAttachmentByID(ctx context.Context, id string) (domain.AttachmentDetails, error) {
+	if err := validateUUIDs("id", []string{id}); err != nil {
+		return domain.AttachmentDetails{}, err
+	}
+
+	a, err := s.repo.GetCaseAttachmentByID(ctx, id)
+	if err != nil {
+		return domain.AttachmentDetails{}, err
+	}
+
+	var createdBy string
+	if a.CreatedBy != nil {
+		createdBy = a.CreatedBy.Email
+	}
+
+	return domain.AttachmentDetails{
+		ID:          a.ID,
+		ReferenceID: a.ReferenceID,
+		Name:        a.Name,
+		Type:        a.Type,
+		SizeBytes:   a.SizeBytes,
+		Description: a.Description,
+		CreatedBy:   createdBy,
+		CreatedOn:   a.CreatedOn,
+		DownloadURL: a.DownloadURL,
+		PreviewURL:  a.PreviewURL,
+		Content:     "",
+		StorageKey:  a.StorageKey,
+	}, nil
 }
 
-func (s *caseService) UpdateAttachment(_ context.Context, _ domain.UpdateAttachmentRequest) (domain.UpdateAttachmentResponse, error) {
-	return domain.UpdateAttachmentResponse{}, &apierror.ServiceUnavailableError{Msg: "attachments are only supported for the ServiceNow data source"}
+// validatePGAttachmentUpdate mirrors the ServiceNow path's
+// validateAttachmentUpdate, narrowed to the one reference type this data
+// source's attachments table actually models: deployment attachments have no
+// Postgres schema backing here, so that branch is rejected outright rather
+// than silently accepted.
+func validatePGAttachmentUpdate(req domain.UpdateAttachmentRequest) error {
+	if req.ReferenceType != domain.ReferenceTypeCase {
+		return &apierror.ValidationError{Msg: fmt.Sprintf("invalid reference type %q: only 'case' is supported for this data source", req.ReferenceType)}
+	}
+	if req.Description != nil {
+		return &apierror.ValidationError{Msg: "description field is not allowed for case reference type"}
+	}
+	if req.Name == nil || strings.TrimSpace(*req.Name) == "" {
+		return &apierror.ValidationError{Msg: "name field is required for case reference type"}
+	}
+	return nil
+}
+
+// UpdateAttachment implements CaseService for the CSM-native (Postgres) data
+// source. Only renaming is supported, mirroring the one mutation the
+// ServiceNow path allows for reference type "case" (name required,
+// description forbidden).
+func (s *caseService) UpdateAttachment(ctx context.Context, req domain.UpdateAttachmentRequest) (domain.UpdateAttachmentResponse, error) {
+	if err := validateUUIDs("id", []string{req.ID}); err != nil {
+		return domain.UpdateAttachmentResponse{}, err
+	}
+	if err := validateUUIDs("referenceId", []string{req.ReferenceID}); err != nil {
+		return domain.UpdateAttachmentResponse{}, err
+	}
+	if err := validatePGAttachmentUpdate(req); err != nil {
+		return domain.UpdateAttachmentResponse{}, err
+	}
+
+	user, err := s.resolveActor(ctx)
+	if err != nil {
+		return domain.UpdateAttachmentResponse{}, err
+	}
+
+	updatedOn, err := s.repo.UpdateCaseAttachmentName(ctx, req.ID, strings.TrimSpace(*req.Name), user.ID)
+	if err != nil {
+		return domain.UpdateAttachmentResponse{}, err
+	}
+
+	return domain.UpdateAttachmentResponse{
+		Message: "Attachment updated successfully",
+		Attachment: domain.UpdatedAttachment{
+			ID:        req.ID,
+			UpdatedOn: updatedOn,
+			UpdatedBy: user.Email,
+		},
+	}, nil
 }

--- a/entity-service/internal/service/case_service_test.go
+++ b/entity-service/internal/service/case_service_test.go
@@ -19,6 +19,7 @@ package service
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/apierror"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
@@ -29,7 +30,12 @@ import (
 // an unsupported field happens before the Postgres backend ever reaches the
 // repository, not merely that the repository ignores the field.
 type stubCaseRepo struct {
-	searchCases func(ctx context.Context, req domain.SearchCasesRequest) ([]domain.SearchCaseView, int, error)
+	searchCases           func(ctx context.Context, req domain.SearchCasesRequest) ([]domain.SearchCaseView, int, error)
+	createCaseAttachment  func(ctx context.Context, req domain.CreateAttachmentRequest) (domain.Attachment, error)
+	searchCaseAttachments func(ctx context.Context, caseID string, pagination domain.Pagination) ([]domain.Attachment, int, error)
+	getCaseAttachmentByID func(ctx context.Context, id string) (domain.Attachment, error)
+	deleteCaseAttachment  func(ctx context.Context, id string) error
+	updateAttachmentName  func(ctx context.Context, id, name, updatedBy string) (time.Time, error)
 }
 
 func (s *stubCaseRepo) CreateCase(context.Context, domain.CreateCaseRequest) (domain.Case, error) {
@@ -53,16 +59,51 @@ func (s *stubCaseRepo) SearchCaseComments(context.Context, domain.SearchCaseComm
 func (s *stubCaseRepo) UpdateCase(context.Context, domain.UpdateCaseRequest) (domain.Case, error) {
 	panic("not implemented")
 }
+func (s *stubCaseRepo) CreateCaseAttachment(ctx context.Context, req domain.CreateAttachmentRequest) (domain.Attachment, error) {
+	if s.createCaseAttachment != nil {
+		return s.createCaseAttachment(ctx, req)
+	}
+	panic("not implemented")
+}
+func (s *stubCaseRepo) SearchCaseAttachments(ctx context.Context, caseID string, pagination domain.Pagination) ([]domain.Attachment, int, error) {
+	if s.searchCaseAttachments != nil {
+		return s.searchCaseAttachments(ctx, caseID, pagination)
+	}
+	panic("not implemented")
+}
+func (s *stubCaseRepo) GetCaseAttachmentByID(ctx context.Context, id string) (domain.Attachment, error) {
+	if s.getCaseAttachmentByID != nil {
+		return s.getCaseAttachmentByID(ctx, id)
+	}
+	panic("not implemented")
+}
+func (s *stubCaseRepo) DeleteCaseAttachment(ctx context.Context, id string) error {
+	if s.deleteCaseAttachment != nil {
+		return s.deleteCaseAttachment(ctx, id)
+	}
+	panic("not implemented")
+}
+func (s *stubCaseRepo) UpdateCaseAttachmentName(ctx context.Context, id, name, updatedBy string) (time.Time, error) {
+	if s.updateAttachmentName != nil {
+		return s.updateAttachmentName(ctx, id, name, updatedBy)
+	}
+	panic("not implemented")
+}
 
 // stubUserRepo is a minimal repository.UserRepository; SearchCases doesn't
 // exercise it beyond the createdBy-current-user path, which these tests don't
 // use.
-type stubUserRepo struct{}
+type stubUserRepo struct {
+	getUserByEmail func(ctx context.Context, email string) (domain.User, error)
+}
 
 func (stubUserRepo) SearchUsers(context.Context, domain.SearchUsersRequest) ([]domain.User, int, error) {
 	panic("not implemented")
 }
-func (stubUserRepo) GetUserByEmail(context.Context, string) (domain.User, error) {
+func (s stubUserRepo) GetUserByEmail(ctx context.Context, email string) (domain.User, error) {
+	if s.getUserByEmail != nil {
+		return s.getUserByEmail(ctx, email)
+	}
 	panic("not implemented")
 }
 

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -337,13 +337,16 @@ type CaseService interface {
 	// is returned for invalid input. Supported by the ServiceNow data source only.
 	SubmitCaseFeedback(ctx context.Context, id string, req domain.SubmitCaseFeedbackRequest) (domain.SubmitCaseFeedbackResponse, error)
 	// GetAttachmentByID returns the metadata and base64-encoded content of the attachment
-	// identified by id. A NotFoundError is returned if it does not exist.
-	// Supported by the ServiceNow data source only.
+	// identified by id. A NotFoundError is returned if it does not exist. For the CSM-native
+	// (Postgres) data source, Content is always "" and StorageKey is populated instead: that
+	// data source holds no bytes, only a reference into external (SFTPGo) storage.
 	GetAttachmentByID(ctx context.Context, id string) (domain.AttachmentDetails, error)
 	// UpdateAttachment updates the name and/or description of the attachment identified by
-	// req.ID. A ValidationError is returned for invalid input (referenceType must be "case"
-	// or "deployment"; "case" requires name and forbids description; "deployment" requires
-	// at least one of name or description). Supported by the ServiceNow data source only.
+	// req.ID. A ValidationError is returned for invalid input. For ServiceNow, referenceType
+	// must be "case" or "deployment" ("case" requires name and forbids description;
+	// "deployment" requires at least one of name or description). The CSM-native (Postgres)
+	// data source only models case attachments, so it accepts referenceType "case" only, with
+	// the same name-required/description-forbidden rule.
 	UpdateAttachment(ctx context.Context, req domain.UpdateAttachmentRequest) (domain.UpdateAttachmentResponse, error)
 }
 

--- a/entity-service/migrations/000012_create_case_attachments.down.sql
+++ b/entity-service/migrations/000012_create_case_attachments.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS case_attachments;

--- a/entity-service/migrations/000012_create_case_attachments.up.sql
+++ b/entity-service/migrations/000012_create_case_attachments.up.sql
@@ -1,0 +1,23 @@
+-- case_attachments stores metadata only. File bytes for this data source live
+-- externally in SFTPGo, addressed by storage_key -- there is no base64-payload
+-- alternative here, unlike the ServiceNow data source's /attachments API.
+CREATE TABLE case_attachments (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  case_id     UUID NOT NULL REFERENCES cases(id),
+  storage_key TEXT NOT NULL,
+  filename    TEXT NOT NULL,
+  mime_type   TEXT NOT NULL,
+  size_bytes  INTEGER NOT NULL CHECK (size_bytes > 0),
+  description TEXT,
+  uploaded_by TEXT NOT NULL REFERENCES users(id),
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_by  TEXT REFERENCES users(id)
+);
+
+-- FK / equality indexes
+CREATE INDEX idx_case_attachments_case_id     ON case_attachments(case_id);
+CREATE INDEX idx_case_attachments_uploaded_by ON case_attachments(uploaded_by);
+
+-- Composite index for the paginated per-case feed (most recent first).
+CREATE INDEX idx_case_attachments_case_created ON case_attachments(case_id, created_at DESC);

--- a/entity-service/migrations/000012_create_case_attachments.up.sql
+++ b/entity-service/migrations/000012_create_case_attachments.up.sql
@@ -1,13 +1,13 @@
 -- case_attachments stores metadata only. File bytes for this data source live
 -- externally in SFTPGo, addressed by storage_key -- there is no base64-payload
 -- alternative here, unlike the ServiceNow data source's /attachments API.
-CREATE TABLE case_attachments (
+CREATE TABLE IF NOT EXISTS case_attachments (
   id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   case_id     UUID NOT NULL REFERENCES cases(id),
   storage_key TEXT NOT NULL,
   filename    TEXT NOT NULL,
   mime_type   TEXT NOT NULL,
-  size_bytes  INTEGER NOT NULL CHECK (size_bytes > 0),
+  size_bytes  BIGINT NOT NULL CHECK (size_bytes > 0),
   description TEXT,
   uploaded_by TEXT NOT NULL REFERENCES users(id),
   created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
@@ -16,8 +16,8 @@ CREATE TABLE case_attachments (
 );
 
 -- FK / equality indexes
-CREATE INDEX idx_case_attachments_case_id     ON case_attachments(case_id);
-CREATE INDEX idx_case_attachments_uploaded_by ON case_attachments(uploaded_by);
+CREATE INDEX IF NOT EXISTS idx_case_attachments_case_id     ON case_attachments(case_id);
+CREATE INDEX IF NOT EXISTS idx_case_attachments_uploaded_by ON case_attachments(uploaded_by);
 
 -- Composite index for the paginated per-case feed (most recent first).
-CREATE INDEX idx_case_attachments_case_created ON case_attachments(case_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_case_attachments_case_created ON case_attachments(case_id, created_at DESC);

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -7750,7 +7750,14 @@ components:
 
     CreateAttachmentRequest:
       type: object
-      required: [referenceId, referenceType, name, type, file]
+      description: >
+        The two data sources populate mutually exclusive fields. ServiceNow requires file
+        (a base64 data URI) and computes sizeBytes from the decoded bytes. The CSM-native
+        (Postgres) data source instead requires storageKey (the file was already uploaded to
+        SFTPGo out of band, referenced by this key) and sizeBytes, since this service never
+        sees the file bytes for that data source -- there is no base64-payload alternative
+        there.
+      required: [referenceId, referenceType, name, type]
       properties:
         referenceId:
           type: string
@@ -7766,10 +7773,24 @@ components:
           description: MIME type of the file (e.g. image/png, application/pdf).
         file:
           type: string
-          description: Base64 data URI of the file content (e.g. data:image/png;base64,...). Maximum decoded size is 10 MB.
+          description: >
+            Base64 data URI of the file content (e.g. data:image/png;base64,...). Maximum
+            decoded size is 10 MB. Required for the ServiceNow data source; not accepted by
+            the CSM-native (Postgres) data source.
         description:
           type: string
           nullable: true
+        storageKey:
+          type: string
+          description: >
+            Reference to file bytes already uploaded to SFTPGo. Required for the CSM-native
+            (Postgres) data source; not accepted by ServiceNow.
+        sizeBytes:
+          type: integer
+          description: >
+            File size in bytes. Required for the CSM-native (Postgres) data source (this
+            service cannot compute it there); ignored for ServiceNow, which computes it from
+            the decoded file payload.
 
     AttachmentDetail:
       type: object
@@ -7786,6 +7807,10 @@ components:
           type: string
         downloadUrl:
           type: string
+        storageKey:
+          type: string
+          nullable: true
+          description: Set only for CSM-native (Postgres) data source attachments. See Attachment.storageKey.
 
     CreateAttachmentResponse:
       type: object
@@ -7827,6 +7852,13 @@ components:
         previewUrl:
           type: string
           nullable: true
+        storageKey:
+          type: string
+          nullable: true
+          description: >
+            Reference to the file's location in external object storage (SFTPGo), set only for
+            CSM-native (Postgres) data source attachments. Null for ServiceNow-sourced
+            attachments, whose bytes are held by ServiceNow itself.
 
     ReferenceType:
       type: string
@@ -11734,7 +11766,9 @@ components:
       description: >
         The response for GET /attachments/{id}. Distinct from GET /attachments/{id}/content,
         which streams the raw binary — this endpoint returns JSON metadata plus the content
-        as a base64 data URI.
+        as a base64 data URI. For a CSM-native (Postgres) data source attachment, content is
+        always "" and storageKey is populated instead: this service holds no bytes for that
+        data source, so content must be resolved externally via storageKey.
       required: [id, referenceId, name, type, sizeBytes, createdBy, createdOn, content]
       properties:
         id:
@@ -11766,6 +11800,10 @@ components:
         content:
           type: string
           description: Base64 data URI of the attachment content (e.g. data:image/png;base64,...).
+        storageKey:
+          type: string
+          nullable: true
+          description: Set only for CSM-native (Postgres) data source attachments. See Attachment.storageKey.
 
     UpdateAttachmentRequest:
       type: object


### PR DESCRIPTION
## Purpose
Give the CSM platform an SFTPGo-backed attachment storage path for the customer-support case attachment flow (upload, download, inline comment images), targeting `dev-app-csm-portal` (net-new CSM platform). Ships **disabled by default** behind `SFTPGO_ATTACHMENT_STORAGE_ENABLED` / `sftpgoAttachmentStorageEnabled` -- the existing byte-streaming attachment implementation is completely unaffected until explicitly flipped per environment.

Depends on the `external_auth_hook` addition in #1593 (split out separately for independent review) for the actual token-minting mechanism this PR's backend calls into.

## Goals
- Real Postgres-backed attachment support for CSM-native cases, which had none before this PR (every method was stubbed "ServiceNow data source only").
- Direct browser<->SFTPGo transfer for upload (TUS, resumable, real progress) and download/inline-images (short-lived Share links), keeping the case service out of the byte path while it still owns every authorization decision.
- Ship fully dark: no behavior change for any existing consumer until the flag is turned on.

## Approach
Four commits, bottom-up:
1. **CSM BE**: token-mint (`POST /cases/{id}/attachments/upload-token`) and lazy Share-creation (`POST /attachments/{id}/share`) endpoints, both ACL-checked, both behind the feature flag -- routes aren't even registered on the mux when the flag is off.
2. **Entity service**: real Postgres attachment support (new `case_attachments` table + implementation), replacing the stub. ServiceNow-backed attachment path (shared with the live production customer portal) is completely untouched.
3. **CSM BE follow-up**: exposes the flag on `GET /users/me`; upload-token mint now generates and returns the full SFTPGo storage key server-side (avoids the frontend inventing a path -- path-traversal/collision risk otherwise).
4. **CSM FE**: TUS direct upload with real progress, Share-based inline-comment-image resolution (3-min staleTime against the backend's 5-min share TTL), and click-only lazy download resolution (list rendering creates zero shares).

**Known, accepted gap, not introduced by this PR**: the Postgres-backed case service has no case-level authorization anywhere (not on comments, not on reads, not even `UpdateCase`). Attachments here are exactly as protected as every other case-scoped write already on this branch -- not a regression. Service-wide case-level authorization is tracked separately, out of scope here.

**Known, accepted cosmetic issue, vendor question pending**: minted upload tokens carry the case service's own internal pod IP in an unencrypted JWT claim (SFTPGo bakes the issuing caller's IP into every token's `aud`), visible to the browser holding it on the upload path. Not end-user PII. Not a blocker.

## User stories
As a CS engineer or customer using the CSM portal, when this flag is enabled for my environment, uploading a case attachment shows real progress for large files, and comment inline images / attachment downloads load without the file passing through the case service's own bandwidth.

## Release note
N/A -- ships disabled; no user-visible change until explicitly enabled per environment.

## Documentation
N/A -- feature is disabled by default; documentation follow-up tracked for when it's enabled.

## Automation tests
- Unit tests: real `go test`/`vitest` output captured per commit during development. All pre-existing tests across all three components pass unmodified.
- Integration tests: none against a live SFTPGo instance in this PR -- validated separately in local development against a real Enterprise SFTPGo instance before this PR was opened.

## Security checks
- Followed secure coding standards: yes
- Ran FindSecurityBugs plugin: no -- Go/TS stack, not applicable to this plugin
- Confirmed no secrets committed: yes

## Samples
N/A

## Related PRs
Depends on #1593 (`external_auth_hook`, split out for independent review).

## Migrations
New migration `entity-service/migrations/000012_create_case_attachments.{up,down}.sql`, additive only (new table, no existing-table changes). Applied and verified against an ephemeral Postgres 16 container during development.

## Test environment
Go 1.26.6 (toolchain-pinned via `go.mod`), Node/vitest per `apps/csm-portal/webapp/package.json`.

## Learning
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional direct-to-storage case attachment uploads with resumable progress tracking.
  * Added short-lived share links for downloading attachments and displaying inline images.
  * Added PostgreSQL-backed case attachment metadata storage.
  * Added configuration reporting so the app can detect whether direct storage is enabled.
  * Existing base64 upload and authenticated download flows remain available when direct storage is disabled.

* **Bug Fixes**
  * Improved validation for attachment access, closed cases, invalid identifiers, and unavailable files.
  * Prevented upload progress from appearing on a different case after navigation.
  * Strengthened storage URL validation and avoided exposing sensitive URL details in startup logs.

* **Documentation**
  * Updated attachment API contracts to document external storage keys and file size requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->