### PR TITLE
[CSM Portal] Support splitting one dashboard's config across multiple files

### DIFF
--- a/apps/csm-portal/backend/internal/dashboard/registry.go
+++ b/apps/csm-portal/backend/internal/dashboard/registry.go
@@ -83,6 +83,39 @@ type dashboardFile struct {
 	PartOf string `json:"partOf,omitempty"`
 }
 
+// partFileAllowedKeys is every JSON key a part file (one with "partOf" set)
+// is allowed to carry — see rejectUnexpectedPartFields.
+var partFileAllowedKeys = map[string]bool{"partOf": true, "widgets": true}
+
+// rejectUnexpectedPartFields is a hard load failure for a part file that
+// also sets any embedded Dashboard field beyond Widgets -- e.g. "id" or
+// "filterPresets". dashboardFile decodes those fields into f.Dashboard like
+// any other file, but loadDir's part-file branch only ever reads f.Widgets
+// back out (see mergeParts): every other field a part file's author sets
+// would otherwise decode successfully and then vanish without a trace,
+// which is exactly the "silently misroutes/drops data" failure mode
+// mergeParts's own doc comment says this loader refuses to tolerate
+// elsewhere. Re-decoding raw into a generic key set (rather than comparing
+// f.Dashboard's fields against their zero values) is deliberate: a
+// zero-value comparison can't tell "the author wrote isDefault: false" apart
+// from "the author never mentioned isDefault at all", but a raw key lookup
+// can.
+func rejectUnexpectedPartFields(raw []byte, path string) error {
+	var keys map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &keys); err != nil {
+		return fmt.Errorf("dashboard definitions: parse %q: %w", path, err)
+	}
+	for key := range keys {
+		if !partFileAllowedKeys[key] {
+			return fmt.Errorf(
+				"dashboard definitions: %s: a part file (\"partOf\" set) may only carry \"partOf\" and \"widgets\", found unexpected field %q",
+				path, key,
+			)
+		}
+	}
+	return nil
+}
+
 // mergeParts folds every part's widgets onto its primary dashboard's own
 // Widgets, in the order the parts were encountered (which is loadDir's
 // lexical filename order, same determinism guarantee LoadDir already makes
@@ -445,6 +478,9 @@ func loadDir(dir string, sharedPresets map[string]map[string]any, sharedSections
 			return nil, fmt.Errorf("dashboard definitions: parse %q: %w", path, err)
 		}
 		if f.PartOf != "" {
+			if err := rejectUnexpectedPartFields(raw, path); err != nil {
+				return nil, err
+			}
 			parts = append(parts, dashboardPart{partOf: f.PartOf, widgets: f.Widgets, source: path})
 			continue
 		}

--- a/apps/csm-portal/backend/internal/dashboard/registry.go
+++ b/apps/csm-portal/backend/internal/dashboard/registry.go
@@ -61,6 +61,70 @@ type sourced struct {
 	source    string
 }
 
