### PR TITLE
[Customer Entity]Implement Postgres data source for account endpoints - unify account response shape

### DIFF
--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -277,10 +277,10 @@ type AccountView struct {
 	RenewalAccountManager *PersonRef `json:"renewalAccountManager"`
 	// CreTeam is the account's CRE (customer relationship engineering) team, resolved to a
 	// named group reference (ServiceNow data source only). Mirrors AccountRef.CreTeam.
-	CreTeam *EntityRef `json:"creTeam,omitempty"`
+	CreTeam *EntityRef `json:"creTeam"`
 	// SreTeam is the account's SRE team, resolved to a named group reference (ServiceNow
 	// data source only). Mirrors AccountRef.SreTeam.
-	SreTeam          *EntityRef `json:"sreTeam,omitempty"`
+	SreTeam          *EntityRef `json:"sreTeam"`
 	ActivationDate   *string    `json:"activationDate"`
 	DeactivationDate *string    `json:"deactivationDate"`
 	HasAgent         bool       `json:"hasAgent"`
@@ -323,10 +323,10 @@ type AccountDetail struct {
 	RenewalAccountManager *PersonRef        `json:"renewalAccountManager"`
 	// CreTeam is the account's CRE (customer relationship engineering) team, resolved to a
 	// named group reference (ServiceNow data source only). Mirrors AccountRef.CreTeam.
-	CreTeam *EntityRef `json:"creTeam,omitempty"`
+	CreTeam *EntityRef `json:"creTeam"`
 	// SreTeam is the account's SRE team, resolved to a named group reference (ServiceNow
 	// data source only). Mirrors AccountRef.SreTeam.
-	SreTeam          *EntityRef `json:"sreTeam,omitempty"`
+	SreTeam          *EntityRef `json:"sreTeam"`
 	ActivationDate   *string    `json:"activationDate"`
 	DeactivationDate *string    `json:"deactivationDate"`
 	HasAgent         bool       `json:"hasAgent"`

--- a/entity-service/internal/domain/entity.go
+++ b/entity-service/internal/domain/entity.go
@@ -244,34 +244,6 @@ type PatchUserMeResponse struct {
 	User    PatchUserMeUpdated `json:"user"`
 }
 
-// AccountTier represents the subscription tier of an account.
-type AccountTier string
-
-const (
-	// AccountTierBasic is the standard subscription tier.
-	AccountTierBasic AccountTier = "basic"
-	// AccountTierEnterprise is the premium subscription tier.
-	AccountTierEnterprise AccountTier = "enterprise"
-)
-
-// Account represents a customer account as stored in the database.
-// TechnicalOwnerID, Region, and DeactivationDate are optional.
-type Account struct {
-	ID                  string      `json:"id"`
-	SfID                string      `json:"sfId"`
-	Name                string      `json:"name"`
-	Tier                AccountTier `json:"tier"`
-	Region              *string     `json:"region"`
-	ActivationDate      time.Time   `json:"activationDate"`
-	DeactivationDate    *time.Time  `json:"deactivationDate"`
-	OwnerID             string      `json:"ownerId"`
-	TechnicalOwnerID    *string     `json:"technicalOwnerId"`
-	AgentEnabled        bool        `json:"agentEnabled"`
-	KbReferencesEnabled bool        `json:"kbReferencesEnabled"`
-	CreatedOn           time.Time   `json:"createdOn"`
-	UpdatedOn           time.Time   `json:"updatedOn"`
-}
-
 // SearchAccountsFilters holds the optional filter criteria for an account search.
 type SearchAccountsFilters struct {
 	SearchQuery    string `json:"searchQuery,omitempty"`
@@ -286,20 +258,12 @@ type SearchAccountsRequest struct {
 	Filters    SearchAccountsFilters `json:"filters,omitempty"`
 }
 
-// SearchAccountsResponse is the paginated result of an account search.
-// HasMore is true when additional pages are available beyond the current offset.
-type SearchAccountsResponse struct {
-	Accounts []Account `json:"accounts"`
-	Total    int       `json:"total"`
-	Limit    int       `json:"limit"`
-	Offset   int       `json:"offset"`
-	HasMore  bool      `json:"hasMore"`
-}
-
-// SNAccountView is the account view returned by the ServiceNow data source.
-// Timestamp fields are kept as strings to accommodate empty values from ServiceNow.
+// AccountView is the unified account search-result shape returned for all data
+// sources. Both Postgres and ServiceNow responses are mapped to this type so
+// callers receive the same fields regardless of which backend is active.
+// Fields not available from a given data source are left nil.
 // SupportTier is returned as a plain label string (no ID).
-type SNAccountView struct {
+type AccountView struct {
 	ID                    string     `json:"id"`
 	Name                  string     `json:"name"`
 	Classification        string     `json:"classification"`
@@ -317,7 +281,7 @@ type SNAccountView struct {
 	// SreTeam is the account's SRE team, resolved to a named group reference (ServiceNow
 	// data source only). Mirrors AccountRef.SreTeam.
 	SreTeam          *EntityRef `json:"sreTeam,omitempty"`
-	ActivationDate   string     `json:"activationDate"`
+	ActivationDate   *string    `json:"activationDate"`
 	DeactivationDate *string    `json:"deactivationDate"`
 	HasAgent         bool       `json:"hasAgent"`
 	HasKbReferences  bool       `json:"hasKbReferences"`
@@ -326,13 +290,14 @@ type SNAccountView struct {
 	UpdatedOn        string     `json:"updatedOn"`
 }
 
-// SearchSNAccountsResponse is the paginated result of a ServiceNow account search.
-type SearchSNAccountsResponse struct {
-	Accounts []SNAccountView `json:"accounts"`
-	Total    int             `json:"total"`
-	Limit    int             `json:"limit"`
-	Offset   int             `json:"offset"`
-	HasMore  bool            `json:"hasMore"`
+// SearchAccountsResponse is the paginated result of an account search, unified
+// across data sources.
+type SearchAccountsResponse struct {
+	Accounts []AccountView `json:"accounts"`
+	Total    int           `json:"total"`
+	Limit    int           `json:"limit"`
+	Offset   int           `json:"offset"`
+	HasMore  bool          `json:"hasMore"`
 }
 
 // SNSupportTierRef is a compact reference to a support tier carrying its label.
@@ -341,9 +306,10 @@ type SNSupportTierRef struct {
 	Label string `json:"label"`
 }
 
-// SNAccountDetail is the full account detail returned by the ServiceNow data source
-// for GET /accounts/{id}. SupportTier is returned as an {id, label} object.
-type SNAccountDetail struct {
+// AccountDetail is the unified account detail shape returned for all data
+// sources for GET /accounts/{id}. SupportTier is returned as an {id, label}
+// object. Fields not available from a given data source are left nil.
+type AccountDetail struct {
 	ID                    string            `json:"id"`
 	Name                  string            `json:"name"`
 	Classification        string            `json:"classification"`
@@ -361,7 +327,7 @@ type SNAccountDetail struct {
 	// SreTeam is the account's SRE team, resolved to a named group reference (ServiceNow
 	// data source only). Mirrors AccountRef.SreTeam.
 	SreTeam          *EntityRef `json:"sreTeam,omitempty"`
-	ActivationDate   string     `json:"activationDate"`
+	ActivationDate   *string    `json:"activationDate"`
 	DeactivationDate *string    `json:"deactivationDate"`
 	HasAgent         bool       `json:"hasAgent"`
 	HasKbReferences  bool       `json:"hasKbReferences"`

--- a/entity-service/internal/repository/account_repo.go
+++ b/entity-service/internal/repository/account_repo.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -29,15 +30,40 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-// AccountRepository defines the persistence operations for the accounts table.
+// AccountRow is the raw shape of one row read from the account table, together
+// with the joined technical-owner/account-manager person refs. It is mapped to
+// domain.AccountView / domain.AccountDetail by the service layer.
+type AccountRow struct {
+	ID                  string
+	Name                string
+	Classification      *string
+	Pod                 *string
+	SfID                *string
+	Region              *string
+	ActivationDate      *time.Time
+	DeactivationDate    *time.Time
+	TechnicalOwnerID    *string
+	TechnicalOwnerName  *string
+	TechnicalOwnerEmail *string
+	AccountManagerID    *string
+	AccountManagerName  *string
+	AccountManagerEmail *string
+	HasAgent            *bool
+	HasKbReferences     *bool
+	CreatedOn           time.Time
+	CreatedBy           string
+	UpdatedOn           time.Time
+}
+
+// AccountRepository defines the persistence operations for the account table.
 type AccountRepository interface {
 	// SearchAccounts returns a filtered, paginated slice of accounts together
 	// with the total count of matching rows before pagination.
 	// COUNT and SELECT are executed concurrently on separate pool connections.
-	SearchAccounts(ctx context.Context, req domain.SearchAccountsRequest) ([]domain.Account, int, error)
+	SearchAccounts(ctx context.Context, req domain.SearchAccountsRequest) ([]AccountRow, int, error)
 	// GetAccountByID returns the account with the given UUID, or a NotFoundError
 	// if no such account exists.
-	GetAccountByID(ctx context.Context, id string) (domain.Account, error)
+	GetAccountByID(ctx context.Context, id string) (AccountRow, error)
 }
 
 type accountRepo struct {
@@ -49,8 +75,34 @@ func NewAccountRepository(db *pgxpool.Pool) AccountRepository {
 	return &accountRepo{db: db}
 }
 
+const accountSelectColumns = `
+	a.id, a.name, a.classification, a.global_pod, a.sf_id, a.region,
+	a.activation_date, a.deactivation_date,
+	tow.id, COALESCE(tow.name, NULLIF(TRIM(CONCAT_WS(' ', tow.first_name, tow.last_name)), '')), tow.email,
+	mgr.id, COALESCE(mgr.name, NULLIF(TRIM(CONCAT_WS(' ', mgr.first_name, mgr.last_name)), '')), mgr.email,
+	a.ai_gen_response_enabled, a.smart_knowledge_base_suggestions_enabled,
+	a.created_on, a.created_by, a.updated_on`
+
+const accountFromJoins = `
+	FROM account a
+	LEFT JOIN "user" tow ON tow.id = a.technical_owner_id
+	LEFT JOIN "user" mgr ON mgr.id = a.account_manager_id`
+
+func scanAccountRow(row interface{ Scan(...any) error }) (AccountRow, error) {
+	var a AccountRow
+	err := row.Scan(
+		&a.ID, &a.Name, &a.Classification, &a.Pod, &a.SfID, &a.Region,
+		&a.ActivationDate, &a.DeactivationDate,
+		&a.TechnicalOwnerID, &a.TechnicalOwnerName, &a.TechnicalOwnerEmail,
+		&a.AccountManagerID, &a.AccountManagerName, &a.AccountManagerEmail,
+		&a.HasAgent, &a.HasKbReferences,
+		&a.CreatedOn, &a.CreatedBy, &a.UpdatedOn,
+	)
+	return a, err
+}
+
 // SearchAccounts implements AccountRepository.
-func (r *accountRepo) SearchAccounts(ctx context.Context, req domain.SearchAccountsRequest) ([]domain.Account, int, error) {
+func (r *accountRepo) SearchAccounts(ctx context.Context, req domain.SearchAccountsRequest) ([]AccountRow, int, error) {
 	filterArgs := []any{}
 	argIdx := 1
 
@@ -59,27 +111,39 @@ func (r *accountRepo) SearchAccounts(ctx context.Context, req domain.SearchAccou
 	if req.Filters.SearchQuery != "" {
 		escaped := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(req.Filters.SearchQuery)
 		pattern := "%" + escaped + "%"
-		where += fmt.Sprintf(" AND (name ILIKE $%d ESCAPE '\\' OR sf_id ILIKE $%d ESCAPE '\\')", argIdx, argIdx)
+		where += fmt.Sprintf(" AND (a.name ILIKE $%d ESCAPE '\\' OR a.sf_id ILIKE $%d ESCAPE '\\')", argIdx, argIdx)
 		filterArgs = append(filterArgs, pattern)
 		argIdx++
 	}
+	if req.Filters.Pod != "" {
+		where += fmt.Sprintf(" AND a.global_pod = $%d", argIdx)
+		filterArgs = append(filterArgs, req.Filters.Pod)
+		argIdx++
+	}
+	if req.Filters.Classification != "" {
+		where += fmt.Sprintf(" AND a.classification = $%d", argIdx)
+		filterArgs = append(filterArgs, req.Filters.Classification)
+		argIdx++
+	}
+	if req.Filters.Active != nil {
+		if *req.Filters.Active {
+			where += " AND a.deactivation_date IS NULL"
+		} else {
+			where += " AND a.deactivation_date IS NOT NULL"
+		}
+	}
 
-	countQuery := "SELECT COUNT(*) FROM accounts " + where
+	countQuery := "SELECT COUNT(*) " + accountFromJoins + " " + where
 
 	dataQuery := fmt.Sprintf(
-		`SELECT id, sf_id, name, tier, region, activation_date, deactivation_date,
-		        owner_id, technical_owner_id, agent_enabled, kb_references_enabled,
-		        created_at, updated_at
-		 FROM accounts %s
-		 ORDER BY created_at DESC, id
-		 LIMIT $%d OFFSET $%d`,
-		where, argIdx, argIdx+1,
+		"SELECT %s %s %s ORDER BY a.created_on DESC, a.id LIMIT $%d OFFSET $%d",
+		accountSelectColumns, accountFromJoins, where, argIdx, argIdx+1,
 	)
 	dataArgs := append(append([]any{}, filterArgs...), req.Pagination.Limit, req.Pagination.Offset)
 
 	// Run COUNT and SELECT in parallel goroutines — each uses its own pool connection.
 	var total int
-	var accounts []domain.Account
+	var accounts []AccountRow
 
 	eg, egCtx := errgroup.WithContext(ctx)
 
@@ -97,16 +161,10 @@ func (r *accountRepo) SearchAccounts(ctx context.Context, req domain.SearchAccou
 		}
 		defer rows.Close()
 
-		result := make([]domain.Account, 0, req.Pagination.Limit)
+		result := make([]AccountRow, 0, req.Pagination.Limit)
 		for rows.Next() {
-			var a domain.Account
-			if err := rows.Scan(
-				&a.ID, &a.SfID, &a.Name, &a.Tier, &a.Region,
-				&a.ActivationDate, &a.DeactivationDate,
-				&a.OwnerID, &a.TechnicalOwnerID,
-				&a.AgentEnabled, &a.KbReferencesEnabled,
-				&a.CreatedOn, &a.UpdatedOn,
-			); err != nil {
+			a, err := scanAccountRow(rows)
+			if err != nil {
 				return fmt.Errorf("scan account: %w", err)
 			}
 			result = append(result, a)
@@ -126,25 +184,14 @@ func (r *accountRepo) SearchAccounts(ctx context.Context, req domain.SearchAccou
 }
 
 // GetAccountByID implements AccountRepository.
-func (r *accountRepo) GetAccountByID(ctx context.Context, id string) (domain.Account, error) {
-	var a domain.Account
-	err := r.db.QueryRow(ctx,
-		`SELECT id, sf_id, name, tier, region, activation_date, deactivation_date,
-		        owner_id, technical_owner_id, agent_enabled, kb_references_enabled,
-		        created_at, updated_at
-		 FROM accounts WHERE id = $1`, id,
-	).Scan(
-		&a.ID, &a.SfID, &a.Name, &a.Tier, &a.Region,
-		&a.ActivationDate, &a.DeactivationDate,
-		&a.OwnerID, &a.TechnicalOwnerID,
-		&a.AgentEnabled, &a.KbReferencesEnabled,
-		&a.CreatedOn, &a.UpdatedOn,
-	)
+func (r *accountRepo) GetAccountByID(ctx context.Context, id string) (AccountRow, error) {
+	query := "SELECT " + accountSelectColumns + " " + accountFromJoins + " WHERE a.id = $1"
+	a, err := scanAccountRow(r.db.QueryRow(ctx, query, id))
 	if errors.Is(err, pgx.ErrNoRows) {
-		return domain.Account{}, &apierror.NotFoundError{Msg: "account not found"}
+		return AccountRow{}, &apierror.NotFoundError{Msg: "account not found"}
 	}
 	if err != nil {
-		return domain.Account{}, fmt.Errorf("get account by id: %w", err)
+		return AccountRow{}, fmt.Errorf("get account by id: %w", err)
 	}
 	return a, nil
 }

--- a/entity-service/internal/service/account_service.go
+++ b/entity-service/internal/service/account_service.go
@@ -19,6 +19,7 @@ package service
 
 import (
 	"context"
+	"time"
 
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/domain"
 	"github.com/wso2-open-operations/cs-tools/entity-service/internal/repository"
@@ -41,9 +42,14 @@ func (s *accountService) SearchAccounts(ctx context.Context, req domain.SearchAc
 	if err := validateSearchQuery(req.Filters.SearchQuery); err != nil {
 		return domain.SearchAccountsResponse{}, err
 	}
-	accounts, total, err := s.repo.SearchAccounts(ctx, req)
+	rows, total, err := s.repo.SearchAccounts(ctx, req)
 	if err != nil {
 		return domain.SearchAccountsResponse{}, err
+	}
+
+	accounts := make([]domain.AccountView, 0, len(rows))
+	for _, row := range rows {
+		accounts = append(accounts, accountRowToView(row))
 	}
 
 	return domain.SearchAccountsResponse{
@@ -56,9 +62,107 @@ func (s *accountService) SearchAccounts(ctx context.Context, req domain.SearchAc
 }
 
 // GetAccountByID implements AccountService.
-func (s *accountService) GetAccountByID(ctx context.Context, id string) (domain.Account, error) {
+func (s *accountService) GetAccountByID(ctx context.Context, id string) (domain.AccountDetail, error) {
 	if err := validateUUIDs("id", []string{id}); err != nil {
-		return domain.Account{}, err
+		return domain.AccountDetail{}, err
 	}
-	return s.repo.GetAccountByID(ctx, id)
+	row, err := s.repo.GetAccountByID(ctx, id)
+	if err != nil {
+		return domain.AccountDetail{}, err
+	}
+	return accountRowToDetail(row), nil
+}
+
+// accountPersonRef builds a PersonRef from a joined person id/name/email triple,
+// returning nil when the id is absent (no owner/manager linked).
+func accountPersonRef(id, name, email *string) *domain.PersonRef {
+	if id == nil || *id == "" {
+		return nil
+	}
+	var personName string
+	if name != nil {
+		personName = *name
+	}
+	return &domain.PersonRef{ID: *id, Name: personName, Email: email}
+}
+
+func dateOnlyOrNil(t *time.Time) *string {
+	if t == nil {
+		return nil
+	}
+	s := t.Format("2006-01-02")
+	return &s
+}
+
+func boolOrFalse(b *bool) bool {
+	return b != nil && *b
+}
+
+// accountRowCommonFields maps the fields shared between the search view and
+// the account detail response. SupportTier, ArrToday, RenewalAccountManager,
+// CreTeam, and SreTeam are not available in the Postgres schema and are
+// always nil.
+func accountRowCommonFields(row repository.AccountRow) (classification string, technicalOwner, accountManager *domain.PersonRef) {
+	if row.Classification != nil {
+		classification = *row.Classification
+	}
+	technicalOwner = accountPersonRef(row.TechnicalOwnerID, row.TechnicalOwnerName, row.TechnicalOwnerEmail)
+	accountManager = accountPersonRef(row.AccountManagerID, row.AccountManagerName, row.AccountManagerEmail)
+	return
+}
+
+func accountRowToView(row repository.AccountRow) domain.AccountView {
+	classification, technicalOwner, accountManager := accountRowCommonFields(row)
+	createdBy := row.CreatedBy
+
+	return domain.AccountView{
+		ID:                    row.ID,
+		Name:                  row.Name,
+		Classification:        classification,
+		Pod:                   row.Pod,
+		SfID:                  row.SfID,
+		Region:                row.Region,
+		SupportTier:           nil,
+		ArrToday:              nil,
+		TechnicalOwner:        technicalOwner,
+		AccountManager:        accountManager,
+		RenewalAccountManager: nil,
+		CreTeam:               nil,
+		SreTeam:               nil,
+		ActivationDate:        dateOnlyOrNil(row.ActivationDate),
+		DeactivationDate:      dateOnlyOrNil(row.DeactivationDate),
+		HasAgent:              boolOrFalse(row.HasAgent),
+		HasKbReferences:       boolOrFalse(row.HasKbReferences),
+		CreatedOn:             row.CreatedOn.Format(time.RFC3339),
+		CreatedBy:             &createdBy,
+		UpdatedOn:             row.UpdatedOn.Format(time.RFC3339),
+	}
+}
+
+func accountRowToDetail(row repository.AccountRow) domain.AccountDetail {
+	classification, technicalOwner, accountManager := accountRowCommonFields(row)
+	createdBy := row.CreatedBy
+
+	return domain.AccountDetail{
+		ID:                    row.ID,
+		Name:                  row.Name,
+		Classification:        classification,
+		Pod:                   row.Pod,
+		SfID:                  row.SfID,
+		Region:                row.Region,
+		SupportTier:           nil,
+		ArrToday:              nil,
+		TechnicalOwner:        technicalOwner,
+		AccountManager:        accountManager,
+		RenewalAccountManager: nil,
+		CreTeam:               nil,
+		SreTeam:               nil,
+		ActivationDate:        dateOnlyOrNil(row.ActivationDate),
+		DeactivationDate:      dateOnlyOrNil(row.DeactivationDate),
+		HasAgent:              boolOrFalse(row.HasAgent),
+		HasKbReferences:       boolOrFalse(row.HasKbReferences),
+		CreatedOn:             row.CreatedOn.Format(time.RFC3339),
+		CreatedBy:             &createdBy,
+		UpdatedOn:             row.UpdatedOn.Format(time.RFC3339),
+	}
 }

--- a/entity-service/internal/service/interfaces.go
+++ b/entity-service/internal/service/interfaces.go
@@ -60,7 +60,7 @@ type AccountService interface {
 	SearchAccounts(ctx context.Context, req domain.SearchAccountsRequest) (domain.SearchAccountsResponse, error)
 	// GetAccountByID returns the account with the given UUID. A ValidationError is
 	// returned for a malformed UUID; a NotFoundError if no account matches.
-	GetAccountByID(ctx context.Context, id string) (domain.Account, error)
+	GetAccountByID(ctx context.Context, id string) (domain.AccountDetail, error)
 }
 
 // EventPublishFailureService defines the operations available on the
@@ -129,9 +129,9 @@ type SLAClockService interface {
 type SNAccountService interface {
 	// SearchAccounts returns a paginated list of ServiceNow accounts matching the
 	// filters in req.
-	SearchAccounts(ctx context.Context, req domain.SearchAccountsRequest) (domain.SearchSNAccountsResponse, error)
+	SearchAccounts(ctx context.Context, req domain.SearchAccountsRequest) (domain.SearchAccountsResponse, error)
 	// GetAccountByID returns the full account detail for the given UUID.
-	GetAccountByID(ctx context.Context, id string) (domain.SNAccountDetail, error)
+	GetAccountByID(ctx context.Context, id string) (domain.AccountDetail, error)
 }
 
 // ProjectService defines the operations available on the project entity.

--- a/entity-service/internal/service/sn_account_service.go
+++ b/entity-service/internal/service/sn_account_service.go
@@ -97,12 +97,12 @@ func NewServiceNowAccountService(client *integrationservice.Client) SNAccountSer
 	return &snAccountService{client: client}
 }
 
-func (s *snAccountService) SearchAccounts(ctx context.Context, req domain.SearchAccountsRequest) (domain.SearchSNAccountsResponse, error) {
+func (s *snAccountService) SearchAccounts(ctx context.Context, req domain.SearchAccountsRequest) (domain.SearchAccountsResponse, error) {
 	if err := normalizePagination(&req.Pagination); err != nil {
-		return domain.SearchSNAccountsResponse{}, err
+		return domain.SearchAccountsResponse{}, err
 	}
 	if err := validateSearchQuery(req.Filters.SearchQuery); err != nil {
-		return domain.SearchSNAccountsResponse{}, err
+		return domain.SearchAccountsResponse{}, err
 	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
@@ -119,20 +119,20 @@ func (s *snAccountService) SearchAccounts(ctx context.Context, req domain.Search
 
 	raw, err := s.client.Post(ctx, "/accounts/search", token, payload)
 	if err != nil {
-		return domain.SearchSNAccountsResponse{}, err
+		return domain.SearchAccountsResponse{}, err
 	}
 
 	var snResp snAccountsResponse
 	if err := json.Unmarshal(raw, &snResp); err != nil {
-		return domain.SearchSNAccountsResponse{}, fmt.Errorf("sn accounts: parse response: %w", err)
+		return domain.SearchAccountsResponse{}, fmt.Errorf("sn accounts: parse response: %w", err)
 	}
 
-	accounts := make([]domain.SNAccountView, 0, len(snResp.Accounts))
+	accounts := make([]domain.AccountView, 0, len(snResp.Accounts))
 	for _, a := range snResp.Accounts {
 		accounts = append(accounts, snAccountToDomain(a))
 	}
 
-	return domain.SearchSNAccountsResponse{
+	return domain.SearchAccountsResponse{
 		Accounts: accounts,
 		Total:    snResp.TotalRecords,
 		Limit:    req.Pagination.Limit,
@@ -141,21 +141,21 @@ func (s *snAccountService) SearchAccounts(ctx context.Context, req domain.Search
 	}, nil
 }
 
-func (s *snAccountService) GetAccountByID(ctx context.Context, id string) (domain.SNAccountDetail, error) {
+func (s *snAccountService) GetAccountByID(ctx context.Context, id string) (domain.AccountDetail, error) {
 	if err := validateUUIDs("id", []string{id}); err != nil {
-		return domain.SNAccountDetail{}, err
+		return domain.AccountDetail{}, err
 	}
 
 	token := middleware.UserIDTokenFromContext(ctx)
 
 	raw, err := s.client.Get(ctx, "/accounts/"+uuidToSysid(id), token)
 	if err != nil {
-		return domain.SNAccountDetail{}, err
+		return domain.AccountDetail{}, err
 	}
 
 	var a snAccount
 	if err := json.Unmarshal(raw, &a); err != nil {
-		return domain.SNAccountDetail{}, fmt.Errorf("sn accounts: parse account response: %w", err)
+		return domain.AccountDetail{}, fmt.Errorf("sn accounts: parse account response: %w", err)
 	}
 
 	return snAccountToDetail(a), nil
@@ -194,7 +194,7 @@ func snAccountCommonFields(a snAccount) (deactivationDate *string, technicalOwne
 	return
 }
 
-func snAccountToDomain(a snAccount) domain.SNAccountView {
+func snAccountToDomain(a snAccount) domain.AccountView {
 	deactivationDate, technicalOwner, accountManager, renewalAccountManager, creTeam, sreTeam := snAccountCommonFields(a)
 
 	var supportTier *string
@@ -202,7 +202,7 @@ func snAccountToDomain(a snAccount) domain.SNAccountView {
 		supportTier = &a.SupportTier.Label
 	}
 
-	return domain.SNAccountView{
+	return domain.AccountView{
 		ID:                    sysidToUUID(a.ID),
 		Name:                  a.Name,
 		Classification:        a.Classification,
@@ -216,7 +216,7 @@ func snAccountToDomain(a snAccount) domain.SNAccountView {
 		RenewalAccountManager: renewalAccountManager,
 		CreTeam:               creTeam,
 		SreTeam:               sreTeam,
-		ActivationDate:        a.ActivationDate,
+		ActivationDate:        nilIfEmpty(&a.ActivationDate),
 		DeactivationDate:      deactivationDate,
 		HasAgent:              a.HasAgent,
 		HasKbReferences:       a.HasKbReferences,
@@ -226,7 +226,7 @@ func snAccountToDomain(a snAccount) domain.SNAccountView {
 	}
 }
 
-func snAccountToDetail(a snAccount) domain.SNAccountDetail {
+func snAccountToDetail(a snAccount) domain.AccountDetail {
 	deactivationDate, technicalOwner, accountManager, renewalAccountManager, creTeam, sreTeam := snAccountCommonFields(a)
 
 	var supportTier *domain.SNSupportTierRef
@@ -237,7 +237,7 @@ func snAccountToDetail(a snAccount) domain.SNAccountDetail {
 		}
 	}
 
-	return domain.SNAccountDetail{
+	return domain.AccountDetail{
 		ID:                    sysidToUUID(a.ID),
 		Name:                  a.Name,
 		Classification:        a.Classification,
@@ -251,7 +251,7 @@ func snAccountToDetail(a snAccount) domain.SNAccountDetail {
 		RenewalAccountManager: renewalAccountManager,
 		CreTeam:               creTeam,
 		SreTeam:               sreTeam,
-		ActivationDate:        a.ActivationDate,
+		ActivationDate:        nilIfEmpty(&a.ActivationDate),
 		DeactivationDate:      deactivationDate,
 		HasAgent:              a.HasAgent,
 		HasKbReferences:       a.HasKbReferences,

--- a/entity-service/internal/service/sn_account_service_test.go
+++ b/entity-service/internal/service/sn_account_service_test.go
@@ -43,7 +43,7 @@ func snAccountJSON(id, sfID string) string {
 
 // TestSNAccountService_GetAccountByID_SfIDRoundTrips verifies that the SF ID
 // ServiceNow's AccountUtils now emits (u_account_id, surfaced as sfId) survives
-// the SN JSON -> domain.SNAccountDetail conversion in GetAccountByID.
+// the SN JSON -> domain.AccountDetail conversion in GetAccountByID.
 func TestSNAccountService_GetAccountByID_SfIDRoundTrips(t *testing.T) {
 	const wantSfID = "001E2000014mQ2hIAE"
 

--- a/entity-service/openapi.yaml
+++ b/entity-service/openapi.yaml
@@ -421,7 +421,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SNAccountDetail'
+                $ref: '#/components/schemas/AccountDetail'
         "400":
           description: Bad request.
           content:
@@ -5236,7 +5236,7 @@ components:
           type: string
           description: Filter by account classification (e.g. enterprise).
 
-    SNAccountView:
+    AccountView:
       type: object
       properties:
         id:
@@ -5259,10 +5259,11 @@ components:
         supportTier:
           type: string
           nullable: true
-          description: Support tier label (e.g. Platinum).
+          description: Support tier label (e.g. Platinum). ServiceNow data source only.
         arrToday:
           type: string
           nullable: true
+          description: ServiceNow data source only.
         technicalOwner:
           nullable: true
           allOf:
@@ -5273,10 +5274,12 @@ components:
             - $ref: '#/components/schemas/PersonRef'
         renewalAccountManager:
           nullable: true
+          description: ServiceNow data source only.
           allOf:
             - $ref: '#/components/schemas/PersonRef'
         activationDate:
           type: string
+          nullable: true
         deactivationDate:
           type: string
           nullable: true
@@ -5301,7 +5304,7 @@ components:
         label:
           type: string
 
-    SNAccountDetail:
+    AccountDetail:
       type: object
       properties:
         id:
@@ -5323,11 +5326,13 @@ components:
           nullable: true
         supportTier:
           nullable: true
+          description: ServiceNow data source only.
           allOf:
             - $ref: '#/components/schemas/SNSupportTierRef'
         arrToday:
           type: string
           nullable: true
+          description: ServiceNow data source only.
         technicalOwner:
           nullable: true
           allOf:
@@ -5338,10 +5343,12 @@ components:
             - $ref: '#/components/schemas/PersonRef'
         renewalAccountManager:
           nullable: true
+          description: ServiceNow data source only.
           allOf:
             - $ref: '#/components/schemas/PersonRef'
         activationDate:
           type: string
+          nullable: true
         deactivationDate:
           type: string
           nullable: true
@@ -5363,7 +5370,7 @@ components:
         accounts:
           type: array
           items:
-            $ref: '#/components/schemas/SNAccountView'
+            $ref: '#/components/schemas/AccountView'
         total:
           type: integer
         limit:


### PR DESCRIPTION
## Summary
- Implements GET /accounts/{id} and POST /accounts/search against the Postgres `account`/`user` tables (previously stubbed against a stale `accounts`/`users` schema), joining technical owner and account manager into PersonRef objects.
- Renames SNAccountView/SNAccountDetail/SearchSNAccountsResponse to AccountView/AccountDetail/SearchAccountsResponse and reuses them for both data sources, so callers get an identical JSON shape regardless of DATA_SOURCE (mirrors the existing ProjectView pattern).
- Fields the Postgres schema doesn't carry (supportTier, arrToday, renewalAccountManager, creTeam, sreTeam) are returned as null rather than omitted or zero-valued.
- Updates openapi.yaml schema names/nullability to match.

## Test plan
- [ ] `go build ./...` / `go vet ./...` / `go test ./...` pass
- [ ] Manually verified POST /accounts/search and GET /accounts/{id} against a Postgres-backed instance (DATA_SOURCE=postgres)
- [ ] Manually verified the same two endpoints against ServiceNow (DATA_SOURCE=servicenow) to confirm the JSON shape is unchanged
- [ ] Confirmed technicalOwner/accountManager resolve correctly when set and are null when the FK is null


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Unified account search and detail responses across supported data sources.
  * Account results now provide consistent summary and detail formats.
  * Activation dates can be omitted when unavailable.

* **Documentation**
  * Updated API schemas and descriptions for unified account responses.
  * Clarified which fields are available only for ServiceNow data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->