### PR TITLE
[Entity-Service] Add EVENT_PUBLISHING_ENABLED kill switch, default off

### DIFF
--- a/entity-service/.env.example
+++ b/entity-service/.env.example
@@ -25,16 +25,14 @@ SERVICENOW_INTEGRATION_SERVICE_SCOPES=<SERVICENOW_INTEGRATION_SERVICE_SCOPES>
 # apps/csm-portal/backend/.env.example. Setting them here has no effect.
 
 # Event Hub — internal/service.EventPublisherService publishes domain events
-# to Event Hub's Kafka-compatible endpoint for csm-notification-service to
-# consume. Currently published: case.created and incident.created, from
-# snCaseService.CreateCase/snIncidentService.CreateIncident (the ServiceNow
-# data source only) — see routes.go's EventPublisherService wiring.
-# All-or-nothing: EVENT_HUB_BROKER is the feature gate (routes.go checks it,
-# not DATA_SOURCE); EVENT_HUB_CONNECTION_STRING/EVENT_HUB_TOPIC are then read
-# unconditionally alongside it — leave all three unset, or set all three
-# together, never just one or two. Config.Validate rejects a partial set at
-# startup. Left unset, CreateCase/CreateIncident work exactly as before this
-# was wired in; nothing is published.
+# (case.created/case.comment_added/case.status_changed/case.assigned/
+# case.acknowledged/case.severity_changed/incident.created, the ServiceNow
+# data source only) to Event Hub's Kafka-compatible endpoint for
+# csm-notification-service to consume — see routes.go's EventPublisherService
+# wiring.
+# EVENT_HUB_BROKER/EVENT_HUB_CONNECTION_STRING/EVENT_HUB_TOPIC are
+# all-or-nothing: leave all three unset, or set all three together, never
+# just one or two — Config.Validate rejects a partial set at startup.
 # EVENT_HUB_CONNECTION_STRING must be a namespace-level Shared Access Policy
 # connection string (no EntityPath suffix) — an Event-Hub-scoped one will
 # only authorize EVENT_HUB_TOPIC, not any other topic this service might
@@ -42,6 +40,14 @@ SERVICENOW_INTEGRATION_SERVICE_SCOPES=<SERVICENOW_INTEGRATION_SERVICE_SCOPES>
 # EVENT_HUB_BROKER=
 # EVENT_HUB_CONNECTION_STRING=
 # EVENT_HUB_TOPIC=
+#
+# EVENT_PUBLISHING_ENABLED is a separate switch on top of the three vars
+# above — even with Event Hub fully configured, nothing is published until
+# this is explicitly set to "true". Defaults to false (safe-by-default), so
+# CreateCase/CreateIncident/etc. behave exactly as before this pipeline
+# existed unless every one of EVENT_HUB_BROKER/_CONNECTION_STRING/_TOPIC AND
+# this are all set.
+# EVENT_PUBLISHING_ENABLED=true
 #
 # No CSM portal base URL config here: this service only publishes the fact
 # that a case/incident was created — it does not build any portal link.

--- a/entity-service/CLAUDE.md
+++ b/entity-service/CLAUDE.md
@@ -39,6 +39,7 @@ The server loads `.env` automatically on startup (silently ignored if absent). P
 | `EVENT_HUB_BROKER` | no | — | Kafka-compatible bootstrap address; feature-gates `EventPublisherService` (see "Event Hub publishing" below) |
 | `EVENT_HUB_CONNECTION_STRING` | no* | — | Event Hub namespace Shared Access Policy connection string. *Required once `EVENT_HUB_BROKER` is set |
 | `EVENT_HUB_TOPIC` | no* | — | Event Hub (Kafka topic) name. *Required once `EVENT_HUB_BROKER` is set |
+| `EVENT_PUBLISHING_ENABLED` | no | `false` | Must be `"true"` for `EventPublisherService` to actually get constructed, even with `EVENT_HUB_BROKER` fully configured — a separate safe-by-default kill switch |
 
 `CSM_TEAM_REGISTRY` and `CSM_USER_ROLES` are **not read here**. The team registry
 and the assignable-role allow-list are organisation vocabulary and live in the CSM
@@ -68,18 +69,26 @@ records the failure via `EventPublishFailureService.CreateEventPublishFailure`
 **Wired in**: `NewEventPublisherService` is constructed in
 `internal/server/routes.go` (not `cmd/api/main.go` — `NewRouter` owns the
 whole dependency graph; see "Adding a new entity" below), gated on