+// dashboardPart is a widgets-only fragment split out of a dashboard whose
+// full definition would otherwise exceed the deploy path's per-file size
+// limit (see loadDir's doc comment on "partOf"). It carries no dashboard
+// metadata of its own -- id, displayName, type and everything else always
+// come from the primary file it belongs to; a part only ever contributes
+// more entries to that primary's Widgets.
+type dashboardPart struct {
+	partOf  string
+	widgets []WidgetTemplate
+	source  string
+}
+
+// dashboardFile is the decode target for one *.json file in DASHBOARDS_DIR.
+// A file is a PART of another dashboard's definition, not a dashboard in its
+// own right, exactly when it carries a non-empty "partOf" -- every other
+// field decodes into the embedded Dashboard as before, unused for a part
+// file except Widgets. See mergeParts.
+type dashboardFile struct {
+	Dashboard
+	PartOf string `json:"partOf,omitempty"`
+}
+
+// mergeParts folds every part's widgets onto its primary dashboard's own
+// Widgets, in the order the parts were encountered (which is loadDir's
+// lexical filename order, same determinism guarantee LoadDir already makes
+// for dashboards themselves).
+//
+// A part file exists purely so a dashboard whose full widget set no longer
+// fits Choreo's confirmed ~20KB per-file deploy limit can keep growing:
+// splitting it across files is invisible past this point -- finalize and
+// validate see one Dashboard with one concatenated Widgets slice, identical
+// to a dashboard that was always small enough to live in one file. That is
+// also why merging happens before finalize runs: a part's widgets go through
+// the exact same key-migration/preset-expansion/type-injection/validation
+// pipeline as any other widget, including the existing duplicate-widget-id
+// check (validateWidgets), which is what catches a widget id colliding
+// across a primary and its part -- no separate collision check is needed
+// here.
+//
+// A part whose "partOf" does not match any loaded primary dashboard's id is
+// a hard load failure, same fail-loud philosophy as everything else this
+// loader rejects (a dropped/misrouted set of widgets is exactly the kind of
+// silent gap this package refuses to tolerate elsewhere).
+func mergeParts(loaded []sourced, parts []dashboardPart) ([]sourced, error) {
+	if len(parts) == 0 {
+		return loaded, nil
+	}
+
+	byID := make(map[string]int, len(loaded))
+	for i, l := range loaded {
+		byID[l.dashboard.ID] = i
+	}
+
+	for _, p := range parts {
+		i, ok := byID[p.partOf]
+		if !ok {
+			return nil, fmt.Errorf("dashboard definitions: %s: \"partOf\" %q does not match any loaded dashboard id", p.source, p.partOf)
+		}
+		loaded[i].dashboard.Widgets = append(loaded[i].dashboard.Widgets, p.widgets...)
+	}
+
+	return loaded, nil
+}
+
 // Registry holds the dashboard definitions a running process serves.
 //
 // Two modes, chosen at construction:
