### PR TITLE
Guide customers through empty deployment/product dropdowns during case creation

### DIFF
--- a/apps/customer-portal/webapp/public/config.js.example
+++ b/apps/customer-portal/webapp/public/config.js.example
@@ -265,4 +265,16 @@ window.config = {
   //   true  – iPad and Android tablets also see the download prompt.
   //           Desktop browsers are never affected by this setting.
   CUSTOMER_PORTAL_MOBILE_APP_INCLUDE_TABLETS: false,
+
+  // ── Case creation: inline add deployment/product ────────────────────────────
+  //
+  // CUSTOMER_PORTAL_ALLOW_DEPLOYMENT_SETUP_DURING_CASE_CREATION  (optional — default: true)
+  //   Kill switch for the case-creation empty-state feature: the
+  //   deployment/product empty-state alert, the in-menu "Add
+  //   Deployment"/"Add Product" row, the two-step add-deployment wizard, and
+  //   auto-selecting a single deployment/product option.
+  //   true  – feature enabled (default when this key is omitted).
+  //   false – reverts to the legacy behavior: a disabled dropdown with no
+  //           alert or CTA, and the form is never blocked on empty options.
+  CUSTOMER_PORTAL_ALLOW_DEPLOYMENT_SETUP_DURING_CASE_CREATION: true,
 };

--- a/apps/customer-portal/webapp/src/components/empty-state/EmptyState.tsx
+++ b/apps/customer-portal/webapp/src/components/empty-state/EmptyState.tsx
@@ -15,11 +15,15 @@
 // under the License.
 
 import { Box, Stack, Typography } from "@wso2/oxygen-ui";
-import { type JSX } from "react";
+import { type JSX, type ReactNode } from "react";
 import EmptyIcon from "@components/empty-state/EmptyIcon";
 
 export interface EmptyStateProps {
   description: string;
+  /** Optional second line, rendered below the description in a more muted tone. */
+  secondaryDescription?: string;
+  /** Optional call-to-action (e.g. a Button) rendered below the description. */
+  action?: ReactNode;
 }
 
 /**
@@ -30,6 +34,8 @@ export interface EmptyStateProps {
  */
 export default function EmptyState({
   description,
+  secondaryDescription,
+  action,
 }: EmptyStateProps): JSX.Element {
   return (
     <Stack
@@ -48,9 +54,21 @@ export default function EmptyState({
       >
         <EmptyIcon />
       </Box>
-      <Typography variant="body2" color="text.secondary">
-        {description}
-      </Typography>
+      <Stack spacing={0.5} alignItems="center">
+        <Typography variant="body2" color="text.secondary" textAlign="center">
+          {description}
+        </Typography>
+        {secondaryDescription && (
+          <Typography variant="caption" color="text.disabled" textAlign="center">
+            {secondaryDescription}
+          </Typography>
+        )}
+      </Stack>
+      {action && (
+        <Box sx={{ display: "flex", justifyContent: "center", mt: 1 }}>
+          {action}
+        </Box>
+      )}
     </Stack>
   );
 }

--- a/apps/customer-portal/webapp/src/components/empty-state/__tests__/EmptyState.test.tsx
+++ b/apps/customer-portal/webapp/src/components/empty-state/__tests__/EmptyState.test.tsx
@@ -30,4 +30,36 @@ describe("EmptyState", () => {
     expect(screen.getByTestId("empty-icon")).toBeInTheDocument();
     expect(screen.getByText(description)).toBeInTheDocument();
   });
+
+  it("should not render an action when none is provided", () => {
+    render(<EmptyState description="Nothing to see here" />);
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("should render the provided action below the description", () => {
+    render(
+      <EmptyState
+        description="Nothing to see here"
+        action={<button type="button">Do something</button>}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: "Do something" }),
+    ).toBeInTheDocument();
+  });
+
+  it("should render a secondary description when provided", () => {
+    render(
+      <EmptyState
+        description="Nothing to see here"
+        secondaryDescription="More context about why"
+      />,
+    );
+    expect(screen.getByText("More context about why")).toBeInTheDocument();
+  });
+
+  it("should not render a secondary description when not provided", () => {
+    render(<EmptyState description="Nothing to see here" />);
+    expect(screen.queryByText("More context about why")).not.toBeInTheDocument();
+  });
 });

--- a/apps/customer-portal/webapp/src/config/caseCreationConfig.ts
+++ b/apps/customer-portal/webapp/src/config/caseCreationConfig.ts
@@ -1,0 +1,27 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+ * Kill switch for the case-creation "add deployment/product inline" feature:
+ * the empty-state alert, the in-menu add-new row, the two-step wizard, and
+ * singleton auto-select. Defaults to enabled when unset - this flag exists
+ * to allow disabling the whole feature quickly, not to gate a rollout.
+ *
+ * @returns {boolean} Whether the feature is enabled.
+ */
+export function isDeploymentSetupDuringCaseCreationEnabled(): boolean {
+  return window.config?.CUSTOMER_PORTAL_ALLOW_DEPLOYMENT_SETUP_DURING_CASE_CREATION ?? true;
+}

