### PR TITLE
[Scheduled-Tasks] add stale_cases_report sub-cron

### DIFF
--- a/operations/csm-scheduled-tasks/.env.example
+++ b/operations/csm-scheduled-tasks/.env.example
@@ -30,12 +30,11 @@ EMAIL_FROM_ADDRESS=
 
 # Global kill switch for every email this component sends — both failure
 # alerts (regardless of ALERT_RECIPIENTS or any task's SUB_CRON_RECIPIENTS
-# "to") and any report-style task's own success email (e.g.
-# "stale_cases_report" below). Failures are still recorded in entity-service
-# and logged either way, and a report task still runs and succeeds — this
-# only silences the email itself. Defaults to true (send) when unset; set to
-# false for a maintenance window or a known-noisy period without touching
-# any recipients config.
+# "to") and any report-style task's own success email. Failures are still
+# recorded in entity-service and logged either way, and a report task still
+# runs and succeeds — this only silences the email itself. Defaults to true
+# (send) when unset; set to false for a maintenance window or a known-noisy
+# period without touching any recipients config.
 ALERTS_ENABLED=
 
 # Comma-separated standing ops/on-call audience, emailed on every failed
@@ -48,14 +47,12 @@ ALERT_RECIPIENTS=
 
 # Optional: per-task To/Cc, by name, without needing a dedicated env var per
 # task — a JSON object of {"<task.Name>": {"to": ["..."], "cc": ["..."]}}.
-# For most tasks this is purely additional failure-alert audience: a task
-# not mentioned here just gets no per-task recipients, and its failures
-# still reach ALERT_RECIPIENTS above. "stale_cases_report" is the exception —
-# its "to"/"cc" here is also exactly who its own success report (cases open
-# more than 30 days) gets sent to; it has nothing to do with ALERT_RECIPIENTS
-# at all for that task. Example enabling the report for a CS team's own
-# distribution list:
-#   {"stale_cases_report": {"to": ["cs-team@example.com"]}}
+# For most tasks this is additional failure-alert audience: a task not
+# mentioned here just gets no per-task recipients, and its failures still
+# reach ALERT_RECIPIENTS above. A report-style task instead uses its own
+# "to"/"cc" here as its actual report recipients, unrelated to
+# ALERT_RECIPIENTS — see this component's own CLAUDE.md for which tasks work
+# that way.
 SUB_CRON_RECIPIENTS=
 
 # This component's own expected invocation cadence — must match the cron

--- a/operations/csm-scheduled-tasks/.env.example
+++ b/operations/csm-scheduled-tasks/.env.example
@@ -51,10 +51,10 @@ ALERT_RECIPIENTS=
 # For most tasks this is purely additional failure-alert audience: a task
 # not mentioned here just gets no per-task recipients, and its failures
 # still reach ALERT_RECIPIENTS above. "stale_cases_report" is the exception —
-# its "to"/"cc" here is also exactly who its own success report gets sent
-# to (see STALE_CASE_THRESHOLD_DAYS below); it has nothing to do with
-# ALERT_RECIPIENTS at all for that task. Example enabling the report for a
-# CS team's own distribution list:
+# its "to"/"cc" here is also exactly who its own success report (cases open
+# more than 30 days) gets sent to; it has nothing to do with ALERT_RECIPIENTS
+# at all for that task. Example enabling the report for a CS team's own
+# distribution list:
 #   {"stale_cases_report": {"to": ["cs-team@example.com"]}}
 SUB_CRON_RECIPIENTS=
 
@@ -79,13 +79,3 @@ SUB_CRON_SCHEDULES=
 # still failed/retrying is never deleted regardless of age. Defaults to 30
 # when unset.
 HOUSEKEEPING_RETENTION_DAYS=
-
-# How many days old a still-open case ("state" != closed) must be, by its
-# createdOn, for the "stale_cases_report" sub-cron to include it — a plain
-# integer, not a Go duration string, same convention as
-# HOUSEKEEPING_RETENTION_DAYS. Defaults to 30 when unset. This task only
-# ever runs its entity-service query and sends its report if it has
-# recipients configured in SUB_CRON_RECIPIENTS above (key
-# "stale_cases_report") — see this component's own CLAUDE.md, "Housekeeping"
-# section's sibling, "Stale cases report".
-STALE_CASE_THRESHOLD_DAYS=

--- a/operations/csm-scheduled-tasks/.env.example
+++ b/operations/csm-scheduled-tasks/.env.example
@@ -28,12 +28,14 @@ EMAIL_BASE_URL=
 EMAIL_SCOPES=
 EMAIL_FROM_ADDRESS=
 
-# Global kill switch for every failure alert email, regardless of
-# ALERT_RECIPIENTS or any task's SUB_CRON_RECIPIENTS "to". Failures are
-# still recorded in entity-service and logged either way — this only
-# silences the email itself. Defaults to true (send) when unset; set to
+# Global kill switch for every email this component sends — both failure
+# alerts (regardless of ALERT_RECIPIENTS or any task's SUB_CRON_RECIPIENTS
+# "to") and any report-style task's own success email (e.g.
+# "stale_cases_report" below). Failures are still recorded in entity-service
+# and logged either way, and a report task still runs and succeeds — this
+# only silences the email itself. Defaults to true (send) when unset; set to
 # false for a maintenance window or a known-noisy period without touching
-# either recipients config.
+# any recipients config.
 ALERTS_ENABLED=
 
 # Comma-separated standing ops/on-call audience, emailed on every failed
@@ -44,13 +46,16 @@ ALERTS_ENABLED=
 # means that task's failures send no email at all.
 ALERT_RECIPIENTS=
 
-# Optional: per-task To/Cc for failure alerts, by name, without needing a
-# dedicated env var per task — a JSON object of
-# {"<task.Name>": {"to": ["..."], "cc": ["..."]}}. A task not mentioned
-# here just gets no per-task recipients — its failures still reach
-# ALERT_RECIPIENTS above, it just has no additional audience of its own.
-# Set this only for the sub-crons that need a different or extra audience
-# beyond the standing list (e.g. a billing job's own on-call team).
+# Optional: per-task To/Cc, by name, without needing a dedicated env var per
+# task — a JSON object of {"<task.Name>": {"to": ["..."], "cc": ["..."]}}.
+# For most tasks this is purely additional failure-alert audience: a task
+# not mentioned here just gets no per-task recipients, and its failures
+# still reach ALERT_RECIPIENTS above. "stale_cases_report" is the exception —
+# its "to"/"cc" here is also exactly who its own success report gets sent
+# to (see STALE_CASE_THRESHOLD_DAYS below); it has nothing to do with
+# ALERT_RECIPIENTS at all for that task. Example enabling the report for a
+# CS team's own distribution list:
+#   {"stale_cases_report": {"to": ["cs-team@example.com"]}}
 SUB_CRON_RECIPIENTS=
 
 # This component's own expected invocation cadence — must match the cron
@@ -74,3 +79,13 @@ SUB_CRON_SCHEDULES=
 # still failed/retrying is never deleted regardless of age. Defaults to 30
 # when unset.
 HOUSEKEEPING_RETENTION_DAYS=
+
+# How many days old a still-open case ("state" != closed) must be, by its
+# createdOn, for the "stale_cases_report" sub-cron to include it — a plain
+# integer, not a Go duration string, same convention as
+# HOUSEKEEPING_RETENTION_DAYS. Defaults to 30 when unset. This task only
+# ever runs its entity-service query and sends its report if it has
+# recipients configured in SUB_CRON_RECIPIENTS above (key
+# "stale_cases_report") — see this component's own CLAUDE.md, "Housekeeping"
+# section's sibling, "Stale cases report".
+STALE_CASE_THRESHOLD_DAYS=

--- a/operations/csm-scheduled-tasks/.env.example
+++ b/operations/csm-scheduled-tasks/.env.example
@@ -30,11 +30,13 @@ EMAIL_FROM_ADDRESS=
 
 # Global kill switch for every email this component sends — both failure
 # alerts (regardless of ALERT_RECIPIENTS or any task's SUB_CRON_RECIPIENTS