-`cfg.EventHubBroker != ""` — the same optional-wiring convention
-`apps/csm-portal/backend/cmd/server/main.go` uses, but keyed on Event Hub
-config specifically, not `cfg.DataSource`: publishing is a distinct concern
-from which backend serves reads. `Config.Validate` rejects a partial
-Event Hub configuration (e.g. `EVENT_HUB_BROKER` set but
+`cfg.EventHubBroker != "" && cfg.EventPublishingEnabled` — the same
+optional-wiring convention `apps/csm-portal/backend/cmd/server/main.go`
+used to use for its own now-removed Event Hub pipeline, but keyed on Event
+Hub config specifically, not `cfg.DataSource`: publishing is a distinct
+concern from which backend serves reads. `EventPublishingEnabled` is a
+second, independent kill switch on top of `EventHubBroker` — it defaults to
+`false` (`EVENT_PUBLISHING_ENABLED` must be exactly `"true"`), so an
+environment can have Event Hub fully configured and still publish nothing
+until this is explicitly turned on; every publisher call site already
+handles `eventPublisher == nil` as a no-op, so this required no changes
+anywhere except `config.go`/`routes.go` themselves. `Config.Validate`
+rejects a partial Event Hub configuration (e.g. `EVENT_HUB_BROKER` set but
 `EVENT_HUB_CONNECTION_STRING`/`EVENT_HUB_TOPIC` empty) at startup — all
 three must be set together or not at all, since `NewRouter`'s gate only
 checks `EventHubBroker`, and constructing `EventPublisherService` with a
 missing connection string or topic would make every publish attempt fail
-silently while the deployment otherwise looks healthy. `NewRouter` returns
-the constructed `EventPublisherService` (nil if unconfigured) alongside the
-`http.Handler`,
+silently while the deployment otherwise looks healthy;
+`EventPublishingEnabled` isn't part of that all-or-nothing group — it's
+just a bool, either `"true"` or not. `NewRouter` returns the constructed
+`EventPublisherService` (nil if unconfigured) alongside the `http.Handler`,
 threaded through `server.New` to `cmd/api/main.go`, which calls `Close()` on
 it during shutdown, after `srv.Shutdown`.
 

--- a/entity-service/README.md
+++ b/entity-service/README.md
@@ -133,19 +133,15 @@ effect.
 
 `internal/service.EventPublisherService` publishes domain events to Event Hub's Kafka-compatible
 endpoint for `csm-notification-service` to consume. Constructed in `internal/server/routes.go`,
-gated on `EVENT_HUB_BROKER` (not `DATA_SOURCE`) — left unset, nothing changes; `CreateCase`/
-`CreateIncident` behave exactly as before this was wired in.
+gated on **both** `EVENT_HUB_BROKER` being set (not `DATA_SOURCE`) **and** `EVENT_PUBLISHING_ENABLED`
+being `"true"` — either left unset/false, nothing changes; `CreateCase`/`CreateIncident`/etc.
+behave exactly as before this was wired in. `EVENT_PUBLISHING_ENABLED` defaults to `false`, so a
+fully-configured Event Hub connection still publishes nothing until it's explicitly turned on.
 
-Currently published, both ServiceNow-data-source-only: `case.created` (from
-`snCaseService.CreateCase`, re-enriched via `GetCaseByID` for the reporter's name/project
-name/watch-list emails — `Recipients` is the watch list's emails only, and publishing is
-skipped for a case with no watchers) and `incident.created` (from
-`snIncidentService.CreateIncident`, built directly from the request — no enrichment call
-needed). This service only publishes the fact that a case/incident was created — it builds
-no portal link for either; `incident.created`'s "Open in Portal" button target is built by
-csm-notification-service itself from the event's own entity id, the same way it already
-builds case.created's portal link. See entity-service's `CLAUDE.md` ("Event Hub publishing")
-for the full reasoning, including why both publish synchronously with a bounded timeout
+Seven ServiceNow-data-source-only call sites publish today: `case.created`, `case.comment_added`,
+`case.status_changed`, `case.assigned`, `case.acknowledged`, `case.severity_changed`, and
+`incident.created`. See entity-service's `CLAUDE.md` ("Event Hub publishing") for the full
+reasoning behind each, including why all seven publish synchronously with a bounded timeout
 rather than async.
 
 | Variable | Description |
@@ -153,6 +149,7 @@ rather than async.
 | `EVENT_HUB_BROKER` | Kafka bootstrap address: `<namespace>.servicebus.windows.net:9093` — the feature gate (optional) |
 | `EVENT_HUB_CONNECTION_STRING` | The namespace's Shared Access Policy connection string — must be namespace-scoped (no `EntityPath`), not scoped to a single Event Hub (required once `EVENT_HUB_BROKER` is set) |
 | `EVENT_HUB_TOPIC` | Event Hub (Kafka topic) name, e.g. `case-events` — must match `csm-notification-service`'s own `EVENT_HUB_TOPIC` (required once `EVENT_HUB_BROKER` is set) |
+| `EVENT_PUBLISHING_ENABLED` | Set to `true` to actually publish. Defaults to `false` — safe by default even with Event Hub fully configured (optional) |
 
 ### SLA clocks
 

--- a/entity-service/internal/config/config.go
+++ b/entity-service/internal/config/config.go
@@ -63,6 +63,13 @@ type Config struct {
 	EventHubBroker           string
 	EventHubConnectionString string
 	EventHubTopic            string
+	// EventPublishingEnabled is a separate kill switch on top of
+	// EventHubBroker being set — it defaults to false (safe-by-default: an
+	// environment can have Event Hub fully configured and still not publish
+	// a single event until this is explicitly turned on). routes.go only
+	// constructs EventPublisherService when both this is true AND
+	// EventHubBroker is set.
+	EventPublishingEnabled bool
 }
 
 // Load reads configuration from environment variables and returns a populated
@@ -86,6 +93,7 @@ func Load() *Config {
 		EventHubBroker:                           os.Getenv("EVENT_HUB_BROKER"),
 		EventHubConnectionString:                 os.Getenv("EVENT_HUB_CONNECTION_STRING"),
 		EventHubTopic:                            os.Getenv("EVENT_HUB_TOPIC"),
+		EventPublishingEnabled:                   os.Getenv("EVENT_PUBLISHING_ENABLED") == "true",
 	}
 }
 

