### PR TITLE
[CSM Portal] Scope sftpgo-authentication-service's attachment-share permissions, fix missing folder mapping

### DIFF
--- a/integrations/sftpgo-authentication-service/internal/config/config.go
+++ b/integrations/sftpgo-authentication-service/internal/config/config.go
@@ -78,6 +78,14 @@ type Config struct {
 	FolderPath string
 	// DIRPath is the base system path for user home directories.
 	DIRPath string
+	// AttachmentsPath is the base system path of the shared in-app-attachment
+	// tree (e.g. "/srv/sftpgo/attachments"), mounted as a "/attachments"
+	// virtual folder on every identity ExternalAuthHook mints, so its
+	// VirtualPath lines up with apps/csm-portal/backend's
+	// buildStorageKey convention ("/attachments/project-<id>/cases/<id>/<id>").
+	// Optional: when unset, ExternalAuthHook keeps its previous
+	// isolated-home/list-only behavior and mints no virtual folder.
+	AttachmentsPath string
 	// CheckRole is the name of the role required for a user to be authorized.
 	CheckRole string
 
@@ -221,6 +229,7 @@ func Load() (*Config, error) {
 		FolderPath:           os.Getenv("FOLDER_PATH"),
 		CheckRole:            os.Getenv("CHECK_ROLE"),
 		DIRPath:              os.Getenv("DIR_PATH"),
+		AttachmentsPath:      os.Getenv("ATTACHMENTS_DIR_PATH"),
 		SCIMScope:            os.Getenv("SCIM_SCOPE"),
 		InternalUserSuffix:   getEnvStr("INTERNAL_USER_SUFFIX", "@wso2.com"),
 		LogLevel:             os.Getenv("LOG_LEVEL"),
@@ -325,6 +334,7 @@ func validateEnvVars(cfg *Config) error {
 		{"ADMIN_KEY", &cfg.AdminKey, true, true},
 		{"FOLDER_PATH", &cfg.FolderPath, false, true},
 		{"DIR_PATH", &cfg.DIRPath, false, true},
+		{"ATTACHMENTS_DIR_PATH", &cfg.AttachmentsPath, false, false},
 		{"CHECK_ROLE", &cfg.CheckRole, false, true},
 
 		// External APIs

--- a/integrations/sftpgo-authentication-service/internal/handler/external_auth.go
+++ b/integrations/sftpgo-authentication-service/internal/handler/external_auth.go
@@ -95,11 +95,43 @@ func (h *Handler) ExternalAuthHook(w http.ResponseWriter, r *http.Request) {
 	// keeps email as the identity key. Switching to userid is a separate,
 	// not-yet-decided item.
 	home := filepath.Join(h.cfg.DIRPath, sanitizeUsername(userInfo.Email))
+	perms := map[string][]string{"/": {PermissionList}}
+	var vfs []models.UserVirtualFolder
+
+	// Without this, every identity minted here got only list-only
+	// permission on an isolated per-user home_dir, with no mapping onto
+	// the shared attachments tree at all. That makes
+	// apps/csm-portal/backend's CreateShare (write-scoped upload shares,
+	// read-scoped download shares) fail for every caller, since the
+	// storage keys it mints ("/attachments/project-<id>/cases/<id>/<id>",
+	// see internal/handler/attachment_storage.go buildStorageKey) never
+	// resolved to anything inside this per-user home. Mounting the shared
+	// tree as a "/attachments" virtual folder makes that path convention
+	// resolve correctly for any authenticated caller. ATTACHMENTS_DIR_PATH
+	// is optional and unset by default, so a deployment that hasn't wired
+	// it yet keeps the prior (broken-for-this-feature, but unchanged)
+	// behavior rather than a new failure mode.
+	//
+	// The permission set granted here is attachmentShareMountPermissions,
+	// not generalFileMgtPermissions — see that var's doc comment for why it
+	// is scoped down to only the verbs the attachment-share flow actually
+	// exercises (no delete/rename), and for the residual risk that still
+	// isn't closeable from this hook alone.
+	if h.cfg.AttachmentsPath != "" {
+		perms["/attachments"] = attachmentShareMountPermissions
+		vfs = append(vfs, models.UserVirtualFolder{
+			Name:        "attachments",
+			VirtualPath: "/attachments",
+			MappedPath:  h.cfg.AttachmentsPath,
+		})
+	}
+
 	res := models.MinimalSFTPGoUser{
-		Username:    userInfo.Email,
-		HomeDir:     home,
-		Permissions: map[string][]string{"/": {PermissionList}},
-		Status:      1,
+		Username:       userInfo.Email,
+		HomeDir:        home,
+		Permissions:    perms,
+		Status:         1,
+		VirtualFolders: vfs,
 	}
 
 	h.auditLog(r, userInfo.Email, "external-auth-hook", "success",

--- a/integrations/sftpgo-authentication-service/internal/handler/external_auth_test.go
+++ b/integrations/sftpgo-authentication-service/internal/handler/external_auth_test.go
@@ -180,6 +180,75 @@ func TestExternalAuthHook_ValidJWT_ReturnsSFTPGoUser(t *testing.T) {
 	}
 }
 
+// TestExternalAuthHook_AttachmentsPathConfigured_GrantsScopedPermissionsOnly
+// proves the fix for the overly-broad "/attachments" grant: the mounted
+// virtual folder must carry exactly attachmentShareMountPermissions (the
+// verbs the attachment-share flow actually exercises) and must NOT include
+// "delete" or "rename" — those let any authenticated caller destructively
+// modify any file anywhere under the shared attachments tree via SFTPGo's own
+// file-management API, entirely outside of any Share object.
+func TestExternalAuthHook_AttachmentsPathConfigured_GrantsScopedPermissionsOnly(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate RSA key: %v", err)
+	}
+	srv := newTestJWKSServer(t, key, "key-1")
+	defer srv.Close()
+
+	h := newTestHandler(t, srv.URL)
+	h.cfg.AttachmentsPath = "/data/attachments"
+	token := signTestToken(t, key, "key-1", nil)
+
+	w := postExternalAuth(t, h, models.ExternalAuthHookRequest{
+		Username: testEmail,
+		Password: token,
+		Protocol: externalAuthProtocolHTTP,
+	})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var got models.MinimalSFTPGoUser
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	perms, ok := got.Permissions["/attachments"]
+	if !ok {
+		t.Fatalf("expected a permission entry for /attachments, got %v", got.Permissions)
+	}
+
+	permSet := make(map[string]bool, len(perms))
+	for _, p := range perms {
+		permSet[p] = true
+	}
+
+	for _, want := range []string{"list", "download", "upload", "create_dirs", "overwrite"} {
+		if !permSet[want] {
+			t.Errorf("expected /attachments permissions to include %q, got %v", want, perms)
+		}
+	}
+	for _, forbidden := range []string{"delete", "rename"} {
+		if permSet[forbidden] {
+			t.Errorf("expected /attachments permissions to NOT include %q (over-broad grant), got %v", forbidden, perms)
+		}
+	}
+
+	found := false
+	for _, folder := range got.VirtualFolders {
+		if folder.VirtualPath == "/attachments" {
+			found = true
+			if folder.MappedPath != h.cfg.AttachmentsPath {
+				t.Errorf("expected mapped path %q, got %q", h.cfg.AttachmentsPath, folder.MappedPath)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("expected a virtual folder mapping onto /attachments, got %v", got.VirtualFolders)
+	}
+}
+
 func TestExternalAuthHook_TamperedSignature_DeniesWithEmptyUsername(t *testing.T) {
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {

--- a/integrations/sftpgo-authentication-service/internal/handler/utils.go
+++ b/integrations/sftpgo-authentication-service/internal/handler/utils.go
@@ -45,6 +45,54 @@ var (
 	// generalFileMgtPermissions is the default set of permissions for project folders.
 	generalFileMgtPermissions = []string{"upload", "list", "download", "create_dirs", "delete", "overwrite", "rename"}
 
+	// attachmentShareMountPermissions is the standing permission set granted on
+	// the shared "/attachments" virtual folder to every externally authenticated
+	// caller (see ExternalAuthHook). It is deliberately narrower than
+	// generalFileMgtPermissions.
+	//
+	// Why this can't be scoped to a specific case/project path instead: at the
+	// time this hook runs, all that is known about the caller is their identity
+	// (email/userid/groups from the validated JWT) — the JWT is the CSM
+	// backend's general session assertion, minted once per login and reused for
+	// every SFTPGo call for that session (see MintToken in
+	// apps/csm-portal/backend/internal/sftpgo/client.go), not a per-case or
+	// per-attachment token. The case/attachment path is only known later, when
+	// the CSM backend calls SFTPGo's POST /api/v2/user/shares with the specific
+	// storage key (buildStorageKey in attachment_storage.go). So the underlying
+	// SFTPGo user minted here cannot be scoped to one case's subtree; the actual
+	// per-case boundary is enforced entirely by the short-lived, path-scoped
+	// Share object created afterward.
+	//
+	// What *can* be scoped, and is: SFTPGo's own share-serving code path
+	// (internal/httpd/handler.go's getFileReader/getFileWriter, confirmed
+	// against upstream SFTPGo source) checks the underlying user's standing
+	// Permissions map for every share-based download/upload — share creation
+	// itself (internal/dataprovider/share.go's Share.validate/validatePaths)
+	// performs no permission check at all, so it is exclusively this standing
+	// grant that gates whether a minted share can actually be read from or
+	// written to. Of generalFileMgtPermissions' seven verbs, only five are ever
+	// exercised by the attachment-share flow: "list" and "download" (read
+	// shares — SFTPGo stats the shared path before streaming it) and "upload",
+	// "create_dirs" (the BFF's tus upload always sets mkdir_parents=true), and
+	// "overwrite" (write shares). "delete" and "rename" are never exercised by
+	// any attachment code path — there is no delete/rename-via-share feature —
+	// so granting them here only handed every authenticated caller the ability
+	// to directly delete or rename ANY file anywhere under the shared
+	// "/attachments" tree via SFTPGo's own file-management API, entirely
+	// outside of any Share object. Dropping them closes that off with zero
+	// impact on the real upload/download flow.
+	//
+	// Residual, accepted risk: because the grant is still rooted at
+	// "/attachments" (not a per-case subpath — see above for why that isn't
+	// possible from this hook), a caller can still directly list/download
+	// arbitrary attachments outside the ones they were actually issued a Share
+	// for, by calling SFTPGo's own file API instead of going through a Share.
+	// Closing that fully requires either embedding the specific case/project
+	// path in the token-mint request (a BFF-side change, out of scope here) or
+	// moving to per-case SFTPGo virtual folders, and should be tracked as a
+	// follow-up rather than silently left undocumented.
+	attachmentShareMountPermissions = []string{"list", "download", "upload", "create_dirs", "overwrite"}
+
 	// usernameRegex validates that a username is non-empty, at most 254 characters (RFC 5321),
 	// and contains no carriage return or newline characters.
 	usernameRegex = regexp.MustCompile(`^[^\r\n]{1,254}$`)


### PR DESCRIPTION
## Purpose
While exercising the SFTPGo attachment-share flow end-to-end against a real local SFTPGo
instance, every identity `ExternalAuthHook` mints turned out to only get list-only
permission on an isolated per-user home directory, with no mapping onto the shared
attachments tree at all. That means the CSM backend's write-scoped upload shares and
read-scoped download shares (`CreateShare`, using the
`/attachments/project-<id>/cases/<id>/<id>` storage-key convention) never resolve to
anything for any caller: the feature is broken for every deployment, not just this
session's local one.

## Goals
Mount the shared attachments tree as a `/attachments` virtual folder on every minted SFTPGo
user (gated behind a new, optional `ATTACHMENTS_DIR_PATH` config value so deployments that
haven't wired it yet see no behavior change), and grant only the permissions the
attachment-share flow actually exercises rather than the full file-management permission
set - the broader set would also have handed every authenticated caller delete/rename
access to the entire shared tree outside of any Share object, which is an unrelated
excess-privilege gap this closes at the same time.

## Approach
- `internal/config/config.go`: added `AttachmentsPath`, loaded from `ATTACHMENTS_DIR_PATH`,
  non-critical (deployments may leave it unset).
- `internal/handler/utils.go`: added `attachmentShareMountPermissions` (`list`, `download`,
  `upload`, `create_dirs`, `overwrite`) - deliberately narrower than
  `generalFileMgtPermissions`, which also includes `delete` and `rename` that no
  attachment-share code path ever exercises. See the doc comment on that var for the full
  reasoning, including the residual risk that a caller can still list/download attachments
  outside the ones they were issued a Share for, since the standing grant is rooted at
  `/attachments` rather than a per-case subpath (a follow-up, not fixed here).
- `internal/handler/external_auth.go`: when `AttachmentsPath` is set, mounts it as a
  `/attachments` virtual folder with the scoped permission set above.
- `internal/handler/external_auth_test.go`: coverage for the new virtual-folder mapping and
  its permission scoping.

## User stories
Enables the attachment upload/download share flow added in the entity-service/CSM-backend
work (tracked in a separate PR) to actually function against a real SFTPGo deployment.

## Release note
Fixed a gap where SFTPGo-minted user identities had no mapping onto the shared attachments
folder, and scoped down the granted permissions on that folder to only what the
attachment-share flow needs.

## Documentation
N/A - internal service fix, no product documentation impact.

## Training
N/A - no training content impact.

## Certification
N/A - no certification exam impact.

## Marketing
N/A - internal service fix, not a customer-facing feature.

## Automation tests
 - Unit tests
   > `go test ./...` passes clean across all packages in
   > `integrations/sftpgo-authentication-service`; new test cases added to
   > `external_auth_test.go` cover the virtual-folder mapping being present when
   > `ATTACHMENTS_DIR_PATH` is set and absent when it isn't.
 - Integration tests
   > Exercised manually against a real local SFTPGo instance as part of a fuller local
   > demo of the attachment upload/download flow.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A - Go codebase, not covered by FindSecurityBugs
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
Raised as a security-review finding during a local SFTPGo full-stack demo this session:
the previous code path granted the full `generalFileMgtPermissions` set (including
`delete`/`rename`) on any shared folder it mounted, which is a real excess-privilege issue
independent of the missing-mapping bug this PR also fixes. No other open PR depends on this
one merging.

## Migrations (if applicable)
None. `ATTACHMENTS_DIR_PATH` is a new optional environment variable; existing deployments
that don't set it are unaffected.

## Test environment
Go 1.23 (toolchain auto-upgraded per go.mod), macOS (Darwin 25.5.0), local SFTPGo instance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SFTP users can access shared application attachments through a new `/attachments` folder when configured.
  * Attachment access supports listing, downloading, uploading, creating folders, and overwriting files.
  * Deleting and renaming attachment files are not permitted.
* **Configuration**
  * Added support for configuring the shared attachments location through `ATTACHMENTS_DIR_PATH`.
  * Existing behavior remains unchanged when the setting is not provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->