### PR TITLE
[CSM Portal] Add view-details action and table layout to case time cards

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.test.tsx
@@ -301,10 +301,22 @@ vi.mock("@features/csm-cases/api/useRequestCaseUpdate", () => ({
 // Two placeholder cards (shape doesn't matter beyond `.length` -- the tab
 // label count is the only thing this page reads from the result;
 // CaseTimeCardsPanel itself is stubbed below and never sees this data).
+// `total` defaults to `cards.length` (no truncation); a test overriding this
+// mock can set `total` higher than `cards.length` to simulate a truncated
+// page and assert the tab count still reflects the real total.
+const useCaseTimeCardsMock = vi.fn();
+function defaultCaseTimeCardsImpl(): unknown {
+  return { data: { cards: [{}, {}], total: 2, truncated: false } };
+}
+useCaseTimeCardsMock.mockImplementation(defaultCaseTimeCardsImpl);
+afterEach(() => {
+  useCaseTimeCardsMock.mockImplementation(defaultCaseTimeCardsImpl);
+});
 vi.mock("@features/csm-timecards/api/useTimeCards", () => ({
   usePostTimeCard: () => ({ mutate: vi.fn(), isPending: false }),
   useUpdateTimeCard: () => ({ mutate: vi.fn(), isPending: false }),
-  useCaseTimeCards: () => ({ data: { cards: [{}, {}], truncated: false } }),
+  useCaseTimeCards: (caseId: string | undefined) =>
+    useCaseTimeCardsMock(caseId),
 }));
 
 // Simple presentational stubs — none of this test's assertions touch these.
@@ -893,6 +905,21 @@ describe("CsmCaseDetailPage — tab label counts", () => {
     // hardcoded to `[]` in useGetCsmCaseDetail and never populated.
     expect(
       screen.getByRole("tab", { name: /time tracking \(2\)/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the case's real total on a truncated time-cards page, not the fetched page size", () => {
+    // A case with more time cards than the fetch page limit: only 2 cards
+    // came back, but the case really has 9. The tab badge must read `total`,
+    // not `cards.length`, or it under-reports the case's real count.
+    useCaseTimeCardsMock.mockImplementation(() => ({
+      data: { cards: [{}, {}], total: 9, truncated: true },
+    }));
+
+    renderPage();
+
+    expect(
+      screen.getByRole("tab", { name: /time tracking \(9\)/i }),
     ).toBeInTheDocument();
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.test.tsx
@@ -298,9 +298,13 @@ vi.mock("@features/csm-cases/api/useRequestCaseUpdate", () => ({
     isPending: false,
   }),
 }));
+// Two placeholder cards (shape doesn't matter beyond `.length` -- the tab
+// label count is the only thing this page reads from the result;
+// CaseTimeCardsPanel itself is stubbed below and never sees this data).
 vi.mock("@features/csm-timecards/api/useTimeCards", () => ({
   usePostTimeCard: () => ({ mutate: vi.fn(), isPending: false }),
   useUpdateTimeCard: () => ({ mutate: vi.fn(), isPending: false }),
+  useCaseTimeCards: () => ({ data: { cards: [{}, {}], truncated: false } }),
 }));
 
 // Simple presentational stubs — none of this test's assertions touch these.
@@ -877,6 +881,19 @@ describe("CsmCaseDetailPage — dashless id normalization", () => {
     expect(screen.getByTestId("location-probe")).toHaveTextContent(
       `/cases/${DASHED_ID}`,
     );
+  });
+});
+
+describe("CsmCaseDetailPage — tab label counts", () => {
+  it("shows the time cards count on the 'Time tracking' tab, sourced from useCaseTimeCards", () => {
+    renderPage();
+
+    // Mocked useCaseTimeCards above returns 2 cards -- this was previously
+    // always 0 because the count read `c.timeLogs.length`, and `timeLogs` is
+    // hardcoded to `[]` in useGetCsmCaseDetail and never populated.
+    expect(
+      screen.getByRole("tab", { name: /time tracking \(2\)/i }),
+    ).toBeInTheDocument();
   });
 });
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -142,7 +142,11 @@ import { CaseSlaTable } from "@features/csm-cases/components/CaseSlaTable";
 import { useGetCsmCaseSlas } from "@features/csm-cases/api/useGetCsmCaseSlas";
 import CaseTimeCardsPanel from "@features/csm-timecards/components/CaseTimeCardsPanel";
 import LogTimeCardDialog from "@features/csm-timecards/components/LogTimeCardDialog";
-import { usePostTimeCard, useUpdateTimeCard } from "@features/csm-timecards/api/useTimeCards";
+import {
+  useCaseTimeCards,
+  usePostTimeCard,
+  useUpdateTimeCard,
+} from "@features/csm-timecards/api/useTimeCards";
 import type { CsmTimeCard } from "@features/csm-timecards/types/timeCards";
 import { caseIdLabel } from "@features/csm-cases/utils/caseIdentity";
 import { useReportCaseTabDraft } from "@features/case-tabs/hooks/useReportCaseTabDraft";
@@ -532,6 +536,9 @@ export default function CsmCaseDetailPage(): JSX.Element {
     isFetching: isFetchingCallRequests,
   } = useGetCsmCaseCallRequests(isAnnouncement ? undefined : caseId);
   const { data: caseTasks } = useSearchCaseTasks(
+    isAnnouncement ? undefined : caseId,
+  );
+  const { data: caseTimeCards } = useCaseTimeCards(
     isAnnouncement ? undefined : caseId,
   );
   // Live deployment lookup for the Details tab's "Deployment info" widget —
@@ -2138,7 +2145,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
                   : t.id === "attachments"
                     ? attachmentList.length
                     : t.id === "time"
-                      ? c.timeLogs.length
+                      ? caseTimeCards?.cards.length
                       : t.id === "call-requests"
                         ? callRequests?.length
                         : t.id === "tasks"

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -2145,7 +2145,7 @@ export default function CsmCaseDetailPage(): JSX.Element {
                   : t.id === "attachments"
                     ? attachmentList.length
                     : t.id === "time"
-                      ? caseTimeCards?.cards.length
+                      ? caseTimeCards?.total
                       : t.id === "call-requests"
                         ? callRequests?.length
                         : t.id === "tasks"

--- a/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeCards.ts
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/api/useTimeCards.ts
@@ -55,9 +55,12 @@ import {
  * plus whether that one page fell short of the case's full `total` — some of
  * the case's cards may not have been fetched if so. No pagination UI here
  * (unlike the three tabs on `/time-cards`) — a single case logging more than
- * a page's worth of time is not expected. */
+ * a page's worth of time is not expected. `total` is the case's real card
+ * count (not just `cards.length`) — use it for any display count so it stays
+ * correct when `truncated` is true. */
 export interface CaseTimeCardsResult {
   cards: CsmTimeCard[];
+  total: number;
   truncated: boolean;
 }
 
@@ -75,9 +78,9 @@ export function useCaseTimeCards(
   return useQuery<CaseTimeCardsResult, Error>({
     queryKey: [ApiQueryKeys.CASE_TIME_CARDS_SEARCH, caseId ?? ""],
     queryFn: async (): Promise<CaseTimeCardsResult> => {
-      if (!caseId) return { cards: [], truncated: false };
+      if (!caseId) return { cards: [], total: 0, truncated: false };
       const { cards, total } = await searchTimeCards(api, { caseId });
-      return { cards, truncated: cards.length < total };
+      return { cards, total, truncated: cards.length < total };
     },
     enabled: !!caseId,
     staleTime: 5_000,

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/CaseTimeCardsPanel.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/CaseTimeCardsPanel.test.tsx
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import "@testing-library/jest-dom/vitest";
 import type { CsmTimeCard } from "@features/csm-timecards/types/timeCards";
@@ -92,35 +92,59 @@ describe("CaseTimeCardsPanel — view details", () => {
     refetch.mockReset();
   });
 
+  it("renders time cards as a grid table with a header row and one row per card", () => {
+    render(<CaseTimeCardsPanel caseId="case-1" onLogTime={vi.fn()} onEditTimeCard={vi.fn()} />);
+
+    // Header cells for the grid/subgrid table (matches the "Call requests"
+    // tab's CallRequestsTable convention). "State" and "Billable" also occur
+    // as row cell values (state chip label, billable label), so those two
+    // just assert at least one match rather than exactly one.
+    for (const label of ["Preview", "Engineer", "Minutes", "Logged", "Actions"]) {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
+    for (const label of ["State", "Billable"]) {
+      expect(screen.getAllByText(label).length).toBeGreaterThan(0);
+    }
+
+    expect(screen.getByText("Jane Doe")).toBeInTheDocument();
+    expect(screen.getByText("John Smith")).toBeInTheDocument();
+    expect(screen.getByText("45 min")).toBeInTheDocument();
+    expect(screen.getByText("20 min")).toBeInTheDocument();
+  });
+
   it("shows a 'View details' action on every card row, regardless of state or ownership", () => {
     render(<CaseTimeCardsPanel caseId="case-1" onLogTime={vi.fn()} onEditTimeCard={vi.fn()} />);
 
-    expect(screen.getAllByRole("button", { name: "View details" })).toHaveLength(2);
+    expect(screen.getByTestId("timecard-view-tc-1")).toBeInTheDocument();
+    expect(screen.getByTestId("timecard-view-tc-2")).toBeInTheDocument();
   });
 
   it("opens the read-only details view with the row's own fields when clicked", () => {
     render(<CaseTimeCardsPanel caseId="case-1" onLogTime={vi.fn()} onEditTimeCard={vi.fn()} />);
 
-    const [viewButtonA] = screen.getAllByRole("button", { name: "View details" });
-    fireEvent.click(viewButtonA);
+    fireEvent.click(screen.getByTestId("timecard-view-tc-1"));
 
-    expect(screen.getByText("Engineer's comment")).toBeInTheDocument();
-    expect(screen.getByText("Investigated the reported latency issue.")).toBeInTheDocument();
+    const dialog = within(screen.getByRole("dialog"));
+    expect(dialog.getByText("Engineer's comment")).toBeInTheDocument();
+    expect(dialog.getByText("Investigated the reported latency issue.")).toBeInTheDocument();
   });
 
   it("opens the details view for an approved, other-engineer's card too", () => {
     render(<CaseTimeCardsPanel caseId="case-1" onLogTime={vi.fn()} onEditTimeCard={vi.fn()} />);
 
-    const [, viewButtonB] = screen.getAllByRole("button", { name: "View details" });
-    fireEvent.click(viewButtonB);
+    fireEvent.click(screen.getByTestId("timecard-view-tc-2"));
 
-    expect(screen.getByText("Approved by: Lead Person")).toBeInTheDocument();
+    // The table row's own State column also shows the decision summary
+    // ("Approved by: Lead Person"), so scope to the dialog specifically.
+    expect(
+      within(screen.getByRole("dialog")).getByText("Approved by: Lead Person"),
+    ).toBeInTheDocument();
   });
 
   it("closes the details view when its row's action is clicked again", () => {
     render(<CaseTimeCardsPanel caseId="case-1" onLogTime={vi.fn()} onEditTimeCard={vi.fn()} />);
 
-    const [viewButtonA] = screen.getAllByRole("button", { name: "View details" });
+    const viewButtonA = screen.getByTestId("timecard-view-tc-1");
     fireEvent.click(viewButtonA);
     expect(screen.getByText("Engineer's comment")).toBeInTheDocument();
 
@@ -131,10 +155,19 @@ describe("CaseTimeCardsPanel — view details", () => {
   it("closes the details view via its own Close button", () => {
     render(<CaseTimeCardsPanel caseId="case-1" onLogTime={vi.fn()} onEditTimeCard={vi.fn()} />);
 
-    const [viewButtonA] = screen.getAllByRole("button", { name: "View details" });
-    fireEvent.click(viewButtonA);
+    fireEvent.click(screen.getByTestId("timecard-view-tc-1"));
     fireEvent.click(screen.getByRole("button", { name: "Close" }));
 
     expect(screen.queryByText("Engineer's comment")).not.toBeInTheDocument();
+  });
+
+  it("shows Edit/Delete actions only for your own still-submitted card", () => {
+    render(<CaseTimeCardsPanel caseId="case-1" onLogTime={vi.fn()} onEditTimeCard={vi.fn()} />);
+
+    // CARD_A (tc-1) is owned by the signed-in engineer (user-1) and
+    // "submitted" -- editable. CARD_B (tc-2) belongs to someone else and is
+    // "approved" -- neither editable.
+    expect(screen.getByRole("button", { name: "Edit time card" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Delete time card" })).toBeInTheDocument();
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/CaseTimeCardsPanel.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/CaseTimeCardsPanel.test.tsx
@@ -1,0 +1,140 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import type { CsmTimeCard } from "@features/csm-timecards/types/timeCards";
+
+// CaseTimeCardsPanel pulls in useCaseTimeCards/useDecideTimeCard/
+// useDeleteTimeCard (React Query hooks backed by useBackendApi) and
+// useCurrentEngineer/useIsTeamLead (auth-derived). None of those are under
+// test here -- the "View details" interaction is -- so every one of them is
+// mocked directly rather than wiring a QueryClientProvider + backend mock,
+// matching how other case-detail-tab tests in this feature folder isolate
+// the component under test from its data layer.
+const CARD_A: CsmTimeCard = {
+  id: "tc-1",
+  caseId: "case-1",
+  caseNumber: "CS0000001",
+  projectId: "proj-1",
+  projectName: "Acme Project",
+  workDate: "2026-07-01",
+  userId: "user-1",
+  userName: "Jane Doe",
+  state: "submitted",
+  billable: true,
+  totalMinutes: 45,
+  workLogComment: "<p>Investigated the reported latency issue.</p>",
+};
+
+const CARD_B: CsmTimeCard = {
+  id: "tc-2",
+  caseId: "case-1",
+  caseNumber: "CS0000001",
+  projectId: "proj-1",
+  projectName: "Acme Project",
+  workDate: "2026-07-02",
+  userId: "user-2",
+  userName: "John Smith",
+  state: "approved",
+  billable: false,
+  totalMinutes: 20,
+  approvedByName: "Lead Person",
+};
+
+// CaseTimeCardsPanel also imports BackendApiError directly from
+// @api/backend/client (for its own error-message narrowing), which reads
+// window.config at module load via @config/apiConfig -- mock it too so
+// importing the panel doesn't trip that, same as TimeCardsTable.test.tsx.
+vi.mock("@config/apiConfig", () => ({ apiConfig: { backendUrl: "https://example.test" } }));
+
+const refetch = vi.fn();
+vi.mock("@features/csm-timecards/api/useTimeCards", () => ({
+  useCaseTimeCards: () => ({
+    data: { cards: [CARD_A, CARD_B], truncated: false },
+    isLoading: false,
+    isError: false,
+    refetch,
+    isFetching: false,
+    dataUpdatedAt: Date.now(),
+  }),
+  useDecideTimeCard: () => ({ mutate: vi.fn(), isPending: false }),
+  useDeleteTimeCard: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+vi.mock("@features/csm-timecards/api/useTimeSheets", () => ({
+  useCurrentEngineer: () => ({ id: "user-1", name: "Jane Doe" }),
+}));
+vi.mock("@features/csm-timecards/hooks/useIsTeamLead", () => ({
+  useIsTeamLead: () => false,
+}));
+vi.mock("@context/error-banner/ErrorBannerContext", () => ({
+  useErrorBanner: () => ({ showError: vi.fn() }),
+}));
+
+import CaseTimeCardsPanel from "@features/csm-timecards/components/CaseTimeCardsPanel";
+
+describe("CaseTimeCardsPanel — view details", () => {
+  beforeEach(() => {
+    refetch.mockReset();
+  });
+
+  it("shows a 'View details' action on every card row, regardless of state or ownership", () => {
+    render(<CaseTimeCardsPanel caseId="case-1" onLogTime={vi.fn()} onEditTimeCard={vi.fn()} />);
+
+    expect(screen.getAllByRole("button", { name: "View details" })).toHaveLength(2);
+  });
+
+  it("opens the read-only details view with the row's own fields when clicked", () => {
+    render(<CaseTimeCardsPanel caseId="case-1" onLogTime={vi.fn()} onEditTimeCard={vi.fn()} />);
+
+    const [viewButtonA] = screen.getAllByRole("button", { name: "View details" });
+    fireEvent.click(viewButtonA);
+
+    expect(screen.getByText("Engineer's comment")).toBeInTheDocument();
+    expect(screen.getByText("Investigated the reported latency issue.")).toBeInTheDocument();
+  });
+
+  it("opens the details view for an approved, other-engineer's card too", () => {
+    render(<CaseTimeCardsPanel caseId="case-1" onLogTime={vi.fn()} onEditTimeCard={vi.fn()} />);
+
+    const [, viewButtonB] = screen.getAllByRole("button", { name: "View details" });
+    fireEvent.click(viewButtonB);
+
+    expect(screen.getByText("Approved by: Lead Person")).toBeInTheDocument();
+  });
+
+  it("closes the details view when its row's action is clicked again", () => {
+    render(<CaseTimeCardsPanel caseId="case-1" onLogTime={vi.fn()} onEditTimeCard={vi.fn()} />);
+
+    const [viewButtonA] = screen.getAllByRole("button", { name: "View details" });
+    fireEvent.click(viewButtonA);
+    expect(screen.getByText("Engineer's comment")).toBeInTheDocument();
+
+    fireEvent.click(viewButtonA);
+    expect(screen.queryByText("Engineer's comment")).not.toBeInTheDocument();
+  });
+
+  it("closes the details view via its own Close button", () => {
+    render(<CaseTimeCardsPanel caseId="case-1" onLogTime={vi.fn()} onEditTimeCard={vi.fn()} />);
+
+    const [viewButtonA] = screen.getAllByRole("button", { name: "View details" });
+    fireEvent.click(viewButtonA);
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+
+    expect(screen.queryByText("Engineer's comment")).not.toBeInTheDocument();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/CaseTimeCardsPanel.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/CaseTimeCardsPanel.tsx
@@ -28,7 +28,7 @@ import {
   Skeleton,
   Typography,
 } from "@wso2/oxygen-ui";
-import { Clock, Pencil, Plus, Trash2 } from "@wso2/oxygen-ui-icons-react";
+import { Clock, Eye, Pencil, Plus, Trash2 } from "@wso2/oxygen-ui-icons-react";
 import RelativeDate from "@components/RelativeDate";
 import {
   useCaseTimeCards,
@@ -41,6 +41,7 @@ import { billableLabel } from "@features/csm-timecards/constants/timeCardConstan
 import { decisionSummary } from "@features/csm-timecards/utils/timeCardDecision";
 import { BackendApiError } from "@api/backend/client";
 import { useErrorBanner } from "@context/error-banner/ErrorBannerContext";
+import TimeCardDetailsDialog from "@features/csm-timecards/components/TimeCardDetailsDialog";
 import TimeCardStatusChip from "@features/csm-timecards/components/TimeCardStatusChip";
 import TimeCardReviewDialog from "@features/csm-timecards/components/TimeCardReviewDialog";
 import TimeCardTruncatedNotice from "@features/csm-timecards/components/TimeCardTruncatedNotice";
@@ -77,6 +78,7 @@ export default function CaseTimeCardsPanel({
   const { showError } = useErrorBanner();
   const [reviewCard, setReviewCard] = useState<CsmTimeCard | null>(null);
   const [pendingDelete, setPendingDelete] = useState<CsmTimeCard | null>(null);
+  const [detailCard, setDetailCard] = useState<CsmTimeCard | null>(null);
 
   const cards = useMemo(() => data?.cards ?? [], [data]);
   const total = useMemo(
@@ -191,6 +193,20 @@ export default function CaseTimeCardsPanel({
                 <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
                   <Typography variant="body2">{c.totalMinutes} min</Typography>
                   <TimeCardStatusChip state={c.state} />
+                  {/* Read-only, so shown on every card regardless of state or
+                   ownership — unlike Edit/Review below, there's no
+                   authorization concern here. Matches the toggle-to-close
+                   "eye" convention in TimeCardsTable. */}
+                  <IconButton
+                    size="small"
+                    aria-label="View details"
+                    aria-pressed={detailCard?.id === c.id}
+                    onClick={() =>
+                      setDetailCard((prev) => (prev?.id === c.id ? null : c))
+                    }
+                  >
+                    <Eye size={14} />
+                  </IconButton>
                   {/* Own card, still submitted: only the submitter can edit
                    its content, matching the backend's own submitter-only +
                    submitted-state-only enforcement (see cardActions). */}
@@ -244,6 +260,10 @@ export default function CaseTimeCardsPanel({
             );
           })}
         </Box>
+      )}
+
+      {detailCard && (
+        <TimeCardDetailsDialog card={detailCard} onClose={() => setDetailCard(null)} />
       )}
 
       {reviewCard && (

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/CaseTimeCardsPanel.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/CaseTimeCardsPanel.tsx
@@ -19,16 +19,17 @@ import {
   Box,
   Button,
   Card,
+  Chip,
   Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
-  Divider,
   IconButton,
   Skeleton,
+  Tooltip,
   Typography,
 } from "@wso2/oxygen-ui";
-import { Clock, Eye, Pencil, Plus, Trash2 } from "@wso2/oxygen-ui-icons-react";
+import { ClipboardCheck, Clock, Eye, Pencil, Plus, Trash2 } from "@wso2/oxygen-ui-icons-react";
 import RelativeDate from "@components/RelativeDate";
 import {
   useCaseTimeCards,
@@ -57,6 +58,23 @@ interface CaseTimeCardsPanelProps {
    * instance, just in different modes). */
   onEditTimeCard: (card: CsmTimeCard) => void;
 }
+
+// Every column is left-aligned for a consistent scan line down the table,
+// except "Actions" -- a row of icon buttons rather than text, which reads
+// better centered under its own column. Mirrors CallRequestsTable's
+// HEADER_CELLS/GRID convention so the two tabs read consistently.
+const HEADER_CELLS: string[] = [
+  "Preview",
+  "Engineer",
+  "State",
+  "Minutes",
+  "Billable",
+  "Logged",
+  "Actions",
+];
+
+const GRID =
+  "minmax(56px, 0.4fr) minmax(140px, 1.1fr) minmax(140px, 1.1fr) minmax(80px, 0.6fr) minmax(90px, 0.6fr) minmax(110px, 0.8fr) minmax(120px, 0.9fr)";
 
 /**
  * The body of a case's "Time tracking" tab: the time cards logged on this
@@ -87,21 +105,29 @@ export default function CaseTimeCardsPanel({
   );
 
   return (
-    <Card variant="outlined" sx={{ p: 2 }}>
+    <Card variant="outlined" sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 2 }}>
+      {/* Header */}
       <Box
         sx={{
           display: "flex",
           alignItems: "center",
           justifyContent: "space-between",
           gap: 1,
-          mb: 1.25,
+          flexWrap: "wrap",
         }}
       >
         <Box sx={{ display: "flex", alignItems: "center", gap: 0.75 }}>
           <Clock size={16} />
           <Typography variant="subtitle2">Time tracked</Typography>
+          {!isLoading && !isError && (
+            <Chip
+              size="small"
+              variant="outlined"
+              label={`${total} min · ${cards.length} ${cards.length === 1 ? "entry" : "entries"}`}
+            />
+          )}
         </Box>
-        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+        <Box sx={{ display: "flex", gap: 1, alignItems: "center", flexWrap: "wrap" }}>
           <RefreshButton
             onRefresh={() => void refetch()}
             isFetching={isFetching}
@@ -110,153 +136,216 @@ export default function CaseTimeCardsPanel({
           />
           <Button
             size="small"
-            variant="text"
+            variant="contained"
             startIcon={<Plus size={14} />}
             onClick={onLogTime}
+            sx={{ textTransform: "none" }}
           >
             Log time
           </Button>
         </Box>
       </Box>
 
-      <Box
-        sx={{
-          display: "flex",
-          alignItems: "baseline",
-          justifyContent: "space-between",
-          mb: 1,
-        }}
-      >
-        <Typography variant="h6" sx={{ lineHeight: 1 }}>
-          {total} min
-        </Typography>
-        <Typography variant="caption" color="text.secondary">
-          Across {cards.length} {cards.length === 1 ? "entry" : "entries"}
-        </Typography>
-      </Box>
-
-      <Divider sx={{ mb: 1 }} />
-
       {!isError && data?.truncated && (
         <TimeCardTruncatedNotice hint="Some entries on this case may not be shown." />
       )}
 
-      {isLoading ? (
+      {/* Content */}
+      {isLoading && (
         <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
           {[0, 1, 2].map((i) => (
-            <Box
-              key={i}
-              sx={{ p: 1, borderRadius: 1, border: 1, borderColor: "divider" }}
-            >
-              <Box sx={{ display: "flex", justifyContent: "space-between", mb: 0.5 }}>
-                <Skeleton variant="rounded" width="40%" height={20} />
-                <Skeleton variant="rounded" width="20%" height={20} />
-              </Box>
-              <Skeleton variant="rounded" width="25%" height={16} />
-            </Box>
+            <Skeleton key={i} variant="rounded" height={64} />
           ))}
         </Box>
-      ) : isError ? (
+      )}
+
+      {isError && (
         <Typography variant="body2" color="error" sx={{ py: 2 }}>
           Could not load time cards.
         </Typography>
-      ) : cards.length === 0 ? (
-        <Typography variant="body2" color="text.secondary" sx={{ py: 2 }}>
-          No time logged on this case yet.
-        </Typography>
-      ) : (
-        <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+      )}
+
+      {!isLoading && !isError && cards.length === 0 && (
+        <Box sx={{ py: 3, textAlign: "center" }}>
+          <Typography variant="body2" color="text.secondary">
+            No time logged on this case yet.
+          </Typography>
+        </Box>
+      )}
+
+      {!isLoading && !isError && cards.length > 0 && (
+        <Box
+          sx={{
+            border: 1,
+            borderColor: "divider",
+            borderRadius: 1,
+            overflowX: "auto",
+            overflowY: "hidden",
+            display: "grid",
+            gridTemplateColumns: GRID,
+            columnGap: 2,
+          }}
+        >
+          {/* Header */}
+          <Box
+            sx={{
+              gridColumn: "1 / -1",
+              display: "grid",
+              gridTemplateColumns: "subgrid",
+              columnGap: 2,
+              alignItems: "center",
+              px: 2,
+              py: 1.25,
+              bgcolor: "action.hover",
+              borderBottom: 1,
+              borderColor: "divider",
+            }}
+          >
+            {HEADER_CELLS.map((label) => (
+              <Typography
+                key={label}
+                variant="caption"
+                color="text.secondary"
+                sx={{ fontWeight: 600, textAlign: label === "Actions" ? "center" : "left" }}
+              >
+                {label}
+              </Typography>
+            ))}
+          </Box>
+
+          {/* Rows */}
           {cards.map((c) => {
             const decision = decisionSummary(c);
+            const canEdit = c.state === "submitted" && !!me.id && c.userId === me.id;
+            // Never shown on your own card: the backend 403s a self-decide
+            // regardless of approver status, so a card you submitted
+            // yourself can never actually be reviewed by you. Also gated on
+            // being in the card's own approver list -- this panel shows
+            // every submitted card on the case, not just ones assigned to
+            // the signed-in lead, and the backend 403s a decision from
+            // anyone not in that list (confirmed live).
+            const canReview =
+              isTeamLead &&
+              c.state === "submitted" &&
+              !!me.id &&
+              c.userId !== me.id &&
+              !!c.approvers?.some((a) => a.id === me.id);
+
             return (
-            <Box
-              key={c.id}
-              sx={{
-                display: "flex",
-                flexDirection: "column",
-                gap: 0.5,
-                p: 1,
-                borderRadius: 1,
-                border: 1,
-                borderColor: "divider",
-              }}
-            >
               <Box
+                key={c.id}
                 sx={{
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "space-between",
-                  gap: 1,
+                  gridColumn: "1 / -1",
+                  display: "grid",
+                  gridTemplateColumns: "subgrid",
+                  columnGap: 2,
+                  alignItems: "start",
+                  px: 2,
+                  py: 1.25,
+                  borderBottom: 1,
+                  borderColor: "divider",
+                  "&:last-of-type": { borderBottom: 0 },
                 }}
               >
-                <Typography variant="body2">{c.userName}</Typography>
-                <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-                  <Typography variant="body2">{c.totalMinutes} min</Typography>
-                  <TimeCardStatusChip state={c.state} />
-                  {/* Read-only, so shown on every card regardless of state or
-                   ownership — unlike Edit/Review below, there's no
-                   authorization concern here. Matches the toggle-to-close
-                   "eye" convention in TimeCardsTable. */}
+                {/* Preview: view-detail eye icon, its own leading column so
+                    it reads as "inspect this row" rather than one of the
+                    row's actions. Read-only, so shown on every row
+                    regardless of state or ownership -- unlike Edit/Review
+                    below, there's no authorization concern here. */}
+                <Box sx={{ justifySelf: "start" }}>
                   <IconButton
                     size="small"
-                    aria-label="View details"
+                    aria-label={`View details for ${c.userName}'s entry`}
                     aria-pressed={detailCard?.id === c.id}
+                    data-testid={`timecard-view-${c.id}`}
                     onClick={() =>
                       setDetailCard((prev) => (prev?.id === c.id ? null : c))
                     }
                   >
-                    <Eye size={14} />
+                    <Eye size={16} />
                   </IconButton>
-                  {/* Own card, still submitted: only the submitter can edit
-                   its content, matching the backend's own submitter-only +
-                   submitted-state-only enforcement (see cardActions). */}
-                  {c.state === "submitted" && !!me.id && c.userId === me.id && (
-                    <>
-                      <Button
-                        size="small"
-                        variant="outlined"
-                        startIcon={<Pencil size={14} />}
-                        onClick={() => onEditTimeCard(c)}
-                      >
-                        Edit
-                      </Button>
-                      <IconButton
-                        size="small"
-                        color="error"
-                        aria-label="Delete time card"
-                        onClick={() => setPendingDelete(c)}
-                      >
-                        <Trash2 size={14} />
-                      </IconButton>
-                    </>
+                </Box>
+
+                <Typography variant="body2" noWrap title={c.userName}>
+                  {c.userName}
+                </Typography>
+
+                {/* State: chip + decision summary, when present. */}
+                <Box sx={{ justifySelf: "start", minWidth: 0 }}>
+                  <TimeCardStatusChip state={c.state} />
+                  {decision && (
+                    <Typography
+                      variant="caption"
+                      color="text.secondary"
+                      noWrap
+                      title={decision}
+                      sx={{ display: "block", mt: 0.5 }}
+                    >
+                      {decision}
+                    </Typography>
                   )}
-                  {/* Never shown on your own card: the backend 403s a
-                   self-decide regardless of approver status, so a card you
-                   submitted yourself can never actually be reviewed by you.
-                   Also gated on being in the card's own approver list — this
-                   panel shows every submitted card on the case, not just
-                   ones assigned to the signed-in lead, and the backend 403s
-                   a decision from anyone not in that list (confirmed live). */}
-                  {isTeamLead &&
-                    c.state === "submitted" &&
-                    !!me.id &&
-                    c.userId !== me.id &&
-                    !!c.approvers?.some((a) => a.id === me.id) && (
-                      <Button
-                        size="small"
-                        variant="outlined"
-                        onClick={() => setReviewCard(c)}
-                      >
-                        Review
-                      </Button>
+                </Box>
+
+                <Typography variant="body2">{c.totalMinutes} min</Typography>
+
+                <Typography variant="body2">{billableLabel(c.billable)}</Typography>
+
+                <Typography variant="caption" color="text.secondary" noWrap>
+                  <RelativeDate value={c.workDate} />
+                </Typography>
+
+                {/* Actions: Edit/Delete for your own still-submitted card,
+                    Review for a team lead. The view-detail eye icon has its
+                    own leading "Preview" column instead. Centered under the
+                    "Actions" header, matching CallRequestsTable. */}
+                <Box sx={{ minWidth: 0, textAlign: "center" }}>
+                  <Box
+                    sx={{
+                      display: "flex",
+                      gap: 0.5,
+                      alignItems: "center",
+                      justifyContent: "center",
+                      flexWrap: "wrap",
+                    }}
+                  >
+                    {canEdit && (
+                      <>
+                        <Tooltip title="Edit">
+                          <IconButton
+                            size="small"
+                            aria-label="Edit time card"
+                            onClick={() => onEditTimeCard(c)}
+                          >
+                            <Pencil size={16} />
+                          </IconButton>
+                        </Tooltip>
+                        <Tooltip title="Delete">
+                          <IconButton
+                            size="small"
+                            color="error"
+                            aria-label="Delete time card"
+                            onClick={() => setPendingDelete(c)}
+                          >
+                            <Trash2 size={16} />
+                          </IconButton>
+                        </Tooltip>
+                      </>
                     )}
+                    {canReview && (
+                      <Tooltip title="Review">
+                        <IconButton
+                          size="small"
+                          color="primary"
+                          aria-label="Review time card"
+                          onClick={() => setReviewCard(c)}
+                        >
+                          <ClipboardCheck size={16} />
+                        </IconButton>
+                      </Tooltip>
+                    )}
+                  </Box>
                 </Box>
               </Box>
-              <Typography variant="caption" color="text.secondary">
-                {billableLabel(c.billable)} · <RelativeDate value={c.workDate} />
-                {decision && ` · ${decision}`}
-              </Typography>
-            </Box>
             );
           })}
         </Box>

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardDetailsDialog.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardDetailsDialog.test.tsx
@@ -43,6 +43,7 @@ describe("TimeCardDetailsDialog", () => {
 
     expect(screen.getByText("Jane Doe")).toBeInTheDocument();
     expect(screen.getByText("Acme")).toBeInTheDocument();
+    expect(screen.getByText("Total time")).toBeInTheDocument();
     expect(screen.getAllByText("30 min").length).toBeGreaterThan(0);
   });
 
@@ -94,7 +95,15 @@ describe("TimeCardDetailsDialog", () => {
 
     expect(screen.getByText("Breakdown")).toBeInTheDocument();
     expect(screen.getByText("Analysis and debugging")).toBeInTheDocument();
+    expect(screen.getByText("Reproduce")).toBeInTheDocument();
+    expect(screen.getByText("Setting up")).toBeInTheDocument();
     expect(screen.getByText("Providing solution")).toBeInTheDocument();
+    expect(screen.getByText("Answering")).toBeInTheDocument();
+
+    expect(screen.getByText("15 min")).toBeInTheDocument();
+    expect(screen.getByText("5 min")).toBeInTheDocument();
+    expect(screen.getByText("10 min")).toBeInTheDocument();
+    expect(screen.getAllByText("0 min").length).toBe(2);
   });
 
   it("renders no breakdown section when the card has none", () => {

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardDetailsDialog.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardDetailsDialog.test.tsx
@@ -1,0 +1,146 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import TimeCardDetailsDialog from "@features/csm-timecards/components/TimeCardDetailsDialog";
+import type { CsmTimeCard } from "@features/csm-timecards/types/timeCards";
+
+function card(overrides: Partial<CsmTimeCard> = {}): CsmTimeCard {
+  return {
+    id: "card-1",
+    caseId: "case-1",
+    caseNumber: "CS0000001",
+    projectId: "proj-1",
+    projectName: "Acme",
+    workDate: "2026-07-13",
+    userId: "user-1",
+    userName: "Jane Doe",
+    state: "submitted",
+    billable: true,
+    totalMinutes: 30,
+    ...overrides,
+  };
+}
+
+describe("TimeCardDetailsDialog", () => {
+  it("shows the card's own fields", () => {
+    render(<TimeCardDetailsDialog card={card()} onClose={vi.fn()} />);
+
+    expect(screen.getByText("Jane Doe")).toBeInTheDocument();
+    expect(screen.getByText("Acme")).toBeInTheDocument();
+    expect(screen.getAllByText("30 min").length).toBeGreaterThan(0);
+  });
+
+  it("shows the engineer's work-log comment, sanitized, when the card has one", () => {
+    render(
+      <TimeCardDetailsDialog
+        card={card({ workLogComment: "<p>Investigated the reported latency issue.</p>" })}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Engineer's comment")).toBeInTheDocument();
+    expect(screen.getByText("Investigated the reported latency issue.")).toBeInTheDocument();
+  });
+
+  it("strips unsafe markup from the work-log comment before rendering", () => {
+    render(
+      <TimeCardDetailsDialog
+        card={card({ workLogComment: '<p>hi<script>window.x=1</script></p><img src=x onerror="window.y=1">' })}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(document.querySelector("script")).not.toBeInTheDocument();
+    const img = document.querySelector("img");
+    expect(img?.getAttribute("onerror")).toBeNull();
+  });
+
+  it("renders no comment section when the card has none", () => {
+    render(<TimeCardDetailsDialog card={card()} onClose={vi.fn()} />);
+    expect(screen.queryByText("Engineer's comment")).not.toBeInTheDocument();
+  });
+
+  it("shows the per-activity breakdown when present, in the fixed display order", () => {
+    render(
+      <TimeCardDetailsDialog
+        card={card({
+          breakdown: {
+            analysisDebugging: 15,
+            reproduce: 5,
+            settingUp: 0,
+            providingSolution: 10,
+            answering: 0,
+          },
+        })}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Breakdown")).toBeInTheDocument();
+    expect(screen.getByText("Analysis and debugging")).toBeInTheDocument();
+    expect(screen.getByText("Providing solution")).toBeInTheDocument();
+  });
+
+  it("renders no breakdown section when the card has none", () => {
+    render(<TimeCardDetailsDialog card={card()} onClose={vi.fn()} />);
+    expect(screen.queryByText("Breakdown")).not.toBeInTheDocument();
+  });
+
+  it("shows issue complexity when present", () => {
+    render(<TimeCardDetailsDialog card={card({ issueComplexity: "High" })} onClose={vi.fn()} />);
+    expect(screen.getByText("Issue complexity")).toBeInTheDocument();
+    expect(screen.getByText("High")).toBeInTheDocument();
+  });
+
+  it("lists the eligible approvers on a submitted card", () => {
+    render(
+      <TimeCardDetailsDialog
+        card={card({
+          approvers: [
+            { id: "lead-1", name: "Lead One" },
+            { id: "lead-2", name: "Lead Two" },
+          ],
+        })}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Approvers")).toBeInTheDocument();
+    expect(screen.getByText("Lead One, Lead Two")).toBeInTheDocument();
+  });
+
+  it("shows the decision summary on a decided card", () => {
+    render(
+      <TimeCardDetailsDialog
+        card={card({ state: "approved", approvedByName: "Lead Person" })}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Approved by: Lead Person")).toBeInTheDocument();
+  });
+
+  it("calls onClose when Close is clicked", () => {
+    const onClose = vi.fn();
+    render(<TimeCardDetailsDialog card={card()} onClose={onClose} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardDetailsDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardDetailsDialog.tsx
@@ -82,14 +82,20 @@ function Breakdown({ breakdown }: { breakdown?: CsmTimeCard["breakdown"] }): JSX
     <Field
       label="Breakdown"
       value={
-        <Box sx={{ display: "flex", flexDirection: "column", gap: 0.25 }}>
+        <Box
+          sx={{
+            display: "grid",
+            gridTemplateColumns: "1fr auto",
+            columnGap: 2,
+            rowGap: 0.25,
+          }}
+        >
           {ACTIVITY_BUCKETS.map((bucket) => (
-            <Box
-              key={bucket.key}
-              sx={{ display: "flex", justifyContent: "space-between", gap: 2 }}
-            >
+            <Box key={bucket.key} sx={{ display: "contents" }}>
               <Typography variant="body2">{bucket.label}</Typography>
-              <Typography variant="body2">{breakdown[bucket.key]} min</Typography>
+              <Typography variant="body2" sx={{ textAlign: "right" }}>
+                {breakdown[bucket.key]} min
+              </Typography>
             </Box>
           ))}
         </Box>
@@ -132,7 +138,7 @@ export default function TimeCardDetailsDialog({
                 </Typography>
               }
             />
-            <Field label="Minutes" value={`${card.totalMinutes} min`} />
+            <Field label="Total time" value={`${card.totalMinutes} min`} />
             <Field
               label="State"
               value={

--- a/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardDetailsDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-timecards/components/TimeCardDetailsDialog.tsx
@@ -1,0 +1,174 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { JSX, ReactNode } from "react";
+import { Box, Button, Dialog, DialogActions, DialogContent, DialogTitle, Typography } from "@wso2/oxygen-ui";
+import RelativeDate from "@components/RelativeDate";
+import TimeCardStatusChip from "@features/csm-timecards/components/TimeCardStatusChip";
+import { ACTIVITY_BUCKETS, billableLabel } from "@features/csm-timecards/constants/timeCardConstants";
+import { decisionSummary } from "@features/csm-timecards/utils/timeCardDecision";
+import { isBlankHtml, sanitizeRichTextHtml } from "@utils/sanitizeHtml";
+import type { CsmTimeCard } from "@features/csm-timecards/types/timeCards";
+
+interface TimeCardDetailsDialogProps {
+  card: CsmTimeCard;
+  onClose: () => void;
+}
+
+function Field({ label, value }: { label: string; value: ReactNode }): JSX.Element {
+  return (
+    <Box sx={{ minWidth: 0, display: "flex", flexDirection: "column", gap: 0.5 }}>
+      <Typography variant="caption" color="text.secondary">
+        {label}
+      </Typography>
+      {typeof value === "string" ? <Typography variant="body2">{value}</Typography> : value}
+    </Box>
+  );
+}
+
+/**
+ * The engineer's own work-log comment from submission — ServiceNow rich-text
+ * HTML, so it's sanitized and rendered as HTML (same policy as a case
+ * comment's body, and the same pattern as `TimeCardReviewDialog`). Renders
+ * nothing when the card has none (e.g. logged before this field was mapped).
+ */
+function WorkLogComment({ html }: { html?: string }): JSX.Element | null {
+  if (!html || isBlankHtml(html)) return null;
+  const safeHtml = sanitizeRichTextHtml(html);
+  return (
+    <Field
+      label="Engineer's comment"
+      value={
+        <Box
+          sx={{
+            fontSize: "0.875rem",
+            lineHeight: 1.5,
+            wordBreak: "break-word",
+            "& p": { my: 0.5 },
+            "& p:first-of-type": { mt: 0 },
+            "& p:last-child": { mb: 0 },
+            "& ul, & ol": { my: 0.5, pl: 3 },
+            "& a": { color: "primary.main" },
+            "& img": { maxWidth: "100%", height: "auto" },
+          }}
+          dangerouslySetInnerHTML={{ __html: safeHtml }}
+        />
+      }
+    />
+  );
+}
+
+/**
+ * Per-activity minute breakdown, in the fixed `ACTIVITY_BUCKETS` display
+ * order — absent on a card logged before this field was mapped (see
+ * `CsmTimeCard.breakdown`), so renders nothing rather than a zeroed-out list.
+ */
+function Breakdown({ breakdown }: { breakdown?: CsmTimeCard["breakdown"] }): JSX.Element | null {
+  if (!breakdown) return null;
+  return (
+    <Field
+      label="Breakdown"
+      value={
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 0.25 }}>
+          {ACTIVITY_BUCKETS.map((bucket) => (
+            <Box
+              key={bucket.key}
+              sx={{ display: "flex", justifyContent: "space-between", gap: 2 }}
+            >
+              <Typography variant="body2">{bucket.label}</Typography>
+              <Typography variant="body2">{breakdown[bucket.key]} min</Typography>
+            </Box>
+          ))}
+        </Box>
+      }
+    />
+  );
+}
+
+/**
+ * Read-only details view of a single time card, opened from its row's "View
+ * details" action in `CaseTimeCardsPanel`. Unlike `TimeCardCasePreviewDrawer`
+ * (the Approvals-tab equivalent), this doesn't also fetch and render the
+ * linked case — the panel this opens from is already embedded in that same
+ * case's own detail page, so re-showing it here would be redundant. Available
+ * on every card regardless of state or ownership: it's read-only, so there's
+ * no authorization concern the way there is for Edit/Review.
+ */
+export default function TimeCardDetailsDialog({
+  card,
+  onClose,
+}: TimeCardDetailsDialogProps): JSX.Element {
+  const decision = decisionSummary(card);
+
+  return (
+    <Dialog open onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>
+        Time card · {card.caseNumber} · {card.totalMinutes} min
+      </DialogTitle>
+      <DialogContent dividers>
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+          <Box sx={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 2 }}>
+            <Field label="Engineer" value={card.userName} />
+            <Field label="Project" value={card.projectName} />
+            <Field label="Billable" value={billableLabel(card.billable)} />
+            <Field
+              label="Logged"
+              value={
+                <Typography variant="body2">
+                  <RelativeDate value={card.workDate} />
+                </Typography>
+              }
+            />
+            <Field label="Minutes" value={`${card.totalMinutes} min`} />
+            <Field
+              label="State"
+              value={
+                <Box sx={{ mt: 0.5 }}>
+                  <TimeCardStatusChip state={card.state} />
+                </Box>
+              }
+            />
+            {card.issueComplexity && (
+              <Field label="Issue complexity" value={card.issueComplexity} />
+            )}
+          </Box>
+
+          <WorkLogComment html={card.workLogComment} />
+
+          <Breakdown breakdown={card.breakdown} />
+
+          {card.state === "submitted" && card.approvers && card.approvers.length > 0 && (
+            <Field
+              label="Approvers"
+              value={card.approvers.map((approver) => approver.name).join(", ")}
+            />
+          )}
+
+          {decision && (
+            <Typography variant="body2" sx={{ whiteSpace: "normal", wordBreak: "break-word" }}>
+              {decision}
+            </Typography>
+          )}
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button color="inherit" onClick={onClose}>
+          Close
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a "View details" action to each time card row in a case's Time tracking tab, opening a read-only details view (engineer, project, billable, date, minutes, state, work-log comment, activity breakdown, issue complexity, approvers, decision).
- Restyles the Time tracking tab from a vertical card list to the same CSS-grid table layout already used by the Call requests tab (Preview/Engineer/State/Minutes/Billable/Logged/Actions columns), for visual consistency between the two tabs.
- Fixes the "Time tracking" tab-strip label so it shows a live count (e.g. "Time tracking (3)"), matching "Call requests (N)"/"SLAs (N)" — it previously always read 0 because it sourced the count from an always-empty placeholder field instead of the real time-cards query.

## Test plan
- [x] `pnpm run lint` — clean (0 errors)
- [x] `pnpm run test -- --run` — 236 test files / 2378 tests passing
- [x] `pnpm run build` — succeeds
- [x] Manual smoke test on a real case's Time tracking tab (view-details action, table layout, tab count)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned time-card viewing with a grid layout, summary totals, and clearer actions.
  * Added a read-only details dialog showing work-log comments, activity breakdowns, approval information, and card details.
  * Added preview, edit, delete, and review actions with improved icon-based controls.
  * Time tracking tab counts now reflect fetched time cards.
* **Bug Fixes**
  * Work-log comments are safely sanitized before display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->