--- a/entity-service/internal/server/routes.go
+++ b/entity-service/internal/server/routes.go
@@ -33,9 +33,9 @@ import (
 // NewRouter builds the dependency graph (repository → service → handler),
 // registers all routes, and wraps the mux with the middleware chain:
 // CorrelationID → Recovery → Logger → UserIDToken → Timeout. Also returns
-// the constructed EventPublisherService (nil if EVENT_HUB_BROKER is unset)
-// so the caller (server.New, then cmd/api/main.go) can close it gracefully
-// on shutdown.
+// the constructed EventPublisherService (nil if EVENT_HUB_BROKER is unset or
+// EVENT_PUBLISHING_ENABLED isn't "true") so the caller (server.New, then
+// cmd/api/main.go) can close it gracefully on shutdown.
 func NewRouter(db *pgxpool.Pool, cfg *config.Config) (http.Handler, service.EventPublisherService) {
 	userRepo := repository.NewUserRepository(db)
 	userSvc := service.NewUserService(userRepo)
@@ -51,10 +51,13 @@ func NewRouter(db *pgxpool.Pool, cfg *config.Config) (http.Handler, service.Even
 	// EventPublisherService is optional, like every ServiceNow-only
 	// dependency below — gated on EventHubBroker rather than cfg.DataSource,
 	// since publishing is a distinct concern from which backend serves reads
-	// (see config.Config.EventHubBroker's doc comment). nil when unset; every
-	// caller (snCaseService, snIncidentService) already handles that.
+	// (see config.Config.EventHubBroker's doc comment). Also gated on
+	// EventPublishingEnabled, a separate safe-by-default kill switch: Event
+	// Hub can be fully configured and this still stays nil until that's
+	// explicitly turned on. nil when unset; every caller (snCaseService,
+	// snIncidentService) already handles that.
 	var eventPublisher service.EventPublisherService
-	if cfg.EventHubBroker != "" {
+	if cfg.EventHubBroker != "" && cfg.EventPublishingEnabled {
 		eventPublisher = service.NewEventPublisherService(
 			eventbus.NewProducer(eventbus.Config{
 				Broker:           cfg.EventHubBroker,


### PR DESCRIPTION
## Summary
`EventPublisherService` used to get constructed whenever `EVENT_HUB_BROKER` was set, publishing `case.created`/`case.comment_added`/`case.status_changed`/`case.assigned`/`case.acknowledged`/`case.severity_changed`/`incident.created` as soon as Event Hub connection details were present. This adds a second, independent switch so a fully-configured Event Hub connection still publishes nothing until it's explicitly turned on.

- `Config.EventPublishingEnabled` reads `EVENT_PUBLISHING_ENABLED == "true"` (defaults to `false`)
- `routes.go` only constructs `EventPublisherService` when both `EventHubBroker` is set **and** `EventPublishingEnabled` is true — every publisher call site already no-ops on a nil publisher, so no changes were needed anywhere else (`sn_case_service.go`, `sn_incident_service.go`)
- Documented the new var in `.env.example`/`README.md`/`CLAUDE.md`, and corrected a couple of stale nearby mentions that undercounted the event types actually published today (they said only `case.created`/`incident.created`; it's actually seven types)

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race -count=1 ./...`
- [x] `gosec -fmt=text ./...` — 0 issues
- [x] `govulncheck ./...` — 0 vulnerabilities