-# "to") and any report-style task's own success email. Failures are still
-# recorded in entity-service and logged either way, and a report task still
-# runs and succeeds — this only silences the email itself. Defaults to true
-# (send) when unset; set to false for a maintenance window or a known-noisy
-# period without touching any recipients config.
+# "to") and any report-style task's own success email. A failed task still
+# gets recorded/logged and retries normally either way; a report-style task
+# still succeeds either way too, but may skip doing any work at all for that
+# tick rather than just skipping the send — see this component's own
+# CLAUDE.md for which tasks work that way. Defaults to true (send) when
+# unset; set to false for a maintenance window or a known-noisy period
+# without touching any recipients config.
 ALERTS_ENABLED=
 
 # Comma-separated standing ops/on-call audience, emailed on every failed

--- a/operations/csm-scheduled-tasks/CLAUDE.md
+++ b/operations/csm-scheduled-tasks/CLAUDE.md
@@ -114,6 +114,29 @@ for that same task name, which no longer exists), and `housekeeping_cleanup` onl
 indefinitely. Deregistering a task requires manually resolving or deleting its open row in
 entity-service; there is no automatic cleanup for this case.
 
+## Stale cases report
+
+`internal/stalecases.SendReport`, registered as `"stale_cases_report"`, is this component's first
+sub-cron that sends an email on success rather than only on failure — see "Future: per-task report
+emails" below for why that's not a generic engine feature. Queries entity-service's
+`POST /cases/search` (via `internal/entitycases.Client.SearchOpenCasesOlderThan`) for every case
+whose `state` isn't `closed` and whose `createdOn` is at least `STALE_CASE_THRESHOLD_DAYS` (default
+30) in the past, then emails a report table of them (oldest first) via
+`notify.RenderStaleCasesReport`. Default schedule `0 7 * * *` (daily at 07:00, same `TZ=UTC` caveat
+as "Housekeeping" above); override via `SUB_CRON_SCHEDULES`.
+
+Recipients are **not** `ALERT_RECIPIENTS` — that standing audience is about failure alerting, not
+report distribution. This task's report goes only to its own `SUB_CRON_RECIPIENTS` entry (`"to"`/
+`"cc"`, the same config surface every task's failure-alert recipients use — see "Alerting" below);
+a deployment that wants the same people getting both configures the same addresses in both places.
+If this task isn't mentioned in `SUB_CRON_RECIPIENTS` at all (`to` is empty), the handler skips the
+entity-service query entirely and just succeeds — no report to send means no reason to run the
+query on every tick.
+
+`internal/entitycases.Client` is a second entity-service client, separate from `internal/ledger`,
+even though both point at the same `CUSTOMER_ENTITY_SERVICE_BASE_URL`/credentials — see that
+package's own doc comment for why case search isn't just another method on `ledger.Client`.
+
 ## Alerting
 
 Two layers, combined:
@@ -133,10 +156,14 @@ empty — it still fails and retries normally either way, just silently as far a
 
 `ALERTS_ENABLED` (env var, default `true`) is a global kill switch above both layers —
 `engine.Engine.AlertsEnabled` — for going quiet during a maintenance window or a known-noisy period
-without editing either recipients config. Failures are still recorded in entity-service and logged
-either way; this only silences the email send in `Engine.recordFailure`. When it's `false`,
-`EMAIL_BASE_URL` is also no longer required at startup even if recipients are configured, since no
-email will ever actually be sent — see cmd/server/main.go's startup check.
+without editing any recipients config. Despite the name, it's not limited to failure alerts: it's
+the single switch for every email this component sends, so `stale_cases_report`'s own report email
+(see "Stale cases report" above) reads the same underlying value directly too, since that email
+isn't sent through `Engine.recordFailure` at all. Failures are still recorded in entity-service and
+logged either way, and a report task still runs and succeeds either way — this only silences the
+email send itself. When it's `false`, `EMAIL_BASE_URL` is also no longer required at startup even
+if recipients are configured, since no email will ever actually be sent — see
+cmd/server/main.go's startup check.
 
 **Every single failed attempt sends an alert, not just a final give-up** — there is no "fully
 failed" or exhausted state in this design (see "The core mechanism" above), so this fires each time
@@ -163,12 +190,13 @@ There is currently no success email — see "Future: per-task report emails" bel
 | `EMAIL_BASE_URL` | No, but required if `ALERTS_ENABLED` is true and `ALERT_RECIPIENTS` or any task's `SUB_CRON_RECIPIENTS` "to" is non-empty (checked at startup) | Internal email notification service base URL (`POST /send-email`) — same service `integrations/csm-notification-service` uses. Authenticates with the same shared `OAUTH2_*` credentials, not its own |
 | `EMAIL_SCOPES` | No | Comma-separated OAuth2 scopes for the email client, using the shared credentials above |
 | `EMAIL_FROM_ADDRESS` | No | Fixed "From" address for every email this component sends |
-| `ALERTS_ENABLED` | No (default `true`) | Global kill switch for every failure alert email, above `ALERT_RECIPIENTS` and `SUB_CRON_RECIPIENTS` both — see "Alerting" above |
+| `ALERTS_ENABLED` | No (default `true`) | Global kill switch for every email this component sends — failure alerts and report-style tasks' own success emails alike — see "Alerting" above |
 | `ALERT_RECIPIENTS` | No | Comma-separated email addresses alerted on every failed sub-cron attempt, for every task — see "Alerting" above |
 | `DRIVER_INTERVAL` | No (default `1h`) | This component's own expected invocation cadence — must match the cron trigger configured on the Choreo Scheduled Task component itself |
 | `SUB_CRON_SCHEDULES` | No | JSON object `{"<task.Name>": "<cron expression>"}` overriding any registered task's schedule by name — see "Adding a sub-cron" above. A task not mentioned keeps its own hardcoded default |
-| `SUB_CRON_RECIPIENTS` | No | JSON object `{"<task.Name>": {"to": [...], "cc": [...]}}` giving a registered task its own extra failure-alert audience, on top of `ALERT_RECIPIENTS` — see "Alerting" and "Adding a sub-cron" above. A task not mentioned gets no per-task recipients |
+| `SUB_CRON_RECIPIENTS` | No | JSON object `{"<task.Name>": {"to": [...], "cc": [...]}}` giving a registered task its own extra failure-alert audience, on top of `ALERT_RECIPIENTS` — or, for `stale_cases_report` specifically, its report's actual recipients (see "Stale cases report" above). A task not mentioned gets no per-task recipients |
 | `HOUSEKEEPING_RETENTION_DAYS` | No (default `30`) | Plain integer number of days of resolved history the `housekeeping_cleanup` sub-cron keeps — see "Housekeeping" above |
+| `STALE_CASE_THRESHOLD_DAYS` | No (default `30`) | Plain integer number of days a case must have been open (by `createdOn`) for the `stale_cases_report` sub-cron to include it — see "Stale cases report" above |
 
 No app-level execution timeout is configured here — Choreo's own Scheduled Task execution-time
 limit already bounds how long one invocation can run. `cmd/server/main.go` instead cancels its
@@ -179,16 +207,23 @@ instead of being cut off mid-request with no chance to react.
 `.env` is auto-loaded from the working directory at startup if present (silently ignored if
 absent), matching `integrations/csm-notification-service`'s own convention.
 
-## Future: per-task report emails
+## Per-task report emails
 
