### PR TITLE
[Customer Portal v2] Decode the comment author reference

### DIFF
--- a/apps/customer-portal/backend-v2/internal/dto/comment.go
+++ b/apps/customer-portal/backend-v2/internal/dto/comment.go
@@ -56,7 +56,7 @@ func MapCommentCreate(r entity.CreateCommentResponse) CommentCreateResponse {
 	return CommentCreateResponse{
 		ID:        r.Comment.ID,
 		CreatedOn: r.Comment.CreatedOn,
-		CreatedBy: r.Comment.CreatedBy.FullName,
+		CreatedBy: userRefDisplayName(r.Comment.CreatedBy),
 	}
 }
 
@@ -152,13 +152,23 @@ func MapSearchComments(r entity.SearchCommentsResponse) SearchCommentsResponse {
 	comments := make([]CommentView, 0, len(r.Comments))
 	for _, c := range r.Comments {
 		comments = append(comments, CommentView{
-			ID:                   c.ID,
-			Content:              c.Content,
-			Type:                 string(c.Type),
-			CreatedOn:            c.CreatedOn,
-			CreatedBy:            c.CreatedBy.FullName,
-			CreatedByFirstName:   c.CreatedBy.FirstName,
-			CreatedByLastName:    c.CreatedBy.LastName,
+			ID:        c.ID,
+			Content:   c.Content,
+			Type:      string(c.Type),
+			CreatedOn: c.CreatedOn,
+			// The display name, not the email. entity-service replaced its
+			// CommentUserRef{firstName,lastName,fullName} with a single
+			// UserReference{id,email,name}, and Name is the direct successor of
+			// FullName — which is what this mapped before and what the portal
+			// depends on: ConversationDetailsPage decides a message came from the
+			// assistant with createdBy.toLowerCase() === "novera", and the
+			// assistant's name is "Novera". Mapping the email here instead would
+			// break that attribution for good.
+			CreatedBy: userRefDisplayName(c.CreatedBy),
+			// createdByFirstName/createdByLastName are no longer sent upstream —
+			// the same change removed them. Left empty rather than split out of
+			// Name: the frontend already falls back to createdBy for the display
+			// label, which now carries the full name, so nothing has to be guessed.
 			HasInlineAttachments: c.HasInlineAttachments,
 			InlineAttachments:    mapCommentInlineAttachments(c.InlineAttachments),
 		})

--- a/apps/customer-portal/backend-v2/internal/dto/comment_author_test.go
+++ b/apps/customer-portal/backend-v2/internal/dto/comment_author_test.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dto
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/wso2-open-operations/cs-tools/apps/customer-portal/backend-v2/internal/entity"
+)
+
+// entityCommentsPayload is shaped exactly as entity-service now sends it, with
+// createdBy as the UserReference object that replaced
+// CommentUserRef{firstName,lastName,fullName}.
+const entityCommentsPayload = `{
+  "comments": [
+    {
+      "id": "9c5a8d1c3b4fcf103e1e088aa4e45a22",
+      "content": "Hello! Do you have a WSO2 question I can help with?",
+      "type": "comment",
+      "createdOn": "2026-08-27T16:23:50Z",
+      "createdBy": {"id": null, "email": "", "name": "Novera"}
+    },
+    {
+      "id": "185a8d1c3b4fcf103e1e088aa4e45a18",
+      "content": "hi",
+      "type": "comment",
+      "createdOn": "2026-08-27T16:23:49Z",
+      "createdBy": {"id": "u-1", "email": "sasmitha@wso2.com", "name": "Sasmitha Ekanayaka"}
+    }
+  ],
+  "total": 2, "limit": 10, "offset": 0
+}`
+
+// TestMapSearchComments_KeepsTheAssistantIdentifiable is the regression guard for
+// the chat history rendering every message as "You" in the wrong order.
+//
+// ConversationDetailsPage decides a message came from the assistant with
+// createdBy.toLowerCase() === "novera", and uses that same signal to break ties
+// between messages sharing a timestamp. When createdBy arrived empty, every
+// message was classified as the user's and the ordering tie-break disappeared.
+func TestMapSearchComments_KeepsTheAssistantIdentifiable(t *testing.T) {
+	var resp entity.SearchCommentsResponse
+	if err := json.Unmarshal([]byte(entityCommentsPayload), &resp); err != nil {
+		t.Fatalf("decoding entity-service's payload failed: %v", err)
+	}
+	if len(resp.Comments) != 2 {
+		t.Fatalf("decoded %d comments, want 2", len(resp.Comments))
+	}
+
+	out := MapSearchComments(resp)
+	if len(out.Comments) != 2 {
+		t.Fatalf("mapped %d comments, want 2", len(out.Comments))
+	}
+
+	assistant, human := out.Comments[0], out.Comments[1]
+
+	if assistant.CreatedBy == "" {
+		t.Fatal("assistant createdBy is empty — the chat renders every message as the user's and loses its ordering tie-break")
+	}
+	if strings.ToLower(assistant.CreatedBy) != "novera" {
+		t.Errorf("assistant createdBy = %q; the frontend matches createdBy.toLowerCase() == \"novera\"", assistant.CreatedBy)
+	}
+	if human.CreatedBy != "Sasmitha Ekanayaka" {
+		t.Errorf("human createdBy = %q, want the display name", human.CreatedBy)
+	}
+	// The display label falls back to createdBy, so a name belongs there — not an
+	// email, and not an empty string.
+	if strings.Contains(human.CreatedBy, "@") {
+		t.Errorf("human createdBy = %q; an email renders where a name belongs", human.CreatedBy)
+	}
+}
+
+// TestMapSearchComments_HandlesAnUnresolvedAuthor keeps a nil reference from
+// panicking and leaves the label empty rather than inventing one.
+func TestMapSearchComments_HandlesAnUnresolvedAuthor(t *testing.T) {
+	out := MapSearchComments(entity.SearchCommentsResponse{
+		Comments: []entity.CommentView{
+			{ID: "c1", Content: "orphan", CreatedBy: nil},
+			{ID: "c2", Content: "email only", CreatedBy: &entity.UserReference{Email: "a@wso2.com"}},
+		},
+		Total: 2,
+	})
+	if len(out.Comments) != 2 {
+		t.Fatalf("mapped %d comments, want 2", len(out.Comments))
+	}
+	if out.Comments[0].CreatedBy != "" {
+		t.Errorf("nil author: createdBy = %q, want empty", out.Comments[0].CreatedBy)
+	}
+	if out.Comments[1].CreatedBy != "" {
+		t.Errorf("email-only author: createdBy = %q, want empty rather than an email in a name field", out.Comments[1].CreatedBy)
+	}
+}
+
+// TestMapCommentCreate_UsesTheAuthorName covers the create path, which mapped the
+// same removed FullName field.
+func TestMapCommentCreate_UsesTheAuthorName(t *testing.T) {
+	out := MapCommentCreate(entity.CreateCommentResponse{
+		Comment: entity.CommentCreated{
+			ID:        "c1",
+			CreatedBy: &entity.UserReference{Email: "a@wso2.com", Name: "A Person"},
+		},
+	})
+	if out.CreatedBy != "A Person" {
+		t.Errorf("createdBy = %q, want the author name", out.CreatedBy)
+	}
+}

--- a/apps/customer-portal/backend-v2/internal/entity/types.go
+++ b/apps/customer-portal/backend-v2/internal/entity/types.go
@@ -1154,19 +1154,11 @@ type CreateCommentRequest struct {
 // "fix" this constant to "novera"; that is the read form, not the write form.
 const CreatedByAgent = "agent"
 
-// CommentUserRef holds user details embedded in a comment response.
-type CommentUserRef struct {
-	ID        string `json:"id"`
-	FirstName string `json:"firstName"`
-	LastName  string `json:"lastName"`
-	FullName  string `json:"fullName"`
-}
-
 // CommentCreated carries the fields returned after creating a comment.
 type CommentCreated struct {
 	ID        string         `json:"id"`
 	CreatedOn time.Time      `json:"createdOn"`
-	CreatedBy CommentUserRef `json:"createdBy"`
+	CreatedBy *UserReference `json:"createdBy"`
 }
 
 // CreateCommentResponse is entity-service's response for POST /comments.
@@ -1205,7 +1197,7 @@ type CommentView struct {
 	Content     string         `json:"content"`
 	Type        CommentType    `json:"type"`
 	CreatedOn   time.Time      `json:"createdOn"`
-	CreatedBy   CommentUserRef `json:"createdBy"`
+	CreatedBy   *UserReference `json:"createdBy"`
 	// Images embedded in the comment body, supplied by entity-service.
 	HasInlineAttachments bool               `json:"hasInlineAttachments"`
 	InlineAttachments    []InlineAttachment `json:"inlineAttachments"`


### PR DESCRIPTION
Chat history rendered **every** message as "You" — the assistant included — and in the **wrong order**.

## One cause, both symptoms

entity-service replaced the comment author's `CommentUserRef{firstName,lastName,fullName}` with a single `UserReference{id,email,name}`, in the same change behind #1573. backend-v2's comment mirror still declared `CommentUserRef`, whose JSON keys no longer match anything the upstream sends — so decoding **succeeded** and left every field empty:

| | Ballerina | backend-v2 |
|---|---|---|
| assistant | `"createdBy": "Novera"` | `"createdBy": ""` |
| human | `"createdBy": "sasmitha@wso2.com"` | `"createdBy": ""` |
| name fields | present | absent |

With `createdBy` empty:

```js
const isBot = msg.type?.toLowerCase() === "bot" ||
              msg.createdBy?.toLowerCase() === "novera";   // never true
```

…so every message was classified as the customer's. **And the same predicate is the tie-break that orders messages sharing a timestamp** — every message in that thread was written in the same second, which is why the order scrambled too. One empty field, two symptoms.

Live chat was never affected: it builds messages client-side and never consults `createdBy`. That is why the thread looked right until it was reloaded — matching the report that it "begins ok, but after a few seconds this happens".

## How this slipped past #1573

That PR swept all 211 **shared struct names** for shape mismatches. `CommentUserRef` and `UserReference` have *different* names, so they were never compared. The sweep was sound for what it checked and blind to exactly this case — matching names is not the same as matching shapes. I'd rather record that than have it look like an unrelated new bug.

## Mapping choices

**`createdBy` ← `Name`**, the direct successor of `FullName` and what this mapped before. Deliberately **not** `Email`: the assistant's name is `"Novera"` and the portal identifies it by that exact string, so mapping the email would break attribution permanently. It also keeps a name rather than an address in the field the frontend falls back to for its display label.

**`createdByFirstName`/`createdByLastName`** are no longer sent upstream. Left empty rather than split out of `Name` — the frontend already falls back to `createdBy`, which now carries the full name, so nothing has to be guessed. `CommentUserRef` is removed now that nothing references it.

## Testing

- `gofmt -l`, `go build`, `go vet`, `go test -race ./...` — all pass
- `gosec -fmt=text ./...` — **0 issues** (109 files)

Tests decode an entity-service-shaped payload and assert the assistant stays identifiable (`createdBy.toLowerCase() == "novera"`), a human keeps a name rather than an email, and an unresolved author neither panics nor invents a label. The three pre-existing comment tests still pass.

## Deployment

**backend-v2 only** — entity-service already has the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)