--- a/apps/customer-portal/webapp/src/config/portalConfig.ts
+++ b/apps/customer-portal/webapp/src/config/portalConfig.ts
@@ -54,6 +54,12 @@ export interface CustomerPortalWindowConfig {
   CUSTOMER_PORTAL_MOBILE_APP_IOS_STORE_URL?: string;
   CUSTOMER_PORTAL_MOBILE_APP_ANDROID_STORE_URL?: string;
   CUSTOMER_PORTAL_MOBILE_APP_INCLUDE_TABLETS?: boolean;
+  /**
+   * Enables the case-creation "add deployment/product inline" empty-state
+   * (alert + in-menu add-new row + wizard + singleton auto-select). Default
+   * ON when unset - this is a kill switch, not an opt-in.
+   */
+  CUSTOMER_PORTAL_ALLOW_DEPLOYMENT_SETUP_DURING_CASE_CREATION?: boolean;
 }
 
 declare global {

--- a/apps/customer-portal/webapp/src/features/project-details/components/deployments/AddDeploymentWizardModal.tsx
+++ b/apps/customer-portal/webapp/src/features/project-details/components/deployments/AddDeploymentWizardModal.tsx
@@ -1,0 +1,454 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  FormControl,
+  IconButton,
+  InputLabel,
+  List,
+  ListItem,
+  MenuItem,
+  Select,
+  Skeleton,
+  Step,
+  StepLabel,
+  Stepper,
+  TextField,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { X } from "@wso2/oxygen-ui-icons-react";
+import {
+  useCallback,
+  useEffect,
+  useState,
+  type ChangeEvent,
+  type JSX,
+} from "react";
+import type { SelectChangeEvent } from "@wso2/oxygen-ui";
+import { usePostCreateDeployment } from "@features/project-details/api/usePostCreateDeployment";
+import useGetProjectFilters from "@api/useGetProjectFilters";
+import ErrorIndicator from "@components/error-indicator/ErrorIndicator";
+import ErrorBanner from "@components/error-banner/ErrorBanner";
+import {
+  useProductForm,
+  type AddedProductSummary,
+} from "@features/project-details/components/deployments/useProductForm";
+import { ProductFormFields } from "@features/project-details/components/deployments/ProductFormFields";
+
+const INITIAL_DEPLOYMENT_FORM = {
+  name: "",
+  deploymentTypeKey: "",
+  description: "",
+};
+
+const WIZARD_STEPS = ["Deployment details", "Add products"] as const;
+
+export type AddDeploymentWizardModalProps = {
+  open: boolean;
+  projectId: string;
+  onClose: () => void;
+  /**
+   * Fired as soon as the deployment is created (before any product is added)
+   * with the deployment's name, so the case-creation form can select it in
+   * its own deployment dropdown once the deployments list refetches.
+   */
+  onDeploymentCreated?: (name: string) => void;
+  /** Fired once per successfully added product. */
+  onProductAdded?: () => void;
+  onError?: (message: string) => void;
+};
+
+/**
+ * Single continuous "add my first deployment" wizard: deployment details,
+ * then one or more products for that deployment, without closing and
+ * reopening separate dialogs in between. Used only for the case where a
+ * project has zero deployments - the persistent "add another deployment"
+ * affordance keeps using the plain AddDeploymentModal with no forced
+ * product step.
+ *
+ * Step 2 reuses useProductForm/ProductFormFields - the same paginated
+ * product/version search logic as the standalone AddProductModal - so
+ * there is one source of truth for that behavior.
+ *
+ * @param {AddDeploymentWizardModalProps} props - open, projectId, onClose, and per-step success/error callbacks.
+ * @returns {JSX.Element} The two-step add-deployment wizard dialog.
+ */
+export default function AddDeploymentWizardModal({
+  open,
+  projectId,
+  onClose,
+  onDeploymentCreated,
+  onProductAdded,
+  onError,
+}: AddDeploymentWizardModalProps): JSX.Element {
+  const [step, setStep] = useState<1 | 2>(1);
+  const [deploymentForm, setDeploymentForm] = useState(
+    INITIAL_DEPLOYMENT_FORM,
+  );
+  const [filtersErrorBanner, setFiltersErrorBanner] = useState(false);
+  const [createdDeployment, setCreatedDeployment] = useState<{
+    id: string;
+    name: string;
+  } | null>(null);
+  const [addedProducts, setAddedProducts] = useState<AddedProductSummary[]>(
+    [],
+  );
+
+  const createDeployment = usePostCreateDeployment(projectId);
+  const {
+    data: filtersData,
+    isLoading: isFiltersLoading,
+    isError: isFiltersError,
+  } = useGetProjectFilters(projectId);
+  const deploymentTypes = filtersData?.deploymentTypes ?? [];
+
+  // Always called (rules of hooks) - only meaningful once step 2 is reached
+  // and createdDeployment.id is known; the product select queries underneath
+  // are harmless to run with an empty deploymentId since submit() checks it.
+  const productForm = useProductForm(createdDeployment?.id ?? "", projectId);
+
+  useEffect(() => {
+    if (isFiltersError) {
+      setFiltersErrorBanner(true);
+    }
+  }, [isFiltersError]);
+
+  const { resetForm: resetProductForm } = productForm;
+
+  const resetWizard = useCallback(() => {
+    setStep(1);
+    setDeploymentForm(INITIAL_DEPLOYMENT_FORM);
+    setFiltersErrorBanner(false);
+    setCreatedDeployment(null);
+    setAddedProducts([]);
+    resetProductForm();
+  }, [resetProductForm]);
+
+  const handleClose = useCallback(() => {
+    resetWizard();
+    onClose();
+  }, [onClose, resetWizard]);
+
+  const isDeploymentFormValid =
+    deploymentForm.name.trim() !== "" &&
+    deploymentForm.deploymentTypeKey !== "" &&
+    deploymentForm.description.trim() !== "";
+
+  const handleDeploymentTextChange =
+    (field: keyof typeof INITIAL_DEPLOYMENT_FORM) =>
+    (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      setDeploymentForm((prev) => ({ ...prev, [field]: event.target.value }));
+    };
+
+  const handleDeploymentTypeChange = (event: SelectChangeEvent<string>) => {
+    setDeploymentForm((prev) => ({
+      ...prev,
+      deploymentTypeKey: event.target.value,
+    }));
+  };
+
+  const handleCreateDeployment = useCallback(() => {
+    if (!isDeploymentFormValid) return;
+
+    const name = deploymentForm.name.trim();
+    createDeployment.mutate(
+      {
+        name,
+        description: deploymentForm.description.trim(),
+        deploymentTypeKey: Number(deploymentForm.deploymentTypeKey),
+      },
+      {
+        onSuccess: (data) => {
+          setCreatedDeployment({ id: data.id, name });
+          setStep(2);
+          onDeploymentCreated?.(name);
+        },
+        onError: (error: Error) => {
+          onError?.(error.message ?? "Failed to create deployment.");
+        },
+      },
+    );
+  }, [
+    isDeploymentFormValid,
+    deploymentForm,
+    createDeployment,
+    onDeploymentCreated,
+    onError,
+  ]);
+
+  const { isValid: isProductFormValid, submit: submitProduct } = productForm;
+
+  const handleAddAnotherProduct = useCallback(async () => {
+    if (!isProductFormValid) return;
+    try {
+      const summary = await submitProduct();
+      setAddedProducts((prev) => [...prev, summary]);
+      resetProductForm();
+      onProductAdded?.();
+    } catch (error) {
+      onError?.(
+        error instanceof Error ? error.message : "Failed to add product",
+      );
+    }
+  }, [
+    isProductFormValid,
+    submitProduct,
+    resetProductForm,
+    onProductAdded,
+    onError,
+  ]);
+
+  const handleDone = useCallback(async () => {
+    if (isProductFormValid) {
+      try {
+        const summary = await submitProduct();
+        setAddedProducts((prev) => [...prev, summary]);
+        onProductAdded?.();
+      } catch (error) {
+        onError?.(
+          error instanceof Error ? error.message : "Failed to add product",
+        );
+        return;
+      }
+    }
+    handleClose();
+  }, [isProductFormValid, submitProduct, onProductAdded, onError, handleClose]);
+
+  return (
+    <>
+      {isFiltersError && filtersErrorBanner && (
+        <ErrorBanner
+          message="Failed to load deployment types. Please close and try again."
+          onClose={() => setFiltersErrorBanner(false)}
+        />
+      )}
+
+      <Dialog
+        open={open}
+        onClose={handleClose}
+        maxWidth="sm"
+        fullWidth
+        aria-labelledby="add-deployment-wizard-title"
+        aria-describedby="add-deployment-wizard-description"
+      >
+        <DialogTitle
+          id="add-deployment-wizard-title"
+          sx={{ pr: 6, position: "relative", pb: 0.5 }}
+        >
+          {step === 1 ? "Add New Deployment" : "Add WSO2 Product"}
+          <Typography
+            id="add-deployment-wizard-description"
+            variant="body2"
+            color="text.secondary"
+            sx={{ mt: 0.5, fontWeight: "normal", fontSize: "0.875rem" }}
+          >
+            {step === 1
+              ? "Create a new deployment environment for your project."
+              : `Add one or more WSO2 products to "${createdDeployment?.name}".`}
+          </Typography>
+          <IconButton
+            aria-label="close"
+            onClick={handleClose}
+            sx={{ position: "absolute", right: 12, top: 12 }}
+            size="small"
+          >
+            <X size={20} aria-hidden />
+          </IconButton>
+        </DialogTitle>
+
+        <Box sx={{ px: 3, pt: 1 }}>
+          <Stepper activeStep={step - 1} alternativeLabel>
+            {WIZARD_STEPS.map((label) => (
+              <Step key={label}>
+                <StepLabel>{label}</StepLabel>
+              </Step>
+            ))}
+          </Stepper>
+        </Box>
+
+        <DialogContent sx={{ pt: 1 }}>
+          {step === 1 ? (
+            <>
+              <TextField
+                id="deployment-name"
+                label="Deployment Name *"
+                placeholder="e.g., Production US-East"
+                value={deploymentForm.name}
+                onChange={handleDeploymentTextChange("name")}
+                fullWidth
+                size="small"
+                sx={{ mt: 3, mb: 2 }}
+                disabled={createDeployment.isPending}
+              />
+
+              {isFiltersLoading ? (
+                <Skeleton
+                  variant="rounded"
+                  height={40}
+                  sx={{ mb: 2, borderRadius: 1 }}
+                />
+              ) : (
+                <Box
+                  sx={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 0.5,
+                    mb: 2,
+                  }}
+                >
+                  <FormControl fullWidth size="small">
+                    <InputLabel id="deployment-type-label">
+                      Deployment Type *
+                    </InputLabel>
+                    <Select<string>
+                      labelId="deployment-type-label"
+                      id="deployment-type"
+                      value={deploymentForm.deploymentTypeKey}
+                      label="Deployment Type *"
+                      onChange={handleDeploymentTypeChange}
+                      disabled={createDeployment.isPending || isFiltersError}
+                    >
+                      {deploymentTypes.map(({ id, label }) => (
+                        <MenuItem key={id} value={id}>
+                          {label}
+                        </MenuItem>
+                      ))}
+                    </Select>
+                  </FormControl>
+                  {isFiltersError && (
+                    <ErrorIndicator entityName="deployment types" size="small" />
+                  )}
+                </Box>
+              )}
+
+              <TextField
+                id="deployment-description"
+                label="Description *"
+                placeholder="Describe this deployment environment..."
+                value={deploymentForm.description}
+                onChange={handleDeploymentTextChange("description")}
+                fullWidth
+                size="small"
+                multiline
+                rows={3}
+                disabled={createDeployment.isPending}
+              />
+            </>
+          ) : (
+            <>
+              {addedProducts.length > 0 && (
+                <Box sx={{ mb: 2 }}>
+                  <Typography variant="subtitle2" sx={{ mb: 1 }}>
+                    Products added so far ({addedProducts.length})
+                  </Typography>
+                  <List dense disablePadding data-testid="added-products-list">
+                    {addedProducts.map((p, index) => (
+                      <ListItem
+                        key={`${p.productId}-${p.versionId}-${index}`}
+                        disableGutters
+                        sx={{ py: 0.25 }}
+                      >
+                        <Chip
+                          size="small"
+                          label={`${p.productLabel} - ${p.versionLabel}`}
+                        />
+                      </ListItem>
+                    ))}
+                  </List>
+                  <Divider sx={{ mt: 1.5 }} />
+                </Box>
+              )}
+
+              <ProductFormFields
+                {...productForm}
+                isSubmitting={productForm.isSubmitting}
+              />
+            </>
+          )}
+        </DialogContent>
+
+        <DialogActions
+          sx={{ px: 3, pb: 3, pt: 1, justifyContent: "flex-end", gap: 1 }}
+        >
+          {step === 1 ? (
+            <>
+              <Button
+                variant="outlined"
+                onClick={handleClose}
+                disabled={createDeployment.isPending}
+              >
+                Cancel
+              </Button>
+              {createDeployment.isPending ? (
+                <Button
+                  variant="contained"
+                  color="primary"
+                  startIcon={<CircularProgress color="inherit" size={16} />}
+                  disabled
+                >
+                  Creating...
+                </Button>
+              ) : (
+                <Button
+                  type="button"
+                  variant="contained"
+                  color="primary"
+                  onClick={handleCreateDeployment}
+                  disabled={!isDeploymentFormValid || isFiltersError}
+                >
+                  Next: Add Products
+                </Button>
+              )}
+            </>
+          ) : (
+            <>
+              <Button
+                variant="outlined"
+                onClick={handleAddAnotherProduct}
+                disabled={!productForm.isValid || productForm.isSubmitting}
+              >
+                Add another product
+              </Button>
+              <Button
+                type="button"
+                variant="contained"
+                color="primary"
+                onClick={handleDone}
+                disabled={productForm.isSubmitting}
+                startIcon={
+                  productForm.isSubmitting ? (
+                    <CircularProgress color="inherit" size={16} />
+                  ) : undefined
+                }
+              >
+                Done
+              </Button>
+            </>
+          )}
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/customer-portal/webapp/src/features/project-details/components/deployments/AddProductModal.tsx
+++ b/apps/customer-portal/webapp/src/features/project-details/components/deployments/AddProductModal.tsx
@@ -15,7 +15,6 @@
 // under the License.
 
 import {
-  Box,
   Button,
   CircularProgress,
   Dialog,
@@ -23,41 +22,20 @@ import {
   DialogContent,
   DialogTitle,
   IconButton,
-  MenuItem,
-  Skeleton,
-  TextField,
   Typography,
 } from "@wso2/oxygen-ui";
 import { X } from "@wso2/oxygen-ui-icons-react";
-import {
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-  type ChangeEvent,
-  type JSX,
-  type UIEvent,
-} from "react";
-import { SelectMenuLoadMoreRow } from "@components/select-menu-load-more-row/SelectMenuLoadMoreRow";
-import { paginatedSelectMenuListProps } from "@utils/common";
-import { useGetProducts } from "@features/project-details/api/useGetProducts";
-import { useSearchProductVersions } from "@features/project-details/api/useSearchProductVersions";
-import { usePostDeploymentProduct } from "@features/project-details/api/usePostDeploymentProduct";
-import type {
-  ProductItem,
-  ProductVersionItem,
-} from "@features/project-details/types/products";
-import {
-  ADD_PRODUCT_MODAL_INITIAL_FORM,
-  parseValidNumber,
-  type AddProductModalFormState,
-} from "@features/project-details/utils/addProductModal";
+import { useCallback, type JSX } from "react";
+import { useProductForm } from "@features/project-details/components/deployments/useProductForm";
+import { ProductFormFields } from "@features/project-details/components/deployments/ProductFormFields";
 import type { AddProductModalProps } from "@features/project-details/types/projectDetailsComponents";
 
 /**
  * Modal for adding a WSO2 product to a deployment environment.
  * Product Name and Version come from paginated APIs; Description and optional metrics are user-entered.
+ * The actual paginated form fields + mutation logic live in useProductForm/ProductFormFields, shared with
+ * the add-deployment wizard's product step - this component only owns the dialog chrome and the
+ * close-on-success behavior standalone callers rely on.
  *
  * @param {AddProductModalProps} props - open, deploymentId, projectId, onClose, optional onSuccess/onError.
  * @returns {JSX.Element} The add product modal.
@@ -70,360 +48,19 @@ export default function AddProductModal({
   onSuccess,
   onError,
 }: AddProductModalProps): JSX.Element {
-  const [form, setForm] = useState<AddProductModalFormState>(() => ({
-    ...ADD_PRODUCT_MODAL_INITIAL_FORM,
-  }));
-  const [productOffset, setProductOffset] = useState(0);
-  const [versionOffset, setVersionOffset] = useState(0);
-  const [products, setProducts] = useState<ProductItem[]>([]);
-  const [versions, setVersions] = useState<ProductVersionItem[]>([]);
-  const previousProductIdRef = useRef<string>("");
-  const [cachedProductsTotalRecords, setCachedProductsTotalRecords] = useState<
-    number | null
-  >(null);
-  const [cachedVersionsTotalRecords, setCachedVersionsTotalRecords] = useState<
-    number | null
-  >(null);
-
-  const [productsLoadMorePending, setProductsLoadMorePending] = useState(false);
-  const [versionsLoadMorePending, setVersionsLoadMorePending] = useState(false);
-  const accumulatedProductsLengthRef = useRef(0);
-  const accumulatedVersionsLengthRef = useRef(0);
-
-  const productsRef = useRef<ProductItem[]>([]);
-  const versionsRef = useRef<ProductVersionItem[]>([]);
-
-  useLayoutEffect(() => {
-    productsRef.current = products;
-    accumulatedProductsLengthRef.current = products.length;
-  }, [products]);
-
-  useLayoutEffect(() => {
-    versionsRef.current = versions;
-    accumulatedVersionsLengthRef.current = versions.length;
-  }, [versions]);
-
-  const resetModalState = useCallback(() => {
-    setForm({ ...ADD_PRODUCT_MODAL_INITIAL_FORM });
-    setProductOffset(0);
-    setProducts([]);
-    setVersionOffset(0);
-    setVersions([]);
-    previousProductIdRef.current = "";
-    setProductsLoadMorePending(false);
-    setVersionsLoadMorePending(false);
-    setCachedProductsTotalRecords(null);
-    setCachedVersionsTotalRecords(null);
-  }, []);
-
-  const {
-    data: productsPage,
-    isLoading: isLoadingProducts,
-    isFetching: isFetchingProducts,
-  } = useGetProducts({
-    offset: productOffset,
-    limit: 10,
-  });
-
-  /* eslint-disable react-hooks/set-state-in-effect -- paginated Select: load-more flags + merged list rows */
-  useEffect(() => {
-    if (!isFetchingProducts) {
-      setProductsLoadMorePending(false);
-    }
-  }, [isFetchingProducts]);
-
-  const {
-    data: versionsPage,
-    isLoading: isLoadingVersions,
-    isFetching: isFetchingVersions,
-  } = useSearchProductVersions(form.productId, {
-    limit: 10,
-    offset: versionOffset,
-  });
-
-  useEffect(() => {
-    if (!isFetchingVersions) {
-      setVersionsLoadMorePending(false);
-    }
-  }, [isFetchingVersions]);
-
-  useEffect(() => {
-    if (!productsPage) return;
-
-    const pageItems = productsPage.products ?? [];
-    const offset = productsPage.offset ?? 0;
-    const pageLimit =
-      typeof productsPage.limit === "number" && productsPage.limit > 0
-        ? productsPage.limit
-        : 10;
-
-    const applyServerProductsTotal = (): void => {
-      if (
-        typeof productsPage.totalRecords === "number" &&
-        !Number.isNaN(productsPage.totalRecords)
-      ) {
-        setCachedProductsTotalRecords(productsPage.totalRecords);
-      }
-    };
-
-    if (offset > 0 && pageItems.length === 0) {
-      setCachedProductsTotalRecords(accumulatedProductsLengthRef.current);
-      return;
-    }
-
-    if (offset === 0) {
-      setProducts(pageItems);
-      if (pageItems.length < pageLimit) {
-        setCachedProductsTotalRecords(pageItems.length);
-      } else {
-        applyServerProductsTotal();
-      }
-      return;
-    }
-
-    const prevProducts = productsRef.current;
-    const prevProductIds = new Set(
-      prevProducts.map((p) => p.id).filter((id): id is string => Boolean(id)),
-    );
-    const newProductItems = pageItems.filter(
-      (p) =>
-        typeof p.id === "string" &&
-        p.id.length > 0 &&
-        !prevProductIds.has(p.id),
-    );
-    const mergedProductsLen = prevProducts.length + newProductItems.length;
-
-    if (newProductItems.length === 0) {
-      setCachedProductsTotalRecords(prevProducts.length);
-      return;
-    }
-
-    if (pageItems.length < pageLimit) {
-      setCachedProductsTotalRecords(mergedProductsLen);
-    } else {
-      applyServerProductsTotal();
-    }
-    setProducts([...prevProducts, ...newProductItems]);
-  }, [productsPage]);
-
-  const productsTotalRecords = Number.isFinite(cachedProductsTotalRecords)
-    ? (cachedProductsTotalRecords as number)
-    : Number.isFinite(productsPage?.totalRecords)
-      ? (productsPage!.totalRecords as number)
-      : products.length;
-  const canLoadMoreProducts = products.length < productsTotalRecords;
-
-  const handleProductsScroll = useCallback(
-    (event: UIEvent<HTMLElement>) => {
-      const target = event.currentTarget;
-      if (
-        productsLoadMorePending ||
-        !canLoadMoreProducts ||
-        isLoadingProducts ||
-        isFetchingProducts ||
-        products.length === 0
-      ) {
-        return;
-      }
-
-      const threshold = 24; // px from bottom to trigger load
-      if (
-        target.scrollHeight - target.scrollTop - target.clientHeight <
-        threshold
-      ) {
-        setProductsLoadMorePending(true);
-        setProductOffset((prev) => prev + 10);
-      }
-    },
-    [
-      productsLoadMorePending,
-      canLoadMoreProducts,
-      isLoadingProducts,
-      isFetchingProducts,
-      products.length,
-    ],
-  );
-
-  useEffect(() => {
-    if (previousProductIdRef.current !== form.productId) {
-      previousProductIdRef.current = form.productId;
-      setVersionOffset(0);
-      setVersions([]);
-      setCachedVersionsTotalRecords(null);
-    }
-
-    if (!form.productId) {
-      return;
-    }
-
-    if (!versionsPage) {
-      return;
-    }
-
-    const pageItems = versionsPage.versions ?? [];
-    const offset = versionsPage.offset ?? 0;
-    const pageLimit =
-      typeof versionsPage.limit === "number" && versionsPage.limit > 0
-        ? versionsPage.limit
-        : 10;
-
-    const applyServerVersionsTotal = (): void => {
-      if (
-        typeof versionsPage.totalRecords === "number" &&
-        !Number.isNaN(versionsPage.totalRecords)
-      ) {
-        setCachedVersionsTotalRecords(versionsPage.totalRecords);
-      }
-    };
-
-    if (offset > 0 && pageItems.length === 0) {
-      setCachedVersionsTotalRecords(accumulatedVersionsLengthRef.current);
-      return;
-    }
-
-    if (offset === 0) {
-      setVersions(pageItems);
-      if (pageItems.length < pageLimit) {
-        setCachedVersionsTotalRecords(pageItems.length);
-      } else {
-        applyServerVersionsTotal();
-      }
-      return;
-    }
-
-    const prevVersions = versionsRef.current;
-    const prevVersionIds = new Set(
-      prevVersions.map((v) => v.id).filter((id): id is string => Boolean(id)),
-    );
-    const newVersionItems = pageItems.filter(
-      (v) =>
-        typeof v.id === "string" &&
-        v.id.length > 0 &&
-        !prevVersionIds.has(v.id),
-    );
-    const mergedVersionsLen = prevVersions.length + newVersionItems.length;
-
-    if (newVersionItems.length === 0) {
-      setCachedVersionsTotalRecords(prevVersions.length);
-      return;
-    }
-
-    if (pageItems.length < pageLimit) {
-      setCachedVersionsTotalRecords(mergedVersionsLen);
-    } else {
-      applyServerVersionsTotal();
-    }
-    setVersions([...prevVersions, ...newVersionItems]);
-  }, [form.productId, versionsPage]);
-  /* eslint-enable react-hooks/set-state-in-effect */
-
-  const versionsTotalRecords = Number.isFinite(cachedVersionsTotalRecords)
-    ? (cachedVersionsTotalRecords as number)
-    : Number.isFinite(versionsPage?.totalRecords)
-      ? (versionsPage!.totalRecords as number)
-      : versions.length;
-  const canLoadMoreVersions = versions.length < versionsTotalRecords;
-
-  /**
-   * Footer spinner only after the user scrolls to load more (pending flag), not for
-   * background refetches or inflated API totalRecords.
-   */
-  const isFetchingMoreProducts =
-    productsLoadMorePending &&
-    isFetchingProducts &&
-    productOffset > 0 &&
-    products.length > 0;
-  const isFetchingMoreVersions =
-    versionsLoadMorePending &&
-    isFetchingVersions &&
-    versionOffset > 0 &&
-    versions.length > 0;
-
-  const handleVersionsScroll = useCallback(
-    (event: UIEvent<HTMLElement>) => {
-      const target = event.currentTarget;
-      if (
-        versionsLoadMorePending ||
-        !canLoadMoreVersions ||
-        isLoadingVersions ||
-        isFetchingVersions ||
-        versions.length === 0
-      ) {
-        return;
-      }
-
-      const threshold = 24;
-      if (
-        target.scrollHeight - target.scrollTop - target.clientHeight <
-        threshold
-      ) {
-        setVersionsLoadMorePending(true);
-        setVersionOffset((prev) => prev + 10);
-      }
-    },
-    [
-      versionsLoadMorePending,
-      canLoadMoreVersions,
-      isLoadingVersions,
-      isFetchingVersions,
-      versions.length,
-    ],
-  );
-
-  const postProduct = usePostDeploymentProduct();
-
-  const isSubmitting = postProduct.isPending;
-  const isValid =
-    !!form.productId &&
-    !!form.versionId &&
-    !!projectId &&
-    deploymentId.length > 0;
+  const productForm = useProductForm(deploymentId, projectId);
+  const { isValid, isSubmitting, submit, resetForm } = productForm;
 
   const handleClose = useCallback(() => {
-    resetModalState();
+    resetForm();
     onClose();
-  }, [onClose, resetModalState]);
-
-  const handleProductChange = useCallback(
-    (event: ChangeEvent<HTMLInputElement>) => {
-      const productId = event.target.value;
-      setForm((prev) => ({
-        ...prev,
-        productId,
-        versionId: "",
-      }));
-    },
-    [],
-  );
-
-  const handleVersionChange = useCallback(
-    (event: ChangeEvent<HTMLInputElement>) => {
-      setForm((prev) => ({ ...prev, versionId: event.target.value }));
-    },
-    [],
-  );
-
-  const handleTextChange =
-    (field: "cores" | "tps" | "description") =>
-    (event: ChangeEvent<HTMLInputElement>) => {
-      setForm((prev) => ({ ...prev, [field]: event.target.value }));
-    };
+  }, [onClose, resetForm]);
 
   const handleSubmit = useCallback(async () => {
     if (!isValid) return;
 
     try {
-      await postProduct.mutateAsync({
-        deploymentId,
-        body: {
-          productId: form.productId,
-          versionId: form.versionId,
-          projectId,
-          cores: parseValidNumber(form.cores),
-          tps: parseValidNumber(form.tps),
-          description: form.description || undefined,
-        },
-      });
+      await submit();
       handleClose();
       onSuccess?.();
     } catch (error) {
@@ -431,20 +68,7 @@ export default function AddProductModal({
         error instanceof Error ? error.message : "Failed to add product",
       );
     }
-  }, [
-    isValid,
-    form.productId,
-    form.versionId,
-    form.cores,
-    form.tps,
-    form.description,
-    deploymentId,
-    projectId,
-    postProduct,
-    handleClose,
-    onSuccess,
-    onError,
-  ]);
+  }, [isValid, submit, handleClose, onSuccess, onError]);
 
   return (
     <Dialog
@@ -487,143 +111,7 @@ export default function AddProductModal({
           },
         }}
       >
-        <Box
-          sx={{
-            display: "grid",
-            gridTemplateColumns: "1fr 1fr",
-            gap: 2,
-            mt: 2,
-            mb: 2,
-          }}
-        >
-          <TextField
-            select
-            fullWidth
-            size="small"
-            id="product-name"
-            label="Product Name *"
-            value={form.productId}
-            onChange={handleProductChange}
-            disabled={isSubmitting || isLoadingProducts}
-            sx={{
-              "& .MuiSelect-select": {
-                color: !form.productId ? "text.secondary" : undefined,
-              },
-            }}
-            SelectProps={{
-              MenuProps: {
-                MenuListProps:
-                  paginatedSelectMenuListProps(handleProductsScroll),
-                PaperProps: {
-                  sx: { zIndex: 1400 },
-                },
-              },
-            }}
-          >
-            <MenuItem value="">Select</MenuItem>
-            {products.map((p) => (
-              <MenuItem key={p.id} value={p.id}>
-                {p.label ?? p.name ?? p.id}
-              </MenuItem>
-            ))}
-            <SelectMenuLoadMoreRow
-              visible={Boolean(canLoadMoreProducts && isFetchingMoreProducts)}
-            />
-            {(isLoadingProducts || isFetchingProducts) &&
-              products.length === 0 && (
-                <MenuItem disabled>
-                  <Skeleton variant="text" width="100%" />
-                </MenuItem>
-              )}
-          </TextField>
-          <TextField
-            select
-            fullWidth
-            size="small"
-            id="product-version"
-            label="Version *"
-            value={form.versionId}
-            onChange={handleVersionChange}
-            disabled={isSubmitting || !form.productId || isLoadingVersions}
-            sx={{
-              "& .MuiSelect-select": {
-                color: !form.versionId ? "text.secondary" : undefined,
-              },
-            }}
-            SelectProps={{
-              MenuProps: {
-                MenuListProps:
-                  paginatedSelectMenuListProps(handleVersionsScroll),
-                PaperProps: {
-                  sx: { zIndex: 1400 },
-                },
-              },
-            }}
-          >
-            <MenuItem value="">Select</MenuItem>
-            {versions.map((v) => (
-              <MenuItem key={v.id} value={v.id}>
-                {v.version}
-              </MenuItem>
-            ))}
-            <SelectMenuLoadMoreRow
-              visible={Boolean(canLoadMoreVersions && isFetchingMoreVersions)}
-            />
-            {(isLoadingVersions || isFetchingVersions) &&
-              versions.length === 0 && (
-                <MenuItem disabled>
-                  <Skeleton variant="text" width="100%" />
-                </MenuItem>
-              )}
-          </TextField>
-        </Box>
-
-        <Box
-          sx={{
-            display: "grid",
-            gridTemplateColumns: "1fr 1fr",
-            gap: 2,
-            mb: 2,
-          }}
-        >
-          <TextField
-            id="product-cores"
-            label="Core Count"
-            placeholder="e.g., 8"
-            type="number"
-            value={form.cores}
-            onChange={handleTextChange("cores")}
-            fullWidth
-            size="small"
-            disabled={isSubmitting}
-            inputProps={{ min: 0 }}
-          />
-          <TextField
-            id="product-tps"
-            label="TPS (Transactions Per Second)"
-            placeholder="e.g., 5000"
-            type="number"
-            value={form.tps}
-            onChange={handleTextChange("tps")}
-            fullWidth
-            size="small"
-            disabled={isSubmitting}
-            inputProps={{ min: 0 }}
-          />
-        </Box>
-
-        <TextField
-          id="product-description"
-          label="Description"
-          placeholder="Enter Description..."
-          fullWidth
-          size="small"
-          multiline
-          rows={2}
-          value={form.description}
-          onChange={handleTextChange("description")}
-          disabled={isSubmitting}
-        />
+        <ProductFormFields {...productForm} isSubmitting={isSubmitting} />
       </DialogContent>
 
       <DialogActions