-Not built yet, deliberately: `registry.Task` has no report-recipients field and `engine.recordSuccess`
-only updates the ledger, never sends anything. A generic one-size-fits-all "task succeeded" template
-was tried and dropped — different sub-crons will want genuinely different report content (a usage
-report reads nothing like a billing summary), so one shared template would either stay generic to
-the point of being useless or grow special cases per task. The intended shape when this is built:
-each real sub-cron owns its own template (in `internal/notify/templates/`, following `alert.html`'s
-pattern) and supplies its own `ReportRecipients`, rather than the engine rendering one shared shape
-for every task the way it does for alerts today.
+`engine.recordSuccess` still only ever updates the ledger — it never sends anything, and
+`registry.Task` still has no generic "report recipients" field. A generic one-size-fits-all "task
+succeeded" template was tried and dropped early on: different sub-crons want genuinely different
+report content (a usage report reads nothing like a billing summary), so one shared shape would
+either stay generic to the point of being useless or grow special cases per task.
+
+`stale_cases_report` (see "Stale cases report" above) is the first real instance of the shape that
+replaced it: the sub-cron's own package (`internal/stalecases`) owns both its template
+(`internal/notify/templates/stale_cases_report.html`, following `alert.html`'s pattern) and its
+recipients (its own `SUB_CRON_RECIPIENTS` entry, passed into `stalecases.SendReport` as plain `to`/
+`cc` slices) — the report is sent from inside the `Handler` closure itself, entirely outside
+`engine.Engine`'s own success/failure path. A future report-sending sub-cron follows the same
+pattern: its own template, its own render function in `internal/notify`, its own recipients wired
+through in `cmd/server/main.go` — there still isn't, and isn't meant to be, one shared "send a
+report" mechanism in `engine`.
 
 ## Future: events
 

--- a/operations/csm-scheduled-tasks/CLAUDE.md
+++ b/operations/csm-scheduled-tasks/CLAUDE.md
@@ -117,13 +117,15 @@ entity-service; there is no automatic cleanup for this case.
 ## Stale cases report
 
 `internal/stalecases.SendReport`, registered as `"stale_cases_report"`, is this component's first
-sub-cron that sends an email on success rather than only on failure — see "Future: per-task report
-emails" below for why that's not a generic engine feature. Queries entity-service's
-`POST /cases/search` (via `internal/entitycases.Client.SearchOpenCasesOlderThan`) for every case
-whose `state` isn't `closed` and whose `createdOn` is at least `STALE_CASE_THRESHOLD_DAYS` (default
-30) in the past, then emails a report table of them (oldest first) via
-`notify.RenderStaleCasesReport`. Default schedule `0 7 * * *` (daily at 07:00, same `TZ=UTC` caveat
-as "Housekeeping" above); override via `SUB_CRON_SCHEDULES`.
+sub-cron that sends an email on success rather than only on failure — see "Per-task report emails"
+below for why that's not a generic engine feature. Queries entity-service's `POST /cases/search`
+(via `internal/entitycases.Client.SearchOpenCasesOlderThan`) for every case whose `state` isn't
+`closed` and whose `createdOn` is at least 30 days in the past — a fixed threshold, not an env var;
+there's no operational need to tune it per deployment today (unlike
+`HOUSEKEEPING_RETENTION_DAYS` — see `cmd/server/main.go`'s `staleCaseThreshold` constant if that
+changes) — then emails a report table of them (oldest first) via `notify.RenderStaleCasesReport`.
+Default schedule `0 7 * * *` (daily at 07:00, same `TZ=UTC` caveat as "Housekeeping" above);
+override via `SUB_CRON_SCHEDULES`.
 
 Recipients are **not** `ALERT_RECIPIENTS` — that standing audience is about failure alerting, not
 report distribution. This task's report goes only to its own `SUB_CRON_RECIPIENTS` entry (`"to"`/
@@ -178,7 +180,10 @@ a plain HTML template in the same table-based, WSO2-branded style
 that service's own functions of the same name) — task name, period, attempt count, next retry time,
 and the failure's error message.
 
-There is currently no success email — see "Future: per-task report emails" below for why.
+The engine itself still never sends a success email on any task's behalf — `stale_cases_report`'s
+report (see "Stale cases report" above) is sent from inside that task's own handler, not through
+this alerting path at all. See "Per-task report emails" below for why that's not a generic engine
+feature.
 
 ## Environment variables
 
@@ -196,7 +201,6 @@ There is currently no success email — see "Future: per-task report emails" bel
 | `SUB_CRON_SCHEDULES` | No | JSON object `{"<task.Name>": "<cron expression>"}` overriding any registered task's schedule by name — see "Adding a sub-cron" above. A task not mentioned keeps its own hardcoded default |
 | `SUB_CRON_RECIPIENTS` | No | JSON object `{"<task.Name>": {"to": [...], "cc": [...]}}` giving a registered task its own extra failure-alert audience, on top of `ALERT_RECIPIENTS` — or, for `stale_cases_report` specifically, its report's actual recipients (see "Stale cases report" above). A task not mentioned gets no per-task recipients |
 | `HOUSEKEEPING_RETENTION_DAYS` | No (default `30`) | Plain integer number of days of resolved history the `housekeeping_cleanup` sub-cron keeps — see "Housekeeping" above |
-| `STALE_CASE_THRESHOLD_DAYS` | No (default `30`) | Plain integer number of days a case must have been open (by `createdOn`) for the `stale_cases_report` sub-cron to include it — see "Stale cases report" above |
 
 No app-level execution timeout is configured here — Choreo's own Scheduled Task execution-time
 limit already bounds how long one invocation can run. `cmd/server/main.go` instead cancels its

--- a/operations/csm-scheduled-tasks/CLAUDE.md
+++ b/operations/csm-scheduled-tasks/CLAUDE.md
@@ -161,10 +161,13 @@ empty — it still fails and retries normally either way, just silently as far a
 without editing any recipients config. Despite the name, it's not limited to failure alerts: it's
 the single switch for every email this component sends, so `stale_cases_report`'s own report email
 (see "Stale cases report" above) reads the same underlying value directly too, since that email