@@ -319,6 +383,19 @@ func SharedSections() map[string]SharedSection { return Active().SharedSections(
 // not authored any definitions yet must still start and serve every other
 // endpoint. A missing directory is not legal — it is a misconfigured path.
 //
+// A dashboard whose widget count outgrows Choreo's confirmed ~20KB per-file
+// deploy limit for this directory can be split across more than one file: the
+// PRIMARY file is unchanged (a complete object carrying id/type/displayName/
+// widgets/etc), and any number of additional PART files carry only
+// {"partOf": "<dashboard id>", "widgets": [...]} -- no other dashboard
+// metadata. Every part's widgets are appended to its primary's Widgets before
+// validation runs (see mergeParts), so a widget-id collision between a
+// primary and any of its parts fails the whole load exactly like a collision
+// within one file already does, and a part whose "partOf" names no loaded
+// dashboard is also a hard load failure. Filenames still carry no meaning:
+// nothing about a part's own filename ties it to its primary, only the
+// "partOf" value does.
+//
 // LoadDir never applies shared filter presets (see LoadSharedPresets) — it is
 // the plain, no-shared-presets form kept for the many callers (including this
 // package's own tests) that only care about a directory of definitions.
@@ -356,17 +433,27 @@ func loadDir(dir string, sharedPresets map[string]map[string]any, sharedSections
 	sort.Strings(names)
 
 	loaded := make([]sourced, 0, len(names))
+	var parts []dashboardPart
 	for _, name := range names {
 		path := filepath.Join(dir, name)
 		raw, err := os.ReadFile(path) //nolint:gosec // path is deployment configuration, not user input
 		if err != nil {
 			return nil, fmt.Errorf("dashboard definitions: read %q: %w", path, err)
 		}
-		var d Dashboard
-		if err := json.Unmarshal(raw, &d); err != nil {
+		var f dashboardFile
+		if err := json.Unmarshal(raw, &f); err != nil {
 			return nil, fmt.Errorf("dashboard definitions: parse %q: %w", path, err)
 		}
-		loaded = append(loaded, sourced{dashboard: d, source: path})
+		if f.PartOf != "" {
+			parts = append(parts, dashboardPart{partOf: f.PartOf, widgets: f.Widgets, source: path})
+			continue
+		}
+		loaded = append(loaded, sourced{dashboard: f.Dashboard, source: path})
+	}
+
+	loaded, err = mergeParts(loaded, parts)
+	if err != nil {
+		return nil, err
 	}
 
 	return finalize(loaded, true, sharedPresets, sharedSections)

--- a/apps/csm-portal/backend/internal/dashboard/registry_test.go
+++ b/apps/csm-portal/backend/internal/dashboard/registry_test.go
@@ -1015,3 +1015,129 @@ func TestLoadDir_ShippedExampleDirectoryIsValid(t *testing.T) {
 		t.Fatalf("%s loaded no dashboards", dir)
 	}
 }
+
+// TestLoadDir_SingleFileDashboardUnaffectedByPartOfSupport is the regression
+// check for the "partOf" mechanism: a dashboard with no parts anywhere in the
+// directory must load exactly as it always has.
+func TestLoadDir_SingleFileDashboardUnaffectedByPartOfSupport(t *testing.T) {
+	dir := t.TempDir()
+	writeDefinition(t, dir, "01-cs.json", csDefinition)
+	writeDefinition(t, dir, "02-cre.json", creDefinition)
+
+	got, err := LoadDir(dir)
+	if err != nil {
+		t.Fatalf("LoadDir returned error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("LoadDir returned %d dashboards, want 2: %+v", len(got), got)
+	}
+	if got[1].ID != "cre-team" || len(got[1].Widgets) != 2 {
+		t.Fatalf("cre-team = %+v; want its usual 2 widgets, untouched by partOf support", got[1])
+	}
+}
+
+// TestLoadDir_MergesPartFilesIntoPrimaryDashboard proves the split
+// mechanism's happy path: a primary file's widgets and a part file's widgets
+// end up concatenated onto one dashboard, and the part file itself
+// contributes no dashboard beyond that.
+func TestLoadDir_MergesPartFilesIntoPrimaryDashboard(t *testing.T) {
+	dir := t.TempDir()
+	writeDefinition(t, dir, "01-primary.json", `{
+	  "id": "cs-overview", "displayName": "CS Overview", "type": "cs",
+	  "widgets": [
+	    {"id": "open-cases", "displayName": "Open Cases", "resourceType": "case", "shape": "count", "gridWidth": 3,
+	     "query": {"filters": [{"field": "state", "op": "in", "values": ["open"]}]}}
+	  ]
+	}`)
+	// Deliberately placed before the primary in lexical order, and under an
+	// unrelated filename, to prove the loader groups by "partOf" rather than
+	// by file adjacency or naming.
+	writeDefinition(t, dir, "00-extra-widgets.json", `{
+	  "partOf": "cs-overview",
+	  "widgets": [
+	    {"id": "closed-cases", "displayName": "Closed Cases", "resourceType": "case", "shape": "count", "gridWidth": 3,
+	     "query": {"filters": [{"field": "state", "op": "in", "values": ["closed"]}]}}
+	  ]
+	}`)
+
+	got, err := LoadDir(dir)
+	if err != nil {
+		t.Fatalf("LoadDir returned error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("LoadDir returned %d dashboards, want 1 (the part file must not become its own dashboard): %+v", len(got), got)
+	}
+	d := got[0]
+	if d.ID != "cs-overview" {
+		t.Fatalf("dashboard id = %q, want cs-overview", d.ID)
+	}
+	if len(d.Widgets) != 2 {
+		t.Fatalf("cs-overview has %d widgets, want 2 (1 primary + 1 from the part file): %+v", len(d.Widgets), d.Widgets)
+	}
+	ids := map[string]bool{}
+	for _, w := range d.Widgets {
+		ids[w.ID] = true
+	}
+	if !ids["open-cases"] || !ids["closed-cases"] {
+		t.Fatalf("merged widget ids = %v, want both open-cases and closed-cases", ids)
+	}
+}
+
+// TestLoadDir_WidgetIDCollisionAcrossPartsFailsWholeLoad mirrors
+// TestLoadDir_RejectsInvalidWidgets's "duplicate widget id" case, but with
+// the colliding widget split across a primary and its part instead of both
+// living in one file -- the merge happens before validateWidgets runs, so
+// the same check and the same error shape catch it.
+func TestLoadDir_WidgetIDCollisionAcrossPartsFailsWholeLoad(t *testing.T) {
+	dir := t.TempDir()
+	writeDefinition(t, dir, "primary.json", `{
+	  "id": "cs-overview", "displayName": "CS Overview", "type": "cs",
+	  "widgets": [
+	    {"id": "w", "displayName": "W", "resourceType": "case", "shape": "count", "gridWidth": 3,
+	     "query": {"filters": [{"field": "state", "op": "in", "values": ["open"]}]}}
+	  ]
+	}`)
+	writeDefinition(t, dir, "part.json", `{
+	  "partOf": "cs-overview",
+	  "widgets": [
+	    {"id": "w", "displayName": "W dup", "resourceType": "case", "shape": "count", "gridWidth": 3,
+	     "query": {"filters": [{"field": "state", "op": "in", "values": ["closed"]}]}}
+	  ]
+	}`)
+
+	_, err := LoadDir(dir)
+	if err == nil {
+		t.Fatal("LoadDir accepted a widget id colliding across a primary and its part; expected an error")
+	}
+	if !strings.Contains(err.Error(), `duplicate widget id "w"`) {
+		t.Fatalf("err = %q, want it to contain the same duplicate-widget-id message the single-file case uses", err.Error())
+	}
+	if !strings.Contains(err.Error(), filepath.Join(dir, "primary.json")) {
+		t.Fatalf("err = %q, want it to name the primary file the merged widget list belongs to", err.Error())
+	}
+}
+
+// TestLoadDir_OrphanPartOfFailsWholeLoad: a part file naming a dashboard id
+// nothing else defines is not silently dropped -- same fail-loud rule as an
+// unknown preset or section reference elsewhere in this loader.
+func TestLoadDir_OrphanPartOfFailsWholeLoad(t *testing.T) {
+	dir := t.TempDir()
+	writeDefinition(t, dir, "cs.json", csDefinition)
+	writeDefinition(t, dir, "orphan-part.json", `{
+	  "partOf": "does-not-exist",
+	  "widgets": [
+	    {"id": "stray", "displayName": "Stray", "resourceType": "case", "shape": "count", "gridWidth": 3,
+	     "query": {"filters": [{"field": "state", "op": "in", "values": ["open"]}]}}
+	  ]
+	}`)
+
+	_, err := LoadDir(dir)
+	if err == nil {
+		t.Fatal("LoadDir accepted a part file whose partOf matched no loaded dashboard; expected an error")
+	}
+	for _, want := range []string{"orphan-part.json", `"partOf"`, "does-not-exist"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("err = %q, does not mention %q", err.Error(), want)
+		}
+	}
+}

--- a/apps/csm-portal/backend/internal/dashboard/registry_test.go
+++ b/apps/csm-portal/backend/internal/dashboard/registry_test.go
@@ -1141,3 +1141,39 @@ func TestLoadDir_OrphanPartOfFailsWholeLoad(t *testing.T) {
 		}
 	}
 }
+
+// TestLoadDir_PartFileWithUnexpectedFieldFailsWholeLoad: a part file is only
+// ever read for its "partOf"/"widgets" -- any other embedded Dashboard field
+// (id, displayName, filterPresets, etc) decodes successfully via
+// dashboardFile's embedded Dashboard and then silently vanishes, since
+// dashboardPart never carries it forward. That must be a hard load failure,
+// not a silent drop, the same fail-loud rule TestLoadDir_OrphanPartOfFailsWholeLoad
+// enforces for a mismatched "partOf".
+func TestLoadDir_PartFileWithUnexpectedFieldFailsWholeLoad(t *testing.T) {
+	dir := t.TempDir()
+	writeDefinition(t, dir, "primary.json", `{
+	  "id": "cs-overview", "displayName": "CS Overview", "type": "cs",
+	  "widgets": [
+	    {"id": "open-cases", "displayName": "Open Cases", "resourceType": "case", "shape": "count", "gridWidth": 3,
+	     "query": {"filters": [{"field": "state", "op": "in", "values": ["open"]}]}}
+	  ]
+	}`)
+	writeDefinition(t, dir, "part.json", `{
+	  "partOf": "cs-overview",
+	  "displayName": "This should never take effect",
+	  "widgets": [
+	    {"id": "closed-cases", "displayName": "Closed Cases", "resourceType": "case", "shape": "count", "gridWidth": 3,
+	     "query": {"filters": [{"field": "state", "op": "in", "values": ["closed"]}]}}
+	  ]
+	}`)
+
+	_, err := LoadDir(dir)
+	if err == nil {
+		t.Fatal("LoadDir accepted a part file carrying an unexpected field (\"displayName\"); expected an error")
+	}
+	for _, want := range []string{"part.json", `"partOf"`, "displayName"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("err = %q, does not mention %q", err.Error(), want)
+		}
+	}
+}


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Choreo's dashboard config deploy path (`DASHBOARDS_DIR`) enforces a per-file size limit of
roughly 20KB. As a CSM portal dashboard accumulates widgets, its single JSON config file can
exceed that limit and fail to deploy, with no way to add more widgets short of removing
others.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

Allow one dashboard's widget config to be split across multiple files, so a dashboard can
keep growing past the per-file size limit without changing the deploy mechanism.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

- A dashboard's primary file is unchanged: a complete object with `id`, `type`,
  `displayName`, `isTeamBased`, `widgets`, etc.
- A new "part" file format is introduced: `{"partOf": "<dashboard id>", "widgets": [...]}` —
  no other dashboard metadata, just the id it belongs to and additional widgets.
- At load time, files are grouped by dashboard id. Every part file's `widgets` are appended
  onto its primary's `widgets` before the existing key-migration / preset-expansion /
  type-injection / validation pipeline runs, so merged widgets are validated exactly like any
  single-file dashboard's widgets.
- A widget-id collision across a primary and its parts fails the whole config load, using the
  existing duplicate-widget-id check (no new collision-detection code needed).
- A part file whose `partOf` doesn't match any loaded dashboard id also fails the whole load.
- Existing single-file dashboards are unaffected — this is purely additive.

## User stories
> Summary of user stories addressed by this change

As a CS ops engineer maintaining dashboard configs, I can keep adding widgets to a dashboard
that has grown large without hitting the deploy size limit, by splitting its config into
multiple files.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

CSM portal dashboard configs can now be split across multiple files via a `partOf` field, so
a dashboard is no longer capped by a single file's size limit.

## Documentation
N/A — internal config-loading mechanism, no end-user-facing product documentation to update.

## Training
N/A — no training content affected.

## Certification
N/A — no certification exam impact.

## Marketing
N/A — internal backend config-loading change, not a marketable feature.

## Automation tests
 - Unit tests
   > 4 new tests in `internal/dashboard/registry_test.go`: single-file dashboard regression,
   two-file merge (part file ordered/named before its primary, proving grouping is by
   `partOf` not file order), widget-id collision across primary+part fails the whole load,
   orphan `partOf` (no matching primary) fails the whole load.
 - Integration tests
   > None added; this is a config-loader unit boundary, no integration test harness touches
   it today.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — Go component, not a JVM target FindSecurityBugs covers
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no new samples.

## Related PRs
None.

## Migrations (if applicable)
N/A — no data or schema migration; existing single-file dashboard configs load unchanged.

## Test environment
Local: `go build ./...`, `go vet ./...`, `gofmt -l .`, `go test ./...` — all clean, Go
toolchain 1.26.6 (via `GOTOOLCHAIN=auto`) on macOS (Darwin).

## Learning
N/A.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboards can now be split across multiple JSON files to support larger widget sets.
  * Widget definitions from related files are automatically combined into the primary dashboard.
  * Invalid references and duplicate widget IDs are detected during dashboard loading.

* **Bug Fixes**
  * Prevented dashboard part files from appearing as separate dashboards.
  * Added validation for missing dashboard references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->