### PR TITLE
[CSM][Web] Advanced/Simple case filters, OR groups, and a Call Requests filter bar

### DIFF
--- a/apps/csm-portal/webapp/src/api/backend/types.ts
+++ b/apps/csm-portal/webapp/src/api/backend/types.ts
@@ -981,6 +981,19 @@ export interface BeCaseSearchFilters {
   /** The generic field/op/values filter array. Omit (or send `[]`) for an
    * unfiltered cross-project search. */
   filters?: BeCaseFieldFilter[];
+  /**
+   * Cross-field OR groups: each entry's own `filters` are ANDed, the entries
+   * themselves are OR'd together, then the whole `anyOf` result is ANDed
+   * with the top-level `filters` array above. Only a restricted field subset
+   * is accepted inside a branch (`type`, `state` `in`-only, `severity`,
+   * `engagementType`, `issueType`, `workState`, `projectId`, `deploymentId`,
+   * `assignedUserId` `in`-only, `escalationLevel`) — see
+   * `features/csm-cases/utils/anyOfFilters.ts`'s own doc comment for the
+   * FE-side allowlist this mirrors. An empty branch (`{filters: []}`/`{}`)
+   * is rejected by the backend (400) rather than silently OR-widening the
+   * result set — never emit one.
+   */
+  anyOf?: { filters: BeCaseFieldFilter[] }[];
 }
 
 export interface BeCaseSearchPayload {

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.test.tsx
@@ -346,7 +346,7 @@ describe("useGetCsmCases — queryKey covers every manually-toggleable filter", 
   // Regression: `csTeams` (and, at the time, several other CasesFilters
   // fields) reached the search payload via `buildCaseSearchFilters` but had
   // no entry in the queryKey array below -- so picking a team from the bar's
-  // "Team" control changed `filters.csTeams` without changing the queryKey,
+  // "CRE Team" control changed `filters.csTeams` without changing the queryKey,
   // and React Query treated it as the identical query and never refetched.
   // Reported live: "when i select a team, no network call goes in the team
   // filter."

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
@@ -26,6 +26,7 @@ import {
   resolveAssignedUserIds,
 } from "@features/csm-cases/utils/caseSearchPayload";
 import { resolveRelativeDatePlaceholder } from "@utils/resolveRelativeDatePlaceholder";
+import { resolveAdvancedFilterDateValues } from "@features/csm-cases/utils/advancedFilters";
 import { ASSIGNEE_ME_TOKEN } from "@features/csm-cases/utils/assignee";
 import { classifyCaseQuery } from "@features/csm-cases/utils/caseQueryScope";
 import { useCurrentUser } from "@context/current-user/CurrentUserContext";
@@ -140,6 +141,12 @@ export function useGetCsmCases(
       filters.updatedOnLte,
       filters.closedOnGte,
       filters.closedOnLte,
+      // JSON-stable-enough for a query key: row order is already
+      // user-controlled (add/remove), and every field/op/values combination
+      // that would otherwise collide is exactly the same shape the `/cases/
+      // search` payload itself carries — no separate normalization needed
+      // here beyond what `buildCaseSearchFilters` already applies.
+      JSON.stringify(filters.advancedFilters),
       currentUserEmail ?? "",
       wantsMe ? (currentUserId ?? "") : "",
       page,
@@ -195,6 +202,10 @@ export function useGetCsmCases(
             ? null
             : (resolveRelativeDatePlaceholder(filters.createdOnLte, "lte", now) ??
               filters.createdOnLte),
+        // Same relative-date resolution, extended to any `createdOn`/
+        // `updatedOn`/`closedOn` row from the "Advanced filters" builder —
+        // see `resolveAdvancedFilterDateValues`.
+        advancedFilters: resolveAdvancedFilterDateValues(filters.advancedFilters, now),
       };
 
       // One cross-project case search. No separate account/project directory

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
@@ -147,6 +147,10 @@ export function useGetCsmCases(
       // search` payload itself carries — no separate normalization needed
       // here beyond what `buildCaseSearchFilters` already applies.
       JSON.stringify(filters.advancedFilters),
+      // Same reasoning as `advancedFilters` above — every field/values
+      // combination an OR-group row carries is already the exact shape the
+      // request payload itself sends.
+      JSON.stringify(filters.anyOfBranches),
       currentUserEmail ?? "",
       wantsMe ? (currentUserId ?? "") : "",
       page,

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useGetCsmCases.ts
@@ -184,28 +184,29 @@ export function useGetCsmCases(
         assignedUserIds = resolved;
       }
 
-      // Resolve `createdOnGte`/`createdOnLte` relative-date placeholders
-      // (`__today__`, `__daysAgo:N__`, ... -- same grammar and resolver as
-      // the dashboard widgets' own `resolveRelativeDateFilters`) against the
-      // viewer's own browser-local "now", right here at query-build time --
-      // no backend change, and "today" correctly means whatever moment the
-      // link is opened, not a moment baked into the URL. Only `createdOn`
-      // is covered for now (`updatedOn`/`closedOn` get the same treatment
-      // later if wanted); anything that isn't a recognized placeholder
-      // (a literal `YYYY-MM-DD`, or garbage) passes through unchanged.
+      // Resolve `createdOnGte`/`createdOnLte`/`updatedOnGte`/`updatedOnLte`/
+      // `closedOnGte`/`closedOnLte` relative-date placeholders (`__today__`,
+      // `__daysAgo:N__`, ... -- same grammar and resolver as the dashboard
+      // widgets' own `resolveRelativeDateFilters`) against the viewer's own
+      // browser-local "now", right here at query-build time -- no backend
+      // change, and "today" correctly means whatever moment the link is
+      // opened, not a moment baked into the URL. Anything that isn't a
+      // recognized placeholder (a literal `YYYY-MM-DD`, or garbage) passes
+      // through unchanged.
       const now = new Date();
+      const resolveBound = (
+        raw: string | null,
+        op: "gte" | "lte",
+      ): string | null =>
+        raw === null ? null : (resolveRelativeDatePlaceholder(raw, op, now) ?? raw);
       const resolvedFilters: CasesFilters = {
         ...filters,
-        createdOnGte:
-          filters.createdOnGte === null
-            ? null
-            : (resolveRelativeDatePlaceholder(filters.createdOnGte, "gte", now) ??
-              filters.createdOnGte),
-        createdOnLte:
-          filters.createdOnLte === null
-            ? null
-            : (resolveRelativeDatePlaceholder(filters.createdOnLte, "lte", now) ??
-              filters.createdOnLte),
+        createdOnGte: resolveBound(filters.createdOnGte, "gte"),
+        createdOnLte: resolveBound(filters.createdOnLte, "lte"),
+        updatedOnGte: resolveBound(filters.updatedOnGte, "gte"),
+        updatedOnLte: resolveBound(filters.updatedOnLte, "lte"),
+        closedOnGte: resolveBound(filters.closedOnGte, "gte"),
+        closedOnLte: resolveBound(filters.closedOnLte, "lte"),
         // Same relative-date resolution, extended to any `createdOn`/
         // `updatedOn`/`closedOn` row from the "Advanced filters" builder —
         // see `resolveAdvancedFilterDateValues`.

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useUserSearch.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useUserSearch.ts
@@ -30,8 +30,11 @@ import {
 /** Page size for the lazy-loaded (scroll-to-load-more) assignee filter. */
 export const USER_PAGE_SIZE = 10;
 
-/** A single directory match: name (label) + email (the filter value). */
+/** A single directory match: name (label), email, and id — different callers
+ * filter on different ones (the assignee/`createdBy` pickers store the
+ * email; an `anyOf` branch's `assignedUserId` row stores the id). */
 export interface UserSearchOption {
+  id: string;
   name: string;
   email: string;
 }
@@ -103,9 +106,9 @@ export function useInfiniteUserSearch(
     const seen = new Set<string>();
     const out: UserSearchOption[] = [];
     for (const u of (result.data?.pages ?? []).flatMap((p) => p.users)) {
-      if (!u.email || !u.name || seen.has(u.email)) continue;
+      if (!u.email || !u.name || !u.id || seen.has(u.email)) continue;
       seen.add(u.email);
-      out.push({ name: u.name, email: u.email });
+      out.push({ id: u.id, name: u.name, email: u.email });
     }
     return out;
   }, [result.data]);

--- a/apps/csm-portal/webapp/src/features/csm-cases/api/useUserSearch.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/api/useUserSearch.ts
@@ -32,9 +32,13 @@ export const USER_PAGE_SIZE = 10;
 
 /** A single directory match: name (label), email, and id — different callers
  * filter on different ones (the assignee/`createdBy` pickers store the
- * email; an `anyOf` branch's `assignedUserId` row stores the id). */
+ * email; an `anyOf` branch's `assignedUserId` row stores the id). `id` is
+ * optional here: `POST /users/search` does not guarantee it on every row, and
+ * an id-less row is still perfectly usable by an email-keyed consumer — only
+ * an id-keyed consumer (`AsyncAssignedUserIdMultiSelect`/
+ * `AsyncUserIdMultiSelect`) needs to additionally filter for it. */
 export interface UserSearchOption {
-  id: string;
+  id?: string;
   name: string;
   email: string;
 }
@@ -101,12 +105,15 @@ export function useInfiniteUserSearch(
 
   // Flatten every fetched page, keeping only rows with both a name (the label)
   // and an email (the filter value), de-duplicated by email so paging can't
-  // surface the same person twice.
+  // surface the same person twice. `id` is kept when present but never
+  // required here — `POST /users/search` doesn't guarantee it, and the
+  // email-keyed pickers (assignee/`createdBy`) don't need it at all; only an
+  // id-keyed consumer filters for `id` itself.
   const users = useMemo(() => {
     const seen = new Set<string>();
     const out: UserSearchOption[] = [];
     for (const u of (result.data?.pages ?? []).flatMap((p) => p.users)) {
-      if (!u.email || !u.name || !u.id || seen.has(u.email)) continue;
+      if (!u.email || !u.name || seen.has(u.email)) continue;
       seen.add(u.email);
       out.push({ id: u.id, name: u.name, email: u.email });
     }

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/AdvancedFiltersBuilder.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/AdvancedFiltersBuilder.tsx
@@ -15,8 +15,10 @@
 // under the License.
 
 import {
+  AdapterDateFns,
   Box,
   Button,
+  DatePickers,
   FormControl,
   IconButton,
   InputLabel,
@@ -26,10 +28,12 @@ import {
   Typography,
 } from "@wso2/oxygen-ui";
 import { Plus, Trash2 } from "@wso2/oxygen-ui-icons-react";
-import type { JSX } from "react";
+import { useState, type JSX } from "react";
 import MultiSelectField from "@components/MultiSelectField";
+import AsyncCreatedByMultiSelect from "@features/csm-cases/components/AsyncCreatedByMultiSelect";
 import {
   ADVANCED_FILTER_FIELDS,
+  RELATIVE_DATE_PRESETS,
   defaultAdvancedFilterRow,
   getAdvancedFilterFieldMeta,
   getAdvancedFilterOpMeta,
@@ -37,9 +41,122 @@ import {
   type AdvancedFilterRow,
 } from "@features/csm-cases/utils/advancedFilters";
 
+const { DatePicker, LocalizationProvider } = DatePickers;
+
 interface AdvancedFiltersBuilderProps {
   rows: AdvancedFilterRow[];
   onChange: (next: AdvancedFilterRow[]) => void;
+  /** SRE team options (`sreGroupId` → display name), computed once in
+   * `CasesFilterBar.tsx` from the same `useTeams(true)` fetch the "Team"
+   * (`creTeam`) bar control uses — the `sreTeam` row's value kind is
+   * `multiSelect`, but its options are fetched data, not a fixed enum, so
+   * they're threaded in here rather than living in the static
+   * `advancedFilters.ts` catalogue. */
+  sreTeamOptions: { value: string; label: string }[];
+}
+
+/** "YYYY-MM-DD" to a local-midnight Date (avoids the UTC-parse day-shift
+ * `new Date(dateString)` can cause depending on the viewer's timezone) —
+ * same helper `DateRangeFilter`/`ChangeRequestsFilterBar` each keep locally
+ * for their own date-only fields; duplicated here for the same reason
+ * `DateRangeFilter` duplicates it rather than importing across features. */
+function parseDateOnly(value: string): Date | null {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) return null;
+  const date = new Date(Number(match[1]), Number(match[2]) - 1, Number(match[3]));
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+/** Local-midnight Date back to "YYYY-MM-DD". */
+function formatDateOnly(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+const CUSTOM_DATE_SENTINEL = "__custom_date__";
+
+function isRelativeDatePreset(value: string): boolean {
+  return RELATIVE_DATE_PRESETS.some((p) => p.value === value);
+}
+
+interface DateOrPresetValueInputProps {
+  /** A relative-date placeholder (one of `RELATIVE_DATE_PRESETS`), a literal
+   * `YYYY-MM-DD`, or `""` (nothing chosen yet). */
+  value: string;
+  onChange: (next: string) => void;
+}
+
+/**
+ * The `createdOn`/`updatedOn`/`closedOn` row's value input: a preset
+ * dropdown (human labels for the common relative-date placeholders — see
+ * `RELATIVE_DATE_PRESETS`) plus an actual calendar date picker for an exact
+ * day, so neither the placeholder grammar (`__daysAgo:N__`, ...) nor a raw
+ * `YYYY-MM-DD` ever has to be hand-typed. Mode (`preset` vs `custom`) is
+ * local state seeded from the incoming value, since a bare string can't
+ * distinguish "no date chosen yet" from "chose Custom, haven't picked a day
+ * yet" — the caller should key this component by `field-op` (see
+ * `AdvancedFiltersBuilder`) so switching to a different date row/op resets
+ * that local state instead of carrying it over.
+ */
+function DateOrPresetValueInput({ value, onChange }: DateOrPresetValueInputProps): JSX.Element {
+  const [mode, setMode] = useState<"preset" | "custom">(
+    value && !isRelativeDatePreset(value) ? "custom" : "preset",
+  );
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+      <FormControl size="small" fullWidth>
+        <InputLabel id="advanced-filter-date-mode-label">Date</InputLabel>
+        <Select
+          labelId="advanced-filter-date-mode-label"
+          label="Date"
+          value={mode === "custom" ? CUSTOM_DATE_SENTINEL : value}
+          displayEmpty
+          onChange={(e) => {
+            const next = e.target.value;
+            if (next === CUSTOM_DATE_SENTINEL) {
+              setMode("custom");
+              onChange("");
+            } else {
+              setMode("preset");
+              onChange(next);
+            }
+          }}
+        >
+          <MenuItem value="">
+            <em>Choose…</em>
+          </MenuItem>
+          {RELATIVE_DATE_PRESETS.map((p) => (
+            <MenuItem key={p.value} value={p.value}>
+              {p.label}
+            </MenuItem>
+          ))}
+          <MenuItem value={CUSTOM_DATE_SENTINEL}>Custom date…</MenuItem>
+        </Select>
+      </FormControl>
+      {mode === "custom" && (
+        <LocalizationProvider dateAdapter={AdapterDateFns}>
+          <DatePicker
+            label="Exact date"
+            value={parseDateOnly(value)}
+            onChange={(date) =>
+              onChange(
+                date instanceof Date && !Number.isNaN(date.getTime())
+                  ? formatDateOnly(date)
+                  : "",
+              )
+            }
+            slotProps={{
+              textField: { size: "small", fullWidth: true },
+              field: { clearable: true },
+            }}
+          />
+        </LocalizationProvider>
+      )}
+    </Box>
+  );
 }
 
 /** Splits a comma-separated free-text entry into a trimmed, non-empty array. */
@@ -61,6 +178,7 @@ function splitCsv(raw: string): string[] {
 export default function AdvancedFiltersBuilder({
   rows,
   onChange,
+  sreTeamOptions,
 }: AdvancedFiltersBuilderProps): JSX.Element {
   const updateRow = (index: number, next: AdvancedFilterRow): void => {
     onChange(rows.map((r, i) => (i === index ? next : r)));
@@ -145,7 +263,18 @@ export default function AdvancedFiltersBuilder({
                   id={`advanced-filter-value-${index}`}
                   label="Value(s)"
                   values={row.values}
-                  options={fieldMeta?.options ?? []}
+                  // `sreTeam`'s options are fetched data (the team registry),
+                  // not part of the static catalogue -- see the
+                  // `sreTeamOptions` prop's own doc comment.
+                  options={
+                    row.field === "sreTeam" ? sreTeamOptions : (fieldMeta?.options ?? [])
+                  }
+                  onChange={(next) => updateRow(index, { ...row, values: next })}
+                />
+              )}
+              {opMeta?.valueKind === "asyncEmailMultiSelect" && (
+                <AsyncCreatedByMultiSelect
+                  values={row.values}
                   onChange={(next) => updateRow(index, { ...row, values: next })}
                 />
               )}
@@ -173,16 +302,11 @@ export default function AdvancedFiltersBuilder({
                   }
                 />
               )}
-              {opMeta?.valueKind === "date" && (
-                <TextField
-                  size="small"
-                  fullWidth
-                  label="Date"
-                  placeholder={fieldMeta?.placeholder ?? "YYYY-MM-DD"}
+              {opMeta?.valueKind === "dateOrPreset" && (
+                <DateOrPresetValueInput
+                  key={`${row.field}-${row.op}`}
                   value={row.values[0] ?? ""}
-                  onChange={(e) =>
-                    updateRow(index, { ...row, values: e.target.value ? [e.target.value] : [] })
-                  }
+                  onChange={(next) => updateRow(index, { ...row, values: next ? [next] : [] })}
                 />
               )}
               {(opMeta?.valueKind === "none" || opMeta?.valueKind === "currentUser") && (

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/AdvancedFiltersBuilder.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/AdvancedFiltersBuilder.tsx
@@ -31,28 +31,44 @@ import { Plus, Trash2 } from "@wso2/oxygen-ui-icons-react";
 import { useState, type JSX } from "react";
 import MultiSelectField from "@components/MultiSelectField";
 import AsyncCreatedByMultiSelect from "@features/csm-cases/components/AsyncCreatedByMultiSelect";
+import AsyncAssigneeMultiSelect from "@features/csm-cases/components/AsyncAssigneeMultiSelect";
+import AsyncProjectMultiSelect from "@features/csm-cases/components/AsyncProjectMultiSelect";
+import ProductNameMultiSelect from "@features/csm-cases/components/ProductNameMultiSelect";
+import AsyncTagMultiSelect from "@features/csm-cases/components/AsyncTagMultiSelect";
 import {
   ADVANCED_FILTER_FIELDS,
   RELATIVE_DATE_PRESETS,
-  defaultAdvancedFilterRow,
   getAdvancedFilterFieldMeta,
   getAdvancedFilterOpMeta,
   type AdvancedFilterField,
   type AdvancedFilterRow,
 } from "@features/csm-cases/utils/advancedFilters";
+import type { UnifiedFilterRow } from "@features/csm-cases/utils/filterFieldAdapters";
 
 const { DatePicker, LocalizationProvider } = DatePickers;
 
 interface AdvancedFiltersBuilderProps {
-  rows: AdvancedFilterRow[];
-  onChange: (next: AdvancedFilterRow[]) => void;
-  /** SRE team options (`sreGroupId` → display name), computed once in
-   * `CasesFilterBar.tsx` from the same `useTeams(true)` fetch the "Team"
-   * (`creTeam`) bar control uses — the `sreTeam` row's value kind is
-   * `multiSelect`, but its options are fetched data, not a fixed enum, so
-   * they're threaded in here rather than living in the static
-   * `advancedFilters.ts` catalogue. */
+  /** The unified row list — one row per non-empty typed field, plus every
+   * untyped ad-hoc row, see `filtersToAdvancedRows`. */
+  rows: UnifiedFilterRow[];
+  onUpdateRow: (row: UnifiedFilterRow, next: AdvancedFilterRow) => void;
+  onRemoveRow: (row: UnifiedFilterRow) => void;
+  onAddRow: () => void;
+  /** CS team options (`creGroupId` → display name) for the `creTeam` row —
+   * fetched data, not part of the static catalogue. */
+  creTeamOptions: { value: string; label: string }[];
+  /** SRE team options (`sreGroupId` → display name) for the `sreTeam` row —
+   * same reasoning as `creTeamOptions`. */
   sreTeamOptions: { value: string; label: string }[];
+  /** Known email → name pairs for the `assignedUserId` row's value input
+   * (`AsyncAssigneeMultiSelect`), so already-selected chips are labelled
+   * before any search has run — same seed the Simple grid's own "Assignee"
+   * control uses. */
+  assigneeNameSeed?: Map<string, string>;
+  /** Known id → name pairs for the `projectId` row's value input
+   * (`AsyncProjectMultiSelect`) — same seed the Simple grid's own "Project"
+   * control uses. */
+  projectNameSeed?: Map<string, string>;
 }
 
 /** "YYYY-MM-DD" to a local-midnight Date (avoids the UTC-parse day-shift
@@ -168,28 +184,40 @@ function splitCsv(raw: string): string[] {
 }
 
 /**
- * Ad-hoc "field → operator → value" filter row builder, additive to the
- * dedicated bar controls (severity, state, case type, work state, engagement
- * type, assignee, project, product) above it — those already cover their own
- * fields well and are never offered here (see `advancedFilters.ts`'s field
- * catalogue). Each row becomes one extra `BeCaseFieldFilter` entry in the
- * `/cases/search` payload (see `caseSearchPayload.ts`).
+ * Strips a {@link UnifiedFilterRow}'s `origin`/`arrayIndex` bookkeeping back
+ * down to a plain {@link AdvancedFilterRow} before spreading it into an edit.
+ * Every `onUpdateRow(row, { ...row, ... })`-shaped call site below needs
+ * this — `UnifiedFilterRow extends AdvancedFilterRow`, so `{ ...row, ... }`
+ * type-checks fine but silently carries `origin`/`arrayIndex` into what's
+ * supposed to be a clean row, and (via the "stays in the untyped array"
+ * branch of `updateUnifiedRow`) that cruft would otherwise land inside a
+ * `filters.advancedFilters` entry — state that round-trips through the URL
+ * and the `/cases/search` payload builder, neither of which expects it.
+ */
+function asRow(row: AdvancedFilterRow): AdvancedFilterRow {
+  return { field: row.field, op: row.op, values: row.values };
+}
+
+/**
+ * The unified "Advanced filters" field/op/value row builder — every field
+ * `/cases/search` accepts (see `advancedFilters.ts`'s catalogue), including
+ * the ones that also have a dedicated Simple-grid control. A row's field is
+ * itself a pickable dropdown (not fixed per row): picking, say, "Severity"
+ * here edits the exact same `filters.severities` the Simple grid's own
+ * "Severity" control does (see `filterFieldAdapters.ts`'s typed-adapter
+ * registry) — there is only ever one place a given predicate lives, this
+ * builder just offers a second, more flexible way to edit it.
  */
 export default function AdvancedFiltersBuilder({
   rows,
-  onChange,
+  onUpdateRow,
+  onRemoveRow,
+  onAddRow,
+  creTeamOptions,
   sreTeamOptions,
+  assigneeNameSeed,
+  projectNameSeed,
 }: AdvancedFiltersBuilderProps): JSX.Element {
-  const updateRow = (index: number, next: AdvancedFilterRow): void => {
-    onChange(rows.map((r, i) => (i === index ? next : r)));
-  };
-  const removeRow = (index: number): void => {
-    onChange(rows.filter((_, i) => i !== index));
-  };
-  const addRow = (): void => {
-    onChange([...rows, defaultAdvancedFilterRow()]);
-  };
-
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
       <Typography variant="subtitle2" color="text.secondary">
@@ -198,9 +226,16 @@ export default function AdvancedFiltersBuilder({
       {rows.map((row, index) => {
         const fieldMeta = getAdvancedFilterFieldMeta(row.field);
         const opMeta = getAdvancedFilterOpMeta(row.field, row.op);
+        // Stable-ish key: typed rows are keyed by field+op (there is only
+        // ever one row per field+op, whether typed or not), array rows by
+        // their array index — matches how `updateUnifiedRow` addresses them.
+        const rowKey =
+          row.origin === "typed"
+            ? `typed-${row.field}-${row.op}`
+            : `array-${row.arrayIndex}`;
         return (
           <Box
-            key={`advanced-filter-row-${index}`}
+            key={rowKey}
             sx={{ display: "flex", gap: 1, alignItems: "flex-start", flexWrap: "wrap" }}
           >
             <FormControl size="small" sx={{ minWidth: 200 }}>
@@ -213,7 +248,7 @@ export default function AdvancedFiltersBuilder({
                   const nextField = e.target.value as AdvancedFilterField;
                   const nextFieldMeta = getAdvancedFilterFieldMeta(nextField);
                   const nextOp = nextFieldMeta?.ops[0]?.op ?? row.op;
-                  updateRow(index, { field: nextField, op: nextOp, values: [] });
+                  onUpdateRow(row, { field: nextField, op: nextOp, values: [] });
                 }}
               >
                 {ADVANCED_FILTER_FIELDS.map((m) => (
@@ -231,7 +266,7 @@ export default function AdvancedFiltersBuilder({
                 label="Operator"
                 value={row.op}
                 onChange={(e) => {
-                  updateRow(index, { ...row, op: e.target.value as typeof row.op, values: [] });
+                  onUpdateRow(row, { ...asRow(row), op: e.target.value as typeof row.op, values: [] });
                 }}
               >
                 {(fieldMeta?.ops ?? []).map((o) => (
@@ -250,7 +285,9 @@ export default function AdvancedFiltersBuilder({
                   label="Value(s)"
                   placeholder={fieldMeta?.placeholder ?? "Comma-separated values"}
                   value={row.values.join(", ")}
-                  onChange={(e) => updateRow(index, { ...row, values: splitCsv(e.target.value) })}
+                  onChange={(e) =>
+                    onUpdateRow(row, { ...asRow(row), values: splitCsv(e.target.value) })
+                  }
                   helperText={
                     fieldMeta?.suggestions?.length
                       ? `Suggestions: ${fieldMeta.suggestions.join(", ")}`
@@ -263,19 +300,56 @@ export default function AdvancedFiltersBuilder({
                   id={`advanced-filter-value-${index}`}
                   label="Value(s)"
                   values={row.values}
-                  // `sreTeam`'s options are fetched data (the team registry),
-                  // not part of the static catalogue -- see the
-                  // `sreTeamOptions` prop's own doc comment.
+                  // `creTeam`/`sreTeam` options are fetched data (the team
+                  // registry), not part of the static catalogue -- see
+                  // `creTeamOptions`/`sreTeamOptions`'s own doc comments.
                   options={
-                    row.field === "sreTeam" ? sreTeamOptions : (fieldMeta?.options ?? [])
+                    row.field === "creTeam"
+                      ? creTeamOptions
+                      : row.field === "sreTeam"
+                        ? sreTeamOptions
+                        : (fieldMeta?.options ?? [])
                   }
-                  onChange={(next) => updateRow(index, { ...row, values: next })}
+                  onChange={(next) => onUpdateRow(row, { ...asRow(row), values: next })}
                 />
               )}
               {opMeta?.valueKind === "asyncEmailMultiSelect" && (
                 <AsyncCreatedByMultiSelect
                   values={row.values}
-                  onChange={(next) => updateRow(index, { ...row, values: next })}
+                  onChange={(next) => onUpdateRow(row, { ...asRow(row), values: next })}
+                />
+              )}
+              {opMeta?.valueKind === "asyncAssigneeMultiSelect" && (
+                <AsyncAssigneeMultiSelect
+                  id={`advanced-filter-value-${index}`}
+                  label="Value(s)"
+                  values={row.values}
+                  onChange={(next) => onUpdateRow(row, { ...asRow(row), values: next })}
+                  nameSeed={assigneeNameSeed}
+                />
+              )}
+              {opMeta?.valueKind === "asyncProjectMultiSelect" && (
+                <AsyncProjectMultiSelect
+                  id={`advanced-filter-value-${index}`}
+                  label="Value(s)"
+                  values={row.values}
+                  onChange={(next) => onUpdateRow(row, { ...asRow(row), values: next })}
+                  nameSeed={projectNameSeed}
+                />
+              )}
+              {opMeta?.valueKind === "asyncProductMultiSelect" && (
+                <ProductNameMultiSelect
+                  id={`advanced-filter-value-${index}`}
+                  label="Value(s)"
+                  values={row.values}
+                  onChange={(next) => onUpdateRow(row, { ...asRow(row), values: next })}
+                />
+              )}
+              {opMeta?.valueKind === "asyncTagMultiSelect" && (
+                <AsyncTagMultiSelect
+                  id={`advanced-filter-value-${index}`}
+                  values={row.values}
+                  onChange={(next) => onUpdateRow(row, { ...asRow(row), values: next })}
                 />
               )}
               {opMeta?.valueKind === "text" && (
@@ -286,7 +360,10 @@ export default function AdvancedFiltersBuilder({
                   placeholder={fieldMeta?.placeholder}
                   value={row.values[0] ?? ""}
                   onChange={(e) =>
-                    updateRow(index, { ...row, values: e.target.value ? [e.target.value] : [] })
+                    onUpdateRow(row, {
+                      ...asRow(row),
+                      values: e.target.value ? [e.target.value] : [],
+                    })
                   }
                 />
               )}
@@ -298,7 +375,10 @@ export default function AdvancedFiltersBuilder({
                   label="Value"
                   value={row.values[0] ?? ""}
                   onChange={(e) =>
-                    updateRow(index, { ...row, values: e.target.value ? [e.target.value] : [] })
+                    onUpdateRow(row, {
+                      ...asRow(row),
+                      values: e.target.value ? [e.target.value] : [],
+                    })
                   }
                 />
               )}
@@ -306,7 +386,7 @@ export default function AdvancedFiltersBuilder({
                 <DateOrPresetValueInput
                   key={`${row.field}-${row.op}`}
                   value={row.values[0] ?? ""}
-                  onChange={(next) => updateRow(index, { ...row, values: next ? [next] : [] })}
+                  onChange={(next) => onUpdateRow(row, { ...asRow(row), values: next ? [next] : [] })}
                 />
               )}
               {(opMeta?.valueKind === "none" || opMeta?.valueKind === "currentUser") && (
@@ -319,7 +399,7 @@ export default function AdvancedFiltersBuilder({
             <IconButton
               size="small"
               aria-label="Remove filter row"
-              onClick={() => removeRow(index)}
+              onClick={() => onRemoveRow(row)}
               sx={{ mt: 0.5 }}
             >
               <Trash2 size={16} />
@@ -328,7 +408,7 @@ export default function AdvancedFiltersBuilder({
         );
       })}
       <Box>
-        <Button size="small" variant="outlined" startIcon={<Plus size={16} />} onClick={addRow}>
+        <Button size="small" variant="outlined" startIcon={<Plus size={16} />} onClick={onAddRow}>
           Add filter
         </Button>
       </Box>

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/AdvancedFiltersBuilder.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/AdvancedFiltersBuilder.tsx
@@ -1,0 +1,213 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Box,
+  Button,
+  FormControl,
+  IconButton,
+  InputLabel,
+  MenuItem,
+  Select,
+  TextField,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { Plus, Trash2 } from "@wso2/oxygen-ui-icons-react";
+import type { JSX } from "react";
+import MultiSelectField from "@components/MultiSelectField";
+import {
+  ADVANCED_FILTER_FIELDS,
+  defaultAdvancedFilterRow,
+  getAdvancedFilterFieldMeta,
+  getAdvancedFilterOpMeta,
+  type AdvancedFilterField,
+  type AdvancedFilterRow,
+} from "@features/csm-cases/utils/advancedFilters";
+
+interface AdvancedFiltersBuilderProps {
+  rows: AdvancedFilterRow[];
+  onChange: (next: AdvancedFilterRow[]) => void;
+}
+
+/** Splits a comma-separated free-text entry into a trimmed, non-empty array. */
+function splitCsv(raw: string): string[] {
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+/**
+ * Ad-hoc "field → operator → value" filter row builder, additive to the
+ * dedicated bar controls (severity, state, case type, work state, engagement
+ * type, assignee, project, product) above it — those already cover their own
+ * fields well and are never offered here (see `advancedFilters.ts`'s field
+ * catalogue). Each row becomes one extra `BeCaseFieldFilter` entry in the
+ * `/cases/search` payload (see `caseSearchPayload.ts`).
+ */
+export default function AdvancedFiltersBuilder({
+  rows,
+  onChange,
+}: AdvancedFiltersBuilderProps): JSX.Element {
+  const updateRow = (index: number, next: AdvancedFilterRow): void => {
+    onChange(rows.map((r, i) => (i === index ? next : r)));
+  };
+  const removeRow = (index: number): void => {
+    onChange(rows.filter((_, i) => i !== index));
+  };
+  const addRow = (): void => {
+    onChange([...rows, defaultAdvancedFilterRow()]);
+  };
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+      <Typography variant="subtitle2" color="text.secondary">
+        Advanced filters
+      </Typography>
+      {rows.map((row, index) => {
+        const fieldMeta = getAdvancedFilterFieldMeta(row.field);
+        const opMeta = getAdvancedFilterOpMeta(row.field, row.op);
+        return (
+          <Box
+            key={`advanced-filter-row-${index}`}
+            sx={{ display: "flex", gap: 1, alignItems: "flex-start", flexWrap: "wrap" }}
+          >
+            <FormControl size="small" sx={{ minWidth: 200 }}>
+              <InputLabel id={`advanced-filter-field-${index}-label`}>Field</InputLabel>
+              <Select
+                labelId={`advanced-filter-field-${index}-label`}
+                label="Field"
+                value={row.field}
+                onChange={(e) => {
+                  const nextField = e.target.value as AdvancedFilterField;
+                  const nextFieldMeta = getAdvancedFilterFieldMeta(nextField);
+                  const nextOp = nextFieldMeta?.ops[0]?.op ?? row.op;
+                  updateRow(index, { field: nextField, op: nextOp, values: [] });
+                }}
+              >
+                {ADVANCED_FILTER_FIELDS.map((m) => (
+                  <MenuItem key={m.field} value={m.field}>
+                    {m.label}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+
+            <FormControl size="small" sx={{ minWidth: 160 }}>
+              <InputLabel id={`advanced-filter-op-${index}-label`}>Operator</InputLabel>
+              <Select
+                labelId={`advanced-filter-op-${index}-label`}
+                label="Operator"
+                value={row.op}
+                onChange={(e) => {
+                  updateRow(index, { ...row, op: e.target.value as typeof row.op, values: [] });
+                }}
+              >
+                {(fieldMeta?.ops ?? []).map((o) => (
+                  <MenuItem key={o.op} value={o.op}>
+                    {o.label}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+
+            <Box sx={{ minWidth: 220, flex: "1 1 220px" }}>
+              {opMeta?.valueKind === "multiText" && (
+                <TextField
+                  size="small"
+                  fullWidth
+                  label="Value(s)"
+                  placeholder={fieldMeta?.placeholder ?? "Comma-separated values"}
+                  value={row.values.join(", ")}
+                  onChange={(e) => updateRow(index, { ...row, values: splitCsv(e.target.value) })}
+                  helperText={
+                    fieldMeta?.suggestions?.length
+                      ? `Suggestions: ${fieldMeta.suggestions.join(", ")}`
+                      : "Comma-separated"
+                  }
+                />
+              )}
+              {opMeta?.valueKind === "multiSelect" && (
+                <MultiSelectField
+                  id={`advanced-filter-value-${index}`}
+                  label="Value(s)"
+                  values={row.values}
+                  options={fieldMeta?.options ?? []}
+                  onChange={(next) => updateRow(index, { ...row, values: next })}
+                />
+              )}
+              {opMeta?.valueKind === "text" && (
+                <TextField
+                  size="small"
+                  fullWidth
+                  label="Value"
+                  placeholder={fieldMeta?.placeholder}
+                  value={row.values[0] ?? ""}
+                  onChange={(e) =>
+                    updateRow(index, { ...row, values: e.target.value ? [e.target.value] : [] })
+                  }
+                />
+              )}
+              {opMeta?.valueKind === "number" && (
+                <TextField
+                  size="small"
+                  fullWidth
+                  type="number"
+                  label="Value"
+                  value={row.values[0] ?? ""}
+                  onChange={(e) =>
+                    updateRow(index, { ...row, values: e.target.value ? [e.target.value] : [] })
+                  }
+                />
+              )}
+              {opMeta?.valueKind === "date" && (
+                <TextField
+                  size="small"
+                  fullWidth
+                  label="Date"
+                  placeholder={fieldMeta?.placeholder ?? "YYYY-MM-DD"}
+                  value={row.values[0] ?? ""}
+                  onChange={(e) =>
+                    updateRow(index, { ...row, values: e.target.value ? [e.target.value] : [] })
+                  }
+                />
+              )}
+              {(opMeta?.valueKind === "none" || opMeta?.valueKind === "currentUser") && (
+                <Typography variant="caption" color="text.secondary" sx={{ lineHeight: "40px" }}>
+                  {opMeta.valueKind === "currentUser" ? "The signed-in user" : "No value needed"}
+                </Typography>
+              )}
+            </Box>
+
+            <IconButton
+              size="small"
+              aria-label="Remove filter row"
+              onClick={() => removeRow(index)}
+              sx={{ mt: 0.5 }}
+            >
+              <Trash2 size={16} />
+            </IconButton>
+          </Box>
+        );
+      })}
+      <Box>
+        <Button size="small" variant="outlined" startIcon={<Plus size={16} />} onClick={addRow}>
+          Add filter
+        </Button>
+      </Box>
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/AdvancedFiltersBuilder.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/AdvancedFiltersBuilder.tsx
@@ -98,6 +98,9 @@ function isRelativeDatePreset(value: string): boolean {
 }
 
 interface DateOrPresetValueInputProps {
+  /** Unique per rendered row, so the label/`labelId` pair stays unambiguous
+   * when several date rows are open at once. */
+  labelId: string;
   /** A relative-date placeholder (one of `RELATIVE_DATE_PRESETS`), a literal
    * `YYYY-MM-DD`, or `""` (nothing chosen yet). */
   value: string;
@@ -116,7 +119,11 @@ interface DateOrPresetValueInputProps {
  * `AdvancedFiltersBuilder`) so switching to a different date row/op resets
  * that local state instead of carrying it over.
  */
-function DateOrPresetValueInput({ value, onChange }: DateOrPresetValueInputProps): JSX.Element {
+function DateOrPresetValueInput({
+  labelId,
+  value,
+  onChange,
+}: DateOrPresetValueInputProps): JSX.Element {
   const [mode, setMode] = useState<"preset" | "custom">(
     value && !isRelativeDatePreset(value) ? "custom" : "preset",
   );
@@ -124,9 +131,9 @@ function DateOrPresetValueInput({ value, onChange }: DateOrPresetValueInputProps
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
       <FormControl size="small" fullWidth>
-        <InputLabel id="advanced-filter-date-mode-label">Date</InputLabel>
+        <InputLabel id={labelId}>Date</InputLabel>
         <Select
-          labelId="advanced-filter-date-mode-label"
+          labelId={labelId}
           label="Date"
           value={mode === "custom" ? CUSTOM_DATE_SENTINEL : value}
           displayEmpty
@@ -385,6 +392,7 @@ export default function AdvancedFiltersBuilder({
               {opMeta?.valueKind === "dateOrPreset" && (
                 <DateOrPresetValueInput
                   key={`${row.field}-${row.op}`}
+                  labelId={`advanced-filter-date-mode-${index}-label`}
                   value={row.values[0] ?? ""}
                   onChange={(next) => onUpdateRow(row, { ...asRow(row), values: next ? [next] : [] })}
                 />

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/AnyOfGroupsBuilder.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/AnyOfGroupsBuilder.tsx
@@ -1,0 +1,245 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import {
+  Box,
+  Button,
+  Chip,
+  Divider,
+  FormControl,
+  IconButton,
+  InputLabel,
+  MenuItem,
+  Paper,
+  Select,
+  TextField,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { Plus, Trash2 } from "@wso2/oxygen-ui-icons-react";
+import type { JSX } from "react";
+import MultiSelectField from "@components/MultiSelectField";
+import AsyncProjectMultiSelect from "@features/csm-cases/components/AsyncProjectMultiSelect";
+import AsyncAssignedUserIdMultiSelect from "@features/csm-cases/components/AsyncAssignedUserIdMultiSelect";
+import {
+  ANY_OF_FILTER_FIELDS,
+  defaultAnyOfBranch,
+  defaultAnyOfFilterRow,
+  getAnyOfFilterFieldMeta,
+  type AnyOfBranch,
+  type AnyOfFilterField,
+  type AnyOfFilterRow,
+} from "@features/csm-cases/utils/anyOfFilters";
+
+interface AnyOfGroupsBuilderProps {
+  branches: AnyOfBranch[];
+  onChange: (next: AnyOfBranch[]) => void;
+}
+
+/** Splits a comma-separated free-text entry into a trimmed, non-empty array. */
+function splitCsv(raw: string): string[] {
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+/**
+ * "OR groups" (`filters.anyOf`) builder: a list of branches, each its own
+ * bordered box of AND-ed field/value conditions (reusing the same row-editor
+ * shape `AdvancedFiltersBuilder` uses, backed by the much narrower branch
+ * field allowlist in `anyOfFilters.ts`), with the branches themselves OR'd
+ * together and the whole result ANDed with every other active filter. See
+ * `CasesFilters.anyOfBranches`'s own doc comment for the exact semantics.
+ */
+export default function AnyOfGroupsBuilder({
+  branches,
+  onChange,
+}: AnyOfGroupsBuilderProps): JSX.Element {
+  const updateBranch = (branchIndex: number, next: AnyOfBranch): void => {
+    onChange(branches.map((b, i) => (i === branchIndex ? next : b)));
+  };
+  const removeBranch = (branchIndex: number): void => {
+    onChange(branches.filter((_, i) => i !== branchIndex));
+  };
+  const addBranch = (): void => {
+    onChange([...branches, defaultAnyOfBranch()]);
+  };
+
+  const updateRow = (branchIndex: number, rowIndex: number, next: AnyOfFilterRow): void => {
+    const branch = branches[branchIndex];
+    updateBranch(branchIndex, {
+      filters: branch.filters.map((r, i) => (i === rowIndex ? next : r)),
+    });
+  };
+  const removeRow = (branchIndex: number, rowIndex: number): void => {
+    const branch = branches[branchIndex];
+    updateBranch(branchIndex, { filters: branch.filters.filter((_, i) => i !== rowIndex) });
+  };
+  const addRow = (branchIndex: number): void => {
+    const branch = branches[branchIndex];
+    updateBranch(branchIndex, { filters: [...branch.filters, defaultAnyOfFilterRow()] });
+  };
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+      <Typography variant="subtitle2" color="text.secondary">
+        OR groups
+      </Typography>
+      <Typography variant="caption" color="text.secondary">
+        Each group&apos;s own conditions are ANDed together; the groups themselves are OR&apos;d,
+        then combined with every other active filter above.
+      </Typography>
+      {branches.map((branch, branchIndex) => (
+        <Box key={`any-of-branch-${branchIndex}`}>
+          {branchIndex > 0 && (
+            <Box sx={{ display: "flex", justifyContent: "center", my: 0.5 }}>
+              <Chip size="small" label="OR" color="default" />
+            </Box>
+          )}
+          <Paper
+            variant="outlined"
+            sx={{ p: 1.5, display: "flex", flexDirection: "column", gap: 1 }}
+          >
+            <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+              <Typography variant="caption" color="text.secondary">
+                Group {branchIndex + 1}
+              </Typography>
+              <IconButton
+                size="small"
+                aria-label={`Remove OR group ${branchIndex + 1}`}
+                onClick={() => removeBranch(branchIndex)}
+              >
+                <Trash2 size={16} />
+              </IconButton>
+            </Box>
+            {branch.filters.map((row, rowIndex) => {
+              const fieldMeta = getAnyOfFilterFieldMeta(row.field);
+              return (
+                <Box key={`any-of-branch-${branchIndex}-row-${rowIndex}`}>
+                  {rowIndex > 0 && (
+                    <Typography
+                      variant="caption"
+                      color="text.secondary"
+                      sx={{ display: "block", mb: 0.5 }}
+                    >
+                      AND
+                    </Typography>
+                  )}
+                  <Box sx={{ display: "flex", gap: 1, alignItems: "flex-start", flexWrap: "wrap" }}>
+                    <FormControl size="small" sx={{ minWidth: 180 }}>
+                      <InputLabel id={`any-of-${branchIndex}-${rowIndex}-field-label`}>
+                        Field
+                      </InputLabel>
+                      <Select
+                        labelId={`any-of-${branchIndex}-${rowIndex}-field-label`}
+                        label="Field"
+                        value={row.field}
+                        onChange={(e) =>
+                          updateRow(branchIndex, rowIndex, {
+                            field: e.target.value as AnyOfFilterField,
+                            values: [],
+                          })
+                        }
+                      >
+                        {ANY_OF_FILTER_FIELDS.map((m) => (
+                          <MenuItem key={m.field} value={m.field}>
+                            {m.label}
+                          </MenuItem>
+                        ))}
+                      </Select>
+                    </FormControl>
+
+                    <Box sx={{ minWidth: 220, flex: "1 1 220px" }}>
+                      {fieldMeta?.valueKind === "multiSelect" && (
+                        <MultiSelectField
+                          id={`any-of-${branchIndex}-${rowIndex}-value`}
+                          label="Value(s)"
+                          values={row.values}
+                          options={fieldMeta.options ?? []}
+                          onChange={(next) =>
+                            updateRow(branchIndex, rowIndex, { ...row, values: next })
+                          }
+                        />
+                      )}
+                      {fieldMeta?.valueKind === "multiText" && (
+                        <TextField
+                          size="small"
+                          fullWidth
+                          label="Value(s)"
+                          placeholder={fieldMeta.placeholder ?? "Comma-separated values"}
+                          value={row.values.join(", ")}
+                          onChange={(e) =>
+                            updateRow(branchIndex, rowIndex, {
+                              ...row,
+                              values: splitCsv(e.target.value),
+                            })
+                          }
+                          helperText="Comma-separated"
+                        />
+                      )}
+                      {fieldMeta?.valueKind === "asyncProject" && (
+                        <AsyncProjectMultiSelect
+                          id={`any-of-${branchIndex}-${rowIndex}-project`}
+                          values={row.values}
+                          onChange={(next) =>
+                            updateRow(branchIndex, rowIndex, { ...row, values: next })
+                          }
+                        />
+                      )}
+                      {fieldMeta?.valueKind === "asyncAssignedUser" && (
+                        <AsyncAssignedUserIdMultiSelect
+                          values={row.values}
+                          onChange={(next) =>
+                            updateRow(branchIndex, rowIndex, { ...row, values: next })
+                          }
+                        />
+                      )}
+                    </Box>
+
+                    <IconButton
+                      size="small"
+                      aria-label="Remove condition"
+                      onClick={() => removeRow(branchIndex, rowIndex)}
+                      sx={{ mt: 0.5 }}
+                    >
+                      <Trash2 size={16} />
+                    </IconButton>
+                  </Box>
+                </Box>
+              );
+            })}
+            <Box>
+              <Button
+                size="small"
+                variant="outlined"
+                startIcon={<Plus size={16} />}
+                onClick={() => addRow(branchIndex)}
+              >
+                Add condition
+              </Button>
+            </Box>
+          </Paper>
+        </Box>
+      ))}
+      <Divider sx={{ display: branches.length > 0 ? "block" : "none" }} />
+      <Box>
+        <Button size="small" variant="outlined" startIcon={<Plus size={16} />} onClick={addBranch}>
+          Add group
+        </Button>
+      </Box>
+    </Box>
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncAssignedUserIdMultiSelect.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncAssignedUserIdMultiSelect.tsx
@@ -1,0 +1,163 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Autocomplete, Box, Checkbox, ListItemText, TextField, Tooltip } from "@wso2/oxygen-ui";
+import { useMemo, useState, type JSX } from "react";
+import type * as React from "react";
+import { useDebouncedValue } from "@hooks/useDebouncedValue";
+import { useInfiniteUserSearch } from "@features/csm-cases/api/useUserSearch";
+
+interface AssignedUserOption {
+  id: string;
+  name: string;
+}
+
+interface AsyncAssignedUserIdMultiSelectProps {
+  /** Selected engineer platform ids (not emails — `assignedUserId` filters
+   * on the id directly, so no email→id resolution step is needed at
+   * request-build time). */
+  values: string[];
+  onChange: (next: string[]) => void;
+}
+
+/**
+ * The `anyOf` branch "Assignee" row's value input — the id-valued twin of
+ * {@link AsyncCreatedByMultiSelect}: same directory search
+ * ({@link useInfiniteUserSearch}), but stores the picked user's id (what
+ * `assignedUserId` actually filters on) rather than their email. No `@me`
+ * sentinel here (unlike the top-level "Assignee" bar control) — an `anyOf`
+ * branch is a comparatively rare, deliberate cross-field OR construction,
+ * and "assigned to me" is already reachable via the bar's own Assignee
+ * control outside any branch.
+ */
+export default function AsyncAssignedUserIdMultiSelect({
+  values,
+  onChange,
+}: AsyncAssignedUserIdMultiSelectProps): JSX.Element {
+  const [input, setInput] = useState("");
+  const [open, setOpen] = useState(false);
+  const debounced = useDebouncedValue(input, 300);
+  const query = debounced.trim();
+
+  const { users, isFetching, isFetchingNextPage, hasNextPage, isError, fetchNextPage } =
+    useInfiniteUserSearch(query, open);
+
+  const handleListboxScroll = (event: React.UIEvent<HTMLElement>): void => {
+    const el = event.currentTarget;
+    if (
+      hasNextPage &&
+      !isFetchingNextPage &&
+      el.scrollHeight - el.scrollTop - el.clientHeight < 80
+    ) {
+      fetchNextPage();
+    }
+  };
+
+  const [pickedNames, setPickedNames] = useState<Map<string, string>>(() => new Map());
+
+  const nameById = useMemo(() => {
+    const m = new Map<string, string>();
+    users.forEach((u) => m.set(u.id, u.name));
+    pickedNames.forEach((name, id) => m.set(id, name));
+    return m;
+  }, [users, pickedNames]);
+
+  const selectedOptions: AssignedUserOption[] = useMemo(
+    () => values.map((v) => ({ id: v, name: nameById.get(v) ?? v })),
+    [values, nameById],
+  );
+
+  const options: AssignedUserOption[] = useMemo(() => {
+    const selected = new Set(values);
+    const results = users
+      .filter((u) => !selected.has(u.id))
+      .map((u) => ({ id: u.id, name: u.name }));
+    return [...selectedOptions, ...results];
+  }, [users, values, selectedOptions]);
+
+  return (
+    <Autocomplete<AssignedUserOption, true>
+      multiple
+      size="small"
+      id="any-of-filter-assigned-user"
+      options={options}
+      value={selectedOptions}
+      open={open}
+      onOpen={() => setOpen(true)}
+      onClose={() => setOpen(false)}
+      loading={isFetching && users.length === 0}
+      disableCloseOnSelect
+      filterOptions={(opts) => opts}
+      getOptionLabel={(opt) => opt.name}
+      isOptionEqualToValue={(opt, val) => opt.id === val.id}
+      slotProps={{ listbox: { onScroll: handleListboxScroll } }}
+      onChange={(_event, next) => {
+        setPickedNames((prev) => {
+          const m = new Map(prev);
+          next.forEach((o) => m.set(o.id, o.name));
+          return m;
+        });
+        onChange(next.map((o) => o.id));
+      }}
+      inputValue={input}
+      onInputChange={(_event, value, reason) => {
+        if (reason === "input" || reason === "clear") setInput(value);
+      }}
+      noOptionsText={
+        isError
+          ? "Couldn't load engineers. Try again."
+          : isFetching
+            ? "Loading engineers…"
+            : "No engineers found"
+      }
+      renderTags={(value) => {
+        const displayText = value.map((o) => o.name).join(", ");
+        const content = (
+          <Box
+            component="span"
+            sx={{ flex: "1 1 0", minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", pl: 1 }}
+          >
+            {displayText}
+          </Box>
+        );
+        return value.length === 1 ? content : (
+          <Tooltip title={displayText} placement="top">{content}</Tooltip>
+        );
+      }}
+      renderOption={(props, option, { selected }) => {
+        const { key, ...liProps } = props as React.HTMLAttributes<HTMLLIElement> & {
+          key: string;
+        };
+        return (
+          <li key={key} {...liProps} style={{ paddingTop: 2, paddingBottom: 2 }}>
+            <Checkbox size="small" checked={selected} sx={{ mr: 1, p: 0.25 }} />
+            <ListItemText
+              primary={option.name}
+              slotProps={{ primary: { style: { fontSize: 13, overflowWrap: "anywhere" } } }}
+            />
+          </li>
+        );
+      }}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          label="Value(s)"
+          placeholder={values.length ? undefined : "Search engineers…"}
+        />
+      )}
+    />
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncAssignedUserIdMultiSelect.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncAssignedUserIdMultiSelect.tsx
@@ -52,8 +52,15 @@ export default function AsyncAssignedUserIdMultiSelect({
   const debounced = useDebouncedValue(input, 300);
   const query = debounced.trim();
 
-  const { users, isFetching, isFetchingNextPage, hasNextPage, isError, fetchNextPage } =
+  const { users: searchResults, isFetching, isFetchingNextPage, hasNextPage, isError, fetchNextPage } =
     useInfiniteUserSearch(query, open);
+  // `id` is optional on `UserSearchOption` (`POST /users/search` doesn't
+  // guarantee it) — this picker filters on the id, so a row without one is
+  // unusable here and dropped, unlike the email-keyed pickers.
+  const users = useMemo(
+    () => searchResults.filter((u): u is typeof u & { id: string } => Boolean(u.id)),
+    [searchResults],
+  );
 
   const handleListboxScroll = (event: React.UIEvent<HTMLElement>): void => {
     const el = event.currentTarget;

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncCreatedByMultiSelect.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncCreatedByMultiSelect.tsx
@@ -1,0 +1,164 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Autocomplete, Box, Checkbox, ListItemText, TextField, Tooltip } from "@wso2/oxygen-ui";
+import { useMemo, useState, type JSX } from "react";
+import type * as React from "react";
+import { useDebouncedValue } from "@hooks/useDebouncedValue";
+import { useInfiniteUserSearch } from "@features/csm-cases/api/useUserSearch";
+
+interface CreatedByOption {
+  email: string;
+  name: string;
+}
+
+interface AsyncCreatedByMultiSelectProps {
+  /** Selected engineer/reporter emails. */
+  values: string[];
+  onChange: (next: string[]) => void;
+}
+
+/**
+ * The "Created by" advanced-filter row's value input — a type-to-search
+ * multi-value email picker over the same user directory
+ * ({@link useInfiniteUserSearch}) `AsyncAssigneeMultiSelect` already searches,
+ * so the "email is one of" op suggests real reporters instead of requiring
+ * them hand-typed. A stripped-down copy of that component's debounce/search
+ * shape — no "Me" pinning (that's the row's own separate "is me" op, backed
+ * by `BE_CURRENT_USER_FILTER_PLACEHOLDER`, not a selectable option here).
+ */
+export default function AsyncCreatedByMultiSelect({
+  values,
+  onChange,
+}: AsyncCreatedByMultiSelectProps): JSX.Element {
+  const [input, setInput] = useState("");
+  const [open, setOpen] = useState(false);
+  const debounced = useDebouncedValue(input, 300);
+  const query = debounced.trim();
+
+  const { users, isFetching, isFetchingNextPage, hasNextPage, isError, fetchNextPage } =
+    useInfiniteUserSearch(query, open);
+
+  const handleListboxScroll = (event: React.UIEvent<HTMLElement>): void => {
+    const el = event.currentTarget;
+    if (
+      hasNextPage &&
+      !isFetchingNextPage &&
+      el.scrollHeight - el.scrollTop - el.clientHeight < 80
+    ) {
+      fetchNextPage();
+    }
+  };
+
+  const [pickedNames, setPickedNames] = useState<Map<string, string>>(() => new Map());
+
+  const nameByEmail = useMemo(() => {
+    const m = new Map<string, string>();
+    users.forEach((u) => m.set(u.email, u.name));
+    pickedNames.forEach((name, email) => m.set(email, name));
+    return m;
+  }, [users, pickedNames]);
+
+  const selectedOptions: CreatedByOption[] = useMemo(
+    () => values.map((v) => ({ email: v, name: nameByEmail.get(v) ?? v })),
+    [values, nameByEmail],
+  );
+
+  const options: CreatedByOption[] = useMemo(() => {
+    const selected = new Set(values);
+    const results = users
+      .filter((u) => !selected.has(u.email))
+      .map((u) => ({ email: u.email, name: u.name }));
+    return [...selectedOptions, ...results];
+  }, [users, values, selectedOptions]);
+
+  return (
+    <Autocomplete<CreatedByOption, true>
+      multiple
+      size="small"
+      id="advanced-filter-created-by"
+      options={options}
+      value={selectedOptions}
+      open={open}
+      onOpen={() => setOpen(true)}
+      onClose={() => setOpen(false)}
+      loading={isFetching && users.length === 0}
+      disableCloseOnSelect
+      filterOptions={(opts) => opts}
+      getOptionLabel={(opt) => opt.name}
+      isOptionEqualToValue={(opt, val) => opt.email === val.email}
+      slotProps={{ listbox: { onScroll: handleListboxScroll } }}
+      onChange={(_event, next) => {
+        setPickedNames((prev) => {
+          const m = new Map(prev);
+          next.forEach((o) => m.set(o.email, o.name));
+          return m;
+        });
+        onChange(next.map((o) => o.email));
+      }}
+      inputValue={input}
+      onInputChange={(_event, value, reason) => {
+        if (reason === "input" || reason === "clear") setInput(value);
+      }}
+      noOptionsText={
+        isError
+          ? "Couldn't load people. Try again."
+          : isFetching
+            ? "Loading…"
+            : "No matches"
+      }
+      renderTags={(value) => {
+        const displayText = value.map((o) => o.name).join(", ");
+        const content = (
+          <Box
+            component="span"
+            sx={{ flex: "1 1 0", minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", pl: 1 }}
+          >
+            {displayText}
+          </Box>
+        );
+        return value.length === 1 ? content : (
+          <Tooltip title={displayText} placement="top">{content}</Tooltip>
+        );
+      }}
+      renderOption={(props, option, { selected }) => {
+        const { key, ...liProps } = props as React.HTMLAttributes<HTMLLIElement> & {
+          key: string;
+        };
+        return (
+          <li key={key} {...liProps} style={{ paddingTop: 2, paddingBottom: 2 }}>
+            <Checkbox size="small" checked={selected} sx={{ mr: 1, p: 0.25 }} />
+            <ListItemText
+              primary={option.name}
+              secondary={option.email}
+              slotProps={{
+                primary: { style: { fontSize: 13, overflowWrap: "anywhere" } },
+                secondary: { style: { fontSize: 11, overflowWrap: "anywhere" } },
+              }}
+            />
+          </li>
+        );
+      }}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          label="Value(s)"
+          placeholder={values.length ? undefined : "Search people…"}
+        />
+      )}
+    />
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncTagMultiSelect.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncTagMultiSelect.tsx
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Autocomplete, Box, TextField, Tooltip } from "@wso2/oxygen-ui";
+import { useMemo, useState, type JSX } from "react";
+import { useDebouncedValue } from "@hooks/useDebouncedValue";
+import { useSearchTags } from "@features/csm-cases/api/useSearchTags";
+
+interface AsyncTagMultiSelectProps {
+  id?: string;
+  label?: string;
+  /** Selected tag labels. */
+  values: string[];
+  onChange: (next: string[]) => void;
+}
+
+/**
+ * Plain (non-tri-state) multi-value tag picker for the unified "Advanced
+ * filters" builder's `tag` field row — the `in`/`notIn` **op** on the row
+ * itself now carries the direction (two separate rows express "includes" and
+ * "excludes" at once, see `advancedFilters.ts`'s `tag` field entry), so
+ * unlike the old dedicated bar control ({@link TagsMultiSelect}, removed from
+ * the Simple grid) this component needs no include/exclude cycling of its
+ * own — it is a normal multi-select, the tag-search twin of
+ * {@link AsyncCreatedByMultiSelect}. Reuses the same `/tags/search`
+ * type-ahead ({@link useSearchTags}) `TagsMultiSelect` and {@link AddTagDialog}
+ * already use, and stays `freeSolo`: a tag is a genuinely free-text label
+ * with no canonical existence check (see `TagsMultiSelect`'s own doc
+ * comment), so typing one with no matching suggestion must still work.
+ */
+export default function AsyncTagMultiSelect({
+  id = "advanced-filter-tag",
+  label = "Value(s)",
+  values,
+  onChange,
+}: AsyncTagMultiSelectProps): JSX.Element {
+  const [input, setInput] = useState("");
+  const [open, setOpen] = useState(false);
+  const debounced = useDebouncedValue(input, 300);
+  const query = debounced.trim();
+
+  const { data, isFetching, isError } = useSearchTags(query, open);
+
+  const options: string[] = useMemo(() => {
+    const seen = new Set(values);
+    const results = (data ?? [])
+      .map((t) => t.label)
+      .filter((l) => l.length > 0 && !seen.has(l));
+    return [...values, ...results];
+  }, [data, values]);
+
+  return (
+    <Autocomplete<string, true, false, true>
+      multiple
+      freeSolo
+      forcePopupIcon
+      size="small"
+      id={id}
+      options={options}
+      value={values}
+      open={open}
+      onOpen={() => setOpen(true)}
+      onClose={() => setOpen(false)}
+      disableCloseOnSelect
+      loading={isFetching && (data ?? []).length === 0}
+      // The backend already filtered by the typed term; don't re-filter
+      // locally (that would also drop the currently-selected values).
+      filterOptions={(opts) => opts}
+      onChange={(_event, next) => onChange(next.map((v) => v.trim()).filter((v) => v.length > 0))}
+      inputValue={input}
+      onInputChange={(_event, value, reason) => {
+        if (reason === "input" || reason === "clear") setInput(value);
+      }}
+      noOptionsText={
+        isError
+          ? "Couldn't load tags. Try again."
+          : isFetching
+            ? "Loading tags…"
+            : "No matching tags — press Enter to filter by it anyway"
+      }
+      renderTags={(value) => {
+        const displayText = value.join(", ");
+        const content = (
+          <Box
+            component="span"
+            sx={{ flex: "1 1 0", minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
+          >
+            {displayText}
+          </Box>
+        );
+        return value.length === 1 ? content : (
+          <Tooltip title={displayText} placement="top">{content}</Tooltip>
+        );
+      }}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          label={label}
+          placeholder={values.length ? undefined : "Search tags…"}
+        />
+      )}
+    />
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncUserIdMultiSelect.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncUserIdMultiSelect.test.tsx
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import AsyncUserIdMultiSelect from "@features/csm-cases/components/AsyncUserIdMultiSelect";
+import { useInfiniteUserSearch } from "@features/csm-cases/api/useUserSearch";
+
+vi.mock("@features/csm-cases/api/useUserSearch", () => ({
+  useInfiniteUserSearch: vi.fn(),
+}));
+
+const mockedUseInfiniteUserSearch = vi.mocked(useInfiniteUserSearch);
+
+afterEach(() => {
+  mockedUseInfiniteUserSearch.mockReset();
+});
+
+const NO_RESULTS = {
+  users: [],
+  isFetching: false,
+  isFetchingNextPage: false,
+  hasNextPage: false,
+  isError: false,
+  fetchNextPage: vi.fn(),
+};
+
+describe("AsyncUserIdMultiSelect — @me label", () => {
+  it("renders a selected value equal to currentUserId as 'Me', not the raw UUID", () => {
+    mockedUseInfiniteUserSearch.mockReturnValue(NO_RESULTS);
+
+    render(
+      <AsyncUserIdMultiSelect
+        values={["11111111-1111-1111-1111-111111111111"]}
+        onChange={vi.fn()}
+        currentUserId="11111111-1111-1111-1111-111111111111"
+      />,
+    );
+
+    expect(screen.getByText("Me")).toBeInTheDocument();
+    expect(
+      screen.queryByText("11111111-1111-1111-1111-111111111111"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("falls back to the raw UUID when the value doesn't match currentUserId and has no nameSeed", () => {
+    mockedUseInfiniteUserSearch.mockReturnValue(NO_RESULTS);
+
+    render(
+      <AsyncUserIdMultiSelect
+        values={["22222222-2222-2222-2222-222222222222"]}
+        onChange={vi.fn()}
+        currentUserId="11111111-1111-1111-1111-111111111111"
+      />,
+    );
+
+    expect(screen.getByText("22222222-2222-2222-2222-222222222222")).toBeInTheDocument();
+    expect(screen.queryByText("Me")).not.toBeInTheDocument();
+  });
+
+  it("prefers a nameSeed label over the raw UUID for a non-'me' selection", () => {
+    mockedUseInfiniteUserSearch.mockReturnValue(NO_RESULTS);
+
+    render(
+      <AsyncUserIdMultiSelect
+        values={["22222222-2222-2222-2222-222222222222"]}
+        onChange={vi.fn()}
+        nameSeed={new Map([["22222222-2222-2222-2222-222222222222", "Jane Doe"]])}
+      />,
+    );
+
+    expect(screen.getByText("Jane Doe")).toBeInTheDocument();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncUserIdMultiSelect.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncUserIdMultiSelect.tsx
@@ -25,6 +25,12 @@ interface UserIdOption {
   name: string;
 }
 
+/** True when the "Me" option should show for the current typed term. */
+function meMatches(input: string): boolean {
+  const t = input.trim().toLowerCase();
+  return t === "" || "me".includes(t);
+}
+
 interface AsyncUserIdMultiSelectProps {
   id?: string;
   label?: string;
@@ -39,17 +45,26 @@ interface AsyncUserIdMultiSelectProps {
    * before any search has run (e.g. seeded from a dashboard widget's own
    * filters). */
   nameSeed?: Map<string, string>;
+  /**
+   * The signed-in user's own platform id, so a selected value equal to it
+   * can render as "Me" instead of its raw UUID, and picking "Me" from the
+   * dropdown stores this id. This field's own contract has no `@me`
+   * sentinel of its own (unlike {@link AsyncAssigneeMultiSelect}'s
+   * `ASSIGNEE_ME_TOKEN`) — the caller resolves `__current_user__`/`@me` to
+   * this real UUID upstream, before this component ever sees the value
+   * (see `resolveCurrentUserSentinels`), so recognizing "Me" here means
+   * comparing selected UUIDs against this id rather than a literal token.
+   * Omit while the current user hasn't resolved yet; already-selected
+   * values just render their raw UUID (or a `nameSeed` label) until it has.
+   */
+  currentUserId?: string;
 }
 
 /**
  * UUID-keyed twin of {@link AsyncAssigneeMultiSelect}: same backend-search
  * Autocomplete (`useInfiniteUserSearch`, the shared user-directory search
  * every assignee-style picker in this app already uses), but stores each
- * selection's platform id instead of its email — for a filter field whose
- * own contract is UUID-typed and has no `@me` sentinel of its own (the
- * caller resolves `__current_user__`/`@me` upstream, before this component
- * ever sees the value — see `resolveCurrentUserSentinels`/
- * `resolveCurrentUserPlaceholder`).
+ * selection's platform id instead of its email.
  */
 export default function AsyncUserIdMultiSelect({
   id = "user-id-multi-select",
@@ -57,6 +72,7 @@ export default function AsyncUserIdMultiSelect({
   values,
   onChange,
   nameSeed,
+  currentUserId,
 }: AsyncUserIdMultiSelectProps): JSX.Element {
   const [input, setInput] = useState("");
   const [open, setOpen] = useState(false);
@@ -87,17 +103,29 @@ export default function AsyncUserIdMultiSelect({
   }, [nameSeed, users, pickedNames]);
 
   const selectedOptions: UserIdOption[] = useMemo(
-    () => values.map((v) => ({ id: v, name: nameById.get(v) ?? v })),
-    [values, nameById],
+    () =>
+      values.map((v) => ({
+        id: v,
+        name: v === currentUserId ? "Me" : (nameById.get(v) ?? v),
+      })),
+    [values, nameById, currentUserId],
   );
 
+  // Pool = current selection (so the field renders its chips) + the search
+  // results, de-duplicated by id, with "Me" pinned first when it matches
+  // the typed term and isn't already selected — mirrors
+  // `AsyncAssigneeMultiSelect`'s own pinned "Me" option, keyed by this
+  // field's own id (`currentUserId`) rather than a literal sentinel token.
   const options: UserIdOption[] = useMemo(() => {
     const selected = new Set(values);
     const results = users
       .filter((u) => !selected.has(u.id))
       .map((u) => ({ id: u.id, name: u.name }));
-    return [...selectedOptions, ...results];
-  }, [users, values, selectedOptions]);
+    const base = [...selectedOptions, ...results];
+    const showMe = Boolean(currentUserId) && !selected.has(currentUserId!) && meMatches(input);
+    const meOption: UserIdOption = { id: currentUserId ?? "", name: "Me" };
+    return showMe ? [meOption, ...base] : base;
+  }, [users, values, selectedOptions, input, currentUserId]);
 
   return (
     <Autocomplete<UserIdOption, true>
@@ -119,7 +147,9 @@ export default function AsyncUserIdMultiSelect({
       onChange={(_event, next) => {
         setPickedNames((prev) => {
           const m = new Map(prev);
-          next.forEach((o) => m.set(o.id, o.name));
+          next.forEach((o) => {
+            if (o.id !== currentUserId) m.set(o.id, o.name);
+          });
           return m;
         });
         onChange(next.map((o) => o.id));

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncUserIdMultiSelect.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncUserIdMultiSelect.tsx
@@ -1,0 +1,186 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { Autocomplete, Box, Checkbox, ListItemText, TextField, Tooltip } from "@wso2/oxygen-ui";
+import { useMemo, useState, type JSX } from "react";
+import type * as React from "react";
+import { useDebouncedValue } from "@hooks/useDebouncedValue";
+import { useInfiniteUserSearch } from "@features/csm-cases/api/useUserSearch";
+
+interface UserIdOption {
+  id: string;
+  name: string;
+}
+
+interface AsyncUserIdMultiSelectProps {
+  id?: string;
+  label?: string;
+  /** Selected values: platform user UUIDs (not emails) — for a filter field
+   * whose downstream contract is UUID-typed (e.g. `/call-requests/search`'s
+   * `assignedUserIds`), unlike {@link AsyncAssigneeMultiSelect}'s
+   * email-keyed `assignees`, which is what the cases list filters on
+   * instead. */
+  values: string[];
+  onChange: (next: string[]) => void;
+  /** Known id -> name pairs so an already-selected user stays labelled
+   * before any search has run (e.g. seeded from a dashboard widget's own
+   * filters). */
+  nameSeed?: Map<string, string>;
+}
+
+/**
+ * UUID-keyed twin of {@link AsyncAssigneeMultiSelect}: same backend-search
+ * Autocomplete (`useInfiniteUserSearch`, the shared user-directory search
+ * every assignee-style picker in this app already uses), but stores each
+ * selection's platform id instead of its email — for a filter field whose
+ * own contract is UUID-typed and has no `@me` sentinel of its own (the
+ * caller resolves `__current_user__`/`@me` upstream, before this component
+ * ever sees the value — see `resolveCurrentUserSentinels`/
+ * `resolveCurrentUserPlaceholder`).
+ */
+export default function AsyncUserIdMultiSelect({
+  id = "user-id-multi-select",
+  label = "Assignee",
+  values,
+  onChange,
+  nameSeed,
+}: AsyncUserIdMultiSelectProps): JSX.Element {
+  const [input, setInput] = useState("");
+  const [open, setOpen] = useState(false);
+  const debounced = useDebouncedValue(input, 300);
+  const query = debounced.trim();
+
+  const { users, isFetching, isFetchingNextPage, hasNextPage, isError, fetchNextPage } =
+    useInfiniteUserSearch(query, open);
+
+  const handleListboxScroll = (event: React.UIEvent<HTMLElement>): void => {
+    const el = event.currentTarget;
+    if (
+      hasNextPage &&
+      !isFetchingNextPage &&
+      el.scrollHeight - el.scrollTop - el.clientHeight < 80
+    ) {
+      fetchNextPage();
+    }
+  };
+
+  const [pickedNames, setPickedNames] = useState<Map<string, string>>(() => new Map());
+
+  const nameById = useMemo(() => {
+    const m = new Map<string, string>(nameSeed);
+    users.forEach((u) => m.set(u.id, u.name));
+    pickedNames.forEach((name, uid) => m.set(uid, name));
+    return m;
+  }, [nameSeed, users, pickedNames]);
+
+  const selectedOptions: UserIdOption[] = useMemo(
+    () => values.map((v) => ({ id: v, name: nameById.get(v) ?? v })),
+    [values, nameById],
+  );
+
+  const options: UserIdOption[] = useMemo(() => {
+    const selected = new Set(values);
+    const results = users
+      .filter((u) => !selected.has(u.id))
+      .map((u) => ({ id: u.id, name: u.name }));
+    return [...selectedOptions, ...results];
+  }, [users, values, selectedOptions]);
+
+  return (
+    <Autocomplete<UserIdOption, true>
+      multiple
+      size="small"
+      id={id}
+      options={options}
+      value={selectedOptions}
+      open={open}
+      onOpen={() => setOpen(true)}
+      onClose={() => setOpen(false)}
+      loading={isFetching && users.length === 0}
+      disableCloseOnSelect
+      sx={{ "& .MuiAutocomplete-inputRoot": { flexWrap: "nowrap", minHeight: 40 } }}
+      filterOptions={(opts) => opts}
+      getOptionLabel={(opt) => opt.name}
+      isOptionEqualToValue={(opt, val) => opt.id === val.id}
+      slotProps={{ listbox: { onScroll: handleListboxScroll } }}
+      onChange={(_event, next) => {
+        setPickedNames((prev) => {
+          const m = new Map(prev);
+          next.forEach((o) => m.set(o.id, o.name));
+          return m;
+        });
+        onChange(next.map((o) => o.id));
+      }}
+      inputValue={input}
+      onInputChange={(_event, value, reason) => {
+        if (reason === "input" || reason === "clear") setInput(value);
+      }}
+      noOptionsText={
+        isError
+          ? "Couldn't load engineers. Try again."
+          : isFetching
+            ? "Loading engineers…"
+            : "No engineers found"
+      }
+      renderTags={(value) => {
+        const displayText = value.map((o) => o.name).join(", ");
+        const content = (
+          <Box
+            component="span"
+            sx={{
+              flex: "1 1 0",
+              minWidth: 0,
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+              pl: 1,
+            }}
+          >
+            {displayText}
+          </Box>
+        );
+        return value.length === 1 ? (
+          content
+        ) : (
+          <Tooltip title={displayText} placement="top">
+            {content}
+          </Tooltip>
+        );
+      }}
+      renderOption={(props, option, { selected }) => {
+        const { key, ...liProps } = props as React.HTMLAttributes<HTMLLIElement> & {
+          key: string;
+        };
+        return (
+          <li key={key} {...liProps} style={{ paddingTop: 2, paddingBottom: 2 }}>
+            <Checkbox size="small" checked={selected} sx={{ mr: 1, p: 0.25 }} />
+            <ListItemText
+              primary={option.name}
+              slotProps={{ primary: { style: { fontSize: 13, overflowWrap: "anywhere" } } }}
+            />
+          </li>
+        );
+      }}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          label={label}
+          placeholder={values.length ? undefined : "Search engineers…"}
+        />
+      )}
+    />
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncUserIdMultiSelect.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/AsyncUserIdMultiSelect.tsx
@@ -79,8 +79,15 @@ export default function AsyncUserIdMultiSelect({
   const debounced = useDebouncedValue(input, 300);
   const query = debounced.trim();
 
-  const { users, isFetching, isFetchingNextPage, hasNextPage, isError, fetchNextPage } =
+  const { users: searchResults, isFetching, isFetchingNextPage, hasNextPage, isError, fetchNextPage } =
     useInfiniteUserSearch(query, open);
+  // `id` is optional on `UserSearchOption` (`POST /users/search` doesn't
+  // guarantee it) — this picker filters on the id, so a row without one is
+  // unusable here and dropped, unlike the email-keyed pickers.
+  const users = useMemo(
+    () => searchResults.filter((u): u is typeof u & { id: string } => Boolean(u.id)),
+    [searchResults],
+  );
 
   const handleListboxScroll = (event: React.UIEvent<HTMLElement>): void => {
     const el = event.currentTarget;

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.test.tsx
@@ -207,7 +207,7 @@ describe("CasesFilterBar — removed bar controls fall back to chips", () => {
   });
 });
 
-describe("CasesFilterBar — 'Team' control (replaces the removed 'Work state' one)", () => {
+describe("CasesFilterBar — 'CRE Team' control (replaces the removed 'Work state' one)", () => {
   beforeEach(() => {
     postMock.mockReset();
     postMock.mockResolvedValue({
@@ -216,6 +216,8 @@ describe("CasesFilterBar — 'Team' control (replaces the removed 'Work state' o
         { id: "abt-2", name: "ABT Two", family: "cre-abt", creGroupId: "g-2" },
         // No creGroupId configured -- must not appear as a selectable option.
         { id: "abt-3", name: "ABT Three", family: "cre-abt" },
+        // Has a creGroupId but a non-`cre-abt` family -- must not appear either.
+        { id: "abt-4", name: "ABT Four", family: "cre", creGroupId: "g-4" },
       ],
     });
   });
@@ -223,16 +225,17 @@ describe("CasesFilterBar — 'Team' control (replaces the removed 'Work state' o
   it("renders team display names as options, backed by creGroupId (what the filter actually matches on)", async () => {
     renderBar({ ...DEFAULT_CASES_FILTERS });
 
-    fireEvent.mouseDown(screen.getByRole("combobox", { name: "Team" }));
+    fireEvent.mouseDown(screen.getByRole("combobox", { name: "CRE Team" }));
     expect(await screen.findByRole("option", { name: "ABT One" })).toBeInTheDocument();
     expect(screen.getByRole("option", { name: "ABT Two" })).toBeInTheDocument();
     expect(screen.queryByRole("option", { name: "ABT Three" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "ABT Four" })).not.toBeInTheDocument();
   });
 
   it("selecting a team sets csTeams to its creGroupId, not its registry id", async () => {
     const { onChange } = renderBar({ ...DEFAULT_CASES_FILTERS });
 
-    fireEvent.mouseDown(screen.getByRole("combobox", { name: "Team" }));
+    fireEvent.mouseDown(screen.getByRole("combobox", { name: "CRE Team" }));
     fireEvent.click(await screen.findByRole("option", { name: "ABT One" }));
 
     expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ csTeams: ["g-1"] }));

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.test.tsx
@@ -586,3 +586,25 @@ describe("CasesFilterBar — case-type control label", () => {
     expect(screen.queryByLabelText("Case type")).not.toBeInTheDocument();
   });
 });
+
+describe("CasesFilterBar — search box placeholder", () => {
+  beforeEach(() => {
+    postMock.mockReset();
+  });
+
+  it("only claims to match case #, subject and internal ID — not customer/project/assignee", () => {
+    renderBar({ ...DEFAULT_CASES_FILTERS });
+    const search = screen.getByPlaceholderText(
+      "Search by case #, subject or internal ID…",
+    );
+    expect(search).toBeInTheDocument();
+    // Regression guard for the removed, inaccurate claim (`searchQuery` never
+    // matched customer/project/assignee on the backend) — checked against
+    // this one input's own placeholder, not the whole bar (the Project
+    // picker below legitimately has its own, unrelated "Type a project…"
+    // placeholder).
+    expect(search).not.toHaveAttribute(
+      "placeholder",
+      "Search by case #, subject, customer, project, assignee…",
+    );
+  });

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.test.tsx
@@ -64,14 +64,22 @@ function renderBar(
   filters: CasesFilters,
   onChange = vi.fn(),
   extraProps: Partial<Parameters<typeof CasesFilterBar>[0]> = {},
-): { onChange: ReturnType<typeof vi.fn> } {
+): {
+  onChange: ReturnType<typeof vi.fn>;
+  /** Re-renders the SAME `CasesFilterBar` instance with new `filters` --
+   * unlike a fresh `renderBar` call, this does NOT remount the component, so
+   * its `mode` state (initialized once at mount, see `CasesFilterBar.tsx`'s
+   * own doc comment on that `useState`) persists across the update, exactly
+   * like a real `onChange` from a bar control or an applied saved view. */
+  rerenderWith: (nextFilters: CasesFilters) => void;
+} {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
-  render(
+  const bar = (f: CasesFilters): ReactNode => (
     <QueryClientProvider client={queryClient}>
       <CasesFilterBar
-        filters={filters}
+        filters={f}
         onChange={onChange}
         onReset={() => {}}
         isFiltersOpen
@@ -80,9 +88,10 @@ function renderBar(
         availableProjects={[]}
         {...extraProps}
       />
-    </QueryClientProvider> as ReactNode,
+    </QueryClientProvider>
   );
-  return { onChange };
+  const { rerender } = render(bar(filters) as ReactNode);
+  return { onChange, rerenderWith: (nextFilters) => rerender(bar(nextFilters) as ReactNode) };
 }
 
 describe("CasesFilterBar — active-filter chips for URL-only fields", () => {
@@ -99,7 +108,43 @@ describe("CasesFilterBar — active-filter chips for URL-only fields", () => {
     expect(screen.queryByText(/^Tag:/)).not.toBeInTheDocument();
   });
 
-  it("renders one chip per URL-only filter and each is independently removable", () => {
+  // `slaElapsedPctGte`/`hasEscalation`/`createdOnGte` are all in
+  // `isSimpleRepresentable`'s gating list, so a filters object with any of
+  // them set mounts the bar directly into Advanced mode (see the mode
+  // `useState` initializer in `CasesFilterBar.tsx`). In Advanced mode every
+  // one of these fields is its own row in the unified builder
+  // (`filtersToAdvancedRows`), so per `buildActiveFilterChips`'s doc
+  // comment this function renders NO chips for them any more — the row is
+  // the only visible/removable UI. This used to be a chip-based test (round
+  // 5 predates the fix); see git history for the old assertions if the row
+  // behavior below ever needs to be cross-checked against the previous
+  // chip-based one.
+  it("renders no chips for URL-only fields once they force Advanced mode -- the row is the only UI", () => {
+    renderBar({
+      ...DEFAULT_CASES_FILTERS,
+      slaElapsedPctGte: 80,
+      hasEscalation: true,
+      createdOnGte: "2026-07-27",
+    });
+
+    // No chip renders for any of these three any more.
+    expect(screen.queryByText("SLA ≥ 80%")).not.toBeInTheDocument();
+    expect(screen.queryByText("Escalated")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Created after/)).not.toBeInTheDocument();
+
+    // Each is its own row in the unified Advanced builder instead, in
+    // catalogue order (`taskSLABusinessElapsedPercent` gte, then
+    // `escalation` isNotEmpty, then `createdOn` gte — see
+    // `advancedFilters.ts`'s `ADVANCED_FILTER_FIELDS`).
+    const fieldSelects = screen.getAllByRole("combobox", { name: "Field" });
+    expect(fieldSelects.map((el) => el.textContent)).toEqual([
+      "SLA business-elapsed %",
+      "Escalation",
+      "Created on",
+    ]);
+  });
+
+  it("removing the SLA row (its own 'Remove filter row' control) clears only slaElapsedPctGte", () => {
     const { onChange } = renderBar({
       ...DEFAULT_CASES_FILTERS,
       slaElapsedPctGte: 80,
@@ -107,16 +152,9 @@ describe("CasesFilterBar — active-filter chips for URL-only fields", () => {
       createdOnGte: "2026-07-27",
     });
 
-    expect(screen.getByText("SLA ≥ 80%")).toBeInTheDocument();
-    expect(screen.getByText("Escalated")).toBeInTheDocument();
-    expect(screen.getByText(/Created after/)).toBeInTheDocument();
-
-    // Removing the SLA chip clears only slaElapsedPctGte, nothing else.
-    const slaChip = screen.getByText("SLA ≥ 80%");
-    const deleteIcon = slaChip.parentElement?.querySelector(
-      '[data-testid="CancelIcon"], svg',
-    );
-    fireEvent.click(deleteIcon ?? slaChip);
+    // Catalogue order puts the SLA row first (see the test above).
+    const removeButtons = screen.getAllByRole("button", { name: "Remove filter row" });
+    fireEvent.click(removeButtons[0]);
 
     expect(onChange).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -127,40 +165,81 @@ describe("CasesFilterBar — active-filter chips for URL-only fields", () => {
     );
   });
 
-  it("renders a date-only bound as the same local calendar date, not shifted by UTC parsing", () => {
-    renderBar({
-      ...DEFAULT_CASES_FILTERS,
-      createdOnGte: "2026-07-27",
-    });
-
-    // A bare YYYY-MM-DD bound must render as that same calendar date
-    // regardless of the runner's local timezone offset from UTC — pinning
-    // this to a fixed local Date (not `new Date("2026-07-27")`, which is
-    // parsed as UTC midnight and can roll back a day) is what makes this
-    // assertion timezone-safe.
-    const expected = new Date(2026, 6, 27).toLocaleDateString();
-    expect(
-      screen.getByText(`Created after ${expected}`),
-    ).toBeInTheDocument();
-  });
-
-  it("both SLA bounds render and clear independently", () => {
+  it("both SLA bounds render as their own rows and clear independently", () => {
     const { onChange } = renderBar({
       ...DEFAULT_CASES_FILTERS,
       slaElapsedPctGte: 80,
       slaElapsedPctLte: 100,
     });
 
-    expect(screen.getByText("SLA ≥ 80%")).toBeInTheDocument();
-    expect(screen.getByText("SLA ≤ 100%")).toBeInTheDocument();
+    // No chips for either bound.
+    expect(screen.queryByText("SLA ≥ 80%")).not.toBeInTheDocument();
+    expect(screen.queryByText("SLA ≤ 100%")).not.toBeInTheDocument();
 
-    const chip = screen.getByText("SLA ≤ 100%");
-    const deleteIcon = chip.parentElement?.querySelector("svg");
-    fireEvent.click(deleteIcon ?? chip);
+    // Two rows: gte (catalogue order puts it before lte).
+    const removeButtons = screen.getAllByRole("button", { name: "Remove filter row" });
+    expect(removeButtons).toHaveLength(2);
+    fireEvent.click(removeButtons[1]);
 
     expect(onChange).toHaveBeenCalledWith(
       expect.objectContaining({ slaElapsedPctGte: 80, slaElapsedPctLte: null }),
     );
+  });
+});
+
+describe("CasesFilterBar — Simple mode keeps its existing chip behavior unchanged", () => {
+  beforeEach(() => {
+    postMock.mockReset();
+    postMock.mockResolvedValue({ teams: [] });
+  });
+
+  // `workStates` is deliberately NOT in `isSimpleRepresentable`'s gating
+  // list (see that function's own doc comment), so a filters object with
+  // only `states`/`workStates` set still mounts into Simple mode, where
+  // there is no unified row list -- the chip stays the only way to see/
+  // clear a value that arrived via a dashboard click-through or a saved
+  // view while looking at the Simple grid.
+  it("still chips workStates in Simple mode, with the row list nowhere in sight", () => {
+    const { onChange } = renderBar({
+      ...DEFAULT_CASES_FILTERS,
+      states: ["work_in_progress"],
+      workStates: ["ongoing"],
+    });
+
+    expect(screen.queryByText("Advanced filters")).not.toBeInTheDocument();
+    const chip = screen.getByText("Work state: Ongoing");
+    expect(chip).toBeInTheDocument();
+
+    fireEvent.click(chip.closest(".MuiChip-root")!.querySelector("svg")!);
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ workStates: [] }));
+  });
+
+  // The scenario from the bug report: a page already sitting in Simple mode
+  // (mounted with no advanced-only value active) picks one up mid-session --
+  // e.g. an applied saved view's `onChange`, which updates `filters` without
+  // remounting `CasesFilterBar` -- rather than arriving pre-set at mount
+  // (which would instead auto-switch to Advanced, see the mode gating tests
+  // above). `mode` state persists across that update, so the value must
+  // still be visible/removable via its old chip, same as before this fix --
+  // this fix only suppresses chips for fields whose row is ALSO on screen
+  // (`mode === "advanced"`), never for Simple mode itself.
+  it("still chips a date-range bound that arrives while already in Simple mode, formatted as the same local calendar date", () => {
+    const { rerenderWith } = renderBar({ ...DEFAULT_CASES_FILTERS });
+    expect(screen.queryByText("Advanced filters")).not.toBeInTheDocument();
+
+    rerenderWith({ ...DEFAULT_CASES_FILTERS, createdOnGte: "2026-07-27" });
+
+    // Still Simple mode (persisted `mode` state) -- the row list never
+    // mounted, so the chip is still the only visible/removable UI, exactly
+    // as before this fix.
+    expect(screen.queryByText("Advanced filters")).not.toBeInTheDocument();
+    // A bare YYYY-MM-DD bound must render as that same calendar date
+    // regardless of the runner's local timezone offset from UTC -- pinning
+    // this to a fixed local Date (not `new Date("2026-07-27")`, which is
+    // parsed as UTC midnight and can roll back a day) is what makes this
+    // assertion timezone-safe.
+    const expected = new Date(2026, 6, 27).toLocaleDateString();
+    expect(screen.getByText(`Created after ${expected}`)).toBeInTheDocument();
   });
 });
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.test.tsx
@@ -608,3 +608,56 @@ describe("CasesFilterBar — search box placeholder", () => {
       "Search by case #, subject, customer, project, assignee…",
     );
   });
+});
+
+describe("CasesFilterBar — per-consumer hidden Simple-mode controls", () => {
+  beforeEach(() => {
+    postMock.mockReset();
+    postMock.mockResolvedValue({ teams: [] });
+  });
+
+  it("shows Onboarding status and CRE Team by default", () => {
+    renderBar({ ...DEFAULT_CASES_FILTERS });
+    expect(
+      screen.getByRole("combobox", { name: "Onboarding status" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: "CRE Team" })).toBeInTheDocument();
+  });
+
+  it("hides Onboarding status when hideOnboardingStatusFilter is set (e.g. a project-scoped view)", () => {
+    renderBar({ ...DEFAULT_CASES_FILTERS }, vi.fn(), {
+      hideOnboardingStatusFilter: true,
+    });
+    expect(
+      screen.queryByRole("combobox", { name: "Onboarding status" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: "CRE Team" })).toBeInTheDocument();
+  });
+
+  it("hides CRE Team when hideCreTeamFilter is set (e.g. a project-scoped view)", () => {
+    renderBar({ ...DEFAULT_CASES_FILTERS }, vi.fn(), {
+      hideCreTeamFilter: true,
+    });
+    expect(
+      screen.queryByRole("combobox", { name: "CRE Team" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("combobox", { name: "Onboarding status" }),
+    ).toBeInTheDocument();
+  });
+
+  it("hides both when both flags are set, without affecting the Severity control", () => {
+    renderBar({ ...DEFAULT_CASES_FILTERS }, vi.fn(), {
+      hideOnboardingStatusFilter: true,
+      hideCreTeamFilter: true,
+      showSeverityFilter: true,
+    });
+    expect(
+      screen.queryByRole("combobox", { name: "Onboarding status" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("combobox", { name: "CRE Team" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: "Severity" })).toBeInTheDocument();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.test.tsx
@@ -36,7 +36,9 @@ vi.mock("@config/apiConfig", () => ({
 }));
 
 // Mocked directly (same approach as AddTagDialog.test.tsx) so tests don't
-// have to drive the real 300ms debounce in TagsMultiSelect.
+// have to drive the real 300ms debounce in `AsyncTagMultiSelect` (rendered
+// only for an Advanced-mode `tag` row now — Tags is Advanced-only, see the
+// mode-toggle tests below).
 vi.mock("@features/csm-cases/api/useSearchTags", () => ({
   useSearchTags: vi.fn(),
 }));
@@ -51,10 +53,9 @@ function mockTagSearchResult(
     ...overrides,
   } as unknown as ReturnType<typeof useSearchTags>);
 }
-// `TagsMultiSelect` (and its `useSearchTags` call) now renders unconditionally
-// as part of every `CasesFilterBar`, so every describe block below needs a
-// default mock return value -- set once here, at file scope, rather than
-// repeating it in each describe block's own `beforeEach`.
+// A default mock return value, set once here at file scope, so any test that
+// does land in Advanced mode with a `tag` row visible doesn't crash for want
+// of a mock.
 beforeEach(() => {
   mockTagSearchResult({});
 });
@@ -171,20 +172,18 @@ describe("CasesFilterBar — removed bar controls fall back to chips", () => {
 
 
   /**
-   * `tags`/`excludeTags` both have their own tri-state "Tags" bar control
-   * now (tested separately below), same as CS team's "Team" control (see
-   * the describe block below) — deliberately NOT chipped, to avoid showing
-   * the same selection twice. `excludeTags` used to have no bar control of
-   * its own (only a dashboard click-through could set it) and fell back to
-   * a chip here; now that `TagsMultiSelect` is tri-state, its own "- tag"
-   * chip inside that control is the only rendering, same as `tags`.
+   * `tags`/`excludeTags` are Advanced-mode-only now (see the mode toggle in
+   * `CasesFilterBar.tsx`): any non-empty value forces Advanced mode on
+   * mount, where the Tag row itself (in the unified builder) is the visible/
+   * removable UI — deliberately still NOT chipped here, to avoid showing the
+   * same selection twice.
    */
-  it("does not render a chip for tags — it has its own 'Tags' bar control", () => {
+  it("does not render a chip for tags — Advanced mode's own Tag row is the visible/removable UI", () => {
     renderBar({ ...DEFAULT_CASES_FILTERS, tags: ["micro-gw"] });
     expect(screen.queryByText(/^Tag: /)).not.toBeInTheDocument();
   });
 
-  it("does not render a chip for excludeTags — it has its own 'Tags' bar control now", () => {
+  it("does not render a chip for excludeTags — Advanced mode's own Tag row is the visible/removable UI", () => {
     renderBar({ ...DEFAULT_CASES_FILTERS, excludeTags: ["s_dip"] });
     expect(screen.queryByText(/^Excluding tag:/)).not.toBeInTheDocument();
   });
@@ -275,131 +274,25 @@ describe("CasesFilterBar — 'State' control (tri-state include/exclude, digiops
   });
 });
 
-describe("CasesFilterBar — 'Tags' control (tri-state include/exclude, digiops-cs#2907)", () => {
-  it("renders matching tag suggestions from the search endpoint", () => {
-    mockTagSearchResult({ data: [{ id: "t1", label: "micro-gw" }] });
+// Tags moved out of Simple mode entirely (Advanced-only now, see
+// `CasesFilterBar.tsx`'s mode toggle) -- the old tri-state cycling control
+// (`TagsMultiSelect`) tested here is no longer rendered in the Simple grid
+// at all. Its replacement — a plain `tag` `in`/`notIn` row in the unified
+// Advanced-mode builder, backed by `AsyncTagMultiSelect` — is covered by
+// `filterFieldAdapters.test.ts`'s adapter round-trip tests and
+// `advancedFilters.test.ts`'s catalogue tests instead.
+describe("CasesFilterBar — Tags is Advanced-only", () => {
+  it("does not render a 'Tags' control in the Simple grid", () => {
     renderBar({ ...DEFAULT_CASES_FILTERS });
-
-    fireEvent.mouseDown(screen.getByRole("combobox", { name: "Tags" }));
-    expect(screen.getByText("micro-gw")).toBeInTheDocument();
+    expect(screen.queryByRole("combobox", { name: "Tags" })).not.toBeInTheDocument();
   });
 
-  it("clicking an unselected suggested tag once includes it", () => {
-    mockTagSearchResult({ data: [{ id: "t1", label: "micro-gw" }] });
-    const { onChange } = renderBar({ ...DEFAULT_CASES_FILTERS });
-
-    fireEvent.mouseDown(screen.getByRole("combobox", { name: "Tags" }));
-    fireEvent.click(screen.getByText("micro-gw"));
-
-    expect(onChange).toHaveBeenCalledWith(
-      expect.objectContaining({ tags: ["micro-gw"], excludeTags: [] }),
-    );
-  });
-
-  it("clicking an included tag a second time moves it to excluded", () => {
-    mockTagSearchResult({ data: [{ id: "t1", label: "micro-gw" }] });
-    const { onChange } = renderBar({
-      ...DEFAULT_CASES_FILTERS,
-      tags: ["micro-gw"],
-    });
-
-    fireEvent.mouseDown(screen.getByRole("combobox", { name: "Tags" }));
-    fireEvent.click(screen.getByText("micro-gw"));
-
-    expect(onChange).toHaveBeenCalledWith(
-      expect.objectContaining({ tags: [], excludeTags: ["micro-gw"] }),
-    );
-  });
-
-  it("clicking an excluded tag a third time clears it back to unselected", () => {
-    mockTagSearchResult({ data: [{ id: "t1", label: "micro-gw" }] });
-    const { onChange } = renderBar({
-      ...DEFAULT_CASES_FILTERS,
-      excludeTags: ["micro-gw"],
-    });
-
-    fireEvent.mouseDown(screen.getByRole("combobox", { name: "Tags" }));
-    fireEvent.click(screen.getByText("micro-gw"));
-
-    expect(onChange).toHaveBeenCalledWith(
-      expect.objectContaining({ tags: [], excludeTags: [] }),
-    );
-  });
-
-  it("leaves any other selected tag untouched when cycling one option", () => {
-    mockTagSearchResult({ data: [{ id: "t1", label: "micro-gw" }] });
-    const { onChange } = renderBar({
-      ...DEFAULT_CASES_FILTERS,
-      tags: ["already-included"],
-      excludeTags: ["already-excluded"],
-    });
-
-    fireEvent.mouseDown(screen.getByRole("combobox", { name: "Tags" }));
-    fireEvent.click(screen.getByText("micro-gw"));
-
-    expect(onChange).toHaveBeenCalledWith(
-      expect.objectContaining({
-        tags: ["already-included", "micro-gw"],
-        excludeTags: ["already-excluded"],
-      }),
-    );
-  });
-
-  // Tags are genuinely free-text (see TagsMultiSelect.tsx's doc comment) --
-  // typing one with no matching suggestion must still work, not just picking
-  // from the search results. A freshly typed tag starts at "included", same
-  // as a first click on a suggested option.
-  it("still accepts a free-typed tag with no matching suggestion", () => {
-    const { onChange } = renderBar({ ...DEFAULT_CASES_FILTERS });
-
-    const input = screen.getByRole("combobox", { name: "Tags" });
-    fireEvent.change(input, { target: { value: "brand-new-tag" } });
-    fireEvent.keyDown(input, { key: "Enter" });
-
-    expect(onChange).toHaveBeenCalledWith(
-      expect.objectContaining({ tags: ["brand-new-tag"], excludeTags: [] }),
-    );
-  });
-
-  it("renders a single included tag as a neutral '+' chip", () => {
-    renderBar({ ...DEFAULT_CASES_FILTERS, tags: ["urgent"] });
-    const includedChip = screen.getByText("+ urgent").closest(".MuiChip-root");
-    expect(includedChip).toBeInTheDocument();
-    expect(includedChip).not.toHaveClass("MuiChip-colorError");
-  });
-
-  it("renders a single excluded tag as an 'error'-tinted '-' chip", () => {
-    renderBar({ ...DEFAULT_CASES_FILTERS, excludeTags: ["spam"] });
-    const excludedChip = screen.getByText("- spam").closest(".MuiChip-root");
-    expect(excludedChip).toBeInTheDocument();
-    expect(excludedChip).toHaveClass("MuiChip-colorError");
-  });
-
-  it("collapses to a 'N tags' summary once both an included and an excluded tag are selected, instead of rendering both chips individually", () => {
-    // The bar's Tags control sits in a narrow filter-grid column that can't
-    // fit two real Chip pills without the row's own `overflow: hidden`
-    // silently clipping the second one -- see TagsMultiSelect's own test
-    // for the full repro (tags=patch&excludeTags=am showed only one,
-    // truncated chip even though both filters were genuinely active).
-    renderBar({ ...DEFAULT_CASES_FILTERS, tags: ["urgent"], excludeTags: ["spam"] });
-
-    expect(screen.getByText("2 tags")).toBeInTheDocument();
-    expect(screen.queryByText("+ urgent")).not.toBeInTheDocument();
-    expect(screen.queryByText("- spam")).not.toBeInTheDocument();
-  });
-
-  it("deleting the one selected excluded tag's chip clears just that tag", () => {
-    const { onChange } = renderBar({
-      ...DEFAULT_CASES_FILTERS,
-      excludeTags: ["spam"],
-    });
-
-    const excludedChip = screen.getByText("- spam").closest(".MuiChip-root")!;
-    fireEvent.click(excludedChip.querySelector("svg")!);
-
-    expect(onChange).toHaveBeenCalledWith(
-      expect.objectContaining({ tags: [], excludeTags: [] }),
-    );
+  it("any active tags/excludeTags filter forces the bar into Advanced mode on mount", () => {
+    renderBar({ ...DEFAULT_CASES_FILTERS, tags: ["micro-gw"] });
+    // In Advanced mode, the Simple-only "State" combobox is gone and the
+    // "Advanced filters" row builder is showing instead.
+    expect(screen.queryByRole("combobox", { name: "State" })).not.toBeInTheDocument();
+    expect(screen.getByText("Advanced filters")).toBeInTheDocument();
   });
 });
 
@@ -412,10 +305,8 @@ describe("CasesFilterBar — 'Project' control is last and wider than its siblin
     renderBar({ ...DEFAULT_CASES_FILTERS });
 
     const project = screen.getByRole("combobox", { name: "Project" });
-    const tags = screen.getByRole("combobox", { name: "Tags" });
     const onboarding = screen.getByRole("combobox", { name: "Onboarding status" });
 
-    expect(project.compareDocumentPosition(tags) & Node.DOCUMENT_POSITION_PRECEDING).toBeTruthy();
     expect(
       project.compareDocumentPosition(onboarding) & Node.DOCUMENT_POSITION_PRECEDING,
     ).toBeTruthy();

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.test.tsx
@@ -239,6 +239,29 @@ describe("CasesFilterBar — Simple mode keeps its existing chip behavior unchan
 });
 
 
+describe("CasesFilterBar — chips stay visible while the panel is collapsed", () => {
+  beforeEach(() => {
+    postMock.mockReset();
+    postMock.mockResolvedValue({ teams: [] });
+  });
+
+  // CodeRabbit finding on PR #1630: `activeFilterChips` renders outside the
+  // `isFiltersOpen` gate by design (chips are the only summary a collapsed
+  // panel has), but gating the memo on `effectiveMode === "simple"` alone
+  // silently emptied it whenever the panel was collapsed while in Advanced
+  // mode -- neither the Simple grid nor the Advanced builder renders when
+  // collapsed, so an Advanced-only value (e.g. from an applied saved view)
+  // was left with no visible summary at all.
+  it("still shows a chip for an Advanced-only value when the panel is collapsed", () => {
+    renderBar(
+      { ...DEFAULT_CASES_FILTERS, escalationLevels: ["2"] },
+      undefined,
+      { isFiltersOpen: false },
+    );
+    expect(screen.getByText("Escalation level: 2")).toBeInTheDocument();
+  });
+});
+
 describe("CasesFilterBar — removed bar controls fall back to chips", () => {
   beforeEach(() => {
     postMock.mockReset();

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.test.tsx
@@ -214,32 +214,27 @@ describe("CasesFilterBar — Simple mode keeps its existing chip behavior unchan
     expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ workStates: [] }));
   });
 
-  // The scenario from the bug report: a page already sitting in Simple mode
-  // (mounted with no advanced-only value active) picks one up mid-session --
-  // e.g. an applied saved view's `onChange`, which updates `filters` without
-  // remounting `CasesFilterBar` -- rather than arriving pre-set at mount
-  // (which would instead auto-switch to Advanced, see the mode gating tests
-  // above). `mode` state persists across that update, so the value must
-  // still be visible/removable via its old chip, same as before this fix --
-  // this fix only suppresses chips for fields whose row is ALSO on screen
-  // (`mode === "advanced"`), never for Simple mode itself.
-  it("still chips a date-range bound that arrives while already in Simple mode, formatted as the same local calendar date", () => {
+  // Originally this test asserted that a date-range bound arriving while
+  // already in Simple mode (e.g. an applied saved view's `onChange`, which
+  // updates `filters` without remounting `CasesFilterBar`) stayed on a chip,
+  // because `mode` state -- set once at mount -- doesn't re-derive on its
+  // own. CodeRabbit correctly flagged that as a real bug: it left an active
+  // filter with no visible control at all once Advanced-mode chips were
+  // suppressed for it (see `activeFilterChips`'s `effectiveMode` gating).
+  // `effectiveMode` now recomputes every render, so this same sequence must
+  // switch into Advanced mode and show the row instead.
+  it("switches into Advanced mode when a date-range bound arrives mid-session in Simple mode, rather than leaving it on a stranded chip", () => {
     const { rerenderWith } = renderBar({ ...DEFAULT_CASES_FILTERS });
     expect(screen.queryByText("Advanced filters")).not.toBeInTheDocument();
 
     rerenderWith({ ...DEFAULT_CASES_FILTERS, createdOnGte: "2026-07-27" });
 
-    // Still Simple mode (persisted `mode` state) -- the row list never
-    // mounted, so the chip is still the only visible/removable UI, exactly
-    // as before this fix.
-    expect(screen.queryByText("Advanced filters")).not.toBeInTheDocument();
-    // A bare YYYY-MM-DD bound must render as that same calendar date
-    // regardless of the runner's local timezone offset from UTC -- pinning
-    // this to a fixed local Date (not `new Date("2026-07-27")`, which is
-    // parsed as UTC midnight and can roll back a day) is what makes this
-    // assertion timezone-safe.
+    // `effectiveMode` flips Simple -> Advanced now that the filters are no
+    // longer Simple-representable, even though `mode` state itself never
+    // changed -- the row list is what's visible, not a chip.
+    expect(screen.getByText("Advanced filters")).toBeInTheDocument();
     const expected = new Date(2026, 6, 27).toLocaleDateString();
-    expect(screen.getByText(`Created after ${expected}`)).toBeInTheDocument();
+    expect(screen.queryByText(`Created after ${expected}`)).not.toBeInTheDocument();
   });
 });
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
@@ -643,7 +643,7 @@ export default function CasesFilterBar({
           <TextField
             fullWidth
             size="small"
-            placeholder="Search by case #, subject, customer, project, assignee…"
+            placeholder="Search by case #, subject or internal ID…"
             value={filters.search}
             onChange={(e) => onChange({ ...filters, search: e.target.value })}
             slotProps={{

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
@@ -514,20 +514,31 @@ export default function CasesFilterBar({
   // `creGroupId` (not the registry `id`) is what a `creTeam`/`csTeams` filter
   // entry actually matches on; only teams with one configured are
   // selectable here (an id-less team has nothing such a filter could hold).
+  // Also scoped to the `cre-abt` family, matching `abtFamilyForDashboardType`
+  // -- a team of a different family (e.g. plain `cre`) may still carry a
+  // `creGroupId` but isn't one of the CRE Team filter's intended options.
   const teamOptions = useMemo(
     () =>
       (teams ?? [])
-        .filter((t): t is typeof t & { creGroupId: string } => Boolean(t.creGroupId))
+        .filter(
+          (t): t is typeof t & { creGroupId: string } =>
+            Boolean(t.creGroupId) && t.family === "cre-abt",
+        )
         .map((t) => ({ value: t.creGroupId, label: t.name })),
     [teams],
   );
   // Same shape, keyed off `sreGroupId` instead — feeds the "Advanced
   // filters" builder's `sreTeam` row (a real multi-select now, not
-  // hand-typed team ids/UUIDs).
+  // hand-typed team ids/UUIDs). Scoped to `cre-abt` family per explicit
+  // product instruction, not `sre-abt` -- see the "SRE Team" filter's
+  // family-scoping note in `advancedFilters.ts` for the caveat.
   const sreTeamOptions = useMemo(
     () =>
       (teams ?? [])
-        .filter((t): t is typeof t & { sreGroupId: string } => Boolean(t.sreGroupId))
+        .filter(
+          (t): t is typeof t & { sreGroupId: string } =>
+            Boolean(t.sreGroupId) && t.family === "cre-abt",
+        )
         .map((t) => ({ value: t.sreGroupId, label: t.name })),
     [teams],
   );
@@ -904,7 +915,7 @@ export default function CasesFilterBar({
                   instead (see `buildActiveFilterChips`). */}
               <MultiSelectField
                 id="cases-filter-cs-team"
-                label="Team"
+                label="CRE Team"
                 values={filters.csTeams}
                 options={teamOptions}
                 onChange={(next) => onChange({ ...filters, csTeams: next })}

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
@@ -585,17 +585,25 @@ export default function CasesFilterBar({
     [teams],
   );
 
-  // Simple mode only -- see `buildActiveFilterChips`'s doc comment. In
-  // Advanced mode every field it would chip is already its own row (via
-  // `AdvancedFiltersBuilder`) or branch (via `AnyOfGroupsBuilder`), both
-  // rendered below whenever `effectiveMode === "advanced"`, so a chip there
-  // would just duplicate what's already visible and editable. Uses
-  // `effectiveMode`, not `mode`, so a non-simple-representable value that
-  // arrives without a remount (e.g. an applied saved view) doesn't sit
-  // chip-less behind a Simple grid that no longer matches reality.
+  // Suppressed only when Advanced mode's own row list/OR-groups are ALSO on
+  // screen (`effectiveMode === "advanced" && isFiltersOpen`) -- that's the
+  // only situation where a chip would duplicate something already visible
+  // and editable (via `AdvancedFiltersBuilder`/`AnyOfGroupsBuilder`). While
+  // the panel is collapsed, neither the Simple grid nor the Advanced builder
+  // renders, so chips are the ONLY way to see what's active regardless of
+  // mode -- this list itself renders outside the `isFiltersOpen` gate below,
+  // by design (see that render site's own doc comment), so this memo must
+  // not silently empty itself out just because the mode happens to be
+  // Advanced. Uses `effectiveMode`, not `mode`, so a non-simple-representable
+  // value that arrives without a remount (e.g. an applied saved view)
+  // doesn't sit chip-less behind a Simple grid that no longer matches
+  // reality.
   const activeFilterChips = useMemo(
-    () => (effectiveMode === "simple" ? buildActiveFilterChips(filters, teamLabels) : []),
-    [filters, teamLabels, effectiveMode],
+    () =>
+      effectiveMode === "simple" || !isFiltersOpen
+        ? buildActiveFilterChips(filters, teamLabels)
+        : [],
+    [filters, teamLabels, effectiveMode, isFiltersOpen],
   );
 
   // ── Saved views ──────────────────────────────────────────────────────────

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
@@ -83,6 +83,13 @@ import TriStateMultiSelectField from "@components/TriStateMultiSelectField";
 import AsyncAssigneeMultiSelect from "@features/csm-cases/components/AsyncAssigneeMultiSelect";
 import ProductNameMultiSelect from "@features/csm-cases/components/ProductNameMultiSelect";
 import TagsMultiSelect from "@features/csm-cases/components/TagsMultiSelect";
+import AdvancedFiltersBuilder from "@features/csm-cases/components/AdvancedFiltersBuilder";
+import {
+  getAdvancedFilterFieldMeta,
+  getAdvancedFilterOpMeta,
+  isCompleteAdvancedFilterRow,
+  type AdvancedFilterRow,
+} from "@features/csm-cases/utils/advancedFilters";
 
 
 /**
@@ -161,6 +168,19 @@ export interface CasesFilters {
   /** `closedOn` range bounds — same shape as `createdOnGte`/`createdOnLte`. */
   closedOnGte: string | null;
   closedOnLte: string | null;
+  /**
+   * Ad-hoc field/op/value rows from the "Advanced filters" builder — the
+   * escape hatch for `/cases/search` fields the dedicated bar controls above
+   * don't cover (`tag`, `projectOnboardingStatus`, `projectType`, `creTeam`,
+   * `sreTeam`, `deploymentId`, `number`, `internalId`, `resolutionNotes`,
+   * `parentId`, `taskSLABusinessElapsedPercent`, `escalationLevel`,
+   * `escalation`, `createdBy`, and the `createdOn`/`updatedOn`/`closedOn`
+   * date ranges) — see `advancedFilters.ts`'s field catalogue. Each row maps
+   * to one extra `BeCaseFieldFilter` entry (`caseSearchPayload.ts`); an
+   * incomplete row (a field/op picked but no value where one is required) is
+   * never emitted — see `isCompleteAdvancedFilterRow`.
+   */
+  advancedFilters: AdvancedFilterRow[];
 }
 
 /**
@@ -403,6 +423,28 @@ function buildActiveFilterChips(
       });
     }
   }
+
+  // Advanced-filter rows (see `AdvancedFiltersBuilder`) each get their own
+  // chip too — same reasoning as the SLA/escalation/date-range group above:
+  // they're an ad-hoc escape hatch with no bar control of their own, so a
+  // chip is the only way to see or clear one once the filter grid is
+  // collapsed (e.g. after a saved view or a shared URL sets one). Only
+  // *complete* rows are chipped; an in-progress row (no value yet) is only
+  // ever visible inside the open builder itself.
+  filters.advancedFilters.forEach((row, index) => {
+    if (!isCompleteAdvancedFilterRow(row)) return;
+    const fieldMeta = getAdvancedFilterFieldMeta(row.field);
+    const opMeta = getAdvancedFilterOpMeta(row.field, row.op);
+    const valueText = row.values.length > 0 ? ` ${row.values.join(", ")}` : "";
+    chips.push({
+      key: `advanced-${row.field}-${row.op}-${index}`,
+      label: `${fieldMeta?.label ?? row.field} ${opMeta?.label ?? row.op}${valueText}`,
+      onRemove: (f) => ({
+        ...f,
+        advancedFilters: f.advancedFilters.filter((_, i) => i !== index),
+      }),
+    });
+  });
 
   return chips;
 }
@@ -873,6 +915,11 @@ export default function CasesFilterBar({
               </Grid>
             )}
           </Grid>
+          <Divider />
+          <AdvancedFiltersBuilder
+            rows={filters.advancedFilters}
+            onChange={(next) => onChange({ ...filters, advancedFilters: next })}
+          />
           {activeCount > 0 && (
             <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
               <Typography variant="caption" color="text.secondary">

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
@@ -524,6 +524,15 @@ export default function CasesFilterBar({
     isSimpleRepresentable(filters) ? "simple" : "advanced",
   );
   const canShowSimple = isSimpleRepresentable(filters);
+  // A filter Simple mode cannot render must never sit silently active behind
+  // the Simple grid with nothing on screen showing it — e.g. applying a
+  // saved view that carries `tags` while already in Simple mode: `onChange`
+  // updates `filters` without remounting this component, so the mount-time
+  // `mode` state above never re-derives on its own. This only ever pushes
+  // Simple -> Advanced (never the reverse), so it doesn't touch the
+  // mount-time-only guarantee `mode`'s own comment describes for the
+  // Advanced-authoring case.
+  const effectiveMode = mode === "simple" && !canShowSimple ? "advanced" : mode;
 
   const unifiedRows: UnifiedFilterRow[] = useMemo(
     () => filtersToAdvancedRows(filters),
@@ -579,11 +588,14 @@ export default function CasesFilterBar({
   // Simple mode only -- see `buildActiveFilterChips`'s doc comment. In
   // Advanced mode every field it would chip is already its own row (via
   // `AdvancedFiltersBuilder`) or branch (via `AnyOfGroupsBuilder`), both
-  // rendered below whenever `mode === "advanced"`, so a chip there would
-  // just duplicate what's already visible and editable.
+  // rendered below whenever `effectiveMode === "advanced"`, so a chip there
+  // would just duplicate what's already visible and editable. Uses
+  // `effectiveMode`, not `mode`, so a non-simple-representable value that
+  // arrives without a remount (e.g. an applied saved view) doesn't sit
+  // chip-less behind a Simple grid that no longer matches reality.
   const activeFilterChips = useMemo(
-    () => (mode === "simple" ? buildActiveFilterChips(filters, teamLabels) : []),
-    [filters, teamLabels, mode],
+    () => (effectiveMode === "simple" ? buildActiveFilterChips(filters, teamLabels) : []),
+    [filters, teamLabels, effectiveMode],
   );
 
   // ── Saved views ──────────────────────────────────────────────────────────
@@ -874,9 +886,9 @@ export default function CasesFilterBar({
               <span>
                 <Button
                   size="small"
-                  variant={mode === "simple" ? "contained" : "outlined"}
-                  color={mode === "simple" ? "primary" : "inherit"}
-                  aria-pressed={mode === "simple"}
+                  variant={effectiveMode === "simple" ? "contained" : "outlined"}
+                  color={effectiveMode === "simple" ? "primary" : "inherit"}
+                  aria-pressed={effectiveMode === "simple"}
                   disabled={!canShowSimple}
                   onClick={() => setMode("simple")}
                   sx={{ borderTopRightRadius: 0, borderBottomRightRadius: 0 }}
@@ -887,16 +899,16 @@ export default function CasesFilterBar({
             </Tooltip>
             <Button
               size="small"
-              variant={mode === "advanced" ? "contained" : "outlined"}
-              color={mode === "advanced" ? "primary" : "inherit"}
-              aria-pressed={mode === "advanced"}
+              variant={effectiveMode === "advanced" ? "contained" : "outlined"}
+              color={effectiveMode === "advanced" ? "primary" : "inherit"}
+              aria-pressed={effectiveMode === "advanced"}
               onClick={() => setMode("advanced")}
               sx={{ borderTopLeftRadius: 0, borderBottomLeftRadius: 0, ml: "-1px" }}
             >
               Advanced
             </Button>
           </Box>
-          {mode === "simple" ? (
+          {effectiveMode === "simple" ? (
           <Grid container spacing={2} sx={{ mt: 0 }}>
             {showSeverityFilter && (
               <Grid size={{ xs: 12, sm: 6, md: 4, lg: 2 }}>

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
@@ -248,6 +248,22 @@ interface CasesFilterBarProps {
   hideProjectFilter?: boolean;
   /** Show the engagement-type multi-select (only relevant when type is locked to engagement). */
   showEngagementTypeFilter?: boolean;
+  /**
+   * Hide the "Onboarding status" Simple-mode control. `onboardingStatuses` is
+   * a per-project attribute, not a per-case one — on a view already scoped to
+   * a single project (e.g. that project's own Work items tab), every case
+   * shown shares the same value, so the control is a no-op that only adds
+   * clutter. The field itself stays in the Advanced-mode catalogue; this only
+   * hides the dedicated Simple control.
+   */
+  hideOnboardingStatusFilter?: boolean;
+  /**
+   * Hide the "CRE Team" Simple-mode control. Same reasoning as
+   * {@link hideOnboardingStatusFilter}: the CS team a case's project is
+   * scoped to is a per-project attribute, a no-op filter on a
+   * single-project-scoped view. Advanced mode still offers the field.
+   */
+  hideCreTeamFilter?: boolean;
 }
 
 // Work state has no bar control of its own (see `buildActiveFilterChips`'s
@@ -486,6 +502,8 @@ export default function CasesFilterBar({
   availableProjects,
   showSeverityFilter = true,
   hideTypeFilter = false,
+  hideOnboardingStatusFilter = false,
+  hideCreTeamFilter = false,
   typeFilterLabel = "Case type",
   hideProjectFilter = false,
   showEngagementTypeFilter = false,
@@ -924,23 +942,25 @@ export default function CasesFilterBar({
                 }
               />
             </Grid>
-            <Grid size={{ xs: 12, sm: 6, md: 4, lg: 2 }}>
-              {/* CS team the case's project is scoped to (`creTeam`). Options
-                  are `creGroupId`s (what the filter actually matches on);
-                  labels are team display names, never the raw group-id
-                  UUID. `workStates` has no bar control of its own now (it's
-                  a narrow, rarely hand-picked sub-filter of "state") -- it
-                  still round-trips losslessly via the URL/a saved view/a
-                  dashboard click-through, surfaced as a removable chip
-                  instead (see `buildActiveFilterChips`). */}
-              <MultiSelectField
-                id="cases-filter-cs-team"
-                label="CRE Team"
-                values={filters.csTeams}
-                options={teamOptions}
-                onChange={(next) => onChange({ ...filters, csTeams: next })}
-              />
-            </Grid>
+            {!hideCreTeamFilter && (
+              <Grid size={{ xs: 12, sm: 6, md: 4, lg: 2 }}>
+                {/* CS team the case's project is scoped to (`creTeam`). Options
+                    are `creGroupId`s (what the filter actually matches on);
+                    labels are team display names, never the raw group-id
+                    UUID. `workStates` has no bar control of its own now (it's
+                    a narrow, rarely hand-picked sub-filter of "state") -- it
+                    still round-trips losslessly via the URL/a saved view/a
+                    dashboard click-through, surfaced as a removable chip
+                    instead (see `buildActiveFilterChips`). */}
+                <MultiSelectField
+                  id="cases-filter-cs-team"
+                  label="CRE Team"
+                  values={filters.csTeams}
+                  options={teamOptions}
+                  onChange={(next) => onChange({ ...filters, csTeams: next })}
+                />
+              </Grid>
+            )}
             {showEngagementTypeFilter && (
               <Grid size={{ xs: 12, sm: 6, md: 4, lg: 2 }}>
                 <MultiSelectField
@@ -982,15 +1002,17 @@ export default function CasesFilterBar({
                 onChange={(next) => onChange({ ...filters, productNames: next })}
               />
             </Grid>
-            <Grid size={{ xs: 12, sm: 6, md: 4, lg: 2 }}>
-              <MultiSelectField
-                id="cases-filter-onboarding-status"
-                label="Onboarding status"
-                values={filters.onboardingStatuses}
-                options={ONBOARDING_STATUS_OPTIONS}
-                onChange={(next) => onChange({ ...filters, onboardingStatuses: next })}
-              />
-            </Grid>
+            {!hideOnboardingStatusFilter && (
+              <Grid size={{ xs: 12, sm: 6, md: 4, lg: 2 }}>
+                <MultiSelectField
+                  id="cases-filter-onboarding-status"
+                  label="Onboarding status"
+                  values={filters.onboardingStatuses}
+                  options={ONBOARDING_STATUS_OPTIONS}
+                  onChange={(next) => onChange({ ...filters, onboardingStatuses: next })}
+                />
+              </Grid>
+            )}
             {!hideProjectFilter && (
               // Last, and wider than every other control: selected project
               // names render as one ellipsized line (see

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
@@ -33,6 +33,7 @@ import {
   MenuItem,
   Paper,
   TextField,
+  Tooltip,
   Typography,
 } from "@wso2/oxygen-ui";
 import {
@@ -51,7 +52,6 @@ import type {
   CaseState,
   Severity,
 } from "@features/csm-dashboard/types/abtDashboard";
-import { STATE_LABEL } from "@features/csm-dashboard/utils/abtDashboard";
 import {
   countActiveFilters,
   readCasesFiltersFromUrl,
@@ -74,15 +74,10 @@ import {
   CASE_TYPE_LABEL,
 } from "@features/csm-cases/utils/caseType";
 import AsyncProjectMultiSelect from "@features/csm-cases/components/AsyncProjectMultiSelect";
-import {
-  ALL_ONBOARDING_STATUSES,
-  ONBOARDING_STATUS_LABEL,
-} from "@features/csm-cases/utils/onboardingStatus";
 import MultiSelectField from "@components/MultiSelectField";
 import TriStateMultiSelectField from "@components/TriStateMultiSelectField";
 import AsyncAssigneeMultiSelect from "@features/csm-cases/components/AsyncAssigneeMultiSelect";
 import ProductNameMultiSelect from "@features/csm-cases/components/ProductNameMultiSelect";
-import TagsMultiSelect from "@features/csm-cases/components/TagsMultiSelect";
 import AdvancedFiltersBuilder from "@features/csm-cases/components/AdvancedFiltersBuilder";
 import AnyOfGroupsBuilder from "@features/csm-cases/components/AnyOfGroupsBuilder";
 import {
@@ -92,6 +87,20 @@ import {
   type AdvancedFilterRow,
 } from "@features/csm-cases/utils/advancedFilters";
 import { isCompleteAnyOfBranch, type AnyOfBranch } from "@features/csm-cases/utils/anyOfFilters";
+import {
+  ENGAGEMENT_TYPE_OPTIONS,
+  ONBOARDING_STATUS_OPTIONS,
+  SEVERITY_OPTIONS,
+  STATE_OPTIONS,
+} from "@features/csm-cases/utils/caseFilterOptions";
+import {
+  addBlankUnifiedRow,
+  filtersToAdvancedRows,
+  isSimpleRepresentable,
+  removeUnifiedRow,
+  updateUnifiedRow,
+  type UnifiedFilterRow,
+} from "@features/csm-cases/utils/filterFieldAdapters";
 
 
 /**
@@ -241,46 +250,12 @@ interface CasesFilterBarProps {
   showEngagementTypeFilter?: boolean;
 }
 
-const ALL_ENGAGEMENT_TYPES: BeEngagementType[] = [
-  "migration",
-  "consultancy",
-  "new_feature_improvement",
-  "follow_up",
-  "onboarding",
-];
-
-const ENGAGEMENT_TYPE_LABEL: Record<BeEngagementType, string> = {
-  migration: "Migration",
-  consultancy: "Consultancy",
-  new_feature_improvement: "New feature / improvement",
-  follow_up: "Follow-up",
-  onboarding: "Onboarding",
-};
-
 // Work state has no bar control of its own (see `buildActiveFilterChips`'s
 // doc comment) -- this only labels its chip now.
 const WORK_STATE_LABEL: Record<BeCaseWorkState, string> = {
   ongoing: "Ongoing",
   paused: "Paused",
 };
-
-const ALL_SEVERITIES: Severity[] = ["S0", "S1", "S2", "S3", "S4"];
-
-// The fixed ServiceNow choice list for `projectOnboardingStatus`, shared with
-// `translateCaseDashboardFilters` (see `onboardingStatus.ts`).
-const ONBOARDING_STATUS_OPTIONS: { value: string; label: string }[] =
-  ALL_ONBOARDING_STATUSES.map((value) => ({
-    value,
-    label: ONBOARDING_STATUS_LABEL[value],
-  }));
-const PRIMARY_STATES: CaseState[] = [
-  "open",
-  "work_in_progress",
-  "awaiting_info",
-  "solution_proposed",
-  "waiting_on_wso2",
-  "closed",
-];
 
 /** Formats a `createdOn`/`updatedOn`/`closedOn` bound for a chip label — a
  * locale date when parseable, the raw string otherwise (never throws on a
@@ -315,14 +290,14 @@ interface ActiveFilterChip {
  * hand-picked, and a better home for advanced filters is still to be
  * designed), so a chip is now the ONLY way a user can see or clear them
  * after arriving from a dashboard click-through. `csTeams`/
- * `onboardingStatuses`/`tags`/`excludeTags` each have their own bar control
- * (see the filter grid below) and are deliberately NOT chipped here too —
- * every other bar-controlled field (`states`, `severities`, ...) shows its
- * selection inside its own control, not as a second, redundant chip.
- * `excludeTags` moved into this group once `TagsMultiSelect` became a
- * tri-state include/exclude control (digiops-cs#2907): its own excluded-tag
- * chips already render inside that control, so a second "Excluding tag: X"
- * chip here would just duplicate the same information right next to it.
+ * `onboardingStatuses` has its own bar control (see the filter grid below)
+ * and is deliberately NOT chipped here — every other bar-controlled field
+ * (`states`, `severities`, ...) shows its selection inside its own control,
+ * not as a second, redundant chip. `tags`/`excludeTags` moved out of Simple
+ * mode entirely (Tags is Advanced-only now — see the mode toggle below): any
+ * value in either one forces `isSimpleRepresentable` to false, so the Tag
+ * row itself is what a user sees (in Advanced mode), never a chip alongside
+ * an invisible control.
  */
 function buildActiveFilterChips(
   filters: CasesFilters,
@@ -345,13 +320,15 @@ function buildActiveFilterChips(
     });
   });
 
-  // `tags`/`excludeTags` and `states`/`excludeStates` each have their own
-  // tri-state bar control now (`TagsMultiSelect`, `TriStateMultiSelectField`
-  // on the State field -- see the filter grid below) -- not chipped here,
-  // same as `csTeams`/`onboardingStatuses`. A dashboard click-through (or a
-  // saved view) that seeds `excludeTags`/`excludeStates` still round-trips
-  // losslessly through the URL and shows up as that control's own "- "
-  // chip, same as any other exclusion a user picks by hand.
+  // `states`/`excludeStates` has its own tri-state bar control
+  // (`TriStateMultiSelectField` on the State field -- see the filter grid
+  // below) -- not chipped here, same as `csTeams`/`onboardingStatuses`. A
+  // dashboard click-through (or a saved view) that seeds `excludeStates`
+  // still round-trips losslessly through the URL and shows up as that
+  // control's own "- " chip, same as any other exclusion a user picks by
+  // hand. `tags`/`excludeTags` are Advanced-mode-only now (see the mode
+  // toggle below) -- also not chipped, since any non-empty value forces
+  // Advanced mode, where the Tag row itself is the visible/removable UI.
 
   filters.workStates.forEach((workState) => {
     chips.push({
@@ -501,6 +478,25 @@ export default function CasesFilterBar({
   const activeCount = countActiveFilters(filters);
   const hasActive = activeCount > 0;
 
+  // Simple/Advanced mode. Lazily initialized from the *filters this
+  // component mounted with* — mount-time-only, deliberately never
+  // recomputed on every `filters` change (that would silently flip the user
+  // out of the mode they're actively editing in, e.g. the instant they add
+  // an Advanced-only field while in Advanced mode, or clear the last
+  // Advanced-only field while reviewing a URL in Simple-representable
+  // territory). `CasesFilterBar` remounts on real navigation (a fresh
+  // `/cases?...` load, a saved view's own page), which is the only time this
+  // should re-derive.
+  const [mode, setMode] = useState<"simple" | "advanced">(() =>
+    isSimpleRepresentable(filters) ? "simple" : "advanced",
+  );
+  const canShowSimple = isSimpleRepresentable(filters);
+
+  const unifiedRows: UnifiedFilterRow[] = useMemo(
+    () => filtersToAdvancedRows(filters),
+    [filters],
+  );
+
   // Team is a fixed, small enough list to fetch in full (same endpoint/hook
   // the team-based dashboards use -- see AbtDashboardHeader) rather than a
   // type-to-search async picker, and doubles as the source for the "CS
@@ -574,22 +570,17 @@ export default function CasesFilterBar({
     setSavedAnchor(null);
   };
 
-  const severityOptions = useMemo(
-    () => ALL_SEVERITIES.map((s) => ({ value: s, label: s })),
-    [],
-  );
-  const stateOptions = useMemo(
-    () => PRIMARY_STATES.map((s) => ({ value: s, label: STATE_LABEL[s] })),
-    [],
-  );
+  // Fixed enums — shared with `advancedFilters.ts`'s catalogue
+  // (`caseFilterOptions.ts` is the one source of truth for each), so a value
+  // picked in either mode renders identically in the other. Plain constants,
+  // not `useMemo`'d, since they're static imports, not derived from props.
+  const severityOptions = SEVERITY_OPTIONS;
+  const stateOptions = STATE_OPTIONS;
   const caseTypeOptions = useMemo(
     () => ALL_CASE_TYPES.map((t) => ({ value: t, label: CASE_TYPE_LABEL[t] })),
     [],
   );
-  const engagementTypeOptions = useMemo(
-    () => ALL_ENGAGEMENT_TYPES.map((t) => ({ value: t, label: ENGAGEMENT_TYPE_LABEL[t] })),
-    [],
-  );
+  const engagementTypeOptions = ENGAGEMENT_TYPE_OPTIONS;
 
   // Project filter loads the first page of projects on open and pages through
   // the rest on scroll (and narrows as you type) rather than loading the whole
@@ -818,6 +809,45 @@ export default function CasesFilterBar({
       {isFiltersOpen && (
         <>
           <Divider />
+          <Box
+            role="group"
+            aria-label="Filter mode"
+            sx={{ display: "flex", alignSelf: "flex-start" }}
+          >
+            <Tooltip
+              title={
+                canShowSimple
+                  ? ""
+                  : "This filter can't be shown as Simple — one or more of the active filters " +
+                    "is only representable in Advanced mode. Clear those to switch back."
+              }
+            >
+              <span>
+                <Button
+                  size="small"
+                  variant={mode === "simple" ? "contained" : "outlined"}
+                  color={mode === "simple" ? "primary" : "inherit"}
+                  aria-pressed={mode === "simple"}
+                  disabled={!canShowSimple}
+                  onClick={() => setMode("simple")}
+                  sx={{ borderTopRightRadius: 0, borderBottomRightRadius: 0 }}
+                >
+                  Simple
+                </Button>
+              </span>
+            </Tooltip>
+            <Button
+              size="small"
+              variant={mode === "advanced" ? "contained" : "outlined"}
+              color={mode === "advanced" ? "primary" : "inherit"}
+              aria-pressed={mode === "advanced"}
+              onClick={() => setMode("advanced")}
+              sx={{ borderTopLeftRadius: 0, borderBottomLeftRadius: 0, ml: "-1px" }}
+            >
+              Advanced
+            </Button>
+          </Box>
+          {mode === "simple" ? (
           <Grid container spacing={2} sx={{ mt: 0 }}>
             {showSeverityFilter && (
               <Grid size={{ xs: 12, sm: 6, md: 4, lg: 2 }}>
@@ -930,18 +960,6 @@ export default function CasesFilterBar({
                 onChange={(next) => onChange({ ...filters, onboardingStatuses: next })}
               />
             </Grid>
-            <Grid size={{ xs: 12, sm: 6, md: 4, lg: 2 }}>
-              {/* One tri-state control drives both `tags` (include) and
-                  `excludeTags` (exclude) -- see `TagsMultiSelect`'s own doc
-                  comment for the cycling model. */}
-              <TagsMultiSelect
-                includedValues={filters.tags}
-                excludedValues={filters.excludeTags}
-                onChange={(next) =>
-                  onChange({ ...filters, tags: next.included, excludeTags: next.excluded })
-                }
-              />
-            </Grid>
             {!hideProjectFilter && (
               // Last, and wider than every other control: selected project
               // names render as one ellipsized line (see
@@ -960,17 +978,25 @@ export default function CasesFilterBar({
               </Grid>
             )}
           </Grid>
-          <Divider />
-          <AdvancedFiltersBuilder
-            rows={filters.advancedFilters}
-            onChange={(next) => onChange({ ...filters, advancedFilters: next })}
-            sreTeamOptions={sreTeamOptions}
-          />
-          <Divider />
-          <AnyOfGroupsBuilder
-            branches={filters.anyOfBranches}
-            onChange={(next) => onChange({ ...filters, anyOfBranches: next })}
-          />
+          ) : (
+            <>
+              <AdvancedFiltersBuilder
+                rows={unifiedRows}
+                onUpdateRow={(row, next) => onChange(updateUnifiedRow(filters, row, next))}
+                onRemoveRow={(row) => onChange(removeUnifiedRow(filters, row))}
+                onAddRow={() => onChange(addBlankUnifiedRow(filters))}
+                creTeamOptions={teamOptions}
+                sreTeamOptions={sreTeamOptions}
+                assigneeNameSeed={assigneeNameSeed}
+                projectNameSeed={projectNameSeed}
+              />
+              <Divider />
+              <AnyOfGroupsBuilder
+                branches={filters.anyOfBranches}
+                onChange={(next) => onChange({ ...filters, anyOfBranches: next })}
+              />
+            </>
+          )}
           {activeCount > 0 && (
             <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
               <Typography variant="caption" color="text.secondary">

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
@@ -84,12 +84,14 @@ import AsyncAssigneeMultiSelect from "@features/csm-cases/components/AsyncAssign
 import ProductNameMultiSelect from "@features/csm-cases/components/ProductNameMultiSelect";
 import TagsMultiSelect from "@features/csm-cases/components/TagsMultiSelect";
 import AdvancedFiltersBuilder from "@features/csm-cases/components/AdvancedFiltersBuilder";
+import AnyOfGroupsBuilder from "@features/csm-cases/components/AnyOfGroupsBuilder";
 import {
   getAdvancedFilterFieldMeta,
   getAdvancedFilterOpMeta,
   isCompleteAdvancedFilterRow,
   type AdvancedFilterRow,
 } from "@features/csm-cases/utils/advancedFilters";
+import { isCompleteAnyOfBranch, type AnyOfBranch } from "@features/csm-cases/utils/anyOfFilters";
 
 
 /**
@@ -171,16 +173,30 @@ export interface CasesFilters {
   /**
    * Ad-hoc field/op/value rows from the "Advanced filters" builder — the
    * escape hatch for `/cases/search` fields the dedicated bar controls above
-   * don't cover (`tag`, `projectOnboardingStatus`, `projectType`, `creTeam`,
-   * `sreTeam`, `deploymentId`, `number`, `internalId`, `resolutionNotes`,
-   * `parentId`, `taskSLABusinessElapsedPercent`, `escalationLevel`,
-   * `escalation`, `createdBy`, and the `createdOn`/`updatedOn`/`closedOn`
-   * date ranges) — see `advancedFilters.ts`'s field catalogue. Each row maps
-   * to one extra `BeCaseFieldFilter` entry (`caseSearchPayload.ts`); an
-   * incomplete row (a field/op picked but no value where one is required) is
-   * never emitted — see `isCompleteAdvancedFilterRow`.
+   * don't cover (`projectType`, `sreTeam`, `deploymentId`, `number`,
+   * `internalId`, `resolutionNotes`, `parentId`,
+   * `taskSLABusinessElapsedPercent`, `escalationLevel`, `escalation`,
+   * `createdBy`, and the `createdOn`/`updatedOn`/`closedOn` date ranges) —
+   * see `advancedFilters.ts`'s field catalogue. Fields that already have a
+   * dedicated bar control of their own (`tag`, `projectOnboardingStatus`,
+   * `creTeam`) are deliberately NOT offered here — see that catalogue's own
+   * doc comment. Each row maps to one extra `BeCaseFieldFilter` entry
+   * (`caseSearchPayload.ts`); an incomplete row (a field/op picked but no
+   * value where one is required) is never emitted — see
+   * `isCompleteAdvancedFilterRow`.
    */
   advancedFilters: AdvancedFilterRow[];
+  /**
+   * Cross-field OR groups from the "OR groups" builder — each branch's own
+   * rows are ANDed, the branches themselves are OR'd, and the whole `anyOf`
+   * result is ANDed with everything else (`filters.anyOf`, see
+   * `anyOfFilters.ts`). Only a restricted field subset may appear inside a
+   * branch — a real, backend-enforced allowlist distinct from (and narrower
+   * than) `advancedFilters`' own field catalogue. A branch with no complete
+   * conditions is never emitted into the request payload — see
+   * `isCompleteAnyOfBranch`.
+   */
+  anyOfBranches: AnyOfBranch[];
 }
 
 /**
@@ -446,6 +462,25 @@ function buildActiveFilterChips(
     });
   });
 
+  // Each OR-branch is a distinct predicate too — chipped by its position
+  // (not its contents, which can be several conditions long) so it stays
+  // visible/removable even once the "OR groups" builder is collapsed. Only
+  // a branch with at least one complete condition is chipped; a branch
+  // that's still being edited (no complete rows yet) is only ever visible
+  // inside the open builder itself, same as an in-progress advanced-filter
+  // row.
+  filters.anyOfBranches.forEach((branch, index) => {
+    if (!isCompleteAnyOfBranch(branch)) return;
+    chips.push({
+      key: `any-of-branch-${index}`,
+      label: `OR group ${index + 1}`,
+      onRemove: (f) => ({
+        ...f,
+        anyOfBranches: f.anyOfBranches.filter((_, i) => i !== index),
+      }),
+    });
+  });
+
   return chips;
 }
 
@@ -488,6 +523,16 @@ export default function CasesFilterBar({
       (teams ?? [])
         .filter((t): t is typeof t & { creGroupId: string } => Boolean(t.creGroupId))
         .map((t) => ({ value: t.creGroupId, label: t.name })),
+    [teams],
+  );
+  // Same shape, keyed off `sreGroupId` instead — feeds the "Advanced
+  // filters" builder's `sreTeam` row (a real multi-select now, not
+  // hand-typed team ids/UUIDs).
+  const sreTeamOptions = useMemo(
+    () =>
+      (teams ?? [])
+        .filter((t): t is typeof t & { sreGroupId: string } => Boolean(t.sreGroupId))
+        .map((t) => ({ value: t.sreGroupId, label: t.name })),
     [teams],
   );
 
@@ -919,6 +964,12 @@ export default function CasesFilterBar({
           <AdvancedFiltersBuilder
             rows={filters.advancedFilters}
             onChange={(next) => onChange({ ...filters, advancedFilters: next })}
+            sreTeamOptions={sreTeamOptions}
+          />
+          <Divider />
+          <AnyOfGroupsBuilder
+            branches={filters.anyOfBranches}
+            onChange={(next) => onChange({ ...filters, anyOfBranches: next })}
           />
           {activeCount > 0 && (
             <Box sx={{ display: "flex", justifyContent: "flex-end" }}>

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CasesFilterBar.tsx
@@ -299,6 +299,21 @@ interface ActiveFilterChip {
  * row itself is what a user sees (in Advanced mode), never a chip alongside
  * an invisible control.
  */
+// All of the reasoning above is Simple-mode only. In Advanced mode every
+// field this function chips (`sreTeams`, `workStates`, the SLA/escalation/
+// project-type/date-range fields, plus `advancedFilters` and
+// `anyOfBranches`) already has its own always-visible, always-editable,
+// always-clearable row: `filtersToAdvancedRows` (`filterFieldAdapters.ts`)
+// turns every typed field, and every `advancedFilters` entry, into a row
+// `AdvancedFiltersBuilder` renders; `anyOfBranches` gets its own bordered
+// box per branch from `AnyOfGroupsBuilder`, unconditionally, whenever it's
+// mounted. Advanced mode only ever shows this function's output *alongside*
+// those two builders (see the call site below), so a chip there would be a
+// redundant, un-synced second rendering of a value the row/branch above it
+// already owns -- hence the caller only invokes this function in Simple
+// mode now. Simple mode has no row list at all, so a chip stays the only
+// way to see/clear an Advanced-only value that arrived via URL/dashboard
+// click-through while looking at the Simple grid -- that part is unchanged.
 function buildActiveFilterChips(
   filters: CasesFilters,
   /** groupId -> team display name, so a team chip never shows a raw UUID.
@@ -543,9 +558,14 @@ export default function CasesFilterBar({
     [teams],
   );
 
+  // Simple mode only -- see `buildActiveFilterChips`'s doc comment. In
+  // Advanced mode every field it would chip is already its own row (via
+  // `AdvancedFiltersBuilder`) or branch (via `AnyOfGroupsBuilder`), both
+  // rendered below whenever `mode === "advanced"`, so a chip there would
+  // just duplicate what's already visible and editable.
   const activeFilterChips = useMemo(
-    () => buildActiveFilterChips(filters, teamLabels),
-    [filters, teamLabels],
+    () => (mode === "simple" ? buildActiveFilterChips(filters, teamLabels) : []),
+    [filters, teamLabels, mode],
   );
 
   // ── Saved views ──────────────────────────────────────────────────────────

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmIssuesView.advancedFiltersUrl.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmIssuesView.advancedFiltersUrl.test.tsx
@@ -1,0 +1,137 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router";
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+
+// Same reasoning as CsmIssuesView.workStateUrl.test.tsx: the bug under test
+// only reproduces through the real round trip of a filter-bar interaction ->
+// CsmIssuesView's setFilters -> the URL -> re-reading the URL back into
+// `filters`, so this keeps the real CasesFilterBar (and CasesList) mounted
+// rather than mocking it away.
+vi.mock("@api/backend/client", () => ({
+  useBackendApi: () => ({ post: vi.fn().mockResolvedValue({ teams: [] }), get: vi.fn() }),
+}));
+vi.mock("@config/apiConfig", () => ({
+  apiConfig: { backendUrl: "https://example.test" },
+}));
+vi.mock("@context/current-user/CurrentUserContext", () => ({
+  useCurrentUser: () => ({ user: { id: "user-1" }, isLoading: false, isError: false }),
+}));
+vi.mock("@context/error-banner/ErrorBannerContext", () => ({
+  useErrorBanner: () => ({ showError: vi.fn() }),
+}));
+vi.mock("@hooks/useIdTokenClaims", () => ({
+  useIdTokenClaims: () => ({ email: "user@example.test" }),
+}));
+vi.mock("@api/useDirectoryUsers", () => ({
+  useDirectoryUsers: () => ({ data: [] }),
+}));
+vi.mock("@features/csm-cases/api/useGetCsmCases", () => ({
+  useGetCsmCases: () => ({
+    data: { cases: [], total: 0, hasMore: false },
+    isLoading: false,
+    isFetching: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+    dataUpdatedAt: 0,
+  }),
+}));
+vi.mock("@components/FilteredCsvExportButton", () => ({
+  default: () => <div>ExportButton</div>,
+}));
+vi.mock("@components/RefreshButton", () => ({
+  default: () => <div>RefreshButton</div>,
+}));
+
+import CsmIssuesView from "@features/csm-cases/components/CsmIssuesView";
+
+/** Exposes the current URL search string so a test can assert on it
+ * directly -- `window.location` doesn't reflect MemoryRouter's history. */
+function LocationSearchProbe() {
+  const location = useLocation();
+  return <div data-testid="search-probe">{location.search}</div>;
+}
+
+function renderAt(initialUrl: string) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[initialUrl]}>
+        <Routes>
+          <Route
+            path="/cases"
+            element={
+              <>
+                <CsmIssuesView title="Cases" />
+                <LocationSearchProbe />
+              </>
+            }
+          />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+// Regression test for: removing the last "Advanced filters" row (a field
+// with no typed `CasesFilters` slot, e.g. "Created by is me") — or the last
+// "OR groups" branch — silently did nothing to the URL, live-verified via
+// the debug Chrome. Root cause: same class of bug the workStates/
+// onboardingStatuses regressions above already document — CsmIssuesView's
+// FILTER_PARAM_KEYS (the URL keys it deletes before rewriting from the next
+// filter state) was missing "af" and "anyOf", so an empty
+// `next.advancedFilters`/`next.anyOfBranches` never actually cleared the
+// stale `af`/`anyOf` URL param, and the next render read the stale row/
+// branch straight back in (`writeCasesFiltersToUrl` only ever *sets* these
+// two once there's at least one row/branch again — it never explicitly
+// clears them, so an explicit `delete` first is required, same as every
+// other filter field).
+describe("CsmIssuesView + real CasesFilterBar — Advanced filters row clears fully from the URL", () => {
+  it("removing the only advancedFilters row clears the `af` param, not just the in-memory value", () => {
+    renderAt('/cases?af=%5B%5B%22createdBy%22%2C%22eq%22%5D%5D');
+
+    // An advanced-only field with no typed `CasesFilters` slot forces
+    // Advanced mode on mount (see `isSimpleRepresentable`).
+    expect(screen.getByText("Created by is me")).toBeInTheDocument();
+    expect(screen.getByTestId("search-probe").textContent).toContain("af=");
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove filter row" }));
+
+    expect(screen.queryByText("Created by is me")).not.toBeInTheDocument();
+    expect(screen.getByTestId("search-probe").textContent).not.toContain("af=");
+  });
+});
+
+describe("CsmIssuesView + real CasesFilterBar — OR groups clears fully from the URL", () => {
+  it("removing the only OR-group branch clears the `anyOf` param, not just the in-memory value", () => {
+    renderAt('/cases?anyOf=%5B%5B%5B%22type%22%2C%5B%22case%22%5D%5D%5D%5D');
+
+    expect(screen.getByText("OR group 1")).toBeInTheDocument();
+    expect(screen.getByTestId("search-probe").textContent).toContain("anyOf=");
+
+    fireEvent.click(
+      screen.getByText("OR group 1").closest(".MuiChip-root")!.querySelector("svg")!,
+    );
+
+    expect(screen.queryByText("OR group 1")).not.toBeInTheDocument();
+    expect(screen.getByTestId("search-probe").textContent).not.toContain("anyOf=");
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmIssuesView.advancedFiltersUrl.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmIssuesView.advancedFiltersUrl.test.tsx
@@ -109,13 +109,16 @@ describe("CsmIssuesView + real CasesFilterBar — Advanced filters row clears fu
     renderAt('/cases?af=%5B%5B%22createdBy%22%2C%22eq%22%5D%5D');
 
     // An advanced-only field with no typed `CasesFilters` slot forces
-    // Advanced mode on mount (see `isSimpleRepresentable`).
-    expect(screen.getByText("Created by is me")).toBeInTheDocument();
+    // Advanced mode on mount (see `isSimpleRepresentable`), where the row
+    // itself (not a chip -- Advanced mode renders zero chips, see
+    // `buildActiveFilterChips`'s doc comment in `CasesFilterBar.tsx`) is
+    // the only visible/removable UI for it.
+    expect(screen.getByRole("button", { name: "Remove filter row" })).toBeInTheDocument();
     expect(screen.getByTestId("search-probe").textContent).toContain("af=");
 
     fireEvent.click(screen.getByRole("button", { name: "Remove filter row" }));
 
-    expect(screen.queryByText("Created by is me")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Remove filter row" })).not.toBeInTheDocument();
     expect(screen.getByTestId("search-probe").textContent).not.toContain("af=");
   });
 });
@@ -124,14 +127,16 @@ describe("CsmIssuesView + real CasesFilterBar — OR groups clears fully from th
   it("removing the only OR-group branch clears the `anyOf` param, not just the in-memory value", () => {
     renderAt('/cases?anyOf=%5B%5B%5B%22type%22%2C%5B%22case%22%5D%5D%5D%5D');
 
-    expect(screen.getByText("OR group 1")).toBeInTheDocument();
+    // The branch itself (rendered by `AnyOfGroupsBuilder`, not a chip --
+    // Advanced mode renders zero chips, see `buildActiveFilterChips`'s doc
+    // comment in `CasesFilterBar.tsx`) is the only visible/removable UI for
+    // it.
+    expect(screen.getByText("Group 1")).toBeInTheDocument();
     expect(screen.getByTestId("search-probe").textContent).toContain("anyOf=");
 
-    fireEvent.click(
-      screen.getByText("OR group 1").closest(".MuiChip-root")!.querySelector("svg")!,
-    );
+    fireEvent.click(screen.getByRole("button", { name: "Remove OR group 1" }));
 
-    expect(screen.queryByText("OR group 1")).not.toBeInTheDocument();
+    expect(screen.queryByText("Group 1")).not.toBeInTheDocument();
     expect(screen.getByTestId("search-probe").textContent).not.toContain("anyOf=");
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmIssuesView.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmIssuesView.test.tsx
@@ -60,8 +60,12 @@ vi.mock("@features/csm-cases/api/useGetCsmCases", () => ({
     };
   },
 }));
+const casesFilterBarPropsSpy = vi.fn();
 vi.mock("@features/csm-cases/components/CasesFilterBar", () => ({
-  default: () => <div>FilterBar</div>,
+  default: (props: unknown) => {
+    casesFilterBarPropsSpy(props);
+    return <div>FilterBar</div>;
+  },
 }));
 vi.mock("@features/csm-cases/components/CasesList", () => ({
   // Forwards `columnCustomizer` (the "Customise columns" trigger, rendered
@@ -88,6 +92,7 @@ import { ALL_CASE_TYPES } from "@features/csm-cases/utils/caseType";
 beforeEach(() => {
   window.localStorage.clear();
   useGetCsmCasesMock.mockClear();
+  casesFilterBarPropsSpy.mockClear();
 });
 
 function LocationProbe() {
@@ -363,6 +368,62 @@ describe("CsmIssuesView defaultCaseTypes (Support page's case-type default, digi
         expect.anything(),
         expect.anything(),
       ),
+    );
+  });
+});
+
+describe("CsmIssuesView showSeverityFilter override (project Work items tab)", () => {
+  it("defaults to hidden when the type filter is unlocked (multi-type view, no lockedFilters.caseTypes)", () => {
+    render(
+      <MemoryRouter initialEntries={["/cases"]}>
+        <CsmIssuesView title="Cases" />
+      </MemoryRouter>,
+    );
+    expect(casesFilterBarPropsSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({ showSeverityFilter: false }),
+    );
+  });
+
+  it("shows Severity when the caller passes showSeverityFilter, even though the type filter is unlocked", () => {
+    render(
+      <MemoryRouter initialEntries={["/projects/p1"]}>
+        <CsmIssuesView
+          entityNoun="work items"
+          lockedFilters={{ projects: ["p1"] }}
+          hideProjectFilter
+          hideOnboardingStatusFilter
+          hideCreTeamFilter
+          showSeverityFilter
+          typeFilterLabel="Work item type"
+        />
+      </MemoryRouter>,
+    );
+    expect(casesFilterBarPropsSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        showSeverityFilter: true,
+        hideOnboardingStatusFilter: true,
+        hideCreTeamFilter: true,
+      }),
+    );
+  });
+
+  it("does not force-clear a chosen severity out of the query when showSeverityFilter is overridden true", () => {
+    render(
+      <MemoryRouter initialEntries={["/projects/p1?severities=S1"]}>
+        <CsmIssuesView
+          entityNoun="work items"
+          lockedFilters={{ projects: ["p1"] }}
+          showSeverityFilter
+        />
+      </MemoryRouter>,
+    );
+    expect(useGetCsmCasesMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ severities: ["S1"] }),
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
     );
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmIssuesView.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmIssuesView.tsx
@@ -154,8 +154,30 @@ interface CsmIssuesViewProps {
   typeFilterLabel?: string;
   /** Hide the project filter control (use when the view is project-scoped). */
   hideProjectFilter?: boolean;
+  /**
+   * Hide the "Onboarding status"/"CRE Team" Simple-mode controls — see
+   * `CasesFilterBar`'s own doc comments. Pass when the view is already
+   * scoped to one project (both are per-project attributes, so filtering by
+   * them on a single-project view is a no-op).
+   */
+  hideOnboardingStatusFilter?: boolean;
+  hideCreTeamFilter?: boolean;
   /** Show the engagement-type sub-filter (pass when the view is locked to engagement cases). */
   showEngagementTypeFilter?: boolean;
+  /**
+   * Force the Severity filter/column on or off, overriding the default
+   * "only when `lockedFilters.caseTypes` is locked to `case`" rule below.
+   * For a caller whose type filter is *unlocked and visible* (e.g. the
+   * project Work items tab, which spans every case type but lets the user
+   * narrow it with the "Work item type" control) that default would always
+   * read false, permanently hiding Severity even once the user filters
+   * down to just Cases. Pass `true` there — Severity is still a genuinely
+   * useful control on a mixed list (non-case rows simply have no severity
+   * to match, so picking a value implicitly narrows to cases, same as
+   * picking "Case" in the type control would) — or `false` to force it off
+   * regardless of the lock.
+   */
+  showSeverityFilter?: boolean;
   /** Base path for row detail links. Defaults to "/cases". */
   detailBasePath?: string;
   /** Hide the Severity column in the list (severity is a support-case
@@ -202,7 +224,10 @@ export default function CsmIssuesView({
   defaultCaseTypes,
   typeFilterLabel,
   hideProjectFilter,
+  hideOnboardingStatusFilter,
+  hideCreTeamFilter,
   showEngagementTypeFilter,
+  showSeverityFilter: showSeverityFilterOverride,
   detailBasePath,
   hideSeverityColumn,
   hideBackButton,
@@ -278,13 +303,17 @@ export default function CsmIssuesView({
     [searchParams, setSearchParams],
   );
 
-  // Severity (S1-S4) is a support-case concept, so the severity filter is only
-  // shown on the support-cases list — i.e. when the surrounding view locks the
-  // record type to `case`. Every other list (service requests, engagements,
-  // security reports, mixed project issues) hides it.
+  // Severity (S1-S4) is a support-case concept, so the severity filter is by
+  // default only shown on the support-cases list — i.e. when the surrounding
+  // view locks the record type to `case`. Every other list (service
+  // requests, engagements, security reports) hides it, unless the caller
+  // overrides with `showSeverityFilter` (see its own doc comment — the
+  // project Work items tab does this since its type filter is unlocked and
+  // visible rather than fixed via `lockedFilters`).
   const showSeverityFilter =
-    lockedFilters?.caseTypes?.length === 1 &&
-    lockedFilters.caseTypes[0] === "case";
+    showSeverityFilterOverride ??
+    (lockedFilters?.caseTypes?.length === 1 &&
+      lockedFilters.caseTypes[0] === "case");
   // Service Requests don't carry a severity, so the column is redundant there.
   const isServiceRequestOnly =
     lockedFilters?.caseTypes?.length === 1 &&
@@ -595,6 +624,8 @@ export default function CsmIssuesView({
         hideTypeFilter={hideTypeFilter}
         typeFilterLabel={typeFilterLabel}
         hideProjectFilter={hideProjectFilter}
+        hideOnboardingStatusFilter={hideOnboardingStatusFilter}
+        hideCreTeamFilter={hideCreTeamFilter}
         showEngagementTypeFilter={showEngagementTypeFilter}
       />
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmIssuesView.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmIssuesView.tsx
@@ -112,6 +112,17 @@ const FILTER_PARAM_KEYS = [
   "updatedTo",
   "closedFrom",
   "closedTo",
+  // Same class of bug as `workStates` above, found the same way while
+  // live-verifying the unified Advanced-mode row builder: removing the last
+  // `filters.advancedFilters` row (or the last `anyOfBranches` OR-group) —
+  // e.g. a "Created by is me" row with no typed `CasesFilters` slot to fall
+  // back to — silently did nothing, because `af`/`anyOf` were missing here.
+  // `writeCasesFiltersToUrl` only ever *sets* these two once there's at
+  // least one row/branch again; it never explicitly clears them, so without
+  // an explicit `delete` here first, the stale value from the previous URL
+  // just kept getting read back on the next render.
+  "af",
+  "anyOf",
 ] as const;
 
 interface CsmIssuesViewProps {

--- a/apps/csm-portal/webapp/src/features/csm-cases/components/CsmIssuesView.workStateUrl.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-cases/components/CsmIssuesView.workStateUrl.test.tsx
@@ -100,7 +100,7 @@ describe("CsmIssuesView + real CasesFilterBar — work state clears fully from t
   // the next render read the stale value straight back in.
   //
   // `workStates` no longer has its own bar control (see CasesFilterBar's
-  // "Team" control, which replaced it) -- the State control's own onChange
+  // "CRE Team" control, which replaced it) -- the State control's own onChange
   // is what clears a stale `workStates` now, when the selection widens past
   // "work_in_progress" alone. This exercises that same URL round trip
   // (not just the in-memory filter object CasesFilterBar.test.tsx already

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/advancedFilters.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/advancedFilters.test.ts
@@ -1,0 +1,107 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { describe, expect, it } from "vitest";
+import {
+  ADVANCED_FILTER_FIELDS,
+  RELATIVE_DATE_PRESETS,
+  getAdvancedFilterFieldMeta,
+  getAdvancedFilterOpMeta,
+} from "./advancedFilters";
+
+describe("ADVANCED_FILTER_FIELDS — duplication fix", () => {
+  it("no longer offers tag, projectOnboardingStatus, or creTeam (each has its own dedicated bar control)", () => {
+    const fields = ADVANCED_FILTER_FIELDS.map((m) => m.field);
+    expect(fields).not.toContain("tag");
+    expect(fields).not.toContain("projectOnboardingStatus");
+    expect(fields).not.toContain("creTeam");
+  });
+
+  it("still offers every other previously-supported field", () => {
+    const fields = ADVANCED_FILTER_FIELDS.map((m) => m.field);
+    expect(fields).toEqual(
+      expect.arrayContaining([
+        "projectType",
+        "issueType",
+        "sreTeam",
+        "deploymentId",
+        "number",
+        "internalId",
+        "resolutionNotes",
+        "parentId",
+        "taskSLABusinessElapsedPercent",
+        "escalationLevel",
+        "escalation",
+        "createdBy",
+        "createdOn",
+        "updatedOn",
+        "closedOn",
+      ]),
+    );
+  });
+});
+
+describe("ADVANCED_FILTER_FIELDS — real suggestions instead of hand-typed values", () => {
+  it("sreTeam is a multiSelect (real options threaded in by the builder), not free text", () => {
+    const opMeta = getAdvancedFilterOpMeta("sreTeam", "in");
+    expect(opMeta?.valueKind).toBe("multiSelect");
+    // Static catalogue carries no options for it — they're fetched team data,
+    // supplied via `AdvancedFiltersBuilder`'s `sreTeamOptions` prop instead.
+    expect(getAdvancedFilterFieldMeta("sreTeam")?.options).toBeUndefined();
+  });
+
+  it("createdBy's `in` op is an async directory search, not hand-typed emails", () => {
+    const opMeta = getAdvancedFilterOpMeta("createdBy", "in");
+    expect(opMeta?.valueKind).toBe("asyncEmailMultiSelect");
+  });
+
+  it("createdBy's `eq` op (\"is me\") is still the value-less currentUser kind", () => {
+    const opMeta = getAdvancedFilterOpMeta("createdBy", "eq");
+    expect(opMeta?.valueKind).toBe("currentUser");
+  });
+
+  it("createdOn/updatedOn/closedOn gte+lte are all the preset-or-date-picker kind, not a bare date TextField", () => {
+    for (const field of ["createdOn", "updatedOn", "closedOn"] as const) {
+      expect(getAdvancedFilterOpMeta(field, "gte")?.valueKind).toBe("dateOrPreset");
+      expect(getAdvancedFilterOpMeta(field, "lte")?.valueKind).toBe("dateOrPreset");
+    }
+  });
+
+  it("deploymentId stays free text — no deployment-search component exists to back it", () => {
+    expect(getAdvancedFilterOpMeta("deploymentId", "in")?.valueKind).toBe("multiText");
+  });
+
+  it("number/internalId/parentId stay free text — genuinely arbitrary opaque identifiers", () => {
+    expect(getAdvancedFilterOpMeta("number", "eq")?.valueKind).toBe("text");
+    expect(getAdvancedFilterOpMeta("internalId", "eq")?.valueKind).toBe("text");
+    expect(getAdvancedFilterOpMeta("parentId", "eq")?.valueKind).toBe("text");
+  });
+
+  it("taskSLABusinessElapsedPercent stays a plain number input", () => {
+    expect(getAdvancedFilterOpMeta("taskSLABusinessElapsedPercent", "gte")?.valueKind).toBe(
+      "number",
+    );
+  });
+});
+
+describe("RELATIVE_DATE_PRESETS", () => {
+  it("every preset value matches the placeholder grammar the resolver recognizes", () => {
+    for (const preset of RELATIVE_DATE_PRESETS) {
+      expect(preset.value).toMatch(/^__[a-zA-Z]+(?::-?\d+)?__$/);
+      expect(preset.label.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/advancedFilters.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/advancedFilters.test.ts
@@ -22,35 +22,54 @@ import {
   getAdvancedFilterOpMeta,
 } from "./advancedFilters";
 
-describe("ADVANCED_FILTER_FIELDS — duplication fix", () => {
-  it("no longer offers tag, projectOnboardingStatus, or creTeam (each has its own dedicated bar control)", () => {
-    const fields = ADVANCED_FILTER_FIELDS.map((m) => m.field);
-    expect(fields).not.toContain("tag");
-    expect(fields).not.toContain("projectOnboardingStatus");
-    expect(fields).not.toContain("creTeam");
-  });
-
-  it("still offers every other previously-supported field", () => {
+describe("ADVANCED_FILTER_FIELDS — full unification", () => {
+  it("offers every field, including the ones that also have a dedicated Simple-grid control", () => {
     const fields = ADVANCED_FILTER_FIELDS.map((m) => m.field);
     expect(fields).toEqual(
       expect.arrayContaining([
+        // Fields with a typed `CasesFilters` slot AND a Simple-grid control
+        // (see `filterFieldAdapters.ts`'s typed-adapter registry) — the
+        // whole point of the unification is that these are no longer
+        // excluded here just because Simple mode also renders them.
+        "severity",
+        "state",
+        "workState",
+        "type",
+        "assignedUserId",
+        "projectId",
+        "product",
+        "creTeam",
+        "tag",
+        "engagementType",
+        "projectOnboardingStatus",
+        // Fields with a typed slot but no Simple-grid control of their own.
         "projectType",
-        "issueType",
         "sreTeam",
+        "taskSLABusinessElapsedPercent",
+        "escalationLevel",
+        "escalation",
+        "createdOn",
+        "updatedOn",
+        "closedOn",
+        // Fields with no typed slot at all (the untyped escape hatch).
+        "issueType",
         "deploymentId",
         "number",
         "internalId",
         "resolutionNotes",
         "parentId",
-        "taskSLABusinessElapsedPercent",
-        "escalationLevel",
-        "escalation",
         "createdBy",
-        "createdOn",
-        "updatedOn",
-        "closedOn",
       ]),
     );
+  });
+
+  it("`tag` offers both `in` (\"includes\") and `notIn` (\"excludes\") — replaces the old tri-state cycling control", () => {
+    expect(getAdvancedFilterOpMeta("tag", "in")?.valueKind).toBe("asyncTagMultiSelect");
+    expect(getAdvancedFilterOpMeta("tag", "notIn")?.valueKind).toBe("asyncTagMultiSelect");
+  });
+
+  it("`state` offers both `in` and `notIn`, same as the Simple grid's tri-state control", () => {
+    expect(getAdvancedFilterFieldMeta("state")?.ops.map((o) => o.op)).toEqual(["in", "notIn"]);
   });
 });
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/advancedFilters.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/advancedFilters.ts
@@ -17,30 +17,35 @@
 import type { BeCaseFieldFilter, BeCaseFieldFilterOp } from "@api/backend/types";
 import { BE_CURRENT_USER_FILTER_PLACEHOLDER } from "@api/backend/types";
 import { ALL_ISSUE_TYPES, ISSUE_TYPE_LABEL } from "@features/csm-cases/utils/caseIssueType";
-import { ALL_ONBOARDING_STATUSES } from "@features/csm-cases/utils/onboardingStatus";
 import { resolveRelativeDatePlaceholder } from "@utils/resolveRelativeDatePlaceholder";
 
 /**
  * The `POST /cases/search` fields the dedicated bar controls in
  * `CasesFilterBar.tsx` (severity, state, case type, work state, engagement
- * type, assignee, project, product) do NOT already cover, exposed instead
- * through the generic "Advanced filters" field/op/value builder. Every one
- * of these is a real, backend-accepted `BeCaseFieldFilterField` — see
- * `types.ts`'s own doc comment on that enum, which mirrors the
- * entity-service's `caseFilterFieldSet` exactly.
+ * type, assignee, project, product, tags, onboarding status, CS team) do NOT
+ * already cover, exposed instead through the generic "Advanced filters"
+ * field/op/value builder. Every one of these is a real, backend-accepted
+ * `BeCaseFieldFilterField` — see `types.ts`'s own doc comment on that enum,
+ * which mirrors the entity-service's `caseFilterFieldSet` exactly.
  *
  * Deliberately excludes two fields a hand-off brief once listed
  * (`accountId`, `resolvedOn`): neither appears in `BeCaseFieldFilterField`,
  * so the backend would reject them — widening that enum is a backend
  * contract change, out of scope for this FE-only builder. Flagged in
  * `PROGRESS.md`, not silently worked around.
+ *
+ * Also deliberately excludes `tag`, `projectOnboardingStatus`, and `creTeam`
+ * even though all three are real, accepted fields: each already has its own
+ * dedicated bar control in `CasesFilterBar.tsx` (the "Tags" tri-state
+ * control, "Onboarding status", and "Team" respectively). Offering a second,
+ * generic advanced-filter row for the same backend field alongside its own
+ * dedicated control would be two independent UI paths writing the same
+ * `/cases/search` predicate — confusing, not additive. Removed 2026-08-31
+ * (they were briefly in this catalogue before the duplication was caught).
  */
 export type AdvancedFilterField =
-  | "tag"
-  | "projectOnboardingStatus"
   | "projectType"
   | "issueType"
-  | "creTeam"
   | "sreTeam"
   | "deploymentId"
   | "number"
@@ -57,23 +62,32 @@ export type AdvancedFilterField =
 
 /** How a row's value input should render for a given field+op combination. */
 export type AdvancedFilterValueKind =
-  /** Free-text, comma-separated multi-value entry. */
+  /** Free-text, comma-separated multi-value entry. Reserved for genuinely
+   * arbitrary/opaque values with no enumerable suggestion source
+   * (`deploymentId`). */
   | "multiText"
   /** Fixed-option multi-select. */
   | "multiSelect"
-  /** A single free-text value. */
+  /** A single free-text value. Reserved for genuinely arbitrary/opaque
+   * identifiers (`number`, `internalId`, `parentId`). */
   | "text"
   /** A single numeric value. */
   | "number"
   /** A single date value — a literal `YYYY-MM-DD`/RFC3339 string, or one of
-   * the relative-date placeholders (`__today__`, `__daysAgo:N__`, ...). */
-  | "date"
+   * the relative-date placeholders (`__today__`, `__daysAgo:N__`, ...),
+   * picked from a preset dropdown or an actual calendar date picker rather
+   * than hand-typed. See {@link RELATIVE_DATE_PRESETS}. */
+  | "dateOrPreset"
   /** No input at all — the op alone is the predicate (`isEmpty`/`isNotEmpty`). */
   | "none"
   /** No input — the row always means "the authenticated caller"; mirrors the
    * old `createdByMe: true` request field via
    * `BE_CURRENT_USER_FILTER_PLACEHOLDER`. */
-  | "currentUser";
+  | "currentUser"
+  /** Multi-value, backend-directory-search-backed email picker (type to
+   * search, same directory `/users/search` the assignee filter already
+   * searches) rather than hand-typed emails. */
+  | "asyncEmailMultiSelect";
 
 export interface AdvancedFilterOpMeta {
   op: BeCaseFieldFilterOp;
@@ -94,8 +108,6 @@ export interface AdvancedFilterFieldMeta {
   /** Placeholder / helper text for a `text`/`multiText`/`number` input. */
   placeholder?: string;
 }
-
-const ONBOARDING_STATUS_SUGGESTIONS: string[] = [...ALL_ONBOARDING_STATUSES];
 
 const PROJECT_TYPE_OPTIONS: { value: string; label: string }[] = [
   "Subscription",
@@ -130,24 +142,6 @@ const ESCALATION_LEVEL_OPTIONS: { value: string; label: string }[] = [
  */
 export const ADVANCED_FILTER_FIELDS: AdvancedFilterFieldMeta[] = [
   {
-    field: "tag",
-    label: "Tag",
-    ops: [
-      { op: "in", label: "is one of", valueKind: "multiText" },
-      { op: "notIn", label: "is not one of", valueKind: "multiText" },
-    ],
-    placeholder: "e.g. micro-gw, ws-policy",
-  },
-  {
-    field: "projectOnboardingStatus",
-    label: "Project onboarding status",
-    ops: [
-      { op: "in", label: "is one of", valueKind: "multiText" },
-      { op: "notIn", label: "is not one of", valueKind: "multiText" },
-    ],
-    suggestions: ONBOARDING_STATUS_SUGGESTIONS,
-  },
-  {
     field: "projectType",
     label: "Project type",
     ops: [{ op: "in", label: "is one of", valueKind: "multiSelect" }],
@@ -160,16 +154,14 @@ export const ADVANCED_FILTER_FIELDS: AdvancedFilterFieldMeta[] = [
     options: ISSUE_TYPE_OPTIONS,
   },
   {
-    field: "creTeam",
-    label: "CRE team",
-    ops: [{ op: "in", label: "is one of", valueKind: "multiText" }],
-    placeholder: "team id, or __current_team__",
-  },
-  {
+    // Options are supplied at render time by `AdvancedFiltersBuilder` (the
+    // `sreTeamOptions` prop, computed once in `CasesFilterBar.tsx` from the
+    // same `useTeams(true)` fetch the "Team" (`creTeam`) bar control uses) —
+    // not listed statically here, since the team registry is fetched data,
+    // not a fixed enum like `projectType`/`issueType` above.
     field: "sreTeam",
     label: "SRE team",
-    ops: [{ op: "in", label: "is one of", valueKind: "multiText" }],
-    placeholder: "team id",
+    ops: [{ op: "in", label: "is one of", valueKind: "multiSelect" }],
   },
   {
     field: "deploymentId",
@@ -224,38 +216,59 @@ export const ADVANCED_FILTER_FIELDS: AdvancedFilterFieldMeta[] = [
     field: "createdBy",
     label: "Created by",
     ops: [
-      { op: "in", label: "email is one of", valueKind: "multiText" },
+      { op: "in", label: "email is one of", valueKind: "asyncEmailMultiSelect" },
       { op: "eq", label: "is me", valueKind: "currentUser" },
     ],
-    placeholder: "e.g. jane.doe@example.com",
   },
   {
     field: "createdOn",
     label: "Created on",
     ops: [
-      { op: "gte", label: "is on/after", valueKind: "date" },
-      { op: "lte", label: "is on/before", valueKind: "date" },
+      { op: "gte", label: "is on/after", valueKind: "dateOrPreset" },
+      { op: "lte", label: "is on/before", valueKind: "dateOrPreset" },
     ],
-    placeholder: "YYYY-MM-DD, or __today__ / __daysAgo:N__",
   },
   {
     field: "updatedOn",
     label: "Updated on",
     ops: [
-      { op: "gte", label: "is on/after", valueKind: "date" },
-      { op: "lte", label: "is on/before", valueKind: "date" },
+      { op: "gte", label: "is on/after", valueKind: "dateOrPreset" },
+      { op: "lte", label: "is on/before", valueKind: "dateOrPreset" },
     ],
-    placeholder: "YYYY-MM-DD, or __today__ / __daysAgo:N__",
   },
   {
     field: "closedOn",
     label: "Closed on",
     ops: [
-      { op: "gte", label: "is on/after", valueKind: "date" },
-      { op: "lte", label: "is on/before", valueKind: "date" },
+      { op: "gte", label: "is on/after", valueKind: "dateOrPreset" },
+      { op: "lte", label: "is on/before", valueKind: "dateOrPreset" },
     ],
-    placeholder: "YYYY-MM-DD, or __today__ / __daysAgo:N__",
   },
+];
+
+/**
+ * Fixed set of relative-date presets offered in the `dateOrPreset` value
+ * input's preset dropdown — human labels for a subset of the placeholder
+ * grammar {@link resolveRelativeDatePlaceholder} (and the entity-service's
+ * own `resolveRelativeDate`, see `case_filters.go`) recognizes. Not
+ * exhaustive of every representable offset (`__daysAgo:N__` accepts any
+ * non-negative N) — these are the common ones; picking an exact calendar day
+ * instead covers everything else, so the grammar itself never needs to be
+ * hand-typed.
+ */
+export const RELATIVE_DATE_PRESETS: { value: string; label: string }[] = [
+  { value: "__today__", label: "Today" },
+  { value: "__daysAgo:7__", label: "7 days ago" },
+  { value: "__daysAgo:30__", label: "30 days ago" },
+  { value: "__daysAgo:90__", label: "90 days ago" },
+  { value: "__startOfMonth:0__", label: "Start of this month" },
+  { value: "__startOfMonth:-1__", label: "Start of last month" },
+  { value: "__endOfMonth:0__", label: "End of this month" },
+  { value: "__endOfMonth:-1__", label: "End of last month" },
+  { value: "__startOfQuarter:0__", label: "Start of this quarter" },
+  { value: "__startOfQuarter:-1__", label: "Start of last quarter" },
+  { value: "__endOfQuarter:0__", label: "End of this quarter" },
+  { value: "__endOfQuarter:-1__", label: "End of last quarter" },
 ];
 
 const FIELD_META_BY_FIELD: Map<AdvancedFilterField, AdvancedFilterFieldMeta> = new Map(

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/advancedFilters.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/advancedFilters.ts
@@ -16,6 +16,7 @@
 
 import type { BeCaseFieldFilter, BeCaseFieldFilterOp } from "@api/backend/types";
 import { BE_CURRENT_USER_FILTER_PLACEHOLDER } from "@api/backend/types";
+import { ALL_ISSUE_TYPES, ISSUE_TYPE_LABEL } from "@features/csm-cases/utils/caseIssueType";
 import { ALL_ONBOARDING_STATUSES } from "@features/csm-cases/utils/onboardingStatus";
 import { resolveRelativeDatePlaceholder } from "@utils/resolveRelativeDatePlaceholder";
 
@@ -38,6 +39,7 @@ export type AdvancedFilterField =
   | "tag"
   | "projectOnboardingStatus"
   | "projectType"
+  | "issueType"
   | "creTeam"
   | "sreTeam"
   | "deploymentId"
@@ -105,6 +107,11 @@ const PROJECT_TYPE_OPTIONS: { value: string; label: string }[] = [
   "Professional Services",
 ].map((v) => ({ value: v, label: v }));
 
+const ISSUE_TYPE_OPTIONS: { value: string; label: string }[] = ALL_ISSUE_TYPES.map((v) => ({
+  value: v,
+  label: ISSUE_TYPE_LABEL[v],
+}));
+
 const ESCALATION_LEVEL_OPTIONS: { value: string; label: string }[] = [
   "0",
   "1",
@@ -145,6 +152,12 @@ export const ADVANCED_FILTER_FIELDS: AdvancedFilterFieldMeta[] = [
     label: "Project type",
     ops: [{ op: "in", label: "is one of", valueKind: "multiSelect" }],
     options: PROJECT_TYPE_OPTIONS,
+  },
+  {
+    field: "issueType",
+    label: "Issue type",
+    ops: [{ op: "in", label: "is one of", valueKind: "multiSelect" }],
+    options: ISSUE_TYPE_OPTIONS,
   },
   {
     field: "creTeam",

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/advancedFilters.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/advancedFilters.ts
@@ -367,6 +367,14 @@ const MAX_ADVANCED_FILTER_VALUES_PER_ROW = 50;
  * `casesFiltersUrl.ts`: a malformed param, an unknown field/op, or an
  * over-long/over-many value list is dropped rather than raising — a
  * hand-edited or stale URL degrades to "that one row is gone", not a crash.
+ *
+ * Deliberately does **not** drop an incomplete row (field+op chosen, no
+ * value yet) — those must round-trip through the URL so the builder can
+ * re-render an in-progress row after `setSearchParams` fires (every other
+ * piece of filter state in this URL is edited the same way: write, re-read,
+ * re-render). Only {@link writeCaseSearchFilters}/`buildCaseSearchFilters`
+ * (the `/cases/search` request-payload boundary) may skip an incomplete row
+ * — never this URL-persistence boundary.
  */
 export function parseAdvancedFiltersParam(raw: string | null): AdvancedFilterRow[] {
   if (!raw) return [];
@@ -396,22 +404,34 @@ export function parseAdvancedFiltersParam(raw: string | null): AdvancedFilterRow
         .slice(0, MAX_ADVANCED_FILTER_VALUES_PER_ROW);
     }
     const row: AdvancedFilterRow = { field: field as AdvancedFilterField, op: op as BeCaseFieldFilterOp, values };
-    if (isCompleteAdvancedFilterRow(row)) rows.push(row);
+    rows.push(row);
   }
   return rows;
 }
 
 /**
- * Serializes only *complete* rows (see {@link isCompleteAdvancedFilterRow})
- * as a single JSON-encoded `af` param value — `URLSearchParams` handles the
- * percent-encoding, so no extra escaping is needed here. An in-progress row
- * (field picked, no value yet) is deliberately not persisted: reloading mid-
- * edit loses only the draft, never emits an empty predicate to the backend.
+ * Serializes every row (complete or not) as a single JSON-encoded `af` param
+ * value — `URLSearchParams` handles the percent-encoding, so no extra
+ * escaping is needed here.
+ *
+ * An in-progress row (field/op picked, no value yet) IS persisted here: this
+ * is purely the URL-persistence boundary, the same one every other filter
+ * field round-trips through, and dropping incomplete rows here — rather than
+ * only at the `/cases/search` request-payload boundary
+ * ({@link advancedFilterRowToFieldFilter}, gated by
+ * {@link isCompleteAdvancedFilterRow} in `caseSearchPayload.ts`) — is exactly
+ * the bug this comment used to describe: `CsmIssuesView` treats the URL as
+ * the single source of truth (`filters = readCasesFiltersFromUrl(searchParams)`),
+ * so a row dropped here on write never survives the round trip back into
+ * `AdvancedFiltersBuilder`'s render — the just-added "Add filter" row
+ * vanished within the same tick, before the user could ever pick a value.
+ * The backend never sees an empty predicate regardless, because
+ * `advancedFilterRowToFieldFilter` still filters incomplete rows out at
+ * request-build time.
  */
 export function writeAdvancedFiltersParam(rows: AdvancedFilterRow[]): string | null {
-  const complete = rows.filter(isCompleteAdvancedFilterRow);
-  if (complete.length === 0) return null;
+  if (rows.length === 0) return null;
   return JSON.stringify(
-    complete.map((r) => (r.values.length > 0 ? [r.field, r.op, r.values] : [r.field, r.op])),
+    rows.map((r) => (r.values.length > 0 ? [r.field, r.op, r.values] : [r.field, r.op])),
   );
 }

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/advancedFilters.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/advancedFilters.ts
@@ -234,10 +234,10 @@ export const ADVANCED_FILTER_FIELDS: AdvancedFilterFieldMeta[] = [
   {
     // Options are supplied at render time by `AdvancedFiltersBuilder` (the
     // `creTeamOptions` prop, computed in `CasesFilterBar.tsx` from the same
-    // `useTeams(true)` fetch the old "Team" bar control used) — fetched
+    // `useTeams(true)` fetch the "CRE Team" bar control used) — fetched
     // data, not a fixed enum, same reasoning as `sreTeam` below.
     field: "creTeam",
-    label: "Team",
+    label: "CRE Team",
     ops: [{ op: "in", label: "is one of", valueKind: "multiSelect" }],
   },
   {
@@ -275,9 +275,9 @@ export const ADVANCED_FILTER_FIELDS: AdvancedFilterFieldMeta[] = [
   {
     // Options are supplied at render time by `AdvancedFiltersBuilder` (the
     // `sreTeamOptions` prop, computed once in `CasesFilterBar.tsx` from the
-    // same `useTeams(true)` fetch the "Team" (`creTeam`) bar control uses) —
-    // not listed statically here, since the team registry is fetched data,
-    // not a fixed enum like `projectType`/`issueType` above.
+    // same `useTeams(true)` fetch the "CRE Team" (`creTeam`) bar control
+    // uses) — not listed statically here, since the team registry is
+    // fetched data, not a fixed enum like `projectType`/`issueType` above.
     field: "sreTeam",
     label: "SRE team",
     ops: [{ op: "in", label: "is one of", valueKind: "multiSelect" }],

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/advancedFilters.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/advancedFilters.ts
@@ -18,15 +18,27 @@ import type { BeCaseFieldFilter, BeCaseFieldFilterOp } from "@api/backend/types"
 import { BE_CURRENT_USER_FILTER_PLACEHOLDER } from "@api/backend/types";
 import { ALL_ISSUE_TYPES, ISSUE_TYPE_LABEL } from "@features/csm-cases/utils/caseIssueType";
 import { resolveRelativeDatePlaceholder } from "@utils/resolveRelativeDatePlaceholder";
+import {
+  ENGAGEMENT_TYPE_OPTIONS,
+  ONBOARDING_STATUS_OPTIONS,
+  SEVERITY_OPTIONS,
+  STATE_OPTIONS,
+  WORK_STATE_OPTIONS,
+} from "@features/csm-cases/utils/caseFilterOptions";
+import { ALL_CASE_TYPES, CASE_TYPE_LABEL } from "@features/csm-cases/utils/caseType";
 
 /**
- * The `POST /cases/search` fields the dedicated bar controls in
- * `CasesFilterBar.tsx` (severity, state, case type, work state, engagement
- * type, assignee, project, product, tags, onboarding status, CS team) do NOT
- * already cover, exposed instead through the generic "Advanced filters"
- * field/op/value builder. Every one of these is a real, backend-accepted
- * `BeCaseFieldFilterField` — see `types.ts`'s own doc comment on that enum,
- * which mirrors the entity-service's `caseFilterFieldSet` exactly.
+ * The complete `POST /cases/search` field/op catalogue offered by the
+ * unified "Advanced filters" builder — every field/op the backend accepts,
+ * whether or not it also has a value slot on `CasesFilters` (see
+ * `filterFieldAdapters.ts`'s per-field typed-adapter registry, which is what
+ * makes switching between Simple and Advanced lossless: a field with a typed
+ * adapter is rendered here from — and written back to — the same real
+ * `CasesFilters` property the Simple grid's own dedicated control reads,
+ * never a second, parallel copy of it). Every one of these is a real,
+ * backend-accepted `BeCaseFieldFilterField` — see `types.ts`'s own doc
+ * comment on that enum, which mirrors the entity-service's
+ * `caseFilterFieldSet` exactly.
  *
  * Deliberately excludes two fields a hand-off brief once listed
  * (`accountId`, `resolvedOn`): neither appears in `BeCaseFieldFilterField`,
@@ -34,16 +46,28 @@ import { resolveRelativeDatePlaceholder } from "@utils/resolveRelativeDatePlaceh
  * contract change, out of scope for this FE-only builder. Flagged in
  * `PROGRESS.md`, not silently worked around.
  *
- * Also deliberately excludes `tag`, `projectOnboardingStatus`, and `creTeam`
- * even though all three are real, accepted fields: each already has its own
- * dedicated bar control in `CasesFilterBar.tsx` (the "Tags" tri-state
- * control, "Onboarding status", and "Team" respectively). Offering a second,
- * generic advanced-filter row for the same backend field alongside its own
- * dedicated control would be two independent UI paths writing the same
- * `/cases/search` predicate — confusing, not additive. Removed 2026-08-31
- * (they were briefly in this catalogue before the duplication was caught).
+ * `tag`, `projectOnboardingStatus`, and `creTeam` were briefly excluded here
+ * (2026-08-31) on the theory that a field with its own dedicated Simple-grid
+ * control shouldn't also get a second, generic row — that created two
+ * independent UI paths writing the same predicate. The unification that
+ * follows replaces that with a single rule instead: every field lives here,
+ * and a field with a typed adapter is *rendered differently* depending on
+ * mode (a dedicated control in Simple, a generic row in Advanced) while
+ * writing to the exact same `CasesFilters` property either way — so there is
+ * only ever one UI path per field, not two.
  */
 export type AdvancedFilterField =
+  | "severity"
+  | "state"
+  | "workState"
+  | "type"
+  | "assignedUserId"
+  | "projectId"
+  | "product"
+  | "creTeam"
+  | "tag"
+  | "engagementType"
+  | "projectOnboardingStatus"
   | "projectType"
   | "issueType"
   | "sreTeam"
@@ -86,8 +110,27 @@ export type AdvancedFilterValueKind =
   | "currentUser"
   /** Multi-value, backend-directory-search-backed email picker (type to
    * search, same directory `/users/search` the assignee filter already
-   * searches) rather than hand-typed emails. */
-  | "asyncEmailMultiSelect";
+   * searches) rather than hand-typed emails. `createdBy`'s `in` op only —
+   * `assignedUserId` uses {@link AdvancedFilterValueKind.asyncAssigneeMultiSelect}
+   * instead (it also offers the `@me` sentinel, `createdBy` does not). */
+  | "asyncEmailMultiSelect"
+  /** {@link AsyncAssigneeMultiSelect} — the `assignedUserId` row's value
+   * input, same user-directory search plus the pinned `@me` sentinel the
+   * Simple grid's own "Assignee" control uses. */
+  | "asyncAssigneeMultiSelect"
+  /** {@link AsyncProjectMultiSelect} — the `projectId` row's value input,
+   * same type-to-search project picker the Simple grid's own "Project"
+   * control uses. */
+  | "asyncProjectMultiSelect"
+  /** {@link ProductNameMultiSelect} — the `product` row's value input, same
+   * type-to-search product-name picker the Simple grid's own "Product"
+   * control uses. */
+  | "asyncProductMultiSelect"
+  /** {@link AsyncTagMultiSelect} — the `tag` row's value input (both `in`
+   * and `notIn` ops), same `/tags/search` type-ahead the removed dedicated
+   * "Tags" bar control used, minus its tri-state cycling (the row's own op
+   * carries the include/exclude direction now). */
+  | "asyncTagMultiSelect";
 
 export interface AdvancedFilterOpMeta {
   op: BeCaseFieldFilterOp;
@@ -124,6 +167,11 @@ const ISSUE_TYPE_OPTIONS: { value: string; label: string }[] = ALL_ISSUE_TYPES.m
   label: ISSUE_TYPE_LABEL[v],
 }));
 
+const CASE_TYPE_OPTIONS: { value: string; label: string }[] = ALL_CASE_TYPES.map((v) => ({
+  value: v,
+  label: CASE_TYPE_LABEL[v],
+}));
+
 const ESCALATION_LEVEL_OPTIONS: { value: string; label: string }[] = [
   "0",
   "1",
@@ -141,6 +189,77 @@ const ESCALATION_LEVEL_OPTIONS: { value: string; label: string }[] = [
  * something to extend speculatively.
  */
 export const ADVANCED_FILTER_FIELDS: AdvancedFilterFieldMeta[] = [
+  {
+    field: "severity",
+    label: "Severity",
+    ops: [{ op: "in", label: "is one of", valueKind: "multiSelect" }],
+    options: SEVERITY_OPTIONS,
+  },
+  {
+    field: "state",
+    label: "State",
+    ops: [
+      { op: "in", label: "is one of", valueKind: "multiSelect" },
+      { op: "notIn", label: "is not one of", valueKind: "multiSelect" },
+    ],
+    options: STATE_OPTIONS,
+  },
+  {
+    field: "workState",
+    label: "Work state",
+    ops: [{ op: "in", label: "is one of", valueKind: "multiSelect" }],
+    options: WORK_STATE_OPTIONS,
+  },
+  {
+    field: "type",
+    label: "Case type",
+    ops: [{ op: "in", label: "is one of", valueKind: "multiSelect" }],
+    options: CASE_TYPE_OPTIONS,
+  },
+  {
+    field: "assignedUserId",
+    label: "Assignee",
+    ops: [{ op: "in", label: "is one of", valueKind: "asyncAssigneeMultiSelect" }],
+  },
+  {
+    field: "projectId",
+    label: "Project",
+    ops: [{ op: "in", label: "is one of", valueKind: "asyncProjectMultiSelect" }],
+  },
+  {
+    field: "product",
+    label: "Product",
+    ops: [{ op: "in", label: "is one of", valueKind: "asyncProductMultiSelect" }],
+  },
+  {
+    // Options are supplied at render time by `AdvancedFiltersBuilder` (the
+    // `creTeamOptions` prop, computed in `CasesFilterBar.tsx` from the same
+    // `useTeams(true)` fetch the old "Team" bar control used) — fetched
+    // data, not a fixed enum, same reasoning as `sreTeam` below.
+    field: "creTeam",
+    label: "Team",
+    ops: [{ op: "in", label: "is one of", valueKind: "multiSelect" }],
+  },
+  {
+    field: "tag",
+    label: "Tag",
+    ops: [
+      { op: "in", label: "includes", valueKind: "asyncTagMultiSelect" },
+      { op: "notIn", label: "excludes", valueKind: "asyncTagMultiSelect" },
+    ],
+  },
+  {
+    field: "engagementType",
+    label: "Engagement type",
+    ops: [{ op: "in", label: "is one of", valueKind: "multiSelect" }],
+    options: ENGAGEMENT_TYPE_OPTIONS,
+  },
+  {
+    field: "projectOnboardingStatus",
+    label: "Onboarding status",
+    ops: [{ op: "in", label: "is one of", valueKind: "multiSelect" }],
+    options: ONBOARDING_STATUS_OPTIONS,
+  },
   {
     field: "projectType",
     label: "Project type",

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/advancedFilters.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/advancedFilters.ts
@@ -1,0 +1,404 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { BeCaseFieldFilter, BeCaseFieldFilterOp } from "@api/backend/types";
+import { BE_CURRENT_USER_FILTER_PLACEHOLDER } from "@api/backend/types";
+import { ALL_ONBOARDING_STATUSES } from "@features/csm-cases/utils/onboardingStatus";
+import { resolveRelativeDatePlaceholder } from "@utils/resolveRelativeDatePlaceholder";
+
+/**
+ * The `POST /cases/search` fields the dedicated bar controls in
+ * `CasesFilterBar.tsx` (severity, state, case type, work state, engagement
+ * type, assignee, project, product) do NOT already cover, exposed instead
+ * through the generic "Advanced filters" field/op/value builder. Every one
+ * of these is a real, backend-accepted `BeCaseFieldFilterField` — see
+ * `types.ts`'s own doc comment on that enum, which mirrors the
+ * entity-service's `caseFilterFieldSet` exactly.
+ *
+ * Deliberately excludes two fields a hand-off brief once listed
+ * (`accountId`, `resolvedOn`): neither appears in `BeCaseFieldFilterField`,
+ * so the backend would reject them — widening that enum is a backend
+ * contract change, out of scope for this FE-only builder. Flagged in
+ * `PROGRESS.md`, not silently worked around.
+ */
+export type AdvancedFilterField =
+  | "tag"
+  | "projectOnboardingStatus"
+  | "projectType"
+  | "creTeam"
+  | "sreTeam"
+  | "deploymentId"
+  | "number"
+  | "internalId"
+  | "resolutionNotes"
+  | "parentId"
+  | "taskSLABusinessElapsedPercent"
+  | "escalationLevel"
+  | "escalation"
+  | "createdBy"
+  | "createdOn"
+  | "updatedOn"
+  | "closedOn";
+
+/** How a row's value input should render for a given field+op combination. */
+export type AdvancedFilterValueKind =
+  /** Free-text, comma-separated multi-value entry. */
+  | "multiText"
+  /** Fixed-option multi-select. */
+  | "multiSelect"
+  /** A single free-text value. */
+  | "text"
+  /** A single numeric value. */
+  | "number"
+  /** A single date value — a literal `YYYY-MM-DD`/RFC3339 string, or one of
+   * the relative-date placeholders (`__today__`, `__daysAgo:N__`, ...). */
+  | "date"
+  /** No input at all — the op alone is the predicate (`isEmpty`/`isNotEmpty`). */
+  | "none"
+  /** No input — the row always means "the authenticated caller"; mirrors the
+   * old `createdByMe: true` request field via
+   * `BE_CURRENT_USER_FILTER_PLACEHOLDER`. */
+  | "currentUser";
+
+export interface AdvancedFilterOpMeta {
+  op: BeCaseFieldFilterOp;
+  /** Shown in the operator `Select`. */
+  label: string;
+  valueKind: AdvancedFilterValueKind;
+}
+
+export interface AdvancedFilterFieldMeta {
+  field: AdvancedFilterField;
+  label: string;
+  ops: AdvancedFilterOpMeta[];
+  /** Fixed options for a `multiSelect` value kind. */
+  options?: { value: string; label: string }[];
+  /** Free-text suggestions for a `multiText` value kind (open vocabulary —
+   * offered, not enforced). */
+  suggestions?: string[];
+  /** Placeholder / helper text for a `text`/`multiText`/`number` input. */
+  placeholder?: string;
+}
+
+const ONBOARDING_STATUS_SUGGESTIONS: string[] = [...ALL_ONBOARDING_STATUSES];
+
+const PROJECT_TYPE_OPTIONS: { value: string; label: string }[] = [
+  "Subscription",
+  "Managed Cloud Subscription",
+  "Evaluation Subscription",
+  "Development Support",
+  "Cloud Support",
+  "Cloud Evaluation Support",
+  "Professional Services",
+].map((v) => ({ value: v, label: v }));
+
+const ESCALATION_LEVEL_OPTIONS: { value: string; label: string }[] = [
+  "0",
+  "1",
+  "2",
+  "3",
+  "4",
+  "5",
+].map((v) => ({ value: v, label: v }));
+
+/**
+ * Ordered field catalogue backing the "Advanced filters" builder — the
+ * single source of truth for which fields/ops/value shapes are offered.
+ * Keep in sync with the field/op/value contract table this was built from
+ * (see the task brief); it mirrors a live-verified backend contract, not
+ * something to extend speculatively.
+ */
+export const ADVANCED_FILTER_FIELDS: AdvancedFilterFieldMeta[] = [
+  {
+    field: "tag",
+    label: "Tag",
+    ops: [
+      { op: "in", label: "is one of", valueKind: "multiText" },
+      { op: "notIn", label: "is not one of", valueKind: "multiText" },
+    ],
+    placeholder: "e.g. micro-gw, ws-policy",
+  },
+  {
+    field: "projectOnboardingStatus",
+    label: "Project onboarding status",
+    ops: [
+      { op: "in", label: "is one of", valueKind: "multiText" },
+      { op: "notIn", label: "is not one of", valueKind: "multiText" },
+    ],
+    suggestions: ONBOARDING_STATUS_SUGGESTIONS,
+  },
+  {
+    field: "projectType",
+    label: "Project type",
+    ops: [{ op: "in", label: "is one of", valueKind: "multiSelect" }],
+    options: PROJECT_TYPE_OPTIONS,
+  },
+  {
+    field: "creTeam",
+    label: "CRE team",
+    ops: [{ op: "in", label: "is one of", valueKind: "multiText" }],
+    placeholder: "team id, or __current_team__",
+  },
+  {
+    field: "sreTeam",
+    label: "SRE team",
+    ops: [{ op: "in", label: "is one of", valueKind: "multiText" }],
+    placeholder: "team id",
+  },
+  {
+    field: "deploymentId",
+    label: "Deployment ID",
+    ops: [{ op: "in", label: "is one of", valueKind: "multiText" }],
+    placeholder: "deployment id",
+  },
+  {
+    field: "number",
+    label: "Case number",
+    ops: [{ op: "eq", label: "is", valueKind: "text" }],
+    placeholder: "e.g. CS0441174",
+  },
+  {
+    field: "internalId",
+    label: "WSO2 case ID",
+    ops: [{ op: "eq", label: "is", valueKind: "text" }],
+  },
+  {
+    field: "resolutionNotes",
+    label: "Resolution notes",
+    ops: [{ op: "isEmpty", label: "is empty", valueKind: "none" }],
+  },
+  {
+    field: "parentId",
+    label: "Parent case ID",
+    ops: [{ op: "eq", label: "is", valueKind: "text" }],
+  },
+  {
+    field: "taskSLABusinessElapsedPercent",
+    label: "SLA business-elapsed %",
+    ops: [
+      { op: "gte", label: "is at least", valueKind: "number" },
+      { op: "lte", label: "is at most", valueKind: "number" },
+    ],
+  },
+  {
+    field: "escalationLevel",
+    label: "Escalation level",
+    ops: [{ op: "in", label: "is one of", valueKind: "multiSelect" }],
+    options: ESCALATION_LEVEL_OPTIONS,
+  },
+  {
+    field: "escalation",
+    label: "Escalation",
+    ops: [
+      { op: "isNotEmpty", label: "is active", valueKind: "none" },
+      { op: "isEmpty", label: "has none", valueKind: "none" },
+    ],
+  },
+  {
+    field: "createdBy",
+    label: "Created by",
+    ops: [
+      { op: "in", label: "email is one of", valueKind: "multiText" },
+      { op: "eq", label: "is me", valueKind: "currentUser" },
+    ],
+    placeholder: "e.g. jane.doe@example.com",
+  },
+  {
+    field: "createdOn",
+    label: "Created on",
+    ops: [
+      { op: "gte", label: "is on/after", valueKind: "date" },
+      { op: "lte", label: "is on/before", valueKind: "date" },
+    ],
+    placeholder: "YYYY-MM-DD, or __today__ / __daysAgo:N__",
+  },
+  {
+    field: "updatedOn",
+    label: "Updated on",
+    ops: [
+      { op: "gte", label: "is on/after", valueKind: "date" },
+      { op: "lte", label: "is on/before", valueKind: "date" },
+    ],
+    placeholder: "YYYY-MM-DD, or __today__ / __daysAgo:N__",
+  },
+  {
+    field: "closedOn",
+    label: "Closed on",
+    ops: [
+      { op: "gte", label: "is on/after", valueKind: "date" },
+      { op: "lte", label: "is on/before", valueKind: "date" },
+    ],
+    placeholder: "YYYY-MM-DD, or __today__ / __daysAgo:N__",
+  },
+];
+
+const FIELD_META_BY_FIELD: Map<AdvancedFilterField, AdvancedFilterFieldMeta> = new Map(
+  ADVANCED_FILTER_FIELDS.map((m) => [m.field, m]),
+);
+
+const ALL_ADVANCED_FIELDS: AdvancedFilterField[] = ADVANCED_FILTER_FIELDS.map((m) => m.field);
+
+export function getAdvancedFilterFieldMeta(
+  field: string,
+): AdvancedFilterFieldMeta | undefined {
+  return FIELD_META_BY_FIELD.get(field as AdvancedFilterField);
+}
+
+export function getAdvancedFilterOpMeta(
+  field: string,
+  op: string,
+): AdvancedFilterOpMeta | undefined {
+  return getAdvancedFilterFieldMeta(field)?.ops.find((o) => o.op === op);
+}
+
+/** One advanced-filter builder row: an ad-hoc field/op/value predicate. */
+export interface AdvancedFilterRow {
+  field: AdvancedFilterField;
+  op: BeCaseFieldFilterOp;
+  /** Empty for a value-less op (`isEmpty`/`isNotEmpty`) or the `currentUser`
+   * value kind (the fixed placeholder value is filled in at request-build
+   * time, not stored here). */
+  values: string[];
+}
+
+export function defaultAdvancedFilterRow(): AdvancedFilterRow {
+  const first = ADVANCED_FILTER_FIELDS[0];
+  return { field: first.field, op: first.ops[0].op, values: [] };
+}
+
+/**
+ * A row is only worth emitting (into the URL or the `/cases/search` payload)
+ * once it carries everything its op needs — never an empty predicate. Ops
+ * with no value requirement (`none`/`currentUser`) are complete as soon as
+ * the field+op is chosen.
+ */
+export function isCompleteAdvancedFilterRow(row: AdvancedFilterRow): boolean {
+  const opMeta = getAdvancedFilterOpMeta(row.field, row.op);
+  if (!opMeta) return false;
+  if (opMeta.valueKind === "none" || opMeta.valueKind === "currentUser") return true;
+  return row.values.some((v) => v.trim().length > 0);
+}
+
+/**
+ * Converts one complete advanced-filter row into the `/cases/search`
+ * `BeCaseFieldFilter` shape. Returns `undefined` for an incomplete row (the
+ * caller should already have filtered those out via
+ * {@link isCompleteAdvancedFilterRow}, but this stays defensive rather than
+ * emitting an empty predicate).
+ */
+export function advancedFilterRowToFieldFilter(
+  row: AdvancedFilterRow,
+): BeCaseFieldFilter | undefined {
+  const opMeta = getAdvancedFilterOpMeta(row.field, row.op);
+  if (!opMeta) return undefined;
+  if (opMeta.valueKind === "none") {
+    return { field: row.field, op: row.op };
+  }
+  if (opMeta.valueKind === "currentUser") {
+    return { field: row.field, op: row.op, values: [BE_CURRENT_USER_FILTER_PLACEHOLDER] };
+  }
+  const values = row.values.map((v) => v.trim()).filter((v) => v.length > 0);
+  if (values.length === 0) return undefined;
+  return { field: row.field, op: row.op, values };
+}
+
+/**
+ * Resolves relative-date placeholders (`__today__`, `__daysAgo:N__`, ...) in
+ * any `createdOn`/`updatedOn`/`closedOn` row's values against `now`, the same
+ * grammar/resolver the dedicated `createdOnGte`/`createdOnLte` bar filter
+ * already uses (see `useGetCsmCases.ts`). A literal date (or anything
+ * unrecognized) passes through unchanged. Returns a new array; input rows are
+ * never mutated.
+ */
+export function resolveAdvancedFilterDateValues(
+  rows: AdvancedFilterRow[],
+  now: Date,
+): AdvancedFilterRow[] {
+  const DATE_FIELDS: ReadonlySet<AdvancedFilterField> = new Set([
+    "createdOn",
+    "updatedOn",
+    "closedOn",
+  ]);
+  return rows.map((row) => {
+    if (!DATE_FIELDS.has(row.field)) return row;
+    if (row.op !== "gte" && row.op !== "lte") return row;
+    return {
+      ...row,
+      values: row.values.map(
+        (v) => resolveRelativeDatePlaceholder(v, row.op, now) ?? v,
+      ),
+    };
+  });
+}
+
+const MAX_ADVANCED_FILTER_ROWS = 20;
+const MAX_ADVANCED_FILTER_VALUE_LEN = 200;
+const MAX_ADVANCED_FILTER_VALUES_PER_ROW = 50;
+
+/**
+ * Parses the `af` URL param (see `writeAdvancedFiltersToUrl`) back into rows.
+ * Same "silently drop, never throw" policy as every other reader in
+ * `casesFiltersUrl.ts`: a malformed param, an unknown field/op, or an
+ * over-long/over-many value list is dropped rather than raising — a
+ * hand-edited or stale URL degrades to "that one row is gone", not a crash.
+ */
+export function parseAdvancedFiltersParam(raw: string | null): AdvancedFilterRow[] {
+  if (!raw) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(parsed)) return [];
+
+  const rows: AdvancedFilterRow[] = [];
+  for (const entry of parsed.slice(0, MAX_ADVANCED_FILTER_ROWS)) {
+    if (!Array.isArray(entry) || entry.length < 2 || entry.length > 3) continue;
+    const [field, op, rawValues] = entry as [unknown, unknown, unknown];
+    if (typeof field !== "string" || typeof op !== "string") continue;
+    if (!ALL_ADVANCED_FIELDS.includes(field as AdvancedFilterField)) continue;
+    const opMeta = getAdvancedFilterOpMeta(field, op);
+    if (!opMeta) continue;
+
+    let values: string[] = [];
+    if (rawValues !== undefined) {
+      if (!Array.isArray(rawValues)) continue;
+      values = rawValues
+        .filter((v): v is string => typeof v === "string")
+        .map((v) => v.slice(0, MAX_ADVANCED_FILTER_VALUE_LEN))
+        .slice(0, MAX_ADVANCED_FILTER_VALUES_PER_ROW);
+    }
+    const row: AdvancedFilterRow = { field: field as AdvancedFilterField, op: op as BeCaseFieldFilterOp, values };
+    if (isCompleteAdvancedFilterRow(row)) rows.push(row);
+  }
+  return rows;
+}
+
+/**
+ * Serializes only *complete* rows (see {@link isCompleteAdvancedFilterRow})
+ * as a single JSON-encoded `af` param value — `URLSearchParams` handles the
+ * percent-encoding, so no extra escaping is needed here. An in-progress row
+ * (field picked, no value yet) is deliberately not persisted: reloading mid-
+ * edit loses only the draft, never emits an empty predicate to the backend.
+ */
+export function writeAdvancedFiltersParam(rows: AdvancedFilterRow[]): string | null {
+  const complete = rows.filter(isCompleteAdvancedFilterRow);
+  if (complete.length === 0) return null;
+  return JSON.stringify(
+    complete.map((r) => (r.values.length > 0 ? [r.field, r.op, r.values] : [r.field, r.op])),
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/anyOfFilters.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/anyOfFilters.test.ts
@@ -1,0 +1,95 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { describe, expect, it } from "vitest";
+import {
+  ANY_OF_FILTER_FIELDS,
+  anyOfBranchToPayload,
+  isCompleteAnyOfBranch,
+  isCompleteAnyOfFilterRow,
+  type AnyOfBranch,
+} from "./anyOfFilters";
+
+describe("ANY_OF_FILTER_FIELDS — branch field allowlist", () => {
+  it("offers exactly the backend-accepted CaseFilterGroup fields", () => {
+    const fields = ANY_OF_FILTER_FIELDS.map((m) => m.field).sort();
+    expect(fields).toEqual(
+      [
+        "assignedUserId",
+        "deploymentId",
+        "engagementType",
+        "escalationLevel",
+        "issueType",
+        "projectId",
+        "severity",
+        "state",
+        "type",
+        "workState",
+      ].sort(),
+    );
+  });
+
+  it("every field is in-only (no notIn/isEmpty inside a branch)", () => {
+    for (const meta of ANY_OF_FILTER_FIELDS) {
+      expect(meta.op).toBe("in");
+    }
+  });
+});
+
+describe("isCompleteAnyOfFilterRow / isCompleteAnyOfBranch", () => {
+  it("a row with no values is incomplete", () => {
+    expect(isCompleteAnyOfFilterRow({ field: "type", values: [] })).toBe(false);
+  });
+
+  it("a row with a value is complete", () => {
+    expect(isCompleteAnyOfFilterRow({ field: "type", values: ["case"] })).toBe(true);
+  });
+
+  it("a branch with only incomplete rows is incomplete", () => {
+    const branch: AnyOfBranch = { filters: [{ field: "type", values: [] }] };
+    expect(isCompleteAnyOfBranch(branch)).toBe(false);
+  });
+
+  it("a branch with at least one complete row is complete", () => {
+    const branch: AnyOfBranch = {
+      filters: [{ field: "type", values: [] }, { field: "severity", values: ["critical"] }],
+    };
+    expect(isCompleteAnyOfBranch(branch)).toBe(true);
+  });
+});
+
+describe("anyOfBranchToPayload", () => {
+  it("emits {filters: [...]} for a branch with complete conditions, dropping incomplete ones", () => {
+    const branch: AnyOfBranch = {
+      filters: [
+        { field: "type", values: ["case"] },
+        { field: "severity", values: [] },
+        { field: "workState", values: ["ongoing", "paused"] },
+      ],
+    };
+    expect(anyOfBranchToPayload(branch)).toEqual({
+      filters: [
+        { field: "type", op: "in", values: ["case"] },
+        { field: "workState", op: "in", values: ["ongoing", "paused"] },
+      ],
+    });
+  });
+
+  it("returns undefined for a branch with zero complete conditions (never emits {filters: []})", () => {
+    const branch: AnyOfBranch = { filters: [{ field: "type", values: [] }] };
+    expect(anyOfBranchToPayload(branch)).toBeUndefined();
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/anyOfFilters.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/anyOfFilters.ts
@@ -1,0 +1,366 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { BeCaseFieldFilter } from "@api/backend/types";
+import { priorityFromSeverity } from "@api/backend/mappers";
+import type { Severity } from "@features/csm-dashboard/types/abtDashboard";
+import { STATE_LABEL } from "@features/csm-dashboard/utils/abtDashboard";
+import { beStateFromUi } from "@api/backend/mappers";
+import { ALL_CASE_TYPES, CASE_TYPE_LABEL } from "@features/csm-cases/utils/caseType";
+import { ALL_ISSUE_TYPES, ISSUE_TYPE_LABEL } from "@features/csm-cases/utils/caseIssueType";
+
+/**
+ * `filters.anyOf` branch field allowlist (`CaseFilterGroup` on the backend —
+ * see `case_filters.go` / the `POST /cases/search` reference doc's own
+ * `filters.anyOf` section). Deliberately a **much** narrower set than
+ * {@link ADVANCED_FILTER_FIELDS "the top-level Advanced filters catalogue"}
+ * — the backend rejects anything outside it by name (`anyOf[i].filters:
+ * unsupported field: x`), so the UI must not offer a field here it can't
+ * accept. `state` is `in`-only inside a branch (no `notIn`), and
+ * `assignedUserId` is `in`-only (no `isEmpty`) — both narrower than their
+ * top-level-filter counterparts, which is why this is its own small
+ * catalogue rather than a filtered view of the top-level one.
+ */
+export type AnyOfFilterField =
+  | "type"
+  | "state"
+  | "severity"
+  | "engagementType"
+  | "issueType"
+  | "workState"
+  | "projectId"
+  | "deploymentId"
+  | "assignedUserId"
+  | "escalationLevel";
+
+/** How an `anyOf` branch row's value input should render. Narrower than
+ * {@link AdvancedFilterValueKind} — every branch field has a real, closed
+ * enum, an async directory search, or (for `deploymentId`) is genuinely
+ * arbitrary free text; nothing here needs the top-level catalogue's date/
+ * number/current-user shapes. */
+export type AnyOfValueKind =
+  | "multiSelect"
+  | "multiText"
+  | "asyncProject"
+  | "asyncAssignedUser";
+
+export interface AnyOfFilterFieldMeta {
+  field: AnyOfFilterField;
+  label: string;
+  /** Every branch field in this catalogue is `in`-only (see the type doc
+   * comment above) — one op per field, not an ops array, since there is
+   * never a choice to present. */
+  op: "in";
+  opLabel: string;
+  valueKind: AnyOfValueKind;
+  /** Fixed options for a `multiSelect` value kind. */
+  options?: { value: string; label: string }[];
+  placeholder?: string;
+}
+
+const ANY_OF_TYPE_OPTIONS = ALL_CASE_TYPES.map((v) => ({ value: v, label: CASE_TYPE_LABEL[v] }));
+
+// `state` inside a branch is `in`-only. Excludes `reopened`, same as the
+// bar's own `PRIMARY_STATES` (`CasesFilterBar.tsx`) — it's a valid backend
+// enum value, but never a case's own `state` (only ever a `nextStates`
+// transition marker, see `CaseState`'s own doc comment), so offering it here
+// would suggest a filter that can never match anything.
+const ANY_OF_STATE_VALUES: (keyof typeof STATE_LABEL)[] = [
+  "open",
+  "work_in_progress",
+  "solution_proposed",
+  "awaiting_info",
+  "waiting_on_wso2",
+  "closed",
+];
+const ANY_OF_STATE_OPTIONS = ANY_OF_STATE_VALUES.map((v) => ({
+  value: beStateFromUi(v),
+  label: STATE_LABEL[v],
+}));
+
+const ANY_OF_SEVERITY_VALUES: Severity[] = ["S0", "S1", "S2", "S3", "S4"];
+const ANY_OF_SEVERITY_OPTIONS = ANY_OF_SEVERITY_VALUES.map((v) => ({
+  value: priorityFromSeverity(v),
+  label: v,
+}));
+
+const ANY_OF_ENGAGEMENT_TYPE_OPTIONS: { value: string; label: string }[] = [
+  { value: "migration", label: "Migration" },
+  { value: "consultancy", label: "Consultancy" },
+  { value: "new_feature_improvement", label: "New feature / improvement" },
+  { value: "follow_up", label: "Follow-up" },
+  { value: "onboarding", label: "Onboarding" },
+];
+
+const ANY_OF_ISSUE_TYPE_OPTIONS = ALL_ISSUE_TYPES.map((v) => ({
+  value: v,
+  label: ISSUE_TYPE_LABEL[v],
+}));
+
+const ANY_OF_WORK_STATE_OPTIONS: { value: string; label: string }[] = [
+  { value: "ongoing", label: "Ongoing" },
+  { value: "paused", label: "Paused" },
+];
+
+const ESCALATION_LEVEL_OPTIONS: { value: string; label: string }[] = [
+  "0",
+  "1",
+  "2",
+  "3",
+  "4",
+  "5",
+].map((v) => ({ value: v, label: v }));
+
+/**
+ * Ordered field catalogue backing the "OR groups" (`filters.anyOf`) branch
+ * builder — the single source of truth for which fields are offered inside
+ * a branch. Every field is real, backend-accepted, and matches the
+ * `CaseFilterGroup` allowlist exactly; do not extend speculatively.
+ */
+export const ANY_OF_FILTER_FIELDS: AnyOfFilterFieldMeta[] = [
+  {
+    field: "type",
+    label: "Case type",
+    op: "in",
+    opLabel: "is one of",
+    valueKind: "multiSelect",
+    options: ANY_OF_TYPE_OPTIONS,
+  },
+  {
+    field: "state",
+    label: "State",
+    op: "in",
+    opLabel: "is one of",
+    valueKind: "multiSelect",
+    options: ANY_OF_STATE_OPTIONS,
+  },
+  {
+    field: "severity",
+    label: "Severity",
+    op: "in",
+    opLabel: "is one of",
+    valueKind: "multiSelect",
+    options: ANY_OF_SEVERITY_OPTIONS,
+  },
+  {
+    field: "engagementType",
+    label: "Engagement type",
+    op: "in",
+    opLabel: "is one of",
+    valueKind: "multiSelect",
+    options: ANY_OF_ENGAGEMENT_TYPE_OPTIONS,
+  },
+  {
+    field: "issueType",
+    label: "Issue type",
+    op: "in",
+    opLabel: "is one of",
+    valueKind: "multiSelect",
+    options: ANY_OF_ISSUE_TYPE_OPTIONS,
+  },
+  {
+    field: "workState",
+    label: "Work state",
+    op: "in",
+    opLabel: "is one of",
+    valueKind: "multiSelect",
+    options: ANY_OF_WORK_STATE_OPTIONS,
+  },
+  {
+    field: "projectId",
+    label: "Project",
+    op: "in",
+    opLabel: "is one of",
+    // Rendered by `AsyncProjectMultiSelect` (type-to-search) — same
+    // component/hook the top-level "Project" bar control already uses.
+    // Values are project ids.
+    valueKind: "asyncProject",
+  },
+  {
+    field: "deploymentId",
+    label: "Deployment ID",
+    op: "in",
+    opLabel: "is one of",
+    // No deployment-search component/hook exists anywhere in this webapp
+    // (confirmed by search) and — unlike tags/teams/projects — there is no
+    // small enumerable global set to suggest from, so this stays free text,
+    // same as the top-level Advanced filters catalogue's own `deploymentId`.
+    valueKind: "multiText",
+    placeholder: "deployment id",
+  },
+  {
+    field: "assignedUserId",
+    label: "Assignee",
+    op: "in",
+    opLabel: "is one of",
+    // Rendered by an async user-directory search (`/users/search`), same
+    // directory the top-level "Assignee" bar control searches — values are
+    // user ids (not emails), since that's what `assignedUserId` filters on
+    // and picking from search results avoids a separate email→id resolution
+    // step at request-build time.
+    valueKind: "asyncAssignedUser",
+  },
+  {
+    field: "escalationLevel",
+    label: "Escalation level",
+    op: "in",
+    opLabel: "is one of",
+    valueKind: "multiSelect",
+    options: ESCALATION_LEVEL_OPTIONS,
+  },
+];
+
+const ANY_OF_FIELD_META_BY_FIELD: Map<AnyOfFilterField, AnyOfFilterFieldMeta> = new Map(
+  ANY_OF_FILTER_FIELDS.map((m) => [m.field, m]),
+);
+
+const ALL_ANY_OF_FIELDS: AnyOfFilterField[] = ANY_OF_FILTER_FIELDS.map((m) => m.field);
+
+export function getAnyOfFilterFieldMeta(field: string): AnyOfFilterFieldMeta | undefined {
+  return ANY_OF_FIELD_META_BY_FIELD.get(field as AnyOfFilterField);
+}
+
+/** One `anyOf` branch's row: an ad-hoc field/value predicate — no `op`
+ * carried per-row, since every branch field is `in`-only (see
+ * {@link AnyOfFilterFieldMeta}'s doc comment). */
+export interface AnyOfFilterRow {
+  field: AnyOfFilterField;
+  values: string[];
+}
+
+/** One OR-branch: its own rows are ANDed together; branches themselves are
+ * OR'd (see `filters.anyOf` in the `POST /cases/search` reference). */
+export interface AnyOfBranch {
+  filters: AnyOfFilterRow[];
+}
+
+export function defaultAnyOfFilterRow(): AnyOfFilterRow {
+  return { field: ANY_OF_FILTER_FIELDS[0].field, values: [] };
+}
+
+export function defaultAnyOfBranch(): AnyOfBranch {
+  return { filters: [defaultAnyOfFilterRow()] };
+}
+
+/** A row is only worth emitting once it carries at least one value — every
+ * branch field in this catalogue requires `values` (none is a value-less op
+ * like the top-level catalogue's `isEmpty`/`isNotEmpty`). */
+export function isCompleteAnyOfFilterRow(row: AnyOfFilterRow): boolean {
+  if (!getAnyOfFilterFieldMeta(row.field)) return false;
+  return row.values.some((v) => v.trim().length > 0);
+}
+
+/** A branch is only worth emitting once it has at least one complete row —
+ * the backend 400s on an empty branch (`"anyOf": [{}]`), so a branch with
+ * zero complete conditions must never reach the request payload. */
+export function isCompleteAnyOfBranch(branch: AnyOfBranch): boolean {
+  return branch.filters.some(isCompleteAnyOfFilterRow);
+}
+
+/** Converts one complete `anyOf` row into the `BeCaseFieldFilter` shape.
+ * Returns `undefined` for an incomplete row — callers should already have
+ * filtered those out via {@link isCompleteAnyOfFilterRow}. */
+export function anyOfFilterRowToFieldFilter(row: AnyOfFilterRow): BeCaseFieldFilter | undefined {
+  const meta = getAnyOfFilterFieldMeta(row.field);
+  if (!meta) return undefined;
+  const values = row.values.map((v) => v.trim()).filter((v) => v.length > 0);
+  if (values.length === 0) return undefined;
+  return { field: row.field, op: meta.op, values };
+}
+
+/** Converts one complete branch into the `{filters: BeCaseFieldFilter[]}`
+ * shape `filters.anyOf[i]` expects. Returns `undefined` for a branch with no
+ * complete rows — never emits `{filters: []}`, which the backend also
+ * rejects. */
+export function anyOfBranchToPayload(
+  branch: AnyOfBranch,
+): { filters: BeCaseFieldFilter[] } | undefined {
+  const filters = branch.filters
+    .filter(isCompleteAnyOfFilterRow)
+    .map(anyOfFilterRowToFieldFilter)
+    .filter((f): f is BeCaseFieldFilter => f !== undefined);
+  if (filters.length === 0) return undefined;
+  return { filters };
+}
+
+const MAX_ANY_OF_BRANCHES = 10;
+const MAX_ANY_OF_ROWS_PER_BRANCH = 20;
+const MAX_ANY_OF_VALUE_LEN = 200;
+const MAX_ANY_OF_VALUES_PER_ROW = 50;
+
+/**
+ * Parses the `anyOf` URL param (see `writeAnyOfBranchesParam`) back into
+ * branches. Same "silently drop, never throw" policy as
+ * `parseAdvancedFiltersParam`: a malformed param, an unknown field, or an
+ * over-long/over-many value list degrades to "that row/branch is gone," not
+ * a crash. An incomplete row (field picked, no value yet) — and an empty
+ * branch (no rows at all, or only incomplete ones) — both round-trip here
+ * unchanged: this is purely the URL-persistence boundary, the same
+ * "never drop an in-progress row here" invariant `parseAdvancedFiltersParam`
+ * documents, so a freshly-added branch/row never vanishes mid-edit. Only
+ * {@link anyOfBranchToPayload} (the `/cases/search` request-payload
+ * boundary) may drop an incomplete row or an empty branch.
+ */
+export function parseAnyOfBranchesParam(raw: string | null): AnyOfBranch[] {
+  if (!raw) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(parsed)) return [];
+
+  const branches: AnyOfBranch[] = [];
+  for (const branchEntry of parsed.slice(0, MAX_ANY_OF_BRANCHES)) {
+    if (!Array.isArray(branchEntry)) continue;
+    const rows: AnyOfFilterRow[] = [];
+    for (const entry of branchEntry.slice(0, MAX_ANY_OF_ROWS_PER_BRANCH)) {
+      if (!Array.isArray(entry) || entry.length < 1 || entry.length > 2) continue;
+      const [field, rawValues] = entry as [unknown, unknown];
+      if (typeof field !== "string") continue;
+      if (!ALL_ANY_OF_FIELDS.includes(field as AnyOfFilterField)) continue;
+
+      let values: string[] = [];
+      if (rawValues !== undefined) {
+        if (!Array.isArray(rawValues)) continue;
+        values = rawValues
+          .filter((v): v is string => typeof v === "string")
+          .map((v) => v.slice(0, MAX_ANY_OF_VALUE_LEN))
+          .slice(0, MAX_ANY_OF_VALUES_PER_ROW);
+      }
+      rows.push({ field: field as AnyOfFilterField, values });
+    }
+    // A branch with zero rows at all (every entry was malformed) is dropped
+    // here — nothing to render — but a branch with only incomplete rows is
+    // kept, same in-progress-survives-the-URL invariant as a single row.
+    if (rows.length > 0) branches.push({ filters: rows });
+  }
+  return branches;
+}
+
+/** Serializes every branch (complete or not) as a single JSON-encoded
+ * `anyOf` param value. */
+export function writeAnyOfBranchesParam(branches: AnyOfBranch[]): string | null {
+  if (branches.length === 0) return null;
+  const nonEmptyBranches = branches.filter((b) => b.filters.length > 0);
+  if (nonEmptyBranches.length === 0) return null;
+  return JSON.stringify(
+    nonEmptyBranches.map((b) =>
+      b.filters.map((r) => (r.values.length > 0 ? [r.field, r.values] : [r.field])),
+    ),
+  );
+}

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/caseFilterOptions.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/caseFilterOptions.ts
@@ -1,0 +1,87 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { CaseState, Severity } from "@features/csm-dashboard/types/abtDashboard";
+import { STATE_LABEL } from "@features/csm-dashboard/utils/abtDashboard";
+import type { BeCaseWorkState, BeEngagementType } from "@api/backend/types";
+import { ALL_ONBOARDING_STATUSES, ONBOARDING_STATUS_LABEL } from "./onboardingStatus";
+
+/**
+ * Fixed-enum option catalogues shared between `CasesFilterBar.tsx`'s Simple
+ * grid controls and `advancedFilters.ts`'s Advanced-mode field catalogue —
+ * one source of truth for each enum, since the same field now renders in
+ * both modes (`filtersToAdvancedRows` reuses these `options` arrays so a
+ * value picked in one mode is recognizable in the other). Lives in its own
+ * (backend-client-free, component-free) module so neither `CasesFilterBar.tsx`
+ * nor `advancedFilters.ts` has to import the other for these constants — both
+ * already have their own real, `import type`-only circular reference to each
+ * other (`CasesFilters`), and adding a *value*-level circular import here
+ * (not type-only) would risk a real module-init-order hazard, unlike a
+ * type-only one which is erased at compile time.
+ */
+
+export const ALL_SEVERITIES: Severity[] = ["S0", "S1", "S2", "S3", "S4"];
+export const SEVERITY_OPTIONS: { value: Severity; label: string }[] = ALL_SEVERITIES.map(
+  (s) => ({ value: s, label: s }),
+);
+
+/** Excludes `reopened` — a valid backend enum value, but never a case's own
+ * `state` (only ever a `nextStates` transition marker, see `CaseState`'s own
+ * doc comment) — so offering it here would suggest a filter that can never
+ * match anything. Mirrors `anyOfFilters.ts`'s own `ANY_OF_STATE_VALUES`. */
+export const PRIMARY_STATES: CaseState[] = [
+  "open",
+  "work_in_progress",
+  "awaiting_info",
+  "solution_proposed",
+  "waiting_on_wso2",
+  "closed",
+];
+export const STATE_OPTIONS: { value: CaseState; label: string }[] = PRIMARY_STATES.map((s) => ({
+  value: s,
+  label: STATE_LABEL[s],
+}));
+
+export const ALL_WORK_STATES: BeCaseWorkState[] = ["ongoing", "paused"];
+export const WORK_STATE_LABEL: Record<BeCaseWorkState, string> = {
+  ongoing: "Ongoing",
+  paused: "Paused",
+};
+export const WORK_STATE_OPTIONS: { value: BeCaseWorkState; label: string }[] =
+  ALL_WORK_STATES.map((w) => ({ value: w, label: WORK_STATE_LABEL[w] }));
+
+export const ALL_ENGAGEMENT_TYPES: BeEngagementType[] = [
+  "migration",
+  "consultancy",
+  "new_feature_improvement",
+  "follow_up",
+  "onboarding",
+];
+export const ENGAGEMENT_TYPE_LABEL: Record<BeEngagementType, string> = {
+  migration: "Migration",
+  consultancy: "Consultancy",
+  new_feature_improvement: "New feature / improvement",
+  follow_up: "Follow-up",
+  onboarding: "Onboarding",
+};
+export const ENGAGEMENT_TYPE_OPTIONS: { value: BeEngagementType; label: string }[] =
+  ALL_ENGAGEMENT_TYPES.map((t) => ({ value: t, label: ENGAGEMENT_TYPE_LABEL[t] }));
+
+export const ONBOARDING_STATUS_OPTIONS: { value: string; label: string }[] =
+  ALL_ONBOARDING_STATUSES.map((value) => ({
+    value,
+    label: ONBOARDING_STATUS_LABEL[value],
+  }));

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/caseSearchPayload.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/caseSearchPayload.test.ts
@@ -366,11 +366,11 @@ describe("mapCaseSearchViewToRow — issueType and createdBy (reporter)", () => 
 describe("buildCaseSearchFilters — advanced filter rows", () => {
   it("emits a multi-value `in` row as a BeCaseFieldFilter with the field's values array", () => {
     const advancedFilters: AdvancedFilterRow[] = [
-      { field: "creTeam", op: "in", values: ["team-1", "team-2"] },
+      { field: "deploymentId", op: "in", values: ["dep-1", "dep-2"] },
     ];
     const filters: CasesFilters = { ...DEFAULT_CASES_FILTERS, advancedFilters };
-    expect(filterOf(filters, "creTeam")).toEqual([
-      { field: "creTeam", op: "in", values: ["team-1", "team-2"] },
+    expect(filterOf(filters, "deploymentId")).toEqual([
+      { field: "deploymentId", op: "in", values: ["dep-1", "dep-2"] },
     ]);
   });
 
@@ -424,7 +424,7 @@ describe("buildCaseSearchFilters — advanced filter rows", () => {
 
   it("appends advanced rows alongside the dedicated-control fields, not in place of them", () => {
     const advancedFilters: AdvancedFilterRow[] = [
-      { field: "tag", op: "notIn", values: ["s_dip"] },
+      { field: "deploymentId", op: "in", values: ["dep-1"] },
     ];
     const filters: CasesFilters = {
       ...DEFAULT_CASES_FILTERS,
@@ -434,7 +434,70 @@ describe("buildCaseSearchFilters — advanced filter rows", () => {
     const result = buildCaseSearchFilters(filters, "", undefined).filters ?? [];
     expect(result).toEqual([
       { field: "severity", op: "in", values: ["critical"] },
-      { field: "tag", op: "notIn", values: ["s_dip"] },
+      { field: "deploymentId", op: "in", values: ["dep-1"] },
     ]);
+  });
+});
+
+describe("buildCaseSearchFilters — anyOf (OR groups)", () => {
+  it("emits one anyOf entry per branch with a complete condition", () => {
+    const filters: CasesFilters = {
+      ...DEFAULT_CASES_FILTERS,
+      anyOfBranches: [
+        { filters: [{ field: "type", values: ["case"] }] },
+        { filters: [{ field: "severity", values: ["critical"] }] },
+      ],
+    };
+    const result = buildCaseSearchFilters(filters, "", undefined);
+    expect(result.anyOf).toEqual([
+      { filters: [{ field: "type", op: "in", values: ["case"] }] },
+      { filters: [{ field: "severity", op: "in", values: ["critical"] }] },
+    ]);
+  });
+
+  it("ANDs multiple conditions within one branch", () => {
+    const filters: CasesFilters = {
+      ...DEFAULT_CASES_FILTERS,
+      anyOfBranches: [
+        {
+          filters: [
+            { field: "type", values: ["case"] },
+            { field: "severity", values: ["critical", "high"] },
+          ],
+        },
+      ],
+    };
+    const result = buildCaseSearchFilters(filters, "", undefined);
+    expect(result.anyOf).toEqual([
+      {
+        filters: [
+          { field: "type", op: "in", values: ["case"] },
+          { field: "severity", op: "in", values: ["critical", "high"] },
+        ],
+      },
+    ]);
+  });
+
+  it("drops a branch with no complete conditions rather than emitting an empty one", () => {
+    const filters: CasesFilters = {
+      ...DEFAULT_CASES_FILTERS,
+      anyOfBranches: [
+        { filters: [{ field: "type", values: [] }] },
+        { filters: [{ field: "severity", values: ["critical"] }] },
+      ],
+    };
+    const result = buildCaseSearchFilters(filters, "", undefined);
+    expect(result.anyOf).toEqual([
+      { filters: [{ field: "severity", op: "in", values: ["critical"] }] },
+    ]);
+  });
+
+  it("omits anyOf entirely when no branch has a complete condition", () => {
+    const filters: CasesFilters = {
+      ...DEFAULT_CASES_FILTERS,
+      anyOfBranches: [{ filters: [{ field: "type", values: [] }] }],
+    };
+    const result = buildCaseSearchFilters(filters, "", undefined);
+    expect(result.anyOf).toBeUndefined();
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/caseSearchPayload.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/caseSearchPayload.test.ts
@@ -374,6 +374,16 @@ describe("buildCaseSearchFilters — advanced filter rows", () => {
     ]);
   });
 
+  it("emits an issueType `in` row (fixed multi-select) as a BeCaseFieldFilter", () => {
+    const advancedFilters: AdvancedFilterRow[] = [
+      { field: "issueType", op: "in", values: ["error", "total_outage"] },
+    ];
+    const filters: CasesFilters = { ...DEFAULT_CASES_FILTERS, advancedFilters };
+    expect(filterOf(filters, "issueType")).toEqual([
+      { field: "issueType", op: "in", values: ["error", "total_outage"] },
+    ]);
+  });
+
   it("emits a value-less op (`resolutionNotes` isEmpty) with no `values` at all", () => {
     const advancedFilters: AdvancedFilterRow[] = [
       { field: "resolutionNotes", op: "isEmpty", values: [] },

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/caseSearchPayload.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/caseSearchPayload.test.ts
@@ -17,6 +17,7 @@
 import { describe, expect, it } from "vitest";
 import type { CasesFilters } from "@features/csm-cases/components/CasesFilterBar";
 import { DEFAULT_CASES_FILTERS } from "@features/csm-cases/utils/casesFiltersUrl";
+import type { AdvancedFilterRow } from "@features/csm-cases/utils/advancedFilters";
 import type { BeCaseSearchView } from "@api/backend/types";
 import { buildCaseSearchFilters, mapCaseSearchViewToRow } from "./caseSearchPayload";
 
@@ -359,5 +360,71 @@ describe("mapCaseSearchViewToRow — issueType and createdBy (reporter)", () => 
   it("falls back to 'Unknown' when the response carries no creator at all", () => {
     const row = mapCaseSearchViewToRow(BASE, undefined);
     expect(row.createdBy).toBe("Unknown");
+  });
+});
+
+describe("buildCaseSearchFilters — advanced filter rows", () => {
+  it("emits a multi-value `in` row as a BeCaseFieldFilter with the field's values array", () => {
+    const advancedFilters: AdvancedFilterRow[] = [
+      { field: "creTeam", op: "in", values: ["team-1", "team-2"] },
+    ];
+    const filters: CasesFilters = { ...DEFAULT_CASES_FILTERS, advancedFilters };
+    expect(filterOf(filters, "creTeam")).toEqual([
+      { field: "creTeam", op: "in", values: ["team-1", "team-2"] },
+    ]);
+  });
+
+  it("emits a value-less op (`resolutionNotes` isEmpty) with no `values` at all", () => {
+    const advancedFilters: AdvancedFilterRow[] = [
+      { field: "resolutionNotes", op: "isEmpty", values: [] },
+    ];
+    const filters: CasesFilters = { ...DEFAULT_CASES_FILTERS, advancedFilters };
+    expect(filterOf(filters, "resolutionNotes")).toEqual([
+      { field: "resolutionNotes", op: "isEmpty" },
+    ]);
+  });
+
+  it("emits a date `gte` row's literal value straight through (relative-date resolution happens upstream in useGetCsmCases)", () => {
+    const advancedFilters: AdvancedFilterRow[] = [
+      { field: "createdOn", op: "gte", values: ["2026-01-01"] },
+    ];
+    const filters: CasesFilters = { ...DEFAULT_CASES_FILTERS, advancedFilters };
+    expect(filterOf(filters, "createdOn")).toEqual([
+      { field: "createdOn", op: "gte", values: ["2026-01-01"] },
+    ]);
+  });
+
+  it("drops an incomplete row (a field/op with no value entered) rather than sending an empty predicate", () => {
+    const advancedFilters: AdvancedFilterRow[] = [
+      { field: "number", op: "eq", values: [] },
+    ];
+    const filters: CasesFilters = { ...DEFAULT_CASES_FILTERS, advancedFilters };
+    expect(filterOf(filters, "number")).toEqual([]);
+  });
+
+  it("emits the `createdBy eq` current-user placeholder value regardless of what's stored in `values`", () => {
+    const advancedFilters: AdvancedFilterRow[] = [
+      { field: "createdBy", op: "eq", values: [] },
+    ];
+    const filters: CasesFilters = { ...DEFAULT_CASES_FILTERS, advancedFilters };
+    expect(filterOf(filters, "createdBy")).toEqual([
+      { field: "createdBy", op: "eq", values: ["__current_user_email__"] },
+    ]);
+  });
+
+  it("appends advanced rows alongside the dedicated-control fields, not in place of them", () => {
+    const advancedFilters: AdvancedFilterRow[] = [
+      { field: "tag", op: "notIn", values: ["s_dip"] },
+    ];
+    const filters: CasesFilters = {
+      ...DEFAULT_CASES_FILTERS,
+      severities: ["S1"],
+      advancedFilters,
+    };
+    const result = buildCaseSearchFilters(filters, "", undefined).filters ?? [];
+    expect(result).toEqual([
+      { field: "severity", op: "in", values: ["critical"] },
+      { field: "tag", op: "notIn", values: ["s_dip"] },
+    ]);
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/caseSearchPayload.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/caseSearchPayload.ts
@@ -32,6 +32,10 @@ import type {
 } from "@api/backend/types";
 import type { CasesFilters } from "@features/csm-cases/components/CasesFilterBar";
 import type { CsmCaseRow } from "@features/csm-cases/types/csmCases";
+import {
+  advancedFilterRowToFieldFilter,
+  isCompleteAdvancedFilterRow,
+} from "@features/csm-cases/utils/advancedFilters";
 
 /**
  * Builds the `/cases/search` `filters` object for the given UI filter state
@@ -212,6 +216,20 @@ export function buildCaseSearchFilters(
   }
   if (filters.closedOnLte !== null) {
     fieldFilters.push({ field: "closedOn", op: "lte", values: [filters.closedOnLte] });
+  }
+
+  // Ad-hoc rows from the "Advanced filters" builder (`AdvancedFiltersBuilder`)
+  // — each becomes one extra `BeCaseFieldFilter` entry. Only complete rows
+  // (see `isCompleteAdvancedFilterRow`) are emitted; an incomplete one (a
+  // field/op picked but no value where the op requires one) is silently
+  // skipped rather than sent as an empty predicate. `filters` here is the
+  // already relative-date-resolved copy the caller (`useGetCsmCases`) passes
+  // in — this function does no date resolution of its own, same as the
+  // dedicated `createdOnGte`/`createdOnLte` fields above.
+  for (const row of filters.advancedFilters) {
+    if (!isCompleteAdvancedFilterRow(row)) continue;
+    const ff = advancedFilterRowToFieldFilter(row);
+    if (ff) fieldFilters.push(ff);
   }
 
   // A typed case number / WSO2 case id goes through as an exact-match field

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/caseSearchPayload.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/caseSearchPayload.ts
@@ -36,6 +36,7 @@ import {
   advancedFilterRowToFieldFilter,
   isCompleteAdvancedFilterRow,
 } from "@features/csm-cases/utils/advancedFilters";
+import { anyOfBranchToPayload } from "@features/csm-cases/utils/anyOfFilters";
 
 /**
  * Builds the `/cases/search` `filters` object for the given UI filter state
@@ -261,9 +262,19 @@ export function buildCaseSearchFilters(
   }
 
   const withFreeText = scope === "text" || !!options?.alsoFreeText;
+
+  // "OR groups" (`filters.anyOf`) — each branch with at least one complete
+  // condition becomes one `{filters: [...]}` entry; an empty branch (no
+  // complete conditions at all) is dropped rather than emitted, since the
+  // backend 400s on `anyOf: [{}]` (see `anyOfBranchToPayload`).
+  const anyOf = filters.anyOfBranches
+    .map(anyOfBranchToPayload)
+    .filter((b): b is { filters: BeCaseFieldFilter[] } => b !== undefined);
+
   return {
     ...(withFreeText && search.length > 0 && { searchQuery: search }),
     ...(fieldFilters.length > 0 && { filters: fieldFilters }),
+    ...(anyOf.length > 0 && { anyOf }),
   };
 }
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.test.ts
@@ -17,6 +17,7 @@
 import { describe, expect, it } from "vitest";
 import type { CasesFilters } from "@features/csm-cases/components/CasesFilterBar";
 import type { AdvancedFilterRow } from "@features/csm-cases/utils/advancedFilters";
+import type { AnyOfBranch } from "@features/csm-cases/utils/anyOfFilters";
 import {
   casesHref,
   countActiveFilters,
@@ -228,7 +229,7 @@ describe("op-awareness (regression: the widgetPreviewUrl field~op bug)", () => {
 describe("advanced filters (`af` param)", () => {
   it("round-trips a multi-value `in` row through the URL", () => {
     const advancedFilters: AdvancedFilterRow[] = [
-      { field: "creTeam", op: "in", values: ["team-1", "team-2"] },
+      { field: "deploymentId", op: "in", values: ["dep-1", "dep-2"] },
     ];
     const filters: CasesFilters = { ...DEFAULT_CASES_FILTERS, advancedFilters };
     const round = readCasesFiltersFromUrl(writeCasesFiltersToUrl(filters));
@@ -277,7 +278,7 @@ describe("advanced filters (`af` param)", () => {
 
   it("round-trips a row whose op takes a value but none has been typed yet (empty `values` array)", () => {
     const advancedFilters: AdvancedFilterRow[] = [
-      { field: "tag", op: "in", values: [] },
+      { field: "internalId", op: "eq", values: [] },
     ];
     const filters: CasesFilters = { ...DEFAULT_CASES_FILTERS, advancedFilters };
     const round = readCasesFiltersFromUrl(writeCasesFiltersToUrl(filters));
@@ -286,7 +287,7 @@ describe("advanced filters (`af` param)", () => {
 
   it("does not count an in-progress (incomplete) row toward the active-filter badge, even though it now round-trips", () => {
     const advancedFilters: AdvancedFilterRow[] = [
-      { field: "tag", op: "in", values: ["a"] },
+      { field: "internalId", op: "eq", values: ["a"] },
       { field: "number", op: "eq", values: [] },
     ];
     expect(
@@ -300,12 +301,12 @@ describe("advanced filters (`af` param)", () => {
       "af",
       JSON.stringify([
         ["not_a_real_field", "in", ["x"]],
-        ["tag", "not_a_real_op", ["y"]],
-        ["tag", "in", ["ok"]],
+        ["internalId", "not_a_real_op", ["y"]],
+        ["internalId", "eq", ["ok"]],
       ]),
     );
     expect(readCasesFiltersFromUrl(params).advancedFilters).toEqual([
-      { field: "tag", op: "in", values: ["ok"] },
+      { field: "internalId", op: "eq", values: ["ok"] },
     ]);
   });
 
@@ -317,12 +318,72 @@ describe("advanced filters (`af` param)", () => {
 
   it("counts each complete advanced-filter row individually toward the active-filter count", () => {
     const advancedFilters: AdvancedFilterRow[] = [
-      { field: "tag", op: "in", values: ["a"] },
+      { field: "internalId", op: "eq", values: ["a"] },
       { field: "number", op: "eq", values: ["CS0441174"] },
     ];
     expect(
       countActiveFilters({ ...DEFAULT_CASES_FILTERS, advancedFilters }),
     ).toBe(2);
+  });
+});
+
+describe("OR groups (`anyOf` param)", () => {
+  it("round-trips a two-branch, single-condition-each anyOf through the URL", () => {
+    const anyOfBranches: AnyOfBranch[] = [
+      { filters: [{ field: "type", values: ["case"] }] },
+      { filters: [{ field: "severity", values: ["critical"] }] },
+    ];
+    const filters: CasesFilters = { ...DEFAULT_CASES_FILTERS, anyOfBranches };
+    const round = readCasesFiltersFromUrl(writeCasesFiltersToUrl(filters));
+    expect(round.anyOfBranches).toEqual(anyOfBranches);
+  });
+
+  it("round-trips an in-progress branch (a row with field picked, no value yet) rather than dropping it", () => {
+    const anyOfBranches: AnyOfBranch[] = [{ filters: [{ field: "type", values: [] }] }];
+    const filters: CasesFilters = { ...DEFAULT_CASES_FILTERS, anyOfBranches };
+    const href = writeCasesFiltersToUrl(filters);
+    expect(href.get("anyOf")).not.toBeNull();
+    const round = readCasesFiltersFromUrl(href);
+    expect(round.anyOfBranches).toEqual(anyOfBranches);
+  });
+
+  it("round-trips a branch with multiple ANDed conditions", () => {
+    const anyOfBranches: AnyOfBranch[] = [
+      {
+        filters: [
+          { field: "type", values: ["case"] },
+          { field: "severity", values: ["critical", "high"] },
+        ],
+      },
+    ];
+    const filters: CasesFilters = { ...DEFAULT_CASES_FILTERS, anyOfBranches };
+    const round = readCasesFiltersFromUrl(writeCasesFiltersToUrl(filters));
+    expect(round.anyOfBranches).toEqual(anyOfBranches);
+  });
+
+  it("does not count a branch with no complete condition toward the active-filter badge, even though it round-trips", () => {
+    const anyOfBranches: AnyOfBranch[] = [
+      { filters: [{ field: "type", values: ["case"] }] },
+      { filters: [{ field: "severity", values: [] }] },
+    ];
+    expect(countActiveFilters({ ...DEFAULT_CASES_FILTERS, anyOfBranches })).toBe(1);
+  });
+
+  it("silently drops an unknown branch field on a hand-edited or stale `anyOf` param instead of throwing", () => {
+    const params = new URLSearchParams();
+    params.set(
+      "anyOf",
+      JSON.stringify([[["not_a_real_field", ["x"]], ["type", ["case"]]]]),
+    );
+    expect(readCasesFiltersFromUrl(params).anyOfBranches).toEqual([
+      { filters: [{ field: "type", values: ["case"] }] },
+    ]);
+  });
+
+  it("silently returns no OR groups for garbage JSON in `anyOf`", () => {
+    const params = new URLSearchParams();
+    params.set("anyOf", "not json{{{");
+    expect(readCasesFiltersFromUrl(params).anyOfBranches).toEqual([]);
   });
 });
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.test.ts
@@ -16,8 +16,10 @@
 
 import { describe, expect, it } from "vitest";
 import type { CasesFilters } from "@features/csm-cases/components/CasesFilterBar";
+import type { AdvancedFilterRow } from "@features/csm-cases/utils/advancedFilters";
 import {
   casesHref,
+  countActiveFilters,
   DEFAULT_CASES_FILTERS,
   readCasesFiltersFromUrl,
   writeCasesFiltersToUrl,
@@ -220,6 +222,77 @@ describe("op-awareness (regression: the widgetPreviewUrl field~op bug)", () => {
     const round = readCasesFiltersFromUrl(writeCasesFiltersToUrl(filters));
     expect(round.slaElapsedPctGte).toBe(90);
     expect(round.slaElapsedPctLte).toBeNull();
+  });
+});
+
+describe("advanced filters (`af` param)", () => {
+  it("round-trips a multi-value `in` row through the URL", () => {
+    const advancedFilters: AdvancedFilterRow[] = [
+      { field: "creTeam", op: "in", values: ["team-1", "team-2"] },
+    ];
+    const filters: CasesFilters = { ...DEFAULT_CASES_FILTERS, advancedFilters };
+    const round = readCasesFiltersFromUrl(writeCasesFiltersToUrl(filters));
+    expect(round.advancedFilters).toEqual(advancedFilters);
+  });
+
+  it("round-trips a value-less op (`escalation isNotEmpty`) without dropping it", () => {
+    const advancedFilters: AdvancedFilterRow[] = [
+      { field: "escalation", op: "isNotEmpty", values: [] },
+    ];
+    const filters: CasesFilters = { ...DEFAULT_CASES_FILTERS, advancedFilters };
+    const href = writeCasesFiltersToUrl(filters);
+    expect(href.get("af")).not.toBeNull();
+    const round = readCasesFiltersFromUrl(href);
+    expect(round.advancedFilters).toEqual(advancedFilters);
+  });
+
+  it("round-trips a date `gte`/`lte` pair on the same field as two distinct rows", () => {
+    const advancedFilters: AdvancedFilterRow[] = [
+      { field: "updatedOn", op: "gte", values: ["2026-01-01"] },
+      { field: "updatedOn", op: "lte", values: ["2026-03-31"] },
+    ];
+    const filters: CasesFilters = { ...DEFAULT_CASES_FILTERS, advancedFilters };
+    const round = readCasesFiltersFromUrl(writeCasesFiltersToUrl(filters));
+    expect(round.advancedFilters).toEqual(advancedFilters);
+  });
+
+  it("drops an incomplete row (no value where the op requires one) rather than writing it to the URL", () => {
+    const advancedFilters: AdvancedFilterRow[] = [
+      { field: "number", op: "eq", values: [] },
+    ];
+    const filters: CasesFilters = { ...DEFAULT_CASES_FILTERS, advancedFilters };
+    expect(writeCasesFiltersToUrl(filters).get("af")).toBeNull();
+  });
+
+  it("silently drops an unknown field/op on a hand-edited or stale `af` param instead of throwing", () => {
+    const params = new URLSearchParams();
+    params.set(
+      "af",
+      JSON.stringify([
+        ["not_a_real_field", "in", ["x"]],
+        ["tag", "not_a_real_op", ["y"]],
+        ["tag", "in", ["ok"]],
+      ]),
+    );
+    expect(readCasesFiltersFromUrl(params).advancedFilters).toEqual([
+      { field: "tag", op: "in", values: ["ok"] },
+    ]);
+  });
+
+  it("silently returns no advanced filters for garbage JSON in `af`", () => {
+    const params = new URLSearchParams();
+    params.set("af", "not json{{{");
+    expect(readCasesFiltersFromUrl(params).advancedFilters).toEqual([]);
+  });
+
+  it("counts each complete advanced-filter row individually toward the active-filter count", () => {
+    const advancedFilters: AdvancedFilterRow[] = [
+      { field: "tag", op: "in", values: ["a"] },
+      { field: "number", op: "eq", values: ["CS0441174"] },
+    ];
+    expect(
+      countActiveFilters({ ...DEFAULT_CASES_FILTERS, advancedFilters }),
+    ).toBe(2);
   });
 });
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.test.ts
@@ -236,7 +236,12 @@ describe("advanced filters (`af` param)", () => {
     expect(round.advancedFilters).toEqual(advancedFilters);
   });
 
-  it("round-trips a value-less op (`escalation isNotEmpty`) without dropping it", () => {
+  // `escalation` now has a typed `CasesFilters` slot (`hasEscalation`, see
+  // `filterFieldAdapters.ts`'s typed-adapter registry) — an `af` row
+  // targeting it is folded (`normalizeCasesFilters`) into that real property
+  // on read rather than staying a dangling `advancedFilters` entry, so the
+  // round-trip is still lossless, just visible on a different property now.
+  it("round-trips a value-less op (`escalation isNotEmpty`) into the typed `hasEscalation` field, not a dangling `af` row", () => {
     const advancedFilters: AdvancedFilterRow[] = [
       { field: "escalation", op: "isNotEmpty", values: [] },
     ];
@@ -244,17 +249,22 @@ describe("advanced filters (`af` param)", () => {
     const href = writeCasesFiltersToUrl(filters);
     expect(href.get("af")).not.toBeNull();
     const round = readCasesFiltersFromUrl(href);
-    expect(round.advancedFilters).toEqual(advancedFilters);
+    expect(round.hasEscalation).toBe(true);
+    expect(round.advancedFilters).toEqual([]);
   });
 
-  it("round-trips a date `gte`/`lte` pair on the same field as two distinct rows", () => {
+  // `createdOn`/`updatedOn`/`closedOn` also now have typed slots
+  // (`updatedOnGte`/`updatedOnLte`, ...) — same normalization as above.
+  it("round-trips a date `gte`/`lte` pair on the same field into the typed `updatedOnGte`/`updatedOnLte` fields", () => {
     const advancedFilters: AdvancedFilterRow[] = [
       { field: "updatedOn", op: "gte", values: ["2026-01-01"] },
       { field: "updatedOn", op: "lte", values: ["2026-03-31"] },
     ];
     const filters: CasesFilters = { ...DEFAULT_CASES_FILTERS, advancedFilters };
     const round = readCasesFiltersFromUrl(writeCasesFiltersToUrl(filters));
-    expect(round.advancedFilters).toEqual(advancedFilters);
+    expect(round.updatedOnGte).toBe("2026-01-01");
+    expect(round.updatedOnLte).toBe("2026-03-31");
+    expect(round.advancedFilters).toEqual([]);
   });
 
   it("round-trips an in-progress row (field/op picked, no value yet) rather than dropping it", () => {

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.test.ts
@@ -256,12 +256,42 @@ describe("advanced filters (`af` param)", () => {
     expect(round.advancedFilters).toEqual(advancedFilters);
   });
 
-  it("drops an incomplete row (no value where the op requires one) rather than writing it to the URL", () => {
+  it("round-trips an in-progress row (field/op picked, no value yet) rather than dropping it", () => {
+    // Regression test for the "Add filter" bug: `CsmIssuesView` treats the
+    // URL as the single source of truth (`filters =
+    // readCasesFiltersFromUrl(searchParams)`), so a freshly-added row with no
+    // value yet used to vanish within the same tick — `writeAdvancedFiltersParam`
+    // filtered it out before it ever reached the URL, and the very next
+    // re-read from that URL then rendered zero rows. An incomplete row must
+    // survive this URL round trip (it's still correctly excluded from the
+    // `/cases/search` request payload — see `caseSearchPayload.test.ts`).
     const advancedFilters: AdvancedFilterRow[] = [
       { field: "number", op: "eq", values: [] },
     ];
     const filters: CasesFilters = { ...DEFAULT_CASES_FILTERS, advancedFilters };
-    expect(writeCasesFiltersToUrl(filters).get("af")).toBeNull();
+    const href = writeCasesFiltersToUrl(filters);
+    expect(href.get("af")).not.toBeNull();
+    const round = readCasesFiltersFromUrl(href);
+    expect(round.advancedFilters).toEqual(advancedFilters);
+  });
+
+  it("round-trips a row whose op takes a value but none has been typed yet (empty `values` array)", () => {
+    const advancedFilters: AdvancedFilterRow[] = [
+      { field: "tag", op: "in", values: [] },
+    ];
+    const filters: CasesFilters = { ...DEFAULT_CASES_FILTERS, advancedFilters };
+    const round = readCasesFiltersFromUrl(writeCasesFiltersToUrl(filters));
+    expect(round.advancedFilters).toEqual(advancedFilters);
+  });
+
+  it("does not count an in-progress (incomplete) row toward the active-filter badge, even though it now round-trips", () => {
+    const advancedFilters: AdvancedFilterRow[] = [
+      { field: "tag", op: "in", values: ["a"] },
+      { field: "number", op: "eq", values: [] },
+    ];
+    expect(
+      countActiveFilters({ ...DEFAULT_CASES_FILTERS, advancedFilters }),
+    ).toBe(1);
   });
 
   it("silently drops an unknown field/op on a hand-edited or stale `af` param instead of throwing", () => {

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.ts
@@ -25,6 +25,11 @@ import type {
 } from "@api/backend/types";
 import type { CasesFilters } from "@features/csm-cases/components/CasesFilterBar";
 import { ALL_CASE_TYPES } from "@features/csm-cases/utils/caseType";
+import {
+  isCompleteAdvancedFilterRow,
+  parseAdvancedFiltersParam,
+  writeAdvancedFiltersParam,
+} from "@features/csm-cases/utils/advancedFilters";
 
 export const DEFAULT_CASES_FILTERS: CasesFilters = {
   search: "",
@@ -53,6 +58,7 @@ export const DEFAULT_CASES_FILTERS: CasesFilters = {
   updatedOnLte: null,
   closedOnGte: null,
   closedOnLte: null,
+  advancedFilters: [],
   // Note: `tags`/`excludeTags` are real, wired-through fields (round-trip
   // URL + `/cases/search` payload), both driven by the one tri-state
   // "Tags" bar control (`TagsMultiSelect`, digiops-cs#2907) — see its own
@@ -179,6 +185,7 @@ export function readCasesFiltersFromUrl(
     updatedOnLte: parseFreeFormScalar(params.get("updatedTo")),
     closedOnGte: parseFreeFormScalar(params.get("closedFrom")),
     closedOnLte: parseFreeFormScalar(params.get("closedTo")),
+    advancedFilters: parseAdvancedFiltersParam(params.get("af")),
   };
 }
 
@@ -262,6 +269,14 @@ export function writeCasesFiltersToUrl(f: CasesFilters): URLSearchParams {
   if (f.updatedOnLte !== null) out.set("updatedTo", f.updatedOnLte);
   if (f.closedOnGte !== null) out.set("closedFrom", f.closedOnGte);
   if (f.closedOnLte !== null) out.set("closedTo", f.closedOnLte);
+  // `af` is the one exception to the "one param per field+op pair" rule this
+  // doc comment argues for above — it IS the generic escape hatch the
+  // comment calls out, so `field~op` (or here, a JSON `[field, op, values]`
+  // triple) is the right shape for it: each row already carries its own op
+  // explicitly, so there's no default-op fallback for a decode to silently
+  // mis-attribute a value to.
+  const af = writeAdvancedFiltersParam(f.advancedFilters);
+  if (af !== null) out.set("af", af);
   return out;
 }
 
@@ -299,6 +314,10 @@ export function countActiveFilters(f: CasesFilters): number {
   if (f.updatedOnLte !== null) n += 1;
   if (f.closedOnGte !== null) n += 1;
   if (f.closedOnLte !== null) n += 1;
+  // Each advanced-filter row is its own distinct predicate (unlike e.g.
+  // `tags`, where every selected tag is really one "tag in [...]" filter) —
+  // count complete rows individually rather than the whole array as one.
+  n += f.advancedFilters.filter(isCompleteAdvancedFilterRow).length;
   return n;
 }
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.ts
@@ -35,6 +35,7 @@ import {
   parseAnyOfBranchesParam,
   writeAnyOfBranchesParam,
 } from "@features/csm-cases/utils/anyOfFilters";
+import { normalizeCasesFilters } from "@features/csm-cases/utils/filterFieldAdapters";
 
 export const DEFAULT_CASES_FILTERS: CasesFilters = {
   search: "",
@@ -164,7 +165,11 @@ export function readCasesFiltersFromUrl(
     states.length === 1 && states[0] === "work_in_progress"
       ? parseCsv(params.get("workStates"), VALID_WORK_STATES)
       : [];
-  return {
+  // `normalizeCasesFilters` folds any `af` row targeting a field that now
+  // has its own typed `CasesFilters` slot (severity/state/tag/...) into that
+  // real property, so a legacy or hand-edited URL can never produce a
+  // dangling duplicate of the same predicate — see its own doc comment.
+  return normalizeCasesFilters({
     search: params.get("search") ?? "",
     severities: parseCsv(params.get("severities"), VALID_SEVERITIES),
     states,
@@ -193,7 +198,7 @@ export function readCasesFiltersFromUrl(
     closedOnLte: parseFreeFormScalar(params.get("closedTo")),
     advancedFilters: parseAdvancedFiltersParam(params.get("af")),
     anyOfBranches: parseAnyOfBranchesParam(params.get("anyOf")),
-  };
+  });
 }
 
 /**

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/casesFiltersUrl.ts
@@ -30,6 +30,11 @@ import {
   parseAdvancedFiltersParam,
   writeAdvancedFiltersParam,
 } from "@features/csm-cases/utils/advancedFilters";
+import {
+  isCompleteAnyOfBranch,
+  parseAnyOfBranchesParam,
+  writeAnyOfBranchesParam,
+} from "@features/csm-cases/utils/anyOfFilters";
 
 export const DEFAULT_CASES_FILTERS: CasesFilters = {
   search: "",
@@ -59,6 +64,7 @@ export const DEFAULT_CASES_FILTERS: CasesFilters = {
   closedOnGte: null,
   closedOnLte: null,
   advancedFilters: [],
+  anyOfBranches: [],
   // Note: `tags`/`excludeTags` are real, wired-through fields (round-trip
   // URL + `/cases/search` payload), both driven by the one tri-state
   // "Tags" bar control (`TagsMultiSelect`, digiops-cs#2907) — see its own
@@ -186,6 +192,7 @@ export function readCasesFiltersFromUrl(
     closedOnGte: parseFreeFormScalar(params.get("closedFrom")),
     closedOnLte: parseFreeFormScalar(params.get("closedTo")),
     advancedFilters: parseAdvancedFiltersParam(params.get("af")),
+    anyOfBranches: parseAnyOfBranchesParam(params.get("anyOf")),
   };
 }
 
@@ -277,6 +284,12 @@ export function writeCasesFiltersToUrl(f: CasesFilters): URLSearchParams {
   // mis-attribute a value to.
   const af = writeAdvancedFiltersParam(f.advancedFilters);
   if (af !== null) out.set("af", af);
+  // Same generic-escape-hatch reasoning as `af` above — `anyOf` already
+  // carries its own field per row (no op at all, since every branch field is
+  // `in`-only, see `anyOfFilters.ts`), so there is no default op for a
+  // decode to silently mis-attribute a value to here either.
+  const anyOf = writeAnyOfBranchesParam(f.anyOfBranches);
+  if (anyOf !== null) out.set("anyOf", anyOf);
   return out;
 }
 
@@ -318,6 +331,9 @@ export function countActiveFilters(f: CasesFilters): number {
   // `tags`, where every selected tag is really one "tag in [...]" filter) —
   // count complete rows individually rather than the whole array as one.
   n += f.advancedFilters.filter(isCompleteAdvancedFilterRow).length;
+  // Same reasoning as advanced-filter rows: each OR group with at least one
+  // complete condition is its own distinct predicate.
+  n += f.anyOfBranches.filter(isCompleteAnyOfBranch).length;
   return n;
 }
 

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/filterFieldAdapters.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/filterFieldAdapters.test.ts
@@ -1,0 +1,235 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { describe, expect, it } from "vitest";
+import { DEFAULT_CASES_FILTERS } from "@features/csm-cases/utils/casesFiltersUrl";
+import type { CasesFilters } from "@features/csm-cases/components/CasesFilterBar";
+import {
+  addBlankUnifiedRow,
+  filtersToAdvancedRows,
+  isSimpleRepresentable,
+  normalizeCasesFilters,
+  removeUnifiedRow,
+  updateUnifiedRow,
+} from "./filterFieldAdapters";
+
+describe("isSimpleRepresentable", () => {
+  it("is true for the untouched default filters", () => {
+    expect(isSimpleRepresentable(DEFAULT_CASES_FILTERS)).toBe(true);
+  });
+
+  it("stays true for every field the Simple grid's own dedicated controls cover", () => {
+    const filters: CasesFilters = {
+      ...DEFAULT_CASES_FILTERS,
+      severities: ["S1"],
+      states: ["open"],
+      excludeStates: ["closed"],
+      caseTypes: ["case"],
+      assignees: ["@me"],
+      workStates: ["ongoing"],
+      projects: ["p1"],
+      engagementTypes: ["onboarding"],
+      productNames: ["API Manager"],
+      csTeams: ["g1"],
+      onboardingStatuses: ["Completed"],
+    };
+    expect(isSimpleRepresentable(filters)).toBe(true);
+  });
+
+  const gatingOverrides: [string, Partial<CasesFilters>][] = [
+    ["tags", { tags: ["urgent"] }],
+    ["excludeTags", { excludeTags: ["spam"] }],
+    ["sreTeams", { sreTeams: ["g1"] }],
+    ["projectTypes", { projectTypes: ["Subscription"] }],
+    ["escalationLevels", { escalationLevels: ["1"] }],
+    ["hasEscalation", { hasEscalation: true }],
+    ["slaElapsedPctGte", { slaElapsedPctGte: 80 }],
+    ["slaElapsedPctLte", { slaElapsedPctLte: 100 }],
+    ["createdOnGte", { createdOnGte: "2026-01-01" }],
+    ["createdOnLte", { createdOnLte: "2026-01-31" }],
+    ["updatedOnGte", { updatedOnGte: "2026-01-01" }],
+    ["updatedOnLte", { updatedOnLte: "2026-01-31" }],
+    ["closedOnGte", { closedOnGte: "2026-01-01" }],
+    ["closedOnLte", { closedOnLte: "2026-01-31" }],
+    ["advancedFilters", { advancedFilters: [{ field: "number", op: "eq", values: ["CS1"] }] }],
+    ["anyOfBranches", { anyOfBranches: [{ filters: [{ field: "type", values: ["case"] }] }] }],
+  ];
+  it.each(gatingOverrides)("is false once %s is set", (_name, override) => {
+    const filters: CasesFilters = { ...DEFAULT_CASES_FILTERS, ...override };
+    expect(isSimpleRepresentable(filters)).toBe(false);
+  });
+});
+
+describe("filtersToAdvancedRows / updateUnifiedRow / removeUnifiedRow — round trip", () => {
+  it("produces no rows for the untouched default filters", () => {
+    expect(filtersToAdvancedRows(DEFAULT_CASES_FILTERS)).toEqual([]);
+  });
+
+  it("shows a typed row for a non-empty Simple-grid field, and it round-trips through the real CasesFilters property", () => {
+    const filters: CasesFilters = { ...DEFAULT_CASES_FILTERS, severities: ["S1", "S2"] };
+    const rows = filtersToAdvancedRows(filters);
+    expect(rows).toEqual([
+      { origin: "typed", field: "severity", op: "in", values: ["S1", "S2"] },
+    ]);
+  });
+
+  it("editing a typed row's values writes straight back to the same CasesFilters property (lossless Simple<->Advanced)", () => {
+    const filters: CasesFilters = { ...DEFAULT_CASES_FILTERS, severities: ["S1"] };
+    const [row] = filtersToAdvancedRows(filters);
+    const next = updateUnifiedRow(filters, row, { field: "severity", op: "in", values: ["S1", "S3"] });
+    expect(next.severities).toEqual(["S1", "S3"]);
+    // Nothing leaked into the untyped escape hatch.
+    expect(next.advancedFilters).toEqual([]);
+  });
+
+  it("removing a typed row clears the real CasesFilters property", () => {
+    const filters: CasesFilters = { ...DEFAULT_CASES_FILTERS, productNames: ["API Manager"] };
+    const [row] = filtersToAdvancedRows(filters);
+    const next = removeUnifiedRow(filters, row);
+    expect(next.productNames).toEqual([]);
+  });
+
+  it("changing a typed row's field to a different typed field moves the value to the new field's property", () => {
+    const filters: CasesFilters = { ...DEFAULT_CASES_FILTERS, severities: ["S1"] };
+    const [row] = filtersToAdvancedRows(filters);
+    // Field-picker reset: values clear to [] on a field change (same as the
+    // pre-existing per-row field dropdown behavior).
+    const afterFieldChange = updateUnifiedRow(filters, row, {
+      field: "type",
+      op: "in",
+      values: [],
+    });
+    expect(afterFieldChange.severities).toEqual([]);
+    expect(afterFieldChange.caseTypes).toEqual([]);
+    // Still incomplete (no value yet) -- lives in the untyped array so the
+    // in-progress row survives a render, exactly like an untyped field would.
+    expect(afterFieldChange.advancedFilters).toEqual([
+      { field: "type", op: "in", values: [] },
+    ]);
+
+    const afterValue = updateUnifiedRow(
+      filters,
+      { origin: "array", field: "type", op: "in", values: [], arrayIndex: 0 },
+      { field: "type", op: "in", values: ["case"] },
+    );
+    expect(afterValue.caseTypes).toEqual(["case"]);
+    expect(afterValue.advancedFilters).toEqual([]);
+  });
+
+  it("an untyped field (no CasesFilters slot) stays in the advancedFilters array end to end", () => {
+    let filters: CasesFilters = { ...DEFAULT_CASES_FILTERS };
+    filters = addBlankUnifiedRow(filters);
+    expect(filters.advancedFilters).toEqual([
+      { field: filters.advancedFilters[0].field, op: filters.advancedFilters[0].op, values: [] },
+    ]);
+
+    const [row] = filtersToAdvancedRows(filters);
+    const next = updateUnifiedRow(filters, row, {
+      field: "internalId",
+      op: "eq",
+      values: ["WSO2-1"],
+    });
+    expect(next.advancedFilters).toEqual([{ field: "internalId", op: "eq", values: ["WSO2-1"] }]);
+  });
+
+  it("editing an in-progress array row's value in place does not reorder it relative to a sibling row", () => {
+    let filters: CasesFilters = { ...DEFAULT_CASES_FILTERS };
+    filters = {
+      ...filters,
+      advancedFilters: [
+        { field: "internalId", op: "eq", values: ["first"] },
+        { field: "parentId", op: "eq", values: [] },
+      ],
+    };
+    const rows = filtersToAdvancedRows(filters);
+    const secondRow = rows[1];
+    const next = updateUnifiedRow(filters, secondRow, {
+      field: "parentId",
+      op: "eq",
+      values: ["p"],
+    });
+    expect(next.advancedFilters).toEqual([
+      { field: "internalId", op: "eq", values: ["first"] },
+      { field: "parentId", op: "eq", values: ["p"] },
+    ]);
+  });
+
+  it("the value-less escalation ops set/clear the tri-state hasEscalation field, not a truthy row value", () => {
+    let filters: CasesFilters = { ...DEFAULT_CASES_FILTERS };
+    filters = addBlankUnifiedRow(filters);
+    filters = updateUnifiedRow(filters, filtersToAdvancedRows(filters)[0], {
+      field: "escalation",
+      op: "isNotEmpty",
+      values: [],
+    });
+    expect(filters.hasEscalation).toBe(true);
+    expect(filtersToAdvancedRows(filters)).toEqual([
+      { origin: "typed", field: "escalation", op: "isNotEmpty", values: [] },
+    ]);
+
+    const [row] = filtersToAdvancedRows(filters);
+    const cleared = removeUnifiedRow(filters, row);
+    expect(cleared.hasEscalation).toBeNull();
+    expect(filtersToAdvancedRows(cleared)).toEqual([]);
+  });
+
+  it("state/in pruning: switching states away from a sole work_in_progress clears workStates", () => {
+    const filters: CasesFilters = {
+      ...DEFAULT_CASES_FILTERS,
+      states: ["work_in_progress"],
+      workStates: ["ongoing"],
+    };
+    const [row] = filtersToAdvancedRows(filters);
+    expect(row.field).toBe("state");
+    const next = updateUnifiedRow(filters, row, {
+      field: "state",
+      op: "in",
+      values: ["work_in_progress", "open"],
+    });
+    expect(next.states).toEqual(["work_in_progress", "open"]);
+    expect(next.workStates).toEqual([]);
+  });
+});
+
+describe("normalizeCasesFilters", () => {
+  it("folds a complete advancedFilters row targeting a now-typed field into the real property", () => {
+    const filters: CasesFilters = {
+      ...DEFAULT_CASES_FILTERS,
+      advancedFilters: [{ field: "severity", op: "in", values: ["S1", "S2"] }],
+    };
+    const next = normalizeCasesFilters(filters);
+    expect(next.severities).toEqual(["S1", "S2"]);
+    expect(next.advancedFilters).toEqual([]);
+  });
+
+  it("leaves an incomplete row targeting a typed field alone (nothing to fold yet)", () => {
+    const filters: CasesFilters = {
+      ...DEFAULT_CASES_FILTERS,
+      advancedFilters: [{ field: "severity", op: "in", values: [] }],
+    };
+    const next = normalizeCasesFilters(filters);
+    expect(next.severities).toEqual([]);
+    expect(next.advancedFilters).toEqual([{ field: "severity", op: "in", values: [] }]);
+  });
+
+  it("leaves a row targeting an untyped field untouched", () => {
+    const filters: CasesFilters = {
+      ...DEFAULT_CASES_FILTERS,
+      advancedFilters: [{ field: "internalId", op: "eq", values: ["WSO2-1"] }],
+    };
+    expect(normalizeCasesFilters(filters)).toEqual(filters);
+  });
+});

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/filterFieldAdapters.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/filterFieldAdapters.ts
@@ -82,6 +82,17 @@ function key(field: string, op: string): string {
   return `${field}:${op}`;
 }
 
+/** Parses an SLA-percent row value, treating a non-numeric input (a
+ * hand-edited or stale `af` URL, e.g. `af=[["taskSLABusinessElapsedPercent",
+ * "gte",["abc"]]]`) as unset rather than writing `NaN` into `CasesFilters` —
+ * `NaN` isn't `null`, so it would otherwise propagate into the active-filter
+ * count, the URL, and the `/cases/search` request body. */
+function parseSlaPct(values: string[]): number | null {
+  if (values.length === 0) return null;
+  const n = Number(values[0]);
+  return Number.isFinite(n) ? n : null;
+}
+
 const TYPED_ADAPTERS: Record<string, TypedFieldAdapter> = {
   [key("severity", "in")]: simpleAdapter(
     (f) => f.severities,
@@ -147,11 +158,11 @@ const TYPED_ADAPTERS: Record<string, TypedFieldAdapter> = {
   ),
   [key("taskSLABusinessElapsedPercent", "gte")]: simpleAdapter(
     (f) => (f.slaElapsedPctGte !== null ? [String(f.slaElapsedPctGte)] : []),
-    (f, v) => ({ ...f, slaElapsedPctGte: v.length > 0 ? Number(v[0]) : null }),
+    (f, v) => ({ ...f, slaElapsedPctGte: parseSlaPct(v) }),
   ),
   [key("taskSLABusinessElapsedPercent", "lte")]: simpleAdapter(
     (f) => (f.slaElapsedPctLte !== null ? [String(f.slaElapsedPctLte)] : []),
-    (f, v) => ({ ...f, slaElapsedPctLte: v.length > 0 ? Number(v[0]) : null }),
+    (f, v) => ({ ...f, slaElapsedPctLte: parseSlaPct(v) }),
   ),
   [key("escalationLevel", "in")]: simpleAdapter(
     (f) => f.escalationLevels,

--- a/apps/csm-portal/webapp/src/features/csm-cases/utils/filterFieldAdapters.ts
+++ b/apps/csm-portal/webapp/src/features/csm-cases/utils/filterFieldAdapters.ts
@@ -1,0 +1,393 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { CaseState, Severity } from "@features/csm-dashboard/types/abtDashboard";
+import type { BeCaseType, BeCaseWorkState, BeEngagementType } from "@api/backend/types";
+import type { CasesFilters } from "@features/csm-cases/components/CasesFilterBar";
+import {
+  ADVANCED_FILTER_FIELDS,
+  defaultAdvancedFilterRow,
+  isCompleteAdvancedFilterRow,
+  type AdvancedFilterField,
+  type AdvancedFilterRow,
+} from "@features/csm-cases/utils/advancedFilters";
+
+/**
+ * The per-field "one canonical state, two presentations" adapter registry —
+ * this is what makes switching between the Simple grid and the unified
+ * Advanced-mode row list lossless. For every `CasesFilters` field that
+ * already has a real, typed slot (the ~20 fields listed in `CasesFilters`'s
+ * own doc comment), `get`/`set` read/write that real property directly —
+ * there is no second, parallel "advanced filter value" for these fields, so
+ * a value picked in one mode is immediately visible, in the same shape, in
+ * the other. A field/op pair with NO entry here (the 7 fields with no typed
+ * `CasesFilters` slot: `deploymentId`, `number`, `internalId`,
+ * `resolutionNotes`, `parentId`, `createdBy`, `issueType`) falls back to the
+ * existing generic `filters.advancedFilters` array mechanism, exactly as it
+ * worked before this unification.
+ *
+ * `values` here is always the row's UI-domain string form (e.g. `Severity`
+ * literals like `"S1"`, not the backend's `priority` encoding) — the same
+ * shape the Simple grid's own dedicated controls already read/write.
+ * Backend-form translation (severity→priority, UI state→BE state, ...)
+ * happens once, downstream, in `caseSearchPayload.ts` — unchanged by this
+ * file, since that already reads straight off the same typed `CasesFilters`
+ * properties these adapters target.
+ */
+interface TypedFieldAdapter {
+  get: (f: CasesFilters) => string[];
+  /** Applies a complete row's values to the real `CasesFilters` property. */
+  set: (f: CasesFilters, values: string[]) => CasesFilters;
+  /** Resets the real `CasesFilters` property back to its "unset" value —
+   * used when a row is removed, or when it's edited away from this
+   * field/op entirely. Defaults to `set(f, [])`, which is exactly right
+   * for every array/scalar-valued field; only the value-less `escalation`
+   * ops (whose `set` doesn't accept an empty-values "clear" — see below)
+   * override it. */
+  clear: (f: CasesFilters) => CasesFilters;
+}
+
+function simpleAdapter(
+  get: (f: CasesFilters) => string[],
+  set: (f: CasesFilters, values: string[]) => CasesFilters,
+): TypedFieldAdapter {
+  return { get, set, clear: (f) => set(f, []) };
+}
+
+/** `state`/`in` and `state`/`notIn` share this: work sub-state only applies
+ * server-side when `work_in_progress` is the *sole* included state (see
+ * `caseSearchPayload.ts`'s own matching guard) — mirror that invariant here
+ * so editing either side of the state row can't silently strand an
+ * inapplicable `workStates` value that only a chip could then reveal. */
+function pruneWorkStatesIfNotSoleWip(f: CasesFilters): BeCaseWorkState[] {
+  const soleWip =
+    f.states.length === 1 && f.states[0] === "work_in_progress" && f.excludeStates.length === 0;
+  return soleWip ? f.workStates : [];
+}
+
+function key(field: string, op: string): string {
+  return `${field}:${op}`;
+}
+
+const TYPED_ADAPTERS: Record<string, TypedFieldAdapter> = {
+  [key("severity", "in")]: simpleAdapter(
+    (f) => f.severities,
+    (f, v) => ({ ...f, severities: v as Severity[] }),
+  ),
+  [key("state", "in")]: simpleAdapter(
+    (f) => f.states,
+    (f, v) => {
+      const next = { ...f, states: v as CaseState[] };
+      return { ...next, workStates: pruneWorkStatesIfNotSoleWip(next) };
+    },
+  ),
+  [key("state", "notIn")]: simpleAdapter(
+    (f) => f.excludeStates,
+    (f, v) => {
+      const next = { ...f, excludeStates: v as CaseState[] };
+      return { ...next, workStates: pruneWorkStatesIfNotSoleWip(next) };
+    },
+  ),
+  [key("workState", "in")]: simpleAdapter(
+    (f) => f.workStates,
+    (f, v) => ({ ...f, workStates: v as BeCaseWorkState[] }),
+  ),
+  [key("type", "in")]: simpleAdapter(
+    (f) => f.caseTypes,
+    (f, v) => ({ ...f, caseTypes: v as BeCaseType[] }),
+  ),
+  [key("assignedUserId", "in")]: simpleAdapter(
+    (f) => f.assignees,
+    (f, v) => ({ ...f, assignees: v }),
+  ),
+  [key("projectId", "in")]: simpleAdapter(
+    (f) => f.projects,
+    (f, v) => ({ ...f, projects: v }),
+  ),
+  [key("product", "in")]: simpleAdapter(
+    (f) => f.productNames,
+    (f, v) => ({ ...f, productNames: v }),
+  ),
+  [key("creTeam", "in")]: simpleAdapter(
+    (f) => f.csTeams,
+    (f, v) => ({ ...f, csTeams: v }),
+  ),
+  [key("sreTeam", "in")]: simpleAdapter(
+    (f) => f.sreTeams,
+    (f, v) => ({ ...f, sreTeams: v }),
+  ),
+  [key("tag", "in")]: simpleAdapter(
+    (f) => f.tags,
+    (f, v) => ({ ...f, tags: v }),
+  ),
+  [key("tag", "notIn")]: simpleAdapter(
+    (f) => f.excludeTags,
+    (f, v) => ({ ...f, excludeTags: v }),
+  ),
+  [key("projectOnboardingStatus", "in")]: simpleAdapter(
+    (f) => f.onboardingStatuses,
+    (f, v) => ({ ...f, onboardingStatuses: v }),
+  ),
+  [key("engagementType", "in")]: simpleAdapter(
+    (f) => f.engagementTypes,
+    (f, v) => ({ ...f, engagementTypes: v as BeEngagementType[] }),
+  ),
+  [key("taskSLABusinessElapsedPercent", "gte")]: simpleAdapter(
+    (f) => (f.slaElapsedPctGte !== null ? [String(f.slaElapsedPctGte)] : []),
+    (f, v) => ({ ...f, slaElapsedPctGte: v.length > 0 ? Number(v[0]) : null }),
+  ),
+  [key("taskSLABusinessElapsedPercent", "lte")]: simpleAdapter(
+    (f) => (f.slaElapsedPctLte !== null ? [String(f.slaElapsedPctLte)] : []),
+    (f, v) => ({ ...f, slaElapsedPctLte: v.length > 0 ? Number(v[0]) : null }),
+  ),
+  [key("escalationLevel", "in")]: simpleAdapter(
+    (f) => f.escalationLevels,
+    (f, v) => ({ ...f, escalationLevels: v }),
+  ),
+  // `escalation` is value-less (`isNotEmpty`/`isEmpty` — the op alone is the
+  // whole predicate, see `hasEscalation`'s own doc comment on `CasesFilters`)
+  // — a row's mere presence with this field/op means "active"/"has none"
+  // regardless of its (always-empty) `values`, so `set` can't reuse the
+  // `simpleAdapter` "set([]) clears" convention: `set(f, [])` here still
+  // means "activate this op", not "clear". `clear` is overridden instead.
+  [key("escalation", "isNotEmpty")]: {
+    get: (f) => (f.hasEscalation === true ? ["true"] : []),
+    set: (f) => ({ ...f, hasEscalation: true }),
+    clear: (f) => ({ ...f, hasEscalation: null }),
+  },
+  [key("escalation", "isEmpty")]: {
+    get: (f) => (f.hasEscalation === false ? ["true"] : []),
+    set: (f) => ({ ...f, hasEscalation: false }),
+    clear: (f) => ({ ...f, hasEscalation: null }),
+  },
+  [key("projectType", "in")]: simpleAdapter(
+    (f) => f.projectTypes,
+    (f, v) => ({ ...f, projectTypes: v }),
+  ),
+  [key("createdOn", "gte")]: simpleAdapter(
+    (f) => (f.createdOnGte !== null ? [f.createdOnGte] : []),
+    (f, v) => ({ ...f, createdOnGte: v[0] ?? null }),
+  ),
+  [key("createdOn", "lte")]: simpleAdapter(
+    (f) => (f.createdOnLte !== null ? [f.createdOnLte] : []),
+    (f, v) => ({ ...f, createdOnLte: v[0] ?? null }),
+  ),
+  [key("updatedOn", "gte")]: simpleAdapter(
+    (f) => (f.updatedOnGte !== null ? [f.updatedOnGte] : []),
+    (f, v) => ({ ...f, updatedOnGte: v[0] ?? null }),
+  ),
+  [key("updatedOn", "lte")]: simpleAdapter(
+    (f) => (f.updatedOnLte !== null ? [f.updatedOnLte] : []),
+    (f, v) => ({ ...f, updatedOnLte: v[0] ?? null }),
+  ),
+  [key("closedOn", "gte")]: simpleAdapter(
+    (f) => (f.closedOnGte !== null ? [f.closedOnGte] : []),
+    (f, v) => ({ ...f, closedOnGte: v[0] ?? null }),
+  ),
+  [key("closedOn", "lte")]: simpleAdapter(
+    (f) => (f.closedOnLte !== null ? [f.closedOnLte] : []),
+    (f, v) => ({ ...f, closedOnLte: v[0] ?? null }),
+  ),
+};
+
+function getTypedAdapter(field: string, op: string): TypedFieldAdapter | undefined {
+  return TYPED_ADAPTERS[key(field, op)];
+}
+
+/** One row in the unified Advanced-mode row list — a normal
+ * {@link AdvancedFilterRow} plus where it actually lives: `"typed"` means
+ * it's a live view of a real `CasesFilters` property (via the registry
+ * above); `"array"` means it's a normal entry in `filters.advancedFilters`
+ * (`arrayIndex` is its position there — required for `"array"` rows,
+ * unused for `"typed"` ones). */
+export interface UnifiedFilterRow extends AdvancedFilterRow {
+  origin: "typed" | "array";
+  arrayIndex?: number;
+}
+
+/**
+ * Builds the unified Advanced-mode row list: one row per non-empty typed
+ * field/op (in catalogue order), followed by every entry in
+ * `filters.advancedFilters` (in its own order) — the untyped escape hatch,
+ * unchanged. Purely a *view* over `filters`; never stored, always
+ * recomputed from it, which is exactly why Simple↔Advanced switching cannot
+ * drop or duplicate anything: there is nothing else to go stale.
+ */
+export function filtersToAdvancedRows(filters: CasesFilters): UnifiedFilterRow[] {
+  const rows: UnifiedFilterRow[] = [];
+  for (const fieldMeta of ADVANCED_FILTER_FIELDS) {
+    for (const opMeta of fieldMeta.ops) {
+      const adapter = getTypedAdapter(fieldMeta.field, opMeta.op);
+      if (!adapter) continue;
+      const raw = adapter.get(filters);
+      if (raw.length === 0) continue;
+      rows.push({
+        origin: "typed",
+        field: fieldMeta.field,
+        op: opMeta.op,
+        values: opMeta.valueKind === "none" ? [] : raw,
+      });
+    }
+  }
+  filters.advancedFilters.forEach((row, arrayIndex) => {
+    rows.push({ ...row, origin: "array", arrayIndex });
+  });
+  return rows;
+}
+
+/**
+ * Applies an edit to one unified row (including changing its own field —
+ * the row's field-picker dropdown — which this handles the same as any
+ * other edit: clear the old identity, then re-derive where the new one
+ * lives). A row that stays in `filters.advancedFilters` before and after
+ * the edit is updated **in place** at its existing array index rather than
+ * removed-and-reappended, so an in-progress row being typed into never
+ * jumps position (and never loses input focus) on every keystroke — it only
+ * moves position at the one real transition: the edit that makes it
+ * complete-and-typed (promoted out of the array) or the edit that makes an
+ * already-typed row incomplete/re-fielded to an untyped field (demoted back
+ * into the array, appended at the end — there is no "original" array
+ * position to restore a typed row to).
+ */
+export function updateUnifiedRow(
+  filters: CasesFilters,
+  current: UnifiedFilterRow,
+  nextRow: AdvancedFilterRow,
+): CasesFilters {
+  const complete = isCompleteAdvancedFilterRow(nextRow);
+  const newAdapter = getTypedAdapter(nextRow.field, nextRow.op);
+  const staysInArrayInPlace =
+    current.origin === "array" && !(complete && newAdapter) && current.arrayIndex !== undefined;
+
+  if (staysInArrayInPlace) {
+    return {
+      ...filters,
+      advancedFilters: filters.advancedFilters.map((r, i) =>
+        i === current.arrayIndex ? nextRow : r,
+      ),
+    };
+  }
+
+  let next = filters;
+  if (current.origin === "typed") {
+    const oldAdapter = getTypedAdapter(current.field, current.op);
+    if (oldAdapter) next = oldAdapter.clear(next);
+  } else if (current.origin === "array" && current.arrayIndex !== undefined) {
+    next = {
+      ...next,
+      advancedFilters: next.advancedFilters.filter((_, i) => i !== current.arrayIndex),
+    };
+  }
+
+  if (complete && newAdapter) {
+    next = newAdapter.set(next, nextRow.values);
+  } else {
+    next = { ...next, advancedFilters: [...next.advancedFilters, nextRow] };
+  }
+  return next;
+}
+
+/** Removes one unified row entirely — clears the real `CasesFilters`
+ * property for a `"typed"` row, splices `filters.advancedFilters` for an
+ * `"array"` one. */
+export function removeUnifiedRow(filters: CasesFilters, row: UnifiedFilterRow): CasesFilters {
+  if (row.origin === "typed") {
+    const adapter = getTypedAdapter(row.field, row.op);
+    return adapter ? adapter.clear(filters) : filters;
+  }
+  if (row.arrayIndex !== undefined) {
+    return {
+      ...filters,
+      advancedFilters: filters.advancedFilters.filter((_, i) => i !== row.arrayIndex),
+    };
+  }
+  return filters;
+}
+
+/** Appends a brand-new, blank row — always lands in `filters.advancedFilters`
+ * (an unset field/op has nothing for a typed adapter to represent yet; see
+ * `filtersToAdvancedRows`, which only shows a typed row once it's non-empty)
+ * exactly like the "Add filter" button did before this unification. */
+export function addBlankUnifiedRow(filters: CasesFilters): CasesFilters {
+  return { ...filters, advancedFilters: [...filters.advancedFilters, defaultAdvancedFilterRow()] };
+}
+
+/**
+ * Folds any `filters.advancedFilters` entry that targets a now-typed
+ * field/op (e.g. a `af` URL param authored — by hand, or by an older build
+ * of this page — before `severity`/`state`/`tag`/... had typed adapters)
+ * into the real `CasesFilters` property instead, so it never lingers as a
+ * dangling duplicate of the same predicate. Called once at the URL-read
+ * boundary (`readCasesFiltersFromUrl`); every edit made through
+ * {@link updateUnifiedRow} already keeps this invariant by construction, so
+ * this is purely a defensive normalization of *external* input, not
+ * something the builder itself needs to re-run.
+ */
+export function normalizeCasesFilters(filters: CasesFilters): CasesFilters {
+  let next = filters;
+  const kept: AdvancedFilterRow[] = [];
+  for (const row of filters.advancedFilters) {
+    const adapter = getTypedAdapter(row.field, row.op);
+    if (adapter && isCompleteAdvancedFilterRow(row)) {
+      next = adapter.set(next, row.values);
+    } else {
+      kept.push(row);
+    }
+  }
+  return { ...next, advancedFilters: kept };
+}
+
+/**
+ * Fields the Simple grid's dedicated controls do NOT cover (after removing
+ * Tags — it's Advanced-only now, see `CasesFilterBar.tsx`). Filters
+ * expressible entirely within the Simple grid's fields (`severities`,
+ * `states`, `excludeStates`, `caseTypes`, `assignees`, `workStates`,
+ * `projects`, `engagementTypes`, `productNames`, `csTeams`,
+ * `onboardingStatuses`) can still be represented in Simple mode regardless
+ * of this check — those fields simply aren't in this list.
+ *
+ * `excludeStates` deliberately does NOT gate Simple mode, unlike `tags`/
+ * `excludeTags`: the Simple grid's "State" control is already a tri-state
+ * (`TriStateMultiSelectField`, digiops-cs#2907) that reads/writes both
+ * `states` AND `excludeStates` directly — it's genuinely Simple-representable
+ * today, not merely tolerated there. `tags`/`excludeTags` have no such
+ * Simple-mode control any more (Tags moved to Advanced-only), which is why
+ * they DO gate it.
+ */
+export function isSimpleRepresentable(filters: CasesFilters): boolean {
+  return (
+    filters.tags.length === 0 &&
+    filters.excludeTags.length === 0 &&
+    filters.sreTeams.length === 0 &&
+    filters.projectTypes.length === 0 &&
+    filters.escalationLevels.length === 0 &&
+    filters.hasEscalation === null &&
+    filters.slaElapsedPctGte === null &&
+    filters.slaElapsedPctLte === null &&
+    filters.createdOnGte === null &&
+    filters.createdOnLte === null &&
+    filters.updatedOnGte === null &&
+    filters.updatedOnLte === null &&
+    filters.closedOnGte === null &&
+    filters.closedOnLte === null &&
+    filters.advancedFilters.length === 0 &&
+    filters.anyOfBranches.length === 0
+  );
+}
+
+// Re-exported so callers that only need the field-catalogue type don't have
+// to also import `advancedFilters.ts` directly.
+export type { AdvancedFilterField };

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.test.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.test.ts
@@ -23,7 +23,12 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { WIDGET_RESOURCE_CONFIG } from "@features/csm-dashboard/config/widgetResourceConfig";
+import {
+  callRequestWidgetFiltersToQuery,
+  DEFAULT_CALL_REQUEST_WIDGET_FILTERS,
+  translateCallRequestDashboardFilters,
+  WIDGET_RESOURCE_CONFIG,
+} from "@features/csm-dashboard/config/widgetResourceConfig";
 import { readCasesFiltersFromUrl } from "@features/csm-cases/utils/casesFiltersUrl";
 
 function hrefParams(href: string): URLSearchParams {
@@ -500,5 +505,83 @@ describe("WIDGET_RESOURCE_CONFIG.case_feedback.buildSearchRequestBody", () => {
     }) as { filters: Record<string, unknown> };
 
     expect(body.filters).toEqual({ dateFrom: "2026-08-01", rating: 5 });
+  });
+});
+
+/**
+ * `translateCallRequestDashboardFilters`/`callRequestWidgetFiltersToQuery` —
+ * the call-requests "View more" landing's own seed/query pair, mirroring
+ * `translateCaseDashboardFilters` for the much smaller (4-field, no op
+ * choice except caseStates/excludeCaseStates) `/call-requests/search`
+ * contract confirmed against `apps/csm-portal/backend/openapi.yaml`'s
+ * `SearchAllCallRequestsPayload`.
+ */
+describe("translateCallRequestDashboardFilters", () => {
+  it("passes every field of a widget's flat call-request filters through unchanged", () => {
+    const out = translateCallRequestDashboardFilters({
+      assignedUserIds: ["11111111-1111-1111-1111-111111111111"],
+      states: ["scheduled", "pending_on_wso2"],
+      caseStates: ["open", "work_in_progress"],
+      excludeCaseStates: ["closed"],
+      assignmentTeamIds: ["22222222-2222-2222-2222-222222222222"],
+    });
+
+    expect(out).toEqual({
+      assignedUserIds: ["11111111-1111-1111-1111-111111111111"],
+      states: ["scheduled", "pending_on_wso2"],
+      caseStates: ["open", "work_in_progress"],
+      excludeCaseStates: ["closed"],
+      assignmentTeamIds: ["22222222-2222-2222-2222-222222222222"],
+    });
+  });
+
+  it("omits a field entirely when its widget value is an empty array, rather than seeding an explicit empty filter", () => {
+    const out = translateCallRequestDashboardFilters({
+      assignedUserIds: [],
+      states: ["scheduled"],
+    });
+
+    expect(out).toEqual({ states: ["scheduled"] });
+    expect(out.assignedUserIds).toBeUndefined();
+  });
+
+  it("returns an empty object for a widget with no call-request filters at all", () => {
+    expect(translateCallRequestDashboardFilters({})).toEqual({});
+  });
+
+  it("ignores a non-array/non-string value for a field rather than throwing", () => {
+    expect(translateCallRequestDashboardFilters({ states: "scheduled" })).toEqual({});
+  });
+});
+
+describe("callRequestWidgetFiltersToQuery", () => {
+  it("omits every empty-array field so an untouched control means 'unfiltered', not 'match nothing'", () => {
+    expect(callRequestWidgetFiltersToQuery(DEFAULT_CALL_REQUEST_WIDGET_FILTERS)).toEqual({});
+  });
+
+  it("includes only the fields that carry a value", () => {
+    const query = callRequestWidgetFiltersToQuery({
+      ...DEFAULT_CALL_REQUEST_WIDGET_FILTERS,
+      states: ["concluded"],
+      excludeCaseStates: ["closed"],
+    });
+
+    expect(query).toEqual({ states: ["concluded"], excludeCaseStates: ["closed"] });
+  });
+
+  it("round-trips a full filter set through translate -> toQuery unchanged", () => {
+    const widgetFilters = {
+      assignedUserIds: ["11111111-1111-1111-1111-111111111111"],
+      states: ["scheduled"],
+      caseStates: ["open"],
+      excludeCaseStates: ["closed"],
+      assignmentTeamIds: ["22222222-2222-2222-2222-222222222222"],
+    };
+    const seeded = {
+      ...DEFAULT_CALL_REQUEST_WIDGET_FILTERS,
+      ...translateCallRequestDashboardFilters(widgetFilters),
+    };
+
+    expect(callRequestWidgetFiltersToQuery(seeded)).toEqual(widgetFilters);
   });
 });

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.ts
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/config/widgetResourceConfig.ts
@@ -33,8 +33,9 @@ import {
   ListChecks,
   type LucideIcon,
 } from "@wso2/oxygen-ui-icons-react";
-import type { BeWidgetResourceType } from "@api/backend/types";
+import type { BeCallRequestStateKey, BeWidgetResourceType } from "@api/backend/types";
 import { humanizeState } from "@features/csm-dashboard/utils/abtDashboard";
+import type { CaseState } from "@features/csm-dashboard/types/abtDashboard";
 import {
   casesHref,
   DEFAULT_CASES_FILTERS,
@@ -508,6 +509,103 @@ function translateChangeRequestDashboardFilters(
   if (states) out.states = states as ChangeRequestFilters["states"];
   const impacts = asStringArray(filters.impacts);
   if (impacts) out.impacts = impacts as ChangeRequestFilters["impacts"];
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// call_request — POST /call-requests/search, whose flat `filters` shape is
+// its own thing (assignee/state/case-state/team, not the case-search DSL).
+// ---------------------------------------------------------------------------
+
+/**
+ * Filter state for the call-requests "View more" landing page's own filter
+ * bar. Mirrors `SearchAllCallRequestsPayload.filters` (the CSM backend's
+ * `POST /call-requests/search` contract — confirmed directly against
+ * `apps/csm-portal/backend/openapi.yaml`, not inferred): `assignedUserIds`
+ * (the parent case's assigned user(s), platform UUIDs — this endpoint has no
+ * `@me` sentinel of its own; any `__current_user__`/`@me` placeholder in a
+ * widget's own filters is already resolved to a real id upstream, before
+ * `translateCallRequestDashboardFilters` below ever sees it — see
+ * `resolveCurrentUserSentinels` in `DashboardWidgetPreviewPage.tsx`),
+ * `states` (call-request state keys — `ALL_CALL_REQUEST_STATES` in
+ * `callRequestState.ts`), `caseStates`/`excludeCaseStates` (the parent
+ * case's state, in vs. not-in — confirmed independent fields on this
+ * contract, "either, both, or neither may be supplied", not one field with
+ * an inferred op), and `assignmentTeamIds` (the parent case's assigned CRE
+ * team, `creGroupId` values — confirmed CRE-only per digiops-cs#2732 "Calls
+ * To Attend"; this contract has no SRE-team equivalent field). Scoped here
+ * rather than exported alongside `CasesFilters` from a shared filter-bar
+ * component: call requests have no other list page of their own for this
+ * shape to be shared with.
+ */
+export interface CallRequestWidgetFilters {
+  assignedUserIds: string[];
+  states: BeCallRequestStateKey[];
+  caseStates: CaseState[];
+  excludeCaseStates: CaseState[];
+  assignmentTeamIds: string[];
+}
+
+export const DEFAULT_CALL_REQUEST_WIDGET_FILTERS: CallRequestWidgetFilters = {
+  assignedUserIds: [],
+  states: [],
+  caseStates: [],
+  excludeCaseStates: [],
+  assignmentTeamIds: [],
+};
+
+/**
+ * Translate a call-request widget's opaque flat filters (the same shape its
+ * own tile fetch already POSTs to `/call-requests/search` — see
+ * `WIDGET_RESOURCE_CONFIG.call_request`, which has no
+ * `buildSearchRequestBody` override, so `useWidgetData`'s default
+ * `{filters, pagination, sortBy?}` passthrough already matches this
+ * endpoint's own contract) into `CallRequestWidgetFilters`, the same "seed
+ * once, then fully editable" input `translateCaseDashboardFilters` builds
+ * for the case-family resourceTypes. No value remapping is needed here
+ * (unlike that translator's severity/state-code tables): every field this
+ * endpoint accepts already uses its own wire values, so this is a
+ * structural narrow, not a translation.
+ */
+export function translateCallRequestDashboardFilters(
+  filters: Record<string, unknown>,
+): Partial<CallRequestWidgetFilters> {
+  const out: Partial<CallRequestWidgetFilters> = {};
+  const assignedUserIds = asStringArray(filters.assignedUserIds);
+  if (assignedUserIds && assignedUserIds.length > 0) out.assignedUserIds = assignedUserIds;
+  const states = asStringArray(filters.states);
+  if (states && states.length > 0) out.states = states as BeCallRequestStateKey[];
+  const caseStates = asStringArray(filters.caseStates);
+  if (caseStates && caseStates.length > 0) out.caseStates = caseStates as CaseState[];
+  const excludeCaseStates = asStringArray(filters.excludeCaseStates);
+  if (excludeCaseStates && excludeCaseStates.length > 0) {
+    out.excludeCaseStates = excludeCaseStates as CaseState[];
+  }
+  const assignmentTeamIds = asStringArray(filters.assignmentTeamIds);
+  if (assignmentTeamIds && assignmentTeamIds.length > 0) {
+    out.assignmentTeamIds = assignmentTeamIds;
+  }
+  return out;
+}
+
+/**
+ * Inverse of `translateCallRequestDashboardFilters`: the filter bar's own
+ * `CallRequestWidgetFilters` state back into the flat `filters` object
+ * `useWidgetData` POSTs to `/call-requests/search`. Empty arrays are
+ * omitted rather than sent as `field: []` — same convention every other
+ * resourceType's own filter-building already follows (an empty array here
+ * would ask the backend to match zero call requests, not "unfiltered",
+ * which is the opposite of what an untouched control means).
+ */
+export function callRequestWidgetFiltersToQuery(
+  filters: CallRequestWidgetFilters,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  if (filters.assignedUserIds.length > 0) out.assignedUserIds = filters.assignedUserIds;
+  if (filters.states.length > 0) out.states = filters.states;
+  if (filters.caseStates.length > 0) out.caseStates = filters.caseStates;
+  if (filters.excludeCaseStates.length > 0) out.excludeCaseStates = filters.excludeCaseStates;
+  if (filters.assignmentTeamIds.length > 0) out.assignmentTeamIds = filters.assignmentTeamIds;
   return out;
 }
 

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/pages/DashboardWidgetPreviewPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/pages/DashboardWidgetPreviewPage.test.tsx
@@ -512,7 +512,6 @@ describe("DashboardWidgetPreviewPage — case-family widgets get the real, edita
     await waitFor(() => expect(screen.getByText("CS-1")).toBeInTheDocument());
     expect(screen.getByRole("combobox", { name: "Severity" })).toBeInTheDocument();
     expect(screen.getByRole("combobox", { name: "State" })).toBeInTheDocument();
-    expect(screen.getByRole("combobox", { name: "Tags" })).toBeInTheDocument();
     expect(screen.queryByRole("group", { name: "Active filters" })).not.toBeInTheDocument();
 
     expect(postMock).toHaveBeenCalledWith(
@@ -599,11 +598,14 @@ describe("DashboardWidgetPreviewPage — case-family widgets get the real, edita
     expect(lastCall?.[1]).toMatchObject({ filters: { searchQuery: "disk" } });
   });
 
-  // The tri-state `TagsMultiSelect` (digiops-cs#2907) means a widget's
-  // `tag notIn [...]` seeds `excludeTags` directly now -- no more catalog
-  // fetch, no more display/query divergence. What's shown and what's
-  // queried are the same `CasesFilters` value from the start.
-  it("seeds a widget's tag notIn directly into excludeTags -- shown as an excluded chip and queried as the same notIn condition", async () => {
+  // `tag`/`excludeTags` is Advanced-mode-only now (see `CasesFilterBar.tsx`'s
+  // mode toggle): a widget's `tag notIn [...]` seeds `excludeTags` directly
+  // (no catalog fetch, no display/query divergence), which also means
+  // `isSimpleRepresentable` is false, so the preview mounts straight into
+  // Advanced mode with the `tag`/`notIn` row already showing that value --
+  // what's shown and what's queried are the same `CasesFilters` value from
+  // the start, same invariant as before, just via the unified builder now.
+  it("seeds a widget's tag notIn directly into excludeTags -- shown in the Advanced-mode tag row and queried as the same notIn condition", async () => {
     mockPost({ cases: { cases: [], total: 0, limit: 10, offset: 0 } });
 
     renderAt(
@@ -618,7 +620,8 @@ describe("DashboardWidgetPreviewPage — case-family widgets get the real, edita
     expect(postMock).not.toHaveBeenCalledWith("/tags/search", expect.anything());
 
     await waitFor(() => {
-      expect(screen.getByText("- s_dip")).toBeInTheDocument();
+      expect(screen.getByText("Advanced filters")).toBeInTheDocument();
+      expect(screen.getByText("s_dip")).toBeInTheDocument();
     });
 
     await waitFor(() => {
@@ -648,7 +651,7 @@ describe("DashboardWidgetPreviewPage — case-family widgets get the real, edita
       }),
     );
 
-    await waitFor(() => expect(screen.getByText("- s_dip")).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText("s_dip")).toBeInTheDocument());
 
     fireEvent.change(screen.getByPlaceholderText(/search by case #/i), {
       target: { value: "disk" },

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/pages/DashboardWidgetPreviewPage.test.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/pages/DashboardWidgetPreviewPage.test.tsx
@@ -212,6 +212,168 @@ describe("DashboardWidgetPreviewPage — case_feedback gets a real, editable rat
   });
 });
 
+/**
+ * `call_request`'s own "View more" landing: unlike the generic
+ * "Filtered by:" chip summary + free-text search box (which
+ * `/call-requests/search` doesn't even support — it has no `searchQuery`
+ * field), this gives a real, editable Simple-only filter bar (call state,
+ * case state, assignee, CRE team) seeded from the widget's own flat
+ * filters and feeding the same `useWidgetData` + `CallRequestWidgetList`
+ * the tile itself renders.
+ */
+describe("DashboardWidgetPreviewPage — call_request gets a real, editable filter bar", () => {
+  beforeEach(() => {
+    postMock.mockReset();
+    postMock.mockImplementation((url: string) => {
+      if (url === "/teams/search") {
+        return Promise.resolve({
+          teams: [
+            {
+              id: "castor",
+              name: "Team Castor",
+              family: "cre-abt",
+              creGroupId: "33333333-3333-3333-3333-333333333333",
+            },
+          ],
+          total: 1,
+          limit: 100,
+          offset: 0,
+        });
+      }
+      if (url === "/call-requests/search") {
+        return Promise.resolve({
+          callRequests: [
+            {
+              id: "cr-1",
+              number: "CR-1",
+              reason: "Kickoff call",
+              state: { id: 3, label: "Scheduled" },
+              case: { id: "case-1", number: "CS-1" },
+            },
+          ],
+          total: 1,
+          limit: 10,
+          offset: 0,
+        });
+      }
+      return Promise.resolve({});
+    });
+  });
+
+  it("renders the real filter bar (not the read-only chip summary), seeded from the widget's own flat filters", async () => {
+    renderAt(
+      buildWidgetPreviewHref({
+        previewSlug: "call-requests",
+        widgetId: "team_open_calls",
+        displayName: "Team Open Calls",
+        filters: { states: ["scheduled"], caseStates: ["open"] },
+      }),
+    );
+
+    await waitFor(() => expect(screen.getByText("CR-1")).toBeInTheDocument());
+    expect(screen.getByRole("combobox", { name: "Call state" })).toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: "Case state" })).toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: "CRE Team" })).toBeInTheDocument();
+    expect(screen.queryByRole("group", { name: "Active filters" })).not.toBeInTheDocument();
+
+    expect(postMock).toHaveBeenCalledWith(
+      "/call-requests/search",
+      expect.objectContaining({
+        filters: { states: ["scheduled"], caseStates: ["open"] },
+        pagination: { offset: 0, limit: 10 },
+      }),
+      { signal: expect.any(AbortSignal) },
+    );
+  });
+
+  it("re-queries /call-requests/search when the Call state filter is changed from the dropdown", async () => {
+    renderAt(
+      buildWidgetPreviewHref({
+        previewSlug: "call-requests",
+        widgetId: "team_open_calls",
+        displayName: "Team Open Calls",
+        filters: {},
+      }),
+    );
+
+    await waitFor(() =>
+      expect(postMock).toHaveBeenCalledWith(
+        "/call-requests/search",
+        expect.objectContaining({ filters: {} }),
+        { signal: expect.any(AbortSignal) },
+      ),
+    );
+
+    fireEvent.mouseDown(screen.getByRole("combobox", { name: "Call state" }));
+    fireEvent.click(screen.getByRole("option", { name: "Concluded" }));
+
+    await waitFor(() =>
+      expect(postMock).toHaveBeenCalledWith(
+        "/call-requests/search",
+        expect.objectContaining({ filters: { states: ["concluded"] } }),
+        { signal: expect.any(AbortSignal) },
+      ),
+    );
+  });
+
+  it("Reset restores the widget's own starting filters after an edit", async () => {
+    renderAt(
+      buildWidgetPreviewHref({
+        previewSlug: "call-requests",
+        widgetId: "team_open_calls",
+        displayName: "Team Open Calls",
+        filters: { states: ["scheduled"] },
+      }),
+    );
+
+    await waitFor(() =>
+      expect(postMock).toHaveBeenCalledWith(
+        "/call-requests/search",
+        expect.objectContaining({ filters: { states: ["scheduled"] } }),
+        { signal: expect.any(AbortSignal) },
+      ),
+    );
+
+    fireEvent.mouseDown(screen.getByRole("combobox", { name: "Call state" }));
+    fireEvent.click(screen.getByRole("option", { name: "Scheduled" }));
+    // Deselecting the only selected option clears the field.
+    await waitFor(() =>
+      expect(postMock).toHaveBeenCalledWith(
+        "/call-requests/search",
+        expect.objectContaining({ filters: {} }),
+        { signal: expect.any(AbortSignal) },
+      ),
+    );
+    // The multi-select's menu stays open after a selection (multi-select UX);
+    // close it so the rest of the page isn't aria-hidden behind the popup.
+    fireEvent.keyDown(screen.getByRole("listbox"), { key: "Escape" });
+
+    fireEvent.click(screen.getByRole("button", { name: /^reset$/i }));
+    await waitFor(() =>
+      expect(postMock).toHaveBeenCalledWith(
+        "/call-requests/search",
+        expect.objectContaining({ filters: { states: ["scheduled"] } }),
+        { signal: expect.any(AbortSignal) },
+      ),
+    );
+  });
+
+  it("offers the CRE-team-family teams loaded from /teams/search as CRE Team options", async () => {
+    renderAt(
+      buildWidgetPreviewHref({
+        previewSlug: "call-requests",
+        widgetId: "team_open_calls",
+        displayName: "Team Open Calls",
+        filters: {},
+      }),
+    );
+
+    await waitFor(() => expect(screen.getByText("CR-1")).toBeInTheDocument());
+    fireEvent.mouseDown(screen.getByRole("combobox", { name: "CRE Team" }));
+    expect(screen.getByRole("option", { name: "Team Castor" })).toBeInTheDocument();
+  });
+});
+
 describe("DashboardWidgetPreviewPage", () => {
   beforeEach(() => {
     postMock.mockReset();

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/pages/DashboardWidgetPreviewPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/pages/DashboardWidgetPreviewPage.tsx
@@ -468,6 +468,15 @@ function CallRequestWidgetPreview({
     setPage(0);
   };
 
+  // So the Assignee control can render a selected value equal to the
+  // signed-in user's own id as "Me" instead of its raw UUID — see
+  // `AsyncUserIdMultiSelect`'s `currentUserId` doc comment. `filters` (this
+  // component's own prop) already had any `__current_user__`/`@me`
+  // sentinel resolved to this same id upstream, before this component ever
+  // saw it (`resolveCurrentUserSentinels`, above) — this is only needed to
+  // recognize that resolved id again for display/re-selection.
+  const currentUserId = useCurrentUser().user?.id;
+
   // Same CRE-team sourcing/scoping `CasesFilterBar`'s own "CRE Team" control
   // uses (`useTeams(true)`, filtered to `family === "cre-abt"`, keyed by
   // `creGroupId` — what `assignmentTeamIds` actually matches on, not the
@@ -563,6 +572,7 @@ function CallRequestWidgetPreview({
               setCrFilters({ ...crFilters, assignedUserIds: next });
               setPage(0);
             }}
+            currentUserId={currentUserId}
           />
         </Box>
         <Box sx={{ minWidth: 220 }}>

--- a/apps/csm-portal/webapp/src/features/csm-dashboard/pages/DashboardWidgetPreviewPage.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-dashboard/pages/DashboardWidgetPreviewPage.tsx
@@ -39,6 +39,7 @@ import {
   useColumnPreferences,
 } from "@hooks/useColumnPreferences";
 import { useWidgetData } from "@features/csm-dashboard/api/useWidgetData";
+import { useTeams } from "@features/csm-dashboard/api/useTeams";
 import ColumnCustomizerButton from "@components/column-customizer/ColumnCustomizerButton";
 import RefreshButton from "@components/RefreshButton";
 import { WIDGET_LIST_RENDERERS } from "@features/csm-dashboard/config/widgetListConfig";
@@ -47,8 +48,12 @@ import {
   type CaseOptionalColumnId,
 } from "@features/csm-cases/utils/caseListColumns";
 import {
+  callRequestWidgetFiltersToQuery,
+  DEFAULT_CALL_REQUEST_WIDGET_FILTERS,
   resourceTypeForPreviewSlug,
+  translateCallRequestDashboardFilters,
   translateCaseDashboardFilters,
+  type CallRequestWidgetFilters,
 } from "@features/csm-dashboard/config/widgetResourceConfig";
 import {
   describeWidgetFilters,
@@ -65,6 +70,14 @@ import { DEFAULT_CASES_FILTERS } from "@features/csm-cases/utils/casesFiltersUrl
 import DateRangeFilter, {
   type DateRangeFilterValue,
 } from "@features/csm-dashboard/components/DateRangeFilter";
+import MultiSelectField from "@components/MultiSelectField";
+import TriStateMultiSelectField from "@components/TriStateMultiSelectField";
+import AsyncUserIdMultiSelect from "@features/csm-cases/components/AsyncUserIdMultiSelect";
+import { STATE_OPTIONS } from "@features/csm-cases/utils/caseFilterOptions";
+import {
+  ALL_CALL_REQUEST_STATES,
+  CALL_REQUEST_STATE_LABEL,
+} from "@features/csm-cases/utils/callRequestState";
 
 const DEFAULT_ROWS_PER_PAGE = 10;
 const ROWS_PER_PAGE_OPTIONS = [10, 20, BE_MAX_PAGE_LIMIT];
@@ -184,6 +197,17 @@ export default function DashboardWidgetPreviewPage(): JSX.Element {
         filters={filters}
         backButton={backButton}
         resourceType={resourceType}
+      />
+    );
+  }
+
+  if (resourceType === "call_request") {
+    return (
+      <CallRequestWidgetPreview
+        widgetId={widgetId}
+        displayName={displayName}
+        filters={filters}
+        backButton={backButton}
       />
     );
   }
@@ -372,6 +396,201 @@ function CaseFamilyWidgetPreview({
                 label={`Customise ${displayName} columns`}
               />
             }
+          />
+          <TablePagination
+            component="div"
+            count={data?.total ?? 0}
+            page={page}
+            onPageChange={(_, newPage) => setPage(newPage)}
+            rowsPerPage={rowsPerPage}
+            onRowsPerPageChange={handleRowsPerPageChange}
+            rowsPerPageOptions={ROWS_PER_PAGE_OPTIONS}
+            showFirstButton
+            showLastButton
+          />
+        </>
+      )}
+    </Box>
+  );
+}
+
+interface CallRequestWidgetPreviewProps {
+  widgetId: string;
+  displayName: string;
+  filters: Record<string, unknown>;
+  backButton: JSX.Element;
+}
+
+/**
+ * The call-requests "View more" landing: a real, editable filter bar seeded
+ * from the widget's own filters (`translateCallRequestDashboardFilters` —
+ * see `widgetResourceConfig.ts`), feeding the same `useWidgetData` +
+ * `CallRequestWidgetList` renderer the widget tile itself already uses —
+ * not the generic, read-only "Filtered by:" chip summary + search box
+ * every other flat-filter resourceType falls back to (`call_request` isn't
+ * in `CASE_FAMILY_RESOURCE_TYPES`: it queries `/call-requests/search`, a
+ * different, much smaller field set than the case-search DSL).
+ *
+ * Deliberately Simple-only — no Simple/Advanced toggle like
+ * `CaseFamilyWidgetPreview`'s. Confirmed directly against
+ * `apps/csm-portal/backend/openapi.yaml`'s `SearchAllCallRequestsPayload`:
+ * this endpoint's filters are `assignedUserIds` (plain UUID list, no op
+ * choice), `states` (plain enum list, no op choice), `assignmentTeamIds`
+ * (plain UUID list, no op choice), and `caseStates`/`excludeCaseStates` —
+ * the ONE field here with an in/notIn distinction at all, and that's
+ * already fully expressible via the Case state control's own tri-state
+ * (include/exclude) cycle, the same `TriStateMultiSelectField` pattern
+ * `CasesFilterBar`'s State control uses for the identical shape. With zero
+ * fields left over that a toggle would add anything for, an Advanced mode
+ * here would just be an empty second tab — busywork, not a feature, for a
+ * 4-field contract this much smaller than the case-search DSL
+ * `AdvancedFiltersBuilder` exists for.
+ */
+function CallRequestWidgetPreview({
+  widgetId,
+  displayName,
+  filters,
+  backButton,
+}: CallRequestWidgetPreviewProps): JSX.Element {
+  // Frozen once at mount, same rationale as `CaseFamilyWidgetPreview`'s own
+  // `initial` — a Reset must restore what the widget actually linked here
+  // with, not whatever the viewer has since edited.
+  const [initial] = useState<CallRequestWidgetFilters>(() => ({
+    ...DEFAULT_CALL_REQUEST_WIDGET_FILTERS,
+    ...translateCallRequestDashboardFilters(filters),
+  }));
+  const [crFilters, setCrFilters] = useState<CallRequestWidgetFilters>(initial);
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_ROWS_PER_PAGE);
+
+  const handleReset = (): void => {
+    setCrFilters(initial);
+    setPage(0);
+  };
+
+  // Same CRE-team sourcing/scoping `CasesFilterBar`'s own "CRE Team" control
+  // uses (`useTeams(true)`, filtered to `family === "cre-abt"`, keyed by
+  // `creGroupId` — what `assignmentTeamIds` actually matches on, not the
+  // registry `id`). This endpoint's `assignmentTeamIds` is CRE-only per
+  // digiops-cs#2732 ("Calls To Attend") — no SRE-team equivalent exists on
+  // this contract, so there is no second team control to add here.
+  const { data: teams } = useTeams(true);
+  const creTeamOptions = useMemo(
+    () =>
+      (teams ?? [])
+        .filter(
+          (t): t is typeof t & { creGroupId: string } =>
+            Boolean(t.creGroupId) && t.family === "cre-abt",
+        )
+        .map((t) => ({ value: t.creGroupId, label: t.name })),
+    [teams],
+  );
+
+  const callStateOptions = useMemo(
+    () =>
+      ALL_CALL_REQUEST_STATES.map((s) => ({ value: s, label: CALL_REQUEST_STATE_LABEL[s] })),
+    [],
+  );
+
+  const queriedFilters = useMemo(
+    () => callRequestWidgetFiltersToQuery(crFilters),
+    [crFilters],
+  );
+
+  const { data, isLoading, isError, isFetching, refetch, dataUpdatedAt } = useWidgetData(
+    widgetId,
+    "call_request",
+    queriedFilters,
+    "list",
+    rowsPerPage,
+    page * rowsPerPage,
+  );
+  const ListRenderer = WIDGET_LIST_RENDERERS.call_request;
+
+  const handleRowsPerPageChange = (e: ChangeEvent<HTMLInputElement>): void => {
+    setRowsPerPage(parseInt(e.target.value, 10));
+    setPage(0);
+  };
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+      {backButton}
+      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 1 }}>
+        <Typography variant="h5">{displayName}</Typography>
+        <RefreshButton
+          onRefresh={() => void refetch()}
+          isFetching={isFetching}
+          updatedAt={dataUpdatedAt}
+          label={`Refresh ${displayName}`}
+        />
+      </Box>
+      <Box sx={{ display: "flex", flexWrap: "wrap", alignItems: "flex-end", gap: 2 }}>
+        <Box sx={{ minWidth: 220 }}>
+          <MultiSelectField
+            id="call-request-filter-state"
+            label="Call state"
+            values={crFilters.states}
+            options={callStateOptions}
+            onChange={(next) => {
+              setCrFilters({ ...crFilters, states: next });
+              setPage(0);
+            }}
+          />
+        </Box>
+        <Box sx={{ minWidth: 220 }}>
+          <TriStateMultiSelectField
+            id="call-request-filter-case-state"
+            label="Case state"
+            includedValues={crFilters.caseStates}
+            excludedValues={crFilters.excludeCaseStates}
+            options={STATE_OPTIONS}
+            onChange={(next) => {
+              setCrFilters({
+                ...crFilters,
+                caseStates: next.included,
+                excludeCaseStates: next.excluded,
+              });
+              setPage(0);
+            }}
+          />
+        </Box>
+        <Box sx={{ minWidth: 220 }}>
+          <AsyncUserIdMultiSelect
+            id="call-request-filter-assignee"
+            label="Assignee"
+            values={crFilters.assignedUserIds}
+            onChange={(next) => {
+              setCrFilters({ ...crFilters, assignedUserIds: next });
+              setPage(0);
+            }}
+          />
+        </Box>
+        <Box sx={{ minWidth: 220 }}>
+          <MultiSelectField
+            id="call-request-filter-team"
+            label="CRE Team"
+            values={crFilters.assignmentTeamIds}
+            options={creTeamOptions}
+            onChange={(next) => {
+              setCrFilters({ ...crFilters, assignmentTeamIds: next });
+              setPage(0);
+            }}
+          />
+        </Box>
+        <Button variant="text" size="small" onClick={handleReset}>
+          Reset
+        </Button>
+      </Box>
+      {isError ? (
+        <Typography variant="body2" color="text.secondary">
+          Could not load this widget.
+        </Typography>
+      ) : (
+        <>
+          <ListRenderer
+            items={data?.items ?? []}
+            isLoading={isLoading}
+            resourceType="call_request"
           />
           <TablePagination
             component="div"

--- a/apps/csm-portal/webapp/src/features/csm-projects/components/WorkItemsTab.tsx
+++ b/apps/csm-portal/webapp/src/features/csm-projects/components/WorkItemsTab.tsx
@@ -53,6 +53,18 @@ interface WorkItemsTabProps {
  * closed `<Select multiple>` dropdown already, not an inline checkbox list)
  * rather than introducing a new control.
  *
+ * `hideOnboardingStatusFilter`/`hideCreTeamFilter` are also passed: both are
+ * per-project attributes (a project's onboarding status, the CS team its
+ * account is scoped to), so every work item on this already project-scoped
+ * tab shares the same value for each — filtering by them here is a no-op
+ * that only adds clutter. `showSeverityFilter` is passed `true` (overriding
+ * `CsmIssuesView`'s own "only when type is locked to Case" default, which
+ * would never fire here since this tab's type filter is unlocked): Severity
+ * is still a genuinely useful control on this mixed list, since narrowing by
+ * it implicitly narrows to Case-type rows (the only type severity applies
+ * to) the same way picking "Case" in the Work item type control would;
+ * non-case rows simply have no severity to match a picked value.
+ *
  * Conversations is the project's chat sessions (`ConversationsTab`), kept as
  * its own sub-tab alongside the flat issues list rather than a third
  * top-level project tab — it was already nested here before this revamp.
@@ -80,6 +92,9 @@ export default function WorkItemsTab({ projectId }: WorkItemsTabProps): JSX.Elem
           entityNoun="work items"
           lockedFilters={{ projects: [projectId] }}
           hideProjectFilter
+          hideOnboardingStatusFilter
+          hideCreTeamFilter
+          showSeverityFilter
           typeFilterLabel="Work item type"
           hideBackButton
         />

--- a/apps/csm-portal/webapp/src/features/help/content/support.md
+++ b/apps/csm-portal/webapp/src/features/help/content/support.md
@@ -7,24 +7,36 @@ working a case once you're on its detail page.
 ## Finding cases
 
 The search box at the top of the list matches on case number, subject, customer, project, or
-assignee. Next to it, **Filters** expands a grid of additional controls:
+assignee. Next to it, **Filters** expands a grid of additional controls, with a **Simple** /
+**Advanced** toggle above it:
 
-- **Severity**: S0 (Catastrophic) through S4 (Low / Query). S0 is reserved for Managed Cloud
-  projects.
-- **State**: Open, Work in progress, Solution proposed, Awaiting info, Waiting on WSO2,
-  Closed. The state chip's color tells you whose move it is: blue for active states on us
-  (Open, Work in progress), amber for an elevated on-us state (Waiting on WSO2), grey for
-  waiting on the customer (Solution proposed, Awaiting info), green for Closed.
-- **Team**, **Case type**, **Assignee** (search the engineer directory, or pick "Me"),
-  **Product**, **Onboarding status**, **Tags**, and **Project**.
-- **Tags** is include/exclude: click a tag once to require it (shown as a `+ tag` chip), click
-  it again to exclude it instead (`- tag`, in red), and a third click clears it. You can mix
-  included and excluded tags at once.
+- **Simple** (the default) is a fixed grid: **Severity**, **State**, **Team**, **Case type**,
+  **Assignee** (search the engineer directory, or pick "Me"), **Product**, **Onboarding
+  status**, and **Project**.
+  - **Severity**: S0 (Catastrophic) through S4 (Low / Query). S0 is reserved for Managed Cloud
+    projects.
+  - **State**: Open, Work in progress, Solution proposed, Awaiting info, Waiting on WSO2,
+    Closed. Click a state once to require it, again to exclude it instead, a third time to
+    clear it — the chip's color tells you whose move it is: blue for active states on us
+    (Open, Work in progress), amber for an elevated on-us state (Waiting on WSO2), grey for
+    waiting on the customer (Solution proposed, Awaiting info), green for Closed.
+- **Advanced** replaces the grid with a list of field/operator/value rows — every field Simple
+  mode covers, plus more (**Tags** — include or exclude a tag by picking the "includes" or
+  "excludes" operator on its row — SRE team, project type, escalation, SLA business-elapsed
+  percent, created/updated/closed date ranges, created-by, and a few opaque IDs). Click **Add
+  filter** for a new row, pick its field, operator, and value, and the trash icon to remove it.
+  Below the rows, **OR groups** lets you combine several conditions with OR instead of the
+  default AND (e.g. "Severity is S1 OR Type is Engagement").
+- The bar switches to Advanced automatically if the filters it's showing (from a saved view, a
+  shared link, or a dashboard click-through) include anything Simple mode can't express — Tags
+  is the most common reason. **Simple** is greyed out (with a tooltip explaining why) whenever
+  the current filters can't be shown there; clear the Advanced-only ones to switch back.
 
 When a case list arrives already filtered, for example after clicking into a dashboard
-widget, any filter that doesn't have its own control in the grid (an excluded state, an
-SLA-percent bound, an escalation filter, and so on) still shows up as a removable chip above
-the grid, so you can always see why the list is filtered and undo it with one click.
+widget, any filter that doesn't have its own control in the Simple grid (an SLA-percent bound,
+an escalation filter, and so on) still shows up as a removable chip above the grid regardless
+of which mode you're in, so you can always see why the list is filtered and undo it with one
+click.
 
 Once any filter is active, the **Filters** button turns into **Clear filters (N)**, showing
 how many are active and clearing all of them in one click.

--- a/apps/csm-portal/webapp/src/features/help/content/support.md
+++ b/apps/csm-portal/webapp/src/features/help/content/support.md
@@ -7,12 +7,12 @@ working a case once you're on its detail page.
 ## Finding cases
 
 The search box at the top of the list matches on case number, subject, or internal ID only —
-use the **Assignee**, **Project**, or **Team** filters below it to narrow by customer, project,
-or assignee instead. Next to the search box, **Filters** expands a grid of additional
+use the **Assignee**, **Project**, or **CRE Team** filters below it to narrow by assignee,
+project, or CRE team instead. Next to the search box, **Filters** expands a grid of additional
 controls, with a **Simple** / **Advanced** toggle above it:
 
-- **Simple** (the default) is a fixed grid: **Severity**, **State**, **Team**, **Case type**,
-  **Assignee** (search the engineer directory, or pick "Me"), **Product**, **Onboarding
+- **Simple** (the default) is a fixed grid: **Severity**, **State**, **CRE Team**, **Case
+  type**, **Assignee** (search the engineer directory, or pick "Me"), **Product**, **Onboarding
   status**, and **Project**.
   - **Severity**: S0 (Catastrophic) through S4 (Low / Query). S0 is reserved for Managed Cloud
     projects.
@@ -34,10 +34,13 @@ controls, with a **Simple** / **Advanced** toggle above it:
   the current filters can't be shown there; clear the Advanced-only ones to switch back.
 
 When a case list arrives already filtered, for example after clicking into a dashboard
-widget, any filter that doesn't have its own control in the Simple grid (an SLA-percent bound,
-an escalation filter, and so on) still shows up as a removable chip above the grid regardless
-of which mode you're in, so you can always see why the list is filtered and undo it with one
-click.
+widget, an Advanced-only filter (an SLA-percent bound, an escalation filter, and so on)
+switches the bar into Advanced mode automatically, where the filter row or OR group it landed
+in is itself the way you see and remove it — Advanced mode doesn't show a separate chip for
+it. The one exception is the work-state sub-filter (Ongoing/Paused, a narrow slice of State
+that stays Simple-representable and has no dedicated control of its own): if one arrives, say
+from a dashboard click-through, while you're in Simple mode, it shows up as a removable chip
+above the grid instead.
 
 Once any filter is active, the **Filters** button turns into **Clear filters (N)**, showing
 how many are active and clearing all of them in one click.

--- a/apps/csm-portal/webapp/src/features/help/content/support.md
+++ b/apps/csm-portal/webapp/src/features/help/content/support.md
@@ -6,9 +6,10 @@ working a case once you're on its detail page.
 
 ## Finding cases
 
-The search box at the top of the list matches on case number, subject, customer, project, or
-assignee. Next to it, **Filters** expands a grid of additional controls, with a **Simple** /
-**Advanced** toggle above it:
+The search box at the top of the list matches on case number, subject, or internal ID only —
+use the **Assignee**, **Project**, or **Team** filters below it to narrow by customer, project,
+or assignee instead. Next to the search box, **Filters** expands a grid of additional
+controls, with a **Simple** / **Advanced** toggle above it:
 
 - **Simple** (the default) is a fixed grid: **Severity**, **State**, **Team**, **Case type**,
   **Assignee** (search the engineer directory, or pick "Me"), **Product**, **Onboarding


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

CS engineers could only filter the cases list, dashboard "View more" pages, and the project
Work items tab through a fixed set of dedicated dropdowns. Several fields the backend already
supports on `POST /cases/search` (tags include/exclude, SRE team, escalation, SLA%, date
ranges, and more) had no way to be filtered from the UI at all — some only arrived via a
dashboard widget click-through and could be seen but never set by hand. There was also no way
to express OR conditions, and the Call Requests dashboard widget's "View more" page had no
filter bar at all.

No linked issues — scoped directly from a working session.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

- A generic "Advanced filters" field/op/value builder for the cases list, covering every
  `/cases/search` filter field, each with real value suggestions (async search / fixed
  enums), not hand-typed text.
- A Simple/Advanced mode toggle: Simple keeps the familiar dedicated dropdowns; Advanced
  unifies every field (dedicated and ad-hoc) into one editable row list backed by the same
  underlying filter state — no parallel model, switching modes never loses data. The page
  defaults to whichever mode the current URL's filters actually need.
- Cross-field OR groups (`anyOf`), restricted to the backend-allowed field subset.
- A real, editable filter bar for the Call Requests dashboard "View more" page (previously a
  static chip summary with no filter bar).
- Small correctness/UX fixes surfaced along the way: an inaccurate search-box placeholder, a
  duplicate-chip bug once Advanced mode existed, a raw UUID showing instead of "Me", and the
  "Team" filter renamed to "CRE Team" with both team pickers scoped to the `cre-abt` team
  family (a related SRE Team gap in that picker is called out below, not silently changed).

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

FE-only, `apps/csm-portal/webapp`. The cases list gained a per-field adapter registry
(`filterFieldAdapters.ts`) mapping every filterable field to a typed get/set pair on the shared
`CasesFilters` state, so Simple and Advanced modes are two renderings of one state rather than
two models kept in sync. The Advanced builder (`AdvancedFiltersBuilder.tsx`) and OR-groups
builder (`AnyOfGroupsBuilder.tsx`) render rows off that registry, reusing existing async-search
components (assignee, project, product, tags, team) as each row's value input rather than
plain text fields. The Call Requests dashboard preview reuses the same design pattern at a
smaller scale (4 fields, no Advanced mode needed since only one field has an op choice).

Live-verified throughout against the running local stack (staging backend, real data) via a
debug Chrome driven over CDP, not just unit tests — this caught a couple of real bugs unit
tests missed (an Advanced-mode row that vanished before it could be filled in; a stale URL
param after clearing the last filter) before they shipped.

## User stories
> Summary of user stories addressed by this change>

- As a CS engineer, I can filter cases by any field the backend supports, not just the ones
  with a dedicated dropdown.
- As a CS engineer, I can combine filters with OR logic for a subset of fields.
- As a CS engineer, I can filter the Call Requests widget's full list the same way I browse
  cases.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Added an Advanced filters mode to the cases list (field/op/value rows with real suggestions,
OR groups) alongside the existing Simple filters, and a new filter bar for the Call Requests
dashboard widget's "View more" page.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter "N/A" plus brief explanation of why there's no doc impact

Updated the in-app Support help topic (`src/features/help/content/support.md`) to describe the
Simple/Advanced toggle and the corrected search-box behavior.

## Training
N/A — no training content repo impact.

## Certification
N/A — no certification exam impact.

## Marketing
N/A — internal CS-engineer tooling, not customer/market-facing.

## Automation tests
 - Unit tests
   > New/updated Vitest coverage across `csm-cases`, `csm-dashboard`, and `csm-projects`: advanced-filter catalogue and URL round-trip (including an in-progress-row regression test), the `anyOf` payload/URL shape, the Simple↔Advanced adapter round trip, `isSimpleRepresentable`, the chip-suppression fix, the call-requests filter translate function, and the `@me`→"Me" label fix. Full run: `npx vitest run src` — passing.
 - Integration tests
   > None added; this is UI-only against an already-live backend contract, exercised live via a debug-Chrome/CDP session against the real staging backend during development (see Approach).

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — TypeScript/React frontend, not a Java/Go target for FindSecurityBugs; `eslint` ran clean on every touched file instead.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no sample apps affected.

## Related PRs
None.

## Migrations (if applicable)
N/A — no data migrations; FE-only change against an existing API contract.

## Test environment
Local dev stack (`scripts/csm-local-stack.sh up stg-be`): webapp on Node/Vite against the
deployed Choreo staging backend, real ServiceNow-backed data, Chrome (latest) via the DevTools
Protocol for live verification.

## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

Read the existing `/cases/search` filter contract (field/op/value allowlist, `anyOf` OR-group
semantics) directly from the entity-service source before designing the UI, rather than
guessing at what the backend accepts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Simple and Advanced case-filtering modes with field, operator, value rows, and cross-field OR groups.
  * Added relative-date presets and improved user, project, product, and tag selection.
  * Added editable call-request filters to dashboard widget previews.
  * Filters persist in URLs and refresh results when advanced criteria change.

* **Bug Fixes**
  * Improved filter validation, cleanup, date handling, and incomplete-filter behavior.
  * Updated filter visibility and state chip interactions.

* **Documentation**
  * Updated case-search guidance for the new filtering experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->