### PR TITLE
[CSM Portal] Case Feedback: fix rating-slice click-through, add editable filter bar

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-dashboard/pages/DashboardWidgetPreviewPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/pages/DashboardWidgetPreviewPage.test.tsx
@@ -112,6 +112,127 @@ function mockPost(responses: {
   });
 }
 
+/**
+ * `case_feedback`'s own "View more" landing: a rating-pie slice click-through
+ * must land the viewer on the exact rating it clicked (regression for the
+ * numeric-`rating`-dropped-from-URL bug — see `widgetPreviewUrl.ts`'s own
+ * regression test for the encoding half of this), and — reported live as "a
+ * must" — the rating/date filters must be real, editable controls, not the
+ * generic resourceTypes' read-only "Filtered by:" chip summary.
+ */
+describe("DashboardWidgetPreviewPage — case_feedback gets a real, editable rating/date filter bar", () => {
+  beforeEach(() => {
+    postMock.mockReset();
+    postMock.mockResolvedValue({
+      results: [
+        {
+          instanceId: "fb-1",
+          caseId: "11111111-1111-1111-1111-111111111111",
+          rating: 5,
+          ratingLabel: "Very Satisfied",
+          comment: "Great support",
+          submittedAt: "2026-08-01T00:00:00Z",
+        },
+      ],
+      totalRecords: 1,
+    });
+  });
+
+  it("queries with the rating a pie slice click-through carried, not the unfiltered list", async () => {
+    // Mirrors what DashboardWidgetTile actually builds for a rating-pie
+    // slice click (see useCaseFeedbackTrendData's `{ rating: 5 }` query,
+    // merged and passed through WIDGET_RESOURCE_CONFIG.case_feedback.buildHref).
+    renderAt(
+      buildWidgetPreviewHref({
+        previewSlug: "case-feedback",
+        widgetId: "feedback_rating_distribution",
+        displayName: "Rating Distribution",
+        filters: { rating: 5 },
+      }),
+    );
+
+    await waitFor(() => expect(screen.getByText("Very Satisfied")).toBeInTheDocument());
+    expect(postMock).toHaveBeenCalledWith(
+      "/cases/feedback/search",
+      { filters: { rating: 5 }, page: 1, pageSize: 10 },
+      { signal: expect.any(AbortSignal) },
+    );
+    // The rating select shows the slice's own rating pre-selected, not "All
+    // ratings" -- confirms the filter bar is seeded, not just the query.
+    expect(screen.getByRole("combobox", { name: /^rating$/i })).toHaveTextContent(
+      /very satisfied/i,
+    );
+  });
+
+  it("re-queries when the rating filter is changed from the dropdown", async () => {
+    renderAt(
+      buildWidgetPreviewHref({
+        previewSlug: "case-feedback",
+        widgetId: "feedback_list",
+        displayName: "Feedback Records",
+        filters: {},
+      }),
+    );
+
+    await waitFor(() =>
+      expect(postMock).toHaveBeenCalledWith(
+        "/cases/feedback/search",
+        { filters: {}, page: 1, pageSize: 10 },
+        { signal: expect.any(AbortSignal) },
+      ),
+    );
+
+    fireEvent.mouseDown(screen.getByRole("combobox", { name: /^rating$/i }));
+    fireEvent.click(screen.getByRole("option", { name: /1 — very dissatisfied/i }));
+
+    await waitFor(() =>
+      expect(postMock).toHaveBeenCalledWith(
+        "/cases/feedback/search",
+        { filters: { rating: 1 }, page: 1, pageSize: 10 },
+        { signal: expect.any(AbortSignal) },
+      ),
+    );
+  });
+
+  it("Reset restores the widget's own original rating, not 'All ratings'", async () => {
+    renderAt(
+      buildWidgetPreviewHref({
+        previewSlug: "case-feedback",
+        widgetId: "feedback_rating_distribution",
+        displayName: "Rating Distribution",
+        filters: { rating: 5 },
+      }),
+    );
+
+    await waitFor(() =>
+      expect(postMock).toHaveBeenCalledWith(
+        "/cases/feedback/search",
+        { filters: { rating: 5 }, page: 1, pageSize: 10 },
+        { signal: expect.any(AbortSignal) },
+      ),
+    );
+
+    fireEvent.mouseDown(screen.getByRole("combobox", { name: /^rating$/i }));
+    fireEvent.click(screen.getByRole("option", { name: /all ratings/i }));
+    await waitFor(() =>
+      expect(postMock).toHaveBeenCalledWith(
+        "/cases/feedback/search",
+        { filters: {}, page: 1, pageSize: 10 },
+        { signal: expect.any(AbortSignal) },
+      ),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /^reset$/i }));
+    await waitFor(() =>
+      expect(postMock).toHaveBeenCalledWith(
+        "/cases/feedback/search",
+        { filters: { rating: 5 }, page: 1, pageSize: 10 },
+        { signal: expect.any(AbortSignal) },
+      ),
+    );
+  });
+});
+
 describe("DashboardWidgetPreviewPage", () => {
   beforeEach(() => {
     postMock.mockReset();

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/pages/DashboardWidgetPreviewPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/pages/DashboardWidgetPreviewPage.tsx
@@ -14,7 +14,18 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Box, Button, Chip, TablePagination, TextField, Typography } from "@wso2/oxygen-ui";
+import {
+  Box,
+  Button,
+  Chip,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  TablePagination,
+  TextField,
+  Typography,
+} from "@wso2/oxygen-ui";
 import { ArrowLeft } from "@wso2/oxygen-ui-icons-react";
 import { useMemo, useState, type ChangeEvent, type JSX } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router";
@@ -42,6 +53,9 @@ import CasesList from "@features/csm-cases/components/CasesList";
 import { useGetCsmCases } from "@features/csm-cases/api/useGetCsmCases";
 import { useSearchTags } from "@features/csm-cases/api/useSearchTags";
 import { DEFAULT_CASES_FILTERS } from "@features/csm-cases/utils/casesFiltersUrl";
+import DateRangeFilter, {
+  type DateRangeFilterValue,
+} from "@features/csm-dashboard/components/DateRangeFilter";
 
 const DEFAULT_ROWS_PER_PAGE = 10;
 const ROWS_PER_PAGE_OPTIONS = [10, 20, BE_MAX_PAGE_LIMIT];
@@ -157,6 +171,17 @@ export default function DashboardWidgetPreviewPage(): JSX.Element {
   if (CASE_FAMILY_RESOURCE_TYPES.has(resourceType) && !isAnyOfBranchArray(filters.anyOf)) {
     return (
       <CaseFamilyWidgetPreview
+        displayName={displayName}
+        filters={filters}
+        backButton={backButton}
+      />
+    );
+  }
+
+  if (resourceType === "case_feedback") {
+    return (
+      <CaseFeedbackWidgetPreview
+        widgetId={widgetId}
         displayName={displayName}
         filters={filters}
         backButton={backButton}
@@ -394,6 +419,176 @@ function CaseFamilyWidgetPreview({
       ) : (
         <>
           <CasesList cases={data?.cases ?? []} isLoading={isLoading} skeletonCount={rowsPerPage} />
+          <TablePagination
+            component="div"
+            count={data?.total ?? 0}
+            page={page}
+            onPageChange={(_, newPage) => setPage(newPage)}
+            rowsPerPage={rowsPerPage}
+            onRowsPerPageChange={handleRowsPerPageChange}
+            rowsPerPageOptions={ROWS_PER_PAGE_OPTIONS}
+            showFirstButton
+            showLastButton
+          />
+        </>
+      )}
+    </Box>
+  );
+}
+
+interface CaseFeedbackWidgetPreviewProps {
+  widgetId: string;
+  displayName: string;
+  filters: Record<string, unknown>;
+  backButton: JSX.Element;
+}
+
+/** The 5 case-feedback rating values, in order — same scale ServiceNow's own
+ * survey uses (see `useCaseFeedbackTrendData`'s `colorForAvgRating` doc
+ * comment for the same 1-5 -> CSAT-label mapping). No shared constant for
+ * this exists elsewhere in the app (every other rating display reads the
+ * label straight off the record itself), so it's scoped here rather than
+ * invented as a new cross-feature export for a single dropdown. */
+const FEEDBACK_RATING_OPTIONS: { value: string; label: string }[] = [
+  { value: "1", label: "1 — Very Dissatisfied" },
+  { value: "2", label: "2 — Dissatisfied" },
+  { value: "3", label: "3 — Neutral" },
+  { value: "4", label: "4 — Satisfied" },
+  { value: "5", label: "5 — Very Satisfied" },
+];
+
+/** First string value out of a filter field that's either a bare string (a
+ * tile/slice click-through's own scalar filters) or a 1-element string[]
+ * (the same field once round-tripped through the preview URL — see
+ * `parseWidgetPreviewFilters`, which decodes every param as a comma-split
+ * array). Either shape lands here since `filters` (this component's own
+ * prop) always came from that URL round trip. */
+function asFeedbackFilterValue(v: unknown): string | undefined {
+  if (typeof v === "string") return v;
+  if (Array.isArray(v) && typeof v[0] === "string") return v[0];
+  return undefined;
+}
+
+/**
+ * The case-feedback "View more" landing: unlike the generic
+ * `DashboardWidgetPreviewContent` fallback below (a static "Filtered by:"
+ * chip summary plus a free-text search box the feedback search endpoint
+ * doesn't even support — `case_feedback` has no `searchQuery` field), this
+ * gives a real, editable rating + date-range filter bar, seeded from the
+ * widget's own filters (a rating-pie or trend-bar slice click-through) and
+ * then freely adjustable from there — the same "seeded then editable"
+ * pattern `CaseFamilyWidgetPreview` already uses for the case-family
+ * resourceTypes, scoped to this resourceType's own flat
+ * `dateFrom`/`dateTo`/`rating` filter shape (see
+ * `WIDGET_RESOURCE_CONFIG.case_feedback`'s own `buildSearchRequestBody`
+ * doc comment) rather than the case-search DSL that component translates.
+ */
+function CaseFeedbackWidgetPreview({
+  widgetId,
+  displayName,
+  filters,
+  backButton,
+}: CaseFeedbackWidgetPreviewProps): JSX.Element {
+  // Frozen once at mount (a fresh "View more"/slice click is a fresh mount),
+  // same rationale as `CaseFamilyWidgetPreview`'s `resetBaseline` — Reset
+  // must restore what the widget/slice actually linked here with, not
+  // whatever the viewer has since edited.
+  const [initial] = useState(() => ({
+    dateFrom: asFeedbackFilterValue(filters.dateFrom),
+    dateTo: asFeedbackFilterValue(filters.dateTo),
+    rating: asFeedbackFilterValue(filters.rating),
+  }));
+  const [dateRange, setDateRange] = useState<DateRangeFilterValue>({
+    from: initial.dateFrom,
+    to: initial.dateTo,
+  });
+  const [rating, setRating] = useState<string>(initial.rating ?? "");
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_ROWS_PER_PAGE);
+
+  const queriedFilters = useMemo(() => {
+    const out: Record<string, unknown> = { ...filters };
+    delete out.dateFrom;
+    delete out.dateTo;
+    delete out.rating;
+    if (dateRange.from) out.dateFrom = dateRange.from;
+    if (dateRange.to) out.dateTo = dateRange.to;
+    if (rating) out.rating = Number(rating);
+    return out;
+  }, [filters, dateRange, rating]);
+
+  const handleReset = (): void => {
+    setDateRange({ from: initial.dateFrom, to: initial.dateTo });
+    setRating(initial.rating ?? "");
+    setPage(0);
+  };
+
+  const { data, isLoading, isError, isFetching, refetch, dataUpdatedAt } = useWidgetData(
+    widgetId,
+    "case_feedback",
+    queriedFilters,
+    "list",
+    rowsPerPage,
+    page * rowsPerPage,
+  );
+  const ListRenderer = WIDGET_LIST_RENDERERS.case_feedback;
+
+  const handleRowsPerPageChange = (e: ChangeEvent<HTMLInputElement>): void => {
+    setRowsPerPage(parseInt(e.target.value, 10));
+    setPage(0);
+  };
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+      {backButton}
+      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 1 }}>
+        <Typography variant="h5">{displayName}</Typography>
+        <RefreshButton
+          onRefresh={() => void refetch()}
+          isFetching={isFetching}
+          updatedAt={dataUpdatedAt}
+          label={`Refresh ${displayName}`}
+        />
+      </Box>
+      <Box sx={{ display: "flex", flexWrap: "wrap", alignItems: "flex-end", gap: 2 }}>
+        <DateRangeFilter
+          label="Feedback submitted"
+          value={dateRange}
+          onChange={(next) => {
+            setDateRange(next);
+            setPage(0);
+          }}
+        />
+        <FormControl size="small" sx={{ minWidth: 220 }}>
+          <InputLabel id="feedback-rating-filter-label">Rating</InputLabel>
+          <Select
+            labelId="feedback-rating-filter-label"
+            label="Rating"
+            value={rating}
+            onChange={(e) => {
+              setRating(e.target.value);
+              setPage(0);
+            }}
+          >
+            <MenuItem value="">All ratings</MenuItem>
+            {FEEDBACK_RATING_OPTIONS.map((option) => (
+              <MenuItem key={option.value} value={option.value}>
+                {option.label}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <Button variant="text" size="small" onClick={handleReset}>
+          Reset
+        </Button>
+      </Box>
+      {isError ? (
+        <Typography variant="body2" color="text.secondary">
+          Could not load this widget.
+        </Typography>
+      ) : (
+        <>
+          <ListRenderer items={data?.items ?? []} isLoading={isLoading} />
           <TablePagination
             component="div"
             count={data?.total ?? 0}

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/utils/widgetPreviewUrl.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/utils/widgetPreviewUrl.test.ts
@@ -42,6 +42,26 @@ describe("widgetPreviewUrl", () => {
     expect(params.get("f")).toBeNull();
   });
 
+  it("encodes a plain numeric filter value, not just string/string[]", () => {
+    // Regression: the rating-distribution pie's slice query is
+    // `{ rating: Math.round(avgRating) }` (see useCaseFeedbackTrendData) — a
+    // number, not a string. Before this branch existed, a numeric filter
+    // value was silently dropped from the URL entirely, so clicking a
+    // rating slice landed on the unfiltered feedback list.
+    const href = buildWidgetPreviewHref({
+      previewSlug: "case-feedback",
+      widgetId: "feedback_rating_distribution",
+      displayName: "Rating Distribution",
+      filters: { rating: 5 },
+    });
+
+    const params = new URLSearchParams(href.split("?")[1]);
+    expect(params.get("rating")).toBe("5");
+
+    const { filters } = parseWidgetPreviewFilters(params);
+    expect(filters.rating).toEqual(["5"]);
+  });
+
   it("masks the current user's own id to @me instead of embedding it verbatim", () => {
     const href = buildWidgetPreviewHref({
       previewSlug: "cases",

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/utils/widgetPreviewUrl.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/utils/widgetPreviewUrl.ts
@@ -189,6 +189,14 @@ export function buildWidgetPreviewHref(params: {
       q.set(key, masked.join(","));
     } else if (typeof value === "string") {
       q.set(key, value === params.currentUserId ? CURRENT_USER_SENTINEL : value);
+    } else if (typeof value === "number" && Number.isFinite(value)) {
+      // A slice's own `query` can carry a plain number (e.g. the rating pie's
+      // `{ rating: 5 }`, from `Math.round(avgRating)` — see
+      // `useCaseFeedbackTrendData`), not just the string/string[] shape every
+      // other widget's filters use. Dropped silently before this branch
+      // existed: a rating-pie click-through landed on the unfiltered list
+      // with no `rating` param in the URL at all.
+      q.set(key, String(value));
     }
   }
   if (usesCaseFieldFilterShape) q.set(CASE_FILTER_MARKER, "1");


### PR DESCRIPTION
## Summary
- `buildWidgetPreviewHref` only serialized `string`/`string[]` filter values. The Rating Distribution pie's slice query is a plain number (`Math.round(avgRating)`), so it was silently dropped from the "View more" URL — clicking "Very Satisfied" landed on the unfiltered feedback list instead of the rating-filtered one. Added a `number` branch alongside the existing ones.
- The Case Feedback "View more" preview page had no editable filters at all — only a read-only "Filtered by:" chip summary and a free-text search box the feedback endpoint doesn't even support. Added a dedicated `CaseFeedbackWidgetPreview` with a real Rating dropdown + date-range filter (reusing the existing `DateRangeFilter` component), seeded from the widget/slice's own filters and freely editable from there, plus a Reset button — mirroring the pattern `CaseFamilyWidgetPreview` already uses for case-family resourceTypes.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `vitest run` — 42/42 passing in `widgetPreviewUrl.test.ts` + `DashboardWidgetPreviewPage.test.tsx`, including 4 new tests: numeric-value URL encoding regression, rating-slice click-through query, rating-dropdown re-query, and Reset restoring the original rating

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added case feedback widget previews with editable rating and date-range filters.
  * Preserved widget filters when opening previews from dashboard charts.
  * Updated preview URLs to retain numeric rating filters.

* **Bug Fixes**
  * Resetting filters now restores the widget’s original rating.
  * Rating changes correctly refresh feedback results.
  * Improved handling of rating-based chart selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->