### PR TITLE
[CSM Portal] Add view-details action to case time cards

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/CaseTimeCardsPanel.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/CaseTimeCardsPanel.test.tsx
@@ -1,0 +1,140 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import type { CsmTimeCard } from "@features/csm-timecards/types/timeCards";
+
+// CaseTimeCardsPanel pulls in useCaseTimeCards/useDecideTimeCard/
+// useDeleteTimeCard (React Query hooks backed by useBackendApi) and
+// useCurrentEngineer/useIsTeamLead (auth-derived). None of those are under
+// test here -- the "View details" interaction is -- so every one of them is
+// mocked directly rather than wiring a QueryClientProvider + backend mock,
+// matching how other case-detail-tab tests in this feature folder isolate
+// the component under test from its data layer.
+const CARD_A: CsmTimeCard = {
+  id: "tc-1",
+  caseId: "case-1",
+  caseNumber: "CS0000001",
+  projectId: "proj-1",
+  projectName: "Acme Project",
+  workDate: "2026-07-01",
+  userId: "user-1",
+  userName: "Jane Doe",
+  state: "submitted",
+  billable: true,
+  totalMinutes: 45,
+  workLogComment: "<p>Investigated the reported latency issue.</p>",
+};
+
+const CARD_B: CsmTimeCard = {
+  id: "tc-2",
+  caseId: "case-1",
+  caseNumber: "CS0000001",
+  projectId: "proj-1",
+  projectName: "Acme Project",
+  workDate: "2026-07-02",
+  userId: "user-2",
+  userName: "John Smith",
+  state: "approved",
+  billable: false,
+  totalMinutes: 20,
+  approvedByName: "Lead Person",
+};
+
+// CaseTimeCardsPanel also imports BackendApiError directly from
+// @api/backend/client (for its own error-message narrowing), which reads
+// window.config at module load via @config/apiConfig -- mock it too so
+// importing the panel doesn't trip that, same as TimeCardsTable.test.tsx.
+vi.mock("@config/apiConfig", () => ({ apiConfig: { backendUrl: "https://example.test" } }));
+
+const refetch = vi.fn();
+vi.mock("@features/csm-timecards/api/useTimeCards", () => ({
+  useCaseTimeCards: () => ({
+    data: { cards: [CARD_A, CARD_B], truncated: false },
+    isLoading: false,
+    isError: false,
+    refetch,
+    isFetching: false,
+    dataUpdatedAt: Date.now(),
+  }),
+  useDecideTimeCard: () => ({ mutate: vi.fn(), isPending: false }),
+  useDeleteTimeCard: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+vi.mock("@features/csm-timecards/api/useTimeSheets", () => ({
+  useCurrentEngineer: () => ({ id: "user-1", name: "Jane Doe" }),
+}));
+vi.mock("@features/csm-timecards/hooks/useIsTeamLead", () => ({
+  useIsTeamLead: () => false,
+}));
+vi.mock("@context/error-banner/ErrorBannerContext", () => ({
+  useErrorBanner: () => ({ showError: vi.fn() }),
+}));
+
+import CaseTimeCardsPanel from "@features/csm-timecards/components/CaseTimeCardsPanel";
+
+describe("CaseTimeCardsPanel — view details", () => {
+  beforeEach(() => {
+    refetch.mockReset();
+  });
+
+  it("shows a 'View details' action on every card row, regardless of state or ownership", () => {
+    render(<CaseTimeCardsPanel caseId="case-1" onLogTime={vi.fn()} onEditTimeCard={vi.fn()} />);
+
+    expect(screen.getAllByRole("button", { name: "View details" })).toHaveLength(2);
+  });
+
+  it("opens the read-only details view with the row's own fields when clicked", () => {
+    render(<CaseTimeCardsPanel caseId="case-1" onLogTime={vi.fn()} onEditTimeCard={vi.fn()} />);
+
+    const [viewButtonA] = screen.getAllByRole("button", { name: "View details" });
+    fireEvent.click(viewButtonA);
+
+    expect(screen.getByText("Engineer's comment")).toBeInTheDocument();
+    expect(screen.getByText("Investigated the reported latency issue.")).toBeInTheDocument();
+  });
+
+  it("opens the details view for an approved, other-engineer's card too", () => {
+    render(<CaseTimeCardsPanel caseId="case-1" onLogTime={vi.fn()} onEditTimeCard={vi.fn()} />);
+
+    const [, viewButtonB] = screen.getAllByRole("button", { name: "View details" });
+    fireEvent.click(viewButtonB);
+
+    expect(screen.getByText("Approved by: Lead Person")).toBeInTheDocument();
+  });
+
+  it("closes the details view when its row's action is clicked again", () => {
+    render(<CaseTimeCardsPanel caseId="case-1" onLogTime={vi.fn()} onEditTimeCard={vi.fn()} />);
+
+    const [viewButtonA] = screen.getAllByRole("button", { name: "View details" });
+    fireEvent.click(viewButtonA);
+    expect(screen.getByText("Engineer's comment")).toBeInTheDocument();
+
+    fireEvent.click(viewButtonA);
+    expect(screen.queryByText("Engineer's comment")).not.toBeInTheDocument();
+  });
+
+  it("closes the details view via its own Close button", () => {
+    render(<CaseTimeCardsPanel caseId="case-1" onLogTime={vi.fn()} onEditTimeCard={vi.fn()} />);
+
+    const [viewButtonA] = screen.getAllByRole("button", { name: "View details" });
+    fireEvent.click(viewButtonA);
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+
+    expect(screen.queryByText("Engineer's comment")).not.toBeInTheDocument();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/CaseTimeCardsPanel.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/CaseTimeCardsPanel.tsx
@@ -28,7 +28,7 @@ import {
   Skeleton,
   Typography,
 } from "@wso2/oxygen-ui";
-import { Clock, Pencil, Plus, Trash2 } from "@wso2/oxygen-ui-icons-react";
+import { Clock, Eye, Pencil, Plus, Trash2 } from "@wso2/oxygen-ui-icons-react";
 import RelativeDate from "@components/RelativeDate";
 import {
   useCaseTimeCards,
@@ -41,6 +41,7 @@ import { billableLabel } from "@features/csm-timecards/constants/timeCardConstan
 import { decisionSummary } from "@features/csm-timecards/utils/timeCardDecision";
 import { BackendApiError } from "@api/backend/client";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
+import TimeCardDetailsDialog from "@features/csm-timecards/components/TimeCardDetailsDialog";
 import TimeCardStatusChip from "@features/csm-timecards/components/TimeCardStatusChip";
 import TimeCardReviewDialog from "@features/csm-timecards/components/TimeCardReviewDialog";
 import TimeCardTruncatedNotice from "@features/csm-timecards/components/TimeCardTruncatedNotice";
@@ -77,6 +78,7 @@ export default function CaseTimeCardsPanel({
   const { showError } = useErrorBanner();
   const [reviewCard, setReviewCard] = useState<CsmTimeCard | null>(null);
   const [pendingDelete, setPendingDelete] = useState<CsmTimeCard | null>(null);
+  const [detailCard, setDetailCard] = useState<CsmTimeCard | null>(null);
 
   const cards = useMemo(() => data?.cards ?? [], [data]);
   const total = useMemo(
@@ -191,6 +193,20 @@ export default function CaseTimeCardsPanel({
                 <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
                   <Typography variant="body2">{c.totalMinutes} min</Typography>
                   <TimeCardStatusChip state={c.state} />
+                  {/* Read-only, so shown on every card regardless of state or
+                   ownership — unlike Edit/Review below, there's no
+                   authorization concern here. Matches the toggle-to-close
+                   "eye" convention in TimeCardsTable. */}
+                  <IconButton
+                    size="small"
+                    aria-label="View details"
+                    aria-pressed={detailCard?.id === c.id}
+                    onClick={() =>
+                      setDetailCard((prev) => (prev?.id === c.id ? null : c))
+                    }
+                  >
+                    <Eye size={14} />
+                  </IconButton>
                   {/* Own card, still submitted: only the submitter can edit
                    its content, matching the backend's own submitter-only +
                    submitted-state-only enforcement (see cardActions). */}
@@ -244,6 +260,10 @@ export default function CaseTimeCardsPanel({
             );
           })}
         </Box>
+      )}
+
+      {detailCard && (
+        <TimeCardDetailsDialog card={detailCard} onClose={() => setDetailCard(null)} />
       )}
 
       {reviewCard && (

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardDetailsDialog.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardDetailsDialog.test.tsx
@@ -1,0 +1,146 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import TimeCardDetailsDialog from "@features/csm-timecards/components/TimeCardDetailsDialog";
+import type { CsmTimeCard } from "@features/csm-timecards/types/timeCards";
+
+function card(overrides: Partial<CsmTimeCard> = {}): CsmTimeCard {
+  return {
+    id: "card-1",
+    caseId: "case-1",
+    caseNumber: "CS0000001",
+    projectId: "proj-1",
+    projectName: "Acme",
+    workDate: "2026-07-13",
+    userId: "user-1",
+    userName: "Jane Doe",
+    state: "submitted",
+    billable: true,
+    totalMinutes: 30,
+    ...overrides,
+  };
+}
+
+describe("TimeCardDetailsDialog", () => {
+  it("shows the card's own fields", () => {
+    render(<TimeCardDetailsDialog card={card()} onClose={vi.fn()} />);
+
+    expect(screen.getByText("Jane Doe")).toBeInTheDocument();
+    expect(screen.getByText("Acme")).toBeInTheDocument();
+    expect(screen.getAllByText("30 min").length).toBeGreaterThan(0);
+  });
+
+  it("shows the engineer's work-log comment, sanitized, when the card has one", () => {
+    render(
+      <TimeCardDetailsDialog
+        card={card({ workLogComment: "<p>Investigated the reported latency issue.</p>" })}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Engineer's comment")).toBeInTheDocument();
+    expect(screen.getByText("Investigated the reported latency issue.")).toBeInTheDocument();
+  });
+
+  it("strips unsafe markup from the work-log comment before rendering", () => {
+    render(
+      <TimeCardDetailsDialog
+        card={card({ workLogComment: '<p>hi<script>window.x=1</script></p><img src=x onerror="window.y=1">' })}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(document.querySelector("script")).not.toBeInTheDocument();
+    const img = document.querySelector("img");
+    expect(img?.getAttribute("onerror")).toBeNull();
+  });
+
+  it("renders no comment section when the card has none", () => {
+    render(<TimeCardDetailsDialog card={card()} onClose={vi.fn()} />);
+    expect(screen.queryByText("Engineer's comment")).not.toBeInTheDocument();
+  });
+
+  it("shows the per-activity breakdown when present, in the fixed display order", () => {
+    render(
+      <TimeCardDetailsDialog
+        card={card({
+          breakdown: {
+            analysisDebugging: 15,
+            reproduce: 5,
+            settingUp: 0,
+            providingSolution: 10,
+            answering: 0,
+          },
+        })}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Breakdown")).toBeInTheDocument();
+    expect(screen.getByText("Analysis and debugging")).toBeInTheDocument();
+    expect(screen.getByText("Providing solution")).toBeInTheDocument();
+  });
+
+  it("renders no breakdown section when the card has none", () => {
+    render(<TimeCardDetailsDialog card={card()} onClose={vi.fn()} />);
+    expect(screen.queryByText("Breakdown")).not.toBeInTheDocument();
+  });
+
+  it("shows issue complexity when present", () => {
+    render(<TimeCardDetailsDialog card={card({ issueComplexity: "High" })} onClose={vi.fn()} />);
+    expect(screen.getByText("Issue complexity")).toBeInTheDocument();
+    expect(screen.getByText("High")).toBeInTheDocument();
+  });
+
+  it("lists the eligible approvers on a submitted card", () => {
+    render(
+      <TimeCardDetailsDialog
+        card={card({
+          approvers: [
+            { id: "lead-1", name: "Lead One" },
+            { id: "lead-2", name: "Lead Two" },
+          ],
+        })}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Approvers")).toBeInTheDocument();
+    expect(screen.getByText("Lead One, Lead Two")).toBeInTheDocument();
+  });
+
+  it("shows the decision summary on a decided card", () => {
+    render(
+      <TimeCardDetailsDialog
+        card={card({ state: "approved", approvedByName: "Lead Person" })}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Approved by: Lead Person")).toBeInTheDocument();
+  });
+
+  it("calls onClose when Close is clicked", () => {
+    const onClose = vi.fn();
+    render(<TimeCardDetailsDialog card={card()} onClose={onClose} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardDetailsDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardDetailsDialog.tsx
@@ -1,0 +1,174 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { JSX, ReactNode } from "react";
+import { Box, Button, Dialog, DialogActions, DialogContent, DialogTitle, Typography } from "@wso2/oxygen-ui";
+import RelativeDate from "@components/RelativeDate";
+import TimeCardStatusChip from "@features/csm-timecards/components/TimeCardStatusChip";
+import { ACTIVITY_BUCKETS, billableLabel } from "@features/csm-timecards/constants/timeCardConstants";
+import { decisionSummary } from "@features/csm-timecards/utils/timeCardDecision";
+import { isBlankHtml, sanitizeRichTextHtml } from "@utils/sanitizeHtml";
+import type { CsmTimeCard } from "@features/csm-timecards/types/timeCards";
+
+interface TimeCardDetailsDialogProps {
+  card: CsmTimeCard;
+  onClose: () => void;
+}
+
+function Field({ label, value }: { label: string; value: ReactNode }): JSX.Element {
+  return (
+    <Box sx={{ minWidth: 0, display: "flex", flexDirection: "column", gap: 0.5 }}>
+      <Typography variant="caption" color="text.secondary">
+        {label}
+      </Typography>
+      {typeof value === "string" ? <Typography variant="body2">{value}</Typography> : value}
+    </Box>
+  );
+}
+
+/**
+ * The engineer's own work-log comment from submission — ServiceNow rich-text
+ * HTML, so it's sanitized and rendered as HTML (same policy as a case
+ * comment's body, and the same pattern as `TimeCardReviewDialog`). Renders
+ * nothing when the card has none (e.g. logged before this field was mapped).
+ */
+function WorkLogComment({ html }: { html?: string }): JSX.Element | null {
+  if (!html || isBlankHtml(html)) return null;
+  const safeHtml = sanitizeRichTextHtml(html);
+  return (
+    <Field
+      label="Engineer's comment"
+      value={
+        <Box
+          sx={{
+            fontSize: "0.875rem",
+            lineHeight: 1.5,
+            wordBreak: "break-word",
+            "& p": { my: 0.5 },
+            "& p:first-of-type": { mt: 0 },
+            "& p:last-child": { mb: 0 },
+            "& ul, & ol": { my: 0.5, pl: 3 },
+            "& a": { color: "primary.main" },
+            "& img": { maxWidth: "100%", height: "auto" },
+          }}
+          dangerouslySetInnerHTML={{ __html: safeHtml }}
+        />
+      }
+    />
+  );
+}
+
+/**
+ * Per-activity minute breakdown, in the fixed `ACTIVITY_BUCKETS` display
+ * order — absent on a card logged before this field was mapped (see
+ * `CsmTimeCard.breakdown`), so renders nothing rather than a zeroed-out list.
+ */
+function Breakdown({ breakdown }: { breakdown?: CsmTimeCard["breakdown"] }): JSX.Element | null {
+  if (!breakdown) return null;
+  return (
+    <Field
+      label="Breakdown"
+      value={
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 0.25 }}>
+          {ACTIVITY_BUCKETS.map((bucket) => (
+            <Box
+              key={bucket.key}
+              sx={{ display: "flex", justifyContent: "space-between", gap: 2 }}
+            >
+              <Typography variant="body2">{bucket.label}</Typography>
+              <Typography variant="body2">{breakdown[bucket.key]} min</Typography>
+            </Box>
+          ))}
+        </Box>
+      }
+    />
+  );
+}
+
+/**
+ * Read-only details view of a single time card, opened from its row's "View
+ * details" action in `CaseTimeCardsPanel`. Unlike `TimeCardCasePreviewDrawer`
+ * (the Approvals-tab equivalent), this doesn't also fetch and render the
+ * linked case — the panel this opens from is already embedded in that same
+ * case's own detail page, so re-showing it here would be redundant. Available
+ * on every card regardless of state or ownership: it's read-only, so there's
+ * no authorization concern the way there is for Edit/Review.
+ */
+export default function TimeCardDetailsDialog({
+  card,
+  onClose,
+}: TimeCardDetailsDialogProps): JSX.Element {
+  const decision = decisionSummary(card);
+
+  return (
+    <Dialog open onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>
+        Time card · {card.caseNumber} · {card.totalMinutes} min
+      </DialogTitle>
+      <DialogContent dividers>
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+          <Box sx={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 2 }}>
+            <Field label="Engineer" value={card.userName} />
+            <Field label="Project" value={card.projectName} />
+            <Field label="Billable" value={billableLabel(card.billable)} />
+            <Field
+              label="Logged"
+              value={
+                <Typography variant="body2">
+                  <RelativeDate value={card.workDate} />
+                </Typography>
+              }
+            />
+            <Field label="Minutes" value={`${card.totalMinutes} min`} />
+            <Field
+              label="State"
+              value={
+                <Box sx={{ mt: 0.5 }}>
+                  <TimeCardStatusChip state={card.state} />
+                </Box>
+              }
+            />
+            {card.issueComplexity && (
+              <Field label="Issue complexity" value={card.issueComplexity} />
+            )}
+          </Box>
+
+          <WorkLogComment html={card.workLogComment} />
+
+          <Breakdown breakdown={card.breakdown} />
+
+          {card.state === "submitted" && card.approvers && card.approvers.length > 0 && (
+            <Field
+              label="Approvers"
+              value={card.approvers.map((approver) => approver.name).join(", ")}
+            />
+          )}
+
+          {decision && (
+            <Typography variant="body2" sx={{ whiteSpace: "normal", wordBreak: "break-word" }}>
+              {decision}
+            </Typography>
+          )}
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button color="inherit" onClick={onClose}>
+          Close
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Purpose
Every card row on a case's Time tracking tab only offered an Edit (own submitted card) or Review (team-lead, submitted card) action. Approved, rejected, and other-engineers' cards had no way to inspect the card's own fields at all.

## Goals
Add a "View details" action to every time card row (regardless of state or ownership, since it's read-only) that opens a read-only details view of that card.

## Approach
Adds a new `TimeCardDetailsDialog` component and wires a row-level eye icon into `CaseTimeCardsPanel` (the case detail page's Time tracking tab body), matching the existing eye/toggle-to-close convention from `TimeCardsTable`. The dialog reuses the `Field`/`WorkLogComment` rendering pattern from `TimeCardReviewDialog`/`TimeCardCasePreviewDrawer`, but is deliberately lighter than `TimeCardCasePreviewDrawer`: it does not also fetch and render the linked case, since this panel is already embedded inside that same case's own detail page.

Fields shown: engineer, project, billable, logged date, minutes, state, work-log comment, per-activity breakdown, issue complexity, approvers (when submitted), and the decision summary (when decided).

No UI screenshot attached — text-only dialog change, same visual language as the two existing reference components.

## User stories
As a CS engineer or team lead, I can inspect the full details of any time card logged on a case, not just cards I can edit or review.

## Release note
Added a "View details" action to time card rows on a case's Time tracking tab, so any card's full details (work-log comment, activity breakdown, issue complexity, approvers, decision) can be inspected regardless of its state or who logged it.

## Documentation
N/A — no separate product documentation surface for this portal; the in-app `/help` guide's time-cards topic doesn't currently document the equivalent eye/view action on the Time cards page table either, so this stays consistent with that.

## Training
N/A — no training content repository changes needed for this UI-only addition.

## Certification
N/A — no certification exam impact from this UI-only addition.

## Marketing
N/A — internal CS-engineer tooling, not a marketed feature.

## Automation tests
 - Unit tests
   Added `TimeCardDetailsDialog.test.tsx` (field rendering, sanitized work-log comment, breakdown, issue complexity, approvers, decision summary, close) and `CaseTimeCardsPanel.test.tsx` (view-details button present on every row regardless of state/ownership, opens/closes the dialog, shows the clicked row's own fields). Full suite: `pnpm run test -- --run` passes (2375 tests, 236 files).
 - Integration tests
   N/A — no integration test harness in this repo layer; covered by the RTL component tests above.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — TypeScript/React frontend, not a JVM component FindSecurityBugs applies to.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no new sample/example artifacts introduced.

## Related PRs
N/A

## Migrations (if applicable)
N/A — no data or schema migration involved.

## Test environment
`pnpm run lint`, `pnpm run test -- --run`, and `pnpm run build` all run and pass locally (Node/pnpm toolchain per `apps/csm-portal/webapp`'s existing `package.json`); no new browser-specific behavior introduced.

## Learning
N/A — followed this feature folder's own existing dialog patterns (`TimeCardReviewDialog`, `TimeCardCasePreviewDrawer`) directly; no external research needed.