### PR TITLE
[CSM Portal] Rework SFTPGo upload to write-scoped Shares (no bearer token to browser)

### DIFF
--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -519,9 +519,14 @@ func mustHTTPSURL(key, value string) string {
 }
 
 // validateHTTPSURL reports an error unless value parses as a URL with scheme
-// "https", a non-empty host, and no embedded userinfo (e.g.
+// "https", a non-empty host, no embedded userinfo (e.g.
 // "https://user:pass@host/...", which could indicate a misconfigured or
-// spoofed URL).
+// spoofed URL), and no path/query/fragment beyond an empty or bare "/" path.
+// The path restriction matters beyond cosmetics: internal/sftpgo.Client
+// builds request URLs by plain string concatenation (baseURL +
+// "/api/v2/user/token", etc.), so a configured value with a path component
+// (e.g. "https://host/api") would silently double up into
+// "https://host/api/api/v2/user/token" rather than erroring.
 func validateHTTPSURL(value string) error {
 	parsed, err := url.Parse(value)
 	if err != nil {
@@ -535,6 +540,15 @@ func validateHTTPSURL(value string) error {
 	}
 	if parsed.User != nil {
 		return errors.New("must not contain embedded userinfo (e.g. \"https://user:pass@host/...\")")
+	}
+	if path := parsed.EscapedPath(); path != "" && path != "/" {
+		return fmt.Errorf("must not include a path (got %q); this value is concatenated with API paths, e.g. \"https://host\" not \"https://host/api\"", path)
+	}
+	if parsed.RawQuery != "" {
+		return errors.New("must not include a query string")
+	}
+	if parsed.Fragment != "" {
+		return errors.New("must not include a fragment")
 	}
 	return nil
 }

--- a/apps/csm-portal/backend/cmd/server/main.go
+++ b/apps/csm-portal/backend/cmd/server/main.go
@@ -170,6 +170,7 @@ func main() {
 	if attachmentStorageHandler != nil {
 		mux.HandleFunc("POST /cases/{id}/attachments/upload-token", attachmentStorageHandler.MintUploadToken)
 		mux.HandleFunc("POST /attachments/{id}/share", attachmentStorageHandler.CreateAttachmentShare)
+		mux.HandleFunc("POST /cases/{caseId}/attachments/{attachmentId}/confirm", attachmentStorageHandler.ConfirmUpload)
 	}
 	mux.HandleFunc("POST /cases/{id}/call-requests", caseHandler.CreateCallRequest)
 	mux.HandleFunc("POST /cases/{id}/call-requests/search", caseHandler.SearchCallRequests)

--- a/apps/csm-portal/backend/cmd/server/main_test.go
+++ b/apps/csm-portal/backend/cmd/server/main_test.go
@@ -35,7 +35,10 @@ func TestValidateHTTPSURL(t *testing.T) {
 		wantErr bool
 	}{
 		{name: "https ok", value: "https://sftpgo.internal.example.com", wantErr: false},
-		{name: "https with path ok", value: "https://sftpgo.internal.example.com/api", wantErr: false},
+		{name: "https with trailing slash ok", value: "https://sftpgo.internal.example.com/", wantErr: false},
+		{name: "https with path rejected", value: "https://sftpgo.internal.example.com/api", wantErr: true},
+		{name: "https with query rejected", value: "https://sftpgo.internal.example.com?x=1", wantErr: true},
+		{name: "https with fragment rejected", value: "https://sftpgo.internal.example.com#frag", wantErr: true},
 		{name: "http rejected", value: "http://sftpgo.internal.example.com", wantErr: true},
 		{name: "scheme-less rejected", value: "sftpgo.internal.example.com", wantErr: true},
 		{name: "unparseable rejected", value: "https://%zz", wantErr: true},

--- a/apps/csm-portal/backend/internal/entity/customer.go
+++ b/apps/csm-portal/backend/internal/entity/customer.go
@@ -345,6 +345,15 @@ func (c *CustomerEntityClient) GetCaseAttachment(ctx context.Context, attachment
 	return c.do(ctx, http.MethodGet, fmt.Sprintf("/attachments/%s", url.PathEscape(attachmentID)), nil)
 }
 
+// ConfirmCaseAttachment calls POST /attachments/{attachmentId}/confirm on the
+// entity service, transitioning a 'pending' attachment row (see
+// CreateCaseAttachment's status field) to 'complete'. Used by the
+// SFTPGo-backed upload flow once the browser's direct-to-SFTPGo upload has
+// succeeded; see handler.AttachmentStorageHandler.ConfirmUpload.
+func (c *CustomerEntityClient) ConfirmCaseAttachment(ctx context.Context, attachmentID string) ([]byte, error) {
+	return c.do(ctx, http.MethodPost, fmt.Sprintf("/attachments/%s/confirm", url.PathEscape(attachmentID)), nil)
+}
+
 // SearchCatalogs calls POST /catalogs/search on the entity service.
 // Response is returned as raw JSON.
 func (c *CustomerEntityClient) SearchCatalogs(ctx context.Context, body []byte) ([]byte, error) {

--- a/apps/csm-portal/backend/internal/handler/attachment_storage.go
+++ b/apps/csm-portal/backend/internal/handler/attachment_storage.go
@@ -21,6 +21,7 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"path"
@@ -85,9 +86,41 @@ func NewAttachmentStorageHandler(entity entityCaseClient, sftpgo sftpgoClient) *
 	return &AttachmentStorageHandler{entity: entity, sftpgo: sftpgo}
 }
 
+// mintUploadTokenRequest is the request body of
+// POST /cases/{id}/attachments/upload-token. The frontend must send the
+// file's metadata up front, before it uploads any bytes: MintUploadToken now
+// creates the attachment's metadata row (in "pending" status) as part of
+// minting the upload credential, and the entity service has no other source
+// for this data — it never sees the file bytes on this data source (see
+// domain.CreateAttachmentRequest in the entity service).
+type mintUploadTokenRequest struct {
+	// Filename is the file's name including extension. Required; forwarded
+	// verbatim as the entity service's CreateAttachmentRequest.Name.
+	Filename string `json:"filename"`
+	// MimeType is the file's MIME type (e.g. "image/png", "application/pdf").
+	// Required; forwarded verbatim as CreateAttachmentRequest.Type.
+	MimeType string `json:"mimeType"`
+	// SizeBytes is the file's size in bytes, as reported by the browser
+	// before upload. Required: this backend never sees the file's bytes, so
+	// this is the only source of truth for size on this data source (mirrors
+	// CreateAttachmentRequest.SizeBytes).
+	SizeBytes int `json:"sizeBytes"`
+	// Description is an optional free-text description, forwarded verbatim.
+	// Mirrors AttachmentCreatePayload.description on the existing
+	// (non-SFTPGo) attachment-creation path.
+	Description *string `json:"description,omitempty"`
+}
+
 // uploadTokenResponse is the response body of
 // POST /cases/{id}/attachments/upload-token.
 type uploadTokenResponse struct {
+	// ID is the id of the attachment metadata row MintUploadToken creates (in
+	// "pending" status) before minting the share below. The frontend must
+	// hold onto this and send it back as the path parameter to
+	// POST /cases/{id}/attachments/{attachmentId}/confirm once the browser's
+	// direct-to-SFTPGo upload succeeds — see
+	// AttachmentStorageHandler.ConfirmUpload.
+	ID string `json:"id"`
 	// ShareID is a write-scoped, passwordless SFTPGo share id, restricted to
 	// StorageKey's parent directory (see the CreateShare call in
 	// MintUploadToken for why it is the directory and not the file itself —
@@ -123,16 +156,30 @@ type uploadTokenResponse struct {
 }
 
 // MintUploadToken handles POST /cases/{id}/attachments/upload-token. It
-// mints a write-scoped, passwordless SFTPGo share restricted to a single,
-// freshly generated storage path, for the browser to use directly against
-// SFTPGo's share-authenticated chunked/TUS upload endpoint
-// (POST /shares-chunked-uploads) — this backend never sees the uploaded
-// bytes, and no bearer credential of any kind reaches the browser: a
-// write-scoped share can do nothing but write to the one path it names.
+// registers the attachment's metadata row up front — in "pending" status,
+// via the entity service — and only then mints a write-scoped, passwordless
+// SFTPGo share restricted to a single, freshly generated storage path, for
+// the browser to use directly against SFTPGo's share-authenticated
+// chunked/TUS upload endpoint (POST /shares-chunked-uploads) — this backend
+// never sees the uploaded bytes, and no bearer credential of any kind
+// reaches the browser: a write-scoped share can do nothing but write to the
+// one path it names.
+//
+// Creating the pending row before minting the share closes a real
+// reliability gap in the previous design: a browser upload could succeed in
+// SFTPGo while CSM never learned the file existed at all, because nothing
+// durable was recorded until the frontend made a second, separate call after
+// the upload finished — a call that could simply never arrive (tab closed,
+// network drop, crash). Recording "an upload was started" first means a
+// future reconciliation job can always find and clean up an upload that
+// never got confirmed; there is no longer a window where a real file in
+// SFTPGo has zero trace in CSM. See AttachmentStorageHandler.ConfirmUpload
+// for the second half of this flow.
+//
 // Requires write access to the target case, checked via the same guard
 // CaseHandler.CreateCaseAttachment already applies (case exists and is not
-// closed): a share is never minted for a case the caller could not otherwise
-// attach a file to.
+// closed): a row is never created, and a share never minted, for a case the
+// caller could not otherwise attach a file to.
 func (h *AttachmentStorageHandler) MintUploadToken(w http.ResponseWriter, r *http.Request) {
 	user := middleware.UserInfoFromContext(r.Context())
 	if user == nil {
@@ -143,6 +190,34 @@ func (h *AttachmentStorageHandler) MintUploadToken(w http.ResponseWriter, r *htt
 	caseID := r.PathValue("id")
 	if caseID == "" || !uuidRe.MatchString(caseID) {
 		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	rawBody, err := io.ReadAll(r.Body)
+	if err != nil {
+		if _, ok := err.(*http.MaxBytesError); ok {
+			writeError(w, http.StatusRequestEntityTooLarge, ErrMsgTooLarge)
+			return
+		}
+		writeError(w, http.StatusBadRequest, errMsgReadBody)
+		return
+	}
+
+	var req mintUploadTokenRequest
+	if err := json.Unmarshal(rawBody, &req); err != nil {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+	// Checked here, cheaply, before any entity/SFTPGo call: these three
+	// fields are the only source of truth for this data (this backend never
+	// sees the file's bytes), and the entity service rejects their absence
+	// anyway (see domain.CreateAttachmentRequest validation) — failing fast
+	// on an obviously-incomplete request avoids a wasted GetCase + MintToken
+	// round trip. The entity service's own validation remains authoritative
+	// for anything more specific than "present."
+	if req.Filename == "" || req.MimeType == "" || req.SizeBytes <= 0 {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
 		return
 	}
 
@@ -177,6 +252,53 @@ func (h *AttachmentStorageHandler) MintUploadToken(w http.ResponseWriter, r *htt
 	attachmentID := newAttachmentID()
 	storageKey := buildStorageKey(projectID, caseID, attachmentID)
 
+	// Create the attachment's metadata row BEFORE minting the upload share —
+	// see the doc comment above on why this ordering is load-bearing. If this
+	// fails, the upload must not proceed: minting a share for a file with no
+	// corresponding CSM record would recreate the exact gap this change
+	// closes.
+	attachmentBody, err := json.Marshal(struct {
+		ReferenceID   string  `json:"referenceId"`
+		ReferenceType string  `json:"referenceType"`
+		Name          string  `json:"name"`
+		Type          string  `json:"type"`
+		StorageKey    string  `json:"storageKey"`
+		SizeBytes     int     `json:"sizeBytes"`
+		Status        string  `json:"status"`
+		Description   *string `json:"description,omitempty"`
+	}{
+		ReferenceID:   caseID,
+		ReferenceType: "case",
+		Name:          req.Filename,
+		Type:          req.MimeType,
+		StorageKey:    storageKey,
+		SizeBytes:     req.SizeBytes,
+		Status:        "pending",
+		Description:   req.Description,
+	})
+	if err != nil {
+		slog.ErrorContext(r.Context(), "failed to marshal pending attachment request", "userID", user.UserID, "caseID", caseID, "err", err)
+		writeError(w, http.StatusInternalServerError, ErrMsgInternal)
+		return
+	}
+
+	createResult, err := h.entity.CreateCaseAttachment(r.Context(), attachmentBody)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity CreateCaseAttachment (pending) failed", "userID", user.UserID, "caseID", caseID, "err", summarizeErr(err))
+		mapUpstreamErrorGeneric(w, err, "Failed to register the attachment.")
+		return
+	}
+	var created struct {
+		Attachment struct {
+			ID string `json:"id"`
+		} `json:"attachment"`
+	}
+	if err := json.Unmarshal(createResult, &created); err != nil || created.Attachment.ID == "" {
+		slog.ErrorContext(r.Context(), "failed to parse entity CreateCaseAttachment response", "userID", user.UserID, "caseID", caseID, "err", err)
+		writeError(w, http.StatusInternalServerError, ErrMsgInternal)
+		return
+	}
+
 	// The share is scoped to storageKey's parent DIRECTORY, not storageKey
 	// itself — confirmed empirically against a real SFTPGo instance that a
 	// write-scope share used with POST /shares-chunked-uploads always
@@ -198,10 +320,53 @@ func (h *AttachmentStorageHandler) MintUploadToken(w http.ResponseWriter, r *htt
 	}
 
 	writeJSONValue(w, http.StatusOK, uploadTokenResponse{
+		ID:            created.Attachment.ID,
 		ShareID:       shareID,
 		SftpgoBaseURL: h.sftpgo.BaseURL(),
 		StorageKey:    storageKey,
 	})
+}
+
+// ConfirmUpload handles POST /cases/{caseId}/attachments/{attachmentId}/confirm.
+// It is the second half of the two-step upload flow MintUploadToken starts:
+// once the browser's direct-to-SFTPGo upload has actually succeeded, the
+// frontend calls this to transition the attachment's metadata row from
+// "pending" to "complete" — see the entity service's ConfirmCaseAttachment,
+// which enforces that only the same actor who created the pending row may
+// confirm it (stricter than this data source's other attachment operations,
+// which impose no per-resource ACL beyond authentication today).
+//
+// caseId is accepted on the path for consistency with this backend's other
+// nested attachment/case routes, but is not otherwise used: the entity
+// service's confirm endpoint is addressed by attachment id alone, and the
+// actor check it performs is what actually authorizes this call — there is
+// no independent case-level guard to apply here.
+func (h *AttachmentStorageHandler) ConfirmUpload(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserInfoFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, ErrMsgUnauthorized)
+		return
+	}
+
+	caseID := r.PathValue("caseId")
+	if caseID == "" || !uuidRe.MatchString(caseID) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+	attachmentID := r.PathValue("attachmentId")
+	if attachmentID == "" || !uuidRe.MatchString(attachmentID) {
+		writeError(w, http.StatusBadRequest, ErrMsgInvalidUUID)
+		return
+	}
+
+	result, err := h.entity.ConfirmCaseAttachment(r.Context(), attachmentID)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "entity ConfirmCaseAttachment failed", "userID", user.UserID, "caseID", caseID, "attachmentID", attachmentID, "err", summarizeErr(err))
+		mapUpstreamErrorGeneric(w, err, "Failed to confirm the attachment upload.")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, result)
 }
 
 // attachmentMeta is the subset of the entity service's Attachment fields this

--- a/apps/csm-portal/backend/internal/handler/attachment_storage.go
+++ b/apps/csm-portal/backend/internal/handler/attachment_storage.go
@@ -17,6 +17,7 @@
 package handler
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"encoding/json"
@@ -204,8 +205,18 @@ func (h *AttachmentStorageHandler) MintUploadToken(w http.ResponseWriter, r *htt
 		return
 	}
 
+	// Decode strictly: reject unknown fields and a trailing second JSON value
+	// rather than silently ignoring either, per this repo's boundary-input
+	// validation convention (validate and reject unexpected input before it
+	// is ever forwarded to an upstream service).
 	var req mintUploadTokenRequest
-	if err := json.Unmarshal(rawBody, &req); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(rawBody))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
+		return
+	}
+	if err := dec.Decode(new(json.RawMessage)); err != io.EOF {
 		writeError(w, http.StatusBadRequest, ErrMsgBadRequest)
 		return
 	}

--- a/apps/csm-portal/backend/internal/handler/attachment_storage.go
+++ b/apps/csm-portal/backend/internal/handler/attachment_storage.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"path"
 	"time"
 
 	"github.com/wso2-open-operations/cs-tools/apps/csm-portal/backend/internal/middleware"
@@ -36,6 +37,16 @@ import (
 // are never created eagerly.
 const shareTTL = 5 * time.Minute
 
+// uploadShareTTL bounds how long a write-scoped upload share (minted by
+// MintUploadToken) stays valid. Deliberately much longer than shareTTL: an
+// upload share has to stay open for the entire duration of the browser's
+// direct TUS upload to SFTPGo — including retries/resumes of a large or
+// slow file — not just long enough to redeem a single GET. 45 minutes is a
+// documented, reasonable choice rather than a value verified against any
+// real-world upload-duration data; revisit if large attachments start
+// failing with an expired-share error near the end of a long upload.
+const uploadShareTTL = 45 * time.Minute
+
 // jwtAssertionHeader mirrors the unexported constant of the same name in
 // internal/middleware/auth.go — that package does not export it, so it is
 // duplicated here rather than introducing a cross-package export for a
@@ -46,21 +57,23 @@ const jwtAssertionHeader = "x-jwt-assertion"
 // allowing the handler to be tested without a live SFTPGo instance.
 type sftpgoClient interface {
 	MintToken(ctx context.Context, email, jwtAssertion string) (*sftpgo.Token, error)
-	CreateShare(ctx context.Context, accessToken, storageKey string, ttl time.Duration) (string, error)
+	CreateShare(ctx context.Context, accessToken, storageKey string, scope int, ttl time.Duration) (string, error)
 	PublicShareURL(shareID string) string
 	BaseURL() string
 }
 
 // AttachmentStorageHandler implements the SFTPGo-backed attachment-storage
-// endpoints: minting a short-lived SFTPGo access token before an upload, and
-// creating a short-lived public download share for an already-stored
-// attachment. It never touches attachment bytes itself — uploads and
-// downloads go directly between the browser and SFTPGo using the
-// credentials this handler mints; see package sftpgo's doc comment. Its
-// routes are only registered (and therefore only reachable) when
-// SFTPGO_ATTACHMENT_STORAGE_ENABLED is on — see cmd/server/main.go. The
-// existing streaming attachment endpoints on CaseHandler are completely
-// unaffected by this handler and by the flag.
+// endpoints: minting a write-scoped SFTPGo share before an upload, and
+// creating a short-lived read-scoped public download share for an
+// already-stored attachment. It never touches attachment bytes itself —
+// uploads and downloads go directly between the browser and SFTPGo, and the
+// browser never sees a bearer credential of any kind: a Share is scoped to
+// exactly one storage path and one direction (read or write), so the worst
+// a leaked share id can do is read or write that single path — see package
+// sftpgo's doc comment. Its routes are only registered (and therefore only
+// reachable) when SFTPGO_ATTACHMENT_STORAGE_ENABLED is on — see
+// cmd/server/main.go. The existing streaming attachment endpoints on
+// CaseHandler are completely unaffected by this handler and by the flag.
 type AttachmentStorageHandler struct {
 	entity entityCaseClient
 	sftpgo sftpgoClient
@@ -75,26 +88,51 @@ func NewAttachmentStorageHandler(entity entityCaseClient, sftpgo sftpgoClient) *
 // uploadTokenResponse is the response body of
 // POST /cases/{id}/attachments/upload-token.
 type uploadTokenResponse struct {
-	SftpgoAccessToken string          `json:"sftpgoAccessToken"`
-	ExpiresAt         json.RawMessage `json:"expiresAt"`
-	SftpgoBaseURL     string          `json:"sftpgoBaseUrl"`
-	// StorageKey is the exact SFTPGo path the frontend must upload the file
-	// to (as the TUS/chunked-upload target) and must later send back
-	// unchanged as CreateAttachmentRequest.storageKey when it creates the
-	// attachment metadata row. Minted here, server-side, rather than left for
-	// the frontend to invent, so the id embedded in it is guaranteed to match
-	// no other attachment. See buildStorageKey for the path convention.
+	// ShareID is a write-scoped, passwordless SFTPGo share id, restricted to
+	// StorageKey's parent directory (see the CreateShare call in
+	// MintUploadToken for why it is the directory and not the file itself —
+	// SFTPGo's shares-chunked-uploads endpoint always resolves the TUS
+	// "path" metadata relative to the share's own scoped path, confirmed
+	// empirically against a real instance; scoping the share to the exact
+	// file, rather than its directory, made every upload fail). The frontend
+	// embeds this id as the "share_id" key in the TUS Upload-Metadata header
+	// it sends to SFTPGo's POST /shares-chunked-uploads, and MUST send only
+	// StorageKey's final path segment (everything after the last "/") as
+	// the "path" key — NOT the full StorageKey — since the share's own root
+	// already covers the directory portion; sending the full StorageKey as
+	// "path" would double it up (e.g. ".../case-1/case-1/<id>") and fail.
+	// That share id is the entire credential; no bearer token or
+	// Authorization header is ever involved in the upload. The frontend must
+	// also set "mkdir_parents" to "true" in the same Upload-Metadata header:
+	// this directory is not guaranteed to already exist (e.g. a case's first
+	// attachment ever), and SFTPGo does not create it implicitly otherwise.
+	// The share's own server-side expiry governs how long the upload window
+	// stays open; the frontend does not need that value, it either works or
+	// the share is gone.
+	ShareID       string `json:"shareId"`
+	SftpgoBaseURL string `json:"sftpgoBaseUrl"`
+	// StorageKey is the exact SFTPGo path the uploaded file must end up at,
+	// and must later be sent back unchanged as
+	// CreateAttachmentRequest.storageKey when the frontend creates the
+	// attachment metadata row. Minted here, server-side, rather than left
+	// for the frontend to invent, so the id embedded in it is guaranteed to
+	// match no other attachment. See buildStorageKey for the path
+	// convention, and ShareID's doc comment above for how the frontend must
+	// derive the TUS upload's "path" metadata from this value.
 	StorageKey string `json:"storageKey"`
 }
 
-// MintUploadToken handles POST /cases/{id}/attachments/upload-token. It mints
-// a short-lived SFTPGo access token scoped to the caller's own identity (the
-// gateway-validated email claim) for the browser to use directly against
-// SFTPGo's chunked/TUS upload endpoint — this backend never sees the
-// uploaded bytes. Requires write access to the target case, checked via the
-// same guard CaseHandler.CreateCaseAttachment already applies (case exists
-// and is not closed): a token is never minted for a case the caller could
-// not otherwise attach a file to.
+// MintUploadToken handles POST /cases/{id}/attachments/upload-token. It
+// mints a write-scoped, passwordless SFTPGo share restricted to a single,
+// freshly generated storage path, for the browser to use directly against
+// SFTPGo's share-authenticated chunked/TUS upload endpoint
+// (POST /shares-chunked-uploads) — this backend never sees the uploaded
+// bytes, and no bearer credential of any kind reaches the browser: a
+// write-scoped share can do nothing but write to the one path it names.
+// Requires write access to the target case, checked via the same guard
+// CaseHandler.CreateCaseAttachment already applies (case exists and is not
+// closed): a share is never minted for a case the caller could not otherwise
+// attach a file to.
 func (h *AttachmentStorageHandler) MintUploadToken(w http.ResponseWriter, r *http.Request) {
 	user := middleware.UserInfoFromContext(r.Context())
 	if user == nil {
@@ -122,6 +160,10 @@ func (h *AttachmentStorageHandler) MintUploadToken(w http.ResponseWriter, r *htt
 		return
 	}
 
+	// MintToken is still needed here even though the resulting access token
+	// is never returned to the frontend: this backend still has to
+	// authenticate its own server-side call to POST /api/v2/user/shares
+	// below, on the caller's behalf.
 	token, err := h.sftpgo.MintToken(r.Context(), user.Email, jwtAssertion)
 	if err != nil {
 		slog.ErrorContext(r.Context(), "sftpgo MintToken failed", "userID", user.UserID, "caseID", caseID, "err", summarizeErr(err))
@@ -135,11 +177,30 @@ func (h *AttachmentStorageHandler) MintUploadToken(w http.ResponseWriter, r *htt
 	attachmentID := newAttachmentID()
 	storageKey := buildStorageKey(projectID, caseID, attachmentID)
 
+	// The share is scoped to storageKey's parent DIRECTORY, not storageKey
+	// itself — confirmed empirically against a real SFTPGo instance that a
+	// write-scope share used with POST /shares-chunked-uploads always
+	// resolves the TUS "path" metadata relative to the share's own path, so
+	// a share scoped to the exact file (rather than its directory) makes
+	// every upload against it fail with "unable to write to file". Scoping
+	// to the directory still keeps the share unable to touch any other
+	// case's files: buildStorageKey gives every case (and, when known,
+	// every project) its own directory, so the worst a leaked share id can
+	// do is write within this one case's attachment directory. See
+	// uploadTokenResponse.ShareID's doc comment for the corresponding
+	// frontend-side contract.
+	shareDir := path.Dir(storageKey)
+	shareID, err := h.sftpgo.CreateShare(r.Context(), token.AccessToken, shareDir, sftpgo.ShareScopeWrite, uploadShareTTL)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "sftpgo CreateShare (write) failed", "userID", user.UserID, "caseID", caseID, "err", summarizeErr(err))
+		writeError(w, http.StatusBadGateway, "Failed to obtain an upload token.")
+		return
+	}
+
 	writeJSONValue(w, http.StatusOK, uploadTokenResponse{
-		SftpgoAccessToken: token.AccessToken,
-		ExpiresAt:         token.ExpiresAt,
-		SftpgoBaseURL:     h.sftpgo.BaseURL(),
-		StorageKey:        storageKey,
+		ShareID:       shareID,
+		SftpgoBaseURL: h.sftpgo.BaseURL(),
+		StorageKey:    storageKey,
 	})
 }
 
@@ -231,9 +292,9 @@ func (h *AttachmentStorageHandler) CreateAttachmentShare(w http.ResponseWriter, 
 		return
 	}
 
-	shareID, err := h.sftpgo.CreateShare(r.Context(), token.AccessToken, *meta.StorageKey, shareTTL)
+	shareID, err := h.sftpgo.CreateShare(r.Context(), token.AccessToken, *meta.StorageKey, sftpgo.ShareScopeRead, shareTTL)
 	if err != nil {
-		slog.ErrorContext(r.Context(), "sftpgo CreateShare failed", "userID", user.UserID, "attachmentID", attachmentID, "err", summarizeErr(err))
+		slog.ErrorContext(r.Context(), "sftpgo CreateShare (read) failed", "userID", user.UserID, "attachmentID", attachmentID, "err", summarizeErr(err))
 		writeError(w, http.StatusBadGateway, "Failed to create a share for this attachment.")
 		return
 	}

--- a/apps/csm-portal/backend/internal/handler/attachment_storage_test.go
+++ b/apps/csm-portal/backend/internal/handler/attachment_storage_test.go
@@ -19,6 +19,7 @@ package handler
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"path"
@@ -76,6 +77,25 @@ func (m *mockSftpgoClient) BaseURL() string {
 
 // ----- MintUploadToken -----
 
+// validMintUploadTokenBody returns a well-formed POST
+// /cases/{id}/attachments/upload-token request body: since MintUploadToken
+// now creates the attachment's metadata row up front, the frontend must
+// supply the file's name/mimeType/size before any bytes are uploaded.
+func validMintUploadTokenBody() io.Reader {
+	return strings.NewReader(`{"filename":"report.pdf","mimeType":"application/pdf","sizeBytes":1024}`)
+}
+
+// mockAttachmentID is the attachment id returned by a mock entity
+// CreateCaseAttachment call configured for a successful pending-row create.
+const mockAttachmentID = "33333333-3333-3333-3333-333333333333"
+
+// createCaseAttachmentFnPending returns a mockEntityCaseClient.createCaseAttachmentFn
+// that mimics the entity service's successful response to a "pending" status
+// CreateCaseAttachment call, carrying mockAttachmentID as the created row's id.
+func createCaseAttachmentFnPending(_ context.Context, _ []byte) ([]byte, error) {
+	return []byte(`{"message":"Attachment created successfully","attachment":{"id":"` + mockAttachmentID + `","status":"pending"}}`), nil
+}
+
 func TestMintUploadTokenRequiresAuth(t *testing.T) {
 	t.Parallel()
 	h := NewAttachmentStorageHandler(&mockEntityCaseClient{}, &mockSftpgoClient{})
@@ -117,7 +137,7 @@ func TestMintUploadTokenBlocksClosedCase(t *testing.T) {
 	h := NewAttachmentStorageHandler(entity, sftpgoMock)
 
 	caseID := "11111111-1111-1111-1111-111111111111"
-	req := withUser(httptest.NewRequest(http.MethodPost, "/cases/"+caseID+"/attachments/upload-token", nil))
+	req := withUser(httptest.NewRequest(http.MethodPost, "/cases/"+caseID+"/attachments/upload-token", validMintUploadTokenBody()))
 	req.SetPathValue("id", caseID)
 	req.Header.Set("x-jwt-assertion", "raw-jwt")
 	w := httptest.NewRecorder()
@@ -146,7 +166,7 @@ func TestMintUploadTokenRequiresJWTAssertionHeader(t *testing.T) {
 	h := NewAttachmentStorageHandler(entity, sftpgoMock)
 
 	caseID := "11111111-1111-1111-1111-111111111111"
-	req := withUser(httptest.NewRequest(http.MethodPost, "/cases/"+caseID+"/attachments/upload-token", nil))
+	req := withUser(httptest.NewRequest(http.MethodPost, "/cases/"+caseID+"/attachments/upload-token", validMintUploadTokenBody()))
 	req.SetPathValue("id", caseID)
 	// Deliberately no x-jwt-assertion header set.
 	w := httptest.NewRecorder()
@@ -159,21 +179,88 @@ func TestMintUploadTokenRequiresJWTAssertionHeader(t *testing.T) {
 	}
 }
 
-// TestMintUploadTokenSuccess verifies a successful mint on an open case
-// forwards the exact x-jwt-assertion header value and returns the expected
-// response shape.
-func TestMintUploadTokenSuccess(t *testing.T) {
+// TestMintUploadTokenRejectsIncompleteBody verifies a request missing any of
+// filename/mimeType/sizeBytes is rejected before any entity or SFTPGo call —
+// this backend never sees the file's bytes, so these three fields are the
+// only source of truth for the pending row's metadata.
+func TestMintUploadTokenRejectsIncompleteBody(t *testing.T) {
 	t.Parallel()
 	entity := &mockEntityCaseClient{
 		getCaseFn: func(ctx context.Context, caseID string) ([]byte, error) {
 			return []byte(`{"state":"work_in_progress"}`), nil
 		},
 	}
-	sftpgoMock := &mockSftpgoClient{baseURL: "https://sftpgo.example.com"}
+	sftpgoMock := &mockSftpgoClient{}
 	h := NewAttachmentStorageHandler(entity, sftpgoMock)
 
 	caseID := "11111111-1111-1111-1111-111111111111"
-	req := withUser(httptest.NewRequest(http.MethodPost, "/cases/"+caseID+"/attachments/upload-token", nil))
+	req := withUser(httptest.NewRequest(http.MethodPost, "/cases/"+caseID+"/attachments/upload-token",
+		strings.NewReader(`{"filename":"report.pdf"}`)))
+	req.SetPathValue("id", caseID)
+	req.Header.Set("x-jwt-assertion", "raw-jwt")
+	w := httptest.NewRecorder()
+
+	h.MintUploadToken(w, req)
+
+	assertStatus(t, w, http.StatusBadRequest)
+	if len(sftpgoMock.mintTokenCalls) != 0 {
+		t.Errorf("MintToken was called %d times; want 0 — an incomplete body must be rejected before any upstream call", len(sftpgoMock.mintTokenCalls))
+	}
+}
+
+// TestMintUploadTokenSuccess verifies a successful mint on an open case
+// forwards the exact x-jwt-assertion header value and returns the expected
+// response shape.
+func TestMintUploadTokenSuccess(t *testing.T) {
+	t.Parallel()
+	const caseID = "11111111-1111-1111-1111-111111111111"
+	var createCaseAttachmentCalls int
+	entity := &mockEntityCaseClient{
+		getCaseFn: func(ctx context.Context, caseID string) ([]byte, error) {
+			return []byte(`{"state":"work_in_progress"}`), nil
+		},
+		createCaseAttachmentFn: func(ctx context.Context, body []byte) ([]byte, error) {
+			createCaseAttachmentCalls++
+			var req struct {
+				ReferenceID   string `json:"referenceId"`
+				ReferenceType string `json:"referenceType"`
+				Name          string `json:"name"`
+				Type          string `json:"type"`
+				StorageKey    string `json:"storageKey"`
+				SizeBytes     int    `json:"sizeBytes"`
+				Status        string `json:"status"`
+			}
+			if err := json.Unmarshal(body, &req); err != nil {
+				t.Fatalf("decode CreateCaseAttachment body: %v; raw: %s", err, body)
+			}
+			if req.ReferenceID != caseID {
+				t.Errorf("CreateCaseAttachment referenceId = %q, want %q", req.ReferenceID, caseID)
+			}
+			if req.ReferenceType != "case" {
+				t.Errorf("CreateCaseAttachment referenceType = %q, want %q", req.ReferenceType, "case")
+			}
+			if req.Name != "report.pdf" {
+				t.Errorf("CreateCaseAttachment name = %q, want %q", req.Name, "report.pdf")
+			}
+			if req.Type != "application/pdf" {
+				t.Errorf("CreateCaseAttachment type = %q, want %q", req.Type, "application/pdf")
+			}
+			if req.SizeBytes != 1024 {
+				t.Errorf("CreateCaseAttachment sizeBytes = %d, want 1024", req.SizeBytes)
+			}
+			if req.Status != "pending" {
+				t.Errorf("CreateCaseAttachment status = %q, want %q — the row must be created pending, before the share is minted", req.Status, "pending")
+			}
+			if req.StorageKey == "" {
+				t.Errorf("CreateCaseAttachment storageKey was empty")
+			}
+			return createCaseAttachmentFnPending(ctx, body)
+		},
+	}
+	sftpgoMock := &mockSftpgoClient{baseURL: "https://sftpgo.example.com"}
+	h := NewAttachmentStorageHandler(entity, sftpgoMock)
+
+	req := withUser(httptest.NewRequest(http.MethodPost, "/cases/"+caseID+"/attachments/upload-token", validMintUploadTokenBody()))
 	req.SetPathValue("id", caseID)
 	req.Header.Set("x-jwt-assertion", "the-raw-jwt-assertion")
 	w := httptest.NewRecorder()
@@ -181,12 +268,18 @@ func TestMintUploadTokenSuccess(t *testing.T) {
 	h.MintUploadToken(w, req)
 
 	assertStatus(t, w, http.StatusOK)
+	if createCaseAttachmentCalls != 1 {
+		t.Fatalf("CreateCaseAttachment was called %d times; want 1", createCaseAttachmentCalls)
+	}
 	if len(sftpgoMock.mintTokenCalls) != 1 || sftpgoMock.mintTokenCalls[0] != "the-raw-jwt-assertion" {
 		t.Fatalf("mintTokenCalls = %v, want exactly one call with the raw x-jwt-assertion value", sftpgoMock.mintTokenCalls)
 	}
 
 	rawBody := w.Body.String()
 	resp := decodeJSON[uploadTokenResponse](t, w)
+	if resp.ID != mockAttachmentID {
+		t.Errorf("ID = %q, want %q — the id of the pending row CreateCaseAttachment created", resp.ID, mockAttachmentID)
+	}
 	if resp.ShareID != "mock-share-id" {
 		t.Errorf("ShareID = %q, want mock-share-id", resp.ShareID)
 	}
@@ -238,12 +331,13 @@ func TestMintUploadTokenStorageKeyIncludesProject(t *testing.T) {
 		getCaseFn: func(ctx context.Context, caseID string) ([]byte, error) {
 			return []byte(`{"state":"work_in_progress","projectId":"` + projectID + `"}`), nil
 		},
+		createCaseAttachmentFn: createCaseAttachmentFnPending,
 	}
 	sftpgoMock := &mockSftpgoClient{}
 	h := NewAttachmentStorageHandler(entity, sftpgoMock)
 
 	caseID := "11111111-1111-1111-1111-111111111111"
-	req := withUser(httptest.NewRequest(http.MethodPost, "/cases/"+caseID+"/attachments/upload-token", nil))
+	req := withUser(httptest.NewRequest(http.MethodPost, "/cases/"+caseID+"/attachments/upload-token", validMintUploadTokenBody()))
 	req.SetPathValue("id", caseID)
 	req.Header.Set("x-jwt-assertion", "raw-jwt")
 	w := httptest.NewRecorder()
@@ -271,13 +365,14 @@ func TestMintUploadTokenStorageKeyUniquePerCall(t *testing.T) {
 		getCaseFn: func(ctx context.Context, caseID string) ([]byte, error) {
 			return []byte(`{"state":"work_in_progress"}`), nil
 		},
+		createCaseAttachmentFn: createCaseAttachmentFnPending,
 	}
 	h := NewAttachmentStorageHandler(entity, &mockSftpgoClient{})
 
 	caseID := "11111111-1111-1111-1111-111111111111"
 	seen := make(map[string]bool)
 	for i := 0; i < 5; i++ {
-		req := withUser(httptest.NewRequest(http.MethodPost, "/cases/"+caseID+"/attachments/upload-token", nil))
+		req := withUser(httptest.NewRequest(http.MethodPost, "/cases/"+caseID+"/attachments/upload-token", validMintUploadTokenBody()))
 		req.SetPathValue("id", caseID)
 		req.Header.Set("x-jwt-assertion", "raw-jwt")
 		w := httptest.NewRecorder()
@@ -306,7 +401,7 @@ func TestMintUploadTokenPropagatesSftpgoFailure(t *testing.T) {
 	h := NewAttachmentStorageHandler(entity, sftpgoMock)
 
 	caseID := "11111111-1111-1111-1111-111111111111"
-	req := withUser(httptest.NewRequest(http.MethodPost, "/cases/"+caseID+"/attachments/upload-token", nil))
+	req := withUser(httptest.NewRequest(http.MethodPost, "/cases/"+caseID+"/attachments/upload-token", validMintUploadTokenBody()))
 	req.SetPathValue("id", caseID)
 	req.Header.Set("x-jwt-assertion", "raw-jwt")
 	w := httptest.NewRecorder()
@@ -325,6 +420,7 @@ func TestMintUploadTokenPropagatesCreateShareFailure(t *testing.T) {
 		getCaseFn: func(ctx context.Context, caseID string) ([]byte, error) {
 			return []byte(`{"state":"work_in_progress"}`), nil
 		},
+		createCaseAttachmentFn: createCaseAttachmentFnPending,
 	}
 	sftpgoMock := &mockSftpgoClient{
 		createShareFn: func(ctx context.Context, accessToken, storageKey string, scope int, ttl time.Duration) (string, error) {
@@ -334,7 +430,7 @@ func TestMintUploadTokenPropagatesCreateShareFailure(t *testing.T) {
 	h := NewAttachmentStorageHandler(entity, sftpgoMock)
 
 	caseID := "11111111-1111-1111-1111-111111111111"
-	req := withUser(httptest.NewRequest(http.MethodPost, "/cases/"+caseID+"/attachments/upload-token", nil))
+	req := withUser(httptest.NewRequest(http.MethodPost, "/cases/"+caseID+"/attachments/upload-token", validMintUploadTokenBody()))
 	req.SetPathValue("id", caseID)
 	req.Header.Set("x-jwt-assertion", "raw-jwt")
 	w := httptest.NewRecorder()
@@ -345,6 +441,80 @@ func TestMintUploadTokenPropagatesCreateShareFailure(t *testing.T) {
 	if len(sftpgoMock.mintTokenCalls) != 1 {
 		t.Errorf("MintToken was called %d times; want 1 (still needed to authenticate the CreateShare call)", len(sftpgoMock.mintTokenCalls))
 	}
+}
+
+// TestMintUploadTokenCreatesPendingRowBeforeShare verifies the call order
+// that closes the reliability gap this change exists for: the entity
+// service's CreateCaseAttachment (with status "pending") must be called
+// strictly before SFTPGo's CreateShare, recorded here via a single shared,
+// ordered call log both mocks append to.
+func TestMintUploadTokenCreatesPendingRowBeforeShare(t *testing.T) {
+	t.Parallel()
+	var calls []string
+	entity := &mockEntityCaseClient{
+		getCaseFn: func(ctx context.Context, caseID string) ([]byte, error) {
+			return []byte(`{"state":"work_in_progress"}`), nil
+		},
+		createCaseAttachmentFn: func(ctx context.Context, body []byte) ([]byte, error) {
+			calls = append(calls, "createCaseAttachment")
+			return createCaseAttachmentFnPending(ctx, body)
+		},
+	}
+	sftpgoMock := &mockSftpgoClient{
+		createShareFn: func(ctx context.Context, accessToken, storageKey string, scope int, ttl time.Duration) (string, error) {
+			calls = append(calls, "createShare")
+			return "mock-share-id", nil
+		},
+	}
+	h := NewAttachmentStorageHandler(entity, sftpgoMock)
+
+	caseID := "11111111-1111-1111-1111-111111111111"
+	req := withUser(httptest.NewRequest(http.MethodPost, "/cases/"+caseID+"/attachments/upload-token", validMintUploadTokenBody()))
+	req.SetPathValue("id", caseID)
+	req.Header.Set("x-jwt-assertion", "raw-jwt")
+	w := httptest.NewRecorder()
+
+	h.MintUploadToken(w, req)
+
+	assertStatus(t, w, http.StatusOK)
+	if got := strings.Join(calls, ","); got != "createCaseAttachment,createShare" {
+		t.Fatalf("call order = %q, want %q — the pending row must be created before the share is minted", got, "createCaseAttachment,createShare")
+	}
+}
+
+// TestMintUploadTokenSkipsShareWhenEntityCreateFails verifies that when the
+// entity service's CreateCaseAttachment call fails, MintUploadToken returns
+// an error and never mints a share: a share with no corresponding CSM
+// metadata row would recreate the exact orphan-upload gap this design
+// change closes.
+func TestMintUploadTokenSkipsShareWhenEntityCreateFails(t *testing.T) {
+	t.Parallel()
+	entity := &mockEntityCaseClient{
+		getCaseFn: func(ctx context.Context, caseID string) ([]byte, error) {
+			return []byte(`{"state":"work_in_progress"}`), nil
+		},
+		createCaseAttachmentFn: func(ctx context.Context, body []byte) ([]byte, error) {
+			return nil, &apierror.Error{StatusCode: http.StatusInternalServerError, Body: "boom"}
+		},
+	}
+	sftpgoMock := &mockSftpgoClient{}
+	h := NewAttachmentStorageHandler(entity, sftpgoMock)
+
+	caseID := "11111111-1111-1111-1111-111111111111"
+	req := withUser(httptest.NewRequest(http.MethodPost, "/cases/"+caseID+"/attachments/upload-token", validMintUploadTokenBody()))
+	req.SetPathValue("id", caseID)
+	req.Header.Set("x-jwt-assertion", "raw-jwt")
+	w := httptest.NewRecorder()
+
+	h.MintUploadToken(w, req)
+
+	assertStatus(t, w, http.StatusInternalServerError)
+	if len(sftpgoMock.createShareCalls) != 0 {
+		t.Errorf("CreateShare was called %d times; want 0 — a share must never be minted when the pending row failed to create", len(sftpgoMock.createShareCalls))
+	}
+	// MintToken (the sftpgo access-token mint used to authenticate the
+	// CreateShare call) may or may not have already run by this point in the
+	// call sequence; what matters is that CreateShare itself never fires.
 }
 
 // ----- CreateAttachmentShare -----
@@ -515,4 +685,165 @@ func TestCreateAttachmentSharePropagatesSftpgoFailure(t *testing.T) {
 	h.CreateAttachmentShare(w, req)
 
 	assertStatus(t, w, http.StatusBadGateway)
+}
+
+// ----- ConfirmUpload -----
+
+func TestConfirmUploadRequiresAuth(t *testing.T) {
+	t.Parallel()
+	h := NewAttachmentStorageHandler(&mockEntityCaseClient{}, &mockSftpgoClient{})
+
+	caseID := "11111111-1111-1111-1111-111111111111"
+	attachmentID := "22222222-2222-2222-2222-222222222222"
+	req := httptest.NewRequest(http.MethodPost, "/cases/"+caseID+"/attachments/"+attachmentID+"/confirm", nil)
+	req.SetPathValue("caseId", caseID)
+	req.SetPathValue("attachmentId", attachmentID)
+	w := httptest.NewRecorder()
+
+	h.ConfirmUpload(w, req)
+
+	assertStatus(t, w, http.StatusUnauthorized)
+}
+
+func TestConfirmUploadRejectsInvalidCaseID(t *testing.T) {
+	t.Parallel()
+	h := NewAttachmentStorageHandler(&mockEntityCaseClient{}, &mockSftpgoClient{})
+
+	attachmentID := "22222222-2222-2222-2222-222222222222"
+	req := withUser(httptest.NewRequest(http.MethodPost, "/cases/not-a-uuid/attachments/"+attachmentID+"/confirm", nil))
+	req.SetPathValue("caseId", "not-a-uuid")
+	req.SetPathValue("attachmentId", attachmentID)
+	w := httptest.NewRecorder()
+
+	h.ConfirmUpload(w, req)
+
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestConfirmUploadRejectsInvalidAttachmentID(t *testing.T) {
+	t.Parallel()
+	h := NewAttachmentStorageHandler(&mockEntityCaseClient{}, &mockSftpgoClient{})
+
+	caseID := "11111111-1111-1111-1111-111111111111"
+	req := withUser(httptest.NewRequest(http.MethodPost, "/cases/"+caseID+"/attachments/not-a-uuid/confirm", nil))
+	req.SetPathValue("caseId", caseID)
+	req.SetPathValue("attachmentId", "not-a-uuid")
+	w := httptest.NewRecorder()
+
+	h.ConfirmUpload(w, req)
+
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+// TestConfirmUploadSuccess verifies the happy path: ConfirmUpload calls the
+// entity service's ConfirmCaseAttachment with exactly the path's attachment
+// id, and forwards its response body and 200 status to the caller unchanged.
+func TestConfirmUploadSuccess(t *testing.T) {
+	t.Parallel()
+	var gotAttachmentID string
+	entity := &mockEntityCaseClient{
+		confirmCaseAttachmentFn: func(ctx context.Context, attachmentID string) ([]byte, error) {
+			gotAttachmentID = attachmentID
+			return []byte(`{"message":"Attachment confirmed successfully","attachment":{"id":"` + attachmentID + `","status":"complete"}}`), nil
+		},
+	}
+	h := NewAttachmentStorageHandler(entity, &mockSftpgoClient{})
+
+	caseID := "11111111-1111-1111-1111-111111111111"
+	attachmentID := "22222222-2222-2222-2222-222222222222"
+	req := withUser(httptest.NewRequest(http.MethodPost, "/cases/"+caseID+"/attachments/"+attachmentID+"/confirm", nil))
+	req.SetPathValue("caseId", caseID)
+	req.SetPathValue("attachmentId", attachmentID)
+	w := httptest.NewRecorder()
+
+	h.ConfirmUpload(w, req)
+
+	assertStatus(t, w, http.StatusOK)
+	if gotAttachmentID != attachmentID {
+		t.Errorf("ConfirmCaseAttachment called with attachmentID = %q, want %q", gotAttachmentID, attachmentID)
+	}
+	var resp struct {
+		Attachment struct {
+			ID     string `json:"id"`
+			Status string `json:"status"`
+		} `json:"attachment"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v; raw: %s", err, w.Body.String())
+	}
+	if resp.Attachment.ID != attachmentID || resp.Attachment.Status != "complete" {
+		t.Errorf("response attachment = %+v, want id=%q status=complete", resp.Attachment, attachmentID)
+	}
+}
+
+// TestConfirmUploadMapsNotFound verifies a 404 from the entity service (the
+// attachment id does not exist) maps to a 404 on this backend's response.
+func TestConfirmUploadMapsNotFound(t *testing.T) {
+	t.Parallel()
+	entity := &mockEntityCaseClient{
+		confirmCaseAttachmentFn: func(ctx context.Context, attachmentID string) ([]byte, error) {
+			return nil, &apierror.Error{StatusCode: http.StatusNotFound, Body: "not found"}
+		},
+	}
+	h := NewAttachmentStorageHandler(entity, &mockSftpgoClient{})
+
+	caseID := "11111111-1111-1111-1111-111111111111"
+	attachmentID := "22222222-2222-2222-2222-222222222222"
+	req := withUser(httptest.NewRequest(http.MethodPost, "/cases/"+caseID+"/attachments/"+attachmentID+"/confirm", nil))
+	req.SetPathValue("caseId", caseID)
+	req.SetPathValue("attachmentId", attachmentID)
+	w := httptest.NewRecorder()
+
+	h.ConfirmUpload(w, req)
+
+	assertStatus(t, w, http.StatusNotFound)
+	assertErrorMessage(t, w, ErrMsgNotFound)
+}
+
+// TestConfirmUploadMapsForbidden verifies a 403 from the entity service (the
+// caller is not the attachment's original uploader) maps to a 403 here.
+func TestConfirmUploadMapsForbidden(t *testing.T) {
+	t.Parallel()
+	entity := &mockEntityCaseClient{
+		confirmCaseAttachmentFn: func(ctx context.Context, attachmentID string) ([]byte, error) {
+			return nil, &apierror.Error{StatusCode: http.StatusForbidden, Body: "attachment was not created by the current user"}
+		},
+	}
+	h := NewAttachmentStorageHandler(entity, &mockSftpgoClient{})
+
+	caseID := "11111111-1111-1111-1111-111111111111"
+	attachmentID := "22222222-2222-2222-2222-222222222222"
+	req := withUser(httptest.NewRequest(http.MethodPost, "/cases/"+caseID+"/attachments/"+attachmentID+"/confirm", nil))
+	req.SetPathValue("caseId", caseID)
+	req.SetPathValue("attachmentId", attachmentID)
+	w := httptest.NewRecorder()
+
+	h.ConfirmUpload(w, req)
+
+	assertStatus(t, w, http.StatusForbidden)
+	assertErrorMessage(t, w, ErrMsgForbidden)
+}
+
+// TestConfirmUploadMapsConflict verifies a 409 from the entity service (the
+// attachment is not in "pending" status, e.g. already confirmed) maps to a
+// 409 here, since mapUpstreamErrorGeneric preserves 409 as the status code.
+func TestConfirmUploadMapsConflict(t *testing.T) {
+	t.Parallel()
+	entity := &mockEntityCaseClient{
+		confirmCaseAttachmentFn: func(ctx context.Context, attachmentID string) ([]byte, error) {
+			return nil, &apierror.Error{StatusCode: http.StatusConflict, Body: `attachment is not pending (current status: "complete")`}
+		},
+	}
+	h := NewAttachmentStorageHandler(entity, &mockSftpgoClient{})
+
+	caseID := "11111111-1111-1111-1111-111111111111"
+	attachmentID := "22222222-2222-2222-2222-222222222222"
+	req := withUser(httptest.NewRequest(http.MethodPost, "/cases/"+caseID+"/attachments/"+attachmentID+"/confirm", nil))
+	req.SetPathValue("caseId", caseID)
+	req.SetPathValue("attachmentId", attachmentID)
+	w := httptest.NewRecorder()
+
+	h.ConfirmUpload(w, req)
+
+	assertStatus(t, w, http.StatusConflict)
 }

--- a/apps/csm-portal/backend/internal/handler/attachment_storage_test.go
+++ b/apps/csm-portal/backend/internal/handler/attachment_storage_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"path"
 	"strings"
 	"testing"
 	"time"
@@ -33,12 +34,13 @@ import (
 
 type mockSftpgoClient struct {
 	mintTokenFn    func(ctx context.Context, email, jwtAssertion string) (*sftpgo.Token, error)
-	createShareFn  func(ctx context.Context, accessToken, storageKey string, ttl time.Duration) (string, error)
+	createShareFn  func(ctx context.Context, accessToken, storageKey string, scope int, ttl time.Duration) (string, error)
 	publicShareURL func(shareID string) string
 	baseURL        string
 
-	mintTokenCalls   []string // records the jwtAssertion passed on each call
-	createShareCalls []string // records the storageKey passed on each call
+	mintTokenCalls    []string // records the jwtAssertion passed on each call
+	createShareCalls  []string // records the storageKey passed on each call
+	createShareScopes []int    // records the scope passed on each CreateShare call
 }
 
 func (m *mockSftpgoClient) MintToken(ctx context.Context, email, jwtAssertion string) (*sftpgo.Token, error) {
@@ -49,10 +51,11 @@ func (m *mockSftpgoClient) MintToken(ctx context.Context, email, jwtAssertion st
 	return &sftpgo.Token{AccessToken: "mock-access-token", ExpiresAt: json.RawMessage(`"2026-08-27T12:00:00Z"`)}, nil
 }
 
-func (m *mockSftpgoClient) CreateShare(ctx context.Context, accessToken, storageKey string, ttl time.Duration) (string, error) {
+func (m *mockSftpgoClient) CreateShare(ctx context.Context, accessToken, storageKey string, scope int, ttl time.Duration) (string, error) {
 	m.createShareCalls = append(m.createShareCalls, storageKey)
+	m.createShareScopes = append(m.createShareScopes, scope)
 	if m.createShareFn != nil {
-		return m.createShareFn(ctx, accessToken, storageKey, ttl)
+		return m.createShareFn(ctx, accessToken, storageKey, scope, ttl)
 	}
 	return "mock-share-id", nil
 }
@@ -182,12 +185,34 @@ func TestMintUploadTokenSuccess(t *testing.T) {
 		t.Fatalf("mintTokenCalls = %v, want exactly one call with the raw x-jwt-assertion value", sftpgoMock.mintTokenCalls)
 	}
 
+	rawBody := w.Body.String()
 	resp := decodeJSON[uploadTokenResponse](t, w)
-	if resp.SftpgoAccessToken != "mock-access-token" {
-		t.Errorf("SftpgoAccessToken = %q, want mock-access-token", resp.SftpgoAccessToken)
+	if resp.ShareID != "mock-share-id" {
+		t.Errorf("ShareID = %q, want mock-share-id", resp.ShareID)
 	}
 	if resp.SftpgoBaseURL != "https://sftpgo.example.com" {
 		t.Errorf("SftpgoBaseURL = %q, want https://sftpgo.example.com", resp.SftpgoBaseURL)
+	}
+	// The share must be scoped to storageKey's parent directory, NOT
+	// storageKey itself — confirmed against a real SFTPGo instance that a
+	// share scoped to the exact file makes every shares-chunked-uploads call
+	// against it fail (see MintUploadToken's doc comment on shareDir).
+	wantShareDir := path.Dir(resp.StorageKey)
+	if len(sftpgoMock.createShareCalls) != 1 || sftpgoMock.createShareCalls[0] != wantShareDir {
+		t.Fatalf("createShareCalls = %v, want exactly [%q] (storageKey's parent directory)", sftpgoMock.createShareCalls, wantShareDir)
+	}
+	if len(sftpgoMock.createShareScopes) != 1 || sftpgoMock.createShareScopes[0] != sftpgo.ShareScopeWrite {
+		t.Errorf("createShareScopes = %v, want exactly [%d] (write)", sftpgoMock.createShareScopes, sftpgo.ShareScopeWrite)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(rawBody), &raw); err != nil {
+		t.Fatalf("decode raw response: %v; raw: %s", err, rawBody)
+	}
+	if _, hasToken := raw["sftpgoAccessToken"]; hasToken {
+		t.Errorf("response body carried sftpgoAccessToken, want no bearer credential exposed to the frontend")
+	}
+	if _, hasExpiry := raw["expiresAt"]; hasExpiry {
+		t.Errorf("response body carried expiresAt, want none — the share's own server-side expiry is not surfaced to the frontend")
 	}
 	// The case fixture above carries no "projectId", so this must fall back
 	// to the project-less path shape rather than emitting a malformed
@@ -289,6 +314,37 @@ func TestMintUploadTokenPropagatesSftpgoFailure(t *testing.T) {
 	h.MintUploadToken(w, req)
 
 	assertStatus(t, w, http.StatusBadGateway)
+}
+
+// TestMintUploadTokenPropagatesCreateShareFailure verifies a failure from the
+// write-share creation call (as opposed to the token mint) also surfaces as
+// a 502, and that the response never leaks a partially-built token/share.
+func TestMintUploadTokenPropagatesCreateShareFailure(t *testing.T) {
+	t.Parallel()
+	entity := &mockEntityCaseClient{
+		getCaseFn: func(ctx context.Context, caseID string) ([]byte, error) {
+			return []byte(`{"state":"work_in_progress"}`), nil
+		},
+	}
+	sftpgoMock := &mockSftpgoClient{
+		createShareFn: func(ctx context.Context, accessToken, storageKey string, scope int, ttl time.Duration) (string, error) {
+			return "", &apierror.Error{StatusCode: http.StatusInternalServerError, Body: "boom"}
+		},
+	}
+	h := NewAttachmentStorageHandler(entity, sftpgoMock)
+
+	caseID := "11111111-1111-1111-1111-111111111111"
+	req := withUser(httptest.NewRequest(http.MethodPost, "/cases/"+caseID+"/attachments/upload-token", nil))
+	req.SetPathValue("id", caseID)
+	req.Header.Set("x-jwt-assertion", "raw-jwt")
+	w := httptest.NewRecorder()
+
+	h.MintUploadToken(w, req)
+
+	assertStatus(t, w, http.StatusBadGateway)
+	if len(sftpgoMock.mintTokenCalls) != 1 {
+		t.Errorf("MintToken was called %d times; want 1 (still needed to authenticate the CreateShare call)", len(sftpgoMock.mintTokenCalls))
+	}
 }
 
 // ----- CreateAttachmentShare -----
@@ -399,9 +455,12 @@ func TestCreateAttachmentShareSuccess(t *testing.T) {
 		},
 	}
 	sftpgoMock := &mockSftpgoClient{
-		createShareFn: func(ctx context.Context, accessToken, gotStorageKey string, ttl time.Duration) (string, error) {
+		createShareFn: func(ctx context.Context, accessToken, gotStorageKey string, scope int, ttl time.Duration) (string, error) {
 			if ttl != shareTTL {
 				t.Errorf("ttl = %v, want %v", ttl, shareTTL)
+			}
+			if scope != sftpgo.ShareScopeRead {
+				t.Errorf("scope = %d, want %d (read) — this download-share path must stay read-only", scope, sftpgo.ShareScopeRead)
 			}
 			return "share-xyz", nil
 		},
@@ -441,7 +500,7 @@ func TestCreateAttachmentSharePropagatesSftpgoFailure(t *testing.T) {
 		},
 	}
 	sftpgoMock := &mockSftpgoClient{
-		createShareFn: func(ctx context.Context, accessToken, gotStorageKey string, ttl time.Duration) (string, error) {
+		createShareFn: func(ctx context.Context, accessToken, gotStorageKey string, scope int, ttl time.Duration) (string, error) {
 			return "", &apierror.Error{StatusCode: http.StatusInternalServerError, Body: "boom"}
 		},
 	}

--- a/apps/csm-portal/backend/internal/handler/cases.go
+++ b/apps/csm-portal/backend/internal/handler/cases.go
@@ -88,6 +88,10 @@ type entityCaseClient interface {
 	// GetCaseAttachment resolves a single attachment's metadata — used by the
 	// SFTPGo-backed share-creation path; see AttachmentStorageHandler.
 	GetCaseAttachment(ctx context.Context, attachmentID string) ([]byte, error)
+	// ConfirmCaseAttachment transitions a 'pending' attachment row (created by
+	// CreateCaseAttachment with status "pending") to 'complete' — used by the
+	// SFTPGo-backed upload-confirm path; see AttachmentStorageHandler.
+	ConfirmCaseAttachment(ctx context.Context, attachmentID string) ([]byte, error)
 	CreateCallRequest(ctx context.Context, body []byte) ([]byte, error)
 	SearchCallRequests(ctx context.Context, body []byte) ([]byte, error)
 	SearchAllCallRequests(ctx context.Context, body []byte) ([]byte, error)

--- a/apps/csm-portal/backend/internal/handler/helpers_test.go
+++ b/apps/csm-portal/backend/internal/handler/helpers_test.go
@@ -107,6 +107,7 @@ type mockEntityCaseClient struct {
 	getCaseAttachmentContentFn func(ctx context.Context, attachmentID string) ([]byte, string, error)
 	deleteCaseAttachmentFn     func(ctx context.Context, attachmentID string) ([]byte, error)
 	getCaseAttachmentFn        func(ctx context.Context, attachmentID string) ([]byte, error)
+	confirmCaseAttachmentFn    func(ctx context.Context, attachmentID string) ([]byte, error)
 	createCallRequestFn        func(ctx context.Context, body []byte) ([]byte, error)
 	searchCallRequestsFn       func(ctx context.Context, body []byte) ([]byte, error)
 	searchAllCallRequestsFn    func(ctx context.Context, body []byte) ([]byte, error)
@@ -210,6 +211,13 @@ func (m *mockEntityCaseClient) GetCaseAttachment(ctx context.Context, attachment
 		return m.getCaseAttachmentFn(ctx, attachmentID)
 	}
 	return []byte(`{}`), nil
+}
+
+func (m *mockEntityCaseClient) ConfirmCaseAttachment(ctx context.Context, attachmentID string) ([]byte, error) {
+	if m.confirmCaseAttachmentFn != nil {
+		return m.confirmCaseAttachmentFn(ctx, attachmentID)
+	}
+	return []byte(`{"message":"Attachment confirmed successfully","attachment":{"id":"` + attachmentID + `","status":"complete"}}`), nil
 }
 
 func (m *mockEntityCaseClient) CreateCallRequest(ctx context.Context, body []byte) ([]byte, error) {

--- a/apps/csm-portal/backend/internal/sftpgo/client.go
+++ b/apps/csm-portal/backend/internal/sftpgo/client.go
@@ -17,10 +17,14 @@
 // Package sftpgo is an HTTP client for the small subset of SFTPGo's REST API
 // this backend calls when the SFTPGo-backed attachment-storage feature flag
 // (SFTPGO_ATTACHMENT_STORAGE_ENABLED) is on: minting a short-lived per-user
-// access token, and creating a short-lived public download share. This
+// access token (used only server-side, to authenticate this backend's own
+// calls into SFTPGo's REST API — never handed to the browser), and creating
+// short-lived shares scoped to a single storage path, either read-only
+// (public download/inline-image shares) or write-only (upload shares). This
 // package never touches attachment bytes: uploads and downloads always go
-// directly between the browser and SFTPGo using the credentials it mints
-// here — see internal/handler.AttachmentStorageHandler for the call sites.
+// directly between the browser and SFTPGo, authenticated with nothing more
+// than the share id a Share.Scope-limited share carries — never a bearer
+// token — see internal/handler.AttachmentStorageHandler for the call sites.
 package sftpgo
 
 import (
@@ -134,11 +138,15 @@ func (c *Client) MintToken(ctx context.Context, email, jwtAssertion string) (*To
 	return &tok, nil
 }
 
-// shareScopeRead is SFTPGo's Share.Scope value for a read-only (download)
-// share. Not verified against a live instance for this change — flagged
-// explicitly in the PR description alongside the other SFTPGo API-shape
-// assumptions this client makes.
-const shareScopeRead = 1
+// ShareScopeRead and ShareScopeWrite are SFTPGo's Share.Scope values for a
+// read-only (download) share and a write-only (upload) share, respectively.
+// Verified against SFTPGo's own OpenAPI spec for this change (unlike several
+// other SFTPGo API shapes elsewhere in this file, which remain unverified
+// assumptions — see their own doc comments).
+const (
+	ShareScopeRead  = 1
+	ShareScopeWrite = 2
+)
 
 // shareCreateRequest is the request body of POST /api/v2/user/shares.
 type shareCreateRequest struct {
@@ -157,17 +165,23 @@ type shareCreateResponseBody struct {
 }
 
 // CreateShare calls SFTPGo's POST /api/v2/user/shares, authenticated as the
-// caller via accessToken (minted by MintToken), to create a short-lived,
-// read-only public share for a single storage path. ttl controls how soon
-// the share expires; callers should keep this short since a share is created
-// fresh on every request that needs one (see
-// AttachmentStorageHandler.CreateAttachmentShare — this is a lazy,
-// per-attachment, per-request operation, never an eager batch one). Returns
-// the created share's id.
-func (c *Client) CreateShare(ctx context.Context, accessToken, storageKey string, ttl time.Duration) (string, error) {
+// caller via accessToken (minted by MintToken), to create a short-lived
+// share for a single storage path with the given scope (ShareScopeRead or
+// ShareScopeWrite). No password is ever set on the created share: for the
+// read-only download-share path (AttachmentStorageHandler.CreateAttachmentShare)
+// the share URL itself is the only credential handed out, and for the
+// write-only upload-share path (AttachmentStorageHandler.MintUploadToken) the
+// share id is only ever used server-to-server-adjacent, ambient in the TUS
+// Upload-Metadata the browser sends — never paired with a bearer token or
+// password. ttl controls how soon the share expires; callers should keep
+// this short since a share is created fresh on every request that needs one
+// (see CreateAttachmentShare and MintUploadToken — this is always a lazy,
+// per-request operation, never an eager batch one). Returns the created
+// share's id.
+func (c *Client) CreateShare(ctx context.Context, accessToken, storageKey string, scope int, ttl time.Duration) (string, error) {
 	reqBody, err := json.Marshal(shareCreateRequest{
 		Paths:     []string{storageKey},
-		Scope:     shareScopeRead,
+		Scope:     scope,
 		ExpiresAt: time.Now().Add(ttl).UnixMilli(),
 	})
 	if err != nil {

--- a/apps/csm-portal/backend/internal/sftpgo/client.go
+++ b/apps/csm-portal/backend/internal/sftpgo/client.go
@@ -76,10 +76,27 @@ func NewClient(cfg Config) *Client {
 		publicBaseURL = cfg.BaseURL
 	}
 	return &Client{
-		http:          &http.Client{Timeout: 15 * time.Second},
+		http: &http.Client{
+			Timeout:       15 * time.Second,
+			CheckRedirect: refuseInsecureRedirect,
+		},
 		baseURL:       strings.TrimRight(cfg.BaseURL, "/"),
 		publicBaseURL: strings.TrimRight(publicBaseURL, "/"),
 	}
+}
+
+// refuseInsecureRedirect is an http.Client.CheckRedirect override that
+// refuses to follow any redirect whose target is not HTTPS. Go's default
+// CheckRedirect copies the Authorization header onto a same-host redirect,
+// which would silently leak this client's bearer token (see MintToken,
+// CreateShare) over cleartext on an HTTPS-to-HTTP downgrade redirect —
+// something a compromised or misconfigured SFTPGo instance, or a
+// man-in-the-middle, could trigger without this check.
+func refuseInsecureRedirect(req *http.Request, via []*http.Request) error {
+	if req.URL.Scheme != "https" {
+		return fmt.Errorf("sftpgo: refusing to follow redirect to non-https URL %q", req.URL.Redacted())
+	}
+	return nil
 }
 
 // BaseURL returns the configured REST API base URL, verbatim — handed back

--- a/apps/csm-portal/backend/internal/sftpgo/client_test.go
+++ b/apps/csm-portal/backend/internal/sftpgo/client_test.go
@@ -331,3 +331,45 @@ func TestBaseURL(t *testing.T) {
 		t.Errorf("BaseURL() = %q, want trailing slash trimmed", got)
 	}
 }
+
+// TestClientRefusesInsecureRedirect proves the http.Client this package
+// constructs does not follow an HTTPS-to-HTTP redirect (which, under Go's
+// default CheckRedirect, would copy the Authorization header onto the
+// downgraded, cleartext request) — see refuseInsecureRedirect. downgradeSrv
+// stands in for the "same host, now-plain-HTTP" redirect target: since
+// CheckRedirect must refuse the redirect before the client ever issues a
+// request to it, downgradeSrv should never see any request at all, bearer
+// token or otherwise.
+func TestClientRefusesInsecureRedirect(t *testing.T) {
+	t.Parallel()
+
+	downgradeHit := false
+	downgradeSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		downgradeHit = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer downgradeSrv.Close()
+
+	tlsSrv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Redirect to the same logical host but downgraded to plain HTTP —
+		// the scenario refuseInsecureRedirect exists to block.
+		http.Redirect(w, r, downgradeSrv.URL+"/api/v2/user/shares", http.StatusFound)
+	}))
+	defer tlsSrv.Close()
+
+	client := NewClient(Config{BaseURL: tlsSrv.URL})
+	// Trust the TLS test server's self-signed certificate; keep our own
+	// CheckRedirect override intact.
+	client.http.Transport = tlsSrv.Client().Transport
+
+	_, err := client.CreateShare(context.Background(), "access-tok", "/attachments/00000000-0000-0000-0000-000000000000", ShareScopeWrite, 5*time.Minute)
+	if err == nil {
+		t.Fatal("CreateShare: expected an error refusing the insecure redirect, got nil")
+	}
+	if !strings.Contains(err.Error(), "refusing to follow redirect") {
+		t.Errorf("CreateShare error = %v, want it to mention refusing the redirect", err)
+	}
+	if downgradeHit {
+		t.Error("downgrade target received a request; CheckRedirect should have refused before dialing it (Authorization would have leaked over plain HTTP)")
+	}
+}

--- a/apps/csm-portal/backend/internal/sftpgo/client_test.go
+++ b/apps/csm-portal/backend/internal/sftpgo/client_test.go
@@ -133,7 +133,7 @@ func TestCreateShareSendsCorrectRequestShape(t *testing.T) {
 	client := NewClient(Config{BaseURL: srv.URL})
 
 	before := time.Now()
-	shareID, err := client.CreateShare(context.Background(), "access-tok", "/attachments/00000000-0000-0000-0000-000000000000", 5*time.Minute)
+	shareID, err := client.CreateShare(context.Background(), "access-tok", "/attachments/00000000-0000-0000-0000-000000000000", ShareScopeRead, 5*time.Minute)
 	if err != nil {
 		t.Fatalf("CreateShare: %v", err)
 	}
@@ -156,8 +156,11 @@ func TestCreateShareSendsCorrectRequestShape(t *testing.T) {
 	if len(paths) != 1 || paths[0] != "/attachments/00000000-0000-0000-0000-000000000000" {
 		t.Errorf("paths = %v, want a single-element array with the storage key", gotBody["paths"])
 	}
-	if scope, _ := gotBody["scope"].(float64); scope != shareScopeRead {
-		t.Errorf("scope = %v, want %d (read-only)", gotBody["scope"], shareScopeRead)
+	if scope, _ := gotBody["scope"].(float64); scope != ShareScopeRead {
+		t.Errorf("scope = %v, want %d (read-only)", gotBody["scope"], ShareScopeRead)
+	}
+	if _, hasPassword := gotBody["password"]; hasPassword {
+		t.Errorf("request body carried a password field, want none")
 	}
 	expiresAtMs, _ := gotBody["expires_at"].(float64)
 	wantMin := float64(before.Add(5 * time.Minute).UnixMilli())
@@ -178,7 +181,7 @@ func TestCreateShareFallsBackToJSONBodyWhenHeaderMissing(t *testing.T) {
 
 	client := NewClient(Config{BaseURL: srv.URL})
 
-	shareID, err := client.CreateShare(context.Background(), "access-tok", "/attachments/x", time.Minute)
+	shareID, err := client.CreateShare(context.Background(), "access-tok", "/attachments/x", ShareScopeRead, time.Minute)
 	if err != nil {
 		t.Fatalf("CreateShare: %v", err)
 	}
@@ -198,7 +201,7 @@ func TestCreateSharePrefersHeaderOverBody(t *testing.T) {
 
 	client := NewClient(Config{BaseURL: srv.URL})
 
-	shareID, err := client.CreateShare(context.Background(), "access-tok", "/attachments/x", time.Minute)
+	shareID, err := client.CreateShare(context.Background(), "access-tok", "/attachments/x", ShareScopeRead, time.Minute)
 	if err != nil {
 		t.Fatalf("CreateShare: %v", err)
 	}
@@ -217,7 +220,7 @@ func TestCreateShareErrorsWhenNoIDFound(t *testing.T) {
 
 	client := NewClient(Config{BaseURL: srv.URL})
 
-	if _, err := client.CreateShare(context.Background(), "access-tok", "/attachments/x", time.Minute); err == nil {
+	if _, err := client.CreateShare(context.Background(), "access-tok", "/attachments/x", ShareScopeRead, time.Minute); err == nil {
 		t.Fatal("expected error when neither header nor body carry an id, got nil")
 	}
 }
@@ -232,7 +235,7 @@ func TestCreateSharePropagatesUpstreamError(t *testing.T) {
 
 	client := NewClient(Config{BaseURL: srv.URL})
 
-	_, err := client.CreateShare(context.Background(), "access-tok", "/attachments/x", time.Minute)
+	_, err := client.CreateShare(context.Background(), "access-tok", "/attachments/x", ShareScopeRead, time.Minute)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -242,6 +245,40 @@ func TestCreateSharePropagatesUpstreamError(t *testing.T) {
 	}
 	if apiErr.StatusCode != http.StatusForbidden {
 		t.Errorf("StatusCode = %d, want 403", apiErr.StatusCode)
+	}
+}
+
+func TestCreateShareSendsWriteScopeAndNoPassword(t *testing.T) {
+	t.Parallel()
+
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &gotBody)
+		w.Header().Set("X-Object-Id", "write-share-abc")
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	client := NewClient(Config{BaseURL: srv.URL})
+
+	shareID, err := client.CreateShare(context.Background(), "access-tok", "/attachments/upload-target", ShareScopeWrite, 45*time.Minute)
+	if err != nil {
+		t.Fatalf("CreateShare: %v", err)
+	}
+	if shareID != "write-share-abc" {
+		t.Errorf("shareID = %q, want write-share-abc", shareID)
+	}
+
+	paths, _ := gotBody["paths"].([]any)
+	if len(paths) != 1 || paths[0] != "/attachments/upload-target" {
+		t.Errorf("paths = %v, want a single-element array with the storage key", gotBody["paths"])
+	}
+	if scope, _ := gotBody["scope"].(float64); scope != ShareScopeWrite {
+		t.Errorf("scope = %v, want %d (write)", gotBody["scope"], ShareScopeWrite)
+	}
+	if _, hasPassword := gotBody["password"]; hasPassword {
+		t.Errorf("request body carried a password field, want none — a server-minted upload share must have no password")
 	}
 }
 

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -2345,6 +2345,28 @@ type CreateCaseGithubIssueResponse struct {
 	Issue   CaseGithubIssueDetail `json:"issue"`
 }
 
+// AttachmentStatus is the upload lifecycle state of a CSM-native (Postgres)
+// data source attachment. ServiceNow-sourced attachments have no such
+// lifecycle -- SN's /attachments API only ever returns fully-uploaded files --
+// so this is meaningful for the Postgres data source only, where the browser
+// uploads directly to SFTPGo and CSM's row can be registered before that
+// upload finishes.
+type AttachmentStatus string
+
+const (
+	// AttachmentStatusPending marks a row created before the browser has
+	// uploaded (or finished uploading) the file to SFTPGo. It exists so an
+	// orphan-file gap can't occur: if the upload never completes or the
+	// browser never calls back, CSM still has a record that something was
+	// started, for a future reconciliation job to find and clean up.
+	AttachmentStatusPending AttachmentStatus = "pending"
+	// AttachmentStatusComplete marks a row whose file is confirmed present in
+	// SFTPGo. This is the only state that has ever existed prior to this
+	// change, and remains the default for every caller that doesn't specify
+	// a status (the ServiceNow path, and any existing Postgres-path caller).
+	AttachmentStatusComplete AttachmentStatus = "complete"
+)
+
 // Attachment represents a file attachment linked to a reference entity.
 type Attachment struct {
 	ID            string        `json:"id"`
@@ -2365,6 +2387,9 @@ type Attachment struct {
 	// (SFTPGo) for CSM-native (Postgres) data source attachments. Nil for
 	// ServiceNow-sourced attachments, whose bytes are held by ServiceNow itself.
 	StorageKey *string `json:"storageKey,omitempty"`
+	// Status is the upload lifecycle state -- see AttachmentStatus. Always
+	// AttachmentStatusComplete for ServiceNow-sourced attachments.
+	Status AttachmentStatus `json:"status,omitempty"`
 }
 
 // CreateAttachmentRequest is the input for POST /attachments.
@@ -2389,6 +2414,15 @@ type CreateAttachmentRequest struct {
 	// sees the file bytes); ignored for ServiceNow, which computes it from
 	// the decoded File payload.
 	SizeBytes int `json:"sizeBytes,omitempty"`
+	// Status requests the initial lifecycle state for a CSM-native
+	// (Postgres) data source attachment -- see AttachmentStatus. Empty
+	// defaults to AttachmentStatusComplete, preserving today's behavior for
+	// every existing caller (including the ServiceNow path, which ignores
+	// this field entirely). Callers that upload directly to SFTPGo should
+	// pass AttachmentStatusPending here *before* minting the upload
+	// credential, then call CaseService.ConfirmCaseAttachment once the
+	// browser reports the upload succeeded.
+	Status AttachmentStatus `json:"status,omitempty"`
 	// CreatedBy is the resolved actor user id, wired in by the Postgres-backed
 	// service from the request's auth token before it reaches the repository.
 	// Not part of the wire contract.
@@ -2405,10 +2439,22 @@ type AttachmentDetail struct {
 	// StorageKey is set only for CSM-native (Postgres) data source attachments.
 	// See Attachment.StorageKey.
 	StorageKey *string `json:"storageKey,omitempty"`
+	// Status is the upload lifecycle state -- see AttachmentStatus. Always
+	// AttachmentStatusComplete for ServiceNow-sourced attachments.
+	Status AttachmentStatus `json:"status,omitempty"`
 }
 
 // CreateAttachmentResponse is the response for POST /cases/{id}/attachments.
 type CreateAttachmentResponse struct {
+	Message    string           `json:"message"`
+	Attachment AttachmentDetail `json:"attachment"`
+}
+
+// ConfirmAttachmentResponse is the response for POST /attachments/{id}/confirm.
+// It reports the same shape as CreateAttachmentResponse -- confirming is just
+// the second half of creating an attachment for the CSM-native (Postgres)
+// data source's two-step (pending -> complete) upload flow.
+type ConfirmAttachmentResponse struct {
 	Message    string           `json:"message"`
 	Attachment AttachmentDetail `json:"attachment"`
 }
@@ -4508,6 +4554,13 @@ type AttachmentDetails struct {
 	// attachments, whose Content is always "" (this service holds no bytes
 	// for them -- see CaseService.GetCaseAttachmentContent).
 	StorageKey *string `json:"storageKey,omitempty"`
+	// Status is the upload lifecycle state -- see AttachmentStatus. Always
+	// AttachmentStatusComplete for ServiceNow-sourced attachments. A
+	// 'pending' row is still returned here (unlike the default search/list
+	// response, which excludes pending rows) since a direct id lookup is how
+	// the confirm step and an uploader checking their own in-flight upload
+	// both work.
+	Status AttachmentStatus `json:"status,omitempty"`
 }
 
 // UpdateAttachmentRequest is the request body for PATCH /attachments/{id}.

--- a/entity-service/internal/handler/case_handler.go
+++ b/entity-service/internal/handler/case_handler.go
@@ -215,6 +215,17 @@ func (h *CaseHandler) CreateCaseAttachment(w http.ResponseWriter, r *http.Reques
 	_ = json.NewEncoder(w).Encode(resp)
 }
 
+// ConfirmCaseAttachment handles POST /attachments/{id}/confirm.
+func (h *CaseHandler) ConfirmCaseAttachment(w http.ResponseWriter, r *http.Request) {
+	resp, err := h.svc.ConfirmCaseAttachment(r.Context(), r.PathValue("id"))
+	if err != nil {
+		writeServiceError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
 // SearchCaseAttachments handles POST /attachments/search.
 func (h *CaseHandler) SearchCaseAttachments(w http.ResponseWriter, r *http.Request) {
 	var req domain.SearchAttachmentsRequest

--- a/entity-service/internal/repository/case_repo.go
+++ b/entity-service/internal/repository/case_repo.go
@@ -75,6 +75,15 @@ type CaseRepository interface {
 	// UpdateCaseAttachmentName renames the attachment identified by id and
 	// records who did it. Returns a NotFoundError if no matching row exists.
 	UpdateCaseAttachmentName(ctx context.Context, id, name, updatedBy string) (updatedOn time.Time, err error)
+	// ConfirmCaseAttachment atomically transitions the attachment identified
+	// by id from status 'pending' to 'complete'. The WHERE clause's
+	// "AND status = 'pending'" guard is the concurrency safety net: if two
+	// confirm calls race, only one affects a row. Returns a ConflictError
+	// (not a silent no-op) if the row is not currently 'pending' -- including
+	// when it doesn't exist, since by the time this is called the caller has
+	// already resolved the row via GetCaseAttachmentByID and any mismatch
+	// here means it changed state concurrently.
+	ConfirmCaseAttachment(ctx context.Context, id string) (domain.Attachment, error)
 }
 
 type caseRepo struct {
@@ -363,9 +372,9 @@ func (r *caseRepo) UpdateCase(ctx context.Context, req domain.UpdateCaseRequest)
 // CreateCaseAttachment implements CaseRepository.
 func (r *caseRepo) CreateCaseAttachment(ctx context.Context, req domain.CreateAttachmentRequest) (domain.Attachment, error) {
 	const query = `
-		INSERT INTO case_attachments (case_id, storage_key, filename, mime_type, size_bytes, description, uploaded_by)
-		VALUES ($1, $2, $3, $4, $5, $6, $7)
-		RETURNING id, case_id, storage_key, filename, mime_type, size_bytes, description, uploaded_by, created_at`
+		INSERT INTO case_attachments (case_id, storage_key, filename, mime_type, size_bytes, description, uploaded_by, status)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+		RETURNING id, case_id, storage_key, filename, mime_type, size_bytes, description, uploaded_by, created_at, status`
 
 	var (
 		a            domain.Attachment
@@ -373,17 +382,17 @@ func (r *caseRepo) CreateCaseAttachment(ctx context.Context, req domain.CreateAt
 		uploadedByID string
 	)
 	err := r.db.QueryRow(ctx, query,
-		req.ReferenceID, req.StorageKey, req.Name, req.Type, req.SizeBytes, req.Description, req.CreatedBy,
+		req.ReferenceID, req.StorageKey, req.Name, req.Type, req.SizeBytes, req.Description, req.CreatedBy, req.Status,
 	).Scan(
 		&a.ID, &a.ReferenceID, &storageKey, &a.Name, &a.Type, &a.SizeBytes, &a.Description,
-		&uploadedByID, &a.CreatedOn,
+		&uploadedByID, &a.CreatedOn, &a.Status,
 	)
 	if err != nil {
 		if pgErr := (*pgconn.PgError)(nil); errors.As(err, &pgErr) {
 			switch pgErr.Code {
 			case "23503": // foreign_key_violation — case_id or uploaded_by does not exist
 				return domain.Attachment{}, &apierror.ValidationError{Msg: "one or more referenced IDs do not exist: " + pgErr.Detail}
-			case "23514": // check_violation — e.g. size_bytes <= 0
+			case "23514": // check_violation — e.g. size_bytes <= 0 or an invalid status
 				return domain.Attachment{}, &apierror.ValidationError{Msg: pgErr.Message}
 			}
 		}
@@ -398,16 +407,50 @@ func (r *caseRepo) CreateCaseAttachment(ctx context.Context, req domain.CreateAt
 	return a, nil
 }
 
+// ConfirmCaseAttachment implements CaseRepository.
+func (r *caseRepo) ConfirmCaseAttachment(ctx context.Context, id string) (domain.Attachment, error) {
+	const query = `
+		UPDATE case_attachments
+		SET status = 'complete', updated_at = NOW()
+		WHERE id = $1 AND status = 'pending'
+		RETURNING id, case_id, storage_key, filename, mime_type, size_bytes, description, uploaded_by, created_at, status`
+
+	var (
+		a            domain.Attachment
+		storageKey   string
+		uploadedByID string
+	)
+	err := r.db.QueryRow(ctx, query, id).Scan(
+		&a.ID, &a.ReferenceID, &storageKey, &a.Name, &a.Type, &a.SizeBytes, &a.Description,
+		&uploadedByID, &a.CreatedOn, &a.Status,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return domain.Attachment{}, &apierror.ConflictError{Msg: "attachment is not pending (it may already be confirmed, or was confirmed/deleted concurrently)"}
+	}
+	if err != nil {
+		return domain.Attachment{}, fmt.Errorf("confirm case attachment: %w", err)
+	}
+	a.ReferenceType = domain.ReferenceTypeCase
+	a.StorageKey = &storageKey
+	a.CreatedBy = domain.NewUserReference(uploadedByID, "", "")
+	return a, nil
+}
+
 // SearchCaseAttachments implements CaseRepository.
+//
+// Both queries filter to status = 'complete' -- see the doc comment on
+// CaseService.SearchCaseAttachments for why pending (still-uploading) rows
+// are excluded from the default list/search response rather than shown with
+// a visible status.
 func (r *caseRepo) SearchCaseAttachments(ctx context.Context, caseID string, pagination domain.Pagination) ([]domain.Attachment, int, error) {
-	const countQuery = `SELECT COUNT(*) FROM case_attachments WHERE case_id = $1`
+	const countQuery = `SELECT COUNT(*) FROM case_attachments WHERE case_id = $1 AND status = 'complete'`
 	const dataQuery = `
 		SELECT ca.id, ca.case_id, ca.filename, ca.mime_type, ca.size_bytes, ca.description,
 		       u.id, u.email, TRIM(u.first_name || ' ' || u.last_name) AS full_name,
-		       ca.created_at, ca.storage_key
+		       ca.created_at, ca.storage_key, ca.status
 		FROM case_attachments ca
 		JOIN users u ON u.id = ca.uploaded_by
-		WHERE ca.case_id = $1
+		WHERE ca.case_id = $1 AND ca.status = 'complete'
 		ORDER BY ca.created_at DESC, ca.id
 		LIMIT $2 OFFSET $3`
 
@@ -439,7 +482,7 @@ func (r *caseRepo) SearchCaseAttachments(ctx context.Context, caseID string, pag
 			)
 			if err := rows.Scan(
 				&a.ID, &a.ReferenceID, &a.Name, &a.Type, &a.SizeBytes, &a.Description,
-				&uploaderID, &uploaderEmail, &uploaderName, &a.CreatedOn, &storageKey,
+				&uploaderID, &uploaderEmail, &uploaderName, &a.CreatedOn, &storageKey, &a.Status,
 			); err != nil {
 				return fmt.Errorf("scan case attachment: %w", err)
 			}
@@ -463,11 +506,17 @@ func (r *caseRepo) SearchCaseAttachments(ctx context.Context, caseID string, pag
 }
 
 // GetCaseAttachmentByID implements CaseRepository.
+//
+// Unlike SearchCaseAttachments, this intentionally does not filter by status:
+// a direct id lookup must return a 'pending' row too, since that's how the
+// confirm step resolves the row it's about to transition, and how an
+// uploader can check on their own in-flight upload. See the doc comment on
+// CaseService.SearchCaseAttachments for the read-path status decision.
 func (r *caseRepo) GetCaseAttachmentByID(ctx context.Context, id string) (domain.Attachment, error) {
 	const query = `
 		SELECT ca.id, ca.case_id, ca.filename, ca.mime_type, ca.size_bytes, ca.description,
 		       u.id, u.email, TRIM(u.first_name || ' ' || u.last_name) AS full_name,
-		       ca.created_at, ca.storage_key
+		       ca.created_at, ca.storage_key, ca.status
 		FROM case_attachments ca
 		JOIN users u ON u.id = ca.uploaded_by
 		WHERE ca.id = $1`
@@ -479,7 +528,7 @@ func (r *caseRepo) GetCaseAttachmentByID(ctx context.Context, id string) (domain
 	)
 	err := r.db.QueryRow(ctx, query, id).Scan(
 		&a.ID, &a.ReferenceID, &a.Name, &a.Type, &a.SizeBytes, &a.Description,
-		&uploaderID, &uploaderEmail, &uploaderName, &a.CreatedOn, &storageKey,
+		&uploaderID, &uploaderEmail, &uploaderName, &a.CreatedOn, &storageKey, &a.Status,
 	)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return domain.Attachment{}, &apierror.NotFoundError{Msg: "attachment not found"}

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -353,6 +353,7 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) (http.Handler, service.Even
 	mux.HandleFunc("POST /cases/{id}/comments", caseHandler.CreateCaseComment)
 	mux.HandleFunc("POST /cases/{id}/activities/search", caseHandler.SearchCaseActivities)
 	mux.HandleFunc("POST /attachments", caseHandler.CreateCaseAttachment)
+	mux.HandleFunc("POST /attachments/{id}/confirm", caseHandler.ConfirmCaseAttachment)
 	mux.HandleFunc("POST /attachments/search", caseHandler.SearchCaseAttachments)
 	mux.HandleFunc("GET /attachments/{id}/content", caseHandler.GetCaseAttachmentContent)
 	mux.HandleFunc("GET /attachments/{id}", caseHandler.GetAttachmentByID)

--- a/entity-service/internal/service/case_attachment_service_test.go
+++ b/entity-service/internal/service/case_attachment_service_test.go
@@ -170,6 +170,224 @@ func TestCaseService_CreateCaseAttachment_RejectsUnauthenticatedCaller(t *testin
 	}
 }
 
+// TestCaseService_CreateCaseAttachment_DefaultsToComplete proves every
+// existing caller that doesn't specify a status (the ServiceNow path is
+// unaffected since it never sets Status at all, but any pre-existing
+// Postgres-path caller behaves the same way) still gets a 'complete' row --
+// this field must be fully backward compatible.
+func TestCaseService_CreateCaseAttachment_DefaultsToComplete(t *testing.T) {
+	repo := &stubCaseRepo{
+		createCaseAttachment: func(_ context.Context, req domain.CreateAttachmentRequest) (domain.Attachment, error) {
+			if req.Status != domain.AttachmentStatusComplete {
+				t.Fatalf("expected repo to receive status 'complete' by default, got %q", req.Status)
+			}
+			return domain.Attachment{
+				ID:         testAttachmentID,
+				Status:     req.Status,
+				StorageKey: req.StorageKey,
+				CreatedBy:  domain.NewUserReference(req.CreatedBy, "", ""),
+			}, nil
+		},
+	}
+	svc := NewCaseService(repo, actorUserRepo(t))
+	ctx := contextWithUserIDToken(fakeJWTWithEmail(t, "jane.doe@example.com"))
+
+	req := validCreateAttachmentRequest() // Status left unset
+	resp, err := svc.CreateCaseAttachment(ctx, req)
+	if err != nil {
+		t.Fatalf("CreateCaseAttachment returned error: %v", err)
+	}
+	if resp.Attachment.Status != domain.AttachmentStatusComplete {
+		t.Fatalf("expected response status 'complete', got %q", resp.Attachment.Status)
+	}
+}
+
+// TestCaseService_CreateCaseAttachment_Pending proves an explicit
+// status="pending" request reaches the repository unchanged and the response
+// reports the pending status, so a caller can register a row before the
+// browser has actually uploaded anything to SFTPGo.
+func TestCaseService_CreateCaseAttachment_Pending(t *testing.T) {
+	var capturedStatus domain.AttachmentStatus
+	repo := &stubCaseRepo{
+		createCaseAttachment: func(_ context.Context, req domain.CreateAttachmentRequest) (domain.Attachment, error) {
+			capturedStatus = req.Status
+			return domain.Attachment{
+				ID:         testAttachmentID,
+				Status:     req.Status,
+				StorageKey: req.StorageKey,
+				CreatedBy:  domain.NewUserReference(req.CreatedBy, "", ""),
+			}, nil
+		},
+	}
+	svc := NewCaseService(repo, actorUserRepo(t))
+	ctx := contextWithUserIDToken(fakeJWTWithEmail(t, "jane.doe@example.com"))
+
+	req := validCreateAttachmentRequest()
+	req.Status = domain.AttachmentStatusPending
+	resp, err := svc.CreateCaseAttachment(ctx, req)
+	if err != nil {
+		t.Fatalf("CreateCaseAttachment returned error: %v", err)
+	}
+	if capturedStatus != domain.AttachmentStatusPending {
+		t.Fatalf("expected repo to receive status 'pending', got %q", capturedStatus)
+	}
+	if resp.Attachment.Status != domain.AttachmentStatusPending {
+		t.Fatalf("expected response status 'pending', got %q", resp.Attachment.Status)
+	}
+}
+
+// TestCaseService_CreateCaseAttachment_RejectsInvalidStatus proves an
+// unrecognized status value is rejected rather than silently passed through
+// to the database (where the CHECK constraint would catch it anyway, but the
+// service should fail fast with a clear message).
+func TestCaseService_CreateCaseAttachment_RejectsInvalidStatus(t *testing.T) {
+	svc := NewCaseService(&stubCaseRepo{}, actorUserRepo(t))
+	ctx := contextWithUserIDToken(fakeJWTWithEmail(t, "jane.doe@example.com"))
+
+	req := validCreateAttachmentRequest()
+	req.Status = "uploading"
+
+	_, err := svc.CreateCaseAttachment(ctx, req)
+	var ve *apierror.ValidationError
+	if !asValidationError(err, &ve) {
+		t.Fatalf("expected *apierror.ValidationError, got %T: %v", err, err)
+	}
+}
+
+// TestCaseService_ConfirmCaseAttachment_TransitionsToComplete proves a
+// pending row owned by the calling actor is transitioned to complete.
+func TestCaseService_ConfirmCaseAttachment_TransitionsToComplete(t *testing.T) {
+	key := testStorageKey
+	var confirmedID string
+	repo := &stubCaseRepo{
+		getCaseAttachmentByID: func(_ context.Context, id string) (domain.Attachment, error) {
+			return domain.Attachment{
+				ID:         id,
+				Status:     domain.AttachmentStatusPending,
+				StorageKey: &key,
+				CreatedBy:  domain.NewUserReference("user-jane", "jane.doe@example.com", "Jane Doe"),
+			}, nil
+		},
+		confirmCaseAttachment: func(_ context.Context, id string) (domain.Attachment, error) {
+			confirmedID = id
+			return domain.Attachment{
+				ID:         id,
+				Status:     domain.AttachmentStatusComplete,
+				StorageKey: &key,
+				CreatedBy:  domain.NewUserReference("user-jane", "jane.doe@example.com", "Jane Doe"),
+			}, nil
+		},
+	}
+	svc := NewCaseService(repo, actorUserRepo(t))
+	ctx := contextWithUserIDToken(fakeJWTWithEmail(t, "jane.doe@example.com"))
+
+	resp, err := svc.ConfirmCaseAttachment(ctx, testAttachmentID)
+	if err != nil {
+		t.Fatalf("ConfirmCaseAttachment returned error: %v", err)
+	}
+	if confirmedID != testAttachmentID {
+		t.Fatalf("expected repo to receive id %q, got %q", testAttachmentID, confirmedID)
+	}
+	if resp.Attachment.Status != domain.AttachmentStatusComplete {
+		t.Fatalf("expected response status 'complete', got %q", resp.Attachment.Status)
+	}
+}
+
+// TestCaseService_ConfirmCaseAttachment_RejectsAlreadyComplete proves
+// confirming a row that is already 'complete' fails clearly (a ConflictError)
+// instead of silently succeeding as a no-op.
+func TestCaseService_ConfirmCaseAttachment_RejectsAlreadyComplete(t *testing.T) {
+	key := testStorageKey
+	repo := &stubCaseRepo{
+		getCaseAttachmentByID: func(_ context.Context, id string) (domain.Attachment, error) {
+			return domain.Attachment{
+				ID:         id,
+				Status:     domain.AttachmentStatusComplete,
+				StorageKey: &key,
+				CreatedBy:  domain.NewUserReference("user-jane", "jane.doe@example.com", "Jane Doe"),
+			}, nil
+		},
+		confirmCaseAttachment: func(context.Context, string) (domain.Attachment, error) {
+			t.Fatal("repository mutation should not be reached for an already-complete row")
+			return domain.Attachment{}, nil
+		},
+	}
+	svc := NewCaseService(repo, actorUserRepo(t))
+	ctx := contextWithUserIDToken(fakeJWTWithEmail(t, "jane.doe@example.com"))
+
+	_, err := svc.ConfirmCaseAttachment(ctx, testAttachmentID)
+	var ce *apierror.ConflictError
+	if !errorsAsConflict(err, &ce) {
+		t.Fatalf("expected *apierror.ConflictError, got %T: %v", err, err)
+	}
+}
+
+// TestCaseService_ConfirmCaseAttachment_RejectsDifferentActor proves a user
+// other than the one who created the pending row cannot confirm it.
+func TestCaseService_ConfirmCaseAttachment_RejectsDifferentActor(t *testing.T) {
+	key := testStorageKey
+	repo := &stubCaseRepo{
+		getCaseAttachmentByID: func(_ context.Context, id string) (domain.Attachment, error) {
+			return domain.Attachment{
+				ID:         id,
+				Status:     domain.AttachmentStatusPending,
+				StorageKey: &key,
+				CreatedBy:  domain.NewUserReference("someone-else", "someone.else@example.com", "Someone Else"),
+			}, nil
+		},
+		confirmCaseAttachment: func(context.Context, string) (domain.Attachment, error) {
+			t.Fatal("repository mutation should not be reached for a non-owning actor")
+			return domain.Attachment{}, nil
+		},
+	}
+	svc := NewCaseService(repo, actorUserRepo(t))
+	ctx := contextWithUserIDToken(fakeJWTWithEmail(t, "jane.doe@example.com"))
+
+	_, err := svc.ConfirmCaseAttachment(ctx, testAttachmentID)
+	var fe *apierror.ForbiddenError
+	if !errorsAsForbidden(err, &fe) {
+		t.Fatalf("expected *apierror.ForbiddenError, got %T: %v", err, err)
+	}
+}
+
+// TestCaseService_ConfirmCaseAttachment_NotFound proves confirming a
+// nonexistent attachment surfaces as a NotFoundError.
+func TestCaseService_ConfirmCaseAttachment_NotFound(t *testing.T) {
+	repo := &stubCaseRepo{
+		getCaseAttachmentByID: func(context.Context, string) (domain.Attachment, error) {
+			return domain.Attachment{}, &apierror.NotFoundError{Msg: "attachment not found"}
+		},
+	}
+	svc := NewCaseService(repo, actorUserRepo(t))
+	ctx := contextWithUserIDToken(fakeJWTWithEmail(t, "jane.doe@example.com"))
+
+	_, err := svc.ConfirmCaseAttachment(ctx, testAttachmentID)
+	var nfe *apierror.NotFoundError
+	if !errorsAsNotFound(err, &nfe) {
+		t.Fatalf("expected *apierror.NotFoundError, got %T: %v", err, err)
+	}
+}
+
+// TestCaseService_ConfirmCaseAttachment_RejectsUnauthenticatedCaller proves
+// confirming is gated behind the same authentication check as every other
+// attachment mutation.
+func TestCaseService_ConfirmCaseAttachment_RejectsUnauthenticatedCaller(t *testing.T) {
+	repo := &stubCaseRepo{
+		getCaseAttachmentByID: func(context.Context, string) (domain.Attachment, error) {
+			t.Fatal("repository should not be reached for an unauthenticated caller")
+			return domain.Attachment{}, nil
+		},
+	}
+	svc := NewCaseService(repo, stubUserRepo{})
+	ctx := contextWithUserIDToken("")
+
+	_, err := svc.ConfirmCaseAttachment(ctx, testAttachmentID)
+	var ue *apierror.UnauthorizedError
+	if !errorsAsUnauthorized(err, &ue) {
+		t.Fatalf("expected *apierror.UnauthorizedError, got %T: %v", err, err)
+	}
+}
+
 // TestCaseService_SearchCaseAttachments_ReturnsStorageKey proves the search
 // path surfaces storageKey for every row, not just create.
 func TestCaseService_SearchCaseAttachments_ReturnsStorageKey(t *testing.T) {
@@ -446,6 +664,22 @@ func errorsAsNotFound(err error, target **apierror.NotFoundError) bool {
 func errorsAsServiceUnavailable(err error, target **apierror.ServiceUnavailableError) bool {
 	if sue, ok := err.(*apierror.ServiceUnavailableError); ok {
 		*target = sue
+		return true
+	}
+	return false
+}
+
+func errorsAsConflict(err error, target **apierror.ConflictError) bool {
+	if ce, ok := err.(*apierror.ConflictError); ok {
+		*target = ce
+		return true
+	}
+	return false
+}
+
+func errorsAsForbidden(err error, target **apierror.ForbiddenError) bool {
+	if fe, ok := err.(*apierror.ForbiddenError); ok {
+		*target = fe
 		return true
 	}
 	return false

--- a/entity-service/internal/service/case_service.go
+++ b/entity-service/internal/service/case_service.go
@@ -627,6 +627,18 @@ func (s *caseService) CreateCaseAttachment(ctx context.Context, req domain.Creat
 	if req.SizeBytes <= 0 {
 		return domain.CreateAttachmentResponse{}, &apierror.ValidationError{Msg: "sizeBytes must be greater than zero"}
 	}
+	// Empty defaults to complete: every caller before this change (and every
+	// existing Postgres-path caller that doesn't know about the pending
+	// state) gets exactly today's behavior. Only a caller that explicitly
+	// wants the two-step upload flow passes "pending".
+	switch req.Status {
+	case "":
+		req.Status = domain.AttachmentStatusComplete
+	case domain.AttachmentStatusPending, domain.AttachmentStatusComplete:
+		// valid
+	default:
+		return domain.CreateAttachmentResponse{}, &apierror.ValidationError{Msg: fmt.Sprintf("invalid status %q: must be 'pending' or 'complete'", req.Status)}
+	}
 
 	user, err := s.resolveActor(ctx)
 	if err != nil {
@@ -647,6 +659,7 @@ func (s *caseService) CreateCaseAttachment(ctx context.Context, req domain.Creat
 			CreatedOn:  a.CreatedOn,
 			CreatedBy:  user.Email,
 			StorageKey: a.StorageKey,
+			Status:     a.Status,
 			// No DownloadURL: this service holds no bytes for a Postgres-sourced
 			// attachment, only its storage_key. Resolving storage_key to an
 			// actual download location is the downstream CSM backend's job.
@@ -654,8 +667,73 @@ func (s *caseService) CreateCaseAttachment(ctx context.Context, req domain.Creat
 	}, nil
 }
 
+// ConfirmCaseAttachment implements CaseService for the CSM-native (Postgres)
+// data source. It is the second half of the two-step upload flow: the caller
+// (the CSM backend) registers a 'pending' row via CreateCaseAttachment
+// *before* minting an SFTPGo upload credential, then calls this once the
+// browser reports the upload succeeded, transitioning the row to 'complete'.
+//
+// Ownership: unlike UpdateAttachment/DeleteCaseAttachment (which any
+// authenticated user may perform on any case attachment -- there is no
+// per-resource ACL in this data source beyond authentication, see
+// resolveActor's doc comment), confirming is restricted to the same actor
+// who created the pending row. A pending row represents an upload a specific
+// user initiated; there is no legitimate case yet for a different user to
+// confirm it on their behalf, and allowing it would let any authenticated
+// user "complete" an attachment they never uploaded.
+func (s *caseService) ConfirmCaseAttachment(ctx context.Context, id string) (domain.ConfirmAttachmentResponse, error) {
+	if err := validateUUIDs("id", []string{id}); err != nil {
+		return domain.ConfirmAttachmentResponse{}, err
+	}
+
+	user, err := s.resolveActor(ctx)
+	if err != nil {
+		return domain.ConfirmAttachmentResponse{}, err
+	}
+
+	existing, err := s.repo.GetCaseAttachmentByID(ctx, id)
+	if err != nil {
+		return domain.ConfirmAttachmentResponse{}, err
+	}
+	if existing.CreatedBy == nil || existing.CreatedBy.ID == nil || *existing.CreatedBy.ID != user.ID {
+		return domain.ConfirmAttachmentResponse{}, &apierror.ForbiddenError{Msg: "attachment was not created by the current user"}
+	}
+	if existing.Status != domain.AttachmentStatusPending {
+		return domain.ConfirmAttachmentResponse{}, &apierror.ConflictError{Msg: fmt.Sprintf("attachment is not pending (current status: %q)", existing.Status)}
+	}
+
+	a, err := s.repo.ConfirmCaseAttachment(ctx, id)
+	if err != nil {
+		return domain.ConfirmAttachmentResponse{}, err
+	}
+
+	return domain.ConfirmAttachmentResponse{
+		Message: "Attachment confirmed successfully",
+		Attachment: domain.AttachmentDetail{
+			ID:         a.ID,
+			SizeBytes:  a.SizeBytes,
+			CreatedOn:  a.CreatedOn,
+			CreatedBy:  user.Email,
+			StorageKey: a.StorageKey,
+			Status:     a.Status,
+		},
+	}, nil
+}
+
 // SearchCaseAttachments implements CaseService for the CSM-native (Postgres)
 // data source.
+//
+// Read-path status decision: the underlying repository query filters out
+// 'pending' rows entirely (see caseRepo.SearchCaseAttachments), so a case's
+// attachment list never shows a still-uploading placeholder to other users.
+// This is a deliberate product-behavior choice, not an oversight: a pending
+// row may never complete (the upload could fail, or the tab could just
+// close), and showing it in a shared list before that's known risks other
+// team members seeing and trying to act on a file that doesn't exist yet. A
+// specific-id lookup (GetAttachmentByID) is not filtered this way -- it
+// still returns a pending row -- which is what the confirm step relies on,
+// and is also how an uploader could be shown their own in-flight upload if
+// the FE chooses to poll it directly rather than via this list.
 func (s *caseService) SearchCaseAttachments(ctx context.Context, req domain.SearchAttachmentsRequest) (domain.SearchAttachmentsResponse, error) {
 	if err := validateUUIDs("referenceId", []string{req.ReferenceID}); err != nil {
 		return domain.SearchAttachmentsResponse{}, err
@@ -765,6 +843,7 @@ func (s *caseService) GetAttachmentByID(ctx context.Context, id string) (domain.
 		PreviewURL:  a.PreviewURL,
 		Content:     "",
 		StorageKey:  a.StorageKey,
+		Status:      a.Status,
 	}, nil
 }
 

--- a/entity-service/internal/service/case_service_test.go
+++ b/entity-service/internal/service/case_service_test.go
@@ -36,6 +36,7 @@ type stubCaseRepo struct {
 	getCaseAttachmentByID func(ctx context.Context, id string) (domain.Attachment, error)
 	deleteCaseAttachment  func(ctx context.Context, id string) error
 	updateAttachmentName  func(ctx context.Context, id, name, updatedBy string) (time.Time, error)
+	confirmCaseAttachment func(ctx context.Context, id string) (domain.Attachment, error)
 }
 
 func (s *stubCaseRepo) CreateCase(context.Context, domain.CreateCaseRequest) (domain.Case, error) {
@@ -86,6 +87,12 @@ func (s *stubCaseRepo) DeleteCaseAttachment(ctx context.Context, id string) erro
 func (s *stubCaseRepo) UpdateCaseAttachmentName(ctx context.Context, id, name, updatedBy string) (time.Time, error) {
 	if s.updateAttachmentName != nil {
 		return s.updateAttachmentName(ctx, id, name, updatedBy)
+	}
+	panic("not implemented")
+}
+func (s *stubCaseRepo) ConfirmCaseAttachment(ctx context.Context, id string) (domain.Attachment, error) {
+	if s.confirmCaseAttachment != nil {
+		return s.confirmCaseAttachment(ctx, id)
 	}
 	panic("not implemented")
 }

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -301,8 +301,20 @@ type CaseService interface {
 	// open task that is visible to the customer (the authoritative case-close gate).
 	UpdateCase(ctx context.Context, req domain.UpdateCaseRequest) (domain.UpdateCaseResponse, error)
 	// CreateCaseAttachment uploads a new attachment for the case identified by req.CaseID.
-	// A ValidationError is returned for invalid input.
+	// A ValidationError is returned for invalid input. For the CSM-native (Postgres) data
+	// source, req.Status controls the initial lifecycle state (see domain.AttachmentStatus):
+	// empty/omitted and "complete" behave exactly as before this field existed; "pending"
+	// registers the row before the caller has uploaded the file to SFTPGo, to be finished off
+	// later via ConfirmCaseAttachment. ServiceNow ignores this field.
 	CreateCaseAttachment(ctx context.Context, req domain.CreateAttachmentRequest) (domain.CreateAttachmentResponse, error)
+	// ConfirmCaseAttachment transitions the CSM-native (Postgres) data source attachment
+	// identified by id from status "pending" to "complete", once its file has finished
+	// uploading to SFTPGo. A NotFoundError is returned if it does not exist; a
+	// ForbiddenError if the caller did not create it; a ConflictError if it is not
+	// currently "pending" (including if it was already confirmed). Supported by the
+	// CSM-native (Postgres) data source only -- ServiceNow attachments have no such
+	// lifecycle, since SN's /attachments API only ever returns fully-uploaded files.
+	ConfirmCaseAttachment(ctx context.Context, id string) (domain.ConfirmAttachmentResponse, error)
 	// SearchCaseAttachments returns a paginated list of attachments for the case identified
 	// by req.CaseID. A ValidationError is returned for invalid input.
 	SearchCaseAttachments(ctx context.Context, req domain.SearchAttachmentsRequest) (domain.SearchAttachmentsResponse, error)

--- a/entity-service/internal/service/sn_case_service.go
+++ b/entity-service/internal/service/sn_case_service.go
@@ -2355,6 +2355,14 @@ func (s *snCaseService) CreateCaseAttachment(ctx context.Context, req domain.Cre
 	}, nil
 }
 
+// ConfirmCaseAttachment implements CaseService. ServiceNow's /attachments API
+// only ever returns fully-uploaded files -- there is no pending/in-progress
+// upload state to confirm -- so this is a CSM-native (Postgres) data
+// source-only operation. See caseService.ConfirmCaseAttachment.
+func (s *snCaseService) ConfirmCaseAttachment(_ context.Context, _ string) (domain.ConfirmAttachmentResponse, error) {
+	return domain.ConfirmAttachmentResponse{}, &apierror.ServiceUnavailableError{Msg: "confirming an attachment is only supported for the CSM-native data source"}
+}
+
 var validReferenceTypes = map[domain.ReferenceType]struct{}{
 	domain.ReferenceTypeCase:          {},
 	domain.ReferenceTypeConversation:  {},

--- a/entity-service/migrations/000013_add_case_attachments_status.down.sql
+++ b/entity-service/migrations/000013_add_case_attachments_status.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_case_attachments_status_created;
+ALTER TABLE case_attachments DROP COLUMN IF EXISTS status;

--- a/entity-service/migrations/000013_add_case_attachments_status.up.sql
+++ b/entity-service/migrations/000013_add_case_attachments_status.up.sql
@@ -1,0 +1,17 @@
+-- Adds an upload lifecycle to case_attachments. Today, a row is only ever
+-- created once the browser has already finished uploading to SFTPGo (see
+-- CaseService.CreateCaseAttachment); if that final registration call never
+-- lands (closed tab, crash, network blip after a successful upload), SFTPGo
+-- holds an orphan file with zero record in CSM. The fix: register a 'pending'
+-- row before the upload credential is even minted, then transition it to
+-- 'complete' once the browser reports success. Default 'complete' keeps this
+-- additive and backward-compatible with any existing rows (none in practice,
+-- since this feature is unshipped, but treated as a real migration regardless).
+ALTER TABLE case_attachments
+  ADD COLUMN status TEXT NOT NULL DEFAULT 'complete' CHECK (status IN ('pending', 'complete'));
+
+-- Supports a future reconciliation job that scans for pending rows whose
+-- upload never completed (e.g. "status = 'pending' AND created_at < now() -
+-- interval '1 hour'"). Not built in this change -- see the status column
+-- comment above.
+CREATE INDEX IF NOT EXISTS idx_case_attachments_status_created ON case_attachments(status, created_at);

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -1832,6 +1832,77 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /attachments/{id}/confirm:
+    post:
+      summary: >
+        Confirm a pending CSM-native (Postgres) data source attachment now that its file has
+        finished uploading to SFTPGo.
+      description: >
+        Second half of the two-step upload flow: the caller registers a "pending" row via
+        POST /attachments before minting an SFTPGo upload credential, then calls this once the
+        browser reports the upload succeeded. This closes the gap where a browser upload could
+        succeed in SFTPGo while the metadata-registration call never lands, leaving an
+        untracked orphan file. Only the actor who created the pending row may confirm it.
+        ServiceNow-sourced attachments have no such lifecycle and are rejected with 503.
+      operationId: confirmCaseAttachment
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Attachment UUID.
+      responses:
+        "200":
+          description: Attachment confirmed successfully; status transitioned to complete.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConfirmAttachmentResponse'
+        "400":
+          description: Bad request (malformed UUID).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "403":
+          description: The attachment was not created by the current user.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: Attachment not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "409":
+          description: Attachment is not pending (already confirmed, or does not exist).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "503":
+          description: Not supported for the ServiceNow data source.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /attachments/search:
     post:
       summary: Search attachments linked to a support case.
@@ -7791,6 +7862,21 @@ components:
             File size in bytes. Required for the CSM-native (Postgres) data source (this
             service cannot compute it there); ignored for ServiceNow, which computes it from
             the decoded file payload.
+        status:
+          $ref: '#/components/schemas/AttachmentStatus'
+
+    AttachmentStatus:
+      type: string
+      enum:
+        - pending
+        - complete
+      description: >
+        Upload lifecycle state for a CSM-native (Postgres) data source attachment. Meaningful
+        for that data source only -- ServiceNow's /attachments API only ever returns
+        fully-uploaded files, so ServiceNow-sourced attachments are always "complete". On
+        create, omitted/empty defaults to "complete" (today's behavior, preserved for every
+        existing caller); pass "pending" to register the row before the file has finished
+        uploading to SFTPGo, then confirm it via POST /attachments/{id}/confirm.
 
     AttachmentDetail:
       type: object
@@ -7811,9 +7897,23 @@ components:
           type: string
           nullable: true
           description: Set only for CSM-native (Postgres) data source attachments. See Attachment.storageKey.
+        status:
+          $ref: '#/components/schemas/AttachmentStatus'
 
     CreateAttachmentResponse:
       type: object
+      properties:
+        message:
+          type: string
+        attachment:
+          $ref: '#/components/schemas/AttachmentDetail'
+
+    ConfirmAttachmentResponse:
+      type: object
+      description: >
+        Response for POST /attachments/{id}/confirm. Same shape as CreateAttachmentResponse --
+        confirming is the second half of the CSM-native (Postgres) data source's two-step
+        (pending -> complete) upload flow.
       properties:
         message:
           type: string
@@ -7859,6 +7959,8 @@ components:
             Reference to the file's location in external object storage (SFTPGo), set only for
             CSM-native (Postgres) data source attachments. Null for ServiceNow-sourced
             attachments, whose bytes are held by ServiceNow itself.
+        status:
+          $ref: '#/components/schemas/AttachmentStatus'
 
     ReferenceType:
       type: string
@@ -11804,6 +11906,8 @@ components:
           type: string
           nullable: true
           description: Set only for CSM-native (Postgres) data source attachments. See Attachment.storageKey.
+        status:
+          $ref: '#/components/schemas/AttachmentStatus'
 
     UpdateAttachmentRequest:
       type: object


### PR DESCRIPTION
## Purpose
Replace the SFTPGo upload path's bearer-token minting with write-scoped SFTPGo Shares, per the vendor's own documented `/shares-chunked-uploads` contract, and close a reliability gap where a successful browser upload could leave no record in CSM. Stacked on #1592 (targets `feature/sftpgo-attachment-storage`, not `dev-app-csm-portal`) — this reworks and extends the upload-token endpoint that PR introduced.

## Goals
- No bearer credential of any kind reaches the browser for uploads (closes the "pod IP embedded in the JWT `aud` claim" concern raised in #1592's design discussion entirely, since there's no JWT in play at all on this path anymore).
- The credential handed to the browser can do nothing except write to the one path it was minted for (closes a "minted tokens aren't case-scoped" review finding from #1592 — a write-scoped Share literally cannot do anything else).
- Genuine TUS resumability via SFTPGo's own `HEAD /api/v2/shares-chunked-uploads/{id}` offset-check, rather than the single-shot POST+PATCH #1592 shipped (which was correctly flagged as "not actually resumable" despite the naming).
- An attachment's metadata row now exists in CSM from the moment an upload *starts*, not only after it fully completes — so a browser upload that succeeds in SFTPGo but whose final confirmation call never lands (closed tab, crash, network blip) no longer disappears into an untracked orphan file with zero record anywhere in CSM.

## Approach
Three commits, in order:

**1. `e0ee65d74` — write-scoped Share replaces the bearer token.** `MintUploadToken`'s response changes from `{sftpgoAccessToken, expiresAt, sftpgoBaseUrl, storageKey}` to `{shareId, sftpgoBaseUrl, storageKey}`. It still calls the existing `MintToken` internally (the backend still needs a credential to call `POST /api/v2/user/shares` on the caller's behalf), but that access token is never returned to the frontend. The share is `scope: 2` (write), TTL 45 minutes (documented constant, chosen to tolerate large/slow uploads and retries), no password. The existing read-only download-share path (`CreateAttachmentShare`, `scope: 1`) is unchanged in behavior.

**Load-bearing correction, found via live testing against a real SFTPGo instance, not assumed from the spec:** despite SFTPGo's own OpenAPI doc calling the TUS `path` metadata field "the absolute destination path," it's actually resolved *relative to the share's own scoped path*. A share minted for the exact target file (the naive reading of the spec) makes every upload fail. The correct, verified scoping: the share is minted for the attachment's *directory* (`path.Dir(storageKey)`), and the frontend's follow-up TUS request must send only the final path segment. Also verified: the real endpoint is mounted at `{sftpgoBaseUrl}/api/v2/shares-chunked-uploads`, not the bare `/shares-chunked-uploads` the OpenAPI path name implies.

**2. `5cde71888` — `pending`/`complete` status on entity-service's `case_attachments`.** Additive migration, `status` column defaulting to `complete` (fully backward compatible). `CreateCaseAttachment` accepts an optional `status`; a new `POST /attachments/{id}/confirm` transitions `pending` -> `complete`, restricted to the original uploader (stricter than this data source's other attachment operations, which have no per-resource ACL today -- a deliberate, documented choice, not an oversight). Case attachment lists filter out `pending` rows by default; direct id lookup still returns them (needed for confirm, and for an uploader to see their own in-flight upload).

**3. `659e58112` — CSM backend wires the two together.** `MintUploadToken` now requires `{filename, mimeType, sizeBytes, description?}` in its request body, creates the attachment as `pending` in entity-service *before* minting the share (if that create fails, no share is minted at all -- proven by test, including call-order assertion), and returns the new attachment's `id` alongside `{shareId, sftpgoBaseUrl, storageKey}`. New `POST /cases/{caseId}/attachments/{attachmentId}/confirm`, called by the frontend after a successful direct-to-SFTPGo upload, forwards to entity-service's confirm endpoint with the same 404/403/409 mapping.

## Not yet included, tracked as follow-up
The frontend TUS client rework to actually call this chain in order (mint -> upload -> confirm; currently still calls the old token-based endpoint from #1592). This PR is backend + entity-service only so far -- no visible behavior change until the frontend lands on top of it.

## User stories
N/A -- no visible behavior change to end users yet (frontend follow-up required before this is reachable).

## Release note
N/A -- not yet wired to any reachable frontend path.

## Documentation
N/A.

## Automation tests
- Unit tests: `internal/sftpgo/client_test.go`, `internal/handler/attachment_storage_test.go` (share scope/directory, pending-before-share ordering, share skipped on entity-create failure, confirm endpoint auth/validation/success/404/403/409), `entity-service/internal/service/case_attachment_service_test.go` (status default, explicit pending, confirm transitions and rejections). All pre-existing tests across all three commits pass unmodified.
- Integration tests: verified against a real, freshly provisioned SFTPGo Enterprise instance (no license) -- real `MintToken`/`CreateShare` calls via this repo's actual client code, followed by a complete real `POST`/`HEAD`/`PATCH /api/v2/shares-chunked-uploads` cycle via curl, with the uploaded content read back and confirmed byte-identical. The `pending`/`complete` migration was applied and its constraints/index verified against a real Postgres 16 container.

## Security checks
- Followed secure coding standards: yes
- Ran FindSecurityBugs plugin: no -- Go stack, not applicable
- Confirmed no secrets committed: yes

## Samples
N/A

## Related PRs
Stacks on cs-tools#1592 (targets its branch, not `dev-app-csm-portal`, so the diff here only shows this PR's own commits).

## Migrations
`entity-service/migrations/000013_add_case_attachments_status.{up,down}.sql` -- additive, backward compatible, live-verified.

## Test environment
Go 1.26.6 (toolchain-pinned), SFTPGo Enterprise `v2.7.20260705` (Docker, no license), Postgres 16 (Docker) for live verification.

## Learning
Confirmed directly against a live instance that SFTPGo's own OpenAPI documentation for `/shares-chunked-uploads`'s `path` metadata field is misleading ("absolute destination path" actually means relative-to-share-scope) -- worth reporting back to the vendor separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional SFTPGo-backed attachment storage for direct, resumable uploads.
  * Uploads now show live progress, including percentage completion.
  * Attachments can be downloaded through short-lived public links and displayed in inline images.
  * Added upload confirmation support and improved attachment metadata handling.
* **Bug Fixes**
  * Upload activity is now scoped to the active case, preventing progress from appearing on another case.
  * Existing attachment upload and download behavior remains available when external storage is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->