--- a/apps/customer-portal/webapp/src/features/project-details/components/deployments/ProductFormFields.tsx
+++ b/apps/customer-portal/webapp/src/features/project-details/components/deployments/ProductFormFields.tsx
@@ -1,0 +1,212 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Box, MenuItem, Skeleton, TextField } from "@wso2/oxygen-ui";
+import type { JSX } from "react";
+import { SelectMenuLoadMoreRow } from "@components/select-menu-load-more-row/SelectMenuLoadMoreRow";
+import { paginatedSelectMenuListProps } from "@utils/common";
+import type { UseProductFormResult } from "@features/project-details/components/deployments/useProductForm";
+
+export type ProductFormFieldsProps = Pick<
+  UseProductFormResult,
+  | "form"
+  | "products"
+  | "versions"
+  | "isLoadingProducts"
+  | "isFetchingProducts"
+  | "isLoadingVersions"
+  | "isFetchingVersions"
+  | "canLoadMoreProducts"
+  | "canLoadMoreVersions"
+  | "isFetchingMoreProducts"
+  | "isFetchingMoreVersions"
+  | "handleProductsScroll"
+  | "handleVersionsScroll"
+  | "handleProductChange"
+  | "handleVersionChange"
+  | "handleTextChange"
+> & {
+  isSubmitting: boolean;
+};
+
+/**
+ * Pure presentational product/version + metrics form fields, shared by the
+ * standalone AddProductModal and the add-deployment wizard's product step.
+ * All state and data-fetching live in useProductForm; this component only
+ * renders and wires up the handlers it is given.
+ *
+ * @param {ProductFormFieldsProps} props - Form state, paginated options, and change handlers from useProductForm.
+ * @returns {JSX.Element} The product form fields.
+ */
+export function ProductFormFields({
+  form,
+  products,
+  versions,
+  isLoadingProducts,
+  isFetchingProducts,
+  isLoadingVersions,
+  isFetchingVersions,
+  canLoadMoreProducts,
+  canLoadMoreVersions,
+  isFetchingMoreProducts,
+  isFetchingMoreVersions,
+  handleProductsScroll,
+  handleVersionsScroll,
+  handleProductChange,
+  handleVersionChange,
+  handleTextChange,
+  isSubmitting,
+}: ProductFormFieldsProps): JSX.Element {
+  return (
+    <>
+      <Box
+        sx={{
+          display: "grid",
+          gridTemplateColumns: "1fr 1fr",
+          gap: 2,
+          mt: 2,
+          mb: 2,
+        }}
+      >
+        <TextField
+          select
+          fullWidth
+          size="small"
+          id="product-name"
+          label="Product Name *"
+          value={form.productId}
+          onChange={handleProductChange}
+          disabled={isSubmitting || isLoadingProducts}
+          sx={{
+            "& .MuiSelect-select": {
+              color: !form.productId ? "text.secondary" : undefined,
+            },
+          }}
+          SelectProps={{
+            MenuProps: {
+              MenuListProps: paginatedSelectMenuListProps(handleProductsScroll),
+              PaperProps: {
+                sx: { zIndex: 1400 },
+              },
+            },
+          }}
+        >
+          <MenuItem value="">Select</MenuItem>
+          {products.map((p) => (
+            <MenuItem key={p.id} value={p.id}>
+              {p.label ?? p.name ?? p.id}
+            </MenuItem>
+          ))}
+          <SelectMenuLoadMoreRow
+            visible={Boolean(canLoadMoreProducts && isFetchingMoreProducts)}
+          />
+          {(isLoadingProducts || isFetchingProducts) &&
+            products.length === 0 && (
+              <MenuItem disabled>
+                <Skeleton variant="text" width="100%" />
+              </MenuItem>
+            )}
+        </TextField>
+        <TextField
+          select
+          fullWidth
+          size="small"
+          id="product-version"
+          label="Version *"
+          value={form.versionId}
+          onChange={handleVersionChange}
+          disabled={isSubmitting || !form.productId || isLoadingVersions}
+          sx={{
+            "& .MuiSelect-select": {
+              color: !form.versionId ? "text.secondary" : undefined,
+            },
+          }}
+          SelectProps={{
+            MenuProps: {
+              MenuListProps: paginatedSelectMenuListProps(handleVersionsScroll),
+              PaperProps: {
+                sx: { zIndex: 1400 },
+              },
+            },
+          }}
+        >
+          <MenuItem value="">Select</MenuItem>
+          {versions.map((v) => (
+            <MenuItem key={v.id} value={v.id}>
+              {v.version}
+            </MenuItem>
+          ))}
+          <SelectMenuLoadMoreRow
+            visible={Boolean(canLoadMoreVersions && isFetchingMoreVersions)}
+          />
+          {(isLoadingVersions || isFetchingVersions) &&
+            versions.length === 0 && (
+              <MenuItem disabled>
+                <Skeleton variant="text" width="100%" />
+              </MenuItem>
+            )}
+        </TextField>
+      </Box>
+
+      <Box
+        sx={{
+          display: "grid",
+          gridTemplateColumns: "1fr 1fr",
+          gap: 2,
+          mb: 2,
+        }}
+      >
+        <TextField
+          id="product-cores"
+          label="Core Count"
+          placeholder="e.g., 8"
+          type="number"
+          value={form.cores}
+          onChange={handleTextChange("cores")}
+          fullWidth
+          size="small"
+          disabled={isSubmitting}
+          inputProps={{ min: 0 }}
+        />
+        <TextField
+          id="product-tps"
+          label="TPS (Transactions Per Second)"
+          placeholder="e.g., 5000"
+          type="number"
+          value={form.tps}
+          onChange={handleTextChange("tps")}
+          fullWidth
+          size="small"
+          disabled={isSubmitting}
+          inputProps={{ min: 0 }}
+        />
+      </Box>
+
+      <TextField
+        id="product-description"
+        label="Description"
+        placeholder="Enter Description..."
+        fullWidth
+        size="small"
+        multiline
+        rows={2}
+        value={form.description}
+        onChange={handleTextChange("description")}
+        disabled={isSubmitting}
+      />
+    </>
+  );
+}

--- a/apps/customer-portal/webapp/src/features/project-details/components/deployments/__tests__/AddDeploymentWizardModal.test.tsx
+++ b/apps/customer-portal/webapp/src/features/project-details/components/deployments/__tests__/AddDeploymentWizardModal.test.tsx
@@ -1,0 +1,193 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import AddDeploymentWizardModal from "@features/project-details/components/deployments/AddDeploymentWizardModal";
+import { usePostCreateDeployment } from "@features/project-details/api/usePostCreateDeployment";
+import useGetProjectFilters from "@api/useGetProjectFilters";
+import { useGetProducts } from "@features/project-details/api/useGetProducts";
+import { useSearchProductVersions } from "@features/project-details/api/useSearchProductVersions";
+import { usePostDeploymentProduct } from "@features/project-details/api/usePostDeploymentProduct";
+
+vi.mock("@features/project-details/api/usePostCreateDeployment");
+vi.mock("@api/useGetProjectFilters");
+vi.mock("@features/project-details/api/useGetProducts");
+vi.mock("@features/project-details/api/useSearchProductVersions");
+vi.mock("@features/project-details/api/usePostDeploymentProduct");
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+});
+
+function renderWithProviders(ui: React.ReactElement) {
+  return render(ui, {
+    wrapper: ({ children }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    ),
+  });
+}
+
+const mockFiltersData = {
+  deploymentTypes: [{ id: "1", label: "Primary Production" }],
+};
+
+const mockProducts = [
+  { id: "prod-api-mgr", label: "WSO2 API Manager", name: "API Manager" },
+];
+
+const mockVersions = [
+  { id: "ver-781", version: "7.8.0", product: { id: "prod-api-mgr", label: "WSO2 API Manager" } },
+];
+
+describe("AddDeploymentWizardModal", () => {
+  const mockCreateDeploymentMutate = vi.fn();
+  const mockPostProductMutateAsync = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(usePostCreateDeployment).mockReturnValue({
+      mutate: mockCreateDeploymentMutate,
+      isPending: false,
+    } as unknown as ReturnType<typeof usePostCreateDeployment>);
+
+    vi.mocked(useGetProjectFilters).mockReturnValue({
+      data: mockFiltersData,
+      isLoading: false,
+      isError: false,
+    } as unknown as ReturnType<typeof useGetProjectFilters>);
+
+    // Static, unchanging offset/limit means the query never refetches after
+    // the initial load - this is the exact condition that exposed the
+    // "Add another product" empty-list regression, since resetForm used to
+    // wipe the local `products` state without anything to repopulate it.
+    vi.mocked(useGetProducts).mockReturnValue({
+      data: { products: mockProducts, totalRecords: mockProducts.length, offset: 0, limit: 10 },
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+    } as unknown as ReturnType<typeof useGetProducts>);
+
+    vi.mocked(useSearchProductVersions).mockImplementation(
+      (productId: string) =>
+        ({
+          data: productId
+            ? { versions: mockVersions, totalRecords: mockVersions.length, offset: 0, limit: 10 }
+            : undefined,
+          isLoading: false,
+          isFetching: false,
+          isError: false,
+        }) as unknown as ReturnType<typeof useSearchProductVersions>,
+    );
+
+    vi.mocked(usePostDeploymentProduct).mockReturnValue({
+      mutateAsync: mockPostProductMutateAsync,
+      isPending: false,
+    } as unknown as ReturnType<typeof usePostDeploymentProduct>);
+  });
+
+  async function advanceToProductStep() {
+    fireEvent.change(screen.getByLabelText(/Deployment Name/i), {
+      target: { value: "Production US-East" },
+    });
+    fireEvent.mouseDown(screen.getByLabelText(/Deployment Type/i));
+    fireEvent.click(await screen.findByRole("option", { name: "Primary Production" }));
+    fireEvent.change(screen.getByLabelText(/Description/i), {
+      target: { value: "New deployment" },
+    });
+
+    mockCreateDeploymentMutate.mockImplementation((_body, { onSuccess }) => {
+      onSuccess({ id: "dep-new" });
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Next: Add Products" }));
+
+    await screen.findByText(/Add one or more WSO2 products/);
+  }
+
+  async function selectProductAndVersion() {
+    const productCombobox = screen.getByRole("combobox", { name: /Product Name/ });
+    fireEvent.mouseDown(productCombobox);
+    fireEvent.click(
+      await screen.findByRole("option", { name: /WSO2 API Manager/, hidden: true }),
+    );
+
+    const versionCombobox = screen.getByRole("combobox", { name: /Version/ });
+    await waitFor(() =>
+      expect(versionCombobox).not.toHaveAttribute("aria-disabled", "true"),
+    );
+    fireEvent.mouseDown(versionCombobox);
+    fireEvent.click(await screen.findByRole("option", { name: /7\.8\.0/, hidden: true }));
+  }
+
+  it("advances from the deployment step to the product step in the same dialog, without a second popup", async () => {
+    renderWithProviders(
+      <AddDeploymentWizardModal open={true} projectId="proj-1" onClose={vi.fn()} />,
+    );
+
+    expect(screen.getAllByRole("dialog")).toHaveLength(1);
+    await advanceToProductStep();
+    expect(screen.getAllByRole("dialog")).toHaveLength(1);
+    expect(screen.getByText("Add WSO2 Product")).toBeInTheDocument();
+  });
+
+  it("keeps the product options populated after adding one and clicking Add another product (regression: list must not go empty)", async () => {
+    mockPostProductMutateAsync.mockResolvedValue(undefined);
+    renderWithProviders(
+      <AddDeploymentWizardModal open={true} projectId="proj-1" onClose={vi.fn()} />,
+    );
+
+    await advanceToProductStep();
+    await selectProductAndVersion();
+
+    fireEvent.click(screen.getByRole("button", { name: "Add another product" }));
+
+    await waitFor(() => expect(mockPostProductMutateAsync).toHaveBeenCalledTimes(1));
+
+    // The just-added product should show in the running list...
+    expect(screen.getByTestId("added-products-list")).toHaveTextContent(
+      "WSO2 API Manager",
+    );
+
+    // ...and the product dropdown for the NEXT entry must still list real
+    // options, not an empty list.
+    const productCombobox = screen.getByRole("combobox", { name: /Product Name/ });
+    fireEvent.mouseDown(productCombobox);
+    expect(
+      await screen.findByRole("option", { name: /WSO2 API Manager/, hidden: true }),
+    ).toBeInTheDocument();
+  });
+
+  it("adds multiple products before Done closes the wizard", async () => {
+    mockPostProductMutateAsync.mockResolvedValue(undefined);
+    const onClose = vi.fn();
+    renderWithProviders(
+      <AddDeploymentWizardModal open={true} projectId="proj-1" onClose={onClose} />,
+    );
+
+    await advanceToProductStep();
+    await selectProductAndVersion();
+    fireEvent.click(screen.getByRole("button", { name: "Add another product" }));
+    await waitFor(() => expect(mockPostProductMutateAsync).toHaveBeenCalledTimes(1));
+
+    await selectProductAndVersion();
+    fireEvent.click(screen.getByRole("button", { name: "Done" }));
+
+    await waitFor(() => expect(mockPostProductMutateAsync).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+});

--- a/apps/customer-portal/webapp/src/features/project-details/components/deployments/__tests__/AddProductModal.test.tsx
+++ b/apps/customer-portal/webapp/src/features/project-details/components/deployments/__tests__/AddProductModal.test.tsx
@@ -301,10 +301,20 @@ describe("AddProductModal", () => {
       />,
     );
 
-    // After reset, Product Name should be cleared (empty selection)
+    // After reset, Product Name should be cleared (empty selection)...
     expect(
       screen.getByRole("combobox", { name: /Product Name/ }),
     ).not.toHaveTextContent("WSO2 API Manager");
+
+    // ...but the option list itself must still be populated, not wiped -
+    // regression check for the "resetForm cleared products without a
+    // matching refetch" bug (useGetProducts is keyed on [offset, limit]
+    // alone, so an unchanged offset never triggers a new fetch to
+    // repopulate an emptied list).
+    fireEvent.mouseDown(screen.getByRole("combobox", { name: /Product Name/ }));
+    expect(
+      await screen.findByRole("option", { name: /WSO2 API Manager/, hidden: true }),
+    ).toBeInTheDocument();
   });
 
   it("should show a fresh product list when remounted with a new key after close", async () => {

--- a/apps/customer-portal/webapp/src/features/project-details/components/deployments/useProductForm.ts
+++ b/apps/customer-portal/webapp/src/features/project-details/components/deployments/useProductForm.ts
@@ -1,0 +1,485 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type UIEvent,
+} from "react";
+import { useGetProducts } from "@features/project-details/api/useGetProducts";
+import { useSearchProductVersions } from "@features/project-details/api/useSearchProductVersions";
+import { usePostDeploymentProduct } from "@features/project-details/api/usePostDeploymentProduct";
+import type {
+  ProductItem,
+  ProductVersionItem,
+} from "@features/project-details/types/products";
+import {
+  ADD_PRODUCT_MODAL_INITIAL_FORM,
+  parseValidNumber,
+  type AddProductModalFormState,
+} from "@features/project-details/utils/addProductModal";
+
+export type AddedProductSummary = {
+  productId: string;
+  productLabel: string;
+  versionId: string;
+  versionLabel: string;
+};
+
+export type UseProductFormResult = {
+  form: AddProductModalFormState;
+  products: ProductItem[];
+  versions: ProductVersionItem[];
+  isLoadingProducts: boolean;
+  isFetchingProducts: boolean;
+  isLoadingVersions: boolean;
+  isFetchingVersions: boolean;
+  canLoadMoreProducts: boolean;
+  canLoadMoreVersions: boolean;
+  isFetchingMoreProducts: boolean;
+  isFetchingMoreVersions: boolean;
+  handleProductsScroll: (event: UIEvent<HTMLElement>) => void;
+  handleVersionsScroll: (event: UIEvent<HTMLElement>) => void;
+  handleProductChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  handleVersionChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  handleTextChange: (
+    field: "cores" | "tps" | "description",
+  ) => (event: ChangeEvent<HTMLInputElement>) => void;
+  isValid: boolean;
+  isSubmitting: boolean;
+  /**
+   * Submits the current form via usePostDeploymentProduct. Resolves with a
+   * summary of the product/version that was just added (looked up from the
+   * currently loaded pages before the form is reset) so a caller can render
+   * a "products added so far" list. Rejects with the underlying error - the
+   * caller decides how to surface it (close-and-report vs. keep dialog open).
+   */
+  submit: () => Promise<AddedProductSummary>;
+  /** Clears the form (and product/version pagination state) for a fresh entry. */
+  resetForm: () => void;
+};
+
+/**
+ * Encapsulates the paginated product/version search + product-add mutation
+ * shared by the standalone AddProductModal and the add-deployment wizard's
+ * product step. Pure form/data logic - no dialog chrome or close/open
+ * decisions, those stay with the caller.
+ *
+ * @param {string} deploymentId - Deployment the product is being added to.
+ * @param {string} projectId - Owning project id, sent in the request body.
+ * @returns {UseProductFormResult} Form state, paginated options, and submit/reset handlers.
+ */
+export function useProductForm(
+  deploymentId: string,
+  projectId: string,
+): UseProductFormResult {
+  const [form, setForm] = useState<AddProductModalFormState>(() => ({
+    ...ADD_PRODUCT_MODAL_INITIAL_FORM,
+  }));
+  const [productOffset, setProductOffset] = useState(0);
+  const [versionOffset, setVersionOffset] = useState(0);
+  const [products, setProducts] = useState<ProductItem[]>([]);
+  const [versions, setVersions] = useState<ProductVersionItem[]>([]);
+  const previousProductIdRef = useRef<string>("");
+  const [cachedProductsTotalRecords, setCachedProductsTotalRecords] = useState<
+    number | null
+  >(null);
+  const [cachedVersionsTotalRecords, setCachedVersionsTotalRecords] = useState<
+    number | null
+  >(null);
+
+  const [productsLoadMorePending, setProductsLoadMorePending] = useState(false);
+  const [versionsLoadMorePending, setVersionsLoadMorePending] = useState(false);
+  const accumulatedProductsLengthRef = useRef(0);
+  const accumulatedVersionsLengthRef = useRef(0);
+
+  const productsRef = useRef<ProductItem[]>([]);
+  const versionsRef = useRef<ProductVersionItem[]>([]);
+
+  useLayoutEffect(() => {
+    productsRef.current = products;
+    accumulatedProductsLengthRef.current = products.length;
+  }, [products]);
+
+  useLayoutEffect(() => {
+    versionsRef.current = versions;
+    accumulatedVersionsLengthRef.current = versions.length;
+  }, [versions]);
+
+  // Only clears form values and version state (versions genuinely depend on
+  // which product is selected, so they're stale once the form resets). The
+  // product catalog itself (products/productOffset/its cached total) is NOT
+  // cleared here: it's independent of any particular submission, and since
+  // useGetProducts is keyed on [offset, limit] alone, resetting productOffset
+  // back to the value it already was would never trigger a refetch - leaving
+  // `products` stuck at [] with no way to repopulate it (the bug this fixes:
+  // "Add another product" after a successful add showed an empty product
+  // list, because the catalog got wiped without a matching refetch).
+  const resetForm = useCallback(() => {
+    setForm({ ...ADD_PRODUCT_MODAL_INITIAL_FORM });
+    setVersionOffset(0);
+    setVersions([]);
+    previousProductIdRef.current = "";
+    setVersionsLoadMorePending(false);
+    setCachedVersionsTotalRecords(null);
+  }, []);
+
+  const {
+    data: productsPage,
+    isLoading: isLoadingProducts,
+    isFetching: isFetchingProducts,
+  } = useGetProducts({
+    offset: productOffset,
+    limit: 10,
+  });
+
+  /* eslint-disable react-hooks/set-state-in-effect -- paginated Select: load-more flags + merged list rows */
+  useEffect(() => {
+    if (!isFetchingProducts) {
+      setProductsLoadMorePending(false);
+    }
+  }, [isFetchingProducts]);
+
+  const {
+    data: versionsPage,
+    isLoading: isLoadingVersions,
+    isFetching: isFetchingVersions,
+  } = useSearchProductVersions(form.productId, {
+    limit: 10,
+    offset: versionOffset,
+  });
+
+  useEffect(() => {
+    if (!isFetchingVersions) {
+      setVersionsLoadMorePending(false);
+    }
+  }, [isFetchingVersions]);
+
+  useEffect(() => {
+    if (!productsPage) return;
+
+    const pageItems = productsPage.products ?? [];
+    const offset = productsPage.offset ?? 0;
+    const pageLimit =
+      typeof productsPage.limit === "number" && productsPage.limit > 0
+        ? productsPage.limit
+        : 10;
+
+    const applyServerProductsTotal = (): void => {
+      if (
+        typeof productsPage.totalRecords === "number" &&
+        !Number.isNaN(productsPage.totalRecords)
+      ) {
+        setCachedProductsTotalRecords(productsPage.totalRecords);
+      }
+    };
+
+    if (offset > 0 && pageItems.length === 0) {
+      setCachedProductsTotalRecords(accumulatedProductsLengthRef.current);
+      return;
+    }
+
+    if (offset === 0) {
+      setProducts(pageItems);
+      if (pageItems.length < pageLimit) {
+        setCachedProductsTotalRecords(pageItems.length);
+      } else {
+        applyServerProductsTotal();
+      }
+      return;
+    }
+
+    const prevProducts = productsRef.current;
+    const prevProductIds = new Set(
+      prevProducts.map((p) => p.id).filter((id): id is string => Boolean(id)),
+    );
+    const newProductItems = pageItems.filter(
+      (p) =>
+        typeof p.id === "string" &&
+        p.id.length > 0 &&
+        !prevProductIds.has(p.id),
+    );
+    const mergedProductsLen = prevProducts.length + newProductItems.length;
+
+    if (newProductItems.length === 0) {
+      setCachedProductsTotalRecords(prevProducts.length);
+      return;
+    }
+
+    if (pageItems.length < pageLimit) {
+      setCachedProductsTotalRecords(mergedProductsLen);
+    } else {
+      applyServerProductsTotal();
+    }
+    setProducts([...prevProducts, ...newProductItems]);
+  }, [productsPage]);
+
+  const productsTotalRecords = Number.isFinite(cachedProductsTotalRecords)
+    ? (cachedProductsTotalRecords as number)
+    : Number.isFinite(productsPage?.totalRecords)
+      ? (productsPage!.totalRecords as number)
+      : products.length;
+  const canLoadMoreProducts = products.length < productsTotalRecords;
+
+  const handleProductsScroll = useCallback(
+    (event: UIEvent<HTMLElement>) => {
+      const target = event.currentTarget;
+      if (
+        productsLoadMorePending ||
+        !canLoadMoreProducts ||
+        isLoadingProducts ||
+        isFetchingProducts ||
+        products.length === 0
+      ) {
+        return;
+      }
+
+      const threshold = 24; // px from bottom to trigger load
+      if (
+        target.scrollHeight - target.scrollTop - target.clientHeight <
+        threshold
+      ) {
+        setProductsLoadMorePending(true);
+        setProductOffset((prev) => prev + 10);
+      }
+    },
+    [
+      productsLoadMorePending,
+      canLoadMoreProducts,
+      isLoadingProducts,
+      isFetchingProducts,
+      products.length,
+    ],
+  );
+
+  useEffect(() => {
+    if (previousProductIdRef.current !== form.productId) {
+      previousProductIdRef.current = form.productId;
+      setVersionOffset(0);
+      setVersions([]);
+      setCachedVersionsTotalRecords(null);
+    }
+
+    if (!form.productId) {
+      return;
+    }
+
+    if (!versionsPage) {
+      return;
+    }
+
+    const pageItems = versionsPage.versions ?? [];
+    const offset = versionsPage.offset ?? 0;
+    const pageLimit =
+      typeof versionsPage.limit === "number" && versionsPage.limit > 0
+        ? versionsPage.limit
+        : 10;
+
+    const applyServerVersionsTotal = (): void => {
+      if (
+        typeof versionsPage.totalRecords === "number" &&
+        !Number.isNaN(versionsPage.totalRecords)
+      ) {
+        setCachedVersionsTotalRecords(versionsPage.totalRecords);
+      }
+    };
+
+    if (offset > 0 && pageItems.length === 0) {
+      setCachedVersionsTotalRecords(accumulatedVersionsLengthRef.current);
+      return;
+    }
+
+    if (offset === 0) {
+      setVersions(pageItems);
+      if (pageItems.length < pageLimit) {
+        setCachedVersionsTotalRecords(pageItems.length);
+      } else {
+        applyServerVersionsTotal();
+      }
+      return;
+    }
+
+    const prevVersions = versionsRef.current;
+    const prevVersionIds = new Set(
+      prevVersions.map((v) => v.id).filter((id): id is string => Boolean(id)),
+    );
+    const newVersionItems = pageItems.filter(
+      (v) =>
+        typeof v.id === "string" &&
+        v.id.length > 0 &&
+        !prevVersionIds.has(v.id),
+    );
+    const mergedVersionsLen = prevVersions.length + newVersionItems.length;
+
+    if (newVersionItems.length === 0) {
+      setCachedVersionsTotalRecords(prevVersions.length);
+      return;
+    }
+
+    if (pageItems.length < pageLimit) {
+      setCachedVersionsTotalRecords(mergedVersionsLen);
+    } else {
+      applyServerVersionsTotal();
+    }
+    setVersions([...prevVersions, ...newVersionItems]);
+  }, [form.productId, versionsPage]);
+  /* eslint-enable react-hooks/set-state-in-effect */
+
+  const versionsTotalRecords = Number.isFinite(cachedVersionsTotalRecords)
+    ? (cachedVersionsTotalRecords as number)
+    : Number.isFinite(versionsPage?.totalRecords)
+      ? (versionsPage!.totalRecords as number)
+      : versions.length;
+  const canLoadMoreVersions = versions.length < versionsTotalRecords;
+
+  /**
+   * Footer spinner only after the user scrolls to load more (pending flag), not for
+   * background refetches or inflated API totalRecords.
+   */
+  const isFetchingMoreProducts =
+    productsLoadMorePending &&
+    isFetchingProducts &&
+    productOffset > 0 &&
+    products.length > 0;
+  const isFetchingMoreVersions =
+    versionsLoadMorePending &&
+    isFetchingVersions &&
+    versionOffset > 0 &&
+    versions.length > 0;
+
+  const handleVersionsScroll = useCallback(
+    (event: UIEvent<HTMLElement>) => {
+      const target = event.currentTarget;
+      if (
+        versionsLoadMorePending ||
+        !canLoadMoreVersions ||
+        isLoadingVersions ||
+        isFetchingVersions ||
+        versions.length === 0
+      ) {
+        return;
+      }
+
+      const threshold = 24;
+      if (
+        target.scrollHeight - target.scrollTop - target.clientHeight <
+        threshold
+      ) {
+        setVersionsLoadMorePending(true);
+        setVersionOffset((prev) => prev + 10);
+      }
+    },
+    [
+      versionsLoadMorePending,
+      canLoadMoreVersions,
+      isLoadingVersions,
+      isFetchingVersions,
+      versions.length,
+    ],
+  );
+
+  const postProduct = usePostDeploymentProduct();
+
+  const isSubmitting = postProduct.isPending;
+  const isValid =
+    !!form.productId &&
+    !!form.versionId &&
+    !!projectId &&
+    deploymentId.length > 0;
+
+  const handleProductChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const productId = event.target.value;
+      setForm((prev) => ({
+        ...prev,
+        productId,
+        versionId: "",
+      }));
+    },
+    [],
+  );
+
+  const handleVersionChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      setForm((prev) => ({ ...prev, versionId: event.target.value }));
+    },
+    [],
+  );
+
+  const handleTextChange = useCallback(
+    (field: "cores" | "tps" | "description") =>
+      (event: ChangeEvent<HTMLInputElement>) => {
+        setForm((prev) => ({ ...prev, [field]: event.target.value }));
+      },
+    [],
+  );
+
+  const submit = useCallback(async (): Promise<AddedProductSummary> => {
+    if (!isValid) {
+      throw new Error("Product and version are required.");
+    }
+
+    const selectedProduct = products.find((p) => p.id === form.productId);
+    const selectedVersion = versions.find((v) => v.id === form.versionId);
+
+    await postProduct.mutateAsync({
+      deploymentId,
+      body: {
+        productId: form.productId,
+        versionId: form.versionId,
+        projectId,
+        cores: parseValidNumber(form.cores),
+        tps: parseValidNumber(form.tps),
+        description: form.description || undefined,
+      },
+    });
+
+    return {
+      productId: form.productId,
+      productLabel:
+        selectedProduct?.label ?? selectedProduct?.name ?? form.productId,
+      versionId: form.versionId,
+      versionLabel: selectedVersion?.version ?? form.versionId,
+    };
+  }, [isValid, products, versions, form, postProduct, deploymentId, projectId]);
+
+  return {
+    form,
+    products,
+    versions,
+    isLoadingProducts,
+    isFetchingProducts,
+    isLoadingVersions,
+    isFetchingVersions,
+    canLoadMoreProducts,
+    canLoadMoreVersions,
+    isFetchingMoreProducts,
+    isFetchingMoreVersions,
+    handleProductsScroll,
+    handleVersionsScroll,
+    handleProductChange,
+    handleVersionChange,
+    handleTextChange,
+    isValid,
+    isSubmitting,
+    submit,
+    resetForm,
+  };
+}

