### PR TITLE
[CSM Portal] Gate Service Request as a case-type transfer target by project subscription

### DIFF
--- a/apps/csm-portal/webapp/src/features/csm-cases/components/ChangeCaseTypeDialog.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/ChangeCaseTypeDialog.test.tsx
@@ -99,6 +99,7 @@ describe("ChangeCaseTypeDialog — step 1: pick target", () => {
         currentType="case"
         currentSeverity="S2"
         hasAttachments
+        currentProjectSubscriptionType="managed_cloud_subscription"
         isSubmitting={false}
         onClose={() => {}}
         onSubmit={() => {}}
@@ -118,6 +119,7 @@ describe("ChangeCaseTypeDialog — step 1: pick target", () => {
         currentType="case"
         currentSeverity="S2"
         hasAttachments
+        currentProjectSubscriptionType="managed_cloud_subscription"
         isSubmitting={false}
         onClose={() => {}}
         onSubmit={() => {}}
@@ -162,6 +164,85 @@ describe("ChangeCaseTypeDialog — step 1: pick target", () => {
     fireEvent.click(screen.getByRole("button", { name: /^cancel$/i }));
     expect(onClose).toHaveBeenCalled();
     expect(onSubmit).not.toHaveBeenCalled();
+  });
+});
+
+describe("ChangeCaseTypeDialog — Service Request gated by project subscription type", () => {
+  it("disables Service Request when the project's subscription type doesn't qualify", () => {
+    render(
+      <ChangeCaseTypeDialog
+        currentType="case"
+        currentSeverity="S2"
+        hasAttachments
+        currentProjectSubscriptionType="subscription"
+        isSubmitting={false}
+        onClose={() => {}}
+        onSubmit={() => {}}
+      />,
+    );
+    const sr = screen.getByRole("radio", { name: /^service request/i });
+    expect(sr).toBeDisabled();
+    expect(screen.getByText(/managed cloud \/ cloud support only/i)).toBeInTheDocument();
+  });
+
+  it("disables Service Request when no subscription type is known at all", () => {
+    render(
+      <ChangeCaseTypeDialog
+        currentType="case"
+        currentSeverity="S2"
+        hasAttachments
+        isSubmitting={false}
+        onClose={() => {}}
+        onSubmit={() => {}}
+      />,
+    );
+    expect(screen.getByRole("radio", { name: /^service request/i })).toBeDisabled();
+  });
+
+  it("enables Service Request for a Managed Cloud project", () => {
+    render(
+      <ChangeCaseTypeDialog
+        currentType="case"
+        currentSeverity="S2"
+        hasAttachments
+        currentProjectSubscriptionType="managed_cloud_subscription"
+        isSubmitting={false}
+        onClose={() => {}}
+        onSubmit={() => {}}
+      />,
+    );
+    expect(screen.getByRole("radio", { name: /^service request$/i })).toBeEnabled();
+  });
+
+  it("enables Service Request for a Cloud Support project", () => {
+    render(
+      <ChangeCaseTypeDialog
+        currentType="case"
+        currentSeverity="S2"
+        hasAttachments
+        currentProjectSubscriptionType="cloud_support"
+        isSubmitting={false}
+        onClose={() => {}}
+        onSubmit={() => {}}
+      />,
+    );
+    expect(screen.getByRole("radio", { name: /^service request$/i })).toBeEnabled();
+  });
+
+  it("does not gate the other transfer targets", () => {
+    render(
+      <ChangeCaseTypeDialog
+        currentType="case"
+        currentSeverity="S2"
+        hasAttachments
+        currentProjectSubscriptionType="subscription"
+        isSubmitting={false}
+        onClose={() => {}}
+        onSubmit={() => {}}
+      />,
+    );
+    expect(screen.getByRole("radio", { name: /^security report$/i })).toBeEnabled();
+    expect(screen.getByRole("radio", { name: /^engagement$/i })).toBeEnabled();
   });
 });
 
@@ -514,6 +595,7 @@ describe("ChangeCaseTypeDialog — transfer into service_request", () => {
         currentType="case"
         currentSeverity="S2"
         hasAttachments
+        currentProjectSubscriptionType="managed_cloud_subscription"
         isSubmitting={false}
         deployedProductId="dp-1"
         onClose={() => {}}
@@ -554,6 +636,7 @@ describe("ChangeCaseTypeDialog — transfer into service_request", () => {
         currentType="case"
         currentSeverity="S2"
         hasAttachments
+        currentProjectSubscriptionType="managed_cloud_subscription"
         isSubmitting={false}
         deployedProductId="dp-1"
         onClose={() => {}}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/ChangeCaseTypeDialog.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/ChangeCaseTypeDialog.test.tsx
@@ -229,6 +229,46 @@ describe("ChangeCaseTypeDialog — Service Request gated by project subscription
     expect(screen.getByRole("radio", { name: /^service request$/i })).toBeEnabled();
   });
 
+  it("blocks the fields-step Next if the subscription type resolves to ineligible after Service Request was already selected", () => {
+    // Regression for a gap where fieldsStepValid/canSubmit didn't reference
+    // serviceRequestAllowed at all — only the step-1 radio's `disabled` did.
+    // If targetType is already "service_request" and the subscription type
+    // then resolves (or changes) to something ineligible, the fields step
+    // must not stay valid just because catalog/item/answers are filled in.
+    const { rerender } = render(
+      <ChangeCaseTypeDialog
+        currentType="case"
+        currentSeverity="S2"
+        hasAttachments
+        currentProjectSubscriptionType="managed_cloud_subscription"
+        isSubmitting={false}
+        deployedProductId="dp-1"
+        onClose={() => {}}
+        onSubmit={() => {}}
+      />,
+    );
+    pickTargetAndAdvanceToFields(/service request/i);
+    fireEvent.mouseDown(screen.getByRole("combobox", { name: "Catalog" }));
+    fireEvent.click(screen.getByRole("option", { name: /api manager support/i }));
+    fireEvent.mouseDown(screen.getByRole("combobox", { name: "Catalog item" }));
+    fireEvent.click(screen.getByRole("option", { name: /request environment scaling/i }));
+    expect(screen.getByRole("button", { name: /^next$/i })).toBeEnabled();
+
+    rerender(
+      <ChangeCaseTypeDialog
+        currentType="case"
+        currentSeverity="S2"
+        hasAttachments
+        currentProjectSubscriptionType="subscription"
+        isSubmitting={false}
+        deployedProductId="dp-1"
+        onClose={() => {}}
+        onSubmit={() => {}}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /^next$/i })).toBeDisabled();
+  });
+
   it("does not gate the other transfer targets", () => {
     render(
       <ChangeCaseTypeDialog

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/ChangeCaseTypeDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/ChangeCaseTypeDialog.tsx
@@ -241,7 +241,10 @@ export default function ChangeCaseTypeDialog({
       : targetType === "security_report_analysis"
         ? hasAttachments
         : targetType === "service_request"
-          ? !!catalogId && !!catalogItemId && firstEmptyRequired === null
+          ? serviceRequestAllowed &&
+            !!catalogId &&
+            !!catalogItemId &&
+            firstEmptyRequired === null
           : true;
 
   // fieldsStepValid already carries each target's own requirements (catalog +

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/ChangeCaseTypeDialog.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/ChangeCaseTypeDialog.tsx
@@ -59,6 +59,8 @@ import {
   SUPPORTED_TRANSFER_TARGETS,
   TRANSFERABLE_CASE_TYPES,
 } from "@features/csm-cases/utils/caseTypeTransfer";
+import type { SubscriptionType } from "@features/csm-projects/types/csmProjects";
+import { isCloudSupportSubscription } from "@features/csm-projects/utils/subscriptionType";
 
 const SEVERITIES: Severity[] = ["S0", "S1", "S2", "S3", "S4"];
 
@@ -121,6 +123,11 @@ interface ChangeCaseTypeDialogProps {
    * target type — shown as disabled dropdowns on the fields step so the
    * user sees what's staying the same alongside what still needs filling. */
   currentProjectName?: string;
+  /** The case's project subscription type — gates whether Service Request is
+   * offered as a transfer target (entity-service only accepts it for Managed
+   * Cloud and Cloud Support projects). Absent renders the option disabled,
+   * same as any other non-qualifying subscription type. */
+  currentProjectSubscriptionType?: SubscriptionType;
   currentDeploymentName?: string;
   currentProductName?: string;
   currentWatchers?: { id: string; name: string }[];
@@ -147,19 +154,18 @@ interface ChangeCaseTypeDialogProps {
  * Service Request. Three steps: pick the target type (a
  * single-row radio choice of the other 3 — the case's current type isn't
  * offered as a target), fill in whatever the target needs, then review
- * what's retained/lost and confirm. Only Case <-> Engagement submits today —
- * SRA/Service Request are still selectable and their own field step is
- * fully previewable (SRA's attachment uploader really uploads; Service
- * Request's catalog picker is real), so the whole proposal is explorable —
- * but the confirm button on step 3 stays disabled for them until
- * entity-service's `caseType` validator accepts them as
- * targets.
+ * what's retained/lost and confirm. All four targets fully submit — the
+ * entity-service `caseType` validator accepts every type on update. Service
+ * Request is additionally gated client-side on the case's project
+ * subscription type (Managed Cloud or Cloud Support only), approximating —
+ * not replacing — the backend's own entitlement check.
  */
 export default function ChangeCaseTypeDialog({
   currentType,
   currentSeverity,
   hasAttachments,
   currentProjectName = "—",
+  currentProjectSubscriptionType,
   currentDeploymentName = "—",
   currentProductName = "—",
   currentWatchers = [],
@@ -191,6 +197,12 @@ export default function ChangeCaseTypeDialog({
 
   const preview = computeTransferPreview(currentType, targetType, hasAttachments);
   const isSupportedTarget = SUPPORTED_TRANSFER_TARGETS.includes(targetType);
+  // Approximates the backend's ProjectTypeFeatureManager entitlement check
+  // (which also weighs SR product category, not just subscription type) —
+  // client-side UX only, the entity-service still enforces the real rule.
+  const serviceRequestAllowed =
+    currentProjectSubscriptionType === "managed_cloud_subscription" ||
+    isCloudSupportSubscription(currentProjectSubscriptionType);
   const engagementTypeMissing = targetType === "engagement" && engagementType === "";
   const engagementPaymentTypeMissing =
     targetType === "engagement" && engagementPaymentType === "";
@@ -322,16 +334,23 @@ export default function ChangeCaseTypeDialog({
                 value={targetType}
                 onChange={(e) => handleTargetChange(e.target.value as BeCaseType)}
               >
-                {TRANSFERABLE_CASE_TYPES.filter((t) => t !== currentType).map((t) => (
-                  <FormControlLabel
-                    key={t}
-                    value={t}
-                    disabled={isSubmitting}
-                    control={<Radio size="small" />}
-                    label={caseTypeTransferLabel(t)}
-                    sx={{ flex: 1, mx: 0, whiteSpace: "nowrap" }}
-                  />
-                ))}
+                {TRANSFERABLE_CASE_TYPES.filter((t) => t !== currentType).map((t) => {
+                  const srBlocked = t === "service_request" && !serviceRequestAllowed;
+                  return (
+                    <FormControlLabel
+                      key={t}
+                      value={t}
+                      disabled={isSubmitting || srBlocked}
+                      control={<Radio size="small" />}
+                      label={
+                        srBlocked
+                          ? `${caseTypeTransferLabel(t)} (Managed Cloud / Cloud Support only)`
+                          : caseTypeTransferLabel(t)
+                      }
+                      sx={{ flex: 1, mx: 0, whiteSpace: "nowrap" }}
+                    />
+                  );
+                })}
               </RadioGroup>
             </FormControl>
           </DialogContent>

--- a/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/pages/CsmCaseDetailPage.tsx
@@ -2655,6 +2655,10 @@ export default function CsmCaseDetailPage(): JSX.Element {
           currentSeverity={c.severity}
           hasAttachments={attachmentList.length > 0}
           currentProjectName={c.projectName}
+          // Service Request is gated to Managed Cloud / Cloud Support projects —
+          // caseProject is the same project fetch already used above (Customer
+          // card, ChangeSeverityDialog's isManagedCloud, showRepoField).
+          currentProjectSubscriptionType={caseProject?.subscriptionType}
           currentDeploymentName={c.productContext.deployment}
           currentProductName={c.productContext.product}
           currentWatchers={c.watchers}


### PR DESCRIPTION
## Purpose
The CSM portal's "change case type" dialog offers **Service Request** as a selectable transfer target for every case regardless of the case's project subscription type. The backend already rejects the transfer with a 403 for projects that aren't entitled to Service Request (Managed Cloud or Cloud Support subscriptions only), so an engineer on a non-qualifying project can fill out the whole 3-step dialog and only find out it fails at the very last step.

## Goals
Disable the Service Request radio option client-side, with a label suffix explaining why, for any project that isn't Managed Cloud or Cloud Support — so the constraint is visible up front instead of surfacing as a late 403. Also fix a stale doc comment in the same file claiming the confirm button was disabled for Service Request/Security Report Analysis transfers pending backend support — that support has since landed and all four transfer targets fully submit today.

## Approach
- Added an optional `currentProjectSubscriptionType` prop to `ChangeCaseTypeDialog`, threaded through from `CsmCaseDetailPage` (same `caseProject` fetch already used for the analogous S0-severity gate in `ChangeSeverityDialog`).
- Computed a `serviceRequestAllowed` flag (`managed_cloud_subscription` OR the existing `isCloudSupportSubscription()` helper) and used it to disable the Service Request radio option with a `(Managed Cloud / Cloud Support only)` label suffix — mirrors the existing S0-severity gating pattern in `ChangeSeverityDialog.tsx` exactly (disable + explain, don't hide).
- This is a client-side UX approximation only, not a replacement for the backend's own entitlement check (which also weighs product category, not just subscription type) — the entity-service still enforces the real rule and is unchanged by this PR.
- Corrected the stale dialog doc comment.

## User stories
As a CS engineer, when I try to change a case's type to Service Request on a project that isn't entitled to it, I want to see that option is unavailable up front, not after filling out the whole dialog.

## Release note
CSM portal: the case-type-transfer dialog no longer offers Service Request as a target for projects that aren't Managed Cloud or Cloud Support subscriptions.

## Documentation
N/A — no user-facing documentation beyond the in-app `/help` guide, which doesn't currently describe Service Request entitlement rules for this dialog, so nothing there is now stale.

## Training
N/A — not part of training content.

## Certification
N/A — no certification exam impact.

## Marketing
N/A — internal CS-engineer tooling change, not customer/marketing facing.

## Automation tests
- Unit tests
  Extended `ChangeCaseTypeDialog.test.tsx` with a new describe block covering: option disabled for a non-qualifying subscription type, disabled when the subscription type is unknown/absent, enabled for Managed Cloud, enabled for Cloud Support, and that the other two transfer targets are never gated. Updated 3 existing tests that exercised the Service Request target to pass a qualifying `currentProjectSubscriptionType` so they keep testing what they were testing. All 26 tests in the file pass.
- Integration tests
  N/A — no BFF/backend change; this is a client-side-only gate.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — TypeScript/React frontend, not a JVM component this tool applies to
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
None

## Migrations (if applicable)
N/A — no schema or data migration involved

## Test environment
Verified with `tsc -b` (clean), `vite build` (clean), and `vitest run` against the affected test files (26/26 and 34/34 passing) on macOS, Node/pnpm as pinned in the repo. Not verified against a running local stack in this session — see PR description note below.

## Learning
Followed the existing precedent in `ChangeSeverityDialog.tsx`, which already gates the S0 severity option to Managed Cloud with the same disable-plus-label-suffix pattern, for consistency.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded case transfers to support Case, Engagement, Security Report Analysis, and Service Request.
  - Service Request transfers are available for Managed Cloud and Cloud Support subscriptions.
  - Service Request is clearly disabled for unsupported or unknown subscription types.

- **Bug Fixes**
  - Updated case detail transfer behavior to accurately reflect the project’s subscription eligibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->