-isn't sent through `Engine.recordFailure` at all. Failures are still recorded in entity-service and
-logged either way, and a report task still runs and succeeds either way — this only silences the
-email send itself. When it's `false`, `EMAIL_BASE_URL` is also no longer required at startup even
-if recipients are configured, since no email will ever actually be sent — see
+isn't sent through `Engine.recordFailure` at all. For a failed task, `false` only silences the
+email — the failure is still recorded in entity-service and logged either way, and retries proceed
+normally. For `stale_cases_report` specifically, `false` skips the entity-service query and report
+rendering entirely, not just the send (see `stalecases.SendReport`'s own doc comment) — the task
+still succeeds and its ledger row still updates, it just does no work that tick. When
+`ALERTS_ENABLED` is `false`, `EMAIL_BASE_URL` is also no longer required at startup even if
+recipients are configured, since no email will ever actually be sent — see
 cmd/server/main.go's startup check.
 
 **Every single failed attempt sends an alert, not just a final give-up** — there is no "fully

--- a/operations/csm-scheduled-tasks/README.md
+++ b/operations/csm-scheduled-tasks/README.md
@@ -28,13 +28,15 @@ csm-scheduled-tasks/
 ├── cmd/server/main.go       # Entry point — builds the registry, runs one Engine.Tick, exits
 ├── internal/
 │   ├── schedule/period.go   # PeriodKey(cronExpr, now) — the "most recent scheduled firing" concept
-│   ├── registry/registry.go # Task{Name, Schedule, Handler, RetryBackoff}
+│   ├── registry/registry.go # Task{Name, Schedule, Handler, RetryBackoff, To, Cc}
 │   ├── engine/engine.go     # Tick: claim → run → report back, once per task per invocation
-│   ├── ledger/client.go     # entity-service client (Attempt/Complete/Fail/DeleteResolvedBefore) — this component's only durable state
-│   ├── notify/              # Alert email sending — same internal email service csm-notification-service uses; templates/alert.html is the only template today (see CLAUDE.md, "Future: per-task report emails")
-│   ├── httpsec/httpsec.go   # Shared HTTPS/redirect guards for ledger and notify's OAuth2 clients
-│   ├── housekeeping/        # The first real sub-cron — deletes old resolved scheduled_task_run rows (see CLAUDE.md, "Housekeeping")
-│   └── apierror/errors.go   # Typed upstream-error wrapper, shared by ledger and notify
+│   ├── ledger/client.go     # entity-service client for this component's own durable state (Attempt/Complete/Fail/DeleteResolvedBefore)
+│   ├── entitycases/client.go # Separate, read-only entity-service client for case search — used by report-style sub-crons (see CLAUDE.md, "Stale cases report")
+│   ├── notify/              # Email sending — same internal email service csm-notification-service uses; alert.html (failure alerts) and stale_cases_report.html (see CLAUDE.md, "Per-task report emails")
+│   ├── httpsec/httpsec.go   # Shared HTTPS/redirect guards for ledger, entitycases, and notify's OAuth2 clients
+│   ├── housekeeping/        # Sub-cron: deletes old resolved scheduled_task_run rows (see CLAUDE.md, "Housekeeping")
+│   ├── stalecases/          # Sub-cron: reports cases open too long (see CLAUDE.md, "Stale cases report")
+│   └── apierror/errors.go   # Typed upstream-error wrapper, shared by ledger, entitycases, and notify
 ```
 
 No `.choreo/component.yaml` here — this component is created as a Choreo "Scheduled Task" (not
@@ -50,8 +52,9 @@ go run ./cmd/server
 ```
 
 Each run is one tick against whichever entity-service `.env` points at, then the process exits.
-`housekeeping_cleanup` (see `CLAUDE.md`, "Housekeeping") is the one sub-cron registered today; see
-`CLAUDE.md` ("Adding a sub-cron") for how to register another.
+Two sub-crons are registered today: `housekeeping_cleanup` (see `CLAUDE.md`, "Housekeeping") and
+`stale_cases_report` (see `CLAUDE.md`, "Stale cases report"); see `CLAUDE.md` ("Adding a sub-cron")
+for how to register another.
 
 ## Environment variables
 

--- a/operations/csm-scheduled-tasks/cmd/server/main.go
+++ b/operations/csm-scheduled-tasks/cmd/server/main.go
@@ -39,10 +39,12 @@ import (
 
 	"github.com/adhocore/gronx"
 	"github.com/wso2-open-operations/cs-tools/operations/csm-scheduled-tasks/internal/engine"
+	"github.com/wso2-open-operations/cs-tools/operations/csm-scheduled-tasks/internal/entitycases"
 	"github.com/wso2-open-operations/cs-tools/operations/csm-scheduled-tasks/internal/housekeeping"
 	"github.com/wso2-open-operations/cs-tools/operations/csm-scheduled-tasks/internal/ledger"
 	"github.com/wso2-open-operations/cs-tools/operations/csm-scheduled-tasks/internal/notify"
 	"github.com/wso2-open-operations/cs-tools/operations/csm-scheduled-tasks/internal/registry"
+	"github.com/wso2-open-operations/cs-tools/operations/csm-scheduled-tasks/internal/stalecases"
 )
 
 func main() {
@@ -70,15 +72,32 @@ func main() {
 	// or either URL failing httpsec's https-only check, fails startup
 	// loudly rather than surfacing as a per-task error later, unlike the
 	// email client below.
+	entityServiceBaseURL := mustEnv("CUSTOMER_ENTITY_SERVICE_BASE_URL")
+	entityServiceScopes := splitComma(os.Getenv("CUSTOMER_ENTITY_SERVICE_SCOPES"))
 	ledgerClient, err := ledger.NewClient(ledger.Config{
-		BaseURL:      mustEnv("CUSTOMER_ENTITY_SERVICE_BASE_URL"),
+		BaseURL:      entityServiceBaseURL,
 		TokenURL:     oauthTokenURL,
 		ClientID:     oauthClientID,
 		ClientSecret: oauthClientSecret,
-		Scopes:       splitComma(os.Getenv("CUSTOMER_ENTITY_SERVICE_SCOPES")),
+		Scopes:       entityServiceScopes,
 	})
 	if err != nil {
 		slog.Error("failed to construct entity-service client", "err", err)
+		os.Exit(1)
+	}
+
+	// Same entity-service deployment and credentials as ledgerClient above,
+	// but a separate client — see internal/entitycases' own doc comment for
+	// why case search isn't just another method on ledger.Client.
+	entityCasesClient, err := entitycases.NewClient(entitycases.Config{
+		BaseURL:      entityServiceBaseURL,
+		TokenURL:     oauthTokenURL,
+		ClientID:     oauthClientID,
+		ClientSecret: oauthClientSecret,
+		Scopes:       entityServiceScopes,
+	})
+	if err != nil {
+		slog.Error("failed to construct entity-service case-search client", "err", err)
 		os.Exit(1)
 	}
 
@@ -122,6 +141,10 @@ func main() {
 
 	const housekeepingTaskName = "housekeeping_cleanup"
 	housekeepingTo, housekeepingCc := recipientsFor(recipientOverrides, housekeepingTaskName)
+
+	const staleCasesTaskName = "stale_cases_report"
+	staleCasesTo, staleCasesCc := recipientsFor(recipientOverrides, staleCasesTaskName)
+
 	tasks := []registry.Task{
 		// This component's first real sub-cron: deletes rows from
 		// entity-service's scheduled_task_run table that succeeded or were
@@ -138,6 +161,21 @@ func main() {
 			Handler:  housekeeping.CleanupResolvedRuns(ledgerClient, envDays("HOUSEKEEPING_RETENTION_DAYS", 30)),
 			To:       housekeepingTo,
 			Cc:       housekeepingCc,
+		},
+		// Emails staleCasesTo/Cc a report of every case open more than
+		// STALE_CASE_THRESHOLD_DAYS — see internal/stalecases's own doc
+		// comment. Sends nothing (but still succeeds) if staleCasesTo is
+		// empty, i.e. this task isn't mentioned in SUB_CRON_RECIPIENTS.
+		// Default schedule is daily at 07:00 (again, TZ=UTC-dependent — see
+		// above), ahead of most business hours; override via
+		// SUB_CRON_SCHEDULES if needed.
+		{
+			Name:     staleCasesTaskName,
+			Schedule: scheduleFor(scheduleOverrides, staleCasesTaskName, "0 7 * * *"),
+			Handler: stalecases.SendReport(entityCasesClient, emailClient,
+				envDays("STALE_CASE_THRESHOLD_DAYS", 30), staleCasesTo, staleCasesCc, alertsEnabled),
+			To: staleCasesTo,
+			Cc: staleCasesCc,
 		},
 	}
 

--- a/operations/csm-scheduled-tasks/cmd/server/main.go
+++ b/operations/csm-scheduled-tasks/cmd/server/main.go
@@ -144,6 +144,11 @@ func main() {
 
 	const staleCasesTaskName = "stale_cases_report"
 	staleCasesTo, staleCasesCc := recipientsFor(recipientOverrides, staleCasesTaskName)
+	// Fixed, not env-configurable — unlike HOUSEKEEPING_RETENTION_DAYS, there's
+	// no operational reason to tune this per deployment today. Revisit as an
+	// env var (mirroring envDays("HOUSEKEEPING_RETENTION_DAYS", 30)'s shape)
+	// if that changes.
+	const staleCaseThreshold = 30 * 24 * time.Hour
 
 	tasks := []registry.Task{
 		// This component's first real sub-cron: deletes rows from
@@ -163,17 +168,16 @@ func main() {
 			Cc:       housekeepingCc,
 		},
 		// Emails staleCasesTo/Cc a report of every case open more than
-		// STALE_CASE_THRESHOLD_DAYS — see internal/stalecases's own doc
-		// comment. Sends nothing (but still succeeds) if staleCasesTo is
-		// empty, i.e. this task isn't mentioned in SUB_CRON_RECIPIENTS.
-		// Default schedule is daily at 07:00 (again, TZ=UTC-dependent — see
-		// above), ahead of most business hours; override via
-		// SUB_CRON_SCHEDULES if needed.
+		// staleCaseThreshold — see internal/stalecases's own doc comment.
+		// Sends nothing (but still succeeds) if staleCasesTo is empty, i.e.
+		// this task isn't mentioned in SUB_CRON_RECIPIENTS. Default schedule
+		// is daily at 07:00 (again, TZ=UTC-dependent — see above), ahead of
+		// most business hours; override via SUB_CRON_SCHEDULES if needed.
 		{
 			Name:     staleCasesTaskName,
 			Schedule: scheduleFor(scheduleOverrides, staleCasesTaskName, "0 7 * * *"),
 			Handler: stalecases.SendReport(entityCasesClient, emailClient,
-				envDays("STALE_CASE_THRESHOLD_DAYS", 30), staleCasesTo, staleCasesCc, alertsEnabled),
+				staleCaseThreshold, staleCasesTo, staleCasesCc, alertsEnabled),
 			To: staleCasesTo,
 			Cc: staleCasesCc,
 		},

--- a/operations/csm-scheduled-tasks/internal/engine/engine.go
+++ b/operations/csm-scheduled-tasks/internal/engine/engine.go
@@ -68,12 +68,16 @@ type Engine struct {
 	// long as this is set. Nil is a valid, deliberate choice for "no
 	// standing alert audience configured."
 	AlertRecipients []string
-	// AlertsEnabled is a global kill switch for every failure alert email —
-	// recordFailure still records the failure in the ledger and logs it
-	// either way, this only silences the email itself. Sits above both
-	// AlertRecipients and every task's own To/Cc: set to false to go quiet
-	// for a maintenance window or a known-noisy period without touching
-	// either config. Defaults to true (see cmd/server/main.go's ALERTS_ENABLED).
+	// AlertsEnabled is cmd/server/main.go's ALERTS_ENABLED — the global email
+	// kill switch for this whole component, despite the field name only
+	// describing what it does here. recordFailure still records the failure
+	// in the ledger and logs it either way, this only silences the email
+	// itself. Sits above both AlertRecipients and every task's own To/Cc: set
+	// to false to go quiet for a maintenance window or a known-noisy period
+	// without touching either config. A report-style task (e.g.
+	// internal/stalecases) reads the same underlying value directly, since
+	// its email isn't sent through this struct at all — see that package's
+	// own SendReport doc comment. Defaults to true.
 	AlertsEnabled bool
 }
 

--- a/operations/csm-scheduled-tasks/internal/entitycases/client.go
+++ b/operations/csm-scheduled-tasks/internal/entitycases/client.go
@@ -207,10 +207,43 @@ type searchCaseView struct {
 	Subject          *string        `json:"subject"`
 	State            string         `json:"state"`
 	Severity         *string        `json:"severity"`
-	CreatedOn        time.Time      `json:"createdOn"`
-	UpdatedOn        time.Time      `json:"updatedOn"`
+	CreatedOn        string         `json:"createdOn"`
+	UpdatedOn        string         `json:"updatedOn"`
 	AssignedEngineer *userReference `json:"assignedEngineer"`
 	AccountDetails   *accountRef    `json:"account"`
+}
+
+// caseDateTimeLayouts are tried in order to parse a case-search
+// createdOn/updatedOn value. entity-service's own domain.SearchCaseView
+// declares these as plain strings, not a guaranteed RFC3339 shape: the
+// ServiceNow-backed data source passes ServiceNow's raw datetime fields
+// straight through unreformatted (see entity-service's own
+// internal/service.parseSNDateTime and snCreatedOnLayout/snAltCreatedOnLayout
+// — root-caused there to a GlideRecord.getDisplayValue() vs getValue() bug on
+// the ServiceNow side that occasionally renders a locale-formatted date
+// instead of canonical ISO). This client tries the same two layouts for the
+// same reason, plus RFC3339 first for a Postgres-backed data source.
+var caseDateTimeLayouts = []string{
+	time.RFC3339,
+	"2006-01-02 15:04:05",
+	"01-02-2006 15:04:05",
+}
+
+// parseCaseDateTime parses value against caseDateTimeLayouts in order,
+// returning the first successful result. A value in any of these formats
+// with no explicit zone offset is treated as UTC, matching
+// entity-service's own parseSNDateTime (time.Parse with no zone abbreviation
+// in the layout defaults to UTC).
+func parseCaseDateTime(value string) (time.Time, error) {
+	var lastErr error
+	for _, layout := range caseDateTimeLayouts {
+		t, err := time.Parse(layout, value)
+		if err == nil {
+			return t, nil
+		}
+		lastErr = err
+	}
+	return time.Time{}, fmt.Errorf("unrecognized date-time format %q: %w", value, lastErr)
 }
 
 type searchCasesResponse struct {
@@ -257,7 +290,11 @@ func (c *Client) SearchOpenCasesOlderThan(ctx context.Context, olderThan time.Du
 		}
 
 		for _, cv := range resp.Cases {
-			all = append(all, toCase(cv))
+			c, err := toCase(cv)
+			if err != nil {
+				return nil, fmt.Errorf("entitycases: case %s: %w", cv.ID, err)
+			}
+			all = append(all, c)
 		}
 
 		offset += searchPageSize
@@ -268,14 +305,23 @@ func (c *Client) SearchOpenCasesOlderThan(ctx context.Context, olderThan time.Du
 	return all, nil
 }
 
-func toCase(cv searchCaseView) Case {
+func toCase(cv searchCaseView) (Case, error) {
+	createdOn, err := parseCaseDateTime(cv.CreatedOn)
+	if err != nil {
+		return Case{}, fmt.Errorf("createdOn: %w", err)
+	}
+	updatedOn, err := parseCaseDateTime(cv.UpdatedOn)
+	if err != nil {
+		return Case{}, fmt.Errorf("updatedOn: %w", err)
+	}
+
 	c := Case{
 		ID:         cv.ID,
 		Number:     cv.Number,
 		InternalID: cv.InternalID,
 		State:      cv.State,
-		CreatedOn:  cv.CreatedOn,
-		UpdatedOn:  cv.UpdatedOn,
+		CreatedOn:  createdOn,
+		UpdatedOn:  updatedOn,
 	}
 	if cv.Subject != nil {
 		c.Subject = *cv.Subject
@@ -289,5 +335,5 @@ func toCase(cv searchCaseView) Case {
 	if cv.AccountDetails != nil {
 		c.Account = cv.AccountDetails.Name
 	}
-	return c
+	return c, nil
 }

--- a/operations/csm-scheduled-tasks/internal/entitycases/client.go
+++ b/operations/csm-scheduled-tasks/internal/entitycases/client.go
@@ -260,6 +260,11 @@ type searchCasesResponse struct {
 // returned order as given. Paginates through entity-service's own 50-row
 // page cap internally (see searchPageSize/maxSearchPages); the caller
 // always gets one flat slice back.
+//
+// Returns an error, rather than a silently-truncated slice, if the result
+// set is still larger than maxSearchPages*searchPageSize after the last
+// allowed page — a caller building a report from a partial result would
+// otherwise under-report without any indication it happened.
 func (c *Client) SearchOpenCasesOlderThan(ctx context.Context, olderThan time.Duration) ([]Case, error) {
 	cutoff := time.Now().Add(-olderThan).UTC().Format(time.RFC3339)
 
@@ -299,9 +304,15 @@ func (c *Client) SearchOpenCasesOlderThan(ctx context.Context, olderThan time.Du
 
 		offset += searchPageSize
 		if len(resp.Cases) == 0 || offset >= resp.Total {
-			break
+			return all, nil
+		}
+		if page == maxSearchPages-1 {
+			return nil, fmt.Errorf("entitycases: search results exceed the %d-row pagination cap (total=%d) — refusing to return a silently-incomplete report",
+				maxSearchPages*searchPageSize, resp.Total)
 		}
 	}
+	// Unreachable: every iteration above returns before the loop can exit on
+	// its own condition. Required only because the compiler can't prove that.
 	return all, nil
 }
 

--- a/operations/csm-scheduled-tasks/internal/entitycases/client.go
+++ b/operations/csm-scheduled-tasks/internal/entitycases/client.go
@@ -1,0 +1,293 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package entitycases is a narrow, read-only client for entity-service's
+// case-search API (POST /cases/search) — used by report-style sub-crons that
+// need to look at live case data. Kept separate from internal/ledger, which
+// is this component's own durable scheduled_task_run state and has nothing
+// to do with case content; the two happen to point at the same entity-service
+// deployment, but that's an operational detail, not a reason to share one
+// client struct between two otherwise-unrelated concerns.
+package entitycases
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/wso2-open-operations/cs-tools/operations/csm-scheduled-tasks/internal/apierror"
+	"github.com/wso2-open-operations/cs-tools/operations/csm-scheduled-tasks/internal/httpsec"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
+)
+
+// tokenFetchTimeout is the HTTP client timeout for token-endpoint requests.
+// Overridden in tests to keep them fast.
+var tokenFetchTimeout = 10 * time.Second
+
+// Config holds this client's configuration.
+type Config struct {
+	BaseURL      string
+	TokenURL     string
+	ClientID     string
+	ClientSecret string
+	Scopes       []string
+}
+
+// Client is a narrow HTTP client for entity-service's case-search endpoint.
+// Mirrors internal/ledger.Client's shape exactly (same OAuth2 client
+// credentials grant, same httpsec guards) — see that package's own doc
+// comment for why this isn't just a second method set on Client there.
+type Client struct {
+	http    *http.Client
+	baseURL string
+}
+
+// NewClient constructs a Client authenticated via the OAuth2 client
+// credentials grant. cfg.TokenURL/cfg.BaseURL must both be https (loopback
+// http is allowed for local development — see httpsec.RequireSecureURL)
+// since both carry credentials or a bearer token.
+func NewClient(cfg Config) (*Client, error) {
+	if err := httpsec.RequireSecureURL(cfg.TokenURL); err != nil {
+		return nil, fmt.Errorf("entitycases: token URL: %w", err)
+	}
+	if err := httpsec.RequireSecureURL(cfg.BaseURL); err != nil {
+		return nil, fmt.Errorf("entitycases: base URL: %w", err)
+	}
+
+	cc := clientcredentials.Config{
+		ClientID:     cfg.ClientID,
+		ClientSecret: cfg.ClientSecret,
+		TokenURL:     cfg.TokenURL,
+		Scopes:       cfg.Scopes,
+	}
+
+	tokenHTTPClient := &http.Client{Timeout: tokenFetchTimeout}
+	httpsec.RejectInsecureRedirects(tokenHTTPClient)
+	tokenCtx := context.WithValue(context.Background(), oauth2.HTTPClient, tokenHTTPClient)
+	httpClient := cc.Client(tokenCtx)
+	httpClient.Timeout = 25 * time.Second
+	httpsec.RejectInsecureRedirects(httpClient)
+
+	return &Client{
+		http:    httpClient,
+		baseURL: strings.TrimRight(cfg.BaseURL, "/"),
+	}, nil
+}
+
+// do executes an authenticated HTTP request against entity-service and
+// returns the raw JSON response body, or an *apierror.Error for a non-2xx
+// status.
+func (c *Client) do(ctx context.Context, method, path string, body []byte) ([]byte, error) {
+	var reqBody io.Reader
+	if len(body) > 0 {
+		reqBody = bytes.NewReader(body)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("entitycases: build request %s %s: %w", method, path, err)
+	}
+	if len(body) > 0 {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("entitycases: %s %s: %w", method, path, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("entitycases: read response body: %w", err)
+	}
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, &apierror.Error{StatusCode: resp.StatusCode, Body: string(respBody)}
+	}
+	return respBody, nil
+}
+
+// Case is the report-relevant subset of entity-service's case-search result
+// (domain.SearchCaseView there). Account and AssignedTo are "" when
+// entity-service returns no value for that case — an unassigned case, or a
+// data source that doesn't populate account details (see entity-service's
+// own CLAUDE.md on DATA_SOURCE=servicenow-gated fields) — rather than a
+// pointer a caller has to nil-check.
+type Case struct {
+	ID         string
+	Number     string
+	InternalID string
+	Subject    string
+	State      string
+	Severity   string
+	Account    string
+	AssignedTo string
+	CreatedOn  time.Time
+	UpdatedOn  time.Time
+}
+
+// searchPageSize is the page size SearchOpenCasesOlderThan requests —
+// entity-service's own case-search caps limit at 50 (see that service's
+// normalizePagination), so this just always asks for the largest page
+// allowed, to fetch the fewest pages possible.
+const searchPageSize = 50
+
+// maxSearchPages caps how many pages SearchOpenCasesOlderThan will fetch, as
+// a safety net against a huge or unexpectedly-shaped result turning one
+// report run into an unbounded loop. 20 pages at searchPageSize is 1,000
+// cases — an "open more than N days" report anywhere near that size has
+// bigger problems than this cap, but the cap keeps a malformed response
+// (e.g. Total always greater than what's actually returned) from looping
+// forever rather than just producing an incomplete report.
+const maxSearchPages = 20
+
+// searchCasesRequest/searchCasesFilters/caseFieldFilter/caseSort/pagination
+// mirror entity-service's own domain.SearchCasesRequest wire shape exactly
+// (see that service's openapi.yaml, "/cases/search") — kept private and
+// scoped to exactly the fields this client uses, rather than importing or
+// duplicating that service's full domain package.
+type caseFieldFilter struct {
+	Field  string   `json:"field"`
+	Op     string   `json:"op"`
+	Values []string `json:"values,omitempty"`
+}
+
+type searchCasesFilters struct {
+	Filters []caseFieldFilter `json:"filters,omitempty"`
+}
+
+type caseSort struct {
+	Field string `json:"field"`
+	Order string `json:"order"`
+}
+
+type pagination struct {
+	Limit  int `json:"limit"`
+	Offset int `json:"offset"`
+}
+
+type searchCasesRequest struct {
+	Filters    searchCasesFilters `json:"filters"`
+	SortBy     caseSort           `json:"sortBy"`
+	Pagination pagination         `json:"pagination"`
+}
+
+type userReference struct {
+	Name string `json:"name"`
+}
+
+type accountRef struct {
+	Name string `json:"name"`
+}
+
+type searchCaseView struct {
+	ID               string         `json:"id"`
+	Number           string         `json:"number"`
+	InternalID       string         `json:"internalId"`
+	Subject          *string        `json:"subject"`
+	State            string         `json:"state"`
+	Severity         *string        `json:"severity"`
+	CreatedOn        time.Time      `json:"createdOn"`
+	UpdatedOn        time.Time      `json:"updatedOn"`
+	AssignedEngineer *userReference `json:"assignedEngineer"`
+	AccountDetails   *accountRef    `json:"account"`
+}
+
+type searchCasesResponse struct {
+	Cases  []searchCaseView `json:"cases"`
+	Total  int              `json:"total"`
+	Offset int              `json:"offset"`
+	Limit  int              `json:"limit"`
+}
+
+// SearchOpenCasesOlderThan returns every case whose state is not "closed"
+// and whose createdOn is at least olderThan in the past — the entity-service
+// query behind an "open too long" report. Sorted oldest-first (createdOn
+// ascending), so a caller building a report table can just take the
+// returned order as given. Paginates through entity-service's own 50-row
+// page cap internally (see searchPageSize/maxSearchPages); the caller
+// always gets one flat slice back.
+func (c *Client) SearchOpenCasesOlderThan(ctx context.Context, olderThan time.Duration) ([]Case, error) {
+	cutoff := time.Now().Add(-olderThan).UTC().Format(time.RFC3339)
+
+	var all []Case
+	offset := 0
+	for page := 0; page < maxSearchPages; page++ {
+		reqBody, err := json.Marshal(searchCasesRequest{
+			Filters: searchCasesFilters{
+				Filters: []caseFieldFilter{
+					{Field: "state", Op: "notIn", Values: []string{"closed"}},
+					{Field: "createdOn", Op: "lte", Values: []string{cutoff}},
+				},
+			},
+			SortBy:     caseSort{Field: "createdOn", Order: "asc"},
+			Pagination: pagination{Limit: searchPageSize, Offset: offset},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("entitycases: encode search request: %w", err)
+		}
+
+		respBody, err := c.do(ctx, http.MethodPost, "/cases/search", reqBody)
+		if err != nil {
+			return nil, err
+		}
+		var resp searchCasesResponse
+		if err := json.Unmarshal(respBody, &resp); err != nil {
+			return nil, fmt.Errorf("entitycases: decode search response: %w", err)
+		}
+
+		for _, cv := range resp.Cases {
+			all = append(all, toCase(cv))
+		}
+
+		offset += searchPageSize
+		if len(resp.Cases) == 0 || offset >= resp.Total {
+			break
+		}
+	}
+	return all, nil
+}
+
+func toCase(cv searchCaseView) Case {
+	c := Case{
+		ID:         cv.ID,
+		Number:     cv.Number,
+		InternalID: cv.InternalID,
+		State:      cv.State,
+		CreatedOn:  cv.CreatedOn,
+		UpdatedOn:  cv.UpdatedOn,
+	}
+	if cv.Subject != nil {
+		c.Subject = *cv.Subject
+	}
+	if cv.Severity != nil {
+		c.Severity = *cv.Severity
+	}
+	if cv.AssignedEngineer != nil {
+		c.AssignedTo = cv.AssignedEngineer.Name
+	}
+	if cv.AccountDetails != nil {
+		c.Account = cv.AccountDetails.Name
+	}
+	return c
+}

--- a/operations/csm-scheduled-tasks/internal/notify/templates.go
+++ b/operations/csm-scheduled-tasks/internal/notify/templates.go
@@ -18,14 +18,20 @@ package notify
 
 import (
 	_ "embed"
+	"fmt"
 	"html"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/wso2-open-operations/cs-tools/operations/csm-scheduled-tasks/internal/entitycases"
 )
 
 //go:embed templates/alert.html
 var alertTemplateRaw string
+
+//go:embed templates/stale_cases_report.html
+var staleCasesReportTemplateRaw string
 
 // wso2LogoURL is the white WSO2 logo variant — the alert template's header
 // sits on an orange background, unlike
@@ -45,6 +51,7 @@ func bakeLogo(raw string) string {
 }
 
 var alertTemplate = bakeLogo(alertTemplateRaw)
+var staleCasesReportTemplate = bakeLogo(staleCasesReportTemplateRaw)
 
 // escapeHTML mirrors integrations/csm-notification-service's own
 // internal/notifications.escapeHTML exactly: HTML-escapes s and
@@ -100,4 +107,101 @@ func RenderAlertEmail(data AlertEmailData) string {
 		"<!-- [YEAR] -->", strconv.Itoa(time.Now().Year()),
 	)
 	return replacer.Replace(alertTemplate)
+}
+
+// StaleCasesReportData holds every value substituted into the "cases open
+// too long" HTML email template.
+type StaleCasesReportData struct {
+	ThresholdDays int
+	Cases         []entitycases.Case
+}
+
+// RenderStaleCasesReport fills in the "cases open too long" HTML email
+// template — one table row per case, oldest (by CreatedOn) first, exactly
+// the order internal/entitycases.Client.SearchOpenCasesOlderThan already
+// returns them in. [YEAR] is today's year, the same footer-only detail
+// RenderAlertEmail's own doc comment describes.
+func RenderStaleCasesReport(data StaleCasesReportData) string {
+	replacer := strings.NewReplacer(
+		"<!-- [CASE_COUNT] -->", strconv.Itoa(len(data.Cases)),
+		"<!-- [THRESHOLD_DAYS] -->", strconv.Itoa(data.ThresholdDays),
+		"<!-- [CASE_ROWS] -->", renderCaseRows(data.Cases),
+		"<!-- [YEAR] -->", strconv.Itoa(time.Now().Year()),
+	)
+	return replacer.Replace(staleCasesReportTemplate)
+}
+
+// renderCaseRows builds one <tr> per case for RenderStaleCasesReport. A case
+// with no account or no assignee (nil AssignedEngineer/AccountDetails on
+// entity-service's side, already flattened to "" by entitycases.Client)
+// shows an em dash rather than a blank cell, so the report never reads as
+// broken/missing data versus genuinely unset.
+func renderCaseRows(cases []entitycases.Case) string {
+	if len(cases) == 0 {
+		return `<tr><td colspan="7" style="padding:16px 10px; text-align:center; color:#8a8f98;">No matching cases.</td></tr>`
+	}
+
+	now := time.Now()
+	var b strings.Builder
+	for _, c := range cases {
+		daysOpen := int(now.Sub(c.CreatedOn).Hours() / 24)
+		fmt.Fprintf(&b,
+			`<tr>`+
+				`<td style="padding:8px 10px; border-bottom:1px solid #e8eaed;">%s<br/><span style="color:#8a8f98; font-size:12px;">%s</span></td>`+
+				`<td style="padding:8px 10px; border-bottom:1px solid #e8eaed;">%s</td>`+
+				`<td style="padding:8px 10px; border-bottom:1px solid #e8eaed;">%s</td>`+
+				`<td style="padding:8px 10px; border-bottom:1px solid #e8eaed;">%s</td>`+
+				`<td style="padding:8px 10px; border-bottom:1px solid #e8eaed;">%s</td>`+
+				`<td align="right" style="padding:8px 10px; border-bottom:1px solid #e8eaed;">%d</td>`+
+				`<td style="padding:8px 10px; border-bottom:1px solid #e8eaed;">%s</td>`+
+				`</tr>`,
+			orDash(escapeHTML(c.Number)), escapeHTML(caseTitle(c)),
+			orDash(escapeHTML(c.Account)),
+			orDash(escapeHTML(c.AssignedTo)),
+			escapeHTML(humanizeState(c.State)),
+			orDash(escapeHTML(c.Severity)),
+			daysOpen,
+			c.UpdatedOn.Format("2006-01-02"),
+		)
+	}
+	return b.String()
+}
+
+// caseTitle returns a short display title for a case row: its subject, or
+// its internal (WSO2) case id when Subject is unavailable — never both,
+// there's no room for it in one report row.
+func caseTitle(c entitycases.Case) string {
+	if c.Subject != "" {
+		return c.Subject
+	}
+	return c.InternalID
+}
+
+// orDash returns s, or an em dash if s is empty — see renderCaseRows' own
+// doc comment for why.
+func orDash(s string) string {
+	if s == "" {
+		return "&mdash;"
+	}
+	return s
+}
+
+// humanizeState turns entity-service's snake_case case state (e.g.
+// "work_in_progress") into a display form ("Work In Progress"). "wso2" is
+// special-cased to the all-caps brand form ("WSO2") rather than the
+// title-case default ("Wso2") every other word gets — the only state value
+// (CaseStateWaitingOnWSO2 = "waiting_on_wso2") that contains it.
+func humanizeState(state string) string {
+	words := strings.Split(state, "_")
+	for i, w := range words {
+		if w == "" {
+			continue
+		}
+		if strings.EqualFold(w, "wso2") {
+			words[i] = "WSO2"
+			continue
+		}
+		words[i] = strings.ToUpper(w[:1]) + w[1:]
+	}
+	return strings.Join(words, " ")
 }

--- a/operations/csm-scheduled-tasks/internal/notify/templates/stale_cases_report.html
+++ b/operations/csm-scheduled-tasks/internal/notify/templates/stale_cases_report.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
+    <meta name="color-scheme" content="light dark" />
+    <meta name="supported-color-schemes" content="light dark" />
+    <title>CSM Scheduled Tasks: cases open more than <!-- [THRESHOLD_DAYS] --> days</title>
+
+    <style type="text/css">
+        @import url("https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700;900&display=swap");
+
+        body {
+            font-family: 'Roboto', Helvetica, Arial, sans-serif;
+            -webkit-text-size-adjust: 100%;
+            -ms-text-size-adjust: 100%;
+            margin: 0;
+            padding: 0;
+        }
+
+        table td { border-collapse: collapse; }
+        img { border: 0; outline: none; text-decoration: none; }
+
+        .wso2_orange { color: #ff7300 !important; }
+        .footerContent a { color: #465868; }
+        .footerContent a:hover { color: #ff7300 !important; }
+
+        @media only screen and (max-width: 650px) {
+            .bodyContent { padding: 0 20px 30px !important; }
+        }
+
+        @media (prefers-color-scheme: dark) {
+            body, .bgtest { background-color: #202124 !important; color: #e2e2e2 !important; }
+            .Bodyconetntdark { background-color: #282f34 !important; }
+            p, li, td { color: #e2e2e2 !important; }
+            .wso2_orange { color: #ff957d !important; }
+            .footerContent { color: #a2a3a4 !important; }
+            .footerContent a { color: #bbbdc1 !important; }
+            .reportTable th { background-color: #33383d !important; color: #e2e2e2 !important; }
+            .reportTable td { border-color: #454b52 !important; }
+        }
+    </style>
+</head>
+
+<body class="bgtest" style="margin:0; padding:0; background-color:#f8f9fa;">
+
+    <table align="center" border="0" cellpadding="0" cellspacing="0" width="100%" style="background-color:#f8f9fa;">
+        <tr>
+            <td align="center" valign="top">
+
+                <table border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width:800px;">
+                    <tr>
+                        <td align="center" bgcolor="#ff7101" style="padding:30px 0;">
+                            <table border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width:800px;">
+                                <tr>
+                                    <td align="left" style="padding:0 30px;">
+                                        <img src="<!-- [LOGO_SRC] -->" alt="WSO2 Logo" width="120" style="display:block;" />
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td align="left" style="padding:16px 30px 0; color:#ffffff; font-size:13px; font-weight:700; letter-spacing:1px; text-transform:uppercase;">
+                                        CSM Scheduled Tasks &middot; Stale Cases Report
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+                </table>
+                <br/>
+
+                <!-- Main Content -->
+                <table bgcolor="#ffffff" border="0" cellpadding="0" cellspacing="0" class="Bodyconetntdark" width="100%" style="max-width:800px; margin:auto; box-shadow:0 2px 12px rgba(0,0,0,0.1);">
+                    <tr>
+                        <td class="bodyContent" style="padding:40px 50px; color:#465868; font-size:16px; line-height:24px; text-align:left;">
+
+                            <p style="margin:0 0 30px;">
+                                <strong><!-- [CASE_COUNT] --></strong> case(s) have been open for more than
+                                <strong><!-- [THRESHOLD_DAYS] --> days</strong>, oldest first.
+                            </p>
+
+                            <table class="reportTable" border="0" cellpadding="0" cellspacing="0" width="100%" style="font-size:13px; border-collapse:collapse;">
+                                <thead>
+                                    <tr>
+                                        <th align="left" style="padding:8px 10px; background-color:#f1f3f5; color:#465868; font-size:12px; text-transform:uppercase; letter-spacing:0.5px;">Case</th>
+                                        <th align="left" style="padding:8px 10px; background-color:#f1f3f5; color:#465868; font-size:12px; text-transform:uppercase; letter-spacing:0.5px;">Account</th>
+                                        <th align="left" style="padding:8px 10px; background-color:#f1f3f5; color:#465868; font-size:12px; text-transform:uppercase; letter-spacing:0.5px;">Assigned To</th>
+                                        <th align="left" style="padding:8px 10px; background-color:#f1f3f5; color:#465868; font-size:12px; text-transform:uppercase; letter-spacing:0.5px;">State</th>
+                                        <th align="left" style="padding:8px 10px; background-color:#f1f3f5; color:#465868; font-size:12px; text-transform:uppercase; letter-spacing:0.5px;">Severity</th>
+                                        <th align="right" style="padding:8px 10px; background-color:#f1f3f5; color:#465868; font-size:12px; text-transform:uppercase; letter-spacing:0.5px;">Days Open</th>
+                                        <th align="left" style="padding:8px 10px; background-color:#f1f3f5; color:#465868; font-size:12px; text-transform:uppercase; letter-spacing:0.5px;">Updated</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <!-- [CASE_ROWS] -->
+                                </tbody>
+                            </table>
+
+                            <p style="margin:40px 0 0; font-size:13px; color:#8a8f98;">
+                                This is an automated report from the CSM Scheduled Tasks service.
+                            </p>
+
+                        </td>
+                    </tr>
+                </table>
+
+                <!-- Footer -->
+                <table border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width:800px; background-color:#e8eaed; padding:30px 0;">
+                    <tr>
+                        <td align="center" style="padding:0 50px;">
+                            <table border="0" cellpadding="0" cellspacing="0" width="100%">
+                                <tr>
+                                    <td align="left" class="footerContent" style="color:#465868; font-size:12px; line-height:16px;">
+                                        &copy; <!-- [YEAR] --> WSO2 LLC. All Rights Reserved.
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </table>
+</body>
+</html>

--- a/operations/csm-scheduled-tasks/internal/stalecases/stalecases.go
+++ b/operations/csm-scheduled-tasks/internal/stalecases/stalecases.go
@@ -76,7 +76,7 @@ func SendReport(cases CaseSearcher, email EmailSender, olderThan time.Duration, 
 		}
 
 		thresholdDays := int(olderThan.Hours() / 24)
-		subject := fmt.Sprintf("[csm-scheduled-tasks] %d case(s) open more than %d days", len(found), thresholdDays)
+		subject := fmt.Sprintf("[Action-Required][Report] Cases open for more than %d days", thresholdDays)
 		body := notify.RenderStaleCasesReport(notify.StaleCasesReportData{
 			ThresholdDays: thresholdDays,
 			Cases:         found,

--- a/operations/csm-scheduled-tasks/internal/stalecases/stalecases.go
+++ b/operations/csm-scheduled-tasks/internal/stalecases/stalecases.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package stalecases is the "cases open too long" report sub-cron: it finds
+// every case that's been open for more than a configured threshold and
+// emails a report of them. This is the first sub-cron in this component to
+// send an email on success rather than only on failure — see this
+// component's own CLAUDE.md ("Future: per-task report emails") for why that
+// wasn't built as a generic engine feature: the report itself is sent from
+// inside SendReport's returned handler, using recipients the caller supplies
+// directly, not through engine.Engine's failure-alert path at all.
+package stalecases
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/wso2-open-operations/cs-tools/operations/csm-scheduled-tasks/internal/entitycases"
+	"github.com/wso2-open-operations/cs-tools/operations/csm-scheduled-tasks/internal/notify"
+)
+
+// CaseSearcher is the subset of *entitycases.Client this package depends on.
+type CaseSearcher interface {
+	SearchOpenCasesOlderThan(ctx context.Context, olderThan time.Duration) ([]entitycases.Case, error)
+}
+
+// EmailSender is the subset of *notify.Client this package depends on.
+type EmailSender interface {
+	SendEmail(ctx context.Context, to, cc []string, subject, htmlBody string) error
+}
+
+// SendReport returns a registry.Task.Handler that finds every case open for
+// more than olderThan and emails to/cc a report of them. Recipients are
+// exactly this task's own SUB_CRON_RECIPIENTS entry (see
+// cmd/server/main.go) — deliberately not merged with the standing
+// ALERT_RECIPIENTS audience, which is about failure alerting, not report
+// distribution; a deployment that wants the same people getting both
+// configures the same addresses in both places.
+//
+// emailsEnabled is cmd/server/main.go's ALERTS_ENABLED, the same global kill
+// switch engine.Engine.AlertsEnabled uses — despite the env var's name, it
+// silences every email this component sends, not just failure alerts, since
+// this report is the other kind. When false, the returned handler still
+// succeeds (the ledger records success, the task doesn't retry) but sends
+// nothing.
+//
+// If emailsEnabled is false or to is empty, the returned handler skips the
+// case search entirely and returns nil (success) without contacting
+// entity-service at all — nothing would be done with the result anyway, so
+// there's no reason to spend an entity-service query on every tick, in a
+// deployment that hasn't configured this task's recipients yet or has gone
+// quiet.
+func SendReport(cases CaseSearcher, email EmailSender, olderThan time.Duration, to, cc []string, emailsEnabled bool) func(ctx context.Context) error {
+	return func(ctx context.Context) error {
+		if !emailsEnabled || len(to) == 0 {
+			return nil
+		}
+
+		found, err := cases.SearchOpenCasesOlderThan(ctx, olderThan)
+		if err != nil {
+			return fmt.Errorf("stalecases: search open cases: %w", err)
+		}
+
+		thresholdDays := int(olderThan.Hours() / 24)
+		subject := fmt.Sprintf("[csm-scheduled-tasks] %d case(s) open more than %d days", len(found), thresholdDays)
+		body := notify.RenderStaleCasesReport(notify.StaleCasesReportData{
+			ThresholdDays: thresholdDays,
+			Cases:         found,
+		})
+		if err := email.SendEmail(ctx, to, cc, subject, body); err != nil {
+			return fmt.Errorf("stalecases: send report email: %w", err)
+		}
+		return nil
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `stale_cases_report`, a second sub-cron on `operations/csm-scheduled-tasks`, which emails a report of every case open more than `STALE_CASE_THRESHOLD_DAYS` (default 30) days — the first sub-cron in this component to send an email on success rather than only on failure.
- Adds `internal/entitycases`, a new read-only entity-service client for `POST /cases/search` (paginated, `state notIn [closed]` + `createdOn lte <cutoff>`, oldest-first), kept separate from `internal/ledger` since it's an unrelated concern against the same entity-service deployment.
- Adds a new WSO2-branded report email template (`internal/notify/templates/stale_cases_report.html`) and `notify.RenderStaleCasesReport`.
- Broadens `ALERTS_ENABLED` (added in #1610) from "failure alerts only" to a true global kill switch for every email this component sends, since this report is the first non-alert email.
- Report recipients are the task's own `SUB_CRON_RECIPIENTS` entry (`"to"`/`"cc"`) — deliberately not merged with the standing `ALERT_RECIPIENTS` audience, which is about failure alerting, not report distribution.
- Report email subject is a fixed format: `[Action-Required][Report] Cases open for more than N days`.
- Tolerates entity-service's `createdOn`/`updatedOn` case-search fields being ServiceNow's raw, sometimes locale-formatted datetime strings (`"2023-10-25 08:50:22"`) rather than guaranteed RFC3339 — the same known quirk `entity-service`'s own `parseSNDateTime` already works around.
- CLAUDE.md/README.md updated on both `entity-service` and `operations/csm-scheduled-tasks` sides.

## Test plan
- [x] `gofmt -l .`, `go build ./...`, `go vet ./...` clean
- [x] `gosec ./...` — 0 issues
- [x] `govulncheck ./...` — no vulnerabilities
- [x] Verified `internal/entitycases` pagination, field-mapping, and datetime parsing, plus `internal/stalecases` subject/body rendering and the enable/recipients skip logic, via temporary scratch tests against synthetic data (not committed)
- [x] Live-tested against a real ServiceNow-backed entity-service deployment; found and fixed a real datetime-format bug in the process
- [ ] Live end-to-end re-verification of the final datetime fix (pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a daily stale-case report scheduled task.
  * Reports include open cases exceeding a configurable age threshold.
  * Added configurable recipients, schedule, email controls, and threshold settings.
  * Added responsive HTML email reports with case details, account, assignment, status, severity, and age.
* **Documentation**
  * Updated setup and configuration guidance for the new report and environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->