--- a/apps/customer-portal/webapp/src/features/project-details/pages/ProjectDetails.tsx
+++ b/apps/customer-portal/webapp/src/features/project-details/pages/ProjectDetails.tsx
@@ -15,7 +15,7 @@
 // under the License.
 
 import { Box, Typography, Grid } from "@wso2/oxygen-ui";
-import { useParams } from "react-router";
+import { useLocation, useParams } from "react-router";
 import { useState, useEffect, useMemo, type JSX } from "react";
 import { useAsgardeo } from "@asgardeo/react";
 import TabBar from "@components/tab-bar/TabBar";
@@ -47,8 +47,17 @@ import {
  * @returns {JSX.Element} The ProjectDetails component.
  */
 export default function ProjectDetails(): JSX.Element {
+  const location = useLocation();
+  const initialTabFromState = (
+    location.state as { initialTab?: string } | null
+  )?.initialTab;
   const [activeTab, setActiveTab] = useState<string>(
-    ProjectDetailsTabId.OVERVIEW,
+    initialTabFromState &&
+      Object.values(ProjectDetailsTabId).includes(
+        initialTabFromState as ProjectDetailsTabId,
+      )
+      ? initialTabFromState
+      : ProjectDetailsTabId.OVERVIEW,
   );
 
   const { projectId } = useParams<{ projectId: string }>();

--- a/apps/customer-portal/webapp/src/features/project-details/pages/__tests__/ProjectDetails.test.tsx
+++ b/apps/customer-portal/webapp/src/features/project-details/pages/__tests__/ProjectDetails.test.tsx
@@ -104,4 +104,39 @@ describe("ProjectDetails", () => {
     expect(screen.getByRole("tab", { name: /overview/i })).toBeInTheDocument();
     expect(screen.getByTestId("project-information-card")).toBeInTheDocument();
   });
+
+  it("renders the deployments tab when navigated with an initialTab location state", () => {
+    render(
+      <MemoryRouter
+        initialEntries={[
+          {
+            pathname: "/projects/proj-1/project-details",
+            state: { initialTab: "deployments" },
+          },
+        ]}
+      >
+        <ProjectDetails />
+      </MemoryRouter>,
+    );
+    expect(screen.getByTestId("project-deployments")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("project-information-card"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("falls back to the overview tab for an unrecognized initialTab value", () => {
+    render(
+      <MemoryRouter
+        initialEntries={[
+          {
+            pathname: "/projects/proj-1/project-details",
+            state: { initialTab: "not-a-real-tab" },
+          },
+        ]}
+      >
+        <ProjectDetails />
+      </MemoryRouter>,
+    );
+    expect(screen.getByTestId("project-information-card")).toBeInTheDocument();
+  });
 });

--- a/apps/customer-portal/webapp/src/features/support/components/case-creation-layout/form-sections/basic-information-section/BasicInformationSection.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-creation-layout/form-sections/basic-information-section/BasicInformationSection.tsx
@@ -16,8 +16,11 @@
 
 import type { BasicInformationSectionProps } from "@features/support/types/supportComponents";
 import {
+  Alert,
   Box,
+  Button,
   Chip,
+  Divider,
   FormControl,
   Grid,
   MenuItem,
@@ -27,12 +30,22 @@ import {
   Typography,
   TextField,
 } from "@wso2/oxygen-ui";
-import { Sparkles } from "@wso2/oxygen-ui-icons-react";
+import { Plus, Sparkles } from "@wso2/oxygen-ui-icons-react";
 import { type JSX, type UIEvent } from "react";
 import { SelectMenuLoadMoreRow } from "@components/select-menu-load-more-row/SelectMenuLoadMoreRow";
 import { EMPTY_DROPDOWN_PLACEHOLDER } from "@constants/common";
+import {
+  isDeploymentDropdownEmpty,
+  isProductDropdownEmpty,
+} from "@features/support/utils/caseCreation";
 import { paginatedSelectMenuListProps } from "@utils/common";
 import { isCloudSupportProject } from "@utils/permission";
+
+// Sentinel values for the "add new" row appended to each dropdown's menu, so
+// it stays reachable while the menu is open instead of living in a button
+// below the field (which the open menu's overlay would otherwise cover).
+const ADD_NEW_DEPLOYMENT_OPTION = "__add_new_deployment__";
+const ADD_NEW_PRODUCT_OPTION = "__add_new_product__";
 
 /**
  * Renders the Basic Information section used during case creation.
@@ -64,6 +77,8 @@ export function BasicInformationSection({
   hasMoreProducts = false,
   isFetchingMoreProducts = false,
   projectTypeLabel,
+  onAddDeployment,
+  onAddProduct,
   children,
 }: BasicInformationSectionProps & { projectTypeLabel?: string | null }): JSX.Element {
   const handleDeploymentsMenuScroll = (e: UIEvent<HTMLElement>) => {
@@ -115,15 +130,23 @@ export function BasicInformationSection({
   const hasEffectiveProductOptions = useProductOptionList
     ? hasProductRows
     : productOptionsLegacy.length > 0;
-  const showNoProductsHint =
-    !hasEffectiveProductOptions &&
-    !isProductDropdownDisabled &&
-    !isProductLoading;
+  const showNoProductsHint = isProductDropdownEmpty(
+    hasEffectiveProductOptions,
+    isProductDropdownDisabled,
+    isProductLoading,
+  );
 
-  const showNoDeploymentsHint =
-    !isDeploymentLoading &&
-    deploymentOptions.length === 0 &&
-    !isDeploymentDisabled;
+  const showNoDeploymentsHint = isDeploymentDropdownEmpty(
+    deploymentOptions,
+    isDeploymentLoading,
+    isDeploymentDisabled,
+  );
+
+  // Only swap in the richer empty-state + CTA when the caller wired up the
+  // corresponding "add" action; otherwise fall back to the legacy disabled
+  // placeholder so other consumers of this section are unaffected.
+  const showNoDeploymentsEmptyState = showNoDeploymentsHint && !!onAddDeployment;
+  const showNoProductsEmptyState = showNoProductsHint && !!onAddProduct;
 
   const deploymentMenuListProps = paginatedSelectMenuListProps(
     onLoadMoreDeployments && hasMoreDeployments
@@ -190,7 +213,7 @@ export function BasicInformationSection({
                 height={40}
                 sx={{ maxWidth: "100%" }}
               />
-            ) : (
+            ) : showNoDeploymentsEmptyState ? null : (
               <FormControl
                 fullWidth
                 size="small"
@@ -198,7 +221,13 @@ export function BasicInformationSection({
               >
                 <Select
                   value={deployment}
-                  onChange={(e) => setDeployment(e.target.value)}
+                  onChange={(e) => {
+                    if (e.target.value === ADD_NEW_DEPLOYMENT_OPTION) {
+                      onAddDeployment?.();
+                      return;
+                    }
+                    setDeployment(e.target.value);
+                  }}
                   displayEmpty
                   renderValue={(value) => {
                     if (value === "") {
@@ -231,8 +260,43 @@ export function BasicInformationSection({
                       deploymentOptions.length > 0,
                     )}
                   />
+                  {onAddDeployment && [
+                    <Divider key="add-deployment-divider" sx={{ my: 0.5 }} />,
+                    <MenuItem
+                      key="add-deployment"
+                      value={ADD_NEW_DEPLOYMENT_OPTION}
+                      sx={{ color: "primary.main", py: 0.5, minHeight: "auto" }}
+                    >
+                      <Plus size={14} aria-hidden style={{ marginRight: 8 }} />
+                      Add Deployment
+                    </MenuItem>,
+                  ]}
                 </Select>
               </FormControl>
+            )}
+            {showNoDeploymentsEmptyState && (
+              <Alert
+                severity="warning"
+                sx={{ mt: 1 }}
+                action={
+                  <Button
+                    variant="outlined"
+                    size="small"
+                    startIcon={<Plus size={16} aria-hidden />}
+                    onClick={onAddDeployment}
+                  >
+                    Add Deployment
+                  </Button>
+                }
+              >
+                <Typography variant="body2">
+                  No deployments configured for this project. Add a
+                  deployment to continue creating your case.
+                </Typography>
+                <Typography variant="caption" color="text.secondary">
+                  This information helps us provide you with better support.
+                </Typography>
+              </Alert>
             )}
           </Grid>
         )}
@@ -259,7 +323,7 @@ export function BasicInformationSection({
           </Box>
           {isProductLoading ? (
             <Skeleton variant="rounded" height={40} sx={{ maxWidth: "100%" }} />
-          ) : (
+          ) : showNoProductsEmptyState ? null : (
             <FormControl
               fullWidth
               size="small"
@@ -267,7 +331,13 @@ export function BasicInformationSection({
             >
               <Select
                 value={product}
-                onChange={(e) => setProduct(e.target.value)}
+                onChange={(e) => {
+                  if (e.target.value === ADD_NEW_PRODUCT_OPTION) {
+                    onAddProduct?.();
+                    return;
+                  }
+                  setProduct(e.target.value);
+                }}
                 displayEmpty
                 renderValue={(value) => {
                   if (value === "") {
@@ -321,8 +391,43 @@ export function BasicInformationSection({
                       : productOptionsLegacy.length > 0),
                   )}
                 />
+                {onAddProduct && !isProductDropdownDisabled && [
+                  <Divider key="add-product-divider" sx={{ my: 0.5 }} />,
+                  <MenuItem
+                    key="add-product"
+                    value={ADD_NEW_PRODUCT_OPTION}
+                    sx={{ color: "primary.main", py: 0.5, minHeight: "auto" }}
+                  >
+                    <Plus size={14} aria-hidden style={{ marginRight: 8 }} />
+                    Add Product
+                  </MenuItem>,
+                ]}
               </Select>
             </FormControl>
+          )}
+          {showNoProductsEmptyState && (
+            <Alert
+              severity="warning"
+              sx={{ mt: 1 }}
+              action={
+                <Button
+                  variant="outlined"
+                  size="small"
+                  startIcon={<Plus size={16} aria-hidden />}
+                  onClick={onAddProduct}
+                >
+                  Add Product
+                </Button>
+              }
+            >
+              <Typography variant="body2">
+                No products found for this deployment. Add a product to
+                proceed.
+              </Typography>
+              <Typography variant="caption" color="text.secondary">
+                This information helps us provide you with better support.
+              </Typography>
+            </Alert>
           )}
         </Grid>
         {children && (

--- a/apps/customer-portal/webapp/src/features/support/components/case-creation-layout/form-sections/basic-information-section/__tests__/BasicInformationSection.test.tsx
+++ b/apps/customer-portal/webapp/src/features/support/components/case-creation-layout/form-sections/basic-information-section/__tests__/BasicInformationSection.test.tsx
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { ThemeProvider, createTheme } from "@wso2/oxygen-ui";
 import { BasicInformationSection } from "@features/support/components/case-creation-layout/form-sections/basic-information-section/BasicInformationSection";
@@ -68,5 +68,194 @@ describe("BasicInformationSection", () => {
       isProductLoading: false,
     });
     expect(screen.getByText("Not available")).toBeInTheDocument();
+  });
+
+  it("should show an Add Deployment alert instead of the dropdown when there are no deployments and onAddDeployment is provided", () => {
+    const onAddDeployment = vi.fn();
+    renderSection({
+      metadata: { deploymentTypes: [] },
+      productOptionList: [{ id: "prod-1", label: "API Manager 4.2.0" }],
+      onAddDeployment,
+    });
+
+    // The dropdown is hidden entirely in favor of the empty-state Alert.
+    expect(screen.queryByText("Not available")).not.toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "No deployments configured for this project. Add a deployment to continue creating your case.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "This information helps us provide you with better support.",
+      ),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Add Deployment" }));
+    expect(onAddDeployment).toHaveBeenCalledTimes(1);
+  });
+
+  it("should render the Add Deployment alert with warning severity", () => {
+    renderSection({
+      metadata: { deploymentTypes: [] },
+      productOptionList: [{ id: "prod-1", label: "API Manager 4.2.0" }],
+      onAddDeployment: vi.fn(),
+    });
+
+    const alertMessage = screen.getByText(
+      "No deployments configured for this project. Add a deployment to continue creating your case.",
+    );
+    const alertRoot = alertMessage.closest(".MuiAlert-root");
+    expect(alertRoot).not.toBeNull();
+    expect(alertRoot).toHaveClass("MuiAlert-standardWarning");
+  });
+
+  it("should show an Add Deployment option inside the dropdown menu when deployments exist, reachable while the menu is open", () => {
+    const onAddDeployment = vi.fn();
+    renderSection({
+      metadata: { deploymentTypes: ["Prod", "Staging"] },
+      onAddDeployment,
+    });
+
+    // The dropdown remains visible; the "add new" row lives inside its menu
+    // (not a button below the field, which an open menu's overlay would cover).
+    expect(screen.getByText("Deployment")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Add Deployment" }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.mouseDown(screen.getAllByRole("combobox")[0]);
+    const addOption = screen.getByRole("option", { name: /add deployment/i });
+    expect(addOption).toBeInTheDocument();
+
+    fireEvent.click(addOption);
+    expect(onAddDeployment).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not show an Add Deployment option in the menu when the deployment field is disabled", () => {
+    renderSection({
+      metadata: { deploymentTypes: ["Prod"] },
+      isDeploymentDisabled: true,
+      onAddDeployment: vi.fn(),
+    });
+
+    fireEvent.mouseDown(screen.getAllByRole("combobox")[0]);
+    expect(
+      screen.queryByRole("option", { name: /add deployment/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should keep the legacy disabled dropdown when there are no deployments and onAddDeployment is not provided", () => {
+    renderSection({
+      metadata: { deploymentTypes: [] },
+      productOptionList: [{ id: "prod-1", label: "API Manager 4.2.0" }],
+    });
+
+    expect(
+      screen.queryByText(
+        "No deployments configured for this project. Add a deployment to continue creating your case.",
+      ),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Not available")).toBeInTheDocument();
+  });
+
+  it("should show an Add Product alert instead of the dropdown when the selected deployment has no products and onAddProduct is provided", () => {
+    const onAddProduct = vi.fn();
+    renderSection({
+      deployment: "Prod",
+      productOptionList: [],
+      isProductDropdownDisabled: false,
+      isProductLoading: false,
+      onAddProduct,
+    });
+
+    expect(screen.queryByText("Not available")).not.toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "No products found for this deployment. Add a product to proceed.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "This information helps us provide you with better support.",
+      ),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Add Product" }));
+    expect(onAddProduct).toHaveBeenCalledTimes(1);
+  });
+
+  it("should render the Add Product alert with warning severity", () => {
+    renderSection({
+      deployment: "Prod",
+      productOptionList: [],
+      isProductDropdownDisabled: false,
+      isProductLoading: false,
+      onAddProduct: vi.fn(),
+    });
+
+    const alertMessage = screen.getByText(
+      "No products found for this deployment. Add a product to proceed.",
+    );
+    const alertRoot = alertMessage.closest(".MuiAlert-root");
+    expect(alertRoot).not.toBeNull();
+    expect(alertRoot).toHaveClass("MuiAlert-standardWarning");
+  });
+
+  it("should show an Add Product option inside the dropdown menu when products exist, reachable while the menu is open", () => {
+    const onAddProduct = vi.fn();
+    renderSection({
+      deployment: "Prod",
+      productOptionList: [{ id: "prod-1", label: "API Manager 4.2.0" }],
+      isProductDropdownDisabled: false,
+      isProductLoading: false,
+      onAddProduct,
+    });
+
+    expect(
+      screen.queryByRole("button", { name: "Add Product" }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.mouseDown(screen.getAllByRole("combobox")[1]);
+    const addOption = screen.getByRole("option", { name: /add product/i });
+    expect(addOption).toBeInTheDocument();
+
+    fireEvent.click(addOption);
+    expect(onAddProduct).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not show an Add Product option in the menu while the product dropdown is disabled (no deployment selected)", () => {
+    renderSection({
+      deployment: "",
+      productOptionList: [],
+      isProductDropdownDisabled: true,
+      isProductLoading: false,
+      onAddProduct: vi.fn(),
+    });
+
+    // The disabled Select can't be opened, so the menu (and its "add new"
+    // row) never renders.
+    fireEvent.mouseDown(screen.getAllByRole("combobox")[1]);
+    expect(
+      screen.queryByRole("option", { name: /add product/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should not show the product empty-state while a deployment has not been selected yet", () => {
+    const onAddProduct = vi.fn();
+    renderSection({
+      deployment: "",
+      productOptionList: [],
+      isProductDropdownDisabled: true,
+      isProductLoading: false,
+      onAddProduct,
+    });
+
+    expect(
+      screen.queryByText(
+        "No products found for this deployment. Add a product to proceed.",
+      ),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Select deployment first")).toBeInTheDocument();
   });
 });

--- a/apps/customer-portal/webapp/src/features/support/pages/CreateCasePage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/CreateCasePage.tsx
@@ -1327,11 +1327,17 @@ export default function CreateCasePage(): JSX.Element {
   const hasNoDeployments =
     !isPrimaryProductionOnly &&
     isDeploymentDropdownEmpty(baseDeploymentOptions, deploymentFieldLoading, false);
-  const hasNoProductsForDeployment = isProductDropdownEmpty(
-    sortedBaseProductOptions.length > 0,
-    isProductDropdownDisabled,
-    productFieldLoading,
-  );
+  // Same exclusion as hasNoDeployments above: these project types have no
+  // self-service add-product affordance (see onAddProduct below), so
+  // treating an empty product list as a blocking dead end here would leave
+  // the customer with no way out.
+  const hasNoProductsForDeployment =
+    !isPrimaryProductionOnly &&
+    isProductDropdownEmpty(
+      sortedBaseProductOptions.length > 0,
+      isProductDropdownDisabled,
+      productFieldLoading,
+    );
   // Nothing valid can be submitted while either dropdown is a dead end.
   const isFormBlockedByMissingOptions =
     isDeploymentSetupEnabled && (hasNoDeployments || hasNoProductsForDeployment);
@@ -1414,8 +1420,22 @@ export default function CreateCasePage(): JSX.Element {
             extraProductOptions={extraProductOptions}
             isDeploymentDisabled={false}
             hideDeploymentField={isPrimaryProductionOnly}
-            onAddDeployment={isDeploymentSetupEnabled ? handleAddDeployment : undefined}
-            onAddProduct={isDeploymentSetupEnabled ? handleAddProduct : undefined}
+            onAddDeployment={
+              isDeploymentSetupEnabled && !isPrimaryProductionOnly
+                ? handleAddDeployment
+                : undefined
+            }
+            // Cloud Support / Cloud Evaluation Support projects are locked
+            // to a single "Primary Production" deployment (the field itself
+            // is hidden via hideDeploymentField below) - since we don't
+            // offer these projects self-service deployment setup, offering
+            // to add a product under that fixed deployment would be
+            // inconsistent.
+            onAddProduct={
+              isDeploymentSetupEnabled && !isPrimaryProductionOnly
+                ? handleAddProduct
+                : undefined
+            }
             onLoadMoreDeployments={() => {
               if (
                 deploymentsQuery.hasNextPage &&

--- a/apps/customer-portal/webapp/src/features/support/pages/CreateCasePage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/CreateCasePage.tsx
@@ -1265,16 +1265,18 @@ export default function CreateCasePage(): JSX.Element {
     return [classificationProductLabel];
   }, [classificationProductLabel, sortedBaseProductOptions]);
 
+  // "Auto detected" means the AI classification suggested this value - it
+  // is misleading for a singleton auto-select (there was nothing to
+  // detect, it was just the only option), so that case intentionally
+  // shows no chip at all rather than reusing this one.
   const isProductAutoDetected =
-    (!noAiMode &&
-      !!classificationProductLabel?.trim() &&
-      !!product?.trim() &&
-      !isProductManuallySet) ||
-    isProductSingleOptionAutoSelected;
+    !noAiMode &&
+    !!classificationProductLabel?.trim() &&
+    !!product?.trim() &&
+    !isProductManuallySet;
 
   const isDeploymentAutoDetected =
-    (!noAiMode && isDeploymentFromClassification && !isDeploymentManuallySet) ||
-    isDeploymentSingleOptionAutoSelected;
+    !noAiMode && isDeploymentFromClassification && !isDeploymentManuallySet;
 
   const isIssueTypeAutoDetected = !noAiMode && isIssueTypeFromClassification;
   const isSeverityAutoDetected = !noAiMode && isSeverityFromClassification;
@@ -1305,11 +1307,22 @@ export default function CreateCasePage(): JSX.Element {
   // below so the "no options configured" empty-state check stays consistent
   // between what the dropdown shows and whether the rest of the form is
   // blocked from submission.
+  //
+  // The *ClassificationPending flags only mean "still paging through
+  // results looking for the AI-suggested match" - once at least one real
+  // option has actually arrived, that search continuing in the background
+  // must not keep masking the dropdown as loading. Without this guard, a
+  // deployment/product added while classification's search was still
+  // in-flight (e.g. right after using "Add Deployment"/"Add Product" from
+  // an empty list) stayed hidden behind a loading skeleton until something
+  // else (like re-picking the deployment) reset the classification state.
   const deploymentFieldLoading =
-    isProjectLoading || isDeploymentsLoading || isDeploymentClassificationPending;
+    isProjectLoading ||
+    isDeploymentsLoading ||
+    (isDeploymentClassificationPending && baseDeploymentOptions.length === 0);
   const productFieldLoading =
     (!!selectedDeploymentId && deploymentProductsLoading) ||
-    isProductClassificationPending;
+    (isProductClassificationPending && sortedBaseProductOptions.length === 0);
 
   const hasNoDeployments =
     !isPrimaryProductionOnly &&

--- a/apps/customer-portal/webapp/src/features/support/pages/CreateCasePage.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/CreateCasePage.tsx
@@ -59,6 +59,8 @@ import {
   getBaseProductOptions,
   getDeploymentDisplayLabelForEnvironment,
   getDeploymentProductDisplayLabel,
+  isDeploymentDropdownEmpty,
+  isProductDropdownEmpty,
   isUnknownPlaceholderProductLabel,
   resolveDeploymentMatch,
   resolveIssueTypeKey,
@@ -88,6 +90,9 @@ import {
 import { usePiiGuard } from "@features/support/hooks/usePiiGuard";
 import PiiWarningDialog from "@features/support/components/dialogs/PiiWarningDialog";
 import UploadAttachmentModal from "@features/support/components/case-details/attachments-tab/UploadAttachmentModal";
+import AddProductModal from "@features/project-details/components/deployments/AddProductModal";
+import AddDeploymentWizardModal from "@features/project-details/components/deployments/AddDeploymentWizardModal";
+import { isDeploymentSetupDuringCaseCreationEnabled } from "@config/caseCreationConfig";
 import type {
   ProductCategory,
   ProjectDeploymentItem,
@@ -174,6 +179,8 @@ export default function CreateCasePage(): JSX.Element {
   const isSubmittingRef = useRef(false);
   const [isPreparingAttachments, setIsPreparingAttachments] = useState(false);
   const [isAttachmentModalOpen, setIsAttachmentModalOpen] = useState(false);
+  const [isAddProductModalOpen, setIsAddProductModalOpen] = useState(false);
+  const [isDeploymentWizardOpen, setIsDeploymentWizardOpen] = useState(false);
   const deploymentsQuery = usePostProjectDeploymentsSearchInfinite(
     projectId || "",
     {
@@ -277,6 +284,18 @@ export default function CreateCasePage(): JSX.Element {
   const classificationDescriptionRef = useRef<string>("");
   const [isDeploymentManuallySet, setIsDeploymentManuallySet] = useState(false);
   const [isProductManuallySet, setIsProductManuallySet] = useState(false);
+  // Set when the deployment/product dropdown was auto-filled because it had
+  // exactly one option (as opposed to a manual pick or an AI-classification
+  // match). Drives the same "Auto detected" affordance as classification so
+  // the pre-fill isn't silent.
+  const [
+    isDeploymentSingleOptionAutoSelected,
+    setIsDeploymentSingleOptionAutoSelected,
+  ] = useState(false);
+  const [
+    isProductSingleOptionAutoSelected,
+    setIsProductSingleOptionAutoSelected,
+  ] = useState(false);
   const [isIssueTypeFromClassification, setIsIssueTypeFromClassification] =
     useState(false);
   const [isSeverityFromClassification, setIsSeverityFromClassification] =
@@ -292,6 +311,10 @@ export default function CreateCasePage(): JSX.Element {
 
   const skipChatMode = skipChat;
   const noAiMode = !!relatedCase || skipChatMode;
+  // Kill switch for the whole "add deployment/product inline" feature
+  // (empty-state alert, in-menu add-new, wizard, singleton auto-select).
+  // Defaults to enabled - see caseCreationConfig.ts.
+  const isDeploymentSetupEnabled = isDeploymentSetupDuringCaseCreationEnabled();
   const queryClient = useQueryClient();
 
   const locationState = location.state as {
@@ -435,6 +458,8 @@ export default function CreateCasePage(): JSX.Element {
     setIsDeploymentFromClassification(false);
     setClassificationDeploymentLabel("");
     setIsProductManuallySet(true);
+    setIsDeploymentSingleOptionAutoSelected(false);
+    setIsProductSingleOptionAutoSelected(false);
   }, []);
 
   // For Cloud Support / Cloud Evaluation Support: auto-pick the first primary
@@ -452,6 +477,7 @@ export default function CreateCasePage(): JSX.Element {
   const handleProductChange = useCallback((value: string) => {
     setProduct(value);
     setIsProductManuallySet(true);
+    setIsProductSingleOptionAutoSelected(false);
   }, []);
 
   const handleIssueTypeChange = useCallback((value: string) => {
@@ -539,7 +565,16 @@ export default function CreateCasePage(): JSX.Element {
     queueMicrotask(() => {
       if (noAiMode) {
         if (!relatedCase) {
-          setDeployment("");
+          // Blank by default (the user picks consciously since there's no
+          // AI-classification signal to justify a guess) - EXCEPT when
+          // there's exactly one deployment: forcing a manual pick from a
+          // single-item dropdown isn't a real choice, just an extra click.
+          if (isDeploymentSetupEnabled && baseDeploymentOptions.length === 1) {
+            setDeployment(baseDeploymentOptions[0]);
+            setIsDeploymentSingleOptionAutoSelected(true);
+          } else {
+            setDeployment("");
+          }
           setTitle("");
           setDescription("");
         }
@@ -563,6 +598,7 @@ export default function CreateCasePage(): JSX.Element {
     isDeploymentsLoading,
     issueTypesList,
     isFiltersLoading,
+    isDeploymentSetupEnabled,
     noAiMode,
     relatedCase,
     severityLevelsList,
@@ -620,6 +656,96 @@ export default function CreateCasePage(): JSX.Element {
       hasRelatedCaseDeploymentInitializedRef.current = true;
     }
   }, [relatedCase, projectDeployments, baseDeploymentOptions]);
+
+  // Auto-select the deployment when there is exactly one option, so the
+  // customer isn't forced to click through a single-item dropdown. This is
+  // deliberately narrow: it only fills gaps left by the flows above, it
+  // never fights them.
+  //   - `noAiMode && !relatedCase` (skipChat) is the one flow that explicitly
+  //     clears deployment to "" on init (see the init effect above) as a
+  //     defensive reset; that reset owns the blank state, so this effect
+  //     stays out of it.
+  //   - A related case that names a deployment (`deploymentId`/
+  //     `deploymentLabel`) is resolved by the effect above from the parent
+  //     case, not from option count, so this effect defers to it entirely
+  //     even if that resolution hasn't landed yet.
+  //   - Everything else (no related case, or a related case with no
+  //     deployment hint, or the AI-classification flow once a
+  //     classificationResponse exists) is fair game: `!deployment` guards
+  //     against re-firing once a value lands from any source, so this can
+  //     only ever run once per "became a singleton" transition.
+  useEffect(() => {
+    if (!isDeploymentSetupEnabled) return;
+    if (deployment) return;
+    if (isDeploymentsLoading) return;
+    if (baseDeploymentOptions.length !== 1) return;
+    if (noAiMode && !relatedCase) return;
+    if (relatedCase?.deploymentId || relatedCase?.deploymentLabel) return;
+
+    setDeployment(baseDeploymentOptions[0]);
+    setIsDeploymentSingleOptionAutoSelected(true);
+  }, [
+    isDeploymentSetupEnabled,
+    deployment,
+    isDeploymentsLoading,
+    baseDeploymentOptions,
+    noAiMode,
+    relatedCase,
+  ]);
+
+  // Same "undo if it turns out not to be a real singleton" guard as the
+  // product effect below - covers the same query-timing race for the
+  // deployments list.
+  useEffect(() => {
+    if (!isDeploymentSingleOptionAutoSelected) return;
+    if (baseDeploymentOptions.length <= 1) return;
+
+    setDeployment("");
+    setIsDeploymentSingleOptionAutoSelected(false);
+  }, [isDeploymentSingleOptionAutoSelected, baseDeploymentOptions]);
+
+  // Auto-select the product/version when the currently selected deployment
+  // resolves to exactly one product option. Mirrors the deployment effect
+  // above, but product has no "intentionally left blank" flow to defer to:
+  // every path clears `product` to "" on init and relies on either the
+  // related-case/classification sync effect (below) or this effect to fill
+  // it back in. A related case that names a product
+  // (`deployedProductId`/`deployedProductLabel`) is resolved there, not from
+  // option count, so this effect steps aside for it.
+  useEffect(() => {
+    if (!isDeploymentSetupEnabled) return;
+    if (!selectedDeploymentId) return;
+    if (product) return;
+    if (deploymentProductsLoading) return;
+    if (sortedBaseProductOptions.length !== 1) return;
+    if (relatedCase?.deployedProductId || relatedCase?.deployedProductLabel)
+      return;
+
+    setProduct(sortedBaseProductOptions[0].id);
+    setIsProductSingleOptionAutoSelected(true);
+  }, [
+    isDeploymentSetupEnabled,
+    selectedDeploymentId,
+    product,
+    deploymentProductsLoading,
+    sortedBaseProductOptions,
+    relatedCase,
+  ]);
+
+  // Undoes the auto-select above if the option list later turns out to have
+  // more than one item after all (e.g. the wizard's product query resolves
+  // incrementally right after adding two products, and the singleton effect
+  // fired on a transient one-item view before the second one caught up).
+  // Only ever reverses a value THIS effect's sibling actually auto-picked
+  // (`isProductSingleOptionAutoSelected`) - a manual selection is never
+  // touched, even if the list happens to change afterward.
+  useEffect(() => {
+    if (!isProductSingleOptionAutoSelected) return;
+    if (sortedBaseProductOptions.length <= 1) return;
+
+    setProduct("");
+    setIsProductSingleOptionAutoSelected(false);
+  }, [isProductSingleOptionAutoSelected, sortedBaseProductOptions]);
 
   useEffect(() => {
     if (noAiMode) return;
@@ -1140,13 +1266,15 @@ export default function CreateCasePage(): JSX.Element {
   }, [classificationProductLabel, sortedBaseProductOptions]);
 
   const isProductAutoDetected =
-    !noAiMode &&
-    !!classificationProductLabel?.trim() &&
-    !!product?.trim() &&
-    !isProductManuallySet;
+    (!noAiMode &&
+      !!classificationProductLabel?.trim() &&
+      !!product?.trim() &&
+      !isProductManuallySet) ||
+    isProductSingleOptionAutoSelected;
 
   const isDeploymentAutoDetected =
-    !noAiMode && isDeploymentFromClassification && !isDeploymentManuallySet;
+    (!noAiMode && isDeploymentFromClassification && !isDeploymentManuallySet) ||
+    isDeploymentSingleOptionAutoSelected;
 
   const isIssueTypeAutoDetected = !noAiMode && isIssueTypeFromClassification;
   const isSeverityAutoDetected = !noAiMode && isSeverityFromClassification;
@@ -1173,6 +1301,74 @@ export default function CreateCasePage(): JSX.Element {
   const isProductDropdownDisabled =
     !selectedDeploymentId || deploymentProductsLoading;
 
+  // These mirror the loading/disabled flags handed to BasicInformationSection
+  // below so the "no options configured" empty-state check stays consistent
+  // between what the dropdown shows and whether the rest of the form is
+  // blocked from submission.
+  const deploymentFieldLoading =
+    isProjectLoading || isDeploymentsLoading || isDeploymentClassificationPending;
+  const productFieldLoading =
+    (!!selectedDeploymentId && deploymentProductsLoading) ||
+    isProductClassificationPending;
+
+  const hasNoDeployments =
+    !isPrimaryProductionOnly &&
+    isDeploymentDropdownEmpty(baseDeploymentOptions, deploymentFieldLoading, false);
+  const hasNoProductsForDeployment = isProductDropdownEmpty(
+    sortedBaseProductOptions.length > 0,
+    isProductDropdownDisabled,
+    productFieldLoading,
+  );
+  // Nothing valid can be submitted while either dropdown is a dead end.
+  const isFormBlockedByMissingOptions =
+    isDeploymentSetupEnabled && (hasNoDeployments || hasNoProductsForDeployment);
+
+  const handleAddDeployment = useCallback(() => {
+    if (!projectId) return;
+    // Always the combined deployment+product wizard: EVERY newly created
+    // deployment starts with zero products of its own, whether it's the
+    // project's first deployment or an additional one added via the
+    // persistent "add another" affordance - there's no case where chaining
+    // into the product step isn't the right next step.
+    setIsDeploymentWizardOpen(true);
+  }, [projectId]);
+
+  const handleAddProduct = useCallback(() => {
+    if (!projectId || !selectedDeploymentId) return;
+    setIsAddProductModalOpen(true);
+  }, [projectId, selectedDeploymentId]);
+
+  const handleProductAdded = useCallback(() => {
+    showSuccess("Product added successfully.");
+  }, [showSuccess]);
+
+  // The wizard's own usePostCreateDeployment mutation response returns the
+  // newly created deployment's id directly, so its product step doesn't
+  // need to wait on `selectedDeploymentId` resolving through a query
+  // refetch the way the old two-dialog chaining did. All this callback
+  // needs to do is make sure the case-creation form's own deployment
+  // dropdown reflects the new deployment once the deployments list
+  // refetches - the same singleton auto-select signal the previous
+  // implementation relied on, just applied immediately instead of via a
+  // watcher effect.
+  const handleWizardDeploymentCreated = useCallback(
+    (name: string) => {
+      showSuccess("Deployment created successfully.");
+      // Reuses the same "manual selection" path a dropdown change goes
+      // through (resets product + both singleton-auto-select flags) rather
+      // than a bare setDeployment: the user just explicitly created THIS
+      // deployment, so it must win over whatever was selected before (even
+      // a previous singleton auto-select) and the undo-guard above must not
+      // later revert it just because the list now has more than one item.
+      handleDeploymentChange(name);
+    },
+    [showSuccess, handleDeploymentChange],
+  );
+
+  const handleWizardProductAdded = useCallback(() => {
+    showSuccess("Product added successfully.");
+  }, [showSuccess]);
+
   const renderContent = () => (
     <Grid container spacing={3}>
       {/* left column - form content (full width when skipChat or no sidebar content) */}
@@ -1198,20 +1394,15 @@ export default function CreateCasePage(): JSX.Element {
             isProductAutoDetected={isProductAutoDetected}
             isDeploymentAutoDetected={isDeploymentAutoDetected}
             metadata={sectionMetadata}
-            isDeploymentLoading={
-              isProjectLoading ||
-              isDeploymentsLoading ||
-              isDeploymentClassificationPending
-            }
+            isDeploymentLoading={deploymentFieldLoading}
             isProductDropdownDisabled={isProductDropdownDisabled}
-            isProductLoading={
-              (!!selectedDeploymentId && deploymentProductsLoading) ||
-              isProductClassificationPending
-            }
+            isProductLoading={productFieldLoading}
             isRelatedCaseMode={noAiMode}
             extraProductOptions={extraProductOptions}
             isDeploymentDisabled={false}
             hideDeploymentField={isPrimaryProductionOnly}
+            onAddDeployment={isDeploymentSetupEnabled ? handleAddDeployment : undefined}
+            onAddProduct={isDeploymentSetupEnabled ? handleAddProduct : undefined}
             onLoadMoreDeployments={() => {
               if (
                 deploymentsQuery.hasNextPage &&
@@ -1235,83 +1426,88 @@ export default function CreateCasePage(): JSX.Element {
             projectTypeLabel={projectDetails?.type?.label}
           />
 
-          <CaseDetailsSection
-            title={title}
-            setTitle={handleTitleChange}
-            description={description}
-            setDescription={handleDescriptionChange}
-            issueType={issueType}
-            setIssueType={handleIssueTypeChange}
-            severity={severity}
-            setSeverity={handleSeverityChange}
-            isIssueTypeAutoDetected={isIssueTypeAutoDetected}
-            isSeverityAutoDetected={isSeverityAutoDetected}
-            isTitleFromChat={isTitleFromClassification}
-            isDescriptionFromConversation={isDescriptionFromClassification}
-            metadata={undefined}
-            filters={filters}
-            isLoading={isFiltersLoading}
-            attachments={attachments.map((a) => a.file)}
-            onAttachmentClick={handleAttachmentClick}
-            onAttachmentRemove={handleAttachmentRemove}
-            storageKey={
-              !relatedCase && projectId
-                ? `create-case-draft-${projectId}`
-                : undefined
-            }
-            isRelatedCaseMode={noAiMode}
-            isTitleDisabled={false}
-            relatedCaseNumber={relatedCase?.number ?? ""}
-            isSecurityReport={isSecurityReport}
-            excludeS0={excludeS0}
-            isSeverityDisabled={forceSeverityS4}
-          />
+          {!isFormBlockedByMissingOptions && (
+            <>
+              <CaseDetailsSection
+                title={title}
+                setTitle={handleTitleChange}
+                description={description}
+                setDescription={handleDescriptionChange}
+                issueType={issueType}
+                setIssueType={handleIssueTypeChange}
+                severity={severity}
+                setSeverity={handleSeverityChange}
+                isIssueTypeAutoDetected={isIssueTypeAutoDetected}
+                isSeverityAutoDetected={isSeverityAutoDetected}
+                isTitleFromChat={isTitleFromClassification}
+                isDescriptionFromConversation={isDescriptionFromClassification}
+                metadata={undefined}
+                filters={filters}
+                isLoading={isFiltersLoading}
+                attachments={attachments.map((a) => a.file)}
+                onAttachmentClick={handleAttachmentClick}
+                onAttachmentRemove={handleAttachmentRemove}
+                storageKey={
+                  !relatedCase && projectId
+                    ? `create-case-draft-${projectId}`
+                    : undefined
+                }
+                isRelatedCaseMode={noAiMode}
+                isTitleDisabled={false}
+                relatedCaseNumber={relatedCase?.number ?? ""}
+                isSecurityReport={isSecurityReport}
+                excludeS0={excludeS0}
+                isSeverityDisabled={forceSeverityS4}
+              />
 
-          <WatchListSection
-            contacts={(projectContacts ?? []).filter(
-              (c) => c.isCsAdmin || c.isCsIntegrationUser || c.isPortalUser || !c.isSecurityContact,
-            )}
-            selectedEmails={watchList}
-            onChange={setWatchList}
-            isLoading={isContactsLoading}
-          />
+              <WatchListSection
+                contacts={(projectContacts ?? []).filter(
+                  (c) => c.isCsAdmin || c.isCsIntegrationUser || c.isPortalUser || !c.isSecurityContact,
+                )}
+                selectedEmails={watchList}
+                onChange={setWatchList}
+                isLoading={isContactsLoading}
+              />
 
-          {/* form actions container */}
-          <Box sx={{ display: "flex", justifyContent: "right" }}>
-            {/* submit button */}
-            <Button
-              type="submit"
-              variant="contained"
-              startIcon={<CircleCheck size={18} />}
-              color="primary"
-              disabled={
-                isProjectLoading ||
-                isProjectFeaturesLoading ||
-                isFiltersLoading ||
-                isCreatePending ||
-                isNavigatingAfterCreate ||
-                isPreparingAttachments ||
-                !projectId ||
-                !selectedDeploymentId ||
-                deploymentProductsLoading ||
-                deploymentProductsError
-              }
-            >
-              {isPreparingAttachments
-                ? "Uploading attachments..."
-                : isCreatePending
-                  ? isSecurityReport
-                    ? "Submitting..."
-                    : "Creating..."
-                  : isNavigatingAfterCreate
-                    ? "Opening case..."
-                    : isSecurityReport
-                      ? "Submit Security Report"
-                      : relatedCase
-                        ? "Create Related Case"
-                        : "Create Support Case"}
-            </Button>
-          </Box>
+              {/* form actions container */}
+              <Box sx={{ display: "flex", justifyContent: "right" }}>
+                {/* submit button */}
+                <Button
+                  type="submit"
+                  variant="contained"
+                  startIcon={<CircleCheck size={18} />}
+                  color="primary"
+                  disabled={
+                    isProjectLoading ||
+                    isProjectFeaturesLoading ||
+                    isFiltersLoading ||
+                    isCreatePending ||
+                    isNavigatingAfterCreate ||
+                    isPreparingAttachments ||
+                    !projectId ||
+                    !selectedDeploymentId ||
+                    deploymentProductsLoading ||
+                    deploymentProductsError ||
+                    isFormBlockedByMissingOptions
+                  }
+                >
+                  {isPreparingAttachments
+                    ? "Uploading attachments..."
+                    : isCreatePending
+                      ? isSecurityReport
+                        ? "Submitting..."
+                        : "Creating..."
+                      : isNavigatingAfterCreate
+                        ? "Opening case..."
+                        : isSecurityReport
+                          ? "Submit Security Report"
+                          : relatedCase
+                            ? "Create Related Case"
+                            : "Create Support Case"}
+                </Button>
+              </Box>
+            </>
+          )}
         </Box>
       </Grid>
 
@@ -1363,6 +1559,28 @@ export default function CreateCasePage(): JSX.Element {
         onClose={() => setIsAttachmentModalOpen(false)}
         onSelect={handleSelectAttachment}
       />
+
+      {projectId && (
+        <AddProductModal
+          open={isAddProductModalOpen}
+          deploymentId={selectedDeploymentId}
+          projectId={projectId}
+          onClose={() => setIsAddProductModalOpen(false)}
+          onSuccess={handleProductAdded}
+          onError={showError}
+        />
+      )}
+
+      {projectId && (
+        <AddDeploymentWizardModal
+          open={isDeploymentWizardOpen}
+          projectId={projectId}
+          onClose={() => setIsDeploymentWizardOpen(false)}
+          onDeploymentCreated={handleWizardDeploymentCreated}
+          onProductAdded={handleWizardProductAdded}
+          onError={showError}
+        />
+      )}
 
       <PiiWarningDialog {...piiGuard.dialogProps} />
     </Box>

--- a/apps/customer-portal/webapp/src/features/support/pages/__tests__/CreateCasePage.test.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/__tests__/CreateCasePage.test.tsx
@@ -14,8 +14,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { render, screen, fireEvent } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import CreateCasePage from "@features/support/pages/CreateCasePage";
 
 const mockNavigate = vi.fn();
@@ -59,26 +59,16 @@ vi.mock("@api/useGetProjectFilters", () => ({
   default: () => ({ data: { issueTypes: [], severities: [] }, isLoading: false }),
 }));
 
+const mockDeploymentsQuery = vi.fn();
 vi.mock("@api/usePostProjectDeploymentsSearch", () => ({
-  usePostProjectDeploymentsSearchInfinite: () => ({
-    data: { pages: [] },
-    isLoading: false,
-    isFetchingNextPage: false,
-    hasNextPage: false,
-    fetchNextPage: vi.fn(),
-  }),
+  usePostProjectDeploymentsSearchInfinite: () => mockDeploymentsQuery(),
 }));
 
+const mockDeploymentProductsQuery = vi.fn();
 vi.mock("@features/project-details/api/usePostDeploymentProductsSearch", () => ({
-  usePostDeploymentProductsSearchInfinite: () => ({
-    data: { pages: [] },
-    isLoading: false,
-    isError: false,
-    isFetchingNextPage: false,
-    hasNextPage: false,
-    fetchNextPage: vi.fn(),
-  }),
-  extractDeploymentProducts: () => [],
+  usePostDeploymentProductsSearchInfinite: () => mockDeploymentProductsQuery(),
+  extractDeploymentProducts: (page: { products?: unknown[] }) =>
+    page?.products ?? [],
 }));
 
 vi.mock("@features/operations/api/usePostCase", () => ({
@@ -87,6 +77,24 @@ vi.mock("@features/operations/api/usePostCase", () => ({
 
 vi.mock("@/hooks/useAuthApiClient", () => ({
   useAuthApiClient: () => vi.fn(),
+}));
+
+// Stable references: the CreateCasePage effects key off of these query
+// results by identity, so a mock that returns a fresh array/object literal
+// on every render would re-trigger those effects forever.
+const EMPTY_PROJECT_CONTACTS: unknown[] = [];
+const MOCK_USER_DETAILS = { email: "jane.doe@example.com" };
+
+vi.mock("@features/settings/api/useGetProjectContacts", () => ({
+  default: () => ({ data: EMPTY_PROJECT_CONTACTS, isLoading: false }),
+}));
+
+vi.mock("@features/settings/api/useGetUserDetails", () => ({
+  default: () => ({ data: MOCK_USER_DETAILS }),
+}));
+
+vi.mock("@features/support/api/usePostAttachments", () => ({
+  usePostAttachments: () => ({ mutateAsync: vi.fn(), mutate: vi.fn() }),
 }));
 
 vi.mock("@tanstack/react-query", async (importOriginal) => {
@@ -127,7 +135,30 @@ vi.mock("@features/support/components/case-creation-layout/header/CaseCreationHe
 vi.mock(
   "@features/support/components/case-creation-layout/form-sections/basic-information-section/BasicInformationSection",
   () => ({
-    BasicInformationSection: () => <div>Basic Section</div>,
+    BasicInformationSection: (props: {
+      deployment?: string;
+      product?: string;
+      setDeployment?: (value: string) => void;
+      onAddDeployment?: () => void;
+      onAddProduct?: () => void;
+    }) => (
+      <div>
+        Basic Section
+        <div>Deployment value: {props.deployment || "(none)"}</div>
+        <div>Product value: {props.product || "(none)"}</div>
+        {props.setDeployment && (
+          <button onClick={() => props.setDeployment?.("Production")}>
+            Select Deployment
+          </button>
+        )}
+        {props.onAddDeployment && (
+          <button onClick={props.onAddDeployment}>Add Deployment CTA</button>
+        )}
+        {props.onAddProduct && (
+          <button onClick={props.onAddProduct}>Add Product CTA</button>
+        )}
+      </div>
+    ),
   }),
 );
 
@@ -135,6 +166,13 @@ vi.mock(
   "@features/support/components/case-creation-layout/form-sections/case-details-section/CaseDetailsSection",
   () => ({
     CaseDetailsSection: () => <div>Details Section</div>,
+  }),
+);
+
+vi.mock(
+  "@features/support/components/case-creation-layout/form-sections/watch-list-section/WatchListSection",
+  () => ({
+    WatchListSection: () => <div>Watch List Section</div>,
   }),
 );
 
@@ -159,6 +197,87 @@ vi.mock(
   }),
 );
 
+vi.mock(
+  "@features/project-details/components/deployments/AddProductModal",
+  () => ({
+    default: ({
+      open,
+      onClose,
+      onSuccess,
+    }: {
+      open: boolean;
+      onClose: () => void;
+      onSuccess?: () => void;
+    }) =>
+      open ? (
+        <div>
+          Add Product Modal
+          <button
+            onClick={() => {
+              onClose();
+              onSuccess?.();
+            }}
+          >
+            Submit Product Modal
+          </button>
+          <button onClick={onClose}>Close Product Modal</button>
+        </div>
+      ) : null,
+  }),
+);
+
+vi.mock(
+  "@features/project-details/components/deployments/AddDeploymentWizardModal",
+  () => ({
+    default: ({
+      open,
+      onClose,
+      onDeploymentCreated,
+      onProductAdded,
+    }: {
+      open: boolean;
+      onClose: () => void;
+      onDeploymentCreated?: (name: string) => void;
+      onProductAdded?: () => void;
+    }) =>
+      open ? (
+        <div>
+          Add Deployment Wizard
+          <button onClick={() => onDeploymentCreated?.("Production")}>
+            Submit Wizard Deployment Step
+          </button>
+          <button onClick={() => onDeploymentCreated?.("Staging")}>
+            Submit Wizard Deployment Step (Staging)
+          </button>
+          <button onClick={() => onProductAdded?.()}>
+            Submit Wizard Product
+          </button>
+          <button onClick={onClose}>Wizard Done</button>
+        </div>
+      ) : null,
+  }),
+);
+
+vi.mock("@features/support/hooks/usePiiGuard", () => ({
+  usePiiGuard: () => ({
+    checkBeforeSubmit: (_text: string, onProceed: () => void) => onProceed(),
+    dialogProps: { open: false },
+  }),
+}));
+
+vi.mock("@features/support/components/dialogs/PiiWarningDialog", () => ({
+  default: () => null,
+}));
+
+const EMPTY_INFINITE_QUERY = {
+  data: { pages: [] as unknown[] },
+  isLoading: false,
+  isError: false,
+  isFetchingNextPage: false,
+  hasNextPage: false,
+  fetchNextPage: vi.fn(),
+};
+
 describe("CreateCasePage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -167,6 +286,22 @@ describe("CreateCasePage", () => {
       pathname: "/projects/project-1/support/chat/create-case",
       search: "",
       state: null,
+    });
+    mockDeploymentsQuery.mockReturnValue({
+      ...EMPTY_INFINITE_QUERY,
+      data: { pages: [{ deployments: [{ id: "dep-1", name: "Production" }] }] },
+    });
+    mockDeploymentProductsQuery.mockReturnValue({
+      ...EMPTY_INFINITE_QUERY,
+      data: {
+        pages: [
+          {
+            products: [
+              { id: "prod-1", product: { label: "API Manager" }, version: "4.2.0" },
+            ],
+          },
+        ],
+      },
     });
   });
 
@@ -178,6 +313,10 @@ describe("CreateCasePage", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("Basic Section")).toBeInTheDocument();
     expect(screen.getByText("Details Section")).toBeInTheDocument();
+    expect(screen.getByText("Watch List Section")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /create support case/i }),
+    ).toBeInTheDocument();
   });
 
   it("should navigate using returnTo on back action", () => {
@@ -191,6 +330,431 @@ describe("CreateCasePage", () => {
     fireEvent.click(screen.getByText("Back Header"));
 
     expect(mockNavigate).toHaveBeenCalledWith("/projects/project-1/support/chat/conv-1");
+  });
+
+  it("should hide case details, watch list, and submit when the project has no deployments", () => {
+    mockDeploymentsQuery.mockReturnValue(EMPTY_INFINITE_QUERY);
+
+    render(<CreateCasePage />);
+
+    expect(screen.getByText("Basic Section")).toBeInTheDocument();
+    expect(screen.queryByText("Details Section")).not.toBeInTheDocument();
+    expect(screen.queryByText("Watch List Section")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /create support case/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should open the wizard (not a plain modal) for the persistent 'add another' affordance too, since every new deployment starts with zero products", () => {
+    // beforeEach already mocks a non-empty deployment list ("Production").
+    render(<CreateCasePage />);
+    expect(screen.queryByText("Add Deployment Wizard")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Add Deployment CTA"));
+
+    expect(screen.getByText("Add Deployment Wizard")).toBeInTheDocument();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("switches the selected deployment to the newly added one, not the previously auto-selected one", () => {
+    // beforeEach already mocks a single deployment ("Production"), which
+    // the general singleton effect would have auto-selected.
+    render(<CreateCasePage />);
+    expect(screen.getByText("Deployment value: Production")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Add Deployment CTA"));
+    fireEvent.click(screen.getByText("Submit Wizard Deployment Step (Staging)"));
+
+    expect(screen.getByText("Deployment value: Staging")).toBeInTheDocument();
+  });
+
+  describe("Add Deployment wizard", () => {
+    it("opens the wizard dialog when the deployment list is empty", () => {
+      mockDeploymentsQuery.mockReturnValue(EMPTY_INFINITE_QUERY);
+
+      render(<CreateCasePage />);
+      expect(screen.queryByText("Add Deployment Wizard")).not.toBeInTheDocument();
+
+      fireEvent.click(screen.getByText("Add Deployment CTA"));
+
+      expect(screen.getByText("Add Deployment Wizard")).toBeInTheDocument();
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    it("selects the newly created deployment in the case-creation form as soon as the wizard's deployment step succeeds, using the mutation response directly rather than waiting on a query refetch", () => {
+      mockDeploymentsQuery.mockReturnValue(EMPTY_INFINITE_QUERY);
+
+      render(<CreateCasePage />);
+      fireEvent.click(screen.getByText("Add Deployment CTA"));
+      expect(screen.getByText("Add Deployment Wizard")).toBeInTheDocument();
+
+      fireEvent.click(screen.getByText("Submit Wizard Deployment Step"));
+
+      expect(screen.getByText("Deployment value: Production")).toBeInTheDocument();
+      // The wizard owns its own step transition internally - it never closes
+      // as a side effect of the deployment step succeeding.
+      expect(screen.getByText("Add Deployment Wizard")).toBeInTheDocument();
+    });
+
+    it("supports adding multiple products in one wizard session without closing, and closes only on Done", () => {
+      mockDeploymentsQuery.mockReturnValue(EMPTY_INFINITE_QUERY);
+
+      render(<CreateCasePage />);
+      fireEvent.click(screen.getByText("Add Deployment CTA"));
+      fireEvent.click(screen.getByText("Submit Wizard Deployment Step"));
+
+      fireEvent.click(screen.getByText("Submit Wizard Product"));
+      expect(screen.getByText("Add Deployment Wizard")).toBeInTheDocument();
+
+      fireEvent.click(screen.getByText("Submit Wizard Product"));
+      expect(screen.getByText("Add Deployment Wizard")).toBeInTheDocument();
+
+      fireEvent.click(screen.getByText("Wizard Done"));
+      expect(
+        screen.queryByText("Add Deployment Wizard"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("should hide case details, watch list, and submit when the selected deployment has no products", () => {
+    mockDeploymentProductsQuery.mockReturnValue(EMPTY_INFINITE_QUERY);
+
+    render(<CreateCasePage />);
+    fireEvent.click(screen.getByText("Select Deployment"));
+
+    expect(screen.getByText("Basic Section")).toBeInTheDocument();
+    expect(screen.queryByText("Details Section")).not.toBeInTheDocument();
+    expect(screen.queryByText("Watch List Section")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /create support case/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should open the Add Product modal inline instead of navigating away when the Add Product CTA is clicked", () => {
+    mockDeploymentProductsQuery.mockReturnValue(EMPTY_INFINITE_QUERY);
+
+    render(<CreateCasePage />);
+    fireEvent.click(screen.getByText("Select Deployment"));
+    expect(screen.queryByText("Add Product Modal")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Add Product CTA"));
+
+    expect(screen.getByText("Add Product Modal")).toBeInTheDocument();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("should close the Add Product modal on successful creation", () => {
+    mockDeploymentProductsQuery.mockReturnValue(EMPTY_INFINITE_QUERY);
+
+    render(<CreateCasePage />);
+    fireEvent.click(screen.getByText("Select Deployment"));
+    fireEvent.click(screen.getByText("Add Product CTA"));
+    expect(screen.getByText("Add Product Modal")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Submit Product Modal"));
+
+    expect(screen.queryByText("Add Product Modal")).not.toBeInTheDocument();
+  });
+
+  it("should show case details and submit when a deployment and its products are available", () => {
+    render(<CreateCasePage />);
+    fireEvent.click(screen.getByText("Select Deployment"));
+
+    expect(screen.getByText("Details Section")).toBeInTheDocument();
+    expect(screen.getByText("Watch List Section")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /create support case/i }),
+    ).toBeInTheDocument();
+  });
+
+  describe("single-option auto-select", () => {
+    // The plain (no-classification) create-case flow already auto-picks
+    // `baseDeploymentOptions[0]` unconditionally via a pre-existing effect
+    // (see the "!classificationResponse" branch of the init effect), so it
+    // can't isolate the *new* singleton auto-select behavior on its own.
+    // These deployment-focused tests instead drive the AI-classification
+    // path (`classificationResponse` present in location.state), which is
+    // exactly the gap the new effect fills: that pre-existing effect does
+    // NOT run once a classificationResponse exists, so any resulting
+    // deployment selection can only have come from the new effect.
+    const CLASSIFICATION_STATE = {
+      classificationResponse: {
+        issueType: "Bug",
+        severityLevel: "S2",
+        caseInfo: {},
+      },
+    };
+
+    it("auto-selects the deployment and reveals case details when there is exactly one deployment option, with no click needed", () => {
+      mockUseLocation.mockReturnValue({
+        pathname: "/projects/project-1/support/chat/create-case",
+        search: "",
+        state: CLASSIFICATION_STATE,
+      });
+      // beforeEach already mocks a single deployment ("Production") and a
+      // single product ("API Manager") for the selected deployment.
+      render(<CreateCasePage />);
+
+      // No "Select Deployment" click: the single option should be picked
+      // automatically, which is what unblocks Details/Watch List/Submit.
+      expect(
+        screen.getByText("Deployment value: Production"),
+      ).toBeInTheDocument();
+      expect(screen.getByText("Details Section")).toBeInTheDocument();
+      expect(screen.getByText("Watch List Section")).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /create support case/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("also switches to a newly-added deployment (not the classification-driven one) when arriving via Novera chat", () => {
+      // The Add Deployment wizard / override-on-create fix isn't gated by
+      // noAiMode at all, so it should behave identically whether the
+      // customer arrived via skipChat (Get Help / New Case) or via Novera
+      // chat's classification path - confirming that here rather than just
+      // asserting it by code inspection.
+      mockUseLocation.mockReturnValue({
+        pathname: "/projects/project-1/support/chat/create-case",
+        search: "",
+        state: CLASSIFICATION_STATE,
+      });
+      render(<CreateCasePage />);
+      expect(
+        screen.getByText("Deployment value: Production"),
+      ).toBeInTheDocument();
+
+      fireEvent.click(screen.getByText("Add Deployment CTA"));
+      fireEvent.click(screen.getByText("Submit Wizard Deployment Step (Staging)"));
+
+      expect(screen.getByText("Deployment value: Staging")).toBeInTheDocument();
+    });
+
+    it("auto-selects a pre-existing single deployment in skipChat mode too, not just right after adding one", async () => {
+      // Regression: the skipChat init effect used to unconditionally blank
+      // `deployment` on load, which meant a project's single PRE-EXISTING
+      // deployment never got picked here even though the general singleton
+      // effect handles every other flow - only the from-empty
+      // add-then-chain path (a different effect) got fixed for skipChat
+      // before. This is the plain "customer already has exactly one
+      // deployment, opens create-case via Get Help / New Case (both set
+      // skipChat: true)" case.
+      mockUseLocation.mockReturnValue({
+        pathname: "/projects/project-1/support/chat/create-case",
+        search: "",
+        state: { skipChat: true },
+      });
+      // beforeEach already mocks a single deployment ("Production").
+      render(<CreateCasePage />);
+
+      // The skipChat init effect defers its state updates to a queued
+      // microtask, so the value lands one tick after render, not
+      // synchronously.
+      await waitFor(() =>
+        expect(
+          screen.getByText("Deployment value: Production"),
+        ).toBeInTheDocument(),
+      );
+    });
+
+    it("does not auto-select the deployment when there are multiple options", () => {
+      mockUseLocation.mockReturnValue({
+        pathname: "/projects/project-1/support/chat/create-case",
+        search: "",
+        state: CLASSIFICATION_STATE,
+      });
+      mockDeploymentsQuery.mockReturnValue({
+        ...EMPTY_INFINITE_QUERY,
+        data: {
+          pages: [
+            {
+              deployments: [
+                { id: "dep-1", name: "Production" },
+                { id: "dep-2", name: "Staging" },
+              ],
+            },
+          ],
+        },
+      });
+
+      render(<CreateCasePage />);
+
+      // No option should be picked on the customer's behalf when there is
+      // more than one to choose from.
+      expect(
+        screen.getByText("Deployment value: (none)"),
+      ).toBeInTheDocument();
+    });
+
+    it("auto-selects the product when the selected deployment has exactly one product option", () => {
+      render(<CreateCasePage />);
+
+      fireEvent.click(screen.getByText("Select Deployment"));
+
+      // The single product should be auto-selected without a manual pick.
+      expect(
+        screen.getByText("Product value: prod-1"),
+      ).toBeInTheDocument();
+    });
+
+    it("does not auto-select the product when there are multiple product options for the selected deployment", () => {
+      mockDeploymentProductsQuery.mockReturnValue({
+        ...EMPTY_INFINITE_QUERY,
+        data: {
+          pages: [
+            {
+              products: [
+                {
+                  id: "prod-1",
+                  product: { label: "API Manager" },
+                  version: "4.2.0",
+                },
+                {
+                  id: "prod-2",
+                  product: { label: "Identity Server" },
+                  version: "6.0.0",
+                },
+              ],
+            },
+          ],
+        },
+      });
+
+      render(<CreateCasePage />);
+      fireEvent.click(screen.getByText("Select Deployment"));
+
+      // Multiple product options still resolve the form (options exist), but
+      // the product itself remains unpicked, matching prior behavior.
+      expect(screen.getByText("Details Section")).toBeInTheDocument();
+      expect(
+        screen.getByText("Product value: (none)"),
+      ).toBeInTheDocument();
+    });
+
+    it("re-evaluates the product auto-select for the new deployment's option list after the deployment changes", () => {
+      render(<CreateCasePage />);
+
+      // First deployment resolves to a single product ("API Manager") from
+      // the default beforeEach mock; confirm it auto-selects.
+      fireEvent.click(screen.getByText("Select Deployment"));
+      expect(
+        screen.getByText("Product value: prod-1"),
+      ).toBeInTheDocument();
+
+      // Now the deployment's product list is refreshed to multiple options
+      // (simulating navigating to a different deployment whose products
+      // just loaded). Re-selecting the deployment goes through
+      // handleDeploymentChange, which resets `product` to "" so the
+      // singleton effect re-evaluates against the *new* list rather than
+      // keeping the stale auto-selected value.
+      mockDeploymentProductsQuery.mockReturnValue({
+        ...EMPTY_INFINITE_QUERY,
+        data: {
+          pages: [
+            {
+              products: [
+                {
+                  id: "prod-1",
+                  product: { label: "API Manager" },
+                  version: "4.2.0",
+                },
+                {
+                  id: "prod-2",
+                  product: { label: "Identity Server" },
+                  version: "6.0.0",
+                },
+              ],
+            },
+          ],
+        },
+      });
+
+      fireEvent.click(screen.getByText("Select Deployment"));
+
+      expect(
+        screen.getByText("Product value: (none)"),
+      ).toBeInTheDocument();
+    });
+
+    it("undoes an auto-selection if the product list turns out to have more than one option after all (e.g. resolves incrementally right after adding two products)", () => {
+      // Starts as a genuine singleton (matches beforeEach's default single
+      // product), so it auto-selects first, same as any other case.
+      const { rerender } = render(<CreateCasePage />);
+      fireEvent.click(screen.getByText("Select Deployment"));
+      expect(
+        screen.getByText("Product value: prod-1"),
+      ).toBeInTheDocument();
+
+      // The list then resolves to a second product (e.g. the wizard's
+      // second "Add another product" catching up). The auto-picked value
+      // must be reverted so the user gets a real choice, not left stuck on
+      // whichever one happened to load first.
+      mockDeploymentProductsQuery.mockReturnValue({
+        ...EMPTY_INFINITE_QUERY,
+        data: {
+          pages: [
+            {
+              products: [
+                { id: "prod-1", product: { label: "API Manager" }, version: "4.2.0" },
+                { id: "prod-2", product: { label: "Identity Server" }, version: "6.0.0" },
+              ],
+            },
+          ],
+        },
+      });
+      rerender(<CreateCasePage />);
+
+      expect(
+        screen.getByText("Product value: (none)"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("CUSTOMER_PORTAL_ALLOW_DEPLOYMENT_SETUP_DURING_CASE_CREATION kill switch", () => {
+    afterEach(() => {
+      window.config = {
+        ...window.config,
+        CUSTOMER_PORTAL_ALLOW_DEPLOYMENT_SETUP_DURING_CASE_CREATION: undefined,
+      };
+    });
+
+    it("falls back to the legacy disabled dropdown, no alert/CTA, and never blocks the form, when explicitly disabled", () => {
+      window.config = {
+        ...window.config,
+        CUSTOMER_PORTAL_ALLOW_DEPLOYMENT_SETUP_DURING_CASE_CREATION: false,
+      };
+      mockDeploymentsQuery.mockReturnValue(EMPTY_INFINITE_QUERY);
+
+      render(<CreateCasePage />);
+
+      expect(screen.queryByText("Add Deployment CTA")).not.toBeInTheDocument();
+      expect(
+        screen.queryByText("Add Deployment Wizard"),
+      ).not.toBeInTheDocument();
+      // Legacy behavior: the form is never blocked, even with zero
+      // deployments, when the feature is switched off.
+      expect(screen.getByText("Details Section")).toBeInTheDocument();
+      expect(screen.getByText("Watch List Section")).toBeInTheDocument();
+    });
+
+    it("does not auto-select a single deployment when disabled", async () => {
+      window.config = {
+        ...window.config,
+        CUSTOMER_PORTAL_ALLOW_DEPLOYMENT_SETUP_DURING_CASE_CREATION: false,
+      };
+      mockUseLocation.mockReturnValue({
+        pathname: "/projects/project-1/support/chat/create-case",
+        search: "",
+        state: { skipChat: true },
+      });
+      // beforeEach already mocks a single deployment ("Production").
+      render(<CreateCasePage />);
+
+      await waitFor(() =>
+        expect(
+          screen.getByText("Deployment value: (none)"),
+        ).toBeInTheDocument(),
+      );
+    });
   });
 });
 

--- a/apps/customer-portal/webapp/src/features/support/pages/__tests__/CreateCasePage.test.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/__tests__/CreateCasePage.test.tsx
@@ -55,8 +55,15 @@ vi.mock("@api/useGetProjectFeatures", () => ({
   default: () => ({ data: {}, isLoading: false }),
 }));
 
+const mockProjectFilters = vi.fn(() => ({
+  data: {
+    issueTypes: [] as { id: string; label: string }[],
+    severities: [] as { id: string; label: string }[],
+  },
+  isLoading: false,
+}));
 vi.mock("@api/useGetProjectFilters", () => ({
-  default: () => ({ data: { issueTypes: [], severities: [] }, isLoading: false }),
+  default: () => mockProjectFilters(),
 }));
 
 const mockDeploymentsQuery = vi.fn();
@@ -141,11 +148,21 @@ vi.mock(
       setDeployment?: (value: string) => void;
       onAddDeployment?: () => void;
       onAddProduct?: () => void;
+      isDeploymentAutoDetected?: boolean;
+      isProductAutoDetected?: boolean;
+      isDeploymentLoading?: boolean;
+      isProductLoading?: boolean;
     }) => (
       <div>
         Basic Section
         <div>Deployment value: {props.deployment || "(none)"}</div>
         <div>Product value: {props.product || "(none)"}</div>
+        <div>
+          Deployment auto detected: {String(!!props.isDeploymentAutoDetected)}
+        </div>
+        <div>Product auto detected: {String(!!props.isProductAutoDetected)}</div>
+        <div>Deployment loading: {String(!!props.isDeploymentLoading)}</div>
+        <div>Product loading: {String(!!props.isProductLoading)}</div>
         {props.setDeployment && (
           <button onClick={() => props.setDeployment?.("Production")}>
             Select Deployment
@@ -505,6 +522,65 @@ describe("CreateCasePage", () => {
       expect(
         screen.getByRole("button", { name: /create support case/i }),
       ).toBeInTheDocument();
+
+      // Regression: a singleton auto-select is not the same thing as an
+      // AI-classification "detection" - reusing the same "Auto detected"
+      // chip for both was misleading, since nothing was actually detected
+      // here, it was just the only option.
+      expect(
+        screen.getByText("Deployment auto detected: false"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("Product auto detected: false"),
+      ).toBeInTheDocument();
+    });
+
+    it("does not mask an already-loaded product behind a loading skeleton just because classification's page search is still in flight", () => {
+      // Regression: adding a product to a deployment while Novera's
+      // classification suggested some (unrelated/not-yet-matched) product
+      // name used to keep the product field stuck in a loading state -
+      // masking the just-added product - until something else reset the
+      // classification-pending flags (e.g. re-picking the deployment).
+      // The classification-apply effect requires a non-empty severities
+      // list to run at all.
+      mockProjectFilters.mockReturnValue({
+        data: {
+          issueTypes: [],
+          severities: [{ id: "sev-2", label: "S2" }],
+        },
+        isLoading: false,
+      });
+      mockUseLocation.mockReturnValue({
+        pathname: "/projects/project-1/support/chat/create-case",
+        search: "",
+        state: {
+          classificationResponse: {
+            issueType: "Bug",
+            severityLevel: "S2",
+            caseInfo: { productName: "Some Other Product Not In The List" },
+          },
+        },
+      });
+      // The deployment's product query still has more pages left to search
+      // for that classification-suggested product, but a real product has
+      // already arrived on the first page - it must not be hidden.
+      mockDeploymentProductsQuery.mockReturnValue({
+        ...EMPTY_INFINITE_QUERY,
+        hasNextPage: true,
+        data: {
+          pages: [
+            {
+              products: [
+                { id: "prod-1", product: { label: "API Manager" }, version: "4.2.0" },
+              ],
+            },
+          ],
+        },
+      });
+
+      render(<CreateCasePage />);
+
+      expect(screen.getByText("Product loading: false")).toBeInTheDocument();
     });
 
     it("also switches to a newly-added deployment (not the classification-driven one) when arriving via Novera chat", () => {

--- a/apps/customer-portal/webapp/src/features/support/pages/__tests__/CreateCasePage.test.tsx
+++ b/apps/customer-portal/webapp/src/features/support/pages/__tests__/CreateCasePage.test.tsx
@@ -112,13 +112,15 @@ vi.mock("@tanstack/react-query", async (importOriginal) => {
   };
 });
 
+const mockShouldRestrictToPrimaryProductionDeployments = vi.fn(() => false);
 vi.mock("@utils/permission", () => ({
   filterDeploymentsForCaseCreation: (items: unknown[]) => items ?? [],
   getProjectSeverityPolicy: () => ({
     excludeS0: false,
     restrictSeverityToLow: false,
   }),
-  shouldRestrictToPrimaryProductionDeployments: () => false,
+  shouldRestrictToPrimaryProductionDeployments: () =>
+    mockShouldRestrictToPrimaryProductionDeployments(),
 }));
 
 vi.mock("@features/support/components/case-creation-layout/header/CaseCreationHeader", () => ({
@@ -830,6 +832,37 @@ describe("CreateCasePage", () => {
           screen.getByText("Deployment value: (none)"),
         ).toBeInTheDocument(),
       );
+    });
+  });
+
+  describe("Cloud Support / Cloud Evaluation Support projects (locked to Primary Production)", () => {
+    afterEach(() => {
+      // mockReturnValue persists across tests (clearAllMocks doesn't reset
+      // it), so restore the default explicitly.
+      mockShouldRestrictToPrimaryProductionDeployments.mockReturnValue(false);
+    });
+
+    it("does not offer Add Product for a fixed-deployment project, since it doesn't offer Add Deployment either", () => {
+      mockShouldRestrictToPrimaryProductionDeployments.mockReturnValue(true);
+      // A project locked to Primary Production has no deployment field at
+      // all (hideDeploymentField), so there is never an "Add Deployment
+      // CTA" to click here - only confirming "Add Product CTA" is also
+      // absent.
+      render(<CreateCasePage />);
+
+      expect(
+        screen.queryByText("Add Product CTA"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("does not block the form on an empty product list either, since there's no way to add one", () => {
+      mockShouldRestrictToPrimaryProductionDeployments.mockReturnValue(true);
+      mockDeploymentProductsQuery.mockReturnValue(EMPTY_INFINITE_QUERY);
+
+      render(<CreateCasePage />);
+
+      expect(screen.getByText("Details Section")).toBeInTheDocument();
+      expect(screen.getByText("Watch List Section")).toBeInTheDocument();
     });
   });
 });

--- a/apps/customer-portal/webapp/src/features/support/types/supportComponents.ts
+++ b/apps/customer-portal/webapp/src/features/support/types/supportComponents.ts
@@ -184,6 +184,19 @@ export type BasicInformationSectionProps = {
   onLoadMoreProducts?: () => void;
   hasMoreProducts?: boolean;
   isFetchingMoreProducts?: boolean;
+  /**
+   * Called when the customer has no deployments configured and clicks the
+   * "Add Deployment" call-to-action shown in place of the empty dropdown.
+   * When omitted, the legacy disabled-dropdown placeholder is shown instead.
+   */
+  onAddDeployment?: () => void;
+  /**
+   * Called when the selected deployment has no products configured and the
+   * customer clicks the "Add Product" call-to-action shown in place of the
+   * empty dropdown. When omitted, the legacy disabled-dropdown placeholder
+   * is shown instead.
+   */
+  onAddProduct?: () => void;
   children?: React.ReactNode;
 };
 

--- a/apps/customer-portal/webapp/src/features/support/utils/__tests__/caseCreation.test.ts
+++ b/apps/customer-portal/webapp/src/features/support/utils/__tests__/caseCreation.test.ts
@@ -27,6 +27,8 @@ import {
   isUnknownPlaceholderProductLabel,
   getBaseDeploymentOptions,
   formatChatHistoryForClassification,
+  isDeploymentDropdownEmpty,
+  isProductDropdownEmpty,
 } from "@features/support/utils/caseCreation";
 import { ChatSender } from "@features/support/types/conversations";
 import type { DeploymentProductItem } from "@features/project-details/types/deployments";
@@ -452,6 +454,44 @@ describe("caseCreation utils", () => {
 
     it("returns empty array for undefined", () => {
       expect(getBaseDeploymentOptions(undefined)).toEqual([]);
+    });
+  });
+
+  describe("isDeploymentDropdownEmpty", () => {
+    it("is true when loaded, disabled=false, and there are zero options", () => {
+      expect(isDeploymentDropdownEmpty([], false, false)).toBe(true);
+    });
+
+    it("is false while still loading", () => {
+      expect(isDeploymentDropdownEmpty([], true, false)).toBe(false);
+    });
+
+    it("is false when options are present", () => {
+      expect(isDeploymentDropdownEmpty(["Production"], false, false)).toBe(
+        false,
+      );
+    });
+
+    it("is false when the field is intentionally disabled", () => {
+      expect(isDeploymentDropdownEmpty([], false, true)).toBe(false);
+    });
+  });
+
+  describe("isProductDropdownEmpty", () => {
+    it("is true when not disabled, not loading, and there are no product options", () => {
+      expect(isProductDropdownEmpty(false, false, false)).toBe(true);
+    });
+
+    it("is false while still loading", () => {
+      expect(isProductDropdownEmpty(false, false, true)).toBe(false);
+    });
+
+    it("is false when the dropdown is disabled (e.g. no deployment selected yet)", () => {
+      expect(isProductDropdownEmpty(false, true, false)).toBe(false);
+    });
+
+    it("is false when product options are present", () => {
+      expect(isProductDropdownEmpty(true, false, false)).toBe(false);
     });
   });
 });

--- a/apps/customer-portal/webapp/src/features/support/utils/caseCreation.ts
+++ b/apps/customer-portal/webapp/src/features/support/utils/caseCreation.ts
@@ -436,3 +436,44 @@ export function getBaseDeploymentOptions(
     []
   );
 }
+
+/**
+ * Determines whether the deployment dropdown has resolved with zero options,
+ * i.e. the project has no self-service deployments configured yet. Used to
+ * show a helpful empty-state instead of a blank `<select>` during case
+ * creation.
+ *
+ * @param {string[]} deploymentOptions - Resolved deployment options.
+ * @param {boolean} isDeploymentLoading - Whether deployments are still loading.
+ * @param {boolean} isDeploymentDisabled - Whether the deployment field is intentionally disabled (e.g. locked to a single value).
+ * @returns {boolean} True when the deployment list has resolved empty.
+ */
+export function isDeploymentDropdownEmpty(
+  deploymentOptions: string[],
+  isDeploymentLoading: boolean,
+  isDeploymentDisabled: boolean,
+): boolean {
+  return (
+    !isDeploymentLoading &&
+    deploymentOptions.length === 0 &&
+    !isDeploymentDisabled
+  );
+}
+
+/**
+ * Determines whether the product dropdown has resolved with zero options for
+ * the currently selected deployment. Used to show a helpful empty-state
+ * instead of a blank `<select>` during case creation.
+ *
+ * @param {boolean} hasProductOptions - Whether the resolved product option list is non-empty.
+ * @param {boolean} isProductDropdownDisabled - Whether the product field is disabled (e.g. no deployment selected yet, or still loading).
+ * @param {boolean} isProductLoading - Whether products are still loading.
+ * @returns {boolean} True when the product list has resolved empty for the selected deployment.
+ */
+export function isProductDropdownEmpty(
+  hasProductOptions: boolean,
+  isProductDropdownDisabled: boolean,
+  isProductLoading: boolean,
+): boolean {
+  return !hasProductOptions && !isProductDropdownDisabled && !isProductLoading;
+}


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

When a customer creates a support case for a project with no deployments configured (or a deployment with no products), the deployment/product dropdowns rendered as empty, unlabeled `<select>` boxes with no explanation and no way forward — a dead end. Read-only audit of `wso2.service-now.com`: ~4.8% of active projects have zero deployments, and ~6.5% of active+deployed projects belong to an account with zero deployed products, so this affects a meaningful slice of real customers.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

- Replace the empty dropdown with an inline warning alert explaining what's missing and why it's needed, with a CTA to add one.
- Let the customer add a deployment/product without leaving the case-creation page (previously required navigating to the project's Deployments tab).
- Chain "add my first deployment" straight into "add its first product" as one continuous two-step wizard, since a brand-new deployment always starts with zero products.
- Support adding multiple products in one sitting instead of one-then-close.
- Auto-select a deployment/product when there's genuinely only one option, instead of forcing a pointless manual click.
- Ship behind a kill-switch config flag (default on) so the whole feature can be turned off instantly if something goes wrong in production, with no further deploy needed.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

- `apps/customer-portal/webapp/src/features/support/components/case-creation-layout/form-sections/basic-information-section/BasicInformationSection.tsx`: when a dropdown's option list is empty, hide the `<Select>` and show a `warning` `Alert` with a two-line message + "Add Deployment"/"Add Product" action. When options exist, an "Add Deployment"/"Add Product" row is available inside the dropdown's own menu (after a divider), so it stays reachable while the menu is open. `EmptyState.tsx` gained an optional `secondaryDescription` prop, reused by other existing empty states.
- `apps/customer-portal/webapp/src/features/project-details/components/deployments/AddDeploymentWizardModal.tsx` (new): a single `Dialog` with a real `Stepper` — step 1 creates the deployment, step 2 lets the customer add one or more products ("Add another product" / "Done"), reusing the same paginated product/version search extracted from `AddProductModal.tsx` into `useProductForm.ts` + `ProductFormFields.tsx` (one source of truth for both).
- `apps/customer-portal/webapp/src/features/support/pages/CreateCasePage.tsx`: "Add Deployment" always opens the wizard now (every new deployment starts with zero products, whether it's the project's first or an additional one); a newly-created deployment always overrides whatever was previously selected; singleton auto-select effects for deployment/product, with a defensive guard that reverts an auto-pick if the option list turns out to have more than one item after all (covers a query-timing race right after adding two products in a row).
- `CUSTOMER_PORTAL_CASE_CREATION_EMPTY_STATE_ENABLED` (`public/config.js`, default `true`) gates the entire feature; disabling it reverts to the exact legacy behavior (disabled dropdown, no alert, form never blocked).
- No screenshot attached here — this was iterated live against the deployed STG environment during development; happy to add one on request before merge.

## User stories
> Summary of user stories addressed by this change

As a customer with no deployments/products configured, when I try to create a support case, I want to understand why the dropdown is empty and be able to fix it without leaving the page, so I can actually submit my case.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Case creation now guides customers who haven't configured a deployment or product yet, letting them add one (or several) inline instead of hitting a dead-end empty dropdown.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

N/A — this is customer-portal (customer-facing), which does not have an in-repo user-guide doc set the way the internal CSM portal does.

## Training
N/A — no training-content change.

## Certification
N/A — no certification exam impact.

## Marketing
N/A — no marketing content for this incremental UX fix.

## Automation tests
 - Unit tests
   > Code coverage information

   New/updated Vitest coverage across the touched components: `BasicInformationSection.test.tsx`, `CreateCasePage.test.tsx`, `EmptyState.test.tsx`, `AddProductModal.test.tsx`, and a new `AddDeploymentWizardModal.test.tsx` (none existed for that component before). All pass; the pre-existing repo-wide baseline of failing tests in `src/features/support` (47) and `src/features/project-details` (47) is unchanged by this PR.
 - Integration tests
   > Details about the test cases and coverage

   No dedicated integration-test suite exists for this app; verified manually against the deployed STG backend (`customer-portal-backend`) with real Asgardeo auth.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — this is a TypeScript/React frontend, not a Java component FindSecurityBugs applies to.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
None

## Migrations (if applicable)
N/A — no data migration; purely additive frontend behavior gated by a config flag.

## Test environment
Verified against the deployed Choreo STG `customer-portal-backend` and real Asgardeo login, from a local `pnpm dev` webapp build (Node 20, macOS). No specific browser/DB version dependency.

## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

Researched the actual deployment/product data model by reading the real `CreateCasePage.tsx` hooks rather than assuming the older SN scoped-app scripts (`x_wso2_customer_0`) still applied — confirmed products are deployment-scoped in the current API, not account-scoped as the legacy scripts suggested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inline deployment and product setup during case creation, including a guided deployment wizard and product additions.
  * Added alerts and “Add” actions when deployment or product options are unavailable.
  * Automatically selects the sole available deployment or product.
  * Added support for opening project details on a specified tab.
  * Added an optional configuration setting to enable or disable inline setup.

* **Bug Fixes**
  * Prevented case forms from becoming unusable when setup options are unavailable.
  * Preserved product options when adding multiple products or reopening the product form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->